### PR TITLE
Pre-1.0 cleanup: agent restart policies, README, lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 **SquadOps** is an AI agent collaboration framework for software development. The system implements a role-based agent architecture where specialized agents handle different aspects of development tasks, from requirements analysis to application deployment.
 
-**Current Status**: Production-ready framework (v0.9.18) with hexagonal architecture, distributed cycle execution pipeline, workload protocols (planning, implementation, wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, Postgres-backed persistence, LangFuse observability, Keycloak authentication, CLI tooling, test quality enforcement, and 2,890+ passing tests.
+**Current Status**: Production-ready framework (v0.9.19) with hexagonal architecture, distributed cycle execution pipeline, multi-run cycle orchestration, workload protocols (planning, implementation, wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, Postgres-backed persistence, LangFuse observability, Keycloak authentication, CLI tooling, test quality enforcement, and 3,030+ passing tests.
 
 ---
 
@@ -118,7 +118,7 @@ Comprehensive documentation and protocols are available in `/docs/`:
 ├── accepted/         # Numbered, approved
 ├── implemented/      # Matched to code
 └── registry.yaml     # Canonical index
-/tests/               # Test suite (2,890+ tests)
+/tests/               # Test suite (3,030+ tests)
 ├── unit/             # Unit tests (mocked deps)
 ├── integration/      # Integration tests (real services)
 └── conftest.py       # Global fixtures
@@ -173,19 +173,19 @@ See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for full setup instructio
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for the full release timeline.
 
-**Current**: v0.9.18 — Wrap-Up Workload Protocol, test quality enforcement
+**Current**: v0.9.19 — Multi-Run Cycle Orchestration, profile-driven bootstrap
 
 ---
 
 ## Current Status
-**Framework Version**: 0.9.18
-**Development Status**: Production-ready multi-agent orchestration with console UI, distributed cycle execution, workload protocols (planning → implementation → wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, durable persistence, authentication, CLI tooling, test quality enforcement, and full observability stack.
+**Framework Version**: 0.9.19
+**Development Status**: Production-ready multi-agent orchestration with console UI, distributed cycle execution, multi-run cycle orchestration, workload protocols (planning → implementation → wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, durable persistence, authentication, CLI tooling, profile-driven bootstrap, test quality enforcement, and full observability stack.
 
 ### Project Statistics
 - **~39,000 lines** of Python source code
 - **~51,000 lines** of test code
 - **~84,000 lines** of documentation
-- **2,890+ tests** passing in regression suite
+- **3,030+ tests** passing in regression suite
 - **~80 SIPs** (54 implemented, 11 proposals, 15 deprecated)
 
 ### Functional Components
@@ -196,6 +196,7 @@ See [docs/ROADMAP.md](docs/ROADMAP.md) for the full release timeline.
 - Workload protocols: planning, implementation, and wrapup lifecycle (SIP-0078/0079/0080)
 - Cycle event system with 25-event taxonomy and bridge subscribers (SIP-0077)
 - Correction protocol: detect → RCA → decide → repair with checkpoint/resume (SIP-0079)
+- Multi-run cycle orchestration with auto-gate and workload forwarding (SIP-0083)
 - Workload & gate canon with artifact promotion model (SIP-0076)
 - LangFuse LLM observability with cross-process trace linking (SIP-0061)
 - Keycloak OIDC authentication with JWT middleware and audit logging (SIP-0062)
@@ -212,6 +213,7 @@ See [docs/ROADMAP.md](docs/ROADMAP.md) for the full release timeline.
 - LanceDB semantic memory (SIP-042)
 - OpenTelemetry with trace correlation
 - Console Control-Plane UI with Continuum plugin shell and auth BFF (SIP-0069)
+- Profile-driven bootstrap with doctor validation (SIP-0081)
 - Test quality enforcement: AST linter blocking in regression suite
 - Docker build system with deterministic multi-stage builds
 - 17-service Docker Compose development environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-max
+    restart: unless-stopped
     secrets:
       - db_password
       - rabbitmq_password
@@ -239,6 +240,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-nat
+    restart: unless-stopped
     secrets:
       - db_password
       - rabbitmq_password
@@ -297,6 +299,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-neo
+    restart: unless-stopped
     secrets:
       - db_password
       - rabbitmq_password
@@ -338,6 +341,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-eve
+    restart: unless-stopped
     secrets:
       - db_password
       - rabbitmq_password
@@ -375,6 +379,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-data
+    restart: unless-stopped
     secrets:
       - db_password
       - rabbitmq_password
@@ -416,6 +421,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-bob
+    restart: unless-stopped
     secrets:
       - db_password
       - rabbitmq_password

--- a/src/squadops/bootstrap/handlers.py
+++ b/src/squadops/bootstrap/handlers.py
@@ -35,6 +35,15 @@ from squadops.capabilities.handlers.governance import (
     TaskAnalysisHandler,
     TaskDelegationHandler,
 )
+from squadops.capabilities.handlers.impl.analyze_failure import (
+    DataAnalyzeFailureHandler,
+)
+from squadops.capabilities.handlers.impl.correction_decision import (
+    GovernanceCorrectionDecisionHandler,
+)
+from squadops.capabilities.handlers.impl.establish_contract import (
+    GovernanceEstablishContractHandler,
+)
 from squadops.capabilities.handlers.planning_tasks import (
     DataResearchContextHandler,
     DevelopmentDesignPlanHandler,
@@ -53,15 +62,6 @@ from squadops.capabilities.handlers.repair_tasks import (
     DevelopmentRepairHandler,
     GovernanceRootCauseHandler,
     StrategyCorrectivePlanHandler,
-)
-from squadops.capabilities.handlers.impl.analyze_failure import (
-    DataAnalyzeFailureHandler,
-)
-from squadops.capabilities.handlers.impl.correction_decision import (
-    GovernanceCorrectionDecisionHandler,
-)
-from squadops.capabilities.handlers.impl.establish_contract import (
-    GovernanceEstablishContractHandler,
 )
 from squadops.capabilities.handlers.warmboot import (
     ContextSyncHandler,

--- a/tests/unit/capabilities/test_cycle_task_generation_recording.py
+++ b/tests/unit/capabilities/test_cycle_task_generation_recording.py
@@ -13,8 +13,7 @@ import pytest
 
 from squadops.capabilities.handlers.cycle_tasks import StrategyAnalyzeHandler
 from squadops.llm.models import ChatMessage
-from squadops.telemetry.models import MAX_OBSERVABILITY_TEXT_LENGTH
-from squadops.telemetry.models import CorrelationContext
+from squadops.telemetry.models import MAX_OBSERVABILITY_TEXT_LENGTH, CorrelationContext
 
 pytestmark = [pytest.mark.domain_capabilities]
 


### PR DESCRIPTION
## Summary
- Add `restart: unless-stopped` to all 6 agent containers (max, nat, neo, eve, data, bob) — completes the work from PR #32 which covered infra services only
- Update README: version 0.9.18 → 0.9.19, test count 2,890+ → 3,030+, add SIP-0081 and SIP-0083 to functional components
- Fix 2 auto-fixable ruff import sorting issues

Closes #35

## Test plan
- [x] 3032/3032 regression tests pass
- [x] `docker compose config | grep restart` — all active services show `unless-stopped`
- [x] `ruff check .` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)