### PR TITLE
refactor(SIP-0092): align code names with the SIP-0092 plan vocabulary (M2.1 prep)

### DIFF
--- a/src/squadops/bootstrap/handlers.py
+++ b/src/squadops/bootstrap/handlers.py
@@ -52,8 +52,8 @@ from squadops.capabilities.handlers.impl.repair_handlers import (
 from squadops.capabilities.handlers.planning_tasks import (
     DataResearchContextHandler,
     DevelopmentDesignPlanHandler,
-    GovernanceAssessReadinessHandler,
     GovernanceIncorporateFeedbackHandler,
+    GovernanceReviewPlanHandler,
     QADefineTestStrategyHandler,
     QAValidateRefinementHandler,
     StrategyFrameObjectiveHandler,
@@ -136,7 +136,7 @@ HANDLER_CONFIGS: list[tuple[type[CapabilityHandler], tuple[str, ...]]] = [
     (StrategyFrameObjectiveHandler, ("strat",)),
     (DevelopmentDesignPlanHandler, ("dev",)),
     (QADefineTestStrategyHandler, ("qa",)),
-    (GovernanceAssessReadinessHandler, ("lead",)),
+    (GovernanceReviewPlanHandler, ("lead",)),
     # Refinement handlers (SIP-0078: Planning Workload Protocol)
     (GovernanceIncorporateFeedbackHandler, ("lead",)),
     (QAValidateRefinementHandler, ("qa",)),

--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -125,7 +125,7 @@ def _estimate_min_artifacts(prd: str, impl_plan: str | None = None) -> int:
 # author on PRD-coverage discipline. Lives at module scope so BOTH
 # manifest-producing prompts use the same source-of-truth text:
 #   - GovernanceReviewHandler._MANIFEST_PROMPT_EXTENSION (this file)
-#   - GovernanceReviewAssessReadinessHandler._produce_manifest in
+#   - GovernanceReviewAssessReadinessHandler._produce_plan in
 #     planning_tasks.py — the one the framing flow actually invokes
 # Keeping the original PR #113 patch in cycle_tasks.py while ALSO wiring
 # planning_tasks.py is defense-in-depth: any present-or-future caller of

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -1,7 +1,7 @@
 """Framing task handlers — LLM-powered handlers for the framing workload pipeline.
 
 5 framing handlers and 2 refinement handlers whose capability_ids match
-the pinned task_type values from FRAMING_TASK_STEPS and REFINEMENT_TASK_STEPS
+the pinned task_type values from PLANNING_TASK_STEPS and REFINEMENT_TASK_STEPS
 (SIP-0078 §5.3, §5.10). The module filename remains ``planning_tasks.py`` as
 a legacy identifier; imports across the codebase pin to that name.
 
@@ -331,7 +331,7 @@ class QADefineTestStrategyHandler(_PlanningTaskHandler):
     _artifact_name = "test_strategy.md"
 
 
-class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
+class GovernanceReviewPlanHandler(_PlanningTaskHandler):
     """Planning handler: consolidate outputs, design sufficiency check, readiness.
 
     Produces the canonical ``planning_artifact.md`` — a reconstituted document
@@ -345,7 +345,7 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
     """
 
     _handler_name = "governance_assess_readiness_handler"
-    _capability_id = "governance.assess_readiness"
+    _capability_id = "governance.review_plan"
     _role = "lead"
     _artifact_name = "planning_artifact.md"
 
@@ -425,15 +425,13 @@ class GovernanceAssessReadinessHandler(_PlanningTaskHandler):
         # The plan decomposes the upcoming build into focused subtasks.
         resolved_config = inputs.get("resolved_config", {})
         if resolved_config.get("implementation_plan", False):
-            manifest_artifact = await self._produce_manifest(
-                context, inputs, content, resolved_config
-            )
+            manifest_artifact = await self._produce_plan(context, inputs, content, resolved_config)
             if manifest_artifact is not None:
                 result.outputs["artifacts"].append(manifest_artifact)
 
         return result
 
-    async def _produce_manifest(
+    async def _produce_plan(
         self,
         context: ExecutionContext,
         inputs: dict[str, Any],

--- a/src/squadops/contracts/cycle_request_profiles/profiles/framing.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/framing.yaml
@@ -8,7 +8,7 @@ defaults:
       - name: progress_plan_review
         description: "Review planning artifact before implementation"
         after_task_types:
-          - governance.assess_readiness
+          - governance.review_plan
   expected_artifact_types:
     - document
   workload_sequence:

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -56,12 +56,12 @@ BUILDER_ASSEMBLY_TASK_STEPS: list[tuple[str, str]] = [
 ]
 
 # Framing task steps (SIP-0078 §5.3) — the pre-build sequence run during a framing workload
-FRAMING_TASK_STEPS: list[tuple[str, str]] = [
+PLANNING_TASK_STEPS: list[tuple[str, str]] = [
     ("data.research_context", "data"),
     ("strategy.frame_objective", "strat"),
     ("development.design_plan", "dev"),
     ("qa.define_test_strategy", "qa"),
-    ("governance.assess_readiness", "lead"),
+    ("governance.review_plan", "lead"),
 ]
 
 # Refinement task steps (SIP-0078 §5.10)
@@ -120,6 +120,7 @@ def repair_steps_for(failed_task_type: str) -> list[tuple[str, str]]:
     type without a specialized pair.
     """
     return _REPAIR_STEPS_BY_FAILED_TASK_TYPE.get(failed_task_type, REPAIR_TASK_STEPS)
+
 
 # Wrap-up task steps (SIP-0080 §7.1)
 WRAPUP_TASK_STEPS: list[tuple[str, str]] = [
@@ -192,7 +193,7 @@ def _resolve_workload_steps(
 
     if workload_type == WorkloadType.FRAMING:
         _check_required_roles(profile.profile_id, REQUIRED_PLAN_ROLES, profile_roles)
-        steps = list(FRAMING_TASK_STEPS)
+        steps = list(PLANNING_TASK_STEPS)
     elif workload_type == WorkloadType.REFINEMENT:
         _check_required_roles(
             profile.profile_id, REQUIRED_REFINEMENT_ROLES, profile_roles, "refinement"

--- a/src/squadops/prompts/fragments/manifest.yaml
+++ b/src/squadops/prompts/fragments/manifest.yaml
@@ -85,8 +85,8 @@ fragments:
   roles:
   - qa
   sha256: 51e353106e276a8486f9f01d1755830d7ad531cc891bc6f30525e08232286d5e
-- fragment_id: task_type.governance.assess_readiness
-  path: shared/task_type/task_type.governance.assess_readiness.md
+- fragment_id: task_type.governance.review_plan
+  path: shared/task_type/task_type.governance.review_plan.md
   layer: task_type
   roles:
   - lead

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.governance.review_plan.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.governance.review_plan.md
@@ -1,5 +1,5 @@
 ---
-fragment_id: task_type.governance.assess_readiness
+fragment_id: task_type.governance.review_plan
 layer: task_type
 version: "0.9.16"
 roles: ["lead"]

--- a/tests/unit/capabilities/test_planning_handlers.py
+++ b/tests/unit/capabilities/test_planning_handlers.py
@@ -20,8 +20,8 @@ from squadops.capabilities.handlers.base import HandlerEvidence, HandlerResult
 from squadops.capabilities.handlers.planning_tasks import (
     DataResearchContextHandler,
     DevelopmentDesignPlanHandler,
-    GovernanceAssessReadinessHandler,
     GovernanceIncorporateFeedbackHandler,
+    GovernanceReviewPlanHandler,
     QADefineTestStrategyHandler,
     QAValidateRefinementHandler,
     StrategyFrameObjectiveHandler,
@@ -44,8 +44,8 @@ PLANNING_HANDLER_SPECS = [
     (DevelopmentDesignPlanHandler, "development.design_plan", "dev", "technical_design.md"),
     (QADefineTestStrategyHandler, "qa.define_test_strategy", "qa", "test_strategy.md"),
     (
-        GovernanceAssessReadinessHandler,
-        "governance.assess_readiness",
+        GovernanceReviewPlanHandler,
+        "governance.review_plan",
         "lead",
         "planning_artifact.md",
     ),
@@ -65,9 +65,9 @@ ALL_HANDLER_SPECS = PLANNING_HANDLER_SPECS + REFINEMENT_HANDLER_SPECS
 ALL_HANDLER_CLASSES = [cls for cls, _, _, _ in ALL_HANDLER_SPECS]
 
 # Handlers that work with generic "LLM planning output" and no special prior_outputs.
-# GovernanceAssessReadinessHandler requires valid YAML frontmatter in LLM response.
+# GovernanceReviewPlanHandler requires valid YAML frontmatter in LLM response.
 # GovernanceIncorporateFeedbackHandler requires artifact_contents in prior_outputs (D17).
-_SPECIAL_HANDLERS = (GovernanceAssessReadinessHandler, GovernanceIncorporateFeedbackHandler)
+_SPECIAL_HANDLERS = (GovernanceReviewPlanHandler, GovernanceIncorporateFeedbackHandler)
 GENERIC_HANDLER_SPECS = [s for s in ALL_HANDLER_SPECS if s[0] not in _SPECIAL_HANDLERS]
 GENERIC_HANDLER_CLASSES = [cls for cls, _, _, _ in GENERIC_HANDLER_SPECS]
 # Handlers where LLM is always reached (GovernanceIncorporateFeedbackHandler may
@@ -300,11 +300,9 @@ class TestHandleSuccess:
 
     @pytest.mark.parametrize(
         "cls, _cap_id, _role, expected_artifact",
-        [s for s in PLANNING_HANDLER_SPECS if s[0] != GovernanceAssessReadinessHandler],
+        [s for s in PLANNING_HANDLER_SPECS if s[0] != GovernanceReviewPlanHandler],
         ids=[
-            c.__name__
-            for c, _, _, _ in PLANNING_HANDLER_SPECS
-            if c != GovernanceAssessReadinessHandler
+            c.__name__ for c, _, _, _ in PLANNING_HANDLER_SPECS if c != GovernanceReviewPlanHandler
         ],
     )
     async def test_planning_artifact_name(
@@ -428,7 +426,7 @@ class TestLLMCallVerification:
 
 # ---------------------------------------------------------------------------
 # Issue #112 (real fix): PRD-coverage discipline must be wired into the
-# framing-time manifest prompt — the LLM call inside _produce_manifest,
+# framing-time manifest prompt — the LLM call inside _produce_plan,
 # which is the actual prompt that produces implementation_plan.yaml.
 # Cycle 5 (cyc_7febd710e565) proved that patching only
 # cycle_tasks.py:_MANIFEST_PROMPT_EXTENSION leaves this prompt untouched.
@@ -486,7 +484,7 @@ class TestPRDCoverageDisciplineReachesManifestPrompt:
         )
 
     async def test_manifest_prompt_includes_coverage_discipline(self):
-        """End-to-end: when GovernanceAssessReadinessHandler runs with
+        """End-to-end: when GovernanceReviewPlanHandler runs with
         implementation_plan enabled, the SECOND LLM call (the manifest
         producer) must include the discipline text. The first call
         (planning artifact) does not."""
@@ -497,7 +495,7 @@ class TestPRDCoverageDisciplineReachesManifestPrompt:
             MagicMock(content=self._MANIFEST_BLOCK),
         ]
 
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         await h.handle(
             ctx,
             {
@@ -526,13 +524,13 @@ class TestPRDCoverageDisciplineReachesManifestPrompt:
         assert "qa_handoff.md" in second_user
 
     async def test_manifest_prompt_omits_discipline_when_implementation_plan_disabled(self):
-        """Defensive: when implementation_plan is off, _produce_manifest
+        """Defensive: when implementation_plan is off, _produce_plan
         is not called — only one LLM call (planning artifact), and the
         discipline text shouldn't appear (it would be misleading without
         a manifest to author)."""
         ctx = _make_context(llm_response=VALID_PLANNING_ARTIFACT)
 
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         await h.handle(
             ctx,
             {
@@ -665,7 +663,7 @@ class TestBootstrapRegistration:
 
 
 # ---------------------------------------------------------------------------
-# 10. GovernanceAssessReadinessHandler — structural validation (Fix B)
+# 10. GovernanceReviewPlanHandler — structural validation (Fix B)
 # ---------------------------------------------------------------------------
 
 
@@ -674,7 +672,7 @@ class TestGovernanceAssessReadinessValidation:
 
     async def test_valid_frontmatter_passes(self):
         ctx = _make_context(VALID_PLANNING_ARTIFACT)
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
         assert result.success is True
@@ -682,7 +680,7 @@ class TestGovernanceAssessReadinessValidation:
 
     async def test_missing_frontmatter_synthesizes_default(self):
         ctx = _make_context("No frontmatter here, just plain text.")
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
         assert result.success is True
@@ -692,7 +690,7 @@ class TestGovernanceAssessReadinessValidation:
 
     async def test_invalid_yaml_fails(self):
         ctx = _make_context("---\n[invalid: yaml: content\n---\n\nBody")
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
         assert result.success is False
@@ -701,7 +699,7 @@ class TestGovernanceAssessReadinessValidation:
     async def test_missing_readiness_defaults_to_revise(self):
         content = "---\nsufficiency_score: 3\nblocker_unknowns: 0\n---\n\nBody"
         ctx = _make_context(content)
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
         assert result.success is True
@@ -709,7 +707,7 @@ class TestGovernanceAssessReadinessValidation:
     async def test_invalid_readiness_value_defaults_to_revise(self):
         content = "---\nreadiness: maybe\nsufficiency_score: 3\n---\n\nBody"
         ctx = _make_context(content)
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
         assert result.success is True
@@ -717,7 +715,7 @@ class TestGovernanceAssessReadinessValidation:
     async def test_missing_sufficiency_score_defaults_to_3(self):
         content = "---\nreadiness: go\nblocker_unknowns: 0\n---\n\nBody"
         ctx = _make_context(content)
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
         assert result.success is True
@@ -725,7 +723,7 @@ class TestGovernanceAssessReadinessValidation:
     async def test_non_integer_sufficiency_score_defaults_to_3(self):
         content = "---\nreadiness: go\nsufficiency_score: high\n---\n\nBody"
         ctx = _make_context(content)
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
         assert result.success is True
@@ -733,7 +731,7 @@ class TestGovernanceAssessReadinessValidation:
     async def test_sufficiency_score_out_of_range_defaults_to_3(self):
         content = "---\nreadiness: go\nsufficiency_score: 7\n---\n\nBody"
         ctx = _make_context(content)
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
         assert result.success is True
@@ -741,7 +739,7 @@ class TestGovernanceAssessReadinessValidation:
     async def test_sufficiency_score_zero_valid(self):
         content = "---\nreadiness: no-go\nsufficiency_score: 0\n---\n\nBody"
         ctx = _make_context(content)
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
         assert result.success is True
@@ -750,23 +748,23 @@ class TestGovernanceAssessReadinessValidation:
     async def test_all_valid_readiness_values(self, readiness):
         content = f"---\nreadiness: {readiness}\nsufficiency_score: 3\n---\n\nBody"
         ctx = _make_context(content)
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
         assert result.success is True
 
     async def test_evidence_preserved_on_frontmatter_synthesis(self):
         ctx = _make_context("No frontmatter")
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
         assert result.success is True
         assert result._evidence is not None
-        assert result._evidence.capability_id == "governance.assess_readiness"
+        assert result._evidence.capability_id == "governance.review_plan"
 
 
 # ---------------------------------------------------------------------------
-# 10b. _produce_manifest retry-on-error (SIP-0086 robustness)
+# 10b. _produce_plan retry-on-error (SIP-0086 robustness)
 # ---------------------------------------------------------------------------
 
 
@@ -852,11 +850,11 @@ class TestProduceManifestRetry:
         resolved_config: dict | None = None,
         profile_roles: list[str] | None = None,
     ) -> dict | None:
-        h = GovernanceAssessReadinessHandler()
+        h = GovernanceReviewPlanHandler()
         inputs: dict = {"prd": "Build a widget"}
         if profile_roles is not None:
             inputs["profile_roles"] = profile_roles
-        return await h._produce_manifest(
+        return await h._produce_plan(
             ctx,
             inputs=inputs,
             planning_content="plan",

--- a/tests/unit/contracts/test_planning_profile.py
+++ b/tests/unit/contracts/test_planning_profile.py
@@ -39,7 +39,7 @@ class TestPlanningProfileGate:
     def test_gate_fires_after_assess_readiness(self):
         profile = load_profile("framing")
         gate = profile.defaults["task_flow_policy"]["gates"][0]
-        assert "governance.assess_readiness" in gate["after_task_types"]
+        assert "governance.review_plan" in gate["after_task_types"]
 
 
 class TestPlanningProfileWorkloadSequence:

--- a/tests/unit/cycles/test_correction_repair_prefect_propagation.py
+++ b/tests/unit/cycles/test_correction_repair_prefect_propagation.py
@@ -5,7 +5,7 @@ Prefect task_runs and emit TASK_DISPATCHED/SUCCEEDED/FAILED with both
 Without this, correction tasks (SIP-0079) and pulse-repair tasks (SIP-0086)
 have no Prefect task pane and the bridge can't transition terminal state —
 acceptance criterion §7.5 ("manifest retry events appear in
-governance.assess_readiness task pane") is unreachable.
+governance.review_plan task pane") is unreachable.
 
 These tests drive ``_run_correction_protocol`` and ``_verify_with_repair``
 directly and pin the contract by inspecting the spied call args of
@@ -166,8 +166,7 @@ class TestCorrectionTaskRunPropagation:
         assert mock_prefect_reporter.create_task_run.await_count == len(captured)
         assert all(c["flow_run_id"] == "fr_main" for c in captured)
         assert all(
-            c["task_run_id"] is not None and c["task_run_id"].startswith("tr_")
-            for c in captured
+            c["task_run_id"] is not None and c["task_run_id"].startswith("tr_") for c in captured
         )
 
         # Every TASK_DISPATCHED / TASK_SUCCEEDED / TASK_FAILED for these
@@ -317,9 +316,7 @@ class TestPulseRepairTaskRunPropagation:
                 return PulseDecision.FAIL, [
                     MagicMock(suite_outcome=SuiteOutcome.FAIL) for _ in suites
                 ]
-            return PulseDecision.PASS, [
-                MagicMock(suite_outcome=SuiteOutcome.PASS) for _ in suites
-            ]
+            return PulseDecision.PASS, [MagicMock(suite_outcome=SuiteOutcome.PASS) for _ in suites]
 
         ex._run_boundary_verification = fake_verify
 

--- a/tests/unit/cycles/test_planning_task_plan.py
+++ b/tests/unit/cycles/test_planning_task_plan.py
@@ -22,7 +22,7 @@ from squadops.cycles.task_plan import (
     BUILDER_ASSEMBLY_TASK_STEPS,
     CYCLE_TASK_STEPS,
     IMPLEMENTATION_TASK_STEPS,
-    FRAMING_TASK_STEPS,
+    PLANNING_TASK_STEPS,
     REFINEMENT_TASK_STEPS,
     generate_task_plan,
 )
@@ -130,13 +130,13 @@ class TestPlanningWorkload:
     def test_task_types_match_planning_steps(self, cycle, full_profile):
         envelopes = generate_task_plan(cycle, _run("framing"), full_profile)
         actual = [e.task_type for e in envelopes]
-        expected = [s[0] for s in FRAMING_TASK_STEPS]
+        expected = [s[0] for s in PLANNING_TASK_STEPS]
         assert actual == expected
 
     def test_roles_match_planning_steps(self, cycle, full_profile):
         envelopes = generate_task_plan(cycle, _run("framing"), full_profile)
         actual = [e.metadata["role"] for e in envelopes]
-        expected = [s[1] for s in FRAMING_TASK_STEPS]
+        expected = [s[1] for s in PLANNING_TASK_STEPS]
         assert actual == expected
 
     def test_agent_ids_resolved_from_profile(self, cycle, full_profile):
@@ -286,5 +286,5 @@ class TestLegacyBackwardCompat:
         # Should produce 5 planning steps, NOT 5 plan + 2 build
         assert len(envelopes) == 5
         actual = [e.task_type for e in envelopes]
-        expected = [s[0] for s in FRAMING_TASK_STEPS]
+        expected = [s[0] for s in PLANNING_TASK_STEPS]
         assert actual == expected

--- a/tests/unit/prompts/test_migration_validation.py
+++ b/tests/unit/prompts/test_migration_validation.py
@@ -36,8 +36,8 @@ from squadops.capabilities.handlers.impl.establish_contract import (
 from squadops.capabilities.handlers.planning_tasks import (
     DataResearchContextHandler,
     DevelopmentDesignPlanHandler,
-    GovernanceAssessReadinessHandler,
     GovernanceIncorporateFeedbackHandler,
+    GovernanceReviewPlanHandler,
     QADefineTestStrategyHandler,
     StrategyFrameObjectiveHandler,
 )
@@ -136,7 +136,7 @@ class TestBaseClassTemplateIdCoverage:
             (StrategyFrameObjectiveHandler, "request.planning_task_base"),
             (DevelopmentDesignPlanHandler, "request.planning_task_base"),
             (QADefineTestStrategyHandler, "request.planning_task_base"),
-            (GovernanceAssessReadinessHandler, "request.planning_task_base"),
+            (GovernanceReviewPlanHandler, "request.planning_task_base"),
             # _RepairTaskHandler base class handlers (4)
             (DataAnalyzeVerificationHandler, "request.repair_task_base"),
             (GovernanceRootCauseHandler, "request.repair_task_base"),
@@ -149,9 +149,7 @@ class TestBaseClassTemplateIdCoverage:
         ],
         ids=lambda x: x.__name__ if isinstance(x, type) else x,
     )
-    async def test_handler_uses_correct_template_id(
-        self, handler_cls, expected_template_id
-    ):
+    async def test_handler_uses_correct_template_id(self, handler_cls, expected_template_id):
         renderer = _mock_renderer()
         ctx = _mock_context(renderer=renderer)
         handler = handler_cls()
@@ -263,9 +261,7 @@ class TestWrapupCustomHandlerTemplateIds:
         ],
         ids=lambda x: x.__name__ if isinstance(x, type) else x,
     )
-    async def test_wrapup_custom_handler_template_id(
-        self, handler_cls, expected_template_id
-    ):
+    async def test_wrapup_custom_handler_template_id(self, handler_cls, expected_template_id):
         renderer = _mock_renderer()
         ctx = _mock_context(renderer=renderer)
         handler = handler_cls()
@@ -313,15 +309,12 @@ class TestPromptGuardPreservation:
             {
                 "prd": "Build a game",
                 "role": "strat",
-                "prior_outputs": (
-                    "## Prior Analysis from Upstream Roles\n\n### dev\ncode review"
-                ),
+                "prior_outputs": ("## Prior Analysis from Upstream Roles\n\n### dev\ncode review"),
             },
         )
 
         assert "## Prior Analysis from Upstream Roles" in rendered.content, (
-            "Rendered template must contain the exact heading that prompt_guard "
-            "uses for truncation"
+            "Rendered template must contain the exact heading that prompt_guard uses for truncation"
         )
 
     async def test_planning_task_rendered_output_has_prior_analysis_heading(self):
@@ -342,9 +335,7 @@ class TestPromptGuardPreservation:
             {
                 "prd": "Plan a game",
                 "role": "strat",
-                "prior_outputs": (
-                    "## Prior Analysis from Upstream Roles\n\n### dev\nanalysis"
-                ),
+                "prior_outputs": ("## Prior Analysis from Upstream Roles\n\n### dev\nanalysis"),
             },
         )
 
@@ -414,9 +405,7 @@ class TestCapabilitySupplementNotInTemplates:
 class TestTemplateContractCompleteness:
     """Every template must declare its contract in frontmatter."""
 
-    _FRONTMATTER_PATTERN = re.compile(
-        r"^---\s*\n(.*?)\n---\s*\n", re.MULTILINE | re.DOTALL
-    )
+    _FRONTMATTER_PATTERN = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.MULTILINE | re.DOTALL)
 
     @pytest.mark.parametrize(
         "template_file",

--- a/tests/unit/prompts/test_planning_fragments.py
+++ b/tests/unit/prompts/test_planning_fragments.py
@@ -46,8 +46,8 @@ PLANNING_FRAGMENTS = [
         "roles": ["qa"],
     },
     {
-        "fragment_id": "task_type.governance.assess_readiness",
-        "path": "shared/task_type/task_type.governance.assess_readiness.md",
+        "fragment_id": "task_type.governance.review_plan",
+        "path": "shared/task_type/task_type.governance.review_plan.md",
         "layer": "task_type",
         "roles": ["lead"],
     },
@@ -73,7 +73,7 @@ def _load_fragment(rel_path: str) -> tuple[dict, str]:
     m = HEADER_PATTERN.match(raw)
     assert m, f"No YAML frontmatter in {rel_path}"
     header = yaml.safe_load(m.group(1))
-    content = raw[m.end():].strip()
+    content = raw[m.end() :].strip()
     return header, content
 
 
@@ -132,9 +132,9 @@ class TestPlanningFragmentsManifest:
     def test_manifest_entry_exists(self, spec):
         manifest = _load_manifest()
         entries = [
-            f for f in manifest["fragments"]
-            if f["fragment_id"] == spec["fragment_id"]
-            and f["path"] == spec["path"]
+            f
+            for f in manifest["fragments"]
+            if f["fragment_id"] == spec["fragment_id"] and f["path"] == spec["path"]
         ]
         assert len(entries) == 1, (
             f"Expected exactly 1 manifest entry for {spec['fragment_id']}, found {len(entries)}"
@@ -152,9 +152,9 @@ class TestPlanningFragmentsManifest:
 
         manifest = _load_manifest()
         entry = next(
-            f for f in manifest["fragments"]
-            if f["fragment_id"] == spec["fragment_id"]
-            and f["path"] == spec["path"]
+            f
+            for f in manifest["fragments"]
+            if f["fragment_id"] == spec["fragment_id"] and f["path"] == spec["path"]
         )
         assert actual_hash == entry["sha256"], (
             f"Hash mismatch for {spec['fragment_id']}: "


### PR DESCRIPTION
## Summary

Carries out the renames the SIP-0092 plan committed to in Rev 3 but were never actually applied to code:

| Old (still in code on main) | New (already in SIP-0092 plan doc) |
|---|---|
| `governance.assess_readiness` (capability ID) | `governance.review_plan` |
| `GovernanceAssessReadinessHandler` (class) | `GovernanceReviewPlanHandler` |
| `_produce_manifest` (function) | `_produce_plan` |
| `FRAMING_TASK_STEPS` (constant) | `PLANNING_TASK_STEPS` |
| `task_type.governance.assess_readiness.md` (fragment) | `task_type.governance.review_plan.md` |

## Why now

The plan-doc/code drift caused real damage during M1 hardening: PR #113's issue body referenced `governance.review_plan` based on the plan doc and patched `cycle_tasks.py:GovernanceReviewHandler` instead of the framing handler — wrong handler entirely. Cycle 5 caught it; PR #116 fixed it with another PR. **This rename removes the same trap from M2.1's surface** so the M2.1 implementer sees plan and code agreeing.

Per PR #117 (gate eval doc proceeding to M2), M2.1 starts after this lands.

## What this is and isn't

**Is**: pure string-substitution rename across code, prompt fragments, profile config, and tests. No semantic changes.

**Is not**:
- Not a migration. The capability_id flows through `task_type` fields in postgres TaskRun records, but those are read-only history of completed runs — nothing routes off historical task_type values, so old records keep their strings without breaking anything.
- Not a behavior change. Same handlers, same dispatch, same flow — just renamed identifiers.
- Not changing M2's design. M2.1 still has the same split structure described in the SIP-0092 plan.

## Test plan

- [x] `./scripts/dev/run_regression_tests.sh` — 3687 pass, 1 skipped (identical to pre-rename count)
- [x] `ruff check` / `ruff format` — clean on changed files (2 pre-existing C901 complexity warnings on unrelated `handle` methods, unchanged)
- [ ] **Rebuild + smoke test** before merge — capability_id changes need fresh agent images (`./scripts/dev/ops/rebuild_and_deploy.sh all`); a quick smoke cycle confirms the rename didn't break dispatch end-to-end
- [ ] **Don't merge while a cycle is in flight** — in-flight envelopes carrying `task_type: governance.assess_readiness` would not match the renamed handler; safe to merge with no active cycles (cycle 6 completed, cycle 7 not yet kicked off)

## Files touched

- `src/squadops/bootstrap/handlers.py`
- `src/squadops/capabilities/handlers/cycle_tasks.py`
- `src/squadops/capabilities/handlers/planning_tasks.py`
- `src/squadops/cycles/task_plan.py`
- `src/squadops/contracts/cycle_request_profiles/profiles/framing.yaml`
- `src/squadops/prompts/fragments/manifest.yaml`
- `src/squadops/prompts/fragments/shared/task_type/task_type.governance.review_plan.md` (renamed from `task_type.governance.assess_readiness.md`)
- 6 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)