### PR TITLE
feat(sip-0092 m1.2): typed-acceptance evaluator framework + six checks

### DIFF
--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -1,0 +1,690 @@
+"""Typed acceptance check evaluators (SIP-0092 M1.2).
+
+Builds on the M1.1 ``CHECK_SPECS`` registry in ``acceptance_check_spec.py``.
+Each spec there declares the contract; this module supplies the runtime
+evaluator. The pairing is enforced at module import: any ``CHECK_SPECS``
+entry without a matching ``_CHECK_IMPLS`` registration will raise.
+
+Outcomes follow RC-9a: ``error`` is reserved for evaluator failures
+(unsafe path, command not in safelist, regex pathological input, etc.) —
+not for application gaps. ``skipped`` is reserved for stack-context-unset
+or syntax-not-supported cases that authoring-time validation deliberately
+allowed through (RC-12 / RC-12a).
+
+This module is import-clean: nothing in the runtime path consumes it yet.
+M1.3 wires it into ``_validate_output_focused``.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import logging
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from squadops.cycles.acceptance_check_spec import CHECK_SPECS, CheckSpec
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Outcome
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CheckOutcome:
+    """Result of evaluating a single typed check.
+
+    ``status`` ∈ {passed, failed, skipped, error}; see RC-9a / RC-12 for
+    the semantic distinction between ``failed`` (app gap) and ``error``
+    (evaluator failure) and ``skipped`` (intentionally not run).
+    """
+
+    status: str
+    actual: dict[str, Any] = field(default_factory=dict)
+    reason: str = ""
+
+    @classmethod
+    def passed(cls, reason: str = "ok", **actual: Any) -> CheckOutcome:
+        return cls(status="passed", actual=dict(actual), reason=reason)
+
+    @classmethod
+    def failed(cls, reason: str, **actual: Any) -> CheckOutcome:
+        return cls(status="failed", actual=dict(actual), reason=reason)
+
+    @classmethod
+    def skipped(cls, reason: str, **actual: Any) -> CheckOutcome:
+        return cls(status="skipped", actual=dict(actual), reason=reason)
+
+    @classmethod
+    def error(cls, reason: str, **actual: Any) -> CheckOutcome:
+        return cls(status="error", actual=dict(actual), reason=reason)
+
+
+# ---------------------------------------------------------------------------
+# Safety
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_GLOB_MATCH_CAP = 10_000
+DEFAULT_COMMAND_TIMEOUT_S = 10
+MAX_COMMAND_TIMEOUT_S = 60
+DEFAULT_REGEX_INPUT_CAP_BYTES = 10 * 1024 * 1024  # 10 MiB
+DEFAULT_REGEX_PATTERN_CAP_CHARS = 4096
+
+
+class _SafetyError(Exception):
+    """Internal signal — a path/glob/regex/command violated a safety bound.
+
+    Caught at the check boundary and converted to ``CheckOutcome.error``.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _safe_resolve(path_str: str, workspace_root: Path) -> Path:
+    """Resolve a workspace-relative path, rejecting traversal/absolute/symlink-escape.
+
+    Raises ``_SafetyError("path_escapes_workspace")`` on:
+    - absolute path
+    - resolved path lying outside ``workspace_root``
+    - symlink whose target lies outside ``workspace_root``
+    """
+    if not isinstance(path_str, str) or not path_str:
+        raise _SafetyError("path_escapes_workspace")
+    p = Path(path_str)
+    if p.is_absolute():
+        raise _SafetyError("path_escapes_workspace")
+
+    root_resolved = workspace_root.resolve()
+    candidate = (workspace_root / path_str).resolve()
+    try:
+        candidate.relative_to(root_resolved)
+    except ValueError as exc:
+        raise _SafetyError("path_escapes_workspace") from exc
+
+    # Symlink escape: any symlink in the chain pointing outside the workspace.
+    cur = workspace_root / path_str
+    walked = []
+    while cur != cur.parent:
+        walked.append(cur)
+        cur = cur.parent
+    for node in walked:
+        if node.is_symlink():
+            target = node.resolve()
+            try:
+                target.relative_to(root_resolved)
+            except ValueError as exc:
+                raise _SafetyError("path_escapes_workspace") from exc
+    return candidate
+
+
+def _restricted_env() -> dict[str, str]:
+    """Build a clean restricted env for subprocess execution.
+
+    Strips LD_PRELOAD, PYTHONPATH, LD_LIBRARY_PATH, and similar injection
+    surfaces. Keeps a small allowlist of locale / path basics.
+    """
+    import os
+
+    keep = {"PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TZ"}
+    return {k: v for k, v in os.environ.items() if k in keep}
+
+
+# ---------------------------------------------------------------------------
+# Command safelist (RC-10a)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _CommandPattern:
+    name: str
+    matcher: Callable[[list[str]], bool]
+
+
+def _exact(*expected: str) -> Callable[[list[str]], bool]:
+    expected_list = list(expected)
+
+    def matcher(argv: list[str]) -> bool:
+        return list(argv) == expected_list
+
+    return matcher
+
+
+def _exact_then_one_path(*prefix: str) -> Callable[[list[str]], bool]:
+    prefix_list = list(prefix)
+
+    def matcher(argv: list[str]) -> bool:
+        return (
+            len(argv) == len(prefix_list) + 1
+            and list(argv[: len(prefix_list)]) == prefix_list
+        )
+
+    return matcher
+
+
+def _prefix_with_args(*prefix: str) -> Callable[[list[str]], bool]:
+    prefix_list = list(prefix)
+
+    def matcher(argv: list[str]) -> bool:
+        return len(argv) > len(prefix_list) and list(argv[: len(prefix_list)]) == prefix_list
+
+    return matcher
+
+
+def _argv0_with_args(name: str) -> Callable[[list[str]], bool]:
+    def matcher(argv: list[str]) -> bool:
+        return len(argv) >= 1 and argv[0] == name
+
+    return matcher
+
+
+# Order matters only for human readability; the matcher is `any(...)`.
+_COMMAND_SAFELIST: tuple[_CommandPattern, ...] = (
+    _CommandPattern("python -m py_compile <file>", _exact_then_one_path("python", "-m", "py_compile")),
+    _CommandPattern("python -m mypy <args...>", _prefix_with_args("python", "-m", "mypy")),
+    _CommandPattern("node --check <file>", _exact_then_one_path("node", "--check")),
+    _CommandPattern("ruff check <args...>", _prefix_with_args("ruff", "check")),
+    _CommandPattern("tsc --noEmit", _exact("tsc", "--noEmit")),
+    _CommandPattern("eslint <args...>", _argv0_with_args("eslint")),
+    _CommandPattern("pyflakes <file>", _exact_then_one_path("pyflakes")),
+)
+
+
+def _argv_matches_safelist(argv: list[str]) -> bool:
+    return any(pat.matcher(argv) for pat in _COMMAND_SAFELIST)
+
+
+# ---------------------------------------------------------------------------
+# Base + registry
+# ---------------------------------------------------------------------------
+
+
+class BaseCheck:
+    """Abstract evaluator for a typed acceptance check.
+
+    Subclasses register against a ``CheckSpec`` from ``CHECK_SPECS`` via
+    ``@register_check(name)``. The registration links ``cls.spec`` so the
+    evaluator can introspect required/optional params and supported stacks
+    if it needs to.
+    """
+
+    spec: CheckSpec  # set by @register_check
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        raise NotImplementedError
+
+
+_CHECK_IMPLS: dict[str, type[BaseCheck]] = {}
+
+
+def register_check(name: str) -> Callable[[type[BaseCheck]], type[BaseCheck]]:
+    """Class decorator: bind an evaluator to a ``CHECK_SPECS`` entry."""
+
+    def decorator(cls: type[BaseCheck]) -> type[BaseCheck]:
+        if name not in CHECK_SPECS:
+            raise ValueError(
+                f"register_check: '{name}' is not in CHECK_SPECS. "
+                f"Add the spec to acceptance_check_spec.py first."
+            )
+        if name in _CHECK_IMPLS:
+            raise ValueError(f"register_check: duplicate registration for '{name}'")
+        cls.spec = CHECK_SPECS[name]
+        _CHECK_IMPLS[name] = cls
+        return cls
+
+    return decorator
+
+
+def get_check(name: str) -> BaseCheck:
+    """Instantiate the evaluator registered for a check name."""
+    if name not in _CHECK_IMPLS:
+        raise KeyError(f"no evaluator registered for check '{name}'")
+    return _CHECK_IMPLS[name]()
+
+
+def assert_registry_complete() -> None:
+    """Verify every ``CHECK_SPECS`` entry has a registered evaluator.
+
+    Called at module import so a missing pairing fails fast at deploy
+    rather than at first use mid-cycle.
+    """
+    missing = set(CHECK_SPECS.keys()) - set(_CHECK_IMPLS.keys())
+    if missing:
+        raise RuntimeError(
+            f"CHECK_SPECS entries lack evaluators in _CHECK_IMPLS: {sorted(missing)}"
+        )
+
+
+def _skip_unsupported_stack() -> CheckOutcome:
+    """RC-12a: unset/unsupported stack → skipped, not error."""
+    return CheckOutcome.skipped(reason="unsupported_stack_or_syntax")
+
+
+# ---------------------------------------------------------------------------
+# Concrete checks
+# ---------------------------------------------------------------------------
+
+
+_HTTP_METHODS = frozenset({"get", "post", "put", "delete", "patch", "options", "head"})
+
+
+def _normalize_route(path: str) -> str:
+    """Normalize trailing slash for tolerant route comparison."""
+    if path != "/" and path.endswith("/"):
+        return path[:-1]
+    return path
+
+
+def _parse_method_path(token: str) -> tuple[str, str] | None:
+    """Parse a `'METHOD /path'` token; return (method, path) or None."""
+    parts = token.strip().split(maxsplit=1)
+    if len(parts) != 2:
+        return None
+    method, path = parts[0].upper(), _normalize_route(parts[1])
+    if method.lower() not in _HTTP_METHODS:
+        return None
+    return method, path
+
+
+def _decorator_route(decorator: ast.expr) -> tuple[str, str] | None:
+    """Extract (METHOD, path) from `@router.METHOD("/path")` or `@app.METHOD("/path")`."""
+    if not isinstance(decorator, ast.Call):
+        return None
+    if not isinstance(decorator.func, ast.Attribute):
+        return None
+    method = decorator.func.attr.lower()
+    if method not in _HTTP_METHODS:
+        return None
+    if not decorator.args:
+        return None
+    arg0 = decorator.args[0]
+    if isinstance(arg0, ast.Constant) and isinstance(arg0.value, str):
+        return method.upper(), _normalize_route(arg0.value)
+    return None
+
+
+@register_check("endpoint_defined")
+class EndpointDefinedCheck(BaseCheck):
+    """FastAPI route decorator presence — `@app.METHOD('/path')` / `@router.METHOD('/path')`."""
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        if stack != "fastapi":
+            return _skip_unsupported_stack()
+        try:
+            file_path = _safe_resolve(params["file"], workspace_root)
+        except _SafetyError as exc:
+            return CheckOutcome.error(reason=exc.reason)
+        if not file_path.is_file():
+            return CheckOutcome.failed(
+                reason="file_not_found", file=str(params["file"])
+            )
+        try:
+            source = file_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return CheckOutcome.error(reason="file_unreadable")
+        try:
+            tree = ast.parse(source, filename=str(file_path))
+        except SyntaxError:
+            return CheckOutcome.error(reason="parse_failed")
+
+        found: set[tuple[str, str]] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                for dec in node.decorator_list:
+                    parsed = _decorator_route(dec)
+                    if parsed is not None:
+                        found.add(parsed)
+
+        expected: list[tuple[str, str]] = []
+        malformed: list[str] = []
+        for token in params["methods_paths"]:
+            parsed = _parse_method_path(str(token))
+            if parsed is None:
+                malformed.append(token)
+            else:
+                expected.append(parsed)
+        if malformed:
+            return CheckOutcome.error(
+                reason="malformed_methods_paths", malformed=malformed
+            )
+
+        missing = [f"{m} {p}" for (m, p) in expected if (m, p) not in found]
+        found_strs = sorted(f"{m} {p}" for (m, p) in found)
+        if missing:
+            return CheckOutcome.failed(
+                reason="endpoints_missing",
+                found=found_strs,
+                missing=missing,
+            )
+        return CheckOutcome.passed(found=found_strs)
+
+
+@register_check("import_present")
+class ImportPresentCheck(BaseCheck):
+    """Import statement presence — Python AST; .ts/.js gated off in M1.2."""
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        try:
+            file_path = _safe_resolve(params["file"], workspace_root)
+        except _SafetyError as exc:
+            return CheckOutcome.error(reason=exc.reason)
+
+        ext = file_path.suffix.lower()
+        if ext in {".ts", ".js"}:
+            # JS/TS regex fallback gated behind frontend_acceptance_checks
+            # follow-up flag — out of scope for M1.2.
+            return CheckOutcome.skipped(reason="frontend_acceptance_checks_disabled")
+        if ext != ".py":
+            return CheckOutcome.skipped(reason="unsupported_file_extension")
+
+        if not file_path.is_file():
+            return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
+        try:
+            source = file_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return CheckOutcome.error(reason="file_unreadable")
+        try:
+            tree = ast.parse(source, filename=str(file_path))
+        except SyntaxError:
+            return CheckOutcome.error(reason="parse_failed")
+
+        target_module = params["module"]
+        target_symbol = params.get("symbol")
+
+        module_imported = False
+        symbol_imported = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == target_module:
+                        module_imported = True
+                        if target_symbol is None:
+                            symbol_imported = True
+            elif isinstance(node, ast.ImportFrom):
+                if node.module == target_module:
+                    module_imported = True
+                    if target_symbol is None:
+                        symbol_imported = True
+                    else:
+                        for alias in node.names:
+                            if alias.name == target_symbol:
+                                symbol_imported = True
+
+        if not module_imported:
+            return CheckOutcome.failed(reason="module_not_imported", module=target_module)
+        if target_symbol is not None and not symbol_imported:
+            return CheckOutcome.failed(
+                reason="symbol_not_imported",
+                module=target_module,
+                symbol=target_symbol,
+            )
+        return CheckOutcome.passed(module=target_module, symbol=target_symbol)
+
+
+def _classdef_field_names(cls_node: ast.ClassDef) -> set[str]:
+    """Collect declared field names from a class body.
+
+    Covers:
+    - ``name: Type`` (AnnAssign) — dataclasses, Pydantic v2.
+    - ``name = field(...)`` / ``name = Field(...)`` (Assign with Name target).
+    """
+    names: set[str] = set()
+    for stmt in cls_node.body:
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            names.add(stmt.target.id)
+        elif isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+    return names
+
+
+@register_check("field_present")
+class FieldPresentCheck(BaseCheck):
+    """Class field presence — Python dataclasses + Pydantic v2."""
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        if stack is None:
+            return _skip_unsupported_stack()
+        try:
+            file_path = _safe_resolve(params["file"], workspace_root)
+        except _SafetyError as exc:
+            return CheckOutcome.error(reason=exc.reason)
+        if not file_path.is_file():
+            return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
+        try:
+            source = file_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return CheckOutcome.error(reason="file_unreadable")
+        try:
+            tree = ast.parse(source, filename=str(file_path))
+        except SyntaxError:
+            return CheckOutcome.error(reason="parse_failed")
+
+        target_class = params["class_name"]
+        cls_node: ast.ClassDef | None = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == target_class:
+                cls_node = node
+                break
+        if cls_node is None:
+            return CheckOutcome.failed(reason="class_not_found", class_name=target_class)
+
+        declared = _classdef_field_names(cls_node)
+        expected = [str(f) for f in params["fields"]]
+        missing = [f for f in expected if f not in declared]
+        if missing:
+            return CheckOutcome.failed(
+                reason="fields_missing",
+                class_name=target_class,
+                declared=sorted(declared),
+                missing=missing,
+            )
+        return CheckOutcome.passed(class_name=target_class, declared=sorted(declared))
+
+
+@register_check("regex_match")
+class RegexMatchCheck(BaseCheck):
+    """Regex match count — stack-agnostic, size-bounded against ReDoS surface."""
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        try:
+            file_path = _safe_resolve(params["file"], workspace_root)
+        except _SafetyError as exc:
+            return CheckOutcome.error(reason=exc.reason)
+
+        pattern = params["pattern"]
+        if not isinstance(pattern, str) or len(pattern) > DEFAULT_REGEX_PATTERN_CAP_CHARS:
+            return CheckOutcome.error(reason="regex_pattern_too_large")
+
+        count_min = int(params.get("count_min", 1))
+        if not file_path.is_file():
+            return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
+
+        try:
+            size = file_path.stat().st_size
+        except OSError:
+            return CheckOutcome.error(reason="file_unreadable")
+        if size > DEFAULT_REGEX_INPUT_CAP_BYTES:
+            return CheckOutcome.error(reason="regex_input_too_large", size_bytes=size)
+
+        try:
+            content = file_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return CheckOutcome.error(reason="file_unreadable")
+
+        try:
+            compiled = re.compile(pattern)
+        except re.error:
+            return CheckOutcome.error(reason="regex_invalid", pattern=pattern)
+
+        matches = compiled.findall(content)
+        match_count = len(matches)
+        if match_count >= count_min:
+            return CheckOutcome.passed(match_count=match_count, count_min=count_min)
+        return CheckOutcome.failed(
+            reason="match_count_below_minimum",
+            match_count=match_count,
+            count_min=count_min,
+        )
+
+
+@register_check("count_at_least")
+class CountAtLeastCheck(BaseCheck):
+    """Glob match count — workspace-chrooted, capped at 10k matches."""
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        glob_str = str(params["glob"])
+        if Path(glob_str).is_absolute() or ".." in Path(glob_str).parts:
+            return CheckOutcome.error(reason="path_escapes_workspace")
+
+        min_count = int(params["min_count"])
+
+        # Stream rather than materialize, so we can short-circuit at the cap.
+        matches: list[Path] = []
+        try:
+            for i, m in enumerate(workspace_root.glob(glob_str)):
+                if i >= DEFAULT_GLOB_MATCH_CAP:
+                    return CheckOutcome.error(
+                        reason="glob_match_cap_exceeded",
+                        cap=DEFAULT_GLOB_MATCH_CAP,
+                    )
+                matches.append(m)
+        except (OSError, ValueError) as exc:
+            return CheckOutcome.error(reason="glob_failed", detail=str(exc))
+
+        count = len(matches)
+        if count >= min_count:
+            return CheckOutcome.passed(count=count, min_count=min_count)
+        return CheckOutcome.failed(
+            reason="count_below_minimum", count=count, min_count=min_count
+        )
+
+
+def _tail(text: str, max_chars: int = 1024) -> str:
+    """Return the last `max_chars` characters of text, for compact evidence."""
+    if len(text) <= max_chars:
+        return text
+    return "..." + text[-max_chars:]
+
+
+@register_check("command_exit_zero")
+class CommandExitZeroCheck(BaseCheck):
+    """Run a safelist-matched command in workspace and check exit code."""
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        argv = params["argv"]
+        if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
+            return CheckOutcome.error(reason="command_must_be_argv")
+        if not argv:
+            return CheckOutcome.error(reason="command_must_be_argv")
+        if not _argv_matches_safelist(argv):
+            return CheckOutcome.error(reason="command_not_in_safelist", argv=argv)
+
+        timeout_s = int(params.get("timeout_s", DEFAULT_COMMAND_TIMEOUT_S))
+        timeout_s = max(1, min(timeout_s, MAX_COMMAND_TIMEOUT_S))
+
+        cwd_str = params.get("cwd")
+        if cwd_str is None:
+            cwd_path = workspace_root.resolve()
+        else:
+            try:
+                cwd_path = _safe_resolve(cwd_str, workspace_root)
+            except _SafetyError as exc:
+                return CheckOutcome.error(reason=exc.reason)
+            if not cwd_path.is_dir():
+                return CheckOutcome.error(reason="cwd_not_a_directory")
+
+        env = _restricted_env()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                cwd=str(cwd_path),
+                env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except (OSError, ValueError) as exc:
+            return CheckOutcome.error(reason="command_spawn_failed", detail=str(exc))
+
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout_s
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            try:
+                await proc.wait()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            return CheckOutcome.error(reason="command_timeout", timeout_s=timeout_s)
+
+        exit_code = proc.returncode
+        stdout = stdout_b.decode("utf-8", errors="replace")
+        stderr = stderr_b.decode("utf-8", errors="replace")
+        if exit_code == 0:
+            return CheckOutcome.passed(exit_code=exit_code)
+        return CheckOutcome.failed(
+            reason="non_zero_exit",
+            exit_code=exit_code,
+            stdout_tail=_tail(stdout),
+            stderr_tail=_tail(stderr),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module import-time invariant: every spec must have an evaluator.
+# ---------------------------------------------------------------------------
+
+
+assert_registry_complete()

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -1,0 +1,648 @@
+"""Tests for typed acceptance check evaluators (SIP-0092 M1.2).
+
+Coverage:
+- Per-check passed/failed/skipped/error matrix.
+- Command safelist pattern matching (RC-10a).
+- Safety boundary tests across check types: path traversal, absolute path,
+  symlink escape, glob match cap.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from squadops.cycles.acceptance_check_spec import CHECK_SPECS
+from squadops.cycles.acceptance_checks import (
+    _CHECK_IMPLS,
+    _argv_matches_safelist,
+    _safe_resolve,
+    assert_registry_complete,
+    get_check,
+)
+
+pytestmark = [pytest.mark.domain_contracts]
+
+
+# ---------------------------------------------------------------------------
+# Registry invariants
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryInvariants:
+    def test_every_spec_has_an_evaluator(self):
+        # Module import already runs assert_registry_complete; calling again
+        # is a no-op when the invariant holds.
+        assert_registry_complete()
+        assert set(CHECK_SPECS.keys()) == set(_CHECK_IMPLS.keys())
+
+    def test_get_check_unknown_raises(self):
+        with pytest.raises(KeyError):
+            get_check("not_a_real_check")
+
+    def test_evaluator_spec_back_reference(self):
+        for name in CHECK_SPECS:
+            evaluator = get_check(name)
+            assert evaluator.spec is CHECK_SPECS[name]
+
+
+# ---------------------------------------------------------------------------
+# endpoint_defined
+# ---------------------------------------------------------------------------
+
+
+_FASTAPI_SOURCE = """
+from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router = APIRouter()
+
+
+@app.get("/users")
+def list_users():
+    return []
+
+
+@router.post("/items/")
+async def create_item():
+    return {}
+
+
+@app.delete("/users/{uid}")
+def delete_user(uid: int):
+    pass
+"""
+
+
+@pytest.fixture
+def fastapi_workspace(tmp_path: Path) -> Path:
+    (tmp_path / "main.py").write_text(_FASTAPI_SOURCE)
+    return tmp_path
+
+
+class TestEndpointDefined:
+    async def test_all_present_passed(self, fastapi_workspace):
+        result = await get_check("endpoint_defined").evaluate(
+            {"file": "main.py", "methods_paths": ["GET /users", "POST /items", "DELETE /users/{uid}"]},
+            fastapi_workspace,
+            stack="fastapi",
+        )
+        assert result.status == "passed"
+        assert "GET /users" in result.actual["found"]
+        assert "POST /items" in result.actual["found"]
+
+    async def test_missing_one_failed(self, fastapi_workspace):
+        result = await get_check("endpoint_defined").evaluate(
+            {"file": "main.py", "methods_paths": ["GET /users", "PUT /users"]},
+            fastapi_workspace,
+            stack="fastapi",
+        )
+        assert result.status == "failed"
+        assert result.actual["missing"] == ["PUT /users"]
+        assert "GET /users" in result.actual["found"]
+
+    async def test_stack_unset_skipped(self, fastapi_workspace):
+        result = await get_check("endpoint_defined").evaluate(
+            {"file": "main.py", "methods_paths": ["GET /users"]},
+            fastapi_workspace,
+            stack=None,
+        )
+        assert result.status == "skipped"
+        assert result.reason == "unsupported_stack_or_syntax"
+
+    async def test_other_stack_skipped(self, fastapi_workspace):
+        result = await get_check("endpoint_defined").evaluate(
+            {"file": "main.py", "methods_paths": ["GET /users"]},
+            fastapi_workspace,
+            stack="flask",
+        )
+        assert result.status == "skipped"
+
+    async def test_missing_file_failed(self, fastapi_workspace):
+        result = await get_check("endpoint_defined").evaluate(
+            {"file": "does_not_exist.py", "methods_paths": ["GET /x"]},
+            fastapi_workspace,
+            stack="fastapi",
+        )
+        assert result.status == "failed"
+        assert result.reason == "file_not_found"
+
+    async def test_unparseable_python_error(self, tmp_path):
+        (tmp_path / "broken.py").write_text("def @@@ broken syntax")
+        result = await get_check("endpoint_defined").evaluate(
+            {"file": "broken.py", "methods_paths": ["GET /x"]},
+            tmp_path,
+            stack="fastapi",
+        )
+        assert result.status == "error"
+        assert result.reason == "parse_failed"
+
+    async def test_malformed_methods_paths_error(self, fastapi_workspace):
+        result = await get_check("endpoint_defined").evaluate(
+            {"file": "main.py", "methods_paths": ["bogus token"]},
+            fastapi_workspace,
+            stack="fastapi",
+        )
+        assert result.status == "error"
+        assert result.reason == "malformed_methods_paths"
+
+
+# ---------------------------------------------------------------------------
+# import_present
+# ---------------------------------------------------------------------------
+
+
+class TestImportPresent:
+    @pytest.fixture
+    def py_workspace(self, tmp_path):
+        (tmp_path / "code.py").write_text(
+            "import json\nfrom pathlib import Path, PurePath\nfrom os import getcwd as cwd\n"
+        )
+        return tmp_path
+
+    async def test_module_present_passed(self, py_workspace):
+        result = await get_check("import_present").evaluate(
+            {"file": "code.py", "module": "json"},
+            py_workspace,
+        )
+        assert result.status == "passed"
+
+    async def test_module_with_symbol_passed(self, py_workspace):
+        result = await get_check("import_present").evaluate(
+            {"file": "code.py", "module": "pathlib", "symbol": "Path"},
+            py_workspace,
+        )
+        assert result.status == "passed"
+
+    async def test_module_present_symbol_missing_failed(self, py_workspace):
+        result = await get_check("import_present").evaluate(
+            {"file": "code.py", "module": "pathlib", "symbol": "PosixPath"},
+            py_workspace,
+        )
+        assert result.status == "failed"
+        assert result.reason == "symbol_not_imported"
+
+    async def test_module_missing_failed(self, py_workspace):
+        result = await get_check("import_present").evaluate(
+            {"file": "code.py", "module": "ssh_keys"},
+            py_workspace,
+        )
+        assert result.status == "failed"
+        assert result.reason == "module_not_imported"
+
+    async def test_ts_extension_skipped(self, tmp_path):
+        (tmp_path / "x.ts").write_text("import { foo } from 'bar';")
+        result = await get_check("import_present").evaluate(
+            {"file": "x.ts", "module": "bar"},
+            tmp_path,
+        )
+        assert result.status == "skipped"
+        assert result.reason == "frontend_acceptance_checks_disabled"
+
+    async def test_unknown_extension_skipped(self, tmp_path):
+        (tmp_path / "x.rb").write_text("require 'json'")
+        result = await get_check("import_present").evaluate(
+            {"file": "x.rb", "module": "json"},
+            tmp_path,
+        )
+        assert result.status == "skipped"
+        assert result.reason == "unsupported_file_extension"
+
+
+# ---------------------------------------------------------------------------
+# field_present
+# ---------------------------------------------------------------------------
+
+
+_PYDANTIC_MODEL = """
+from pydantic import BaseModel, Field
+from dataclasses import dataclass
+
+
+class User(BaseModel):
+    name: str
+    age: int = Field(default=0)
+
+
+@dataclass
+class Item:
+    sku: str
+    qty: int = 1
+"""
+
+
+class TestFieldPresent:
+    @pytest.fixture
+    def models_workspace(self, tmp_path):
+        (tmp_path / "models.py").write_text(_PYDANTIC_MODEL)
+        return tmp_path
+
+    async def test_all_fields_passed(self, models_workspace):
+        result = await get_check("field_present").evaluate(
+            {"file": "models.py", "class_name": "User", "fields": ["name", "age"]},
+            models_workspace,
+            stack="python",
+        )
+        assert result.status == "passed"
+
+    async def test_dataclass_fields_passed(self, models_workspace):
+        result = await get_check("field_present").evaluate(
+            {"file": "models.py", "class_name": "Item", "fields": ["sku", "qty"]},
+            models_workspace,
+            stack="python",
+        )
+        assert result.status == "passed"
+
+    async def test_partial_failed(self, models_workspace):
+        result = await get_check("field_present").evaluate(
+            {"file": "models.py", "class_name": "User", "fields": ["name", "email"]},
+            models_workspace,
+            stack="python",
+        )
+        assert result.status == "failed"
+        assert result.actual["missing"] == ["email"]
+
+    async def test_class_not_found_failed(self, models_workspace):
+        result = await get_check("field_present").evaluate(
+            {"file": "models.py", "class_name": "Ghost", "fields": ["x"]},
+            models_workspace,
+            stack="python",
+        )
+        assert result.status == "failed"
+        assert result.reason == "class_not_found"
+
+    async def test_stack_unset_skipped(self, models_workspace):
+        result = await get_check("field_present").evaluate(
+            {"file": "models.py", "class_name": "User", "fields": ["name"]},
+            models_workspace,
+            stack=None,
+        )
+        assert result.status == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# regex_match
+# ---------------------------------------------------------------------------
+
+
+class TestRegexMatch:
+    @pytest.fixture
+    def text_workspace(self, tmp_path):
+        (tmp_path / "log.txt").write_text("ERROR: a\nERROR: b\nINFO: c\nERROR: d\n")
+        return tmp_path
+
+    async def test_meets_min_passed(self, text_workspace):
+        result = await get_check("regex_match").evaluate(
+            {"file": "log.txt", "pattern": r"ERROR:", "count_min": 2},
+            text_workspace,
+        )
+        assert result.status == "passed"
+        assert result.actual["match_count"] == 3
+
+    async def test_default_count_min_one_passed(self, text_workspace):
+        result = await get_check("regex_match").evaluate(
+            {"file": "log.txt", "pattern": r"INFO"},
+            text_workspace,
+        )
+        assert result.status == "passed"
+
+    async def test_below_min_failed(self, text_workspace):
+        result = await get_check("regex_match").evaluate(
+            {"file": "log.txt", "pattern": r"ERROR:", "count_min": 10},
+            text_workspace,
+        )
+        assert result.status == "failed"
+        assert result.actual["match_count"] == 3
+
+    async def test_invalid_regex_error(self, text_workspace):
+        result = await get_check("regex_match").evaluate(
+            {"file": "log.txt", "pattern": "((unclosed"},
+            text_workspace,
+        )
+        assert result.status == "error"
+        assert result.reason == "regex_invalid"
+
+    async def test_oversized_pattern_error(self, text_workspace):
+        result = await get_check("regex_match").evaluate(
+            {"file": "log.txt", "pattern": "x" * 10_000},
+            text_workspace,
+        )
+        assert result.status == "error"
+        assert result.reason == "regex_pattern_too_large"
+
+    async def test_oversized_input_error(self, tmp_path, monkeypatch):
+        # Avoid actually allocating a 10MiB file by patching the cap.
+        from squadops.cycles import acceptance_checks as ac
+
+        big = tmp_path / "big.txt"
+        big.write_text("x" * 1024)
+        monkeypatch.setattr(ac, "DEFAULT_REGEX_INPUT_CAP_BYTES", 100)
+        result = await get_check("regex_match").evaluate(
+            {"file": "big.txt", "pattern": "x"},
+            tmp_path,
+        )
+        assert result.status == "error"
+        assert result.reason == "regex_input_too_large"
+
+
+# ---------------------------------------------------------------------------
+# count_at_least
+# ---------------------------------------------------------------------------
+
+
+class TestCountAtLeast:
+    @pytest.fixture
+    def files_workspace(self, tmp_path):
+        (tmp_path / "a.py").write_text("")
+        (tmp_path / "b.py").write_text("")
+        (tmp_path / "c.txt").write_text("")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "d.py").write_text("")
+        return tmp_path
+
+    async def test_meets_min_passed(self, files_workspace):
+        result = await get_check("count_at_least").evaluate(
+            {"glob": "*.py", "min_count": 2},
+            files_workspace,
+        )
+        assert result.status == "passed"
+        assert result.actual["count"] == 2
+
+    async def test_recursive_glob_passed(self, files_workspace):
+        result = await get_check("count_at_least").evaluate(
+            {"glob": "**/*.py", "min_count": 3},
+            files_workspace,
+        )
+        assert result.status == "passed"
+        assert result.actual["count"] == 3
+
+    async def test_below_min_failed(self, files_workspace):
+        result = await get_check("count_at_least").evaluate(
+            {"glob": "*.py", "min_count": 10},
+            files_workspace,
+        )
+        assert result.status == "failed"
+        assert result.actual["count"] == 2
+
+    async def test_traversal_error(self, files_workspace):
+        result = await get_check("count_at_least").evaluate(
+            {"glob": "../*", "min_count": 1},
+            files_workspace,
+        )
+        assert result.status == "error"
+        assert result.reason == "path_escapes_workspace"
+
+    async def test_absolute_glob_error(self, files_workspace):
+        result = await get_check("count_at_least").evaluate(
+            {"glob": "/etc/*", "min_count": 1},
+            files_workspace,
+        )
+        assert result.status == "error"
+        assert result.reason == "path_escapes_workspace"
+
+    async def test_cap_exceeded_error(self, tmp_path, monkeypatch):
+        from squadops.cycles import acceptance_checks as ac
+
+        for i in range(20):
+            (tmp_path / f"f{i}.txt").write_text("")
+        monkeypatch.setattr(ac, "DEFAULT_GLOB_MATCH_CAP", 5)
+        result = await get_check("count_at_least").evaluate(
+            {"glob": "*.txt", "min_count": 1},
+            tmp_path,
+        )
+        assert result.status == "error"
+        assert result.reason == "glob_match_cap_exceeded"
+
+
+# ---------------------------------------------------------------------------
+# command_exit_zero
+# ---------------------------------------------------------------------------
+
+
+class TestCommandExitZero:
+    @pytest.fixture
+    def py_workspace(self, tmp_path):
+        (tmp_path / "ok.py").write_text("x = 1\n")
+        (tmp_path / "broken.py").write_text("def @@@ ::: invalid\n")
+        return tmp_path
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX subprocess assumed")
+    async def test_compile_ok_passed(self, py_workspace):
+        result = await get_check("command_exit_zero").evaluate(
+            {"argv": [sys.executable, "-m", "py_compile", "ok.py"]},
+            py_workspace,
+        )
+        # argv[0] is sys.executable (typically /path/to/python); pattern wants
+        # literal "python", so the safelist should reject this. We assert the
+        # safelist behavior, not the run-result, to keep the test hermetic.
+        assert result.status == "error"
+        assert result.reason == "command_not_in_safelist"
+
+    async def test_string_instead_of_list_error(self, py_workspace):
+        result = await get_check("command_exit_zero").evaluate(
+            {"argv": "python -m py_compile ok.py"},
+            py_workspace,
+        )
+        assert result.status == "error"
+        assert result.reason == "command_must_be_argv"
+
+    async def test_empty_argv_error(self, py_workspace):
+        result = await get_check("command_exit_zero").evaluate(
+            {"argv": []},
+            py_workspace,
+        )
+        assert result.status == "error"
+        assert result.reason == "command_must_be_argv"
+
+    async def test_non_string_elements_error(self, py_workspace):
+        result = await get_check("command_exit_zero").evaluate(
+            {"argv": ["python", 123]},
+            py_workspace,
+        )
+        assert result.status == "error"
+        assert result.reason == "command_must_be_argv"
+
+    async def test_safelist_run_passes(self, tmp_path):
+        # Use /bin/true via a synthetic safelist entry — actually, the simpler
+        # path is to test a real safelist match that produces zero exit.
+        # `pyflakes ok.py` is in the safelist; test instead with a real
+        # subprocess via the matched pattern. To avoid dep on pyflakes being
+        # installed, we run the safelist-matcher directly here, then run a
+        # known-good command via the safelist for end-to-end coverage.
+        (tmp_path / "ok.py").write_text("x = 1\n")
+        # pyflakes may not be installed; gate.
+        import shutil
+
+        if shutil.which("pyflakes") is None:
+            pytest.skip("pyflakes not on PATH")
+        result = await get_check("command_exit_zero").evaluate(
+            {"argv": ["pyflakes", "ok.py"]},
+            tmp_path,
+        )
+        assert result.status == "passed"
+
+    async def test_safelist_run_fails(self, tmp_path):
+        import shutil
+
+        if shutil.which("pyflakes") is None:
+            pytest.skip("pyflakes not on PATH")
+        (tmp_path / "broken.py").write_text("import not_a_module\n")
+        result = await get_check("command_exit_zero").evaluate(
+            {"argv": ["pyflakes", "broken.py"]},
+            tmp_path,
+        )
+        # pyflakes warns about the unused import → non-zero exit.
+        assert result.status == "failed"
+        assert "exit_code" in result.actual
+
+    async def test_timeout_clamped_below_max(self, tmp_path, monkeypatch):
+        # Verify the clamp logic works without invoking a real long process.
+        from squadops.cycles import acceptance_checks as ac
+
+        captured: dict = {}
+
+        async def fake_create_subprocess_exec(*argv, cwd, env, stdout, stderr):
+            captured["argv"] = list(argv)
+
+            class FakeProc:
+                returncode = 0
+
+                async def communicate(self):
+                    return (b"", b"")
+
+                def kill(self):
+                    pass
+
+                async def wait(self):
+                    pass
+
+            return FakeProc()
+
+        monkeypatch.setattr("asyncio.create_subprocess_exec", fake_create_subprocess_exec)
+        result = await get_check("command_exit_zero").evaluate(
+            {"argv": ["tsc", "--noEmit"], "timeout_s": 9999},
+            tmp_path,
+        )
+        assert result.status == "passed"
+        assert captured["argv"] == ["tsc", "--noEmit"]
+
+
+# ---------------------------------------------------------------------------
+# Command safelist pattern matching (RC-10a)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "argv,expected",
+    [
+        # Allowed shapes
+        (["python", "-m", "py_compile", "backend/main.py"], True),
+        (["python", "-m", "mypy", "src/"], True),
+        (["python", "-m", "mypy", "--strict", "src/"], True),
+        (["node", "--check", "app.js"], True),
+        (["ruff", "check", "src/"], True),
+        (["ruff", "check", "src/", "--select", "E"], True),
+        (["tsc", "--noEmit"], True),
+        (["eslint", "src/"], True),
+        (["pyflakes", "main.py"], True),
+        # Rejected shapes
+        (["python", "-c", "print(1)"], False),
+        (["python", "-m", "pip", "install", "anything"], False),
+        (["python", "-m", "unknown_module"], False),
+        (["python"], False),
+        (["node", "-e", "console.log(1)"], False),
+        (["pyflakes"], False),  # missing the file arg → not exact-then-one-path
+        (["pyflakes", "a.py", "b.py"], False),  # exact-then-ONE-path
+        (["bash", "-c", "echo hi"], False),
+        (["sh", "echo hi"], False),
+    ],
+)
+def test_argv_matches_safelist(argv, expected):
+    assert _argv_matches_safelist(argv) is expected
+
+
+# ---------------------------------------------------------------------------
+# Path safety (RC-10)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeResolve:
+    def test_traversal_rejected(self, tmp_path):
+        with pytest.raises(Exception):  # _SafetyError, but it's module-private
+            _safe_resolve("../etc/passwd", tmp_path)
+
+    def test_absolute_rejected(self, tmp_path):
+        with pytest.raises(Exception):
+            _safe_resolve("/etc/passwd", tmp_path)
+
+    def test_empty_rejected(self, tmp_path):
+        with pytest.raises(Exception):
+            _safe_resolve("", tmp_path)
+
+    def test_relative_ok(self, tmp_path):
+        (tmp_path / "f.txt").write_text("x")
+        resolved = _safe_resolve("f.txt", tmp_path)
+        assert resolved == (tmp_path / "f.txt").resolve()
+
+    def test_symlink_to_outside_rejected(self, tmp_path):
+        outside = tmp_path.parent / "outside_target.txt"
+        outside.write_text("secret")
+        link = tmp_path / "evil"
+        try:
+            link.symlink_to(outside)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unsupported in this environment")
+        with pytest.raises(Exception):
+            _safe_resolve("evil", tmp_path)
+
+    def test_symlink_inside_workspace_ok(self, tmp_path):
+        target = tmp_path / "real.txt"
+        target.write_text("ok")
+        link = tmp_path / "link.txt"
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unsupported in this environment")
+        resolved = _safe_resolve("link.txt", tmp_path)
+        assert resolved.is_relative_to(tmp_path.resolve())
+
+
+# ---------------------------------------------------------------------------
+# Cross-check safety boundary — every path-taking check rejects traversal/abs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "check_name,params",
+    [
+        ("endpoint_defined", {"file": "../escape.py", "methods_paths": ["GET /x"]}),
+        ("import_present", {"file": "../escape.py", "module": "json"}),
+        ("field_present", {"file": "../escape.py", "class_name": "X", "fields": ["a"]}),
+        ("regex_match", {"file": "../escape.py", "pattern": "x"}),
+    ],
+)
+async def test_path_traversal_all_path_checks_error(check_name, params, tmp_path):
+    stack = "fastapi" if check_name == "endpoint_defined" else "python"
+    result = await get_check(check_name).evaluate(params, tmp_path, stack=stack)
+    assert result.status == "error"
+    assert result.reason == "path_escapes_workspace"
+
+
+@pytest.mark.parametrize(
+    "check_name,params",
+    [
+        ("endpoint_defined", {"file": "/etc/passwd", "methods_paths": ["GET /x"]}),
+        ("import_present", {"file": "/etc/passwd", "module": "json"}),
+        ("field_present", {"file": "/etc/passwd", "class_name": "X", "fields": ["a"]}),
+        ("regex_match", {"file": "/etc/passwd", "pattern": "x"}),
+    ],
+)
+async def test_absolute_path_all_path_checks_error(check_name, params, tmp_path):
+    stack = "fastapi" if check_name == "endpoint_defined" else "python"
+    result = await get_check(check_name).evaluate(params, tmp_path, stack=stack)
+    assert result.status == "error"
+    assert result.reason == "path_escapes_workspace"


### PR DESCRIPTION
## Summary

SIP-0092 Stage M1, Phase 1.2 — typed-acceptance evaluator framework. Builds on the M1.1 `CHECK_SPECS` registry by supplying the runtime evaluator that actually runs typed checks against the workspace. Two new files only; nothing in the runtime path consumes this yet (M1.3 wires it into `_validate_output_focused`).

## What lands

**`src/squadops/cycles/acceptance_checks.py`** (production):
- `CheckOutcome` dataclass with `passed/failed/skipped/error` factories.
- `BaseCheck` abstract + `@register_check(name)` decorator that binds evaluator classes to `CHECK_SPECS` entries.
- `assert_registry_complete()` runs at module import — any `CHECK_SPECS` entry without a paired evaluator raises immediately at deploy, not mid-cycle.
- Six concrete evaluators:
  - `endpoint_defined` — FastAPI route AST walk; tolerant of trailing slash; rejects malformed `methods_paths` tokens with `error` rather than silent miss.
  - `import_present` — Python AST for `.py`; `.ts/.js` returns `skipped` reason `frontend_acceptance_checks_disabled` (gated behind a follow-up flag); other extensions return `skipped` reason `unsupported_file_extension`.
  - `field_present` — Python class AST covering dataclasses and Pydantic v2 (annotated assignments + plain assignments to a `Name` target).
  - `regex_match` — size-bounded against ReDoS surface (pattern cap, content cap); no implicit `re.MULTILINE` (authors opt in via `(?m)`).
  - `count_at_least` — workspace-chrooted glob with 10k match cap; absolute and `..` globs rejected upfront.
  - `command_exit_zero` — argv-only; pattern safelist matched against the full argv (not just `argv[0]`); clean restricted env; per-command timeout clamped to ≤60s.

**Safety (RC-10 / RC-10a):**
- `_safe_resolve` rejects absolute paths, `..` traversal, and symlinks whose targets escape `workspace_root`.
- Command safelist: `python -c`, `python -m pip`, `python -m <unlisted-module>`, shell strings, and any unmatched argv produce `error` reason `command_not_in_safelist` per RC-9a — *not* `skipped`. The plan asked for something we explicitly will not run; treat as a check failure rather than silent pass.
- Restricted env strips `LD_PRELOAD` / `PYTHONPATH` / `LD_LIBRARY_PATH`; keeps `PATH`/`HOME`/locale/`TZ`.

**RC-12a stack-context handling:** checks with `requires_stack_context=True` return `skipped` reason `unsupported_stack_or_syntax` when stack is unset (not `error`). Stack is passed as a keyword to `evaluate()`; M1.3 will populate from the resolved profile or plan metadata.

**`tests/unit/cycles/test_acceptance_checks.py`** (72 new tests):
- Per-check `passed/failed/skipped/error` matrix.
- 18 parametrized command-safelist cases — allowed and rejected argv shapes per RC-10a.
- Path safety boundary across every path-taking check: `..` traversal and absolute paths both yield `error` `path_escapes_workspace`. Symlink-out-of-workspace rejected; symlink-inside allowed.
- Glob match cap and regex input cap both produce `error` outcomes.
- Registry invariants: every spec has an evaluator; `get_check` raises on unknown names.

## Out of scope (deferred to M1.3)

- Wiring into `_validate_output_focused`'s FC3 — typed-check evaluation does not yet steer self-eval or correction.
- Authoring prompt updates (telling Neo/Max about the new typed-check vocabulary).
- Stack-context plumbing — the evaluator accepts a `stack` keyword today; M1.3 is the phase that decides where it comes from (resolved profile vs plan metadata, per RC-12a).

## Why now

PR #74 (workload_type rename) merged. M1.2 is additive; it doesn't touch any runtime paths and ships under the same M1 → M2 gate as M1.1 and M1.3 (the plan doc explicitly: "Each stage's PR sequence ships under one stage's gate, not three sub-gates"). No regression-cycle requirement before merge.

## Test plan

- [x] `./scripts/dev/run_regression_tests.sh` — 3546 passed, 1 skipped (was 3474 before this PR; +72 new tests).
- [x] Module import smoke-test: `_CHECK_IMPLS` and `CHECK_SPECS` keys match exactly; `_argv_matches_safelist` rejects `python -c`, accepts `python -m py_compile <file>`, etc.
- [ ] No runtime-path integration to verify — by design. M1.3 is where typed-check outcomes start affecting cycle decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
