### PR TITLE
docs(sip): split agent runtime modes into three SIPs (v1.1/1.2/1.3)

### DIFF
--- a/sips/proposed/SIP-Agent-Embodiment-Substrate.md
+++ b/sips/proposed/SIP-Agent-Embodiment-Substrate.md
@@ -1,0 +1,300 @@
+# SIP: Agent Embodiment Substrate
+
+**Status:** Proposed (draft)
+**Authors:** Jason Ladd
+**Created:** 2026-04-25
+**Revision:** 1
+**Targets:** v1.2
+**Depends on:** `SIP-Agent-Runtime-State.md` (v1.1) — must land first
+**Parent vision:** `sips/proposed/SIP-Agent-Runtime-Modes.md` (umbrella index)
+**Sibling:** `SIP-Duty-Durability-Temporal.md` (v1.3)
+
+---
+
+## 1. Summary
+
+This SIP introduces an **embodiment abstraction** that lets a SquadOps agent act through a runtime surface in a world or system — without making any specific world part of the core domain.
+
+The first proof point is intentionally **not** Minecraft. It is a lighter surface (Discord presence or browser session) chosen because it is easier to test in CI, has well-established adapter patterns, and exercises the embodiment model without dragging in physics, blocks, mob AI, or pathfinding.
+
+The agent identity remains durable. The embodiment is the runtime surface through which it acts. They are separable: the same agent can detach from one embodiment and reattach to another.
+
+Minecraft remains a future proof point, addressed in a follow-on SIP after this substrate proves stable.
+
+---
+
+## 2. Problem Statement
+
+Once an agent can be persistent (per `SIP-Agent-Runtime-State.md`), the next architectural question is:
+
+> How does an agent act in environments that are not its own process?
+
+Without a substrate:
+
+- Discord, browser, Minecraft, and any future surface get bolted directly onto agents
+- Agent state and embodiment state get conflated in prompt context
+- Embodiment health (connection, disconnection, desync) becomes invisible
+- Location, when it matters, has nowhere clean to live
+- Each new world brings ad-hoc state machines
+
+The problem is not "how do we play Minecraft." It is:
+
+> How can SquadOps represent embodied presence in any external surface, with observable attachment state and health, without contaminating the core domain with surface-specific knowledge?
+
+---
+
+## 3. Design Intent
+
+1. Separate **agent identity** from **embodiment** — the agent is durable, the embodiment is a runtime surface.
+2. Make embodiment **observable**: attachment state, health, capability set, location reference.
+3. Keep **location generic** in the core; world-specific detail lives in adapters.
+4. Prove the abstraction with a **lightweight first surface** (Discord or browser), not Minecraft.
+5. Establish the adapter pattern so future surfaces (Minecraft, Decentraland, etc.) plug in cleanly.
+6. Introduce **resource budgets** as a first-cut guard against irresponsible scheduling.
+
+---
+
+## 4. Non-Goals
+
+This SIP does **not** propose:
+
+- Minecraft, Mineflayer, or any virtual-world game logic — that's a follow-on SIP after this substrate stabilizes
+- Spatial reasoning, pathfinding, or world simulation
+- Replacing existing agent communication (RabbitMQ, message envelopes) with embodiment events
+- Temporal or durable workflow integration — see `SIP-Duty-Durability-Temporal.md`
+- Ambient autonomy beyond what the runtime-state SIP already permits
+
+---
+
+## 5. Proposed Embodiment Model
+
+### 5.1 The agent / embodiment split
+
+```
+Agent (durable)            Embodiment (runtime surface)
+  identity                   discord_session / browser_ctx / minecraft_avatar
+  mode/focus/activity        attachment_state / health / location / capabilities
+```
+
+An agent without an embodiment is still a fully valid agent — it just can't act in external surfaces. An embodiment without an agent is meaningless and should never exist.
+
+### 5.2 Embodiment lifecycle
+
+```
+unattached → attaching → attached → desynced → reconnecting → attached
+                                  ↘ detached
+```
+
+- **unattached** — embodiment record exists, no live connection
+- **attaching** — adapter is connecting; transient
+- **attached** — live, healthy, capable of action
+- **desynced** — connection live but state divergence detected (e.g., Discord rate limit, browser context lost)
+- **reconnecting** — adapter recovering
+- **detached** — explicitly released or terminally failed
+
+Each transition is evented and auditable, mirroring the runtime-state SIP's approach to mode transitions.
+
+### 5.3 Embodiment fields
+
+```yaml
+Embodiment:
+  embodiment_id: string
+  agent_id: string                    # owning agent
+  embodiment_type: discord | browser | minecraft | cli | other
+  platform: string                    # e.g., "discord:guild_id", "browser:chromium"
+  attachment_state: unattached | attaching | attached | desynced | reconnecting | detached
+  health: healthy | degraded | failed
+  capability_set: [string]            # what this embodiment can do
+  location_ref: string | null         # see Location below
+  last_health_check_at: timestamp
+```
+
+### 5.4 Location (generic in core)
+
+Core knows that location exists and matters. Adapter-specific shape lives in adapters.
+
+```yaml
+Location:
+  location_type: string               # opaque to core; e.g., "discord_channel", "url", "minecraft_xyz"
+  location_system: string             # e.g., "discord", "browser", "minecraft"
+  location_ref: string                # opaque ref the adapter understands
+  updated_at: timestamp
+```
+
+Core never inspects `location_ref`. Adapters interpret it.
+
+### 5.5 Capability set
+
+Embodiment capabilities are declared by the adapter at attach time. Examples:
+
+- Discord embodiment: `send_message`, `read_channel`, `add_reaction`, `manage_threads`
+- Browser embodiment: `navigate`, `click`, `type`, `screenshot`, `extract_text`
+
+The runtime-state Activity model can require an embodiment with a specific capability before scheduling. This is the seam where embodiment integrates with the SIP-1.1 substrate.
+
+---
+
+## 6. Resource Budgets
+
+The goal is not to simulate a human body. The goal is to prevent irresponsible scheduling — especially for ambient agents that may otherwise burn tokens or take unbounded action.
+
+First-cut budget dimensions (coarse, intentionally simple):
+
+- **attention_budget** — how much focused time the agent can hold per window
+- **compute_budget** — token / inference cost ceiling
+- **action_budget** — count of embodied actions per window
+- **concurrency_allowance** — how many activities can be open at once
+
+Budget exhaustion forces a transition (e.g., back to ambient, or detach embodiment) rather than silent overrun.
+
+Budgets attach to the agent, not the embodiment, so cross-embodiment usage is summed.
+
+---
+
+## 7. Adapter Pattern
+
+Embodiments follow the existing SquadOps hexagonal pattern.
+
+- **Port:** `EmbodimentPort` in `src/squadops/ports/`
+- **Adapters:** `adapters/embodiment/discord/`, `adapters/embodiment/browser/`, etc.
+- **Factory:** `EmbodimentFactory` selects adapter by `embodiment_type` and platform config
+
+The adapter owns:
+
+- Connection lifecycle (attach, reconnect, detach)
+- Health checks
+- Capability declaration
+- Translating Activity goals into surface-specific actions
+- Updating location_ref when the adapter knows location changed
+
+The core owns:
+
+- Embodiment record (attachment_state, health, capability_set, location_ref)
+- Resource budget enforcement
+- Event emission on state transitions
+- Integration with Activity and FocusLease from the v1.1 substrate
+
+---
+
+## 8. First Proof Point: Discord Presence
+
+Recommended first surface: **Discord**.
+
+Why Discord:
+
+- Stable, well-documented SDK (discord.py / discord.js)
+- No physics or world simulation
+- Clean message-event model maps naturally to Activity
+- Easy to test in CI with a private guild
+- Real Backspring use case: agents that monitor channels, respond to mentions, post status
+
+Minimum capability set:
+
+- Connect to a Discord guild
+- Listen on a configured channel
+- Send messages
+- React to mentions
+- Cleanly detach
+
+Acceptance for Phase 1 of this SIP:
+
+- An ambient agent can attach a Discord embodiment, listen on a channel, respond to a mention, and detach cleanly on shutdown
+- Embodiment state transitions are observable via the existing telemetry seam
+- A focus lease prevents two activities from claiming the embodiment simultaneously
+
+---
+
+## 9. Future Surfaces (Out of Scope for v1.2)
+
+Documented here so reviewers see the trajectory, but **not** part of this SIP:
+
+- **Browser** — natural second surface; reuses existing browser automation patterns
+- **Minecraft via Mineflayer** — requires its own SIP; pulls in pathfinding, block placement, world acceptance checks
+- **Decentraland / The Sandbox** — far future; depends on platform stability
+
+The substrate proposed here should accommodate all of them without core changes.
+
+---
+
+## 10. Implementation Phases
+
+### Phase 1 — Core embodiment model
+
+- `EmbodimentPort` interface
+- Embodiment record + Postgres table
+- Lifecycle state machine
+- Event emission
+- Resource budget primitives (attention, compute, action, concurrency)
+
+**Acceptance:** Embodiment records exist and transition states cleanly. No adapter required yet.
+
+### Phase 2 — Discord adapter
+
+- `adapters/embodiment/discord/` with full lifecycle support
+- Connect, listen, send, react, detach
+- Capability declaration
+- Health checks via Discord gateway
+
+**Acceptance:** an ambient agent can hold a Discord presence end-to-end.
+
+### Phase 3 — Activity integration
+
+- Activities can declare `requires_embodiment: <type>` and `required_capabilities: [...]`
+- Scheduler refuses to start an Activity without a matching attached embodiment
+- Pause/resume semantics handle embodiment desync
+
+**Acceptance:** a duty agent can hold a Discord embodiment, take a moderation Activity, pause it on disconnect, and resume it on reconnect.
+
+### Phase 4 — Browser adapter (optional, demonstrates substrate generality)
+
+- Headless browser embodiment with navigate/click/type/screenshot
+- Validates the abstraction by exercising a second surface
+
+**Acceptance:** the browser adapter ships without changing any core embodiment code.
+
+---
+
+## 11. Acceptance Criteria
+
+The SIP is successful when:
+
+1. **Identity / embodiment separation** is clean — agents survive embodiment loss; embodiments cannot exist without agents
+2. **Observable lifecycle** — every embodiment state transition is evented and queryable
+3. **Generic location** — core never interprets `location_ref`; adapters do
+4. **Capability-aware scheduling** — Activities cannot start without a matching embodiment capability
+5. **Budget enforcement** — exhaustion causes explicit transitions, never silent overrun
+6. **First proof point lives** — Discord adapter passes integration tests in CI
+7. **Substrate generality** — adding the browser adapter requires zero core changes
+8. **No regressions** — `run_regression_tests.sh` continues to pass; v1.1 runtime-state primitives unaffected
+
+---
+
+## 12. Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Surface-specific concerns leak into core | Keep `location_ref` opaque; review every PR for adapter-specific imports in core |
+| Discord adapter complexity bleeds in | Keep adapter behind clean port; use a minimal capability set |
+| Budgets become a new policy quagmire | Start coarse (4 dimensions); resist adding more until needed |
+| Embodiment desync silently degrades agents | Mandatory health checks; desync transitions trigger explicit Activity pause |
+| Multiple embodiments per agent contention | Defer multi-embodiment to a follow-on; v1.2 is one embodiment per agent |
+
+---
+
+## 13. Open Questions
+
+1. Should one agent be allowed to hold multiple embodiments simultaneously in v1.2, or is it strictly one-at-a-time?
+2. How does embodiment attachment interact with the focus lease from v1.1? Same lease type, or a distinct embodiment lease?
+3. Where do embodiment credentials (Discord bot tokens, browser cookies) live? `SecretManager` already exists — likely reuse via `secret://` refs.
+4. Should resource budgets be configurable per agent role, or global defaults?
+5. Does the Discord adapter belong in the main `adapters/` tree, or does it warrant a separate optional install (extras dependency)?
+
+---
+
+## 14. References
+
+- Depends on: `sips/proposed/SIP-Agent-Runtime-State.md` (v1.1)
+- Parent vision: `sips/proposed/SIP-Agent-Runtime-Modes.md`
+- Original full proposal: commit `76a1f90` on main
+- Related: SIP-0061 (LangFuse Observability — telemetry pattern reused for embodiment events), SIP-0042 (memory adapter — pattern for optional integrations)
+- Hexagonal pattern: existing `src/squadops/ports/` and `adapters/` structure

--- a/sips/proposed/SIP-Agent-Embodiment-Substrate.md
+++ b/sips/proposed/SIP-Agent-Embodiment-Substrate.md
@@ -3,11 +3,12 @@
 **Status:** Proposed (draft)
 **Authors:** Jason Ladd
 **Created:** 2026-04-25
-**Revision:** 1
+**Revision:** 2 (incorporated review feedback on 2026-04-25)
 **Targets:** v1.2
 **Depends on:** `SIP-Agent-Runtime-State.md` (v1.1) — must land first
 **Parent vision:** `sips/proposed/SIP-Agent-Runtime-Modes.md` (umbrella index)
 **Sibling:** `SIP-Duty-Durability-Temporal.md` (v1.3)
+**Future follow-on:** `SIP-Minecraft-Embodiment-Adapter.md` (not in this package)
 
 ---
 
@@ -15,11 +16,11 @@
 
 This SIP introduces an **embodiment abstraction** that lets a SquadOps agent act through a runtime surface in a world or system — without making any specific world part of the core domain.
 
-The first proof point is intentionally **not** Minecraft. It is a lighter surface (Discord presence or browser session) chosen because it is easier to test in CI, has well-established adapter patterns, and exercises the embodiment model without dragging in physics, blocks, mob AI, or pathfinding.
+The first proof point is intentionally **not** Minecraft. It is a lighter surface (Discord presence) chosen because it is easier to test than world-simulation surfaces, has well-established adapter patterns, and exercises the embodiment model without dragging in physics, blocks, mob AI, or pathfinding.
 
 The agent identity remains durable. The embodiment is the runtime surface through which it acts. They are separable: the same agent can detach from one embodiment and reattach to another.
 
-Minecraft remains a future proof point, addressed in a follow-on SIP after this substrate proves stable.
+Minecraft is a **named future follow-on** (`SIP-Minecraft-Embodiment-Adapter.md`), addressed after this substrate proves stable.
 
 ---
 
@@ -37,7 +38,7 @@ Without a substrate:
 - Location, when it matters, has nowhere clean to live
 - Each new world brings ad-hoc state machines
 
-The problem is not "how do we play Minecraft." It is:
+The challenge:
 
 > How can SquadOps represent embodied presence in any external surface, with observable attachment state and health, without contaminating the core domain with surface-specific knowledge?
 
@@ -48,9 +49,10 @@ The problem is not "how do we play Minecraft." It is:
 1. Separate **agent identity** from **embodiment** — the agent is durable, the embodiment is a runtime surface.
 2. Make embodiment **observable**: attachment state, health, capability set, location reference.
 3. Keep **location generic** in the core; world-specific detail lives in adapters.
-4. Prove the abstraction with a **lightweight first surface** (Discord or browser), not Minecraft.
-5. Establish the adapter pattern so future surfaces (Minecraft, Decentraland, etc.) plug in cleanly.
-6. Introduce **resource budgets** as a first-cut guard against irresponsible scheduling.
+4. Prove the abstraction with a **lightweight first surface** (Discord), not Minecraft.
+5. Establish the adapter pattern so future surfaces (Minecraft, browser, Decentraland, etc.) plug in cleanly.
+6. Introduce **resource budgets** as a first-cut guard against irresponsible scheduling, with explicit decrement and exhaustion rules.
+7. **Preserve the package invariant:** embodiment never decides intent.
 
 ---
 
@@ -58,11 +60,13 @@ The problem is not "how do we play Minecraft." It is:
 
 This SIP does **not** propose:
 
-- Minecraft, Mineflayer, or any virtual-world game logic — that's a follow-on SIP after this substrate stabilizes
+- Minecraft, Mineflayer, or any virtual-world game logic — see `SIP-Minecraft-Embodiment-Adapter.md` (future)
 - Spatial reasoning, pathfinding, or world simulation
 - Replacing existing agent communication (RabbitMQ, message envelopes) with embodiment events
 - Temporal or durable workflow integration — see `SIP-Duty-Durability-Temporal.md`
 - Ambient autonomy beyond what the runtime-state SIP already permits
+- A full EmbodiedAction ledger as a first-class table — explicitly deferred (see §5.6)
+- Multiple simultaneously-attached embodiments per agent — explicitly deferred (see §5.5)
 
 ---
 
@@ -72,7 +76,7 @@ This SIP does **not** propose:
 
 ```
 Agent (durable)            Embodiment (runtime surface)
-  identity                   discord_session / browser_ctx / minecraft_avatar
+  identity                   discord_session / browser_ctx / minecraft_avatar (future)
   mode/focus/activity        attachment_state / health / location / capabilities
 ```
 
@@ -92,7 +96,7 @@ unattached → attaching → attached → desynced → reconnecting → attached
 - **reconnecting** — adapter recovering
 - **detached** — explicitly released or terminally failed
 
-Each transition is evented and auditable, mirroring the runtime-state SIP's approach to mode transitions.
+Each transition is evented from the canonical `embodiment.*` event set in the umbrella SIP.
 
 ### 5.3 Embodiment fields
 
@@ -105,53 +109,118 @@ Embodiment:
   attachment_state: unattached | attaching | attached | desynced | reconnecting | detached
   health: healthy | degraded | failed
   capability_set: [string]            # what this embodiment can do
-  location_ref: string | null         # see Location below
+  location_ref: string | null         # opaque to core; see 5.4
   last_health_check_at: timestamp
+  credentials_ref: string             # secret:// reference; never the credential itself
 ```
 
-### 5.4 Location (generic in core)
+### 5.4 Location (generic in core, opaque to core)
 
 Core knows that location exists and matters. Adapter-specific shape lives in adapters.
 
 ```yaml
 Location:
-  location_type: string               # opaque to core; e.g., "discord_channel", "url", "minecraft_xyz"
+  location_type: string               # opaque; e.g., "discord_channel", "url", "minecraft_xyz"
   location_system: string             # e.g., "discord", "browser", "minecraft"
-  location_ref: string                # opaque ref the adapter understands
+  location_ref: string                # opaque; the adapter understands its content
   updated_at: timestamp
 ```
 
-Core never inspects `location_ref`. Adapters interpret it.
+**Location opacity rules** (binding):
 
-### 5.5 Capability set
+- Core MAY compare whether `location_ref` changed (equality only).
+- Core MAY route `location_ref` back to the owning adapter for interpretation.
+- Core MAY NOT parse or interpret `location_ref` content.
+- Core MAY NOT branch scheduling logic on the internal contents of `location_ref`.
+
+This keeps Minecraft coordinates, Discord channel IDs, and browser URLs from leaking into core scheduling.
+
+### 5.5 Single-active-embodiment rule (decided for v1.2)
+
+**v1.2 supports at most one *active* (attached) embodiment per agent.** Multiple Embodiment records may be configured, but only one may be in `attached` or `desynced` or `reconnecting` state at a time.
+
+Multi-embodiment presence is **explicitly deferred** to a future SIP. This keeps the v1.2 implementation tractable and avoids resolving complex cross-surface coordination prematurely.
+
+### 5.6 EmbodiedAction (deferred, with light hooks)
+
+A full EmbodiedAction event ledger is **not introduced in v1.2**. Adapter calls may be logged as lightweight events linked to the active RuntimeActivity, sufficient for observability but not a new first-class table.
+
+If Minecraft or browser automation later requires stronger replayability or evidence chains, a follow-on SIP will promote embodied actions to first-class records. The v1.2 substrate accommodates this without requiring core changes.
+
+### 5.7 Capability set
 
 Embodiment capabilities are declared by the adapter at attach time. Examples:
 
 - Discord embodiment: `send_message`, `read_channel`, `add_reaction`, `manage_threads`
 - Browser embodiment: `navigate`, `click`, `type`, `screenshot`, `extract_text`
 
-The runtime-state Activity model can require an embodiment with a specific capability before scheduling. This is the seam where embodiment integrates with the SIP-1.1 substrate.
+The runtime-state RuntimeActivity model can require an embodiment with a specific capability before scheduling. This is the seam where embodiment integrates with the v1.1 substrate.
 
 ---
 
-## 6. Resource Budgets
+## 6. Embodiment Authority Boundary
+
+**Invariant:** Embodiment adapters do not decide agent intent, mode, or priority. They:
+
+- expose capabilities,
+- report surface events,
+- execute already-authorized action requests,
+- report health and location.
+
+Core runtime policy decides whether an embodied action may proceed. This prevents Discord, Minecraft, or browser adapters from becoming mini-agent brains.
+
+### 6.1 What adapters DO translate
+
+Adapters translate **already-authorized, surface-specific action requests** into platform calls:
+
+- "send a message to channel X" → Discord API call
+- "click selector Y" → browser DOM operation
+- "navigate to URL Z" → browser navigation
+- "capture a screenshot" → browser screenshot
+- "place a block at (x,y,z)" → Minecraft protocol call (future)
+
+### 6.2 What adapters DO NOT do
+
+Adapters do not decompose broad goals or decide whether an action should be taken. The following are **never** adapter-level responsibilities:
+
+- "Handle a customer support conversation" — must be planned by SquadOps and decomposed into individual authorized actions
+- "Build a Minecraft base" — same
+- "Complete a browser research assignment" — same
+
+If a goal needs decomposition, the decomposition happens in SquadOps (handlers, planners, RuntimeActivities). The adapter sees only the resulting concrete actions.
+
+---
+
+## 7. Resource Budgets (with explicit decrement and enforcement)
 
 The goal is not to simulate a human body. The goal is to prevent irresponsible scheduling — especially for ambient agents that may otherwise burn tokens or take unbounded action.
 
-First-cut budget dimensions (coarse, intentionally simple):
+### 7.1 Budget dimensions and decrement rules
 
-- **attention_budget** — how much focused time the agent can hold per window
-- **compute_budget** — token / inference cost ceiling
-- **action_budget** — count of embodied actions per window
-- **concurrency_allowance** — how many activities can be open at once
+| Budget | Decremented by |
+|--------|----------------|
+| **attention_budget** | Time the agent holds a primary FocusLease |
+| **compute_budget** | LLM token / cost usage attributed to the agent |
+| **action_budget** | Embodied actions executed |
+| **concurrency_allowance** | Simultaneously-open RuntimeActivities or held leases |
 
-Budget exhaustion forces a transition (e.g., back to ambient, or detach embodiment) rather than silent overrun.
+Budgets attach to the **agent**, not the embodiment, so cross-embodiment usage sums correctly.
 
-Budgets attach to the agent, not the embodiment, so cross-embodiment usage is summed.
+### 7.2 Exhaustion behavior (must not be silent)
+
+Budget exhaustion must produce a `budget_exhausted` event (canonical reason code) and force one of:
+
+- **reject_new_activity** — new RuntimeActivities denied
+- **pause_current_activity** — current RuntimeActivity paused if `can_pause`
+- **detach_embodiment** — release the active Embodiment
+- **transition_to_ambient** — force mode back to `ambient`
+- **require_operator_override** — block until `operator_override` reason code is supplied
+
+Silent degradation is forbidden. Every exhaustion produces a visible policy event.
 
 ---
 
-## 7. Adapter Pattern
+## 8. Adapter Pattern
 
 Embodiments follow the existing SquadOps hexagonal pattern.
 
@@ -164,31 +233,43 @@ The adapter owns:
 - Connection lifecycle (attach, reconnect, detach)
 - Health checks
 - Capability declaration
-- Translating Activity goals into surface-specific actions
-- Updating location_ref when the adapter knows location changed
+- Translating already-authorized action requests into platform calls (per §6.1)
+- Updating `location_ref` when the adapter detects location change
 
 The core owns:
 
 - Embodiment record (attachment_state, health, capability_set, location_ref)
 - Resource budget enforcement
 - Event emission on state transitions
-- Integration with Activity and FocusLease from the v1.1 substrate
+- Integration with RuntimeActivity and FocusLease from the v1.1 substrate
+- Authorization decisions (what the adapter is permitted to execute)
 
 ---
 
-## 8. First Proof Point: Discord Presence
+## 9. Credentials
+
+Embodiment credentials are **never** stored in Embodiment records.
+
+- The Embodiment record carries `credentials_ref` — a `secret://` reference resolved by the existing `SecretManager`.
+- Adapters receive resolved credentials at `attach` time only.
+- Adapters must not log, persist, or echo credentials.
+
+This avoids accidental token persistence in Postgres and reuses the existing secret-management seam.
+
+---
+
+## 10. First Proof Point: Discord Presence
 
 Recommended first surface: **Discord**.
 
 Why Discord:
 
-- Stable, well-documented SDK (discord.py / discord.js)
+- Stable, well-documented SDK
 - No physics or world simulation
-- Clean message-event model maps naturally to Activity
-- Easy to test in CI with a private guild
+- Clean message-event model maps naturally to RuntimeActivity
 - Real Backspring use case: agents that monitor channels, respond to mentions, post status
 
-Minimum capability set:
+### 10.1 Minimum capability set
 
 - Connect to a Discord guild
 - Listen on a configured channel
@@ -196,35 +277,68 @@ Minimum capability set:
 - React to mentions
 - Cleanly detach
 
-Acceptance for Phase 1 of this SIP:
+### 10.2 Staged test strategy (realistic)
+
+Discord integration is not as easy to CI as the original draft implied. Use a layered approach:
+
+| Tier | What | When |
+|------|------|------|
+| Adapter unit tests | Mocked gateway/events; pure logic | Always run in CI |
+| Local integration | Real Discord client against a private guild | Run on-demand by developers |
+| CI integration (optional) | Real Discord against a CI-only guild | Only when bot credentials are configured in CI secrets |
+
+### 10.3 Phase-1 acceptance for the proof point
 
 - An ambient agent can attach a Discord embodiment, listen on a channel, respond to a mention, and detach cleanly on shutdown
-- Embodiment state transitions are observable via the existing telemetry seam
-- A focus lease prevents two activities from claiming the embodiment simultaneously
+- Embodiment state transitions are observable via the canonical `embodiment.*` events
+- A FocusLease prevents two RuntimeActivities from claiming the embodiment simultaneously
+- An ambient agent **cannot** send a Discord message without first acquiring a FocusLease and starting a RuntimeActivity (per the v1.1 ambient irreversibility rule)
 
 ---
 
-## 9. Future Surfaces (Out of Scope for v1.2)
+## 11. Substrate Generality Proof: Browser (narrow)
 
-Documented here so reviewers see the trajectory, but **not** part of this SIP:
+A second adapter validates that the substrate is general. Recommended: a **narrow browser embodiment**.
 
-- **Browser** — natural second surface; reuses existing browser automation patterns
-- **Minecraft via Mineflayer** — requires its own SIP; pulls in pathfinding, block placement, world acceptance checks
+**v1.2 browser scope is deterministic navigation and observation only:**
+
+- Navigate to a configured URL
+- Read text content
+- Capture screenshot
+- Cleanly detach
+
+**Not in v1.2 browser scope:**
+
+- Autonomous browsing
+- Form filling against arbitrary sites
+- Multi-tab orchestration
+- Persistent session state
+
+This proves the substrate without committing to a full browser-automation rabbit hole. Full browser autonomy can be a future SIP if needed.
+
+---
+
+## 12. Future Surfaces (Out of Scope for v1.2)
+
+Documented for trajectory clarity, but **not** part of this SIP:
+
+- **Minecraft via Mineflayer** — `SIP-Minecraft-Embodiment-Adapter.md`. Scope will include adapter, pathfinding, block placement, spatial action plans, world-state observation, acceptance checks for built structures, embodied safety constraints.
 - **Decentraland / The Sandbox** — far future; depends on platform stability
-
-The substrate proposed here should accommodate all of them without core changes.
+- **Multi-tab / multi-session browser** — follow-on if v1.2 browser proof point reveals demand
+- **Multi-active-embodiment per agent** — follow-on after v1.2 single-embodiment model is proven
 
 ---
 
-## 10. Implementation Phases
+## 13. Implementation Phases
 
 ### Phase 1 — Core embodiment model
 
 - `EmbodimentPort` interface
 - Embodiment record + Postgres table
 - Lifecycle state machine
-- Event emission
-- Resource budget primitives (attention, compute, action, concurrency)
+- Canonical event emission
+- Resource budget primitives with decrement rules and exhaustion behaviors per §7
+- SecretManager integration via `credentials_ref`
 
 **Acceptance:** Embodiment records exist and transition states cleanly. No adapter required yet.
 
@@ -234,67 +348,77 @@ The substrate proposed here should accommodate all of them without core changes.
 - Connect, listen, send, react, detach
 - Capability declaration
 - Health checks via Discord gateway
+- Staged test strategy per §10.2
 
-**Acceptance:** an ambient agent can hold a Discord presence end-to-end.
+**Acceptance:** an ambient agent can hold a Discord presence end-to-end with the §10.3 acceptance criteria.
 
-### Phase 3 — Activity integration
+### Phase 3 — RuntimeActivity integration
 
-- Activities can declare `requires_embodiment: <type>` and `required_capabilities: [...]`
-- Scheduler refuses to start an Activity without a matching attached embodiment
-- Pause/resume semantics handle embodiment desync
+- RuntimeActivities can declare `requires_embodiment: <type>` and `required_capabilities: [...]`
+- Scheduler refuses to start a RuntimeActivity without a matching attached embodiment
+- Pause/resume semantics handle embodiment desync via `embodiment_desynced` event
 
-**Acceptance:** a duty agent can hold a Discord embodiment, take a moderation Activity, pause it on disconnect, and resume it on reconnect.
+**Acceptance:** a duty agent can hold a Discord embodiment, take a moderation RuntimeActivity, pause it on disconnect, and resume it on reconnect.
 
-### Phase 4 — Browser adapter (optional, demonstrates substrate generality)
+### Phase 4 — Narrow browser adapter (substrate generality proof)
 
-- Headless browser embodiment with navigate/click/type/screenshot
+- Headless browser embodiment with navigate/read/screenshot only (per §11)
 - Validates the abstraction by exercising a second surface
+- Demonstrates that adding a new surface requires zero core embodiment changes
 
 **Acceptance:** the browser adapter ships without changing any core embodiment code.
 
 ---
 
-## 11. Acceptance Criteria
+## 14. Acceptance Criteria
 
 The SIP is successful when:
 
 1. **Identity / embodiment separation** is clean — agents survive embodiment loss; embodiments cannot exist without agents
-2. **Observable lifecycle** — every embodiment state transition is evented and queryable
-3. **Generic location** — core never interprets `location_ref`; adapters do
-4. **Capability-aware scheduling** — Activities cannot start without a matching embodiment capability
-5. **Budget enforcement** — exhaustion causes explicit transitions, never silent overrun
-6. **First proof point lives** — Discord adapter passes integration tests in CI
-7. **Substrate generality** — adding the browser adapter requires zero core changes
-8. **No regressions** — `run_regression_tests.sh` continues to pass; v1.1 runtime-state primitives unaffected
+2. **Single-active-embodiment rule** is enforced (one attached embodiment per agent in v1.2)
+3. **Adapter authority boundary** holds — no adapter decides intent, mode, or priority
+4. **Observable lifecycle** — every embodiment state transition is evented from the canonical set
+5. **Generic location** — core never interprets `location_ref`; adapters do
+6. **Capability-aware scheduling** — RuntimeActivities cannot start without a matching embodiment capability
+7. **Budget enforcement** — exhaustion produces a `budget_exhausted` event and forces one of the §7.2 outcomes; never silent
+8. **Credentials safety** — no embodiment record contains credentials; all access via `secret://` refs
+9. **First proof point lives** — Discord adapter passes the §10.3 acceptance with the staged test strategy
+10. **Substrate generality** — adding the narrow browser adapter requires zero core changes
+11. **Ambient irreversibility upheld** — ambient agents cannot perform irreversible embodied actions without a FocusLease and RuntimeActivity
+12. **No regressions** — `run_regression_tests.sh` continues to pass; v1.1 runtime-state primitives unaffected
 
 ---
 
-## 12. Risks and Mitigations
+## 15. Risks and Mitigations
 
 | Risk | Mitigation |
 |------|------------|
-| Surface-specific concerns leak into core | Keep `location_ref` opaque; review every PR for adapter-specific imports in core |
-| Discord adapter complexity bleeds in | Keep adapter behind clean port; use a minimal capability set |
-| Budgets become a new policy quagmire | Start coarse (4 dimensions); resist adding more until needed |
-| Embodiment desync silently degrades agents | Mandatory health checks; desync transitions trigger explicit Activity pause |
-| Multiple embodiments per agent contention | Defer multi-embodiment to a follow-on; v1.2 is one embodiment per agent |
+| Surface-specific concerns leak into core | Location opacity rules in §5.4; review every PR for adapter-specific imports in core |
+| Adapter authority creep (decomposing goals) | §6 invariant; reject any adapter PR that branches on goal text |
+| Discord adapter complexity bleeds in | Keep adapter behind clean port; minimal capability set |
+| Budgets become a new policy quagmire | Start with 4 dimensions in §7.1; resist additions until proven need |
+| Embodiment desync silently degrades agents | Mandatory health checks; `embodiment_desynced` event triggers explicit RuntimeActivity pause |
+| Multiple embodiments contend | Single-active rule in §5.5; deferred to future SIP |
+| Browser adapter scope creep | §11 explicitly limits v1.2 browser to deterministic navigation |
+| Credentials leak into DB or logs | §9 rule: credentials never persisted; adapter must not log |
 
 ---
 
-## 13. Open Questions
+## 16. Open Questions
 
-1. Should one agent be allowed to hold multiple embodiments simultaneously in v1.2, or is it strictly one-at-a-time?
-2. How does embodiment attachment interact with the focus lease from v1.1? Same lease type, or a distinct embodiment lease?
-3. Where do embodiment credentials (Discord bot tokens, browser cookies) live? `SecretManager` already exists — likely reuse via `secret://` refs.
-4. Should resource budgets be configurable per agent role, or global defaults?
-5. Does the Discord adapter belong in the main `adapters/` tree, or does it warrant a separate optional install (extras dependency)?
+1. How does embodiment attachment interact with the v1.1 FocusLease? Same lease type, or a distinct EmbodimentLease? **Recommend deferring to implementation; default to reusing primary FocusLease.**
+2. Should resource budgets be configurable per agent role (`max`, `bob`, `eve`, etc.) or only global defaults?
+3. Does the Discord adapter belong in the main `adapters/` tree, or as an optional install (extras dependency `squadops[discord]`)?
+4. Should `embodiment.attached` events include the full capability set in the payload, or just a capability hash with capabilities queried separately?
+5. For the browser adapter, do we use Playwright, Puppeteer, or an existing SquadOps browser harness if one exists?
 
 ---
 
-## 14. References
+## 17. References
 
 - Depends on: `sips/proposed/SIP-Agent-Runtime-State.md` (v1.1)
-- Parent vision: `sips/proposed/SIP-Agent-Runtime-Modes.md`
+- Parent vision: `sips/proposed/SIP-Agent-Runtime-Modes.md` (canonical reason codes, event names, terminology, package invariant)
+- Future follow-on: `SIP-Minecraft-Embodiment-Adapter.md`
 - Original full proposal: commit `76a1f90` on main
-- Related: SIP-0061 (LangFuse Observability — telemetry pattern reused for embodiment events), SIP-0042 (memory adapter — pattern for optional integrations)
+- Related: SIP-0061 (LangFuse Observability — telemetry pattern reused for embodiment events), SIP-0042 (memory adapter — pattern for optional integrations), `SecretManager` in `src/squadops/core/`
 - Hexagonal pattern: existing `src/squadops/ports/` and `adapters/` structure

--- a/sips/proposed/SIP-Agent-Runtime-Modes.md
+++ b/sips/proposed/SIP-Agent-Runtime-Modes.md
@@ -1,1103 +1,132 @@
-# SIP: Agent Runtime Modes, Duty Windows, and Durable Operational Orchestration
+# SIP: Agent Runtime Modes — Vision and Index
 
-**Status:** Proposed (draft)
+**Status:** Proposed (umbrella / vision)
 **Authors:** Jason Ladd
 **Created:** 2026-04-25
-**Revision:** 1
-**Scope:** SquadOps runtime model evolution
-**Related concepts:** Persistent agents, embodied agents, Duty mode, Ambient mode, Cycle execution, virtual world embodiment, Temporal duty orchestration
+**Revision:** 2 (split into three implementing SIPs on 2026-04-25)
+**Original full proposal:** commit `76a1f90` on main
 
 ---
 
-## 1. Summary
+## Purpose of this document
 
-This SIP proposes a deliberately small but extensible runtime model for persistent SquadOps agents that may:
+This document is the **umbrella vision** for evolving SquadOps from a cycle-only execution framework into a runtime that supports persistent, schedule-aware, and (eventually) embodied agents.
 
-- participate in formal **cycle** work,
-- hold scheduled or ongoing **duty** responsibilities,
-- remain online in low-priority **ambient** presence,
-- later support embodied execution surfaces such as Minecraft, Decentraland, or other virtual worlds,
-- and eventually support real Backspring operational functions such as support, monitoring, inventory, and research.
+It does **not** propose implementation. The actionable proposals live in three sibling SIPs, each independently reviewable and shippable.
 
-The core recommendation is to **avoid exploding SquadOps into a fully generalized "always-on autonomous life simulation"** and instead introduce a compact set of runtime primitives that preserve architectural discipline.
-
-The top-level runtime model should begin with **three mutually exclusive modes**:
-
-- **Duty** — on-duty, service-responsible, availability-constrained operation
-- **Cycle** — bounded, formal, assigned work with explicit completion semantics
-- **Ambient** — off-duty, low-priority, interruptible background presence
-
-These modes should be treated as the agent's **current operating posture**, while **assignment**, **schedule**, **eligibility**, **focus**, and **activity** remain separate but related concepts.
-
-This separation is critical. It allows an agent to be:
-
-- currently in **Ambient**,
-- scheduled to enter **Duty** at 1:00 AM,
-- and still eligible for short **Cycle** recruitment until that duty window begins.
-
-That distinction gives SquadOps a clean path toward persistent operations without breaking the existing cycle loop or introducing vague autonomous behavior that cannot be scheduled, recalled, or reasoned about.
+The original revision-1 draft was a single 1,100-line proposal. After design discussion it was split into three smaller SIPs so each scope (runtime taxonomy, embodiment, Temporal) can be reviewed and accepted independently. The original full content is preserved in git history at commit `76a1f90`.
 
 ---
 
-## 2. Problem Statement
-
-SquadOps is hardening around a cycle-oriented execution model. That is the right foundation. But the broader vision requires agents that are more than one-shot task executors:
-
-- agents may remain online for the life of their container,
-- agents may exist within a spatial environment,
-- agents may need to remember where they are and what they are doing,
-- agents may need to be interruptible and recallable,
-- agents may need to hold operational responsibilities during scheduled windows,
-- and agents may eventually support business operations that do not cleanly map to a fixed run or workload.
-
-Examples include:
-
-- building a structure in Minecraft as a formal cycle workload,
-- exploring Minecraft or remaining socially present in a world during low-priority time,
-- serving customer support during a duty window,
-- performing inventory watch or nightly research,
-- supporting a real operating business where agents cannot be simultaneously "on duty," "free roaming," and "committed to a long build cycle."
-
-If SquadOps responds to this need by simply bolting Mineflayer onto the current agent abstraction, or by allowing a persistent agent to improvise across multiple contexts without explicit runtime discipline, the framework will drift toward hidden state, unclear ownership, poor interruptibility, and unreliable operational semantics.
-
-The challenge is therefore:
-
-> How can SquadOps introduce persistent, embodied, schedule-aware agent behavior without undermining the simplicity and reliability of the current cycle-oriented architecture?
-
----
-
-## 3. Design Intent
-
-This SIP is intended to achieve the following:
-
-1. **Preserve the cycle model** as the canonical mechanism for bounded, acceptance-oriented work.
-2. **Introduce persistent runtime behavior** without forcing all agent activity into cycles.
-3. **Support service-like operational responsibility** through a Duty concept with explicit duty windows.
-4. **Support embodied or spatial presence** without making virtual-world logic the center of the framework.
-5. **Allow interruption, recall, and scheduling** through explicit runtime policy rather than prompt magic.
-6. **Create a durable base for future Backspring operational use cases** such as support, monitoring, research, and inventory.
-7. **Keep the model small enough to implement safely.**
-
-This SIP is intentionally conservative. It does **not** aim to define a full cognition architecture, social simulation layer, or universal autonomy engine.
-
----
-
-## 4. Non-Goals
-
-This SIP does **not** propose:
-
-- fully autonomous free-roaming agents with unconstrained self-direction,
-- an "always multitasking" agent that can deeply converse, build, and perform duty work simultaneously,
-- replacing the current cycle mechanism,
-- treating embodiment platforms such as Minecraft as the new source of truth for agent state,
-- or using Temporal or any other orchestration engine as the entire agent runtime brain.
-
-This is a runtime discipline proposal, not a general AGI fantasy paper.
-
----
-
-## 5. Proposed Runtime Model
-
-### 5.1 Top-Level Modes
-
-An agent should have exactly one **current mode** at a time:
-
-- `duty`
-- `cycle`
-- `ambient`
-
-These are **mutually exclusive top-level modes**.
-
-### 5.2 Why these are modes, not just focus flavors
-
-These three categories are not merely different tasks. They imply different rules for:
-
-- interruptibility,
-- accountability,
-- scheduling,
-- reporting,
-- resource use,
-- recall policy,
-- and what kinds of commitments the agent is allowed to accept.
-
-That makes them operational postures, not just task labels.
-
-### 5.3 The modes in plain English
-
-#### Duty
-
-**Duty** means the agent is **on duty**.
-
-It is responsible for a role or function that requires availability, responsiveness, and policy-governed behavior.
-
-Examples:
-
-- customer support
-- inventory watch
-- nightly research
-- monitoring/moderation
-- event-driven operational observation
-
-Duty implies the agent cannot casually wander off into a virtual world or commit to a long blocking cycle task if that would undermine the duty obligation.
-
-#### Cycle
-
-**Cycle** means the agent is committed to **bounded assigned work**.
-
-Examples:
-
-- building a web app,
-- executing an experiment,
-- producing an artifact,
-- performing a validation pass,
-- or building a defined structure in Minecraft as part of a formal workload.
-
-Cycle work should continue to be the most structured and acceptance-oriented form of execution in SquadOps.
-
-#### Ambient
-
-**Ambient** means the agent is online, present, lightly available, and **off duty**.
-
-Examples:
-
-- exploring Minecraft,
-- remaining in a home base,
-- patrolling a small area,
-- performing light observation,
-- casual low-resource social presence,
-- idling with purpose.
-
-Ambient is not "do whatever forever." It is simply the low-priority, interruptible background state for agents that are online but not currently assigned to serious work.
-
----
-
-## 6. Orthogonal Concepts: Mode vs Assignment vs Schedule vs Focus vs Activity
-
-One of the most important architectural distinctions in this proposal is that **mode is not the same thing as assignment or schedule**.
-
-### 6.1 Current mode
-
-Current mode answers:
-
-> What is the agent doing right now?
-
-Examples:
-
-- ambient
-- cycle
-- duty
-
-### 6.2 Assignment
-
-Assignment answers:
-
-> What role or commitment has been associated with the agent?
-
-Examples:
-
-- assigned to nightly research
-- assigned to support duty
-- eligible for cycle recruitment
-- reserved for monitoring window
-
-An agent can be assigned to a duty without currently being in Duty mode.
-
-### 6.3 Schedule / duty window
-
-Schedule answers:
-
-> When is that assignment active or claimable?
-
-Examples:
-
-- support duty active 9 AM–5 PM
-- nightly research active 1 AM–6 AM
-- reserve window begins at 10 PM
-
-### 6.4 Focus
-
-Focus answers:
-
-> What currently owns the agent's primary attention within its current mode?
-
-Examples:
-
-- duty focus: queue watch
-- duty focus: handling support case #184
-- cycle focus: implementation task A7
-- ambient focus: explore nearby biome
-
-### 6.5 Activity
-
-Activity answers:
-
-> What concrete action is happening right now?
-
-Examples:
-
-- move_to(x,y,z)
-- summarize_findings
-- classify_ticket
-- place_block
-- answer_status_ping
-
-### 6.6 Why this distinction matters
-
-This gives SquadOps the ability to model a clean and realistic case such as:
-
-- current mode = `ambient`
-- duty assignment = `nightly_research`
-- duty window starts at `01:00`
-- cycle eligible = `true until reserve threshold`
-
-That means the agent can be ambient now, recruited into a short cycle task if safe, and later transition into Duty mode automatically when the window opens.
-
-That is operationally coherent and significantly safer than treating "free" and "committed" as vague prompt-level concepts.
-
----
-
-## 7. Core Runtime Primitives
-
-The following primitives are the minimum recommended scaffolding.
-
-### 7.1 Agent Runtime State
-
-A persistent agent should expose runtime state such as:
-
-- `agent_id`
-- `mode`
-- `focus`
-- `activity_id`
-- `runtime_status`
-- `interruptibility`
-- `last_heartbeat_at`
-- `current_assignment_ref`
-- `resource_budget_ref`
-- `location_ref`
-
-### 7.2 Assignment
-
-An assignment represents a durable relationship between an agent and a future or potential responsibility.
-
-Examples:
-
-- support duty assignment
-- nightly research assignment
-- cycle eligibility window
-- reserve window
-
-Suggested fields:
-
-- `assignment_id`
-- `assignment_type`
-- `assigned_role`
-- `active_window`
-- `strictness`
-- `priority`
-- `recall_policy`
-- `allowed_off_window_modes`
-
-### 7.3 Duty Window
-
-Duty windows should be explicit. A duty is not a permanent identity lock.
-
-Suggested fields:
-
-- `window_start`
-- `window_end`
-- `timezone`
-- `strictness: hard | soft`
-- `grace_before_start`
-- `grace_after_end`
-
-#### Hard duty window
-
-During the window, the agent is reserved for duty only.
-
-#### Soft duty window
-
-During the window, duty has priority, but short, preemptible work may be allowed if the duty can reclaim focus.
-
-### 7.4 Focus Lease
-
-A focus lease is the runtime claim over an agent's primary attention.
-
-This is a conceptual and implementation pattern, not necessarily a direct copy of Kubernetes Lease objects. But the analogy is useful: leases exist to coordinate ownership and availability in distributed systems.
-
-Suggested fields:
-
-- `lease_id`
-- `owner_type` (`duty`, `cycle`, `ambient`)
-- `owner_ref`
-- `acquired_at`
-- `expires_at` or `renewal_policy`
-- `interruptibility`
-- `recall_policy`
-
-### 7.5 Activity
-
-Activities represent the concrete unit of work currently being performed.
-
-Suggested fields:
-
-- `activity_id`
-- `activity_type`
-- `mode`
-- `goal`
-- `priority`
-- `requires_embodiment`
-- `can_pause`
-- `can_resume`
-- `can_abort`
-- `completion_conditions`
-- `evidence_requirements`
-
-### 7.6 Embodiment
-
-An agent identity should be separated from its embodiment.
-
-The agent is the durable actor. The embodiment is the runtime surface through which it acts in a world or system.
-
-Examples of embodiments:
-
-- Mineflayer avatar in Minecraft
-- Decentraland/Sandbox avatar
-- Discord presence
-- CLI session
-- browser automation context
-
-Suggested fields:
-
-- `embodiment_id`
-- `embodiment_type`
-- `platform`
-- `attachment_state`
-- `health`
-- `capability_set`
-- `location_ref`
-
-### 7.7 Location
-
-Location should be generic at the core.
-
-Suggested fields:
-
-- `location_type`
-- `location_system`
-- `location_ref`
-- `updated_at`
-
-The core only needs to know that location exists and matters. World-specific detail can stay in adapters.
-
-### 7.8 Resource Budget
-
-The goal is not to simulate a human body. The goal is to prevent irresponsible scheduling.
-
-Suggested coarse-grained budget dimensions:
-
-- attention budget
-- compute/token budget
-- action budget
-- concurrency allowance
-- uptime / fatigue threshold
-
-The first release can keep this extremely simple.
-
----
-
-## 8. Direct Interaction Is Not a Top-Level Mode
-
-A useful simplification from the discussion is that **direct human interaction should not be modeled as a separate peer mode**.
-
-Instead, direct interaction should be treated as a **cross-cutting interaction path** that may occur against an agent already in one of the three top-level modes.
-
-That means:
-
-- in **Ambient**, direct interaction usually interrupts easily,
-- in **Duty**, direct interaction may be limited, deferred, or handled minimally,
-- in **Cycle**, direct interaction may return status or require priority escalation.
-
-This keeps the mode model small while still preserving the reality that humans may speak to agents in any mode.
-
----
-
-## 9. Cycle Participation with Non-Code Execution Surfaces
-
-A key insight from the discussion is that a cycle does **not** need to mean only software-building work.
-
-A cycle can target any execution surface, including:
-
-- code repositories,
-- documents,
-- data systems,
-- and virtual worlds such as Minecraft.
-
-The clean framing is:
-
-> The cycle does not "happen inside Minecraft."
-> The cycle orchestrates tasks whose execution surface is Minecraft.
-
-This means SquadOps can support a cycle workload such as:
-
-- build a shelter near spawn,
-- gather wood,
-- craft planks,
-- place torches,
-- verify a structure footprint,
-- and produce evidence of completion.
-
-The existing cycle philosophy remains intact if Minecraft world actions are represented as:
-
-- task work,
-- observable state changes,
-- acceptance-checked outcomes,
-- and run artifacts.
-
-That is an important extension point for future embodied execution.
-
----
-
-## 10. Ambient as a First-Class Low-Priority Runtime Posture
-
-Ambient should remain intentionally narrow.
-
-It exists so that a persistent agent can be:
-
-- online,
-- embodied,
-- recallable,
-- lightly interactive,
-- and not currently holding a serious obligation.
-
-Ambient should be:
-
-- highly interruptible,
-- low-resource,
-- bounded by policy,
-- and explicitly lower priority than Duty and Cycle.
-
-Ambient is not a loophole for uncontrolled autonomous drift.
-
-Recommended constraints:
-
-- bounded exploration radius,
-- bounded budget,
-- bounded allowed actions,
-- immediate recall support,
-- and no long blocking commitments.
-
----
-
-## 11. Duty as Scheduled Operational Responsibility
-
-Duty is the most important new concept in this proposal.
-
-### 11.1 Why Duty matters
-
-Many future Backspring uses are not well expressed as a fixed cycle:
-
-- customer support
-- inventory watch
-- nightly research
-- moderation / queue watch
-- event-driven monitoring
-
-These are better modeled as **operational responsibilities** that may run during windows, wait on events, and require recallable focus.
-
-### 11.2 Duty is not permanent lock-in
-
-A duty should be understood as:
-
-- an assignment,
-- with a schedule or active window,
-- that may claim the agent into Duty mode during that window,
-- and release the agent back to Ambient or Cycle outside that window.
-
-This is a critical design refinement. It allows the framework to support realistic staffing-like behavior without freezing agents into static identities.
-
-### 11.3 Duty strictness
-
-Recommended first-cut policy:
-
-- **hard duty** — during the window, no cycle participation, no ambient exploration beyond minimal local idle behavior
-- **soft duty** — during the window, duty has priority, but preemptible short work may be allowed if duty can reclaim the agent
-
-### 11.4 Duty and "off duty"
-
-The "off duty" framing is operationally correct and should be preserved in the conceptual model:
-
-- if an agent is in Duty mode, it is **on duty**,
-- if an agent is in Ambient or Cycle, it is effectively **off duty** for that period,
-- but assignments and schedules may still already exist in the background.
-
-That is intuitive and useful.
-
----
-
-## 12. Temporal as the Best Initial Seam for Duty Mode
-
-This discussion surfaced a particularly strong architectural seam:
-
-> Temporal should be considered primarily for **Duty orchestration**, not as the agent's full runtime brain.
-
-### 12.1 Why Temporal fits Duty
-
-Temporal workflows are durable and support long waits, retries, schedules, and signal-driven interaction. Workflows can run for extended periods, receive messages, and resume after failures. This is especially well-aligned to service-like operational duties that must wait on timers or events rather than constantly execute hot loops. See Temporal Workflow and Workflow Execution documentation, especially the discussion of durable execution, signals/queries/updates, and schedules:
-
-- https://docs.temporal.io/workflows
-- https://docs.temporal.io/workflow-execution
-- https://docs.temporal.io/encyclopedia/workflow-message-passing
-
-That makes Temporal a strong fit for:
-
-- duty windows,
-- durable waiting,
-- event wake-ups,
-- recall and preemption signals,
-- periodic operational duty ticks,
-- and resumable long-lived duty flows.
-
-### 12.2 Why Temporal should not own the whole agent runtime
-
-Temporal also records event history and expects deterministic workflow behavior. A single workflow execution has practical limits on throughput and size, even though the platform scales to huge numbers of executions overall. That makes it a poor first choice for:
-
-- every tiny Minecraft movement,
-- continuous embodiment telemetry,
-- an immortal all-purpose "agent life workflow,"
-- or free-form cognition loops.
-
-### 12.3 Recommended boundary
-
-The clean boundary is:
-
-- **SquadOps owns agent semantics**: identity, current mode, focus rules, policy, activity model, embodiment model.
-- **Temporal optionally owns duty durability**: windows, timers, durable waiting, wake-on-event logic, retry semantics, recall signals, and long-lived duty flows.
-
-That boundary keeps Temporal where it is strongest and keeps SquadOps in control of the agent runtime model.
-
----
-
-## 13. Industry and Standards Alignment
-
-This proposal does not need to copy any external standard exactly, but it should align with a few proven ideas.
-
-### 13.1 BPMN for bounded, explicit workflow semantics
-
-BPMN 2.0.2 remains one of the most durable standards for modeling bounded workflows, process events, tasks, and execution-oriented process structures. It is relevant here not because SquadOps should become BPMN, but because BPMN reinforces the idea that formal work should have:
-
-- explicit start and end conditions,
-- defined tasks,
-- event handling,
-- structured control flow,
-- and execution semantics.
-
-That maps well to **Cycle** and parts of **Duty** orchestration.
-
-Reference:
-
-- OMG BPMN 2.0.2 specification: https://www.omg.org/spec/BPMN/2.0.2/PDF
-
-### 13.2 State-machine semantics for mutually exclusive operating postures
-
-The proposal to treat `duty | cycle | ambient` as mutually exclusive top-level modes is strongly consistent with the general state-machine approach used in UML state machines and W3C SCXML. These standards distinguish current state from transitions, events, and nested execution concerns.
-
-This supports the notion that:
-
-- current mode should be singular,
-- transitions should be explicit,
-- and nested detail should live under the current mode rather than creating endless peer categories.
-
-References:
-
-- W3C SCXML Recommendation: https://www.w3.org/TR/scxml/
-- OMG UML overview: https://www.omg.org/spec/UML/2.5.1/About-UML
-
-### 13.3 Prefect for bounded flow/task state and orchestration history
-
-Prefect's model of flows, tasks, and explicit state histories reinforces the value of:
-
-- bounded runs,
-- tracked execution state,
-- retries, schedules, and timeouts,
-- and distinguishing the state lifecycle of a run from the business meaning of the work.
-
-This aligns strongly with the continuing role of **Cycle** in SquadOps.
-
-References:
-
-- Prefect flows: https://docs.prefect.io/v3/concepts/flows
-- Prefect states: https://docs.prefect.io/v3/concepts/states
-
-### 13.4 Kubernetes Lease pattern for coordination and ownership claims
-
-Kubernetes Lease objects provide a widely used example of how distributed systems represent:
-
-- shared resource coordination,
-- leader election,
-- heartbeats,
-- and lightweight ownership/availability tracking.
-
-This does **not** mean SquadOps should literally use Kubernetes Lease objects for focus. But it is a strong precedent for introducing a **focus lease / ownership claim** concept rather than allowing multiple ambiguous owners to contend for the same agent attention.
-
-Reference:
-
-- Kubernetes Leases: https://kubernetes.io/docs/concepts/architecture/leases/
-
-### 13.5 Temporal for durable, event-driven, long-running operational flows
-
-Temporal's workflow model reinforces the idea that some responsibilities are better represented as durable, event-aware, long-lived orchestrations that can survive failures and react to timers and signals.
-
-That aligns most naturally to **Duty mode**, especially scheduled or event-driven duties.
-
-References:
-
-- Temporal Workflows: https://docs.temporal.io/workflows
-- Workflow Execution: https://docs.temporal.io/workflow-execution
-- Signals / Queries / Updates: https://docs.temporal.io/encyclopedia/workflow-message-passing
-
----
-
-## 14. Recommended Architectural Principles
-
-### 14.1 Keep top-level runtime postures small
-
-Do not create a large taxonomy of near-overlapping modes.
-
-Start with:
-
-- Duty
-- Cycle
-- Ambient
-
-### 14.2 Keep current mode singular
-
-An agent should not be "kind of duty and kind of cycle and a little ambient."
-
-Current posture must be singular for the runtime to be understandable.
-
-### 14.3 Keep assignments and schedules orthogonal
-
-An agent may have future commitments while still being Ambient now.
-
-### 14.4 Treat direct interaction as a cross-cutting path
-
-Do not make "direct" a peer mode.
-
-### 14.5 Do not embed world semantics into core too early
-
-Core should know that embodiment and location exist, not every detail of every world.
-
-### 14.6 Keep Cycle canonical for bounded work
-
-Even Minecraft build tasks should still respect the cycle philosophy:
-
-- defined goal,
-- bounded workload,
-- acceptance criteria,
-- evidence,
-- wrap-up.
-
-### 14.7 Use Duty for service-like persistence
-
-Do not stretch Cycle until it becomes a poor imitation of long-running operations.
-
-### 14.8 Prefer explicit recalls over implicit interruption
-
-A higher-priority claim should produce an explicit mode transition or focus transition, not mysterious prompt drift.
-
----
-
-## 15. Proposed Data Model Sketch
-
-```yaml
-AgentRuntimeState:
-  agent_id: string
-  mode: duty | cycle | ambient
-  runtime_status: online | idle | busy | paused | degraded | recovering | offline
-  focus: string
-  activity_id: string | null
-  interruptibility: none | low | medium | high
-  last_heartbeat_at: timestamp
-  embodiment_id: string | null
-  location_ref: string | null
-  resource_budget_ref: string | null
-
-Assignment:
-  assignment_id: string
-  assignment_type: duty | reserve | cycle_eligibility
-  assigned_role: string
-  priority: integer
-  strictness: hard | soft
-  active_window:
-    start: timestamp
-    end: timestamp
-    timezone: string
-  recall_policy: immediate | graceful | none
-  allowed_off_window_modes:
-    - ambient
-    - cycle
-
-FocusLease:
-  lease_id: string
-  owner_type: duty | cycle | ambient
-  owner_ref: string
-  acquired_at: timestamp
-  renewal_policy: heartbeat | ttl | fixed_window
-  interruptibility: none | low | medium | high
-  recall_policy: immediate | graceful | none
-
-Activity:
-  activity_id: string
-  mode: duty | cycle | ambient
-  activity_type: string
-  goal: string
-  priority: integer
-  requires_embodiment: boolean
-  can_pause: boolean
-  can_resume: boolean
-  can_abort: boolean
-  completion_conditions: []
-  evidence_requirements: []
-
-Embodiment:
-  embodiment_id: string
-  embodiment_type: minecraft | discord | browser | cli | other
-  platform: string
-  attachment_state: unattached | attaching | attached | desynced | reconnecting | detached
-  health: healthy | degraded | failed
-  location_ref: string | null
-```
-
-This is intentionally not final schema. It is simply sufficient to prove the architecture.
-
----
-
-## 16. Transition Semantics
-
-A minimal transition model should include at least:
-
-- `ambient -> cycle`
-- `ambient -> duty`
-- `cycle -> ambient`
-- `cycle -> duty` (only if policy permits preemption or explicit interruption)
-- `duty -> ambient`
-- `duty -> cycle` (generally only after duty window ends or if policy explicitly allows it)
-
-Additional conditions:
-
-- mode transitions should be evented and auditable,
-- transitions should carry reason codes,
-- higher-priority transitions should not silently discard current activity state,
-- and interruptions should either pause, abort, or checkpoint the current activity explicitly.
-
----
-
-## 17. Implementation Path
-
-### Phase 0 — Document and agree on the runtime taxonomy
-
-Deliverables:
-
-- SIP approval
-- vocabulary freeze for `mode`, `assignment`, `window`, `focus`, `activity`, `embodiment`
-- no code changes yet
-
-### Phase 1 — Add minimal runtime state to agents
-
-Implement:
-
-- current mode
-- runtime status
-- heartbeat
-- focus field
-- current activity id
-
-Acceptance:
-
-- an operator can see an agent's current mode and current activity
-- runtime does not require embodiment support yet
-
-### Phase 2 — Add assignments and duty windows
-
-Implement:
-
-- assignment model
-- duty window model
-- hard vs soft duty flag
-- transition scheduler hooks
-
-Acceptance:
-
-- an agent can be Ambient now but scheduled to enter Duty later
-- an upcoming duty window can restrict cycle recruitment according to policy
-
-### Phase 3 — Add focus lease / ownership claim
-
-Implement:
-
-- explicit primary owner of agent attention
-- lease acquisition / release / renew semantics
-- reasoned rejection when a conflicting owner attempts to claim focus
-
-Acceptance:
-
-- the framework can explain why an agent did or did not accept a cycle request
-- duty, cycle, and ambient cannot all claim the same agent simultaneously
-
-### Phase 4 — Add activity model
-
-Implement:
-
-- current activity object
-- pause/resume/abort semantics
-- evidence requirement hooks
-
-Acceptance:
-
-- current work is observable as an activity, not hidden in prompt history
-
-### Phase 5 — Add embodiment abstraction
-
-Implement:
-
-- embodiment attachment state
-- embodiment health
-- location reference
-
-Acceptance:
-
-- the framework can represent a Mineflayer-backed embodiment without making Minecraft core knowledge part of the domain
-
-### Phase 6 — Add one minimal embodied proof point
-
-Recommended proof point:
-
-- Minecraft embodiment that can:
-  - connect,
-  - move to a location,
-  - report position,
-  - gather a small material target,
-  - place a simple marker structure.
-
-Acceptance:
-
-- a cycle can target Minecraft as an execution surface with acceptance checks
-- ambient exploration can be interrupted and recalled
-
-### Phase 7 — Add optional Duty durability using Temporal
-
-Recommended proof point:
-
-- one `nightly_research` duty
-- one duty window
-- one timer-based wake-up
-- one event-based wake-up
-- one recall signal
-- one handoff back into SquadOps activity execution
-
-Acceptance:
-
-- the duty survives worker interruption,
-- duty window transitions occur reliably,
-- recall behavior is explicit,
-- and SquadOps remains semantic owner of mode and activity.
-
----
-
-## 18. Acceptance Criteria
-
-This SIP should only be considered successful if the following become true.
-
-### 18.1 Runtime clarity
-
-- The framework can always answer:
-  - what mode is the agent in now?
-  - what assignment(s) does it have?
-  - what is its current activity?
-  - what may claim it next?
-
-### 18.2 Exclusivity
-
-- An agent cannot be simultaneously in Duty, Cycle, and Ambient.
-- Current mode is singular and explicit.
-
-### 18.3 Scheduling sanity
-
-- An agent can be Ambient now and scheduled for future Duty.
-- Cycle recruitment respects future duty windows and reservation policy.
-
-### 18.4 Recallability
-
-- Ambient behavior can be recalled.
-- Duty transitions can preempt Ambient.
-- Policy governs whether Cycle can preempt or interrupt Duty.
-
-### 18.5 Cycle preservation
-
-- Existing cycle architecture remains intact.
-- Non-code execution surfaces such as Minecraft can participate without changing the fundamental cycle semantics.
-
-### 18.6 Duty realism
-
-- Duty supports explicit windows.
-- Hard and soft duty behavior are representable.
-- Duty can model service-like operational work without pretending it is just a cycle.
-
-### 18.7 Embodiment safety
-
-- Embodied activity is represented through adapters and activities, not hidden inside agent prompt context.
-- Location and embodiment health are observable.
-
-### 18.8 Incremental rollout
-
-- The first implementation can stop after mode + assignment + focus + activity and still be useful.
-- Embodiment and Temporal are optional later layers, not prerequisites for the entire model.
-
----
-
-## 19. Risks and Failure Modes
-
-### 19.1 Too many top-level modes
-
-Risk:
-The runtime becomes a taxonomy soup.
-
-Mitigation:
-Stay with three top-level modes for now.
-
-### 19.2 Making direct interaction a peer mode
-
-Risk:
-The mode model gets muddy and repetitive.
-
-Mitigation:
-Treat direct interaction as cross-cutting.
-
-### 19.3 Treating Duty as permanent identity lock
-
-Risk:
-Agents become unusably rigid.
-
-Mitigation:
-Use assignment + duty window + current mode.
-
-### 19.4 Treating Ambient as unrestricted autonomy
-
-Risk:
-Framework loses control and predictability.
-
-Mitigation:
-Keep ambient bounded, low-priority, and recallable.
-
-### 19.5 Letting Minecraft or embodiment drive the domain model
-
-Risk:
-Core becomes contaminated by adapter-specific concerns.
-
-Mitigation:
-Separate identity from embodiment and keep location generic.
-
-### 19.6 Overusing Temporal
-
-Risk:
-A second orchestration system swallows the runtime.
-
-Mitigation:
-Use Temporal narrowly for Duty durability first.
-
-### 19.7 Hidden attention contention
-
-Risk:
-Agent "kind of" accepts multiple serious responsibilities at once.
-
-Mitigation:
-Introduce explicit focus ownership / lease semantics.
-
----
-
-## 20. Open Questions
-
-1. Should `hard | soft` duty strictness be enough for v1, or is a richer policy model needed later?
-2. Should cycle recruitment be blocked by a configurable pre-duty reserve buffer?
-3. Does Ambient need geographic bounds from day one for embodied agents?
-4. Should a duty window transition be implemented inside SquadOps first, or only once Temporal is introduced?
-5. What evidence model is required for world-state acceptance checks in Minecraft workloads?
-6. Does the current agent factory need new runtime traits to support persistent mode/state fields?
-7. How should budget exhaustion change mode eligibility or cause forced transitions?
-
----
-
-## 21. Recommendation
-
-Proceed with this SIP in a staged way.
-
-Do **not** begin by building a rich virtual-world agent.
-Do **not** begin by making Temporal the whole system.
-Do **not** begin by exploding the taxonomy.
-
-Instead:
-
-1. freeze the three top-level modes,
-2. separate current mode from assignments and schedules,
-3. add focus and activity visibility,
-4. add duty windows,
-5. preserve cycles as the bounded-work canonical path,
-6. then add one embodied proof point,
-7. then add one narrow Temporal duty proof point.
-
-That path gives SquadOps a disciplined runway toward persistent operational agents, embodied worlds, and future Backspring business support without wrecking the current framework with a half-baked runtime model.
-
----
-
-## 22. Proposed Working Definitions
-
-For ease of future reference:
-
-### Mode
-The agent's current operating posture.
-Exactly one of: `duty | cycle | ambient`.
-
-### Duty
-On-duty, service-responsible mode with availability expectations.
-
-### Cycle
-Bounded, formal assigned work with explicit completion semantics.
-
-### Ambient
-Off-duty, low-priority, interruptible background presence.
-
-### Assignment
-A scheduled or durable commitment associated with the agent.
-
-### Duty Window
-The time range during which a duty assignment may or must claim the agent.
-
-### Focus
-The current primary concern owning the agent's attention inside its mode.
-
-### Activity
-The concrete action or unit of work currently being executed.
-
-### Embodiment
-A runtime surface through which the agent acts in a world or system.
-
-### Recall
-A policy-driven interruption or reassignment request that changes or reclaims the agent's current focus or mode.
-
----
-
-## 23. Closing View
-
-The most important idea in this document is not Minecraft, not Temporal, and not even Duty itself.
-
-It is this:
+## The central insight
 
 > **Current posture, future commitments, and immediate action must be modeled separately.**
 
-In other words:
+- **Mode** is what the agent is doing now — exactly one of `duty | cycle | ambient`.
+- **Assignment / schedule** is what may claim the agent later.
+- **Focus / activity** is what currently owns its attention.
 
-- **mode** is what the agent is doing now,
-- **assignment/schedule** is what may claim it later,
-- **focus/activity** is what currently owns its attention.
+Without this separation, persistent agents become unobservable — schedules live in prompts, recall happens by vibes, and "free" vs. "committed" become guesses. With it, SquadOps gains a credible path to operational agents (Backspring support, monitoring, research) and embodied surfaces (Discord, browser, eventually Minecraft) without diluting the cycle model.
 
-That separation is what gives SquadOps a credible path to persistent, embodied, operational agents without collapsing the framework into ambiguity.
+---
+
+## The three top-level modes
+
+| Mode | Meaning | Examples |
+|------|---------|----------|
+| **Duty** | On-duty, service-responsible, availability-constrained | Customer support, inventory watch, nightly research |
+| **Cycle** | Bounded, formal, assigned work with explicit completion semantics | Build a feature, run an experiment, validate an artifact |
+| **Ambient** | Off-duty, low-priority, interruptible background presence | Idling, lightweight observation, recallable presence |
+
+These are mutually exclusive. An agent has exactly one mode at a time. Direct human interaction is **not** a mode — it is a cross-cutting interaction path that can occur in any mode.
+
+---
+
+## The three implementing SIPs
+
+### 1. `SIP-Agent-Runtime-State.md` — v1.1 candidate
+
+**Scope:** Mode, assignment, duty window, focus lease, activity model. Pure runtime-state primitives. No embodiment, no Temporal.
+
+**Why first:** Everything else depends on these primitives. Once an agent has `mode`, `focus`, `activity`, `assignments`, and `focus_lease`, it is observable and schedulable. Embodiment and durable workflows attach to these primitives later.
+
+### 2. `SIP-Agent-Embodiment-Substrate.md` — v1.2 candidate
+
+**Scope:** Embodiment abstraction (identity / runtime-surface separation), location as a generic concept, capability-aware Activity scheduling, resource budgets, first proof point on Discord.
+
+**Why second:** Once persistent agents exist, the next architectural question is "how do they act in external surfaces?" Discord is chosen as the first proof point because it is lighter to test than Minecraft. Minecraft becomes a follow-on SIP once the substrate is proven.
+
+### 3. `SIP-Duty-Durability-Temporal.md` — v1.3 candidate
+
+**Scope:** Temporal as a narrowly-scoped durability layer for Duty workflows only. Optional dependency. Proof point: a `nightly_research` duty surviving worker restarts.
+
+**Why third:** Duty windows can be served by an in-process scheduler in v1.1. Temporal becomes valuable when production-grade durability matters — and the right time to add a second orchestrator is after the duty model has shape.
+
+---
+
+## Why three SIPs instead of one
+
+The original umbrella proposal was good design but bad packaging. Reviewing it required signing off on:
+
+- A new runtime taxonomy
+- An embodiment abstraction
+- A new optional orchestrator (Temporal)
+- A virtual-world execution surface (Minecraft)
+
+…all at once. That made meaningful design review difficult — reviewers either had to accept the whole vision or push back on the whole thing.
+
+Splitting into three lets each design review happen on its own merits:
+
+- The runtime taxonomy can be approved and shipped without committing to Temporal.
+- The embodiment substrate can be approved without committing to Minecraft.
+- The Temporal adapter can be approved without rewriting agent semantics.
+
+It also bounds the blast radius. If the embodiment substrate doesn't pan out as expected, v1.1 still ships and is useful. If Temporal turns out to be the wrong answer, v1.1 and v1.2 are unaffected.
+
+---
+
+## Sequencing rules
+
+- **v1.1 must land before v1.2 or v1.3.** Both follow-ons depend on the runtime-state primitives.
+- **v1.2 and v1.3 are independent.** They can be reviewed and shipped in either order, or in parallel.
+- **No version bump is implied by accepting these SIPs.** Acceptance is a design commitment. The actual `pyproject.toml` bump to 1.1 happens when the v1.1 implementation is feature-complete.
+- **In-flight 1.0.x cycle hardening continues unaffected.** Nothing in these SIPs touches the cycle execution path until implementation lands behind feature flags.
+
+---
+
+## Architectural principles (carried forward from the original proposal)
+
+These principles should govern all three implementing SIPs:
+
+1. **Keep top-level runtime postures small.** Three modes. Resist additions.
+2. **Keep current mode singular.** No "kind of duty and kind of cycle."
+3. **Keep assignments and schedules orthogonal to current mode.** Future commitments are not the same as current state.
+4. **Treat direct interaction as cross-cutting.** Not a peer mode.
+5. **Do not embed world semantics into core too early.** Core knows embodiment and location exist; adapters know the rest.
+6. **Keep Cycle canonical for bounded work.** Even Minecraft builds respect cycle semantics.
+7. **Use Duty for service-like persistence.** Don't stretch Cycle into a poor imitation of long-running operations.
+8. **Prefer explicit recalls over implicit interruption.** Higher-priority claims produce explicit transitions, not prompt drift.
+
+---
+
+## What this umbrella does NOT contain
+
+The full architectural argument, data model sketches, transition tables, risk register, and open-questions list from the original proposal are **not** duplicated here. They have been distributed into the three implementing SIPs where they are actionable, and the original full text is preserved in git at commit `76a1f90`.
+
+This document exists only to:
+
+- Frame the central insight
+- Index the three implementing SIPs
+- Document the sequencing and rationale for the split
+- Preserve the architectural principles that govern all three
+
+For implementation detail, read the implementing SIPs.
+
+---
+
+## References
+
+- `sips/proposed/SIP-Agent-Runtime-State.md` — v1.1 candidate
+- `sips/proposed/SIP-Agent-Embodiment-Substrate.md` — v1.2 candidate
+- `sips/proposed/SIP-Duty-Durability-Temporal.md` — v1.3 candidate
+- Original full proposal: commit `76a1f90` on main (`git show 76a1f90:sips/proposed/SIP-Agent-Runtime-Modes.md`)

--- a/sips/proposed/SIP-Agent-Runtime-Modes.md
+++ b/sips/proposed/SIP-Agent-Runtime-Modes.md
@@ -3,14 +3,14 @@
 **Status:** Proposed (umbrella / vision)
 **Authors:** Jason Ladd
 **Created:** 2026-04-25
-**Revision:** 2 (split into three implementing SIPs on 2026-04-25)
+**Revision:** 3 (incorporated review feedback on 2026-04-25; r2 split umbrella into three implementing SIPs)
 **Original full proposal:** commit `76a1f90` on main
 
 ---
 
 ## Purpose of this document
 
-This document is the **umbrella vision** for evolving SquadOps from a cycle-only execution framework into a runtime that supports persistent, schedule-aware, and (eventually) embodied agents.
+This document is the **umbrella vision** for evolving SquadOps from a cycle-only execution framework into a runtime that supports persistent runtime state, scheduled operational responsibilities, and (eventually) embodied presence.
 
 It does **not** propose implementation. The actionable proposals live in three sibling SIPs, each independently reviewable and shippable.
 
@@ -18,15 +18,58 @@ The original revision-1 draft was a single 1,100-line proposal. After design dis
 
 ---
 
+## What this package introduces — and what it does not
+
+This package introduces **persistent runtime state for agents** — the ability to observe, schedule, recall, and reason about an agent across cycles and duty windows.
+
+It does **not** introduce always-on autonomous entities, unbounded "agent life" loops, or general-purpose self-direction. Persistence here means *durable state and explicit lifecycle*, not *uncapped autonomy*.
+
+---
+
 ## The central insight
 
 > **Current posture, future commitments, and immediate action must be modeled separately.**
 
-- **Mode** is what the agent is doing now — exactly one of `duty | cycle | ambient`.
+- **RuntimeMode** is what the agent is doing now — exactly one of `duty | cycle | ambient`.
 - **Assignment / schedule** is what may claim the agent later.
-- **Focus / activity** is what currently owns its attention.
+- **FocusLease / RuntimeActivity** is what currently owns its attention.
 
 Without this separation, persistent agents become unobservable — schedules live in prompts, recall happens by vibes, and "free" vs. "committed" become guesses. With it, SquadOps gains a credible path to operational agents (Backspring support, monitoring, research) and embodied surfaces (Discord, browser, eventually Minecraft) without diluting the cycle model.
+
+---
+
+## Package-level invariant
+
+The following invariant governs all three implementing SIPs:
+
+> **RuntimeMode, Assignment, FocusLease, RuntimeActivity, Embodiment, and DutyDurability must remain separate concepts. No implementation may use one of these primitives as a hidden substitute for another.**
+
+Concrete consequences:
+
+- A duty assignment does not mean the agent is currently in Duty mode.
+- A focus lease does not imply a specific embodiment.
+- An embodiment attachment does not imply permission to act.
+- A Temporal workflow does not own agent state.
+- A RuntimeActivity does not define the top-level runtime mode.
+- A RuntimeActivity does not replace cycle, task, workload, or handler execution.
+
+---
+
+## Conceptual boundary table
+
+This table is canonical for the package. Every implementing SIP must respect it.
+
+| Primitive | Owns | Does NOT own |
+|-----------|------|--------------|
+| **RuntimeMode** | Current top-level posture (duty/cycle/ambient) | Future commitments, external presence, work execution |
+| **Assignment** | Future or potential responsibility | Current attention, current mode |
+| **DutyWindow** | When duty may claim the agent | Work execution, focus arbitration |
+| **FocusLease** | Primary attention ownership | Agent identity, schedule, embodiment lifecycle |
+| **RuntimeActivity** | Observable record of current work | Execution engine semantics; replacement of cycle/task/workload/handler |
+| **Embodiment** | External surface attachment, capabilities, location, health | Intent, priority, mode, scheduling decisions |
+| **EmbodimentAdapter** | Translating *authorized* surface-specific action requests into platform calls | Goal decomposition, intent decisions, mode transitions |
+| **DutyDurabilityPort** | Durable duty wake/recall mechanics | Agent semantics, runtime state |
+| **Temporal adapter** | Timers, schedules, durable signals | Runtime state, cognition, embodiment, transition authority |
 
 ---
 
@@ -38,7 +81,53 @@ Without this separation, persistent agents become unobservable — schedules liv
 | **Cycle** | Bounded, formal, assigned work with explicit completion semantics | Build a feature, run an experiment, validate an artifact |
 | **Ambient** | Off-duty, low-priority, interruptible background presence | Idling, lightweight observation, recallable presence |
 
-These are mutually exclusive. An agent has exactly one mode at a time. Direct human interaction is **not** a mode — it is a cross-cutting interaction path that can occur in any mode.
+These are mutually exclusive. An agent has exactly one mode at a time. **Direct human interaction is not a mode** — it is a cross-cutting interaction path that can occur in any mode (see policy table below).
+
+---
+
+## Direct interaction policy by mode
+
+| Current mode | Default direct-interaction behavior |
+|--------------|--------------------------------------|
+| Ambient | May interrupt directly if budget permits |
+| Duty | Answer, defer, or route per duty policy; should not silently abandon duty obligation |
+| Cycle | Status-only by default; deeper engagement requires escalation |
+| Offline / Degraded | Return last known state or "unavailable"; never fabricate |
+
+This keeps "chat with the agent" from becoming a hidden fourth mode.
+
+---
+
+## What must not happen
+
+Reviewer-driven guardrails. Implementations of the three follow-ons must not violate any of these:
+
+- Cycle must not become a long-running service loop.
+- Duty must not become a generic background task runner.
+- Ambient must not become unsupervised autonomy. In particular, ambient must not perform irreversible external actions, spend material compute, or mutate external systems unless a focus lease is granted and a RuntimeActivity is started.
+- Embodiment must not become a second agent identity.
+- Temporal must not become the runtime brain.
+- Minecraft, Discord, or any other surface concept must not appear in core.
+- Direct human interaction must not become a fourth top-level mode.
+- A RuntimeActivity must not replace cycle, task, workload, or handler execution semantics.
+
+---
+
+## Canonical terminology
+
+Use these names in code, schemas, and design discussion. "Activity" is permitted as prose shorthand for RuntimeActivity but should never appear unqualified in schemas (collision with Temporal's `Activity`).
+
+| Canonical name | Notes |
+|----------------|-------|
+| `RuntimeMode` | The enum: `duty`, `cycle`, `ambient` |
+| `Assignment` | Durable commitment record |
+| `DutyWindow` | Time range during which a duty may claim the agent |
+| `FocusLease` | Attention ownership claim |
+| `RuntimeActivity` | Observable current work record (NOT Temporal Activity) |
+| `Embodiment` | External surface attachment record |
+| `EmbodimentAdapter` | Adapter implementing surface-specific port |
+| `DutyDurabilityPort` | Port for durable duty timer/signal mechanics |
+| `DutyDurabilityRun` | Runtime correlation record between Assignment and external durability backend |
 
 ---
 
@@ -46,15 +135,15 @@ These are mutually exclusive. An agent has exactly one mode at a time. Direct hu
 
 ### 1. `SIP-Agent-Runtime-State.md` — v1.1 candidate
 
-**Scope:** Mode, assignment, duty window, focus lease, activity model. Pure runtime-state primitives. No embodiment, no Temporal.
+**Scope:** RuntimeMode, Assignment, DutyWindow, FocusLease, RuntimeActivity. Pure runtime-state primitives. No embodiment, no Temporal.
 
-**Why first:** Everything else depends on these primitives. Once an agent has `mode`, `focus`, `activity`, `assignments`, and `focus_lease`, it is observable and schedulable. Embodiment and durable workflows attach to these primitives later.
+**Why first:** Everything else depends on these primitives. Once an agent has `mode`, `focus`, `current_runtime_activity`, `assignments`, and `focus_lease`, it is observable and schedulable. Embodiment and durable workflows attach to these primitives later.
 
 ### 2. `SIP-Agent-Embodiment-Substrate.md` — v1.2 candidate
 
-**Scope:** Embodiment abstraction (identity / runtime-surface separation), location as a generic concept, capability-aware Activity scheduling, resource budgets, first proof point on Discord.
+**Scope:** Embodiment abstraction (identity / runtime-surface separation), generic location, capability-aware RuntimeActivity scheduling, resource budgets, first proof point on Discord.
 
-**Why second:** Once persistent agents exist, the next architectural question is "how do they act in external surfaces?" Discord is chosen as the first proof point because it is lighter to test than Minecraft. Minecraft becomes a follow-on SIP once the substrate is proven.
+**Why second:** Once persistent agents exist, the next architectural question is "how do they act in external surfaces?" Discord is chosen as the first proof point because it is lighter to test than Minecraft. Minecraft becomes a future follow-on SIP (`SIP-Minecraft-Embodiment-Adapter.md`, not in this package).
 
 ### 3. `SIP-Duty-Durability-Temporal.md` — v1.3 candidate
 
@@ -73,15 +162,12 @@ The original umbrella proposal was good design but bad packaging. Reviewing it r
 - A new optional orchestrator (Temporal)
 - A virtual-world execution surface (Minecraft)
 
-…all at once. That made meaningful design review difficult — reviewers either had to accept the whole vision or push back on the whole thing.
+…all at once. Splitting bounds the blast radius:
 
-Splitting into three lets each design review happen on its own merits:
-
-- The runtime taxonomy can be approved and shipped without committing to Temporal.
+- The runtime taxonomy can be approved without committing to Temporal.
 - The embodiment substrate can be approved without committing to Minecraft.
 - The Temporal adapter can be approved without rewriting agent semantics.
-
-It also bounds the blast radius. If the embodiment substrate doesn't pan out as expected, v1.1 still ships and is useful. If Temporal turns out to be the wrong answer, v1.1 and v1.2 are unaffected.
+- If the embodiment substrate doesn't pan out, v1.1 still ships and is useful.
 
 ---
 
@@ -94,9 +180,9 @@ It also bounds the blast radius. If the embodiment substrate doesn't pan out as 
 
 ---
 
-## Architectural principles (carried forward from the original proposal)
+## Architectural principles
 
-These principles should govern all three implementing SIPs:
+These principles govern all three implementing SIPs:
 
 1. **Keep top-level runtime postures small.** Three modes. Resist additions.
 2. **Keep current mode singular.** No "kind of duty and kind of cycle."
@@ -106,6 +192,61 @@ These principles should govern all three implementing SIPs:
 6. **Keep Cycle canonical for bounded work.** Even Minecraft builds respect cycle semantics.
 7. **Use Duty for service-like persistence.** Don't stretch Cycle into a poor imitation of long-running operations.
 8. **Prefer explicit recalls over implicit interruption.** Higher-priority claims produce explicit transitions, not prompt drift.
+9. **FocusLease is the hard gate for attention.** No attention-owning RuntimeActivity may begin without a compatible lease.
+10. **Embodiment never decides intent.** Adapters execute authorized actions; they do not interpret goals.
+11. **Temporal makes time durable, not state.** Runtime state always lives in SquadOps.
+
+---
+
+## Package-level acceptance criteria
+
+The package as a whole is successful when:
+
+1. **RuntimeMode** remains singular and limited to `duty`, `cycle`, or `ambient`.
+2. **Assignments** may be multiple; current mode may only be one.
+3. **FocusLease** is required for primary attention ownership.
+4. **RuntimeActivity** records current work but does not replace cycle, task, or workload semantics.
+5. **Embodiment** exposes capabilities and health but does not own agent intent.
+6. **Temporal** makes duty timing durable but does not own agent state or perform transitions directly.
+7. **Direct human interaction** remains cross-cutting and never becomes a fourth mode.
+8. All mode, focus, activity, and embodiment transitions emit **reason-coded events** (see canonical reason codes below).
+9. Existing cycle execution remains unchanged unless explicitly gated by recruitment/focus policy.
+10. Minecraft remains a follow-on adapter SIP, not part of core runtime state or the v1.2 embodiment substrate.
+
+---
+
+## Canonical reason codes
+
+All three SIPs share these reason codes for events and rejection responses. Implementations may extend the set; they must not redefine these.
+
+| Code | Meaning |
+|------|---------|
+| `duty_window_opened` | Duty window has begun; mode transition requested |
+| `duty_window_closed` | Duty window has ended; release transition requested |
+| `cycle_recruitment_accepted` | Agent agreed to join a cycle |
+| `cycle_recruitment_rejected_upcoming_duty` | Cycle declined because a hard duty window is within the reserve buffer |
+| `cycle_recruitment_rejected_focus_lease_conflict` | Cycle declined because focus lease cannot be acquired |
+| `focus_lease_granted` | Lease acquired |
+| `focus_lease_rejected` | Lease denied (carries owner ref + retry-after) |
+| `focus_lease_queued` | Lease request queued behind current owner |
+| `focus_lease_preempting` | Higher-priority owner displacing current owner |
+| `recall_requested` | Higher-priority claim wants the agent's attention |
+| `budget_exhausted` | A resource budget hit its ceiling |
+| `embodiment_desynced` | External surface state diverged from local view |
+| `operator_override` | Manual intervention forced a transition or decision |
+
+---
+
+## Canonical event names
+
+All three SIPs share these event names. Implementations may extend; they must not redefine.
+
+- `agent.mode.transition.requested` / `.completed` / `.rejected`
+- `focus_lease.requested` / `.granted` / `.rejected` / `.queued` / `.preempted` / `.released`
+- `runtime_activity.started` / `.paused` / `.resumed` / `.completed` / `.aborted`
+- `assignment.window.opened` / `.closed`
+- `embodiment.attach.requested` / `.attached` / `.desynced` / `.reconnecting` / `.detached`
+- `duty_durability.window.scheduled` / `.signal.received` / `.workflow.failed`
 
 ---
 
@@ -116,9 +257,10 @@ The full architectural argument, data model sketches, transition tables, risk re
 This document exists only to:
 
 - Frame the central insight
+- Establish the package invariant and conceptual boundary table
 - Index the three implementing SIPs
 - Document the sequencing and rationale for the split
-- Preserve the architectural principles that govern all three
+- Preserve the architectural principles, terminology, reason codes, and event names that govern all three
 
 For implementation detail, read the implementing SIPs.
 
@@ -129,4 +271,5 @@ For implementation detail, read the implementing SIPs.
 - `sips/proposed/SIP-Agent-Runtime-State.md` — v1.1 candidate
 - `sips/proposed/SIP-Agent-Embodiment-Substrate.md` — v1.2 candidate
 - `sips/proposed/SIP-Duty-Durability-Temporal.md` — v1.3 candidate
+- Future follow-on: `SIP-Minecraft-Embodiment-Adapter.md` (not in this package)
 - Original full proposal: commit `76a1f90` on main (`git show 76a1f90:sips/proposed/SIP-Agent-Runtime-Modes.md`)

--- a/sips/proposed/SIP-Agent-Runtime-State.md
+++ b/sips/proposed/SIP-Agent-Runtime-State.md
@@ -1,9 +1,9 @@
-# SIP: Agent Runtime State — Modes, Duty Windows, Focus, and Activity
+# SIP: Agent Runtime State — Modes, Duty Windows, Focus, and RuntimeActivity
 
 **Status:** Proposed (draft)
 **Authors:** Jason Ladd
 **Created:** 2026-04-25
-**Revision:** 1
+**Revision:** 2 (incorporated review feedback on 2026-04-25)
 **Targets:** v1.1
 **Parent vision:** `sips/proposed/SIP-Agent-Runtime-Modes.md` (umbrella index)
 **Sibling SIPs:**
@@ -18,12 +18,15 @@ This SIP introduces the **runtime-state foundation** for persistent SquadOps age
 
 It proposes the minimum runtime primitives needed to make persistent agents observable, schedulable, and recallable, without introducing embodiment or durable workflow concerns.
 
-The four primitives:
+**This SIP introduces a runtime coordination layer around existing execution paths.** It does not redefine how cycles are planned, executed, validated, or accepted. Cycle, workload, task, and handler semantics are unchanged — they continue to do the work. The new primitives observe and arbitrate; they do not execute.
 
-1. **Mode** — current operating posture, exactly one of `duty | cycle | ambient`
-2. **Assignment + Duty Window** — durable commitments and the time ranges in which they may claim the agent
-3. **Focus Lease** — explicit ownership claim over the agent's primary attention
-4. **Activity** — the concrete unit of work currently executing, with pause/resume/abort semantics
+The five primitives:
+
+1. **RuntimeMode** — current operating posture, exactly one of `duty | cycle | ambient`
+2. **Assignment + DutyWindow** — durable commitments and the time ranges in which they may claim the agent
+3. **FocusLease** — explicit ownership claim over the agent's primary attention
+4. **RuntimeActivity** — observable runtime record of current work (the canonical name; `Activity` is reserved for Temporal's distinct concept)
+5. **Runtime status** — agent health/availability, distinct from work posture
 
 This SIP **does not** propose embodiment, location, virtual worlds, or Temporal integration. Those are deferred to the sibling SIPs.
 
@@ -48,12 +51,13 @@ The challenge:
 
 ## 3. Design Intent
 
-1. Preserve the cycle model as the canonical mechanism for bounded, acceptance-oriented work.
-2. Introduce persistent runtime behavior without forcing all activity into cycles.
+1. Preserve the cycle model as the canonical mechanism for bounded, acceptance-oriented work. **Cycle execution paths are not modified by this SIP.**
+2. Introduce persistent runtime *state* — not autonomous behavior — without forcing all activity into cycles.
 3. Support service-like operational responsibility through Duty mode with explicit windows.
 4. Make current state, future commitments, and immediate action separately observable.
 5. Allow interruption and recall through explicit policy rather than implicit prompt drift.
-6. Keep the model small enough to ship in v1.1.
+6. Establish FocusLease as the **hard gate** for primary attention.
+7. Keep the model small enough to ship in v1.1.
 
 ---
 
@@ -65,6 +69,7 @@ This SIP does **not** propose:
 - Location modeling — see `SIP-Agent-Embodiment-Substrate.md`
 - Temporal or any external workflow durability layer — see `SIP-Duty-Durability-Temporal.md`
 - Replacing the current cycle mechanism
+- Replacing or competing with the existing task/workload/handler execution model
 - A fully autonomous "agent life" loop
 - Direct human interaction as a peer mode (treated as cross-cutting; see §8)
 
@@ -74,7 +79,7 @@ This SIP does **not** propose:
 
 ### 5.1 Top-Level Modes
 
-An agent has exactly one **current mode** at a time:
+An agent has exactly one **current RuntimeMode** at a time:
 
 - `duty` — on-duty, service-responsible, availability-constrained
 - `cycle` — bounded, formal, assigned work with explicit completion semantics
@@ -88,7 +93,7 @@ These modes are **mutually exclusive**. They imply different rules for interrupt
 
 **Cycle.** The agent is committed to bounded assigned work with acceptance criteria. Examples: building a web app, executing an experiment, producing an artifact, performing a validation pass. This remains the most structured form of execution in SquadOps.
 
-**Ambient.** The agent is online, present, lightly available, and off-duty. Bounded, interruptible, low-resource. Not a loophole for uncontrolled autonomous drift — a low-priority interruptible background state.
+**Ambient.** The agent is online, present, lightly available, and off-duty. Bounded, interruptible, low-resource. **Ambient may observe, idle, respond lightly, or prepare context. Ambient may NOT perform irreversible external actions, spend material compute, or mutate external systems unless a FocusLease is granted and a RuntimeActivity is started.** This becomes critical once embodiment exists in v1.2.
 
 ---
 
@@ -98,111 +103,50 @@ The most important architectural distinction: **mode is not the same as assignme
 
 | Concept | Answers | Example |
 |---------|---------|---------|
-| **Mode** | What is the agent doing right now? | `ambient` |
+| **RuntimeMode** | What is the agent doing right now? | `ambient` |
 | **Assignment** | What role or commitment is associated with the agent? | `nightly_research`, `support_duty` |
-| **Schedule / Duty Window** | When is that assignment active or claimable? | `01:00–06:00 UTC` |
-| **Focus** | What currently owns the agent's primary attention within its current mode? | `handling support case #184` |
-| **Activity** | What concrete action is happening right now? | `summarize_findings`, `classify_ticket` |
+| **DutyWindow** | When is that assignment active or claimable? | `01:00–06:00 UTC` |
+| **Focus** (held via FocusLease) | What currently owns the agent's primary attention within its current mode? | `handling support case #184` |
+| **RuntimeActivity** | What concrete unit of work is currently observable? | `summarize_findings`, `classify_ticket` |
 
 This separation enables a coherent state like:
 
 - current mode = `ambient`
 - duty assignment = `nightly_research`
 - duty window starts at `01:00`
-- cycle eligible = `true until reserve threshold`
+- cycle eligible = `true` until reserve buffer begins
 
-The agent can be ambient now, recruited into a short cycle if safe, and transition into Duty automatically when the window opens. That is operationally coherent and significantly safer than treating "free" and "committed" as vague prompt-level concepts.
+The agent can be ambient now, recruited into a short cycle if safe, and transition into Duty automatically when the window opens.
 
 ---
 
-## 7. Core Runtime Primitives
+## 7. RuntimeActivity vs Existing Execution Concepts
 
-### 7.1 Agent Runtime State
+This is the most-asked question on first reading. The mapping:
 
-A persistent agent should expose runtime state such as:
+| Concept | Role | Owner |
+|---------|------|-------|
+| **Cycle** | Bounded unit of formal work with acceptance | Existing cycle subsystem (unchanged) |
+| **Workload** | DAG or grouped execution structure within a cycle | Existing workload runner (unchanged) |
+| **Task** | Planned capability-level execution unit | Existing task model (unchanged) |
+| **Handler** | Implementation path that performs task work | Existing handler registry (unchanged) |
+| **RuntimeActivity** | Runtime-visible observation/control record for what an agent is currently doing | **New, this SIP** |
 
-- `agent_id`
-- `mode` — `duty | cycle | ambient`
-- `runtime_status` — `online | idle | busy | paused | degraded | recovering | offline`
-- `focus` — string label for primary concern within current mode
-- `activity_id` — reference to current Activity, or null
-- `interruptibility` — `none | low | medium | high`
-- `last_heartbeat_at`
-- `current_assignment_ref` — null in pure ambient
+**A RuntimeActivity is not a new execution engine primitive.** It is the runtime-visible representation of current work, whether that work is being performed by a cycle task, a duty handler, an ambient observation, or (in v1.2) an embodied action.
 
-### 7.2 Assignment
+Concretely:
 
-A durable relationship between an agent and a future or potential responsibility.
+- A single cycle task may create one or more RuntimeActivity records over its lifetime
+- A RuntimeActivity may reference a cycle, workload, task, duty assignment, or embodiment action depending on context
+- Existing execution mechanisms emit and update RuntimeActivity records; they are not replaced by them
 
-Suggested fields:
-
-- `assignment_id`
-- `assignment_type` — `duty | reserve | cycle_eligibility`
-- `assigned_role`
-- `priority`
-- `strictness` — `hard | soft`
-- `active_window` — start, end, timezone
-- `recall_policy` — `immediate | graceful | none`
-- `allowed_off_window_modes`
-
-An agent can hold an assignment without currently being in the corresponding mode.
-
-### 7.3 Duty Window
-
-Duty windows are explicit. Duty is not a permanent identity lock.
-
-Suggested fields:
-
-- `window_start`, `window_end`, `timezone`
-- `strictness: hard | soft`
-- `grace_before_start`, `grace_after_end`
-
-**Hard duty window:** during the window, the agent is reserved for duty only.
-
-**Soft duty window:** during the window, duty has priority, but short preemptible work may be allowed if the duty can reclaim focus.
-
-### 7.4 Focus Lease
-
-A focus lease is the runtime claim over an agent's primary attention. Conceptually analogous to the Kubernetes Lease pattern, but not literally implemented as one.
-
-Suggested fields:
-
-- `lease_id`
-- `owner_type` — `duty | cycle | ambient`
-- `owner_ref`
-- `acquired_at`
-- `expires_at` or `renewal_policy`
-- `interruptibility`
-- `recall_policy`
-
-The lease is what prevents two owners from ambiguously claiming the same agent.
-
-### 7.5 Activity
-
-The concrete unit of work currently being performed.
-
-Suggested fields:
-
-- `activity_id`
-- `activity_type`
-- `mode` — which top-level mode this activity belongs to
-- `goal`
-- `priority`
-- `can_pause`, `can_resume`, `can_abort`
-- `completion_conditions`
-- `evidence_requirements`
-
-Activities make current work observable without digging into prompt history.
+Implementation pattern: handlers and workload runners gain a thin observability hook that opens, updates, and closes a RuntimeActivity record. Execution itself stays where it is.
 
 ---
 
 ## 8. Direct Interaction Is Cross-Cutting
 
-Direct human interaction is **not** a peer mode. It is a cross-cutting interaction path that may occur against an agent already in one of the three top-level modes.
-
-- In **Ambient**, direct interaction usually interrupts easily.
-- In **Duty**, direct interaction may be limited, deferred, or handled minimally.
-- In **Cycle**, direct interaction may return status or require priority escalation.
+Direct human interaction is **not** a peer mode. It is a cross-cutting interaction path that may occur against an agent already in one of the three top-level modes. See the policy table in the umbrella SIP.
 
 This keeps the mode model small while preserving the reality that humans may speak to agents in any mode.
 
@@ -212,23 +156,29 @@ This keeps the mode model small while preserving the reality that humans may spe
 
 This SIP preserves Cycle as the canonical bounded-work mechanism. Cycle execution semantics, planning workloads, acceptance criteria, gates, and artifacts are unchanged.
 
-What changes: an agent may decline cycle recruitment if a hard duty window is approaching, or if a focus lease cannot be granted under current policy. That decision becomes **explainable** rather than implicit.
+What changes: an agent may decline cycle recruitment if a hard duty window is approaching (within the reserve buffer; see §11.4) or if a focus lease cannot be granted under current policy. That decision becomes **explainable** rather than implicit, via the canonical reason codes in the umbrella.
 
 ---
 
-## 10. Data Model Sketch
+## 10. Core Runtime Primitives
+
+### 10.1 Agent Runtime State
 
 ```yaml
 AgentRuntimeState:
   agent_id: string
   mode: duty | cycle | ambient
-  runtime_status: online | idle | busy | paused | degraded | recovering | offline
-  focus: string
-  activity_id: string | null
-  interruptibility: none | low | medium | high
+  runtime_status: online | degraded | recovering | offline   # health only — see 10.5
+  focus: string                                              # short label for primary concern
+  current_runtime_activity_id: string | null
+  interruptibility: none | low | medium | high               # current posture
   last_heartbeat_at: timestamp
-  current_assignment_ref: string | null
+  current_assignment_ref: string | null                      # the ACTIVE assignment, if any
+```
 
+### 10.2 Assignment
+
+```yaml
 Assignment:
   assignment_id: string
   assignment_type: duty | reserve | cycle_eligibility
@@ -239,26 +189,68 @@ Assignment:
     start: timestamp
     end: timestamp
     timezone: string
+  reserve_before_window: duration   # see 11.4 — first-class policy in v1.1
+  reserve_after_window: duration
   recall_policy: immediate | graceful | none
+  graceful_window: duration
   allowed_off_window_modes:
     - ambient
     - cycle
+```
 
+**Assignment cardinality:** an agent may hold **multiple Assignments** but exactly **one current RuntimeMode** and at most **one primary FocusLease**. Conflicts among assignments are resolved by scheduling policy *before* a focus claim is attempted. `current_assignment_ref` names the currently active assignment, not the only one held.
+
+### 10.3 DutyWindow
+
+DutyWindows are explicit. Duty is not a permanent identity lock. Window fields live inside the Assignment (`active_window`, `reserve_before_window`, `reserve_after_window`, `graceful_window`).
+
+### 10.4 FocusLease
+
+```yaml
 FocusLease:
   lease_id: string
   owner_type: duty | cycle | ambient
   owner_ref: string
   acquired_at: timestamp
+  expires_at: timestamp | null
   renewal_policy: heartbeat | ttl | fixed_window
   interruptibility: none | low | medium | high
   recall_policy: immediate | graceful | none
+```
 
-Activity:
-  activity_id: string
-  mode: duty | cycle | ambient
+**Invariant:** No RuntimeActivity that requires primary attention may begin unless the agent holds a compatible FocusLease.
+
+Permitted exceptions to the FocusLease requirement:
+
+- Passive heartbeat
+- Status query
+- Low-cost ambient observation (only if policy explicitly allows a shared/low-priority lease)
+- Embodied actions in v1.2 may require either the primary FocusLease or a future EmbodimentLease (deferred decision)
+
+### 10.5 Runtime status
+
+`runtime_status` describes **agent runtime health and availability only**. It does not encode work posture.
+
+- `online` — healthy, reachable, heartbeating
+- `degraded` — reachable but impaired (e.g., LLM provider failover, partial connectivity)
+- `recovering` — attempting to return to `online` after a failure
+- `offline` — unreachable
+
+Whether the agent is "idle" or "busy" is **derived** from FocusLease + RuntimeActivity, not stored in `runtime_status`. Whether the agent is "paused" is a **RuntimeActivity** state, not a runtime-status state.
+
+### 10.6 RuntimeActivity
+
+```yaml
+RuntimeActivity:
+  runtime_activity_id: string
+  mode: duty | cycle | ambient                  # which top-level mode this belongs to
   activity_type: string
   goal: string
   priority: integer
+  state: pending | running | paused | completed | aborted | failed
+  source_ref:                                   # what created this activity
+    kind: cycle_task | workload | duty_handler | ambient_observation | embodied_action
+    ref: string                                 # opaque; the source subsystem interprets
   can_pause: boolean
   can_resume: boolean
   can_abort: boolean
@@ -266,37 +258,90 @@ Activity:
   evidence_requirements: []
 ```
 
-Not final schema. Sufficient to prove the architecture.
+RuntimeActivities make current work observable without digging into prompt history. They do not perform work; existing handlers and workloads do, while emitting RuntimeActivity records.
 
 ---
 
 ## 11. Transition Semantics
 
-Minimal transitions:
+### 11.1 Allowed transitions
 
-- `ambient -> cycle`
-- `ambient -> duty`
-- `cycle -> ambient`
-- `cycle -> duty` (only if policy permits preemption)
-- `duty -> ambient`
-- `duty -> cycle` (generally only after duty window ends or if policy explicitly allows)
+- `ambient → cycle`
+- `ambient → duty`
+- `cycle → ambient`
+- `cycle → duty` (only if policy permits preemption)
+- `duty → ambient`
+- `duty → cycle` (generally only after duty window ends or if policy explicitly allows)
 
-Rules:
+### 11.2 Required preconditions for any mode transition
 
-- Mode transitions are evented and auditable
-- Transitions carry reason codes
-- Higher-priority transitions do not silently discard current activity state — interruptions explicitly pause, abort, or checkpoint the current activity
-- A focus lease must be released or revoked before a new owner can acquire one
+Every mode transition must:
+
+1. Carry a **reason code** from the canonical set in the umbrella SIP
+2. Resolve a **FocusLease decision** (acquired, released, or transferred)
+3. Resolve a **RuntimeActivity decision** (paused, resumed, aborted, completed, or none)
+4. Pass a **policy evaluation** (priority, interruptibility, reserve buffer, graceful window)
+5. Emit a **runtime event** from the canonical event set in the umbrella SIP
+
+Invalid transitions must be rejected with an explainable reason code; they must not silently no-op.
+
+### 11.3 Specific transition constraints
+
+- **Ambient → Cycle:** requires cycle recruitment policy approval and FocusLease acquisition.
+- **Cycle → Duty:** requires duty priority to exceed cycle interruptibility policy AND current RuntimeActivity to be `can_pause` or `can_abort`.
+- **Duty → Cycle:** requires DutyWindow end OR explicit policy allowance with FocusLease re-arbitration.
+- **Offline → Duty:** **not permitted directly.** Runtime must first reach `online` or `recovering` status.
+- **Any → Any with destructive RuntimeActivity loss:** rejected unless explicit `operator_override` reason code is provided.
+
+### 11.4 Pre-duty reserve buffer (first-class v1.1 policy)
+
+Cycle recruitment must respect a configurable **reserve buffer** before a hard duty window. Without this, a long cycle can be accepted minutes before a hard duty window opens and immediately create a conflict.
+
+- `reserve_before_window: duration` — declared on the Assignment
+- During the buffer, cycle recruitment is rejected with reason `cycle_recruitment_rejected_upcoming_duty`
+- Soft duties may permit recruitment during the buffer if the cycle's `can_pause` is true and the cycle accepts the duty's `recall_policy`
+
+Default if unspecified: 15 minutes for hard duties, 0 minutes for soft duties.
+
+### 11.5 FocusLease conflict outcomes
+
+A FocusLease request resolves to exactly one of:
+
+| Outcome | Meaning | Required response fields |
+|---------|---------|--------------------------|
+| `granted` | Lease acquired | `lease_id`, `expires_at`, reason code |
+| `rejected` | Lease denied; current owner holds | `current_owner_ref`, reason code, optional `retry_after` |
+| `queued` | Lease will be granted when current owner releases | `queue_position`, `current_owner_ref`, reason code |
+| `preempting` | Higher-priority owner displacing current owner | `current_owner_ref`, `preemption_grace`, reason code |
+
+All outcomes emit a `focus_lease.*` event from the canonical event set.
 
 ---
 
-## 12. Persistence
+## 12. Hard vs Soft Duty (Operational Semantics)
+
+### Hard duty
+
+- **Blocks** new cycle recruitment during the DutyWindow AND reserve buffer
+- **May preempt** ambient work
+- **May preempt** cycle work only if the cycle accepted that interruptibility policy at recruitment time
+- Direct interaction during the window is `defer-or-route`, not `interrupt`
+
+### Soft duty
+
+- **Allows** preemptible work during the window
+- Reclaims focus per `recall_policy` and `graceful_window`
+- **Should not accept** new work that cannot pause or checkpoint within the graceful window
+- Direct interaction is `answer` by default
+
+---
+
+## 13. Persistence
 
 Runtime state, assignments, and focus leases need a durable home. Recommended placement (to be confirmed during design review):
 
-- **AgentRuntimeState, FocusLease** — Postgres (cycle registry already lives there; same connection pool)
-- **Assignment** — Postgres
-- **Activity** — Postgres for the durable record; in-memory for the live working set
+- **AgentRuntimeState, FocusLease, Assignment, RuntimeActivity** — Postgres (cycle registry already lives there; same connection pool)
+- **Live RuntimeActivity working set** — in-memory cache; Postgres for durable record
 
 Heartbeat already flows through `AgentHeartbeatReporter`; extending it to carry mode/focus is the cheapest path.
 
@@ -304,87 +349,110 @@ LanceDB (SIP-042) is **not** the right home — semantic memory is for retrieval
 
 ---
 
-## 13. Implementation Phases
+## 14. Implementation Phases
 
 ### Phase 0 — Vocabulary freeze
 
 - SIP approval
-- Lock terminology for `mode`, `assignment`, `window`, `focus`, `activity`
+- Lock terminology per the umbrella's canonical names
 - No code changes
 
 ### Phase 1 — Minimal runtime state
 
-- Add `mode`, `runtime_status`, `focus`, `activity_id`, heartbeat fields to agent runtime
+- Add `mode`, `runtime_status`, `focus`, `current_runtime_activity_id`, heartbeat fields to agent runtime
 - Extend `AgentHeartbeatReporter` to carry the new fields
 - Postgres migration for `agent_runtime_state` table
 
-**Acceptance:** an operator can query an agent's current mode and current activity.
+**Acceptance:** an operator can query an agent's current mode and current RuntimeActivity.
 
 ### Phase 2 — Assignments and duty windows
 
-- Implement Assignment model and Postgres table
-- Implement Duty Window with hard/soft strictness
-- Add a transition scheduler (initially in-process, no Temporal)
+- Implement Assignment model and Postgres table (including `reserve_before_window`)
+- Implement DutyWindow with hard/soft strictness
+- Add a transition scheduler (in-process; no Temporal)
+- Implement reserve-buffer policy in cycle recruitment
 
-**Acceptance:** an agent can be Ambient now and scheduled to enter Duty later. An upcoming hard duty window restricts cycle recruitment per policy.
+**Acceptance:** an agent can be Ambient now and scheduled to enter Duty later. An upcoming hard duty window restricts cycle recruitment per the reserve buffer.
 
 ### Phase 3 — Focus lease
 
 - Implement FocusLease model with acquire/release/renew semantics
+- All four outcome types (granted/rejected/queued/preempting) with reason codes
 - Reasoned rejection when a conflicting owner attempts to claim focus
 
-**Acceptance:** the framework can explain why an agent did or did not accept a cycle request.
+**Acceptance:** the framework can explain why an agent did or did not accept a cycle request. Lease conflict outcomes are observable via events.
 
-### Phase 4 — Activity model
+### Phase 4 — RuntimeActivity model
 
-- Implement Activity object with pause/resume/abort
+- Implement RuntimeActivity object with pause/resume/abort
 - Evidence requirement hooks
-- Wire current cycle handlers to emit Activity records
+- Wire current cycle handlers and workload runners to emit RuntimeActivity records
 
-**Acceptance:** current work is observable as an Activity, not hidden in prompt history.
+**Acceptance:** current work is observable as a RuntimeActivity, not hidden in prompt history. No regression in cycle execution.
 
 ---
 
-## 14. Acceptance Criteria
+## 15. Acceptance Criteria
 
 The SIP is successful when:
 
-1. **Runtime clarity** — the framework can always answer: what mode? what assignments? what activity? what may claim the agent next?
+1. **Runtime clarity** — the framework can always answer: what mode? what assignments? what RuntimeActivity? what may claim the agent next?
 2. **Exclusivity** — an agent cannot be simultaneously in Duty, Cycle, and Ambient. Current mode is singular and explicit.
-3. **Scheduling sanity** — cycle recruitment respects future duty windows and reservation policy.
+3. **Scheduling sanity** — cycle recruitment respects future duty windows AND the reserve buffer.
 4. **Recallability** — Ambient behavior can be recalled. Duty transitions can preempt Ambient. Policy governs whether Cycle can preempt Duty.
 5. **Cycle preservation** — existing cycle architecture remains intact. No regressions in `run_regression_tests.sh`.
-6. **Duty realism** — Duty supports explicit windows, hard and soft strictness, and service-like operational work without pretending it is a cycle.
-7. **Incremental rollout** — Phases 1–4 ship and are useful even before embodiment or Temporal integration land.
+6. **Duty realism** — Duty supports explicit windows, hard and soft strictness with operational semantics in §12, and service-like operational work.
+7. **Lease as gate** — no attention-owning RuntimeActivity begins without a compatible FocusLease.
+8. **Explainability** — every transition and lease decision carries a reason code from the canonical set.
+9. **Incremental rollout** — Phases 1–4 ship and are useful even before embodiment or Temporal integration land.
 
 ---
 
-## 15. Risks and Mitigations
+## 16. Canonical Example: Nightly Research Duty
+
+End-to-end walkthrough exercising the v1.1 model:
+
+| Time | State | Event |
+|------|-------|-------|
+| 00:30 UTC | mode=`ambient`, assignment=`nightly_research` (window 01:00–06:00, hard, reserve_before=15m) | — |
+| 00:45 UTC | Reserve buffer begins | A cycle request arrives. Recruitment rejected with `cycle_recruitment_rejected_upcoming_duty`; event emitted. |
+| 01:00 UTC | Scheduler requests `ambient → duty` | Transition validated: reason=`duty_window_opened`, FocusLease acquired by `nightly_research`, RuntimeActivity `research_scan` started. |
+| 03:15 UTC | Human asks for status | Direct interaction handled cross-cutting per duty policy (`answer`); mode unchanged; no transition. |
+| 04:30 UTC | Embodied action attempt (v1.2 hypothetical) | Requires capability-aware lease check; in v1.1 scope: not applicable. |
+| 06:00 UTC | DutyWindow ends | RuntimeActivity completes; FocusLease released; reason=`duty_window_closed`; transition `duty → ambient`; event emitted. |
+
+Every step produces a queryable event with a reason code. Nothing is implicit.
+
+---
+
+## 17. Risks and Mitigations
 
 | Risk | Mitigation |
 |------|------------|
 | Mode taxonomy expands over time | Stay with three top-level modes; resist additions |
-| Direct interaction creeps in as a peer mode | Treat as cross-cutting; document explicitly |
-| Duty becomes a permanent identity lock | Use assignment + window + current mode separation |
-| Ambient becomes uncontrolled autonomy | Keep bounded, low-priority, interruptible; enforce in policy |
-| Hidden attention contention | Focus lease as the single source of truth for ownership |
+| Direct interaction creeps in as a peer mode | Treat as cross-cutting; document explicitly in umbrella |
+| Duty becomes a permanent identity lock | Use Assignment + DutyWindow + current mode separation |
+| Ambient becomes uncontrolled autonomy | Hard rule in §5.2 forbidding irreversible action without lease+activity |
+| Hidden attention contention | FocusLease is the single source of truth for ownership |
+| RuntimeActivity becomes a parallel execution model | §7 mapping table; reviewers must reject any PR that makes RuntimeActivity *do* work |
 | State persistence collides with cycle registry | Reuse Postgres + connection pool; share migrations sequence |
+| Activity name collision with Temporal Activity | Canonical name `RuntimeActivity` everywhere in code/schema |
 
 ---
 
-## 16. Open Questions
+## 18. Open Questions
 
 1. Is `hard | soft` duty strictness sufficient for v1.1, or is a richer policy model needed?
-2. Should cycle recruitment be blocked by a configurable pre-duty reserve buffer (e.g., no new cycle within 30 min of a duty window)?
-3. Does the agent factory need new constructor parameters for runtime state, or should it be injected via the existing `PortsBundle`?
-4. How should Postgres migrations be sequenced to avoid colliding with in-flight 1.0.x work on the Spark?
-5. Should `runtime_status` be inferred from the current activity, or stored independently?
+2. Should the agent factory accept new constructor parameters for runtime state, or should it be injected via the existing `PortsBundle`?
+3. How should Postgres migrations be sequenced to avoid colliding with in-flight 1.0.x work on the Spark?
+4. Should embodied actions in v1.2 require the primary FocusLease, or a separate EmbodimentLease? (Decision deferred to v1.2 SIP.)
+5. Should `current_runtime_activity_id` allow multiple concurrent activities, or strictly one? (Recommend strict-one for v1.1; multi-activity is a future expansion.)
 
 ---
 
-## 17. References
+## 19. References
 
-- Parent vision: `sips/proposed/SIP-Agent-Runtime-Modes.md`
+- Parent vision: `sips/proposed/SIP-Agent-Runtime-Modes.md` (canonical reason codes, event names, terminology)
 - Original full proposal: commit `76a1f90` on main
 - Related: SIP-0042 (LanceDB Semantic Memory), SIP-0061 (LangFuse Observability), SIP-0067 (Postgres Cycle Registry), SIP-0071 (Builder Role)
 - W3C SCXML — https://www.w3.org/TR/scxml/

--- a/sips/proposed/SIP-Agent-Runtime-State.md
+++ b/sips/proposed/SIP-Agent-Runtime-State.md
@@ -1,0 +1,392 @@
+# SIP: Agent Runtime State — Modes, Duty Windows, Focus, and Activity
+
+**Status:** Proposed (draft)
+**Authors:** Jason Ladd
+**Created:** 2026-04-25
+**Revision:** 1
+**Targets:** v1.1
+**Parent vision:** `sips/proposed/SIP-Agent-Runtime-Modes.md` (umbrella index)
+**Sibling SIPs:**
+- `SIP-Agent-Embodiment-Substrate.md` (v1.2 candidate, builds on this)
+- `SIP-Duty-Durability-Temporal.md` (v1.3 candidate, builds on this)
+
+---
+
+## 1. Summary
+
+This SIP introduces the **runtime-state foundation** for persistent SquadOps agents. It is the first of three SIPs that emerged from splitting the original umbrella proposal (`SIP-Agent-Runtime-Modes.md`).
+
+It proposes the minimum runtime primitives needed to make persistent agents observable, schedulable, and recallable, without introducing embodiment or durable workflow concerns.
+
+The four primitives:
+
+1. **Mode** — current operating posture, exactly one of `duty | cycle | ambient`
+2. **Assignment + Duty Window** — durable commitments and the time ranges in which they may claim the agent
+3. **Focus Lease** — explicit ownership claim over the agent's primary attention
+4. **Activity** — the concrete unit of work currently executing, with pause/resume/abort semantics
+
+This SIP **does not** propose embodiment, location, virtual worlds, or Temporal integration. Those are deferred to the sibling SIPs.
+
+---
+
+## 2. Problem Statement
+
+SquadOps is hardening around a cycle-oriented execution model. That works for bounded acceptance-oriented work. But the framework cannot currently express:
+
+- an agent that is online but not assigned to a cycle,
+- an agent that holds a scheduled operational responsibility (e.g. nightly research, support duty),
+- an agent that is "free" right now but reserved for a duty window starting in two hours,
+- the difference between *what* an agent is doing now and *what* may claim it next.
+
+Without explicit runtime state, these conditions live in prompt history or in the absence of an active cycle, which makes scheduling and recall unreasoned and unobservable.
+
+The challenge:
+
+> How can SquadOps introduce persistent, schedule-aware agent behavior without undermining the simplicity of the current cycle-oriented architecture?
+
+---
+
+## 3. Design Intent
+
+1. Preserve the cycle model as the canonical mechanism for bounded, acceptance-oriented work.
+2. Introduce persistent runtime behavior without forcing all activity into cycles.
+3. Support service-like operational responsibility through Duty mode with explicit windows.
+4. Make current state, future commitments, and immediate action separately observable.
+5. Allow interruption and recall through explicit policy rather than implicit prompt drift.
+6. Keep the model small enough to ship in v1.1.
+
+---
+
+## 4. Non-Goals
+
+This SIP does **not** propose:
+
+- Embodiment abstractions (Mineflayer, Discord, browser) — see `SIP-Agent-Embodiment-Substrate.md`
+- Location modeling — see `SIP-Agent-Embodiment-Substrate.md`
+- Temporal or any external workflow durability layer — see `SIP-Duty-Durability-Temporal.md`
+- Replacing the current cycle mechanism
+- A fully autonomous "agent life" loop
+- Direct human interaction as a peer mode (treated as cross-cutting; see §8)
+
+---
+
+## 5. Proposed Runtime Model
+
+### 5.1 Top-Level Modes
+
+An agent has exactly one **current mode** at a time:
+
+- `duty` — on-duty, service-responsible, availability-constrained
+- `cycle` — bounded, formal, assigned work with explicit completion semantics
+- `ambient` — off-duty, low-priority, interruptible background presence
+
+These modes are **mutually exclusive**. They imply different rules for interruptibility, accountability, scheduling, recall policy, and what commitments the agent is allowed to accept. They are operational postures, not task labels.
+
+### 5.2 Mode definitions
+
+**Duty.** The agent is responsible for a role or function requiring availability and policy-governed behavior. Examples: customer support, inventory watch, nightly research, monitoring/moderation.
+
+**Cycle.** The agent is committed to bounded assigned work with acceptance criteria. Examples: building a web app, executing an experiment, producing an artifact, performing a validation pass. This remains the most structured form of execution in SquadOps.
+
+**Ambient.** The agent is online, present, lightly available, and off-duty. Bounded, interruptible, low-resource. Not a loophole for uncontrolled autonomous drift — a low-priority interruptible background state.
+
+---
+
+## 6. Orthogonal Concepts: Mode vs Assignment vs Schedule vs Focus vs Activity
+
+The most important architectural distinction: **mode is not the same as assignment or schedule.**
+
+| Concept | Answers | Example |
+|---------|---------|---------|
+| **Mode** | What is the agent doing right now? | `ambient` |
+| **Assignment** | What role or commitment is associated with the agent? | `nightly_research`, `support_duty` |
+| **Schedule / Duty Window** | When is that assignment active or claimable? | `01:00–06:00 UTC` |
+| **Focus** | What currently owns the agent's primary attention within its current mode? | `handling support case #184` |
+| **Activity** | What concrete action is happening right now? | `summarize_findings`, `classify_ticket` |
+
+This separation enables a coherent state like:
+
+- current mode = `ambient`
+- duty assignment = `nightly_research`
+- duty window starts at `01:00`
+- cycle eligible = `true until reserve threshold`
+
+The agent can be ambient now, recruited into a short cycle if safe, and transition into Duty automatically when the window opens. That is operationally coherent and significantly safer than treating "free" and "committed" as vague prompt-level concepts.
+
+---
+
+## 7. Core Runtime Primitives
+
+### 7.1 Agent Runtime State
+
+A persistent agent should expose runtime state such as:
+
+- `agent_id`
+- `mode` — `duty | cycle | ambient`
+- `runtime_status` — `online | idle | busy | paused | degraded | recovering | offline`
+- `focus` — string label for primary concern within current mode
+- `activity_id` — reference to current Activity, or null
+- `interruptibility` — `none | low | medium | high`
+- `last_heartbeat_at`
+- `current_assignment_ref` — null in pure ambient
+
+### 7.2 Assignment
+
+A durable relationship between an agent and a future or potential responsibility.
+
+Suggested fields:
+
+- `assignment_id`
+- `assignment_type` — `duty | reserve | cycle_eligibility`
+- `assigned_role`
+- `priority`
+- `strictness` — `hard | soft`
+- `active_window` — start, end, timezone
+- `recall_policy` — `immediate | graceful | none`
+- `allowed_off_window_modes`
+
+An agent can hold an assignment without currently being in the corresponding mode.
+
+### 7.3 Duty Window
+
+Duty windows are explicit. Duty is not a permanent identity lock.
+
+Suggested fields:
+
+- `window_start`, `window_end`, `timezone`
+- `strictness: hard | soft`
+- `grace_before_start`, `grace_after_end`
+
+**Hard duty window:** during the window, the agent is reserved for duty only.
+
+**Soft duty window:** during the window, duty has priority, but short preemptible work may be allowed if the duty can reclaim focus.
+
+### 7.4 Focus Lease
+
+A focus lease is the runtime claim over an agent's primary attention. Conceptually analogous to the Kubernetes Lease pattern, but not literally implemented as one.
+
+Suggested fields:
+
+- `lease_id`
+- `owner_type` — `duty | cycle | ambient`
+- `owner_ref`
+- `acquired_at`
+- `expires_at` or `renewal_policy`
+- `interruptibility`
+- `recall_policy`
+
+The lease is what prevents two owners from ambiguously claiming the same agent.
+
+### 7.5 Activity
+
+The concrete unit of work currently being performed.
+
+Suggested fields:
+
+- `activity_id`
+- `activity_type`
+- `mode` — which top-level mode this activity belongs to
+- `goal`
+- `priority`
+- `can_pause`, `can_resume`, `can_abort`
+- `completion_conditions`
+- `evidence_requirements`
+
+Activities make current work observable without digging into prompt history.
+
+---
+
+## 8. Direct Interaction Is Cross-Cutting
+
+Direct human interaction is **not** a peer mode. It is a cross-cutting interaction path that may occur against an agent already in one of the three top-level modes.
+
+- In **Ambient**, direct interaction usually interrupts easily.
+- In **Duty**, direct interaction may be limited, deferred, or handled minimally.
+- In **Cycle**, direct interaction may return status or require priority escalation.
+
+This keeps the mode model small while preserving the reality that humans may speak to agents in any mode.
+
+---
+
+## 9. Cycle Preservation
+
+This SIP preserves Cycle as the canonical bounded-work mechanism. Cycle execution semantics, planning workloads, acceptance criteria, gates, and artifacts are unchanged.
+
+What changes: an agent may decline cycle recruitment if a hard duty window is approaching, or if a focus lease cannot be granted under current policy. That decision becomes **explainable** rather than implicit.
+
+---
+
+## 10. Data Model Sketch
+
+```yaml
+AgentRuntimeState:
+  agent_id: string
+  mode: duty | cycle | ambient
+  runtime_status: online | idle | busy | paused | degraded | recovering | offline
+  focus: string
+  activity_id: string | null
+  interruptibility: none | low | medium | high
+  last_heartbeat_at: timestamp
+  current_assignment_ref: string | null
+
+Assignment:
+  assignment_id: string
+  assignment_type: duty | reserve | cycle_eligibility
+  assigned_role: string
+  priority: integer
+  strictness: hard | soft
+  active_window:
+    start: timestamp
+    end: timestamp
+    timezone: string
+  recall_policy: immediate | graceful | none
+  allowed_off_window_modes:
+    - ambient
+    - cycle
+
+FocusLease:
+  lease_id: string
+  owner_type: duty | cycle | ambient
+  owner_ref: string
+  acquired_at: timestamp
+  renewal_policy: heartbeat | ttl | fixed_window
+  interruptibility: none | low | medium | high
+  recall_policy: immediate | graceful | none
+
+Activity:
+  activity_id: string
+  mode: duty | cycle | ambient
+  activity_type: string
+  goal: string
+  priority: integer
+  can_pause: boolean
+  can_resume: boolean
+  can_abort: boolean
+  completion_conditions: []
+  evidence_requirements: []
+```
+
+Not final schema. Sufficient to prove the architecture.
+
+---
+
+## 11. Transition Semantics
+
+Minimal transitions:
+
+- `ambient -> cycle`
+- `ambient -> duty`
+- `cycle -> ambient`
+- `cycle -> duty` (only if policy permits preemption)
+- `duty -> ambient`
+- `duty -> cycle` (generally only after duty window ends or if policy explicitly allows)
+
+Rules:
+
+- Mode transitions are evented and auditable
+- Transitions carry reason codes
+- Higher-priority transitions do not silently discard current activity state — interruptions explicitly pause, abort, or checkpoint the current activity
+- A focus lease must be released or revoked before a new owner can acquire one
+
+---
+
+## 12. Persistence
+
+Runtime state, assignments, and focus leases need a durable home. Recommended placement (to be confirmed during design review):
+
+- **AgentRuntimeState, FocusLease** — Postgres (cycle registry already lives there; same connection pool)
+- **Assignment** — Postgres
+- **Activity** — Postgres for the durable record; in-memory for the live working set
+
+Heartbeat already flows through `AgentHeartbeatReporter`; extending it to carry mode/focus is the cheapest path.
+
+LanceDB (SIP-042) is **not** the right home — semantic memory is for retrieval, not transactional state.
+
+---
+
+## 13. Implementation Phases
+
+### Phase 0 — Vocabulary freeze
+
+- SIP approval
+- Lock terminology for `mode`, `assignment`, `window`, `focus`, `activity`
+- No code changes
+
+### Phase 1 — Minimal runtime state
+
+- Add `mode`, `runtime_status`, `focus`, `activity_id`, heartbeat fields to agent runtime
+- Extend `AgentHeartbeatReporter` to carry the new fields
+- Postgres migration for `agent_runtime_state` table
+
+**Acceptance:** an operator can query an agent's current mode and current activity.
+
+### Phase 2 — Assignments and duty windows
+
+- Implement Assignment model and Postgres table
+- Implement Duty Window with hard/soft strictness
+- Add a transition scheduler (initially in-process, no Temporal)
+
+**Acceptance:** an agent can be Ambient now and scheduled to enter Duty later. An upcoming hard duty window restricts cycle recruitment per policy.
+
+### Phase 3 — Focus lease
+
+- Implement FocusLease model with acquire/release/renew semantics
+- Reasoned rejection when a conflicting owner attempts to claim focus
+
+**Acceptance:** the framework can explain why an agent did or did not accept a cycle request.
+
+### Phase 4 — Activity model
+
+- Implement Activity object with pause/resume/abort
+- Evidence requirement hooks
+- Wire current cycle handlers to emit Activity records
+
+**Acceptance:** current work is observable as an Activity, not hidden in prompt history.
+
+---
+
+## 14. Acceptance Criteria
+
+The SIP is successful when:
+
+1. **Runtime clarity** — the framework can always answer: what mode? what assignments? what activity? what may claim the agent next?
+2. **Exclusivity** — an agent cannot be simultaneously in Duty, Cycle, and Ambient. Current mode is singular and explicit.
+3. **Scheduling sanity** — cycle recruitment respects future duty windows and reservation policy.
+4. **Recallability** — Ambient behavior can be recalled. Duty transitions can preempt Ambient. Policy governs whether Cycle can preempt Duty.
+5. **Cycle preservation** — existing cycle architecture remains intact. No regressions in `run_regression_tests.sh`.
+6. **Duty realism** — Duty supports explicit windows, hard and soft strictness, and service-like operational work without pretending it is a cycle.
+7. **Incremental rollout** — Phases 1–4 ship and are useful even before embodiment or Temporal integration land.
+
+---
+
+## 15. Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Mode taxonomy expands over time | Stay with three top-level modes; resist additions |
+| Direct interaction creeps in as a peer mode | Treat as cross-cutting; document explicitly |
+| Duty becomes a permanent identity lock | Use assignment + window + current mode separation |
+| Ambient becomes uncontrolled autonomy | Keep bounded, low-priority, interruptible; enforce in policy |
+| Hidden attention contention | Focus lease as the single source of truth for ownership |
+| State persistence collides with cycle registry | Reuse Postgres + connection pool; share migrations sequence |
+
+---
+
+## 16. Open Questions
+
+1. Is `hard | soft` duty strictness sufficient for v1.1, or is a richer policy model needed?
+2. Should cycle recruitment be blocked by a configurable pre-duty reserve buffer (e.g., no new cycle within 30 min of a duty window)?
+3. Does the agent factory need new constructor parameters for runtime state, or should it be injected via the existing `PortsBundle`?
+4. How should Postgres migrations be sequenced to avoid colliding with in-flight 1.0.x work on the Spark?
+5. Should `runtime_status` be inferred from the current activity, or stored independently?
+
+---
+
+## 17. References
+
+- Parent vision: `sips/proposed/SIP-Agent-Runtime-Modes.md`
+- Original full proposal: commit `76a1f90` on main
+- Related: SIP-0042 (LanceDB Semantic Memory), SIP-0061 (LangFuse Observability), SIP-0067 (Postgres Cycle Registry), SIP-0071 (Builder Role)
+- W3C SCXML — https://www.w3.org/TR/scxml/
+- Kubernetes Leases — https://kubernetes.io/docs/concepts/architecture/leases/
+- BPMN 2.0.2 — https://www.omg.org/spec/BPMN/2.0.2/PDF

--- a/sips/proposed/SIP-Duty-Durability-Temporal.md
+++ b/sips/proposed/SIP-Duty-Durability-Temporal.md
@@ -1,0 +1,279 @@
+# SIP: Duty Durability via Temporal
+
+**Status:** Proposed (draft)
+**Authors:** Jason Ladd
+**Created:** 2026-04-25
+**Revision:** 1
+**Targets:** v1.3
+**Depends on:** `SIP-Agent-Runtime-State.md` (v1.1) — must land first
+**Parent vision:** `sips/proposed/SIP-Agent-Runtime-Modes.md` (umbrella index)
+**Sibling:** `SIP-Agent-Embodiment-Substrate.md` (v1.2)
+
+---
+
+## 1. Summary
+
+This SIP introduces **Temporal as a narrowly-scoped durability layer for Duty mode** — and only Duty mode.
+
+Temporal handles what it is best at: durable timers, schedule-driven wake-ups, signal-driven interruption, and long-lived flows that survive worker failure. SquadOps continues to own everything else — agent identity, mode semantics, focus lease policy, activity model, embodiment.
+
+The boundary is deliberate and enforceable:
+
+> **SquadOps owns agent semantics. Temporal owns duty workflow durability.**
+
+This SIP is intentionally the smallest of the three split SIPs. It adds one optional dependency, one workflow pattern, and one proof point. It does not become the agent runtime brain.
+
+---
+
+## 2. Problem Statement
+
+Once duty windows exist (per `SIP-Agent-Runtime-State.md`), the next question is durability:
+
+- A duty agent must wake up at `01:00` even if the worker was offline at midnight
+- A duty workflow may wait minutes, hours, or days for an event
+- A recall signal must reliably preempt an in-flight duty
+- A duty must survive process restarts without losing its position
+
+The v1.1 SIP proposes an in-process scheduler for duty windows. That works for development and basic ops, but it has well-known limits:
+
+- Worker crashes lose pending transitions
+- Long waits hold connections and memory
+- Signal delivery becomes unreliable
+- Retry semantics get reinvented per-duty
+
+The challenge:
+
+> How can SquadOps make Duty workflows durable without letting Temporal consume the rest of the runtime?
+
+---
+
+## 3. Why Temporal — and Why Only for Duty
+
+### 3.1 Where Temporal fits
+
+Temporal workflows are durable, support long waits, schedules, retries, and signal-driven interaction. Workflow Execution can run for extended periods, receive signals/queries/updates, and resume after failures. This maps cleanly to:
+
+- Duty windows (durable timers)
+- Event-driven duty wake-ups (signals)
+- Recall and preemption (signals + cancellation)
+- Periodic operational duty ticks (Schedules)
+- Resumable long-lived duty flows (history replay)
+
+References:
+- https://docs.temporal.io/workflows
+- https://docs.temporal.io/workflow-execution
+- https://docs.temporal.io/encyclopedia/workflow-message-passing
+
+### 3.2 Where Temporal does NOT fit
+
+Temporal records event history and expects deterministic workflow behavior. Practical limits per workflow execution make it a poor fit for:
+
+- Every Minecraft movement or embodiment event
+- Continuous embodiment telemetry
+- An "agent life workflow" running forever
+- Free-form cognition loops or per-token decisions
+
+If we let Temporal own the entire agent runtime, history bloat, determinism constraints, and workflow size limits will dominate the architecture.
+
+### 3.3 The boundary
+
+| Concern | Owner |
+|---------|-------|
+| Agent identity | SquadOps |
+| Current mode (duty/cycle/ambient) | SquadOps |
+| Focus lease policy | SquadOps |
+| Activity model | SquadOps |
+| Embodiment lifecycle | SquadOps + adapters |
+| **Duty workflow durability** | **Temporal** |
+| **Duty timer / schedule wake-ups** | **Temporal** |
+| **Recall signal delivery** | **Temporal** |
+| **Long-running operational flows** | **Temporal** |
+| Cycle execution | Prefect (unchanged) |
+| Inter-agent comms | RabbitMQ (unchanged) |
+
+Temporal does not replace Prefect. Prefect orchestrates bounded cycle execution. Temporal orchestrates open-ended duty durability. They coexist.
+
+---
+
+## 4. Design Intent
+
+1. Make duty windows durable across worker restarts.
+2. Make recall signals reliable.
+3. Keep Temporal scoped to Duty workflows — not Ambient, not Cycle, not Activities, not Embodiment.
+4. Keep SquadOps the semantic owner — Temporal is a backend, not a peer runtime.
+5. Make Temporal opt-in. Without it, the v1.1 in-process scheduler still works.
+6. Provide a clean port/adapter so Temporal can be swapped (or removed) without rewriting duty semantics.
+
+---
+
+## 5. Non-Goals
+
+This SIP does **not** propose:
+
+- Migrating cycle execution to Temporal
+- Migrating agent comms to Temporal
+- Embodiment events flowing through Temporal
+- An "agent life" workflow that owns the agent for its lifetime
+- Removing Prefect or RabbitMQ
+- Making Temporal mandatory — it is an optional adapter
+
+---
+
+## 6. Proposed Architecture
+
+### 6.1 Port
+
+```python
+# src/squadops/ports/duty_durability.py
+
+class DutyDurabilityPort(ABC):
+    async def schedule_duty_window(self, assignment_id, window_start, window_end) -> str: ...
+    async def signal_recall(self, duty_run_id, reason) -> None: ...
+    async def cancel_duty(self, duty_run_id) -> None: ...
+    async def query_status(self, duty_run_id) -> DutyStatus: ...
+```
+
+### 6.2 Adapters
+
+- `adapters/duty_durability/in_process/` — the v1.1 default; suitable for dev and small deployments
+- `adapters/duty_durability/temporal/` — the new adapter; production-grade durability
+
+Selection by config, same pattern as the cycle registry adapter (memory vs postgres).
+
+### 6.3 What lives in a Temporal workflow
+
+A duty workflow is **thin**. It does not contain agent logic. It only:
+
+1. Waits for the duty window to open (durable timer)
+2. Signals SquadOps to transition the agent into Duty mode
+3. Waits for either window end, recall signal, or duty completion
+4. Signals SquadOps to release the agent back to its prior mode
+
+```
+DutyWorkflow:
+  await timer(window_start - now)
+  signal squadops: enter_duty(assignment_id)
+  await any of:
+    - timer(window_end - now)
+    - signal recall(reason)
+    - signal duty_complete()
+  signal squadops: release_duty(assignment_id, reason)
+```
+
+The actual duty work — answering support tickets, watching inventory, doing research — runs in SquadOps as Activities. Temporal just owns the *duration and interruption* of the duty.
+
+### 6.4 What does NOT live in Temporal
+
+- Activity execution (stays in SquadOps)
+- Embodiment lifecycle (stays in SquadOps + adapters)
+- Focus lease management (stays in SquadOps)
+- Heartbeats and runtime status (stays in SquadOps)
+
+---
+
+## 7. Proof Point
+
+One narrow proof point demonstrates the boundary:
+
+**Duty:** `nightly_research`
+
+- Window: `01:00–06:00 UTC` daily
+- Wake-up: durable timer
+- Activity during window: research synthesis using existing handler infrastructure
+- Recall: signal-driven (e.g., a higher-priority cycle needs the agent)
+- Completion: agent finishes early via `duty_complete` signal
+
+**Acceptance for the proof point:**
+
+- Stop the Temporal worker mid-window. Restart. Duty resumes correctly.
+- Send recall signal. Agent transitions out of Duty cleanly within graceful_window seconds.
+- Cancel the workflow. Agent releases focus lease and returns to Ambient.
+- Run two consecutive nights. Both windows fire on schedule.
+
+---
+
+## 8. Implementation Phases
+
+### Phase 1 — Port and in-process adapter
+
+- Define `DutyDurabilityPort`
+- Refactor v1.1 in-process scheduler behind the port
+- Adapter selection via config
+
+**Acceptance:** v1.1 behavior unchanged; Temporal not yet introduced.
+
+### Phase 2 — Temporal adapter (basic)
+
+- Add Temporal as optional dependency
+- Implement Temporal adapter with durable timer + signal handling
+- Workflow design as described in §6.3
+- Local Temporal dev stack via docker-compose (optional service)
+
+**Acceptance:** the `nightly_research` proof point passes the four acceptance tests in §7.
+
+### Phase 3 — Schedules and recurrence
+
+- Use Temporal Schedules for recurring duty windows
+- Replace per-duty workflow spawning with schedule-triggered runs
+
+**Acceptance:** duties can be defined as recurring without per-day workflow management.
+
+### Phase 4 — Production hardening
+
+- Retry policies for transient failures
+- Graceful degradation if Temporal worker is down (fall back to in-process scheduler with degraded warning)
+- Observability: link Temporal workflow IDs to SquadOps duty assignments in LangFuse traces
+
+**Acceptance:** Temporal becomes the recommended duty-durability adapter for production.
+
+---
+
+## 9. Acceptance Criteria
+
+The SIP is successful when:
+
+1. **Boundary holds** — Temporal does not own agent identity, mode, focus, activity, or embodiment
+2. **Optional dependency** — SquadOps runs without Temporal; Temporal is opt-in via adapter selection
+3. **Durability proven** — duty workflows survive worker restarts mid-window
+4. **Signals reliable** — recall signals deliver within configured graceful_window
+5. **Schedules work** — recurring duties run reliably across multiple windows
+6. **Coexistence** — Prefect (cycle execution) and Temporal (duty durability) operate in the same deployment without contention
+7. **Graceful degradation** — if Temporal is unavailable, the in-process adapter still serves duty windows with a clear warning
+8. **No regressions** — v1.1 and v1.2 behavior unaffected when Temporal adapter is selected
+
+---
+
+## 10. Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Temporal scope creeps to own non-duty logic | Port interface is narrow; review every PR that adds Temporal-aware code outside the duty adapter |
+| Workflow history bloats | Keep workflows thin (timer + signals only); offload work to SquadOps Activities |
+| Determinism violations break replay | Workflow code touches only durable primitives; no LLM calls or agent logic inside the workflow |
+| Operators add Temporal as a hard requirement | Keep in-process adapter as a first-class option; document selection clearly |
+| Duplication with Prefect | Document boundary: Prefect = bounded cycle execution; Temporal = open-ended duty durability |
+| Signal loss between Temporal and SquadOps | Idempotent transition handlers on the SquadOps side |
+
+---
+
+## 11. Open Questions
+
+1. Should the Temporal adapter run in the same Python process as SquadOps, or as a separate worker container?
+2. How are recall signals authenticated? (Temporal namespace per environment, or a shared signal token?)
+3. What is the migration path for an existing in-process duty if the operator switches to the Temporal adapter mid-cycle?
+4. Should LangFuse traces include Temporal workflow IDs as a span attribute, or stay separate?
+5. Do we need a CLI command (`squadops duty status <assignment-id>`) that proxies to the durability adapter, or is querying the Temporal UI directly acceptable?
+6. How does graceful_window interact with hard duty strictness — does a hard duty refuse recall signals during the window?
+
+---
+
+## 12. References
+
+- Depends on: `sips/proposed/SIP-Agent-Runtime-State.md` (v1.1)
+- Parent vision: `sips/proposed/SIP-Agent-Runtime-Modes.md`
+- Original full proposal: commit `76a1f90` on main
+- Temporal Workflows — https://docs.temporal.io/workflows
+- Workflow Execution — https://docs.temporal.io/workflow-execution
+- Signals/Queries/Updates — https://docs.temporal.io/encyclopedia/workflow-message-passing
+- Schedules — https://docs.temporal.io/schedules
+- Related: SIP-0066 (Distributed Cycle Execution Pipeline — Prefect coexistence), SIP-0061 (LangFuse — observability seam)

--- a/sips/proposed/SIP-Duty-Durability-Temporal.md
+++ b/sips/proposed/SIP-Duty-Durability-Temporal.md
@@ -3,7 +3,7 @@
 **Status:** Proposed (draft)
 **Authors:** Jason Ladd
 **Created:** 2026-04-25
-**Revision:** 1
+**Revision:** 2 (incorporated review feedback on 2026-04-25)
 **Targets:** v1.3
 **Depends on:** `SIP-Agent-Runtime-State.md` (v1.1) — must land first
 **Parent vision:** `sips/proposed/SIP-Agent-Runtime-Modes.md` (umbrella index)
@@ -15,11 +15,11 @@
 
 This SIP introduces **Temporal as a narrowly-scoped durability layer for Duty mode** — and only Duty mode.
 
-Temporal handles what it is best at: durable timers, schedule-driven wake-ups, signal-driven interruption, and long-lived flows that survive worker failure. SquadOps continues to own everything else — agent identity, mode semantics, focus lease policy, activity model, embodiment.
+Temporal handles what it is best at: durable timers, schedule-driven wake-ups, signal-driven interruption, and long-lived flows that survive worker failure. SquadOps continues to own everything else — agent identity, mode semantics, focus lease policy, RuntimeActivity model, embodiment.
 
 The boundary is deliberate and enforceable:
 
-> **SquadOps owns agent semantics. Temporal owns duty workflow durability.**
+> **SquadOps owns agent semantics. Temporal owns duty workflow durability. Temporal does not transition agent state directly — it requests transitions through SquadOps.**
 
 This SIP is intentionally the smallest of the three split SIPs. It adds one optional dependency, one workflow pattern, and one proof point. It does not become the agent runtime brain.
 
@@ -34,7 +34,7 @@ Once duty windows exist (per `SIP-Agent-Runtime-State.md`), the next question is
 - A recall signal must reliably preempt an in-flight duty
 - A duty must survive process restarts without losing its position
 
-The v1.1 SIP proposes an in-process scheduler for duty windows. That works for development and basic ops, but it has well-known limits:
+The v1.1 SIP proposes an in-process scheduler. That works for development and basic ops, but has well-known limits:
 
 - Worker crashes lose pending transitions
 - Long waits hold connections and memory
@@ -51,11 +51,11 @@ The challenge:
 
 ### 3.1 Where Temporal fits
 
-Temporal workflows are durable, support long waits, schedules, retries, and signal-driven interaction. Workflow Execution can run for extended periods, receive signals/queries/updates, and resume after failures. This maps cleanly to:
+Temporal workflows are durable, support long waits, schedules, retries, and signal-driven interaction. This maps cleanly to:
 
-- Duty windows (durable timers)
+- DutyWindow timing (durable timers)
 - Event-driven duty wake-ups (signals)
-- Recall and preemption (signals + cancellation)
+- Recall and preemption requests (signals + cancellation)
 - Periodic operational duty ticks (Schedules)
 - Resumable long-lived duty flows (history replay)
 
@@ -63,6 +63,7 @@ References:
 - https://docs.temporal.io/workflows
 - https://docs.temporal.io/workflow-execution
 - https://docs.temporal.io/encyclopedia/workflow-message-passing
+- https://docs.temporal.io/schedules
 
 ### 3.2 Where Temporal does NOT fit
 
@@ -80,14 +81,14 @@ If we let Temporal own the entire agent runtime, history bloat, determinism cons
 | Concern | Owner |
 |---------|-------|
 | Agent identity | SquadOps |
-| Current mode (duty/cycle/ambient) | SquadOps |
-| Focus lease policy | SquadOps |
-| Activity model | SquadOps |
+| Current RuntimeMode | SquadOps |
+| FocusLease arbitration | SquadOps |
+| RuntimeActivity model | SquadOps |
 | Embodiment lifecycle | SquadOps + adapters |
 | **Duty workflow durability** | **Temporal** |
-| **Duty timer / schedule wake-ups** | **Temporal** |
+| **DutyWindow timer wake-ups** | **Temporal** |
 | **Recall signal delivery** | **Temporal** |
-| **Long-running operational flows** | **Temporal** |
+| **Long-running operational flows (timer + signal scaffolding)** | **Temporal** |
 | Cycle execution | Prefect (unchanged) |
 | Inter-agent comms | RabbitMQ (unchanged) |
 
@@ -97,12 +98,13 @@ Temporal does not replace Prefect. Prefect orchestrates bounded cycle execution.
 
 ## 4. Design Intent
 
-1. Make duty windows durable across worker restarts.
+1. Make DutyWindows durable across worker restarts.
 2. Make recall signals reliable.
-3. Keep Temporal scoped to Duty workflows — not Ambient, not Cycle, not Activities, not Embodiment.
+3. Keep Temporal scoped to Duty workflows — not Ambient, not Cycle, not RuntimeActivities, not Embodiment.
 4. Keep SquadOps the semantic owner — Temporal is a backend, not a peer runtime.
-5. Make Temporal opt-in. Without it, the v1.1 in-process scheduler still works.
-6. Provide a clean port/adapter so Temporal can be swapped (or removed) without rewriting duty semantics.
+5. **Temporal requests transitions; SquadOps performs them.** Temporal never mutates agent state directly.
+6. Make Temporal opt-in. Without it, the v1.1 in-process scheduler still works.
+7. Provide a clean port/adapter so Temporal can be swapped (or removed) without rewriting duty semantics.
 
 ---
 
@@ -116,6 +118,7 @@ This SIP does **not** propose:
 - An "agent life" workflow that owns the agent for its lifetime
 - Removing Prefect or RabbitMQ
 - Making Temporal mandatory — it is an optional adapter
+- Letting Temporal be the source of truth for Assignment records
 
 ---
 
@@ -127,11 +130,32 @@ This SIP does **not** propose:
 # src/squadops/ports/duty_durability.py
 
 class DutyDurabilityPort(ABC):
-    async def schedule_duty_window(self, assignment_id, window_start, window_end) -> str: ...
-    async def signal_recall(self, duty_run_id, reason) -> None: ...
-    async def cancel_duty(self, duty_run_id) -> None: ...
-    async def query_status(self, duty_run_id) -> DutyStatus: ...
+    async def register_duty_window(
+        self,
+        assignment_id: str,
+        window_start: datetime,
+        window_end: datetime,
+        idempotency_key: str,
+    ) -> DutyDurabilityRunRef: ...
+
+    async def request_recall(
+        self,
+        duty_run_id: str,
+        reason_code: str,
+        idempotency_key: str,
+    ) -> None: ...
+
+    async def cancel_duty_window(
+        self,
+        duty_run_id: str,
+        reason_code: str,
+        idempotency_key: str,
+    ) -> None: ...
+
+    async def get_duty_run_status(self, duty_run_id: str) -> DutyDurabilityRun: ...
 ```
+
+Method names are deliberately semantic, not Temporal-shaped. `request_recall` may be implemented as a Temporal signal in the Temporal adapter, but the port name does not assume that.
 
 ### 6.2 Adapters
 
@@ -140,137 +164,272 @@ class DutyDurabilityPort(ABC):
 
 Selection by config, same pattern as the cycle registry adapter (memory vs postgres).
 
-### 6.3 What lives in a Temporal workflow
+### 6.3 DutyDurabilityRun correlation record
+
+A SquadOps-side record links the SquadOps Assignment to whatever the durability backend uses. It is the queryable handle for CLI/UI without coupling directly to Temporal.
+
+```yaml
+DutyDurabilityRun:
+  duty_run_id: string                       # SquadOps-issued
+  assignment_id: string                     # FK to Assignment
+  adapter_kind: in_process | temporal
+  external_workflow_id: string | null       # Temporal workflow ID, if applicable
+  external_run_id: string | null            # Temporal run ID, if applicable
+  window_start: timestamp
+  window_end: timestamp
+  durability_status: scheduled | active | recalled | completed | failed | cancelled
+  last_event_at: timestamp
+  last_reason_code: string
+```
+
+The **Assignment** remains the source of truth for what a duty *is*. The DutyDurabilityRun records how a *specific window* of that assignment is being made durable.
+
+### 6.4 What lives in a Temporal workflow
 
 A duty workflow is **thin**. It does not contain agent logic. It only:
 
 1. Waits for the duty window to open (durable timer)
-2. Signals SquadOps to transition the agent into Duty mode
+2. **Requests** SquadOps to enter Duty mode (durable activity that calls SquadOps API)
 3. Waits for either window end, recall signal, or duty completion
-4. Signals SquadOps to release the agent back to its prior mode
+4. **Requests** SquadOps to release Duty mode
 
 ```
 DutyWorkflow:
   await timer(window_start - now)
-  signal squadops: enter_duty(assignment_id)
+  request_to_squadops: enter_duty(assignment_id, idempotency_key)   # SquadOps decides if/how
   await any of:
     - timer(window_end - now)
-    - signal recall(reason)
+    - signal recall(reason_code)
     - signal duty_complete()
-  signal squadops: release_duty(assignment_id, reason)
+  request_to_squadops: release_duty(assignment_id, reason_code, idempotency_key)
 ```
 
-The actual duty work — answering support tickets, watching inventory, doing research — runs in SquadOps as Activities. Temporal just owns the *duration and interruption* of the duty.
+The actual duty work — answering support tickets, watching inventory, doing research — runs in SquadOps as RuntimeActivities. Temporal owns only the *duration and interruption* of the duty.
 
-### 6.4 What does NOT live in Temporal
+### 6.5 What does NOT live in Temporal
 
-- Activity execution (stays in SquadOps)
+- RuntimeActivity execution (stays in SquadOps)
 - Embodiment lifecycle (stays in SquadOps + adapters)
-- Focus lease management (stays in SquadOps)
+- FocusLease management (stays in SquadOps)
 - Heartbeats and runtime status (stays in SquadOps)
+- Assignment records (stays in SquadOps Postgres)
+- LLM calls or any agent cognition (must never enter the workflow — would break determinism)
 
 ---
 
-## 7. Proof Point
+## 7. Idempotency Requirements (mandatory)
+
+Temporal replay and external transition calls require idempotency. Every Temporal-originated request into SquadOps must be safe to replay.
+
+### 7.1 Idempotency keys
+
+Every request from a Temporal workflow into SquadOps must carry an idempotency key constructed from:
+
+- Workflow ID
+- Run ID
+- Assignment ID
+- Transition type (`enter_duty`, `release_duty`, `recall`, `cancel`)
+- Scheduled window start (timestamp)
+
+Format: `{workflow_id}:{run_id}:{assignment_id}:{transition_type}:{window_start_iso}`
+
+### 7.2 Server-side handler requirements
+
+SquadOps transition handlers receiving these requests must be **idempotent**:
+
+- Replayed or duplicated requests must not double-acquire FocusLeases
+- Replayed or duplicated requests must not double-release FocusLeases
+- Replayed or duplicated requests must not create duplicate RuntimeActivities
+- Replayed requests must return the original response (recorded result), not re-execute the side effect
+
+Implementation: an `idempotency_log` table indexed by key, recording the first-seen result.
+
+This is **not optional**. Without it, a Temporal worker restart can double-execute duty transitions.
+
+---
+
+## 8. Failure Behaviors
+
+### 8.1 SquadOps unavailable
+
+If a Temporal workflow wakes at `window_start` but SquadOps API is unreachable:
+
+- Temporal retries the transition request using a configured retry policy (exponential backoff, max attempts)
+- The DutyDurabilityRun status becomes `transition_pending` with a `last_reason_code` indicating the failure mode
+- The agent is **not** considered in Duty mode until SquadOps records the transition successfully
+- If retries exhaust, missed-window policy (§8.2) applies
+
+### 8.2 Missed-window policy
+
+When a duty window is missed (worker downtime, repeated failure, late wake), the Assignment's `missed_window_policy` governs behavior:
+
+| Policy | Behavior |
+|--------|----------|
+| `skip` | Mark window as missed; wait for next scheduled window. Emit `duty_window_missed` event. |
+| `start_late_within_grace` | Start the duty if `now ≤ window_end - graceful_window`. Otherwise skip. |
+| `require_operator_review` | Mark window as `awaiting_review`. Block until `operator_override` is supplied. |
+
+Default if unspecified: `start_late_within_grace`.
+
+### 8.3 Production fallback rule (critical safety)
+
+Silent fallback from Temporal → in-process scheduling is **forbidden in production** for any Assignment registered with the Temporal adapter. This prevents the foot-gun of double duty execution if the in-process scheduler also fires the same window.
+
+| Mode | Fallback behavior |
+|------|------------------|
+| `dev` | Automatic fallback allowed; emit warning |
+| `prod` | Fallback requires explicit `operator_override` setting per Assignment; otherwise the system surfaces the unavailability and refuses to schedule |
+
+The mode is read from the SquadOps configuration (`SQUADOPS__DEPLOYMENT__MODE` or equivalent).
+
+---
+
+## 9. What Temporal Worker Restart Actually Resumes
+
+A precise statement to avoid overstating Temporal's guarantees:
+
+> Restarting the Temporal worker resumes the **workflow's timer and signal state**, including pending timers, recorded signals, and the workflow's position in its execution. It does **not** automatically resume any in-flight duty *work* unless the SquadOps RuntimeActivity model also supports checkpointing for that work.
+
+In other words: Temporal makes the *scheduling* survive. Whether the *work* survives depends on the RuntimeActivity having `can_resume` semantics and durable checkpoints, which is a SquadOps responsibility.
+
+---
+
+## 10. Authentication and Authorization Posture
+
+Temporal signals and workflow requests must be authenticated. This is not an open question for production.
+
+- Recall signals must originate from authenticated SquadOps services, not arbitrary callers reaching Temporal directly.
+- External user intent (e.g., an operator triggering a recall) enters through the SquadOps API or CLI. SquadOps authorizes the action and then calls `DutyDurabilityPort.request_recall()`.
+- Temporal namespaces and task queues must be **environment-scoped** (e.g., `squadops-prod-duty`, `squadops-staging-duty`). Cross-namespace signal injection is prohibited.
+- Temporal workflows calling SquadOps must use a service account with limited scope (only the duty-transition endpoints).
+
+---
+
+## 11. Temporal Schedules vs Assignment
+
+Temporal Schedules are a **durability mechanism for recurring wake-ups**. They are not the canonical record of what duties exist.
+
+- The **SquadOps Assignment** remains the source of truth for what a duty *is*: role, window, strictness, recall policy, missed-window policy.
+- A **Temporal Schedule** creates or triggers workflow runs for individual DutyWindows of that Assignment.
+- If an Assignment is deleted in SquadOps, the corresponding Temporal Schedule must be cancelled.
+- If a Temporal Schedule is removed manually, SquadOps must detect this on next reconciliation and either re-register or surface the discrepancy.
+
+A reconciliation loop in the Temporal adapter compares Assignment state with Schedule state and surfaces drift.
+
+---
+
+## 12. Proof Point
 
 One narrow proof point demonstrates the boundary:
 
 **Duty:** `nightly_research`
 
 - Window: `01:00–06:00 UTC` daily
-- Wake-up: durable timer
-- Activity during window: research synthesis using existing handler infrastructure
+- Wake-up: durable Temporal Schedule
+- RuntimeActivity during window: research synthesis using existing handler infrastructure
 - Recall: signal-driven (e.g., a higher-priority cycle needs the agent)
 - Completion: agent finishes early via `duty_complete` signal
+- Missed-window policy: `start_late_within_grace`
 
-**Acceptance for the proof point:**
+### Acceptance for the proof point
 
-- Stop the Temporal worker mid-window. Restart. Duty resumes correctly.
-- Send recall signal. Agent transitions out of Duty cleanly within graceful_window seconds.
-- Cancel the workflow. Agent releases focus lease and returns to Ambient.
-- Run two consecutive nights. Both windows fire on schedule.
+- Stop the Temporal worker mid-window. Restart. The **workflow** resumes and the duty correctly remains in `active` durability status. RuntimeActivity resumes per its own `can_resume` semantics.
+- Send a recall signal. SquadOps receives the recall request, authorizes it, and transitions the agent out of Duty cleanly within `graceful_window` seconds. Idempotency holds: replayed signal does not double-recall.
+- Cancel the workflow. SquadOps releases the FocusLease and returns the agent to Ambient.
+- Run two consecutive nights. Both windows fire on schedule with distinct DutyDurabilityRun records.
+- Take SquadOps API down at `window_start`. Temporal retries. When SquadOps returns, transition completes; no duplicate transition occurs.
 
 ---
 
-## 8. Implementation Phases
+## 13. Implementation Phases
 
 ### Phase 1 — Port and in-process adapter
 
 - Define `DutyDurabilityPort`
+- Implement `DutyDurabilityRun` record + Postgres table
 - Refactor v1.1 in-process scheduler behind the port
 - Adapter selection via config
+- Idempotency log table
 
-**Acceptance:** v1.1 behavior unchanged; Temporal not yet introduced.
+**Acceptance:** v1.1 behavior unchanged; Temporal not yet introduced. Idempotent transition handlers in place and tested against replay.
 
 ### Phase 2 — Temporal adapter (basic)
 
 - Add Temporal as optional dependency
 - Implement Temporal adapter with durable timer + signal handling
-- Workflow design as described in §6.3
+- Workflow design as described in §6.4
 - Local Temporal dev stack via docker-compose (optional service)
+- Authentication posture per §10
 
-**Acceptance:** the `nightly_research` proof point passes the four acceptance tests in §7.
+**Acceptance:** the `nightly_research` proof point passes the §12 acceptance, including the idempotency and unavailable-API tests.
 
 ### Phase 3 — Schedules and recurrence
 
-- Use Temporal Schedules for recurring duty windows
+- Use Temporal Schedules for recurring DutyWindows
+- Reconciliation loop comparing Assignments to Schedules
 - Replace per-duty workflow spawning with schedule-triggered runs
 
-**Acceptance:** duties can be defined as recurring without per-day workflow management.
+**Acceptance:** duties can be defined as recurring without per-day workflow management. Drift between Assignment and Schedule is surfaced.
 
 ### Phase 4 — Production hardening
 
 - Retry policies for transient failures
-- Graceful degradation if Temporal worker is down (fall back to in-process scheduler with degraded warning)
-- Observability: link Temporal workflow IDs to SquadOps duty assignments in LangFuse traces
+- Production fallback rule per §8.3 (refuse silent fallback in prod)
+- Observability: link Temporal workflow IDs to SquadOps duty Assignments in LangFuse traces via DutyDurabilityRun
 
 **Acceptance:** Temporal becomes the recommended duty-durability adapter for production.
 
 ---
 
-## 9. Acceptance Criteria
+## 14. Acceptance Criteria
 
 The SIP is successful when:
 
-1. **Boundary holds** — Temporal does not own agent identity, mode, focus, activity, or embodiment
-2. **Optional dependency** — SquadOps runs without Temporal; Temporal is opt-in via adapter selection
-3. **Durability proven** — duty workflows survive worker restarts mid-window
-4. **Signals reliable** — recall signals deliver within configured graceful_window
-5. **Schedules work** — recurring duties run reliably across multiple windows
-6. **Coexistence** — Prefect (cycle execution) and Temporal (duty durability) operate in the same deployment without contention
-7. **Graceful degradation** — if Temporal is unavailable, the in-process adapter still serves duty windows with a clear warning
-8. **No regressions** — v1.1 and v1.2 behavior unaffected when Temporal adapter is selected
+1. **Boundary holds** — Temporal does not own agent identity, mode, FocusLease, RuntimeActivity, or embodiment
+2. **Temporal requests, SquadOps decides** — workflows never mutate agent state directly
+3. **Idempotency** — every Temporal-originated request carries an idempotency key; handlers are replay-safe
+4. **Optional dependency** — SquadOps runs without Temporal; Temporal is opt-in via adapter selection
+5. **Durability proven** — duty workflow timer/signal state survives worker restarts mid-window
+6. **Signals reliable** — recall signals deliver within `graceful_window`
+7. **Schedules work** — recurring duties run reliably across multiple windows; drift is surfaced
+8. **Coexistence** — Prefect (cycle execution) and Temporal (duty durability) operate in the same deployment without contention
+9. **Production safety** — no silent fallback to in-process in production; missed-window policy explicit
+10. **Auth posture enforced** — recall signals only from authenticated SquadOps services; namespaces environment-scoped
+11. **No regressions** — v1.1 and v1.2 behavior unaffected when Temporal adapter is selected
 
 ---
 
-## 10. Risks and Mitigations
+## 15. Risks and Mitigations
 
 | Risk | Mitigation |
 |------|------------|
 | Temporal scope creeps to own non-duty logic | Port interface is narrow; review every PR that adds Temporal-aware code outside the duty adapter |
-| Workflow history bloats | Keep workflows thin (timer + signals only); offload work to SquadOps Activities |
+| Workflow history bloats | Keep workflows thin (timer + signal requests only); offload work to SquadOps RuntimeActivities |
 | Determinism violations break replay | Workflow code touches only durable primitives; no LLM calls or agent logic inside the workflow |
 | Operators add Temporal as a hard requirement | Keep in-process adapter as a first-class option; document selection clearly |
 | Duplication with Prefect | Document boundary: Prefect = bounded cycle execution; Temporal = open-ended duty durability |
-| Signal loss between Temporal and SquadOps | Idempotent transition handlers on the SquadOps side |
+| Signal loss between Temporal and SquadOps | Idempotent transition handlers + retry policy in §8.1 |
+| **Silent fallback causes double execution** | Production fallback rule §8.3 — refuse silent fallback in prod |
+| Workflow "resumes work" expectation | Precise wording in §9 — Temporal resumes scheduling, not RuntimeActivity work |
+| Recall signals from arbitrary callers | Auth posture §10 — only authenticated SquadOps services |
+| Assignment vs Schedule drift | Reconciliation loop §11 |
 
 ---
 
-## 11. Open Questions
+## 16. Open Questions
 
 1. Should the Temporal adapter run in the same Python process as SquadOps, or as a separate worker container?
-2. How are recall signals authenticated? (Temporal namespace per environment, or a shared signal token?)
-3. What is the migration path for an existing in-process duty if the operator switches to the Temporal adapter mid-cycle?
-4. Should LangFuse traces include Temporal workflow IDs as a span attribute, or stay separate?
-5. Do we need a CLI command (`squadops duty status <assignment-id>`) that proxies to the durability adapter, or is querying the Temporal UI directly acceptable?
-6. How does graceful_window interact with hard duty strictness — does a hard duty refuse recall signals during the window?
+2. How should LangFuse traces link to Temporal workflow IDs? Span attribute on the SquadOps side referencing `external_workflow_id`?
+3. What CLI surface should expose duty status — `squadops duty status <assignment-id>` proxying to `DutyDurabilityPort.get_duty_run_status()`, or just direct Temporal UI access?
+4. How does `graceful_window` interact with hard duty strictness — does a hard duty refuse recall signals during the window, or honor them with extended grace?
+5. Should the idempotency log have a TTL (e.g., 30 days) to bound storage, or persist indefinitely for audit?
 
 ---
 
-## 12. References
+## 17. References
 
 - Depends on: `sips/proposed/SIP-Agent-Runtime-State.md` (v1.1)
-- Parent vision: `sips/proposed/SIP-Agent-Runtime-Modes.md`
+- Parent vision: `sips/proposed/SIP-Agent-Runtime-Modes.md` (canonical reason codes, event names, package invariant)
 - Original full proposal: commit `76a1f90` on main
 - Temporal Workflows — https://docs.temporal.io/workflows
 - Workflow Execution — https://docs.temporal.io/workflow-execution


### PR DESCRIPTION
## Summary

Splits the merged `SIP-Agent-Runtime-Modes` umbrella into three independently reviewable SIPs, so each scope can land on its own merits without forcing reviewers to sign off on the whole vision at once.

| File | Targets | Scope |
|------|---------|-------|
| `SIP-Agent-Runtime-State.md` | **v1.1** | Modes (Duty/Cycle/Ambient), assignments, duty windows, focus lease, activity model. No embodiment, no Temporal. **Foundational — the other two depend on it.** |
| `SIP-Agent-Embodiment-Substrate.md` | **v1.2** | Embodiment abstraction (identity / runtime-surface separation), generic location, capability-aware Activity scheduling, resource budgets. First proof point: **Discord** (lighter than Minecraft for testing). |
| `SIP-Duty-Durability-Temporal.md` | **v1.3** | Temporal as a narrowly-scoped durability layer for Duty only. Optional dependency. Boundary: SquadOps owns agent semantics, Temporal owns durable timers and signals. |
| `SIP-Agent-Runtime-Modes.md` | — | **Trimmed from 1,103 → 132 lines** to serve as the umbrella vision/index. References the three implementing SIPs and the original commit (`76a1f90`) for historical content. |

## Why split

The original umbrella was good design but bad packaging. Reviewing it required signing off on a new runtime taxonomy + embodiment abstraction + new optional orchestrator + virtual-world execution surface, all at once. Splitting bounds the blast radius:

- v1.1 can ship without committing to Temporal
- v1.2 can ship without committing to Minecraft
- v1.3 can ship without rewriting agent semantics

If any one piece doesn't pan out, the others are unaffected.

## Sequencing

- **v1.1 must land before v1.2 or v1.3** — both follow-ons depend on the runtime-state primitives.
- v1.2 and v1.3 are independent; can be reviewed in either order.
- **No version bump** — acceptance is a design commitment. The actual `pyproject.toml` 1.1 bump happens when the v1.1 implementation is feature-complete.
- **In-flight 1.0.x cycle hardening on the Spark continues unaffected** — nothing in these SIPs touches the cycle execution path until implementation lands behind feature flags.

## What's in this PR

- Pure documentation. No code, no migrations, no version bump.
- Net diff is balanced: 1,042 lines added, 1,042 removed (the umbrella content was redistributed into the three implementing SIPs).
- Original full proposal preserved in git at commit `76a1f90`.

## Test plan

- [x] All four files render correctly as markdown
- [ ] Design review on `SIP-Agent-Runtime-State` (the v1.1 candidate — most urgent)
- [ ] Design review on `SIP-Agent-Embodiment-Substrate` (v1.2)
- [ ] Design review on `SIP-Duty-Durability-Temporal` (v1.3)
- [ ] Confirm sequencing rule (v1.1 first) is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)