### PR TITLE
fix(correction-loop): preserve analyze_failure outputs through to PlanDelta (#95)

### DIFF
--- a/adapters/cycles/distributed_flow_executor.py
+++ b/adapters/cycles/distributed_flow_executor.py
@@ -1952,7 +1952,13 @@ class DistributedFlowExecutor(FlowExecutionPort):
             "outcome_class": (result.outputs or {}).get("outcome_class", ""),
         }
 
-        correction_outputs: dict[str, Any] = {}
+        # Issue #95: capture each correction step's outputs in its own variable
+        # so the analyzer's classification/analysis_summary survive past the
+        # subsequent governance.correction_decision step (which doesn't carry
+        # those fields forward). Reusing a single variable used to mask the
+        # analyzer's diagnosis with defaults at PlanDelta time.
+        analysis_outputs: dict[str, Any] = {}
+        decision_outputs: dict[str, Any] = {}
         corr_correlation_id = uuid4().hex
 
         for step_idx, (task_type, role) in enumerate(CORRECTION_TASK_STEPS):
@@ -1965,8 +1971,8 @@ class DistributedFlowExecutor(FlowExecutionPort):
                 "prior_outputs": prior_outputs,
                 "artifact_refs": list(all_artifact_refs),
             }
-            if correction_outputs:
-                corr_inputs["failure_analysis"] = correction_outputs
+            if analysis_outputs:
+                corr_inputs["failure_analysis"] = analysis_outputs
 
             corr_envelope = TaskEnvelope(
                 task_id=corr_task_id,
@@ -2035,13 +2041,19 @@ class DistributedFlowExecutor(FlowExecutionPort):
                     payload={"task_type": task_type, "error": corr_result.error or ""},
                 )
 
-            # Collect correction task outputs
-            correction_outputs = {
+            # Collect correction task outputs into the right named bucket so
+            # downstream PlanDelta construction reads each field from the
+            # handler that owns it (issue #95).
+            step_outputs = {
                 k: v for k, v in (corr_result.outputs or {}).items() if k != "artifacts"
             }
+            if task_type == "data.analyze_failure":
+                analysis_outputs = step_outputs
+            elif task_type == "governance.correction_decision":
+                decision_outputs = step_outputs
 
         # 4. Read correction_path
-        correction_path = correction_outputs.get("correction_path", "abort")
+        correction_path = decision_outputs.get("correction_path", "abort")
 
         # 5. Emit CORRECTION_DECIDED
         self._cycle_event_bus.emit(
@@ -2051,7 +2063,7 @@ class DistributedFlowExecutor(FlowExecutionPort):
             context={"cycle_id": cycle.cycle_id, "run_id": run_id},
             payload={
                 "correction_path": correction_path,
-                "decision_rationale": correction_outputs.get("decision_rationale", ""),
+                "decision_rationale": decision_outputs.get("decision_rationale", ""),
             },
         )
 
@@ -2061,11 +2073,11 @@ class DistributedFlowExecutor(FlowExecutionPort):
             run_id=run_id,
             correction_path=correction_path,
             trigger=f"task_failure:{envelope.task_type}",
-            failure_classification=correction_outputs.get("classification", "unknown"),
-            analysis_summary=correction_outputs.get("analysis_summary", "N/A"),
-            decision_rationale=correction_outputs.get("decision_rationale", "N/A"),
-            changes=tuple(correction_outputs.get("affected_task_types", [])),
-            affected_task_types=tuple(correction_outputs.get("affected_task_types", [])),
+            failure_classification=analysis_outputs.get("classification", "unknown"),
+            analysis_summary=analysis_outputs.get("analysis_summary", "N/A"),
+            decision_rationale=decision_outputs.get("decision_rationale", "N/A"),
+            changes=tuple(decision_outputs.get("affected_task_types", [])),
+            affected_task_types=tuple(decision_outputs.get("affected_task_types", [])),
             created_at=datetime.now(UTC),
         )
         delta_content = json.dumps(delta.to_dict(), default=str).encode()
@@ -2094,7 +2106,7 @@ class DistributedFlowExecutor(FlowExecutionPort):
                 repair_inputs: dict[str, Any] = {
                     "prd": cycle.prd_ref,
                     "failure_evidence": failure_evidence,
-                    "correction_decision": correction_outputs,
+                    "correction_decision": decision_outputs,
                     "prior_outputs": prior_outputs,
                     "artifact_refs": list(all_artifact_refs),
                 }

--- a/tests/unit/cycles/test_correction_protocol.py
+++ b/tests/unit/cycles/test_correction_protocol.py
@@ -511,31 +511,40 @@ class TestPlanDelta:
     async def test_plan_delta_stored(
         self, executor, mock_queue, mock_registry, mock_vault, mock_event_bus
     ):
-        """Correction protocol stores a plan_delta artifact."""
+        """Correction protocol stores a plan_delta artifact whose
+        classification/analysis_summary come from data.analyze_failure
+        and decision_rationale comes from governance.correction_decision.
+
+        Regression for issue #95: the lead's correction_decision handler does
+        not echo back classification/analysis_summary, so previously the
+        executor's reused `correction_outputs` variable lost those fields by
+        the time the PlanDelta was constructed. Each handler's outputs must be
+        sourced from the right step.
+        """
+        import json
+
         semantic_outputs = {
             "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
             "role": "strat",
         }
+        # Mirrors GovernanceCorrectionDecisionHandler outputs in prod:
+        # NO classification or analysis_summary keys.
         correction_decision = {
             "summary": "abort",
             "role": "lead",
             "correction_path": "abort",
             "decision_rationale": "Cannot fix",
             "affected_task_types": [],
-            "classification": "execution",
-            "analysis_summary": "Something broke",
+        }
+        analyze_failure = {
+            "classification": "work_product",
+            "analysis_summary": "Bob produced output without qa_handoff.md",
+            "contributing_factors": ["missing required deployment file"],
+            "role": "data",
         }
         script = [
             ("FAILED", semantic_outputs, "bad"),
-            (
-                "SUCCEEDED",
-                {
-                    "classification": "execution",
-                    "analysis_summary": "broke",
-                    "role": "data",
-                },
-                None,
-            ),
+            ("SUCCEEDED", analyze_failure, None),
             ("SUCCEEDED", correction_decision, None),
         ]
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
@@ -546,14 +555,18 @@ class TestPlanDelta:
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
 
-        # Check that a plan_delta artifact was stored
         store_calls = mock_vault.store.call_args_list
         delta_stores = [c for c in store_calls if c.args[0].artifact_type == "plan_delta"]
         assert len(delta_stores) == 1
 
-        delta_ref = delta_stores[0].args[0]
-        assert delta_ref.artifact_type == "plan_delta"
+        delta_ref, delta_content = delta_stores[0].args
         assert "plan_delta" in delta_ref.filename
+
+        delta = json.loads(delta_content.decode())
+        assert delta["failure_classification"] == "work_product"
+        assert delta["analysis_summary"] == "Bob produced output without qa_handoff.md"
+        assert delta["decision_rationale"] == "Cannot fix"
+        assert delta["correction_path"] == "abort"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #95 — the correction protocol's `_run_correction_protocol` reused a single `correction_outputs` variable across both `CORRECTION_TASK_STEPS` iterations, so the analyzer's `classification`/`analysis_summary` were silently overwritten by the lead's correction-decision outputs (which don't carry those fields). Every plan_delta in production had defaulted `failure_classification: "unknown"` and `analysis_summary: "N/A"`, even after PR #88's Pydantic validation made the analyzer reliable.
- Each correction step's outputs are now captured in their own named variable (`analysis_outputs`, `decision_outputs`); each PlanDelta field is read from the handler that owns it.
- Patch-path repair dispatch now passes `decision_outputs` as `correction_decision` (semantically what it always meant — same value as before, just renamed).

## Live evidence

Cycle `cyc_000a71ca883b` / run `run_1eba35363a38` (group_run, 2026-05-03). Both plan_deltas:

```
delta_0: failure_classification="unknown", analysis_summary="N/A"
delta_1: failure_classification="unknown", analysis_summary="N/A"
```

Despite `decision_rationale` text in both deltas explicitly referencing the analyzer's diagnosis ("the failure analysis indicates…"), confirming `data.analyze_failure` ran successfully and the lead consumed its output — the executor just dropped it before storing the delta.

## Test plan

- [x] Updated `tests/unit/cycles/test_correction_protocol.py::TestPlanDelta::test_plan_delta_stored` to mirror prod by removing `classification`/`analysis_summary` from the mocked `governance.correction_decision` outputs, and to assert on delta CONTENT not just storage.
- [x] Verified the new test fails on `main` with the exact assertion: `'unknown' == 'work_product'` — confirms it's a real regression test.
- [x] Full regression suite passes: 3597 passed, 1 pre-existing skip.

## References

- Issue: #95
- Related already-merged: PR #88 (issue #84) — Pydantic validation; PR #91 — parser tolerance
- Code touched: `adapters/cycles/distributed_flow_executor.py:1955-2070`, `tests/unit/cycles/test_correction_protocol.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)