### PR TITLE
docs(sip): Build Manifest Maturation rev 2 — reviewer feedback

### DIFF
--- a/sips/proposed/SIP-Build-Manifest-Maturation.md
+++ b/sips/proposed/SIP-Build-Manifest-Maturation.md
@@ -3,7 +3,8 @@
 **Status:** Proposed
 **Authors:** SquadOps Architecture
 **Created:** 2026-04-27
-**Revision:** 1
+**Revision:** 2
+**Updated:** 2026-04-27 (rev 2 — incorporated external review)
 
 ---
 
@@ -19,11 +20,11 @@ Three follow-up gaps now bound how reliably a squad can build a non-trivial app 
 
 This SIP introduces three independently shippable capabilities that close those gaps:
 
-- **Capability M1 — Mechanical Acceptance Criteria.** Add a typed acceptance check schema embedded in manifest tasks; evaluate them at handler validation time; surface results as first-class check entries in `ValidationResult.checks` alongside the existing FC1/FC2 checks.
-- **Capability M2 — Separated Manifest Authoring.** Introduce a dedicated `governance.plan_build` planning task that authors the manifest. `governance.assess_readiness` reviews and signs off, restoring the proposer/reviewer separation.
-- **Capability M3 — Manifest Delta Overlays.** Define a `manifest_delta.yaml` overlay schema and an applier that produces a derived working manifest from `(original_manifest, [overlay_1, ..., overlay_N])`. Wire the correction protocol and replan path to emit overlays instead of either mutating the original manifest or being unable to evolve it.
+- **Capability M1 — Mechanical Acceptance Criteria.** Add a typed acceptance check schema embedded in manifest tasks; evaluate them at handler validation time; surface results as first-class check entries in `ValidationResult.checks` alongside the existing FC1/FC2 checks. Checks carry severity (`error` / `warning` / `info`) and produce a typed `CheckOutcome` (`passed` / `failed` / `skipped` / `error`).
+- **Capability M2 — Separated Manifest Authoring.** Introduce a dedicated `governance.plan_build` planning task that authors the manifest. `governance.assess_readiness` reviews and signs off, restoring the proposer/reviewer separation. Reviewer concerns are produced as a typed `manifest_review.yaml` artifact that can be fed mechanically into a bounded revision loop.
+- **Capability M3 — Manifest Delta Overlays.** Define a `manifest_delta.yaml` overlay schema and a *pure structural applier* paired with an *execution-aware validator*. Wire the correction protocol to emit overlays restricted to `add_task` and `tighten_acceptance` operations only — the broader operation set (`remove_task` / `replace_task` / `reorder`) is supported in the schema and applier but reserved for operator action or a future `governance.replan` task, not autonomous correction.
 
-Each capability is independently valuable. M1 alone makes today's manifests far more discriminating. M2 alone improves planning-phase quality. M3 alone unlocks long-cycle adaptability. Together they turn the manifest from "produced once, consumed once" into a living plan the squad can iterate against.
+Each capability is independently valuable. M1 alone makes today's manifests far more discriminating. M2 alone improves planning-phase quality. M3 alone unlocks long-cycle adaptability. Together they turn the manifest from "produced once, consumed once" into a living plan the squad can iterate against — without giving autonomous correction the keys to rewrite history.
 
 ---
 
@@ -105,9 +106,7 @@ That's the design intent. The implementation has only the immutability half. The
 For a one-hour cycle this is acceptable — the repair handler converges or the cycle terminates. For a multi-hour cycle, the failure modes that warrant manifest evolution show up routinely:
 
 - **Discovered missing layer** (e.g., manifest has no `auth` task because Max underweighted the PRD's auth requirement; correction needs to add a subtask, not just patch).
-- **Re-order required** (e.g., frontend integration depends on a new backend endpoint that wasn't in the original manifest).
 - **Stricter acceptance** (e.g., Eve discovers the original criteria were too loose; needs to ratchet them on a re-run).
-- **Task split** (a subtask consistently fails because it bundled too much; needs to be split into two).
 
 Without overlays, the cycle either limps along on a stale plan or terminates at the gate.
 
@@ -119,23 +118,35 @@ Without overlays, the cycle either limps along on a stale plan or terminates at 
 
 Free-text criteria are operator-readable, model-readable, and validator-illegible. The minimum useful unit is a typed check the validator can run. Criteria authoring should be guided into typed shapes rather than left as prose.
 
-### 3.2 Separate the proposer from the reviewer
+### 3.2 Treat the manifest as untrusted input
+
+The manifest is LLM-authored. Typed checks reference file paths, glob patterns, regexes, and command specs. Every one of those is a foot-gun if treated as trusted. The evaluator chroots paths to the workspace root, rejects shell strings, runs commands as argv arrays, and enforces a safelist.
+
+### 3.3 Separate the proposer from the reviewer
 
 Authoring the build plan and signing off on planning readiness are different cognitive tasks. They should be different handler calls — even if the same agent role (Max) performs both — so the second call has a chance to catch the first call's mistakes.
 
-### 3.3 Original manifest is the source of truth; overlays accumulate
+### 3.4 Original manifest is the source of truth; overlays accumulate
 
 The approved manifest stays immutable. Overlays are append-only audit trail. The "current working manifest" is always derived: `apply(original, overlays)`. This preserves the gate's contract (what the operator approved) while admitting evolution.
 
-### 3.4 Overlays are governed, not free-form
+### 3.5 Pure structural applier; execution-aware validator
 
-A manifest overlay is a control-plane artifact like the manifest itself. It is produced by Max (or the repair chain on Max's behalf), validated against a schema, stored with `artifact_type: "control_manifest_delta"`, and observable. It is not a runtime mutation of in-memory state.
+The applier is pure: same `(original, overlays)` always yields the same working manifest. Runtime constraints — "this overlay would invalidate already-completed work" — live in a separate execution-aware validator that consults run state. Keeping these layers apart preserves test tractability without weakening runtime safety.
 
-### 3.5 Backward-compatible at every layer
+### 3.6 Autonomous correction is conservative
+
+The schema supports five operations (`add_task`, `remove_task`, `replace_task`, `tighten_acceptance`, `reorder`). The autonomous correction producer in Revision 1 emits only the two safe ones (`add_task`, `tighten_acceptance`). Everything else requires operator action or a future `governance.replan` task. Correction can grow the plan and tighten the contract; it cannot rewrite history.
+
+### 3.7 Overlays affect only the remaining execution plan
+
+Overlays do not replace, remove, reorder, or otherwise rewrite the semantic meaning of already-completed task checkpoints. Corrections to completed work are represented as new tasks, not mutations of prior ones. This protects artifact lineage so the working manifest never makes history look different from what actually happened.
+
+### 3.8 Backward-compatible at every layer
 
 Manifests without typed acceptance still work (criteria continue to be informational for those tasks). Cycles without `governance.plan_build` still work (manifest production stays in `assess_readiness` as today). Cycles with no overlays produced still work (the working manifest equals the original).
 
-### 3.6 Build on what shipped, don't re-spec it
+### 3.9 Build on what shipped, don't re-spec it
 
 This SIP does not redefine SIP-0086's manifest schema, executor materialization, deterministic task IDs, or correction routing. All of that is reused. Only acceptance evaluation, the authoring split, and the overlay format are new.
 
@@ -143,12 +154,16 @@ This SIP does not redefine SIP-0086's manifest schema, executor materialization,
 
 ## 4. Goals
 
-1. **Acceptance criteria with teeth.** A manifest task can carry typed acceptance checks (`endpoint_defined`, `import_present`, `field_present`, `command_exit_zero`, `regex_match`, `count_at_least`) that the build validator evaluates and reports as pass/fail, alongside existing FC1/FC2.
-2. **Separated authoring.** A new `governance.plan_build` planning task authors the manifest. `governance.assess_readiness` becomes a true reviewer/sign-off step that may reject or request revisions to the manifest.
-3. **Manifest delta overlays.** A typed overlay format supporting `add_task`, `remove_task`, `replace_task`, `tighten_acceptance`, and `reorder` operations, with an applier that produces the working manifest deterministically.
-4. **Correction integration.** The correction protocol can produce overlays instead of (or in addition to) repair patches when a structural manifest change is the right response to a `SEMANTIC_FAILURE`.
-5. **Observability.** Every overlay is stored as an artifact with `artifact_type: "control_manifest_delta"`. Every typed acceptance check result is in `ValidationResult.checks` and surfaced in evidence for the run.
-6. **No regression.** Existing build profiles and existing manifests (with informational criteria, no overlays, monolithic authoring) continue to work without change.
+1. **Acceptance criteria with teeth.** A manifest task can carry typed acceptance checks with explicit severity that the build validator evaluates and reports as pass/fail/skipped/error in `ValidationResult.checks`.
+2. **Untrusted-input safety.** All paths chrooted to workspace root, no shell execution, command invocations are argv-only and safelisted.
+3. **Authoring-time validation.** Unknown check names or malformed params fail manifest validation (at planning/gate), not at hour 2 of build.
+4. **Bounded stack support.** Stack-specific check evaluators target the actual reference-app stacks (FastAPI, React+Vite); other stacks produce `skipped` outcomes rather than guessing.
+5. **Separated authoring.** A new `governance.plan_build` planning task authors the manifest. `governance.assess_readiness` becomes a true reviewer/sign-off step that may reject or request structured revisions to the manifest.
+6. **Manifest delta overlays — schema and pure applier.** Five operation types in the schema; pure structural applier producing a deterministic working manifest from `(original, [overlay_1, ..., overlay_N])`.
+7. **Execution-aware overlay validation.** Before any overlay is accepted for an active run, an execution-aware validator rejects overlays that would invalidate already-started or completed work.
+8. **Conservative autonomous correction.** The correction protocol can produce overlays — but only `add_task` and `tighten_acceptance` operations. Removal/replacement/reordering require operator action or future `governance.replan`.
+9. **Observability.** Every overlay is stored as `artifact_type: "control_manifest_delta"`. Every overlay-created task carries provenance metadata (`overlay_id`, `operation_index`, `reason`, `correction_decision_id`). Every typed acceptance check result is in `ValidationResult.checks`.
+10. **No regression.** Existing build profiles and existing manifests (with informational criteria, no overlays, monolithic authoring) continue to work without change.
 
 ---
 
@@ -156,11 +171,13 @@ This SIP does not redefine SIP-0086's manifest schema, executor materialization,
 
 - Replacing the SIP-0086 manifest schema or task materialization mechanism.
 - Defining a general-purpose constraint language. Typed acceptance checks are a small, fixed vocabulary chosen for build verification, not a Turing-complete DSL.
-- Sandbox execution of generated code. Acceptance checks are static analysis (AST, regex, file content) plus targeted shell invocations (lint exit code, type-check exit code) — not running the app. Running the app is the smoke pack's job (separate SIP).
-- Browser/UI verification. Same reason as above.
+- Sandbox execution of generated code. Acceptance checks are static analysis (AST, regex, file content) plus targeted shell invocations against a safelist (lint exit code, type-check exit code) — not running the app. Running the app is the smoke pack's job (separate SIP).
+- Browser/UI verification.
 - Cross-handler "did the test exercise the code" checks. Listed in SIP-0086 §10 future work; remains out of scope here.
+- Autonomous overlay operations beyond `add_task` and `tighten_acceptance` in Revision 1. The applier supports more; the autonomous producer does not.
 - Adaptive thresholds learned from prior cycles. Out of scope; criteria are author-specified per cycle.
 - Replacing the operator gate. The gate still exists; M2 adds an *internal* reviewer step on top of it, not instead of it.
+- Universal framework parsing. `endpoint_defined` and similar checks target the reference-app stacks only; other stacks return `skipped` rather than risk false negatives.
 
 ---
 
@@ -168,16 +185,18 @@ This SIP does not redefine SIP-0086's manifest schema, executor materialization,
 
 ### 6.1 Capability M1 — Mechanical Acceptance Criteria
 
-#### 6.1.1 Schema extension
+#### 6.1.1 Schema: flat YAML, normalized internal form
 
-`ManifestTask.acceptance_criteria` today is `list[str]`. Extend it to accept either strings (informational, backward-compatible) or typed check dicts:
+`ManifestTask.acceptance_criteria` today is `list[str]`. Extend it to accept either strings (informational, backward-compatible) or **flat-YAML typed entries**. The parser normalizes every typed entry into a `TypedCheck` object before evaluators see it.
+
+**Authoring-friendly YAML (flat keys):**
 
 ```yaml
 acceptance_criteria:
   # Existing free-text form (informational, kept for back-compat)
   - "All 5 required endpoints are defined"
 
-  # New typed forms (evaluated):
+  # Typed forms — flat keys at top level, plus optional severity/description:
   - check: endpoint_defined
     file: backend/routes.py
     methods_paths:
@@ -186,37 +205,38 @@ acceptance_criteria:
       - [GET, /runs/{id}]
       - [POST, /runs/{id}/join]
       - [POST, /runs/{id}/leave]
+    severity: error
+    description: "Backend exposes the 5 PRD endpoints"
 
   - check: import_present
     file: backend/routes.py
     module: backend.repository
     symbols: [Repository]
-
-  - check: field_present
-    file: backend/models.py
-    target: class:RunEvent
-    fields: [id, title, datetime, location, distance, pace_target, route_notes, participants]
+    severity: error
 
   - check: regex_match
     file: backend/routes.py
     pattern: "status_code\\s*=\\s*409"
+    count_min: 1
+    severity: warning              # rolling out; not yet a hard fail
     description: "Duplicate join returns 409"
 
   - check: command_exit_zero
     command: ["python", "-m", "py_compile", "backend/routes.py"]
     cwd: "."
     timeout_seconds: 10
-    description: "Backend compiles"
+    severity: error
 ```
 
-Parser changes localized to `build_manifest.py`. A `ManifestTask` becomes:
+**Normalized internal form** (what evaluators see):
 
 ```python
 @dataclass(frozen=True)
 class TypedCheck:
-    check: str
-    params: dict          # check-specific payload (frozen)
-    description: str = "" # human-readable summary
+    check: str                 # vocabulary name, e.g., "endpoint_defined"
+    params: dict               # all check-specific fields except check/severity/description
+    severity: str = "error"    # error | warning | info
+    description: str = ""
 
 @dataclass(frozen=True)
 class ManifestTask:
@@ -230,63 +250,129 @@ class ManifestTask:
     depends_on: list[int] = field(default_factory=list)
 ```
 
-Free-text strings remain accepted; mixed lists are valid.
+**Normalization rule (canonical):**
 
-#### 6.1.2 Check vocabulary (Revision 1)
+> Typed-check YAML uses flat keys for authoring convenience. The parser normalizes every typed criterion into a `TypedCheck` where `params` contains all fields *except* `check`, `severity`, and `description`. Only the normalized form is passed to evaluators or surfaced in `ValidationResult`. Mixed lists (some typed, some prose) are valid; prose strings remain informational.
 
-A small, targeted set chosen because each one catches a real category of partial-build failures observed on group_run cycles:
+This eliminates the implementation hazard where authors and evaluators see different shapes.
+
+#### 6.1.2 Severity
+
+Each typed check carries a `severity` field with values `error` (default), `warning`, or `info`.
+
+| Severity | Behavior |
+|---|---|
+| `error` | Failed check contributes to `missing_components` and triggers self-eval/correction. |
+| `warning` | Failed check is reported in evidence but does not fail the task or block progress. |
+| `info` | Informational; result captured in evidence for tuning, never fails or warns. |
+
+This gives a safe rollout path for new checks without globally disabling `mechanical_acceptance`.
+
+#### 6.1.3 Check vocabulary (Revision 1)
 
 | Check | Params | What it validates |
 |---|---|---|
-| `endpoint_defined` | `file`, `methods_paths` | FastAPI/Flask route decorator with method + path is present in the file. AST-based for FastAPI; regex fallback. Catches "wrote 2 of 5 endpoints" failures. |
-| `import_present` | `file`, `module`, `symbols` | `from <module> import <symbols>` (or equivalent JS `import`) is present. Catches "wrote endpoints but never wired the repository." |
-| `field_present` | `file`, `target` (class/dataclass/Pydantic model), `fields` | Named fields are declared on the named target. AST-based. Catches "model missing required attributes per PRD." |
-| `regex_match` | `file`, `pattern`, optional `count_min` | Regex matches at least N times. Escape hatch for things AST checks don't cover (e.g., specific status codes, error messages). |
-| `command_exit_zero` | `command`, `cwd`, `timeout_seconds` | Subprocess exits 0. Used for `py_compile`, `tsc --noEmit`, `eslint`, `ruff check`. Bounded by timeout; sandboxed via existing ACI executor. |
-| `count_at_least` | `glob`, `min` | At least N files match the glob. Catches "wrote one component but PRD said three." |
+| `endpoint_defined` | `file`, `methods_paths` | Route decorator with method + path is present. AST-based for FastAPI; regex fallback. Targets observed "wrote 2 of 5 endpoints" failures. |
+| `import_present` | `file`, `module`, `symbols` | `from <module> import <symbols>` (or equivalent JS `import`) is present. Targets "wrote endpoints but never wired the repository." |
+| `field_present` | `file`, `target` (class/dataclass/Pydantic model), `fields` | Named fields are declared on the named target. AST-based. Targets "model missing required attributes per PRD." |
+| `regex_match` | `file`, `pattern`, optional `count_min` (default 1) | Regex matches at least N times. Escape hatch for things AST checks don't cover (specific status codes, error messages, mention counts). |
+| `command_exit_zero` | `command` (argv list), `cwd`, `timeout_seconds` | Subprocess from safelist exits 0. Used for `py_compile`, `tsc --noEmit`, `eslint`, `ruff check`. Bounded by timeout; sandboxed via existing ACI executor. |
+| `count_at_least` | `glob`, `min` | At least N files match the glob. Targets "wrote one component but PRD said three." |
 
-Each check is implemented as a class with `evaluate(workspace_root, artifacts) -> CheckOutcome` returning `passed: bool`, `actual: dict`, `reason: str`. New checks are added by registering a class in a small registry — no dispatch logic in the validator.
+Each check is implemented as a class with `evaluate(workspace_root, artifacts) -> CheckOutcome`. New checks are added by registering a class in a small registry — no dispatch logic in the validator.
 
-The vocabulary is intentionally small. Future checks (e.g., `openapi_contract_match`, `pytest_collects`) can be added without touching the schema; the schema's open `params` dict accommodates them.
+#### 6.1.4 CheckOutcome status enum
 
-#### 6.1.3 Validator integration
+```python
+@dataclass(frozen=True)
+class CheckOutcome:
+    status: str          # "passed" | "failed" | "skipped" | "error"
+    actual: dict         # check-specific evidence (e.g., found endpoints, file size)
+    reason: str          # human-readable summary
+```
+
+Status values:
+
+| Status | When |
+|---|---|
+| `passed` | Check evaluated and the assertion held. |
+| `failed` | Check evaluated and the assertion did not hold. |
+| `skipped` | Check is well-formed but not evaluable in this context — e.g., target file missing, unsupported stack/syntax (`unsupported_stack_or_syntax` reason), command type disabled by config (`command_acceptance_checks: false`), or `mechanical_acceptance: false`. Reported as evidence; not a failure. |
+| `error` | Evaluator itself raised an unexpected exception. Treated as a failure for `error`-severity checks; logged with stack trace. |
+
+`ValidationResult` consumers that expect a legacy `passed: bool` derive it from `status == "passed"` (with severity weighting — `warning`/`info` failures are not `passed=False`).
+
+This separation is what lets a "no FastAPI in this stack" outcome (skipped) be distinguished from "the endpoints aren't there" (failed) — the same evidence shape that makes triage tractable.
+
+#### 6.1.5 Path and command safety
+
+All typed checks are evaluated against LLM-authored input. The evaluator treats every value as untrusted:
+
+- **Paths** (`file`, `cwd`, `glob`): resolved relative to the workspace root; absolute paths rejected; `..` traversal rejected; symlinks pointing outside the workspace rejected when feasible. A path that resolves outside the workspace produces `status: error` with reason `path_escapes_workspace`.
+- **Globs**: bounded by max-match count (default 10,000) to prevent denial of service via pathological globs.
+- **Regex patterns**: compiled with a timeout (where the regex engine supports it) or with input-size bound; pathological regexes produce `status: error` with reason `regex_timeout`.
+- **Commands**: only argv lists accepted; shell strings rejected outright. Argv[0] must be in the safelist (`python -m py_compile`, `python -m mypy`, `ruff check`, `tsc --noEmit`, `eslint`, `pyflakes`, `node --check`, `npm run lint`). Out-of-safelist commands produce `status: skipped` with reason `command_not_in_safelist`. Execution runs in the existing ACI executor (`adapters/capabilities/aci_executor.py`) with the workspace as cwd and a clean restricted environment (no `LD_PRELOAD`, no `PYTHONPATH` injection, etc.).
+- **Timeouts**: every command-bearing check has a hard timeout (default 10s, max 60s).
+
+The safelist is configurable via `command_check_safelist`; entries can only be added by operator-controlled config, not by manifest authors.
+
+#### 6.1.6 Stack-aware bounded evaluators
+
+Several checks are stack-specific (`endpoint_defined` understands FastAPI/Flask decorators; `import_present` understands Python `from X import Y` and ES module imports). Rather than letting any one check become a universal framework parser, each evaluator declares its supported stacks and returns `status: skipped` with reason `unsupported_stack_or_syntax` for anything outside that set.
+
+Revision 1 stack support:
+
+| Check | Supports |
+|---|---|
+| `endpoint_defined` | FastAPI (AST). Flask added on demand. |
+| `import_present` | Python (AST). JS/TS (regex fallback) added when reference-app frontend stack lands. |
+| `field_present` | Python dataclasses, Pydantic v2 models (AST). |
+| `regex_match`, `count_at_least`, `command_exit_zero` | Stack-agnostic. |
+
+Adding a new stack is a separate, scoped PR — not a heuristic expansion inside an existing check.
+
+#### 6.1.7 Authoring-time validation
+
+Bad typed checks should be caught at planning/gate time, not at hour 2 of build:
+
+| Condition | Outcome |
+|---|---|
+| Unknown `check` name | Manifest invalid; `BuildTaskManifest.from_yaml()` raises `ValueError`. Manifest production retry loop sees the error and re-prompts. |
+| Malformed `params` for a known check (missing required field, wrong type) | Manifest invalid; same handling. |
+| Well-formed check for unsupported stack | Manifest valid; check evaluates with `status: skipped`, reason `unsupported_stack_or_syntax`. |
+| Free-text string criterion | Valid; informational. |
+| Unknown `severity` value | Manifest invalid. |
+
+The retry loop in `_produce_manifest` (`planning_tasks.py:572`) already re-prompts on `ValueError`; this rule extends what counts as invalid.
+
+#### 6.1.8 Validator integration
 
 `_validate_output_focused` in `cycle_tasks.py` already returns a `ValidationResult` with `checks: list[dict]`. Add a third check class alongside FC1 (expected_artifacts) and FC2 (non-stub):
 
 ```python
-# FC3 (replaces today's "informational" stub)
-typed_checks = [c for c in inputs.get("acceptance_criteria", []) if isinstance(c, dict)]
+typed_checks = [c for c in inputs.get("acceptance_criteria", []) if isinstance(c, TypedCheck)]
 for criterion in typed_checks:
     outcome = await self._evaluate_typed_check(criterion, artifacts, context)
     checks.append({
-        "check": f"acceptance:{criterion['check']}",
-        "params": criterion.get("params", {}),
-        "description": criterion.get("description", ""),
-        "passed": outcome.passed,
+        "check": f"acceptance:{criterion.check}",
+        "severity": criterion.severity,
+        "params": criterion.params,
+        "description": criterion.description,
+        "status": outcome.status,
         "actual": outcome.actual,
         "reason": outcome.reason,
     })
-    if not outcome.passed:
-        missing.append(f"acceptance:{criterion.get('description') or criterion['check']}")
+    if outcome.status == "failed" and criterion.severity == "error":
+        missing.append(f"acceptance:{criterion.description or criterion.check}")
 ```
 
-Failed typed checks contribute to `missing_components`, which feeds the existing self-evaluation prompt unchanged. The self-eval LLM call now sees concrete failures ("acceptance: endpoint_defined POST /runs/{id}/join — actual: only GET /runs and POST /runs found") instead of generic "your output is incomplete."
+Only `error`-severity failed checks contribute to `missing_components`. The self-eval LLM call sees these specific named gaps in its follow-up prompt instead of generic "your output is incomplete." `warning`/`info` failures and `skipped` outcomes appear in evidence for operator triage.
 
-Cumulative effect: today's self-eval pass produces additional files chasing keyword guesses; with typed checks it produces additional files chasing specific named gaps.
+#### 6.1.9 Authoring guidance
 
-#### 6.1.4 Authoring guidance
+The manifest authoring prompt is extended to document the typed-check vocabulary, severity defaults, the stack-bounded check semantics, and the path/command safety rules:
 
-The manifest authoring prompt (currently in `planning_tasks.py:508` and being moved by M2 to `governance.plan_build`) is extended to document the typed-check vocabulary and to encourage typed checks for any criterion that maps to one:
-
-> *Where possible, express acceptance criteria as typed checks rather than prose. Available checks: `endpoint_defined`, `import_present`, `field_present`, `regex_match`, `command_exit_zero`, `count_at_least`. Mixed lists (some typed, some prose) are fine; prose criteria are surfaced to the implementer but not auto-evaluated.*
-
-Free-text criteria remain valid. The authoring guidance is a quality nudge, not a constraint.
-
-#### 6.1.5 Sandbox concerns for `command_exit_zero`
-
-`command_exit_zero` runs subprocesses against generated code. This re-uses the existing ACI executor (`adapters/capabilities/aci_executor.py` — already used elsewhere) which provides a contained working directory and timeout. Allowed commands are restricted to a safelist (`python -m py_compile`, `python -m mypy`, `ruff check`, `tsc --noEmit`, `eslint`, `pyflakes`, `node --check`, `npm run lint`) — full sandbox isolation for arbitrary commands is left to the smoke-pack SIP, which needs proper container isolation anyway.
-
-If a typed check requests a command outside the safelist, the validator records the check as `passed: false, reason: "command_not_in_safelist"`. The check authoring prompt references the safelist.
+> *Where possible, express acceptance criteria as typed checks rather than prose. Available checks: `endpoint_defined`, `import_present`, `field_present`, `regex_match`, `count_at_least`, `command_exit_zero`. Use flat YAML keys for the check-specific fields. Severity defaults to `error`; use `warning` for new or experimental checks. All paths must be inside the workspace root. Commands must be argv lists drawn from the safelist. Mixed prose+typed lists are fine; prose criteria are surfaced to the implementer but not auto-evaluated.*
 
 ### 6.2 Capability M2 — Separated Manifest Authoring
 
@@ -303,32 +389,70 @@ CURRENT (post-SIP-0086):
 PROPOSED:
   Planning: data.research → strategy.frame → development.design_plan
             → qa.define_test_strategy → governance.plan_build (manifest authoring)
-            → governance.assess_readiness (sign-off, may reject/revise manifest)
+            → governance.assess_readiness (sign-off + manifest review)
+            → [optional governance.plan_build_revise loop, bounded by max_planning_revisions]
             → [GATE]
 ```
 
 Implementation: a new handler `GovernancePlanBuildHandler` in `planning_tasks.py` that takes the existing `_produce_manifest` logic (and its retry loop) verbatim, returns the manifest as its primary output rather than a side-effect on the planning artifact.
 
-`governance.assess_readiness` loses its manifest-production responsibility and gains a manifest-review responsibility:
+`governance.assess_readiness` loses its manifest-production responsibility and gains a manifest-review responsibility.
 
-- Reads the manifest produced by `governance.plan_build` from prior outputs.
-- Sanity-checks: subtask coverage vs. PRD, dependency sanity, role sanity.
-- Either signs off (planning is ready, manifest is approved) or emits a revision request.
+#### 6.2.2 `manifest_review.yaml` schema
 
-#### 6.2.2 Revision flow
+The reviewer step produces a structured artifact. Prose-only review concerns are explicitly disallowed.
 
-If `assess_readiness` requests revision, options for handling:
+```yaml
+# manifest_review.yaml
+version: 1
+review_status: approved | revision_requested | approved_with_concerns
+reviewer_confidence: low | medium | high
+target_manifest_id: <manifest artifact id>
 
-- **Option A (Revision 1):** Surface the revision request as a `governance.plan_build_revise` task that re-runs manifest authoring with the reviewer feedback as input. Bounded by `max_planning_revisions: int = 1` in resolved config. After exhaustion, planning proceeds with the latest manifest and the reviewer concerns documented in the planning artifact for the operator gate.
-- **Option B (deferred):** Full multi-round dialogue. Out of scope for Revision 1.
+coverage_concerns:
+  - prd_requirement: "duplicate-join 409 handling"
+    target_task_index: null            # null = missing entirely from manifest
+    note: "PRD requires 409 on duplicate join; no manifest task references it."
 
-Option A is small, bounded, and reuses existing handler dispatch. The revision input is a structured `manifest_review.yaml` artifact produced by `assess_readiness` listing concrete concerns (e.g., "task 4 has no acceptance checks for the duplicate-join requirement").
+dependency_concerns:
+  - target_task_index: 4
+    note: "Frontend detail view depends on task 1 (API) but does not list it in depends_on."
 
-#### 6.2.3 Backward compatibility
+role_concerns:
+  - target_task_index: 6
+    note: "Test task assigned to dev role; should be qa."
 
-`governance.plan_build` is opt-in via `applied_defaults.split_manifest_authoring: bool = False` (default off in Revision 1, flipped to default on after stabilization). When false, the existing path stays — `assess_readiness` produces the manifest as today, and the new handler is skipped. When true, the planning step list inserts `governance.plan_build` and removes manifest production from `assess_readiness`.
+acceptance_concerns:
+  - target_task_index: 1
+    missing_check: "endpoint_defined for POST /runs/{id}/join"
+    suggested_check:
+      check: endpoint_defined
+      file: backend/routes.py
+      methods_paths: [[POST, /runs/{id}/join]]
 
-Step-list resolution is in `task_plan.py`'s `_resolve_workload_steps`; the change is local.
+revision_instructions: |
+  Free-text guidance for the next manifest authoring attempt.
+
+operator_notes: |
+  Anything the operator should see at gate, even on approval.
+```
+
+**Rule:** `governance.assess_readiness` may not return `review_status: revision_requested` unless it emits at least one structured concern with a `target_task_index` or `prd_requirement` reference where applicable. Pure prose revision requests are rejected and treated as `approved_with_concerns`.
+
+#### 6.2.3 Revision loop
+
+If `review_status: revision_requested`, dispatch `governance.plan_build_revise` — a lightweight task that re-runs manifest authoring with the structured concerns appended to the prompt. Bounded by `max_planning_revisions: int = 1` in resolved config. After exhaustion, planning proceeds with the latest manifest and the unresolved concerns documented in `operator_notes` for the gate.
+
+#### 6.2.4 Default-flip criteria
+
+`split_manifest_authoring: bool = false` in Revision 1. Flip to `true` once these conditions hold across a tracking window:
+
+- At least 5 successful long-cycle planning runs with the split enabled (no gate failures attributable to the new flow).
+- Manifest YAML validity rate (parses on first attempt) is equal to or better than the colocated baseline.
+- Planning workload duration regression ≤ 20% relative to the colocated baseline.
+- Revision-loop activation rate is below 50% (otherwise the reviewer is requesting too many revisions, which usually means the prompt or rubric is wrong).
+
+These thresholds are intentionally low-bar; the goal is to prevent indefinite "after stabilization" drift, not to set perfectionist gates. Flipping the default is a small follow-up PR, not part of this SIP's first delivery.
 
 ### 6.3 Capability M3 — Manifest Delta Overlays
 
@@ -338,7 +462,7 @@ Step-list resolution is in `task_plan.py`'s `_resolve_workload_steps`; the chang
 # manifest_delta.yaml
 version: 1
 overlay_id: ovl_<uuid>
-parent_manifest_hash: <sha256 of original manifest YAML>
+parent_manifest_hash: <sha256 of CANONICAL serialized manifest, see 6.3.6>
 parent_overlay_id: <prior overlay's overlay_id, or null if first>
 created_at: 2026-04-27T18:00:00Z
 created_by: governance.correction_decision
@@ -347,7 +471,7 @@ operations:
   - op: add_task
     after_index: 4
     task:
-      task_index: 8        # Always > max existing index
+      task_index: 8        # Always > max existing index across original + prior overlays
       task_type: development.develop
       role: dev
       focus: "Add 409 duplicate-join handling"
@@ -358,6 +482,7 @@ operations:
         - check: regex_match
           file: backend/routes.py
           pattern: "status_code\\s*=\\s*409"
+          severity: error
       depends_on: [1]
 
   - op: tighten_acceptance
@@ -366,21 +491,24 @@ operations:
       - check: endpoint_defined
         file: backend/routes.py
         methods_paths: [[POST, /runs/{id}/join]]
+        severity: error
 ```
 
-Operations supported in Revision 1:
+#### 6.3.2 Operations and invariants
 
-| Op | Effect |
+Five operations are supported in the schema and the applier. Each has explicit invariants enforced at apply time.
+
+| Op | Invariants |
 |---|---|
-| `add_task` | Append a new task. New `task_index` must be greater than max existing index across original + prior overlays (preserves deterministic IDs). `after_index` controls execution order placement. |
-| `remove_task` | Mark a task as removed. Dependencies on a removed task are an error if the depending task is not also removed. |
-| `replace_task` | Replace a task's body wholesale (focus/description/expected_artifacts/acceptance). `task_index` and `task_type` are immutable. |
-| `tighten_acceptance` | Append additional `acceptance_criteria` entries to an existing task. Cannot remove existing criteria — tightening only. |
-| `reorder` | Change execution order without changing dependencies. |
+| `add_task` | New `task_index` strictly greater than max existing index across original + prior overlays. Dependencies must reference existing (active or tombstoned) task indices. Added task must include at least one `expected_artifact` or one `error`-severity typed acceptance criterion (no empty-contract additions). |
+| `remove_task` | Cannot remove a task that has already started or completed in the current run (execution-aware validation, §6.3.4). Tombstones the task in the working manifest; does not delete from history. Any active task that depends on the removed task is an error unless the dependent is also tombstoned in the same overlay. |
+| `replace_task` | `task_index` and `task_type` immutable. Cannot replace a task that has already started or completed (use `add_task` for a follow-up instead). May not loosen acceptance — replacement criteria must be at least as strict as the original. |
+| `tighten_acceptance` | Append-only. New criteria added; existing criteria neither removed nor weakened. Severity may be raised (`warning` → `error`) but not lowered. |
+| `reorder` | Must not violate `depends_on`. Revision 1 limited to not-yet-started tasks. |
 
-`loosen_acceptance` (removing criteria) is intentionally not supported in Revision 1. Loosening is suspicious and should be a manual operator action via re-gate, not a correction-driven overlay.
+`loosen_acceptance` (removing or weakening criteria) is intentionally not supported in any form. Loosening is suspicious and should be a manual operator action via re-gate, not a correction-driven overlay.
 
-#### 6.3.2 Applier semantics
+#### 6.3.3 Pure structural applier
 
 ```python
 def apply_overlays(
@@ -389,46 +517,115 @@ def apply_overlays(
 ) -> WorkingManifest:
     """Apply overlays in order to produce the working manifest.
 
-    Each overlay's parent_overlay_id must equal the prior overlay's overlay_id
-    (or null for the first), forming a linear chain. The original's hash must
-    match every overlay's parent_manifest_hash.
+    Pure function: same (original, overlays) always yields same WorkingManifest.
+    Validates structural invariants ONLY:
+      - parent_overlay_id chain is linear and well-formed
+      - parent_manifest_hash matches canonical hash of original
+      - operations satisfy structural invariants (§6.3.2)
+      - new task indices are monotonic and unique
+
+    Does NOT validate runtime constraints (that's apply_overlay_for_active_run).
     """
 ```
 
-The applier is pure: same `(original, overlays)` always yields the same `WorkingManifest`. The working manifest is what `_replace_build_steps_with_manifest` consumes; today it consumes the `BuildTaskManifest` directly. The change at the consumer side is one line — load and apply overlays before passing to expansion.
-
-**Identity invariants:**
+Identity invariants the applier guarantees:
 
 - Original task indices never change.
 - Original task IDs (`task-{run}-m{idx}-{type}`) never change. Already-completed checkpoints stay valid.
 - New tasks added via overlays use indices strictly greater than any prior index, including across overlays. Deterministic IDs continue to be unique and stable.
 - Removed tasks are tombstoned, not deleted — the working manifest preserves them as `status: removed_by_overlay` so audit trail and prior task IDs remain queryable.
 
-#### 6.3.3 Storage and lookup
+#### 6.3.4 Execution-aware validator
 
-Overlays are stored in the artifact vault with `artifact_type: "control_manifest_delta"`. Forwarding to the implementation workload (the same path that today forwards `control_manifest`, fixed in `075fd9e`) is extended to forward all overlays for the run, ordered by `created_at`.
+Before an overlay is accepted for an active run, an execution-aware validator consults run state and rejects overlays that would invalidate already-started or completed work:
+
+```python
+def validate_overlay_for_run(
+    overlay: ManifestDelta,
+    working_manifest: WorkingManifest,
+    run_state: RunState,        # which task IDs have started/completed/checkpointed
+) -> list[ValidationError]:
+    """Reject overlays that mutate completed or in-flight work.
+
+    Returns empty list if overlay is safe to accept.
+    """
+```
+
+Rejection rules:
+
+- `remove_task` targeting a task that has started or completed → reject.
+- `replace_task` targeting a task that has started or completed → reject.
+- `reorder` involving any started task → reject in Revision 1.
+- `add_task` whose dependencies include a tombstoned task that has not produced the artifacts the new task expects → reject.
+
+The applier produces the manifest derivation; the validator approves the overlay for runtime use. Both must succeed before an overlay is forwarded to the executor.
+
+#### 6.3.5 Completed-work immutability (explicit)
+
+> Overlays affect the remaining execution plan. They do not rewrite the semantic meaning of already-completed task checkpoints. Corrections to completed work are represented as new tasks (`add_task`) or repair tasks, not mutations of prior ones.
+
+This is what the execution-aware validator enforces; called out separately because it's the load-bearing safety property.
+
+#### 6.3.6 Canonical hashing and chain order
+
+- **Manifest hash** is computed over a canonical serialization of the parsed `BuildTaskManifest` (sorted keys, normalized whitespace, deterministic list ordering), not over raw YAML text. Raw YAML hashing is a footgun because re-saved manifests can produce different bytes despite identical content.
+- **Overlay chain order** is determined by `parent_overlay_id` linkage, forming a strict linear chain rooted at the original manifest. `created_at` is metadata for display only; it does not affect chain order or hash inputs.
+- `overlay_id` uniqueness is enforced; collisions are rejected at apply time.
+
+#### 6.3.7 Task identity vs. execution order
+
+The applier preserves task indices as identity; execution order can diverge when overlays add tasks. For example, an overlay adding `task_index: 9` `after_index: 4` produces a working manifest where `m009` executes between `m004` and `m005` despite its higher index.
+
+> **Task index is identity, not execution order.** `task-{run}-m009-development.develop` is a stable, unique reference for that task across checkpoints, logs, and artifacts. Its position in the working manifest's execution order is determined by `after_index` and `depends_on`, not by index sort order.
+
+Tooling and operator UI must not assume monotone-index ⇒ monotone-execution.
+
+#### 6.3.8 Overlay-created task provenance
+
+Every task materialized from an overlay carries metadata identifying the overlay that produced it:
+
+```python
+metadata = {
+    "step_index": ...,
+    "role": ...,
+    "routing_reason": ...,
+    # SIP-Build-Manifest-Maturation: overlay provenance
+    "overlay_id": "ovl_abc123",
+    "overlay_operation_index": 0,         # which op in the overlay produced this task
+    "overlay_reason": "Subtask 4 failed acceptance...",
+    "correction_decision_id": "corr_def456",  # if produced by correction protocol
+}
+```
+
+This is what lets an operator answer "why does task `m009` exist" without grepping logs.
+
+#### 6.3.9 Storage and forwarding
+
+Overlays are stored in the artifact vault with `artifact_type: "control_manifest_delta"`. The forwarding path that today carries `control_manifest` artifacts to the implementation workload (fixed in `075fd9e`) is extended to carry all `control_manifest_delta` artifacts for the run, ordered by `parent_overlay_id` chain.
 
 The executor's manifest-loading code (`_load_manifest_for_run`) becomes:
 
 ```python
 manifest = load_original_manifest(run)
-overlays = load_overlays_for_run(run)
+overlays = load_overlays_for_run(run)            # ordered by parent_overlay_id chain
 working_manifest = apply_overlays(manifest, overlays)
 ```
 
-#### 6.3.4 Overlay producers
+#### 6.3.10 Re-gate matrix
 
-Three sources can produce overlays:
+| Operation | Autonomous correction producer (Rev 1) | Operator action | Future `governance.replan` |
+|---|---|---|---|
+| `add_task` | ✅ allowed | ✅ allowed | ✅ allowed |
+| `tighten_acceptance` | ✅ allowed | ✅ allowed | ✅ allowed |
+| `remove_task` | ❌ requires re-gate | ✅ allowed | reserved |
+| `replace_task` | ❌ requires re-gate | ✅ allowed | reserved |
+| `reorder` (not-yet-started) | ❌ requires re-gate | ✅ allowed | reserved |
 
-1. **`governance.correction_decision` (M3 + correction).** When the correction protocol decides the right response to a `SEMANTIC_FAILURE` is structural rather than patch-only, it emits an overlay. The decision becomes typed: `decision: patch | overlay | escalate`. Today the decision is `patch | escalate` only.
-2. **`governance.replan` (new, optional).** A standalone task that can be triggered (cadence-bound or on demand) to revise the manifest mid-run. Out of scope for M3 Revision 1; reserved as the integration point.
-3. **Operator action via API** (future). Not in this SIP. Mentioned only to clarify the schema is operator-friendly.
+The autonomous correction protocol in Revision 1 may only emit overlays containing `add_task` or `tighten_acceptance` operations. An overlay containing any other operation type produced by the correction protocol is rejected by the execution-aware validator.
 
-Revision 1 wires only producer (1) — the correction-decision integration. Producer (2) is left as a future-work hook with the schema and applier in place to support it.
+#### 6.3.11 Bounded overlay count
 
-#### 6.3.5 Bounded overlay count
-
-Unbounded overlays are a runaway risk. Add `max_manifest_overlays: int = 5` to resolved config. When exhausted, the correction protocol can no longer produce overlays — only patch or escalate. Operators see a clear signal that the manifest itself is the wrong shape and the cycle should re-gate.
+Unbounded overlays are a runaway risk. `max_manifest_overlays: int = 5` in resolved config. When exhausted, the correction protocol can no longer produce overlays — only patch or escalate. Operators see a clear signal that the manifest itself is the wrong shape and the cycle should re-gate.
 
 ### 6.4 Configuration Keys
 
@@ -437,7 +634,8 @@ Add to `_APPLIED_DEFAULTS_EXTRA_KEYS`:
 | Key | Type | Default | Capability |
 |-----|------|---------|------|
 | `mechanical_acceptance` | `bool` | `true` | M1 — evaluate typed checks |
-| `command_check_safelist` | `list[str]` | (built-in safelist) | M1 — `command_exit_zero` allowlist |
+| `command_acceptance_checks` | `bool` | `true` (false in `selftest`) | M1 — enable `command_exit_zero` |
+| `command_check_safelist` | `list[str]` | (built-in safelist, see §6.1.5) | M1 |
 | `split_manifest_authoring` | `bool` | `false` | M2 — enable `governance.plan_build` |
 | `max_planning_revisions` | `int` | `1` | M2 — bounded revision rounds |
 | `manifest_overlays_enabled` | `bool` | `true` | M3 — apply overlays on load |
@@ -452,20 +650,29 @@ defaults:
   output_validation: true
   max_self_eval_passes: 1
   mechanical_acceptance: true
+  command_acceptance_checks: true
   manifest_overlays_enabled: true
   max_manifest_overlays: 5
-  split_manifest_authoring: false   # Flip true after M2 stabilizes
+  split_manifest_authoring: false   # Flip true after §6.2.4 criteria met
 
-# implementation profile (long-cycle — all on)
+# implementation profile (long-cycle — all on, deeper)
 defaults:
   build_manifest: true
   output_validation: true
   max_self_eval_passes: 2
   mechanical_acceptance: true
+  command_acceptance_checks: true
   manifest_overlays_enabled: true
   max_manifest_overlays: 8
   split_manifest_authoring: true
   max_correction_attempts: 3
+
+# selftest profile (smoke — minimal mechanical surface)
+defaults:
+  mechanical_acceptance: true
+  command_acceptance_checks: false   # static checks only
+  manifest_overlays_enabled: true
+  max_manifest_overlays: 2
 ```
 
 ---
@@ -479,22 +686,22 @@ Long-cycle group_run (4-hour budget) running `implementation` profile:
 2. `strategy.frame` → objective frame
 3. `development.design_plan` → design plan
 4. `qa.define_test_strategy` → test strategy with concrete typed criteria suggestions
-5. **`governance.plan_build`** (Max) → manifest with 9 subtasks, typed acceptance on 5 of them
-6. **`governance.assess_readiness`** (Max) → reviews the manifest, requests one revision (subtask 6 has no acceptance for join/leave 409 handling)
-7. `governance.plan_build_revise` (Max) → tightens subtask 6's criteria
-8. **Gate** — operator sees the original manifest, the review concerns, and the revised manifest side-by-side; approves.
+5. **`governance.plan_build`** (Max) → manifest with 9 subtasks; typed acceptance with mixed `error` and `warning` severity on 5 of them
+6. **`governance.assess_readiness`** (Max) → reviews manifest, emits `manifest_review.yaml` with `review_status: revision_requested` and one structured `acceptance_concern` (subtask 6 has no acceptance check for join/leave 409 handling)
+7. `governance.plan_build_revise` (Max) → tightens subtask 6 acceptance with a `regex_match` for the 409 status code
+8. **Gate** — operator sees the original manifest, the structured review concerns, and the revised manifest side-by-side; approves.
 
 **Build phase (~2.5 hours):**
 - Subtasks 0–4 run sequentially. Each validates against typed acceptance:
-  - Subtask 1 (Backend API endpoints): `endpoint_defined` for all 5 endpoints + `import_present` for repository → passes.
-  - Subtask 4 (Frontend detail view): `regex_match` for duplicate-name error display → fails. Self-eval fires; second LLM call sees the specific missing pattern and adds the handler. Re-validates → passes.
-- Subtask 6 (qa.test backend) fails: tests run but only cover 3 of 5 endpoints (`count_at_least` glob `tests/test_*.py` failed at `actual=1, expected_min=1` — passed; but `endpoint_defined` cross-check on test file finds only 3 endpoint test functions). **Correction protocol fires.**
-- Correction decision: `overlay` (not `patch`). Overlay adds a new subtask 9 ("Add tests for join/leave endpoints") and tightens subtask 6's criteria. Working manifest now has 10 active tasks. Original task IDs unchanged; new subtask gets `task-{run}-m009-qa.test`.
-- Build resumes from subtask 9. Subtask 6's prior checkpoint stays.
+  - Subtask 1 (Backend API endpoints): `endpoint_defined` for all 5 endpoints (severity `error`) + `import_present` for repository → all `passed`.
+  - Subtask 4 (Frontend detail view): `regex_match` for duplicate-name error display (severity `error`) → `failed`. Self-eval fires; second LLM call sees the specific missing pattern in the failure description and adds the handler. Re-validates → `passed`.
+- Subtask 6 (qa.test backend): tests run but only cover 3 of 5 endpoints. `regex_match` over `tests/test_backend.py` with `pattern: "client\\.(get|post)\\(['\"]/runs"`, `count_min: 5`, severity `error` → `failed` (only 3 matches). **Correction protocol fires.**
+- Correction decision: `overlay` (not `patch`). The autonomous producer is restricted to `add_task` and `tighten_acceptance`. It emits an overlay with one `add_task` operation (new subtask 9 "Add tests for join/leave endpoints") plus a `tighten_acceptance` on subtask 6 (raise `count_min` to enforce future runs see all 5). The execution-aware validator confirms neither operation touches completed work — subtask 6's existing checkpoint is preserved as `status: original_failed`; subtask 9 is appended. Working manifest now has 10 active tasks.
+- Build resumes from subtask 9. The new task carries provenance metadata (`overlay_id: ovl_xyz`, `correction_decision_id: corr_abc`, `overlay_reason: "qa.test backend coverage failed regex_match count_min=5"`), so any operator looking at task `m009` can trace exactly why it exists.
 
-**Wrap-up (~5 minutes):** Standard. Closeout artifact references the original manifest, the one overlay, and the working manifest.
+**Wrap-up (~5 minutes):** Standard. Closeout artifact references the original manifest, the one overlay, the working manifest, and the `manifest_review.yaml`.
 
-**Net effect compared to today:** typed checks catch the partial test coverage that today's filename-only validation misses; the overlay lets the squad add a missing test subtask without re-gating; the separated authoring caught a planning gap before the gate.
+**Net effect compared to today:** typed `regex_match` with explicit `count_min` catches the partial test coverage that today's filename-only validation misses; the autonomous correction overlay (limited to `add_task` + `tighten_acceptance`) lets the squad add a missing test subtask without re-gating; the separated authoring caught a planning gap before the gate; the structured `manifest_review.yaml` made the revision loop mechanical rather than prose-driven.
 
 ---
 
@@ -504,22 +711,26 @@ Three independently shippable stages mapped to the three capabilities. Each stag
 
 ### Stage M1 — Mechanical Acceptance (3 PRs)
 
-**PR 1.1:** Schema + parser
-- Extend `ManifestTask.acceptance_criteria` to accept typed dicts.
-- Add `TypedCheck` dataclass.
-- Update `BuildTaskManifest.from_yaml()` to parse mixed lists.
-- Tests: typed-only, prose-only, mixed; malformed typed shapes; unknown check name.
+**PR 1.1:** Schema + parser + authoring-time validation
+- Extend `ManifestTask.acceptance_criteria` to accept typed dicts via flat YAML.
+- Add `TypedCheck` dataclass and the normalization rule (§6.1.1).
+- Update `BuildTaskManifest.from_yaml()` to parse mixed lists and reject unknown check names / malformed params (§6.1.7).
+- Tests: typed-only, prose-only, mixed; malformed typed shapes; unknown check name; unknown severity; flat-vs-nested parsing.
 
-**PR 1.2:** Check evaluator framework
+**PR 1.2:** Check evaluator framework + static checks + safety
 - New module `src/squadops/cycles/acceptance_checks.py`.
-- Base class + registry; implement `endpoint_defined`, `import_present`, `field_present`, `regex_match`, `count_at_least`, `command_exit_zero` (safelisted only).
-- Tests per check: passing, failing, malformed params.
+- `CheckOutcome` with status enum (§6.1.4).
+- Base class + registry; implement `endpoint_defined` (FastAPI), `import_present` (Python), `field_present`, `regex_match`, `count_at_least`. Plus `command_exit_zero` behind `command_acceptance_checks` flag (§6.1.5).
+- Path/command safety enforcement (workspace chroot, argv-only, safelist, timeouts).
+- Stack-aware bounded evaluation with `unsupported_stack_or_syntax` skip outcome (§6.1.6).
+- Tests per check: passing, failing, skipped, error; severity behavior; safety rejections (path traversal, shell strings, oversize globs, command-not-in-safelist).
 
 **PR 1.3:** Wire into `_validate_output_focused`
 - Replace today's informational FC3 with typed-check evaluation.
+- `error`-severity failures contribute to `missing_components`; `warning`/`info` and `skipped` reported in evidence only.
 - Update self-eval prompt to include specific failed check descriptions.
-- Update authoring prompt to document the check vocabulary.
-- Integration test: a manifest with typed checks fails when generated code is incomplete; passes when complete.
+- Update authoring prompt to document the check vocabulary, severity, and safety rules.
+- Integration test: a manifest with typed checks fails when generated code is incomplete; passes when complete; warning-severity check failure does not fail the task.
 
 ### Stage M2 — Separated Authoring (2 PRs)
 
@@ -529,27 +740,33 @@ Three independently shippable stages mapped to the three capabilities. Each stag
 - Add to planning step list when `split_manifest_authoring: true`.
 - Backward-compat: keep `assess_readiness` manifest production behind the flag.
 
-**PR 2.2:** Reviewer logic in `assess_readiness` + revision loop
-- Add manifest-review prompt and `manifest_review.yaml` output schema.
-- Add `governance.plan_build_revise` task triggered by review concerns.
+**PR 2.2:** Reviewer logic + structured review schema + revision loop
+- Add `manifest_review.yaml` schema (§6.2.2) and reviewer prompt.
+- Reject prose-only revision requests (§6.2.2 rule).
+- Add `governance.plan_build_revise` task triggered on `review_status: revision_requested`.
 - Bound revisions by `max_planning_revisions`.
-- Integration test: revision request produces a revised manifest; bound exhaustion proceeds with annotations.
+- Document default-flip criteria (§6.2.4) in the SIP and surface a metric the operator can check.
+- Integration test: structured concern produces a revised manifest that addresses the concern; bound exhaustion proceeds with annotations in `operator_notes`.
 
 ### Stage M3 — Delta Overlays (3 PRs)
 
-**PR 3.1:** Overlay schema + applier
-- New module `src/squadops/cycles/manifest_overlay.py`: `ManifestDelta`, `apply_overlays`, hash check, parent chain check, identity invariants.
-- Tests for each operation type, parent-chain mismatches, removed-task dependency errors, index uniqueness.
+**PR 3.1:** Overlay schema + pure structural applier
+- New module `src/squadops/cycles/manifest_overlay.py`: `ManifestDelta`, `apply_overlays`, canonical hashing (§6.3.6), parent chain check, identity invariants, structural operation invariants (§6.3.2).
+- Schema supports all 5 operations.
+- Tests for each operation type, parent-chain mismatches, hash mismatches, removed-task dependency errors, index uniqueness, severity-tightening rules.
 
-**PR 3.2:** Loader integration
-- Update `_load_manifest_for_run` to load and apply overlays.
-- Update overlay forwarding (the path fixed in `075fd9e` for `control_manifest`) to also forward `control_manifest_delta` artifacts.
-- Tests: working-manifest derivation across 0, 1, N overlays.
+**PR 3.2:** Execution-aware validator + loader integration + provenance
+- `validate_overlay_for_run()` (§6.3.4) consulting run state.
+- Update `_load_manifest_for_run` to load and apply overlays via the chain order.
+- Update overlay forwarding to carry `control_manifest_delta` artifacts.
+- Add overlay provenance metadata to materialized envelopes (§6.3.8).
+- Tests: working-manifest derivation across 0/1/N overlays; rejection of overlays mutating started/completed tasks; provenance fields populated on materialized envelopes.
 
-**PR 3.3:** Correction-protocol integration
+**PR 3.3:** Correction-protocol integration (restricted operations only)
 - Extend `governance.correction_decision` to emit `decision: overlay` with a generated `manifest_delta.yaml`.
+- **Producer-side restriction:** correction protocol may only emit `add_task` and `tighten_acceptance` operations. Any other operation in a correction-produced overlay is rejected by the execution-aware validator.
 - Bound by `max_manifest_overlays`.
-- Integration test: a `SEMANTIC_FAILURE` that warrants a structural change produces an overlay; overlay is applied; cycle continues with revised plan.
+- Integration test: a `SEMANTIC_FAILURE` that warrants a structural change produces an overlay with a single `add_task` (or `tighten_acceptance`); overlay is applied; cycle continues with revised plan; provenance metadata flows through.
 
 ### Tests
 
@@ -558,7 +775,7 @@ Coverage targets per stage:
 | Layer | M1 | M2 | M3 |
 |-------|----|----|----|
 | Unit (parser/dataclasses) | ✅ | ✅ | ✅ |
-| Unit (check eval / overlay applier) | ✅ | n/a | ✅ |
+| Unit (check eval / overlay applier / overlay validator) | ✅ | n/a | ✅ |
 | Integration (handler) | ✅ | ✅ | ✅ |
 | End-to-end cycle | ✅ | ✅ | ✅ |
 
@@ -570,16 +787,19 @@ Every test must catch a specific bug per `docs/TEST_QUALITY_STANDARD.md`. No tau
 
 | Risk | Capability | Mitigation |
 |---|---|---|
-| Typed checks too strict; valid output flagged | M1 | Conservative initial vocabulary (no semantic `_intent_match`-style checks); `mechanical_acceptance: false` escape hatch; failed-check details in evidence support fast tuning. |
+| Typed checks too strict; valid output flagged | M1 | Severity field lets new checks ship at `warning`. `mechanical_acceptance: false` global escape hatch. Failed-check details in evidence support fast tuning. |
 | Authoring prompt drowns in check syntax docs | M1 | Examples-first prompting (one concrete typed criterion per check type) plus a single-paragraph reference; mixed prose+typed lists explicitly allowed. |
-| `command_exit_zero` runs untrusted code | M1 | Hard safelist; commands run in ACI-executor sandbox; per-check timeout; future smoke pack provides full container isolation. |
-| Reviewer rubber-stamps the proposer (M2) | M2 | Reviewer prompt is structured against named gaps (PRD coverage, role coverage, acceptance coverage); operator gate remains as final external check. Reviewer cannot reduce criteria, only flag missing ones. |
+| `command_exit_zero` runs untrusted code | M1 | Hard safelist; commands run in ACI-executor sandbox; per-check timeout; `command_acceptance_checks: false` disable flag; future smoke pack provides full container isolation. |
+| Path/glob/regex injection from LLM-authored manifests | M1 | Workspace chroot, argv-only, glob match cap, regex timeout, symlink rejection (§6.1.5). Manifest is treated as untrusted input by design. |
+| Stack expansion creep in `endpoint_defined` etc. | M1 | Explicit `unsupported_stack_or_syntax` skip outcome; new stacks added only via separate scoped PR (§6.1.6). |
+| Reviewer rubber-stamps the proposer (M2) | M2 | Reviewer prompt is structured against named gaps; structured `manifest_review.yaml` cannot be prose-only. Operator gate remains as final external check. |
 | Revision loop oscillates | M2 | `max_planning_revisions: 1` bound (Revision 1); future expansion only after metrics support it. |
+| `split_manifest_authoring` flag stays default-off forever | M2 | Concrete flip criteria (§6.2.4) instead of "after stabilization." |
 | Overlay storms (correction repeatedly emits overlays) | M3 | `max_manifest_overlays: 5` bound; after exhaustion, correction limited to patch or escalate. |
-| Working-manifest divergence between runs | M3 | Pure deterministic applier; parent-hash and parent-overlay-id chain checks; replay tests on every PR. |
-| Removed-task dependency errors (orphan dependencies) | M3 | Applier rejects overlays that orphan dependencies; correction-decision prompt requires the LLM to declare dependent removals together. |
-| Existing manifests break | M1, M3 | Backward-compatible schema (prose criteria still valid; absent overlays = working manifest = original); feature flags default-on for new keys, default-off for M2. |
-| Operator confusion: which manifest am I looking at? | M3 | Console must show original + overlay chain + working manifest distinctly. Console UI is downstream work but the artifact types make the distinction explicit. |
+| Autonomous correction makes plan incoherent via removal/replacement | M3 | Producer-side restriction: correction protocol may only emit `add_task` and `tighten_acceptance` (§6.3.10). Schema and applier support more operations, but only operator or future `governance.replan` may produce them. |
+| Working-manifest divergence between runs | M3 | Pure deterministic applier; canonical-form hashing (not raw YAML); parent-overlay-id chain ordering; replay tests on every PR. |
+| Overlay mutates completed work, invalidating checkpoints | M3 | Execution-aware validator (§6.3.4) rejects any overlay touching started/completed task IDs. Completed-work immutability is an explicit principle (§3.7) and an enforced rule. |
+| Operator confusion: which manifest am I looking at? | M3 | Console must show original + overlay chain + working manifest distinctly. Overlay-created tasks carry `overlay_id` / `overlay_reason` / `correction_decision_id` provenance metadata (§6.3.8). |
 
 ---
 
@@ -589,9 +809,9 @@ Every test must catch a specific bug per `docs/TEST_QUALITY_STANDARD.md`. No tau
 
 Cleaner, but loses operator-readable intent. Mixed lists let prose carry the "why" while typed checks carry the "what we'll measure."
 
-### 10.2 Author manifest in `governance.review` instead of `governance.plan_build`
+### 10.2 Allow autonomous correction to emit any operation
 
-The original SIP-0086 spec called for `governance.review`; the implementation diverged to `governance.assess_readiness` because review was renamed. M2 lands the originally intended separation under the implemented naming, not a third name. `governance.plan_build` is more descriptive than reusing either existing name.
+Initial draft of M3 allowed the correction producer to emit all five operation types. Rev 2 restricted to `add_task` + `tighten_acceptance` because removal/replacement/reordering can easily make a long-cycle plan incoherent — the very situation correction is supposed to fix. Conservative producer plus full schema support gives us the full operation set when an operator (or future `governance.replan`) needs it, without giving autonomous correction the keys to rewrite history.
 
 ### 10.3 Treat overlays as in-place mutations of the manifest
 
@@ -603,22 +823,52 @@ Re-gate is heavy: it implies operator attention every time the squad needs to ad
 
 ### 10.5 Defer mechanical acceptance until full sandbox execution lands
 
-Sandbox execution (run-the-app) is the smoke pack's job and is significant work (port allocation, container teardown, stack-aware startup). Mechanical acceptance via static analysis + safelisted commands is small, ships now, and complements the smoke pack rather than competing with it. Smoke pack later validates "the app runs"; M1 validates "the code says what the manifest said it should say." Both useful; not redundant.
+Sandbox execution (run-the-app) is the smoke pack's job and is significant work. Mechanical acceptance via static analysis + safelisted commands is small, ships now, and complements the smoke pack rather than competing with it. Smoke pack later validates "the app runs"; M1 validates "the code says what the manifest said it should say." Both useful; not redundant.
+
+### 10.6 Hash raw YAML rather than canonical serialization
+
+Raw-YAML hashing is the obvious approach but unstable across whitespace/key-order changes. Canonical serialization adds a small amount of complexity for parent-hash stability across re-saves. Worth it.
 
 ---
 
 ## 11. Future Work
 
+- **Expand autonomous correction operation set.** Once long-cycle telemetry supports it, `governance.replan` can be the producer for `remove_task` / `replace_task` / `reorder`. Correction protocol stays conservative.
 - **Stack-aware acceptance defaults.** When SIP-0072 (Stack Capability Registry) concretization lands, manifest authoring can pull stack-default check sets (e.g., FastAPI ⇒ `endpoint_defined` + `import_present` for the repo; React ⇒ `count_at_least` for components).
-- **Operator-driven overlays via API.** An endpoint to submit an overlay manually for active runs, with the same applier and bounds.
-- **Replan task.** A `governance.replan` cadence-bound task that produces overlays based on accumulated cycle state (time-budget pressure, defect density). Hooks reserved by M3.
 - **Cross-handler validation.** A check that QA tests actually exercise the dev artifacts (named in SIP-0086 §10).
+- **Operator-driven overlays via API.** An endpoint to submit an overlay manually for active runs, with the same applier and bounds. Operator overlays may use any of the five operations.
+- **Replan task.** A `governance.replan` cadence-bound task that produces overlays based on accumulated cycle state (time-budget pressure, defect density). Hooks reserved by M3.
 - **Adaptive safelist.** Per-stack expansions to `command_check_safelist` driven by the stack capability registry.
 - **Loosen-acceptance via gate.** Operator-initiated acceptance loosening as a re-gated action, distinct from in-cycle correction overlays.
 
 ---
 
-## 12. References
+## 12. Revision History
+
+- **Rev 2 (2026-04-27):** Incorporated external review. Major changes:
+  - Typed-check schema normalized: flat YAML for authoring, internal `TypedCheck(check, params, severity, description)` for evaluators (§6.1.1).
+  - Added severity field (§6.1.2) — `error` (default), `warning`, `info`. Only `error` failures contribute to `missing_components`.
+  - Added `CheckOutcome` status enum (§6.1.4) — `passed` / `failed` / `skipped` / `error`.
+  - Added explicit path/command safety subsection (§6.1.5).
+  - Added stack-aware bounded evaluation rule with `unsupported_stack_or_syntax` skip outcome (§6.1.6).
+  - Added authoring-time validation rules (§6.1.7) — unknown check names / malformed params fail manifest validation at parse time.
+  - Added `command_acceptance_checks` config flag for independent rollback of `command_exit_zero`.
+  - Added `manifest_review.yaml` schema (§6.2.2) with rule that revision requests cannot be prose-only.
+  - Added M2 default-flip criteria (§6.2.4) replacing "after stabilization."
+  - Split overlay handling into pure structural applier (§6.3.3) and execution-aware validator (§6.3.4).
+  - Added explicit completed-work immutability principle (§3.7) and rule (§6.3.5).
+  - **Restricted autonomous correction producer to `add_task` + `tighten_acceptance` only** (§6.3.10). Schema and applier still support all 5 ops; producer does not.
+  - Tightened operation-level invariants per op (§6.3.2).
+  - Specified canonical hashing and parent-overlay-id chain order (§6.3.6).
+  - Clarified task index ≠ execution order after overlays (§6.3.7).
+  - Added overlay-created task provenance metadata (§6.3.8).
+  - Fixed group_run example: replaced `endpoint_defined` cross-applied to test files with `regex_match` `count_min: 5` over the test file (§7).
+  - Added Alternatives 10.2 and 10.6.
+- **Rev 1 (2026-04-27):** Initial proposal.
+
+---
+
+## 13. References
 
 - **SIP-0086** — Build Convergence Loop (parent SIP; this SIP closes its §10 "Mechanical acceptance criteria evaluation" and "Separate manifest authoring from governance review" future-work items)
 - **SIP-0079** — Implementation Run Contract (correction protocol the overlay producer integrates with)
@@ -630,5 +880,6 @@ Sandbox execution (run-the-app) is the smoke pack's job and is significant work 
 - `src/squadops/cycles/task_plan.py:341` — current `_replace_build_steps_with_manifest` (extended by M3 to apply overlays)
 - `src/squadops/capabilities/handlers/cycle_tasks.py` — current `_validate_output_focused` (extended by M1)
 - `src/squadops/api/routes/cycles/runs.py` — gate promotion + control_manifest forwarding (extended by M3 to forward `control_manifest_delta`)
+- `adapters/capabilities/aci_executor.py` — sandbox executor for `command_exit_zero`
 - Memory: `project_sip0086_manifest_handoff_bug.md` — observed manifest forwarding bugs that motivate the artifact-type discipline overlays inherit
 - Memory: `project_spark_cycle_status.md` — observed YAML emission failures motivating M2's authoring-vs-review split


### PR DESCRIPTION
## Summary

Updates `sips/proposed/SIP-Build-Manifest-Maturation.md` to rev 2 based on external SIP review.

17 of 18 reviewer points adopted, 1 modified. Three capabilities (M1/M2/M3) and overall scope unchanged. ~12 new subsections, mostly safety/correctness rails.

## Highest-leverage changes

1. **Autonomous correction producer restricted to `add_task` + `tighten_acceptance` only.** Schema and applier still support all 5 ops; the autonomous correction protocol does not. `remove_task` / `replace_task` / `reorder` require operator action or a future `governance.replan` task. Collapses M3's risk surface dramatically — autonomous correction can grow the plan but cannot rewrite history.

2. **Split overlay handling: pure structural applier + execution-aware validator.** Applier stays a pure deterministic function (test-tractable). The execution-aware validator consults run state and rejects overlays mutating started/completed work. Both must succeed before an overlay is forwarded to the executor.

3. **Typed-check schema normalized.** Flat YAML for authoring, internal `TypedCheck(check, params, severity, description)` for evaluators. Eliminates the previous implementation hazard where authors and evaluators could see different shapes.

4. **Severity (`error` / `warning` / `info`) and `CheckOutcome` status enum (`passed` / `failed` / `skipped` / `error`).** Enables safe rollout of new checks (ship as `warning`, promote to `error` after telemetry). Distinguishes "no FastAPI in this stack" (skipped) from "endpoints aren't there" (failed).

5. **Path/command safety subsection.** The manifest is LLM-authored; treat as untrusted input by design. Workspace chroot, argv-only commands, safelist, glob/regex bounds, symlink rejection.

6. **Stack-aware bounded evaluation.** `endpoint_defined` etc. target reference-app stacks (FastAPI, Python imports) only; other stacks return `skipped` with reason `unsupported_stack_or_syntax`. Prevents the universal-framework-parser drift.

7. **`manifest_review.yaml` schema.** Reviewer concerns are typed and mechanically actionable, not prose. Revision requests cannot be prose-only by rule.

8. **Concrete M2 default-flip criteria** replacing "after stabilization" — N successful runs, validity rate, duration regression cap, revision rate cap.

9. **Canonical hashing + parent_overlay_id chain order.** Raw YAML hashing was unstable across re-saves.

10. **Overlay-created task provenance metadata.** Operators can answer "why does `m009` exist" without grepping logs.

11. **Fixed group_run worked example** — replaced `endpoint_defined`-on-test-file (which conflated route check with test coverage) with `regex_match` `count_min: 5` over the test file.

## What I pushed back on

Just one item: keeping `command_exit_zero` inside the same M1 PR series rather than splitting into 1.2a / 1.2b. The independent disable flag (`command_acceptance_checks`) handles the rollback risk without fragmenting the work.

## Net effect

- 412 insertions, 161 deletions
- Three capabilities unchanged, scope unchanged
- Implementation surface clarified at every layer that previously had ambiguity

## Test plan

- [ ] SIP renders cleanly on GitHub
- [ ] No code changes — no test suite impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)