### PR TITLE
fix(prompts): register SIP-0079 task_type fragments missing from manifest

### DIFF
--- a/src/squadops/prompts/fragments/manifest.yaml
+++ b/src/squadops/prompts/fragments/manifest.yaml
@@ -1,5 +1,5 @@
-version: 0.9.18
-updated_at: '2026-03-13T14:40:23.887991Z'
+version: 0.9.19
+updated_at: '2026-05-06T13:45:00.000000Z'
 fragments:
 - fragment_id: identity
   path: roles/comms/identity.md
@@ -133,4 +133,22 @@ fragments:
   roles:
   - lead
   sha256: 91af4ac066ce276fb60d7a049321c9f2743e5e32da671de40c9c7476fab0d28a
-manifest_hash: 1468b9fca859dab1d46171f6e5e66236b785cfc4a43655c7e5f64c69506d3dde
+- fragment_id: task_type.governance.establish_contract
+  path: shared/task_type/task_type.governance.establish_contract.md
+  layer: task_type
+  roles:
+  - lead
+  sha256: 737da7b531599a8bedf7c811394af4cae50e3506512244b6309cd646111b8bcb
+- fragment_id: task_type.governance.correction_decision
+  path: shared/task_type/task_type.governance.correction_decision.md
+  layer: task_type
+  roles:
+  - lead
+  sha256: 5c265c612f8262a016392ec929ced75e7cbe576afa3c26e3d0d5de5bbe87a5e3
+- fragment_id: task_type.data.analyze_failure
+  path: shared/task_type/task_type.data.analyze_failure.md
+  layer: task_type
+  roles:
+  - data
+  sha256: fd44a28f65e449c6320b5ee5f1d8121013a03c7baa757965334c4e19c7904779
+manifest_hash: fa45dab78329e0882ec1e5a4b449d4b7b9926a1f7d27513ac7178a256c4b64bf

--- a/tests/unit/prompts/test_manifest_completeness.py
+++ b/tests/unit/prompts/test_manifest_completeness.py
@@ -1,0 +1,68 @@
+"""Regression: prompt manifest must register every fragment file on disk.
+
+Bug it catches: PR #126 added three task_type fragment files
+(`task_type.governance.establish_contract`, `task_type.governance.correction_decision`,
+`task_type.data.analyze_failure`) but did not register them in
+`fragments/manifest.yaml`. PR #129 then made them mandatory via
+`assemble_task_only`, which failed at runtime with
+`MandatoryLayerMissingError` on the first impl task of every cycle (Max's
+`governance.establish_contract`).
+
+The shared-fragment lookup goes through the manifest, so an unregistered
+fragment is invisible regardless of whether the file exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+FRAGMENTS_DIR = Path(__file__).resolve().parents[3] / "src" / "squadops" / "prompts" / "fragments"
+
+
+def _load_manifest() -> dict:
+    with open(FRAGMENTS_DIR / "manifest.yaml", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _disk_fragment_paths() -> set[Path]:
+    return {p for p in FRAGMENTS_DIR.rglob("*.md") if p.name != "manifest.yaml"}
+
+
+def test_every_fragment_file_is_registered_in_manifest():
+    """Every .md fragment under fragments/ must be referenced by the manifest."""
+    manifest = _load_manifest()
+    registered = {FRAGMENTS_DIR / entry["path"] for entry in manifest["fragments"]}
+    on_disk = _disk_fragment_paths()
+
+    unregistered = on_disk - registered
+    assert not unregistered, (
+        "Fragment files exist on disk but are not registered in manifest.yaml — "
+        "shared-fragment lookups will fail with MandatoryLayerMissingError.\n"
+        f"Unregistered: {sorted(str(p.relative_to(FRAGMENTS_DIR)) for p in unregistered)}"
+    )
+
+
+def test_every_manifest_entry_points_to_existing_file():
+    """Every manifest entry's `path` must resolve to an existing file."""
+    manifest = _load_manifest()
+    missing = [entry["path"] for entry in manifest["fragments"]
+               if not (FRAGMENTS_DIR / entry["path"]).exists()]
+    assert not missing, f"Manifest references missing files: {missing}"
+
+
+def test_impl_handler_task_type_fragments_registered():
+    """Explicit guard for the SIP-0079 impl handler fragments that PR #126/#129 missed."""
+    manifest = _load_manifest()
+    registered_ids = {entry["fragment_id"] for entry in manifest["fragments"]}
+    required = {
+        "task_type.governance.establish_contract",
+        "task_type.governance.correction_decision",
+        "task_type.data.analyze_failure",
+    }
+    missing = required - registered_ids
+    assert not missing, (
+        "SIP-0079 impl handler task_type fragments are not registered in manifest.yaml. "
+        f"Missing: {sorted(missing)}. These are mandatory for assemble_task_only()."
+    )


### PR DESCRIPTION
## Summary

- PR #126 created three task_type fragment files on disk but never registered them in `fragments/manifest.yaml`. The shared-fragment lookup goes through the manifest, so unregistered fragments are invisible.
- Latent until PR #129 made the task_type layer mandatory via `assemble_task_only()`. Every cycle now fails at its first impl task (Max / `governance.establish_contract`) with `MandatoryLayerMissingError`.
- Adds the missing manifest entries, bumps manifest version, and adds regression tests so this can't happen again.

## Repro / impact

Cycle `cyc_8c27dc7f3260` / run `run_1a627a5d7fb1` (group_run, 2026-05-06): framing completed cleanly, impl run failed in 0.6 seconds on the first dispatch — `governance.establish_contract` (Max) raised `MandatoryLayerMissingError: Mandatory layer 'task_type' missing for role 'lead'` from `prompts/assembler.py:248` (`assemble_task_only`).

Same failure mode would hit `governance.correction_decision` (Max) and `data.analyze_failure` (Data) when SIP-0086 corrections kick in.

## Root cause

`FileSystemPromptRepository._resolve_path` for shared fragments calls `manifest.get_fragment_meta(fragment_id)` and falls back to None when the entry is missing. Three SIP-0079 impl handler fragments were missing from the manifest:

| Fragment | File on disk | In manifest? |
|---|---|---|
| `task_type.governance.establish_contract` | yes | no |
| `task_type.governance.correction_decision` | yes | no |
| `task_type.data.analyze_failure` | yes | no |

Before PR #129 these were optional via `assemble()`; PR #129 made them mandatory via `assemble_task_only()` which exposed the gap.

## Changes

- `src/squadops/prompts/fragments/manifest.yaml`: add the three entries with computed sha256, bump version `0.9.18 -> 0.9.19`, refresh `updated_at`, recompute `manifest_hash`.
- `tests/unit/prompts/test_manifest_completeness.py` (new): three regression tests
  - every `*.md` fragment file on disk is registered in the manifest
  - every manifest entry points to an existing file
  - explicit guard naming the three SIP-0079 impl-handler fragments

## Test plan

- [x] `pytest tests/unit/prompts/test_manifest_completeness.py -v` — 3 passed
- [x] `pytest tests/unit/prompts/ -v` — 305 passed
- [x] `./scripts/dev/run_regression_tests.sh` — 3785 passed, 1 skipped, 0 failed
- [x] Round-trip verification: `assemble_task_only(role, task_type)` succeeds for all three new entries
- [ ] Rebuild agent + runtime-api images on Spark and relaunch a `group_run` validation cycle to confirm impl phase gets past `governance.establish_contract`

## Notes

While running the manifest-completeness check I noticed two unrelated preexisting hash mismatches between the manifest and `roles/comms/identity.md` / `shared/identity/identity.md`. Those are out of scope for this fix; will track separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)