### PR TITLE
fix: scope unattached artifacts under project directory

### DIFF
--- a/adapters/cycles/filesystem_artifact_vault.py
+++ b/adapters/cycles/filesystem_artifact_vault.py
@@ -8,7 +8,7 @@ Layout:
   <base_dir>/
     <project_id>/<cycle_id>/<run_id>/<artifact_id>/metadata.json + <filename>
     <project_id>/.baselines.json
-    _unattached/<artifact_id>/metadata.json + <filename>
+    <project_id>/_unattached/<artifact_id>/metadata.json + <filename>
     _index.json   (artifact_id → relative path)
 """
 
@@ -80,7 +80,7 @@ class FilesystemArtifactVault(ArtifactVaultPort):
     def _artifact_dir_for_ref(self, ref: ArtifactRef) -> Path:
         if ref.cycle_id and ref.run_id:
             return self._base_dir / ref.project_id / ref.cycle_id / ref.run_id / ref.artifact_id
-        return self._base_dir / "_unattached" / ref.artifact_id
+        return self._base_dir / ref.project_id / "_unattached" / ref.artifact_id
 
     def _baselines_path_for_project(self, project_id: str) -> Path:
         return self._base_dir / project_id / ".baselines.json"
@@ -181,20 +181,6 @@ class FilesystemArtifactVault(ArtifactVaultPort):
         self._collect_artifacts(
             scan_dir, results, project_id, cycle_id, run_id, artifact_type, promotion_status
         )
-
-        # Also scan _unattached when doing unscoped or project-scoped queries
-        if not (cycle_id or run_id):
-            unattached = self._base_dir / "_unattached"
-            if unattached.exists() and unattached != scan_dir:
-                self._collect_artifacts(
-                    unattached,
-                    results,
-                    project_id,
-                    cycle_id,
-                    run_id,
-                    artifact_type,
-                    promotion_status,
-                )
 
         return results
 

--- a/tests/unit/cycles/test_adapters.py
+++ b/tests/unit/cycles/test_adapters.py
@@ -631,13 +631,9 @@ class TestFilesystemArtifactVault:
 
     async def test_unattached_artifact_stored_correctly(self, vault, unattached_ref, base_dir):
         await vault.store(unattached_ref, b"bare")
-        expected = base_dir / "_unattached" / "art_bare"
+        expected = base_dir / "hello_squad" / "_unattached" / "art_bare"
         assert expected.is_dir()
         assert (expected / "metadata.json").exists()
-        # Unattached should appear in full scan
-        results = await vault.list_artifacts()
-        ids = [r.artifact_id for r in results]
-        assert "art_bare" in ids
 
     async def test_unattached_in_project_scoped_list(self, vault, unattached_ref):
         await vault.store(unattached_ref, b"bare")


### PR DESCRIPTION
## Summary
- Unattached artifacts (no cycle/run) were stored in a global `_unattached/` at the vault root, mixing all projects together
- Now stored under `<project_id>/_unattached/` so they remain project-scoped
- Removed the separate `_unattached` scan in `list_artifacts()` — now redundant since it's a subdirectory picked up by the project-level recursive scan
- Moved 8 existing misplaced artifacts to their correct project directories (5 → group_run, 3 → play_game)

Closes #33

## Test plan
- [x] 3032 regression tests pass (0 failures)
- [x] `test_unattached_artifact_stored_correctly` — verifies path is `<project>/_unattached/<id>`
- [x] `test_unattached_in_project_scoped_list` — verifies project-scoped list includes unattached
- [ ] Rebuild runtime-api (`./scripts/dev/ops/rebuild_and_deploy.sh runtime-api`) — index auto-rebuilds on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)