### PR TITLE
fix(correction-loop): pydantic-validate FailureAnalysis output (#84)

### DIFF
--- a/src/squadops/capabilities/handlers/impl/analyze_failure.py
+++ b/src/squadops/capabilities/handlers/impl/analyze_failure.py
@@ -3,6 +3,10 @@
 Receives failure evidence from the executor and asks the LLM to
 classify the failure using the FailureClassification taxonomy,
 producing a structured analysis summary.
+
+Issue #84: Pydantic-validated output schema — empty/missing required
+fields now fail loudly and route to NEEDS_REPLAN instead of being
+silently coerced into useless defaults.
 """
 
 from __future__ import annotations
@@ -12,12 +16,14 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
 from squadops.capabilities.handlers.base import (
     HandlerEvidence,
     HandlerResult,
 )
 from squadops.capabilities.handlers.cycle_tasks import _CycleTaskHandler
-from squadops.cycles.task_outcome import FailureClassification
+from squadops.cycles.task_outcome import FailureClassification, TaskOutcome
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
 
@@ -25,6 +31,47 @@ if TYPE_CHECKING:
     from squadops.capabilities.handlers.context import ExecutionContext
 
 logger = logging.getLogger(__name__)
+
+
+_VALID_CLASSIFICATIONS = {
+    FailureClassification.EXECUTION,
+    FailureClassification.WORK_PRODUCT,
+    FailureClassification.ALIGNMENT,
+    FailureClassification.DECISION,
+    FailureClassification.MODEL_LIMITATION,
+}
+
+
+class FailureAnalysis(BaseModel):
+    """Structured failure analysis output (issue #84).
+
+    Required fields are required for a reason — downstream
+    governance.correction_decision needs concrete inputs to author a
+    plan delta. Empty strings and unknown classifications are rejected.
+    """
+
+    classification: str = Field(min_length=1)
+    analysis_summary: str = Field(min_length=20)
+    contributing_factors: list[str] = Field(min_length=1)
+
+    @field_validator("classification")
+    @classmethod
+    def classification_must_be_known(cls, v: str) -> str:
+        if v not in _VALID_CLASSIFICATIONS:
+            raise ValueError(
+                f"classification {v!r} not in {sorted(_VALID_CLASSIFICATIONS)}"
+            )
+        return v
+
+    @field_validator("contributing_factors")
+    @classmethod
+    def contributing_factors_must_be_substantive(cls, v: list[str]) -> list[str]:
+        if not all(isinstance(s, str) and len(s.strip()) >= 5 for s in v):
+            raise ValueError(
+                "each contributing factor must be a string >=5 chars"
+            )
+        return v
+
 
 _ANALYSIS_SYSTEM_PROMPT = f"""\
 You are a data analyst performing root cause analysis on a task failure.
@@ -36,12 +83,18 @@ Classify the failure into one of these categories:
 - {FailureClassification.DECISION}: wrong approach or architectural choice
 - {FailureClassification.MODEL_LIMITATION}: LLM capability gap
 
-Return JSON with:
-- classification (string): one of the categories above
-- analysis_summary (string): 2-3 sentence explanation of root cause
-- contributing_factors (list[string]): factors that contributed
+Return JSON with these REQUIRED fields:
+- classification (string): EXACTLY one of: {", ".join(sorted(_VALID_CLASSIFICATIONS))}
+- analysis_summary (string, >=20 chars): concrete 2-3 sentence root cause. State the
+  specific component, the specific symptom, and (if knowable) the specific cause.
+  Do NOT write "N/A", "unknown", or empty strings — if you cannot determine the cause
+  from the evidence, say SO and name the missing evidence.
+- contributing_factors (list[string], >=1 item, each >=5 chars): factors that contributed.
+  Each factor must be a concrete observable, not a generic phrase.
 
-Return ONLY valid JSON, no markdown fences."""
+Empty fields, the literal "N/A", and the literal "unknown" will be rejected.
+
+Return ONLY valid JSON, no markdown fences, no explanation."""
 
 
 class DataAnalyzeFailureHandler(_CycleTaskHandler):
@@ -101,22 +154,40 @@ class DataAnalyzeFailureHandler(_CycleTaskHandler):
 
         content = response.content
 
-        # Parse JSON analysis
-        try:
-            cleaned = content.strip()
-            if cleaned.startswith("```"):
-                lines = cleaned.split("\n")
-                lines = [ln for ln in lines if not ln.strip().startswith("```")]
-                cleaned = "\n".join(lines)
-            analysis = json.loads(cleaned)
-        except (json.JSONDecodeError, ValueError):
-            # Fallback: use raw content as analysis summary
-            analysis = {
-                "classification": FailureClassification.EXECUTION,
-                "analysis_summary": content[:500],
-                "contributing_factors": [],
-            }
+        # Parse JSON, then validate against schema (issue #84). Validation
+        # failure routes to NEEDS_REPLAN with a clear log line — silent
+        # coercion to a useless default produced wrong corrections in the
+        # past (live evidence: cyc_4cac11018af7).
+        cleaned = content.strip()
+        if cleaned.startswith("```"):
+            lines = cleaned.split("\n")
+            lines = [ln for ln in lines if not ln.strip().startswith("```")]
+            cleaned = "\n".join(lines)
 
+        try:
+            raw = json.loads(cleaned)
+            analysis_model = FailureAnalysis.model_validate(raw)
+        except (json.JSONDecodeError, ValidationError) as exc:
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            logger.warning(
+                "analyze_failure_handler rejected output: %s | raw=%s",
+                exc,
+                content[:300],
+            )
+            evidence = HandlerEvidence.create(
+                handler_name=self._handler_name,
+                capability_id=self._capability_id,
+                duration_ms=duration_ms,
+                inputs_hash=self._hash_dict(inputs),
+            )
+            return HandlerResult(
+                success=False,
+                outputs={"outcome_class": TaskOutcome.NEEDS_REPLAN},
+                _evidence=evidence,
+                error=f"Failure analysis rejected by schema: {exc}",
+            )
+
+        analysis = analysis_model.model_dump()
         duration_ms = (time.perf_counter() - start_time) * 1000
 
         # SIP-0084 §10: prompt provenance (Stage 2 only — no assembled prompt)

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -156,7 +156,9 @@ class TestAnalyzeFailure:
         assert result.outputs["classification"] == FailureClassification.WORK_PRODUCT
         assert "quality" in result.outputs["analysis_summary"]
 
-    async def test_unparseable_falls_back_to_execution(self, mock_context):
+    async def test_unparseable_routes_to_needs_replan(self, mock_context):
+        """Issue #84: unparseable LLM output rejects to NEEDS_REPLAN
+        instead of silently coercing to a useless EXECUTION default."""
         _set_llm_mock(
             mock_context,
             return_value=ChatMessage(role="assistant", content="unstructured analysis text"),
@@ -165,8 +167,68 @@ class TestAnalyzeFailure:
         h = DataAnalyzeFailureHandler()
         result = await h.handle(mock_context, {"prd": "test"})
 
-        assert result.success is True
-        assert result.outputs["classification"] == FailureClassification.EXECUTION
+        assert result.success is False
+        assert result.outputs["outcome_class"] == TaskOutcome.NEEDS_REPLAN
+        assert "rejected" in (result.error or "").lower() or "schema" in (result.error or "").lower()
+
+    async def test_empty_analysis_summary_rejected(self, mock_context):
+        """Issue #84: ``analysis_summary: ""`` is the failure mode that
+        produced ``analysis_summary: "N/A"`` corrections in the wild."""
+        analysis = {
+            "classification": FailureClassification.EXECUTION,
+            "analysis_summary": "",  # blocked by min_length=20
+            "contributing_factors": ["something specific enough"],
+        }
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=json.dumps(analysis)),
+        )
+        h = DataAnalyzeFailureHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+        assert result.success is False
+        assert result.outputs["outcome_class"] == TaskOutcome.NEEDS_REPLAN
+
+    async def test_unknown_classification_rejected(self, mock_context):
+        analysis = {
+            "classification": "weird-made-up-bucket",
+            "analysis_summary": "Plenty long enough to pass the length gate.",
+            "contributing_factors": ["something specific enough"],
+        }
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=json.dumps(analysis)),
+        )
+        h = DataAnalyzeFailureHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+        assert result.success is False
+
+    async def test_empty_contributing_factors_rejected(self, mock_context):
+        analysis = {
+            "classification": FailureClassification.EXECUTION,
+            "analysis_summary": "Plenty long enough to pass the length gate.",
+            "contributing_factors": [],  # blocked by min_length=1
+        }
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=json.dumps(analysis)),
+        )
+        h = DataAnalyzeFailureHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+        assert result.success is False
+
+    async def test_short_contributing_factor_rejected(self, mock_context):
+        analysis = {
+            "classification": FailureClassification.EXECUTION,
+            "analysis_summary": "Plenty long enough to pass the length gate.",
+            "contributing_factors": ["x"],  # blocked by per-item >=5 chars
+        }
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=json.dumps(analysis)),
+        )
+        h = DataAnalyzeFailureHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+        assert result.success is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`data.analyze_failure` was silently coercing missing/empty LLM output fields into useless defaults. Live evidence on `cyc_4cac11018af7` (2026-05-02): Bob's `qa_handoff.md` section failure produced a `plan_delta` with `classification="unknown"`, `analysis_summary="N/A"`, and `changes=["backend_tests","frontend_tests","integration_testing"]` — none of which would have fixed the actual missing-markdown-sections problem. Data's response was 79 tokens on qwen2.5:3b.

## Two changes

### 1. `FailureAnalysis` Pydantic model

```python
classification: str        # must be in FailureClassification taxonomy
analysis_summary: str      # min_length=20 (blocks empty + "N/A")
contributing_factors: list[str]  # min_length=1, each item >= 5 chars
```

Validation failure now returns `success=False` with `TaskOutcome.NEEDS_REPLAN` and a clear `analyze_failure_handler rejected output: ...` log line, rather than fabricating a plausible-looking but useless analysis.

### 2. Stricter prompt

The system prompt now:
- Enumerates valid classification values inline (no inference required)
- Explicitly rejects `"N/A"`, `"unknown"`, and empty strings
- Demands concrete observables in `contributing_factors`

## Test plan

- [x] 6 tests in `TestAnalyzeFailure`: happy path, unparseable→NEEDS_REPLAN, empty `analysis_summary` rejected, unknown classification rejected, empty `contributing_factors` rejected, short factor rejected
- [x] Full `test_impl_handlers.py` regression: 19/19 pass
- [ ] Live re-run of a focused-mode cycle on bumped data role (qwen3.6:27b — see PR #85) to confirm classifier now produces concrete diagnoses

## Note

Pairs naturally with PR #85 (data role bump 7b → 27b). The schema fix alone provides the safety net; the model bump should mean the safety net rarely fires because the larger model produces specific outputs out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)