### PR TITLE
fix(correction-loop): enrich failure_evidence with validation context (#84)

### DIFF
--- a/adapters/cycles/distributed_flow_executor.py
+++ b/adapters/cycles/distributed_flow_executor.py
@@ -1906,6 +1906,62 @@ class DistributedFlowExecutor(FlowExecutionPort):
     # Correction protocol
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _build_failure_evidence(
+        envelope: TaskEnvelope,
+        result: TaskResult,
+        *,
+        prior_plan_deltas_count: int,
+    ) -> dict[str, Any]:
+        """Assemble the failure-evidence payload handed to data.analyze_failure.
+
+        Issue #84 follow-up: Data was previously handed only `error` +
+        `outcome_class` and had to guess at the failure shape; downstream
+        correction-decision then picked rewind on content failures because
+        it had no indication that a patch would suffice. Pull through the
+        failed handler's structured `validation_result` + preliminary
+        `failure_classification` + rejected artifact summaries so the
+        analyzer reasons about concrete checks instead of free-text
+        error strings. Each rejected-artifact content snippet is capped
+        at 1500 chars so a multi-file failure doesn't bloat the prompt.
+        """
+        result_outputs = result.outputs or {}
+        validation_result = result_outputs.get("validation_result") or {}
+        rejected_artifacts: list[dict[str, Any]] = []
+        for art in result_outputs.get("artifacts", []) or []:
+            content = art.get("content", "")
+            if isinstance(content, str):
+                size = len(content)
+                snippet = content[:1500]
+            else:
+                size = 0
+                snippet = ""
+            rejected_artifacts.append(
+                {
+                    "name": art.get("name", ""),
+                    "type": art.get("type", ""),
+                    "size": size,
+                    "content_snippet": snippet,
+                }
+            )
+        return {
+            "failed_task_id": envelope.task_id,
+            "failed_task_type": envelope.task_type,
+            "error": result.error or "",
+            "outcome_class": result_outputs.get("outcome_class", ""),
+            "preliminary_failure_classification": result_outputs.get(
+                "failure_classification", ""
+            ),
+            "validation_result": {
+                "passed": validation_result.get("passed"),
+                "summary": validation_result.get("summary", ""),
+                "missing_components": validation_result.get("missing_components", []),
+                "checks": validation_result.get("checks", []),
+            },
+            "rejected_artifacts": rejected_artifacts,
+            "prior_plan_deltas_count": prior_plan_deltas_count,
+        }
+
     async def _run_correction_protocol(
         self,
         run_id: str,
@@ -1945,12 +2001,9 @@ class DistributedFlowExecutor(FlowExecutionPort):
         )
 
         # 2. Build correction task envelopes (deterministic IDs)
-        failure_evidence = {
-            "failed_task_id": envelope.task_id,
-            "failed_task_type": envelope.task_type,
-            "error": result.error or "",
-            "outcome_class": (result.outputs or {}).get("outcome_class", ""),
-        }
+        failure_evidence = self._build_failure_evidence(
+            envelope, result, prior_plan_deltas_count=len(plan_delta_refs)
+        )
 
         # Issue #95: capture each correction step's outputs in its own variable
         # so the analyzer's classification/analysis_summary survive past the

--- a/src/squadops/capabilities/handlers/impl/analyze_failure.py
+++ b/src/squadops/capabilities/handlers/impl/analyze_failure.py
@@ -76,21 +76,46 @@ class FailureAnalysis(BaseModel):
 _ANALYSIS_SYSTEM_PROMPT = f"""\
 You are a data analyst performing root cause analysis on a task failure.
 
+The Failure Evidence block below carries structured signals from the failed
+handler. When present, USE THEM rather than restating the error string:
+
+- `validation_result.checks` — per-criterion typed-acceptance outcomes from
+  the failed handler. A `failed`-status check tells you the EXACT criterion
+  that rejected the work (regex pattern, missing field, missing endpoint).
+  Quote the failing check's name and `actual` field in your analysis.
+- `validation_result.missing_components` — specific files/sections the
+  validator expected but did not find. Name them in your analysis.
+- `rejected_artifacts[*].content_snippet` — the first ~1500 chars of what
+  the handler actually emitted. Compare against the failing checks to
+  identify whether it's a format issue, a missing-content issue, or a
+  scope-too-large issue.
+- `preliminary_failure_classification` — the failed handler's own classification.
+  Do not just echo it; corroborate or override it with evidence.
+
+Distinguish content-quality failures from structural failures explicitly,
+because downstream correction-decision uses your analysis to choose between
+patch (single-task content fix) and rewind (multi-task scope change). State
+which you observed.
+
 Classify the failure into one of these categories:
 - {FailureClassification.EXECUTION}: runtime error, timeout, infrastructure issue
 - {FailureClassification.WORK_PRODUCT}: output doesn't meet quality/correctness bar
+  (typed check failed on emitted artifact — usually patchable)
 - {FailureClassification.ALIGNMENT}: output doesn't match requirements/contract
+  (artifact correct in isolation but wrong against PRD/contract — may need rewind)
 - {FailureClassification.DECISION}: wrong approach or architectural choice
-- {FailureClassification.MODEL_LIMITATION}: LLM capability gap
+- {FailureClassification.MODEL_LIMITATION}: LLM capability gap (e.g. completion
+  truncated at token cap, scope exceeds single-call budget)
 
 Return JSON with these REQUIRED fields:
 - classification (string): EXACTLY one of: {", ".join(sorted(_VALID_CLASSIFICATIONS))}
 - analysis_summary (string, >=20 chars): concrete 2-3 sentence root cause. State the
-  specific component, the specific symptom, and (if knowable) the specific cause.
-  Do NOT write "N/A", "unknown", or empty strings — if you cannot determine the cause
-  from the evidence, say SO and name the missing evidence.
-- contributing_factors (list[string], >=1 item, each >=5 chars): factors that contributed.
-  Each factor must be a concrete observable, not a generic phrase.
+  specific component, the specific symptom (cite the failing check name when
+  available), and (if knowable) the specific cause. Do NOT write "N/A", "unknown",
+  or empty strings — if you cannot determine the cause from the evidence, say SO
+  and name the missing evidence.
+- contributing_factors (list[string], >=1 item, each >=5 chars): factors that
+  contributed. Each factor must be a concrete observable, not a generic phrase.
 
 Empty fields, the literal "N/A", and the literal "unknown" will be rejected.
 

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -191,6 +191,82 @@ class TestAnalyzeFailure:
         assert result.success is False
         assert result.outputs["outcome_class"] == TaskOutcome.NEEDS_REPLAN
 
+    async def test_enriched_failure_evidence_appears_in_user_prompt(self, mock_context):
+        # Issue #84 follow-up: when the executor passes in validation_result
+        # + rejected_artifacts + preliminary_failure_classification, the
+        # handler must surface them to the LLM (currently via JSON-dumped
+        # failure_evidence under the "## Failure Evidence" heading). Without
+        # this the LLM sees only the bare error string and downstream
+        # correction-decision picks rewind on patchable content failures.
+        captured: dict[str, str] = {}
+
+        async def _capture(messages, **_kwargs):
+            captured["user_prompt"] = messages[-1].content
+            return ChatMessage(
+                role="assistant",
+                content=json.dumps(
+                    {
+                        "classification": FailureClassification.WORK_PRODUCT,
+                        "analysis_summary": (
+                            "qa_handoff regex check 'how to run backend' failed; "
+                            "Bob emitted manifest content but missed required section"
+                        ),
+                        "contributing_factors": [
+                            "build profile required qa_handoff in non-handoff task"
+                        ],
+                    }
+                ),
+            )
+
+        mock_context.ports.llm.chat = _capture
+        mock_context.ports.llm.chat_stream_with_usage = _capture
+
+        enriched_evidence = {
+            "failed_task_id": "t-7",
+            "failed_task_type": "builder.assemble",
+            "error": "validation failed",
+            "outcome_class": "semantic_failure",
+            "preliminary_failure_classification": FailureClassification.WORK_PRODUCT,
+            "validation_result": {
+                "passed": False,
+                "summary": "1 typed check failed",
+                "missing_components": ["qa_handoff.md::## How to run backend"],
+                "checks": [
+                    {
+                        "name": "regex_match:how to run backend",
+                        "status": "failed",
+                        "actual": {"match_count": 0},
+                    }
+                ],
+            },
+            "rejected_artifacts": [
+                {
+                    "name": "qa_handoff.md",
+                    "type": "document",
+                    "size": 4200,
+                    "content_snippet": "## Implemented Scope\n\nFastAPI backend...",
+                }
+            ],
+            "prior_plan_deltas_count": 0,
+        }
+
+        h = DataAnalyzeFailureHandler()
+        result = await h.handle(
+            mock_context,
+            {"prd": "test PRD", "failure_evidence": enriched_evidence},
+        )
+
+        assert result.success is True
+        prompt = captured["user_prompt"]
+        # Each enriched field must reach the LLM as identifiable text — not
+        # buried under a generic "error" string.
+        assert "validation_result" in prompt
+        assert "regex_match:how to run backend" in prompt
+        assert "qa_handoff.md" in prompt
+        assert "missing_components" in prompt
+        assert "rejected_artifacts" in prompt
+        assert "Implemented Scope" in prompt  # snippet content reaches LLM
+
     async def test_unknown_classification_rejected(self, mock_context):
         analysis = {
             "classification": "weird-made-up-bucket",

--- a/tests/unit/cycles/test_distributed_flow_executor.py
+++ b/tests/unit/cycles/test_distributed_flow_executor.py
@@ -193,6 +193,119 @@ def executor(mock_registry, mock_vault, mock_queue, mock_squad_profile, cycle, r
 # ---------------------------------------------------------------------------
 
 
+class TestBuildFailureEvidence:
+    """Issue #84 follow-up: the executor must hand data.analyze_failure
+    a structured payload that surfaces validation_result, the failed
+    handler's preliminary classification, and per-artifact content
+    snippets — without these, downstream correction-decision picks
+    rewind on patchable content failures (cyc_4178f25a0dff delta_2 →
+    cyc_d1c1a259c983 delta_0 had to guess the failure shape)."""
+
+    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+
+    def _envelope(self, task_type: str) -> TaskEnvelope:
+        return TaskEnvelope(
+            task_id="t-7",
+            agent_id="bob",
+            cycle_id="cyc_x",
+            pulse_id="pulse",
+            project_id="proj",
+            task_type=task_type,
+            correlation_id="corr",
+            causation_id=None,
+            trace_id="trace",
+            span_id="span",
+            inputs={},
+            metadata={},
+        )
+
+    def _result(self, error: str | None, outputs: dict) -> TaskResult:
+        return TaskResult(
+            task_id="t-7",
+            status="FAILED" if error else "SUCCEEDED",
+            outputs=outputs,
+            error=error,
+        )
+
+    def test_includes_validation_result_when_present(self):
+        envelope = self._envelope("builder.assemble")
+        result = self._result(
+            "validation failed",
+            {
+                "outcome_class": "semantic_failure",
+                "failure_classification": "work_product",
+                "validation_result": {
+                    "passed": False,
+                    "summary": "1 typed check failed",
+                    "missing_components": ["qa_handoff.md::## How to run backend"],
+                    "checks": [
+                        {"name": "regex:how to run backend", "status": "failed"}
+                    ],
+                },
+                "artifacts": [],
+            },
+        )
+
+        evidence = self.DistributedFlowExecutor._build_failure_evidence(
+            envelope, result, prior_plan_deltas_count=0
+        )
+
+        assert evidence["validation_result"]["passed"] is False
+        assert evidence["validation_result"]["missing_components"] == [
+            "qa_handoff.md::## How to run backend"
+        ]
+        assert evidence["validation_result"]["checks"][0]["status"] == "failed"
+        assert evidence["preliminary_failure_classification"] == "work_product"
+
+    def test_truncates_artifact_content_snippets_to_1500_chars(self):
+        envelope = self._envelope("development.develop")
+        big = "x" * 5000
+        result = self._result(
+            "validation failed",
+            {
+                "artifacts": [
+                    {"name": "huge.py", "type": "source", "content": big},
+                    {"name": "small.py", "type": "source", "content": "ok"},
+                ]
+            },
+        )
+
+        evidence = self.DistributedFlowExecutor._build_failure_evidence(
+            envelope, result, prior_plan_deltas_count=2
+        )
+
+        rejected = evidence["rejected_artifacts"]
+        assert rejected[0]["name"] == "huge.py"
+        assert rejected[0]["size"] == 5000  # original size preserved
+        assert len(rejected[0]["content_snippet"]) == 1500  # snippet truncated
+        assert rejected[1]["content_snippet"] == "ok"
+        assert evidence["prior_plan_deltas_count"] == 2
+
+    def test_handles_empty_outputs_without_crashing(self):
+        # Failed handler that returned no outputs at all (e.g. crashed
+        # before assembling anything) — analyze_failure must still get a
+        # well-formed envelope, not a KeyError downstream.
+        envelope = self._envelope("development.develop")
+        result = TaskResult(
+            task_id="t-7", status="FAILED", outputs=None, error="connection reset"
+        )
+
+        evidence = self.DistributedFlowExecutor._build_failure_evidence(
+            envelope, result, prior_plan_deltas_count=0
+        )
+
+        assert evidence["error"] == "connection reset"
+        assert evidence["outcome_class"] == ""
+        assert evidence["preliminary_failure_classification"] == ""
+        assert evidence["validation_result"] == {
+            "passed": None,
+            "summary": "",
+            "missing_components": [],
+            "checks": [],
+        }
+        assert evidence["rejected_artifacts"] == []
+
+
 class TestBuildTaskName:
     """Gantt-friendly Prefect task names: focused-mode envelopes show the
     manifest focus and index instead of N identical role:task_type rows."""


### PR DESCRIPTION
Closes #84.

## Summary

The structural half of #84 (Pydantic-validated FailureAnalysis output) landed in 93c1694, but Data was still reasoning from impoverished inputs. This PR is the data-flow half: hand Data the structured signals the failed handler already produces, so the analysis is concrete enough for downstream correction-decision to pick patch vs rewind correctly.

**Live evidence motivating this PR:** \`cyc_d1c1a259c983\` (cycle 3 of the SIP-0092 gate batch) produced a structurally clean analysis (\`'missing qa_handoff sections'\`) and the correction LLM *still* picked rewind over patch — because \`failure_evidence\` carried only \`error\` + \`outcome_class\`. No way for Data (or downstream Max) to see that this was a content-fix-suffices situation rather than a scope-too-wrong one.

## What changed

- Pull through the failed handler's structured outputs into \`failure_evidence\`:
  - \`validation_result\` (passed/summary/missing_components/checks) — already populated by handlers when \`output_validation\` is on (\`cycle_tasks.py:1615\`); executor was just dropping it
  - \`preliminary_failure_classification\` — handler's own call (e.g. \`WORK_PRODUCT\` for typed-check rejections); Data may corroborate or override
  - \`rejected_artifacts\` — name/type/size + first 1500 chars of each emitted artifact, so Data can compare what was produced against what the failing checks expected
- Update analyze_failure system prompt to explicitly direct the LLM at these fields and to distinguish patchable content failures (\`WORK_PRODUCT\`) from structural failures (\`ALIGNMENT\`) — that's the distinction downstream correction-decision uses to choose patch vs rewind
- Extract \`_build_failure_evidence\` as a static helper so the dict construction is unit-testable without mocking the whole executor

## Out of scope (deliberate)

- **Bumping the data role's model.** The full-squad profile uses qwen2.5:3b for data; the spark-squad-with-builder profile already uses qwen3.6:27b. Issue #84's suggested fix #1 was a config change, not a code change — it can be done in \`config/squad-profiles.yaml\` independently. This PR keeps to the data-flow fix that benefits all squad profiles.

## Test plan

- [x] New: \`test_enriched_failure_evidence_appears_in_user_prompt\` — verifies enriched fields reach the LLM as identifiable text (validation_result keys, check names, snippet content)
- [x] New: \`TestBuildFailureEvidence\` (3 tests) — validation_result passthrough, snippet truncation at 1500 chars, empty-outputs safety
- [x] Full regression: **3649 passed, 1 skipped, 0 failures**
- [x] Ruff clean (1 pre-existing C901 on \`execute_run\` unrelated)
- [ ] Manual cycle verification: rebuild + run cycle 4 of the gate batch, confirm correction-decision picks \`patch\` (not \`rewind\`) on a builder.assemble qa_handoff failure — and confirm PR #104's \`builder.assemble_repair\` routing is finally exercised end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)