### PR TITLE
fix(impl): tolerant JSON extraction + raw-response logging in SIP-0079 handlers

### DIFF
--- a/src/squadops/capabilities/handlers/impl/_json_extraction.py
+++ b/src/squadops/capabilities/handlers/impl/_json_extraction.py
@@ -1,0 +1,183 @@
+"""Robust JSON extraction for SIP-0079 impl handlers.
+
+The three SIP-0079 implementation handlers (establish_contract,
+correction_decision, analyze_failure) ask the LLM to return a JSON
+object as the entire response. Strict-from-start parsing is brittle —
+LLMs commonly emit:
+
+- ``<think>...</think>`` blocks (Qwen3-family thinking mode) before
+  the actual content.
+- Prose preamble like ``"Here is the contract:"`` before a fenced
+  JSON block.
+- Trailing prose after the JSON.
+- Code fences (``` json ... ```) anywhere in the response, not just
+  at the start.
+
+Any of those produce ``json.loads("<think>...") -> "char 0"`` errors
+even when the actual JSON the LLM emitted is well-formed.
+
+This module provides ``extract_first_json_object(text)`` — a tolerant
+parser that finds the first balanced ``{...}`` after stripping
+fences and brace-matching, returning the parsed object or raising
+``JSONExtractionError`` with the truncated raw response so callers
+can log it for triage.
+
+The brace-matcher is string-aware: it ignores ``{`` and ``}`` inside
+double-quoted strings (handling escaped quotes) so a JSON value like
+``"description": "Use {} for placeholders"`` doesn't false-match.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+
+
+class JSONExtractionError(ValueError):
+    """Raised when no parseable JSON object is present in the response.
+
+    Carries ``raw_excerpt`` (first N chars of the response) so the
+    caller can include it in a structured log line without having to
+    re-truncate.
+    """
+
+    def __init__(self, message: str, raw_excerpt: str) -> None:
+        super().__init__(message)
+        self.raw_excerpt = raw_excerpt
+
+
+def _strip_think_blocks(text: str) -> str:
+    """Remove any ``<think>...</think>`` segments anywhere in the text.
+
+    Qwen3-family models emit these blocks regardless of where they
+    appear in the response. The handler doesn't care about reasoning
+    traces — only the final JSON object.
+    """
+    return _THINK_BLOCK_RE.sub("", text)
+
+
+def _strip_all_fences(text: str) -> str:
+    """Strip every `````...````` block's
+    fence markers (keeping the inner content).
+
+    Handles `````json``, ```````,
+    `````yaml``, etc. — every fence-language tag — by
+    replacing the opening and closing fences with empty strings and
+    leaving the inner content in place. JSON inside any fence becomes
+    candidate text for the brace matcher.
+    """
+    fence_open = re.compile(r"```[a-zA-Z0-9_+\-]*\s*\n?")
+    fence_close = re.compile(r"\n?```")
+    text = fence_open.sub("", text)
+    text = fence_close.sub("", text)
+    return text
+
+
+def _find_first_balanced_object(text: str) -> str | None:
+    """Locate the first balanced ``{...}`` substring.
+
+    String-aware: ignores ``{`` and ``}`` inside double-quoted strings
+    so a JSON value like ``"format: {field}"`` doesn't false-match.
+
+    Returns the balanced substring (including the surrounding braces)
+    or ``None`` if no balanced object is found.
+    """
+    start: int | None = None
+    depth = 0
+    i = 0
+    in_string = False
+    escape_next = False
+
+    while i < len(text):
+        ch = text[i]
+
+        if in_string:
+            if escape_next:
+                escape_next = False
+            elif ch == "\\":
+                escape_next = True
+            elif ch == '"':
+                in_string = False
+        else:
+            if ch == '"':
+                in_string = True
+            elif ch == "{":
+                if start is None:
+                    start = i
+                depth += 1
+            elif ch == "}" and start is not None:
+                depth -= 1
+                if depth == 0:
+                    return text[start : i + 1]
+
+        i += 1
+
+    return None
+
+
+def extract_first_json_object(
+    text: str,
+    *,
+    excerpt_length: int = 500,
+) -> dict[str, Any]:
+    """Parse the first JSON object from a possibly-noisy LLM response.
+
+    Tolerates (in order):
+
+    1. ``<think>...</think>`` reasoning blocks (Qwen3-family thinking
+       mode).
+    2. Markdown code fences anywhere in the text.
+    3. Prose preamble or trailing content around the JSON.
+    4. Whitespace.
+
+    Args:
+        text: The raw LLM response.
+        excerpt_length: How many leading chars to include in the
+            ``JSONExtractionError.raw_excerpt`` for diagnostic logging.
+
+    Returns:
+        The parsed JSON object (always a dict — JSON arrays raise
+        ``JSONExtractionError`` because every impl handler expects a
+        top-level object).
+
+    Raises:
+        JSONExtractionError: when no balanced ``{...}`` block exists,
+        when the matched block fails ``json.loads``, or when the
+        decoded value is not a dict.
+    """
+    if not text:
+        raise JSONExtractionError("empty response", "")
+
+    # Build an excerpt up-front so the caller always has it, even if
+    # the rest of this function mutates `text` for parsing.
+    raw_excerpt = text[:excerpt_length]
+
+    cleaned = _strip_think_blocks(text)
+    cleaned = _strip_all_fences(cleaned)
+
+    candidate = _find_first_balanced_object(cleaned)
+    if candidate is None:
+        raise JSONExtractionError(
+            "no balanced JSON object found in response",
+            raw_excerpt,
+        )
+
+    try:
+        parsed = json.loads(candidate)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise JSONExtractionError(
+            f"first balanced object failed json.loads: {exc}",
+            raw_excerpt,
+        ) from exc
+
+    if not isinstance(parsed, dict):
+        raise JSONExtractionError(
+            f"top-level JSON must be an object, got {type(parsed).__name__}",
+            raw_excerpt,
+        )
+
+    return parsed

--- a/src/squadops/capabilities/handlers/impl/analyze_failure.py
+++ b/src/squadops/capabilities/handlers/impl/analyze_failure.py
@@ -23,6 +23,10 @@ from squadops.capabilities.handlers.base import (
     HandlerResult,
 )
 from squadops.capabilities.handlers.cycle_tasks import _CycleTaskHandler
+from squadops.capabilities.handlers.impl._json_extraction import (
+    JSONExtractionError,
+    extract_first_json_object,
+)
 from squadops.cycles.task_outcome import FailureClassification, TaskOutcome
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
@@ -135,25 +139,24 @@ class DataAnalyzeFailureHandler(_CycleTaskHandler):
 
         content = response.content
 
-        # Parse JSON, then validate against schema (issue #84). Validation
-        # failure routes to NEEDS_REPLAN with a clear log line — silent
-        # coercion to a useless default produced wrong corrections in the
-        # past (live evidence: cyc_4cac11018af7).
-        cleaned = content.strip()
-        if cleaned.startswith("```"):
-            lines = cleaned.split("\n")
-            lines = [ln for ln in lines if not ln.strip().startswith("```")]
-            cleaned = "\n".join(lines)
-
+        # Parse JSON, then validate against schema (issue #84).
+        # Tolerates <think> blocks, code fences, and prose preamble
+        # around the JSON. Validation failure routes to NEEDS_REPLAN
+        # with a clear log line — silent coercion to a useless default
+        # produced wrong corrections in the past (live evidence:
+        # cyc_4cac11018af7). Raw response is logged on parse failure
+        # for triage of new model behavior modes.
         try:
-            raw = json.loads(cleaned)
+            raw = extract_first_json_object(content)
             analysis_model = FailureAnalysis.model_validate(raw)
-        except (json.JSONDecodeError, ValidationError) as exc:
+        except (JSONExtractionError, ValidationError) as exc:
             duration_ms = (time.perf_counter() - start_time) * 1000
+            raw_excerpt = exc.raw_excerpt if isinstance(exc, JSONExtractionError) else content[:500]
             logger.warning(
-                "analyze_failure_handler rejected output: %s | raw=%s",
+                "%s: rejected output: %s | raw[:500]=%r",
+                self._handler_name,
                 exc,
-                content[:300],
+                raw_excerpt,
             )
             evidence = HandlerEvidence.create(
                 handler_name=self._handler_name,

--- a/src/squadops/capabilities/handlers/impl/correction_decision.py
+++ b/src/squadops/capabilities/handlers/impl/correction_decision.py
@@ -16,6 +16,10 @@ from squadops.capabilities.handlers.base import (
     HandlerResult,
 )
 from squadops.capabilities.handlers.cycle_tasks import _CycleTaskHandler
+from squadops.capabilities.handlers.impl._json_extraction import (
+    JSONExtractionError,
+    extract_first_json_object,
+)
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
 
@@ -109,19 +113,23 @@ class GovernanceCorrectionDecisionHandler(_CycleTaskHandler):
 
         content = response.content
 
-        # Parse JSON decision
+        # Parse JSON decision. Tolerates <think> blocks, code fences,
+        # and prose preamble. Falls back to a structured `abort`
+        # decision if no balanced JSON object is found anywhere in
+        # the response, and logs a truncated raw response so triage
+        # has the actual model output.
         try:
-            cleaned = content.strip()
-            if cleaned.startswith("```"):
-                lines = cleaned.split("\n")
-                lines = [ln for ln in lines if not ln.strip().startswith("```")]
-                cleaned = "\n".join(lines)
-            decision = json.loads(cleaned)
-        except (json.JSONDecodeError, ValueError):
-            # Fallback: abort if unparseable
+            decision = extract_first_json_object(content)
+        except JSONExtractionError as exc:
+            logger.warning(
+                "%s: failed to parse correction decision JSON: %s | raw[:500]=%r",
+                self._handler_name,
+                exc,
+                exc.raw_excerpt,
+            )
             decision = {
                 "correction_path": "abort",
-                "decision_rationale": f"Unable to parse LLM response: {content[:200]}",
+                "decision_rationale": (f"Unable to parse LLM response: {exc.raw_excerpt[:200]}"),
                 "affected_task_types": [],
             }
 

--- a/src/squadops/capabilities/handlers/impl/establish_contract.py
+++ b/src/squadops/capabilities/handlers/impl/establish_contract.py
@@ -17,6 +17,10 @@ from squadops.capabilities.handlers.base import (
     HandlerResult,
 )
 from squadops.capabilities.handlers.cycle_tasks import _CycleTaskHandler
+from squadops.capabilities.handlers.impl._json_extraction import (
+    JSONExtractionError,
+    extract_first_json_object,
+)
 from squadops.cycles.task_outcome import TaskOutcome
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
@@ -91,17 +95,21 @@ class GovernanceEstablishContractHandler(_CycleTaskHandler):
 
         content = response.content
 
-        # Parse JSON contract from LLM response
+        # Parse JSON contract from LLM response. Tolerates <think>
+        # blocks, code fences, and prose preamble around the JSON —
+        # every impl handler is one model tantrum away from a "char 0"
+        # parse error otherwise. Logs a truncated raw response on
+        # failure so triage doesn't have to reconstruct what the LLM
+        # wrote from token counts alone.
         try:
-            # Strip markdown fences if present
-            cleaned = content.strip()
-            if cleaned.startswith("```"):
-                lines = cleaned.split("\n")
-                lines = [ln for ln in lines if not ln.strip().startswith("```")]
-                cleaned = "\n".join(lines)
-            contract_data = json.loads(cleaned)
-        except (json.JSONDecodeError, ValueError) as exc:
-            logger.warning("Failed to parse run contract JSON: %s", exc)
+            contract_data = extract_first_json_object(content)
+        except JSONExtractionError as exc:
+            logger.warning(
+                "%s: failed to parse run contract JSON: %s | raw[:500]=%r",
+                self._handler_name,
+                exc,
+                exc.raw_excerpt,
+            )
             duration_ms = (time.perf_counter() - start_time) * 1000
             evidence = HandlerEvidence.create(
                 handler_name=self._handler_name,

--- a/tests/unit/capabilities/handlers/test_json_extraction.py
+++ b/tests/unit/capabilities/handlers/test_json_extraction.py
@@ -1,0 +1,174 @@
+"""Tests for the robust JSON extraction helper used by SIP-0079 impl handlers.
+
+The pre-existing parse pattern (strip-leading-fence then ``json.loads``)
+fails on every common LLM-output shape that isn't pure JSON: thinking
+blocks, prose preamble, json-in-fence-after-prose. This regression hit
+``governance.establish_contract`` on cyc_a4e6dc3afe7a (2026-05-05) and
+silently aborted the implementation phase in ~4 minutes. The tolerant
+extractor below is the load-bearing fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.handlers.impl._json_extraction import (
+    JSONExtractionError,
+    extract_first_json_object,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+# ---------------------------------------------------------------------------
+# Happy path — pure JSON
+# ---------------------------------------------------------------------------
+
+
+class TestPureJSON:
+    def test_minimal_object(self):
+        assert extract_first_json_object('{"x": 1}') == {"x": 1}
+
+    def test_nested_object(self):
+        text = '{"outer": {"inner": [1, 2, {"deep": true}]}}'
+        assert extract_first_json_object(text) == {"outer": {"inner": [1, 2, {"deep": True}]}}
+
+    def test_pure_json_with_surrounding_whitespace(self):
+        assert extract_first_json_object('\n  {"x": 1}  \n') == {"x": 1}
+
+
+# ---------------------------------------------------------------------------
+# Real LLM-output shapes — the failure modes the cycle hit
+# ---------------------------------------------------------------------------
+
+
+class TestRealLLMShapes:
+    def test_think_block_then_json(self):
+        """Qwen3-family models emit <think>...</think> before content.
+        Strict parsing sees `<` as char 0 and dies with the same error
+        cyc_a4e6dc3afe7a hit."""
+        text = (
+            "<think>\n"
+            "The user wants a contract. Let me think about the objective...\n"
+            "Acceptance criteria should cover the join/leave endpoints.\n"
+            "</think>\n"
+            '{"objective": "Build runs app", "acceptance_criteria": ["passes tests"]}'
+        )
+        assert extract_first_json_object(text) == {
+            "objective": "Build runs app",
+            "acceptance_criteria": ["passes tests"],
+        }
+
+    def test_json_in_fence_with_prose_preamble(self):
+        """The dominant mode: lead role narrating before emitting JSON."""
+        text = (
+            "Here is the run contract:\n\n"
+            "```json\n"
+            '{"correction_path": "patch", "decision_rationale": "fix it"}\n'
+            "```\n\n"
+            "Let me know if you have questions."
+        )
+        assert extract_first_json_object(text) == {
+            "correction_path": "patch",
+            "decision_rationale": "fix it",
+        }
+
+    def test_json_then_trailing_prose(self):
+        """Some models emit JSON first, then explain. Trailing prose
+        must be tolerated — we want the JSON, not the explanation."""
+        text = (
+            '{"objective": "x", "acceptance_criteria": []}\n\n'
+            "Above is the contract. Note that I had to..."
+        )
+        assert extract_first_json_object(text) == {
+            "objective": "x",
+            "acceptance_criteria": [],
+        }
+
+    def test_think_block_and_fence_combined(self):
+        """Belt-and-suspenders: thinking mode + fenced output is common."""
+        text = (
+            '<think>reasoning here</think>\n\nSure, here\'s the JSON:\n```\n{"path": "abort"}\n```'
+        )
+        assert extract_first_json_object(text) == {"path": "abort"}
+
+    def test_only_first_object_returned_when_multiple_present(self):
+        """If the LLM emits two JSON blocks, take the first — every
+        impl handler expects exactly one decision/contract object."""
+        text = '{"correction_path": "patch"}\n\nAnd an alternative:\n{"correction_path": "abort"}'
+        assert extract_first_json_object(text) == {"correction_path": "patch"}
+
+
+# ---------------------------------------------------------------------------
+# String-aware brace matching
+# ---------------------------------------------------------------------------
+
+
+class TestBraceMatchingStringAware:
+    """Brace-matcher must ignore { and } inside double-quoted strings.
+    A JSON value like ``"description": "Use {} for placeholders"`` must
+    not throw the matcher off-balance — this is the bug that would
+    surface most often on values that quote source code or templates."""
+
+    def test_braces_in_string_value_dont_break_matcher(self):
+        text = '{"format": "Use {} for placeholders", "ok": true}'
+        assert extract_first_json_object(text) == {
+            "format": "Use {} for placeholders",
+            "ok": True,
+        }
+
+    def test_escaped_quote_in_string_value(self):
+        text = '{"msg": "She said \\"hi\\" with a {brace}", "n": 1}'
+        assert extract_first_json_object(text) == {
+            "msg": 'She said "hi" with a {brace}',
+            "n": 1,
+        }
+
+    def test_brace_in_string_followed_by_real_brace(self):
+        text = '{"k": "value with } inside"}'
+        assert extract_first_json_object(text) == {"k": "value with } inside"}
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    def test_empty_response_raises(self):
+        with pytest.raises(JSONExtractionError, match="empty"):
+            extract_first_json_object("")
+
+    def test_no_braces_at_all_raises(self):
+        with pytest.raises(JSONExtractionError, match="no balanced"):
+            extract_first_json_object("just prose, no JSON anywhere")
+
+    def test_unbalanced_open_brace_raises(self):
+        with pytest.raises(JSONExtractionError, match="no balanced"):
+            extract_first_json_object('{"x": 1')  # missing closing }
+
+    def test_top_level_array_raises(self):
+        """Every impl handler expects a top-level object. An array is
+        a contract violation; reject it with a clear error."""
+        with pytest.raises(JSONExtractionError, match="object"):
+            # The brace-matcher only finds {...} so a bare [...] gets
+            # the no-balanced error, but a {...} containing array-only
+            # content is technically still an object — this is fine.
+            extract_first_json_object("[1, 2, 3]")
+
+    def test_malformed_json_inside_braces_raises(self):
+        with pytest.raises(JSONExtractionError, match="json.loads"):
+            extract_first_json_object('{"x": notvalid}')
+
+    def test_raw_excerpt_on_error(self):
+        """The raw_excerpt attribute on the error carries the truncated
+        response so callers can log it without having to re-truncate."""
+        with pytest.raises(JSONExtractionError) as exc_info:
+            extract_first_json_object("not json at all" * 100)
+        assert exc_info.value.raw_excerpt.startswith("not json at all")
+        assert len(exc_info.value.raw_excerpt) <= 500
+
+    def test_raw_excerpt_respects_length_param(self):
+        with pytest.raises(JSONExtractionError) as exc_info:
+            extract_first_json_object("xxxxxxxxxxxxxx" * 50, excerpt_length=10)
+        assert len(exc_info.value.raw_excerpt) == 10

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -135,6 +135,61 @@ class TestEstablishContract:
         assert result.success is True
         assert result.outputs["contract"]["objective"] == "Test"
 
+    async def test_handles_think_block_then_json(self, mock_context):
+        """Regression: cyc_a4e6dc3afe7a (2026-05-05) failed at this
+        handler with `Expecting value: line 1 column 1 (char 0)` on
+        what was likely a Qwen3 <think> block followed by valid JSON.
+        The strict-from-start parser couldn't see past the thinking
+        block. Tolerant extraction must recover."""
+        contract = {
+            "objective": "Build runs app",
+            "acceptance_criteria": ["passes pytest"],
+            "non_goals": [],
+            "time_budget_seconds": 1800,
+            "stop_conditions": [],
+            "required_artifacts": ["main.py"],
+        }
+        thinking_response = (
+            "<think>\n"
+            "The user wants a contract for a runs app. Let me consider...\n"
+            "Acceptance should cover the join/leave endpoints.\n"
+            "</think>\n\n"
+            f"{json.dumps(contract)}"
+        )
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=thinking_response),
+        )
+
+        h = GovernanceEstablishContractHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+
+        assert result.success is True
+        assert result.outputs["contract"]["objective"] == "Build runs app"
+
+    async def test_handles_prose_preamble_before_fenced_json(self, mock_context):
+        """Same shape as the cyc_a4e6dc failure but with prose preamble
+        instead of a thinking block — plausible under the new
+        role-identity-prepended assembly path from PR #126."""
+        contract = {"objective": "Ship it", "acceptance_criteria": ["green CI"]}
+        response = (
+            "Here is the run contract you requested:\n\n"
+            "```json\n"
+            f"{json.dumps(contract)}\n"
+            "```\n"
+            "Let me know if any field needs adjustment."
+        )
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=response),
+        )
+
+        h = GovernanceEstablishContractHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+
+        assert result.success is True
+        assert result.outputs["contract"]["objective"] == "Ship it"
+
 
 # ---------------------------------------------------------------------------
 # DataAnalyzeFailureHandler


### PR DESCRIPTION
## Summary

Cycle \`cyc_a4e6dc3afe7a\` (2026-05-05) failed implementation in ~4 minutes when \`governance.establish_contract\` returned a 2521-token response that the handler parser rejected with \`Expecting value: line 1 column 1 (char 0)\`. The handler never persisted the raw response, so root cause had to be inferred from token counts alone.

This PR is the load-bearing fix regardless of root cause: the strip-leading-fence-then-\`json.loads\` pattern was always one model-behavior change away from this same failure. PR #126's prompt assembly change may have been the trigger; the brittleness was always the root.

## Honest scope

I called PR #126 the root cause earlier and the user pushed back — fairly. I was inferring from token counts and correlation; I hadn't seen the actual response. This PR ships defense regardless: it would have prevented the cycle-2 failure whether the actual issue was:

- PR #126's role-identity prepend biasing prose-preamble output
- Qwen3 \`<think>\` block emission that wasn't there in cycle 1
- Pure LLM nondeterminism on a single sample

The new logging path means **next time we will see the raw response** and won't have to guess.

## What ships

### New: \`src/squadops/capabilities/handlers/impl/_json_extraction.py\`

Shared helper \`extract_first_json_object(text)\` that:

- Strips \`<think>...</think>\` blocks anywhere in the text (Qwen3-family).
- Strips markdown code fences anywhere, not just at the start.
- Finds the first balanced \`{...}\` substring with a string-aware brace matcher (ignores \`{\`/\`}\` inside double-quoted strings, handles escaped quotes).
- Raises \`JSONExtractionError\` with a \`raw_excerpt\` attribute so callers can log the truncated response without re-truncating.

### Modified: all three SIP-0079 impl handlers

\`establish_contract.py\`, \`correction_decision.py\`, \`analyze_failure.py\` now call the shared helper. On parse failure, each emits a structured warning carrying the raw response — \`%s: failed to parse ... | raw[:500]=%r\`.

### Tests

- 18 unit tests for the extractor: pure JSON, all real LLM output shapes (think-block, prose preamble, json-in-fence, json-then-prose, combined), string-aware brace matching (3 cases), 7 error paths.
- 2 handler-level regression tests on \`GovernanceEstablishContractHandler\` pinning the cycle-2 failure modes (\`<think>\` block + prose preamble before fenced JSON).

## Test plan

- [x] \`pytest tests/unit/capabilities/handlers/test_json_extraction.py tests/unit/capabilities/test_impl_handlers.py\` — 70 passed
- [x] \`./scripts/dev/run_regression_tests.sh\` — 3779 passed (+20), 1 skipped (was 3759)
- [x] \`ruff format\` clean
- [ ] Validate end-to-end on a re-cycled run: \`establish_contract\` no longer dies on first task; if a parse failure does occur somewhere, the raw response is in the logs for triage.

## What we learn from the next cycle

Even if this fix prevents the visible failure, the new logging tells us **what** the LLM was actually emitting. If it was a \`<think>\` block, that confirms Qwen3 thinking mode is firing under #126's longer prompt; we may want to disable thinking mode at the model layer or strip it earlier (the extractor handles it, but the wasted tokens are a real cost). If it was prose-preamble, we get the actual prose for prompt-tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)