### PR TITLE
fix(builder): scope required_files by task expected_artifacts (#107)

### DIFF
--- a/src/squadops/capabilities/handlers/build_profiles.py
+++ b/src/squadops/capabilities/handlers/build_profiles.py
@@ -80,10 +80,20 @@ class BuildProfile:
 
     @property
     def full_system_prompt(self) -> str:
-        """Compose the narrative template with the canonical file list block.
+        """Profile-level prompt — every file the profile requires, qa_handoff section block always present.
 
-        The file list is derived from `required_files`/`optional_files` so
-        the prompt stays in lockstep with what the validator enforces.
+        Used when the executing task has no `expected_artifacts` to scope
+        the requirements down (legacy single-task builder flows). Prefer
+        :meth:`system_prompt_for_files` when the framing step decomposed
+        builder work and the active task only owns a subset of the
+        profile's required files.
+        """
+        return self.system_prompt_for_files(None)
+
+    def system_prompt_for_files(
+        self, task_required_files: tuple[str, ...] | list[str] | None
+    ) -> str:
+        """Compose the system prompt scoped to the active task's required files.
 
         Cycle-1 evidence (cyc_11367982fd06, 2026-05-03): the build profile
         validator and the plan author can disagree about which qa_handoff
@@ -95,36 +105,58 @@ class BuildProfile:
         "non-negotiable" with a worked skeleton so the user prompt's task
         description cannot quietly override it. Additional sections
         requested by the task are welcome on top of the required ones.
+
+        Issue #107 (cyc_d1c1a259c983, 2026-05-03): when framing decomposes
+        builder work into multiple tasks (one for manifests, one for
+        qa_handoff documentation), the profile-level required_files
+        forced every builder task to redundantly emit the full set —
+        which exceeded the per-call token budget and produced incomplete
+        outputs that failed the validator. When `task_required_files` is
+        provided and non-empty, the prompt scopes the required-files
+        list to only those files, and includes the qa_handoff skeleton
+        block only when `qa_handoff.md` is one of them. This makes the
+        framing decomposition load-bearing instead of overridden.
         """
-        required_lines = "\n".join(f"- `{name}`" for name in self.required_files)
+        scoped = (
+            tuple(task_required_files)
+            if task_required_files
+            else self.required_files
+        )
+        required_lines = "\n".join(f"- `{name}`" for name in scoped)
         optional_block = ""
         if self.optional_files:
             optional_lines = "\n".join(f"- `{name}`" for name in self.optional_files)
             optional_block = f"\n\n## Optional artifacts (emit only if needed)\n\n{optional_lines}"
-        qa_lines = "\n".join(f"- `{name}`" for name in self.qa_handoff_expectations)
-        skeleton_sections = "\n\n".join(
-            f"{heading}\n\n<content>" for heading in self.qa_handoff_expectations
-        )
+
+        qa_block = ""
+        if "qa_handoff.md" in scoped:
+            qa_lines = "\n".join(f"- `{name}`" for name in self.qa_handoff_expectations)
+            skeleton_sections = "\n\n".join(
+                f"{heading}\n\n<content>" for heading in self.qa_handoff_expectations
+            )
+            qa_block = (
+                "\n\n## qa_handoff.md required sections (NON-NEGOTIABLE)\n\n"
+                f"{qa_lines}\n\n"
+                "These section headings are **mandatory** and must appear in "
+                "`qa_handoff.md` **exactly as written above**, including the "
+                "leading `## ` and the exact casing. The validator does literal "
+                "substring matching with a small set of fallbacks; paraphrased "
+                "or reworded headings will be rejected. The user prompt's task "
+                "description may ask for additional sections — include those "
+                "after the required ones, but the required headings above must "
+                "always be present.\n\n"
+                "Skeleton (copy these headings exactly, then fill in content):\n\n"
+                "```markdown:qa_handoff.md\n"
+                f"{skeleton_sections}\n"
+                "```"
+            )
 
         return (
             f"{self.system_prompt_template}\n\n"
             "## Required artifacts (you MUST emit every file in this list)\n\n"
             f"{required_lines}"
-            f"{optional_block}\n\n"
-            "## qa_handoff.md required sections (NON-NEGOTIABLE)\n\n"
-            f"{qa_lines}\n\n"
-            "These section headings are **mandatory** and must appear in "
-            "`qa_handoff.md` **exactly as written above**, including the "
-            "leading `## ` and the exact casing. The validator does literal "
-            "substring matching with a small set of fallbacks; paraphrased "
-            "or reworded headings will be rejected. The user prompt's task "
-            "description may ask for additional sections — include those "
-            "after the required ones, but the required headings above must "
-            "always be present.\n\n"
-            "Skeleton (copy these headings exactly, then fill in content):\n\n"
-            "```markdown:qa_handoff.md\n"
-            f"{skeleton_sections}\n"
-            "```"
+            f"{optional_block}"
+            f"{qa_block}"
         )
 
 

--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -2519,38 +2519,57 @@ class BuilderAssembleHandler(_CycleTaskHandler):
         extracted: list[dict],
         profile: Any,
         required_sections: tuple[str, ...],
+        task_required_files: tuple[str, ...] | list[str] | None = None,
     ) -> str | None:
         """Validate builder output: qa_handoff, sections, required files.
+
+        Issue #107: when `task_required_files` is provided and non-empty,
+        the active task's expected_artifacts are the source of truth for
+        what must be emitted (framing decomposed builder work and the
+        active task only owns a subset of the profile's defaults). When
+        omitted/empty, falls back to `profile.required_files` to preserve
+        single-task builder behavior. The qa_handoff section check is
+        skipped when `qa_handoff.md` is not in scope, otherwise Bob would
+        be forced to emit a full qa_handoff in every builder task even if
+        framing routed it to a different task.
 
         Returns an error message string if validation fails, None if OK.
         """
         import os
 
-        qa_handoff_content = None
-        for file_rec in extracted:
-            if os.path.basename(file_rec["filename"]) == "qa_handoff.md":
-                qa_handoff_content = file_rec["content"]
-                break
-
-        if qa_handoff_content is None:
-            return "qa_handoff.md not found in builder output"
-
-        qa_lower = qa_handoff_content.lower()
-        _SECTION_KEYWORDS: dict[str, tuple[str, ...]] = {
-            "## How to Run": ("how to run", "running", "## run"),
-            "## How to Test": ("how to test", "testing", "## test"),
-            "## Expected Behavior": ("expected behavior", "expected output", "## expected"),
-        }
-        missing_sections = []
-        for section in required_sections:
-            keywords = _SECTION_KEYWORDS.get(section, (section.lower(),))
-            if not any(kw in qa_lower for kw in keywords):
-                missing_sections.append(section)
-        if missing_sections:
-            return f"qa_handoff.md missing required sections: {missing_sections}"
+        effective_required = (
+            tuple(task_required_files)
+            if task_required_files
+            else profile.required_files
+        )
 
         extracted_basenames = {os.path.basename(f["filename"]) for f in extracted}
-        missing_files = [rf for rf in profile.required_files if rf not in extracted_basenames]
+
+        if "qa_handoff.md" in effective_required:
+            qa_handoff_content = None
+            for file_rec in extracted:
+                if os.path.basename(file_rec["filename"]) == "qa_handoff.md":
+                    qa_handoff_content = file_rec["content"]
+                    break
+
+            if qa_handoff_content is None:
+                return "qa_handoff.md not found in builder output"
+
+            qa_lower = qa_handoff_content.lower()
+            _SECTION_KEYWORDS: dict[str, tuple[str, ...]] = {
+                "## How to Run": ("how to run", "running", "## run"),
+                "## How to Test": ("how to test", "testing", "## test"),
+                "## Expected Behavior": ("expected behavior", "expected output", "## expected"),
+            }
+            missing_sections = []
+            for section in required_sections:
+                keywords = _SECTION_KEYWORDS.get(section, (section.lower(),))
+                if not any(kw in qa_lower for kw in keywords):
+                    missing_sections.append(section)
+            if missing_sections:
+                return f"qa_handoff.md missing required sections: {missing_sections}"
+
+        missing_files = [rf for rf in effective_required if rf not in extracted_basenames]
         if missing_files:
             return f"Required deployment files missing: {missing_files}"
 
@@ -2743,6 +2762,17 @@ class BuilderAssembleHandler(_CycleTaskHandler):
         # Step 1b: Resolve task tags (profile defaults + experiment_context overrides)
         task_tags = self._resolve_task_tags(profile, resolved_config)
 
+        # Issue #107: when framing decomposed builder work, the active
+        # task's expected_artifacts is the source of truth for what must
+        # be emitted. Tuple of basenames (paths normalized) is what the
+        # validator and prompt scoper both expect.
+        import os as _os
+
+        task_expected = inputs.get("expected_artifacts") or []
+        task_required_files: tuple[str, ...] = tuple(
+            _os.path.basename(p) for p in task_expected if isinstance(p, str) and p
+        )
+
         # Step 2: Resolve source artifacts from dev role (assembly input)
         sources = self._get_assembly_inputs(inputs)
 
@@ -2763,7 +2793,10 @@ class BuilderAssembleHandler(_CycleTaskHandler):
         )
 
         assembled = context.ports.prompt_service.get_system_prompt(self._role)
-        system_prompt = assembled.content + "\n\n" + profile.full_system_prompt
+        # Issue #107: scope the profile prompt to this task's required
+        # files when the framing step decomposed builder work.
+        profile_prompt = profile.system_prompt_for_files(task_required_files or None)
+        system_prompt = assembled.content + "\n\n" + profile_prompt
 
         messages = [
             ChatMessage(role="system", content=system_prompt),
@@ -2816,7 +2849,10 @@ class BuilderAssembleHandler(_CycleTaskHandler):
 
         # Step 6-8: Validate builder output
         validation_error = self._validate_builder_output(
-            extracted, profile, QA_HANDOFF_REQUIRED_SECTIONS
+            extracted,
+            profile,
+            QA_HANDOFF_REQUIRED_SECTIONS,
+            task_required_files=task_required_files or None,
         )
         if validation_error is not None:
             from squadops.cycles.task_outcome import FailureClassification, TaskOutcome

--- a/tests/unit/capabilities/test_build_profiles.py
+++ b/tests/unit/capabilities/test_build_profiles.py
@@ -322,3 +322,62 @@ class TestProfileSourceOfTruthInvariants:
         assert "```markdown:qa_handoff.md" in prompt, (
             f"{name}: prompt missing the worked qa_handoff.md skeleton example"
         )
+
+
+class TestSystemPromptForFiles:
+    """Issue #107: when framing decomposes builder work, the active task's
+    expected_artifacts is the source of truth for what must be emitted.
+    `system_prompt_for_files(scope)` produces a prompt scoped to that
+    subset; `full_system_prompt` (no scope) preserves the legacy
+    profile-wide behavior for tasks framing didn't decompose."""
+
+    def _profile(self):
+        from squadops.capabilities.handlers.build_profiles import BUILD_PROFILES
+
+        return BUILD_PROFILES["fullstack_fastapi_react"]
+
+    def test_full_system_prompt_unchanged_by_default(self):
+        # Legacy callers that read full_system_prompt should still get the
+        # profile-wide prompt with every required file + qa_handoff block.
+        profile = self._profile()
+        prompt = profile.full_system_prompt
+        for required in profile.required_files:
+            assert f"`{required}`" in prompt
+        assert "qa_handoff.md required sections (NON-NEGOTIABLE)" in prompt
+
+    def test_scoped_prompt_lists_only_task_required_files(self):
+        # Cycle 3 task 8 scope: manifests + scripts, NO qa_handoff.
+        profile = self._profile()
+        scope = ("package.json", "vite.config.js", "Dockerfile")
+        prompt = profile.system_prompt_for_files(scope)
+
+        for name in scope:
+            assert f"`{name}`" in prompt
+        # Profile-required qa_handoff is intentionally absent — task 9 owns it.
+        assert "`qa_handoff.md`" not in prompt
+        assert "qa_handoff.md required sections" not in prompt
+        assert "```markdown:qa_handoff.md" not in prompt
+
+    def test_scoped_prompt_includes_qa_handoff_block_when_in_scope(self):
+        # Cycle 3 task 9 scope: qa_handoff documentation only.
+        profile = self._profile()
+        prompt = profile.system_prompt_for_files(("qa_handoff.md",))
+
+        assert "`qa_handoff.md`" in prompt
+        assert "qa_handoff.md required sections (NON-NEGOTIABLE)" in prompt
+        assert "```markdown:qa_handoff.md" in prompt
+        # And the OTHER profile-required files are NOT listed when not in scope.
+        assert "`Dockerfile`" not in prompt
+
+    def test_none_scope_falls_back_to_profile_required(self):
+        # Tasks framing didn't decompose pass through with no scope.
+        profile = self._profile()
+        prompt_none = profile.system_prompt_for_files(None)
+        prompt_full = profile.full_system_prompt
+        assert prompt_none == prompt_full
+
+    def test_empty_scope_falls_back_to_profile_required(self):
+        profile = self._profile()
+        prompt_empty = profile.system_prompt_for_files(())
+        prompt_full = profile.full_system_prompt
+        assert prompt_empty == prompt_full

--- a/tests/unit/capabilities/test_builder_assemble_handler.py
+++ b/tests/unit/capabilities/test_builder_assemble_handler.py
@@ -352,6 +352,96 @@ class TestRequiredFileValidation:
 
 
 # ---------------------------------------------------------------------------
+# Issue #107: task expected_artifacts overrides profile required_files
+# ---------------------------------------------------------------------------
+
+
+class TestTaskScopedRequiredFiles:
+    """When framing decomposes builder work into multiple tasks, the
+    active task's ``expected_artifacts`` is the source of truth for what
+    must be emitted; the profile's blanket ``required_files`` becomes the
+    fallback for tasks framing didn't decompose. Without this scoping,
+    every builder task in a decomposed plan was forced to redundantly
+    emit qa_handoff (cycle 3 cyc_d1c1a259c983 task 8 hit the 8K cap
+    trying to emit manifests + a full qa_handoff).
+    """
+
+    LLM_MANIFESTS_ONLY = (
+        "```dockerfile:Dockerfile\nFROM python:3.11-slim\n```\n\n"
+        "```text:requirements.txt\nfastapi\n```\n\n"
+        "```json:package.json\n{\"name\":\"frontend\"}\n```\n"
+    )
+
+    async def test_manifest_task_passes_without_qa_handoff(self, mock_context, builder_inputs):
+        # Task 8 in cycle 3's plan: manifests only, qa_handoff routed to task 9.
+        # Bob emits manifests, no qa_handoff — must succeed because the task
+        # scope doesn't include qa_handoff.
+        mock_context.ports.llm.chat = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=self.LLM_MANIFESTS_ONLY),
+        )
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=self.LLM_MANIFESTS_ONLY),
+        )
+        scoped_inputs = dict(builder_inputs)
+        scoped_inputs["expected_artifacts"] = [
+            "Dockerfile",
+            "requirements.txt",
+            "package.json",
+        ]
+        handler = BuilderAssembleHandler()
+        result = await handler.handle(mock_context, scoped_inputs)
+
+        assert result.success is True, f"task-scoped validation should pass: {result.error}"
+        artifact_names = {a["name"] for a in result.outputs["artifacts"]}
+        assert "qa_handoff.md" not in artifact_names
+
+    async def test_qa_handoff_task_still_required_when_in_scope(
+        self, mock_context, builder_inputs
+    ):
+        # Task 9 in cycle 3's plan: qa_handoff is the scope. The validator
+        # MUST still reject if Bob produces it without the required sections.
+        mock_context.ports.llm.chat = AsyncMock(
+            return_value=ChatMessage(
+                role="assistant", content=LLM_QA_HANDOFF_MISSING_SECTION
+            ),
+        )
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(
+                role="assistant", content=LLM_QA_HANDOFF_MISSING_SECTION
+            ),
+        )
+        scoped_inputs = dict(builder_inputs)
+        scoped_inputs["expected_artifacts"] = ["qa_handoff.md"]
+        handler = BuilderAssembleHandler()
+        result = await handler.handle(mock_context, scoped_inputs)
+
+        assert result.success is False
+        # The section regex must still bite when qa_handoff is in scope.
+        assert "Expected Behavior" in result.error
+
+    async def test_empty_expected_artifacts_falls_back_to_profile(
+        self, mock_context, builder_inputs
+    ):
+        # Tasks framing didn't decompose pass through with no expected_artifacts;
+        # the existing profile-required validation must still apply (regression
+        # guard against breaking single-task builder flows).
+        mock_context.ports.llm.chat = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=self.LLM_MANIFESTS_ONLY),
+        )
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=self.LLM_MANIFESTS_ONLY),
+        )
+        scoped_inputs = dict(builder_inputs)
+        scoped_inputs["expected_artifacts"] = []
+        handler = BuilderAssembleHandler()
+        result = await handler.handle(mock_context, scoped_inputs)
+
+        # python_cli_builder profile requires qa_handoff.md — still missing.
+        assert result.success is False
+        assert "qa_handoff.md not found" in result.error
+
+
+# ---------------------------------------------------------------------------
 # Duplicate filename detection
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #107.

## Summary

When framing decomposes builder work into multiple tasks (one for manifests, one for qa_handoff documentation), the profile-level \`required_files\` used to override the framing decomposition: every builder task was forced to redundantly emit the full set, exceeding the per-call token budget. This PR makes the framing decomposition load-bearing — the active task's \`expected_artifacts\` is the source of truth, with profile defaults as the fallback for tasks framing didn't decompose.

## Live evidence

\`cyc_d1c1a259c983\` task 8 (\"Dependency manifests, Vite proxy & start scripts\"): the \`fullstack_fastapi_react\` profile requires \`qa_handoff.md\`, so Bob tried to emit manifests AND a full qa_handoff in one shot, hit the 8192 clamp at 8435 completion tokens, qa_handoff was incomplete, validator rejected, run failed.

The same coupling caused the qa_handoff regex rejection across cycles 1, 2, and 3 of the SIP-0092 gate batch — masked as M1 typed-acceptance signal but really substrate. Until this lands, the gate criterion #2 tally (typed-acceptance changed an outcome) is over-credited from substrate noise.

## What changed

- \`BuildProfile.system_prompt_for_files(scope)\` produces a prompt scoped to the active task's required files. The qa_handoff NON-NEGOTIABLE section block appears only when \`qa_handoff.md\` is in scope. \`full_system_prompt\` becomes a thin wrapper passing \`None\` so both paths stay in sync.
- \`_validate_builder_output\` accepts an optional \`task_required_files\` parameter; when provided, validates against those instead of \`profile.required_files\` and skips the qa_handoff section check when qa_handoff.md is out of scope. Empty/\`None\` falls back to profile defaults — preserves single-task builder behavior.
- \`BuilderAssembleHandler.handle\` reads \`expected_artifacts\` from the task envelope (already plumbed through by \`task_plan.py\` since SIP-0086), derives \`task_required_files\` as basenames, and threads it through to both prompt assembly and validation.

## Verification path

After this lands, a fullstack validation cycle should let framing's multi-builder-task decomposition land cleanly:
- task 8 emits only manifests, task 9 emits only qa_handoff
- Both fit under the 8192 clamp
- Bob's failure mode shifts away from \"qa_handoff missing required sections\" — the dominant failure pattern across cycles 1–3 is unblocked
- PR #104's \`builder.assemble_repair\` routing finally gets a real shot at exercising end-to-end if any builder failure does occur (the rewind/patch trigger goes away)

## Test plan

- [x] Six new tests on \`BuildProfile.system_prompt_for_files\` (scoped subset, qa_handoff inclusion/exclusion, None/empty fallback equivalence)
- [x] Three new tests on \`BuilderAssembleHandler\` (manifest-only task success, qa_handoff-task validation still biting, empty-expected-artifacts profile fallback)
- [x] Full regression: **3658 passed, 1 skipped, 0 failures**
- [x] Ruff clean (2 pre-existing C901 on \`handle\` methods unrelated)
- [ ] Manual cycle verification: rebuild + run cycle 4 of the gate batch with the same overrides, confirm task 8 (manifests) no longer requires qa_handoff and the run progresses past it

## Related

- PR #103 (qa_handoff prompt hardening) — necessary but not sufficient: ensured Bob couldn't quietly produce a malformed qa_handoff; this PR ensures Bob isn't forced to produce qa_handoff in tasks framing didn't route to him for it
- PR #104 (repair-handler routing) — the routing fix needs a builder failure that picks correction_path: patch; #107 + #106 together unblock that scenario
- PR #105 (qwen3.6:27b model registry) — the 8192 clamp is what surfaced #107; both fixes ship as a pair, with the clamp encoding pressure to decompose and #107 letting decomposition actually take effect
- PR #106 (failure_evidence enrichment for #84) — orthogonal correction-decision quality fix
- SIP-0092 gate eval doc (forthcoming) — should reference this issue: criterion #2's tally needs revisiting since 3 of 3 typed-acceptance hits across cycles 1–3 were the same coupling defect, not three independent M1 trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)