### PR TITLE
chore(release): promote SIP-0086 and bump to v1.0.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 SquadOps is a multi-agent orchestration framework for software development. It uses a hexagonal architecture (ports & adapters) with dependency injection for testability.
 
-**Framework Version**: 1.0.3 (single-sourced via `importlib.metadata.version("squadops")`)
+**Framework Version**: 1.0.4 (single-sourced via `importlib.metadata.version("squadops")`)
 **Python Requirement**: 3.11+
 
 ## Commands
@@ -183,6 +183,7 @@ Key principle: **acceptance is a design commitment on main, not an implementatio
 - **SIP-0069** – Console Control-Plane UI (Continuum Plugins)
 - **SIP-0070** – Pulse Checks and Verification Framework
 - **SIP-0071** – Builder Role (Dedicated Product Builder Agent)
+- **SIP-0086** – Build Convergence Loop (Dynamic Task Decomposition, Output Validation, Correction Activation)
 
 ### Moving a SIP (maintainer only)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 **SquadOps** is an AI agent collaboration framework for software development. The system implements a role-based agent architecture where specialized agents handle different aspects of development tasks, from requirements analysis to application deployment.
 
-**Current Status**: v1.0.3 — Production-ready framework with hexagonal architecture, distributed cycle execution pipeline, multi-run cycle orchestration, workload protocols (planning, implementation, wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, Postgres-backed persistence, LangFuse observability, Keycloak authentication, CLI tooling, test quality enforcement, and 3,030+ passing tests.
+**Current Status**: v1.0.4 — Production-ready framework with hexagonal architecture, distributed cycle execution pipeline, multi-run cycle orchestration, workload protocols (planning, implementation, wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, build convergence loop with dynamic task decomposition (SIP-0086), Postgres-backed persistence, LangFuse observability, Keycloak authentication, CLI tooling, test quality enforcement, and 3,400+ passing tests.
 
 ---
 
@@ -173,12 +173,12 @@ See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for full setup instructio
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for the full release timeline.
 
-**Current**: v1.0.3 — Post-1.0 stable; distributed cycle execution, multi-run orchestration, and correction protocol shipped
+**Current**: v1.0.4 — Post-1.0 stable; distributed cycle execution, multi-run orchestration, correction protocol, and build convergence loop (SIP-0086) shipped
 
 ---
 
 ## Current Status
-**Framework Version**: 1.0.3
+**Framework Version**: 1.0.4
 **Development Status**: Post-1.0 stable multi-agent orchestration with console UI, distributed cycle execution, multi-run cycle orchestration, workload protocols (planning → implementation → wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, durable persistence, authentication, CLI tooling, profile-driven bootstrap, test quality enforcement, and full observability stack.
 
 ### Project Statistics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["squadops*", "adapters*"]  # Include both packages
 
 [project]
 name = "squadops"
-version = "1.0.3"
+version = "1.0.4"
 description = "SquadOps: a production-grade multi-agent orchestration framework."
 requires-python = ">=3.11"
 authors = [

--- a/sips/implemented/SIP-0086-Build-Convergence-Loop-Dynamic.md
+++ b/sips/implemented/SIP-0086-Build-Convergence-Loop-Dynamic.md
@@ -1,11 +1,11 @@
 ---
 title: Build Convergence Loop — Dynamic Task Decomposition, Output Validation & Correction
   Activation
-status: accepted
+status: implemented
 author: SquadOps Architecture
 created_at: '2026-03-31T00:00:00Z'
 sip_number: 86
-updated_at: '2026-03-31T18:05:54.695240Z'
+updated_at: '2026-04-19T16:22:45.032124Z'
 ---
 # SIP-XXXX: Build Convergence Loop — Dynamic Task Decomposition, Output Validation & Correction Activation
 

--- a/sips/registry.yaml
+++ b/sips/registry.yaml
@@ -776,9 +776,9 @@ sips:
   sip_number: 86
   title: Build Convergence Loop — Dynamic Task Decomposition, Output Validation &
     Correction Activation
-  path: sips/accepted/SIP-0086-Build-Convergence-Loop-Dynamic.md
-  status: accepted
+  path: sips/implemented/SIP-0086-Build-Convergence-Loop-Dynamic.md
+  status: implemented
   author: SquadOps Architecture
   approver: jladd
   created_at: '2026-03-31T00:00:00Z'
-  updated_at: '2026-03-31T18:05:54.718507Z'
+  updated_at: '2026-04-19T16:22:45.033678Z'


### PR DESCRIPTION
## Summary

Post-merge maintainer housekeeping for SIP-0086 (which landed in #55).

- Promotes `SIP-0086-Build-Convergence-Loop-Dynamic.md` from `sips/accepted/` → `sips/implemented/` via `scripts/maintainer/update_sip_status.py` (requires `SQUADOPS_MAINTAINER=1`).
- Bumps framework version `1.0.3` → `1.0.4` via `scripts/maintainer/version_cli.py`.
- Manually reconciles the version strings in `README.md` and `CLAUDE.md` that `version_cli.py` doesn't touch. This is the exact drift pattern the proposed [SIP-Version-Bump-Hardening](sips/proposed/SIP-Version-Bump-Hardening.md) will eliminate once it lands.
- Adds SIP-0086 to the "Key Implemented SIPs" section in `CLAUDE.md`.

## Why a separate PR

Workflow step 8 in `CLAUDE.md` is explicit: *"Promote | main | Maintainer | Runs `update_sip_status.py ... implemented` after verification."* Doing it as a tiny follow-up PR keeps the audit trail clean — the promotion commit is trivially reviewable, separate from the 30-commit feature branch.

## Test plan

- [x] `pyproject.toml` version is `1.0.4`
- [x] `sips/registry.yaml` shows SIP-0086 `status: implemented` with correct path
- [x] SIP file physically moved from `sips/accepted/` to `sips/implemented/`
- [x] No stray `1.0.3` left in `README.md` / `CLAUDE.md` (grep returns empty)
- [x] `CLAUDE.md` "Key Implemented SIPs" includes SIP-0086

## Note for future releases

The manual README/CLAUDE.md step here is the drift pattern called out in the proposed [SIP-Version-Bump-Hardening](sips/proposed/SIP-Version-Bump-Hardening.md). When that ships, `version_cli.py bump` will rewrite marker-bracketed version strings in both files automatically and this follow-up becomes a single command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)