### PR TITLE
fix(cycle-reply): recover lost agent replies via long-block consume + cache invalidation

### DIFF
--- a/adapters/comms/rabbitmq.py
+++ b/adapters/comms/rabbitmq.py
@@ -64,14 +64,35 @@ class RabbitMQAdapter(QueuePort):
         return queue_name
 
     async def _get_queue(self, queue_name: str) -> Queue:
-        """Get or create a queue, applying namespace if configured."""
+        """Get or create a queue, applying namespace if configured.
+
+        Cached Queue handles are bound to the channel they were declared on.
+        If the underlying channel reconnects (RobustChannel) the cached
+        handle can become stale and operations against it raise
+        ``Channel was not opened``. We track which channel each cached
+        queue is bound to and re-declare on mismatch.
+        """
         full_name = self._apply_namespace(queue_name)
-        if full_name not in self._queues:
-            await self._ensure_connection()
-            queue = await self._channel.declare_queue(full_name, durable=True)
-            self._queues[full_name] = queue
-            logger.debug(f"Declared queue: {full_name}")
-        return self._queues[full_name]
+        await self._ensure_connection()
+
+        cached = self._queues.get(full_name)
+        if cached is not None and getattr(cached, "channel", None) is self._channel:
+            return cached
+
+        queue = await self._channel.declare_queue(full_name, durable=True)
+        self._queues[full_name] = queue
+        logger.debug(f"Declared queue: {full_name}")
+        return queue
+
+    async def invalidate_queue(self, queue_name: str) -> None:
+        """Drop the cached Queue handle for ``queue_name``.
+
+        Called by long-running consume loops after a transient failure
+        (e.g. ``Channel was not opened``) so the next call re-declares
+        against the current channel.
+        """
+        full_name = self._apply_namespace(queue_name)
+        self._queues.pop(full_name, None)
 
     async def publish(
         self, queue_name: str, payload: str, delay_seconds: int | None = None
@@ -187,6 +208,59 @@ class RabbitMQAdapter(QueuePort):
         except Exception as e:
             logger.error(f"Failed to consume messages from queue {queue_name}: {e}")
             raise QueueError(f"Failed to consume messages: {e}") from e
+
+    async def consume_blocking(
+        self, queue_name: str, timeout: float, max_messages: int = 1
+    ) -> list[QueueMessage]:
+        """Hold a single consumer registration on ``queue_name`` for up to
+        ``timeout`` seconds, returning as soon as ``max_messages`` arrive.
+
+        This avoids the consumer-tag churn of repeatedly calling :meth:`consume`
+        in a poll loop, which on busy/empty queues can race with arriving
+        messages (a message dispatched to a consumer tag that's about to be
+        canceled may not be redelivered to the next short-lived iterator).
+        """
+        try:
+            await self._ensure_connection()
+            queue = await self._get_queue(queue_name)
+
+            messages: list[QueueMessage] = []
+
+            async def collect_messages():
+                async with queue.iterator(no_ack=False) as queue_iter:
+                    async for message in queue_iter:
+                        payload = message.body.decode("utf-8")
+                        receipt_handle = str(message.delivery_tag)
+                        message_attributes = {
+                            "delivery_tag": message.delivery_tag,
+                            "routing_key": message.routing_key,
+                            "exchange": message.exchange,
+                            "redelivered": message.redelivered,
+                            "message": message,
+                        }
+                        messages.append(
+                            QueueMessage(
+                                message_id=str(message.delivery_tag),
+                                queue_name=queue_name,
+                                payload=payload,
+                                receipt_handle=receipt_handle,
+                                attributes=message_attributes,
+                            )
+                        )
+                        if len(messages) >= max_messages:
+                            break
+
+            try:
+                await asyncio.wait_for(collect_messages(), timeout=timeout)
+            except TimeoutError:
+                pass
+
+            logger.debug(f"consume_blocking returned {len(messages)} message(s) from {queue.name}")
+            return messages
+
+        except Exception as e:
+            logger.error(f"Failed to consume_blocking from queue {queue_name}: {e}")
+            raise QueueError(f"Failed to consume_blocking: {e}") from e
 
     async def ack(self, message: QueueMessage) -> None:
         """

--- a/adapters/cycles/distributed_flow_executor.py
+++ b/adapters/cycles/distributed_flow_executor.py
@@ -581,11 +581,7 @@ class DistributedFlowExecutor(FlowExecutionPort):
         idx = inputs.get("subtask_index")
         if focus:
             focus_short = str(focus)[:60]
-            return (
-                f"{role}[{idx}]: {focus_short}"
-                if idx is not None
-                else f"{role}: {focus_short}"
-            )
+            return f"{role}[{idx}]: {focus_short}" if idx is not None else f"{role}: {focus_short}"
         return f"{role}: {envelope.task_type}"
 
     async def _create_task_run_if_enabled(
@@ -716,8 +712,38 @@ class DistributedFlowExecutor(FlowExecutionPort):
         )
 
         deadline = time.monotonic() + self._task_timeout
-        while time.monotonic() < deadline:
-            messages = await self._queue.consume(reply_queue, max_messages=1)
+        # Block on the reply queue in long chunks so a single consumer
+        # registration covers each chunk — avoids the consumer-tag churn
+        # of poll-and-sleep that previously raced with arriving replies.
+        # Cap each chunk well below typical broker idle-disconnect windows.
+        chunk_seconds = 30.0
+
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            wait = min(chunk_seconds, remaining)
+
+            try:
+                messages = await self._queue.consume_blocking(
+                    reply_queue, timeout=wait, max_messages=1
+                )
+            except Exception as exc:
+                # Channel went stale or broker hiccup. Drop the cached
+                # queue handle and back off briefly before retrying so
+                # the next call re-declares against a fresh channel.
+                logger.warning(
+                    "consume_blocking on %s failed (%s); invalidating cache and retrying",
+                    reply_queue,
+                    exc,
+                )
+                try:
+                    await self._queue.invalidate_queue(reply_queue)
+                except Exception:
+                    logger.debug("invalidate_queue raised; continuing", exc_info=True)
+                await asyncio.sleep(min(1.0, max(0.0, deadline - time.monotonic())))
+                continue
+
             for msg in messages:
                 data = json.loads(msg.payload)
                 result_data = data.get("payload", {})
@@ -726,7 +752,6 @@ class DistributedFlowExecutor(FlowExecutionPort):
                     return TaskResult.from_dict(result_data)
                 # Not our message — ack to avoid blocking
                 await self._queue.ack(msg)
-            await asyncio.sleep(0.5)
 
         return TaskResult(
             task_id=envelope.task_id,

--- a/docs/plans/1-0-x-build-reliability-hardening-plan.md
+++ b/docs/plans/1-0-x-build-reliability-hardening-plan.md
@@ -1,13 +1,21 @@
 # 1.0.x Build Reliability Hardening Plan
 
 **Created:** 2026-04-27
-**Updated:** 2026-04-27 (rev 2 — incorporated external review feedback)
-**Status:** Active — #1 drafted, #2 next
+**Updated:** 2026-05-02 (rev 3 — added runtime substrate precondition)
+**Status:** Active — #1 drafted, #2 next; substrate SIP S1 proposed
 **Scope:** SquadOps 1.0.x patch series (Spark lane); orthogonal to v1.1 work (SIP-0088+)
 
 ## Intent
 
 The 1.0.x series targets **autonomous cycles long enough to build the best possible vertical slice** — not 1-hour timeboxes. That scoping decision changes what "reliability" means: in a 1-hour cycle the bottleneck is *did the squad ship anything*; in a multi-hour cycle the bottleneck is *did the squad stay coherent over time*. Plans drift, decisions get re-litigated, context windows reset, runaway loops compound into cost incidents, and a half-right manifest at hour two poisons the rest of the run. The proposals in this plan are ordered to attack that "stay coherent" failure mode directly: each SIP either gives the squad better evidence to act on, a better way to evolve its plan when reality diverges, or a guardrail that keeps the loop bounded. Build-reliability work runs as a focused track; release/API hardening runs as a parallel track and is not the target of this plan.
+
+## Runtime substrate (preconditions to the build-reliability axis)
+
+These are not part of the "stay coherent over time" axis below — they are the dispatch/transport layer the axis runs on. Listed separately so they don't compete with planning/QA/continuation items for slot ordering, but called out as preconditions because every item below assumes the orchestrator reliably receives an agent reply on a long task. That assumption broke on `cyc_c9ca088599c0` (2026-05-02): a 9-minute dev[3] reply was lost because the reply-queue poll loop churned ~3600 short-lived consumer subscriptions over a 30-min wait, then wedged the channel.
+
+| # | SIP | Status | Where |
+|---|-----|--------|-------|
+| S1 | **Long-Lived Subscription Model for Cycle Reply Channels** — replace `_publish_and_await` poll loop with a single long-lived consumer per task, add reply-queue TTL/cleanup, drain-before-retry on lost replies. Tactical patch (cache invalidation + `consume_blocking()` chunked waits) already on PR #89. | proposed (2026-05-02); tactical patch on PR #89 | `sips/proposed/SIP-Reply-Channel-Subscription-Model.md` |
 
 ## Build-reliability axis (priority order)
 
@@ -56,6 +64,7 @@ These ship on the 1.0.x patch lane but do not contribute to build-reliability. L
 
 ## Why this order
 
+- **Substrate (S1) is a precondition, not a competitor.** Reply-channel reliability is not on the build-reliability axis but every item on the axis depends on it. The tactical patch lands first (PR #89); structural SIP soaks in dev before being slotted against axis work for engineering time.
 - **#1 first.** The current build manifest is informational and one-shot. There is no point hardening downstream signals until the plan can both *validate* against typed criteria and *evolve* via overlays when reality diverges.
 - **#2 and #3 next.** They produce the evidence every later SIP cites. A continuation decision (#5) cannot be stronger than the acceptance signal (#2) and the evaluation contract (#3) it references.
 - **#4 before #5.** Run trajectory and continuation only work if cross-run memory exists. Otherwise run N+1 starts amnesiac and re-litigates run N's decisions.
@@ -86,5 +95,6 @@ Everything else is either already in `sips/proposed/`, a follow-up to an accepte
 
 ## Revision history
 
+- **rev 3 (2026-05-02):** Added Runtime Substrate section with S1 (Reply-Channel Subscription Model) as a precondition to the build-reliability axis. Triggered by `cyc_c9ca088599c0` lost-reply incident. Tactical patch on PR #89; structural SIP in `sips/proposed/`.
 - **rev 2 (2026-04-27):** Incorporated external review. Three structural changes: (1) split former #9 into #5a (minimal breakers, precondition for #5) and #9 (full operator surface, original slot); (2) swapped former #6 ↔ #7 — Defect Report now precedes Resume Contract, with Resume scoped to technical idempotency only; (3) added explicit Capability/Policy Boundaries section. Plus annotations on #4 (typed-not-soup), #6 (machine-actionable fields), #8 (duration AND risk), #10↔#2 link, #11 (empirical, revertible).
 - **rev 1 (2026-04-27):** Initial plan landed via PR #67.

--- a/sips/proposed/SIP-Reply-Channel-Subscription-Model.md
+++ b/sips/proposed/SIP-Reply-Channel-Subscription-Model.md
@@ -1,0 +1,144 @@
+# SIP-0XXX: Long-Lived Subscription Model for Cycle Reply Channels
+
+**Status:** Proposed
+**Authors:** SquadOps Architecture
+**Created:** 2026-05-02
+**Revision:** 1
+
+## 1. Abstract
+
+The orchestrator's request/reply path between `runtime-api` and agents uses a poll-and-sleep loop on a per-run RabbitMQ reply queue. The loop opens a fresh, short-lived consumer subscription on every poll, generating thousands of consumer-tag open/close cycles per long task. This pattern is fragile under aio_pika RobustChannel: replies have been observed to remain undelivered for the full task timeout (30 minutes) even though the agent published them within the first few minutes. This SIP replaces the polling loop with a single long-lived subscription per wait and cleans up the reply-queue lifecycle so we eliminate the entire class of "agent succeeded but reply lost" failures. A tactical patch (`fix/cycle-results-channel-recovery`) has already landed cache-recovery and longer poll chunks that contain the bleeding; this SIP is the structural fix.
+
+## 2. Problem Statement
+
+Investigation of `cyc_c9ca088599c0` / `run_edc1d0dc7bf4` (group_run, 2026-05-02) confirmed:
+
+- Agent (Neo) published the reply to `cycle_results_run_edc1d0dc7bf4` at 21:50:26 — 9 minutes after dispatch.
+- Orchestrator's polling loop never delivered the reply during the next 21 minutes.
+- At exactly the 1800s task timeout, the polling loop hit `Channel was not opened`, and the task was marked FAILED.
+- A retry was triggered, which consumed another 8 minutes of GPU time before failing again.
+- Three reply messages remain durably stuck in the queue, never consumed.
+
+Root cause: `RabbitMQAdapter.consume()` opens `queue.iterator(no_ack=False)` with a 1.0-second timeout on every call. Called every ~0.5s by `_publish_and_await`, this generates ~3600 consumer subscriptions per 30-minute wait. Per AMQP semantics, when a consumer is canceled while a message is being dispatched to it, the message is meant to be redelivered to another consumer — but with the orchestrator's pattern there are no other consumers, only a future iterator that hasn't been created yet. Messages can be lost in the gap, and the constant subscribe/cancel churn appears to push the channel into states from which it does not recover.
+
+The tactical fix in `fix/cycle-results-channel-recovery` introduces `consume_blocking()` (one consumer per chunk, default 30 s) and queue-cache invalidation on transient errors. That shrinks the failure window dramatically but still uses chunked polling — there is still a (small) gap between chunks during which messages must be redelivered. The structural fix is to maintain a single subscription for the whole wait.
+
+Secondary problems this SIP also addresses:
+
+- **Reply-queue leakage**: `cycle_results_*` queues are declared `durable=True` and never deleted. Production has 18+ orphan queues from completed runs.
+- **Redispatch on lost reply**: `_dispatch_task_with_retry` re-runs the task on timeout, even though the agent's reply may already be in the queue. This wastes another full LLM run.
+
+## 3. Goals
+
+1. Replace the chunked-poll wait in `_publish_and_await` with a single long-lived consumer subscription that survives the full task timeout.
+2. Define an explicit `subscribe()` primitive on `QueuePort` with callback / async-iterator semantics so reply waiting is no longer expressed as polling.
+3. Add reply-queue lifecycle management: declare with TTL or auto-delete (whichever is safe for the runtime topology) and explicit cleanup on run completion.
+4. Before re-dispatching a task on timeout, drain the existing reply queue once — recover the original reply if it arrived late, instead of paying for a duplicate LLM run.
+
+## 4. Non-Goals
+
+- Replacing RabbitMQ with another transport.
+- Changing the request/reply pairing semantics (still 1 reply queue per run, still task_id-based correlation).
+- Refactoring the agent-side `_consume_messages` loop in `entrypoint.py`. That loop has the same anti-pattern but is tolerable because the comms queue is rarely empty for long. Will be addressed in a follow-up.
+- Changing the per-task timeout (`SQUADOPS__LLM__TIMEOUT=1800`).
+- Per-message TTL on individual messages — queue-level TTL is sufficient and simpler.
+
+## 5. Approach Sketch
+
+### 5.1 New port primitive
+
+```python
+class QueuePort(ABC):
+    async def subscribe(
+        self,
+        queue_name: str,
+        *,
+        until: Callable[[QueueMessage], bool],
+        timeout: float,
+    ) -> QueueMessage | None:
+        """Hold a single consumer on ``queue_name`` for up to ``timeout``
+        seconds. Return the first message for which ``until(msg)`` is True;
+        ack and discard others. Return None on timeout."""
+```
+
+`subscribe()` takes a predicate so the executor can match on `task_id` directly inside the consumer callback — no separate ack/discard dance in user code. Default implementation in the abstract base falls back to `consume_blocking()` for adapters that don't have native long-subscription support.
+
+### 5.2 RabbitMQ implementation
+
+In `RabbitMQAdapter.subscribe()`:
+
+```python
+async with queue.iterator(no_ack=False) as queue_iter:
+    deadline_task = asyncio.create_task(asyncio.sleep(timeout))
+    async for message in queue_iter:
+        if predicate matches:
+            await message.ack()
+            return QueueMessage(...)
+        await message.ack()  # discard non-matching
+        if deadline_task.done():
+            return None
+```
+
+One iterator, one consumer tag, lives for the whole timeout. Messages dispatched while the consumer is registered land in the iterator immediately. No subscribe/cancel churn.
+
+### 5.3 Executor wiring
+
+`_publish_and_await` becomes:
+
+```python
+reply = await self._queue.subscribe(
+    reply_queue,
+    until=lambda msg: json.loads(msg.payload).get("payload", {}).get("task_id") == envelope.task_id,
+    timeout=self._task_timeout,
+)
+if reply is None:
+    return TaskResult(task_id=envelope.task_id, status="FAILED", error="Timed out ...")
+data = json.loads(reply.payload)
+return TaskResult.from_dict(data["payload"])
+```
+
+No while loop, no asyncio.sleep, no error-recovery branch (subscribe internally retries on transient channel errors).
+
+### 5.4 Reply-queue lifecycle
+
+Declare reply queues with both:
+
+- `arguments={"x-expires": 3600 * 1000}` — broker auto-deletes the queue if no consumer binds for 1 hour. Catches orphan cleanup.
+- Explicit `delete_queue(reply_queue)` call in the run-completion path of `DistributedFlowExecutor.execute()`. Catches the happy path immediately.
+
+### 5.5 Drain-before-retry
+
+In `_dispatch_task_with_retry` before re-dispatching a timed-out task, call `subscribe(reply_queue, until=task_id-match, timeout=5)` to scoop any reply that arrived after the wait timed out. If found, return SUCCEEDED without paying for a re-run.
+
+## 6. Migration / Compatibility
+
+- `consume()` and `consume_blocking()` (added in tactical patch) remain on `QueuePort`. They are still useful for the agent-side comms loop and future use cases.
+- `subscribe()` is added as a non-abstract method with a default implementation that wraps `consume_blocking()`. NoOpQueuePort needs no changes. RabbitMQAdapter overrides with the native long-iterator implementation.
+- Existing tests using `mock_queue.consume.side_effect = ...` continue to work.
+- Tests that exercise `_publish_and_await` after this SIP must mock `subscribe()` instead.
+
+## 7. Risks
+
+- **Single-consumer failure mode**: if the long-lived consumer's channel dies mid-wait, we lose the reply window. The implementation must catch channel-close events and re-subscribe transparently (RobustChannel reconnect plus our own re-declare on the new channel).
+- **Reply queue auto-delete races**: if the consumer binds late (e.g., orchestrator restart), the broker may have already deleted the queue and the agent's reply will be lost. Mitigation: declare the queue at dispatch time, before publishing the request, with a generous TTL (1 hour). Run-completion cleanup is best-effort.
+- **Drain-before-retry false positives**: if a stale reply from a prior dispatch matches the new dispatch's task_id (which would indicate a deeper bug), drain returns the stale result. Use the run-completion cleanup to keep the queue fresh; additionally, increment a dispatch attempt counter and include it in correlation metadata so stale matches can be detected.
+
+## 8. Test Plan
+
+- Unit: `subscribe()` happy path, timeout returns None, predicate filters non-matching messages, transient channel error is retried internally.
+- Unit: reply-queue declaration includes TTL argument; explicit cleanup is called on run completion (success and failure).
+- Unit: drain-before-retry returns existing reply without re-publishing.
+- Integration (`tests/integration/adapters/test_rabbitmq_adapter.py`): publish 100 messages while a single subscriber is held — all 100 delivered, zero lost. Compare to the same load against `consume()` to demonstrate the regression.
+- E2E: re-run the `group_run` cycle that surfaced this issue (`cyc_c9ca088599c0`) on a clean stack; verify dev[3] completes within the same wall time as dev[0–2].
+
+## 9. Rollout
+
+1. Land tactical patch (`fix/cycle-results-channel-recovery`) — already in PR. Contains the bleeding.
+2. Implement subscribe() + RabbitMQ override + executor wiring on a feature branch.
+3. Soak in dev environment for one full long-cycle build.
+4. Promote.
+
+## 10. Open Questions
+
+- Should reply queues be per-run (current) or per-task? Per-task gives natural isolation but multiplies queue declarations. Recommend keeping per-run.
+- Should `subscribe()`'s predicate be sync or async? Sync is simpler; async unlocks future use cases (e.g., HTTP lookup to validate a result). Recommend sync for v1.

--- a/src/squadops/ports/comms/queue.py
+++ b/src/squadops/ports/comms/queue.py
@@ -46,6 +46,56 @@ class QueuePort(ABC):
         """
         pass
 
+    async def consume_blocking(
+        self, queue_name: str, timeout: float, max_messages: int = 1
+    ) -> list[QueueMessage]:
+        """Block on a queue until a message arrives or ``timeout`` elapses.
+
+        Unlike :meth:`consume` (which opens a fresh, short-lived consumer per
+        call and returns immediately), this method holds a single consumer
+        registration for the whole ``timeout`` window. That is the right
+        primitive for request/reply waits where the reply queue is empty for
+        most of the wait and a message must be delivered the moment it
+        arrives. Implementations should fall back to short-lived polling if
+        they cannot subscribe long-term.
+
+        Args:
+            queue_name: Name of the queue
+            timeout: Max seconds to block; returns empty list if no message
+                arrives in this window
+            max_messages: Maximum messages to retrieve (default: 1)
+
+        Returns:
+            List of QueueMessage objects (possibly empty on timeout)
+
+        Raises:
+            QueueError: If consumption fails
+        """
+        # Default fallback: poll consume() until a message arrives or deadline.
+        import asyncio
+        import time
+
+        deadline = time.monotonic() + timeout
+        while True:
+            messages = await self.consume(queue_name, max_messages=max_messages)
+            if messages:
+                return messages
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return []
+            await asyncio.sleep(min(0.5, remaining))
+
+    async def invalidate_queue(self, queue_name: str) -> None:
+        """Drop any cached handle for ``queue_name`` so subsequent operations
+        re-resolve against the current channel.
+
+        Useful after a transient ``QueueError`` so the next consume/publish
+        re-declares the queue rather than reusing a stale, channel-bound
+        handle. Default implementation is a no-op for adapters that don't
+        cache.
+        """
+        return None
+
     @abstractmethod
     async def ack(self, message: QueueMessage) -> None:
         """

--- a/tests/unit/comms/test_rabbitmq_adapter.py
+++ b/tests/unit/comms/test_rabbitmq_adapter.py
@@ -1,0 +1,124 @@
+"""Unit tests for RabbitMQAdapter cache-recovery and consume_blocking.
+
+Targets the stale-Queue-cache and consumer-tag-churn bugs that caused
+``cycle_results_*`` replies to be lost during long waits (see fix branch
+``fix/cycle-results-channel-recovery``). Uses MagicMock-backed channels so
+no broker is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from adapters.comms.rabbitmq import QueueError, RabbitMQAdapter
+
+pytestmark = [pytest.mark.unit]
+
+
+def _make_adapter_with_channel(channel_obj) -> RabbitMQAdapter:
+    """Build an adapter with pre-wired connection/channel mocks."""
+    adapter = RabbitMQAdapter(url="amqp://test", namespace=None)
+    conn = MagicMock()
+    conn.is_closed = False
+    adapter._connection = conn
+    adapter._channel = channel_obj
+    return adapter
+
+
+class TestQueueCacheInvalidation:
+    """Cached Queue handles are bound to a channel; if the channel is
+    swapped (RobustChannel reconnect) the cache must re-declare."""
+
+    async def test_get_queue_redeclares_when_channel_changes(self) -> None:
+        """Regression: a cached Queue tied to a closed channel produced
+        ``Channel was not opened`` even after RobustChannel reconnected.
+        ``_get_queue`` must detect the channel swap and re-declare."""
+        ch1 = MagicMock()
+        ch1.is_closed = False
+        old_queue = MagicMock()
+        old_queue.channel = ch1
+        ch1.declare_queue = AsyncMock(return_value=old_queue)
+
+        adapter = _make_adapter_with_channel(ch1)
+        first = await adapter._get_queue("cycle_results_run_x")
+        assert first is old_queue
+        ch1.declare_queue.assert_awaited_once()
+
+        # Simulate RobustChannel reconnect: the adapter now holds a fresh
+        # channel object. The cached queue is bound to the old one.
+        ch2 = MagicMock()
+        ch2.is_closed = False
+        new_queue = MagicMock()
+        new_queue.channel = ch2
+        ch2.declare_queue = AsyncMock(return_value=new_queue)
+        adapter._channel = ch2
+
+        second = await adapter._get_queue("cycle_results_run_x")
+
+        assert second is new_queue
+        ch2.declare_queue.assert_awaited_once_with("cycle_results_run_x", durable=True)
+
+    async def test_invalidate_queue_drops_cached_handle(self) -> None:
+        """``invalidate_queue`` must remove the cached Queue so the next
+        ``_get_queue`` call re-declares — the recovery hook used by long-
+        running poll loops after a transient channel error."""
+        ch = MagicMock()
+        ch.is_closed = False
+        original = MagicMock()
+        original.channel = ch
+        replacement = MagicMock()
+        replacement.channel = ch
+        ch.declare_queue = AsyncMock(side_effect=[original, replacement])
+
+        adapter = _make_adapter_with_channel(ch)
+        first = await adapter._get_queue("reply_q")
+        assert first is original
+
+        await adapter.invalidate_queue("reply_q")
+
+        # After invalidation, next call must re-declare and return the new handle.
+        second = await adapter._get_queue("reply_q")
+        assert second is replacement
+        assert ch.declare_queue.await_count == 2
+
+    async def test_invalidate_queue_unknown_name_is_noop(self) -> None:
+        """Invalidating a queue that was never cached must not raise — recovery
+        paths can call this defensively."""
+        ch = MagicMock()
+        ch.is_closed = False
+        adapter = _make_adapter_with_channel(ch)
+
+        # Must not raise, even though no cache entry exists.
+        await adapter.invalidate_queue("never_cached")
+        assert "never_cached" not in adapter._queues
+
+
+class TestConsumeBlockingErrorWrapping:
+    """``consume_blocking`` must wrap broker errors in QueueError so callers
+    can recover (invalidate cache, retry) instead of crashing on raw
+    aio_pika exceptions."""
+
+    async def test_raises_queue_error_on_broker_failure(self) -> None:
+        """If the underlying channel/iterator raises mid-consume, the caller
+        sees a typed ``QueueError`` — not a leaky aio_pika exception."""
+        ch = MagicMock()
+        ch.is_closed = False
+        broken_queue = MagicMock()
+        broken_queue.channel = ch
+        broken_queue.name = "reply_q"
+
+        # Raise a realistic broker-side error from iterator setup.
+        def explode(*_a, **_kw):
+            raise RuntimeError("Channel was not opened")
+
+        broken_queue.iterator = explode
+        ch.declare_queue = AsyncMock(return_value=broken_queue)
+
+        adapter = _make_adapter_with_channel(ch)
+
+        with pytest.raises(QueueError) as exc_info:
+            await adapter.consume_blocking("reply_q", timeout=0.05, max_messages=1)
+
+        assert "Channel was not opened" in str(exc_info.value)

--- a/tests/unit/cycles/test_correction_protocol.py
+++ b/tests/unit/cycles/test_correction_protocol.py
@@ -106,7 +106,13 @@ def mock_queue():
     mock = AsyncMock()
     mock.publish.return_value = None
     mock.ack.return_value = None
+    mock.invalidate_queue.return_value = None
     mock.consume.return_value = []
+
+    async def _consume_blocking(queue_name, timeout, max_messages=1):
+        return await mock.consume(queue_name, max_messages=max_messages)
+
+    mock.consume_blocking.side_effect = _consume_blocking
     return mock
 
 

--- a/tests/unit/cycles/test_distributed_flow_executor.py
+++ b/tests/unit/cycles/test_distributed_flow_executor.py
@@ -112,8 +112,16 @@ def mock_queue():
     mock = AsyncMock()
     mock.publish.return_value = None
     mock.ack.return_value = None
+    mock.invalidate_queue.return_value = None
     # Default: consume returns empty (override per-test)
     mock.consume.return_value = []
+
+    # Route consume_blocking through consume so tests that set
+    # consume.side_effect continue to work without modification.
+    async def _consume_blocking(queue_name, timeout, max_messages=1):
+        return await mock.consume(queue_name, max_messages=max_messages)
+
+    mock.consume_blocking.side_effect = _consume_blocking
     return mock
 
 
@@ -374,6 +382,107 @@ class TestDispatchTask:
 
         assert result.status == "FAILED"
         assert "Timed out" in result.error
+
+    async def test_recovers_from_transient_consume_error(
+        self, executor, mock_queue
+    ) -> None:
+        """A transient QueueError must invalidate the cached queue handle and
+        the loop must keep waiting until the deadline — not fail the task.
+
+        Regression: prior to fix, a single ``Channel was not opened`` from
+        the broker would propagate out of ``_publish_and_await`` and fail an
+        otherwise-recoverable wait, even though the agent's reply was sitting
+        in the queue.
+        """
+        executor._task_timeout = 1.0
+
+        envelope = TaskEnvelope(
+            task_id="task_recover",
+            agent_id="neo",
+            cycle_id="cyc_001",
+            pulse_id="p1",
+            project_id="proj_001",
+            task_type="development.design",
+            correlation_id="corr",
+            causation_id="cause",
+            trace_id="trace",
+            span_id="span",
+            metadata={"role": "dev"},
+        )
+
+        # First consume_blocking raises (stale channel); second returns the
+        # reply that was waiting all along.
+        result_msg = _make_result_message(
+            task_id="task_recover",
+            outputs={"summary": "recovered", "artifacts": []},
+        )
+        call_count = {"n": 0}
+
+        async def flaky_consume_blocking(queue_name, timeout, max_messages=1):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("Channel was not opened")
+            return [result_msg]
+
+        mock_queue.consume_blocking.side_effect = flaky_consume_blocking
+
+        with patch(
+            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            result = await executor._dispatch_task(envelope, "run_001")
+
+        assert result.status == "SUCCEEDED"
+        assert result.outputs["summary"] == "recovered"
+        # Cache must be invalidated so the retry re-declares against a fresh
+        # channel rather than reusing the broken handle.
+        mock_queue.invalidate_queue.assert_awaited_with("cycle_results_run_001")
+
+    async def test_uses_long_block_consume_not_short_poll(
+        self, executor, mock_queue
+    ) -> None:
+        """The wait must use ``consume_blocking`` (one consumer per chunk),
+        not the legacy ``consume`` poll-and-sleep that churned consumer tags.
+
+        Regression: the old loop opened ~3600 short-lived consumers per
+        30-min wait, racing with arriving messages. New loop must call
+        ``consume_blocking`` with a multi-second timeout.
+        """
+        executor._task_timeout = 0.05  # shortcut: single iteration
+
+        result_msg = _make_result_message(
+            task_id="task_blk",
+            outputs={"summary": "ok", "artifacts": []},
+        )
+        mock_queue.consume_blocking.side_effect = None
+        mock_queue.consume_blocking.return_value = [result_msg]
+
+        envelope = TaskEnvelope(
+            task_id="task_blk",
+            agent_id="neo",
+            cycle_id="cyc_001",
+            pulse_id="p1",
+            project_id="proj_001",
+            task_type="development.design",
+            correlation_id="corr",
+            causation_id="cause",
+            trace_id="trace",
+            span_id="span",
+            metadata={"role": "dev"},
+        )
+
+        result = await executor._dispatch_task(envelope, "run_001")
+
+        assert result.status == "SUCCEEDED"
+        # Must have called consume_blocking, not the short-poll consume.
+        assert mock_queue.consume_blocking.await_count >= 1
+        # Each call must request a meaningful blocking window so the
+        # consumer subscription is held long enough to receive a reply.
+        first_call = mock_queue.consume_blocking.await_args_list[0]
+        timeout_arg = first_call.kwargs.get("timeout")
+        if timeout_arg is None and len(first_call.args) >= 2:
+            timeout_arg = first_call.args[1]
+        assert timeout_arg is not None and timeout_arg > 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cycles/test_distributed_flow_executor_observability.py
+++ b/tests/unit/cycles/test_distributed_flow_executor_observability.py
@@ -132,7 +132,13 @@ def mock_queue():
     mock = AsyncMock()
     mock.publish.return_value = None
     mock.ack.return_value = None
+    mock.invalidate_queue.return_value = None
     mock.consume.return_value = []
+
+    async def _consume_blocking(queue_name, timeout, max_messages=1):
+        return await mock.consume(queue_name, max_messages=max_messages)
+
+    mock.consume_blocking.side_effect = _consume_blocking
     return mock
 
 

--- a/tests/unit/cycles/test_executor_checkpoint.py
+++ b/tests/unit/cycles/test_executor_checkpoint.py
@@ -133,7 +133,13 @@ def mock_queue():
     mock = AsyncMock()
     mock.publish.return_value = None
     mock.ack.return_value = None
+    mock.invalidate_queue.return_value = None
     mock.consume.return_value = []
+
+    async def _consume_blocking(queue_name, timeout, max_messages=1):
+        return await mock.consume(queue_name, max_messages=max_messages)
+
+    mock.consume_blocking.side_effect = _consume_blocking
     return mock
 
 

--- a/tests/unit/cycles/test_outcome_routing.py
+++ b/tests/unit/cycles/test_outcome_routing.py
@@ -105,7 +105,13 @@ def mock_queue():
     mock = AsyncMock()
     mock.publish.return_value = None
     mock.ack.return_value = None
+    mock.invalidate_queue.return_value = None
     mock.consume.return_value = []
+
+    async def _consume_blocking(queue_name, timeout, max_messages=1):
+        return await mock.consume(queue_name, max_messages=max_messages)
+
+    mock.consume_blocking.side_effect = _consume_blocking
     return mock
 
 

--- a/tests/unit/events/test_drift_detection.py
+++ b/tests/unit/events/test_drift_detection.py
@@ -147,7 +147,13 @@ def mock_queue():
     mock = AsyncMock()
     mock.publish.return_value = None
     mock.ack.return_value = None
+    mock.invalidate_queue.return_value = None
     mock.consume.return_value = []
+
+    async def _consume_blocking(queue_name, timeout, max_messages=1):
+        return await mock.consume(queue_name, max_messages=max_messages)
+
+    mock.consume_blocking.side_effect = _consume_blocking
     return mock
 
 


### PR DESCRIPTION
## Summary

- Fixes the bug where `dev[3]` in `cyc_c9ca088599c0`/`run_edc1d0dc7bf4` (group_run, 2026-05-02) was marked FAILED even though Neo published its reply 21 minutes earlier — the orchestrator's reply-queue poll loop never delivered it. Three reply messages remain durably stuck in `cycle_results_run_edc1d0dc7bf4` as concrete proof.
- Tactical: replaces the per-0.5s short-iterator churn in `_publish_and_await` with `consume_blocking()` (one consumer per ~30s chunk), adds queue-cache invalidation so a stale handle bound to a closed RobustChannel is re-declared, and adds try/except recovery so a single transient `Channel was not opened` no longer kills a 30-min wait.
- Structural follow-up proposed in `sips/proposed/SIP-Reply-Channel-Subscription-Model.md`: replace chunked polling entirely with a `subscribe(queue, until, timeout)` primitive, add reply-queue TTL/cleanup (production has 18+ orphan `cycle_results_*` queues), and drain-before-retry to avoid duplicate LLM runs on lost-reply timeouts.

## Root cause (short)

`RabbitMQAdapter.consume()` opens a fresh `queue.iterator(no_ack=False)` per call with a 1.0 s timeout. Called every ~0.5 s by the orchestrator's poll loop, this churns ~3600 consumer subscriptions on one channel per 30-min wait. Per AMQP semantics a message dispatched to a tag that's about to be canceled is supposed to be redelivered, but with the orchestrator's pattern there is no other consumer ready — only a future iterator that hasn't been created yet. Replies vanish into the gap and the channel eventually wedges.

## What changed

- `src/squadops/ports/comms/queue.py` — `consume_blocking()` and `invalidate_queue()` added to the port (with default impls so existing adapters keep working).
- `adapters/comms/rabbitmq.py` — native `consume_blocking()` with one long-lived iterator per call; `_get_queue()` now detects channel-swap and re-declares; `invalidate_queue()` drops the cached handle.
- `adapters/cycles/distributed_flow_executor.py:_publish_and_await` — rewritten to call `consume_blocking()` in chunks, with try/except + invalidate-on-error.
- 6 `mock_queue` test fixtures updated to wire `consume_blocking` through `consume.side_effect` so all 30+ existing tests keep passing without modification.
- New unit tests: cache invalidation across channel-swap, defensive invalidation of unknown queues, error wrapping in `consume_blocking`, and two new `_dispatch_task` tests for transient-error recovery and use-of-blocking-consume.

## Test plan

- [x] All 3579 existing regression tests pass (`./scripts/dev/run_regression_tests.sh`).
- [x] 4 new unit tests in `tests/unit/comms/test_rabbitmq_adapter.py` — pass.
- [x] 2 new unit tests in `tests/unit/cycles/test_distributed_flow_executor.py::TestDispatchTask` — pass.
- [x] `ruff check`/`ruff format` clean (one pre-existing C901 on `execute_run` not from this PR).
- [ ] **Manual verification**: rebuild runtime-api + agent images, re-run a `group_run` cycle, confirm dev[3]-equivalent task succeeds without channel-staleness errors. (Memory: `feedback_rebuild_before_sip_test.md` — restart alone won't pick up the new code.)
- [ ] After deploy, confirm orphan messages in `cycle_results_run_edc1d0dc7bf4` get drained on the next run touching the queue, OR delete it explicitly.

## Follow-ups (in proposed SIP, not this PR)

- Replace chunked polling with `subscribe()` primitive for true single-consumer waits.
- Reply-queue TTL (`x-expires`) + explicit run-completion `delete_queue()`.
- Drain-before-retry to recover late-arriving replies instead of paying for a duplicate LLM run.
- Same anti-pattern in `entrypoint.py:_consume_messages` and `aci_executor.py:140` is unchanged here — both tolerable because their queues are rarely empty for long, but worth fixing for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)