### PR TITLE
fix(repair): surface repaired artifact contents to qa.validate_repair

### DIFF
--- a/adapters/cycles/distributed_flow_executor.py
+++ b/adapters/cycles/distributed_flow_executor.py
@@ -2369,11 +2369,16 @@ class DistributedFlowExecutor(FlowExecutionPort):
                         payload={"task_type": task_type, "error": repair_result.error or ""},
                     )
 
-                # Collect repair outputs
+                # Collect repair outputs. Unlike the regular fan-in path
+                # (line ~1525), keep `artifacts` so the next step in this
+                # sequence — `qa.validate_repair` — can see the actual
+                # repaired files rather than only the role-keyed one-line
+                # summary. Without this Eve renders Verdict: FAIL on
+                # repairs whose artifacts are already in the registry,
+                # because the validate-repair prompt has no visibility
+                # into what the upstream repair handler produced.
                 role_key = repair_envelope.metadata.get("role", "unknown")
-                prior_outputs[role_key] = {
-                    k: v for k, v in (repair_result.outputs or {}).items() if k != "artifacts"
-                }
+                prior_outputs[role_key] = dict(repair_result.outputs or {})
 
         # 8. Emit CORRECTION_COMPLETED
         self._cycle_event_bus.emit(

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -96,6 +96,58 @@ def _format_failure_summary(failure_evidence: Any, failure_analysis: Any) -> str
     return "\n\n".join(parts) if parts else "(no structured failure evidence available)"
 
 
+_FENCE_LANG_BY_EXT: dict[str, str] = {
+    ".py": "python",
+    ".js": "javascript",
+    ".jsx": "jsx",
+    ".ts": "typescript",
+    ".tsx": "tsx",
+    ".json": "json",
+    ".md": "markdown",
+    ".yml": "yaml",
+    ".yaml": "yaml",
+    ".sh": "bash",
+    ".sql": "sql",
+    ".html": "html",
+    ".css": "css",
+    ".toml": "toml",
+}
+
+
+def _fence_language_for(filename: str) -> str:
+    if not isinstance(filename, str):
+        return ""
+    lower = filename.lower()
+    for ext, lang in _FENCE_LANG_BY_EXT.items():
+        if lower.endswith(ext):
+            return lang
+    return ""
+
+
+def _format_repair_artifacts(artifacts: Any) -> str:
+    """Render repair artifacts as fenced code blocks with filename headers.
+
+    Eve previously saw only the role-keyed one-line summary, so she would
+    return Verdict: FAIL on repairs whose artifacts were already in the
+    registry. Surfacing the full content here lets her cite specific
+    lines when checking acceptance criteria.
+    """
+    if not isinstance(artifacts, list) or not artifacts:
+        return ""
+    rendered: list[str] = []
+    for art in artifacts:
+        if not isinstance(art, dict):
+            continue
+        name = art.get("name") or "(unnamed)"
+        content = art.get("content")
+        if content is None:
+            continue
+        lang = _fence_language_for(name)
+        fence_open = f"```{lang}" if lang else "```"
+        rendered.append(f"#### `{name}`\n{fence_open}\n{content}\n```")
+    return "\n\n".join(rendered)
+
+
 def _format_correction_decision(correction_decision: Any) -> str:
     """Render the lead's correction decision rationale for the prompt."""
     if isinstance(correction_decision, dict):
@@ -256,12 +308,14 @@ class QAValidateRepairHandler(_CycleTaskHandler):
 
     @staticmethod
     def _format_repair_summary(prior_outputs: dict[str, Any] | None) -> str:
-        """Pull the upstream repair handler's outputs out of prior_outputs.
+        """Render the upstream repair handler's artifacts for Eve's prompt.
 
         The executor stores the repair task's outputs under its role key
-        (e.g. `prior_outputs["builder"]` for builder.assemble_repair).
-        Surface those so Eve checks the repair, not the original failed
-        attempt.
+        (e.g. `prior_outputs["builder"]` for builder.assemble_repair). For
+        repair tasks the executor preserves the `artifacts` list (unlike
+        the regular fan-in path), so we surface filename + content here so
+        Eve can verify against the original acceptance criteria. Falls
+        back to the role-keyed summary when no artifacts are present.
         """
         if not prior_outputs:
             return "(no repair output available)"
@@ -271,11 +325,22 @@ class QAValidateRepairHandler(_CycleTaskHandler):
         parts: list[str] = []
         for key in repair_keys:
             block = prior_outputs[key]
-            summary = block.get("summary") if isinstance(block, dict) else None
-            if summary:
-                parts.append(f"### {key} repair\n{summary}")
-            else:
+            if not isinstance(block, dict):
                 parts.append(f"### {key} repair\n{block!r}")
+                continue
+
+            section = [f"### {key} repair"]
+            summary = block.get("summary")
+            if summary:
+                section.append(str(summary))
+
+            artifacts = block.get("artifacts") or []
+            rendered_artifacts = _format_repair_artifacts(artifacts)
+            if rendered_artifacts:
+                section.append(rendered_artifacts)
+            elif not summary:
+                section.append(repr(block))
+            parts.append("\n\n".join(section))
         return "\n\n".join(parts)
 
     def _build_render_variables(

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -600,3 +600,173 @@ class TestRepairHandlers:
         assert "Repaired qa_handoff.md with new sections" in prompt
         assert "Validate Repair" in prompt
         assert "PASS" in prompt or "FAIL" in prompt
+
+    async def test_validate_repair_prompt_includes_repaired_artifact_content(self, mock_context):
+        """Eve must see the actual repaired files, not just a one-line summary.
+
+        Cycle 8 regression: both repair_validation.md outputs returned
+        Verdict: FAIL because `_format_repair_summary` only rendered the
+        role-keyed summary string, so Eve had no way to verify the
+        artifact against the acceptance criteria. Surfacing the artifact
+        name + content lets her cite specific lines.
+        """
+        captured: dict = {}
+
+        async def _capture(messages, **_kw):
+            captured["user"] = messages[-1].content
+            return ChatMessage(role="assistant", content="# Repair Validation\nVerdict: PASS")
+
+        mock_context.ports.llm.chat_stream_with_usage = _capture
+
+        repaired_handoff = (
+            "# QA Handoff\n\n"
+            "## How to Test\n\nRun `pytest backend/tests`.\n\n"
+            "## Expected Behavior\n\nAll tests pass.\n"
+        )
+        inputs = {
+            "prd": "Build a runs app",
+            "failed_task_type": "builder.assemble",
+            "expected_artifacts": ["qa_handoff.md"],
+            "acceptance_criteria": [
+                "qa_handoff.md must contain '## How to Test'",
+                "qa_handoff.md must contain '## Expected Behavior'",
+            ],
+            "prior_outputs": {
+                "builder": {
+                    "summary": "[builder] Build a runs app",
+                    "artifacts": [
+                        {
+                            "name": "qa_handoff.md",
+                            "content": repaired_handoff,
+                            "media_type": "text/markdown",
+                            "type": "document",
+                        },
+                    ],
+                },
+            },
+        }
+
+        h = QAValidateRepairHandler()
+        result = await h.handle(mock_context, inputs)
+
+        assert result.success is True
+        prompt = captured["user"]
+        assert "qa_handoff.md" in prompt
+        assert "## How to Test" in prompt
+        assert "## Expected Behavior" in prompt
+        assert "Run `pytest backend/tests`." in prompt
+        assert "```markdown" in prompt
+
+    async def test_validate_repair_prompt_falls_back_to_summary_without_artifacts(
+        self, mock_context
+    ):
+        """Backwards compat: pre-fix executor checkpoints have no artifacts key."""
+        captured: dict = {}
+
+        async def _capture(messages, **_kw):
+            captured["user"] = messages[-1].content
+            return ChatMessage(role="assistant", content="Verdict: PASS")
+
+        mock_context.ports.llm.chat_stream_with_usage = _capture
+
+        inputs = {
+            "prd": "test",
+            "failed_task_type": "builder.assemble",
+            "prior_outputs": {
+                "builder": {"summary": "Repaired qa_handoff.md"},
+            },
+        }
+
+        h = QAValidateRepairHandler()
+        result = await h.handle(mock_context, inputs)
+
+        assert result.success is True
+        assert "Repaired qa_handoff.md" in captured["user"]
+
+
+# ---------------------------------------------------------------------------
+# _format_repair_summary unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatRepairSummary:
+    @pytest.mark.parametrize(
+        "filename,expected_fence",
+        [
+            ("RunDetail.jsx", "```jsx"),
+            ("backend/main.py", "```python"),
+            ("qa_handoff.md", "```markdown"),
+            ("config.yaml", "```yaml"),
+            ("noext", "```"),
+        ],
+    )
+    def test_renders_artifacts_with_language_fenced_blocks(self, filename, expected_fence):
+        prior_outputs = {
+            "dev": {
+                "summary": "[dev] sample",
+                "artifacts": [
+                    {"name": filename, "content": "BODY", "type": "source"},
+                ],
+            },
+        }
+        rendered = QAValidateRepairHandler._format_repair_summary(prior_outputs)
+        assert f"#### `{filename}`" in rendered
+        assert expected_fence in rendered
+        assert "BODY" in rendered
+        assert "[dev] sample" in rendered
+
+    def test_renders_multiple_artifacts_across_roles(self):
+        prior_outputs = {
+            "builder": {
+                "summary": "[builder] s",
+                "artifacts": [
+                    {"name": "qa_handoff.md", "content": "## How to Test\nrun it"},
+                    {"name": "backend/requirements.txt", "content": "fastapi==0.115.0"},
+                ],
+            },
+        }
+        rendered = QAValidateRepairHandler._format_repair_summary(prior_outputs)
+        assert "qa_handoff.md" in rendered
+        assert "backend/requirements.txt" in rendered
+        assert "## How to Test" in rendered
+        assert "fastapi==0.115.0" in rendered
+
+    def test_returns_placeholder_when_no_prior_outputs(self):
+        assert (
+            QAValidateRepairHandler._format_repair_summary(None) == "(no repair output available)"
+        )
+        assert QAValidateRepairHandler._format_repair_summary({}) == "(no repair output available)"
+
+    def test_returns_placeholder_when_no_repair_role_keys(self):
+        # `qa` and `lead` are not repair roles — only dev/builder produce repairs.
+        result = QAValidateRepairHandler._format_repair_summary(
+            {"qa": {"summary": "noise"}, "lead": {"summary": "noise"}}
+        )
+        assert result == "(no repair output from dev or builder role)"
+
+    def test_skips_artifacts_with_no_content(self):
+        prior_outputs = {
+            "dev": {
+                "summary": "[dev] s",
+                "artifacts": [
+                    {"name": "ghost.py"},  # no content
+                    {"name": "real.py", "content": "x = 1"},
+                ],
+            },
+        }
+        rendered = QAValidateRepairHandler._format_repair_summary(prior_outputs)
+        assert "real.py" in rendered
+        assert "x = 1" in rendered
+        assert "ghost.py" not in rendered
+
+    def test_falls_back_to_summary_when_artifacts_empty(self):
+        prior_outputs = {"dev": {"summary": "narrative-only repair", "artifacts": []}}
+        rendered = QAValidateRepairHandler._format_repair_summary(prior_outputs)
+        assert "narrative-only repair" in rendered
+        assert "```" not in rendered
+
+    def test_handles_non_dict_block(self):
+        # Defensive: if the executor ever stores a string instead of a dict we
+        # surface it rather than crashing.
+        rendered = QAValidateRepairHandler._format_repair_summary({"dev": "raw string"})
+        assert "raw string" in rendered

--- a/tests/unit/cycles/test_correction_protocol.py
+++ b/tests/unit/cycles/test_correction_protocol.py
@@ -575,6 +575,89 @@ class TestCorrectionTaskArtifactStorage:
         terminal_statuses = [c.args[1] for c in status_calls]
         assert RunStatus.COMPLETED in terminal_statuses
 
+    async def test_validate_repair_envelope_carries_repair_artifacts_in_prior_outputs(
+        self, executor, mock_queue, mock_registry, mock_vault, mock_event_bus
+    ):
+        """qa.validate_repair must see the upstream repair task's artifacts.
+
+        Cycle 8 regression: the executor previously stripped `artifacts`
+        from the repair task's outputs when collecting prior_outputs, so
+        Eve only saw the role-keyed one-line summary and rendered
+        Verdict: FAIL even when the repaired file was already in the
+        registry. This pins the executor side of the fix — the
+        downstream prompt formatting is covered by repair handler tests."""
+        semantic_outputs = {
+            "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
+            "role": "strat",
+        }
+        correction_decision = {
+            "summary": "patch",
+            "role": "lead",
+            "correction_path": "patch",
+            "decision_rationale": "Localized fix",
+            "affected_task_types": ["development.develop"],
+            "classification": "work_product",
+            "analysis_summary": "Output quality issue",
+        }
+        repair_with_artifacts = {
+            "summary": "[dev] repaired",
+            "role": "dev",
+            "artifacts": [
+                {
+                    "name": "frontend/src/components/RunDetail.jsx",
+                    "content": "import React from 'react';\nexport default function RunDetail() {}\n",
+                    "media_type": "text/javascript",
+                    "type": "source",
+                },
+            ],
+        }
+        script = [
+            ("FAILED", semantic_outputs, "missing component"),
+            (
+                "SUCCEEDED",
+                {
+                    "classification": "work_product",
+                    "analysis_summary": "missing RunDetail.jsx",
+                    "role": "data",
+                },
+                None,
+            ),
+            ("SUCCEEDED", correction_decision, None),
+            ("SUCCEEDED", repair_with_artifacts, None),
+            ("SUCCEEDED", {"summary": "validated", "role": "qa"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "dev"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "dev"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "data"}, None),
+        ]
+        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+
+        with patch(
+            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        publishes = [_published_envelope(c) for c in mock_queue.publish.call_args_list]
+        validate = next(p for p in publishes if p["task_type"] == "qa.validate_repair")
+
+        prior = validate["inputs"]["prior_outputs"]
+        dev_block = prior.get("dev")
+        assert dev_block is not None, (
+            f"dev repair output missing from prior_outputs; got keys: {list(prior.keys())}"
+        )
+        artifacts = dev_block.get("artifacts")
+        assert artifacts, (
+            "validate_repair envelope must carry repair artifacts; "
+            "without this Eve cannot verify the repair against acceptance criteria"
+        )
+        names = [a.get("name") for a in artifacts]
+        assert "frontend/src/components/RunDetail.jsx" in names
+        # Content travels too — Eve needs to read it, not just see the filename.
+        assert any(
+            "export default function RunDetail" in (a.get("content") or "") for a in artifacts
+        )
+
 
 # ---------------------------------------------------------------------------
 # Correction protocol: abort and rewind paths


### PR DESCRIPTION
## Summary

- Cycle 8 (`cyc_f2f178c101b8`) follow-up identified during PR #120 validation: Eve returned `Verdict: FAIL` on both repair-validation outputs even though the repaired artifacts (`RunDetail.jsx`, `qa_handoff.md`) were already in the registry. Root cause: the executor stripped `artifacts` from repair task outputs when collecting `prior_outputs`, and `_format_repair_summary` only rendered a one-line role summary — Eve had no visibility into the file she was supposed to judge.
- Executor now preserves `artifacts` on repair-task outputs (regular fan-in path still strips, so this is scoped to the dev/builder → `qa.validate_repair` handoff). `_format_repair_summary` now renders each repaired artifact as a filename-headed fenced block with language inferred from extension, and falls back to the prior summary-only behavior when no artifacts are present.
- Not a regression of PR #120 — the structured PASS/FAIL format from PR #120 is what made this preexisting visibility gap observable. Not blocking the M1 cohort.

## Test plan

- [x] `pytest tests/unit/capabilities/test_impl_handlers.py tests/unit/cycles/test_correction_protocol.py` (57 passed)
- [x] `./scripts/dev/run_regression_tests.sh` (3718 passed, 1 skipped)
- [x] `ruff format` clean on changed files
- [ ] Validate end-to-end on the next M1 cohort cycle: `repair_validation.md` should now cite specific artifact content and emit `Verdict: PASS` when the repair satisfies acceptance criteria

## New test coverage

- `TestRepairHandlers` × 2 — validate-repair prompt now contains the actual file content; backwards-compat fallback works without artifacts.
- `TestFormatRepairSummary` × 11 — parametrized fence-language detection (`.jsx`/`.py`/`.md`/`.yaml`/no-ext); multi-artifact rendering; empty/missing/non-dict edge cases; no-content artifacts skipped; falls back to summary when artifacts list empty.
- `TestCorrectionTaskArtifactStorage` × 1 — end-to-end through the patch flow: the published `qa.validate_repair` envelope's `prior_outputs["dev"]["artifacts"]` carries both filename and content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)