### PR TITLE
fix: eliminate PrefectBridge deadlock on task.dispatched (#25)

### DIFF
--- a/src/squadops/events/bridges/prefect.py
+++ b/src/squadops/events/bridges/prefect.py
@@ -75,11 +75,10 @@ class PrefectBridge:
 
             task_name = event.payload.get("task_name", task_key)
             if flow_run_id:
-                task_run_id = self._schedule_with_result(
-                    self._prefect.create_task_run(flow_run_id, task_key, task_name)
+                self._dispatched_tasks[dedup_key] = ""  # placeholder enables dedup immediately
+                self._schedule(
+                    self._create_and_start_task(flow_run_id, task_key, task_name, dedup_key)
                 )
-                self._dispatched_tasks[dedup_key] = task_run_id
-                self._schedule(self._prefect.set_task_run_state(task_run_id, "RUNNING", "Running"))
             return
 
         # Task succeeded/failed → set task run state
@@ -95,6 +94,14 @@ class PrefectBridge:
                 )
             return
 
+    async def _create_and_start_task(
+        self, flow_run_id: str, task_key: str, task_name: str, dedup_key: tuple[str, str]
+    ) -> None:
+        """Create a Prefect task run and set it to RUNNING (non-blocking)."""
+        task_run_id = await self._prefect.create_task_run(flow_run_id, task_key, task_name)
+        self._dispatched_tasks[dedup_key] = task_run_id
+        await self._prefect.set_task_run_state(task_run_id, "RUNNING", "Running")
+
     @staticmethod
     def _schedule(coro) -> None:  # noqa: ANN001
         """Schedule an async coroutine from synchronous context."""
@@ -104,16 +111,3 @@ class PrefectBridge:
         except RuntimeError:
             # No running event loop — run synchronously as fallback
             asyncio.run(coro)
-
-    @staticmethod
-    def _schedule_with_result(coro) -> str:  # noqa: ANN001
-        """Run an async coroutine and return its result."""
-        try:
-            loop = asyncio.get_running_loop()
-            # If we're in an async context, we can't await directly from sync.
-            # Use run_coroutine_threadsafe for thread-safe scheduling, but
-            # since PrefectReporter is best-effort, we run in a new loop as fallback.
-            future = asyncio.run_coroutine_threadsafe(coro, loop)
-            return future.result(timeout=10)
-        except RuntimeError:
-            return asyncio.run(coro)

--- a/tests/unit/events/bridges/test_prefect_bridge.py
+++ b/tests/unit/events/bridges/test_prefect_bridge.py
@@ -1,5 +1,6 @@
 """Tests for PrefectBridge subscriber."""
 
+import asyncio
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
@@ -130,6 +131,19 @@ class TestPrefectBridge:
         bridge.on_event(event)
         bridge.on_event(event)
         assert mock_reporter.create_task_run.call_count == 1
+
+    async def test_task_dispatched_no_deadlock_in_async_context(self, bridge, mock_reporter):
+        """on_event from async context must not block the event loop."""
+        event = _make_event(
+            event_type=EventType.TASK_DISPATCHED,
+            entity_type="task",
+            entity_id="task_a",
+            payload={"task_name": "My Task"},
+        )
+        bridge.on_event(event)
+        await asyncio.sleep(0)  # yield to let scheduled task complete
+        mock_reporter.create_task_run.assert_called_once()
+        mock_reporter.set_task_run_state.assert_called_once_with("tr_123", "RUNNING", "Running")
 
     def test_no_flow_run_id_skips_run_state(self, bridge, mock_reporter):
         event = _make_event(


### PR DESCRIPTION
## Summary
- `_schedule_with_result()` blocked the event loop via `future.result(timeout=10)`, adding a 10-second delay per `task.dispatched` event when called from async context (the production path)
- Replaced with fire-and-forget `_create_and_start_task()` that combines create + set-RUNNING into a single coroutine scheduled via `_schedule()`
- Deleted `_schedule_with_result()` entirely — no remaining callers
- Added async test that exercises the running-loop path (the exact scenario that deadlocked but was never tested)

## Test plan
- [x] `pytest tests/unit/events/bridges/test_prefect_bridge.py -v` — 12/12 pass (11 existing + 1 new)
- [x] `ruff check .` — clean
- [x] `./scripts/dev/run_regression_tests.sh` — 2939 passed
- [x] E2E selftest cycle completed successfully with no 10-second delays

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)