### PR TITLE
config(spark): upgrade max/neo/nat/bob to qwen3.6:27b

### DIFF
--- a/config/squad-profiles.yaml
+++ b/config/squad-profiles.yaml
@@ -24,13 +24,13 @@ profiles:
 
   - profile_id: spark-squad-with-builder
     name: "Spark Squad with Builder"
-    description: "6 agents optimized for DGX Spark — 32b for lead/dev/strat, 14b for builder/qa, 7b for data"
-    version: 2
+    description: "6 agents optimized for DGX Spark — qwen3.6:27b for lead/dev/builder, qwen2.5:32b for strat, 14b for qa, 7b for data"
+    version: 3
     agents:
-      - { agent_id: max, role: lead, model: "qwen2.5:32b", enabled: true }
-      - { agent_id: neo, role: dev, model: "qwen2.5:32b", enabled: true }
+      - { agent_id: max, role: lead, model: "qwen3.6:27b", enabled: true }
+      - { agent_id: neo, role: dev, model: "qwen3.6:27b", enabled: true }
       - { agent_id: nat, role: strat, model: "qwen2.5:32b", enabled: true }
-      - { agent_id: bob, role: builder, model: "qwen2.5:14b", enabled: true }
+      - { agent_id: bob, role: builder, model: "qwen3.6:27b", enabled: true }
       - { agent_id: eve, role: qa, model: "qwen2.5:14b", enabled: true }
       - { agent_id: data, role: data, model: "qwen2.5:7b", enabled: true }
 

--- a/config/squad-profiles.yaml
+++ b/config/squad-profiles.yaml
@@ -24,12 +24,12 @@ profiles:
 
   - profile_id: spark-squad-with-builder
     name: "Spark Squad with Builder"
-    description: "6 agents optimized for DGX Spark — qwen3.6:27b for lead/dev/builder, qwen2.5:32b for strat, 14b for qa, 7b for data"
+    description: "6 agents optimized for DGX Spark — qwen3.6:27b for lead/dev/strat/builder, 14b for qa, 7b for data"
     version: 3
     agents:
       - { agent_id: max, role: lead, model: "qwen3.6:27b", enabled: true }
       - { agent_id: neo, role: dev, model: "qwen3.6:27b", enabled: true }
-      - { agent_id: nat, role: strat, model: "qwen2.5:32b", enabled: true }
+      - { agent_id: nat, role: strat, model: "qwen3.6:27b", enabled: true }
       - { agent_id: bob, role: builder, model: "qwen3.6:27b", enabled: true }
       - { agent_id: eve, role: qa, model: "qwen2.5:14b", enabled: true }
       - { agent_id: data, role: data, model: "qwen2.5:7b", enabled: true }


### PR DESCRIPTION
## Summary
- Swap Spark squad's lead/dev/strat/builder (max, neo, nat, bob) to the new **Qwen3.6-27B** dense model (released 2026-04-22).
- eve (qa) stays on `qwen2.5:14b`; data stays on `qwen2.5:7b`.
- Only the `spark-squad-with-builder` profile changes — `full-squad` and `full-squad-with-builder` are untouched.

## Why
- **Smaller footprint, better coding**: Qwen3.6-27B is 17GB quantized vs 19GB for the 32b it replaces, and publishes SWE-bench Verified 77.2 / Terminal-Bench 59.3.
- **Fits SIP-0086**: the build convergence loop rewards per-iteration quality over throughput; dense reasoning + 262K native context beats MoE routing for manifest/diff-heavy builder flows.
- **Strategy is dense's home turf**: nat's role is long multi-step planning, the workload where dense coherence most clearly beats MoE routing.
- **Hybrid attention (Gated DeltaNet + Gated Attention)** keeps throughput competitive on Spark's compute budget.

## Test plan
- [ ] `squadops doctor local-spark` — verify `qwen3.6:27b` is pulled and reachable
- [ ] Kick a `spark-squad-with-builder` cycle end-to-end; confirm max/neo/nat/bob load the new model
- [ ] Spot-check LangFuse traces to confirm model tag = `qwen3.6:27b`
- [ ] Compare cycle iteration count / duration against prior `qwen2.5:32b` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)