### PR TITLE
fix(governance): make Max's structured outputs reliable enough for M2 (#109)

### DIFF
--- a/src/squadops/capabilities/handlers/context.py
+++ b/src/squadops/capabilities/handlers/context.py
@@ -70,6 +70,7 @@ class ExecutionContext:
         role_id: Role of the agent
         task_id: Current task ID
         cycle_id: Current cycle ID
+        project_id: Current project ID
         ports: PortsBundle for port access
         skill_registry: Registry for skill execution
     """
@@ -80,6 +81,7 @@ class ExecutionContext:
     cycle_id: str
     ports: PortsBundle
     skill_registry: SkillRegistry
+    project_id: str = ""
     correlation_context: CorrelationContext | None = None
     _skill_executions: list[SkillExecutionRecord] = field(default_factory=list)
 
@@ -92,6 +94,7 @@ class ExecutionContext:
         cycle_id: str,
         ports: PortsBundle,
         skill_registry: SkillRegistry,
+        project_id: str = "",
         correlation_context: CorrelationContext | None = None,
     ) -> ExecutionContext:
         """Factory method for creating execution context.
@@ -103,6 +106,10 @@ class ExecutionContext:
             cycle_id: Current cycle ID
             ports: PortsBundle from agent
             skill_registry: SkillRegistry with available skills
+            project_id: Current project ID (issue #109 — handlers that
+                emit implementation_plan.yaml need authoritative
+                project_id alongside cycle_id so they don't ask the LLM
+                to invent it)
             correlation_context: Optional LangFuse correlation context
 
         Returns:
@@ -115,6 +122,7 @@ class ExecutionContext:
             cycle_id=cycle_id,
             ports=ports,
             skill_registry=skill_registry,
+            project_id=project_id,
             correlation_context=correlation_context,
         )
 

--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -130,6 +130,72 @@ def _estimate_min_artifacts(prd: str, impl_plan: str | None = None) -> int:
 # Keeping the original PR #113 patch in cycle_tasks.py while ALSO wiring
 # planning_tasks.py is defense-in-depth: any present-or-future caller of
 # either prompt path gets the discipline.
+def _rewrite_manifest_identifiers(
+    yaml_content: str,
+    project_id: str,
+    cycle_id: str,
+    prd_hash: str,
+    handler_name: str,
+) -> str:
+    """Overwrite the top-level identifier fields with authoritative values.
+
+    Issue #109: LLMs (especially small models) fabricate plausible-looking
+    project_id / cycle_id / prd_hash values when asked to fill them in.
+    These are facts the executor owns, so we rewrite them on the parsed
+    YAML before persisting. Logs a structured warning when the LLM-emitted
+    value disagreed so the rewrite stays observable.
+    """
+    import re
+
+    rewritten = yaml_content
+    fields = (
+        ("project_id", project_id),
+        ("cycle_id", cycle_id),
+        ("prd_hash", prd_hash),
+    )
+    version_line_re = re.compile(r"^version:[ \t]*.*$", re.MULTILINE)
+    for field_name, authoritative in fields:
+        if not authoritative:
+            continue
+        pattern = re.compile(
+            rf"^(?P<indent>[ \t]*){re.escape(field_name)}:[ \t]*(?P<value>.*)$",
+            re.MULTILINE,
+        )
+        match = pattern.search(rewritten)
+        if match is None:
+            # Field missing entirely — inject after the version line so
+            # the manifest validates downstream. Pre-pend if no version
+            # line exists; from_yaml will surface the structural error.
+            insertion = f"{field_name}: {authoritative}"
+            v_match = version_line_re.search(rewritten)
+            if v_match is None:
+                rewritten = insertion + "\n" + rewritten
+            else:
+                end = v_match.end()
+                rewritten = rewritten[:end] + "\n" + insertion + rewritten[end:]
+            logger.warning(
+                "%s: implementation_plan.yaml missing %s — injected authoritative value",
+                handler_name,
+                field_name,
+            )
+            continue
+        emitted = match.group("value").strip()
+        if emitted != authoritative:
+            logger.warning(
+                "%s: implementation_plan.yaml %s mismatch (LLM emitted %r, rewritten to %r)",
+                handler_name,
+                field_name,
+                emitted[:64],
+                authoritative,
+            )
+            rewritten = pattern.sub(
+                f"{match.group('indent')}{field_name}: {authoritative}",
+                rewritten,
+                count=1,
+            )
+    return rewritten
+
+
 _PRD_COVERAGE_DISCIPLINE_SECTION = (
     "## PRD Coverage Discipline (load-bearing)\n\n"
     "Before emitting the manifest, perform an explicit PRD ↔ acceptance_criteria "
@@ -684,6 +750,12 @@ class GovernanceReviewHandler(_CycleTaskHandler):
     _role = "lead"
     _artifact_name = "governance_review.md"
 
+    # Issue #109: project_id / cycle_id / prd_hash are facts the system
+    # owns, not values the LLM should invent. The braced placeholders
+    # below are substituted with authoritative values at render time
+    # (see _render_manifest_extension); the parsed manifest is also
+    # rewritten with these same values at extract time so the artifact
+    # is correct even if the LLM ignores the substituted prompt.
     _MANIFEST_PROMPT_EXTENSION = (
         "\n\n---\n\n"
         "## Build Task Manifest\n\n"
@@ -704,12 +776,14 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         "- Put QA handoff last\n\n" + _PRD_COVERAGE_DISCIPLINE_SECTION + "\n"
         "Output the manifest as a YAML code block with filename: "
         "implementation_plan.yaml\n\n"
-        "Use this exact schema:\n"
+        "Use this exact schema. The first three fields are pre-filled with "
+        "the cycle's authoritative values — copy them verbatim, do not invent "
+        "or modify them:\n"
         "```yaml:implementation_plan.yaml\n"
         "version: 1\n"
-        "project_id: <project_id>\n"
-        "cycle_id: <cycle_id>\n"
-        "prd_hash: <sha256 of PRD>\n"
+        "project_id: {project_id}\n"
+        "cycle_id: {cycle_id}\n"
+        "prd_hash: {prd_hash}\n"
         "tasks:\n"
         "  - task_index: 0\n"
         "    task_type: development.develop  # or qa.test\n"
@@ -730,6 +804,14 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         "```\n"
     )
 
+    @staticmethod
+    def _render_manifest_extension(project_id: str, cycle_id: str, prd_hash: str) -> str:
+        return GovernanceReviewHandler._MANIFEST_PROMPT_EXTENSION.format(
+            project_id=project_id or "(unknown)",
+            cycle_id=cycle_id or "(unknown)",
+            prd_hash=prd_hash or "(unknown)",
+        )
+
     async def handle(
         self,
         context: ExecutionContext,
@@ -742,9 +824,22 @@ class GovernanceReviewHandler(_CycleTaskHandler):
             return await super().handle(context, inputs)
 
         # Multi-artifact path: governance review + implementation plan
+        import hashlib
+
         start_time = time.perf_counter()
         prd = inputs.get("prd", "")
         prior_outputs = inputs.get("prior_outputs")
+
+        # Issue #109: substitute authoritative cycle identifiers into the
+        # manifest prompt so the LLM never has to invent project_id /
+        # cycle_id / prd_hash. Same values also overwrite the parsed
+        # manifest at extract time as a defense-in-depth measure.
+        prd_hash = hashlib.sha256(prd.encode()).hexdigest() if prd else ""
+        manifest_extension = self._render_manifest_extension(
+            project_id=context.project_id,
+            cycle_id=context.cycle_id,
+            prd_hash=prd_hash,
+        )
 
         # Build prompt with manifest extension
         renderer = getattr(context.ports, "request_renderer", None)
@@ -752,11 +847,9 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         if renderer is not None:
             variables = self._build_render_variables(prd, prior_outputs, inputs)
             rendered = await renderer.render(self._request_template_id, variables)
-            user_prompt = rendered.content + self._MANIFEST_PROMPT_EXTENSION
+            user_prompt = rendered.content + manifest_extension
         else:
-            user_prompt = (
-                self._build_user_prompt(prd, prior_outputs) + self._MANIFEST_PROMPT_EXTENSION
-            )
+            user_prompt = self._build_user_prompt(prd, prior_outputs) + manifest_extension
 
         assembled = context.ports.prompt_service.get_system_prompt(self._role)
         system_prompt = assembled.content
@@ -798,7 +891,14 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         ]
 
         # Extract and validate build task manifest
-        manifest_artifact = self._extract_manifest(content, resolved_config, prd)
+        manifest_artifact = self._extract_manifest(
+            content,
+            resolved_config,
+            prd,
+            project_id=context.project_id,
+            cycle_id=context.cycle_id,
+            prd_hash=prd_hash,
+        )
         if manifest_artifact is not None:
             artifacts.append(manifest_artifact)
 
@@ -821,14 +921,23 @@ class GovernanceReviewHandler(_CycleTaskHandler):
         return HandlerResult(success=True, outputs=outputs, _evidence=evidence)
 
     def _extract_manifest(
-        self, content: str, resolved_config: dict[str, Any], prd: str = ""
+        self,
+        content: str,
+        resolved_config: dict[str, Any],
+        prd: str = "",
+        project_id: str = "",
+        cycle_id: str = "",
+        prd_hash: str = "",
     ) -> dict[str, Any] | None:
         """Extract and validate build task manifest from LLM response.
 
         Returns manifest artifact dict, or None on graceful fallback (RC-4).
+        Issue #109: overwrites project_id / cycle_id / prd_hash in the
+        emitted YAML with the authoritative values held by the executor —
+        these are facts the system owns, not values the LLM should
+        invent. We log when the LLM-emitted value disagreed so the
+        substitution remains observable.
         """
-        import hashlib
-
         from squadops.capabilities.handlers.fenced_parser import extract_fenced_files
         from squadops.cycles.implementation_plan import ImplementationPlan
 
@@ -853,6 +962,17 @@ class GovernanceReviewHandler(_CycleTaskHandler):
                 self._handler_name,
             )
 
+        # Issue #109: substitute authoritative identifiers before
+        # parsing-validation so a structurally-fine manifest with
+        # fabricated identifiers can't poison downstream lookups.
+        yaml_content = _rewrite_manifest_identifiers(
+            yaml_content,
+            project_id=project_id,
+            cycle_id=cycle_id,
+            prd_hash=prd_hash,
+            handler_name=self._handler_name,
+        )
+
         # Structural validation
         try:
             manifest = ImplementationPlan.from_yaml(yaml_content)
@@ -863,21 +983,6 @@ class GovernanceReviewHandler(_CycleTaskHandler):
                 exc,
             )
             return None
-
-        # PRD hash integrity check
-        if prd and manifest.prd_hash:
-            expected_hash = hashlib.sha256(prd.encode()).hexdigest()
-            if manifest.prd_hash != expected_hash:
-                logger.warning(
-                    "%s: manifest prd_hash mismatch (got %s, expected %s), "
-                    "continuing with manifest (LLM-generated hash is best-effort)",
-                    self._handler_name,
-                    manifest.prd_hash[:12],
-                    expected_hash[:12],
-                )
-                # Note: this is a warning, not a fallback. The LLM generates
-                # the hash and may not produce an exact SHA-256. The hash is
-                # informational for audit, not a security gate.
 
         # Policy validation — subtask count bounds from resolved config
         min_subtasks = resolved_config.get("min_build_subtasks", 3)

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -30,6 +30,7 @@ from squadops.capabilities.handlers.base import (
 from squadops.capabilities.handlers.cycle_tasks import (
     _PRD_COVERAGE_DISCIPLINE_SECTION,
     _CycleTaskHandler,
+    _rewrite_manifest_identifiers,
 )
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
@@ -349,17 +350,62 @@ class GovernanceReviewPlanHandler(_PlanningTaskHandler):
     _role = "lead"
     _artifact_name = "planning_artifact.md"
 
-    _DEFAULT_FRONTMATTER = (
-        "---\nreadiness: revise\nsufficiency_score: 3\nblocker_unknowns: 0\n---\n\n"
-    )
+    async def _retry_without_frontmatter(
+        self,
+        context: ExecutionContext,
+        inputs: dict[str, Any],
+        prior_content: str,
+    ) -> str | None:
+        """Re-prompt Max once with a corrective instruction.
 
-    def _synthesize_frontmatter(self, content: str) -> str:
-        """Prepend default frontmatter when LLM omits it."""
-        logger.warning(
-            "assess_readiness: LLM omitted YAML frontmatter — "
-            "synthesizing default (readiness=revise, score=3)"
+        Returns the new artifact content if the retry produced any
+        response, else ``None`` so the caller can fail the task. The
+        caller still validates frontmatter on the result, so a retry
+        that comes back empty or still missing frontmatter terminates
+        the task.
+        """
+        prd = inputs.get("prd", "")
+        prior_outputs = inputs.get("prior_outputs")
+        raw_budget = inputs.get("resolved_config", {}).get("time_budget_seconds")
+        time_budget_seconds = int(raw_budget) if raw_budget is not None else None
+
+        renderer = getattr(context.ports, "request_renderer", None)
+        if renderer is not None:
+            variables = self._build_render_variables(prd, prior_outputs, inputs)
+            rendered = await renderer.render(self._request_template_id, variables)
+            user_prompt = rendered.content
+        else:
+            user_prompt = self._build_user_prompt(prd, prior_outputs, time_budget_seconds)
+
+        assembled = context.ports.prompt_service.assemble(
+            role=self._role,
+            hook="agent_start",
+            task_type=self._capability_id,
         )
-        return self._DEFAULT_FRONTMATTER + content
+
+        messages = [
+            ChatMessage(role="system", content=assembled.content),
+            ChatMessage(role="user", content=user_prompt),
+            ChatMessage(role="assistant", content=prior_content),
+            ChatMessage(role="user", content=self._FRONTMATTER_RETRY_INSTRUCTION),
+        ]
+        chat_kwargs = self._build_chat_kwargs(inputs)
+
+        try:
+            response = await context.ports.llm.chat_stream_with_usage(messages, **chat_kwargs)
+        except LLMError as exc:
+            logger.warning("assess_readiness: frontmatter-retry LLM call failed: %s", exc)
+            return None
+
+        return response.content if response and response.content else None
+
+    _FRONTMATTER_RETRY_INSTRUCTION = (
+        "Your previous response did not include the required YAML frontmatter. "
+        "The planning artifact MUST start with a `---` delimited block "
+        "containing `readiness` (one of `go`, `revise`, `no-go`) and "
+        "`sufficiency_score` (integer 0–5), followed by `---` and the body. "
+        "Re-emit the full planning artifact, starting with the frontmatter."
+    )
 
     async def handle(
         self,
@@ -372,15 +418,36 @@ class GovernanceReviewPlanHandler(_PlanningTaskHandler):
 
         content = result.outputs["artifacts"][0]["content"]
 
-        # Structural validation: YAML frontmatter
+        # Structural validation: YAML frontmatter must be authored by the
+        # LLM. Issue #109: we used to silently synthesize a default
+        # `readiness=revise / sufficiency_score=3` block when frontmatter
+        # was missing, which made it look like Max had reviewed the plan
+        # when in fact every downstream consumer was reading defaults.
+        # Now: retry once with a corrective prompt; if the retry still
+        # omits frontmatter, fail the task so the cycle's correction
+        # loop can fire instead of papering over it.
         m = _FRONTMATTER_RE.match(content)
         if not m:
-            # Graceful degradation: synthesize default frontmatter so the
-            # cycle can proceed.  The default readiness=revise ensures the
-            # plan is flagged for review rather than silently accepted.
-            content = self._synthesize_frontmatter(content)
-            result.outputs["artifacts"][0]["content"] = content
-            m = _FRONTMATTER_RE.match(content)
+            retry_content = await self._retry_without_frontmatter(context, inputs, content)
+            if retry_content is not None:
+                content = retry_content
+                result.outputs["artifacts"][0]["content"] = content
+                m = _FRONTMATTER_RE.match(content)
+
+            if not m:
+                logger.warning(
+                    "assess_readiness: LLM omitted YAML frontmatter on initial "
+                    "response and retry; failing task to surface the gap"
+                )
+                return HandlerResult(
+                    success=False,
+                    outputs={},
+                    _evidence=result._evidence,
+                    error=(
+                        "Planning artifact missing required YAML frontmatter "
+                        "(readiness, sufficiency_score) after one corrective retry"
+                    ),
+                )
 
         try:
             fm = yaml.safe_load(m.group(1))
@@ -443,6 +510,8 @@ class GovernanceReviewPlanHandler(_PlanningTaskHandler):
         Separate from the planning artifact generation to keep prompts focused.
         Returns manifest artifact dict or None on graceful fallback (RC-4).
         """
+
+        import hashlib
 
         from squadops.capabilities.handlers.fenced_parser import extract_fenced_files
         from squadops.llm.models import ChatMessage
@@ -600,12 +669,19 @@ class GovernanceReviewPlanHandler(_PlanningTaskHandler):
             # cycle_tasks.py:_MANIFEST_PROMPT_EXTENSION uses.
             f"{_PRD_COVERAGE_DISCIPLINE_SECTION}"
             "\n"
-            "Output ONLY the manifest as a YAML code block with filename tag:\n"
+            # Issue #109: substitute authoritative identifiers so Max
+            # never has to invent project_id / cycle_id / prd_hash. The
+            # parsed manifest is also rewritten at extract time as
+            # defense in depth.
+            "Output ONLY the manifest as a YAML code block with filename tag. "
+            "The first three fields below are pre-filled with the cycle's "
+            "authoritative values — copy them verbatim, do not invent or "
+            "modify them:\n"
             "```yaml:implementation_plan.yaml\n"
             "version: 1\n"
-            "project_id: <project_id>\n"
-            "cycle_id: <cycle_id>\n"
-            "prd_hash: <hash>\n"
+            f"project_id: {context.project_id or '(unknown)'}\n"
+            f"cycle_id: {context.cycle_id or '(unknown)'}\n"
+            f"prd_hash: {hashlib.sha256(prd.encode()).hexdigest() if prd else '(unknown)'}\n"
             "tasks:\n"
             "  - task_index: 0\n"
             "    task_type: development.develop\n"
@@ -674,6 +750,17 @@ class GovernanceReviewPlanHandler(_PlanningTaskHandler):
                     "assess_readiness: produced build task manifest with %d subtasks on attempt %d",
                     len(manifest.tasks),
                     attempt,
+                )
+                # Issue #109: overwrite identifiers with authoritative
+                # values before persisting so a structurally-valid plan
+                # with fabricated project_id/cycle_id/prd_hash can't
+                # poison downstream lookups.
+                yaml_content = _rewrite_manifest_identifiers(
+                    yaml_content,
+                    project_id=context.project_id,
+                    cycle_id=context.cycle_id,
+                    prd_hash=hashlib.sha256(prd.encode()).hexdigest() if prd else "",
+                    handler_name=self._handler_name,
                 )
                 return {
                     "name": "implementation_plan.yaml",

--- a/src/squadops/orchestration/handler_executor.py
+++ b/src/squadops/orchestration/handler_executor.py
@@ -121,6 +121,7 @@ class HandlerExecutor(CapabilityExecutor):
                 cycle_id=envelope.cycle_id,
                 ports=self._ports,
                 skill_registry=self._skill_registry,
+                project_id=envelope.project_id,
                 correlation_context=corr_ctx,
             )
 

--- a/tests/unit/capabilities/handlers/test_governance_review_plan.py
+++ b/tests/unit/capabilities/handlers/test_governance_review_plan.py
@@ -69,13 +69,21 @@ class _FakeAssembled:
     assembly_hash: str = "hash123"
 
 
-def _make_context() -> MagicMock:
+def _make_context(
+    project_id: str = "group_run",
+    cycle_id: str = "cyc_test",
+) -> MagicMock:
     ctx = MagicMock()
     ctx.ports.prompt_service.get_system_prompt.return_value = _FakeAssembled()
     ctx.ports.llm.chat_stream_with_usage = AsyncMock()
     ctx.ports.llm.default_model = "test-model"
     ctx.ports.request_renderer = None
     ctx.correlation_context = None
+    # Issue #109: cycle_id / project_id need to be real strings for the
+    # manifest identifier rewrite step. MagicMock auto-attrs would
+    # stringify to <MagicMock ...> and break the YAML.
+    ctx.project_id = project_id
+    ctx.cycle_id = cycle_id
     return ctx
 
 
@@ -227,6 +235,117 @@ class TestGovernanceReviewManifest:
 
         assert not result.success
         assert "timeout" in result.error
+
+
+class TestManifestIdentifierRewrite:
+    """Issue #109: project_id / cycle_id / prd_hash must be authoritative.
+
+    Max (especially under small models) fabricates plausible-looking but
+    incorrect identifiers (`group_run_mvp`, `cycle_v03`, `a1b2c3d4e5f6`).
+    The handler must overwrite the LLM-emitted values with the cycle's
+    real identifiers before persisting the manifest, AND substitute
+    those values into the prompt so the LLM doesn't have to invent them.
+    """
+
+    async def test_rewrites_fabricated_project_id(self):
+        import hashlib
+
+        handler = GovernanceReviewHandler()
+        ctx = _make_context(project_id="group_run", cycle_id="cyc_real_001")
+        # LLM emits a fabricated project_id (the cyc_4cac11018af7 failure mode)
+        fabricated_block = (
+            VALID_MANIFEST_BLOCK.replace("project_id: group_run", "project_id: group_run_mvp")
+            .replace("cycle_id: cyc_test", "cycle_id: cycle_v03")
+            .replace("prd_hash: abc123", "prd_hash: a1b2c3d4e5f6")
+        )
+        ctx.ports.llm.chat_stream_with_usage.return_value = _make_llm_response(
+            "Review.\n\n" + fabricated_block
+        )
+
+        result = await handler.handle(ctx, _make_inputs())
+
+        assert result.success
+        manifest_yaml = result.outputs["artifacts"][1]["content"]
+        prd = "Build a group run app with FastAPI and React."
+        expected_hash = hashlib.sha256(prd.encode()).hexdigest()
+        assert "project_id: group_run\n" in manifest_yaml
+        assert "cycle_id: cyc_real_001\n" in manifest_yaml
+        assert f"prd_hash: {expected_hash}\n" in manifest_yaml
+        # Fabricated values are gone.
+        assert "group_run_mvp" not in manifest_yaml
+        assert "cycle_v03" not in manifest_yaml
+        assert "a1b2c3d4e5f6" not in manifest_yaml
+
+    async def test_keeps_correct_identifiers_unchanged(self):
+        """When the LLM happens to emit the right values, the rewrite is a no-op
+        (no warnings about mismatch in the wild)."""
+        import hashlib
+
+        handler = GovernanceReviewHandler()
+        ctx = _make_context(project_id="group_run", cycle_id="cyc_real_001")
+        prd = "Build a group run app with FastAPI and React."
+        good_hash = hashlib.sha256(prd.encode()).hexdigest()
+        good_block = (
+            VALID_MANIFEST_BLOCK.replace("project_id: group_run", "project_id: group_run")
+            .replace("cycle_id: cyc_test", "cycle_id: cyc_real_001")
+            .replace("prd_hash: abc123", f"prd_hash: {good_hash}")
+        )
+        ctx.ports.llm.chat_stream_with_usage.return_value = _make_llm_response(
+            "Review.\n\n" + good_block
+        )
+
+        result = await handler.handle(ctx, _make_inputs())
+
+        assert result.success
+        manifest_yaml = result.outputs["artifacts"][1]["content"]
+        assert "project_id: group_run\n" in manifest_yaml
+        assert "cycle_id: cyc_real_001\n" in manifest_yaml
+        assert f"prd_hash: {good_hash}\n" in manifest_yaml
+
+    async def test_prompt_substitutes_authoritative_identifiers(self):
+        """The prompt sent to the LLM must contain the real project_id /
+        cycle_id / prd_hash so Max doesn't fall back to fabricating them."""
+        import hashlib
+
+        handler = GovernanceReviewHandler()
+        ctx = _make_context(project_id="group_run", cycle_id="cyc_real_001")
+        ctx.ports.llm.chat_stream_with_usage.return_value = _make_llm_response(
+            "Review.\n\n" + VALID_MANIFEST_BLOCK
+        )
+
+        await handler.handle(ctx, _make_inputs())
+
+        sent_messages = ctx.ports.llm.chat_stream_with_usage.call_args.args[0]
+        user_prompt = next(m for m in sent_messages if m.role == "user").content
+        prd = "Build a group run app with FastAPI and React."
+        expected_hash = hashlib.sha256(prd.encode()).hexdigest()
+        assert "project_id: group_run\n" in user_prompt
+        assert "cycle_id: cyc_real_001\n" in user_prompt
+        assert f"prd_hash: {expected_hash}\n" in user_prompt
+        # The literal `<placeholder>` strings are gone — that was the bug
+        # in #109 where the LLM saw `<project_id>` and invented values.
+        assert "<project_id>" not in user_prompt
+        assert "<cycle_id>" not in user_prompt
+        assert "<sha256 of PRD>" not in user_prompt
+
+    async def test_falls_back_when_context_identifiers_missing(self):
+        """Defensive: handler shouldn't crash if context has empty
+        project_id / cycle_id (e.g. a misconfigured test or an envelope
+        that lost its metadata). LLM-emitted values pass through and
+        the manifest is still parseable."""
+        handler = GovernanceReviewHandler()
+        ctx = _make_context(project_id="", cycle_id="")
+        ctx.ports.llm.chat_stream_with_usage.return_value = _make_llm_response(
+            "Review.\n\n" + VALID_MANIFEST_BLOCK
+        )
+
+        result = await handler.handle(ctx, _make_inputs())
+
+        assert result.success
+        manifest_yaml = result.outputs["artifacts"][1]["content"]
+        # Original LLM-emitted identifiers preserved (no rewrite).
+        assert "project_id: group_run\n" in manifest_yaml
+        assert "cycle_id: cyc_test\n" in manifest_yaml
 
 
 class TestPRDCoverageDiscipline:

--- a/tests/unit/capabilities/test_planning_handlers.py
+++ b/tests/unit/capabilities/test_planning_handlers.py
@@ -74,6 +74,12 @@ GENERIC_HANDLER_CLASSES = [cls for cls, _, _, _ in GENERIC_HANDLER_SPECS]
 # short-circuit at D17 before calling LLM).
 LLM_REACHABLE_SPECS = [s for s in ALL_HANDLER_SPECS if s[0] != GovernanceIncorporateFeedbackHandler]
 LLM_REACHABLE_CLASSES = [cls for cls, _, _, _ in LLM_REACHABLE_SPECS]
+# Issue #109: GovernanceReviewPlanHandler now retries the LLM call once when
+# the response omits YAML frontmatter, so single-call assertions fail under
+# the generic mock content. Exclude it from those parametrized checks; it
+# has dedicated tests under TestGovernanceAssessReadinessValidation.
+LLM_SINGLE_CALL_SPECS = [s for s in LLM_REACHABLE_SPECS if s[0] is not GovernanceReviewPlanHandler]
+LLM_SINGLE_CALL_CLASSES = [cls for cls, _, _, _ in LLM_SINGLE_CALL_SPECS]
 
 VALID_PLANNING_ARTIFACT = """\
 ---
@@ -93,7 +99,11 @@ This is a valid planning artifact with proper YAML frontmatter.
 # ---------------------------------------------------------------------------
 
 
-def _make_context(llm_response="LLM planning output"):
+def _make_context(
+    llm_response="LLM planning output",
+    project_id: str = "test_proj",
+    cycle_id: str = "test_cyc",
+):
     """Build a minimal ExecutionContext mock for planning handler tests."""
     llm = AsyncMock()
     llm.chat.return_value = MagicMock(content=llm_response)
@@ -116,6 +126,11 @@ def _make_context(llm_response="LLM planning output"):
     ctx = MagicMock()
     ctx.ports = ports
     ctx.correlation_context = None
+    # Issue #109: cycle_id / project_id need to be real strings so the
+    # manifest identifier rewrite can substitute them; MagicMock auto-attrs
+    # would stringify to <MagicMock ...> and corrupt the YAML.
+    ctx.project_id = project_id
+    ctx.cycle_id = cycle_id
     return ctx
 
 
@@ -249,8 +264,8 @@ class TestHandleUsesAssemble:
 
     @pytest.mark.parametrize(
         "cls, expected_cap_id, expected_role, _artifact",
-        LLM_REACHABLE_SPECS,
-        ids=[c.__name__ for c, _, _, _ in LLM_REACHABLE_SPECS],
+        LLM_SINGLE_CALL_SPECS,
+        ids=[c.__name__ for c, _, _, _ in LLM_SINGLE_CALL_SPECS],
     )
     async def test_assemble_called_with_task_type(
         self, cls, expected_cap_id, expected_role, _artifact, mock_context
@@ -402,8 +417,8 @@ class TestHandlePriorOutputs:
 class TestLLMCallVerification:
     @pytest.mark.parametrize(
         "cls",
-        LLM_REACHABLE_CLASSES,
-        ids=[c.__name__ for c in LLM_REACHABLE_CLASSES],
+        LLM_SINGLE_CALL_CLASSES,
+        ids=[c.__name__ for c in LLM_SINGLE_CALL_CLASSES],
     )
     async def test_llm_chat_called_once(self, cls, mock_context):
         h = cls()
@@ -678,15 +693,57 @@ class TestGovernanceAssessReadinessValidation:
         assert result.success is True
         assert result.outputs["artifacts"][0]["name"] == "planning_artifact.md"
 
-    async def test_missing_frontmatter_synthesizes_default(self):
+    async def test_missing_frontmatter_retries_then_fails(self):
+        """Issue #109: silent default-synthesis used to mask Max's omission.
+
+        New contract: the handler retries Max once with a corrective
+        instruction; if the retry still omits frontmatter, the task fails
+        so the cycle's correction loop can fire instead of papering over
+        a defaulted readiness/sufficiency_score that Max never authored.
+        """
         ctx = _make_context("No frontmatter here, just plain text.")
+        h = GovernanceReviewPlanHandler()
+        result = await h.handle(ctx, {"prd": "Build a widget"})
+
+        assert result.success is False
+        assert "frontmatter" in result.error.lower()
+        # Both LLM call and retry call should have happened.
+        assert ctx.ports.llm.chat_stream_with_usage.await_count == 2
+
+    async def test_missing_frontmatter_retry_recovers_when_llm_complies(self):
+        """Retry succeeds → handler proceeds with the recovered content."""
+        recovered = "---\nreadiness: go\nsufficiency_score: 4\n---\n\n## Body\n"
+        ctx = _make_context()
+        # First call returns no-frontmatter; retry returns valid frontmatter.
+        ctx.ports.llm.chat_stream_with_usage.side_effect = [
+            MagicMock(content="No frontmatter on first response"),
+            MagicMock(content=recovered),
+        ]
         h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
         assert result.success is True
         content = result.outputs["artifacts"][0]["content"]
         assert content.startswith("---\n")
-        assert "readiness: revise" in content
+        assert "readiness: go" in content
+        assert ctx.ports.llm.chat_stream_with_usage.await_count == 2
+
+    async def test_retry_corrective_message_targets_frontmatter(self):
+        """The retry's corrective message must call out the missing
+        frontmatter explicitly so Max can fix the specific gap rather
+        than re-running the whole prompt blind."""
+        ctx = _make_context("No frontmatter on first response either")
+        h = GovernanceReviewPlanHandler()
+        await h.handle(ctx, {"prd": "Build a widget"})
+
+        # Inspect the second LLM call's messages for the corrective text.
+        calls = ctx.ports.llm.chat_stream_with_usage.await_args_list
+        assert len(calls) == 2
+        retry_messages = calls[1].args[0]
+        assert any("YAML frontmatter" in m.content for m in retry_messages if m.role == "user")
+        # And it must include the prior failed assistant turn so Max sees
+        # what came back wrong.
+        assert any(m.role == "assistant" for m in retry_messages)
 
     async def test_invalid_yaml_fails(self):
         ctx = _make_context("---\n[invalid: yaml: content\n---\n\nBody")
@@ -753,12 +810,15 @@ class TestGovernanceAssessReadinessValidation:
 
         assert result.success is True
 
-    async def test_evidence_preserved_on_frontmatter_synthesis(self):
+    async def test_evidence_preserved_when_frontmatter_retry_fails(self):
+        """Issue #109: even when the retry can't recover, the evidence
+        from the first LLM call must travel with the failure result so
+        triage can attribute the failure to the right capability."""
         ctx = _make_context("No frontmatter")
         h = GovernanceReviewPlanHandler()
         result = await h.handle(ctx, {"prd": "Build a widget"})
 
-        assert result.success is True
+        assert result.success is False
         assert result._evidence is not None
         assert result._evidence.capability_id == "governance.review_plan"
 
@@ -839,6 +899,63 @@ summary:
   total_tasks: 1
 ```
 """
+
+
+class TestProduceManifestIdentifierRewrite:
+    """Issue #109: framing-time _produce_plan must overwrite fabricated
+    project_id / cycle_id / prd_hash with the cycle's authoritative
+    values, and pre-fill the prompt with the same so Max doesn't have
+    to invent them."""
+
+    async def _call(self, ctx, prd: str = "Build a widget") -> dict | None:
+        h = GovernanceReviewPlanHandler()
+        return await h._produce_plan(
+            ctx,
+            inputs={"prd": prd},
+            planning_content="plan",
+            resolved_config={},
+        )
+
+    async def test_rewrites_fabricated_identifiers(self):
+        import hashlib
+
+        fabricated = (
+            _VALID_MANIFEST_YAML.replace("project_id: test_proj", "project_id: group_run_mvp")
+            .replace("cycle_id: test_cyc", "cycle_id: cycle_v03")
+            .replace("prd_hash: abc", "prd_hash: a1b2c3d4e5f6")
+        )
+        ctx = _make_context(fabricated, project_id="group_run", cycle_id="cyc_real")
+
+        result = await self._call(ctx, prd="Build a widget")
+
+        assert result is not None
+        manifest_yaml = result["content"]
+        expected_hash = hashlib.sha256(b"Build a widget").hexdigest()
+        assert "project_id: group_run\n" in manifest_yaml
+        assert "cycle_id: cyc_real\n" in manifest_yaml
+        assert f"prd_hash: {expected_hash}\n" in manifest_yaml
+        assert "group_run_mvp" not in manifest_yaml
+        assert "cycle_v03" not in manifest_yaml
+
+    async def test_prompt_pre_fills_authoritative_identifiers(self):
+        """The manifest prompt sent to Max must contain real values, not
+        the literal `<project_id>` / `<cycle_id>` / `<hash>` placeholders
+        that triggered fabrication in the first place."""
+        import hashlib
+
+        ctx = _make_context(_VALID_MANIFEST_YAML, project_id="group_run", cycle_id="cyc_real")
+
+        await self._call(ctx, prd="Build a widget")
+
+        sent = ctx.ports.llm.chat_stream_with_usage.call_args.args[0]
+        user_prompt = next(m for m in sent if m.role == "user").content
+        expected_hash = hashlib.sha256(b"Build a widget").hexdigest()
+        assert "project_id: group_run\n" in user_prompt
+        assert "cycle_id: cyc_real\n" in user_prompt
+        assert f"prd_hash: {expected_hash}\n" in user_prompt
+        assert "<project_id>" not in user_prompt
+        assert "<cycle_id>" not in user_prompt
+        assert "<hash>" not in user_prompt
 
 
 class TestProduceManifestRetry:

--- a/tests/unit/prompts/test_migration_validation.py
+++ b/tests/unit/prompts/test_migration_validation.py
@@ -152,6 +152,16 @@ class TestBaseClassTemplateIdCoverage:
     async def test_handler_uses_correct_template_id(self, handler_cls, expected_template_id):
         renderer = _mock_renderer()
         ctx = _mock_context(renderer=renderer)
+
+        # Issue #109: GovernanceReviewPlanHandler retries on missing
+        # frontmatter, which would call render() twice. Hand it a valid
+        # frontmatter-bearing response so the assertion stays single-call.
+        if handler_cls is GovernanceReviewPlanHandler:
+            valid_content = "---\nreadiness: go\nsufficiency_score: 4\n---\n\nbody\n"
+            ctx.ports.llm.chat_stream_with_usage = AsyncMock(
+                return_value=ChatMessage(role="assistant", content=valid_content),
+            )
+
         handler = handler_cls()
 
         # Provide minimal inputs that satisfy all handlers


### PR DESCRIPTION
## Summary

Two Max-output reliability failure modes that silently degraded structured outputs would, left in place, mask the SIP-0092 M2 \`plan_review.yaml\` rubric the same way they masked \`assess_readiness\`. Fixing them before M2 dev starts so the new artifact lands on a trustworthy substrate.

**1. Frontmatter omission (assess_readiness / governance.review_plan).** The handler used to silently prepend a default \`readiness=revise / sufficiency_score=3\` block when the LLM omitted YAML frontmatter — every downstream consumer saw a value Max never authored. Now retries Max once with a corrective instruction; if the retry still omits frontmatter, the task fails so the cycle's correction loop can fire instead of papering over it.

**2. Identifier fabrication (governance.review / governance.review_plan).** Both manifest-producing prompts asked the LLM to fill \`<project_id>\` / \`<cycle_id>\` / \`<sha256 of PRD>\` placeholders. Small models fabricated plausible-looking values (\`group_run_mvp\`, \`cycle_v03\`, \`a1b2c3d4e5f6\`) that pass syntax validation but break downstream lookups. Now: the prompt is pre-filled with the cycle's authoritative identifiers, and the parsed manifest is rewritten server-side as defense in depth.

Closes #109. Subsumes #78 (already closed as duplicate).

## Mechanism

- \`ExecutionContext\` gains \`project_id\` alongside the existing \`cycle_id\`; \`HandlerExecutor\` wires it from \`envelope.project_id\`.
- \`_MANIFEST_PROMPT_EXTENSION\` uses \`.format()\` placeholders; new \`_render_manifest_extension\` substitutes from context at prompt-build time.
- New module-scope helper \`_rewrite_manifest_identifiers\` overwrites \`project_id\` / \`cycle_id\` / \`prd_hash\` on the parsed YAML and logs the diff when the LLM disagreed (visibility, not silence).
- \`GovernanceReviewPlanHandler\` gets a single corrective retry on missing frontmatter via \`_retry_without_frontmatter\`, then fails the task on continued omission.

## Test plan

- [x] \`pytest tests/unit/capabilities/test_planning_handlers.py tests/unit/capabilities/handlers/test_governance_review_plan.py tests/unit/prompts/test_migration_validation.py\` (227 passed)
- [x] \`./scripts/dev/run_regression_tests.sh\` (3724 passed, 1 skipped — up 6 from 3718 baseline)
- [x] \`ruff format\` clean on changed files
- [ ] First M2-dev cycle: confirm \`implementation_plan.yaml\` carries the real \`project_id\` / \`cycle_id\` / \`prd_hash\` (was the cyc_4cac11018af7 failure mode in #109)
- [ ] First M2-dev cycle that tickles framing without frontmatter: confirm the corrective retry fires and either recovers or fails visibly (was the cyc_d1c1a259c983 silent-default mode)

## New test coverage

- \`TestManifestIdentifierRewrite\` × 4 — fabricated-id rewrite, identity no-op, prompt pre-fill verification, fallback when context identifiers are empty.
- \`TestProduceManifestIdentifierRewrite\` × 2 — same coverage on the framing-time \`_produce_plan\` path.
- Replaced silent-synthesis tests with retry-then-fail contract: \`test_missing_frontmatter_retries_then_fails\`, \`test_missing_frontmatter_retry_recovers_when_llm_complies\`, \`test_retry_corrective_message_targets_frontmatter\`, \`test_evidence_preserved_when_frontmatter_retry_fails\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)