### PR TITLE
fix(parser): tolerate common LLM fenced-block format drift

### DIFF
--- a/src/squadops/capabilities/handlers/fenced_parser.py
+++ b/src/squadops/capabilities/handlers/fenced_parser.py
@@ -4,6 +4,22 @@ Extracts tagged fenced code blocks from LLM responses into structured
 file records. Used by DevelopmentDevelopHandler, BuilderAssembleHandler,
 and QATestHandler to parse multi-file output.
 
+Recognized formats, in priority order (most explicit first):
+
+1. Strict tagged fence — ``` ``` <language>:<filepath>``` ```
+2. Filename in language slot for special names — ``` ``` Dockerfile``` ```,
+   ``` ``` Makefile``` ```, etc.
+3. Filename heading immediately preceding the fence — ``#`` through ``######``
+   ending in a path-like token (``models.py``, ``backend/main.py``,
+   ``Dockerfile``).
+4. First-line filename comment inside the fence — ``# path/to/file.py`` or
+   ``// path/to/file.py`` as the first line of the body. The comment line
+   is stripped from the extracted content.
+
+Models naturally drift between these formats; the parser tolerates all of
+them so a one-character format slip doesn't drop the whole task on the floor.
+The strict format is still the recommended one and round-trips losslessly.
+
 Part of SIP-Enhanced-Agent-Build-Capabilities, Phase 1.
 """
 
@@ -11,83 +27,175 @@ from __future__ import annotations
 
 import re
 
-# Match fence headers: ```<lang>:<path>
-# Language is \w+, path is \S+ (no spaces), no other content on the line.
-_FENCE_HEADER_RE = re.compile(r"^```(\w+):(\S+)\s*$", re.MULTILINE)
+# Strict format header: ```<lang>:<path>
+_STRICT_HEADER_RE = re.compile(r"^```(\w+):(\S+)\s*$", re.MULTILINE)
 
-# Match a closing fence: ``` on its own line (possibly with trailing whitespace)
+# Permissive open fence: ```<token> where <token> may be empty. Models
+# sometimes emit a bare ``` immediately after a filename heading
+# (``## Dockerfile`` then ``` ```\n...```\n`` `), so we cannot require
+# a non-empty language slot. The ambiguity with a close fence is resolved
+# by sequential scanning: after parsing a fence we advance past its
+# close, so a stray unmatched ``` only causes a wasted lookahead.
+_OPEN_FENCE_RE = re.compile(r"^```(\S*)\s*$", re.MULTILINE)
+
+# Closing fence: ``` on its own line (possibly trailing whitespace)
 _FENCE_CLOSE_RE = re.compile(r"^```\s*$", re.MULTILINE)
+
+# Markdown heading whose text is a path-like token. Accepts headings of the
+# form "## models.py", "### `backend/main.py`", "# Dockerfile". Requires
+# either an extension (e.g. ``.py``) or a known special name so prose
+# headings like "## Implementation Notes" don't match.
+_SPECIAL_NAMES = ("Dockerfile", "Makefile", "Rakefile", "Gemfile", "Procfile")
+_SPECIAL_NAMES_RE = "|".join(_SPECIAL_NAMES)
+_HEADING_RE = re.compile(
+    rf"^#{{1,6}}\s+`?(?P<path>[\w./-]+\.[a-zA-Z0-9]+|{_SPECIAL_NAMES_RE})`?\s*$",
+    re.MULTILINE,
+)
+
+# First line of fence body containing a filename inside a comment. Recognizes
+# Python/shell ``#``, C/JS ``//``, SQL ``--``, and C-block ``/*`` openers.
+_FILENAME_COMMENT_RE = re.compile(
+    rf"^\s*(?:#|//|--|/\*)\s*(?P<path>[\w./-]+\.[a-zA-Z0-9]+|{_SPECIAL_NAMES_RE})\b",
+)
+
+# Filenames that LLMs often emit as the language slot (``` ```Dockerfile``` ```).
+_SPECIAL_FILENAMES_AS_LANG = set(_SPECIAL_NAMES)
+
+_HEADING_PROSE_DISTANCE_LINES = 4
+"""Max newline count between a filename heading and the fence it labels.
+
+Accepts ``heading\\nfence`` (1), ``heading\\n\\nfence`` (2), and a short
+prose paragraph (≤4) between them. Tighter than this drops legitimate
+patterns; looser starts capturing unrelated headings.
+"""
+
+
+def _path_is_safe(path: str) -> bool:
+    """Reject absolute paths, traversal segments, and colons (LLM artifacts)."""
+    if path.startswith("/"):
+        return False
+    if ".." in path.split("/"):
+        return False
+    if ":" in path:
+        return False
+    return True
+
+
+def _strip_trailing_newline(content: str) -> str:
+    return content[:-1] if content.endswith("\n") else content
+
+
+def _resolve_filename_from_heading(
+    response: str,
+    fence_start: int,
+    last_used_heading_pos: int,
+) -> tuple[str | None, int]:
+    """Return ``(filename, heading_pos)`` if a filename-shaped heading sits
+    just before ``fence_start`` (within ``_HEADING_PROSE_DISTANCE_LINES``
+    newlines) and *after* ``last_used_heading_pos``. Otherwise
+    ``(None, last_used_heading_pos)``.
+    """
+    window_start = max(last_used_heading_pos + 1, max(0, fence_start - 500))
+    window = response[window_start:fence_start]
+    matches = list(_HEADING_RE.finditer(window))
+    for match in reversed(matches):
+        lines_between = window[match.end() : len(window)].count("\n")
+        if lines_between <= _HEADING_PROSE_DISTANCE_LINES:
+            # Track the END of the heading line so the next fence's window
+            # starts on the line *after* this heading. Tracking the start
+            # would let the same heading match again on the next iteration
+            # (the regex's ^ anchor still finds the line beginning even
+            # one character into the heading text).
+            return match.group("path"), window_start + match.end()
+    return None, last_used_heading_pos
+
+
+def _resolve_filename_from_first_comment(body: str) -> tuple[str | None, str]:
+    """If the first line of ``body`` is a comment containing a filename,
+    return ``(filename, body_with_first_line_stripped)``. Otherwise
+    ``(None, body)``.
+    """
+    nl = body.find("\n")
+    first_line = body if nl == -1 else body[:nl]
+    match = _FILENAME_COMMENT_RE.match(first_line)
+    if match is None:
+        return None, body
+    remainder = "" if nl == -1 else body[nl + 1 :]
+    return match.group("path"), remainder
 
 
 def extract_fenced_files(response: str) -> list[dict]:
-    """Parse ``<lang>:<path>`` fenced code blocks into structured file records.
+    """Parse fenced code blocks into structured file records.
 
-    Scans the LLM response for fenced code blocks whose opening line matches
-    the pattern ``\\`\\`\\`<language>:<filepath>``. Extracts the content between
-    the opening and closing fences.
+    Tries multiple resolution strategies per fence (see module docstring).
+    Returns a list of ``{filename, content, language}`` dicts. Empty list
+    if no resolvable, security-safe fences are found.
 
-    Security: rejects absolute paths and paths containing ``..`` segments.
+    Security: rejects absolute paths, paths containing ``..`` segments,
+    and paths containing ``:``.
 
     Args:
         response: Raw LLM response text.
 
     Returns:
         List of dicts with keys ``filename``, ``content``, ``language``.
-        Empty list if no valid tagged fences are found.
     """
     if not response:
         return []
 
     results: list[dict] = []
     pos = 0
+    last_used_heading_pos = -1
 
     while pos < len(response):
-        header_match = _FENCE_HEADER_RE.search(response, pos)
-        if not header_match:
+        open_match = _OPEN_FENCE_RE.search(response, pos)
+        if not open_match:
             break
 
-        language = header_match.group(1)
-        filepath = header_match.group(2)
-
-        # Start of content is after the header line
-        content_start = header_match.end() + 1  # skip newline after header
-
-        # Find the closing fence
-        close_match = _FENCE_CLOSE_RE.search(response, content_start)
+        body_start = open_match.end() + 1  # skip newline after header
+        close_match = _FENCE_CLOSE_RE.search(response, body_start)
         if not close_match:
-            # No closing fence — skip this header
-            pos = content_start
+            # No closing fence — abandon this opener and resume past it
+            pos = body_start
             continue
 
-        content = response[content_start : close_match.start()]
+        body = response[body_start : close_match.start()]
+        token = open_match.group(1)
+        filename: str | None = None
+        language: str = token
 
-        # Security: reject absolute paths
-        if filepath.startswith("/"):
+        if ":" in token:
+            # Strategy 1: strict ```<lang>:<path>
+            language, _, filename = token.partition(":")
+        elif token in _SPECIAL_FILENAMES_AS_LANG:
+            # Strategy 2: ```Dockerfile (filename in language slot)
+            filename = token
+            language = token.lower()
+        else:
+            # Strategy 3: filename heading immediately preceding the fence
+            heading_filename, last_used_heading_pos = _resolve_filename_from_heading(
+                response, open_match.start(), last_used_heading_pos
+            )
+            if heading_filename is not None:
+                filename = heading_filename
+            else:
+                # Strategy 4: first-line filename comment inside body
+                comment_filename, stripped_body = _resolve_filename_from_first_comment(body)
+                if comment_filename is not None:
+                    filename = comment_filename
+                    body = stripped_body
+
+        if filename is None or not _path_is_safe(filename):
             pos = close_match.end()
             continue
-
-        # Security: reject path traversal
-        if ".." in filepath.split("/"):
-            pos = close_match.end()
-            continue
-
-        # Reject colons in filenames (invalid on macOS/Windows, LLM artifact)
-        if ":" in filepath:
-            pos = close_match.end()
-            continue
-
-        # Strip single trailing newline from content (fence artifact)
-        if content.endswith("\n"):
-            content = content[:-1]
 
         results.append(
             {
-                "filename": filepath,
-                "content": content,
-                "language": language,
+                "filename": filename,
+                "content": _strip_trailing_newline(body),
+                "language": language or "text",
             }
         )
-
         pos = close_match.end()
 
     return results

--- a/src/squadops/prompts/request_templates/request.builder_assemble.build_assemble.md
+++ b/src/squadops/prompts/request_templates/request.builder_assemble.build_assemble.md
@@ -20,26 +20,49 @@ optional_variables:
 
 You are ASSEMBLING the source code above into a deployable package. Do NOT rewrite or regenerate the source code — it is already written. Your job is to add deployment and packaging artifacts.
 
-Use tagged fenced code blocks with the language and path separated by a colon, for example:
+## Output format (MANDATORY)
+
+Each file MUST be emitted as a fenced code block whose opening line is `` ```<language>:<filepath> `` — language and filepath separated by a single colon, no space, on its own line. Closing line is `` ``` ``.
+
+Worked example (copy this exact shape):
+
+````
 ```dockerfile:Dockerfile
-<content>
-```
-```markdown:qa_handoff.md
-<content>
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+RUN pip install -r requirements.txt
+CMD ["python", "-m", "myapp"]
 ```
 
-Produce the following deployment artifacts:
-- __main__.py entrypoint (if not already present)
-- Dockerfile for containerized deployment
-- requirements.txt (if not already present)
+```markdown:qa_handoff.md
+## How to Run
+docker build -t myapp . && docker run -p 8000:8000 myapp
+
+## How to Test
+pytest
+
+## Expected Behavior
+Service responds with HTTP 200 on GET /health.
+```
+````
+
+Output that does NOT use this exact `<language>:<filepath>` header will be rejected.
+
+## Required deployment artifacts
+
+- `__main__.py` entrypoint (if not already present)
+- `Dockerfile` for containerized deployment
+- `requirements.txt` (if not already present)
 - Any startup scripts or config files needed for deployment
 
-IMPORTANT: You MUST also include a `qa_handoff.md` file with these required sections:
-- ## How to Run
-- ## How to Test
-- ## Expected Behavior
+You MUST also include a `qa_handoff.md` file containing these three sections, exactly as shown:
+- `## How to Run`
+- `## How to Test`
+- `## Expected Behavior`
 
-File path rules:
-- File paths must use forward slashes, no colons, no spaces.
-- Do NOT re-emit source files that the developer already wrote.
+## File path rules
+
+- File paths use forward slashes only. No colons, no spaces, no leading slash.
+- Do NOT re-emit source files the developer already wrote.
 - Only emit NEW files needed for packaging and deployment.

--- a/tests/unit/capabilities/test_fenced_parser.py
+++ b/tests/unit/capabilities/test_fenced_parser.py
@@ -191,3 +191,199 @@ class TestEdgeCases:
         assert len(result) == 2
         assert result[0]["content"] == "a = 1"
         assert result[1]["content"] == "b = 2"
+
+
+class TestSpecialFilenameInLanguageSlot:
+    """Models commonly emit ``` ```Dockerfile``` ``` (no path) for files whose
+    name *is* the canonical language tag. Treat the language slot as the
+    filename for an allowlist of well-known names."""
+
+    def test_dockerfile_in_language_slot(self):
+        response = "```Dockerfile\nFROM python:3.11\nCOPY . /app\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "Dockerfile"
+        assert "FROM python:3.11" in result[0]["content"]
+        assert result[0]["language"] == "dockerfile"
+
+    def test_makefile_in_language_slot(self):
+        response = "```Makefile\nbuild:\n\tgo build\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "Makefile"
+
+    def test_lowercase_dockerfile_does_not_match(self):
+        """Lowercase 'dockerfile' is a language, not a filename — must NOT
+        be auto-resolved (filename must come from heading or comment)."""
+        response = "```dockerfile\nFROM python:3.11\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 0
+
+
+class TestHeadingPrecedingFence:
+    """Models often write ``### path/to/file.py`` then a plain
+    ``` ```python``` `` fence."""
+
+    def test_heading_directly_before_fence(self):
+        response = "### backend/models.py\n```python\nclass Run: pass\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "backend/models.py"
+        assert result[0]["content"] == "class Run: pass"
+
+    def test_heading_with_blank_line_before_fence(self):
+        response = "### models.py\n\n```python\nclass Run: pass\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "models.py"
+
+    def test_heading_with_backticked_filename(self):
+        """``### `models.py``` ``-style headings are common in chat UIs."""
+        response = "### `backend/models.py`\n```python\nx = 1\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "backend/models.py"
+
+    def test_dockerfile_heading(self):
+        response = "## Dockerfile\n```\nFROM python:3.11\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "Dockerfile"
+
+    def test_prose_heading_does_not_match(self):
+        """Headings like '## Implementation Notes' are not filenames."""
+        response = "## Implementation Notes\n```python\nx = 1\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 0
+
+    def test_far_heading_is_not_used(self):
+        """Heading separated by many lines of prose does not label the fence."""
+        response = (
+            "### models.py\n"
+            "\n"
+            "Here is a very long description.\n"
+            "It spans multiple lines.\n"
+            "And another line.\n"
+            "And yet another.\n"
+            "And one more line of prose.\n"
+            "\n"
+            "```python\n"
+            "x = 1\n"
+            "```\n"
+        )
+        result = extract_fenced_files(response)
+        assert len(result) == 0
+
+    def test_heading_consumed_only_once(self):
+        """A heading labels the *next* fence, not subsequent unlabelled fences."""
+        response = "### a.py\n```python\na = 1\n```\n```python\nb = 2\n```\n"
+        result = extract_fenced_files(response)
+        # First fence resolves via heading; second has no heading and no
+        # comment, so it's dropped (not silently attributed to a.py).
+        assert len(result) == 1
+        assert result[0]["filename"] == "a.py"
+
+    def test_two_headings_two_fences(self):
+        response = "### a.py\n```python\na = 1\n```\n### b.py\n```python\nb = 2\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 2
+        assert result[0]["filename"] == "a.py"
+        assert result[1]["filename"] == "b.py"
+
+
+class TestFirstLineFilenameComment:
+    """Models often emit ``` ```python\\n# path/to/file.py\\n...``` `` — a
+    comment on line 1 of the body that names the file."""
+
+    def test_python_comment_filename(self):
+        response = "```python\n# backend/models.py\nclass Run: pass\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "backend/models.py"
+        # The filename comment line must NOT appear in the extracted content.
+        assert result[0]["content"] == "class Run: pass"
+
+    def test_js_double_slash_comment_filename(self):
+        response = "```javascript\n// frontend/src/App.jsx\nexport default function App() {}\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "frontend/src/App.jsx"
+        assert "App()" in result[0]["content"]
+        assert "frontend/src/App.jsx" not in result[0]["content"]
+
+    def test_filename_comment_only_first_line(self):
+        """A filename-shaped comment on a later line does NOT count."""
+        response = (
+            "```python\n"
+            "import os\n"
+            "# helpers/util.py is imported below\n"
+            "from helpers import util\n"
+            "```\n"
+        )
+        result = extract_fenced_files(response)
+        # No first-line filename, no heading, no strict format → dropped.
+        assert len(result) == 0
+
+    def test_prose_comment_does_not_match(self):
+        """First line is a comment but doesn't look like a filename."""
+        response = (
+            "```python\n# This module implements the run repository.\nclass Repo: pass\n```\n"
+        )
+        result = extract_fenced_files(response)
+        assert len(result) == 0
+
+
+class TestStrictWinsOverPermissive:
+    """When both strict and permissive signals are present, strict wins."""
+
+    def test_strict_overrides_heading(self):
+        response = "### wrong.py\n```python:right.py\nx = 1\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "right.py"
+
+    def test_strict_overrides_first_line_comment(self):
+        response = "```python:right.py\n# wrong.py\nx = 1\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "right.py"
+        # First-line comment is NOT stripped when strict format won.
+        assert result[0]["content"] == "# wrong.py\nx = 1"
+
+
+class TestRealWorldFailurePatterns:
+    """Reproduces the format-drift patterns observed on cyc_b7cf604aed46
+    where Bob and Eve produced output the strict-only parser dropped."""
+
+    def test_bobs_likely_fullstack_assemble_output(self):
+        """Bob assembling fullstack: Dockerfile via language slot,
+        docker-compose.yaml via heading, qa_handoff.md via heading."""
+        response = (
+            "Here's the deployment package:\n\n"
+            "```Dockerfile\n"
+            "FROM python:3.11\n"
+            "WORKDIR /app\n"
+            "```\n\n"
+            "### docker-compose.yaml\n"
+            "```yaml\n"
+            "services:\n"
+            "  backend:\n"
+            "    image: app\n"
+            "```\n\n"
+            "### qa_handoff.md\n"
+            "```markdown\n"
+            "## How to Run\n"
+            "uvicorn main:app\n"
+            "## How to Test\n"
+            "pytest\n"
+            "## Expected Behavior\n"
+            "200 on GET /runs\n"
+            "```\n"
+        )
+        result = extract_fenced_files(response)
+        filenames = [r["filename"] for r in result]
+        assert "Dockerfile" in filenames
+        assert "docker-compose.yaml" in filenames
+        assert "qa_handoff.md" in filenames
+        qa_handoff = next(r for r in result if r["filename"] == "qa_handoff.md")
+        assert "## How to Run" in qa_handoff["content"]


### PR DESCRIPTION
## Summary

The strict \`\`\`<lang>:<path>\` fence parser silently dropped any block whose header didn't match exactly. On cyc_b7cf604aed46 this turned **8821 tokens of Bob's builder output and 4877 tokens of Eve's qa output into \"No valid fenced code blocks found\" failures** — both classified as content bugs but actually format bugs. The cycle then spent ~25 GPU minutes in correction loops chasing the wrong problem.

This PR adds three permissive resolution paths after the strict format, plus a worked-example block in the builder.assemble request template so models have a concrete pattern to imitate.

## Changes

**Parser (\`src/squadops/capabilities/handlers/fenced_parser.py\`)** — strict format stays primary; new fallbacks tried in priority order:

1. **Special filename in language slot** — \`\`\`\`Dockerfile\`\`\`, \`\`\`\`Makefile\`\`\` etc. for files whose name *is* the canonical language tag.
2. **Filename heading immediately preceding the fence** — \`### path/to/file.py\` then a plain \`\`\`\`python\`\`\` fence. Each heading labels exactly one fence (tracked via \`last_used_heading_pos\`) so subsequent unlabelled fences don't get silently attributed to a stale heading.
3. **First-line filename comment inside fence body** — \`# path/to/file.py\` or \`// path/to/file.py\` as line 1; comment line is stripped from the extracted content.

Path security checks (no traversal, no absolute, no colons) apply to all paths uniformly.

**Builder request template (\`src/squadops/prompts/request_templates/request.builder_assemble.build_assemble.md\`)** — adds a worked example showing the exact \`<language>:<filepath>\` shape with a real Dockerfile + qa_handoff.md, plus an explicit \"output that does NOT use this header will be rejected\" warning. Models are imitative; one good example beats two paragraphs of rules.

## Tests

- All 19 existing parser tests pass unchanged (strict format behavior preserved).
- 18 new tests covering: special filename in language slot, heading-before-fence (including distance limits and one-heading-per-fence), first-line comment, strict-wins-over-permissive, and a real-world reproduction of the Bob fullstack-assemble pattern.
- \`./scripts/dev/run_regression_tests.sh\` — 3597 passed, 1 skipped.
- \`ruff check\` + \`ruff format\` clean.

## What this does NOT fix

Two related issues observed on cyc_b7cf604aed46 are out of scope for this PR:

1. **Three-way conflict between request template, profile system prompt, and validator \`required_files\`** for \`fullstack_fastapi_react\` (request says \`__main__.py\` + \`Dockerfile\` + \`requirements.txt\`; profile system prompt says \`Dockerfile\` + \`docker-compose.yaml\` + \`start.sh\`; validator only requires \`Dockerfile\` + \`qa_handoff.md\`). Fix in a separate PR scoped to profile reconciliation.
2. **\`qa: validate_repair\` failed in 13ms with no LLM call** — likely a routing/inputs precondition bug separate from the parser. Worth a focused investigation.

## Test plan

- [x] 37/37 parser unit tests pass
- [x] 3597/3598 regression tests pass (1 skipped)
- [x] Lint + format clean
- [ ] After merge: rebuild runtime-api + agent images; re-run \`group_run\` with the \`build\` profile; verify Bob and Eve now produce extractable output

🤖 Generated with [Claude Code](https://claude.com/claude-code)