### PR TITLE
feat(sip-0092 m1.1): implementation plan rename + typed acceptance schema/parser

### DIFF
--- a/adapters/cycles/distributed_flow_executor.py
+++ b/adapters/cycles/distributed_flow_executor.py
@@ -168,14 +168,14 @@ class DistributedFlowExecutor(FlowExecutionPort):
                     },
                 )
 
-            # SIP-0086: Load manifest for implementation workloads.
-            # The manifest is produced by the planning workload and forwarded
-            # via plan_artifact_refs. Loading it here (not mid-loop) keeps the
-            # executor deterministic — the plan is fully materialized before
-            # task dispatch begins.
-            manifest = await self._load_manifest_for_run(cycle, run)
+            # SIP-0086 / SIP-0092: Load implementation plan for implementation
+            # workloads. The plan is produced by the planning workload and
+            # forwarded via plan_artifact_refs. Loading it here (not mid-loop)
+            # keeps the executor deterministic — the plan is fully materialized
+            # before task dispatch begins.
+            implementation_plan = await self._load_plan_for_run(cycle, run)
 
-            plan = generate_task_plan(cycle, run, profile, manifest=manifest)
+            plan = generate_task_plan(cycle, run, profile, plan=implementation_plan)
 
             # Build-only validation (D6): require plan_artifact_refs
             include_plan = bool(cycle.applied_defaults.get("plan_tasks", True))
@@ -520,9 +520,10 @@ class DistributedFlowExecutor(FlowExecutionPort):
         # workload-type-specific keys
         wt = completed_run.workload_type
         if wt == "planning":
-            # SIP-0086: include control_manifest alongside documents so the
-            # build_task_manifest.yaml reaches the implementation workload.
-            plan_types = {"document", "control_manifest"}
+            # SIP-0086 / SIP-0092: include control_implementation_plan
+            # alongside documents so the implementation_plan.yaml reaches the
+            # implementation workload.
+            plan_types = {"document", "control_implementation_plan"}
             plan_candidates = [a for a in promoted if a.artifact_type in plan_types]
             plan_refs = [a.artifact_id for a in sorted(plan_candidates, key=lambda a: a.created_at)]
             if "plan_artifact_refs" in overrides:
@@ -1019,26 +1020,26 @@ class DistributedFlowExecutor(FlowExecutionPort):
     # SIP-0086: Manifest loading for implementation workloads
     # ------------------------------------------------------------------
 
-    async def _load_manifest_for_run(
+    async def _load_plan_for_run(
         self,
         cycle: Any,
         run: Any,
     ) -> Any:
-        """Load build task manifest for an implementation workload run.
+        """Load implementation plan for an implementation workload run.
 
-        Searches forwarded plan_artifact_refs for a control_manifest artifact.
-        Called before generate_task_plan() so the plan is fully materialized
-        before task dispatch begins — no mid-loop mutation.
+        Searches forwarded plan_artifact_refs for a control_implementation_plan
+        artifact. Called before generate_task_plan() so the plan is fully
+        materialized before task dispatch begins — no mid-loop mutation.
 
-        Returns BuildTaskManifest or None (RC-4 graceful fallback).
+        Returns ImplementationPlan or None (RC-4 graceful fallback).
         """
-        from squadops.cycles.build_manifest import BuildTaskManifest
+        from squadops.cycles.implementation_plan import ImplementationPlan
 
-        # Only load manifest when build_manifest is enabled
-        if not cycle.applied_defaults.get("build_manifest", False):
+        # Only load the plan when build_plan is enabled
+        if not cycle.applied_defaults.get("build_plan", False):
             return None
 
-        # Search forwarded planning artifacts for manifest
+        # Search forwarded planning artifacts for the plan
         plan_refs = cycle.execution_overrides.get("plan_artifact_refs", [])
         if not plan_refs:
             return None
@@ -1046,13 +1047,14 @@ class DistributedFlowExecutor(FlowExecutionPort):
         for ref_id in plan_refs:
             try:
                 ref, content_bytes = await self._artifact_vault.retrieve(ref_id)
-                if ref.filename == "build_task_manifest.yaml" or (
-                    hasattr(ref, "artifact_type") and ref.artifact_type == "control_manifest"
+                if ref.filename == "implementation_plan.yaml" or (
+                    hasattr(ref, "artifact_type")
+                    and ref.artifact_type == "control_implementation_plan"
                 ):
                     yaml_content = content_bytes.decode(errors="replace")
-                    manifest = BuildTaskManifest.from_yaml(yaml_content)
+                    manifest = ImplementationPlan.from_yaml(yaml_content)
                     logger.info(
-                        "Loaded build task manifest with %d subtasks for run %s",
+                        "Loaded implementation plan with %d subtasks for run %s",
                         len(manifest.tasks),
                         run.run_id,
                     )

--- a/adapters/cycles/distributed_flow_executor.py
+++ b/adapters/cycles/distributed_flow_executor.py
@@ -1035,8 +1035,8 @@ class DistributedFlowExecutor(FlowExecutionPort):
         """
         from squadops.cycles.implementation_plan import ImplementationPlan
 
-        # Only load the plan when build_plan is enabled
-        if not cycle.applied_defaults.get("build_plan", False):
+        # Only load the plan when implementation_plan is enabled in resolved config
+        if not cycle.applied_defaults.get("implementation_plan", False):
             return None
 
         # Search forwarded planning artifacts for the plan

--- a/docs/plans/SIP-0092-implementation-plan-improvement-plan.md
+++ b/docs/plans/SIP-0092-implementation-plan-improvement-plan.md
@@ -652,7 +652,7 @@ These ship with the M1 PRs. They activate typed acceptance and leave the M2/M3 s
 ```yaml
 # build profile — current rollout (M1 on, M2 off, M3 off)
 defaults:
-  build_plan: true
+  implementation_plan: true
   output_validation: true
   max_self_eval_passes: 1
   typed_acceptance: true               # M1 default-on
@@ -668,7 +668,7 @@ defaults:
 # signal and the structural_plan_change_candidate diagnostic field
 # (added in M2.2) accumulate at the rate the gates require.
 defaults:
-  build_plan: true
+  implementation_plan: true
   output_validation: true
   max_self_eval_passes: 2                   # implementation-profile depth
   max_correction_attempts: 3                # enough budget for correction to surface structural-change candidates (RC-9b / diagnostic field)
@@ -696,7 +696,7 @@ Do **not** enable these flags before the corresponding gate evaluation docs are 
 ```yaml
 # implementation profile — post-gate target (long-cycle, all on, deeper)
 defaults:
-  build_plan: true
+  implementation_plan: true
   output_validation: true
   max_self_eval_passes: 2
   typed_acceptance: true

--- a/sips/accepted/SIP-0092-Implementation-Plan-Improvement.md
+++ b/sips/accepted/SIP-0092-Implementation-Plan-Improvement.md
@@ -667,7 +667,7 @@ The default profiles for the SIP-0092 rollout keep M2 and M3 off because their s
 ```yaml
 # build profile (current rollout — M1 on, M2 off, M3 off)
 defaults:
-  build_plan: true
+  implementation_plan: true
   output_validation: true
   max_self_eval_passes: 1
   typed_acceptance: true               # M1 default-on
@@ -681,7 +681,7 @@ defaults:
 # Intentionally distinct from `build` (which has shallow self-eval) and from
 # `implementation` (which is the post-gate target with M2/M3 on).
 defaults:
-  build_plan: true
+  implementation_plan: true
   output_validation: true
   max_self_eval_passes: 2                   # implementation-profile depth — exercises typed checks meaningfully
   max_correction_attempts: 3                # gives correction enough budget to surface structural-change candidates (RC-9b / diagnostic field)
@@ -709,7 +709,7 @@ These profiles show the **target state after the M1 → M2 and M2 → M3 milesto
 ```yaml
 # implementation profile (long-cycle — post-gate target, all on, deeper)
 defaults:
-  build_plan: true
+  implementation_plan: true
   output_validation: true
   max_self_eval_passes: 2
   typed_acceptance: true

--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -517,9 +517,9 @@ class DataReportHandler(_CycleTaskHandler):
 class GovernanceReviewHandler(_CycleTaskHandler):
     """Cycle task handler for governance review (lead role).
 
-    When ``build_manifest`` is enabled in resolved config, this handler
-    produces both a governance review document AND a build task manifest
-    (SIP-0086 §6.1.3). The manifest is a control-plane artifact that
+    When ``build_plan`` is enabled in resolved config, this handler
+    produces both a governance review document AND an implementation plan
+    (SIP-0086 §6.1.3 / SIP-0092). The plan is a control-plane artifact that
     decomposes the build into focused subtasks.
     """
 
@@ -547,9 +547,9 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         "- Put tests after the code they test\n"
         "- Put QA handoff last\n\n"
         "Output the manifest as a YAML code block with filename: "
-        "build_task_manifest.yaml\n\n"
+        "implementation_plan.yaml\n\n"
         "Use this exact schema:\n"
-        "```yaml:build_task_manifest.yaml\n"
+        "```yaml:implementation_plan.yaml\n"
         "version: 1\n"
         "project_id: <project_id>\n"
         "cycle_id: <cycle_id>\n"
@@ -580,12 +580,12 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         inputs: dict[str, Any],
     ) -> HandlerResult:
         resolved_config = inputs.get("resolved_config", {})
-        build_manifest_enabled = resolved_config.get("build_manifest", True)
+        build_plan_enabled = resolved_config.get("build_plan", True)
 
-        if not build_manifest_enabled:
+        if not build_plan_enabled:
             return await super().handle(context, inputs)
 
-        # Multi-artifact path: governance review + build task manifest
+        # Multi-artifact path: governance review + implementation plan
         start_time = time.perf_counter()
         prd = inputs.get("prd", "")
         prior_outputs = inputs.get("prior_outputs")
@@ -677,11 +677,11 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         import hashlib
 
         from squadops.capabilities.handlers.fenced_parser import extract_fenced_files
-        from squadops.cycles.build_manifest import BuildTaskManifest
+        from squadops.cycles.implementation_plan import ImplementationPlan
 
         extracted = extract_fenced_files(content)
         manifest_files = [
-            f for f in extracted if f["filename"] == "build_task_manifest.yaml"
+            f for f in extracted if f["filename"] == "implementation_plan.yaml"
         ]
 
         if manifest_files:
@@ -692,7 +692,7 @@ class GovernanceReviewHandler(_CycleTaskHandler):
             yaml_content = self._find_manifest_in_raw_yaml(content)
             if yaml_content is None:
                 logger.warning(
-                    "%s: no build_task_manifest.yaml found in response, "
+                    "%s: no implementation_plan.yaml found in response, "
                     "falling back to static task steps",
                     self._handler_name,
                 )
@@ -704,7 +704,7 @@ class GovernanceReviewHandler(_CycleTaskHandler):
 
         # Structural validation
         try:
-            manifest = BuildTaskManifest.from_yaml(yaml_content)
+            manifest = ImplementationPlan.from_yaml(yaml_content)
         except ValueError as exc:
             logger.warning(
                 "%s: manifest validation failed (%s), "
@@ -754,17 +754,17 @@ class GovernanceReviewHandler(_CycleTaskHandler):
             return None
 
         return {
-            "name": "build_task_manifest.yaml",
+            "name": "implementation_plan.yaml",
             "content": yaml_content,
             "media_type": "text/yaml",
-            "type": "control_manifest",
+            "type": "control_implementation_plan",
         }
 
     @staticmethod
     def _find_manifest_in_raw_yaml(content: str) -> str | None:
         """Search for an untagged ```yaml block containing manifest-like content.
 
-        Fallback for when the LLM uses ```yaml instead of ```yaml:build_task_manifest.yaml.
+        Fallback for when the LLM uses ```yaml instead of ```yaml:implementation_plan.yaml.
         Returns the YAML string if found, or None.
         """
         import re

--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -517,7 +517,7 @@ class DataReportHandler(_CycleTaskHandler):
 class GovernanceReviewHandler(_CycleTaskHandler):
     """Cycle task handler for governance review (lead role).
 
-    When ``build_plan`` is enabled in resolved config, this handler
+    When ``implementation_plan`` is enabled in resolved config, this handler
     produces both a governance review document AND an implementation plan
     (SIP-0086 §6.1.3 / SIP-0092). The plan is a control-plane artifact that
     decomposes the build into focused subtasks.
@@ -580,9 +580,9 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         inputs: dict[str, Any],
     ) -> HandlerResult:
         resolved_config = inputs.get("resolved_config", {})
-        build_plan_enabled = resolved_config.get("build_plan", True)
+        implementation_plan_enabled = resolved_config.get("implementation_plan", True)
 
-        if not build_plan_enabled:
+        if not implementation_plan_enabled:
             return await super().handle(context, inputs)
 
         # Multi-artifact path: governance review + implementation plan

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -417,10 +417,10 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
             )
             score = 3
 
-        # SIP-0086: Produce build task manifest when enabled.
-        # The manifest decomposes the upcoming build into focused subtasks.
+        # SIP-0086 / SIP-0092: Produce implementation plan when enabled.
+        # The plan decomposes the upcoming build into focused subtasks.
         resolved_config = inputs.get("resolved_config", {})
-        if resolved_config.get("build_manifest", False):
+        if resolved_config.get("build_plan", False):
             manifest_artifact = await self._produce_manifest(
                 context, inputs, content, resolved_config
             )
@@ -461,7 +461,7 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
         # Constrain task_type to the known build task_types. Without this,
         # models invent task_types like 'quality_assurance.validate' instead
         # of the canonical 'qa.test'.
-        from squadops.cycles.build_manifest import _KNOWN_BUILD_TASK_TYPES
+        from squadops.cycles.implementation_plan import _KNOWN_BUILD_TASK_TYPES
 
         allowed_task_types = sorted(_KNOWN_BUILD_TASK_TYPES)
         task_types_section = (
@@ -528,7 +528,7 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
             f"{qa_handoff_guideline}"
             "\n"
             "Output ONLY the manifest as a YAML code block with filename tag:\n"
-            "```yaml:build_task_manifest.yaml\n"
+            "```yaml:implementation_plan.yaml\n"
             "version: 1\n"
             "project_id: <project_id>\n"
             "cycle_id: <cycle_id>\n"
@@ -586,7 +586,7 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
 
             # Extract manifest YAML — prefer filename-tagged fence
             extracted = extract_fenced_files(response.content)
-            manifest_files = [f for f in extracted if f["filename"] == "build_task_manifest.yaml"]
+            manifest_files = [f for f in extracted if f["filename"] == "implementation_plan.yaml"]
             if manifest_files:
                 yaml_content = manifest_files[0]["content"]
             else:
@@ -603,10 +603,10 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
                     attempt,
                 )
                 return {
-                    "name": "build_task_manifest.yaml",
+                    "name": "implementation_plan.yaml",
                     "content": yaml_content,
                     "media_type": "text/yaml",
-                    "type": "control_manifest",
+                    "type": "control_implementation_plan",
                 }
 
             logger.warning(
@@ -639,26 +639,26 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
         max_subtasks: int,
         profile_roles: list[str],
     ) -> tuple[Any | None, str | None]:
-        """Validate a candidate manifest YAML. Returns (manifest, error_msg).
+        """Validate a candidate plan YAML. Returns (plan, error_msg).
 
-        error_msg is None iff the manifest is valid; in that case manifest is
-        the parsed BuildTaskManifest. The error_msg is the corrective feedback
-        appended to the next LLM attempt.
+        error_msg is None iff the plan is valid; in that case the first return
+        is the parsed ImplementationPlan. The error_msg is the corrective
+        feedback appended to the next LLM attempt.
         """
-        from squadops.cycles.build_manifest import BuildTaskManifest
+        from squadops.cycles.implementation_plan import ImplementationPlan
 
         if yaml_content is None:
             return None, (
                 "Your response did not contain a fenced YAML block tagged "
-                "build_task_manifest.yaml. Reply with ONLY the fenced block."
+                "implementation_plan.yaml. Reply with ONLY the fenced block."
             )
 
         try:
-            manifest = BuildTaskManifest.from_yaml(yaml_content)
+            manifest = ImplementationPlan.from_yaml(yaml_content)
         except ValueError as exc:
             return None, (
-                f"The previous manifest YAML failed validation: {exc}. "
-                "Produce a corrected build_task_manifest.yaml. "
+                f"The previous plan YAML failed validation: {exc}. "
+                "Produce a corrected implementation_plan.yaml. "
                 "Quote every file path; do not put parenthetical comments "
                 "after quoted strings on list items."
             )
@@ -668,7 +668,7 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
             return None, (
                 f"The previous manifest had {n} subtasks; bounds are "
                 f"{min_subtasks}-{max_subtasks}. Produce a corrected "
-                "build_task_manifest.yaml within bounds."
+                "implementation_plan.yaml within bounds."
             )
 
         if profile_roles:
@@ -679,7 +679,7 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
                     f"The previous manifest used role(s) not in the "
                     f"squad profile: {', '.join(bad)}. "
                     f"Use ONLY these roles: {', '.join(profile_roles)}. "
-                    "Produce a corrected build_task_manifest.yaml."
+                    "Produce a corrected implementation_plan.yaml."
                 )
 
         return manifest, None

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -420,7 +420,7 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
         # SIP-0086 / SIP-0092: Produce implementation plan when enabled.
         # The plan decomposes the upcoming build into focused subtasks.
         resolved_config = inputs.get("resolved_config", {})
-        if resolved_config.get("build_plan", False):
+        if resolved_config.get("implementation_plan", False):
             manifest_artifact = await self._produce_manifest(
                 context, inputs, content, resolved_config
             )

--- a/src/squadops/contracts/cycle_request_profiles/profiles/build.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/build.yaml
@@ -20,7 +20,7 @@ defaults:
     - type: implementation
       gate: null
   build_tasks: true
-  build_manifest: true
+  build_plan: true
   output_validation: true
   max_self_eval_passes: 1
   max_build_subtasks: 15

--- a/src/squadops/contracts/cycle_request_profiles/profiles/build.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/build.yaml
@@ -20,7 +20,7 @@ defaults:
     - type: implementation
       gate: null
   build_tasks: true
-  build_plan: true
+  implementation_plan: true
   output_validation: true
   max_self_eval_passes: 1
   max_build_subtasks: 15

--- a/src/squadops/contracts/cycle_request_profiles/profiles/implementation.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/implementation.yaml
@@ -56,7 +56,7 @@ defaults:
   cadence_policy:
     max_pulse_seconds: 600
     max_tasks_per_pulse: 3
-  build_manifest: true
+  build_plan: true
   output_validation: true
   max_self_eval_passes: 2
   max_build_subtasks: 15

--- a/src/squadops/contracts/cycle_request_profiles/profiles/implementation.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/implementation.yaml
@@ -56,7 +56,7 @@ defaults:
   cadence_policy:
     max_pulse_seconds: 600
     max_tasks_per_pulse: 3
-  build_plan: true
+  implementation_plan: true
   output_validation: true
   max_self_eval_passes: 2
   max_build_subtasks: 15

--- a/src/squadops/contracts/cycle_request_profiles/profiles/selftest.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/selftest.yaml
@@ -7,7 +7,7 @@ defaults:
     gates: []
   expected_artifact_types:
     - test_report
-  build_plan: false
+  implementation_plan: false
   output_validation: false
   execution_overrides: {}
   experiment_context:

--- a/src/squadops/contracts/cycle_request_profiles/profiles/selftest.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/selftest.yaml
@@ -7,7 +7,7 @@ defaults:
     gates: []
   expected_artifact_types:
     - test_report
-  build_manifest: false
+  build_plan: false
   output_validation: false
   execution_overrides: {}
   experiment_context:

--- a/src/squadops/contracts/cycle_request_profiles/schema.py
+++ b/src/squadops/contracts/cycle_request_profiles/schema.py
@@ -32,7 +32,7 @@ _APPLIED_DEFAULTS_EXTRA_KEYS = {
     "max_correction_attempts",
     "time_budget_seconds",
     "implementation_pulse_checks",
-    "build_plan",
+    "implementation_plan",
     "max_build_subtasks",
     "min_build_subtasks",
     "output_validation",

--- a/src/squadops/contracts/cycle_request_profiles/schema.py
+++ b/src/squadops/contracts/cycle_request_profiles/schema.py
@@ -32,7 +32,7 @@ _APPLIED_DEFAULTS_EXTRA_KEYS = {
     "max_correction_attempts",
     "time_budget_seconds",
     "implementation_pulse_checks",
-    "build_manifest",
+    "build_plan",
     "max_build_subtasks",
     "min_build_subtasks",
     "output_validation",

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -1,0 +1,139 @@
+"""Acceptance check specification registry — single source of truth (SIP-0092 M1).
+
+This module defines the contract for every typed acceptance check vocabulary
+entry. It is consumed by:
+
+- The parser in ``implementation_plan.py`` (RC-11 authoring-time validation)
+  to reject unknown check names, missing required params, wrong types, and
+  malformed values at plan-parse time.
+- The evaluator framework in ``acceptance_checks.py`` (M1.2, not yet shipped)
+  to declare the per-check evaluator implementation against the same spec.
+
+Adding a new check means adding one entry to ``CHECK_SPECS`` here plus one
+evaluator class registration in M1.2 — no separate ``_KNOWN_CHECKS`` table
+that could drift between parser and evaluator. This is the registry-of-record
+going forward.
+
+Per the SIP-0092 plan doc Terminology Lock, this module is allowed to read
+legacy on-disk artifact names during a future migration, but new code in this
+file should use the post-rename vocabulary (TypedCheck, ImplementationPlan,
+PlanTask, etc.).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class CheckSpec:
+    """Static contract for a typed acceptance check.
+
+    Attributes:
+        name: Vocabulary name (e.g., ``endpoint_defined``). Must match the
+            ``check`` field in the authored TypedCheck.
+        required_params: Param keys that must be present on every authored
+            instance. Missing → ValueError at parse time.
+        optional_params: Param keys that may be present. Unknown keys are
+            rejected at parse time.
+        param_types: Map of param key → expected Python type (or tuple of
+            types). The parser does an ``isinstance`` check; mismatches →
+            ValueError.
+        supported_stacks: Frozen set of stack identifiers (e.g., ``fastapi``,
+            ``python``) on which the M1.2 evaluator can act. Empty set means
+            stack-agnostic. The parser does NOT enforce stack compatibility —
+            stack-unsupported but well-formed checks are valid plans (RC-11)
+            that the evaluator returns ``skipped`` for at runtime (RC-12).
+        requires_stack_context: When true, the M1.2 evaluator needs declared
+            stack context (from ``HandlerContext``) to evaluate. When false,
+            language-level cues (file extension) are sufficient. Per RC-12a,
+            stack-context-unset for a check that requires it returns
+            ``status: skipped`` reason ``unsupported_stack_or_syntax``, NOT
+            ``error``.
+        path_params: Param keys whose values are workspace-relative file or
+            glob paths. The parser applies cheap pre-eval rejection (absolute
+            paths, ``..`` traversal) on these so authoring-time errors don't
+            slip through to evaluation. Full chrooting and symlink rejection
+            still happens at evaluation time (M1.2).
+    """
+
+    name: str
+    required_params: frozenset[str]
+    optional_params: frozenset[str] = frozenset()
+    param_types: dict[str, type | tuple[type, ...]] = field(default_factory=dict)
+    supported_stacks: frozenset[str] = frozenset()
+    requires_stack_context: bool = False
+    path_params: frozenset[str] = frozenset()
+
+
+# Allowed severity values. Anything else → ValueError at parse time.
+ALLOWED_SEVERITIES: frozenset[str] = frozenset({"error", "warning", "info"})
+
+
+# Rev 1 vocabulary. Each entry's evaluator implementation lands in M1.2;
+# the parser already rejects authoring errors against this spec.
+CHECK_SPECS: dict[str, CheckSpec] = {
+    "endpoint_defined": CheckSpec(
+        name="endpoint_defined",
+        required_params=frozenset({"file", "methods_paths"}),
+        param_types={"file": str, "methods_paths": list},
+        supported_stacks=frozenset({"fastapi"}),
+        requires_stack_context=True,
+        path_params=frozenset({"file"}),
+    ),
+    "import_present": CheckSpec(
+        name="import_present",
+        required_params=frozenset({"file", "module"}),
+        optional_params=frozenset({"symbol"}),
+        param_types={"file": str, "module": str, "symbol": str},
+        supported_stacks=frozenset({"python", "javascript", "typescript"}),
+        requires_stack_context=False,
+        path_params=frozenset({"file"}),
+    ),
+    "field_present": CheckSpec(
+        name="field_present",
+        required_params=frozenset({"file", "class_name", "fields"}),
+        param_types={"file": str, "class_name": str, "fields": list},
+        supported_stacks=frozenset({"python"}),
+        requires_stack_context=True,
+        path_params=frozenset({"file"}),
+    ),
+    "regex_match": CheckSpec(
+        name="regex_match",
+        required_params=frozenset({"file", "pattern"}),
+        optional_params=frozenset({"count_min"}),
+        param_types={"file": str, "pattern": str, "count_min": int},
+        supported_stacks=frozenset(),
+        requires_stack_context=False,
+        path_params=frozenset({"file"}),
+    ),
+    "count_at_least": CheckSpec(
+        name="count_at_least",
+        required_params=frozenset({"glob", "min_count"}),
+        param_types={"glob": str, "min_count": int},
+        supported_stacks=frozenset(),
+        requires_stack_context=False,
+        path_params=frozenset({"glob"}),
+    ),
+    "command_exit_zero": CheckSpec(
+        name="command_exit_zero",
+        required_params=frozenset({"argv"}),
+        optional_params=frozenset({"cwd", "timeout_s"}),
+        param_types={"argv": list, "cwd": str, "timeout_s": int},
+        supported_stacks=frozenset(),
+        requires_stack_context=False,
+        # argv elements are not single paths; the M1.2 safelist (RC-10a)
+        # validates argv shapes pattern-by-pattern. cwd is path-checked at
+        # evaluation time, not here.
+        path_params=frozenset(),
+    ),
+}
+
+
+def reserved_keys_for(check_name: str) -> frozenset[str]:
+    """Return the keys reserved for the wrapper (not part of params).
+
+    Useful for the parser's flat-YAML normalization rule: params is the
+    authored dict minus these keys.
+    """
+    return frozenset({"check", "severity", "description"})

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -1,12 +1,16 @@
-"""Build Task Manifest — control-plane artifact for dynamic build decomposition (SIP-0086 §6.1).
+"""Implementation Plan — control-plane artifact for dynamic build decomposition.
 
-The manifest is produced by GovernanceReviewHandler during planning and consumed
-by generate_task_plan() after gate approval. It decomposes a build into focused
-subtasks, each targeting a specific component with explicit expected artifacts
-and acceptance criteria.
+Originally introduced as the build task manifest in SIP-0086 §6.1. Renamed to
+"implementation plan" by SIP-0092 to disambiguate from build/CI/Docker manifests
+and to align with the artifact's actual role as the squad's plan for the build
+phase.
 
-The approved manifest becomes immutable after gate approval (RC-1). Correction-
-driven changes are represented as delta overlays, not mutations.
+The plan is produced during planning and consumed by generate_task_plan() after
+gate approval. It decomposes a build into focused subtasks, each targeting a
+specific component with explicit expected artifacts and acceptance criteria.
+
+The approved plan becomes immutable after gate approval (RC-1). Correction-
+driven changes are represented as plan changes (SIP-0092 M3), not mutations.
 """
 
 from __future__ import annotations
@@ -17,7 +21,7 @@ from dataclasses import dataclass, field
 import yaml
 
 
-# Known task types that may appear in manifest tasks.
+# Known task types that may appear in plan tasks.
 _KNOWN_BUILD_TASK_TYPES = {
     "development.develop",
     "qa.test",
@@ -26,8 +30,8 @@ _KNOWN_BUILD_TASK_TYPES = {
 
 
 @dataclass(frozen=True)
-class ManifestTask:
-    """A single focused build subtask within the manifest."""
+class PlanTask:
+    """A single focused build subtask within the plan."""
 
     task_index: int
     task_type: str
@@ -40,8 +44,8 @@ class ManifestTask:
 
 
 @dataclass(frozen=True)
-class ManifestSummary:
-    """Metadata summary for the manifest."""
+class PlanSummary:
+    """Metadata summary for the plan."""
 
     total_dev_tasks: int
     total_qa_tasks: int
@@ -50,7 +54,7 @@ class ManifestSummary:
 
 
 @dataclass(frozen=True)
-class BuildTaskManifest:
+class ImplementationPlan:
     """Structured build decomposition plan — a control-plane artifact.
 
     Produced at planning time by GovernanceReviewHandler. Consumed at build
@@ -61,12 +65,12 @@ class BuildTaskManifest:
     project_id: str
     cycle_id: str
     prd_hash: str
-    tasks: list[ManifestTask]
-    summary: ManifestSummary
+    tasks: list[PlanTask]
+    summary: PlanSummary
 
     @classmethod
-    def from_yaml(cls, content: str) -> BuildTaskManifest:
-        """Parse and validate a manifest from YAML string.
+    def from_yaml(cls, content: str) -> ImplementationPlan:
+        """Parse and validate a plan from YAML string.
 
         Performs structural validation: required fields, known task types,
         dependency DAG correctness, and non-empty task list.
@@ -83,7 +87,7 @@ class BuildTaskManifest:
             raise ValueError(f"Malformed YAML: {exc}") from exc
 
         if not isinstance(data, dict):
-            raise ValueError("Manifest must be a YAML mapping")
+            raise ValueError("Plan must be a YAML mapping")
 
         # Required top-level fields
         for key in ("version", "project_id", "cycle_id", "prd_hash", "tasks", "summary"):
@@ -92,10 +96,10 @@ class BuildTaskManifest:
 
         tasks_data = data["tasks"]
         if not isinstance(tasks_data, list) or len(tasks_data) == 0:
-            raise ValueError("Manifest must contain at least one task")
+            raise ValueError("Plan must contain at least one task")
 
         # Parse tasks
-        tasks: list[ManifestTask] = []
+        tasks: list[PlanTask] = []
         seen_indices: set[int] = set()
         for i, td in enumerate(tasks_data):
             if not isinstance(td, dict):
@@ -122,7 +126,7 @@ class BuildTaskManifest:
                 raise ValueError(f"Task {task_index}: depends_on must be a list")
 
             tasks.append(
-                ManifestTask(
+                PlanTask(
                     task_index=task_index,
                     task_type=task_type,
                     role=td["role"],
@@ -151,7 +155,7 @@ class BuildTaskManifest:
         summary_data = data["summary"]
         if not isinstance(summary_data, dict):
             raise ValueError("summary must be a mapping")
-        summary = ManifestSummary(
+        summary = PlanSummary(
             total_dev_tasks=summary_data.get("total_dev_tasks", 0),
             total_qa_tasks=summary_data.get("total_qa_tasks", 0),
             total_tasks=summary_data.get("total_tasks", len(tasks)),
@@ -168,7 +172,7 @@ class BuildTaskManifest:
         )
 
     def validate_against_profile(self, profile: object) -> list[str]:
-        """Check that all manifest roles exist in the squad profile.
+        """Check that all plan roles exist in the squad profile.
 
         Args:
             profile: A SquadProfile object with an ``agents`` attribute.
@@ -190,7 +194,7 @@ class BuildTaskManifest:
         return dataclasses.asdict(self)
 
 
-def _check_dependency_dag(tasks: list[ManifestTask]) -> None:
+def _check_dependency_dag(tasks: list[PlanTask]) -> None:
     """Validate that task dependencies form a DAG (no cycles).
 
     Raises:

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -17,8 +17,15 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass, field
+from typing import Union
 
 import yaml
+
+from squadops.cycles.acceptance_check_spec import (
+    ALLOWED_SEVERITIES,
+    CHECK_SPECS,
+    reserved_keys_for,
+)
 
 
 # Known task types that may appear in plan tasks.
@@ -27,6 +34,31 @@ _KNOWN_BUILD_TASK_TYPES = {
     "qa.test",
     "builder.assemble",
 }
+
+
+@dataclass(frozen=True)
+class TypedCheck:
+    """Canonical internal form of a machine-evaluable acceptance criterion (SIP-0092 M1).
+
+    Authored in YAML as a flat dict with check, severity, description, and
+    check-specific param keys. The parser normalizes the flat shape into this
+    dataclass so the evaluator framework (M1.2) doesn't need to re-parse the
+    raw YAML.
+
+    Attributes:
+        check: Vocabulary name. Must be a key in CHECK_SPECS.
+        params: Check-specific parameters. Equals the authored dict minus the
+            reserved keys ({check, severity, description}).
+        severity: One of {error, warning, info}. Defaults to ``error``.
+            Per RC-9, only severity=error AND status ∈ {failed, error}
+            blocks validation.
+        description: Human-readable description for evidence/UI. Optional.
+    """
+
+    check: str
+    params: dict
+    severity: str = "error"
+    description: str = ""
 
 
 @dataclass(frozen=True)
@@ -39,7 +71,10 @@ class PlanTask:
     focus: str
     description: str
     expected_artifacts: list[str] = field(default_factory=list)
-    acceptance_criteria: list[str] = field(default_factory=list)
+    # Mixed list: prose strings stay informational; TypedCheck instances are
+    # machine-evaluated by the M1.2 framework. The parser normalizes flat-YAML
+    # typed entries into TypedCheck (see ImplementationPlan.from_yaml).
+    acceptance_criteria: list[Union[str, TypedCheck]] = field(default_factory=list)
     depends_on: list[int] = field(default_factory=list)
 
 
@@ -125,6 +160,13 @@ class ImplementationPlan:
             if not isinstance(depends_on, list):
                 raise ValueError(f"Task {task_index}: depends_on must be a list")
 
+            raw_criteria = td.get("acceptance_criteria", [])
+            if not isinstance(raw_criteria, list):
+                raise ValueError(
+                    f"Task {task_index}: acceptance_criteria must be a list"
+                )
+            criteria = _parse_acceptance_criteria(raw_criteria, task_index)
+
             tasks.append(
                 PlanTask(
                     task_index=task_index,
@@ -133,7 +175,7 @@ class ImplementationPlan:
                     focus=td["focus"],
                     description=td["description"],
                     expected_artifacts=td.get("expected_artifacts", []),
-                    acceptance_criteria=td.get("acceptance_criteria", []),
+                    acceptance_criteria=criteria,
                     depends_on=depends_on,
                 )
             )
@@ -190,8 +232,21 @@ class ImplementationPlan:
         return errors
 
     def to_dict(self) -> dict:
-        """Serialize to dict for YAML/JSON transport."""
-        return dataclasses.asdict(self)
+        """Serialize to dict for YAML/JSON transport.
+
+        TypedCheck entries in ``acceptance_criteria`` are serialized as flat
+        authored-form mappings (params spread to top level alongside check /
+        severity / description), matching the on-disk YAML schema parsed by
+        ``from_yaml``. This makes round-trip ``from_yaml → to_dict → safe_dump
+        → from_yaml`` a stable identity, which is load-bearing for the
+        canonical-hashing helper SIP-0092 M3 introduces.
+        """
+        result = dataclasses.asdict(self)
+        for task_dict, task in zip(result["tasks"], self.tasks):
+            task_dict["acceptance_criteria"] = [
+                _serialize_acceptance_criterion(c) for c in task.acceptance_criteria
+            ]
+        return result
 
 
 def _check_dependency_dag(tasks: list[PlanTask]) -> None:
@@ -218,3 +273,178 @@ def _check_dependency_dag(tasks: list[PlanTask]) -> None:
 
     for task in tasks:
         _visit(task.task_index)
+
+
+def _serialize_acceptance_criterion(c: Union[str, TypedCheck]) -> Union[str, dict]:
+    """Inverse of the parser's flat-YAML normalization.
+
+    str entries pass through unchanged. TypedCheck entries become flat dicts
+    with the wrapper keys (check, severity, description) at top level next to
+    the check-specific params.
+    """
+    if isinstance(c, str):
+        return c
+    flat: dict = {"check": c.check}
+    flat.update(c.params)
+    flat["severity"] = c.severity
+    if c.description:
+        flat["description"] = c.description
+    return flat
+
+
+def _parse_acceptance_criteria(
+    raw: list, task_index: int
+) -> list[Union[str, TypedCheck]]:
+    """Parse a mixed acceptance_criteria list per SIP-0092 M1.
+
+    Accepts:
+        - str items: kept as-is (informational prose)
+        - dict items: normalized into TypedCheck per the flat-YAML rule
+          (params = dict minus reserved keys {check, severity, description})
+
+    Authoring-time rejections (RC-11):
+        - Unknown check name (not in CHECK_SPECS).
+        - Missing required param per CHECK_SPECS[check].required_params.
+        - Wrong-type param per CHECK_SPECS[check].param_types.
+        - Unknown param key (not in required_params ∪ optional_params).
+        - Unknown severity value (not in {error, warning, info}).
+        - Path-typed param value containing absolute path or '..' traversal
+          (cheap pre-eval rejection; full chrooting still applies at
+          evaluation time per RC-10).
+
+    Returns:
+        Mixed list of str and TypedCheck instances, preserving authored order.
+    """
+    parsed: list[Union[str, TypedCheck]] = []
+    for j, item in enumerate(raw):
+        if isinstance(item, str):
+            parsed.append(item)
+            continue
+
+        if not isinstance(item, dict):
+            raise ValueError(
+                f"Task {task_index}.acceptance_criteria[{j}]: "
+                f"each entry must be a string (informational) or mapping (typed)"
+            )
+
+        # Typed check — must declare which check
+        if "check" not in item:
+            raise ValueError(
+                f"Task {task_index}.acceptance_criteria[{j}]: "
+                f"typed criterion missing required key 'check'"
+            )
+        check_name = item["check"]
+        if not isinstance(check_name, str):
+            raise ValueError(
+                f"Task {task_index}.acceptance_criteria[{j}]: "
+                f"'check' must be a string"
+            )
+        if check_name not in CHECK_SPECS:
+            raise ValueError(
+                f"Task {task_index}.acceptance_criteria[{j}]: "
+                f"unknown check '{check_name}'. "
+                f"Known checks: {', '.join(sorted(CHECK_SPECS))}"
+            )
+
+        spec = CHECK_SPECS[check_name]
+
+        # Severity
+        severity = item.get("severity", "error")
+        if severity not in ALLOWED_SEVERITIES:
+            raise ValueError(
+                f"Task {task_index}.acceptance_criteria[{j}] "
+                f"({check_name}): unknown severity '{severity}'. "
+                f"Allowed: {', '.join(sorted(ALLOWED_SEVERITIES))}"
+            )
+
+        # Description
+        description = item.get("description", "")
+        if not isinstance(description, str):
+            raise ValueError(
+                f"Task {task_index}.acceptance_criteria[{j}] "
+                f"({check_name}): 'description' must be a string"
+            )
+
+        # Params = item minus reserved keys
+        reserved = reserved_keys_for(check_name)
+        params = {k: v for k, v in item.items() if k not in reserved}
+
+        # Required params
+        missing = spec.required_params - set(params)
+        if missing:
+            raise ValueError(
+                f"Task {task_index}.acceptance_criteria[{j}] "
+                f"({check_name}): missing required param(s): "
+                f"{', '.join(sorted(missing))}"
+            )
+
+        # Unknown params
+        allowed_params = spec.required_params | spec.optional_params
+        unknown = set(params) - allowed_params
+        if unknown:
+            raise ValueError(
+                f"Task {task_index}.acceptance_criteria[{j}] "
+                f"({check_name}): unknown param(s): "
+                f"{', '.join(sorted(unknown))}. "
+                f"Allowed: {', '.join(sorted(allowed_params))}"
+            )
+
+        # Param types
+        for key, value in params.items():
+            expected = spec.param_types.get(key)
+            if expected is None:
+                continue  # spec didn't declare a type; tolerated
+            if not isinstance(value, expected):
+                expected_name = (
+                    expected.__name__
+                    if isinstance(expected, type)
+                    else " | ".join(t.__name__ for t in expected)
+                )
+                raise ValueError(
+                    f"Task {task_index}.acceptance_criteria[{j}] "
+                    f"({check_name}): param '{key}' must be {expected_name}, "
+                    f"got {type(value).__name__}"
+                )
+
+        # Path-traversal pre-eval rejection
+        for path_key in spec.path_params:
+            if path_key in params:
+                _reject_unsafe_path(
+                    params[path_key], path_key, task_index, j, check_name
+                )
+
+        parsed.append(
+            TypedCheck(
+                check=check_name,
+                params=params,
+                severity=severity,
+                description=description,
+            )
+        )
+
+    return parsed
+
+
+def _reject_unsafe_path(
+    value: object, key: str, task_index: int, criterion_index: int, check_name: str
+) -> None:
+    """Cheap pre-evaluation rejection of obviously unsafe paths.
+
+    Full chrooting and symlink rejection still happens at evaluation time
+    (M1.2, RC-10). This catches authoring errors at parse time so the squad
+    sees feedback at the gate rather than at hour 2 of build.
+    """
+    if not isinstance(value, str):
+        return  # type validation already handled by param_types check
+    if value.startswith("/") or value.startswith("\\"):
+        raise ValueError(
+            f"Task {task_index}.acceptance_criteria[{criterion_index}] "
+            f"({check_name}): {key}={value!r} is absolute "
+            f"(must be workspace-relative)"
+        )
+    parts = value.replace("\\", "/").split("/")
+    if ".." in parts:
+        raise ValueError(
+            f"Task {task_index}.acceptance_criteria[{criterion_index}] "
+            f"({check_name}): {key}={value!r} contains '..' traversal"
+        )

--- a/src/squadops/cycles/models.py
+++ b/src/squadops/cycles/models.py
@@ -76,7 +76,7 @@ class ArtifactType:
     BUILD_PLAN = "build_plan"
     CONFIG_SNAPSHOT = "config_snapshot"
     QA_HANDOFF = "qa_handoff"
-    CONTROL_MANIFEST = "control_manifest"
+    CONTROL_IMPLEMENTATION_PLAN = "control_implementation_plan"
 
 
 class RunInitiator:

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -20,7 +20,7 @@ from squadops.capabilities.handlers.build_profiles import (
     ROUTING_BUILDER_PRESENT,
     ROUTING_FALLBACK_NO_BUILDER,
 )
-from squadops.cycles.build_manifest import BuildTaskManifest
+from squadops.cycles.implementation_plan import ImplementationPlan
 from squadops.cycles.models import (
     REQUIRED_PLAN_ROLES,
     REQUIRED_REFINEMENT_ROLES,
@@ -211,7 +211,7 @@ def generate_task_plan(
     cycle: Cycle,
     run: Run,
     profile: SquadProfile,
-    manifest: BuildTaskManifest | None = None,
+    plan: ImplementationPlan | None = None,
 ) -> list[TaskEnvelope]:
     """Generate a task plan for a cycle run.
 
@@ -219,16 +219,16 @@ def generate_task_plan(
     type (SIP-0078). Otherwise falls back to legacy ``plan_tasks`` /
     ``build_tasks`` flags from ``applied_defaults``.
 
-    When a ``manifest`` is provided (SIP-0086), the build-phase segment
-    is materialized from the approved manifest instead of static
-    ``BUILD_TASK_STEPS``. The approved manifest is the build-phase plan;
+    When a ``plan`` is provided (SIP-0086 / SIP-0092), the build-phase segment
+    is materialized from the approved implementation plan instead of static
+    ``BUILD_TASK_STEPS``. The approved plan is the build-phase contract;
     ``TaskEnvelope`` objects are its deterministic execution materialization.
 
     Args:
         cycle: The cycle containing experiment config.
         run: The run to generate tasks for.
         profile: The squad profile for agent resolution.
-        manifest: Optional approved build task manifest (SIP-0086).
+        plan: Optional approved implementation plan (SIP-0086 / SIP-0092).
 
     Returns:
         Ordered list of TaskEnvelopes, one per pipeline step.
@@ -240,11 +240,11 @@ def generate_task_plan(
     else:
         steps, builder_used = _resolve_legacy_steps(cycle, profile, profile_roles)
 
-    # SIP-0086: replace static build steps with manifest-derived steps.
+    # SIP-0086: replace static build steps with plan-derived steps.
     # Only applies when the step list actually contains build steps.
     has_build_steps = any(s[0] in _BUILD_TASK_TYPES for s in steps)
-    if manifest is not None and has_build_steps:
-        steps = _replace_build_steps_with_manifest(steps, manifest, profile, profile_roles)
+    if plan is not None and has_build_steps:
+        steps = _replace_build_steps_with_plan(steps, plan, profile, profile_roles)
 
     # Shared lineage IDs for the entire plan
     correlation_id = uuid4().hex
@@ -266,19 +266,19 @@ def generate_task_plan(
     prev_task_id: str | None = None
 
     for step_index, step in enumerate(steps):
-        # Steps are either (task_type, role) tuples or ManifestTask objects
+        # Steps are either (task_type, role) tuples or PlanTask objects
         if isinstance(step, tuple):
             task_type, role = step
-            manifest_task = None
+            plan_task = None
         else:
             task_type = step.task_type
             role = step.role
-            manifest_task = step
+            plan_task = step
 
         # Determine task ID
-        if manifest_task is not None:
-            # SIP-0086 RC-2: deterministic manifest namespace
-            task_id = f"task-{run.run_id[:12]}-m{manifest_task.task_index:03d}-{task_type}"
+        if plan_task is not None:
+            # SIP-0086 RC-2: deterministic plan-task namespace
+            task_id = f"task-{run.run_id[:12]}-m{plan_task.task_index:03d}-{task_type}"
         elif use_deterministic_ids:
             task_id = f"task-{run.run_id[:12]}-{step_index:03d}-{task_type}"
         else:
@@ -306,17 +306,17 @@ def generate_task_plan(
             "agent_model": agent_model,
             "agent_config_overrides": agent_overrides,
             # SIP-0086: expose active profile roles so planning handlers can
-            # constrain manifest role choices to what the squad actually has.
+            # constrain plan role choices to what the squad actually has.
             "profile_roles": sorted(profile_roles),
         }
 
-        # SIP-0086: populate subtask fields from manifest
-        if manifest_task is not None:
-            inputs["subtask_focus"] = manifest_task.focus
-            inputs["subtask_description"] = manifest_task.description
-            inputs["expected_artifacts"] = manifest_task.expected_artifacts
-            inputs["subtask_index"] = manifest_task.task_index
-            inputs["acceptance_criteria"] = manifest_task.acceptance_criteria
+        # SIP-0086: populate subtask fields from plan
+        if plan_task is not None:
+            inputs["subtask_focus"] = plan_task.focus
+            inputs["subtask_description"] = plan_task.description
+            inputs["expected_artifacts"] = plan_task.expected_artifacts
+            inputs["subtask_index"] = plan_task.task_index
+            inputs["acceptance_criteria"] = plan_task.acceptance_criteria
 
         envelope = TaskEnvelope(
             task_id=task_id,
@@ -338,22 +338,22 @@ def generate_task_plan(
     return envelopes
 
 
-def _replace_build_steps_with_manifest(
+def _replace_build_steps_with_plan(
     steps: list,
-    manifest: BuildTaskManifest,
+    plan: ImplementationPlan,
     profile: SquadProfile,
     profile_roles: set[str],
 ) -> list:
-    """Replace static build steps with manifest-derived ManifestTask objects.
+    """Replace static build steps with plan-derived PlanTask objects.
 
     Preserves planning steps; only the build-phase segment is replaced.
-    Validates that all manifest roles exist in the profile.
+    Validates that all plan roles exist in the profile.
     """
-    # Validate manifest roles against profile
-    errors = manifest.validate_against_profile(profile)
+    # Validate plan roles against profile
+    errors = plan.validate_against_profile(profile)
     if errors:
         raise CycleError(
-            f"Manifest validation failed against profile '{profile.profile_id}': "
+            f"Plan validation failed against profile '{profile.profile_id}': "
             + "; ".join(errors)
         )
 
@@ -363,5 +363,5 @@ def _replace_build_steps_with_manifest(
     }
     non_build_steps = [s for s in steps if s[0] not in static_build_types]
 
-    # Append manifest tasks (ManifestTask objects, not tuples)
-    return non_build_steps + list(manifest.tasks)
+    # Append plan tasks (PlanTask objects, not tuples)
+    return non_build_steps + list(plan.tasks)

--- a/tests/unit/capabilities/handlers/test_governance_review_plan.py
+++ b/tests/unit/capabilities/handlers/test_governance_review_plan.py
@@ -16,7 +16,7 @@ from squadops.capabilities.handlers.cycle_tasks import GovernanceReviewHandler
 # ---------------------------------------------------------------------------
 
 VALID_MANIFEST_BLOCK = """\
-```yaml:build_task_manifest.yaml
+```yaml:implementation_plan.yaml
 version: 1
 project_id: group_run
 cycle_id: cyc_test
@@ -83,7 +83,7 @@ def _make_context() -> MagicMock:
 
 
 def _make_inputs(
-    build_manifest: bool = True,
+    build_plan: bool = True,
     min_subtasks: int = 3,
     max_subtasks: int = 15,
 ) -> dict[str, Any]:
@@ -91,7 +91,7 @@ def _make_inputs(
         "prd": "Build a group run app with FastAPI and React.",
         "prior_outputs": {"strat": "Strategy analysis content"},
         "resolved_config": {
-            "build_manifest": build_manifest,
+            "build_plan": build_plan,
             "min_build_subtasks": min_subtasks,
             "max_build_subtasks": max_subtasks,
         },
@@ -125,17 +125,17 @@ class TestGovernanceReviewManifest:
         assert review["type"] == "document"
 
         manifest = artifacts[1]
-        assert manifest["name"] == "build_task_manifest.yaml"
-        assert manifest["type"] == "control_manifest"
+        assert manifest["name"] == "implementation_plan.yaml"
+        assert manifest["type"] == "control_implementation_plan"
 
-    async def test_review_only_when_build_manifest_disabled(self):
+    async def test_review_only_when_build_plan_disabled(self):
         handler = GovernanceReviewHandler()
         ctx = _make_context()
         ctx.ports.llm.chat_stream_with_usage.return_value = _make_llm_response(
             "## Governance Review\nLooks good."
         )
 
-        result = await handler.handle(ctx, _make_inputs(build_manifest=False))
+        result = await handler.handle(ctx, _make_inputs(build_plan=False))
 
         assert result.success
         artifacts = result.outputs["artifacts"]
@@ -158,7 +158,7 @@ class TestGovernanceReviewManifest:
     async def test_graceful_fallback_malformed_yaml(self):
         handler = GovernanceReviewHandler()
         ctx = _make_context()
-        bad_manifest = "```yaml:build_task_manifest.yaml\n{{invalid yaml\n```"
+        bad_manifest = "```yaml:implementation_plan.yaml\n{{invalid yaml\n```"
         ctx.ports.llm.chat_stream_with_usage.return_value = _make_llm_response(
             "Review.\n\n" + bad_manifest
         )
@@ -206,7 +206,7 @@ class TestGovernanceReviewManifest:
 
         manifest = result.outputs["artifacts"][1]
         assert manifest["media_type"] == "text/yaml"
-        assert manifest["type"] == "control_manifest"
+        assert manifest["type"] == "control_implementation_plan"
 
     async def test_prd_hash_mismatch_logs_warning_but_accepts(self):
         """PRD hash is informational — mismatch logs warning but doesn't reject."""

--- a/tests/unit/capabilities/handlers/test_governance_review_plan.py
+++ b/tests/unit/capabilities/handlers/test_governance_review_plan.py
@@ -83,7 +83,7 @@ def _make_context() -> MagicMock:
 
 
 def _make_inputs(
-    build_plan: bool = True,
+    implementation_plan: bool = True,
     min_subtasks: int = 3,
     max_subtasks: int = 15,
 ) -> dict[str, Any]:
@@ -91,7 +91,7 @@ def _make_inputs(
         "prd": "Build a group run app with FastAPI and React.",
         "prior_outputs": {"strat": "Strategy analysis content"},
         "resolved_config": {
-            "build_plan": build_plan,
+            "implementation_plan": implementation_plan,
             "min_build_subtasks": min_subtasks,
             "max_build_subtasks": max_subtasks,
         },
@@ -128,14 +128,14 @@ class TestGovernanceReviewManifest:
         assert manifest["name"] == "implementation_plan.yaml"
         assert manifest["type"] == "control_implementation_plan"
 
-    async def test_review_only_when_build_plan_disabled(self):
+    async def test_review_only_when_implementation_plan_disabled(self):
         handler = GovernanceReviewHandler()
         ctx = _make_context()
         ctx.ports.llm.chat_stream_with_usage.return_value = _make_llm_response(
             "## Governance Review\nLooks good."
         )
 
-        result = await handler.handle(ctx, _make_inputs(build_plan=False))
+        result = await handler.handle(ctx, _make_inputs(implementation_plan=False))
 
         assert result.success
         artifacts = result.outputs["artifacts"]

--- a/tests/unit/capabilities/test_planning_handlers.py
+++ b/tests/unit/capabilities/test_planning_handlers.py
@@ -649,7 +649,7 @@ class TestGovernanceAssessReadinessValidation:
 
 
 _VALID_MANIFEST_YAML = """\
-```yaml:build_task_manifest.yaml
+```yaml:implementation_plan.yaml
 version: 1
 project_id: test_proj
 cycle_id: test_cyc
@@ -697,7 +697,7 @@ summary:
 """
 
 _MALFORMED_MANIFEST_YAML = """\
-```yaml:build_task_manifest.yaml
+```yaml:implementation_plan.yaml
 version: 1
 project_id: test_proj
 cycle_id: test_cyc
@@ -746,8 +746,8 @@ class TestProduceManifestRetry:
         result = await self._call_produce(ctx)
 
         assert result is not None
-        assert result["name"] == "build_task_manifest.yaml"
-        assert result["type"] == "control_manifest"
+        assert result["name"] == "implementation_plan.yaml"
+        assert result["type"] == "control_implementation_plan"
         assert ctx.ports.llm.chat_stream_with_usage.await_count == 1
 
     async def test_malformed_yaml_retries_then_succeeds(self):
@@ -760,7 +760,7 @@ class TestProduceManifestRetry:
         result = await self._call_produce(ctx)
 
         assert result is not None
-        assert result["name"] == "build_task_manifest.yaml"
+        assert result["name"] == "implementation_plan.yaml"
         assert ctx.ports.llm.chat_stream_with_usage.await_count == 2
 
     async def test_retry_prompt_includes_parse_error(self):

--- a/tests/unit/cycles/test_api_runs.py
+++ b/tests/unit/cycles/test_api_runs.py
@@ -209,8 +209,8 @@ class TestGateDecision:
         working_manifest = ArtifactRef(
             artifact_id="art_manifest",
             project_id="hello_squad",
-            artifact_type="control_manifest",
-            filename="build_task_manifest.yaml",
+            artifact_type="control_implementation_plan",
+            filename="implementation_plan.yaml",
             content_hash="h2",
             size_bytes=20,
             media_type="text/yaml",

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -924,7 +924,7 @@ class TestBuildForwardingOverrides:
         assert result["prior_workload_artifact_refs"] == []
 
     async def test_planning_run_forwards_plan_artifact_refs(self, executor):
-        """Planning workload forwards promoted documents + control_manifests."""
+        """Planning workload forwards promoted documents + control_implementation_plans."""
         cycle = _make_cycle()
         completed = _make_run("run_001", 1, "completed", "planning")
         doc1 = _make_artifact_ref("art_plan_01", artifact_type="document", created_at=T2)
@@ -937,13 +937,13 @@ class TestBuildForwardingOverrides:
         assert result["plan_artifact_refs"] == ["art_plan_02", "art_plan_01"]
         assert "impl_run_id" not in result
 
-    async def test_planning_run_includes_control_manifest(self, executor):
-        """SIP-0086: control_manifest artifacts are forwarded as plan_artifact_refs."""
+    async def test_planning_run_includes_control_implementation_plan(self, executor):
+        """SIP-0086: control_implementation_plan artifacts are forwarded as plan_artifact_refs."""
         cycle = _make_cycle()
         completed = _make_run("run_001", 1, "completed", "planning")
         doc = _make_artifact_ref("art_doc", artifact_type="document", created_at=T1)
         manifest = _make_artifact_ref(
-            "art_manifest", artifact_type="control_manifest", created_at=T2
+            "art_manifest", artifact_type="control_implementation_plan", created_at=T2
         )
         noise = _make_artifact_ref("art_report", artifact_type="run_report", created_at=T3)
 

--- a/tests/unit/cycles/test_executor_plan_loading.py
+++ b/tests/unit/cycles/test_executor_plan_loading.py
@@ -92,7 +92,7 @@ class TestLoadManifestForRun:
 
     def _make_cycle(self, **overrides) -> MagicMock:
         cycle = MagicMock()
-        cycle.applied_defaults = {"build_plan": True}
+        cycle.applied_defaults = {"implementation_plan": True}
         cycle.execution_overrides = {}
         for k, v in overrides.items():
             setattr(cycle, k, v)
@@ -114,7 +114,7 @@ class TestLoadManifestForRun:
     async def test_build_plan_disabled_returns_none(self):
         executor = self._make_executor()
         cycle = self._make_cycle(
-            applied_defaults={"build_plan": False},
+            applied_defaults={"implementation_plan": False},
             execution_overrides={"plan_artifact_refs": ["art_manifest"]},
         )
 

--- a/tests/unit/cycles/test_executor_plan_loading.py
+++ b/tests/unit/cycles/test_executor_plan_loading.py
@@ -53,8 +53,8 @@ summary:
 @dataclass
 class _FakeArtifactRef:
     artifact_id: str = "art_manifest"
-    filename: str = "build_task_manifest.yaml"
-    artifact_type: str = "control_manifest"
+    filename: str = "implementation_plan.yaml"
+    artifact_type: str = "control_implementation_plan"
     metadata: dict = field(default_factory=dict)
 
 
@@ -79,7 +79,7 @@ class _FakeDocArtifactRef:
 
 
 # ---------------------------------------------------------------------------
-# Phase 3b: _load_manifest_for_run
+# Phase 3b: _load_plan_for_run
 # ---------------------------------------------------------------------------
 
 
@@ -92,7 +92,7 @@ class TestLoadManifestForRun:
 
     def _make_cycle(self, **overrides) -> MagicMock:
         cycle = MagicMock()
-        cycle.applied_defaults = {"build_manifest": True}
+        cycle.applied_defaults = {"build_plan": True}
         cycle.execution_overrides = {}
         for k, v in overrides.items():
             setattr(cycle, k, v)
@@ -107,18 +107,18 @@ class TestLoadManifestForRun:
         executor = self._make_executor()
         cycle = self._make_cycle(execution_overrides={})
 
-        result = await executor._load_manifest_for_run(cycle, self._make_run())
+        result = await executor._load_plan_for_run(cycle, self._make_run())
 
         assert result is None
 
-    async def test_build_manifest_disabled_returns_none(self):
+    async def test_build_plan_disabled_returns_none(self):
         executor = self._make_executor()
         cycle = self._make_cycle(
-            applied_defaults={"build_manifest": False},
+            applied_defaults={"build_plan": False},
             execution_overrides={"plan_artifact_refs": ["art_manifest"]},
         )
 
-        result = await executor._load_manifest_for_run(cycle, self._make_run())
+        result = await executor._load_plan_for_run(cycle, self._make_run())
 
         assert result is None
 
@@ -133,7 +133,7 @@ class TestLoadManifestForRun:
             execution_overrides={"plan_artifact_refs": ["art_manifest"]},
         )
 
-        result = await executor._load_manifest_for_run(cycle, self._make_run())
+        result = await executor._load_plan_for_run(cycle, self._make_run())
 
         assert result is not None
         assert len(result.tasks) == 3
@@ -150,7 +150,7 @@ class TestLoadManifestForRun:
             execution_overrides={"plan_artifact_refs": ["art_doc"]},
         )
 
-        result = await executor._load_manifest_for_run(cycle, self._make_run())
+        result = await executor._load_plan_for_run(cycle, self._make_run())
 
         assert result is None
 
@@ -161,7 +161,7 @@ class TestLoadManifestForRun:
             execution_overrides={"plan_artifact_refs": ["art_manifest"]},
         )
 
-        result = await executor._load_manifest_for_run(cycle, self._make_run())
+        result = await executor._load_plan_for_run(cycle, self._make_run())
 
         assert result is None
 
@@ -176,15 +176,15 @@ class TestLoadManifestForRun:
             execution_overrides={"plan_artifact_refs": ["art_manifest"]},
         )
 
-        result = await executor._load_manifest_for_run(cycle, self._make_run())
+        result = await executor._load_plan_for_run(cycle, self._make_run())
 
         assert result is None
 
     def test_rc1_manifest_is_frozen_dataclass(self):
-        """RC-1: BuildTaskManifest is a frozen dataclass — field reassignment blocked."""
-        from squadops.cycles.build_manifest import BuildTaskManifest
+        """RC-1: ImplementationPlan is a frozen dataclass — field reassignment blocked."""
+        from squadops.cycles.implementation_plan import ImplementationPlan
 
-        manifest = BuildTaskManifest.from_yaml(MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
 
         with pytest.raises(AttributeError):
             manifest.version = 99  # type: ignore[misc]

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -1,4 +1,4 @@
-"""Tests for BuildTaskManifest model (SIP-0086 Phase 1a)."""
+"""Tests for ImplementationPlan model (SIP-0086 Phase 1a)."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from squadops.cycles.build_manifest import BuildTaskManifest
+from squadops.cycles.implementation_plan import ImplementationPlan
 
 
 # ---------------------------------------------------------------------------
@@ -74,9 +74,9 @@ class _FakeProfile:
 # ---------------------------------------------------------------------------
 
 
-class TestBuildTaskManifestParsing:
+class TestImplementationPlanParsing:
     def test_valid_manifest_round_trips(self):
-        manifest = BuildTaskManifest.from_yaml(VALID_MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
 
         assert manifest.version == 1
         assert manifest.project_id == "group_run"
@@ -86,7 +86,7 @@ class TestBuildTaskManifestParsing:
         assert manifest.summary.total_tasks == 3
 
     def test_task_fields_populated(self):
-        manifest = BuildTaskManifest.from_yaml(VALID_MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
         task0 = manifest.tasks[0]
 
         assert task0.task_index == 0
@@ -98,20 +98,20 @@ class TestBuildTaskManifestParsing:
         assert task0.depends_on == []
 
     def test_dependency_chain_parsed(self):
-        manifest = BuildTaskManifest.from_yaml(VALID_MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
 
         assert manifest.tasks[1].depends_on == [0]
         assert manifest.tasks[2].depends_on == [0, 1]
 
     def test_acceptance_criteria_optional(self):
         """Tasks without acceptance_criteria default to empty list."""
-        manifest = BuildTaskManifest.from_yaml(VALID_MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
 
         # Task 1 has no acceptance_criteria in the YAML
         assert manifest.tasks[1].acceptance_criteria == []
 
     def test_to_dict_serializes(self):
-        manifest = BuildTaskManifest.from_yaml(VALID_MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
         d = manifest.to_dict()
 
         assert d["version"] == 1
@@ -124,14 +124,14 @@ class TestBuildTaskManifestParsing:
 # ---------------------------------------------------------------------------
 
 
-class TestBuildTaskManifestValidation:
+class TestImplementationPlanValidation:
     def test_malformed_yaml_raises(self):
         with pytest.raises(ValueError, match="Malformed YAML"):
-            BuildTaskManifest.from_yaml("{{not: valid: yaml::")
+            ImplementationPlan.from_yaml("{{not: valid: yaml::")
 
     def test_non_mapping_raises(self):
         with pytest.raises(ValueError, match="must be a YAML mapping"):
-            BuildTaskManifest.from_yaml("- just a list")
+            ImplementationPlan.from_yaml("- just a list")
 
     def test_missing_required_field_raises(self):
         yaml_str = """\
@@ -140,7 +140,7 @@ project_id: test
 # missing cycle_id, prd_hash, tasks, summary
 """
         with pytest.raises(ValueError, match="Missing required field"):
-            BuildTaskManifest.from_yaml(yaml_str)
+            ImplementationPlan.from_yaml(yaml_str)
 
     def test_empty_tasks_raises(self):
         yaml_str = """\
@@ -153,7 +153,7 @@ summary:
   total_tasks: 0
 """
         with pytest.raises(ValueError, match="at least one task"):
-            BuildTaskManifest.from_yaml(yaml_str)
+            ImplementationPlan.from_yaml(yaml_str)
 
     def test_unknown_task_type_raises(self):
         yaml_str = """\
@@ -171,7 +171,7 @@ summary:
   total_tasks: 1
 """
         with pytest.raises(ValueError, match="unknown task_type"):
-            BuildTaskManifest.from_yaml(yaml_str)
+            ImplementationPlan.from_yaml(yaml_str)
 
     def test_missing_task_field_raises(self):
         yaml_str = """\
@@ -187,7 +187,7 @@ summary:
   total_tasks: 1
 """
         with pytest.raises(ValueError, match="missing required field"):
-            BuildTaskManifest.from_yaml(yaml_str)
+            ImplementationPlan.from_yaml(yaml_str)
 
     def test_depends_on_out_of_range_raises(self):
         yaml_str = """\
@@ -206,7 +206,7 @@ summary:
   total_tasks: 1
 """
         with pytest.raises(ValueError, match="non-existent task_index 99"):
-            BuildTaskManifest.from_yaml(yaml_str)
+            ImplementationPlan.from_yaml(yaml_str)
 
     def test_dependency_cycle_raises(self):
         yaml_str = """\
@@ -231,7 +231,7 @@ summary:
   total_tasks: 2
 """
         with pytest.raises(ValueError, match="Dependency cycle"):
-            BuildTaskManifest.from_yaml(yaml_str)
+            ImplementationPlan.from_yaml(yaml_str)
 
     def test_duplicate_task_index_raises(self):
         yaml_str = """\
@@ -254,7 +254,7 @@ summary:
   total_tasks: 2
 """
         with pytest.raises(ValueError, match="Duplicate task_index"):
-            BuildTaskManifest.from_yaml(yaml_str)
+            ImplementationPlan.from_yaml(yaml_str)
 
 
 # ---------------------------------------------------------------------------
@@ -264,7 +264,7 @@ summary:
 
 class TestValidateAgainstProfile:
     def test_valid_profile_returns_no_errors(self):
-        manifest = BuildTaskManifest.from_yaml(VALID_MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
         profile = _FakeProfile(agents=[_FakeAgent("dev"), _FakeAgent("qa")])
 
         errors = manifest.validate_against_profile(profile)
@@ -272,7 +272,7 @@ class TestValidateAgainstProfile:
         assert errors == []
 
     def test_missing_role_returns_error(self):
-        manifest = BuildTaskManifest.from_yaml(VALID_MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
         profile = _FakeProfile(agents=[_FakeAgent("dev")])  # no qa
 
         errors = manifest.validate_against_profile(profile)
@@ -281,7 +281,7 @@ class TestValidateAgainstProfile:
         assert "role 'qa' not in profile" in errors[0]
 
     def test_disabled_agent_treated_as_missing(self):
-        manifest = BuildTaskManifest.from_yaml(VALID_MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
         profile = _FakeProfile(
             agents=[_FakeAgent("dev"), _FakeAgent("qa", enabled=False)]
         )

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -1,4 +1,4 @@
-"""Tests for ImplementationPlan model (SIP-0086 Phase 1a)."""
+"""Tests for ImplementationPlan model (SIP-0086 Phase 1a + SIP-0092 M1.1)."""
 
 from __future__ import annotations
 
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 
 import pytest
 
-from squadops.cycles.implementation_plan import ImplementationPlan
+from squadops.cycles.acceptance_check_spec import CHECK_SPECS
+from squadops.cycles.implementation_plan import ImplementationPlan, TypedCheck
 
 
 # ---------------------------------------------------------------------------
@@ -290,3 +291,250 @@ class TestValidateAgainstProfile:
 
         assert len(errors) == 1
         assert "qa" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# SIP-0092 M1.1 — Typed acceptance criteria
+# ---------------------------------------------------------------------------
+
+
+def _plan_with_criteria(criteria_yaml: str) -> str:
+    """Helper: build a minimal valid plan with a custom acceptance_criteria block."""
+    return f"""\
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+
+tasks:
+  - task_index: 0
+    task_type: development.develop
+    role: dev
+    focus: "Backend"
+    description: "Build endpoints"
+    expected_artifacts:
+      - "backend/routes.py"
+    acceptance_criteria:
+{criteria_yaml}
+    depends_on: []
+
+summary:
+  total_dev_tasks: 1
+  total_qa_tasks: 0
+  total_tasks: 1
+"""
+
+
+class TestTypedAcceptanceParsing:
+    """SIP-0092 M1.1: parser normalizes mixed prose+typed lists into TypedCheck."""
+
+    def test_mixed_prose_and_typed_preserved(self):
+        yaml_block = """\
+      - "Endpoint exists"
+      - check: regex_match
+        file: backend/routes.py
+        pattern: "status_code\\\\s*=\\\\s*409"
+"""
+        plan = ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+        criteria = plan.tasks[0].acceptance_criteria
+        assert len(criteria) == 2
+        assert criteria[0] == "Endpoint exists"
+        assert isinstance(criteria[1], TypedCheck)
+        assert criteria[1].check == "regex_match"
+
+    def test_typed_only_list_parses(self):
+        yaml_block = """\
+      - check: regex_match
+        file: backend/routes.py
+        pattern: "status_code"
+      - check: count_at_least
+        glob: "tests/**/*.py"
+        min_count: 1
+"""
+        plan = ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+        assert all(isinstance(c, TypedCheck) for c in plan.tasks[0].acceptance_criteria)
+
+    def test_params_excludes_reserved_keys(self):
+        """flat-YAML normalization: params = entry minus {check, severity, description}."""
+        yaml_block = """\
+      - check: regex_match
+        severity: warning
+        description: "Coverage"
+        file: backend/routes.py
+        pattern: "status_code"
+"""
+        plan = ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+        tc = plan.tasks[0].acceptance_criteria[0]
+        assert isinstance(tc, TypedCheck)
+        assert tc.severity == "warning"
+        assert tc.description == "Coverage"
+        assert set(tc.params.keys()) == {"file", "pattern"}
+        # Reserved keys must NOT appear in params
+        assert "check" not in tc.params
+        assert "severity" not in tc.params
+        assert "description" not in tc.params
+
+    def test_default_severity_is_error(self):
+        yaml_block = """\
+      - check: regex_match
+        file: backend/routes.py
+        pattern: "x"
+"""
+        plan = ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+        tc = plan.tasks[0].acceptance_criteria[0]
+        assert isinstance(tc, TypedCheck)
+        assert tc.severity == "error"
+
+    def test_round_trip_re_serialize(self):
+        """from_yaml → to_dict → re-emit YAML → from_yaml produces equal task criteria."""
+        import yaml as _yaml
+
+        original_yaml = """\
+      - "Prose entry"
+      - check: regex_match
+        severity: warning
+        file: backend/routes.py
+        pattern: "x"
+"""
+        plan = ImplementationPlan.from_yaml(_plan_with_criteria(original_yaml))
+        serialized = _yaml.safe_dump(plan.to_dict())
+        plan2 = ImplementationPlan.from_yaml(serialized)
+        assert plan.tasks[0].acceptance_criteria == plan2.tasks[0].acceptance_criteria
+
+
+class TestTypedAcceptanceRejections:
+    """RC-11 authoring-time validation: parser rejects malformed typed criteria."""
+
+    def test_unknown_check_raises_with_name_in_message(self):
+        yaml_block = """\
+      - check: invented_check
+        file: foo.py
+"""
+        with pytest.raises(ValueError, match="invented_check"):
+            ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+
+    @pytest.mark.parametrize(
+        "check_name,present_param",
+        [
+            ("regex_match", "pattern"),  # missing 'file'
+            ("count_at_least", "min_count"),  # missing 'glob'
+            ("import_present", "module"),  # missing 'file'
+        ],
+    )
+    def test_missing_required_param_raises(self, check_name, present_param):
+        yaml_block = f"""\
+      - check: {check_name}
+        {present_param}: "x"
+"""
+        with pytest.raises(ValueError, match="missing required param"):
+            ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+
+    def test_wrong_param_type_raises(self):
+        """methods_paths: "GET /runs" as string instead of list → ValueError."""
+        yaml_block = """\
+      - check: endpoint_defined
+        file: backend/routes.py
+        methods_paths: "GET /runs"
+"""
+        with pytest.raises(ValueError, match="methods_paths.*must be list"):
+            ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+
+    def test_unknown_severity_raises(self):
+        yaml_block = """\
+      - check: regex_match
+        severity: critical
+        file: backend/routes.py
+        pattern: "x"
+"""
+        with pytest.raises(ValueError, match="unknown severity"):
+            ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+
+    def test_unknown_param_raises(self):
+        yaml_block = """\
+      - check: regex_match
+        file: backend/routes.py
+        pattern: "x"
+        bogus_param: 1
+"""
+        with pytest.raises(ValueError, match="unknown param"):
+            ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+
+    def test_absolute_path_raises(self):
+        yaml_block = """\
+      - check: regex_match
+        file: "/etc/passwd"
+        pattern: "x"
+"""
+        with pytest.raises(ValueError, match="absolute"):
+            ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+
+    def test_dotdot_traversal_raises(self):
+        yaml_block = """\
+      - check: regex_match
+        file: "../../etc/passwd"
+        pattern: "x"
+"""
+        with pytest.raises(ValueError, match=r"'\.\.' traversal"):
+            ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+
+    def test_typed_entry_missing_check_key_raises(self):
+        yaml_block = """\
+      - file: backend/routes.py
+        pattern: "x"
+"""
+        with pytest.raises(ValueError, match="missing required key 'check'"):
+            ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+
+    def test_non_str_non_dict_entry_raises(self):
+        yaml_block = """\
+      - 42
+"""
+        with pytest.raises(ValueError, match="string.*or mapping"):
+            ImplementationPlan.from_yaml(_plan_with_criteria(yaml_block))
+
+    def test_acceptance_criteria_must_be_list(self):
+        yaml = """\
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+tasks:
+  - task_index: 0
+    task_type: development.develop
+    role: dev
+    focus: "x"
+    description: "x"
+    acceptance_criteria: "not a list"
+    depends_on: []
+summary:
+  total_dev_tasks: 1
+  total_qa_tasks: 0
+  total_tasks: 1
+"""
+        with pytest.raises(ValueError, match="acceptance_criteria must be a list"):
+            ImplementationPlan.from_yaml(yaml)
+
+
+class TestTypedCheckRegistryCoverage:
+    """The CHECK_SPECS registry is the single source of truth — sanity-check it."""
+
+    def test_all_rev1_checks_registered(self):
+        rev1 = {
+            "endpoint_defined",
+            "import_present",
+            "field_present",
+            "regex_match",
+            "count_at_least",
+            "command_exit_zero",
+        }
+        assert rev1.issubset(CHECK_SPECS.keys())
+
+    def test_each_spec_path_params_subset_of_declared_params(self):
+        """A path_param key must be a declared (required or optional) param."""
+        for name, spec in CHECK_SPECS.items():
+            declared = spec.required_params | spec.optional_params
+            stragglers = spec.path_params - declared
+            assert not stragglers, (
+                f"CHECK_SPECS[{name!r}].path_params declares "
+                f"{stragglers} which are not in required ∪ optional params"
+            )

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -6,7 +6,7 @@ import pytest
 
 from datetime import datetime, timezone
 
-from squadops.cycles.build_manifest import BuildTaskManifest
+from squadops.cycles.implementation_plan import ImplementationPlan
 from squadops.cycles.models import (
     AgentProfileEntry,
     Cycle,
@@ -125,12 +125,12 @@ def _make_profile() -> SquadProfile:
 
 class TestGenerateTaskPlanWithManifest:
     def test_manifest_produces_correct_envelope_count(self):
-        manifest = BuildTaskManifest.from_yaml(MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
         cycle = _make_cycle()
         run = _make_run()
         profile = _make_profile()
 
-        envelopes = generate_task_plan(cycle, run, profile, manifest=manifest)
+        envelopes = generate_task_plan(cycle, run, profile, plan=manifest)
 
         # 5 planning steps + 4 manifest build steps = 9
         assert len(envelopes) == 9
@@ -140,18 +140,18 @@ class TestGenerateTaskPlanWithManifest:
         run = _make_run()
         profile = _make_profile()
 
-        envelopes = generate_task_plan(cycle, run, profile, manifest=None)
+        envelopes = generate_task_plan(cycle, run, profile, plan=None)
 
         # 5 planning steps + 2 static build steps = 7
         assert len(envelopes) == 7
 
     def test_manifest_envelopes_have_deterministic_ids(self):
-        manifest = BuildTaskManifest.from_yaml(MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
         cycle = _make_cycle()
         run = _make_run()
         profile = _make_profile()
 
-        envelopes = generate_task_plan(cycle, run, profile, manifest=manifest)
+        envelopes = generate_task_plan(cycle, run, profile, plan=manifest)
 
         # Manifest-derived envelopes are the last 4
         manifest_envelopes = envelopes[5:]
@@ -169,12 +169,12 @@ class TestGenerateTaskPlanWithManifest:
         )
 
     def test_manifest_envelopes_have_subtask_focus(self):
-        manifest = BuildTaskManifest.from_yaml(MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
         cycle = _make_cycle()
         run = _make_run()
         profile = _make_profile()
 
-        envelopes = generate_task_plan(cycle, run, profile, manifest=manifest)
+        envelopes = generate_task_plan(cycle, run, profile, plan=manifest)
 
         build_env = envelopes[5]  # First manifest task
         assert build_env.inputs["subtask_focus"] == "Backend models"
@@ -183,35 +183,35 @@ class TestGenerateTaskPlanWithManifest:
         assert build_env.inputs["subtask_index"] == 0
 
     def test_manifest_envelopes_have_acceptance_criteria(self):
-        manifest = BuildTaskManifest.from_yaml(MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
         cycle = _make_cycle()
         run = _make_run()
         profile = _make_profile()
 
-        envelopes = generate_task_plan(cycle, run, profile, manifest=manifest)
+        envelopes = generate_task_plan(cycle, run, profile, plan=manifest)
 
         build_env = envelopes[5]
         assert build_env.inputs["acceptance_criteria"] == ["Models exist"]
 
     def test_causation_chain_links_sequentially(self):
-        manifest = BuildTaskManifest.from_yaml(MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
         cycle = _make_cycle()
         run = _make_run()
         profile = _make_profile()
 
-        envelopes = generate_task_plan(cycle, run, profile, manifest=manifest)
+        envelopes = generate_task_plan(cycle, run, profile, plan=manifest)
 
         # Each envelope's causation_id should be the previous task's task_id
         for i in range(1, len(envelopes)):
             assert envelopes[i].causation_id == envelopes[i - 1].task_id
 
     def test_planning_steps_preserved_before_manifest(self):
-        manifest = BuildTaskManifest.from_yaml(MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
         cycle = _make_cycle()
         run = _make_run()
         profile = _make_profile()
 
-        envelopes = generate_task_plan(cycle, run, profile, manifest=manifest)
+        envelopes = generate_task_plan(cycle, run, profile, plan=manifest)
 
         # First 5 are planning steps
         planning_types = [e.task_type for e in envelopes[:5]]
@@ -224,18 +224,18 @@ class TestGenerateTaskPlanWithManifest:
         ]
 
     def test_planning_envelopes_have_no_subtask_focus(self):
-        manifest = BuildTaskManifest.from_yaml(MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
         cycle = _make_cycle()
         run = _make_run()
         profile = _make_profile()
 
-        envelopes = generate_task_plan(cycle, run, profile, manifest=manifest)
+        envelopes = generate_task_plan(cycle, run, profile, plan=manifest)
 
         for env in envelopes[:5]:
             assert "subtask_focus" not in env.inputs
 
     def test_missing_role_raises_cycle_error(self):
-        manifest = BuildTaskManifest.from_yaml(MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
         cycle = _make_cycle()
         run = _make_run()
         # Profile without qa role
@@ -264,16 +264,16 @@ class TestGenerateTaskPlanWithManifest:
         from squadops.cycles.models import CycleError
 
         with pytest.raises(CycleError, match="qa"):
-            generate_task_plan(cycle, run, profile, manifest=manifest)
+            generate_task_plan(cycle, run, profile, plan=manifest)
 
     def test_task_id_namespaces_do_not_collide(self):
         """Planning (UUID), manifest (-m{idx}-), correction (corr-) are distinct."""
-        manifest = BuildTaskManifest.from_yaml(MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
         cycle = _make_cycle()
         run = _make_run()
         profile = _make_profile()
 
-        envelopes = generate_task_plan(cycle, run, profile, manifest=manifest)
+        envelopes = generate_task_plan(cycle, run, profile, plan=manifest)
 
         planning_ids = [e.task_id for e in envelopes[:5]]
         manifest_ids = [e.task_id for e in envelopes[5:]]
@@ -287,12 +287,12 @@ class TestGenerateTaskPlanWithManifest:
 
     def test_no_build_tasks_skips_manifest(self):
         """Manifest is ignored when build_tasks is not enabled."""
-        manifest = BuildTaskManifest.from_yaml(MANIFEST_YAML)
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
         cycle = _make_cycle(applied_defaults={"plan_tasks": True, "build_tasks": False})
         run = _make_run()
         profile = _make_profile()
 
-        envelopes = generate_task_plan(cycle, run, profile, manifest=manifest)
+        envelopes = generate_task_plan(cycle, run, profile, plan=manifest)
 
         # Only planning steps, no build steps at all
         assert len(envelopes) == 5


### PR DESCRIPTION
## Summary

PR 1.1 of 3 for SIP-0092 Stage M1. Adds typed acceptance schema and parser-side validation; doesn't touch the validator yet (that's PR 1.3) or evaluator framework (PR 1.2).

Two commits, intentionally split for review legibility:

- **`a8dd313` Commit A — rename sweep (no behavior change).** `build_manifest.py → implementation_plan.py`, `BuildTaskManifest → ImplementationPlan`, `ManifestTask → PlanTask`, `ManifestSummary → PlanSummary`, config key `build_manifest → build_plan`, artifact_type `control_manifest → control_implementation_plan`, four test files renamed, all 13 importers updated. 3455 tests stay green — verifiable in isolation.
- **`1cf9ca4` Commit B — typed acceptance (the actual M1.1 work).** Adds `TypedCheck` dataclass, the `acceptance_check_spec.py` registry as single source of truth, and parser-side rejection of malformed typed criteria at plan-parse time per RC-11. 19 new tests, 3474 total green.

## What's in scope (per plan doc M1.1)

- `TypedCheck(check, params, severity, description)` frozen dataclass; canonical internal form
- `acceptance_check_spec.py` with `CheckSpec` + `CHECK_SPECS` registry — Rev 1 vocabulary entries: `endpoint_defined`, `import_present`, `field_present`, `regex_match`, `count_at_least`, `command_exit_zero`. The same registry is consumed by both the parser (today) and the M1.2 evaluator framework (next), preventing drift.
- `PlanTask.acceptance_criteria` widened to `list[str | TypedCheck]`. Prose strings still pass through unchanged.
- `from_yaml()` parses mixed prose+typed lists with the flat-YAML normalization rule (params = entry minus `{check, severity, description}`)
- Authoring-time rejections (RC-11): unknown check name, missing required param, unknown param, wrong param type, unknown severity, absolute path / `..` traversal in path-typed params, malformed entries
- `to_dict()` serializes typed checks as flat authored form so `from_yaml → to_dict → safe_dump → from_yaml` is stable identity (load-bearing for M3's canonical hashing per §6.3.6)

## What's NOT in scope (deferred)

- **Evaluator framework / static checks / safety** — PR 1.2 (`acceptance_checks.py`, the actual `endpoint_defined` etc. evaluators, command safelist, path chrooting at evaluation time)
- **Validator integration / self-eval prompt / authoring prompt** — PR 1.3 (wiring typed checks into `_validate_output_focused`, severity-weighted contribution to `missing_components`, prompt updates to document the check vocabulary)
- **`governance.assess_readiness` task type rename + `_produce_manifest` extraction** — M2.1's responsibility (separated authoring is gated on M1 → M2 gate)

## Backward compatibility

- Plans with only prose `acceptance_criteria` parse identically — the existing SIP-0086 plan-production code path is untouched.
- The `build_plan` config flag replaces `build_manifest`. Both CRP profile YAMLs and the schema have been updated; no shipped profile uses the old key.
- Artifact_type rename `control_manifest → control_implementation_plan` is consistent across emitter (planning_tasks.py + cycle_tasks.py), forwarder (distributed_flow_executor.py), enum, and tests.
- Per the SIP-0092 plan doc Terminology Lock, this is the last commit allowed to introduce the legacy names; all future PRs must use the canonical terms.

## Test plan

- [x] Regression suite green: 3474 passed, 1 skipped, 0 failures
- [x] Typed-acceptance parser rejects malformed inputs at plan-parse time (10 rejection tests)
- [x] Typed-acceptance parser preserves mixed prose+typed lists (5 happy-path tests, including round-trip)
- [x] CHECK_SPECS registry coverage sanity (2 tests guarding registry shape)
- [x] Backward compat: existing SIP-0086 plan-production tests (3455) still pass after the rename + parser extension

## Follow-ups (separate PRs / cycle work, not preconditions for this merge)

- **PR 1.2** — Check evaluator framework, static-check implementations, safety (path chroot, regex bounds, argv-only command execution, pattern-based safelist).
- **PR 1.3** — Wire typed checks into `_validate_output_focused`, replace today's informational FC3, update self-eval and authoring prompts.
- **Manual smoke** — run a `validation` profile cycle once M1 is fully landed (after PR 1.3).
- **M1 → M2 gate evaluation** — gather ≥10 long-cycle group_run cycles on the `validation` profile per the plan's Milestone Gates section, summarized in `docs/plans/SIP-0092-gate-M1-evaluation.md` before any M2 work begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)