### PR TITLE
chore(sip): accept SIP-0092 Build Manifest Maturation

### DIFF
--- a/sips/accepted/SIP-0092-Build-Manifest-Maturation-Mechanical.md
+++ b/sips/accepted/SIP-0092-Build-Manifest-Maturation-Mechanical.md
@@ -1,6 +1,15 @@
-# SIP-XXXX: Build Manifest Maturation — Mechanical Acceptance, Separated Authoring, and Delta Overlays
+---
+title: Build Manifest Maturation — Mechanical Acceptance, Separated Authoring, and
+  Delta Overlays
+status: accepted
+author: SquadOps Architecture
+created_at: '2026-04-27T00:00:00Z'
+sip_number: 92
+updated_at: '2026-04-29T23:39:19.875323Z'
+---
+# SIP-0092: Build Manifest Maturation — Mechanical Acceptance, Separated Authoring, and Delta Overlays
 
-**Status:** Proposed
+**Status:** Accepted
 **Authors:** SquadOps Architecture
 **Created:** 2026-04-27
 **Revision:** 2

--- a/sips/registry.yaml
+++ b/sips/registry.yaml
@@ -1,4 +1,4 @@
-last_assigned: 91
+last_assigned: 92
 sips:
 - sip_uid: null
   sip_number: null
@@ -826,5 +826,14 @@ sips:
   author: Jason Ladd
   approver: jladd
   created_at: '2026-04-25T00:00:00Z'
-  updated_at: '2026-04-25T17:57:14.030222Z'
   updated_at: '2026-04-24T22:18:28.183743Z'
+- sip_uid: null
+  sip_number: 92
+  title: Build Manifest Maturation — Mechanical Acceptance, Separated Authoring, and
+    Delta Overlays
+  path: sips/accepted/SIP-0092-Build-Manifest-Maturation-Mechanical.md
+  status: accepted
+  author: SquadOps Architecture
+  approver: jladd
+  created_at: '2026-04-27T00:00:00Z'
+  updated_at: '2026-04-29T23:39:19.899538Z'


### PR DESCRIPTION
## Summary
- Promotes SIP-Build-Manifest-Maturation from `proposed` to `accepted` via the maintainer script.
- Assigns SIP-0092; renames file to `SIP-0092-Build-Manifest-Maturation-Mechanical.md`.
- Adds YAML frontmatter required by `scripts/maintainer/update_sip_status.py` (the proposal had only the markdown body header).
- Updates body title `SIP-XXXX` → `SIP-0092` and `Status: Proposed` → `Status: Accepted` to match SIP-0086 convention.

This is the maintainer step that follows PR #69 (design-review merge). After this lands, implementation begins on a new `feature/sip-0092-build-manifest-maturation` branch off main, with the implementation plan as its first commit.

## Test plan
- [x] `update_sip_status.py` reports `proposed → accepted`, no duplicates, no orphans.
- [x] Registry `last_assigned: 91 → 92`.
- [x] File now at `sips/accepted/SIP-0092-Build-Manifest-Maturation-Mechanical.md`.
- [x] Frontmatter `status: accepted`, `sip_number: 92`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)