### PR TITLE
fix(repair): split development.repair into pulse-check vs correction-loop variants (#100)

### DIFF
--- a/src/squadops/bootstrap/handlers.py
+++ b/src/squadops/bootstrap/handlers.py
@@ -44,6 +44,10 @@ from squadops.capabilities.handlers.impl.correction_decision import (
 from squadops.capabilities.handlers.impl.establish_contract import (
     GovernanceEstablishContractHandler,
 )
+from squadops.capabilities.handlers.impl.repair_handlers import (
+    DevelopmentCorrectionRepairHandler,
+    QAValidateRepairHandler,
+)
 from squadops.capabilities.handlers.planning_tasks import (
     DataResearchContextHandler,
     DevelopmentDesignPlanHandler,
@@ -119,6 +123,11 @@ HANDLER_CONFIGS: list[tuple[type[CapabilityHandler], tuple[str, ...]]] = [
     (GovernanceEstablishContractHandler, ("lead",)),
     (DataAnalyzeFailureHandler, ("data",)),
     (GovernanceCorrectionDecisionHandler, ("lead",)),
+    # Correction-loop repair pair (SIP-0079 §7.7).
+    # Distinct from the SIP-0070 `development.repair` registered above
+    # via handlers.repair_tasks.DevelopmentRepairHandler. See issue #100.
+    (DevelopmentCorrectionRepairHandler, ("dev",)),
+    (QAValidateRepairHandler, ("qa",)),
     # Planning handlers (SIP-0078: Planning Workload Protocol)
     (DataResearchContextHandler, ("data",)),
     (StrategyFrameObjectiveHandler, ("strat",)),

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -1,8 +1,15 @@
-"""Repair handlers for correction protocol (SIP-0079 §7.7).
+"""Repair handlers for the SIP-0079 correction protocol.
 
-Thin subclasses of _CycleTaskHandler that handle the repair phase
-of the correction protocol: development.repair (dev) and
+Thin subclasses of _CycleTaskHandler used by REPAIR_TASK_STEPS in
+cycles/task_plan.py: development.correction_repair (dev) and
 qa.validate_repair (qa).
+
+Issue #100: this file used to define a `DevelopmentRepairHandler` with
+`_capability_id = "development.repair"`. That collided with the SIP-0070
+pulse-check `DevelopmentRepairHandler` in handlers/repair_tasks.py. The
+correction-loop variant is now `DevelopmentCorrectionRepairHandler` with
+`_capability_id = "development.correction_repair"` so the pulse-check and
+correction-loop flows have distinct, non-overlapping capability ids.
 """
 
 from __future__ import annotations
@@ -10,11 +17,18 @@ from __future__ import annotations
 from squadops.capabilities.handlers.cycle_tasks import _CycleTaskHandler
 
 
-class DevelopmentRepairHandler(_CycleTaskHandler):
-    """Repair handler: applies fixes based on failure analysis."""
+class DevelopmentCorrectionRepairHandler(_CycleTaskHandler):
+    """Correction-loop repair handler.
 
-    _handler_name = "development_repair_handler"
-    _capability_id = "development.repair"
+    Reads `failure_evidence`, `failure_analysis`, and `correction_decision`
+    from inputs (set by the executor's correction protocol) and asks the
+    LLM to author a repair. Distinct from the SIP-0070 pulse-check
+    `DevelopmentRepairHandler`, which consumes `verification_context` from
+    a different upstream chain.
+    """
+
+    _handler_name = "development_correction_repair_handler"
+    _capability_id = "development.correction_repair"
     _role = "dev"
     _artifact_name = "repair_output.md"
 

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -83,9 +83,11 @@ CORRECTION_TASK_STEPS: list[tuple[str, str]] = [
     ("governance.correction_decision", "lead"),
 ]
 
-# Repair task steps (SIP-0079 §7.7)
+# Repair task steps (SIP-0079 §7.7).
+# Issue #100: development.correction_repair (NOT development.repair) — the
+# latter belongs to the SIP-0070 pulse-check chain in pulse_verification.py.
 REPAIR_TASK_STEPS: list[tuple[str, str]] = [
-    ("development.repair", "dev"),
+    ("development.correction_repair", "dev"),
     ("qa.validate_repair", "qa"),
 ]
 
@@ -353,8 +355,7 @@ def _replace_build_steps_with_plan(
     errors = plan.validate_against_profile(profile)
     if errors:
         raise CycleError(
-            f"Plan validation failed against profile '{profile.profile_id}': "
-            + "; ".join(errors)
+            f"Plan validation failed against profile '{profile.profile_id}': " + "; ".join(errors)
         )
 
     # Remove static build steps, keep everything else (planning steps)

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -1,7 +1,7 @@
 """Tests for SIP-0079 implementation handlers.
 
 Covers GovernanceEstablishContractHandler, DataAnalyzeFailureHandler,
-GovernanceCorrectionDecisionHandler, DevelopmentRepairHandler,
+GovernanceCorrectionDecisionHandler, DevelopmentCorrectionRepairHandler,
 QAValidateRepairHandler.
 """
 
@@ -22,7 +22,7 @@ from squadops.capabilities.handlers.impl.establish_contract import (
     GovernanceEstablishContractHandler,
 )
 from squadops.capabilities.handlers.impl.repair_handlers import (
-    DevelopmentRepairHandler,
+    DevelopmentCorrectionRepairHandler,
     QAValidateRepairHandler,
 )
 from squadops.cycles.task_outcome import FailureClassification, TaskOutcome
@@ -169,7 +169,9 @@ class TestAnalyzeFailure:
 
         assert result.success is False
         assert result.outputs["outcome_class"] == TaskOutcome.NEEDS_REPLAN
-        assert "rejected" in (result.error or "").lower() or "schema" in (result.error or "").lower()
+        assert (
+            "rejected" in (result.error or "").lower() or "schema" in (result.error or "").lower()
+        )
 
     async def test_empty_analysis_summary_rejected(self, mock_context):
         """Issue #84: ``analysis_summary: ""`` is the failure mode that
@@ -315,11 +317,12 @@ class TestRepairHandlers:
             return_value=ChatMessage(role="assistant", content="Repair applied"),
         )
 
-        h = DevelopmentRepairHandler()
+        h = DevelopmentCorrectionRepairHandler()
         result = await h.handle(mock_context, {"prd": "test"})
 
         assert result.success is True
         assert result.outputs["role"] == "dev"
+        assert h.capability_id == "development.correction_repair"
 
     async def test_validate_repair_produces_output(self, mock_context):
         _set_llm_mock(

--- a/tests/unit/cycles/test_task_plan_implementation.py
+++ b/tests/unit/cycles/test_task_plan_implementation.py
@@ -115,8 +115,10 @@ class TestCorrectionAndRepairSteps:
         ]
 
     def test_repair_steps_defined(self):
+        # Issue #100: development.correction_repair, NOT development.repair
+        # (the latter belongs to the pulse-check chain in pulse_verification.py).
         assert REPAIR_TASK_STEPS == [
-            ("development.repair", "dev"),
+            ("development.correction_repair", "dev"),
             ("qa.validate_repair", "qa"),
         ]
 


### PR DESCRIPTION
## Summary

Fixes #100. Resolves the \`_capability_id = \"development.repair\"\` collision between the SIP-0070 pulse-check handler (in \`handlers/repair_tasks.py\`) and the SIP-0079 correction-loop handler (in \`handlers/impl/repair_handlers.py\`) by renaming the correction-loop variant.

| Capability | Owner | Reads from inputs |
|---|---|---|
| \`development.repair\` (unchanged) | \`handlers/repair_tasks.py:DevelopmentRepairHandler\` | \`verification_context\`, \`corrective_plan\` (SIP-0070 pulse-check chain) |
| \`development.correction_repair\` (new) | \`handlers/impl/repair_handlers.py:DevelopmentCorrectionRepairHandler\` (renamed) | \`failure_evidence\`, \`failure_analysis\`, \`correction_decision\` (SIP-0079 correction-loop) |

\`cycles/task_plan.py:REPAIR_TASK_STEPS\` now dispatches \`development.correction_repair\` instead of \`development.repair\`, so the SIP-0079 correction protocol invokes the right handler. \`cycles/pulse_verification.py:REPAIR_TASK_STEPS\` is unchanged — pulse-check repair keeps the original capability.

## Why split

The two flows produce structurally different upstream evidence and call for different recovery semantics. Sharing one capability_id forced a mush: the wrong handler ran, fell back to a minimal prompt, and returned a 25 s repair on qwen3.6:27b that was nowhere near long enough to be a real LLM-driven fix.

## Changes

- \`src/squadops/capabilities/handlers/impl/repair_handlers.py\` — class rename + capability_id rename + module docstring updated
- \`src/squadops/cycles/task_plan.py\` — REPAIR_TASK_STEPS uses \`development.correction_repair\`
- \`src/squadops/bootstrap/handlers.py\` — register \`DevelopmentCorrectionRepairHandler\` for the dev role (alongside the existing pulse-check \`DevelopmentRepairHandler\`)
- \`tests/unit/capabilities/test_impl_handlers.py\` — rename references; add capability_id assertion
- \`tests/unit/cycles/test_task_plan_implementation.py\` — expected REPAIR_TASK_STEPS now lists the new capability

## Test plan

- [x] Targeted test sweep: 85 passed in \`test_impl_handlers.py\`, \`test_task_plan_implementation.py\`, \`test_correction_protocol.py\`, \`test_repair_loop.py\`, \`test_bootstrap.py\`
- [x] Full regression suite passes: 3621 passed, 1 pre-existing skip (matches main; this branch was cut from main without #99's +2 generalized tests)
- [x] \`ruff check\` clean for changed files
- [x] After PR #99 merges, that branch's generalized \`test_correction_protocol_capabilities_registered\` test will validate \`development.correction_repair\` against the registry automatically

## Dependencies / merge order

This PR depends on PR #99 (issue #93) for the \`QAValidateRepairHandler\` import line in \`bootstrap/handlers.py\`. Either order works:

- **#99 merges first** (likely): rebase this PR onto main; my \`from impl.repair_handlers import (DevelopmentCorrectionRepairHandler, QAValidateRepairHandler)\` consolidates with the existing import already present
- **This PR merges first**: PR #99 needs a trivial rebase since \`QAValidateRepairHandler\` is already imported here

## Out of scope

- Improving either handler's prompt (the rename is structural — prompt-quality is its own follow-up)
- Changing the pulse-check repair chain
- Changing the correction-loop step count
- The 25 s \"is the LLM even running\" suspicion in the original cycle — once \`development.correction_repair\` actually dispatches to the correction-loop handler, that handler runs the standard \`_CycleTaskHandler.handle()\` LLM path with the full failure_analysis/correction_decision context. Whether that produces a USEFUL repair is a separate question (depends on prompt quality + model strength), but at least it's now running the right code

## References

- Issue: #100
- Triggering: PR #99 follow-up flag
- Related already-merged: PR #91 (parser tolerance), PR #96 (#95 correction-loop output preservation), PR #98 (#92 builder source-of-truth)
- Code touched: \`src/squadops/capabilities/handlers/impl/repair_handlers.py\`, \`src/squadops/cycles/task_plan.py\`, \`src/squadops/bootstrap/handlers.py\`, \`tests/unit/capabilities/test_impl_handlers.py\`, \`tests/unit/cycles/test_task_plan_implementation.py\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)