### PR TITLE
refactor: externalize SIP-0079 impl handler system prompts to task_type fragments

### DIFF
--- a/src/squadops/capabilities/handlers/impl/analyze_failure.py
+++ b/src/squadops/capabilities/handlers/impl/analyze_failure.py
@@ -58,68 +58,15 @@ class FailureAnalysis(BaseModel):
     @classmethod
     def classification_must_be_known(cls, v: str) -> str:
         if v not in _VALID_CLASSIFICATIONS:
-            raise ValueError(
-                f"classification {v!r} not in {sorted(_VALID_CLASSIFICATIONS)}"
-            )
+            raise ValueError(f"classification {v!r} not in {sorted(_VALID_CLASSIFICATIONS)}")
         return v
 
     @field_validator("contributing_factors")
     @classmethod
     def contributing_factors_must_be_substantive(cls, v: list[str]) -> list[str]:
         if not all(isinstance(s, str) and len(s.strip()) >= 5 for s in v):
-            raise ValueError(
-                "each contributing factor must be a string >=5 chars"
-            )
+            raise ValueError("each contributing factor must be a string >=5 chars")
         return v
-
-
-_ANALYSIS_SYSTEM_PROMPT = f"""\
-You are a data analyst performing root cause analysis on a task failure.
-
-The Failure Evidence block below carries structured signals from the failed
-handler. When present, USE THEM rather than restating the error string:
-
-- `validation_result.checks` — per-criterion typed-acceptance outcomes from
-  the failed handler. A `failed`-status check tells you the EXACT criterion
-  that rejected the work (regex pattern, missing field, missing endpoint).
-  Quote the failing check's name and `actual` field in your analysis.
-- `validation_result.missing_components` — specific files/sections the
-  validator expected but did not find. Name them in your analysis.
-- `rejected_artifacts[*].content_snippet` — the first ~1500 chars of what
-  the handler actually emitted. Compare against the failing checks to
-  identify whether it's a format issue, a missing-content issue, or a
-  scope-too-large issue.
-- `preliminary_failure_classification` — the failed handler's own classification.
-  Do not just echo it; corroborate or override it with evidence.
-
-Distinguish content-quality failures from structural failures explicitly,
-because downstream correction-decision uses your analysis to choose between
-patch (single-task content fix) and rewind (multi-task scope change). State
-which you observed.
-
-Classify the failure into one of these categories:
-- {FailureClassification.EXECUTION}: runtime error, timeout, infrastructure issue
-- {FailureClassification.WORK_PRODUCT}: output doesn't meet quality/correctness bar
-  (typed check failed on emitted artifact — usually patchable)
-- {FailureClassification.ALIGNMENT}: output doesn't match requirements/contract
-  (artifact correct in isolation but wrong against PRD/contract — may need rewind)
-- {FailureClassification.DECISION}: wrong approach or architectural choice
-- {FailureClassification.MODEL_LIMITATION}: LLM capability gap (e.g. completion
-  truncated at token cap, scope exceeds single-call budget)
-
-Return JSON with these REQUIRED fields:
-- classification (string): EXACTLY one of: {", ".join(sorted(_VALID_CLASSIFICATIONS))}
-- analysis_summary (string, >=20 chars): concrete 2-3 sentence root cause. State the
-  specific component, the specific symptom (cite the failing check name when
-  available), and (if knowable) the specific cause. Do NOT write "N/A", "unknown",
-  or empty strings — if you cannot determine the cause from the evidence, say SO
-  and name the missing evidence.
-- contributing_factors (list[string], >=1 item, each >=5 chars): factors that
-  contributed. Each factor must be a concrete observable, not a generic phrase.
-
-Empty fields, the literal "N/A", and the literal "unknown" will be rejected.
-
-Return ONLY valid JSON, no markdown fences, no explanation."""
 
 
 class DataAnalyzeFailureHandler(_CycleTaskHandler):
@@ -157,8 +104,17 @@ class DataAnalyzeFailureHandler(_CycleTaskHandler):
                 user_parts.append(f"\n\n## Failure Evidence\n\n{evidence_json}")
             user_prompt = "\n".join(user_parts)
 
+        # System prompt assembled from role + task_type fragments
+        # (fragments/roles/data + fragments/shared/task_type/
+        # task_type.data.analyze_failure.md). PromptService tracks
+        # the version and surfaces it to LangFuse.
+        assembled = context.ports.prompt_service.assemble(
+            role=self._role,
+            hook="agent_start",
+            task_type=self._capability_id,
+        )
         messages = [
-            ChatMessage(role="system", content=_ANALYSIS_SYSTEM_PROMPT),
+            ChatMessage(role="system", content=assembled.content),
             ChatMessage(role="user", content=user_prompt),
         ]
 

--- a/src/squadops/capabilities/handlers/impl/correction_decision.py
+++ b/src/squadops/capabilities/handlers/impl/correction_decision.py
@@ -26,22 +26,6 @@ logger = logging.getLogger(__name__)
 
 _VALID_CORRECTION_PATHS = ("continue", "patch", "rewind", "abort")
 
-_DECISION_SYSTEM_PROMPT = """\
-You are the governance lead deciding how to respond to a failure during
-implementation. Given the failure analysis, select ONE correction path:
-
-- continue: the failure is non-critical; proceed with the remaining tasks
-- patch: inject repair tasks to fix the specific issue, then continue
-- rewind: restore the last checkpoint and retry from that point
-- abort: the failure is unrecoverable; stop the run
-
-Return JSON with:
-- correction_path (string): one of continue/patch/rewind/abort
-- decision_rationale (string): 2-3 sentence justification
-- affected_task_types (list[string]): task types affected by the decision
-
-Return ONLY valid JSON, no markdown fences."""
-
 
 class GovernanceCorrectionDecisionHandler(_CycleTaskHandler):
     """Decide the correction path after a failure analysis."""
@@ -83,8 +67,19 @@ class GovernanceCorrectionDecisionHandler(_CycleTaskHandler):
                 )
             user_prompt = "\n".join(user_parts)
 
+        # System prompt assembled from role + task_type fragments
+        # (fragments/roles/lead + fragments/shared/task_type/
+        # task_type.governance.correction_decision.md). Aligns this
+        # handler with the planning_tasks.py pattern so prompt
+        # versions are tracked by PromptService and surfaced to
+        # LangFuse rather than living as a Python string.
+        assembled = context.ports.prompt_service.assemble(
+            role=self._role,
+            hook="agent_start",
+            task_type=self._capability_id,
+        )
         messages = [
-            ChatMessage(role="system", content=_DECISION_SYSTEM_PROMPT),
+            ChatMessage(role="system", content=assembled.content),
             ChatMessage(role="user", content=user_prompt),
         ]
 

--- a/src/squadops/capabilities/handlers/impl/establish_contract.py
+++ b/src/squadops/capabilities/handlers/impl/establish_contract.py
@@ -26,18 +26,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_CONTRACT_SYSTEM_PROMPT = """\
-You are the governance lead. Given the planning artifacts and PRD, produce a
-JSON run contract with these fields:
-- objective (string): one-sentence goal
-- acceptance_criteria (list[string]): measurable success criteria
-- non_goals (list[string]): explicitly out of scope
-- time_budget_seconds (int): maximum wall-clock seconds
-- stop_conditions (list[string]): conditions that should halt execution
-- required_artifacts (list[string]): artifact filenames that must be produced
-
-Return ONLY valid JSON, no markdown fences, no explanation."""
-
 
 class GovernanceEstablishContractHandler(_CycleTaskHandler):
     """Establish a run contract before implementation begins."""
@@ -67,8 +55,17 @@ class GovernanceEstablishContractHandler(_CycleTaskHandler):
         else:
             user_prompt = self._build_user_prompt(prd, prior_outputs)
 
+        # System prompt assembled from role + task_type fragments
+        # (fragments/roles/lead + fragments/shared/task_type/
+        # task_type.governance.establish_contract.md). PromptService
+        # tracks the version and surfaces it to LangFuse.
+        assembled = context.ports.prompt_service.assemble(
+            role=self._role,
+            hook="agent_start",
+            task_type=self._capability_id,
+        )
         messages = [
-            ChatMessage(role="system", content=_CONTRACT_SYSTEM_PROMPT),
+            ChatMessage(role="system", content=assembled.content),
             ChatMessage(role="user", content=user_prompt),
         ]
 

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.data.analyze_failure.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.data.analyze_failure.md
@@ -1,0 +1,61 @@
+---
+fragment_id: task_type.data.analyze_failure
+layer: task_type
+version: "1.0.0"
+roles: ["data"]
+---
+## Failure Analysis (SIP-0079 §7.7)
+
+You are performing root cause analysis on a task failure.
+
+The Failure Evidence block carries structured signals from the failed
+handler. When present, USE THEM rather than restating the error string:
+
+- `validation_result.checks` — per-criterion typed-acceptance outcomes from
+  the failed handler. A `failed`-status check tells you the EXACT criterion
+  that rejected the work (regex pattern, missing field, missing endpoint).
+  Quote the failing check's name and `actual` field in your analysis.
+- `validation_result.missing_components` — specific files/sections the
+  validator expected but did not find. Name them in your analysis.
+- `rejected_artifacts[*].content_snippet` — the first ~1500 chars of what
+  the handler actually emitted. Compare against the failing checks to
+  identify whether it's a format issue, a missing-content issue, or a
+  scope-too-large issue.
+- `preliminary_failure_classification` — the failed handler's own classification.
+  Do not just echo it; corroborate or override it with evidence.
+
+Distinguish content-quality failures from structural failures explicitly,
+because downstream correction-decision uses your analysis to choose between
+patch (single-task content fix) and rewind (multi-task scope change). State
+which you observed.
+
+### Classification Categories
+
+Classify the failure into one of these categories:
+
+- `execution`: runtime error, timeout, infrastructure issue
+- `work_product`: output doesn't meet quality/correctness bar
+  (typed check failed on emitted artifact — usually patchable)
+- `alignment`: output doesn't match requirements/contract
+  (artifact correct in isolation but wrong against PRD/contract — may need rewind)
+- `decision`: wrong approach or architectural choice
+- `model_limitation`: LLM capability gap (e.g. completion truncated at
+  token cap, scope exceeds single-call budget)
+
+### Output Format
+
+Return JSON with these REQUIRED fields:
+
+- `classification` (string): EXACTLY one of the categories above.
+- `analysis_summary` (string, >=20 chars): concrete 2-3 sentence root cause.
+  State the specific component, the specific symptom (cite the failing check
+  name when available), and (if knowable) the specific cause. Do NOT write
+  "N/A", "unknown", or empty strings — if you cannot determine the cause from
+  the evidence, say SO and name the missing evidence.
+- `contributing_factors` (list[string], >=1 item, each >=5 chars): factors
+  that contributed. Each factor must be a concrete observable, not a generic
+  phrase.
+
+Empty fields, the literal "N/A", and the literal "unknown" will be rejected.
+
+Return ONLY valid JSON, no markdown fences, no explanation.

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.governance.correction_decision.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.governance.correction_decision.md
@@ -1,0 +1,25 @@
+---
+fragment_id: task_type.governance.correction_decision
+layer: task_type
+version: "1.0.0"
+roles: ["lead"]
+---
+## Correction Decision (SIP-0079 §7.7)
+
+You are deciding how to respond to a failure during implementation. Given
+the failure analysis, select ONE correction path:
+
+- `continue`: the failure is non-critical; proceed with the remaining tasks
+- `patch`: inject repair tasks to fix the specific issue, then continue
+- `rewind`: restore the last checkpoint and retry from that point
+- `abort`: the failure is unrecoverable; stop the run
+
+### Output Format
+
+Return JSON with these fields:
+
+- `correction_path` (string): one of `continue` / `patch` / `rewind` / `abort`
+- `decision_rationale` (string): 2-3 sentence justification
+- `affected_task_types` (list[string]): task types affected by the decision
+
+Return ONLY valid JSON, no markdown fences.

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.governance.establish_contract.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.governance.establish_contract.md
@@ -1,0 +1,19 @@
+---
+fragment_id: task_type.governance.establish_contract
+layer: task_type
+version: "1.0.0"
+roles: ["lead"]
+---
+## Establish Run Contract (SIP-0079)
+
+Given the planning artifacts and PRD, produce a JSON run contract with
+these fields:
+
+- `objective` (string): one-sentence goal
+- `acceptance_criteria` (list[string]): measurable success criteria
+- `non_goals` (list[string]): explicitly out of scope
+- `time_budget_seconds` (int): maximum wall-clock seconds
+- `stop_conditions` (list[string]): conditions that should halt execution
+- `required_artifacts` (list[string]): artifact filenames that must be produced
+
+Return ONLY valid JSON, no markdown fences, no explanation.

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -55,7 +55,13 @@ def mock_context():
     ctx.ports.llm.chat_stream_with_usage = chat_mock
     assembled = MagicMock()
     assembled.content = "System prompt"
+    assembled.assembly_hash = "sha256:test"
     ctx.ports.prompt_service.get_system_prompt = MagicMock(return_value=assembled)
+    # Externalized impl-handler system prompts (correction_decision /
+    # analyze_failure / establish_contract) now call assemble(role, hook,
+    # task_type) instead of using a hardcoded constant. Mock it here so
+    # the auto-attribute MagicMock doesn't return a non-string.
+    ctx.ports.prompt_service.assemble = MagicMock(return_value=assembled)
     ctx.ports.request_renderer = None
     ctx.correlation_context = None
     return ctx
@@ -308,6 +314,107 @@ class TestAnalyzeFailure:
         h = DataAnalyzeFailureHandler()
         result = await h.handle(mock_context, {"prd": "test"})
         assert result.success is False
+
+
+# ---------------------------------------------------------------------------
+# Externalized system prompts — pattern alignment with planning_tasks.py
+# ---------------------------------------------------------------------------
+
+
+class TestImplHandlerSystemPromptExternalization:
+    """The three SIP-0079 impl handlers (analyze_failure,
+    correction_decision, establish_contract) used to hardcode their
+    system prompts as Python string constants, bypassing PromptService
+    and missing LangFuse version tracking. Pinning the new contract:
+    each handler must call assemble(role, hook='agent_start',
+    task_type=capability_id) so role+task_type fragments compose the
+    system prompt the same way planning handlers do."""
+
+    @pytest.mark.parametrize(
+        "handler_cls,role,capability_id",
+        [
+            (
+                DataAnalyzeFailureHandler,
+                "data",
+                "data.analyze_failure",
+            ),
+            (
+                GovernanceCorrectionDecisionHandler,
+                "lead",
+                "governance.correction_decision",
+            ),
+            (
+                GovernanceEstablishContractHandler,
+                "lead",
+                "governance.establish_contract",
+            ),
+        ],
+        ids=lambda x: x.__name__ if isinstance(x, type) else x,
+    )
+    async def test_handler_assembles_system_prompt(
+        self, mock_context, handler_cls, role, capability_id
+    ):
+        # Drive the handler with a minimal-shaped LLM response so the
+        # success path runs and reaches the assemble() call before any
+        # parse-validation logic.
+        if handler_cls is DataAnalyzeFailureHandler:
+            payload = json.dumps(
+                {
+                    "classification": FailureClassification.EXECUTION,
+                    "analysis_summary": "Plenty long enough to pass the gate.",
+                    "contributing_factors": ["concrete factor"],
+                }
+            )
+        elif handler_cls is GovernanceCorrectionDecisionHandler:
+            payload = json.dumps(
+                {
+                    "correction_path": "patch",
+                    "decision_rationale": "Localized fix",
+                    "affected_task_types": [],
+                }
+            )
+        else:  # GovernanceEstablishContractHandler
+            payload = json.dumps(
+                {
+                    "objective": "Build a thing",
+                    "acceptance_criteria": ["passes tests"],
+                    "non_goals": [],
+                    "time_budget_seconds": 600,
+                    "stop_conditions": [],
+                    "required_artifacts": ["main.py"],
+                }
+            )
+        _set_llm_mock(mock_context, return_value=ChatMessage(role="assistant", content=payload))
+
+        h = handler_cls()
+        await h.handle(mock_context, {"prd": "test"})
+
+        mock_context.ports.prompt_service.assemble.assert_called_once_with(
+            role=role,
+            hook="agent_start",
+            task_type=capability_id,
+        )
+
+    async def test_decision_constant_removed(self):
+        """Defense against future drift back to a hardcoded string —
+        if someone re-introduces a `_DECISION_SYSTEM_PROMPT`-shaped
+        constant the import here will start succeeding and surface
+        the violation in CI."""
+        from squadops.capabilities.handlers.impl import correction_decision as _mod
+
+        assert not hasattr(_mod, "_DECISION_SYSTEM_PROMPT")
+        assert not hasattr(_mod, "_ANALYSIS_SYSTEM_PROMPT")
+        assert not hasattr(_mod, "_CONTRACT_SYSTEM_PROMPT")
+
+    async def test_analysis_constant_removed(self):
+        from squadops.capabilities.handlers.impl import analyze_failure as _mod
+
+        assert not hasattr(_mod, "_ANALYSIS_SYSTEM_PROMPT")
+
+    async def test_contract_constant_removed(self):
+        from squadops.capabilities.handlers.impl import establish_contract as _mod
+
+        assert not hasattr(_mod, "_CONTRACT_SYSTEM_PROMPT")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/prompts/test_planning_fragments.py
+++ b/tests/unit/prompts/test_planning_fragments.py
@@ -173,7 +173,10 @@ class TestPlanningFragmentsContent:
         assert len(content) > 50, f"Fragment content too short: {len(content)} chars"
 
     def test_task_type_fragments_total(self):
-        """Exactly 12 task_type fragments exist (5 planning + 2 refinement + 5 wrap-up)."""
+        """Exactly 15 task_type fragments exist:
+        5 planning + 2 refinement + 5 wrap-up + 3 SIP-0079 impl
+        (analyze_failure, correction_decision, establish_contract —
+        moved out of hardcoded constants in impl/*.py)."""
         task_type_dir = FRAGMENTS_DIR / "shared" / "task_type"
         md_files = list(task_type_dir.glob("*.md"))
-        assert len(md_files) == 12
+        assert len(md_files) == 15


### PR DESCRIPTION
## Summary

The three SIP-0079 implementation handlers — \`correction_decision\`, \`analyze_failure\`, \`establish_contract\` — hardcoded their system prompts as Python string constants (\`_DECISION_SYSTEM_PROMPT\`, \`_ANALYSIS_SYSTEM_PROMPT\`, \`_CONTRACT_SYSTEM_PROMPT\`). That bypassed the PromptService / LangFuse versioning the \`planning_tasks.py\` handlers already use, and meant prompt edits couldn't be tracked or A/B'd.

Move each system prompt into a \`task_type\` fragment file under \`src/squadops/prompts/fragments/shared/task_type/\`. Handlers now call \`prompt_service.assemble(role, hook=\"agent_start\", task_type=capability_id)\` — the same plumbing the planning handlers use. Composes role identity + task_type fragment automatically.

## What ships

| File | Purpose |
|---|---|
| \`fragments/shared/task_type/task_type.governance.correction_decision.md\` | Was \`_DECISION_SYSTEM_PROMPT\` |
| \`fragments/shared/task_type/task_type.data.analyze_failure.md\` | Was \`_ANALYSIS_SYSTEM_PROMPT\` (with FailureClassification enum interpolation resolved to literals) |
| \`fragments/shared/task_type/task_type.governance.establish_contract.md\` | Was \`_CONTRACT_SYSTEM_PROMPT\` |
| \`impl/correction_decision.py\` / \`impl/analyze_failure.py\` / \`impl/establish_contract.py\` | Constants deleted; handlers call \`prompt_service.assemble(...)\` |
| \`tests/unit/capabilities/test_impl_handlers.py\` | New \`TestImplHandlerSystemPromptExternalization\` class — pinned contract |
| \`tests/unit/prompts/test_planning_fragments.py\` | Fragment-count assertion bumped 12 → 15 |

## Behavior change

\`assemble()\` composes the role identity fragment (\`fragments/roles/{role}/identity.md\`) + the new task_type fragment, where previously the hardcoded constant was passed alone. So the system prompt now also includes the role identity content. This is consistent with how every planning handler works today — the impl handlers were the outliers.

I'd expect quality to be neutral-to-slightly-better (richer role context primes the LLM more consistently), but it's a measurable change. If the next gate cycle shows worse correction-decision quality, easy revert: pull the role-identity layer out of \`assemble()\` for these specific task_types.

## Relationship to PR #124

PR #124 (still open) added a \`structural_plan_change_candidate\` diagnostic to the correction-decision flow. It modified the now-deleted \`_DECISION_SYSTEM_PROMPT\` constant. After this PR merges, #124 will rebase and the diagnostic-question content moves into \`task_type.governance.correction_decision.md\` instead of the deleted constant. Trivial mechanical merge.

## Test plan

- [x] \`pytest tests/unit/capabilities/test_impl_handlers.py\` — 45 passed
- [x] \`./scripts/dev/run_regression_tests.sh\` — 3730 passed (+5 new), 1 skipped
- [x] \`ruff format\` clean
- [ ] Validate end-to-end on next cycle: confirm correction-decision / analyze-failure / establish-contract still produce parseable JSON (the existing parse-failure regression tests give me confidence; live cycle is the final proof)

## What this enables

- LangFuse now tracks versions of these three system prompts (was: invisible).
- Prompt edits become reviewable diffs in fragment files (was: blame-only on Python string constants).
- Future task_type fragment work (SIP-0093 propose/merge handlers) can follow a consistent pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)