### PR TITLE
sip(rev2): per-agent reply queues replace per-run cycle_results scoping

### DIFF
--- a/docs/plans/1-0-x-build-reliability-hardening-plan.md
+++ b/docs/plans/1-0-x-build-reliability-hardening-plan.md
@@ -1,7 +1,7 @@
 # 1.0.x Build Reliability Hardening Plan
 
 **Created:** 2026-04-27
-**Updated:** 2026-05-02 (rev 3 — added runtime substrate precondition)
+**Updated:** 2026-05-02 (rev 4 — S1 reshaped to per-agent reply queues)
 **Status:** Active — #1 drafted, #2 next; substrate SIP S1 proposed
 **Scope:** SquadOps 1.0.x patch series (Spark lane); orthogonal to v1.1 work (SIP-0088+)
 
@@ -15,7 +15,7 @@ These are not part of the "stay coherent over time" axis below — they are the 
 
 | # | SIP | Status | Where |
 |---|-----|--------|-------|
-| S1 | **Long-Lived Subscription Model for Cycle Reply Channels** — replace `_publish_and_await` poll loop with a single long-lived consumer per task, add reply-queue TTL/cleanup, drain-before-retry on lost replies. Tactical patch (cache invalidation + `consume_blocking()` chunked waits) already on PR #89. | proposed (2026-05-02); tactical patch on PR #89 | `sips/proposed/SIP-Reply-Channel-Subscription-Model.md` |
+| S1 | **Per-Agent Reply Queues + Long-Lived Subscription Model** — replace per-run `cycle_results_{run_id}` queues with per-agent `{agent_id}_results` queues (parallel to existing `{agent_id}_comms`), and replace `_publish_and_await` poll loop with a single orchestrator-startup subscription per agent feeding an in-process reply router. Eliminates orphan-queue leakage and consumer-tag-churn failure classes in one structural step. Tactical patch (PR #89, merged 2026-05-02) contains the bleeding. | proposed rev 2 (2026-05-02); tactical patch merged via PR #89 | `sips/proposed/SIP-Reply-Channel-Subscription-Model.md` |
 
 ## Build-reliability axis (priority order)
 
@@ -95,6 +95,7 @@ Everything else is either already in `sips/proposed/`, a follow-up to an accepte
 
 ## Revision history
 
+- **rev 4 (2026-05-02):** S1 reshaped to per-agent reply queues (`{agent_id}_results`) replacing per-run `cycle_results_*` queues. Eliminates the orphan-queue leakage class entirely instead of mitigating it via TTL + run-completion cleanup. Drain-before-retry dropped (no longer needed — the always-on consumer never misses a reply window). SIP rev bumped to 2.
 - **rev 3 (2026-05-02):** Added Runtime Substrate section with S1 (Reply-Channel Subscription Model) as a precondition to the build-reliability axis. Triggered by `cyc_c9ca088599c0` lost-reply incident. Tactical patch on PR #89; structural SIP in `sips/proposed/`.
 - **rev 2 (2026-04-27):** Incorporated external review. Three structural changes: (1) split former #9 into #5a (minimal breakers, precondition for #5) and #9 (full operator surface, original slot); (2) swapped former #6 ↔ #7 — Defect Report now precedes Resume Contract, with Resume scoped to technical idempotency only; (3) added explicit Capability/Policy Boundaries section. Plus annotations on #4 (typed-not-soup), #6 (machine-actionable fields), #8 (duration AND risk), #10↔#2 link, #11 (empirical, revertible).
 - **rev 1 (2026-04-27):** Initial plan landed via PR #67.

--- a/sips/proposed/SIP-Reply-Channel-Subscription-Model.md
+++ b/sips/proposed/SIP-Reply-Channel-Subscription-Model.md
@@ -1,13 +1,13 @@
-# SIP-0XXX: Long-Lived Subscription Model for Cycle Reply Channels
+# SIP-0XXX: Per-Agent Reply Queues + Long-Lived Subscription Model
 
 **Status:** Proposed
 **Authors:** SquadOps Architecture
 **Created:** 2026-05-02
-**Revision:** 1
+**Revision:** 2
 
 ## 1. Abstract
 
-The orchestrator's request/reply path between `runtime-api` and agents uses a poll-and-sleep loop on a per-run RabbitMQ reply queue. The loop opens a fresh, short-lived consumer subscription on every poll, generating thousands of consumer-tag open/close cycles per long task. This pattern is fragile under aio_pika RobustChannel: replies have been observed to remain undelivered for the full task timeout (30 minutes) even though the agent published them within the first few minutes. This SIP replaces the polling loop with a single long-lived subscription per wait and cleans up the reply-queue lifecycle so we eliminate the entire class of "agent succeeded but reply lost" failures. A tactical patch (`fix/cycle-results-channel-recovery`) has already landed cache-recovery and longer poll chunks that contain the bleeding; this SIP is the structural fix.
+The orchestrator's request/reply path between `runtime-api` and agents has two structural problems: (a) it polls a per-run RabbitMQ reply queue with thousands of short-lived consumer subscriptions per long task, losing replies in the gap between subscriptions, and (b) it scopes the reply queue by run instead of by agent, so every completed run leaves an orphaned `cycle_results_*` queue that nobody ever cleans up. This SIP fixes both by mirroring the existing dispatch-channel design — replace per-run reply queues with per-agent reply queues (`{agent_id}_results`, parallel to the existing `{agent_id}_comms`), and replace the polling loop with a single long-lived subscription per agent, established at orchestrator startup. The result eliminates the "agent succeeded but reply lost" failure class and the orphan-queue leakage class in one step. A tactical patch (PR #89, `fix/cycle-results-channel-recovery`, merged 2026-05-02) already lands cache-recovery and longer poll chunks that contain the bleeding; this SIP is the structural fix.
 
 ## 2. Problem Statement
 
@@ -19,33 +19,46 @@ Investigation of `cyc_c9ca088599c0` / `run_edc1d0dc7bf4` (group_run, 2026-05-02)
 - A retry was triggered, which consumed another 8 minutes of GPU time before failing again.
 - Three reply messages remain durably stuck in the queue, never consumed.
 
-Root cause: `RabbitMQAdapter.consume()` opens `queue.iterator(no_ack=False)` with a 1.0-second timeout on every call. Called every ~0.5s by `_publish_and_await`, this generates ~3600 consumer subscriptions per 30-minute wait. Per AMQP semantics, when a consumer is canceled while a message is being dispatched to it, the message is meant to be redelivered to another consumer — but with the orchestrator's pattern there are no other consumers, only a future iterator that hasn't been created yet. Messages can be lost in the gap, and the constant subscribe/cancel churn appears to push the channel into states from which it does not recover.
+Two independent root causes:
 
-The tactical fix in `fix/cycle-results-channel-recovery` introduces `consume_blocking()` (one consumer per chunk, default 30 s) and queue-cache invalidation on transient errors. That shrinks the failure window dramatically but still uses chunked polling — there is still a (small) gap between chunks during which messages must be redelivered. The structural fix is to maintain a single subscription for the whole wait.
+**Cause A — Polling-iterator anti-pattern.** `RabbitMQAdapter.consume()` opens `queue.iterator(no_ack=False)` with a 1.0-second timeout on every call. Called every ~0.5s by `_publish_and_await`, this generates ~3600 consumer subscriptions per 30-minute wait. Per AMQP semantics, when a consumer is canceled while a message is being dispatched to it, the message is meant to be redelivered to another consumer — but with the orchestrator's pattern there are no other consumers, only a future iterator that hasn't been created yet. Messages can be lost in the gap, and the constant subscribe/cancel churn appears to push the channel into states from which it does not recover.
 
-Secondary problems this SIP also addresses:
+**Cause B — Per-run reply queue scoping.** The reply queue is named `cycle_results_{run_id}` and declared `durable=True` on first dispatch. There is no run-completion cleanup. As of 2026-05-02 production has 18+ orphan `cycle_results_*` queues from prior runs. The per-run choice is unmotivated: tasks within a run dispatch sequentially, only the orchestrator consumes from the queue, and `task_id` is already the correlation key. The per-run partition gives no isolation that `task_id` matching doesn't already provide; it only adds lifecycle work that nobody is doing.
 
-- **Reply-queue leakage**: `cycle_results_*` queues are declared `durable=True` and never deleted. Production has 18+ orphan queues from completed runs.
-- **Redispatch on lost reply**: `_dispatch_task_with_retry` re-runs the task on timeout, even though the agent's reply may already be in the queue. This wastes another full LLM run.
+The tactical fix on PR #89 introduces `consume_blocking()` (one consumer per chunk, default 30s) and queue-cache invalidation on transient errors. That shrinks Cause A's failure window dramatically but still uses chunked polling — there is still a (small) gap between chunks during which messages must be redelivered. It does nothing about Cause B.
 
 ## 3. Goals
 
-1. Replace the chunked-poll wait in `_publish_and_await` with a single long-lived consumer subscription that survives the full task timeout.
-2. Define an explicit `subscribe()` primitive on `QueuePort` with callback / async-iterator semantics so reply waiting is no longer expressed as polling.
-3. Add reply-queue lifecycle management: declare with TTL or auto-delete (whichever is safe for the runtime topology) and explicit cleanup on run completion.
-4. Before re-dispatching a task on timeout, drain the existing reply queue once — recover the original reply if it arrived late, instead of paying for a duplicate LLM run.
+1. Replace per-run reply queues (`cycle_results_{run_id}`) with per-agent reply queues (`{agent_id}_results`). One declaration per agent at orchestrator startup; durable; never cleaned up because they are the agent's permanent reply address (parallel structure to the existing `{agent_id}_comms` dispatch queue). Eliminates the orphan-queue class.
+2. Replace `_publish_and_await`'s polling loop with a long-lived per-agent subscription established at orchestrator startup, plus an in-process router that resolves an `asyncio.Future` keyed by `task_id` when a matching reply arrives. Eliminates the consumer-tag-churn failure class.
+3. Define an explicit `subscribe()` primitive on `QueuePort` with callback/async-iterator semantics so reply consumption is no longer expressed as polling at any layer.
 
 ## 4. Non-Goals
 
 - Replacing RabbitMQ with another transport.
-- Changing the request/reply pairing semantics (still 1 reply queue per run, still task_id-based correlation).
-- Refactoring the agent-side `_consume_messages` loop in `entrypoint.py`. That loop has the same anti-pattern but is tolerable because the comms queue is rarely empty for long. Will be addressed in a follow-up.
+- Refactoring the agent-side `_consume_messages` loop in `entrypoint.py`. That loop has the same iterator-churn anti-pattern but is tolerable because the comms queue is rarely empty for long. Will be addressed in a follow-up.
 - Changing the per-task timeout (`SQUADOPS__LLM__TIMEOUT=1800`).
-- Per-message TTL on individual messages — queue-level TTL is sufficient and simpler.
+- Adopting `amq.rabbitmq.reply-to` (broker-managed temporary reply channel). Architecturally cleaner still, but requires a different consumer-binding model than what aio_pika's high-level abstractions provide. Tracked as a future evolution; per-agent queues land first because they slot into the existing dispatch-queue pattern with minimal new infrastructure.
+- Per-message TTL or queue-level TTL. Per-agent queues are persistent by design, like the dispatch queues — no TTL needed.
 
 ## 5. Approach Sketch
 
-### 5.1 New port primitive
+### 5.1 Per-agent reply queue
+
+Each agent gets a permanent reply queue named `{agent_id}_results`, declared durable. Symmetric to the existing `{agent_id}_comms`:
+
+| Direction | Queue | Writer | Reader |
+|---|---|---|---|
+| Dispatch | `{agent_id}_comms` | runtime-api | the named agent |
+| Reply (new) | `{agent_id}_results` | the named agent | runtime-api |
+
+Declaration happens in two places:
+- **Orchestrator startup**: declare reply queues for every agent listed in the active squad profile. Idempotent (broker no-ops on re-declare with same args).
+- **Agent startup**: also declares its own `{agent_id}_results` (defensive — if orchestrator hasn't booted yet, the agent shouldn't fail its first reply).
+
+The `reply_queue` field in dispatch metadata becomes `{envelope.agent_id}_results` instead of `cycle_results_{run_id}`. Agents see no semantic change — they still publish wherever metadata says to publish.
+
+### 5.2 New port primitive
 
 ```python
 class QueuePort(ABC):
@@ -53,92 +66,118 @@ class QueuePort(ABC):
         self,
         queue_name: str,
         *,
-        until: Callable[[QueueMessage], bool],
-        timeout: float,
-    ) -> QueueMessage | None:
-        """Hold a single consumer on ``queue_name`` for up to ``timeout``
-        seconds. Return the first message for which ``until(msg)`` is True;
-        ack and discard others. Return None on timeout."""
+        on_message: Callable[[QueueMessage], Awaitable[None]],
+    ) -> SubscriptionHandle:
+        """Open a long-lived consumer on ``queue_name``. Each delivery is
+        handed to ``on_message``, which is responsible for ack/discard. Returns
+        a handle whose ``cancel()`` shuts down the consumer cleanly."""
 ```
 
-`subscribe()` takes a predicate so the executor can match on `task_id` directly inside the consumer callback — no separate ack/discard dance in user code. Default implementation in the abstract base falls back to `consume_blocking()` for adapters that don't have native long-subscription support.
+This shape is closer to "register a callback" than "wait for one message." It's the right shape for the orchestrator's reply-router pattern (one subscription per agent, lives for the orchestrator's lifetime, dispatches every delivery to a router). Default implementation in the abstract base spawns a background task that polls `consume_blocking()` for adapters that don't have native long-subscription support.
 
-### 5.2 RabbitMQ implementation
+### 5.3 Reply router
 
-In `RabbitMQAdapter.subscribe()`:
+A new `ReplyRouter` component in `adapters/cycles/`:
 
 ```python
-async with queue.iterator(no_ack=False) as queue_iter:
-    deadline_task = asyncio.create_task(asyncio.sleep(timeout))
-    async for message in queue_iter:
-        if predicate matches:
-            await message.ack()
-            return QueueMessage(...)
-        await message.ack()  # discard non-matching
-        if deadline_task.done():
-            return None
+class ReplyRouter:
+    def __init__(self, queue: QueuePort, agent_ids: list[str]):
+        self._futures: dict[str, asyncio.Future[TaskResult]] = {}
+        ...
+
+    async def start(self) -> None:
+        for agent_id in self._agent_ids:
+            await self._queue.subscribe(
+                f"{agent_id}_results",
+                on_message=self._handle_reply,
+            )
+
+    async def _handle_reply(self, msg: QueueMessage) -> None:
+        data = json.loads(msg.payload)
+        task_id = data["payload"]["task_id"]
+        fut = self._futures.pop(task_id, None)
+        await self._queue.ack(msg)
+        if fut is None or fut.done():
+            logger.warning("Reply for unknown/late task %s — dropping", task_id)
+            return
+        fut.set_result(TaskResult.from_dict(data["payload"]))
+
+    def register(self, task_id: str) -> asyncio.Future[TaskResult]:
+        fut = asyncio.get_event_loop().create_future()
+        self._futures[task_id] = fut
+        return fut
 ```
 
-One iterator, one consumer tag, lives for the whole timeout. Messages dispatched while the consumer is registered land in the iterator immediately. No subscribe/cancel churn.
+Lifecycle: started at runtime-api boot (after squad profile is resolved), stopped at shutdown. One subscription per agent, never torn down within a process lifetime.
 
-### 5.3 Executor wiring
+### 5.4 Executor wiring
 
 `_publish_and_await` becomes:
 
 ```python
-reply = await self._queue.subscribe(
-    reply_queue,
-    until=lambda msg: json.loads(msg.payload).get("payload", {}).get("task_id") == envelope.task_id,
-    timeout=self._task_timeout,
-)
-if reply is None:
-    return TaskResult(task_id=envelope.task_id, status="FAILED", error="Timed out ...")
-data = json.loads(reply.payload)
-return TaskResult.from_dict(data["payload"])
+fut = self._reply_router.register(envelope.task_id)
+reply_queue = f"{envelope.agent_id}_results"
+message = {
+    "action": "comms.task",
+    "metadata": {"reply_queue": reply_queue, "correlation_id": envelope.correlation_id},
+    "payload": envelope.to_dict(),
+}
+await self._queue.publish(f"{envelope.agent_id}_comms", json.dumps(message))
+try:
+    return await asyncio.wait_for(fut, timeout=self._task_timeout)
+except asyncio.TimeoutError:
+    self._reply_router.cancel(envelope.task_id)
+    return TaskResult(
+        task_id=envelope.task_id,
+        status="FAILED",
+        error=f"Timed out waiting for agent {envelope.agent_id} after {self._task_timeout}s",
+    )
 ```
 
-No while loop, no asyncio.sleep, no error-recovery branch (subscribe internally retries on transient channel errors).
+No while loop, no asyncio.sleep, no error-recovery branch (the long-lived consumer's channel-close events are handled inside `subscribe()` via RobustChannel + our own resubscribe-on-channel-swap logic). Drain-before-retry is unnecessary: a reply that arrives after timeout still hits the always-on consumer, finds no awaiting future, and is logged-and-dropped — no orphan messages.
 
-### 5.4 Reply-queue lifecycle
+### 5.5 Migration
 
-Declare reply queues with both:
+The dispatch-side change (use `{agent_id}_results` as `reply_queue`) is invisible to agents because they read the address out of metadata. The cutover is therefore a runtime-api-only change once the agents have their `_results` queues declared. Order of operations:
 
-- `arguments={"x-expires": 3600 * 1000}` — broker auto-deletes the queue if no consumer binds for 1 hour. Catches orphan cleanup.
-- Explicit `delete_queue(reply_queue)` call in the run-completion path of `DistributedFlowExecutor.execute()`. Catches the happy path immediately.
+1. Land tactical patch (PR #89, done).
+2. Add `_results` queue declaration to agent startup (`entrypoint.py`). Deploy agents first. Old runtime-api still uses `cycle_results_{run_id}`; agents now have an extra unused queue. No behavior change.
+3. Land `subscribe()` + `ReplyRouter` + executor wiring in runtime-api. Deploy.
+4. After one soak cycle, manually drop the historical `cycle_results_*` queues (one-shot rabbitmqctl command).
 
-### 5.5 Drain-before-retry
+## 6. Compatibility
 
-In `_dispatch_task_with_retry` before re-dispatching a timed-out task, call `subscribe(reply_queue, until=task_id-match, timeout=5)` to scoop any reply that arrived after the wait timed out. If found, return SUCCEEDED without paying for a re-run.
-
-## 6. Migration / Compatibility
-
-- `consume()` and `consume_blocking()` (added in tactical patch) remain on `QueuePort`. They are still useful for the agent-side comms loop and future use cases.
-- `subscribe()` is added as a non-abstract method with a default implementation that wraps `consume_blocking()`. NoOpQueuePort needs no changes. RabbitMQAdapter overrides with the native long-iterator implementation.
-- Existing tests using `mock_queue.consume.side_effect = ...` continue to work.
-- Tests that exercise `_publish_and_await` after this SIP must mock `subscribe()` instead.
+- `consume()` and `consume_blocking()` (added in tactical patch) remain on `QueuePort`. Still useful for the agent-side comms loop and other future use cases.
+- `subscribe()` is added as a non-abstract method with a default implementation that spawns a background task polling `consume_blocking()`. NoOpQueuePort needs no changes. RabbitMQAdapter overrides with the native long-iterator implementation.
+- Existing tests using `mock_queue.consume.side_effect = ...` continue to work for code paths that don't go through the executor.
+- Tests that exercise `_publish_and_await` after this SIP must mock the `ReplyRouter` rather than `consume_blocking()` (they no longer interact with the queue port directly during a wait).
 
 ## 7. Risks
 
-- **Single-consumer failure mode**: if the long-lived consumer's channel dies mid-wait, we lose the reply window. The implementation must catch channel-close events and re-subscribe transparently (RobustChannel reconnect plus our own re-declare on the new channel).
-- **Reply queue auto-delete races**: if the consumer binds late (e.g., orchestrator restart), the broker may have already deleted the queue and the agent's reply will be lost. Mitigation: declare the queue at dispatch time, before publishing the request, with a generous TTL (1 hour). Run-completion cleanup is best-effort.
-- **Drain-before-retry false positives**: if a stale reply from a prior dispatch matches the new dispatch's task_id (which would indicate a deeper bug), drain returns the stale result. Use the run-completion cleanup to keep the queue fresh; additionally, increment a dispatch attempt counter and include it in correlation metadata so stale matches can be detected.
+- **Long-lived consumer channel death**: if a `_results` consumer's channel closes (network blip, broker restart), in-flight waits are silently stranded until either the channel reconnects or the dispatch times out. Mitigation: `subscribe()` implementation must register channel-close callbacks, re-declare its queue on the new channel, and re-establish the consumer. Existing `_get_queue` channel-swap detection (already in tactical patch) covers re-declaration; subscription resumption is new code.
+- **Cross-run task_id collision**: per-agent queues are shared across runs, so task_id must be globally unique (not just per-run). Audit `TaskEnvelope.task_id` generation — currently UUID-based (`task-{run_short}-{m_idx}-{capability}`), which encodes the run prefix, so collision is unlikely but worth a deliberate test.
+- **Late-reply leakage**: if an agent's reply arrives after the orchestrator has timed out and given up on a task, the reply lands in `_results`, gets ack'd by the router, and is dropped with a warning log. Cost: zero broker-side leakage but a small observability gap. Mitigation: counter metric for late-drop events so we can detect a regression.
+- **Agent-orchestrator startup ordering**: if runtime-api boots before any agent has declared its `_results` queue, the orchestrator's `subscribe()` calls fail. Mitigation: declare the `_results` queues from runtime-api too (idempotent re-declare). Both sides own their queue declarations; first-mover wins.
 
 ## 8. Test Plan
 
-- Unit: `subscribe()` happy path, timeout returns None, predicate filters non-matching messages, transient channel error is retried internally.
-- Unit: reply-queue declaration includes TTL argument; explicit cleanup is called on run completion (success and failure).
-- Unit: drain-before-retry returns existing reply without re-publishing.
-- Integration (`tests/integration/adapters/test_rabbitmq_adapter.py`): publish 100 messages while a single subscriber is held — all 100 delivered, zero lost. Compare to the same load against `consume()` to demonstrate the regression.
-- E2E: re-run the `group_run` cycle that surfaced this issue (`cyc_c9ca088599c0`) on a clean stack; verify dev[3] completes within the same wall time as dev[0–2].
+- Unit: `ReplyRouter` registers/resolves futures by task_id; late replies (no awaiting future) are dropped with a warning; on shutdown, all pending futures are failed with a typed error.
+- Unit: `subscribe()` happy path; channel-close triggers re-subscribe transparently; cancel cleans up consumer tag.
+- Unit: `_publish_and_await` registers with router before publishing, resolves on reply, fails cleanly on timeout, and unregisters on timeout to avoid future-leak.
+- Integration (`tests/integration/adapters/test_rabbitmq_adapter.py`): publish 100 replies to one `{agent_id}_results` queue while a single subscriber is held — all 100 routed correctly to their futures, zero lost. Compare to the same load against the legacy `consume()` path to demonstrate the regression.
+- E2E: re-run the `group_run` cycle that surfaced this issue (`cyc_c9ca088599c0`) on a clean stack; verify dev[3] completes within the same wall time as dev[0–2]. Verify no `cycle_results_*` queues are created. Verify `{agent_id}_results` queues exist and have zero ready messages after the run completes.
 
 ## 9. Rollout
 
-1. Land tactical patch (`fix/cycle-results-channel-recovery`) — already in PR. Contains the bleeding.
-2. Implement subscribe() + RabbitMQ override + executor wiring on a feature branch.
-3. Soak in dev environment for one full long-cycle build.
-4. Promote.
+1. **Done**: tactical patch (`fix/cycle-results-channel-recovery`, PR #89, merged 2026-05-02). Contains the bleeding.
+2. Agent-side: declare `{agent_id}_results` queue at agent startup. Ship and deploy first so that when runtime-api starts using the new path, the queues exist. No behavior change in this step.
+3. Runtime-api side: land `subscribe()` + `ReplyRouter` + dispatch-metadata change in one feature branch off main. Tests required per §8.
+4. Soak in Spark dev environment for one full long-cycle build.
+5. Drop historical `cycle_results_*` queues via one-shot rabbitmqctl command after soak.
+6. Promote SIP to implemented.
 
 ## 10. Open Questions
 
-- Should reply queues be per-run (current) or per-task? Per-task gives natural isolation but multiplies queue declarations. Recommend keeping per-run.
-- Should `subscribe()`'s predicate be sync or async? Sync is simpler; async unlocks future use cases (e.g., HTTP lookup to validate a result). Recommend sync for v1.
+- Should `subscribe()`'s `on_message` callback be sync or async? Async is required for the router (which calls `await queue.ack(msg)` inside it). Recommend async.
+- Should the router survive runtime-api restarts? If runtime-api restarts mid-task, in-process futures vanish and any reply already in flight will be ack'd-and-dropped on next boot. Out of scope for this SIP — that's the SIP-0079-style resume contract's job.
+- Should `{agent_id}_results` queues be declared with `auto_delete=False, exclusive=False` (current per-run default) or `exclusive=True` to enforce single-consumer semantics? Recommend non-exclusive — exclusive prevents the orchestrator from running multiple instances behind a load balancer. Single-consumer is enforced by convention, not broker.


### PR DESCRIPTION
## Summary

Reshapes proposed SIP-Reply-Channel-Subscription-Model.md based on the design walk-through after PR #89 merged. Per-run reply queues (`cycle_results_{run_id}`) are not just leaky — they were the wrong partition key in the first place. Replacing with per-agent reply queues (`{agent_id}_results`, parallel to the existing `{agent_id}_comms`) eliminates the orphan-queue leakage class structurally instead of mitigating it with TTL + run-completion cleanup.

## What changed in the SIP

- **§1 abstract / §3 goals**: reframed around per-agent queues as the primary structural change; long-lived subscriptions become the consumer pattern that fits.
- **§5.1 (new)**: per-agent reply queue design, parallel to the dispatch queue table.
- **§5.2 `subscribe()` primitive**: shape changed from "wait for one matching message with timeout" to "register an `on_message` callback for the consumer's lifetime" — the right shape for an orchestrator-startup router.
- **§5.3 (new) `ReplyRouter`**: in-process futures keyed by `task_id`, started at runtime-api boot.
- **§5.4 executor wiring**: `_publish_and_await` becomes `register-future, publish, await future`. No while loop, no sleep, no error-recovery branch.
- **§5.5 migration**: ordered cutover — agents declare `_results` queues first (no behavior change), then runtime-api switches the dispatch metadata's `reply_queue` field.
- **§4 non-goals**: explicitly defers `amq.rabbitmq.reply-to` (cleaner still, but doesn't slot into the existing `{agent_id}_X` pattern as cleanly).
- **§7 risks**: replaced "auto-delete races" and "drain false positives" with the new ones (cross-run task_id collision, late-reply leakage, startup ordering).
- **§9 rollout**: drop drain-before-retry; add explicit step for one-shot `cycle_results_*` cleanup after soak.
- Plan doc `docs/plans/1-0-x-build-reliability-hardening-plan.md` updated to rev 4 to reflect the reshape.

## Why per-agent over per-run

| | per-run (current) | per-agent (proposed) |
|---|---|---|
| Queues over time | one per run, accumulates | fixed: one per agent (≤7) |
| Cleanup needed | yes (TTL + explicit delete) | none |
| Correlation key | task_id (already present) | task_id (already present) |
| Symmetric to dispatch design | no | yes (`{agent_id}_X`) |
| Stale-reply isolation | by queue identity | by task_id matching in router (with cross-run UUID guarantee) |

The per-run partition was giving us no isolation that `task_id` matching wasn't already providing — only lifecycle work that nobody was doing.

## Test plan

- [x] Plan doc rev bump applied.
- [x] Memory `project_consume_iterator_churn.md` updated to reflect rev 2.
- [ ] When this lands, accept the SIP and start an implementation branch off main per the standard SIP workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)