### PR TITLE
fix(m1.3): emit observability log lines for typed-acceptance evaluation (#83)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -1013,6 +1013,21 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
                 f"Typed checks failed: {len(typed_failed)} of {sum(1 for c in checks if c.get('check', '').startswith('acceptance:'))}"
             )
 
+        # Issue #83: emit a single summary line per focused validation so
+        # operators can see at-a-glance whether M1.3 ran and what it found.
+        acceptance_checks = [c for c in checks if c.get("check", "").startswith("acceptance:")]
+        if acceptance_checks:
+            ac_passed = sum(1 for c in acceptance_checks if c.get("passed", False))
+            logger.info(
+                "typed_acceptance_summary subtask=%s evaluated=%d passed=%d blocking_failures=%d "
+                "overall_passed=%s",
+                inputs.get("subtask_index"),
+                len(acceptance_checks),
+                ac_passed,
+                len(typed_failed),
+                passed,
+            )
+
         return ValidationResult(
             passed=passed,
             checks=checks,
@@ -1088,6 +1103,23 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
                     ),
                 }
                 checks.append(check_record)
+
+                # Issue #83: per-check observability. Without these the M1.3
+                # path is invisible to operators — see issue body for context.
+                blocking = (
+                    criterion.severity == "error"
+                    and outcome.status in {"failed", "error"}
+                )
+                log_fn = logger.info if blocking else logger.debug
+                log_fn(
+                    "typed_acceptance_check subtask=%s check=%s severity=%s status=%s blocking=%s reason=%s",
+                    inputs.get("subtask_index"),
+                    criterion.check,
+                    criterion.severity,
+                    outcome.status,
+                    blocking,
+                    outcome.reason or "",
+                )
 
                 # RC-9: severity AND status are independent. Only error+blocking missions.
                 if criterion.severity != "error":

--- a/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
+++ b/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
@@ -357,3 +357,88 @@ class TestFingerprint:
         c1 = TypedCheck(check="regex_match", params={"file": "a", "pattern": "x"})
         c2 = TypedCheck(check="regex_match", params={"pattern": "x", "file": "a"})
         assert c1.fingerprint() == c2.fingerprint()
+
+
+# ---------------------------------------------------------------------------
+# Issue #83 — M1.3 observability: log per-check + per-validation summary
+# ---------------------------------------------------------------------------
+
+
+class TestM13Observability:
+    """Verify _evaluate_typed_acceptance + _validate_focused emit log lines
+    operators can grep for. Without these the M1.3 path is invisible.
+    """
+
+    async def test_per_check_log_emitted_on_pass(self, caplog):
+        h = DevelopmentDevelopHandler()
+        criterion = TypedCheck(
+            check="endpoint_defined",
+            params={"file": "main.py", "methods_paths": ["GET /users"]},
+            severity="error",
+            description="users endpoint",
+        )
+        with caplog.at_level("DEBUG", logger="squadops.capabilities.handlers.cycle_tasks"):
+            await h._validate_output(
+                _inputs([criterion], config={"stack": "fastapi"}),
+                [_art("main.py", _FASTAPI_ALL)],
+            )
+        check_logs = [r for r in caplog.records if "typed_acceptance_check" in r.getMessage()]
+        assert len(check_logs) == 1
+        msg = check_logs[0].getMessage()
+        assert "check=endpoint_defined" in msg
+        assert "severity=error" in msg
+        assert "status=passed" in msg
+        assert "blocking=False" in msg
+
+    async def test_per_check_log_marks_blocking_failure_at_info_level(self, caplog):
+        h = DevelopmentDevelopHandler()
+        criterion = TypedCheck(
+            check="endpoint_defined",
+            params={"file": "main.py", "methods_paths": ["GET /users", "POST /users"]},
+            severity="error",
+            description="users CRUD",
+        )
+        with caplog.at_level("INFO", logger="squadops.capabilities.handlers.cycle_tasks"):
+            await h._validate_output(
+                _inputs([criterion], config={"stack": "fastapi"}),
+                [_art("main.py", _FASTAPI_MISSING)],
+            )
+        check_logs = [
+            r for r in caplog.records
+            if "typed_acceptance_check" in r.getMessage() and r.levelname == "INFO"
+        ]
+        assert len(check_logs) == 1
+        msg = check_logs[0].getMessage()
+        assert "status=failed" in msg
+        assert "blocking=True" in msg
+
+    async def test_summary_log_emitted_when_typed_checks_present(self, caplog):
+        h = DevelopmentDevelopHandler()
+        criterion = TypedCheck(
+            check="endpoint_defined",
+            params={"file": "main.py", "methods_paths": ["GET /users"]},
+            severity="error",
+        )
+        with caplog.at_level("INFO", logger="squadops.capabilities.handlers.cycle_tasks"):
+            await h._validate_output(
+                _inputs([criterion], focus="check focus", config={"stack": "fastapi"}),
+                [_art("main.py", _FASTAPI_ALL)],
+            )
+        summary_logs = [r for r in caplog.records if "typed_acceptance_summary" in r.getMessage()]
+        assert len(summary_logs) == 1
+        msg = summary_logs[0].getMessage()
+        assert "evaluated=1" in msg
+        assert "passed=1" in msg
+        assert "blocking_failures=0" in msg
+        assert "overall_passed=True" in msg
+
+    async def test_summary_log_skipped_when_no_typed_checks(self, caplog):
+        # Prose-only criteria → summary log should NOT fire (it would be noise).
+        h = DevelopmentDevelopHandler()
+        with caplog.at_level("INFO", logger="squadops.capabilities.handlers.cycle_tasks"):
+            await h._validate_output(
+                _inputs([_PROSE_CRITERION], config={"stack": "fastapi"}),
+                [_art("main.py", _FASTAPI_ALL)],
+            )
+        summary_logs = [r for r in caplog.records if "typed_acceptance_summary" in r.getMessage()]
+        assert len(summary_logs) == 0


### PR DESCRIPTION
## Summary

The M1.3 typed-acceptance evaluator was running silently. Verified live on `cyc_4cac11018af7` (2026-05-02): zero `acceptance:` log lines and zero acceptance signals in artifact metadata even after focused-mode dispatch fired correctly. Operators couldn't tell whether the evaluator had run, what it had found, or whether the cycle's outcome reflected its decisions.

## Changes

1. **Per-check log in `_evaluate_typed_acceptance`** — `debug`-level on pass, `info`-level on blocking failure (severity=error AND status in {failed, error}). Single grep target: `typed_acceptance_check subtask=N check=X severity=Y status=Z blocking=B reason=R`.
2. **Per-validation summary log in `_validate_focused`** — `info`-level when typed checks are present. Format: `typed_acceptance_summary subtask=N evaluated=K passed=P blocking_failures=B overall_passed=T`. Skipped when no typed criteria (avoid noise on legacy cycles).

## What this enables

```bash
# Was the M1.3 evaluator called at all in the last cycle?
docker logs --since 1h squadops-runtime-api | grep typed_acceptance_summary

# Which subtasks blocked on a typed check?
docker logs --since 1h squadops-runtime-api | grep "typed_acceptance_check.*blocking=True"
```

Phase 2 (persist evaluation results to `ArtifactRef.metadata`) is left as follow-on; logging is the unblock for the next validation cycle.

## Test plan

- [x] 4 new tests in `TestM13Observability` covering: per-check log on pass (debug), per-check log on blocking failure (info), summary log present when typed checks ran, summary log skipped when only prose criteria
- [x] Full `test_typed_acceptance_validation.py` + `test_output_validation.py` regression: 63/63 pass

Closes #83 (logging portion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)