### PR TITLE
fix(bootstrap): register QAValidateRepairHandler — closes #93 (qa.validate_repair 13ms failure)

### DIFF
--- a/src/squadops/bootstrap/handlers.py
+++ b/src/squadops/bootstrap/handlers.py
@@ -44,6 +44,9 @@ from squadops.capabilities.handlers.impl.correction_decision import (
 from squadops.capabilities.handlers.impl.establish_contract import (
     GovernanceEstablishContractHandler,
 )
+from squadops.capabilities.handlers.impl.repair_handlers import (
+    QAValidateRepairHandler,
+)
 from squadops.capabilities.handlers.planning_tasks import (
     DataResearchContextHandler,
     DevelopmentDesignPlanHandler,
@@ -119,6 +122,15 @@ HANDLER_CONFIGS: list[tuple[type[CapabilityHandler], tuple[str, ...]]] = [
     (GovernanceEstablishContractHandler, ("lead",)),
     (DataAnalyzeFailureHandler, ("data",)),
     (GovernanceCorrectionDecisionHandler, ("lead",)),
+    # Correction-loop repair validator (SIP-0079 §7.7).
+    # NOTE: `development.repair` is registered above via the SIP-0070
+    # pulse-check version (handlers.repair_tasks.DevelopmentRepairHandler)
+    # rather than the cycle-task version in impl/repair_handlers.py.
+    # Both classes share `_capability_id = "development.repair"`; the
+    # pulse-check one wins because it is imported and registered above.
+    # Issue #93 follow-up: decide which implementation should own
+    # `development.repair` for the correction loop and remove the duplicate.
+    (QAValidateRepairHandler, ("qa",)),
     # Planning handlers (SIP-0078: Planning Workload Protocol)
     (DataResearchContextHandler, ("data",)),
     (StrategyFrameObjectiveHandler, ("strat",)),

--- a/tests/unit/agent_foundation/bootstrap/test_bootstrap.py
+++ b/tests/unit/agent_foundation/bootstrap/test_bootstrap.py
@@ -261,6 +261,41 @@ class TestHandlerBootstrap:
         qa_caps = registry.list_by_role("qa")
         assert "qa.test_execution" in qa_caps
 
+    def test_correction_protocol_capabilities_registered(self):
+        """Issue #93: every capability the executor's correction protocol
+        dispatches MUST be in the bootstrap registry. An unregistered
+        capability fails fast with HandlerNotFoundError (~13ms, no LLM
+        call), which masquerades as a queue/agent issue. Catch the
+        wiring gap at startup-test time, not in production cycles.
+        """
+        from squadops.cycles.task_plan import (
+            CORRECTION_TASK_STEPS,
+            REPAIR_TASK_STEPS,
+            WRAPUP_TASK_STEPS,
+        )
+
+        registry = create_handler_registry()
+        capabilities = set(registry.list_capabilities())
+
+        all_dispatched: list[tuple[str, str]] = (
+            CORRECTION_TASK_STEPS + REPAIR_TASK_STEPS + WRAPUP_TASK_STEPS
+        )
+        missing = [cap for cap, _role in all_dispatched if cap not in capabilities]
+        assert not missing, (
+            f"Capabilities dispatched by the executor are not registered "
+            f"in bootstrap.handlers: {missing}. Add them to HANDLER_CONFIGS "
+            f"or remove them from the corresponding *_TASK_STEPS list."
+        )
+
+    def test_qa_validate_repair_registered_for_qa_role(self):
+        """Issue #93 regression: qa.validate_repair must be available to
+        the qa role specifically. Adding it to the registry without the
+        right role would still 13ms-fail when dispatched to eve.
+        """
+        registry = create_handler_registry()
+        qa_caps = registry.list_by_role("qa")
+        assert "qa.validate_repair" in qa_caps
+
 
 class TestSystemBootstrap:
     """Tests for system bootstrap functions."""


### PR DESCRIPTION
## Summary

Fixes #93. Root cause confirmed: \`QAValidateRepairHandler\` (in \`src/squadops/capabilities/handlers/impl/repair_handlers.py\`) was never imported or added to \`HANDLER_CONFIGS\` in \`src/squadops/bootstrap/handlers.py\`. When the correction protocol's REPAIR_TASK_STEPS dispatched \`qa.validate_repair\` to eve, eve's HandlerExecutor hit \`HandlerNotFoundError\` at \`handler_executor.py:100\` and returned a FAILED TaskResult in ~13 ms with no LLM call — exactly the symptom #93 reported.

Of the three root-cause candidates listed in #93, this is **candidate 1: capability routing failure (handler not registered)**.

This is gate-readiness block-list item **B3** in #97.

## Changes

- **\`bootstrap/handlers.py\`**: import \`QAValidateRepairHandler\` from \`impl/repair_handlers\` and add \`(QAValidateRepairHandler, ("qa",))\` to \`HANDLER_CONFIGS\`. A comment flags the parallel \`DevelopmentRepairHandler\` duplicate (see Follow-ups below).
- **\`tests/unit/agent_foundation/bootstrap/test_bootstrap.py\`**: two new tests
  - \`test_correction_protocol_capabilities_registered\` iterates \`CORRECTION_TASK_STEPS\` + \`REPAIR_TASK_STEPS\` + \`WRAPUP_TASK_STEPS\` and asserts every dispatched capability is in the registry. This generalizes the regression so the same wiring gap can't recur for any future step.
  - \`test_qa_validate_repair_registered_for_qa_role\` asserts the capability is reachable specifically via the qa role.

## Verified

- Pre-fix the new tests fail with a perfectly diagnostic message:

  > AssertionError: Capabilities dispatched by the executor are not registered in bootstrap.handlers: ['qa.validate_repair']. Add them to HANDLER_CONFIGS or remove them from the corresponding *_TASK_STEPS list.

- Full regression suite passes: 3623 passed (+2 new), 1 pre-existing skip.
- \`ruff check\` clean for changed files.

## Follow-ups (NOT in this PR)

There are **two** \`DevelopmentRepairHandler\` classes that share \`_capability_id = "development.repair"\`:

| File | Parent | Currently registered? |
|---|---|---|
| \`handlers/repair_tasks.py\` | \`_RepairTaskHandler\` (SIP-0070 pulse-check) | Yes — wins in registry |
| \`handlers/impl/repair_handlers.py\` | \`_CycleTaskHandler\` (SIP-0079 correction-loop) | No |

This explains the \"compounding observation\" in #93: \`development.repair\` completed in 25 s during cyc_b7cf604aed46, suspiciously fast for an LLM repair on qwen3.6:27b. The correction loop dispatched it, but the pulse-check handler ran (it expects \`verification_context\` from the pulse loop and falls back to a minimal prompt without it). I left a comment in \`HANDLER_CONFIGS\` flagging this; deciding which class should own \`development.repair\` for the correction loop (and removing the duplicate) belongs in a separate, more involved PR rather than expanding this one.

## References

- Issue: #93
- Meta tracking: #97 (B3 of the gate-readiness block list — only B4 \"validation profile\" remains after this lands)
- Related already-merged: PR #91 (parser tolerance), PR #96 (correction-loop output preservation, #95), PR #98 (builder source-of-truth, #92)
- Code touched: \`src/squadops/bootstrap/handlers.py\`, \`tests/unit/agent_foundation/bootstrap/test_bootstrap.py\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)