### PR TITLE
fix(impl): suppress role-identity prepend on JSON-emitting impl handlers

### DIFF
--- a/src/squadops/capabilities/handlers/impl/analyze_failure.py
+++ b/src/squadops/capabilities/handlers/impl/analyze_failure.py
@@ -108,13 +108,16 @@ class DataAnalyzeFailureHandler(_CycleTaskHandler):
                 user_parts.append(f"\n\n## Failure Evidence\n\n{evidence_json}")
             user_prompt = "\n".join(user_parts)
 
-        # System prompt assembled from role + task_type fragments
-        # (fragments/roles/data + fragments/shared/task_type/
-        # task_type.data.analyze_failure.md). PromptService tracks
-        # the version and surfaces it to LangFuse.
-        assembled = context.ports.prompt_service.assemble(
+        # System prompt is the task_type fragment ALONE — no role
+        # identity prepend. Same regression as governance.correction_decision
+        # captured in cycle cyc_a867cbf02205 (2026-05-05): Data wrote
+        # "# Data Agent Initialization Cycle / Role: Data Agent
+        # (SquadOps) / ## 1. Initialization Check" instead of the
+        # required JSON FailureAnalysis schema. Role-identity layer
+        # primes the role-play response. Suppress it for this
+        # JSON-emitting handler.
+        assembled = context.ports.prompt_service.assemble_task_only(
             role=self._role,
-            hook="agent_start",
             task_type=self._capability_id,
         )
         messages = [

--- a/src/squadops/capabilities/handlers/impl/correction_decision.py
+++ b/src/squadops/capabilities/handlers/impl/correction_decision.py
@@ -80,15 +80,18 @@ class GovernanceCorrectionDecisionHandler(_CycleTaskHandler):
                 )
             user_prompt = "\n".join(user_parts)
 
-        # System prompt assembled from role + task_type fragments
-        # (fragments/roles/lead + fragments/shared/task_type/
-        # task_type.governance.correction_decision.md). Aligns this
-        # handler with the planning_tasks.py pattern so prompt
-        # versions are tracked by PromptService and surfaced to
-        # LangFuse rather than living as a Python string.
-        assembled = context.ports.prompt_service.assemble(
+        # System prompt is the task_type fragment ALONE — no role
+        # identity prepend. Cycle cyc_a867cbf02205 (2026-05-05)
+        # captured raw output where Max (under the lead-identity
+        # prepend introduced by PR #126) wrote a "### Initialization
+        # Verification / Role Configuration: LeadAgent_SquadOps
+        # loaded ✅" markdown narrative instead of the JSON contract
+        # the prompt asked for. The role-identity fragment primes
+        # small models to enter role-play mode. Suppress it here
+        # while keeping the task_type fragment as the externalized
+        # source of truth.
+        assembled = context.ports.prompt_service.assemble_task_only(
             role=self._role,
-            hook="agent_start",
             task_type=self._capability_id,
         )
         messages = [

--- a/src/squadops/capabilities/handlers/impl/establish_contract.py
+++ b/src/squadops/capabilities/handlers/impl/establish_contract.py
@@ -59,13 +59,14 @@ class GovernanceEstablishContractHandler(_CycleTaskHandler):
         else:
             user_prompt = self._build_user_prompt(prd, prior_outputs)
 
-        # System prompt assembled from role + task_type fragments
-        # (fragments/roles/lead + fragments/shared/task_type/
-        # task_type.governance.establish_contract.md). PromptService
-        # tracks the version and surfaces it to LangFuse.
-        assembled = context.ports.prompt_service.assemble(
+        # System prompt is the task_type fragment ALONE — no role
+        # identity prepend. Same regression family as the other two
+        # SIP-0079 impl handlers; cycle cyc_a4e6dc3afe7a's "char 0"
+        # parse failure was the first symptom in this handler.
+        # Role-identity layer primes role-play responses; suppress
+        # it for this JSON-emitting handler.
+        assembled = context.ports.prompt_service.assemble_task_only(
             role=self._role,
-            hook="agent_start",
             task_type=self._capability_id,
         )
         messages = [

--- a/src/squadops/ports/prompts/service.py
+++ b/src/squadops/ports/prompts/service.py
@@ -68,6 +68,42 @@ class PromptService(ABC):
         pass
 
     @abstractmethod
+    def assemble_task_only(self, role: str, task_type: str) -> AssembledPrompt:
+        """
+        Assemble a system prompt from ONLY the task_type fragment.
+
+        Skips identity, global constraints, and lifecycle layers.
+        Used by handlers whose system prompt must contain only the
+        task instructions — no role identity preamble.
+
+        Cycle cyc_a867cbf02205 (2026-05-05) showed that the lead and
+        data role-identity fragments cause spark-squad models
+        (qwen3.6:27b) to enter "agent role-play initialization mode"
+        before doing the requested task. The result: handlers that
+        ask for JSON output get back markdown narratives like
+        "### Initialization Verification / Role Configuration: Loaded ✅"
+        instead of the structured response. The fix is to suppress
+        the role-identity layer for these JSON-emitting handlers
+        while keeping the externalized task_type fragment as the
+        single source of truth for the prompt content.
+
+        Args:
+            role: Agent role ID. Used only for role-specific fragment
+                override lookup; identity content is NOT prepended.
+            task_type: ACI task type whose fragment becomes the
+                entire system prompt.
+
+        Returns:
+            AssembledPrompt containing only the task_type fragment.
+
+        Raises:
+            MandatoryLayerMissingError: If the task_type fragment
+                doesn't exist for the given role.
+            HashMismatchError: If the fragment fails integrity check.
+        """
+        pass
+
+    @abstractmethod
     def get_version(self) -> str:
         """
         Get the current prompt system version.

--- a/src/squadops/prompts/assembler.py
+++ b/src/squadops/prompts/assembler.py
@@ -233,6 +233,23 @@ class PromptAssembler(PromptService):
         """
         return self.assemble(role=role, hook="agent_start")
 
+    def assemble_task_only(self, role: str, task_type: str) -> AssembledPrompt:
+        """
+        Assemble system prompt from ONLY the task_type fragment.
+
+        Skips the identity / constraints / lifecycle layers that
+        :meth:`assemble` composes. See port docstring for the
+        cycle-evidenced motivation (lead/data identities priming
+        smaller models into "role-play initialization" responses
+        instead of doing the requested JSON task).
+        """
+        fragment = self._resolve_fragment("task_type", role=role, hook=None, task_type=task_type)
+        if fragment is None:
+            raise MandatoryLayerMissingError(layer="task_type", role=role)
+
+        self._verify_hash(fragment)
+        return self._compose([fragment], role=role, hook="agent_start")
+
     def get_version(self) -> str:
         """
         Get the current prompt system version.

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -58,10 +58,12 @@ def mock_context():
     assembled.assembly_hash = "sha256:test"
     ctx.ports.prompt_service.get_system_prompt = MagicMock(return_value=assembled)
     # Externalized impl-handler system prompts (correction_decision /
-    # analyze_failure / establish_contract) now call assemble(role, hook,
-    # task_type) instead of using a hardcoded constant. Mock it here so
-    # the auto-attribute MagicMock doesn't return a non-string.
+    # analyze_failure / establish_contract) call assemble_task_only(role,
+    # task_type) — the task_type fragment with NO role-identity prepend.
+    # Mock both forms so the auto-attribute MagicMock doesn't return a
+    # non-string.
     ctx.ports.prompt_service.assemble = MagicMock(return_value=assembled)
+    ctx.ports.prompt_service.assemble_task_only = MagicMock(return_value=assembled)
     ctx.ports.request_renderer = None
     ctx.correlation_context = None
     return ctx
@@ -380,10 +382,18 @@ class TestImplHandlerSystemPromptExternalization:
     """The three SIP-0079 impl handlers (analyze_failure,
     correction_decision, establish_contract) used to hardcode their
     system prompts as Python string constants, bypassing PromptService
-    and missing LangFuse version tracking. Pinning the new contract:
-    each handler must call assemble(role, hook='agent_start',
-    task_type=capability_id) so role+task_type fragments compose the
-    system prompt the same way planning handlers do."""
+    and missing LangFuse version tracking.
+
+    Cycle cyc_a867cbf02205 (2026-05-05) caught a regression in the
+    initial externalization: composing role identity + task_type
+    fragments via assemble() primed spark-squad models to write
+    role-play "Initialization Verification" markdown narratives
+    instead of the requested JSON. Updated contract: handlers call
+    assemble_task_only(role, task_type) — the task_type fragment
+    only, no identity / constraints / lifecycle prepend. The
+    externalized fragment remains the single source of truth for
+    prompt content; LangFuse versioning still applies; identity
+    no longer triggers role-play."""
 
     @pytest.mark.parametrize(
         "handler_cls,role,capability_id",
@@ -406,12 +416,12 @@ class TestImplHandlerSystemPromptExternalization:
         ],
         ids=lambda x: x.__name__ if isinstance(x, type) else x,
     )
-    async def test_handler_assembles_system_prompt(
+    async def test_handler_uses_task_only_assembly(
         self, mock_context, handler_cls, role, capability_id
     ):
         # Drive the handler with a minimal-shaped LLM response so the
-        # success path runs and reaches the assemble() call before any
-        # parse-validation logic.
+        # success path runs and reaches the assemble_task_only() call
+        # before any parse-validation logic.
         if handler_cls is DataAnalyzeFailureHandler:
             payload = json.dumps(
                 {
@@ -444,11 +454,15 @@ class TestImplHandlerSystemPromptExternalization:
         h = handler_cls()
         await h.handle(mock_context, {"prd": "test"})
 
-        mock_context.ports.prompt_service.assemble.assert_called_once_with(
+        # New contract: task_type fragment ONLY — no role identity
+        # prepend that primes role-play responses on small models.
+        mock_context.ports.prompt_service.assemble_task_only.assert_called_once_with(
             role=role,
-            hook="agent_start",
             task_type=capability_id,
         )
+        # And the legacy full-assembly path must NOT be called for
+        # these JSON-emitting handlers.
+        mock_context.ports.prompt_service.assemble.assert_not_called()
 
     async def test_decision_constant_removed(self):
         """Defense against future drift back to a hardcoded string —

--- a/tests/unit/prompts/test_assembler.py
+++ b/tests/unit/prompts/test_assembler.py
@@ -290,3 +290,80 @@ class TestPromptAssembler:
         version = assembler.get_version()
 
         assert version == "0.8.5"
+
+    def test_assemble_task_only_returns_task_fragment_alone(self):
+        """assemble_task_only must NOT prepend identity / constraints /
+        lifecycle. Used by the SIP-0079 impl handlers whose system
+        prompt is JUST the task instructions — role-identity prepend
+        primed spark-squad models into role-play markdown narratives
+        instead of JSON output (cyc_a867cbf02205, 2026-05-05)."""
+        identity_text = "You are the Lead Agent in the SquadOps framework."
+        task_text = "## Correction Decision\n\nReturn JSON with correction_path and rationale."
+        fragments = {
+            "identity": create_mock_fragment("identity", "identity", identity_text),
+            "constraints.global": create_mock_fragment(
+                "constraints.global", "constraints", "Be safe."
+            ),
+            "task_type.governance.correction_decision": create_mock_fragment(
+                "task_type.governance.correction_decision",
+                "task_type",
+                task_text,
+            ),
+        }
+        repo = create_mock_repository(fragments)
+        assembler = PromptAssembler(repo)
+
+        result = assembler.assemble_task_only(
+            role="lead", task_type="governance.correction_decision"
+        )
+
+        # Only the task_type fragment content lands in the prompt.
+        assert task_text in result.content
+        # And identity / constraints content does NOT — that's the
+        # whole point of this method.
+        assert identity_text not in result.content
+        assert "Be safe." not in result.content
+        # Single fragment in the lineage chain.
+        assert len(result.fragment_hashes) == 1
+
+    def test_assemble_task_only_missing_fragment_raises(self):
+        """If the task_type fragment doesn't exist for the requested
+        role, raise MandatoryLayerMissingError so the caller can
+        surface a clear failure rather than silently produce an empty
+        system prompt."""
+        fragments = {
+            "identity": create_mock_fragment("identity", "identity", "I am."),
+        }
+        repo = create_mock_repository(fragments)
+        assembler = PromptAssembler(repo)
+
+        with pytest.raises(MandatoryLayerMissingError):
+            assembler.assemble_task_only(role="lead", task_type="nonexistent.task")
+
+    def test_assemble_task_only_role_specific_override(self):
+        """Role-specific task_type fragment wins over the shared
+        version, same precedence rule the regular assemble path uses."""
+        shared_text = "Shared task instructions."
+        role_text = "Role-specific override of the same task."
+        fragments = {
+            "task_type.governance.correction_decision": create_mock_fragment(
+                "task_type.governance.correction_decision",
+                "task_type",
+                shared_text,
+            ),
+            "task_type.governance.correction_decision:lead": create_mock_fragment(
+                "task_type.governance.correction_decision",
+                "task_type",
+                role_text,
+                roles=("lead",),
+            ),
+        }
+        repo = create_mock_repository(fragments)
+        assembler = PromptAssembler(repo)
+
+        result = assembler.assemble_task_only(
+            role="lead", task_type="governance.correction_decision"
+        )
+
+        assert role_text in result.content
+        assert shared_text not in result.content


### PR DESCRIPTION
## Summary

PR #128's raw-response logging caught the actual root cause of the cycle 2 / cycle 4 failures. **Direct evidence**, captured from cycle \`cyc_a867cbf02205\` (2026-05-05):

**Max (governance.correction_decision):**
\`\`\`
### 🔹 Initialization Verification
1. **Role Configuration**: \`LeadAgent_SquadOps\` loaded ✅
2. **Resource Access**: ...
3. **Pending Tasks**: ...
4. **Ready Status**: \`READY_FOR_CYCLE_START\`
### 🔹 Replan Strategy ...
\`\`\`

**Data (data.analyze_failure):**
\`\`\`
# Data Agent Initialization Cycle
**Status:** Ready
**Role:** Data Agent (SquadOps)
**Context:** Recovery from failed \`development.develop\` task...
## 1. Initialization Check
- **Role Configuration:** Loaded...
\`\`\`

Both handlers asked for JSON; both received role-play markdown narratives instead. The cause: PR #126 externalized impl handler system prompts to fragments and switched assembly to \`PromptService.assemble()\`, which by design layers identity + constraints + lifecycle + task_type. The lead/data identity fragments (\"You are the Lead Agent in the SquadOps framework... Orchestration / Decision Making / Communication / Maintain a strategic perspective...\") prime smaller spark-squad models (qwen3.6:27b) to introduce themselves before doing the requested task.

Pre-#126 these handlers used hardcoded \`_*_SYSTEM_PROMPT\` constants containing JUST the task instructions — no role-identity preamble. That's why cycles 1+2's \`establish_contract\` succeeded.

## Honest accounting

I called PR #126 the root cause earlier. You pushed back fairly because I was inferring from token counts. PR #128's logging finally surfaced the raw responses. **You were right to challenge the premature claim, and the evidence now confirms it.**

## Fix

| Layer | Change |
|---|---|
| **Port** \`squadops/ports/prompts/service.py\` | New abstract method \`assemble_task_only(role, task_type)\` |
| **Adapter** \`squadops/prompts/assembler.py\` | Concrete impl: resolves the task_type fragment via \`_resolve_fragment\`, verifies hash, composes alone (no identity / constraints / lifecycle) |
| **Handlers** \`impl/correction_decision.py\` / \`analyze_failure.py\` / \`establish_contract.py\` | Switched from \`assemble()\` → \`assemble_task_only()\`. Externalized fragments stay as the single source of truth; LangFuse version tracking still applies. |

The three task_type fragment files (added in #126) are unchanged and stay authoritative. Only the assembly path differs.

## What this preserves vs the old hardcoded constants

| | Pre-#126 hardcoded | Post-this-PR |
|---|---|---|
| LLM-visible content shape | task instructions only | task instructions only — identical |
| LangFuse version tracking | ❌ | ✅ |
| Prompt edits as reviewable diffs | ❌ (\`git blame\` on string constants) | ✅ (fragment file diffs) |
| Triggers role-play priming | ❌ | ❌ |

## Test plan

- [x] \`pytest tests/unit/prompts/test_assembler.py tests/unit/capabilities/test_impl_handlers.py\` — 69 passed
- [x] \`./scripts/dev/run_regression_tests.sh\` — 3782 passed (+3), 1 skipped
- [x] \`ruff format\` clean
- [ ] **Validate end-to-end on next cycle:** governance.correction_decision and data.analyze_failure should produce JSON, not role-play narratives. PR #128's \`raw[:500]=\` logging will capture any residual failure mode.

## New tests

- 3 assembler tests for \`assemble_task_only\`: returns task fragment alone (identity/constraints content NOT present), raises \`MandatoryLayerMissingError\` when fragment missing, honors role-specific override precedence.
- Existing \`TestImplHandlerSystemPromptExternalization\` updated: asserts \`assemble_task_only\` is called and the legacy \`assemble\` is NOT.

## Follow-up filed separately

Neo's \`development.develop\` fence-drop pattern (cycle 1 + cycle 4 both showed Neo emitting unparseable code without fenced blocks) is a different brittleness in a different handler — issue filed for separate triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)