### PR TITLE
chore(model-registry): register qwen3.6:27b for spark-squad cycles

### DIFF
--- a/src/squadops/llm/model_registry.py
+++ b/src/squadops/llm/model_registry.py
@@ -38,6 +38,23 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         context_window=131_072,
         default_max_completion=16_384,
     ),
+    # qwen3.6:27b is the uniform model used by the spark-squad-with-builder
+    # profile on DGX Spark. Without a registry entry, get_model_spec()
+    # returned None for spark cycles and the per-model completion clamp at
+    # cycle_tasks._resolve_model_budget never fired — capability defaults
+    # passed through unchecked, so the python_cli fallback (4000 tokens)
+    # silently capped React/fullstack work that should have run under
+    # higher per-capability budgets. 8192 here intentionally clamps the
+    # fullstack_fastapi_react capability (12000) downward: empirically
+    # qwen3.6:27b at ~10 t/s on Spark takes ~13 min for 8K tokens, and
+    # outputs longer than that drift in coherence. Fullstack work should
+    # decompose into smaller per-file dev tasks rather than rely on a
+    # higher single-call ceiling.
+    "qwen3.6:27b": ModelSpec(
+        name="qwen3.6:27b",
+        context_window=131_072,
+        default_max_completion=8_192,
+    ),
     "llama3:70b": ModelSpec(
         name="llama3:70b",
         context_window=131_072,

--- a/tests/unit/llm/test_model_registry.py
+++ b/tests/unit/llm/test_model_registry.py
@@ -46,3 +46,13 @@ class TestGetModelSpec:
     def test_unknown_returns_none(self):
         """'unknown' (LLMPort.default_model default) returns None."""
         assert get_model_spec("unknown") is None
+
+    def test_spark_squad_model_registered(self):
+        # Regression: spark-squad-with-builder runs uniformly on
+        # qwen3.6:27b. Missing this entry caused the per-model completion
+        # clamp to no-op, so the python_cli fallback (4000 tokens) silently
+        # capped React/fullstack dev work in cyc_4178f25a0dff (cycle 2).
+        spec = get_model_spec("qwen3.6:27b")
+        assert spec is not None
+        assert spec.context_window == 131_072
+        assert spec.default_max_completion == 8_192


### PR DESCRIPTION
## Summary

- Register \`qwen3.6:27b\` in \`MODEL_SPECS\` so the per-model completion clamp at \`cycle_tasks._resolve_model_budget\` actually fires for spark cycles. Without this entry, \`get_model_spec(\"qwen3.6:27b\")\` returned \`None\` and capability defaults passed through unchecked.
- Set \`default_max_completion=8192\` (intentionally lower than the \`fullstack_fastapi_react\` capability's 12000): empirically qwen3.6:27b on Spark runs ~10 t/s, so 8K tokens is ~13 min per call and outputs longer than that drift in coherence. Multi-file fullstack work should decompose into single-file dev tasks rather than rely on a higher single-call ceiling.

## Why

Companion finding to PR #104. The two-layer failure in cyc_4178f25a0dff dev[4]:
1. The validation request profile doesn't set \`dev_capability\` → fell back to \`python_cli\` (4000 tokens)
2. The missing model registry entry → nothing in the resolution chain could detect that a 27b model on Spark could in principle generate more

Both had to fail for the cap to land at 4000.

This PR fixes only layer 2. Layer 1 (validation profile not knowing the project's stack identity) is unblocked operationally for cycle 3 with \`--set dev_capability=fullstack_fastapi_react\` overrides; the durable home for that signal is still being decided (per-project default vs framing-emitted vs per-task plan field).

## Test plan

- [x] New: \`test_spark_squad_model_registered\` — exact context_window + default_max_completion values
- [x] Existing \`test_registered_models_resolvable\` covers the new entry by iteration
- [x] Existing \`test_all_specs_context_exceeds_completion\` covers the new entry by iteration
- [x] Targeted suite passes: 8/8 in \`test_model_registry.py\`
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)