### PR TITLE
fix(repair): plumb failed-task contract into correction-loop repair envelope

### DIFF
--- a/adapters/cycles/distributed_flow_executor.py
+++ b/adapters/cycles/distributed_flow_executor.py
@@ -2268,14 +2268,26 @@ class DistributedFlowExecutor(FlowExecutionPort):
                 repair_task_id = f"repair-{run_id[:12]}-{correction_attempts:02d}-{task_type}"
                 agent_id, agent_model, agent_overrides = self._resolve_agent_config(role, profile)
 
+                # Plumb the failed task's contract through to the repair
+                # envelope. Without this the repair handler only sees the
+                # PRD + failure evidence and produces a generic "repair_output.md"
+                # rather than re-emitting the named artifact (e.g. qa_handoff.md)
+                # that originally failed acceptance.
+                failed_inputs = envelope.inputs or {}
                 repair_inputs: dict[str, Any] = {
                     "prd": cycle.prd_ref,
+                    "failed_task_type": envelope.task_type,
                     "failure_evidence": failure_evidence,
+                    "failure_analysis": analysis_outputs,
                     "correction_decision": decision_outputs,
                     "prior_outputs": prior_outputs,
                     "artifact_refs": list(all_artifact_refs),
                     "agent_model": agent_model,
                     "agent_config_overrides": agent_overrides,
+                    "subtask_focus": failed_inputs.get("subtask_focus"),
+                    "subtask_description": failed_inputs.get("subtask_description"),
+                    "expected_artifacts": failed_inputs.get("expected_artifacts", []),
+                    "acceptance_criteria": failed_inputs.get("acceptance_criteria", []),
                 }
 
                 repair_envelope = TaskEnvelope(

--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -282,8 +282,16 @@ class _CycleTaskHandler(CapabilityHandler):
         self,
         prd: str,
         prior_outputs: dict[str, Any] | None,
+        inputs: dict[str, Any] | None = None,
     ) -> str:
-        """Assemble user prompt from PRD and upstream handler outputs."""
+        """Assemble user prompt from PRD and upstream handler outputs.
+
+        ``inputs`` is the full task inputs dict; the default implementation
+        ignores it but subclasses (notably the correction-loop repair
+        handlers) consume it to surface failure context, expected
+        artifacts, and acceptance criteria that aren't reachable from
+        ``prd`` or ``prior_outputs`` alone.
+        """
         parts = [f"## Product Requirements Document\n\n{prd}"]
         if prior_outputs:
             parts.append("\n\n## Prior Analysis from Upstream Roles\n")
@@ -507,7 +515,7 @@ class _CycleTaskHandler(CapabilityHandler):
             rendered = await renderer.render(self._request_template_id, variables)
             user_prompt = rendered.content
         else:
-            user_prompt = self._build_user_prompt(prd, prior_outputs)
+            user_prompt = self._build_user_prompt(prd, prior_outputs, inputs)
 
         assembled = context.ports.prompt_service.get_system_prompt(self._role)
         system_prompt = assembled.content

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -56,7 +56,151 @@ def _artifacts_from_fenced_blocks(content: str, fallback_name: str) -> list[dict
     return artifacts
 
 
-class DevelopmentCorrectionRepairHandler(_CycleTaskHandler):
+def _format_bullets(items: Any) -> str:
+    """Format list-of-strings inputs as a markdown bullet list, "(none)" if empty."""
+    if not items:
+        return "(none specified)"
+    if isinstance(items, str):
+        return items
+    try:
+        rendered = "\n".join(
+            f"- `{item}`" if "/" in str(item) or "." in str(item) else f"- {item}" for item in items
+        )
+        return rendered or "(none specified)"
+    except TypeError:
+        return str(items)
+
+
+def _format_failure_summary(failure_evidence: Any, failure_analysis: Any) -> str:
+    """Compose a compact failure description from evidence + analysis."""
+    parts: list[str] = []
+    if isinstance(failure_evidence, dict):
+        vr = failure_evidence.get("validation_result") or {}
+        summary = vr.get("summary") or failure_evidence.get("error") or ""
+        if summary:
+            parts.append(f"Validation summary: {summary}")
+        missing = vr.get("missing_components") or []
+        if missing:
+            parts.append("Missing components: " + ", ".join(str(m) for m in missing))
+        rejected = failure_evidence.get("rejected_artifacts") or []
+        if rejected:
+            names = ", ".join(str(r.get("name", "?")) for r in rejected)
+            parts.append(f"Rejected artifacts: {names}")
+    if isinstance(failure_analysis, dict):
+        analysis = failure_analysis.get("analysis_summary")
+        if analysis:
+            parts.append(f"Analyzer summary: {analysis}")
+        factors = failure_analysis.get("contributing_factors") or []
+        if factors:
+            parts.append("Contributing factors:\n" + "\n".join(f"- {f}" for f in factors))
+    return "\n\n".join(parts) if parts else "(no structured failure evidence available)"
+
+
+def _format_correction_decision(correction_decision: Any) -> str:
+    """Render the lead's correction decision rationale for the prompt."""
+    if isinstance(correction_decision, dict):
+        rationale = correction_decision.get("decision_rationale") or ""
+        path = correction_decision.get("correction_path") or ""
+        if rationale:
+            return f"Path: {path}\n\n{rationale}" if path else rationale
+        return str(correction_decision)
+    return str(correction_decision or "(no decision available)")
+
+
+class _RepairPromptMixin:
+    """Shared prompt-building for correction-loop repair handlers.
+
+    The base `_CycleTaskHandler` user prompt is PRD + prior_outputs only —
+    the repair handler never sees the failed task's expected_artifacts /
+    acceptance_criteria, so Bob/Neo emit generic content instead of
+    re-producing the named artifact that failed acceptance. This mixin
+    surfaces the failed task's contract and the failure context to the
+    LLM. Used by all three repair handlers below.
+    """
+
+    _request_template_id = "request.cycle_repair_task"
+
+    def _build_render_variables(
+        self,
+        prd: str,
+        prior_outputs: dict[str, Any] | None,
+        inputs: dict[str, Any],
+    ) -> dict[str, str]:
+        return {
+            "prd": prd,
+            "role": self._role,
+            "failed_task_type": str(inputs.get("failed_task_type", "")),
+            "failure_summary": _format_failure_summary(
+                inputs.get("failure_evidence"),
+                inputs.get("failure_analysis"),
+            ),
+            "correction_decision": _format_correction_decision(inputs.get("correction_decision")),
+            "subtask_focus": str(inputs.get("subtask_focus") or ""),
+            "subtask_description": str(inputs.get("subtask_description") or ""),
+            "expected_artifacts": _format_bullets(inputs.get("expected_artifacts")),
+            "acceptance_criteria": _format_bullets(inputs.get("acceptance_criteria")),
+            "prior_outputs": self._format_prior_outputs(prior_outputs),
+        }
+
+    def _build_user_prompt(
+        self,
+        prd: str,
+        prior_outputs: dict[str, Any] | None,
+        inputs: dict[str, Any] | None = None,
+    ) -> str:
+        inputs = inputs or {}
+        parts = ["## Repair Task"]
+        failed_type = inputs.get("failed_task_type")
+        if failed_type:
+            parts.append(
+                f"You are repairing a failed `{failed_type}` task. Re-produce the "
+                "named artifact(s) below so they satisfy the acceptance criteria. "
+                "Do not produce a generic narrative."
+            )
+
+        focus = inputs.get("subtask_focus")
+        if focus:
+            parts.append(f"### Focus\n{focus}")
+        desc = inputs.get("subtask_description")
+        if desc:
+            parts.append(f"### Description\n{desc}")
+
+        expected = inputs.get("expected_artifacts")
+        if expected:
+            parts.append(
+                "### Required Output Artifacts\n"
+                "Emit each file with a fenced code block in the format "
+                "` ```language:path/to/file `:\n" + _format_bullets(expected)
+            )
+
+        criteria = inputs.get("acceptance_criteria")
+        if criteria:
+            parts.append("### Acceptance Criteria\n" + _format_bullets(criteria))
+
+        failure_summary = _format_failure_summary(
+            inputs.get("failure_evidence"),
+            inputs.get("failure_analysis"),
+        )
+        parts.append("### Why the Prior Attempt Failed\n" + failure_summary)
+
+        decision = _format_correction_decision(inputs.get("correction_decision"))
+        parts.append("### Correction Decision\n" + decision)
+
+        parts.append(f"### Product Requirements Document\n\n{prd}")
+
+        if prior_outputs:
+            parts.append("### Prior Analysis from Upstream Roles")
+            for role, summary in prior_outputs.items():
+                parts.append(f"#### {role}\n{summary}")
+
+        parts.append(
+            "Produce the named artifacts now using fenced code blocks "
+            "(` ```language:path/to/file `). Do not emit unrelated files."
+        )
+        return "\n\n".join(parts)
+
+
+class DevelopmentCorrectionRepairHandler(_RepairPromptMixin, _CycleTaskHandler):
     """Correction-loop repair handler.
 
     Reads `failure_evidence`, `failure_analysis`, and `correction_decision`
@@ -75,7 +219,7 @@ class DevelopmentCorrectionRepairHandler(_CycleTaskHandler):
         return _artifacts_from_fenced_blocks(content, self._artifact_name)
 
 
-class BuilderAssembleRepairHandler(_CycleTaskHandler):
+class BuilderAssembleRepairHandler(_RepairPromptMixin, _CycleTaskHandler):
     """Correction-loop repair handler for failed builder.assemble tasks.
 
     Mirrors `DevelopmentCorrectionRepairHandler` but routed to the builder
@@ -96,9 +240,104 @@ class BuilderAssembleRepairHandler(_CycleTaskHandler):
 
 
 class QAValidateRepairHandler(_CycleTaskHandler):
-    """Validate repair handler: verifies the repair was successful."""
+    """Validate repair handler: verifies the repair was successful.
+
+    Receives the original failed task's contract (expected_artifacts,
+    acceptance_criteria) plus the upstream repair handler's outputs via
+    `prior_outputs`, and produces a structured PASS/FAIL `repair_validation.md`
+    against those criteria — not a fresh QA strategy document.
+    """
 
     _handler_name = "qa_validate_repair_handler"
     _capability_id = "qa.validate_repair"
     _role = "qa"
     _artifact_name = "repair_validation.md"
+    _request_template_id = "request.cycle_validate_repair"
+
+    @staticmethod
+    def _format_repair_summary(prior_outputs: dict[str, Any] | None) -> str:
+        """Pull the upstream repair handler's outputs out of prior_outputs.
+
+        The executor stores the repair task's outputs under its role key
+        (e.g. `prior_outputs["builder"]` for builder.assemble_repair).
+        Surface those so Eve checks the repair, not the original failed
+        attempt.
+        """
+        if not prior_outputs:
+            return "(no repair output available)"
+        repair_keys = [k for k in ("dev", "builder") if k in prior_outputs]
+        if not repair_keys:
+            return "(no repair output from dev or builder role)"
+        parts: list[str] = []
+        for key in repair_keys:
+            block = prior_outputs[key]
+            summary = block.get("summary") if isinstance(block, dict) else None
+            if summary:
+                parts.append(f"### {key} repair\n{summary}")
+            else:
+                parts.append(f"### {key} repair\n{block!r}")
+        return "\n\n".join(parts)
+
+    def _build_render_variables(
+        self,
+        prd: str,
+        prior_outputs: dict[str, Any] | None,
+        inputs: dict[str, Any],
+    ) -> dict[str, str]:
+        return {
+            "prd": prd,
+            "role": self._role,
+            "failed_task_type": str(inputs.get("failed_task_type", "")),
+            "expected_artifacts": _format_bullets(inputs.get("expected_artifacts")),
+            "acceptance_criteria": _format_bullets(inputs.get("acceptance_criteria")),
+            "failure_summary": _format_failure_summary(
+                inputs.get("failure_evidence"),
+                inputs.get("failure_analysis"),
+            ),
+            "repair_summary": self._format_repair_summary(prior_outputs),
+            "prior_outputs": self._format_prior_outputs(prior_outputs),
+        }
+
+    def _build_user_prompt(
+        self,
+        prd: str,
+        prior_outputs: dict[str, Any] | None,
+        inputs: dict[str, Any] | None = None,
+    ) -> str:
+        inputs = inputs or {}
+        parts = [
+            "## Validate Repair",
+            "Decide whether the repair output satisfies the original acceptance "
+            "criteria. Do NOT write a fresh QA strategy. Answer the specific "
+            "question: was the failure fixed?",
+        ]
+
+        failed_type = inputs.get("failed_task_type")
+        if failed_type:
+            parts.append(f"### Failed Task Type\n`{failed_type}`")
+
+        expected = inputs.get("expected_artifacts")
+        if expected:
+            parts.append("### Original Required Artifacts\n" + _format_bullets(expected))
+
+        criteria = inputs.get("acceptance_criteria")
+        if criteria:
+            parts.append("### Original Acceptance Criteria\n" + _format_bullets(criteria))
+
+        failure_summary = _format_failure_summary(
+            inputs.get("failure_evidence"),
+            inputs.get("failure_analysis"),
+        )
+        parts.append("### Original Failure\n" + failure_summary)
+
+        parts.append("### Repair Output\n" + self._format_repair_summary(prior_outputs))
+
+        parts.append(f"### Product Requirements Document\n\n{prd}")
+
+        parts.append(
+            "Produce a `repair_validation.md` with sections: Verdict (PASS|FAIL), "
+            "Per-Artifact Findings, Per-Criterion Findings, Recommendation. "
+            "Be concrete. Cite the criterion and the specific content (or absence) "
+            "that satisfies or violates it."
+        )
+        return "\n\n".join(parts)

--- a/src/squadops/capabilities/handlers/repair_tasks.py
+++ b/src/squadops/capabilities/handlers/repair_tasks.py
@@ -43,6 +43,7 @@ class _RepairTaskHandler(_CycleTaskHandler):
         self,
         prd: str,
         prior_outputs: dict[str, Any] | None,
+        inputs: dict[str, Any] | None = None,
     ) -> str:
         """Assemble prompt with PRD, verification context, and upstream outputs."""
         parts = [f"## Product Requirements Document\n\n{prd}"]

--- a/src/squadops/prompts/request_templates/request.cycle_repair_task.md
+++ b/src/squadops/prompts/request_templates/request.cycle_repair_task.md
@@ -1,0 +1,57 @@
+---
+template_id: request.cycle_repair_task
+version: "1"
+required_variables:
+  - prd
+  - role
+  - failed_task_type
+  - failure_summary
+  - correction_decision
+optional_variables:
+  - subtask_focus
+  - subtask_description
+  - expected_artifacts
+  - acceptance_criteria
+  - prior_outputs
+---
+## Repair Task
+
+You are repairing a failed `{{failed_task_type}}` task. Your job is to re-produce the named output artifact(s) below so they satisfy the acceptance criteria. Do not rewrite the PRD, do not produce a status tracker, do not emit a generic narrative document.
+
+### Failed Task Contract
+
+Focus: {{subtask_focus}}
+
+{{subtask_description}}
+
+### Required Output Artifacts
+
+The repair MUST produce the following file(s) by name, using fenced code blocks in the format ` ```language:path/to/file ` so the framework can extract them:
+
+{{expected_artifacts}}
+
+### Acceptance Criteria
+
+The output must satisfy every criterion below. Each criterion was the original spec — if the prior attempt failed because a section was missing or empty, your repair must include it explicitly.
+
+{{acceptance_criteria}}
+
+### Why the Prior Attempt Failed
+
+{{failure_summary}}
+
+### Correction Decision
+
+The lead reviewed the failure and chose to patch (not rewind). Their rationale:
+
+{{correction_decision}}
+
+### Product Requirements Document
+
+{{prd}}
+
+{{prior_outputs}}
+
+---
+
+Produce the named artifacts now. Use fenced code blocks (` ```language:path/to/file `) for every file you emit. Do not include explanatory prose between code blocks unless it is essential.

--- a/src/squadops/prompts/request_templates/request.cycle_validate_repair.md
+++ b/src/squadops/prompts/request_templates/request.cycle_validate_repair.md
@@ -1,0 +1,63 @@
+---
+template_id: request.cycle_validate_repair
+version: "1"
+required_variables:
+  - prd
+  - role
+  - failed_task_type
+  - failure_summary
+optional_variables:
+  - expected_artifacts
+  - acceptance_criteria
+  - repair_summary
+  - prior_outputs
+---
+## Validate Repair
+
+You are validating the repair of a previously failed `{{failed_task_type}}` task. Your job is to decide whether the repair output satisfies the original acceptance criteria. Do not write a fresh QA strategy. Do not enumerate test cases for the whole project. Answer the specific question: was the failure fixed?
+
+### Original Required Artifacts
+
+{{expected_artifacts}}
+
+### Original Acceptance Criteria
+
+The repair must satisfy every criterion below.
+
+{{acceptance_criteria}}
+
+### Original Failure
+
+{{failure_summary}}
+
+### Repair Output
+
+{{repair_summary}}
+
+### Product Requirements Document
+
+{{prd}}
+
+{{prior_outputs}}
+
+---
+
+Produce a `repair_validation.md` document with this exact structure:
+
+```
+# Repair Validation
+
+## Verdict
+PASS or FAIL
+
+## Per-Artifact Findings
+For each required artifact: was it produced? If yes, does its content satisfy the original acceptance criteria? Cite the specific criterion and the specific content (or absence of content) that satisfies or violates it.
+
+## Per-Criterion Findings
+For each acceptance criterion: PASS or FAIL with one-line justification grounded in the repair output.
+
+## Recommendation
+If FAIL, name the specific gap that remains. If PASS, state which criteria were the close calls.
+```
+
+Be concrete. Do not produce a generic QA framework.

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -413,9 +413,7 @@ class TestRepairHandlers:
         assert result.success is True
         assert result.outputs["role"] == "qa"
 
-    async def test_dev_repair_extracts_fenced_code_into_per_file_artifacts(
-        self, mock_context
-    ):
+    async def test_dev_repair_extracts_fenced_code_into_per_file_artifacts(self, mock_context):
         # Regression: previously this whole response was wrapped as a single
         # repair_output.md document and the source files never landed.
         response = (
@@ -446,9 +444,7 @@ class TestRepairHandlers:
         # No leftover repair_output.md when extraction succeeds
         assert "repair_output.md" not in names
 
-    async def test_dev_repair_falls_back_to_markdown_when_no_fenced_blocks(
-        self, mock_context
-    ):
+    async def test_dev_repair_falls_back_to_markdown_when_no_fenced_blocks(self, mock_context):
         # Without fenced files we still preserve the LLM output instead of
         # silently dropping it — the fallback is what keeps narrative-only
         # repairs (e.g. "no code change needed, root cause was X") visible.
@@ -491,3 +487,116 @@ class TestRepairHandlers:
         assert h.capability_id == "builder.assemble_repair"
         names = [a["name"] for a in result.outputs["artifacts"]]
         assert names == ["qa_handoff.md", "backend/requirements.txt"]
+
+    async def test_repair_prompt_carries_failed_task_contract(self, mock_context):
+        """Repair handler must surface expected_artifacts + acceptance_criteria.
+
+        Without this plumbing the repair LLM sees only PRD + prior_outputs
+        and produces a generic narrative — the cyc_3d5d31717603 failure mode
+        where Bob emitted a "Joi communications status tracker" instead of
+        the qa_handoff.md the original task was specced to produce.
+        """
+        captured: dict = {}
+
+        async def _capture(messages, **_kw):
+            captured["user"] = messages[-1].content
+            return ChatMessage(role="assistant", content="```markdown:qa_handoff.md\nfixed\n```")
+
+        mock_context.ports.llm.chat_stream_with_usage = _capture
+
+        inputs = {
+            "prd": "Build a runs app",
+            "failed_task_type": "builder.assemble",
+            "subtask_focus": "QA handoff packaging",
+            "subtask_description": "Assemble the qa_handoff.md with run instructions",
+            "expected_artifacts": ["qa_handoff.md", "backend/requirements.txt"],
+            "acceptance_criteria": [
+                "qa_handoff.md must contain '## How to Test'",
+                "qa_handoff.md must contain '## Expected Behavior'",
+            ],
+            "failure_evidence": {
+                "validation_result": {
+                    "summary": "Missing required headings in qa_handoff.md",
+                    "missing_components": ["## How to Test", "## Expected Behavior"],
+                },
+                "rejected_artifacts": [{"name": "qa_handoff.md"}],
+            },
+            "failure_analysis": {
+                "analysis_summary": "Builder skipped two mandatory sections.",
+            },
+            "correction_decision": {
+                "correction_path": "patch",
+                "decision_rationale": "Append missing headings; do not rewind.",
+            },
+        }
+
+        h = BuilderAssembleRepairHandler()
+        result = await h.handle(mock_context, inputs)
+
+        assert result.success is True
+        prompt = captured["user"]
+        assert "qa_handoff.md" in prompt
+        assert "## How to Test" in prompt
+        assert "## Expected Behavior" in prompt
+        assert "Missing required headings" in prompt
+        assert "Append missing headings" in prompt
+        assert "builder.assemble" in prompt
+        assert "QA handoff packaging" in prompt
+
+    async def test_repair_prompt_works_without_failure_context(self, mock_context):
+        """Backwards compat: handler still works with bare {"prd": ...} inputs."""
+        captured: dict = {}
+
+        async def _capture(messages, **_kw):
+            captured["user"] = messages[-1].content
+            return ChatMessage(role="assistant", content="ok")
+
+        mock_context.ports.llm.chat_stream_with_usage = _capture
+
+        h = DevelopmentCorrectionRepairHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+
+        assert result.success is True
+        prompt = captured["user"]
+        assert "test" in prompt
+        assert "Repair Task" in prompt
+
+    async def test_validate_repair_prompt_carries_criteria_and_repair_output(self, mock_context):
+        """Validate-repair must check the repair against the original criteria.
+
+        Otherwise Eve emits a generic QA-strategy doc (the cyc_3d5d31717603
+        failure mode) instead of a PASS/FAIL judgement on the named artifact.
+        """
+        captured: dict = {}
+
+        async def _capture(messages, **_kw):
+            captured["user"] = messages[-1].content
+            return ChatMessage(role="assistant", content="# Repair Validation\nVerdict: PASS")
+
+        mock_context.ports.llm.chat_stream_with_usage = _capture
+
+        inputs = {
+            "prd": "Build a runs app",
+            "failed_task_type": "builder.assemble",
+            "expected_artifacts": ["qa_handoff.md"],
+            "acceptance_criteria": [
+                "qa_handoff.md must contain '## How to Test'",
+            ],
+            "failure_evidence": {
+                "validation_result": {"summary": "Missing '## How to Test'"},
+            },
+            "prior_outputs": {
+                "builder": {"summary": "Repaired qa_handoff.md with new sections"},
+            },
+        }
+
+        h = QAValidateRepairHandler()
+        result = await h.handle(mock_context, inputs)
+
+        assert result.success is True
+        prompt = captured["user"]
+        assert "qa_handoff.md" in prompt
+        assert "## How to Test" in prompt
+        assert "Repaired qa_handoff.md with new sections" in prompt
+        assert "Validate Repair" in prompt
+        assert "PASS" in prompt or "FAIL" in prompt

--- a/tests/unit/cycles/test_correction_protocol.py
+++ b/tests/unit/cycles/test_correction_protocol.py
@@ -1127,6 +1127,130 @@ class TestCorrectionModelResolution:
         assert repair["inputs"]["agent_model"] == "model-dev"
         assert repair["inputs"]["agent_config_overrides"] == {"temperature": 0.42}
 
+    async def test_repair_envelopes_carry_failed_task_contract(
+        self,
+        executor,
+        mock_queue,
+        mock_squad_profile,
+        model_diverse_profile,
+    ):
+        """Patch-path repair envelopes plumb the failed task's contract.
+
+        Cycle 7 (run_8b0805798d71) showed corrections firing but the repair
+        agents producing a generic ``repair_output.md`` instead of the
+        ``qa_handoff.md`` the original task was specced to produce. Root
+        cause: the repair envelope only carried PRD + failure_evidence,
+        not ``expected_artifacts`` or ``acceptance_criteria``. With those
+        plumbed through, downstream prompt-building can ground the LLM in
+        what to actually emit.
+        """
+        from squadops.tasks.models import TaskEnvelope
+
+        mock_squad_profile.resolve_snapshot.return_value = (
+            model_diverse_profile,
+            "sha256:diverse",
+        )
+
+        # Wrap generate_task_plan so the failed task carries a real plan
+        # contract. (The static plan generator only sets these when an
+        # ImplementationPlan is supplied — the path under test here.)
+        import adapters.cycles.distributed_flow_executor as exec_mod
+        from squadops.cycles.task_plan import generate_task_plan as real_gen
+
+        def _gen_with_contract(*args, **kwargs):
+            envelopes = real_gen(*args, **kwargs)
+            tagged = []
+            for env in envelopes:
+                # The default cycle plan uses development.design as the
+                # dev step (not development.develop, which is plan-driven).
+                if env.task_type == "development.design":
+                    new_inputs = {
+                        **env.inputs,
+                        "subtask_focus": "QA handoff packaging",
+                        "subtask_description": "Assemble qa_handoff.md",
+                        "expected_artifacts": ["qa_handoff.md", "backend/requirements.txt"],
+                        "acceptance_criteria": [
+                            "qa_handoff.md must contain '## How to Test'",
+                            "qa_handoff.md must contain '## Expected Behavior'",
+                        ],
+                    }
+                    tagged.append(
+                        TaskEnvelope(
+                            task_id=env.task_id,
+                            agent_id=env.agent_id,
+                            cycle_id=env.cycle_id,
+                            pulse_id=env.pulse_id,
+                            project_id=env.project_id,
+                            task_type=env.task_type,
+                            correlation_id=env.correlation_id,
+                            causation_id=env.causation_id,
+                            trace_id=env.trace_id,
+                            span_id=env.span_id,
+                            inputs=new_inputs,
+                            metadata=env.metadata,
+                        )
+                    )
+                else:
+                    tagged.append(env)
+            return tagged
+
+        dev_failure = {
+            "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
+            "role": "dev",
+        }
+        decision = {
+            "summary": "patch",
+            "role": "lead",
+            "correction_path": "patch",
+            "decision_rationale": "localized fix",
+            "affected_task_types": ["development.design"],
+            "classification": "work_product",
+            "analysis_summary": "Missing required headings",
+        }
+        script = [
+            ("SUCCEEDED", {"summary": "framed", "role": "strat"}, None),
+            ("FAILED", dev_failure, "missing headings"),
+            (
+                "SUCCEEDED",
+                {
+                    "classification": "work_product",
+                    "analysis_summary": "Missing '## How to Test'",
+                    "role": "data",
+                },
+                None,
+            ),
+            ("SUCCEEDED", decision, None),
+            ("SUCCEEDED", {"summary": "repaired", "role": "dev"}, None),
+            ("SUCCEEDED", {"summary": "validated", "role": "qa"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "dev"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "data"}, None),
+        ]
+        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+
+        with (
+            patch.object(exec_mod, "generate_task_plan", _gen_with_contract),
+            patch(
+                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        publishes = [_published_envelope(c) for c in mock_queue.publish.call_args_list]
+        repair = next(p for p in publishes if p["task_id"].startswith("repair-"))
+
+        inputs = repair["inputs"]
+        assert inputs["failed_task_type"] == "development.design"
+        assert inputs["expected_artifacts"] == [
+            "qa_handoff.md",
+            "backend/requirements.txt",
+        ]
+        assert any("How to Test" in c for c in inputs["acceptance_criteria"])
+        assert inputs["subtask_focus"] == "QA handoff packaging"
+        assert inputs["failure_analysis"]["analysis_summary"] == "Missing '## How to Test'"
+        assert inputs["correction_decision"]["correction_path"] == "patch"
+
     def test_resolve_agent_config_falls_back_when_role_absent(self):
         """Helper returns (role, None, {}) when profile has no enabled match.
 


### PR DESCRIPTION
## Summary

Cycle 7 (`run_8b0805798d71`) showed SIP-0086 corrections firing twice but the repair agents producing a generic `repair_output.md` instead of the `qa_handoff.md` the original task was specced to produce — the run marked `completed` while the originally-failed artifact was never emitted. Root cause: the repair envelope only carried PRD + failure_evidence, never the failed task's `expected_artifacts` or `acceptance_criteria`, and the base `_CycleTaskHandler` user prompt is PRD + prior_outputs only. So Bob/Neo got a generic "you are a builder" prompt with no reference to which file to repair or what acceptance to satisfy. PR #119 fixed *artifact persistence* — this PR fixes the upstream contract gap.

This is a targeted slice of #6 in the 1.0.x hardening plan ("Structured Defect Report & Targeted Repair") — just the repair-envelope plumbing needed to unblock the SIP-0092 M1 → M2 gate evaluation. The full `defect_report.json` schema + `qa.localize_defect` task remain for the proper #6 SIP later.

## Changes

- **Executor** (`adapters/cycles/distributed_flow_executor.py`, `_run_correction_protocol`): add `failed_task_type`, `failure_analysis`, `subtask_focus`, `subtask_description`, `expected_artifacts`, `acceptance_criteria` to the repair envelope inputs, sourced from the failed envelope's own inputs.
- **Base handler** (`src/squadops/capabilities/handlers/cycle_tasks.py`): `_build_user_prompt` and `handle()` now pass the full `inputs` dict to the prompt builder so repair handlers can override prompt building without forking `handle()`.
- **New request templates** (`src/squadops/prompts/request_templates/request.cycle_repair_task.md`, `request.cycle_validate_repair.md`): surface failure summary, original contract, and (for validate) the upstream repair output.
- **Repair handlers** (`src/squadops/capabilities/handlers/impl/repair_handlers.py`): `DevelopmentCorrectionRepairHandler` and `BuilderAssembleRepairHandler` now share a `_RepairPromptMixin` that renders an explicit prompt with required artifact list, acceptance criteria, failure summary, and correction decision rationale — and instructs the LLM to emit fenced code blocks for each named file. `QAValidateRepairHandler` consumes the original criteria + the prior repair output and is told to produce a structured PASS/FAIL judgement rather than a fresh QA strategy doc.
- **Pulse-check handler** (`src/squadops/capabilities/handlers/repair_tasks.py`): `_RepairTaskHandler._build_user_prompt` signature updated for base-class change (accepts optional `inputs`).

## Why this isn't in M1/M2/M3 of SIP-0092

SIP-0092 M3 wires the correction protocol to emit `add_task` / `tighten_acceptance` plan changes — but explicitly leaves the existing "patch" repair-handler path alone. Cycle 7 chose `correction_path: "patch"` for both failures, so M3 wouldn't have touched those flows. The repair-handler envelope is the actual bottleneck for the gate eval cohort, and fixing it doesn't require waiting on M2/M3.

## Test plan

- [x] Targeted: `pytest tests/unit/capabilities/test_impl_handlers.py tests/unit/cycles/test_correction_protocol.py tests/unit/capabilities/test_repair_handlers.py` — 54 passed
- [x] Full regression: `./scripts/dev/run_regression_tests.sh` — 3704 passed, 1 skipped
- [x] `ruff format` clean
- [x] `ruff check` no new errors (3 pre-existing C901 complexity warnings unchanged)
- [ ] Re-run a defect-driving cycle on Spark (e.g. group_run with the same PRD) and confirm `qa_handoff.md` is produced by the repair pass and reaches the registry

## New tests

- `test_repair_prompt_carries_failed_task_contract` — repair prompt includes `qa_handoff.md`, `## How to Test`, failure summary, decision rationale.
- `test_repair_prompt_works_without_failure_context` — backwards compat with bare `{"prd": ...}` inputs.
- `test_validate_repair_prompt_carries_criteria_and_repair_output` — Eve's prompt cites original criteria + the repair output.
- `test_repair_envelopes_carry_failed_task_contract` — executor plumbs `expected_artifacts`, `acceptance_criteria`, `subtask_focus`, `failure_analysis`, `correction_decision` into repair envelope inputs.

## Out of scope

- Typed-acceptance evaluation in `qa.validate_repair` (the LLM still makes the call) — that's M1's typed checks applied to the repair output, a follow-up after this lands.
- The full `defect_report.json` schema + `qa.localize_defect` task — proper #6 SIP later.

## References

- Cycle 7 evidence: `cyc_3d5d31717603` / `run_8b0805798d71`
- 1.0.x hardening plan: `docs/plans/1-0-x-build-reliability-hardening-plan.md` (#6)
- Prior persistence fix: PR #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)