### PR TITLE
chore(squad-profiles): spark-squad-with-builder all roles → qwen3.6:27b

### DIFF
--- a/config/squad-profiles.yaml
+++ b/config/squad-profiles.yaml
@@ -35,14 +35,14 @@ profiles:
 
   - profile_id: spark-squad-with-builder
     name: "Spark Squad with Builder"
-    description: "6 agents optimized for DGX Spark — qwen3.6:27b for lead/dev/strat/builder, 14b for qa, 7b for data"
-    version: 3
+    description: "6 agents on DGX Spark — all roles on qwen3.6:27b (uniform, single loaded model, max reasoning depth)"
+    version: 4
     agents:
       - { agent_id: max, role: lead, model: "qwen3.6:27b", enabled: true }
       - { agent_id: neo, role: dev, model: "qwen3.6:27b", enabled: true }
       - { agent_id: nat, role: strat, model: "qwen3.6:27b", enabled: true }
       - { agent_id: bob, role: builder, model: "qwen3.6:27b", enabled: true }
-      - { agent_id: eve, role: qa, model: "qwen2.5:14b", enabled: true }
-      - { agent_id: data, role: data, model: "qwen2.5:7b", enabled: true }
+      - { agent_id: eve, role: qa, model: "qwen3.6:27b", enabled: true }
+      - { agent_id: data, role: data, model: "qwen3.6:27b", enabled: true }
 
 active_profile: full-squad


### PR DESCRIPTION
## Summary

Uniform 27b across all 6 roles in `spark-squad-with-builder` (was: 27b for max/neo/nat/bob, 14b for eve, 7b for data). Eliminates Ollama model swapping under load and gives Eve + Data the same reasoning depth as the rest of the squad.

## Why

User-requested upgrade following observation that `data.analyze_failure` on the small model produced too-shallow analyses to drive useful corrections (see #84). Uniform 27b also means a single loaded model in Ollama for the whole cycle — no swap latency.

Trade-off: Eve + Data tasks slower per token (10.9 t/s vs 22-41 t/s prior). Acceptable since their dispatches are typically short.

## Test plan

- [ ] Restart agent containers and verify `qwen3.6:27b` is the active model in Eve + Data containers
- [ ] Run a short focused-mode cycle and confirm Eve + Data complete their tasks
- [ ] Confirm `governance.correction_decision` plan_delta diagnoses are improved when paired with the schema fix from #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)