### PR TITLE
fix(framing): wire PRD coverage discipline into the manifest prompt actually used (#112 real fix)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -121,6 +121,75 @@ def _estimate_min_artifacts(prd: str, impl_plan: str | None = None) -> int:
     return max(3, len(layers) * 2)
 
 
+# Issue #112: shared prompt section that drills the framing-time plan
+# author on PRD-coverage discipline. Lives at module scope so BOTH
+# manifest-producing prompts use the same source-of-truth text:
+#   - GovernanceReviewHandler._MANIFEST_PROMPT_EXTENSION (this file)
+#   - GovernanceReviewAssessReadinessHandler._produce_manifest in
+#     planning_tasks.py — the one the framing flow actually invokes
+# Keeping the original PR #113 patch in cycle_tasks.py while ALSO wiring
+# planning_tasks.py is defense-in-depth: any present-or-future caller of
+# either prompt path gets the discipline.
+_PRD_COVERAGE_DISCIPLINE_SECTION = (
+    "## PRD Coverage Discipline (load-bearing)\n\n"
+    "Before emitting the manifest, perform an explicit PRD ↔ acceptance_criteria "
+    "coverage pass. This catches a recurring class of defect where the PRD mandates "
+    "structural sub-requirements for a deliverable (e.g. required markdown sections, "
+    "required model fields, required API endpoints, required config keys) but the "
+    "plan's acceptance_criteria check only a subset, letting downstream agents ship "
+    "files that pass the typed checks while violating the PRD.\n\n"
+    "Procedure:\n"
+    "1. List every deliverable file the PRD requires.\n"
+    "2. For each deliverable, scan the PRD for structural sub-requirements stated "
+    "about it. Common shapes:\n"
+    "   - Markdown documents (`qa_handoff.md`, `README.md`): required section headers, "
+    'e.g. "must contain ## How to Test and ## Expected Behavior sections".\n'
+    "   - Data models / schemas: required fields, required field types.\n"
+    "   - APIs / route maps: required endpoints (method + path), required status codes.\n"
+    "   - Config files: required keys, required env vars.\n"
+    "3. For every sub-requirement enumerated in step 2, ensure the manifest task that "
+    "produces that deliverable has at least one acceptance_criteria typed check "
+    "covering it. Pick the right check type for the shape:\n"
+    "   - Required markdown section → `regex_match` on the section header pattern "
+    '(e.g. `pattern: "## How to Test"`, `count_min: 1`).\n'
+    "   - Required model field → `field_present` with the class_name and fields list.\n"
+    "   - Required endpoint → `endpoint_defined` with methods_paths.\n"
+    "   - Required import/symbol → `import_present` with module and symbol.\n"
+    "   - Required config key → `regex_match` with the key pattern.\n"
+    "4. If a sub-requirement has no covering typed check, ADD one to the manifest "
+    "before emitting it. Do not emit a manifest with known coverage gaps.\n"
+    "5. Surface the coverage mapping as a brief 'PRD Coverage' section in your output "
+    "(in the governance review document if one is being produced; otherwise as a "
+    "comment block at the top of the manifest YAML). This is the audit trail for "
+    "the gate evaluator.\n\n"
+    "Concrete worked example. PRD says:\n"
+    "  > §10. The qa_handoff.md document must contain `## How to Test`, "
+    "`## Expected Behavior`, and `## Known Limitations` sections.\n\n"
+    "The manifest task producing `qa_handoff.md` must include three typed checks:\n"
+    "```yaml\n"
+    "acceptance_criteria:\n"
+    "  - check: regex_match\n"
+    '    description: "Contains How to Test section"\n'
+    "    file: qa_handoff.md\n"
+    '    pattern: "## How to Test"\n'
+    "    count_min: 1\n"
+    "  - check: regex_match\n"
+    '    description: "Contains Expected Behavior section"\n'
+    "    file: qa_handoff.md\n"
+    '    pattern: "## Expected Behavior"\n'
+    "    count_min: 1\n"
+    "  - check: regex_match\n"
+    '    description: "Contains Known Limitations section"\n'
+    "    file: qa_handoff.md\n"
+    '    pattern: "## Known Limitations"\n'
+    "    count_min: 1\n"
+    "```\n\n"
+    'A pattern-only check like `pattern: "how to test|how to run"` is NOT '
+    "sufficient — it can match running prose and lets the deliverable ship without "
+    "the actual section header.\n"
+)
+
+
 def _build_typed_check_evaluation_artifact(
     validation_checks: list[dict],
     task_index: Any,
@@ -624,62 +693,7 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         "- Separate UI shell/routing from individual view components\n"
         "- Put integration config (CORS, proxy, requirements) in its own task\n"
         "- Put tests after the code they test\n"
-        "- Put QA handoff last\n\n"
-        "## PRD Coverage Discipline (load-bearing)\n\n"
-        "Before emitting the manifest, perform an explicit PRD ↔ acceptance_criteria "
-        "coverage pass. This catches a recurring class of defect where the PRD mandates "
-        "structural sub-requirements for a deliverable (e.g. required markdown sections, "
-        "required model fields, required API endpoints, required config keys) but the "
-        "plan's acceptance_criteria check only a subset, letting downstream agents ship "
-        "files that pass the typed checks while violating the PRD.\n\n"
-        "Procedure:\n"
-        "1. List every deliverable file the PRD requires.\n"
-        "2. For each deliverable, scan the PRD for structural sub-requirements stated "
-        "about it. Common shapes:\n"
-        "   - Markdown documents (`qa_handoff.md`, `README.md`): required section headers, "
-        'e.g. "must contain ## How to Test and ## Expected Behavior sections".\n'
-        "   - Data models / schemas: required fields, required field types.\n"
-        "   - APIs / route maps: required endpoints (method + path), required status codes.\n"
-        "   - Config files: required keys, required env vars.\n"
-        "3. For every sub-requirement enumerated in step 2, ensure the manifest task that "
-        "produces that deliverable has at least one acceptance_criteria typed check "
-        "covering it. Pick the right check type for the shape:\n"
-        "   - Required markdown section → `regex_match` on the section header pattern "
-        '(e.g. `pattern: "## How to Test"`, `count_min: 1`).\n'
-        "   - Required model field → `field_present` with the class_name and fields list.\n"
-        "   - Required endpoint → `endpoint_defined` with methods_paths.\n"
-        "   - Required import/symbol → `import_present` with module and symbol.\n"
-        "   - Required config key → `regex_match` with the key pattern.\n"
-        "4. If a sub-requirement has no covering typed check, ADD one to the manifest "
-        "before emitting it. Do not emit a manifest with known coverage gaps.\n"
-        "5. In your governance review document above, include a brief 'PRD Coverage' "
-        "section that lists each deliverable, its enumerated sub-requirements, and the "
-        "typed check(s) covering each. This is the audit trail for the gate evaluator.\n\n"
-        "Concrete worked example. PRD says:\n"
-        "  > §10. The qa_handoff.md document must contain `## How to Test`, "
-        "`## Expected Behavior`, and `## Known Limitations` sections.\n\n"
-        "The manifest task producing `qa_handoff.md` must include three typed checks:\n"
-        "```yaml\n"
-        "acceptance_criteria:\n"
-        "  - check: regex_match\n"
-        '    description: "Contains How to Test section"\n'
-        "    file: qa_handoff.md\n"
-        '    pattern: "## How to Test"\n'
-        "    count_min: 1\n"
-        "  - check: regex_match\n"
-        '    description: "Contains Expected Behavior section"\n'
-        "    file: qa_handoff.md\n"
-        '    pattern: "## Expected Behavior"\n'
-        "    count_min: 1\n"
-        "  - check: regex_match\n"
-        '    description: "Contains Known Limitations section"\n'
-        "    file: qa_handoff.md\n"
-        '    pattern: "## Known Limitations"\n'
-        "    count_min: 1\n"
-        "```\n\n"
-        'A pattern-only check like `pattern: "how to test|how to run"` is NOT '
-        "sufficient — it can match running prose and lets the deliverable ship without "
-        "the actual section header.\n\n"
+        "- Put QA handoff last\n\n" + _PRD_COVERAGE_DISCIPLINE_SECTION + "\n"
         "Output the manifest as a YAML code block with filename: "
         "implementation_plan.yaml\n\n"
         "Use this exact schema:\n"

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -27,7 +27,10 @@ from squadops.capabilities.handlers.base import (
     HandlerEvidence,
     HandlerResult,
 )
-from squadops.capabilities.handlers.cycle_tasks import _CycleTaskHandler
+from squadops.capabilities.handlers.cycle_tasks import (
+    _PRD_COVERAGE_DISCIPLINE_SECTION,
+    _CycleTaskHandler,
+)
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
 
@@ -523,50 +526,50 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
             "# endpoint_defined — FastAPI route presence (stack: fastapi)\n"
             "- check: endpoint_defined\n"
             "  severity: error\n"
-            "  description: \"Backend exposes the user CRUD routes\"\n"
+            '  description: "Backend exposes the user CRUD routes"\n'
             "  file: backend/main.py\n"
-            "  methods_paths: [\"GET /users\", \"POST /users\", \"DELETE /users/{uid}\"]\n"
+            '  methods_paths: ["GET /users", "POST /users", "DELETE /users/{uid}"]\n'
             "\n"
             "# import_present — Python import (or .ts/.js with frontend flag)\n"
             "- check: import_present\n"
-            "  description: \"Pydantic is wired in for request models\"\n"
+            '  description: "Pydantic is wired in for request models"\n'
             "  file: backend/main.py\n"
             "  module: pydantic\n"
             "  symbol: BaseModel\n"
             "\n"
             "# field_present — class fields on a Python dataclass / Pydantic v2 model\n"
             "- check: field_present\n"
-            "  description: \"User model carries id and email\"\n"
+            '  description: "User model carries id and email"\n'
             "  file: backend/models.py\n"
             "  class_name: User\n"
             "  fields: [id, email]\n"
             "\n"
             "# regex_match — pattern present count_min times in a file (stack-agnostic)\n"
             "- check: regex_match\n"
-            "  description: \"At least three test functions exist\"\n"
+            '  description: "At least three test functions exist"\n'
             "  file: tests/test_users.py\n"
-            "  pattern: \"def test_\"\n"
+            '  pattern: "def test_"\n'
             "  count_min: 3\n"
             "\n"
             "# count_at_least — glob match count under workspace (stack-agnostic)\n"
             "- check: count_at_least\n"
-            "  description: \"Non-trivial component coverage on the frontend\"\n"
-            "  glob: \"frontend/src/components/**/*.tsx\"\n"
+            '  description: "Non-trivial component coverage on the frontend"\n'
+            '  glob: "frontend/src/components/**/*.tsx"\n'
             "  min_count: 3\n"
             "\n"
             "# command_exit_zero — argv-only safelist of static checkers; cannot run shell strings\n"
             "- check: command_exit_zero\n"
-            "  description: \"Backend file syntactically valid\"\n"
+            '  description: "Backend file syntactically valid"\n'
             "  argv: [python, -m, py_compile, backend/main.py]\n"
             "```\n\n"
             "**Safety rules for `command_exit_zero`:**\n"
-            "- `argv` MUST be a YAML list, not a string. `\"ruff check src/\"` is rejected.\n"
+            '- `argv` MUST be a YAML list, not a string. `"ruff check src/"` is rejected.\n'
             "- Only safelisted argv shapes run: `python -m py_compile <file>`, `python -m mypy <args>`, "
             "`node --check <file>`, `ruff check <args>`, `tsc --noEmit`, `eslint <args>`, `pyflakes <file>`. "
             "Anything else (notably `python -c`, `python -m pip`, shell strings) errors at evaluation time — "
             "treat the safelist as the universe.\n"
             "- Per-command timeout is bounded; do not author long-running builds as acceptance checks.\n\n"
-            "**When in doubt, prefer typed checks over prose.** Prose like \"User model exists\" "
+            '**When in doubt, prefer typed checks over prose.** Prose like "User model exists" '
             "is a good candidate to typed-encode as `field_present` against the actual class.\n"
         )
 
@@ -592,6 +595,12 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
             f"{builder_guideline}"
             f"{qa_handoff_guideline}"
             f"{typed_acceptance_section}"
+            "\n"
+            # Issue #112 (real fix): wires the shared PRD-coverage discipline
+            # into the framing-time prompt that actually produces the
+            # implementation_plan.yaml. Same source-of-truth string as
+            # cycle_tasks.py:_MANIFEST_PROMPT_EXTENSION uses.
+            f"{_PRD_COVERAGE_DISCIPLINE_SECTION}"
             "\n"
             "Output ONLY the manifest as a YAML code block with filename tag:\n"
             "```yaml:implementation_plan.yaml\n"

--- a/tests/unit/capabilities/test_planning_handlers.py
+++ b/tests/unit/capabilities/test_planning_handlers.py
@@ -427,6 +427,128 @@ class TestLLMCallVerification:
 
 
 # ---------------------------------------------------------------------------
+# Issue #112 (real fix): PRD-coverage discipline must be wired into the
+# framing-time manifest prompt — the LLM call inside _produce_manifest,
+# which is the actual prompt that produces implementation_plan.yaml.
+# Cycle 5 (cyc_7febd710e565) proved that patching only
+# cycle_tasks.py:_MANIFEST_PROMPT_EXTENSION leaves this prompt untouched.
+# ---------------------------------------------------------------------------
+
+
+class TestPRDCoverageDisciplineReachesManifestPrompt:
+    _MANIFEST_BLOCK = (
+        "```yaml:implementation_plan.yaml\n"
+        "version: 1\n"
+        "project_id: test\n"
+        "cycle_id: cyc_test\n"
+        "prd_hash: abc\n"
+        "tasks:\n"
+        "  - task_index: 0\n"
+        "    task_type: development.develop\n"
+        "    role: dev\n"
+        '    focus: "f"\n'
+        '    description: "d"\n'
+        '    expected_artifacts: ["x.py"]\n'
+        "    acceptance_criteria: []\n"
+        "    depends_on: []\n"
+        "  - task_index: 1\n"
+        "    task_type: development.develop\n"
+        "    role: dev\n"
+        '    focus: "f"\n'
+        '    description: "d"\n'
+        '    expected_artifacts: ["y.py"]\n'
+        "    acceptance_criteria: []\n"
+        "    depends_on: [0]\n"
+        "  - task_index: 2\n"
+        "    task_type: qa.test\n"
+        "    role: qa\n"
+        '    focus: "f"\n'
+        '    description: "d"\n'
+        '    expected_artifacts: ["z.py"]\n'
+        "    acceptance_criteria: []\n"
+        "    depends_on: [0, 1]\n"
+        "summary:\n"
+        "  total_dev_tasks: 2\n"
+        "  total_qa_tasks: 1\n"
+        "  total_tasks: 3\n"
+        "  estimated_layers: [a]\n"
+        "```\n"
+    )
+
+    def test_planning_tasks_imports_shared_constant(self):
+        """Defense against a future refactor that drops the import."""
+        from squadops.capabilities.handlers import planning_tasks
+
+        assert hasattr(planning_tasks, "_PRD_COVERAGE_DISCIPLINE_SECTION"), (
+            "planning_tasks must import _PRD_COVERAGE_DISCIPLINE_SECTION — without "
+            "it the framing-time manifest prompt loses PRD-coverage discipline and "
+            "regresses to the cycle-5 defect (cyc_7febd710e565)"
+        )
+
+    async def test_manifest_prompt_includes_coverage_discipline(self):
+        """End-to-end: when GovernanceAssessReadinessHandler runs with
+        implementation_plan enabled, the SECOND LLM call (the manifest
+        producer) must include the discipline text. The first call
+        (planning artifact) does not."""
+        ctx = _make_context()
+        # Two responses: first is planning artifact, second is the manifest.
+        ctx.ports.llm.chat_stream_with_usage.side_effect = [
+            MagicMock(content=VALID_PLANNING_ARTIFACT),
+            MagicMock(content=self._MANIFEST_BLOCK),
+        ]
+
+        h = GovernanceAssessReadinessHandler()
+        await h.handle(
+            ctx,
+            {
+                "prd": "Build app. qa_handoff.md must contain ## Expected Behavior.",
+                "resolved_config": {"implementation_plan": True},
+                "profile_roles": ["lead", "dev", "qa"],
+            },
+        )
+
+        calls = ctx.ports.llm.chat_stream_with_usage.call_args_list
+        assert len(calls) == 2, f"expected 2 LLM calls, got {len(calls)}"
+
+        # First call = planning artifact prompt; should NOT mention coverage discipline
+        first_user = calls[0][0][0][1].content
+        assert "PRD Coverage Discipline" not in first_user
+
+        # Second call = manifest prompt; MUST mention coverage discipline
+        second_user = calls[1][0][0][1].content
+        assert "PRD Coverage Discipline" in second_user, (
+            "manifest prompt missing PRD coverage discipline — issue #112 regression"
+        )
+        # And the worked example case the discipline cites — pinning the
+        # specific defect class so a future prompt rewrite that strips
+        # the qa_handoff example fails loudly.
+        assert "## Expected Behavior" in second_user
+        assert "qa_handoff.md" in second_user
+
+    async def test_manifest_prompt_omits_discipline_when_implementation_plan_disabled(self):
+        """Defensive: when implementation_plan is off, _produce_manifest
+        is not called — only one LLM call (planning artifact), and the
+        discipline text shouldn't appear (it would be misleading without
+        a manifest to author)."""
+        ctx = _make_context(llm_response=VALID_PLANNING_ARTIFACT)
+
+        h = GovernanceAssessReadinessHandler()
+        await h.handle(
+            ctx,
+            {
+                "prd": "Build app",
+                "resolved_config": {"implementation_plan": False},
+                "profile_roles": ["lead", "dev", "qa"],
+            },
+        )
+
+        calls = ctx.ports.llm.chat_stream_with_usage.call_args_list
+        assert len(calls) == 1
+        user_msg = calls[0][0][0][1].content
+        assert "PRD Coverage Discipline" not in user_msg
+
+
+# ---------------------------------------------------------------------------
 # 8. GovernanceIncorporateFeedbackHandler — custom prompt and dual artifacts
 # ---------------------------------------------------------------------------
 
@@ -861,13 +983,9 @@ class TestProduceManifestRetry:
     async def test_builder_guidance_added_when_builder_role_present(self):
         """When profile includes builder, prompt directs Max to use builder.assemble."""
         ctx = _make_context(_VALID_MANIFEST_YAML)
-        await self._call_produce(
-            ctx, profile_roles=["dev", "qa", "lead", "builder"]
-        )
+        await self._call_produce(ctx, profile_roles=["dev", "qa", "lead", "builder"])
 
-        user_prompt = ctx.ports.llm.chat_stream_with_usage.await_args_list[0].args[0][
-            1
-        ].content
+        user_prompt = ctx.ports.llm.chat_stream_with_usage.await_args_list[0].args[0][1].content
         assert "`builder.assemble`" in user_prompt
         assert "AFTER all `development.develop`" in user_prompt
         assert "BEFORE any `qa.test`" in user_prompt
@@ -885,9 +1003,7 @@ class TestProduceManifestRetry:
         ctx = _make_context(_VALID_MANIFEST_YAML)
         await self._call_produce(ctx, profile_roles=["dev", "qa", "lead"])
 
-        user_prompt = ctx.ports.llm.chat_stream_with_usage.await_args_list[0].args[0][
-            1
-        ].content
+        user_prompt = ctx.ports.llm.chat_stream_with_usage.await_args_list[0].args[0][1].content
         assert "task_type: builder.assemble" not in user_prompt
         assert "total_builder_tasks" not in user_prompt
         assert "total_tasks: N+M" in user_prompt


### PR DESCRIPTION
## Summary

PR #113 patched the wrong handler. Cycle 5 (`cyc_7febd710e565`) proved it: the framing flow's `implementation_plan.yaml` reproduced the exact qa_handoff acceptance-coverage defect class. This PR puts the prompt change in the prompt path the framing flow actually invokes.

Reopens #112.

## Root cause of the miss

Two manifest-producing prompt paths exist in this codebase:

| Path | File | When invoked |
|---|---|---|
| `GovernanceReviewHandler._MANIFEST_PROMPT_EXTENSION` | `cycle_tasks.py:610` | `governance.review` task — not used by current framing |
| `GovernanceReviewAssessReadinessHandler._produce_manifest` (`manifest_prompt`) | `planning_tasks.py:573` | `governance.assess_readiness` task — **what the framing flow actually runs** |

PR #113 patched the first. The framing uses the second. My audit caught tautological-test concerns but missed the bigger structural issue.

## What this PR does

- **Extracted** the PRD-coverage discipline section to a module-level constant `_PRD_COVERAGE_DISCIPLINE_SECTION` in `cycle_tasks.py` — single source of truth.
- **Wired** it into `planning_tasks.py:manifest_prompt` (the prompt the framing LLM actually sees) by importing and inserting it between `typed_acceptance_section` and the schema output.
- **Kept** the `cycle_tasks.py` reference (defense-in-depth — any present-or-future caller of `GovernanceReviewHandler` still gets the discipline).
- **Added 3 behavioral tests** that exercise `GovernanceAssessReadinessHandler.handle()` with a mocked LLM and assert the discipline text lands in the SECOND LLM call (the manifest producer). This is the regression guard the original PR lacked.

## Test plan

- [x] `pytest tests/unit/capabilities/test_planning_handlers.py::TestPRDCoverageDisciplineReachesManifestPrompt -v` — 3/3 pass
- [x] `pytest tests/unit/capabilities/test_planning_handlers.py tests/unit/capabilities/handlers/test_governance_review_plan.py` — 201 pass (16 existing on the constant + 3 new behavioral + the rest of the planning_handlers suite)
- [x] `./scripts/dev/run_regression_tests.sh` — 3687 pass, 1 skipped (+3 new vs main)
- [x] `ruff check` / `ruff format` — clean (3 pre-existing C901 complexity warnings on unrelated handle methods, unchanged)
- [ ] **Verification cycle on `group_run` validation profile** (post-merge, after rebuild): confirm task 6's qa_handoff acceptance_criteria now includes typed checks for `## Expected Behavior` (and any other PRD-mandated sections), AND the cycle-5 defect class doesn't recur

Per `feedback_rebuild_before_sip_test`: rebuild agent + runtime-api images before verification.

## Lesson recorded

Audit miss documented in commit message. For prompt-mediated fixes, tests targeting prompt SOURCE (constant) must be paired with tests exercising prompt USE (LLM call) — otherwise the test passes against a code path the cycle doesn't take. Same pattern likely applies to other prompt-engineering fixes; will watch for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)