### PR TITLE
config(squad): add smoke profile (5x qwen2.5:3b-instruct)

### DIFF
--- a/config/squad-profiles.yaml
+++ b/config/squad-profiles.yaml
@@ -1,4 +1,15 @@
 profiles:
+  - profile_id: smoke
+    name: "Smoke Squad"
+    description: "All 5 agents on qwen2.5:3b-instruct — for hello_squad / selftest cycles only"
+    version: 1
+    agents:
+      - { agent_id: max, role: lead, model: "qwen2.5:3b-instruct", enabled: true }
+      - { agent_id: neo, role: dev, model: "qwen2.5:3b-instruct", enabled: true }
+      - { agent_id: nat, role: strat, model: "qwen2.5:3b-instruct", enabled: true }
+      - { agent_id: eve, role: qa, model: "qwen2.5:3b-instruct", enabled: true }
+      - { agent_id: data, role: data, model: "qwen2.5:3b-instruct", enabled: true }
+
   - profile_id: full-squad
     name: "Full Squad"
     description: "All 5 agents with per-role models"


### PR DESCRIPTION
## Summary
- Adds a `smoke` squad profile to `config/squad-profiles.yaml`: all 5 agents on `qwen2.5:3b-instruct`.
- Intended for `hello_squad` / `selftest` cycles only — keeps smoke runs in seconds rather than minutes.

## Why
During SIP-0087 hex-arch verification (PR #60), an end-to-end smoke cycle on the new `smoke` profile completed in ~28s — vs. multi-minute runs on `full-squad` (lead = `qwen2.5:32b`) or `spark-squad-with-builder` (mostly `qwen3.6:27b`). When the goal is "did dispatch + log forwarding survive the last refactor", small models are enough.

## Scope
- One file changed: `config/squad-profiles.yaml`
- No code changes, no version bump (stays on 1.0.5)
- No hot-zone overlap with v1.1 SIP-0089 work

## Test plan
- [x] Profile loads via `squadops cycles create hello_squad --squad-profile smoke --request-profile selftest`
- [x] Verified end-to-end on Spark during PR #60 smoke (cycle `cyc_755bca347011` completed in ~28s, all 5 agents on 3b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)