### PR TITLE
fix(correction-loop): persist repair source files + route by failed task type

### DIFF
--- a/adapters/cycles/distributed_flow_executor.py
+++ b/adapters/cycles/distributed_flow_executor.py
@@ -1929,7 +1929,7 @@ class DistributedFlowExecutor(FlowExecutionPort):
         """
         from uuid import uuid4
 
-        from squadops.cycles.task_plan import CORRECTION_TASK_STEPS, REPAIR_TASK_STEPS
+        from squadops.cycles.task_plan import CORRECTION_TASK_STEPS, repair_steps_for
 
         # 1. Emit CORRECTION_INITIATED
         self._cycle_event_bus.emit(
@@ -2098,8 +2098,15 @@ class DistributedFlowExecutor(FlowExecutionPort):
         plan_delta_refs.append(delta_ref.artifact_id)
 
         # 7. Handle patch path: dispatch repair tasks
+        # Repair-step selection is keyed on the failed task's task_type
+        # (authoritative) rather than the LLM-emitted `affected_task_types`
+        # field, which is free-text and previously caused builder failures
+        # (`affected_task_types: ["QA Handoff"]`) to silently route to the
+        # dev repair handler.
         if correction_path == "patch":
-            for step_idx, (task_type, role) in enumerate(REPAIR_TASK_STEPS):
+            for step_idx, (task_type, role) in enumerate(
+                repair_steps_for(envelope.task_type)
+            ):
                 repair_task_id = f"repair-{run_id[:12]}-{correction_attempts:02d}-{task_type}"
                 agent_id = self._resolve_agent_id(role, profile)
 

--- a/src/squadops/bootstrap/handlers.py
+++ b/src/squadops/bootstrap/handlers.py
@@ -45,6 +45,7 @@ from squadops.capabilities.handlers.impl.establish_contract import (
     GovernanceEstablishContractHandler,
 )
 from squadops.capabilities.handlers.impl.repair_handlers import (
+    BuilderAssembleRepairHandler,
     DevelopmentCorrectionRepairHandler,
     QAValidateRepairHandler,
 )
@@ -128,6 +129,7 @@ HANDLER_CONFIGS: list[tuple[type[CapabilityHandler], tuple[str, ...]]] = [
     # handlers.repair_tasks.DevelopmentRepairHandler — see issue #100 for
     # the rationale behind the split into `development.correction_repair`.
     (DevelopmentCorrectionRepairHandler, ("dev",)),
+    (BuilderAssembleRepairHandler, ("builder",)),
     (QAValidateRepairHandler, ("qa",)),
     # Planning handlers (SIP-0078: Planning Workload Protocol)
     (DataResearchContextHandler, ("data",)),

--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -193,6 +193,26 @@ class _CycleTaskHandler(CapabilityHandler):
             "prior_outputs": self._format_prior_outputs(prior_outputs),
         }
 
+    def _build_artifacts_from_content(self, content: str) -> list[dict[str, Any]]:
+        """Build artifact list from LLM response content.
+
+        Default wraps the full response as a single markdown document under
+        ``self._artifact_name``. Handlers whose LLM emits multi-file source
+        output (fenced code blocks, e.g. development.develop and
+        development.correction_repair) override this to extract per-file
+        artifacts via ``extract_fenced_files``. The default exists so the
+        majority of handlers (that produce narrative deliverables) keep
+        working without each one re-implementing the wrap.
+        """
+        return [
+            {
+                "name": self._artifact_name,
+                "content": content,
+                "media_type": "text/markdown",
+                "type": "document",
+            },
+        ]
+
     def _fail_result(
         self,
         start_time: float,
@@ -463,14 +483,7 @@ class _CycleTaskHandler(CapabilityHandler):
         outputs = {
             "summary": f"[{self._role}] {prd_summary}",
             "role": self._role,
-            "artifacts": [
-                {
-                    "name": self._artifact_name,
-                    "content": content,
-                    "media_type": "text/markdown",
-                    "type": "document",
-                },
-            ],
+            "artifacts": self._build_artifacts_from_content(content),
             "prompt_provenance": provenance,
         }
 

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -1,8 +1,8 @@
 """Repair handlers for the SIP-0079 correction protocol.
 
-Thin subclasses of _CycleTaskHandler used by REPAIR_TASK_STEPS in
-cycles/task_plan.py: development.correction_repair (dev) and
-qa.validate_repair (qa).
+Thin subclasses of _CycleTaskHandler used by the repair-task selector in
+cycles/task_plan.py: development.correction_repair (dev),
+builder.assemble_repair (builder), and qa.validate_repair (qa).
 
 Issue #100: this file used to define a `DevelopmentRepairHandler` with
 `_capability_id = "development.repair"`. That collided with the SIP-0070
@@ -14,7 +14,46 @@ correction-loop flows have distinct, non-overlapping capability ids.
 
 from __future__ import annotations
 
-from squadops.capabilities.handlers.cycle_tasks import _CycleTaskHandler
+from typing import Any
+
+from squadops.capabilities.handlers.cycle_tasks import _classify_file, _CycleTaskHandler
+from squadops.capabilities.handlers.fenced_parser import extract_fenced_files
+
+
+def _artifacts_from_fenced_blocks(content: str, fallback_name: str) -> list[dict[str, Any]]:
+    """Extract per-file artifacts from fenced code blocks in *content*.
+
+    Repair handlers ask the LLM to emit replacement source files in the
+    same fenced format the develop handler uses. Without this extraction
+    the base handler wraps the entire response as a single markdown doc
+    and the repaired files never land in artifact storage — the failure
+    mode that motivated this helper.
+
+    Falls back to a single markdown wrap when no fenced blocks are found
+    so the LLM output is not silently dropped.
+    """
+    extracted = extract_fenced_files(content)
+    if not extracted:
+        return [
+            {
+                "name": fallback_name,
+                "content": content,
+                "media_type": "text/markdown",
+                "type": "document",
+            },
+        ]
+    artifacts: list[dict[str, Any]] = []
+    for file_rec in extracted:
+        artifact_type, media_type = _classify_file(file_rec["filename"])
+        artifacts.append(
+            {
+                "name": file_rec["filename"],
+                "content": file_rec["content"],
+                "media_type": media_type,
+                "type": artifact_type,
+            }
+        )
+    return artifacts
 
 
 class DevelopmentCorrectionRepairHandler(_CycleTaskHandler):
@@ -31,6 +70,29 @@ class DevelopmentCorrectionRepairHandler(_CycleTaskHandler):
     _capability_id = "development.correction_repair"
     _role = "dev"
     _artifact_name = "repair_output.md"
+
+    def _build_artifacts_from_content(self, content: str) -> list[dict[str, Any]]:
+        return _artifacts_from_fenced_blocks(content, self._artifact_name)
+
+
+class BuilderAssembleRepairHandler(_CycleTaskHandler):
+    """Correction-loop repair handler for failed builder.assemble tasks.
+
+    Mirrors `DevelopmentCorrectionRepairHandler` but routed to the builder
+    role so packaging/handoff failures (e.g. qa_handoff.md missing
+    required sections, missing requirements.txt or package.json) get
+    repaired by Bob with the build-profile system prompt rather than by
+    Neo with the dev system prompt — Neo has no useful context for
+    builder.assemble outputs and simply ignores the assignment.
+    """
+
+    _handler_name = "builder_assemble_repair_handler"
+    _capability_id = "builder.assemble_repair"
+    _role = "builder"
+    _artifact_name = "repair_output.md"
+
+    def _build_artifacts_from_content(self, content: str) -> list[dict[str, Any]]:
+        return _artifacts_from_fenced_blocks(content, self._artifact_name)
 
 
 class QAValidateRepairHandler(_CycleTaskHandler):

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -86,10 +86,40 @@ CORRECTION_TASK_STEPS: list[tuple[str, str]] = [
 # Repair task steps (SIP-0079 §7.7).
 # Issue #100: development.correction_repair (NOT development.repair) — the
 # latter belongs to the SIP-0070 pulse-check chain in pulse_verification.py.
+#
+# Default sequence used when the failed task type has no specialized repair
+# pair registered below. Kept as a module constant for direct import in
+# tests and for use as the fallback inside `repair_steps_for`.
 REPAIR_TASK_STEPS: list[tuple[str, str]] = [
     ("development.correction_repair", "dev"),
     ("qa.validate_repair", "qa"),
 ]
+
+# Specialized repair sequences keyed by the failed task's task_type. The
+# correction loop dispatches the right pair instead of always running the
+# dev-flavored default — without this mapping a failed `builder.assemble`
+# task gets repaired by Neo (dev) who has no useful context, and Bob
+# (builder) is silently bypassed even though the failed work is his.
+_REPAIR_STEPS_BY_FAILED_TASK_TYPE: dict[str, list[tuple[str, str]]] = {
+    "development.develop": REPAIR_TASK_STEPS,
+    "builder.assemble": [
+        ("builder.assemble_repair", "builder"),
+        ("qa.validate_repair", "qa"),
+    ],
+}
+
+
+def repair_steps_for(failed_task_type: str) -> list[tuple[str, str]]:
+    """Return the repair (task_type, role) sequence for a failed task.
+
+    Looked up by the failed task's `task_type`, which is authoritative —
+    the LLM-emitted `affected_task_types` field on a PlanDelta is
+    free-text and was previously the only routing signal, so a builder
+    failure tagged `["QA Handoff"]` would mis-route to the dev repair
+    handler. Falls back to `REPAIR_TASK_STEPS` (dev + qa) for any task
+    type without a specialized pair.
+    """
+    return _REPAIR_STEPS_BY_FAILED_TASK_TYPE.get(failed_task_type, REPAIR_TASK_STEPS)
 
 # Wrap-up task steps (SIP-0080 §7.1)
 WRAPUP_TASK_STEPS: list[tuple[str, str]] = [

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -22,6 +22,7 @@ from squadops.capabilities.handlers.impl.establish_contract import (
     GovernanceEstablishContractHandler,
 )
 from squadops.capabilities.handlers.impl.repair_handlers import (
+    BuilderAssembleRepairHandler,
     DevelopmentCorrectionRepairHandler,
     QAValidateRepairHandler,
 )
@@ -335,3 +336,82 @@ class TestRepairHandlers:
 
         assert result.success is True
         assert result.outputs["role"] == "qa"
+
+    async def test_dev_repair_extracts_fenced_code_into_per_file_artifacts(
+        self, mock_context
+    ):
+        # Regression: previously this whole response was wrapped as a single
+        # repair_output.md document and the source files never landed.
+        response = (
+            "Here is the patched code.\n\n"
+            "```python:backend/main.py\n"
+            "from fastapi import FastAPI\n"
+            "app = FastAPI()\n"
+            "```\n\n"
+            "And the helper:\n\n"
+            "```python:backend/util.py\n"
+            "def helper(): return 1\n"
+            "```\n"
+        )
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=response),
+        )
+
+        h = DevelopmentCorrectionRepairHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+
+        artifacts = result.outputs["artifacts"]
+        names = [a["name"] for a in artifacts]
+        assert names == ["backend/main.py", "backend/util.py"]
+        assert all(a["type"] == "source" for a in artifacts)
+        assert artifacts[0]["content"].startswith("from fastapi")
+        assert artifacts[1]["content"].strip() == "def helper(): return 1"
+        # No leftover repair_output.md when extraction succeeds
+        assert "repair_output.md" not in names
+
+    async def test_dev_repair_falls_back_to_markdown_when_no_fenced_blocks(
+        self, mock_context
+    ):
+        # Without fenced files we still preserve the LLM output instead of
+        # silently dropping it — the fallback is what keeps narrative-only
+        # repairs (e.g. "no code change needed, root cause was X") visible.
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(
+                role="assistant",
+                content="No code change needed; the failure was a flaky test.",
+            ),
+        )
+
+        h = DevelopmentCorrectionRepairHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+
+        artifacts = result.outputs["artifacts"]
+        assert len(artifacts) == 1
+        assert artifacts[0]["name"] == "repair_output.md"
+        assert artifacts[0]["type"] == "document"
+        assert "flaky test" in artifacts[0]["content"]
+
+    async def test_builder_assemble_repair_extracts_fenced_files(self, mock_context):
+        response = (
+            "```markdown:qa_handoff.md\n"
+            "## How to run backend\n\n`uvicorn main:app`\n"
+            "```\n\n"
+            "```text:backend/requirements.txt\n"
+            "fastapi==0.115.0\n"
+            "```\n"
+        )
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=response),
+        )
+
+        h = BuilderAssembleRepairHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+
+        assert result.success is True
+        assert result.outputs["role"] == "builder"
+        assert h.capability_id == "builder.assemble_repair"
+        names = [a["name"] for a in result.outputs["artifacts"]]
+        assert names == ["qa_handoff.md", "backend/requirements.txt"]

--- a/tests/unit/cycles/test_task_plan_implementation.py
+++ b/tests/unit/cycles/test_task_plan_implementation.py
@@ -21,6 +21,7 @@ from squadops.cycles.task_plan import (
     IMPLEMENTATION_TASK_STEPS,
     REPAIR_TASK_STEPS,
     generate_task_plan,
+    repair_steps_for,
 )
 
 pytestmark = [pytest.mark.domain_orchestration]
@@ -121,6 +122,26 @@ class TestCorrectionAndRepairSteps:
             ("development.correction_repair", "dev"),
             ("qa.validate_repair", "qa"),
         ]
+
+
+class TestRepairStepsFor:
+    def test_dev_develop_uses_dev_repair_pair(self):
+        assert repair_steps_for("development.develop") == [
+            ("development.correction_repair", "dev"),
+            ("qa.validate_repair", "qa"),
+        ]
+
+    def test_builder_assemble_routes_to_builder_repair_handler(self):
+        # Regression: previously a failed builder.assemble silently routed
+        # to development.correction_repair (Neo) because the executor
+        # always looped REPAIR_TASK_STEPS.
+        steps = repair_steps_for("builder.assemble")
+        assert steps[0] == ("builder.assemble_repair", "builder")
+        assert steps[-1] == ("qa.validate_repair", "qa")
+
+    def test_unknown_failed_task_type_falls_back_to_dev_pair(self):
+        assert repair_steps_for("strategy.frame_objective") == REPAIR_TASK_STEPS
+        assert repair_steps_for("") == REPAIR_TASK_STEPS
 
 
 class TestDeterministicTaskIds:


### PR DESCRIPTION
## Summary

Two substrate bugs surfaced in `cyc_4178f25a0dff` (the second SIP-0092 validation cycle, 2026-05-03) that confounded the M1 → M2 gate signal by silently losing repair work. Both fixed here.

- **Repair handlers swallowed source code into a single markdown doc.** `DevelopmentCorrectionRepairHandler` did not override `handle()`, so the base wrapped the entire LLM response as `repair_output.md` regardless of fenced source files. The repair LLM ran twice in the failing cycle (44.5 t/s, 803 tokens; 42.5 t/s, 1263 tokens) but no `backend/main.py` or `frontend/src/pages/*` ever landed in artifact storage — repaired files dropped on the floor inside an inert markdown artifact.
- **Repair routing ignored the failed task's type.** The correction loop hardcoded `for ... in REPAIR_TASK_STEPS` (always the dev pair). The LLM-emitted `affected_task_types: [\"QA Handoff\"]` was free-text and unvalidated, so a failed `builder.assemble` silently routed to Neo (dev), who had no context for qa_handoff/packaging output and ignored the assignment. Bob never received a repair task.

## What changed

- `_CycleTaskHandler` gains a `_build_artifacts_from_content` hook (default keeps the existing single-document wrap so narrative handlers are unaffected).
- `DevelopmentCorrectionRepairHandler` and the **new** `BuilderAssembleRepairHandler` override the hook to extract per-file artifacts via `extract_fenced_files`, with a markdown fallback so narrative-only repairs (\"no code change needed, root cause was X\") are still preserved.
- New `repair_steps_for(failed_task_type)` lookup in `cycles/task_plan.py`. The executor now calls it with `envelope.task_type` (authoritative) instead of looping the static `REPAIR_TASK_STEPS`. `builder.assemble` → `builder.assemble_repair` + `qa.validate_repair`. Unknown task types fall back to the existing dev pair.
- `BuilderAssembleRepairHandler` registered in `bootstrap/handlers.py` for the `builder` role so Bob picks up `builder.assemble_repair` messages.

## Why this matters for SIP-0092 gate evidence

These two bugs were inflating the apparent failure rate of the correction loop in the validation-profile cycles — repaired files weren't landing, and the wrong agent was answering the page. Without these fixes, the M1 → M2 gate batch is measuring substrate noise rather than M1's typed-acceptance behavior. PR #103's qa_handoff prompt hardening can only help if the resulting repair work actually reaches Bob and the resulting files actually persist.

## Test plan

- [x] New: `test_dev_repair_extracts_fenced_code_into_per_file_artifacts` — regression for the markdown-swallow bug
- [x] New: `test_dev_repair_falls_back_to_markdown_when_no_fenced_blocks` — fallback preserves narrative-only output
- [x] New: `test_builder_assemble_repair_extracts_fenced_files` — covers the new handler end-to-end
- [x] New: `TestRepairStepsFor` — three tests covering dev / builder / unknown failed types
- [x] Full regression suite: **3645 passed, 1 skipped, 0 failures**
- [ ] Manual verification: rebuild agent + runtime-api images, kick off a fresh validation cycle on `group_run`, confirm a forced builder.assemble failure routes to Bob and a forced dev failure persists fenced files into artifact storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)