### PR TITLE
fix(correction-loop): propagate squad-profile model to correction & repair envelopes

### DIFF
--- a/adapters/cycles/distributed_flow_executor.py
+++ b/adapters/cycles/distributed_flow_executor.py
@@ -1860,13 +1860,23 @@ class DistributedFlowExecutor(FlowExecutionPort):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _resolve_agent_id(role: str, profile: Any) -> str:
-        """Resolve a role to an agent_id using the squad profile, or fall back to role."""
+    def _resolve_agent_config(role: str, profile: Any) -> tuple[str, str | None, dict[str, Any]]:
+        """Resolve a role to ``(agent_id, agent_model, agent_overrides)`` from the squad profile.
+
+        Mirrors ``squadops.cycles.task_plan._resolve_agent_config`` so correction
+        and repair envelopes propagate the cycle's profile-specified model and
+        config overrides into the handler. Without this, ``inputs["agent_model"]``
+        is absent and the handler falls back to the agent container's instance
+        default — silently diverging from the cycle's squad profile (issue #110).
+        Falls back to ``(role, None, {})`` when no enabled match exists.
+        """
         if profile:
             for agent in profile.agents:
                 if agent.role == role and agent.enabled:
-                    return agent.agent_id
-        return role
+                    model = agent.model if agent.model else None
+                    overrides = dict(agent.config_overrides or {})
+                    return agent.agent_id, model, overrides
+        return role, None, {}
 
     async def _checkpoint_correction_task(
         self,
@@ -1949,9 +1959,7 @@ class DistributedFlowExecutor(FlowExecutionPort):
             "failed_task_type": envelope.task_type,
             "error": result.error or "",
             "outcome_class": result_outputs.get("outcome_class", ""),
-            "preliminary_failure_classification": result_outputs.get(
-                "failure_classification", ""
-            ),
+            "preliminary_failure_classification": result_outputs.get("failure_classification", ""),
             "validation_result": {
                 "passed": validation_result.get("passed"),
                 "summary": validation_result.get("summary", ""),
@@ -2016,13 +2024,19 @@ class DistributedFlowExecutor(FlowExecutionPort):
 
         for step_idx, (task_type, role) in enumerate(CORRECTION_TASK_STEPS):
             corr_task_id = f"corr-{run_id[:12]}-{correction_attempts:02d}-{task_type}"
-            agent_id = self._resolve_agent_id(role, profile)
+            agent_id, agent_model, agent_overrides = self._resolve_agent_config(role, profile)
 
+            # Issue #110: propagate squad-profile model + overrides so
+            # correction-loop reasoning runs on the cycle's specified model
+            # (e.g. spark-squad-with-builder pins data/lead to qwen3.6:27b)
+            # rather than the agent container's instance default.
             corr_inputs: dict[str, Any] = {
                 "prd": cycle.prd_ref,
                 "failure_evidence": failure_evidence,
                 "prior_outputs": prior_outputs,
                 "artifact_refs": list(all_artifact_refs),
+                "agent_model": agent_model,
+                "agent_config_overrides": agent_overrides,
             }
             if analysis_outputs:
                 corr_inputs["failure_analysis"] = analysis_outputs
@@ -2157,11 +2171,9 @@ class DistributedFlowExecutor(FlowExecutionPort):
         # (`affected_task_types: ["QA Handoff"]`) to silently route to the
         # dev repair handler.
         if correction_path == "patch":
-            for step_idx, (task_type, role) in enumerate(
-                repair_steps_for(envelope.task_type)
-            ):
+            for step_idx, (task_type, role) in enumerate(repair_steps_for(envelope.task_type)):
                 repair_task_id = f"repair-{run_id[:12]}-{correction_attempts:02d}-{task_type}"
-                agent_id = self._resolve_agent_id(role, profile)
+                agent_id, agent_model, agent_overrides = self._resolve_agent_config(role, profile)
 
                 repair_inputs: dict[str, Any] = {
                     "prd": cycle.prd_ref,
@@ -2169,6 +2181,8 @@ class DistributedFlowExecutor(FlowExecutionPort):
                     "correction_decision": decision_outputs,
                     "prior_outputs": prior_outputs,
                     "artifact_refs": list(all_artifact_refs),
+                    "agent_model": agent_model,
+                    "agent_config_overrides": agent_overrides,
                 }
 
                 repair_envelope = TaskEnvelope(

--- a/tests/unit/cycles/test_correction_protocol.py
+++ b/tests/unit/cycles/test_correction_protocol.py
@@ -758,3 +758,190 @@ class TestCorrectionEvents:
         assert len(decided_calls) == 1
         payload = decided_calls[0].kwargs.get("payload", {})
         assert payload["correction_path"] == "continue"
+
+
+# ---------------------------------------------------------------------------
+# Issue #110: correction & repair tasks must propagate squad-profile model
+# ---------------------------------------------------------------------------
+
+
+def _published_envelope(call) -> dict:
+    """Decode a mock_queue.publish call into the inner TaskEnvelope dict."""
+    return json.loads(call.args[1])["payload"]
+
+
+class TestCorrectionModelResolution:
+    """Issue #110: correction-loop envelopes carry profile-resolved model.
+
+    Without this, ``inputs["agent_model"]`` is absent and the agent falls
+    back to the container's instance default — silently bypassing the cycle's
+    squad profile. Observed in cyc_d1c1a259c983 where data.analyze_failure
+    ran on qwen2.5:3b-instruct under a profile that pinned all roles to
+    qwen3.6:27b.
+    """
+
+    @pytest.fixture
+    def model_diverse_profile(self):
+        """Profile where each role has a distinctive model string."""
+        from squadops.cycles.models import SquadProfile
+
+        return SquadProfile(
+            profile_id="diverse",
+            name="Diverse",
+            description="distinct per-role models",
+            version=1,
+            agents=(
+                AgentProfileEntry(
+                    agent_id="strat-a", role="strat", model="model-strat", enabled=True
+                ),
+                AgentProfileEntry(
+                    agent_id="dev-a",
+                    role="dev",
+                    model="model-dev",
+                    enabled=True,
+                    config_overrides={"temperature": 0.42},
+                ),
+                AgentProfileEntry(agent_id="qa-a", role="qa", model="model-qa", enabled=True),
+                AgentProfileEntry(agent_id="data-a", role="data", model="model-data", enabled=True),
+                AgentProfileEntry(agent_id="lead-a", role="lead", model="model-lead", enabled=True),
+            ),
+            created_at=NOW,
+        )
+
+    async def test_correction_envelopes_carry_profile_model(
+        self,
+        executor,
+        mock_queue,
+        mock_squad_profile,
+        model_diverse_profile,
+    ):
+        """data.analyze_failure + governance.correction_decision get role-specific model."""
+        mock_squad_profile.resolve_snapshot.return_value = (
+            model_diverse_profile,
+            "sha256:diverse",
+        )
+        semantic_outputs = {
+            "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
+            "role": "strat",
+        }
+        decision = {
+            "summary": "abort",
+            "role": "lead",
+            "correction_path": "abort",
+            "decision_rationale": "halt",
+            "affected_task_types": [],
+            "classification": "execution",
+            "analysis_summary": "halt",
+        }
+        script = [
+            ("FAILED", semantic_outputs, "bad"),
+            (
+                "SUCCEEDED",
+                {"classification": "execution", "analysis_summary": "x", "role": "data"},
+                None,
+            ),
+            ("SUCCEEDED", decision, None),
+        ]
+        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+
+        with patch(
+            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        publishes = [_published_envelope(c) for c in mock_queue.publish.call_args_list]
+        analyze = next(p for p in publishes if p["task_type"] == "data.analyze_failure")
+        decide = next(p for p in publishes if p["task_type"] == "governance.correction_decision")
+
+        assert analyze["agent_id"] == "data-a"
+        assert analyze["inputs"]["agent_model"] == "model-data"
+        assert decide["agent_id"] == "lead-a"
+        assert decide["inputs"]["agent_model"] == "model-lead"
+
+    async def test_repair_envelopes_carry_profile_model_and_overrides(
+        self,
+        executor,
+        mock_queue,
+        mock_squad_profile,
+        model_diverse_profile,
+    ):
+        """Patch-path repair tasks get the repaired role's model + config_overrides."""
+        mock_squad_profile.resolve_snapshot.return_value = (
+            model_diverse_profile,
+            "sha256:diverse",
+        )
+        # Trigger correction on a development.develop task so the patch path
+        # routes repair to the dev role (which has config_overrides set).
+        dev_failure = {
+            "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
+            "role": "dev",
+        }
+        decision = {
+            "summary": "patch",
+            "role": "lead",
+            "correction_path": "patch",
+            "decision_rationale": "localized fix",
+            "affected_task_types": ["development.develop"],
+            "classification": "work_product",
+            "analysis_summary": "code issue",
+        }
+        script = [
+            # Task 0 (strat) succeeds, task 1 (dev) fails.
+            ("SUCCEEDED", {"summary": "framed", "role": "strat"}, None),
+            ("FAILED", dev_failure, "bad code"),
+            (
+                "SUCCEEDED",
+                {"classification": "work_product", "analysis_summary": "x", "role": "data"},
+                None,
+            ),
+            ("SUCCEEDED", decision, None),
+            # Repair tasks + remaining task plan succeed.
+            ("SUCCEEDED", {"summary": "repaired", "role": "dev"}, None),
+            ("SUCCEEDED", {"summary": "validated", "role": "qa"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "dev"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "data"}, None),
+        ]
+        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+
+        with patch(
+            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        publishes = [_published_envelope(c) for c in mock_queue.publish.call_args_list]
+        repair = next(
+            p for p in publishes if p["task_id"].startswith("repair-") and p["agent_id"] == "dev-a"
+        )
+
+        assert repair["inputs"]["agent_model"] == "model-dev"
+        assert repair["inputs"]["agent_config_overrides"] == {"temperature": 0.42}
+
+    def test_resolve_agent_config_falls_back_when_role_absent(self):
+        """Helper returns (role, None, {}) when profile has no enabled match.
+
+        Reachable only via direct calls (the run-level path validates required
+        roles upstream), but the fallback exists so a misconfigured profile
+        can't crash the correction loop.
+        """
+        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+
+        class _ProfileStub:
+            agents = (
+                AgentProfileEntry(agent_id="strat-a", role="strat", model="m", enabled=True),
+                AgentProfileEntry(
+                    agent_id="data-disabled",
+                    role="data",
+                    model="m-data",
+                    enabled=False,
+                ),
+            )
+
+        agent_id, model, overrides = DistributedFlowExecutor._resolve_agent_config(
+            "data", _ProfileStub()
+        )
+        assert agent_id == "data"
+        assert model is None
+        assert overrides == {}


### PR DESCRIPTION
## Summary
- Replaces `_resolve_agent_id` with `_resolve_agent_config` returning `(agent_id, agent_model, agent_overrides)` — mirroring `task_plan._resolve_agent_config`.
- Threads `agent_model` and `agent_config_overrides` into the correction-step inputs (`data.analyze_failure`, `governance.correction_decision`) and repair-step inputs in `_run_correction_protocol`.
- Without this, `inputs.get("agent_model")` returned `None` and the handler fell back to the agent container's instance default, silently bypassing the cycle's squad profile.

## Why this matters
Observed in `cyc_d1c1a259c983` / `run_271201dc9bcf`:

| Task | Model used | `spark-squad-with-builder` says |
|------|-----------|-------------------------------|
| `data: data.analyze_failure` | qwen2.5:3b-instruct | qwen3.6:27b |
| `lead: governance.correction_decision` | llama3.1:8b | qwen3.6:27b |

The 3B summarizing PR #84's enriched `failure_evidence` produced a misleading plan_delta (*\"missing qa_handoff with required sections\"* for a builder task whose `expected_artifacts` didn't include `qa_handoff.md` at all), and the 8B made the rewind/patch decision off-profile. Patch-path repair tasks would have hit the same bug for builder/dev roles.

Closes #110

## Test plan
- [x] New `TestCorrectionModelResolution` in `tests/unit/cycles/test_correction_protocol.py`:
  - `test_correction_envelopes_carry_profile_model` — asserts the published `data.analyze_failure` and `governance.correction_decision` envelopes carry the role's profile model.
  - `test_repair_envelopes_carry_profile_model_and_overrides` — asserts repair envelopes carry the role's model **and** `config_overrides`.
  - `test_resolve_agent_config_falls_back_when_role_absent` — guards the `(role, None, {})` fallback for misconfigured profiles.
- [x] Full `tests/unit/cycles/` suite: 1120 passed.
- [ ] Regression on Spark: trigger a correction loop on `spark-squad-with-builder`; confirm Prefect logs show `model=qwen3.6:27b` for both correction tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)