### PR TITLE
refactor: drop proper agent names from source comments and docstrings

### DIFF
--- a/adapters/cycles/distributed_flow_executor.py
+++ b/adapters/cycles/distributed_flow_executor.py
@@ -1965,8 +1965,9 @@ class DistributedFlowExecutor(FlowExecutionPort):
     ) -> dict[str, Any]:
         """Assemble the failure-evidence payload handed to data.analyze_failure.
 
-        Issue #84 follow-up: Data was previously handed only `error` +
-        `outcome_class` and had to guess at the failure shape; downstream
+        Issue #84 follow-up: the data role was previously handed only
+        `error` + `outcome_class` and had to guess at the failure shape;
+        downstream
         correction-decision then picked rewind on content failures because
         it had no indication that a patch would suffice. Pull through the
         failed handler's structured `validation_result` + preliminary
@@ -2373,8 +2374,8 @@ class DistributedFlowExecutor(FlowExecutionPort):
                 # (line ~1525), keep `artifacts` so the next step in this
                 # sequence — `qa.validate_repair` — can see the actual
                 # repaired files rather than only the role-keyed one-line
-                # summary. Without this Eve renders Verdict: FAIL on
-                # repairs whose artifacts are already in the registry,
+                # summary. Without this the qa role renders Verdict: FAIL
+                # on repairs whose artifacts are already in the registry,
                 # because the validate-repair prompt has no visibility
                 # into what the upstream repair handler produced.
                 role_key = repair_envelope.metadata.get("role", "unknown")

--- a/src/squadops/agents/skills/data/__init__.py
+++ b/src/squadops/agents/skills/data/__init__.py
@@ -1,4 +1,4 @@
-"""Data agent skills.
+"""Skills for the data role.
 
 Skills for analytics and data processing.
 Part of SIP-0.8.8 Phase 4.

--- a/src/squadops/agents/skills/data/data_analysis.py
+++ b/src/squadops/agents/skills/data/data_analysis.py
@@ -1,6 +1,6 @@
 """Data Analysis skill - analyze data and generate insights.
 
-Data agent skill for analytics.
+Skill for the data role's analytics duties.
 Part of SIP-0.8.8 Phase 4.
 """
 from __future__ import annotations

--- a/src/squadops/agents/skills/data/metrics_collection.py
+++ b/src/squadops/agents/skills/data/metrics_collection.py
@@ -1,6 +1,6 @@
 """Metrics Collection skill - collect and aggregate metrics.
 
-Data agent skill for metrics.
+Skill for the data role's metrics duties.
 Part of SIP-0.8.8 Phase 4.
 """
 from __future__ import annotations

--- a/src/squadops/capabilities/handlers/build_profiles.py
+++ b/src/squadops/capabilities/handlers/build_profiles.py
@@ -99,9 +99,9 @@ class BuildProfile:
         validator and the plan author can disagree about which qa_handoff
         sections are required. The plan task description named different
         sections (e.g. "Implemented Scope", "Known Limitations") than the
-        validator's hard-coded set. Bob followed the more specific task
-        description and the validator rejected on a missing canonical
-        section. We surface the validator's section list as
+        validator's hard-coded set. The builder role followed the more
+        specific task description and the validator rejected on a missing
+        canonical section. We surface the validator's section list as
         "non-negotiable" with a worked skeleton so the user prompt's task
         description cannot quietly override it. Additional sections
         requested by the task are welcome on top of the required ones.
@@ -117,11 +117,7 @@ class BuildProfile:
         block only when `qa_handoff.md` is one of them. This makes the
         framing decomposition load-bearing instead of overridden.
         """
-        scoped = (
-            tuple(task_required_files)
-            if task_required_files
-            else self.required_files
-        )
+        scoped = tuple(task_required_files) if task_required_files else self.required_files
         required_lines = "\n".join(f"- `{name}`" for name in scoped)
         optional_block = ""
         if self.optional_files:

--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -2686,9 +2686,9 @@ class BuilderAssembleHandler(_CycleTaskHandler):
         active task only owns a subset of the profile's defaults). When
         omitted/empty, falls back to `profile.required_files` to preserve
         single-task builder behavior. The qa_handoff section check is
-        skipped when `qa_handoff.md` is not in scope, otherwise Bob would
-        be forced to emit a full qa_handoff in every builder task even if
-        framing routed it to a different task.
+        skipped when `qa_handoff.md` is not in scope, otherwise the builder
+        role would be forced to emit a full qa_handoff in every builder
+        task even if framing routed it to a different task.
 
         Returns an error message string if validation fails, None if OK.
         """
@@ -2792,8 +2792,9 @@ class BuilderAssembleHandler(_CycleTaskHandler):
                 parts.append(f"- **{tag_key}**: {tag_value}")
         # Issue #92: do NOT enumerate filenames here. The build profile's
         # `full_system_prompt` (composed from required_files/optional_files)
-        # is the single source of truth for what Bob must produce. This
-        # fallback only carries the format/path rules that are universal.
+        # is the single source of truth for what the builder role must
+        # produce. This fallback only carries the format/path rules that
+        # are universal.
         parts.append(
             "\n\nYou are ASSEMBLING the source code above into a deployable package. "
             "Do NOT rewrite or regenerate the source code — it is already written. "
@@ -2863,8 +2864,8 @@ class BuilderAssembleHandler(_CycleTaskHandler):
     def _get_assembly_inputs(self, inputs: dict[str, Any]) -> dict[str, str]:
         """Get all source/config artifacts for assembly (D8 — static, not capability-driven).
 
-        Bob always needs to see all source files regardless of stack to produce
-        correct packaging.
+        The builder role always needs to see all source files regardless of
+        stack to produce correct packaging.
         """
         contents = inputs.get("artifact_contents", {})
         sources = {}

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -127,10 +127,10 @@ def _fence_language_for(filename: str) -> str:
 def _format_repair_artifacts(artifacts: Any) -> str:
     """Render repair artifacts as fenced code blocks with filename headers.
 
-    Eve previously saw only the role-keyed one-line summary, so she would
-    return Verdict: FAIL on repairs whose artifacts were already in the
-    registry. Surfacing the full content here lets her cite specific
-    lines when checking acceptance criteria.
+    The qa role previously saw only the role-keyed one-line summary, so
+    it would return Verdict: FAIL on repairs whose artifacts were
+    already in the registry. Surfacing the full content here lets the
+    validator cite specific lines when checking acceptance criteria.
     """
     if not isinstance(artifacts, list) or not artifacts:
         return ""
@@ -164,10 +164,10 @@ class _RepairPromptMixin:
 
     The base `_CycleTaskHandler` user prompt is PRD + prior_outputs only —
     the repair handler never sees the failed task's expected_artifacts /
-    acceptance_criteria, so Bob/Neo emit generic content instead of
-    re-producing the named artifact that failed acceptance. This mixin
-    surfaces the failed task's contract and the failure context to the
-    LLM. Used by all three repair handlers below.
+    acceptance_criteria, so the dev/builder roles emit generic content
+    instead of re-producing the named artifact that failed acceptance.
+    This mixin surfaces the failed task's contract and the failure
+    context to the LLM. Used by all three repair handlers below.
     """
 
     _request_template_id = "request.cycle_repair_task"
@@ -277,9 +277,10 @@ class BuilderAssembleRepairHandler(_RepairPromptMixin, _CycleTaskHandler):
     Mirrors `DevelopmentCorrectionRepairHandler` but routed to the builder
     role so packaging/handoff failures (e.g. qa_handoff.md missing
     required sections, missing requirements.txt or package.json) get
-    repaired by Bob with the build-profile system prompt rather than by
-    Neo with the dev system prompt — Neo has no useful context for
-    builder.assemble outputs and simply ignores the assignment.
+    repaired by the builder role with the build-profile system prompt
+    rather than by the dev role with the dev system prompt — the dev
+    role has no useful context for builder.assemble outputs and simply
+    ignores the assignment.
     """
 
     _handler_name = "builder_assemble_repair_handler"
@@ -308,14 +309,15 @@ class QAValidateRepairHandler(_CycleTaskHandler):
 
     @staticmethod
     def _format_repair_summary(prior_outputs: dict[str, Any] | None) -> str:
-        """Render the upstream repair handler's artifacts for Eve's prompt.
+        """Render the upstream repair handler's artifacts for the qa prompt.
 
         The executor stores the repair task's outputs under its role key
         (e.g. `prior_outputs["builder"]` for builder.assemble_repair). For
         repair tasks the executor preserves the `artifacts` list (unlike
-        the regular fan-in path), so we surface filename + content here so
-        Eve can verify against the original acceptance criteria. Falls
-        back to the role-keyed summary when no artifacts are present.
+        the regular fan-in path), so we surface filename + content here
+        so the qa role can verify against the original acceptance
+        criteria. Falls back to the role-keyed summary when no artifacts
+        are present.
         """
         if not prior_outputs:
             return "(no repair output available)"

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -98,8 +98,9 @@ REPAIR_TASK_STEPS: list[tuple[str, str]] = [
 # Specialized repair sequences keyed by the failed task's task_type. The
 # correction loop dispatches the right pair instead of always running the
 # dev-flavored default — without this mapping a failed `builder.assemble`
-# task gets repaired by Neo (dev) who has no useful context, and Bob
-# (builder) is silently bypassed even though the failed work is his.
+# task gets repaired by the dev role (which has no useful context for
+# packaging output) and the builder role is silently bypassed even though
+# the failed work is the builder's.
 _REPAIR_STEPS_BY_FAILED_TASK_TYPE: dict[str, list[tuple[str, str]]] = {
     "development.develop": REPAIR_TASK_STEPS,
     "builder.assemble": [

--- a/src/squadops/ports/observability/heartbeat.py
+++ b/src/squadops/ports/observability/heartbeat.py
@@ -29,7 +29,7 @@ class AgentHeartbeatReporter(ABC):
         Send an agent status update.
 
         Args:
-            agent_id: Logical agent name/id (e.g., \"Neo\") — health-check stores lowercase.
+            agent_id: Logical agent name/id — health-check stores lowercase.
             lifecycle_state: Canonical lifecycle state (STARTING/READY/WORKING/BLOCKED/CRASHED/STOPPING).
             current_task_id: Optional current task id.
             version: Optional agent/framework version string.


### PR DESCRIPTION
## Summary

Agent names (Max/Neo/Bob/Eve/Nat/Data) are user-configurable via the squad profile, but several handler comments and docstrings hard-coded the default-squad names as if they were stable identifiers. A profile that names its dev agent \"Trinity\" instead of \"Neo\" would leave the source comments lying about who does what.

Replaced with role references (lead/dev/builder/qa/strat/data) — the role identifiers are the actual stable contract surface; the names are just labels.

## Touched

- \`src/squadops/capabilities/handlers/cycle_tasks.py\` (3 spots): \"Bob\" → \"the builder role\".
- \`src/squadops/capabilities/handlers/impl/repair_handlers.py\` (4 spots): \"Eve\" / \"Bob\" / \"Neo\" → role references.
- \`src/squadops/capabilities/handlers/build_profiles.py\`: \"Bob\" → \"the builder role\".
- \`src/squadops/cycles/task_plan.py\`: \"Neo\" / \"Bob\" → role references.
- \`adapters/cycles/distributed_flow_executor.py\` (2 spots): \"Data\" → \"the data role\"; \"Eve\" → \"the qa role\".
- \`src/squadops/ports/observability/heartbeat.py\`: dropped the \`e.g., \"Neo\"\` example from the agent_id docstring.
- \`src/squadops/agents/skills/data/__init__.py\`, \`data_analysis.py\`, \`metrics_collection.py\`: \"Data agent skill\" → \"skill for the data role\" (disambiguates from the proper-noun \"Data\" agent name).

## What stays

- Role display names like \`display_name=\"Data Agent\"\` in \`agents/models.py\` — those are role labels, not proper-noun names.
- All \"Max\" matches that are \"Maximum\" abbreviations (\`Max upload size\`, \`Max pool overflow\`, \`Max correction attempts\`, etc.).
- Filenames like \`data.py\` and \"data\" used as a role identifier.

## Test plan

- [x] \`./scripts/dev/run_regression_tests.sh\` (3718 passed, 1 skipped — no behavior changes).
- [x] \`grep -rE '\\b(Neo|Bob|Eve|Nat)\\b' src/ adapters/ --include='*.py'\` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)