### PR TITLE
docs(SIP-0093/0092): initial plan doc + tightening from review

### DIFF
--- a/docs/plans/SIP-0092-implementation-plan-improvement-plan.md
+++ b/docs/plans/SIP-0092-implementation-plan-improvement-plan.md
@@ -5,7 +5,7 @@
 SIP-0092 is a SIP-0086 follow-up that closes three deferred gaps in the implementation plan pipeline:
 
 - **M1 — Typed Acceptance Criteria.** Today `acceptance_criteria` is `list[str]` informational input only; FC3 in `_validate_output_focused` is `included_in_evidence`. M1 introduces typed checks, severity, a `CheckOutcome` status enum, untrusted-input safety, and validator integration.
-- **M2 — Multi-Role Plan Authoring (implemented by SIP-0093).** `_produce_plan` currently runs as a side-effect inside `GovernanceReviewPlanHandler.handle()` (`planning_tasks.py:424`). The M1→M2 gate evaluation (`docs/plans/SIP-0092-gate-M1-evaluation.md`, merged 2026-05-05) selected the multi-role authoring path. M2 introduces a shared `plan_authoring_brief.yaml`, parallel domain proposers (`development.propose_plan_tasks`, `qa.propose_plan_tasks`, `strategy.propose_plan_guidance`), and a `governance.merge_plan` handler that assembles the canonical plan + `merge_decisions.yaml`. Full design in `sips/accepted/SIP-0093-Multi-Role-Plan-Authoring.md`; per-PR scope in `docs/plans/SIP-0093-multi-role-plan-authoring-plan.md` (to be drafted).
+- **M2 — Multi-Role Plan Authoring (implemented by SIP-0093).** `_produce_plan` currently runs as a side-effect inside `GovernanceReviewPlanHandler.handle()` (`planning_tasks.py:424`). The M1→M2 gate evaluation (`docs/plans/SIP-0092-gate-M1-evaluation.md`, merged 2026-05-05) selected the multi-role authoring path. M2 introduces a shared `plan_authoring_brief.yaml`, parallel domain proposers (`development.propose_plan_tasks`, `qa.propose_plan_tasks`, `strategy.propose_plan_guidance`), and a `governance.merge_plan` handler that assembles the canonical plan + `merge_decisions.yaml`. Full design in `sips/accepted/SIP-0093-Multi-Role-Plan-Authoring.md`; per-PR scope, runtime contracts, and tests in `docs/plans/SIP-0093-multi-role-plan-authoring-plan.md`.
 - **M3 — Plan Changes.** SIP-0086 §6.1.6 specified plan changes as the immutability-preserving evolution path; nothing was implemented. M3 introduces a plan-change schema, a pure structural applier, an execution-aware validator, conservative producer-side restrictions on autonomous correction (`add_task` + `tighten_acceptance` only), and provenance metadata on change-created tasks.
 
 **SIP:** `sips/accepted/SIP-0092-Implementation-Plan-Improvement.md` (Rev 2)
@@ -302,7 +302,7 @@ Integration (`tests/integration/cycles/test_plan_acceptance.py`, new):
 
 **Path forward:** The M1 → M2 gate evaluation (`docs/plans/SIP-0092-gate-M1-evaluation.md`, merged 2026-05-05) selected multi-role authoring. M2 is implemented by **SIP-0093 (Multi-Role Plan Authoring)** in five PRs (PR 93.0–93.4). The original M2 design (proposer/reviewer split with `development.plan_implementation`, `plan_review.yaml`, `plan_implementation_revise`, `review_status`, `max_planning_revisions`) is not implemented and lives in git history.
 
-**Stage scope at the SIP-0092 plan level.** The full design lives in `sips/accepted/SIP-0093-Multi-Role-Plan-Authoring.md`; per-PR file changes, schemas, and tests live in the SIP-0093 implementation plan doc to be drafted at `docs/plans/SIP-0093-multi-role-plan-authoring-plan.md`. This section keeps the SIP-0092 plan doc accurate at the cross-reference level — it does not duplicate SIP-0093 content.
+**Stage scope at the SIP-0092 plan level.** The full design lives in `sips/accepted/SIP-0093-Multi-Role-Plan-Authoring.md`; per-PR file changes, schemas, runtime contracts (RC-22..RC-28), and tests live in the SIP-0093 implementation plan doc at `docs/plans/SIP-0093-multi-role-plan-authoring-plan.md`. This section keeps the SIP-0092 plan doc accurate at the cross-reference level — it does not duplicate SIP-0093 content.
 
 ### Stage commitments at the SIP-0092 level
 
@@ -507,7 +507,11 @@ M1 has concrete prod evidence forcing the issue (filename-only validation passin
 
 Gate samples are long-cycle group_run runs, defined as:
 
-- **Profile:** the `validation` profile (defined in §6.4.1 / Profile Config Examples). It runs M1 at implementation-profile depth (`max_self_eval_passes: 2`, `max_correction_attempts: 3`) with M2 and M3 still off, so the typed-check signal and correction-decision diagnostics accumulate without M2/M3 confounding the measurement. Materially longer execution budget than the historical 1-hour smoke cycles — ≥2 hours wall-clock or until natural termination, whichever comes first. The same profile shape with M2/M3 flags flipped on becomes the M2 → M3 gate's measurement profile after those stages ship.
+- **Profile:** the `validation` profile (defined in §6.4.1 / Profile Config Examples). The profile's flag values are **time-dependent** — what the profile measures changes as stages ship:
+  - **Before SIP-0093 ships (M1 → M2 gate window):** `multi_role_plan_authoring: false`, M3 flags `false`. Runs M1 at implementation-profile depth (`max_self_eval_passes: 2`, `max_correction_attempts: 3`) so the typed-check signal and correction-decision diagnostics accumulate without M2/M3 confounding the measurement. This is the form the M1 → M2 gate evaluation used.
+  - **After SIP-0093 ships (M2 → M3 gate window):** `multi_role_plan_authoring: true`, M3 flags still `false`. The same profile shape with M2 (SIP-0093) on becomes the measurement profile for the M2 → M3 gate criteria (multi-role contribution non-redundancy, sole-author fallback rate, plan-quality regression, structural-change candidate rate).
+  - **After M2 → M3 gate passes:** all flags on; the profile becomes the post-gate `implementation` target (§6.4.2).
+- **Execution budget:** materially longer than the historical 1-hour smoke cycles — ≥2 hours wall-clock or until natural termination, whichever comes first.
 - **Reaches plan-relevant execution:** the run reaches at least the planning-phase gate, exposing plan-authoring, plan-validation, plan-review (when M2 is on), or correction behavior. Runs that fail before planning completes due to **infrastructure-only failures unrelated to the plan artifact** (RabbitMQ outage, Postgres connection refused, OOM kill, cosmic-ray restart) are **excluded** from the sample.
 - **Inclusion when build-phase fails:** runs that reach planning or build and surface plan, validation, correction, or review behavior count toward the sample **even if they ultimately fail to produce a working app**. The gate is measuring whether SIP-0092's machinery is doing real work, not whether the squad is shipping perfect apps.
 
@@ -525,7 +529,7 @@ Proceed to Stage M2 only when **all** of the following hold across a tracking wi
 
 If any criterion fails, **M2 is spun out as a separate proposed SIP** (`SIP-Implementation-Plan-Reviewer-Separation`) that re-litigates the design with the evidence-in-hand.
 
-**Alternative authoring model on the table.** A sibling proposed SIP — [`SIP-Multi-Role-Plan-Authoring`](../../sips/proposed/SIP-Multi-Role-Plan-Authoring.md) — argues that both M1's combined-author/reviewer and M2's split (Neo authors, Max reviews) share a sole-broker structural property, and proposes a propose-merge model where each contributing role authors plan tasks for its domain and Max merges. The M1 → M2 gate evaluation should treat the gate's "is M2 needed?" question as "is *some* authoring change needed, and if so, which model?" — with three paths: ship M2 as written, ship the multi-role alternative, or ship neither and revisit. The evaluation doc must explicitly record which path was chosen and why; if a path other than M2-as-written wins, M2 is the spun-out SIP rather than the alternative.
+**M1 → M2 gate has completed (2026-05-05).** The selected path is **SIP-0093 (Multi-Role Plan Authoring)**, accepted on 2026-05-05 (`sips/accepted/SIP-0093-Multi-Role-Plan-Authoring.md`). The gate evaluation lives at `docs/plans/SIP-0092-gate-M1-evaluation.md`. The original SIP-0092 M2-as-written design (single proposer/reviewer split with `development.plan_implementation` / `plan_review.yaml` / revision loop) is no longer active and remains only in git history. The "three paths" framing that produced this decision is preserved here for context but should not be read as an open choice — the choice is made.
 
 ### Gate M2 → M3
 
@@ -541,6 +545,21 @@ Proceed to Stage M3 only when **all** of the following hold across ≥10 long-cy
 | Plan-quality regression check | Merged `implementation_plan.yaml` schema-validity rate ≥ baseline (per SIP §6.2.4); typed-acceptance evaluator-error rate stays under the 5% bar from the M1→M2 gate | Ensures the merge step didn't regress the artifact M1 is built on. Multi-role authoring multiplies the surface for malformed YAML; if the merger smooths that out, the rate holds. If not, fix the merger before M3. |
 
 If any criterion fails, **M3 is spun out as a separate proposed SIP** (`SIP-Implementation-Plan-Changes`) with the gate evidence appended to its motivation section.
+
+#### Required telemetry inputs to the M2 → M3 gate evaluation doc
+
+The criteria above are computed from per-cycle telemetry SIP-0093 PR 93.4 emits. The gate evaluation doc must cite these inputs (sourced from `merge_decisions.yaml` and the LangFuse traces) per cycle in scope:
+
+| Input | Source | Used by |
+|---|---|---|
+| Complete-proposal count | `merge_decisions.yaml` `proposal_completeness: complete` | C1 denominator, C2 numerator-complement |
+| Partial-proposal count | `merge_decisions.yaml` `proposal_completeness: partial` | C1 (must still show non-redundancy), gate health context |
+| Fallback count | `merge_decisions.yaml` `proposal_completeness: fallback` | C2 numerator |
+| Missing-role distribution | `merge_decisions.yaml` `missing_proposals: [...]` | Gate health context (which role is dropping out) |
+| Merge-conflict count | `merge_decisions.yaml` `brief_conflicts_disposition` rollup | Plan-quality signal beyond C4 |
+| Per-canonical-task `proposed_by` | `merge_decisions.yaml` `canonical_tasks[].proposed_by` | C1 measurement |
+
+Without these inputs visible in the evaluation doc, "the gate criteria are met" is unverifiable. The doc must list per-cycle measured values for at least the first three rows and aggregate values for the rest.
 
 #### Diagnostic field for measuring M3 demand (added during M2 tracking, before M3 ships)
 

--- a/docs/plans/SIP-0093-multi-role-plan-authoring-plan.md
+++ b/docs/plans/SIP-0093-multi-role-plan-authoring-plan.md
@@ -1,0 +1,453 @@
+# Plan: SIP-0093 Multi-Role Plan Authoring
+
+## Context
+
+SIP-0093 implements SIP-0092 M2 via shared brief → parallel domain proposals → governed merge. The full design lives in `sips/accepted/SIP-0093-Multi-Role-Plan-Authoring.md` (Rev 2, accepted 2026-05-05, tightened in PR #136 on 2026-05-08). This plan doc pins per-PR file changes, schemas, runtime contracts, and tests.
+
+**SIP:** `sips/accepted/SIP-0093-Multi-Role-Plan-Authoring.md`
+**Parent SIP:** `sips/accepted/SIP-0092-Implementation-Plan-Improvement.md` (M2 implementation path)
+**Branch model:** Each PR lands on a feature branch off main; M1 substrate behavior is preserved under `multi_role_plan_authoring: false` at every PR.
+
+The five PRs (per SIP-0093 §8):
+
+- **PR 93.0** — `plan_authoring_brief.yaml` schema and `governance.prepare_plan_authoring_brief` handler. Plus the `PlanAuthoringService` extraction from `_produce_plan` (called by both the M1-substrate path and the SIP-0093 fallback path).
+- **PR 93.1** — Proposal and merge schemas (`ProposedPlanTasks` extension, `PlanGuidance`, `MergeDecisions`); brief-conflict model; per-canonical-task provenance.
+- **PR 93.2** — Role proposer handlers (`development.propose_plan_tasks`, `qa.propose_plan_tasks`, `strategy.propose_plan_guidance`); fan-out wiring; proposal failure handling.
+- **PR 93.3** — `governance.merge_plan` handler with deterministic merge policy (SIP-0093 §5.8) and `merge_decisions.yaml` output.
+- **PR 93.4** — Single-author fallback path; proposal completeness classification; gate package; observability metrics.
+
+**What already shipped** (do not re-create):
+
+- `src/squadops/cycles/proposed_role_tasks.py` — `ProposedRoleTasks` + `ProposedTask` dataclasses plus a `from_yaml()` parser. Landed in PR #125. **PR 93.1 extends this** rather than rewriting it.
+- `src/squadops/capabilities/handlers/_plan_authoring.py` — fenced YAML extraction and retry-with-corrective-feedback helpers. Used by all SIP-0093 handlers.
+- `governance.correction_decision` `structural_plan_change_candidate` diagnostic field. Landed in commit `9657449`. SIP-0093 leaves this handler intact.
+
+---
+
+## Runtime Contracts
+
+These extend SIP-0092's RC-9..RC-21. New contracts are RC-22 through RC-26.
+
+**RC-22 (Brief authority and immutability):** The `plan_authoring_brief.yaml` is authored once per cycle by `governance.prepare_plan_authoring_brief` and is immutable after emission. Proposers and the merger consume the brief as untrusted-input-shaped read-only context. The merger may *escalate* a `severity: blocking` brief conflict (per SIP-0093 §5.5) to operator at gate; the merger may *not* edit the brief. A revised brief, if needed, requires a re-run of the framing tail (out of scope for Rev 1).
+
+**RC-23 (Proposal-merger artifact flow):** Every `proposed_plan_tasks.yaml` and `plan_guidance.yaml` artifact MUST reference the brief by `source_brief_id`. The merger rejects any proposal whose `source_brief_id` does not match the upstream brief — that proposal is treated as a missing proposal (`proposal_completeness: partial`, role recorded in `missing_proposals`). This prevents stale proposals from a prior framing attempt from contaminating a re-run.
+
+**RC-24 (Merger-only task indices):** Proposers MUST NOT emit final numeric `task_index` values. Cross-proposal task references use `depends_on_focus` keys of the form `{role}:{focus}` per `proposed_role_tasks.focus_key()` (or symbolic dependency tags per SIP-0093 §5.4.3 — the existing implementation chose `{role}:{focus}` and Rev 1 adopts that). The proposal parser rejects integer values in `depends_on_focus`. The merger resolves these keys to numeric `depends_on` indices in the canonical `implementation_plan.yaml`.
+
+**RC-25 (`merge_decisions.yaml` audit completeness):** Every canonical task in `implementation_plan.yaml` MUST appear in `merge_decisions.yaml` with `task_index`, `source_proposal_task_keys`, `proposed_by`, and `merge_action ∈ {accepted, merged, modified, gap_filled}`. Tasks created by the merger to fill gaps (no proposal source) are marked `merge_action: gap_filled`. Test: full canonical-plan / merge-decisions correspondence asserted in PR 93.3.
+
+**RC-26 (Fallback marker authority):** When `multi_role_plan_authoring: true` and all role proposals fail, `merge_decisions.yaml` MUST set `authoring_mode: fallback_single_author` AND `proposal_completeness: fallback`. The canonical plan is produced by the shared `PlanAuthoringService.produce_plan(...)`. The system MUST NOT silently mark a fallback as `multi_role`; tests assert this property explicitly. Fallback frequency is a tracked gate metric (M2→M3 gate criterion C2).
+
+---
+
+## PR 93.0 — Brief schema, handler, and `PlanAuthoringService` extraction
+
+**Why this PR exists first:** lets the brief flow be validated end-to-end before scaling proposer parallelism. Also extracts the M1-substrate's `_produce_plan` body into a shared service so the SIP-0093 fallback path (PR 93.4) and the existing M1 path use one implementation. No proposer code yet — this PR is foundational.
+
+### Modified / new files
+
+| File | Change |
+|------|--------|
+| `src/squadops/cycles/plan_authoring_brief.py` (new) | `PlanAuthoringBrief` frozen dataclass + `from_yaml()` parser. Required Rev 1 fields: `version`, `brief_id`, `objective_summary`, `accepted_stack`, `must_cover_requirements`, `scope_cuts`, `risk_areas`. Optional fields preserved as-parsed but not validated beyond YAML well-formedness. |
+| `src/squadops/capabilities/handlers/planning_tasks.py` | New `GovernancePreparePlanAuthoringBriefHandler` (`governance.prepare_plan_authoring_brief`) — reads framing artifacts from `prior_outputs`, prompts the lead for a brief, parses with `PlanAuthoringBrief.from_yaml()`, returns the brief as primary output. Uses `_plan_authoring.retry_yaml_call` for the LLM loop. |
+| `src/squadops/capabilities/handlers/_plan_authoring_service.py` (new) | **`PlanAuthoringService`**: extracts the body of `_produce_plan` from `planning_tasks.py:432–620` into a function-style service with one entry point — `produce_plan(prompt_inputs, llm_client, run_state) -> ImplementationPlan`. The retry loop, prompt construction, role/task_type constraint logic, and YAML validation move here intact. Both legacy (M1 substrate) and SIP-0093 fallback paths call this service. NO duplicated logic. |
+| `src/squadops/capabilities/handlers/planning_tasks.py` | `GovernanceReviewPlanHandler.handle()` calls `PlanAuthoringService.produce_plan(...)` when `multi_role_plan_authoring: false` (replacing the inline `_produce_plan` invocation). When `multi_role_plan_authoring: true`, this handler does NOT call the service — it consumes the canonical plan produced by upstream `governance.merge_plan` (wired in PR 93.3). |
+| `src/squadops/cycles/task_plan.py` | Add `governance.prepare_plan_authoring_brief` to `PLANNING_TASK_STEPS` immediately after `qa.define_test_strategy`, gated on `multi_role_plan_authoring`. When the flag is false, the brief step is skipped. |
+| Capability registry (where planning task types are registered) | Register `governance.prepare_plan_authoring_brief`. |
+| `src/squadops/contracts/cycle_request_profiles/profiles/framing.yaml` | Conditional inclusion of the brief step when the resolved profile has `multi_role_plan_authoring: true`. |
+
+**Why a service, not a verbatim move:** verbatim move would leave the M1 path with a near-duplicate of the new code, guaranteed to drift on the next prompt or retry-loop tweak. Extracting first means both paths share one implementation; the only difference is *which handler invokes it* and *whether the resulting plan is the `review_plan` primary output or the fallback path's*.
+
+**Backward compatibility (RC-19):** when `multi_role_plan_authoring: false`, the M1 path calls `PlanAuthoringService.produce_plan(...)` with the same `prompt_inputs` as today's `_produce_plan` invocation, producing a byte-identical plan given identical seeded LLM responses. The verbatim-equivalence test below is the regression anchor.
+
+### `PlanAuthoringBrief` schema (Rev 1)
+
+```python
+@dataclass(frozen=True)
+class PlanAuthoringBrief:
+    version: int
+    brief_id: str
+    objective_summary: str
+    accepted_stack: dict[str, str]                     # e.g., {"language": "python", "framework": "fastapi"}
+    must_cover_requirements: list[str]
+    scope_cuts: list[str]
+    risk_areas: list[str]
+    # Optional Rev 1 fields (parsed if present, no validation beyond YAML shape):
+    source_artifact_refs: list[str] = field(default_factory=list)
+    major_components: list[str] = field(default_factory=list)
+    dependency_assumptions: list[str] = field(default_factory=list)
+    time_budget_guidance: dict[str, Any] = field(default_factory=dict)
+    task_granularity_guidance: str = ""
+    artifact_naming_conventions: list[str] = field(default_factory=list)
+    open_questions: list[str] = field(default_factory=list)
+```
+
+`brief_id` is a UUID generated at handler entry; the merger and proposers use it for `source_brief_id` matching (RC-23).
+
+### Config keys
+
+| Key | Default | Notes |
+|---|---|---|
+| `multi_role_plan_authoring` | `false` | Master switch. |
+| `plan_authoring_contributors` | `["development", "qa", "strategy"]` | Parsed and validated in PR 93.0 even though no proposers consume it yet. |
+
+### Tests
+
+- Unit (`tests/unit/cycles/test_plan_authoring_brief.py`, new):
+  - Required fields enforced; missing field raises `ValueError` with the field name in the message.
+  - Optional fields default to empty when absent; populated fields parse round-trip.
+  - Malformed YAML at top level raises `ValueError`.
+  - Edge case: brief with `must_cover_requirements: []` parses but a downstream consumer-level test asserts the merger surfaces a warning operator-note.
+- Unit (`tests/unit/capabilities/test_plan_authoring_service.py`, new):
+  - `PlanAuthoringService.produce_plan(...)` produces the same `ImplementationPlan` as `_produce_plan` for an identical seeded LLM response (verbatim-equivalence regression anchor).
+  - Service surfaces parse failures the same way `_produce_plan` did (no wording regression).
+- Unit (`tests/unit/capabilities/test_prepare_plan_authoring_brief.py`, new):
+  - Handler produces a `PlanAuthoringBrief` artifact for a seeded LLM response.
+  - Handler emits a structured failure when the LLM response cannot be parsed after `retry_yaml_call` exhaustion.
+- Integration (`tests/integration/cycles/test_brief_handler.py`, new):
+  - Framing phase end-to-end with `multi_role_plan_authoring: true` produces a brief artifact AND an unchanged `governance.review_plan` plan output (since proposers don't exist yet, this PR keeps the legacy path active even with the flag on — the brief step is decorative until PR 93.2 wires proposers).
+  - With `multi_role_plan_authoring: false`, the brief step is skipped and the cycle output is byte-identical to today's.
+
+---
+
+## PR 93.1 — Proposal and merge schemas
+
+Pure schema work. No new handlers; no behavior change. Lets PR 93.2 and 93.3 layer on a stable schema surface.
+
+### Modified / new files
+
+| File | Change |
+|------|--------|
+| `src/squadops/cycles/proposed_role_tasks.py` (extend) | Add required field `source_brief_id: str` to `ProposedRoleTasks`. Add `proposal_id: str`, `scope_statement: str`, `brief_conflicts: list[BriefConflict]` (default empty). Optional Rev 1 recommended fields: `source_artifact_refs`, `assumptions`, `risks`, `gaps_not_covered`, `confidence`. Update `from_yaml()` to enforce the new required fields and reject integer entries in `depends_on_focus` (RC-24). |
+| `src/squadops/cycles/proposed_role_tasks.py` (extend) | New `BriefConflict` frozen dataclass with fields: `brief_field: str`, `proposed_change: str`, `reason: str`, `severity: Literal["warning", "blocking"]`, `affected_proposal_task_keys: list[str]`. Parse rejects unknown severity. |
+| `src/squadops/cycles/plan_guidance.py` (new) | `PlanGuidance` frozen dataclass + `from_yaml()`. Fields: `version`, `guidance_id`, `source_brief_id`, `proposing_role: Literal["strategy"]`, `priority_guidance`, `ordering_guidance`, `risk_guidance`, `time_budget_guidance`, `scope_cut_guidance`, `must_not_skip`, `defer_if_time_constrained`, `confidence`. Required: `version`, `guidance_id`, `source_brief_id`, `proposing_role`. Rest optional. |
+| `src/squadops/cycles/merge_decisions.py` (new) | `MergeDecisions` frozen dataclass + `from_yaml()`. Required Rev 1 fields: `version`, `target_plan_id`, `brief_id`, `proposal_ids`, `guidance_ids`, `authoring_mode: Literal["multi_role", "fallback_single_author"]`, `proposal_completeness: Literal["complete", "partial", "fallback"]`, `missing_proposals: list[str]`, `canonical_tasks: list[CanonicalTaskProvenance]`, `brief_conflicts_disposition: list[BriefConflictDisposition]`, `operator_notes: str`. |
+| `src/squadops/cycles/merge_decisions.py` (new) | `CanonicalTaskProvenance` frozen dataclass: `task_index: int`, `source_proposal_task_keys: list[str]`, `proposed_by: list[str]`, `merge_action: Literal["accepted", "merged", "modified", "gap_filled"]`, `reason: str`. |
+| `src/squadops/cycles/merge_decisions.py` (new) | `BriefConflictDisposition` frozen dataclass: `brief_field: str`, `severity: Literal["warning", "blocking"]`, `disposition: Literal["accepted", "rejected", "escalated_to_operator"]`, `reason: str`. |
+
+### Schema invariants enforced by parsers
+
+- `ProposedRoleTasks.from_yaml()` rejects integer `depends_on_focus` entries (RC-24). Existing `focus_key()` collision check is preserved.
+- `PlanGuidance.from_yaml()` rejects `proposing_role != "strategy"` since strategy is the only Rev 1 contributor of guidance.
+- `MergeDecisions.from_yaml()` enforces: every `canonical_tasks[i].task_index` is unique and contiguous starting at 0; `proposal_completeness == "fallback"` requires `authoring_mode == "fallback_single_author"` (RC-26 link).
+
+### Config keys
+
+No new keys in this PR.
+
+### Tests
+
+- Unit (`tests/unit/cycles/test_proposed_role_tasks_v2.py`, extends existing test file):
+  - New required fields enforced with `ValueError` when missing.
+  - `depends_on_focus` integer entry rejected; string entry parses; unknown collision rule enforced.
+  - `BriefConflict` parses warning + blocking severities; unknown severity raises.
+- Unit (`tests/unit/cycles/test_plan_guidance.py`, new):
+  - Required fields enforced.
+  - `proposing_role: development` rejected.
+  - Optional fields default to empty when absent.
+- Unit (`tests/unit/cycles/test_merge_decisions.py`, new):
+  - Required fields enforced.
+  - `proposal_completeness: fallback` with `authoring_mode: multi_role` rejected (the RC-26 invariant).
+  - Non-contiguous `task_index` rejected.
+  - Duplicate `task_index` rejected.
+  - `BriefConflictDisposition` parses each disposition value; unknown rejected.
+
+---
+
+## PR 93.2 — Role proposer handlers and fan-out wiring
+
+Adds the three role proposers and wires them into the framing sequence after the brief.
+
+### Modified / new files
+
+| File | Change |
+|------|--------|
+| `src/squadops/capabilities/handlers/planning_tasks.py` | New `DevelopmentProposePlanTasksHandler` (`development.propose_plan_tasks`). Reads brief + framing artifacts; prompts dev for domain-scoped task proposals; parses with `ProposedRoleTasks.from_yaml()`; returns proposal as primary output. |
+| `src/squadops/capabilities/handlers/planning_tasks.py` | New `QaProposePlanTasksHandler` (`qa.propose_plan_tasks`). Same shape, qa-scoped prompt. |
+| `src/squadops/capabilities/handlers/planning_tasks.py` | New `StrategyProposePlanGuidanceHandler` (`strategy.propose_plan_guidance`). Reads brief + framing artifacts; produces `plan_guidance.yaml`. |
+| `src/squadops/cycles/task_plan.py` | Insert proposer steps into `PLANNING_TASK_STEPS` between `governance.prepare_plan_authoring_brief` and `governance.review_plan` when `multi_role_plan_authoring: true`. **Rev 1 ships sequential, not parallel** — see Risks section. |
+| Capability registry | Register the three new task types. |
+
+### Sequencing decision: Rev 1 ships sequential proposers
+
+SIP-0093 §5.11 specifies parallel fan-out. The current executor (`task_plan.py`) walks `PLANNING_TASK_STEPS` sequentially with no parallel-group construct. Adding parallelism requires:
+
+- Extending step-list shape to `list[tuple[str, str] | list[tuple[str, str]]]` and updating every consumer in `task_plan.py` and `planning_tasks.py`, OR
+- A new "fan-out group" marker the dispatcher recognizes.
+
+Both are non-trivial executor changes that broaden Rev 1's blast radius. **Rev 1 ships sequential.** Cost impact: framing tail extends from ~5–9 min (parallel target per SIP-0093 §6) to ~12–17 min (sequential). Still fits the validation profile's ≥2h cycle budget. Parallel fan-out becomes a Rev 2 follow-up after the propose-merge architecture has shown stability.
+
+The plan doc surfaces this trade-off explicitly so future-us doesn't think parallelism was forgotten.
+
+### Failure handling per RC-23
+
+When a proposer fails (LLM error, timeout, malformed YAML after `retry_yaml_call` exhaustion, mismatched `source_brief_id`), the handler emits a structured failure record into the cycle artifact stream — not an exception that kills the cycle. The merger (PR 93.3) reads these failure records as "this role's proposal is missing" and proceeds.
+
+### Config keys
+
+`plan_authoring_contributors` (already validated in PR 93.0) is consumed here. Omitting `qa` from the contributors list skips the qa proposer step at sequence-build time. Adding `build` is a Rev 2 extension (SIP-0093 §5.12); Rev 1 raises a config validation error if `build` is in the contributors list.
+
+### Tests
+
+- Unit (`tests/unit/capabilities/test_propose_plan_tasks.py`, new):
+  - Each of the three handlers produces its expected artifact for a seeded LLM response.
+  - Each handler emits a structured failure (not an exception) when `retry_yaml_call` exhausts.
+  - Each proposer's parsed output has `source_brief_id` matching the upstream brief; mismatch raises (failure record).
+- Integration (`tests/integration/cycles/test_proposer_fanout.py`, new):
+  - Framing phase end-to-end with `multi_role_plan_authoring: true` produces brief + 3 proposals + (still) the M1 substrate plan from `governance.review_plan` since the merger doesn't exist yet. This PR is foundational for PR 93.3.
+  - With one proposer's LLM seeded to fail, the cycle continues; the failed proposer's artifact is absent; remaining proposals exist.
+  - With `plan_authoring_contributors: ["development", "qa"]`, no strategy guidance is produced; cycle continues.
+
+---
+
+## PR 93.3 — `governance.merge_plan` handler with deterministic merge policy
+
+### Modified / new files
+
+| File | Change |
+|------|--------|
+| `src/squadops/capabilities/handlers/planning_tasks.py` | New `GovernanceMergePlanHandler` (`governance.merge_plan`). Reads brief + all proposal artifacts + guidance artifact + proposer-failure records from `prior_outputs`. Prompts the lead for a merge decision following the deterministic policy below. Emits canonical `implementation_plan.yaml` AND `merge_decisions.yaml`. |
+| `src/squadops/cycles/task_plan.py` | Insert `governance.merge_plan` after the proposer steps. `governance.review_plan` becomes sign-off only when the flag is on. |
+| Capability registry | Register `governance.merge_plan`. |
+
+### Deterministic merge policy (per SIP-0093 §5.8)
+
+The merger applies these rules in order:
+
+1. **Resolve brief conflicts.** Each `BriefConflict` from the proposers gets a `BriefConflictDisposition`. `severity: warning` → merger arbitrates (`accepted`/`rejected`). `severity: blocking` → `escalated_to_operator` automatic; canonical plan still emits.
+2. **Domain-owner wins for task ownership.** Dev tasks: development. QA tasks: qa. Strategy never owns tasks.
+3. **Deduplicate** — overlapping tasks across role proposals (Neo proposes "tests for endpoints"; Eve proposes the same → Eve wins because qa-domain).
+4. **Merge compatible acceptance criteria** — dev and qa criteria can both survive on the same canonical task when they test different surfaces. Strictest-compatible-wins for criteria on a strictness ordering (e.g., `count_min` higher wins).
+5. **Resolve dependency edges.** Convert `depends_on_focus` keys (`{role}:{focus}`) to numeric `depends_on` indices in the canonical plan. Unresolved keys (referencing a task no proposer produced) become `gap_fills` candidates per rule 7.
+6. **Apply strategy guidance.** Ordering, priority, time-budget, risk callouts. Guidance affects ordering and priority hints, never task content or ownership.
+7. **Fill gaps.** If qa references a dev component dev didn't propose, the merger may add the missing component (`merge_action: gap_filled`) or escalate via operator notes.
+8. **Assign final task indices** producing the canonical 0..N sequence.
+9. **Emit `merge_decisions.yaml`** with per-canonical-task provenance and brief-conflict dispositions.
+
+### Worked-example test (the central regression anchor)
+
+Per SIP-0093 §5.8 worked example: Neo proposes `dev.api.join` with `endpoint_defined`; Eve proposes `qa.backend.join_tests` with `regex_match` + `depends_on_focus: ["development:api join"]`. Merger emits two canonical tasks with the qa task's numeric `depends_on` resolved correctly. This test is mandatory; it's the deterministic-merge regression anchor.
+
+### The single most important integration test
+
+Per SIP-0093 §10: **"Eve proposes a QA task Neo omitted; merged plan includes it."** The seeded scenario: brief lists "duplicate-join 409 handling" in `must_cover_requirements`; Neo's proposal omits a corresponding qa task; Eve's proposal includes one. Assertion: the merged canonical plan contains the qa task. If this can't be reproduced, SIP-0093 isn't done. Lives in `tests/integration/cycles/test_merge_plan.py`.
+
+### Config keys
+
+No new keys.
+
+### Tests
+
+- Unit (`tests/unit/capabilities/test_merge_plan_handler.py`, new):
+  - Worked-example test (above).
+  - Brief conflict warning → merger records arbitration in `merge_decisions.yaml` `BriefConflictDisposition`.
+  - Brief conflict blocking → merger records `escalated_to_operator`; canonical plan still emits.
+  - Strict-compatible-wins acceptance criterion merging.
+  - Dependency resolution: known `{role}:{focus}` keys resolve to indices; unknown keys flow into gap-fill candidates.
+  - All-canonical-tasks-have-provenance invariant (RC-25).
+- Integration (`tests/integration/cycles/test_merge_plan.py`, new):
+  - **The Eve-proposes-omitted-qa-task test.** Required gate criterion.
+  - Full framing-phase end-to-end with merger: brief → 3 proposals → merger → `governance.review_plan` sign-off. Canonical plan validates against `ImplementationPlan` schema.
+  - Merger receives missing strategy proposal: cycle continues; `proposal_completeness: partial`; missing strategy guidance recorded as warning operator-note.
+
+---
+
+## PR 93.4 — Fallback, gate integration, observability
+
+Closes the loop: all-proposals-failed fallback, completeness classification surfaced at gate, metrics for the M2→M3 gate criteria.
+
+### Modified / new files
+
+| File | Change |
+|------|--------|
+| `src/squadops/capabilities/handlers/planning_tasks.py` | `GovernanceMergePlanHandler.handle()` — when all proposals failed, call `PlanAuthoringService.produce_plan(...)` (extracted in PR 93.0). Set `authoring_mode: fallback_single_author` and `proposal_completeness: fallback` on the emitted `merge_decisions.yaml`. RC-26 invariant. |
+| `src/squadops/capabilities/handlers/planning_tasks.py` | `GovernanceReviewPlanHandler.handle()` (sign-off path under `multi_role_plan_authoring: true`) surfaces `merge_decisions.yaml` content into the planning artifact's evidence section so the operator sees brief, canonical plan, and merge decisions side-by-side at gate. |
+| `src/squadops/api/routes/cycles/runs.py` | Gate-package extension — pass `plan_authoring_brief.yaml` and `merge_decisions.yaml` to the gate response alongside the canonical plan. |
+| `src/squadops/telemetry/...` (new metric emissions) | Authoring duration (per role + total), proposal completeness counts (`complete`/`partial`/`fallback`), merge conflict counts (`brief_conflicts_disposition` rollup), fallback frequency. |
+
+### Operator-visible artifacts at gate
+
+Per SIP-0093 §4 (Non-Goals — operator visibility):
+
+- **Primary** — `implementation_plan.yaml`, `plan_authoring_brief.yaml`, `merge_decisions.yaml`.
+- **Intermediate evidence** — per-role `proposed_plan_tasks.yaml` and `plan_guidance.yaml` available for inspection but not surfaced as primary artifacts.
+- **Fallback marker** — `authoring_mode: fallback_single_author` is visible at gate (operator must see when the cycle silently degraded to single-author).
+
+### Metrics (M2→M3 gate criteria support)
+
+The amended Gate M2→M3 criteria (per `docs/plans/SIP-0092-implementation-plan-improvement-plan.md`) need:
+
+- **C1 — Multi-role contribution non-redundancy rate.** Computed from `merge_decisions.yaml` per-canonical-task `proposed_by`. A cycle counts toward the threshold when at least one canonical task has `proposed_by` containing a non-dev role and is not present in the dev proposal.
+- **C2 — Sole-author fallback rate.** Computed from `authoring_mode: fallback_single_author` count over total cycles.
+- **C3 — Structural-change candidate rate.** Already emitted by `governance.correction_decision` (commit `9657449`). No change here.
+- **C4 — Plan-quality regression check.** Canonical-plan schema-validity rate; typed-acceptance evaluator-error rate. Existing M1 telemetry covers this.
+
+### Config keys
+
+No new keys.
+
+### Tests
+
+- Unit (`tests/unit/capabilities/test_merge_plan_fallback.py`, new):
+  - All three proposers seeded to fail → merger calls `PlanAuthoringService.produce_plan(...)` → emits canonical plan AND `merge_decisions.yaml` with `authoring_mode: fallback_single_author` AND `proposal_completeness: fallback`.
+  - RC-26 invariant: `authoring_mode: multi_role` with `proposal_completeness: fallback` is impossible (parser rejects; merger code asserts).
+  - Two proposers fail, one succeeds → fallback NOT triggered; `proposal_completeness: partial`; surviving proposal is honored.
+- Integration (`tests/integration/cycles/test_gate_package.py`, new):
+  - Gate response includes brief + canonical plan + merge_decisions.
+  - Cycle with full multi-role authoring → `authoring_mode: multi_role`, `proposal_completeness: complete`.
+  - Cycle with one missing proposer → `proposal_completeness: partial`; missing role surfaced in `missing_proposals`.
+  - Fallback cycle → operator sees `authoring_mode: fallback_single_author` in the gate package.
+- Integration (`tests/integration/telemetry/test_plan_authoring_metrics.py`, new):
+  - Authoring duration metrics emitted per role + total.
+  - Proposal completeness counts emitted as separate counters.
+  - Fallback frequency counter increments only on fallback cycles.
+
+---
+
+## Profile Config Examples
+
+Mirrors SIP-0092 §6.4. Each PR's flag flips are deliberately small.
+
+### After PR 93.0 lands (brief + service extraction; M1 path unchanged)
+
+```yaml
+# build profile — no behavior change
+defaults:
+  multi_role_plan_authoring: false          # M1 substrate behavior preserved
+```
+
+The brief handler exists and is wired but never runs at this stage. PR 93.0's gate is "M1 path is byte-identical to today" plus "brief handler works in isolation."
+
+### After PR 93.4 lands (post-SIP-0093 ship; default-off)
+
+```yaml
+# build profile — short-cycle work, M1 substrate (cost analysis: SIP-0093 §6)
+defaults:
+  multi_role_plan_authoring: false
+
+# validation profile — gate-cycle target with multi-role on
+defaults:
+  max_self_eval_passes: 2
+  max_correction_attempts: 3
+  multi_role_plan_authoring: true
+  plan_authoring_contributors: ["development", "qa", "strategy"]
+
+# selftest profile — smoke, M1 substrate (multi-role costs not justified for short cycles)
+defaults:
+  multi_role_plan_authoring: false
+```
+
+### Post-default-flip (separate small PR after stability criteria met)
+
+```yaml
+# build profile — multi-role on by default once stable
+defaults:
+  multi_role_plan_authoring: true
+  plan_authoring_contributors: ["development", "qa", "strategy"]
+```
+
+The default flip is **out of scope for PR 93.4**. It is a separate small PR after the M2→M3 gate's stability criteria hold across a tracking window.
+
+---
+
+## Out of Scope (Plan-Level)
+
+These are explicitly NOT in this plan. Each is named in SIP-0093 §12 (Future Work) or is a deliberate scope cut.
+
+- **Parallel proposer fan-out.** Rev 1 ships sequential. Parallelism is a Rev 2 executor change.
+- **Builder/Bob contributor (`build.propose_plan_tasks`).** SIP-0093 §5.12 explicit Rev 2 extension. Config validation rejects `build` in `plan_authoring_contributors` for Rev 1.
+- **Per-role plan-change authoring at correction time.** SIP-0093 §12; depends on M3 shipping.
+- **Proposer competition** (two proposers per role with different prompts).
+- **Operator-visible per-role contribution surface in console UI.**
+- **Adaptive proposer selection** based on telemetry.
+- **Brief revision loop.** Rev 1 escalates blocking conflicts to operator; brief is immutable per RC-22.
+- **Default flip of `multi_role_plan_authoring`.** Separate small PR after stability criteria met across a tracking window.
+
+---
+
+## Test Coverage Targets
+
+Every test must catch a specific bug per `docs/TEST_QUALITY_STANDARD.md`. No tautological tests on dataclass fields.
+
+| Layer | PR 93.0 | PR 93.1 | PR 93.2 | PR 93.3 | PR 93.4 |
+|-------|---------|---------|---------|---------|---------|
+| Unit (parser / dataclasses) | ✅ | ✅ | n/a | n/a | n/a |
+| Unit (handler) | ✅ | n/a | ✅ | ✅ | ✅ |
+| Integration (handler) | ✅ | n/a | ✅ | ✅ | ✅ |
+| End-to-end cycle | n/a | n/a | ✅ | ✅ | ✅ |
+
+**Self-check before committing tests:** re-read each test and delete any that only assert class attributes, only check `is not None`, or duplicate another test's coverage with different constants. Pair every mock-call-count assertion with an output/state assertion.
+
+**Required gate criteria** (cannot ship SIP-0093 without these passing):
+
+- Verbatim-equivalence test: M1 path through `PlanAuthoringService` produces byte-identical plans for identical seeded LLM responses (PR 93.0).
+- Worked-example test: SIP-0093 §5.8 deterministic merge example (PR 93.3).
+- "Eve proposes a QA task Neo omitted; merged plan includes it" (PR 93.3).
+- Fallback path test: all-proposers-failed → `authoring_mode: fallback_single_author` (PR 93.4).
+- RC-26 invariant test: `authoring_mode: multi_role` with `proposal_completeness: fallback` cannot occur (PR 93.4).
+
+---
+
+## Risks and Mitigations (Plan-Specific)
+
+These are *plan-execution* risks — distinct from SIP-0093 §6 cost analysis and SIP-0092 §9 design risks.
+
+| Risk | Mitigation |
+|---|---|
+| Parallel fan-out shipped accidentally before executor support exists | Rev 1 ships sequential. The plan doc explicitly notes this and SIP-0093 §6 cost analysis is recomputed in this plan doc with sequential numbers (~12–17 min framing tail). |
+| `PlanAuthoringService` extraction in PR 93.0 introduces a regression in the M1 path | Verbatim-equivalence test on every PR (regression anchor). The service is a function-style module, not a class — minimizes refactoring surface. |
+| Existing `proposed_role_tasks.py` shipped in PR #125 drifts from SIP-0093 Rev 2 vocabulary | PR 93.1 extends, doesn't rewrite. The `{role}:{focus}` dependency convention is grandfathered as the Rev 1 implementation form (RC-24); SIP-0093 §5.4.3's `dev.api.routes` shape was illustrative. |
+| Merger LLM choreography drifts from the deterministic merge policy | Worked-example test from SIP-0093 §5.8 is a regression anchor. Merger prompt is structured around the policy steps explicitly. |
+| Fallback path silently masquerades as multi-role authoring | RC-26 invariant + parser-level rejection of `multi_role` + `fallback` combination. Test asserts the impossibility. |
+| Brief becomes "the plan" in practice (proposers rubber-stamp) | M2→M3 gate criterion C1 measures non-redundancy directly. If C1 fails after SIP-0093 ships, the brief prompt or proposer prompts are wrong, not the architecture. |
+| `multi_role_plan_authoring` flag stays default-off forever | M2→M3 gate criteria measure SIP-0093 directly; default-flip is a follow-up PR after stability criteria hold across a tracking window. Call it out in retro after each long cycle so it doesn't drift. |
+| Sequencing change to `PLANNING_TASK_STEPS` breaks downstream consumers | PR 93.0's `task_plan.py` change is gated by `multi_role_plan_authoring: false` default. Existing tests on the M1 path keep running unchanged. |
+
+---
+
+## Terminology Lock additions (PR Checklist)
+
+Extends the SIP-0092 plan doc Terminology Lock. The SIP-0093 canonical terms (already added to SIP-0092 plan doc Terminology Lock in PR #136) are reproduced here for PR-time reference:
+
+**Banned in new code** (allowed only in historical comments or migration tests):
+
+- `split_implementation_planning`, `development.plan_implementation`, `development.plan_implementation_revise`, `plan_review.yaml`, `PlanReview`, `max_planning_revisions`, `review_status: revision_requested`, `revision_instructions`.
+
+**Canonical terms:**
+
+| Concept | Canonical term |
+|---|---|
+| Brief artifact | `plan_authoring_brief.yaml`, `PlanAuthoringBrief` |
+| Brief handler | `GovernancePreparePlanAuthoringBriefHandler` (`governance.prepare_plan_authoring_brief`) |
+| Role proposal artifact | `proposed_plan_tasks.yaml`, `ProposedRoleTasks`, `ProposedTask` |
+| Strategy guidance artifact | `plan_guidance.yaml`, `PlanGuidance` |
+| Per-role proposer task types | `development.propose_plan_tasks`, `qa.propose_plan_tasks`, `strategy.propose_plan_guidance` |
+| Merger handler | `GovernanceMergePlanHandler` (`governance.merge_plan`) |
+| Merge audit artifact | `merge_decisions.yaml`, `MergeDecisions` |
+| Per-canonical-task provenance | `CanonicalTaskProvenance` |
+| Brief-conflict disposition | `BriefConflictDisposition` |
+| M2 master flag | `multi_role_plan_authoring` |
+| M2 contributors flag | `plan_authoring_contributors` |
+
+**Implementation:** the SIP-0092 plan doc's terminology-lock test (or PR-template checkbox) extends to cover SIP-0093 terms.
+
+---
+
+## References
+
+- `sips/accepted/SIP-0093-Multi-Role-Plan-Authoring.md` — design (this plan implements §5 and §8)
+- `sips/accepted/SIP-0092-Implementation-Plan-Improvement.md` — parent SIP; SIP-0093 implements its §6.2 (Capability M2)
+- `docs/plans/SIP-0092-implementation-plan-improvement-plan.md` — Stage M2 cross-references this plan; Gate M2→M3 criteria measure SIP-0093 behavior directly
+- `docs/plans/SIP-0092-gate-M1-evaluation.md` — the M1→M2 gate evaluation that selected the multi-role authoring path
+- `src/squadops/cycles/proposed_role_tasks.py` — schema foundation (extended by PR 93.1)
+- `src/squadops/capabilities/handlers/_plan_authoring.py` — shared LLM-loop helpers (used by all SIP-0093 handlers)
+- `src/squadops/capabilities/handlers/planning_tasks.py:432` — `_produce_plan`, source for the `PlanAuthoringService` extraction in PR 93.0
+- `src/squadops/cycles/task_plan.py:59` — `PLANNING_TASK_STEPS`, extended by PR 93.0 / 93.2 / 93.3
+- `examples/03_group_run/prd.md` — the canonical reference PRD this SIP would author plan tasks for
+- `docs/TEST_QUALITY_STANDARD.md` — bar every test in this plan must clear
+
+---
+
+## Plan Revision History
+
+- **Plan Rev 1 (2026-05-08):** Initial plan. Five PRs (93.0 through 93.4). RC-22..RC-26 runtime contracts. Sequential proposers in Rev 1 (parallel fan-out deferred to Rev 2). PR 93.0 extracts `PlanAuthoringService` for both M1-substrate and SIP-0093 fallback paths.

--- a/docs/plans/SIP-0093-multi-role-plan-authoring-plan.md
+++ b/docs/plans/SIP-0093-multi-role-plan-authoring-plan.md
@@ -24,6 +24,44 @@ The five PRs (per SIP-0093 §8):
 
 ---
 
+## Routing under `multi_role_plan_authoring`
+
+The flag is the single switch between two unambiguous routes through framing. There is no hybrid mode.
+
+**`multi_role_plan_authoring: false`** (M1 substrate path):
+
+```
+data.research → strategy.frame → development.design_plan → qa.define_test_strategy
+  → governance.review_plan
+      → calls PlanAuthoringService.produce_plan(...) inline
+      → emits canonical implementation_plan.yaml
+  → [GATE]
+```
+
+No `plan_authoring_brief.yaml`. No proposers. No `merge_decisions.yaml`. The route is byte-identical to today, with the only change being that `_produce_plan` now lives inside `PlanAuthoringService` (PR 93.0 extraction). Proven by the verbatim-equivalence test below.
+
+**`multi_role_plan_authoring: true`** (SIP-0093 path):
+
+```
+data.research → strategy.frame → development.design_plan → qa.define_test_strategy
+  → governance.prepare_plan_authoring_brief        (emits plan_authoring_brief.yaml)
+  → development.propose_plan_tasks  ┐
+  → qa.propose_plan_tasks           ├─ Rev 1: sequential; Rev 2: parallel fan-out
+  → strategy.propose_plan_guidance  ┘
+  → governance.merge_plan
+      → if any proposal succeeded: deterministic merge per SIP-0093 §5.8
+      → if all proposals failed: PlanAuthoringService.produce_plan(...) (RC-26 fallback)
+      → emits canonical implementation_plan.yaml + merge_decisions.yaml
+  → governance.review_plan          (sign-off only)
+  → [GATE]
+```
+
+`governance.review_plan` does not call `PlanAuthoringService` on this route — its body conditions on the flag and either authors (flag off) or signs off (flag on).
+
+This routing is the load-bearing simplification SIP-0093 makes possible: one flag, two complete routes, no hybrid behavior. Tests in PR 93.0 and PR 93.4 assert that the wrong route never fires for a given flag value.
+
+---
+
 ## Runtime Contracts
 
 These extend SIP-0092's RC-9..RC-21. New contracts are RC-22 through RC-26.
@@ -37,6 +75,10 @@ These extend SIP-0092's RC-9..RC-21. New contracts are RC-22 through RC-26.
 **RC-25 (`merge_decisions.yaml` audit completeness):** Every canonical task in `implementation_plan.yaml` MUST appear in `merge_decisions.yaml` with `task_index`, `source_proposal_task_keys`, `proposed_by`, and `merge_action ∈ {accepted, merged, modified, gap_filled}`. Tasks created by the merger to fill gaps (no proposal source) are marked `merge_action: gap_filled`. Test: full canonical-plan / merge-decisions correspondence asserted in PR 93.3.
 
 **RC-26 (Fallback marker authority):** When `multi_role_plan_authoring: true` and all role proposals fail, `merge_decisions.yaml` MUST set `authoring_mode: fallback_single_author` AND `proposal_completeness: fallback`. The canonical plan is produced by the shared `PlanAuthoringService.produce_plan(...)`. The system MUST NOT silently mark a fallback as `multi_role`; tests assert this property explicitly. Fallback frequency is a tracked gate metric (M2→M3 gate criterion C2).
+
+**RC-27 (Canonical plan is the sole executor input):** The build executor consumes only the canonical `implementation_plan.yaml`. `plan_authoring_brief.yaml`, `proposed_plan_tasks.yaml`, `plan_guidance.yaml`, and `merge_decisions.yaml` are planning/gate evidence artifacts only — they MUST NOT be required by build execution after gate approval. This preserves the SIP-0086/SIP-0092 execution boundary: multi-role authoring changes plan *production*, not task *execution* semantics. The forwarding layer (`api/routes/cycles/runs.py`) only adds these new artifact types as gate evidence; existing `control_implementation_plan` forwarding to the build workload is unchanged.
+
+**RC-28 (M3 independence from SIP-0093 internals):** When SIP-0092 Capability M3 (Plan Changes) ships, plan changes operate on the canonical `implementation_plan.yaml` regardless of whether that plan was produced by colocated authoring (M1 substrate), single-author fallback, or SIP-0093 multi-role merge. M3 MUST NOT couple to `merge_decisions.yaml`, per-role proposal artifacts, or proposal provenance. SIP-0093 changes the *origin* of the plan; M3 governs how it *evolves*. The two are orthogonal by construction.
 
 ---
 
@@ -101,6 +143,7 @@ class PlanAuthoringBrief:
 - Unit (`tests/unit/capabilities/test_plan_authoring_service.py`, new):
   - `PlanAuthoringService.produce_plan(...)` produces the same `ImplementationPlan` as `_produce_plan` for an identical seeded LLM response (verbatim-equivalence regression anchor).
   - Service surfaces parse failures the same way `_produce_plan` did (no wording regression).
+  - **M1-substrate side-effect-absence assertion** (added per Rev 2 review): when `multi_role_plan_authoring: false` and `GovernanceReviewPlanHandler.handle()` runs end-to-end through `PlanAuthoringService`, the run produces *no* `plan_authoring_brief.yaml`, *no* `proposed_plan_tasks.yaml`, *no* `plan_guidance.yaml`, and *no* `merge_decisions.yaml` artifacts. Hybrid behavior would silently leak SIP-0093 artifacts into the M1 path; this test pins the route boundary defined in §"Routing under `multi_role_plan_authoring`".
 - Unit (`tests/unit/capabilities/test_prepare_plan_authoring_brief.py`, new):
   - Handler produces a `PlanAuthoringBrief` artifact for a seeded LLM response.
   - Handler emits a structured failure when the LLM response cannot be parsed after `retry_yaml_call` exhaustion.
@@ -450,4 +493,5 @@ Extends the SIP-0092 plan doc Terminology Lock. The SIP-0093 canonical terms (al
 
 ## Plan Revision History
 
+- **Plan Rev 2 (2026-05-09):** Targeted tightening from review. Added explicit "Routing under `multi_role_plan_authoring`" section pinning flag-off vs flag-on routes (no hybrid mode). Added RC-27 (canonical plan is the sole executor input) and RC-28 (M3 independence from SIP-0093 internals). Extended PR 93.0's verbatim-equivalence test with an M1-substrate side-effect-absence assertion (no SIP-0093 artifacts produced when flag is off). No scope changes to the five-PR sequence.
 - **Plan Rev 1 (2026-05-08):** Initial plan. Five PRs (93.0 through 93.4). RC-22..RC-26 runtime contracts. Sequential proposers in Rev 1 (parallel fan-out deferred to Rev 2). PR 93.0 extracts `PlanAuthoringService` for both M1-substrate and SIP-0093 fallback paths.

--- a/sips/accepted/SIP-0092-Implementation-Plan-Improvement.md
+++ b/sips/accepted/SIP-0092-Implementation-Plan-Improvement.md
@@ -411,13 +411,22 @@ The shared brief frames stack/scope/constraints before fan-out so role proposers
 
 #### 6.2.2 Operator-visible artifacts
 
-The gate package contains:
+The gate package separates **primary** artifacts (must appear in the operator's first view) from **intermediate evidence** (available on drill-down, must not clutter the primary surface).
+
+**Primary gate artifacts:**
 
 - `implementation_plan.yaml` — canonical plan, M1 schema (unchanged).
 - `plan_authoring_brief.yaml` — the shared frame all proposers consumed.
 - `merge_decisions.yaml` — per-canonical-task provenance, brief-conflict dispositions, proposal completeness, missing roles, fallback markers.
+- Proposal completeness status (rolled up from `merge_decisions.yaml`).
+- Fallback status when applicable (see §6.2.5).
 
-Per-role `proposed_plan_tasks.yaml` and `plan_guidance.yaml` artifacts are intermediate evidence available for inspection but are not primary gate artifacts.
+**Intermediate evidence (available, not surfaced as primary):**
+
+- Per-role `proposed_plan_tasks.yaml` artifacts.
+- `plan_guidance.yaml`.
+
+The split keeps the primary operator review surface bounded while preserving full auditability. Per-role proposals must remain queryable for forensic review of the merger's decisions, but they should not be in the operator's default field of view at gate.
 
 See SIP-0093 §5.1 (brief schema), §5.4 (proposal schemas), §5.7 (`merge_decisions.yaml` schema), and §5.8 (deterministic merge policy) for the full design.
 
@@ -434,11 +443,30 @@ Compatible criteria from different roles on the same canonical task survive merg
 
 SIP-0093 changes who authors the *original* plan; M3 governs how that plan evolves in-cycle. The two are orthogonal — M3's autonomous-correction plan changes operate on whatever original plan landed at gate, regardless of authorship model.
 
+> **M3 independence invariant.** When M3 ships, plan changes consume the canonical `implementation_plan.yaml` and do not depend on whether that plan was produced by colocated authoring (M1 substrate), single-author fallback, or SIP-0093 multi-role merge. M3 must not couple to `merge_decisions.yaml`, per-role proposal artifacts, or proposal provenance.
+
 The non-operative `structural_plan_change_candidate` diagnostic on `governance.correction_decision` (introduced as M2-tracking infrastructure for the M2→M3 gate) continues to be elicited under SIP-0093 unchanged. See SIP-0093 §5.13.
 
 #### 6.2.5 Fallback behavior
 
-If all role proposals fail (LLM errors, timeouts, malformed YAML), the merger falls back to single-author plan production using the M1-substrate plan-authoring path (extracted into a shared `PlanAuthoringService` per the SIP-0092 plan doc). Fallback is explicitly marked (`authoring_mode: fallback_single_author`) and visible at gate. Fallback frequency is a tracked gate metric (M2→M3 gate criterion C2). See SIP-0093 §5.10.
+If all role proposals fail (LLM errors, timeouts, malformed YAML), the merger falls back to single-author plan production using the M1-substrate plan-authoring path (extracted into a shared `PlanAuthoringService` per the SIP-0092 plan doc). Fallback frequency is a tracked gate metric (M2→M3 gate criterion C2). See SIP-0093 §5.10.
+
+**SIP-0092-level fallback visibility commitment.** A silent fallback would let the operator believe a plan had multi-role coverage when it did not. Fallback MUST be explicit in `merge_decisions.yaml` and surfaced in gate metadata via the following fields:
+
+- `authoring_mode: fallback_single_author`
+- `proposal_completeness: fallback`
+- `missing_proposals` — list of role IDs whose proposals failed
+- `failure_reasons` — per-role failure summary (LLM error / timeout / malformed YAML / `source_brief_id` mismatch)
+- `fallback_producer` — identifier for the path that produced the canonical plan (`PlanAuthoringService` in Rev 1)
+- Operator warning rendered alongside the canonical plan at gate
+
+Tests in SIP-0093 PR 93.4 assert that the `multi_role` + `fallback` combination is impossible (RC-26 of the SIP-0093 plan doc) and that the visibility fields are populated on every fallback cycle.
+
+#### 6.2.6 Executor-input invariant
+
+The build executor consumes only the canonical `implementation_plan.yaml`. `plan_authoring_brief.yaml`, `proposed_plan_tasks.yaml`, `plan_guidance.yaml`, and `merge_decisions.yaml` are planning/gate evidence artifacts only — they MUST NOT be required by build execution after gate approval. SIP-0093 changes plan *production*; it does not change task *execution* semantics. The forwarding layer (`api/routes/cycles/runs.py`) carries the new artifact types as gate evidence; existing `control_implementation_plan` forwarding to the build workload is unchanged.
+
+This is the SIP-0086/SIP-0092 execution boundary, restated for SIP-0093. The plan doc enforces it as RC-27.
 
 ### 6.3 Capability M3 — Plan Changes
 
@@ -763,7 +791,7 @@ Three independently shippable stages mapped to the three capabilities. Each stag
 
 ### Stage M2 — Multi-Role Plan Authoring (5 PRs, implemented as SIP-0093)
 
-M2 is delivered by SIP-0093 in five PRs. Full design and per-PR scope live in `sips/accepted/SIP-0093-Multi-Role-Plan-Authoring.md` §8 and the SIP-0093 implementation plan doc (to be drafted at `docs/plans/SIP-0093-multi-role-plan-authoring-plan.md`). Summary:
+M2 is delivered by SIP-0093 in five PRs. Full design and per-PR scope live in `sips/accepted/SIP-0093-Multi-Role-Plan-Authoring.md` §8 and the SIP-0093 implementation plan doc at `docs/plans/SIP-0093-multi-role-plan-authoring-plan.md` (per-PR file changes, schemas, runtime contracts RC-22..RC-28, tests). Summary:
 
 - **PR 93.0** — `plan_authoring_brief.yaml` schema and `governance.prepare_plan_authoring_brief` handler.
 - **PR 93.1** — Proposal and merge schemas (`ProposedPlanTasks`, `PlanGuidance`, `MergeDecisions`); symbolic-dependency convention; brief-conflict model.
@@ -871,6 +899,12 @@ Raw-YAML hashing is the obvious approach but unstable across whitespace/key-orde
 
 ## 12. Revision History
 
+- **Rev 5 (2026-05-09):** Targeted tightening of §6.2 (Capability M2) from review of the SIP-0093 implementation plan doc. No design changes; clarifications and explicit invariants:
+  - §6.2.2 split gate-package artifacts into **primary** vs **intermediate evidence**, named the rationale (bounded operator review surface, full auditability preserved on drill-down).
+  - §6.2.4 added an explicit **M3 independence invariant** — M3 plan changes operate on the canonical `implementation_plan.yaml` and must not couple to `merge_decisions.yaml`, per-role proposal artifacts, or proposal provenance.
+  - §6.2.5 added a **fallback visibility commitment** at SIP-0092 level (the structured fields silent fallback would otherwise allow to be missing): `authoring_mode`, `proposal_completeness`, `missing_proposals`, `failure_reasons`, `fallback_producer`, plus an operator warning at gate.
+  - Added §6.2.6 **executor-input invariant** restating the SIP-0086/SIP-0092 execution boundary for SIP-0093: the executor consumes only `implementation_plan.yaml`; brief / proposals / guidance / merge_decisions are planning evidence only.
+  - §8 dropped the stale "to be drafted" reference to the SIP-0093 implementation plan doc (the doc now exists at `docs/plans/SIP-0093-multi-role-plan-authoring-plan.md`).
 - **Rev 4 (2026-04-30):** "Mechanical Acceptance" → "Typed Acceptance" rename throughout.
   - Title: "Implementation Plan Improvement — **Mechanical Acceptance**, Separated Authoring, and Plan Changes" → "Implementation Plan Improvement — **Typed Acceptance**, Separated Authoring, and Plan Changes."
   - Config flag: `mechanical_acceptance` → `typed_acceptance`. Status reason `mechanical_acceptance_disabled` → `typed_acceptance_disabled`.


### PR DESCRIPTION
## Summary

Drafts the SIP-0093 (Multi-Role Plan Authoring) implementation plan doc — pinning per-PR file changes, schemas, runtime contracts, and tests for the five PRs SIP-0093 §8 outlines — plus targeted tightening of SIP-0092 §6.2 and the SIP-0092 plan doc from review of the initial draft.

This is the natural follow-on to PR #136 (SIP tightening + SIP-0092 §6.2 rewrite). The SIP describes the design; this plan doc is what PR 93.0–93.4 reviewers will measure code against.

## Commits

1. **`docs(SIP-0093): initial implementation plan`** — drafts `docs/plans/SIP-0093-multi-role-plan-authoring-plan.md` (Rev 1).
2. **`docs(SIP-0092/0093): tightening from review of plan doc`** — applies eight review items as clarifications and explicit invariants (no design changes).

## Key decisions in Rev 1

- **PR 93.0 extracts `PlanAuthoringService`** (function-style module) used by both the M1 substrate path (`multi_role_plan_authoring: false`) and the SIP-0093 fallback path (all proposals failed). One implementation, no drift.
- **PR 93.1 extends, doesn't rewrite, `proposed_role_tasks.py`** (already shipped in PR #125). The `{role}:{focus}` dependency convention in the existing `focus_key()` helper is grandfathered as Rev 1 symbolic-dependency form (RC-24).
- **Rev 1 ships sequential proposers, not parallel.** The current executor has no parallel-group construct; adding one broadens Rev 1's blast radius. Cost impact: ~12–17 min framing tail (sequential) vs ~5–9 min (parallel target per SIP-0093 §6). Parallel fan-out becomes a Rev 2 follow-up.
- **Runtime contracts RC-22..RC-26** covering brief immutability, `source_brief_id` matching, merger-only task indices, `merge_decisions.yaml` audit completeness, and fallback-marker authority.

## Tightening added in Rev 2 (review feedback)

**SIP-0093 plan doc:**
- New "Routing under `multi_role_plan_authoring`" section pinning flag-off vs flag-on routes — no hybrid mode by construction.
- RC-27 (canonical `implementation_plan.yaml` is the sole executor input).
- RC-28 (M3 plan changes are independent from SIP-0093 internals).
- PR 93.0 verbatim-equivalence test extended with M1-substrate side-effect-absence assertion (no SIP-0093 artifacts produced when flag is off).

**SIP-0092 (Rev 5):**
- §6.2.2 split gate-package into primary vs intermediate evidence.
- §6.2.4 explicit M3 independence invariant.
- §6.2.5 fallback visibility commitment (`authoring_mode`, `missing_proposals`, `failure_reasons`, `fallback_producer`, operator warning).
- §6.2.6 executor-input invariant.

**SIP-0092 plan doc:**
- Gate M1 → M2 stale "alternative authoring model on the table" replaced with "gate completed; SIP-0093 selected" notice.
- Validation profile wording made time-aware (pre-SIP-0093 / M2 → M3 window / post-gate).
- New "Required telemetry inputs" subsection on Gate M2 → M3 listing the `merge_decisions.yaml` fields the evaluation doc must cite.

## Required gate-criteria tests (unchanged from Rev 1)

- Verbatim-equivalence: M1 path through `PlanAuthoringService` produces byte-identical plans (PR 93.0).
- Worked-example merge from SIP-0093 §5.8 (PR 93.3).
- "Eve proposes a QA task Neo omitted; merged plan includes it" (PR 93.3).
- All-proposers-failed fallback (PR 93.4).
- RC-26 impossibility: `multi_role` + `fallback` cannot coexist (PR 93.4).

## Out of scope (explicit)

- Parallel proposer fan-out (Rev 2 of SIP-0093).
- Builder/Bob contributor `build.propose_plan_tasks` (Rev 2; SIP-0093 §5.12).
- Default flip of `multi_role_plan_authoring` (separate small PR after stability criteria met).
- Any code changes — design-doc only.

## Test plan

- [ ] Maintainer reads the plan doc end-to-end and confirms the five-PR scope is reviewable in those chunks.
- [ ] Maintainer confirms RC-22..RC-28 don't conflict with existing RC-9..RC-21.
- [ ] Maintainer confirms the sequential-Rev-1 trade-off is acceptable (parallel deferred to Rev 2).
- [ ] Maintainer confirms the routing pin (no hybrid mode) and the executor-input invariant are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)