### PR TITLE
fix(builder): make required_files/optional_files the single source of truth (#92)

### DIFF
--- a/src/squadops/capabilities/handlers/build_profiles.py
+++ b/src/squadops/capabilities/handlers/build_profiles.py
@@ -3,6 +3,14 @@
 Typed build profiles that control handler behavior: prompt templates,
 required files, validation rules, and QA handoff expectations.
 V1 profiles are code-defined frozen dataclass instances.
+
+Issue #92 (2026-05-03): each profile's `required_files` and `optional_files`
+are the single source of truth. The system prompt that the builder LLM sees
+is composed at access time via `BuildProfile.full_system_prompt` so the
+narrative `system_prompt_template` cannot drift away from what the validator
+will accept. Adding a file to `required_files` automatically adds it to the
+prompt; the file list cannot be edited in the prompt without also editing
+the validator's `required_files`.
 """
 
 from __future__ import annotations
@@ -53,6 +61,12 @@ class BuildProfile:
 
     Handlers must not mutate profile fields; treat get_profile() return
     as read-only.
+
+    `system_prompt_template` holds only the *narrative* portion (stack
+    description and stack-specific guidance). The concrete file list seen
+    by the builder LLM is generated from `required_files`/`optional_files`/
+    `qa_handoff_expectations` via `full_system_prompt`. Do not list specific
+    filenames inside `system_prompt_template`.
     """
 
     name: str
@@ -63,6 +77,29 @@ class BuildProfile:
     artifact_output_mode: str = ARTIFACT_MODE_MULTI_FILE
     qa_handoff_expectations: tuple[str, ...] = QA_HANDOFF_REQUIRED_SECTIONS
     default_task_tags: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def full_system_prompt(self) -> str:
+        """Compose the narrative template with the canonical file list block.
+
+        The file list is derived from `required_files`/`optional_files` so
+        the prompt stays in lockstep with what the validator enforces.
+        """
+        required_lines = "\n".join(f"- `{name}`" for name in self.required_files)
+        optional_block = ""
+        if self.optional_files:
+            optional_lines = "\n".join(f"- `{name}`" for name in self.optional_files)
+            optional_block = f"\n\n## Optional artifacts (emit only if needed)\n\n{optional_lines}"
+        qa_lines = "\n".join(f"- `{name}`" for name in self.qa_handoff_expectations)
+
+        return (
+            f"{self.system_prompt_template}\n\n"
+            "## Required artifacts (you MUST emit every file in this list)\n\n"
+            f"{required_lines}"
+            f"{optional_block}\n\n"
+            "## qa_handoff.md required sections\n\n"
+            f"{qa_lines}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -76,19 +113,13 @@ BUILD_PROFILES: dict[str, BuildProfile] = {
             "You are a Python application assembler. You receive source code "
             "that a developer has already written and your job is to package "
             "it into a deployable artifact.\n\n"
-            "DO NOT rewrite or regenerate the source code — it is already done.\n\n"
-            "Your outputs are DEPLOYMENT artifacts only:\n"
-            "- __main__.py entrypoint (wiring to the developer's main module)\n"
-            "- Dockerfile for containerized deployment\n"
-            "- requirements.txt (consolidate from source imports)\n"
-            "- Any startup scripts or config files needed\n\n"
-            "Emit each file as a fenced code block, e.g. ```python:main.py or ```dockerfile:Dockerfile\n"
-            "After all deployment files, emit a QA handoff document as "
-            "```markdown:qa_handoff.md with sections: "
-            "## How to Run, ## How to Test, ## Expected Behavior."
+            "DO NOT rewrite or regenerate the source code — it is already done. "
+            "Your outputs are deployment artifacts only: container packaging, "
+            "an entrypoint that wires to the developer's existing main module, "
+            "and a consolidated dependency manifest derived from the source imports."
         ),
-        required_files=("Dockerfile", "__main__.py", "requirements.txt"),
-        optional_files=("requirements.txt",),
+        required_files=("Dockerfile", "__main__.py", "requirements.txt", "qa_handoff.md"),
+        optional_files=(),
         validation_rules=(
             "Dockerfile must be valid",
             "__main__.py must wire to developer's entry point",
@@ -101,18 +132,10 @@ BUILD_PROFILES: dict[str, BuildProfile] = {
         system_prompt_template=(
             "You are a static web application builder. Generate a complete, "
             "browser-openable web application from the implementation plan.\n\n"
-            "Requirements:\n"
-            "- Include an index.html as the entry point.\n"
-            "- Include a styles.css for styling.\n"
-            "- Include a main.js for interactivity.\n"
-            "- All assets must use relative paths (no CDN dependencies).\n"
-            "- The result must be openable by double-clicking index.html.\n\n"
-            "Emit each file as a fenced code block, e.g. ```python:main.py or ```dockerfile:Dockerfile\n"
-            "After all source files, emit a QA handoff document as "
-            "```markdown:qa_handoff.md with sections: "
-            "## How to Run, ## How to Test, ## Expected Behavior."
+            "All assets must use relative paths (no CDN dependencies). The "
+            "result must open by double-clicking the HTML entry point."
         ),
-        required_files=("index.html", "styles.css", "main.js"),
+        required_files=("index.html", "styles.css", "main.js", "qa_handoff.md"),
         optional_files=("favicon.ico", "manifest.json"),
         validation_rules=(
             "index.html must be valid HTML5",
@@ -125,19 +148,11 @@ BUILD_PROFILES: dict[str, BuildProfile] = {
         name="web_app_builder",
         system_prompt_template=(
             "You are a web application builder. Generate a complete, "
-            "runnable web application from the implementation plan.\n\n"
-            "Requirements:\n"
-            "- Include a server entry point (app.py or main.py).\n"
-            "- Include an index.html template for the UI.\n"
-            "- Include requirements.txt for Python dependencies.\n"
-            "- Use a lightweight framework (Flask preferred).\n"
-            "- The application must start with a single command.\n\n"
-            "Emit each file as a fenced code block, e.g. ```python:main.py or ```dockerfile:Dockerfile\n"
-            "After all source files, emit a QA handoff document as "
-            "```markdown:qa_handoff.md with sections: "
-            "## How to Run, ## How to Test, ## Expected Behavior."
+            "runnable Python web application from the implementation plan.\n\n"
+            "Use a lightweight framework (Flask preferred). The application "
+            "must start with a single command."
         ),
-        required_files=("app.py", "index.html", "requirements.txt"),
+        required_files=("app.py", "index.html", "requirements.txt", "qa_handoff.md"),
         optional_files=("static/styles.css", "static/main.js", "templates/"),
         validation_rules=(
             "app.py must be valid Python",
@@ -149,19 +164,15 @@ BUILD_PROFILES: dict[str, BuildProfile] = {
     "fullstack_fastapi_react": BuildProfile(
         name="fullstack_fastapi_react",
         system_prompt_template=(
-            "You are assembling a fullstack web application with a FastAPI backend "
-            "and a React (Vite) frontend.\n\n"
-            "Produce the following artifacts:\n"
-            "1. A multi-stage Dockerfile: Python base for backend, Node build stage "
-            "   for frontend static assets, final stage serves both.\n"
-            "2. A docker-compose.yaml for local development (backend on :8000, "
-            "   frontend dev server on :5173, with proxy config).\n"
-            "3. A startup script (start.sh) that runs both services.\n"
-            "4. CORS configuration notes for the backend.\n"
-            "5. A qa_handoff.md covering how to run, test, and verify both stacks.\n\n"
+            "You are assembling a fullstack web application with a FastAPI "
+            "backend and a React (Vite) frontend.\n\n"
             "The source code from the development step is provided as context. "
-            "Do not regenerate application code — focus on packaging, configuration, "
-            "and operational readiness."
+            "Do not regenerate application code — focus on packaging, "
+            "configuration, and operational readiness. The container build "
+            "must be multi-stage: a Python base for the backend, a Node build "
+            "stage for the frontend static assets, and a final stage that "
+            "serves both. The QA handoff document must include CORS "
+            "configuration notes for the backend."
         ),
         required_files=("Dockerfile", "qa_handoff.md"),
         optional_files=("docker-compose.yaml", "start.sh", ".env.example", "nginx.conf"),

--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -301,9 +301,7 @@ class _CycleTaskHandler(CapabilityHandler):
             f"**Validation Summary:** {validation.summary}\n\n",
         ]
         if validation.missing_components:
-            parts.append(
-                f"**Missing Components:** {', '.join(validation.missing_components)}\n\n"
-            )
+            parts.append(f"**Missing Components:** {', '.join(validation.missing_components)}\n\n")
         parts.append(f"**Files You Already Produced:** {', '.join(artifact_names)}\n\n")
         parts.append(
             "Please produce ONLY the missing files. Use the same fenced code block format "
@@ -328,18 +326,22 @@ class _CycleTaskHandler(CapabilityHandler):
         for art in new:
             name = art["name"]
             if name in by_name:
-                merge_log.append({
-                    "action": "replaced",
-                    "name": name,
-                    "old_size": len(by_name[name].get("content", "")),
-                    "new_size": len(art.get("content", "")),
-                })
+                merge_log.append(
+                    {
+                        "action": "replaced",
+                        "name": name,
+                        "old_size": len(by_name[name].get("content", "")),
+                        "new_size": len(art.get("content", "")),
+                    }
+                )
             else:
-                merge_log.append({
-                    "action": "added",
-                    "name": name,
-                    "size": len(art.get("content", "")),
-                })
+                merge_log.append(
+                    {
+                        "action": "added",
+                        "name": name,
+                        "size": len(art.get("content", "")),
+                    }
+                )
             by_name[name] = art
 
         evidence.setdefault("self_eval_merge_log", []).extend(merge_log)
@@ -569,13 +571,13 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         "  - task_index: 0\n"
         "    task_type: development.develop  # or qa.test\n"
         "    role: dev  # or qa\n"
-        "    focus: \"Short description of this subtask\"\n"
+        '    focus: "Short description of this subtask"\n'
         "    description: |\n"
         "      Detailed description of what to build.\n"
         "    expected_artifacts:\n"
-        "      - \"path/to/file.py\"\n"
+        '      - "path/to/file.py"\n'
         "    acceptance_criteria:\n"
-        "      - \"Criterion 1\"\n"
+        '      - "Criterion 1"\n'
         "    depends_on: []  # list of task_index values\n"
         "summary:\n"
         "  total_dev_tasks: N\n"
@@ -610,8 +612,7 @@ class GovernanceReviewHandler(_CycleTaskHandler):
             user_prompt = rendered.content + self._MANIFEST_PROMPT_EXTENSION
         else:
             user_prompt = (
-                self._build_user_prompt(prd, prior_outputs)
-                + self._MANIFEST_PROMPT_EXTENSION
+                self._build_user_prompt(prd, prior_outputs) + self._MANIFEST_PROMPT_EXTENSION
             )
 
         assembled = context.ports.prompt_service.get_system_prompt(self._role)
@@ -625,9 +626,7 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         chat_kwargs = self._build_chat_kwargs(inputs)
 
         try:
-            response = await context.ports.llm.chat_stream_with_usage(
-                messages, **chat_kwargs
-            )
+            response = await context.ports.llm.chat_stream_with_usage(messages, **chat_kwargs)
         except LLMError as exc:
             logger.warning("LLM call failed for %s: %s", self._handler_name, exc)
             return self._fail_result(start_time, inputs, str(exc))
@@ -691,9 +690,7 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         from squadops.cycles.implementation_plan import ImplementationPlan
 
         extracted = extract_fenced_files(content)
-        manifest_files = [
-            f for f in extracted if f["filename"] == "implementation_plan.yaml"
-        ]
+        manifest_files = [f for f in extracted if f["filename"] == "implementation_plan.yaml"]
 
         if manifest_files:
             yaml_content = manifest_files[0]["content"]
@@ -718,8 +715,7 @@ class GovernanceReviewHandler(_CycleTaskHandler):
             manifest = ImplementationPlan.from_yaml(yaml_content)
         except ValueError as exc:
             logger.warning(
-                "%s: manifest validation failed (%s), "
-                "falling back to static task steps",
+                "%s: manifest validation failed (%s), falling back to static task steps",
                 self._handler_name,
                 exc,
             )
@@ -746,8 +742,7 @@ class GovernanceReviewHandler(_CycleTaskHandler):
 
         if len(manifest.tasks) < min_subtasks:
             logger.warning(
-                "%s: manifest has %d subtasks (min %d), "
-                "falling back to static task steps",
+                "%s: manifest has %d subtasks (min %d), falling back to static task steps",
                 self._handler_name,
                 len(manifest.tasks),
                 min_subtasks,
@@ -756,8 +751,7 @@ class GovernanceReviewHandler(_CycleTaskHandler):
 
         if len(manifest.tasks) > max_subtasks:
             logger.warning(
-                "%s: manifest has %d subtasks (max %d), "
-                "falling back to static task steps",
+                "%s: manifest has %d subtasks (max %d), falling back to static task steps",
                 self._handler_name,
                 len(manifest.tasks),
                 max_subtasks,
@@ -822,16 +816,12 @@ class GovernanceReviewHandler(_CycleTaskHandler):
                 prompt_layer_set_id=f"{self._role}-cycle",
                 layers=(
                     PromptLayer(layer_type="system", layer_id=f"{self._role}-system"),
-                    PromptLayer(
-                        layer_type="user", layer_id=f"cycle-{self._capability_id}"
-                    ),
+                    PromptLayer(layer_type="user", layer_id=f"cycle-{self._capability_id}"),
                 ),
             )
             llm_obs.record_generation(context.correlation_context, gen_record, layers)
 
-    def _build_provenance(
-        self, assembled: Any, renderer: Any, rendered: Any
-    ) -> dict[str, Any]:
+    def _build_provenance(self, assembled: Any, renderer: Any, rendered: Any) -> dict[str, Any]:
         """Build prompt provenance dict for artifact traceability (SIP-0084)."""
         provenance: dict[str, Any] = {
             "system_prompt_bundle_hash": assembled.assembly_hash,
@@ -972,23 +962,27 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         # FC1: Expected artifacts present (required gate)
         expected = inputs.get("expected_artifacts", [])
         missing_files = [f for f in expected if f not in artifact_names]
-        checks.append({
-            "check": "expected_artifacts",
-            "expected": expected,
-            "present": [f for f in expected if f in artifact_names],
-            "missing": missing_files,
-            "passed": len(missing_files) == 0,
-        })
+        checks.append(
+            {
+                "check": "expected_artifacts",
+                "expected": expected,
+                "present": [f for f in expected if f in artifact_names],
+                "missing": missing_files,
+                "passed": len(missing_files) == 0,
+            }
+        )
         if missing_files:
             missing.extend(f"file:{f}" for f in missing_files)
 
         # FC2: Non-stub files (required gate)
         stubs = _detect_stubs(artifacts)
-        checks.append({
-            "check": "non_stub_files",
-            "stubs_found": stubs,
-            "passed": len(stubs) == 0,
-        })
+        checks.append(
+            {
+                "check": "non_stub_files",
+                "stubs_found": stubs,
+                "passed": len(stubs) == 0,
+            }
+        )
 
         # FC3 (SIP-0092 M1.3): Typed acceptance criteria evaluation.
         await self._evaluate_typed_acceptance(
@@ -1005,8 +999,10 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         if stubs:
             summary_parts.append(f"Stub files: {', '.join(stubs)}")
         typed_failed = [
-            c for c in checks
-            if c.get("check", "").startswith("acceptance:") and c.get("status") in {"failed", "error"}
+            c
+            for c in checks
+            if c.get("check", "").startswith("acceptance:")
+            and c.get("status") in {"failed", "error"}
         ]
         if typed_failed:
             summary_parts.append(
@@ -1059,12 +1055,14 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         # Prose strings stay informational, evidence-only — same as Rev 1's
         # included_in_evidence behavior. They never block.
         if prose_criteria:
-            checks.append({
-                "check": "acceptance_criteria_prose",
-                "criteria": prose_criteria,
-                "evaluation": "included_in_evidence",
-                "passed": True,
-            })
+            checks.append(
+                {
+                    "check": "acceptance_criteria_prose",
+                    "criteria": prose_criteria,
+                    "evaluation": "included_in_evidence",
+                    "passed": True,
+                }
+            )
 
         if not typed_criteria:
             return
@@ -1098,18 +1096,14 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
                     # all-checks-pass aggregator: only severity=error AND
                     # blocking status counts as not-passed.
                     "passed": not (
-                        criterion.severity == "error"
-                        and outcome.status in {"failed", "error"}
+                        criterion.severity == "error" and outcome.status in {"failed", "error"}
                     ),
                 }
                 checks.append(check_record)
 
                 # Issue #83: per-check observability. Without these the M1.3
                 # path is invisible to operators — see issue body for context.
-                blocking = (
-                    criterion.severity == "error"
-                    and outcome.status in {"failed", "error"}
-                )
+                blocking = criterion.severity == "error" and outcome.status in {"failed", "error"}
                 log_fn = logger.info if blocking else logger.debug
                 log_fn(
                     "typed_acceptance_check subtask=%s check=%s severity=%s status=%s blocking=%s reason=%s",
@@ -1133,9 +1127,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
                     prior = typed_error_counts.get(fp, 0)
                     if prior < 2:
                         # RC-9a: evaluator-error wording, distinct from app-incomplete.
-                        missing.append(
-                            f"evaluator-error:{criterion.check}: {outcome.reason}"
-                        )
+                        missing.append(f"evaluator-error:{criterion.check}: {outcome.reason}")
                     else:
                         self._escalate_persistent_evaluator_error(criterion, outcome)
                     typed_error_counts[fp] = prior + 1
@@ -1189,14 +1181,10 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
             # Should not happen — parser already enforces vocabulary — but
             # treat as evaluator-error rather than crashing the cycle.
             return CheckOutcome.error(reason="no_evaluator_registered")
-        return await evaluator.evaluate(
-            criterion.params, workspace_root, stack=stack
-        )
+        return await evaluator.evaluate(criterion.params, workspace_root, stack=stack)
 
     @staticmethod
-    def _escalate_persistent_evaluator_error(
-        criterion: TypedCheck, outcome: CheckOutcome
-    ) -> None:
+    def _escalate_persistent_evaluator_error(criterion: TypedCheck, outcome: CheckOutcome) -> None:
         """RC-9b: surface a persistent evaluator error outside the self-eval feedback loop.
 
         Logged at WARNING with structured fields; the correction protocol
@@ -1242,30 +1230,36 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         missing_layers = set(expected_layers.keys()) - present_layers
         if missing_layers:
             missing.extend(f"stack_layer:{layer}" for layer in missing_layers)
-        checks.append({
-            "check": "stack_coverage_heuristic",
-            "expected": list(expected_layers.keys()),
-            "present": list(present_layers),
-            "missing": list(missing_layers),
-            "passed": len(missing_layers) == 0,
-        })
+        checks.append(
+            {
+                "check": "stack_coverage_heuristic",
+                "expected": list(expected_layers.keys()),
+                "present": list(present_layers),
+                "missing": list(missing_layers),
+                "passed": len(missing_layers) == 0,
+            }
+        )
 
         # C2: Artifact count heuristic
         min_artifacts = _estimate_min_artifacts(prd)
-        checks.append({
-            "check": "artifact_count_heuristic",
-            "expected_min": min_artifacts,
-            "actual": len(artifacts),
-            "passed": len(artifacts) >= min_artifacts,
-        })
+        checks.append(
+            {
+                "check": "artifact_count_heuristic",
+                "expected_min": min_artifacts,
+                "actual": len(artifacts),
+                "passed": len(artifacts) >= min_artifacts,
+            }
+        )
 
         # C3: Non-stub files
         stubs = _detect_stubs(artifacts)
-        checks.append({
-            "check": "non_stub_files",
-            "stubs_found": stubs,
-            "passed": len(stubs) == 0,
-        })
+        checks.append(
+            {
+                "check": "non_stub_files",
+                "stubs_found": stubs,
+                "passed": len(stubs) == 0,
+            }
+        )
 
         passed = all(c["passed"] for c in checks)
         passed_count = sum(1 for c in checks if c["passed"])
@@ -1275,9 +1269,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         if missing_layers:
             summary_parts.append(f"Missing stack layers: {', '.join(missing_layers)}")
         if len(artifacts) < min_artifacts:
-            summary_parts.append(
-                f"Only {len(artifacts)} artifacts, expected >= {min_artifacts}"
-            )
+            summary_parts.append(f"Only {len(artifacts)} artifacts, expected >= {min_artifacts}")
         if stubs:
             summary_parts.append(f"Stub files: {', '.join(stubs)}")
 
@@ -1598,9 +1590,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
                         }
                         for f in new_extracted
                     ]
-                    artifacts = self._merge_artifacts(
-                        artifacts, new_artifacts, evidence_extra
-                    )
+                    artifacts = self._merge_artifacts(artifacts, new_artifacts, evidence_extra)
 
                     # RC-7: validate merged artifact set
                     validation = await self._validate_output(
@@ -1802,37 +1792,44 @@ class QATestHandler(_CycleTaskHandler):
             expected = inputs.get("expected_artifacts", [])
             artifact_names = [a.get("name", "") for a in artifacts]
             missing_files = [f for f in expected if f not in artifact_names]
-            checks.append({
-                "check": "expected_artifacts",
-                "expected": expected,
-                "present": [f for f in expected if f in artifact_names],
-                "missing": missing_files,
-                "passed": len(missing_files) == 0,
-            })
+            checks.append(
+                {
+                    "check": "expected_artifacts",
+                    "expected": expected,
+                    "present": [f for f in expected if f in artifact_names],
+                    "missing": missing_files,
+                    "passed": len(missing_files) == 0,
+                }
+            )
             if missing_files:
                 missing.extend(f"file:{f}" for f in missing_files)
         else:
             # Legacy mode: at least one test file with content
             test_files = [
-                a for a in artifacts
+                a
+                for a in artifacts
                 if "test" in a.get("name", "").lower()
                 and len(a.get("content", "")) > _STUB_THRESHOLD_BYTES
             ]
-            checks.append({
-                "check": "test_file_presence",
-                "test_files_found": len(test_files),
-                "passed": len(test_files) > 0,
-            })
+            checks.append(
+                {
+                    "check": "test_file_presence",
+                    "test_files_found": len(test_files),
+                    "passed": len(test_files) > 0,
+                }
+            )
             if not test_files:
                 missing.append("test_files")
 
         # Non-stub check (both modes)
         stubs = _detect_stubs(artifacts)
-        checks.append({
-            "check": "non_stub_files",
-            "stubs_found": stubs,
-            "passed": len(stubs) == 0,
-        })
+        checks.append(
+            {
+                "check": "non_stub_files",
+                "stubs_found": stubs,
+                "passed": len(stubs) == 0,
+            }
+        )
 
         passed = all(c["passed"] for c in checks)
         passed_count = sum(1 for c in checks if c["passed"])
@@ -2224,9 +2221,7 @@ class QATestHandler(_CycleTaskHandler):
                         }
                         for f in new_extracted
                     ]
-                    artifacts = self._merge_artifacts(
-                        artifacts, new_artifacts, evidence_extra
-                    )
+                    artifacts = self._merge_artifacts(artifacts, new_artifacts, evidence_extra)
                     validation = await self._validate_output(inputs, artifacts)
 
                 evidence_extra["self_eval_passes"] = self_eval_count
@@ -2245,9 +2240,7 @@ class QATestHandler(_CycleTaskHandler):
         # passing test file count with exit_code != 0 (e.g., import errors
         # causing pytest to collect 0 tests) must surface as SEMANTIC_FAILURE
         # so the correction protocol activates.
-        if output_validation_enabled and not (
-            test_result.executed and test_result.tests_passed
-        ):
+        if output_validation_enabled and not (test_result.executed and test_result.tests_passed):
             if test_result.executed:
                 detail = f"tests_failed:exit_{test_result.exit_code}"
                 fail_note = f"Tests failed (exit {test_result.exit_code})"
@@ -2610,6 +2603,10 @@ class BuilderAssembleHandler(_CycleTaskHandler):
             parts.append("\n\n## Builder Tags\n")
             for tag_key, tag_value in sorted(task_tags.items()):
                 parts.append(f"- **{tag_key}**: {tag_value}")
+        # Issue #92: do NOT enumerate filenames here. The build profile's
+        # `full_system_prompt` (composed from required_files/optional_files)
+        # is the single source of truth for what Bob must produce. This
+        # fallback only carries the format/path rules that are universal.
         parts.append(
             "\n\nYou are ASSEMBLING the source code above into a deployable package. "
             "Do NOT rewrite or regenerate the source code — it is already written. "
@@ -2618,20 +2615,12 @@ class BuilderAssembleHandler(_CycleTaskHandler):
             "separated by a colon, for example:\n"
             "```dockerfile:Dockerfile\n<content>\n```\n"
             "```markdown:qa_handoff.md\n<content>\n```\n\n"
-            "Produce the following deployment artifacts:\n"
-            "- __main__.py entrypoint (if not already present)\n"
-            "- Dockerfile for containerized deployment\n"
-            "- requirements.txt (if not already present)\n"
-            "- Any startup scripts or config files needed for deployment\n\n"
-            "IMPORTANT: You MUST also include a `qa_handoff.md` file with these "
-            "required sections:\n"
-            "- ## How to Run\n"
-            "- ## How to Test\n"
-            "- ## Expected Behavior\n\n"
             "File path rules:\n"
             "- File paths must use forward slashes, no colons, no spaces.\n"
             "- Do NOT re-emit source files that the developer already wrote.\n"
-            "- Only emit NEW files needed for packaging and deployment."
+            "- Only emit NEW files needed for packaging and deployment.\n"
+            "- The required and optional file list, plus qa_handoff.md required "
+            "sections, is given in the system prompt — produce exactly that set."
         )
         return None, "\n".join(parts)
 
@@ -2761,7 +2750,7 @@ class BuilderAssembleHandler(_CycleTaskHandler):
         )
 
         assembled = context.ports.prompt_service.get_system_prompt(self._role)
-        system_prompt = assembled.content + "\n\n" + profile.system_prompt_template
+        system_prompt = assembled.content + "\n\n" + profile.full_system_prompt
 
         messages = [
             ChatMessage(role="system", content=system_prompt),

--- a/src/squadops/prompts/request_templates/request.builder_assemble.build_assemble.md
+++ b/src/squadops/prompts/request_templates/request.builder_assemble.build_assemble.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.builder_assemble.build_assemble
-version: "1"
+version: "2"
 required_variables:
   - prd
   - source_files
@@ -49,20 +49,14 @@ Service responds with HTTP 200 on GET /health.
 
 Output that does NOT use this exact `<language>:<filepath>` header will be rejected.
 
-## Required deployment artifacts
-
-- `__main__.py` entrypoint (if not already present)
-- `Dockerfile` for containerized deployment
-- `requirements.txt` (if not already present)
-- Any startup scripts or config files needed for deployment
-
-You MUST also include a `qa_handoff.md` file containing these three sections, exactly as shown:
-- `## How to Run`
-- `## How to Test`
-- `## Expected Behavior`
-
 ## File path rules
 
 - File paths use forward slashes only. No colons, no spaces, no leading slash.
 - Do NOT re-emit source files the developer already wrote.
 - Only emit NEW files needed for packaging and deployment.
+
+## Which files to produce
+
+The exact set of required and optional files for this build, plus the
+`qa_handoff.md` required sections, is given in the system prompt for the
+build profile. Produce exactly that set — no more, no less.

--- a/tests/unit/capabilities/test_build_profiles.py
+++ b/tests/unit/capabilities/test_build_profiles.py
@@ -188,3 +188,106 @@ class TestBuildProfilesRegistry:
             assert len(profile.qa_handoff_expectations) > 0, (
                 f"{name} has no qa_handoff_expectations"
             )
+
+
+class TestProfileSourceOfTruthInvariants:
+    """Issue #92: required_files/optional_files are the single source of truth.
+
+    The narrative `system_prompt_template` must NOT enumerate filenames; the
+    full prompt seen by the LLM is composed via `full_system_prompt` from
+    the validator's required/optional tuples. These invariants catch any
+    re-introduced drift between the prompt the LLM sees and the validator
+    that grades its output.
+    """
+
+    @pytest.mark.parametrize("name,profile", list(BUILD_PROFILES.items()))
+    def test_qa_handoff_md_in_required_files(self, name, profile):
+        """The validator unconditionally rejects builder output without
+        qa_handoff.md (cycle_tasks.py:_validate_builder_output). Every
+        profile must list it in required_files so the prompt asks for it.
+        """
+        assert "qa_handoff.md" in profile.required_files, (
+            f"{name}: validator demands qa_handoff.md but profile doesn't list it"
+        )
+
+    @pytest.mark.parametrize("name,profile", list(BUILD_PROFILES.items()))
+    def test_required_and_optional_disjoint(self, name, profile):
+        """A filename must appear in exactly one of required_files or
+        optional_files. Duplicates were a real source of LLM confusion.
+        """
+        required_set = set(profile.required_files)
+        optional_set = set(profile.optional_files)
+        overlap = required_set & optional_set
+        assert not overlap, f"{name}: files appear in both required and optional: {sorted(overlap)}"
+
+    @pytest.mark.parametrize("name,profile", list(BUILD_PROFILES.items()))
+    def test_full_system_prompt_lists_every_required_file(self, name, profile):
+        """The composed system prompt the LLM sees must mention every
+        required file by name. Otherwise the LLM is being graded on a file
+        it was never asked to produce.
+        """
+        prompt = profile.full_system_prompt
+        for required in profile.required_files:
+            assert required in prompt, (
+                f"{name}: required file {required!r} not mentioned in full_system_prompt"
+            )
+
+    @pytest.mark.parametrize("name,profile", list(BUILD_PROFILES.items()))
+    def test_full_system_prompt_lists_every_optional_file(self, name, profile):
+        """Optional files should be advertised so the LLM knows it MAY
+        produce them. Without this, optional files become invisible.
+        """
+        prompt = profile.full_system_prompt
+        for optional in profile.optional_files:
+            assert optional in prompt, (
+                f"{name}: optional file {optional!r} not mentioned in full_system_prompt"
+            )
+
+    @pytest.mark.parametrize("name,profile", list(BUILD_PROFILES.items()))
+    def test_narrative_template_does_not_enumerate_filenames(self, name, profile):
+        """The narrative `system_prompt_template` must NOT enumerate
+        filenames — the file list comes from required_files/optional_files
+        via `full_system_prompt`. If a filename leaks into the narrative,
+        the prompt has two sources of truth again.
+
+        Heuristic: any token containing a recognized file extension or
+        a literal known structural file (Dockerfile) appearing in the
+        narrative template is a violation. We allow extensions only inside
+        backticked code-block languages (e.g. ```python:foo) by stripping
+        those before scanning.
+        """
+        import re
+
+        narrative = profile.system_prompt_template
+        # Strip backticked code/format tokens — those describe the output
+        # FORMAT (```dockerfile:Dockerfile), not enumerate which files.
+        # We only care about filenames that appear as literal prose.
+        stripped = re.sub(r"`[^`]*`", "", narrative)
+
+        # Forbidden patterns: anything that looks like a file with an
+        # extension, or known extension-less structural files.
+        forbidden = []
+        # Simple file-with-extension regex (word chars + dot + 2-5 letter ext)
+        for match in re.finditer(r"\b[\w./-]+\.[a-zA-Z]{2,5}\b", stripped):
+            forbidden.append(match.group(0))
+        for sentinel in ("Dockerfile", "Makefile"):
+            if sentinel in stripped:
+                forbidden.append(sentinel)
+
+        assert not forbidden, (
+            f"{name}: narrative system_prompt_template enumerates filenames "
+            f"{forbidden!r}; move them to required_files/optional_files so the "
+            f"prompt and validator share one source of truth (issue #92)."
+        )
+
+    @pytest.mark.parametrize("name,profile", list(BUILD_PROFILES.items()))
+    def test_full_system_prompt_lists_qa_handoff_sections(self, name, profile):
+        """The composed prompt must surface every required QA handoff
+        section. Otherwise the LLM doesn't know what shape qa_handoff.md
+        must take.
+        """
+        prompt = profile.full_system_prompt
+        for section in profile.qa_handoff_expectations:
+            assert section in prompt, (
+                f"{name}: qa_handoff section {section!r} missing from full_system_prompt"
+            )


### PR DESCRIPTION
## Summary

Fixes #92 — Bob's prompt, build profile system prompt, and validator no longer disagree about what files he must produce. The validator's \`required_files\` / \`optional_files\` tuples are now the single source of truth, and the system prompt the LLM sees is composed from them via \`BuildProfile.full_system_prompt\`. The narrative \`system_prompt_template\` is forbidden from enumerating filenames; six new parametrized invariants enforce this and prevent re-introduction of drift.

This is gate-readiness block-list item **B2** in #97.

## Changes

- **`build_profiles.py`**: added \`BuildProfile.full_system_prompt\` property; cleaned each profile's narrative template to drop filenames; added \`qa_handoff.md\` to every profile's \`required_files\` (the validator already demanded it universally — the divergence was just unstated); removed duplicate \`requirements.txt\` from \`python_cli_builder.optional_files\`.
- **\`cycle_tasks.py\`**: \`BuilderAssembleHandler\` now passes \`profile.full_system_prompt\` to the LLM (was \`profile.system_prompt_template\`); the fallback inline prompt in \`_build_assembly_prompt\` no longer enumerates filenames.
- **\`request.builder_assemble.build_assemble.md\`** (v1 → v2): dropped the hard-coded file list. The build profile's \`full_system_prompt\` owns it.
- **\`test_build_profiles.py\`**: six new parametrized invariants in \`TestProfileSourceOfTruthInvariants\` (24 tests across 4 profiles).

## Live evidence this is the dominant remaining failure mode

Cycle \`cyc_000a71ca883b\` / run \`run_1eba35363a38\` (group_run, 2026-05-03, post-PR #91 / #96): Bob produced **zero** of the four files the request template asked for. Validator tripped immediately on missing \`qa_handoff.md\`. The correction loop fired, then qa.test failed (separately tracked as #93), and the run terminated.

Comparison vs. the prior failed cycle (pre-PR #91): PR #91 fixed the parser layer (Neo's 10 frontend files now land correctly). But Bob's three-sources-of-truth issue means he was being asked for one set in three slightly different ways and chose none of them consistently. This PR removes that ambiguity.

## Test plan

- [x] Updated \`test_build_profiles.py\` with 24 new parametrized invariants covering all four profiles
- [x] Verified each invariant catches a real failure mode: removing \`qa_handoff.md\` from a profile's \`required_files\` makes \`test_qa_handoff_md_in_required_files\` fail; leaving a filename in the narrative template makes \`test_narrative_template_does_not_enumerate_filenames\` fail (caught \`Dockerfile\` + \`qa_handoff.md\` in the fullstack narrative during development of this PR)
- [x] Full regression suite passes: 3621 passed, 1 pre-existing skip (was 3597 — 24 new invariants)
- [x] Pre-existing C901 lint warnings on \`cycle_tasks.py::handle\` are unchanged by this PR

## Out of scope (deferred to separate work)

- Same audit shape for \`qa.test\` handler (validator vs. \`request.qa_test.test_validate.md\` vs. system prompt) — issue #92 mentions this; will surface in a follow-up if cycles continue to fail there post-merge.
- Validator leniency itself — the looseness isn't the bug; the disagreement was. Now that they agree, future tightening can be a separate decision.

## References

- Issue: #92
- Meta tracking: #97 (B2 of the gate-readiness block list)
- Related already-merged: PR #91 (parser tolerance), PR #96 (correction loop fix, issue #95)
- Code touched: \`src/squadops/capabilities/handlers/build_profiles.py\`, \`src/squadops/capabilities/handlers/cycle_tasks.py:2614-2640,2764\`, \`src/squadops/prompts/request_templates/request.builder_assemble.build_assemble.md\`, \`tests/unit/capabilities/test_build_profiles.py\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)