### PR TITLE
fix: eliminate Pydantic deprecation and PytestCollection warnings

### DIFF
--- a/src/squadops/api/routes/cycles/dtos.py
+++ b/src/squadops/api/routes/cycles/dtos.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 # =============================================================================
 # Nested DTOs
@@ -43,8 +43,7 @@ class CycleCreateRequest(BaseModel):
     experiment_context: dict = Field(default_factory=dict)
     notes: str | None = None
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class GateDecisionRequest(BaseModel):
@@ -58,15 +57,13 @@ class GateDecisionRequest(BaseModel):
     ]
     notes: str | None = None
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class SetActiveProfileRequest(BaseModel):
     profile_id: str
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class AgentProfileEntryRequest(BaseModel):
@@ -78,8 +75,7 @@ class AgentProfileEntryRequest(BaseModel):
     enabled: bool = True
     config_overrides: dict = Field(default_factory=dict)
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class ProfileCreateRequest(BaseModel):
@@ -89,8 +85,7 @@ class ProfileCreateRequest(BaseModel):
     description: str = ""
     agents: list[AgentProfileEntryRequest]
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class ProfileUpdateRequest(BaseModel):
@@ -100,8 +95,7 @@ class ProfileUpdateRequest(BaseModel):
     description: str | None = None
     agents: list[AgentProfileEntryRequest] | None = None
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class ProfileCloneRequest(BaseModel):
@@ -109,15 +103,13 @@ class ProfileCloneRequest(BaseModel):
 
     name: str
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class BaselinePromoteRequest(BaseModel):
     artifact_id: str
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 # =============================================================================
@@ -272,8 +264,7 @@ class PullModelRequest(BaseModel):
 
     name: str
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class PullStatusResponse(BaseModel):
@@ -290,8 +281,7 @@ class RunResumeRequest(BaseModel):
 
     resume_reason: str | None = None
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class CheckpointSummaryResponse(BaseModel):

--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -2,11 +2,11 @@
 
 Materialises source + test files into a temporary workspace and runs
 test frameworks (pytest, vitest, or both) as subprocesses.  The result
-is captured as a ``TestRunResult`` frozen dataclass that the QA handler
+is captured as a ``RunTestsResult`` frozen dataclass that the QA handler
 can attach as an artifact.
 
 All exceptions are caught so that a test-runner failure never crashes
-the handler — callers always get a ``TestRunResult``.
+the handler — callers always get a ``RunTestsResult``.
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ _STDOUT_LIMIT = 64 * 1024  # 64 KB
 
 
 @dataclass(frozen=True)
-class TestRunResult:
+class RunTestsResult:
     """Outcome of running generated tests in a temporary workspace."""
 
     executed: bool
@@ -73,15 +73,15 @@ async def run_generated_tests(
     source_files: list[dict[str, str]],
     test_files: list[dict[str, str]],
     timeout_seconds: int = 60,
-) -> TestRunResult:
+) -> RunTestsResult:
     """Run *test_files* against *source_files* in an isolated temp directory.
 
     Each element is ``{"path": "<relative>", "content": "<text>"}``.
 
-    Returns a ``TestRunResult`` — never raises.
+    Returns a ``RunTestsResult`` — never raises.
     """
     if not test_files:
-        return TestRunResult(
+        return RunTestsResult(
             executed=False,
             error="no test files provided",
             test_file_count=0,
@@ -113,7 +113,7 @@ async def run_generated_tests(
         except TimeoutError:
             proc.kill()
             await proc.wait()
-            return TestRunResult(
+            return RunTestsResult(
                 executed=False,
                 error=f"pytest timed out after {timeout_seconds}s",
                 test_file_count=len(test_files),
@@ -123,7 +123,7 @@ async def run_generated_tests(
         stdout = raw_stdout.decode(errors="replace")[:_STDOUT_LIMIT]
         stderr = raw_stderr.decode(errors="replace")[:_STDOUT_LIMIT]
 
-        return TestRunResult(
+        return RunTestsResult(
             executed=True,
             exit_code=proc.returncode or 0,
             stdout=stdout,
@@ -134,7 +134,7 @@ async def run_generated_tests(
 
     except Exception as exc:
         logger.warning("Test runner error: %s", exc, exc_info=True)
-        return TestRunResult(
+        return RunTestsResult(
             executed=False,
             error=str(exc),
             test_file_count=len(test_files),
@@ -149,17 +149,17 @@ async def run_node_tests(
     test_files: list[dict[str, str]],
     target_dir: str | None = None,
     timeout_seconds: int = 60,
-) -> TestRunResult:
+) -> RunTestsResult:
     """Run vitest in a Node workspace (D6).
 
     Materializes files, runs ``npm install`` then ``npx vitest run``.
     *target_dir* is the subdirectory within the workspace where
     ``package.json`` lives (e.g., ``"frontend"`` for fullstack projects).
 
-    Returns a ``TestRunResult`` — never raises.
+    Returns a ``RunTestsResult`` — never raises.
     """
     if not test_files:
-        return TestRunResult(
+        return RunTestsResult(
             executed=False,
             error="no test files provided",
             test_file_count=0,
@@ -176,7 +176,7 @@ async def run_node_tests(
 
         # Check for package.json
         if not os.path.isfile(os.path.join(cwd, "package.json")):
-            return TestRunResult(
+            return RunTestsResult(
                 executed=False,
                 error=f"No package.json found in {target_dir or 'workspace root'}",
                 test_file_count=len(test_files),
@@ -202,7 +202,7 @@ async def run_node_tests(
             except TimeoutError:
                 install_proc.kill()
                 await install_proc.wait()
-                return TestRunResult(
+                return RunTestsResult(
                     executed=False,
                     error=f"npm install timed out after {timeout_seconds}s",
                     test_file_count=len(test_files),
@@ -210,14 +210,14 @@ async def run_node_tests(
                 )
 
             if install_proc.returncode != 0:
-                return TestRunResult(
+                return RunTestsResult(
                     executed=False,
                     error="npm install failed (dependency resolution error)",
                     test_file_count=len(test_files),
                     source_file_count=len(source_files),
                 )
         except FileNotFoundError:
-            return TestRunResult(
+            return RunTestsResult(
                 executed=False,
                 error="npm not found — Node.js is not installed",
                 test_file_count=len(test_files),
@@ -236,7 +236,7 @@ async def run_node_tests(
                 stderr=asyncio.subprocess.PIPE,
             )
         except FileNotFoundError:
-            return TestRunResult(
+            return RunTestsResult(
                 executed=False,
                 error="npx not found — Node.js is not installed",
                 test_file_count=len(test_files),
@@ -251,7 +251,7 @@ async def run_node_tests(
         except TimeoutError:
             proc.kill()
             await proc.wait()
-            return TestRunResult(
+            return RunTestsResult(
                 executed=False,
                 error=f"vitest timed out after {timeout_seconds}s",
                 test_file_count=len(test_files),
@@ -261,7 +261,7 @@ async def run_node_tests(
         stdout = raw_stdout.decode(errors="replace")[:_STDOUT_LIMIT]
         stderr = raw_stderr.decode(errors="replace")[:_STDOUT_LIMIT]
 
-        return TestRunResult(
+        return RunTestsResult(
             executed=True,
             exit_code=proc.returncode or 0,
             stdout=stdout,
@@ -272,7 +272,7 @@ async def run_node_tests(
 
     except Exception as exc:
         logger.warning("Node test runner error: %s", exc, exc_info=True)
-        return TestRunResult(
+        return RunTestsResult(
             executed=False,
             error=str(exc),
             test_file_count=len(test_files),
@@ -286,14 +286,14 @@ async def run_fullstack_tests(
     source_files: list[dict[str, str]],
     test_files: list[dict[str, str]],
     timeout_seconds: int = 60,
-) -> TestRunResult:
+) -> RunTestsResult:
     """Run both pytest (backend) and vitest (frontend) tests (D12).
 
     Splits files by path prefix (``backend/`` vs ``frontend/``), runs
     both test suites, and merges results per the V1 merge policy (D13):
     backend pytest controls pass/fail; frontend vitest is non-blocking.
 
-    Returns a ``TestRunResult`` — never raises.
+    Returns a ``RunTestsResult`` — never raises.
     """
     # Split files by path prefix
     backend_source, frontend_source = [], []
@@ -350,7 +350,7 @@ async def run_fullstack_tests(
     if frontend_result.error:
         error_parts.append(f"frontend (non-blocking): {frontend_result.error}")
 
-    return TestRunResult(
+    return RunTestsResult(
         executed=combined_executed,
         exit_code=combined_exit_code,
         stdout="\n\n".join(combined_stdout_parts)[:_STDOUT_LIMIT],

--- a/src/squadops/config/schema.py
+++ b/src/squadops/config/schema.py
@@ -6,7 +6,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class TasksBackend(StrEnum):
@@ -669,10 +669,4 @@ class AppConfig(BaseModel):
             v["root"] = Path(v["root"])
         return v
 
-    class Config:
-        """Pydantic model configuration."""
-
-        # Forbid extra fields - unknown keys will cause validation errors
-        extra = "forbid"
-        validate_assignment = True
-        use_enum_values = True
+    model_config = ConfigDict(extra="forbid", validate_assignment=True, use_enum_values=True)

--- a/src/squadops/tasks/legacy_models.py
+++ b/src/squadops/tasks/legacy_models.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TaskState(StrEnum):
@@ -112,10 +112,7 @@ class Task(BaseModel):
     delegated_to: str | None = None
     created_at: datetime | None = None
 
-    class Config:
-        """Pydantic model configuration."""
-
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class LegacyTaskEnvelope(BaseModel):

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -21,11 +21,11 @@ from squadops.capabilities.handlers.cycle_tasks import (
     _classify_file,
     _is_test_file,
 )
-from squadops.capabilities.handlers.test_runner import TestRunResult
+from squadops.capabilities.handlers.test_runner import RunTestsResult
 from squadops.llm.exceptions import LLMConnectionError
 from squadops.llm.models import ChatMessage
 
-_MOCK_TEST_RESULT_PASSED = TestRunResult(
+_MOCK_TEST_RESULT_PASSED = RunTestsResult(
     executed=True,
     exit_code=0,
     stdout="1 passed",
@@ -34,7 +34,7 @@ _MOCK_TEST_RESULT_PASSED = TestRunResult(
     source_file_count=2,
 )
 
-_MOCK_TEST_RESULT_FAILED = TestRunResult(
+_MOCK_TEST_RESULT_FAILED = RunTestsResult(
     executed=True,
     exit_code=1,
     stdout="1 failed",
@@ -43,7 +43,7 @@ _MOCK_TEST_RESULT_FAILED = TestRunResult(
     source_file_count=2,
 )
 
-_MOCK_TEST_RESULT_NOT_RUN = TestRunResult(
+_MOCK_TEST_RESULT_NOT_RUN = RunTestsResult(
     executed=False,
     error="no test files provided",
     test_file_count=0,

--- a/tests/unit/capabilities/test_node_test_runner.py
+++ b/tests/unit/capabilities/test_node_test_runner.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from squadops.capabilities.handlers.test_runner import (
-    TestRunResult,
+    RunTestsResult,
     run_fullstack_tests,
     run_node_tests,
 )
@@ -220,7 +220,7 @@ class TestRunNodeTestsTargetDir:
 _RUN_PYTEST_PATH = "squadops.capabilities.handlers.test_runner.run_generated_tests"
 _RUN_NODE_PATH = "squadops.capabilities.handlers.test_runner.run_node_tests"
 
-_BACKEND_PASS = TestRunResult(
+_BACKEND_PASS = RunTestsResult(
     executed=True,
     exit_code=0,
     stdout="backend ok",
@@ -228,7 +228,7 @@ _BACKEND_PASS = TestRunResult(
     test_file_count=2,
     source_file_count=3,
 )
-_BACKEND_FAIL = TestRunResult(
+_BACKEND_FAIL = RunTestsResult(
     executed=True,
     exit_code=1,
     stdout="backend fail",
@@ -236,7 +236,7 @@ _BACKEND_FAIL = TestRunResult(
     test_file_count=2,
     source_file_count=3,
 )
-_FRONTEND_PASS = TestRunResult(
+_FRONTEND_PASS = RunTestsResult(
     executed=True,
     exit_code=0,
     stdout="frontend ok",
@@ -244,7 +244,7 @@ _FRONTEND_PASS = TestRunResult(
     test_file_count=1,
     source_file_count=2,
 )
-_FRONTEND_FAIL = TestRunResult(
+_FRONTEND_FAIL = RunTestsResult(
     executed=True,
     exit_code=1,
     stdout="frontend fail",
@@ -252,7 +252,7 @@ _FRONTEND_FAIL = TestRunResult(
     test_file_count=1,
     source_file_count=2,
 )
-_FRONTEND_NOT_RUN = TestRunResult(
+_FRONTEND_NOT_RUN = RunTestsResult(
     executed=False,
     error="npm not found — Node.js is not installed",
     test_file_count=1,

--- a/tests/unit/capabilities/test_test_runner.py
+++ b/tests/unit/capabilities/test_test_runner.py
@@ -1,6 +1,6 @@
 """Unit tests for the QA test runner (real subprocess execution).
 
-Tests ``TestRunResult``, ``_materialize_files``, and ``run_generated_tests``
+Tests ``RunTestsResult``, ``_materialize_files``, and ``run_generated_tests``
 from ``squadops.capabilities.handlers.test_runner``.
 """
 
@@ -12,7 +12,7 @@ import tempfile
 import pytest
 
 from squadops.capabilities.handlers.test_runner import (
-    TestRunResult,
+    RunTestsResult,
     _materialize_files,
     run_generated_tests,
 )
@@ -21,29 +21,29 @@ pytestmark = [pytest.mark.domain_capabilities]
 
 
 # ---------------------------------------------------------------------------
-# TestRunResult properties
+# RunTestsResult properties
 # ---------------------------------------------------------------------------
 
 
-class TestTestRunResultProperties:
+class TestRunTestsResultProperties:
     def test_summary_passed(self):
-        r = TestRunResult(executed=True, exit_code=0, test_file_count=2, source_file_count=3)
+        r = RunTestsResult(executed=True, exit_code=0, test_file_count=2, source_file_count=3)
         assert "all tests passed" in r.summary
         assert "2 test file(s)" in r.summary
         assert "3 source file(s)" in r.summary
 
     def test_summary_failed(self):
-        r = TestRunResult(executed=True, exit_code=1, test_file_count=1, source_file_count=1)
+        r = RunTestsResult(executed=True, exit_code=1, test_file_count=1, source_file_count=1)
         assert "tests failed" in r.summary
         assert "exit code 1" in r.summary
 
     def test_summary_not_run_with_error(self):
-        r = TestRunResult(executed=False, error="no test files provided")
+        r = RunTestsResult(executed=False, error="no test files provided")
         assert "tests not run" in r.summary
         assert "no test files" in r.summary
 
     def test_frozen(self):
-        r = TestRunResult(executed=True, exit_code=0)
+        r = RunTestsResult(executed=True, exit_code=0)
         with pytest.raises(AttributeError):
             r.exit_code = 42  # type: ignore[misc]
 


### PR DESCRIPTION
## Summary
- Replace deprecated `class Config:` inner class with `model_config = ConfigDict(...)` across 12 Pydantic models in 3 files (dtos.py, legacy_models.py, schema.py) — eliminates ~22 `PydanticDeprecatedSince20` warnings
- Rename `TestRunResult` → `RunTestsResult` in test_runner.py and 3 test files — eliminates `PytestCollectionWarning` from class name starting with `Test`

## Test plan
- [x] `./scripts/dev/run_new_arch_tests.sh` — 2890 passed, 0 Pydantic/PytestCollection warnings
- [x] `ruff check` — clean on all 7 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)