### PR TITLE
fix(governance): repair merge-conflict resolution between #124 and #126

### DIFF
--- a/src/squadops/capabilities/handlers/impl/correction_decision.py
+++ b/src/squadops/capabilities/handlers/impl/correction_decision.py
@@ -26,6 +26,15 @@ logger = logging.getLogger(__name__)
 
 _VALID_CORRECTION_PATHS = ("continue", "patch", "rewind", "abort")
 
+# SIP-0092 M2 → M3 gate diagnostic. The correction protocol can today
+# only choose continue/patch/rewind/abort — it cannot mutate the
+# implementation plan. M3 will add `decision: plan_change` with two
+# operations (add_task, tighten_acceptance). To know whether M3 is
+# worth shipping, we capture which structural plan change the lead
+# would have chosen if it were available — the field is non-operative
+# and exists only to drive the M3 justification gate.
+_VALID_PLAN_CHANGE_CANDIDATES = ("none", "add_task", "tighten_acceptance", "other")
+
 
 class GovernanceCorrectionDecisionHandler(_CycleTaskHandler):
     """Decide the correction path after a failure analysis."""

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.governance.correction_decision.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.governance.correction_decision.md
@@ -1,7 +1,7 @@
 ---
 fragment_id: task_type.governance.correction_decision
 layer: task_type
-version: "1.0.0"
+version: "1.1.0"
 roles: ["lead"]
 ---
 ## Correction Decision (SIP-0079 §7.7)
@@ -14,12 +14,37 @@ the failure analysis, select ONE correction path:
 - `rewind`: restore the last checkpoint and retry from that point
 - `abort`: the failure is unrecoverable; stop the run
 
-### Output Format
+## Diagnostic question (non-operative)
+
+Then, separately, answer a diagnostic question: if you could ALSO modify
+the implementation plan itself (not yet available in this framework),
+which structural plan change would you choose?
+
+- `none`: the failure does not call for a plan change; continue/patch/rewind/abort suffices
+- `add_task`: a new task should be inserted into the plan to cover a gap the
+  original plan missed (e.g., a coverage gap for an endpoint, an integration
+  step the framing phase did not anticipate)
+- `tighten_acceptance`: an existing task's acceptance criteria should be
+  strengthened so this failure mode is caught next time (e.g., adding a
+  required regex_match or field_present check to an existing task)
+- `other`: a different structural change would be needed (remove/replace/reorder)
+
+This is a DIAGNOSTIC field. Your operative decision is the correction path
+above; the plan-change candidate does not run anything. Pick the answer
+that best describes what you would do if plan changes were available,
+even if you have to extrapolate.
+
+## Output Format
 
 Return JSON with these fields:
 
 - `correction_path` (string): one of `continue` / `patch` / `rewind` / `abort`
-- `decision_rationale` (string): 2-3 sentence justification
+- `decision_rationale` (string): 2-3 sentence justification of `correction_path`
 - `affected_task_types` (list[string]): task types affected by the decision
+- `structural_plan_change_candidate` (string): one of `none` /
+  `add_task` / `tighten_acceptance` / `other`
+- `structural_plan_change_rationale` (string): 1-2 sentence justification
+  of the plan-change candidate; explain what task would be added or what
+  acceptance would be tightened. Empty string if candidate is `none`.
 
 Return ONLY valid JSON, no markdown fences.

--- a/src/squadops/prompts/request_templates/request.governance_correction_decision.md
+++ b/src/squadops/prompts/request_templates/request.governance_correction_decision.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.governance_correction_decision
-version: "2"
+version: "3"
 required_variables:
   - prd
 optional_variables:
@@ -10,14 +10,3 @@ optional_variables:
 
 {{prd}}
 {{failure_analysis}}
-
-## Diagnostic question (non-operative)
-
-Today the framework can only run continue/patch/rewind/abort. A future
-version will allow `add_task` (insert a new task to cover a gap) and
-`tighten_acceptance` (strengthen an existing task's acceptance criteria).
-In addition to your operative decision above, answer: if those two plan
-changes were available, would you have chosen one of them, and why? Use
-`none` when continue/patch/rewind/abort fully addresses the failure.
-
-This answer is captured for measurement only — it does not run anything.


### PR DESCRIPTION
## Summary

**Main is broken.** The conflict resolution when #124 and #126 both merged dropped two pieces:

1. **\`_VALID_PLAN_CHANGE_CANDIDATES\` tuple lost** from \`correction_decision.py\`. The handler still references it on line 130 (in the diagnostic-field validation block from #124), so every code path that exercises \`governance.correction_decision\` raises \`NameError\` at runtime. **16 tests fail on main today.**

2. **Diagnostic-question content didn't migrate to the fragment.** PR #124 added the diagnostic-question section + the 5-field JSON schema to the (now-deleted) \`_DECISION_SYSTEM_PROMPT\` constant. PR #126 deleted the constant in favor of the new fragment file. The conflict resolution kept the new fragment but didn't carry over #124's additions — so the LLM is never asked to emit \`structural_plan_change_candidate\`, every \`plan_delta\` would silently default it to \`\"none\"\`, and the SIP-0092 M3 gate evidence we wanted to start collecting is invisible.

## Fix

- **Restore \`_VALID_PLAN_CHANGE_CANDIDATES\`** in \`correction_decision.py\` with the same allowed values from #124 (\`none\` / \`add_task\` / \`tighten_acceptance\` / \`other\`).
- **Move the diagnostic-question section + the 5-field JSON output schema** into \`task_type.governance.correction_decision.md\` (the fragment that #126 introduced as the new authoritative source). Bumped fragment version 1.0.0 → 1.1.0.
- **Remove the now-redundant \"Diagnostic question\" section from the request template** — was added in #124 as a fallback when only the hardcoded constant existed; now duplicated by the fragment. Single source of truth in the fragment. Bumped template version 2 → 3.

## Test plan

- [x] \`./scripts/dev/run_regression_tests.sh\` — was 3743 passed / 16 failed against current main; **3759 passed / 0 failed after this fix**.
- [x] \`pytest tests/unit/capabilities/test_impl_handlers.py::TestCorrectionDecision\` — 14 tests now pass (were all failing).
- [x] \`pytest tests/unit/cycles/test_correction_protocol.py::TestPlanDelta\` — both tests now pass (were failing).
- [ ] Validate end-to-end on next cycle that fires correction: confirm \`plan_delta_*.json\` carries a non-default \`structural_plan_change_candidate\` when the LLM picks one. (The previous validation cycle would have silently emitted \`\"none\"\` regardless of what the LLM thought, so the next cycle is the real first measurement.)

## Why this slipped past CI

#124 and #126 each passed their own regression suite at PR-author time — but each was authored against \`main\` independently and didn't see the other's deletes. The conflict resolution at merge time needed to take #124's diagnostic-field additions and rewrite them onto #126's fragment file (instead of the deleted constant). That manual lift didn't happen.

Trivially preventable in retrospect: when a follow-up PR (#126) deletes the surface a sibling PR (#124) is modifying, the rebase should be done before merge, not at it. Worth flagging as a soft rule for future stacked-PR situations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)