### PR TITLE
feat(governance): structural_plan_change_candidate diagnostic on correction_decision

### DIFF
--- a/adapters/cycles/distributed_flow_executor.py
+++ b/adapters/cycles/distributed_flow_executor.py
@@ -2240,6 +2240,13 @@ class DistributedFlowExecutor(FlowExecutionPort):
             changes=tuple(decision_outputs.get("affected_task_types", [])),
             affected_task_types=tuple(decision_outputs.get("affected_task_types", [])),
             created_at=datetime.now(UTC),
+            # SIP-0092 M2 → M3 gate diagnostic.
+            structural_plan_change_candidate=str(
+                decision_outputs.get("structural_plan_change_candidate", "none")
+            ),
+            structural_plan_change_rationale=str(
+                decision_outputs.get("structural_plan_change_rationale", "")
+            ),
         )
         delta_content = json.dumps(delta.to_dict(), default=str).encode()
         delta_ref = ArtifactRef(

--- a/src/squadops/capabilities/handlers/impl/correction_decision.py
+++ b/src/squadops/capabilities/handlers/impl/correction_decision.py
@@ -25,7 +25,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _VALID_CORRECTION_PATHS = ("continue", "patch", "rewind", "abort")
+_VALID_PLAN_CHANGE_CANDIDATES = ("none", "add_task", "tighten_acceptance", "other")
 
+# SIP-0092 M2 → M3 gate diagnostic. The correction protocol can today
+# only choose continue/patch/rewind/abort — it cannot mutate the
+# implementation plan. M3 will add `decision: plan_change` with two
+# operations (add_task, tighten_acceptance). To know whether M3 is
+# worth shipping, we need to know how often the lead would have chosen
+# a structural plan change if it were available. This field captures
+# that intent without changing behavior.
 _DECISION_SYSTEM_PROMPT = """\
 You are the governance lead deciding how to respond to a failure during
 implementation. Given the failure analysis, select ONE correction path:
@@ -35,10 +43,33 @@ implementation. Given the failure analysis, select ONE correction path:
 - rewind: restore the last checkpoint and retry from that point
 - abort: the failure is unrecoverable; stop the run
 
+Then, separately, answer a diagnostic question: if you could ALSO modify
+the implementation plan itself (not yet available in this framework),
+which structural plan change would you choose?
+
+- none: the failure does not call for a plan change; continue/patch/rewind/abort suffices
+- add_task: a new task should be inserted into the plan to cover a gap the
+  original plan missed (e.g., a coverage gap for an endpoint, an integration
+  step the framing phase did not anticipate)
+- tighten_acceptance: an existing task's acceptance criteria should be
+  strengthened so this failure mode is caught next time (e.g., adding a
+  required regex_match or field_present check to an existing task)
+- other: a different structural change would be needed (remove/replace/reorder)
+
+This is a DIAGNOSTIC field. Your operative decision is the correction path
+above; the plan-change candidate does not run anything. Pick the answer
+that best describes what you would do if plan changes were available,
+even if you have to extrapolate.
+
 Return JSON with:
 - correction_path (string): one of continue/patch/rewind/abort
-- decision_rationale (string): 2-3 sentence justification
+- decision_rationale (string): 2-3 sentence justification of correction_path
 - affected_task_types (list[string]): task types affected by the decision
+- structural_plan_change_candidate (string): one of
+  none/add_task/tighten_acceptance/other
+- structural_plan_change_rationale (string): 1-2 sentence justification of
+  the plan-change candidate; explain what task would be added or what
+  acceptance would be tightened. Empty string if candidate is `none`.
 
 Return ONLY valid JSON, no markdown fences."""
 
@@ -127,6 +158,22 @@ class GovernanceCorrectionDecisionHandler(_CycleTaskHandler):
             path = "abort"
             decision["correction_path"] = path
 
+        # SIP-0092 M2 → M3 gate diagnostic. Validate and surface the
+        # plan-change candidate; default to `none` when missing or
+        # invalid so the field is always present in the artifact for
+        # gate-evidence aggregation.
+        plan_change_candidate = decision.get("structural_plan_change_candidate", "none")
+        if plan_change_candidate not in _VALID_PLAN_CHANGE_CANDIDATES:
+            logger.warning(
+                "%s: invalid structural_plan_change_candidate %r — defaulting to 'none'",
+                self._handler_name,
+                plan_change_candidate,
+            )
+            plan_change_candidate = "none"
+        decision["structural_plan_change_candidate"] = plan_change_candidate
+        plan_change_rationale = str(decision.get("structural_plan_change_rationale", ""))
+        decision["structural_plan_change_rationale"] = plan_change_rationale
+
         duration_ms = (time.perf_counter() - start_time) * 1000
 
         # SIP-0084 §10: prompt provenance (Stage 2 only — no assembled prompt)
@@ -143,6 +190,8 @@ class GovernanceCorrectionDecisionHandler(_CycleTaskHandler):
             "correction_path": path,
             "decision_rationale": decision.get("decision_rationale", ""),
             "affected_task_types": decision.get("affected_task_types", []),
+            "structural_plan_change_candidate": plan_change_candidate,
+            "structural_plan_change_rationale": plan_change_rationale,
             "artifacts": [
                 {
                     "name": self._artifact_name,

--- a/src/squadops/cycles/plan_delta.py
+++ b/src/squadops/cycles/plan_delta.py
@@ -29,6 +29,13 @@ class PlanDelta:
     changes: tuple[str, ...]
     affected_task_types: tuple[str, ...]
     created_at: datetime
+    # SIP-0092 M2 → M3 gate diagnostic (non-operative). Captures what
+    # structural plan change the lead would have chosen if M3's
+    # plan-mutation operations were available. The operative decision
+    # is `correction_path`; this field exists only to drive the M3
+    # justification gate.
+    structural_plan_change_candidate: str = "none"
+    structural_plan_change_rationale: str = ""
 
     def __post_init__(self) -> None:
         """Validate required fields are non-empty."""
@@ -54,6 +61,8 @@ class PlanDelta:
         """Deserialize from dict.
 
         Converts list fields to tuples and ISO string to datetime.
+        Tolerates payloads without the SIP-0092 diagnostic fields so
+        old persisted plan_delta artifacts still load.
         """
         coerced = dict(data)
         for field_name in ("changes", "affected_task_types"):

--- a/src/squadops/prompts/request_templates/request.governance_correction_decision.md
+++ b/src/squadops/prompts/request_templates/request.governance_correction_decision.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.governance_correction_decision
-version: "1"
+version: "2"
 required_variables:
   - prd
 optional_variables:
@@ -10,3 +10,14 @@ optional_variables:
 
 {{prd}}
 {{failure_analysis}}
+
+## Diagnostic question (non-operative)
+
+Today the framework can only run continue/patch/rewind/abort. A future
+version will allow `add_task` (insert a new task to cover a gap) and
+`tighten_acceptance` (strengthen an existing task's acceptance criteria).
+In addition to your operative decision above, answer: if those two plan
+changes were available, would you have chosen one of them, and why? Use
+`none` when continue/patch/rewind/abort fully addresses the failure.
+
+This answer is captured for measurement only — it does not run anything.

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -381,6 +381,100 @@ class TestCorrectionDecision:
 
         assert result.outputs["correction_path"] == "abort"
 
+    # ------------------------------------------------------------------
+    # SIP-0092 M2 → M3 gate diagnostic field (structural_plan_change_candidate)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("candidate", ["none", "add_task", "tighten_acceptance", "other"])
+    async def test_plan_change_candidate_passes_through(self, mock_context, candidate):
+        decision = {
+            "correction_path": "patch",
+            "decision_rationale": "Localized",
+            "affected_task_types": ["development.develop"],
+            "structural_plan_change_candidate": candidate,
+            "structural_plan_change_rationale": (
+                "Coverage gap on join/leave endpoints" if candidate != "none" else ""
+            ),
+        }
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=json.dumps(decision)),
+        )
+
+        h = GovernanceCorrectionDecisionHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+
+        assert result.outputs["structural_plan_change_candidate"] == candidate
+        assert (
+            result.outputs["structural_plan_change_rationale"]
+            == decision["structural_plan_change_rationale"]
+        )
+
+    async def test_plan_change_candidate_invalid_falls_back_to_none(self, mock_context):
+        """Invalid values shouldn't break the run — degrade to `none` so the
+        diagnostic field is always present and parseable for gate aggregation."""
+        decision = {
+            "correction_path": "patch",
+            "decision_rationale": "Localized",
+            "affected_task_types": [],
+            "structural_plan_change_candidate": "remove_task",  # not in Rev 1 scope
+            "structural_plan_change_rationale": "Should be dropped",
+        }
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=json.dumps(decision)),
+        )
+
+        h = GovernanceCorrectionDecisionHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+
+        assert result.outputs["structural_plan_change_candidate"] == "none"
+
+    async def test_plan_change_candidate_missing_defaults_to_none(self, mock_context):
+        """LLM may omit the field; the artifact must still carry the diagnostic
+        so gate-evidence aggregation can count `none` cycles separately from
+        cycles where the field never appeared."""
+        decision = {
+            "correction_path": "patch",
+            "decision_rationale": "Localized",
+            "affected_task_types": [],
+        }
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=json.dumps(decision)),
+        )
+
+        h = GovernanceCorrectionDecisionHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+
+        assert result.outputs["structural_plan_change_candidate"] == "none"
+        assert result.outputs["structural_plan_change_rationale"] == ""
+
+    async def test_plan_change_candidate_persists_in_artifact(self, mock_context):
+        """The persisted correction_decision.md JSON must contain both the
+        operative decision and the diagnostic so post-run analysis can pull
+        them off a single artifact."""
+        decision = {
+            "correction_path": "patch",
+            "decision_rationale": "Localized",
+            "affected_task_types": ["development.develop"],
+            "structural_plan_change_candidate": "add_task",
+            "structural_plan_change_rationale": "Need a separate join/leave test task",
+        }
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=json.dumps(decision)),
+        )
+
+        h = GovernanceCorrectionDecisionHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+
+        artifact = result.outputs["artifacts"][0]
+        body = json.loads(artifact["content"])
+        assert body["correction_path"] == "patch"
+        assert body["structural_plan_change_candidate"] == "add_task"
+        assert "join/leave" in body["structural_plan_change_rationale"]
+
 
 # ---------------------------------------------------------------------------
 # Repair handlers (thin subclasses)

--- a/tests/unit/cycles/test_correction_protocol.py
+++ b/tests/unit/cycles/test_correction_protocol.py
@@ -858,6 +858,67 @@ class TestPlanDelta:
         assert delta["analysis_summary"] == "Bob produced output without qa_handoff.md"
         assert delta["decision_rationale"] == "Cannot fix"
         assert delta["correction_path"] == "abort"
+        # SIP-0092 M2 → M3 gate diagnostic — must default to "none" when
+        # the correction-decision handler doesn't surface a candidate.
+        assert delta["structural_plan_change_candidate"] == "none"
+        assert delta["structural_plan_change_rationale"] == ""
+
+    async def test_plan_delta_carries_structural_change_candidate(
+        self, executor, mock_queue, mock_registry, mock_vault, mock_event_bus
+    ):
+        """SIP-0092 M2 → M3 gate diagnostic: when the correction-decision
+        handler emits `structural_plan_change_candidate`, the field
+        must travel into the persisted plan_delta artifact so gate-evidence
+        aggregation can count cycles where the lead would have wanted a
+        plan change if M3 were available."""
+        import json
+
+        semantic_outputs = {
+            "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
+            "role": "strat",
+        }
+        correction_decision = {
+            "summary": "patch",
+            "role": "lead",
+            "correction_path": "patch",
+            "decision_rationale": "Localized fix",
+            "affected_task_types": ["development.develop"],
+            "structural_plan_change_candidate": "add_task",
+            "structural_plan_change_rationale": "Need a separate join/leave test task",
+        }
+        analyze_failure = {
+            "classification": "work_product",
+            "analysis_summary": "Coverage gap on join/leave endpoints",
+            "role": "data",
+        }
+        script = [
+            ("FAILED", semantic_outputs, "bad"),
+            ("SUCCEEDED", analyze_failure, None),
+            ("SUCCEEDED", correction_decision, None),
+            # repair tasks (development.correction_repair, qa.validate_repair)
+            ("SUCCEEDED", {"summary": "ok", "role": "dev"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
+            # remaining tasks
+            ("SUCCEEDED", {"summary": "ok", "role": "dev"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "dev"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
+            ("SUCCEEDED", {"summary": "ok", "role": "data"}, None),
+        ]
+        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+
+        with patch(
+            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        delta_stores = [
+            c for c in mock_vault.store.call_args_list if c.args[0].artifact_type == "plan_delta"
+        ]
+        assert len(delta_stores) == 1
+        delta = json.loads(delta_stores[0].args[1].decode())
+        assert delta["structural_plan_change_candidate"] == "add_task"
+        assert "join/leave" in delta["structural_plan_change_rationale"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cycles/test_plan_delta.py
+++ b/tests/unit/cycles/test_plan_delta.py
@@ -100,3 +100,41 @@ class TestPlanDelta:
     def test_abort_allows_empty_changes(self):
         pd = _make_delta(correction_path="abort", changes=())
         assert pd.changes == ()
+
+    # --- SIP-0092 M2 → M3 gate diagnostic ---
+
+    def test_plan_change_candidate_defaults_to_none(self):
+        """Old call sites that don't yet populate the diagnostic must
+        still build a valid PlanDelta — the diagnostic is additive."""
+        pd = _make_delta()
+        assert pd.structural_plan_change_candidate == "none"
+        assert pd.structural_plan_change_rationale == ""
+
+    def test_plan_change_candidate_round_trips(self):
+        pd = _make_delta(
+            structural_plan_change_candidate="add_task",
+            structural_plan_change_rationale="Coverage gap on join/leave endpoints",
+        )
+        restored = PlanDelta.from_dict(pd.to_dict())
+        assert restored.structural_plan_change_candidate == "add_task"
+        assert restored.structural_plan_change_rationale == "Coverage gap on join/leave endpoints"
+
+    def test_from_dict_tolerates_legacy_payload_without_diagnostic(self):
+        """Persisted plan_delta_*.json artifacts from cycles before this
+        PR must still load — the diagnostic fields are absent and
+        from_dict must default them rather than KeyError."""
+        legacy = {
+            "delta_id": "d1",
+            "run_id": "r1",
+            "correction_path": "continue",
+            "trigger": "failure",
+            "failure_classification": "execution",
+            "analysis_summary": "summary",
+            "decision_rationale": "rationale",
+            "changes": [],
+            "affected_task_types": [],
+            "created_at": NOW.isoformat(),
+        }
+        pd = PlanDelta.from_dict(legacy)
+        assert pd.structural_plan_change_candidate == "none"
+        assert pd.structural_plan_change_rationale == ""


### PR DESCRIPTION
## Summary

Non-operative diagnostic field on \`governance.correction_decision\` to start collecting SIP-0092 M3 gate evidence in advance of any plan-mutation code.

The lead is asked, in addition to the operative \`correction_path\` (continue/patch/rewind/abort), what structural plan change they would have chosen if M3's \`add_task\` / \`tighten_acceptance\` operations were available — or \`none\` when the operative decision suffices. The field travels into the persisted \`plan_delta_*.json\` artifact so post-run aggregation can count cycles where the lead would have wanted a plan change without M3 yet being implemented.

## Why now (decoupled from M2)

SIP-0092 originally placed this diagnostic inside M2.2 (alongside the structured \`plan_review.yaml\` rubric). Hoisting it out into its own ~270-line PR lets the M3-justification signal start accumulating while M2's authoring-model question (sole-broker vs multi-role) is still being decided.

## Mechanism

- Allowed values: \`none | add_task | tighten_acceptance | other\`. Invalid or missing values default to \`none\` with a structured warning, so the field is always present on every \`plan_delta\` artifact.
- The companion \`structural_plan_change_rationale\` (free-prose, 1–2 sentence justification) carries the *what* of the candidate so triage doesn't have to infer.
- Travels: LLM response → handler outputs → executor's \`PlanDelta\` construction → persisted artifact.
- \`PlanDelta.from_dict\` tolerates legacy payloads without the diagnostic so older \`plan_delta_*.json\` artifacts still load.

## Test plan

- [x] \`pytest tests/unit/capabilities/test_impl_handlers.py tests/unit/cycles/test_plan_delta.py tests/unit/cycles/test_correction_protocol.py\` — 79 passed
- [x] \`./scripts/dev/run_regression_tests.sh\` — 3735 passed (+11 new), 1 skipped
- [x] \`ruff format\` clean
- [ ] Validate end-to-end: next cycle that fires correction should produce a \`plan_delta_*.json\` artifact with the diagnostic populated. Inspect the JSON; confirm the field appears regardless of the LLM's choice.

## New test coverage

- \`TestCorrectionDecision\` × 4 — parametrized candidate pass-through; invalid value falls back to \`none\`; missing field defaults to \`none\`; both operative + diagnostic fields persist into the artifact.
- \`TestPlanDelta\` × 3 — diagnostic defaults to \`none\` for old call sites; round-trips through \`to_dict\` / \`from_dict\`; legacy-payload tolerance.
- \`TestPlanDelta::test_plan_delta_carries_structural_change_candidate\` (executor path) — end-to-end through the executor's correction-loop with seeded responses; persisted \`plan_delta\` JSON carries the candidate and rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)