### PR TITLE
fix(executor): use manifest focus in Prefect task names (#81)

### DIFF
--- a/adapters/cycles/distributed_flow_executor.py
+++ b/adapters/cycles/distributed_flow_executor.py
@@ -567,6 +567,27 @@ class DistributedFlowExecutor(FlowExecutionPort):
 
     # SIP-0087: task-run lifecycle lives here (moved out of WorkflowTrackerBridge) so
     # the task_run_id is known before the agent starts producing logs.
+    @staticmethod
+    def _build_task_name(role: str, envelope: TaskEnvelope) -> str:
+        """Build a Gantt-friendly Prefect task name.
+
+        Focused-mode envelopes (manifest-decomposed subtasks) get
+        ``role[idx]: focus`` so the Gantt distinguishes parallel subtasks
+        instead of showing N identical ``role: task_type`` rows.
+        Legacy / non-focused envelopes keep ``role: task_type``.
+        """
+        inputs = envelope.inputs or {}
+        focus = inputs.get("subtask_focus")
+        idx = inputs.get("subtask_index")
+        if focus:
+            focus_short = str(focus)[:60]
+            return (
+                f"{role}[{idx}]: {focus_short}"
+                if idx is not None
+                else f"{role}: {focus_short}"
+            )
+        return f"{role}: {envelope.task_type}"
+
     async def _create_task_run_if_enabled(
         self,
         flow_run_id: str | None,
@@ -576,7 +597,7 @@ class DistributedFlowExecutor(FlowExecutionPort):
         if self._workflow_tracker is None or not flow_run_id:
             return None
         role = envelope.metadata.get("role", "unknown") if envelope.metadata else "unknown"
-        task_name = f"{role}: {envelope.task_type}"
+        task_name = self._build_task_name(role, envelope)
         task_run_id = await self._workflow_tracker.create_task_run(
             flow_run_id, envelope.task_id, task_name
         )

--- a/tests/unit/cycles/test_distributed_flow_executor.py
+++ b/tests/unit/cycles/test_distributed_flow_executor.py
@@ -181,6 +181,78 @@ def executor(mock_registry, mock_vault, mock_queue, mock_squad_profile, cycle, r
 
 
 # ---------------------------------------------------------------------------
+# Prefect task name construction (issue #81)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTaskName:
+    """Gantt-friendly Prefect task names: focused-mode envelopes show the
+    manifest focus and index instead of N identical role:task_type rows."""
+
+    @staticmethod
+    def _envelope(task_type: str = "development.develop", inputs: dict | None = None) -> TaskEnvelope:
+        return TaskEnvelope(
+            task_id="task_abc",
+            agent_id="neo",
+            cycle_id="cyc_001",
+            pulse_id="p1",
+            project_id="proj_001",
+            task_type=task_type,
+            correlation_id="corr",
+            causation_id="cause",
+            trace_id="trace",
+            span_id="span",
+            inputs=inputs or {},
+            metadata={"role": "dev"},
+        )
+
+    def test_focused_envelope_uses_focus_and_index(self) -> None:
+        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+
+        env = self._envelope(inputs={
+            "subtask_focus": "Backend data models and in-memory repository",
+            "subtask_index": 0,
+        })
+        assert DistributedFlowExecutor._build_task_name("dev", env) == (
+            "dev[0]: Backend data models and in-memory repository"
+        )
+
+    def test_focused_envelope_without_index_omits_brackets(self) -> None:
+        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+
+        env = self._envelope(inputs={"subtask_focus": "FastAPI endpoints and validation"})
+        assert (
+            DistributedFlowExecutor._build_task_name("dev", env)
+            == "dev: FastAPI endpoints and validation"
+        )
+
+    def test_non_focused_envelope_falls_back_to_task_type(self) -> None:
+        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+
+        env = self._envelope(task_type="development.develop", inputs={})
+        assert (
+            DistributedFlowExecutor._build_task_name("dev", env)
+            == "dev: development.develop"
+        )
+
+    def test_long_focus_truncates_at_60_chars(self) -> None:
+        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+
+        long_focus = "X" * 100
+        env = self._envelope(inputs={"subtask_focus": long_focus, "subtask_index": 3})
+        name = DistributedFlowExecutor._build_task_name("dev", env)
+        assert name == f"dev[3]: {'X' * 60}"
+        assert len(name.split(": ", 1)[1]) == 60
+
+    def test_index_zero_renders_as_zero_not_omitted(self) -> None:
+        """Subtask index 0 must render as ``[0]`` — falsy but valid."""
+        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+
+        env = self._envelope(inputs={"subtask_focus": "first", "subtask_index": 0})
+        assert DistributedFlowExecutor._build_task_name("dev", env) == "dev[0]: first"
+
+
+# ---------------------------------------------------------------------------
 # Dispatch mechanics
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Focused-mode dispatch previously named all subtasks ``<role>: <task_type>``, producing N identical Gantt rows like ``dev: development.develop`` x4 for the 4 dev subtasks of a fullstack manifest. Use the envelope's ``subtask_focus`` and ``subtask_index`` to render ``<role>[<idx>]: <focus>`` so the Gantt distinguishes parallel subtasks.

**Before:**
```
dev: development.develop
dev: development.develop
dev: development.develop
dev: development.develop
builder: builder.assemble
qa: qa.test
qa: qa.test
```

**After:**
```
dev[0]: Backend data models and in-memory repository
dev[1]: FastAPI endpoints and validation
dev[2]: Frontend app shell, routing, and API utilities
dev[3]: Frontend views (List, Create, Detail)
builder[4]: Project configuration, entrypoints, and QA handoff
qa[5]: Backend test suite
qa[6]: Frontend basic test coverage
```

## Implementation

Extracted `_build_task_name(role, envelope)` static helper on `DistributedFlowExecutor`. Hits the focus path when `inputs["subtask_focus"]` is present; falls back to legacy `role: task_type` otherwise. Truncates focus at 60 chars to fit Prefect's UI.

## Test plan

- [x] 5 new unit tests covering: focused with index, focused without index, non-focused fallback, truncation at 60 chars, index=0 (falsy but valid)
- [x] Full `test_distributed_flow_executor.py` regression: 52/52 pass

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)