### PR TITLE
fix(builder-prompt): mark qa_handoff section list non-negotiable + worked skeleton

### DIFF
--- a/src/squadops/capabilities/handlers/build_profiles.py
+++ b/src/squadops/capabilities/handlers/build_profiles.py
@@ -84,6 +84,17 @@ class BuildProfile:
 
         The file list is derived from `required_files`/`optional_files` so
         the prompt stays in lockstep with what the validator enforces.
+
+        Cycle-1 evidence (cyc_11367982fd06, 2026-05-03): the build profile
+        validator and the plan author can disagree about which qa_handoff
+        sections are required. The plan task description named different
+        sections (e.g. "Implemented Scope", "Known Limitations") than the
+        validator's hard-coded set. Bob followed the more specific task
+        description and the validator rejected on a missing canonical
+        section. We surface the validator's section list as
+        "non-negotiable" with a worked skeleton so the user prompt's task
+        description cannot quietly override it. Additional sections
+        requested by the task are welcome on top of the required ones.
         """
         required_lines = "\n".join(f"- `{name}`" for name in self.required_files)
         optional_block = ""
@@ -91,14 +102,29 @@ class BuildProfile:
             optional_lines = "\n".join(f"- `{name}`" for name in self.optional_files)
             optional_block = f"\n\n## Optional artifacts (emit only if needed)\n\n{optional_lines}"
         qa_lines = "\n".join(f"- `{name}`" for name in self.qa_handoff_expectations)
+        skeleton_sections = "\n\n".join(
+            f"{heading}\n\n<content>" for heading in self.qa_handoff_expectations
+        )
 
         return (
             f"{self.system_prompt_template}\n\n"
             "## Required artifacts (you MUST emit every file in this list)\n\n"
             f"{required_lines}"
             f"{optional_block}\n\n"
-            "## qa_handoff.md required sections\n\n"
-            f"{qa_lines}"
+            "## qa_handoff.md required sections (NON-NEGOTIABLE)\n\n"
+            f"{qa_lines}\n\n"
+            "These section headings are **mandatory** and must appear in "
+            "`qa_handoff.md` **exactly as written above**, including the "
+            "leading `## ` and the exact casing. The validator does literal "
+            "substring matching with a small set of fallbacks; paraphrased "
+            "or reworded headings will be rejected. The user prompt's task "
+            "description may ask for additional sections — include those "
+            "after the required ones, but the required headings above must "
+            "always be present.\n\n"
+            "Skeleton (copy these headings exactly, then fill in content):\n\n"
+            "```markdown:qa_handoff.md\n"
+            f"{skeleton_sections}\n"
+            "```"
         )
 
 

--- a/tests/unit/capabilities/test_build_profiles.py
+++ b/tests/unit/capabilities/test_build_profiles.py
@@ -291,3 +291,34 @@ class TestProfileSourceOfTruthInvariants:
             assert section in prompt, (
                 f"{name}: qa_handoff section {section!r} missing from full_system_prompt"
             )
+
+    @pytest.mark.parametrize("name,profile", list(BUILD_PROFILES.items()))
+    def test_qa_handoff_sections_marked_non_negotiable(self, name, profile):
+        """Cycle-1 evidence (cyc_11367982fd06): when the plan task description
+        names different qa_handoff sections than the validator requires, Bob
+        follows the more specific user-prompt task and the validator rejects
+        on a missing canonical section.
+
+        The system prompt MUST frame the validator's required sections as
+        non-negotiable so the user prompt's task description cannot quietly
+        override them. We assert on the explicit framing language and on
+        the worked-skeleton example.
+        """
+        prompt = profile.full_system_prompt
+        # Headline framing: the section list is mandatory, not advisory.
+        assert "NON-NEGOTIABLE" in prompt, (
+            f"{name}: qa_handoff section header lost the NON-NEGOTIABLE marker"
+        )
+        assert "mandatory" in prompt.lower(), (
+            f"{name}: missing 'mandatory' framing for qa_handoff sections"
+        )
+        # Tells Bob extra task-requested sections are welcome ON TOP of required.
+        assert "additional sections" in prompt.lower(), (
+            f"{name}: prompt should explicitly allow additional sections "
+            "beyond the required set, otherwise Bob may drop task-specific "
+            "sections in favor of the required ones"
+        )
+        # Worked skeleton showing exact heading text in a fenced qa_handoff block.
+        assert "```markdown:qa_handoff.md" in prompt, (
+            f"{name}: prompt missing the worked qa_handoff.md skeleton example"
+        )


### PR DESCRIPTION
## Summary

Cycle 1 of the SIP-0092 M1 gate batch (cyc_11367982fd06, 2026-05-03) failed because Bob's qa_handoff.md was missing one of the validator's three required sections (\`## Expected Behavior\`). Inspection showed the failure wasn't model laxity — it was a contract drift: the plan author (Neo) wrote a typed acceptance criterion asking for sections \`## How to Run|## How to Test|## Implemented Scope|## Known Limitations\` (no Expected Behavior), and Bob followed the more specific user-prompt task description over the system prompt's section list. Validator rejected, lead chose rewind, run terminated after one correction.

Tighten the system prompt so the validator's section list cannot be quietly overridden:

- Mark the section list **NON-NEGOTIABLE** in the heading
- State that headings must appear exactly as written, with the leading \`## \` and exact casing
- Note that the validator does literal substring matching; paraphrased headings will be rejected
- Explicitly permit task-requested additional sections, on top of the required ones
- Show a worked qa_handoff.md skeleton with the exact heading text in a copy-pasteable fenced block

## Why this and not validator tuning

The validator's looseness isn't the bug; the prompt drift is. Loosening the validator (e.g. accepting \`## Run\` for \`## How to Run\`) would hide future drift. Tightening Bob's prompt forces the LLM to satisfy the contract that already exists.

## Why not the deeper architectural fix instead

The cleanest end-state is to pass the build profile's \`qa_handoff_expectations\` into the planning handler so Neo's typed checks always include the validator's sections — eliminating the drift instead of patching around it. That's a bigger plumbing change (touches the planning handler's input). This PR is the faster first lever; if cycle 2 still fails on a related issue, the architectural fix becomes the next move.

## Test plan

- [x] 4 new parametrized invariants (\`test_qa_handoff_sections_marked_non_negotiable\`, one per profile) assert on:
  - \`NON-NEGOTIABLE\` marker in the heading
  - \`mandatory\` framing language (lowercased substring check)
  - \`additional sections\` clause permitting on-top extras (lowercased substring check)
  - presence of the \`\`\`markdown:qa_handoff.md\` worked skeleton example
- [x] Existing \`test_narrative_template_does_not_enumerate_filenames\` still passes — the worked skeleton uses backticked code-block tokens that the existing invariant strips before scanning
- [x] All 66 build_profile tests pass (was 62)
- [x] Full regression: 3639 passed, 1 pre-existing skip
- [x] \`ruff check\` clean

## Live evidence link

- Failed cycle: cyc_11367982fd06 / run_5e56b2a9aea2 (group_run, 2026-05-03)
- plan_delta_0 was the first plan_delta in any group_run history with a real, non-default \`failure_classification\` (\"work_product\") and \`analysis_summary\` (\"The qa_handoff artifact is missing key sections...\") — confirming PR #96 working in production. The prompt-drift this PR addresses was diagnosed *because* PR #96 surfaced the actual cause.

## Code touched

- \`src/squadops/capabilities/handlers/build_profiles.py\` — \`BuildProfile.full_system_prompt\` property
- \`tests/unit/capabilities/test_build_profiles.py\` — 4 new parametrized invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)