### PR TITLE
feat: Docker boot resilience for DGX Spark

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   rabbitmq:
     image: rabbitmq:3.12-management
     container_name: squadops-rabbitmq
+    restart: unless-stopped
     ports:
     - 5672:5672
     - 15672:15672
@@ -23,6 +24,7 @@ services:
   postgres:
     image: postgres:15
     container_name: squadops-postgres
+    restart: unless-stopped
     ports:
     - 5432:5432
     environment:
@@ -48,6 +50,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: squadops-redis
+    restart: unless-stopped
     ports:
     - 6379:6379
     volumes:
@@ -65,6 +68,7 @@ services:
   prefect-server:
     image: prefecthq/prefect:2.14-python3.11
     container_name: squadops-prefect-server
+    restart: unless-stopped
     ports:
     - 4200:4200
     environment:
@@ -100,6 +104,7 @@ services:
   squadops-keycloak:
     image: quay.io/keycloak/keycloak:24.0.5
     container_name: squadops-keycloak
+    restart: unless-stopped
     command: start-dev --import-realm
     environment:
       KEYCLOAK_ADMIN: admin
@@ -126,6 +131,7 @@ services:
   langfuse:
     container_name: squadops-langfuse
     image: langfuse/langfuse:2
+    restart: unless-stopped
     environment:
       DATABASE_URL: postgresql://langfuse:langfuse@postgres:5432/langfuse
       NEXTAUTH_SECRET: mysecret            # local dev only

--- a/scripts/bootstrap/lib/docker_setup.sh
+++ b/scripts/bootstrap/lib/docker_setup.sh
@@ -2,6 +2,26 @@
 # Docker setup functions for bootstrap (SIP-0081).
 # Sourced by bootstrap.sh — not executed directly.
 
+# Prompt to enable Docker daemon on boot (systemd only).
+enable_docker_on_boot() {
+    if [[ "${SKIP_DOCKER:-0}" == "1" ]]; then
+        return 0
+    fi
+    if ! check_command systemctl; then
+        return 0
+    fi
+    if systemctl is-enabled docker &>/dev/null; then
+        success "Docker already enabled on boot"
+        return 0
+    fi
+    if confirm_install "Docker auto-start on boot (systemctl enable docker)"; then
+        run_or_dry sudo systemctl enable docker
+        success "Docker enabled on boot"
+    else
+        warn "Skipping Docker on boot — services won't auto-start after reboot"
+    fi
+}
+
 # Start Docker Compose services.
 start_docker_services() {
     if [[ "${SKIP_DOCKER:-0}" == "1" ]]; then

--- a/scripts/bootstrap/profiles/local-spark.sh
+++ b/scripts/bootstrap/profiles/local-spark.sh
@@ -41,6 +41,8 @@ run_bootstrap() {
     # ── Docker services ────────────────────────────────────────────
     info "=== Docker Services ==="
 
+    enable_docker_on_boot
+
     if ! start_docker_services; then
         DOCKER_OK=0
         warn "Docker startup failed — skipping model pulls"


### PR DESCRIPTION
## Summary
- Add `enable_docker_on_boot()` to bootstrap lib — prompts user during `local-spark` bootstrap to run `systemctl enable docker` (uses existing `confirm_install()`, respects `--yes`/`--dry-run`, skips if already enabled or non-systemd)
- Add `restart: unless-stopped` to 6 infrastructure services missing it: rabbitmq, postgres, redis, prefect-server, keycloak, langfuse (agents/runtime-api/console/caddy/monitoring already had it)

After both changes, a DGX Spark reboot brings the full stack back automatically.

Closes #31

## Test plan
- [ ] `./scripts/bootstrap/bootstrap.sh local-spark --dry-run` prints `[dry-run] sudo systemctl enable docker`
- [ ] `./scripts/bootstrap/bootstrap.sh local-spark --dry-run --yes` auto-approves without prompt
- [ ] `docker compose config | grep -c restart` shows all services have the policy
- [ ] On macOS (no systemctl), `enable_docker_on_boot` silently skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)