### PR TITLE
feat(SIP-0093 PR 93.1): proposal/guidance/merge_decisions schemas

### DIFF
--- a/src/squadops/cycles/merge_decisions.py
+++ b/src/squadops/cycles/merge_decisions.py
@@ -1,0 +1,399 @@
+"""MergeDecisions — auditable record of `governance.merge_plan` (SIP-0093 §5.7).
+
+The merger produces two artifacts: ``implementation_plan.yaml`` (the canonical
+plan, SIP-0092 M1 schema unchanged) and ``merge_decisions.yaml``. This module
+defines the on-the-wire shape of the latter so the merger isn't a new opaque
+sole broker — every canonical task carries provenance back to the proposals it
+came from, every brief conflict gets a recorded disposition, and the
+authoring-mode invariants from RC-26 are enforced at parse time.
+
+RC-26 invariants (enforced by ``MergeDecisions.from_yaml()``):
+
+- ``authoring_mode == "multi_role"`` ⇒ ``sole_author_reason is None`` AND
+  ``proposal_completeness in {"complete", "partial"}``.
+- ``authoring_mode == "sole_author"`` ⇒ ``sole_author_reason in
+  {"no_contributors_configured", "all_proposals_failed"}`` AND
+  ``proposal_completeness == "sole_author"``.
+
+Asserting these at the parser level means downstream consumers (gate
+package, observability, M3 plan-change applier) can trust the combination
+without re-checking.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import yaml
+
+_VALID_AUTHORING_MODES = frozenset({"multi_role", "sole_author"})
+_VALID_SOLE_AUTHOR_REASONS = frozenset(
+    {"no_contributors_configured", "all_proposals_failed"}
+)
+_VALID_PROPOSAL_COMPLETENESS = frozenset({"complete", "partial", "sole_author"})
+_VALID_MERGE_ACTIONS = frozenset({"accepted", "merged", "modified", "gap_filled"})
+_VALID_BRIEF_CONFLICT_SEVERITIES = frozenset({"warning", "blocking"})
+_VALID_CONFLICT_DISPOSITIONS = frozenset(
+    {"accepted", "rejected", "escalated_to_operator"}
+)
+
+
+@dataclass(frozen=True)
+class CanonicalTaskProvenance:
+    """Per-canonical-task lineage from proposed tasks to merger output.
+
+    Attributes:
+        task_index: the canonical 0..N index in ``implementation_plan.yaml``.
+        source_proposal_task_keys: focus_keys (``{role}:{focus}``) of the
+            proposed tasks that contributed to this canonical task.
+        proposed_by: role IDs that proposed any of the source tasks.
+        merge_action:
+            ``accepted`` — copied through from a single proposed task.
+            ``merged`` — combined from multiple compatible proposed tasks
+                (e.g. dev + qa proposed overlapping acceptance criteria).
+            ``modified`` — the merger materially changed the proposed task
+                (renamed, restructured, retyped) — reason must explain.
+            ``gap_filled`` — the merger added this canonical task because
+                a proposal referenced it but no proposal proposed it.
+        reason: human-readable explanation of the merge decision; surfaces
+            in the gate package and the operator console.
+    """
+
+    task_index: int
+    source_proposal_task_keys: list[str]
+    proposed_by: list[str]
+    merge_action: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class BriefConflictDisposition:
+    """How the merger handled a single proposer-raised brief conflict (§5.5).
+
+    Attributes:
+        brief_field: brief field the conflict targets.
+        severity: ``warning`` (merger resolves) or ``blocking`` (escalated).
+        disposition:
+            ``accepted`` — merger sided with the proposer; brief value
+                overridden in this cycle's canonical plan.
+            ``rejected`` — merger sided with the brief.
+            ``escalated_to_operator`` — surfaced in ``operator_notes`` for
+                gate decision (always the disposition for ``blocking``
+                conflicts under Rev 1).
+        reason: why this disposition.
+    """
+
+    brief_field: str
+    severity: str
+    disposition: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class MissingProposal:
+    """A role's proposal that was expected but missing or failed (§5.7).
+
+    Attributes:
+        role: role ID (``development``, ``qa``, ``strategy``, ``builder``).
+        failure_reason: short tag explaining why — typically one of
+            ``not_run``, ``llm_error``, ``timeout``, ``malformed_yaml``,
+            ``mismatched_brief_id``. Free-form string at the parser level;
+            proposer-handlers (PR 93.2) will adopt a convention.
+    """
+
+    role: str
+    failure_reason: str
+
+
+@dataclass(frozen=True)
+class MergeDecisions:
+    """Structured audit of how the canonical plan was assembled.
+
+    Required Rev 1 fields (per SIP-0093 §5.7) cover provenance, completeness,
+    and conflict disposition. The optional ``operator_notes`` is the surface
+    where blocking brief conflicts and other operator-relevant context get
+    free-form prose — kept optional so a cycle with no operator-facing
+    issues doesn't need to emit it.
+    """
+
+    version: int
+    target_plan_id: str
+    brief_id: str
+    proposal_ids: list[str]
+    guidance_ids: list[str]
+    authoring_mode: str
+    sole_author_reason: str | None
+    proposal_completeness: str
+    missing_proposals: list[MissingProposal]
+    canonical_tasks: list[CanonicalTaskProvenance]
+    brief_conflicts_disposition: list[BriefConflictDisposition]
+    operator_notes: str = ""
+
+    @classmethod
+    def from_yaml(cls, content: str) -> MergeDecisions:
+        """Parse a ``merge_decisions.yaml`` document.
+
+        Raises:
+            ValueError: malformed YAML, missing required fields, invalid
+                enum values, RC-26 invariant violation, or canonical task
+                indices that aren't unique-and-contiguous from 0.
+        """
+        try:
+            data = yaml.safe_load(content)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Malformed merge_decisions YAML: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise ValueError("merge_decisions must be a YAML mapping at the top level")
+
+        for key in (
+            "version",
+            "target_plan_id",
+            "brief_id",
+            "authoring_mode",
+            "proposal_completeness",
+        ):
+            if key not in data:
+                raise ValueError(f"merge_decisions missing required field: {key}")
+
+        version = data["version"]
+        if not isinstance(version, int):
+            raise ValueError(
+                f"merge_decisions version must be int, got {type(version).__name__}"
+            )
+
+        target_plan_id = str(data["target_plan_id"]).strip()
+        brief_id = str(data["brief_id"]).strip()
+        if not target_plan_id:
+            raise ValueError("merge_decisions target_plan_id must be non-empty")
+        if not brief_id:
+            raise ValueError("merge_decisions brief_id must be non-empty")
+
+        authoring_mode = _validate_enum(
+            data["authoring_mode"], _VALID_AUTHORING_MODES, "authoring_mode"
+        )
+        proposal_completeness = _validate_enum(
+            data["proposal_completeness"],
+            _VALID_PROPOSAL_COMPLETENESS,
+            "proposal_completeness",
+        )
+
+        raw_sole_author_reason = data.get("sole_author_reason", None)
+        if raw_sole_author_reason is None:
+            sole_author_reason: str | None = None
+        else:
+            sole_author_reason = _validate_enum(
+                raw_sole_author_reason,
+                _VALID_SOLE_AUTHOR_REASONS,
+                "sole_author_reason",
+            )
+
+        _validate_rc26(authoring_mode, sole_author_reason, proposal_completeness)
+
+        proposal_ids = _parse_str_list(data.get("proposal_ids", []), "proposal_ids")
+        guidance_ids = _parse_str_list(data.get("guidance_ids", []), "guidance_ids")
+        missing_proposals = _parse_missing_proposals(data.get("missing_proposals", []))
+        canonical_tasks = _parse_canonical_tasks(data.get("canonical_tasks", []))
+        brief_conflicts_disposition = _parse_brief_conflicts_disposition(
+            data.get("brief_conflicts_disposition", [])
+        )
+
+        return cls(
+            version=version,
+            target_plan_id=target_plan_id,
+            brief_id=brief_id,
+            proposal_ids=proposal_ids,
+            guidance_ids=guidance_ids,
+            authoring_mode=authoring_mode,
+            sole_author_reason=sole_author_reason,
+            proposal_completeness=proposal_completeness,
+            missing_proposals=missing_proposals,
+            canonical_tasks=canonical_tasks,
+            brief_conflicts_disposition=brief_conflicts_disposition,
+            operator_notes=str(data.get("operator_notes", "")).strip(),
+        )
+
+
+def _validate_rc26(
+    authoring_mode: str,
+    sole_author_reason: str | None,
+    proposal_completeness: str,
+) -> None:
+    """Enforce SIP-0093 RC-26: authoring mode, sole_author_reason, and
+    proposal_completeness must agree.
+
+    Pulled out of ``from_yaml`` so the parser stays under ruff's C901 bound;
+    also makes the invariant separately testable and re-callable from the
+    merger when it constructs decisions in code rather than parsing YAML.
+    """
+    if authoring_mode == "multi_role":
+        if sole_author_reason is not None:
+            raise ValueError(
+                "merge_decisions: authoring_mode 'multi_role' requires "
+                f"sole_author_reason to be null, got {sole_author_reason!r}"
+            )
+        if proposal_completeness not in {"complete", "partial"}:
+            raise ValueError(
+                "merge_decisions: authoring_mode 'multi_role' requires "
+                "proposal_completeness in {'complete', 'partial'}, got "
+                f"{proposal_completeness!r}"
+            )
+        return
+
+    # sole_author
+    if sole_author_reason is None:
+        raise ValueError(
+            "merge_decisions: authoring_mode 'sole_author' requires "
+            "sole_author_reason to be set"
+        )
+    if proposal_completeness != "sole_author":
+        raise ValueError(
+            "merge_decisions: authoring_mode 'sole_author' requires "
+            "proposal_completeness 'sole_author', got "
+            f"{proposal_completeness!r}"
+        )
+
+
+def _validate_enum(raw: object, valid: frozenset[str], field_name: str) -> str:
+    value = str(raw).strip()
+    if value not in valid:
+        raise ValueError(
+            f"merge_decisions {field_name} must be one of {sorted(valid)}, got {raw!r}"
+        )
+    return value
+
+
+def _parse_str_list(raw: object, field_name: str) -> list[str]:
+    if raw is None or raw == "":
+        return []
+    if not isinstance(raw, list):
+        raise ValueError(f"merge_decisions {field_name} must be a YAML list")
+    return [str(x).strip() for x in raw if str(x).strip()]
+
+
+def _parse_missing_proposals(raw: object) -> list[MissingProposal]:
+    if raw is None or raw == "":
+        return []
+    if not isinstance(raw, list):
+        raise ValueError("merge_decisions missing_proposals must be a list")
+    parsed: list[MissingProposal] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ValueError(f"merge_decisions missing_proposals[{i}] must be a mapping")
+        for req in ("role", "failure_reason"):
+            if req not in entry:
+                raise ValueError(
+                    f"merge_decisions missing_proposals[{i}] missing required field: {req}"
+                )
+        parsed.append(
+            MissingProposal(
+                role=str(entry["role"]).strip(),
+                failure_reason=str(entry["failure_reason"]).strip(),
+            )
+        )
+    return parsed
+
+
+def _parse_canonical_tasks(raw: object) -> list[CanonicalTaskProvenance]:
+    if raw is None or raw == "":
+        return []
+    if not isinstance(raw, list):
+        raise ValueError("merge_decisions canonical_tasks must be a list")
+
+    parsed: list[CanonicalTaskProvenance] = []
+    seen_indices: list[int] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ValueError(f"merge_decisions canonical_tasks[{i}] must be a mapping")
+        for req in ("task_index", "merge_action", "reason"):
+            if req not in entry:
+                raise ValueError(
+                    f"merge_decisions canonical_tasks[{i}] missing required field: {req}"
+                )
+
+        task_index = entry["task_index"]
+        if not isinstance(task_index, int) or isinstance(task_index, bool):
+            raise ValueError(
+                f"merge_decisions canonical_tasks[{i}].task_index must be int, "
+                f"got {type(task_index).__name__}"
+            )
+        seen_indices.append(task_index)
+
+        merge_action = _validate_enum(
+            entry["merge_action"],
+            _VALID_MERGE_ACTIONS,
+            f"canonical_tasks[{i}].merge_action",
+        )
+
+        source_keys = entry.get("source_proposal_task_keys", [])
+        if not isinstance(source_keys, list):
+            raise ValueError(
+                f"merge_decisions canonical_tasks[{i}].source_proposal_task_keys "
+                "must be a list"
+            )
+        proposed_by = entry.get("proposed_by", [])
+        if not isinstance(proposed_by, list):
+            raise ValueError(
+                f"merge_decisions canonical_tasks[{i}].proposed_by must be a list"
+            )
+
+        parsed.append(
+            CanonicalTaskProvenance(
+                task_index=task_index,
+                source_proposal_task_keys=[str(k).strip() for k in source_keys],
+                proposed_by=[str(r).strip() for r in proposed_by],
+                merge_action=merge_action,
+                reason=str(entry["reason"]).strip(),
+            )
+        )
+
+    # Unique-and-contiguous from 0 (enforces SIP-0092 M1 schema canonical ordering)
+    if seen_indices:
+        if sorted(seen_indices) != list(range(len(seen_indices))):
+            raise ValueError(
+                "merge_decisions canonical_tasks task_index values must be unique "
+                f"and contiguous from 0, got {sorted(seen_indices)}"
+            )
+
+    return parsed
+
+
+def _parse_brief_conflicts_disposition(raw: object) -> list[BriefConflictDisposition]:
+    if raw is None or raw == "":
+        return []
+    if not isinstance(raw, list):
+        raise ValueError("merge_decisions brief_conflicts_disposition must be a list")
+
+    parsed: list[BriefConflictDisposition] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"merge_decisions brief_conflicts_disposition[{i}] must be a mapping"
+            )
+        for req in ("brief_field", "severity", "disposition", "reason"):
+            if req not in entry:
+                raise ValueError(
+                    f"merge_decisions brief_conflicts_disposition[{i}] "
+                    f"missing required field: {req}"
+                )
+        severity = _validate_enum(
+            entry["severity"],
+            _VALID_BRIEF_CONFLICT_SEVERITIES,
+            f"brief_conflicts_disposition[{i}].severity",
+        )
+        disposition = _validate_enum(
+            entry["disposition"],
+            _VALID_CONFLICT_DISPOSITIONS,
+            f"brief_conflicts_disposition[{i}].disposition",
+        )
+        parsed.append(
+            BriefConflictDisposition(
+                brief_field=str(entry["brief_field"]).strip(),
+                severity=severity,
+                disposition=disposition,
+                reason=str(entry["reason"]).strip(),
+            )
+        )
+    return parsed
+
+

--- a/src/squadops/cycles/plan_guidance.py
+++ b/src/squadops/cycles/plan_guidance.py
@@ -1,0 +1,136 @@
+"""PlanGuidance — strategy's plan-authoring contribution (SIP-0093 §5.4.2).
+
+Strategy is the only Rev 1 role that contributes guidance rather than
+proposed tasks. The guidance is overlay metadata the merger applies during
+``governance.merge_plan``: priority hints, ordering edges, risk callouts,
+time-budget allocations, and the small set of items that must not be
+skipped under budget pressure.
+
+Required fields are kept tight (`version`, `guidance_id`, `source_brief_id`,
+`proposing_role`) so a strategy LLM that produces only partial overlays
+still parses. The merger records gaps in ``merge_decisions.yaml`` rather
+than relying on strategy to self-report missing dimensions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import yaml
+
+_REQUIRED_PROPOSING_ROLE = "strategy"
+
+
+@dataclass(frozen=True)
+class PlanGuidance:
+    """Strategy's overlay guidance for ``governance.merge_plan``.
+
+    The merger reads each list as advisory: priorities and ordering bias the
+    canonical-task sequencing; ``must_not_skip`` survives merge regardless of
+    time pressure; ``defer_if_time_constrained`` is the merger's preferred
+    cut surface. None of these fields are typed beyond YAML list/mapping
+    shape — over-typing pushes too much format burden onto the LLM for
+    inconsistent return.
+    """
+
+    version: int
+    guidance_id: str
+    source_brief_id: str
+    proposing_role: str
+    priority_guidance: list[dict[str, Any]] = field(default_factory=list)
+    ordering_guidance: list[dict[str, Any]] = field(default_factory=list)
+    risk_guidance: list[dict[str, Any]] = field(default_factory=list)
+    time_budget_guidance: list[dict[str, Any]] = field(default_factory=list)
+    scope_cut_guidance: list[str] = field(default_factory=list)
+    must_not_skip: list[str] = field(default_factory=list)
+    defer_if_time_constrained: list[str] = field(default_factory=list)
+    confidence: str = ""
+
+    @classmethod
+    def from_yaml(cls, content: str) -> PlanGuidance:
+        """Parse a ``plan_guidance.yaml`` document.
+
+        Raises:
+            ValueError: malformed YAML, missing required fields, or a
+                non-strategy ``proposing_role``. The merger drops a
+                malformed guidance file and proceeds without overlay.
+        """
+        try:
+            data = yaml.safe_load(content)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Malformed plan_guidance YAML: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise ValueError("plan_guidance must be a YAML mapping at the top level")
+
+        for key in ("version", "guidance_id", "source_brief_id", "proposing_role"):
+            if key not in data:
+                raise ValueError(f"plan_guidance missing required field: {key}")
+
+        version = data["version"]
+        if not isinstance(version, int):
+            raise ValueError(
+                f"plan_guidance version must be int, got {type(version).__name__}"
+            )
+
+        guidance_id = str(data["guidance_id"]).strip()
+        if not guidance_id:
+            raise ValueError("plan_guidance guidance_id must be non-empty")
+
+        source_brief_id = str(data["source_brief_id"]).strip()
+        if not source_brief_id:
+            raise ValueError("plan_guidance source_brief_id must be non-empty")
+
+        proposing_role = str(data["proposing_role"]).strip().lower()
+        if proposing_role != _REQUIRED_PROPOSING_ROLE:
+            raise ValueError(
+                f"plan_guidance proposing_role must be {_REQUIRED_PROPOSING_ROLE!r}, "
+                f"got {data['proposing_role']!r}"
+            )
+
+        return cls(
+            version=version,
+            guidance_id=guidance_id,
+            source_brief_id=source_brief_id,
+            proposing_role=proposing_role,
+            priority_guidance=_parse_mapping_list(
+                data.get("priority_guidance", []), "priority_guidance"
+            ),
+            ordering_guidance=_parse_mapping_list(
+                data.get("ordering_guidance", []), "ordering_guidance"
+            ),
+            risk_guidance=_parse_mapping_list(data.get("risk_guidance", []), "risk_guidance"),
+            time_budget_guidance=_parse_mapping_list(
+                data.get("time_budget_guidance", []), "time_budget_guidance"
+            ),
+            scope_cut_guidance=_parse_str_list(
+                data.get("scope_cut_guidance", []), "scope_cut_guidance"
+            ),
+            must_not_skip=_parse_str_list(data.get("must_not_skip", []), "must_not_skip"),
+            defer_if_time_constrained=_parse_str_list(
+                data.get("defer_if_time_constrained", []), "defer_if_time_constrained"
+            ),
+            confidence=str(data.get("confidence", "")).strip(),
+        )
+
+
+def _parse_mapping_list(raw: object, field_name: str) -> list[dict[str, Any]]:
+    if raw is None or raw == "":
+        return []
+    if not isinstance(raw, list):
+        raise ValueError(f"plan_guidance {field_name} must be a YAML list")
+    parsed: list[dict[str, Any]] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ValueError(f"plan_guidance {field_name}[{i}] must be a mapping")
+        parsed.append(dict(entry))
+    return parsed
+
+
+def _parse_str_list(raw: object, field_name: str) -> list[str]:
+    if raw is None or raw == "":
+        return []
+    if not isinstance(raw, list):
+        raise ValueError(f"plan_guidance {field_name} must be a YAML list")
+    return [str(x).strip() for x in raw if str(x).strip()]

--- a/src/squadops/cycles/proposed_role_tasks.py
+++ b/src/squadops/cycles/proposed_role_tasks.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from typing import Union
 
 import yaml
 
@@ -32,7 +31,6 @@ from squadops.cycles.implementation_plan import (
     TypedCheck,
     _parse_acceptance_criteria,
 )
-
 
 _FOCUS_NORMALIZE_RE = re.compile(r"\s+")
 
@@ -79,17 +77,78 @@ class ProposedTask:
     focus: str
     description: str
     expected_artifacts: list[str] = field(default_factory=list)
-    acceptance_criteria: list[Union[str, TypedCheck]] = field(default_factory=list)
+    acceptance_criteria: list[str | TypedCheck] = field(default_factory=list)
     depends_on_focus: list[str] = field(default_factory=list)
+
+
+_VALID_BRIEF_CONFLICT_SEVERITIES = frozenset({"warning", "blocking"})
+
+
+@dataclass(frozen=True)
+class BriefConflict:
+    """A proposer's structured disagreement with the shared brief (SIP-0093 §5.5).
+
+    Raised in a proposal's ``brief_conflicts`` list when a role believes the
+    brief contradicts the PRD, omits a requirement, or pins a stack/scope
+    choice the role can't honor. The merger resolves each conflict per its
+    severity:
+
+    - ``warning``: merger may resolve unilaterally; disposition recorded.
+    - ``blocking``: merger escalates to operator at gate; canonical plan
+      still emits, blocking conflict surfaces in ``operator_notes``.
+
+    Attributes:
+        brief_field: which brief field the conflict targets (e.g.,
+            ``accepted_stack``, ``must_cover_requirements``, ``scope_cuts``).
+        proposed_change: what the proposer wants done instead.
+        reason: why — typically a citation to the upstream PRD or a
+            correctness argument.
+        severity: ``warning`` or ``blocking``.
+        affected_proposal_task_keys: focus_keys of tasks in this proposal
+            that depend on the conflict's resolution. Empty if the conflict
+            is informational.
+    """
+
+    brief_field: str
+    proposed_change: str
+    reason: str
+    severity: str
+    affected_proposal_task_keys: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
 class ProposedRoleTasks:
-    """A single role's plan-task proposal."""
+    """A single role's plan-task proposal (SIP-0093 §5.4.1).
+
+    Required fields (Rev 1):
+        version, proposal_id, source_brief_id, proposing_role, scope_statement.
+
+    The ``source_brief_id`` ties the proposal to an immutable
+    ``plan_authoring_brief.yaml`` (RC-22); the merger rejects proposals that
+    cite a brief other than the one it received.
+
+    ``brief_conflicts`` defaults empty — most proposals will have none.
+
+    Recommended optional fields (parsed if present, no validation beyond
+    YAML shape): ``source_artifact_refs``, ``assumptions``, ``risks``,
+    ``gaps_not_covered``, ``confidence``. These are LLM-output fields that
+    populate inconsistently even when required (per SIP-0093 §5.4.1) — kept
+    optional so a proposer that fails to surface its assumptions doesn't
+    invalidate an otherwise good proposal.
+    """
 
     version: int
+    proposal_id: str
+    source_brief_id: str
     proposing_role: str
+    scope_statement: str
     tasks: list[ProposedTask] = field(default_factory=list)
+    brief_conflicts: list[BriefConflict] = field(default_factory=list)
+    source_artifact_refs: list[str] = field(default_factory=list)
+    assumptions: list[str] = field(default_factory=list)
+    risks: list[str] = field(default_factory=list)
+    gaps_not_covered: list[str] = field(default_factory=list)
+    confidence: str = ""
 
     @classmethod
     def from_yaml(cls, content: str) -> ProposedRoleTasks:
@@ -113,7 +172,16 @@ class ProposedRoleTasks:
         if not isinstance(data, dict):
             raise ValueError("Proposal must be a YAML mapping at the top level")
 
-        for key in ("version", "proposing_role"):
+        # Order matters for error-test stability: version + proposing_role first,
+        # then SIP-0093 PR 93.1 requireds. Each test asserting on a specific
+        # missing-field message expects its target to be checked first.
+        for key in (
+            "version",
+            "proposing_role",
+            "proposal_id",
+            "source_brief_id",
+            "scope_statement",
+        ):
             if key not in data:
                 raise ValueError(f"Proposal missing required field: {key}")
 
@@ -125,6 +193,18 @@ class ProposedRoleTasks:
         if not proposing_role:
             raise ValueError("Proposal proposing_role must be non-empty")
 
+        proposal_id = str(data["proposal_id"]).strip()
+        if not proposal_id:
+            raise ValueError("Proposal proposal_id must be non-empty")
+
+        source_brief_id = str(data["source_brief_id"]).strip()
+        if not source_brief_id:
+            raise ValueError("Proposal source_brief_id must be non-empty")
+
+        scope_statement = str(data["scope_statement"]).strip()
+        if not scope_statement:
+            raise ValueError("Proposal scope_statement must be non-empty")
+
         raw_tasks = data.get("tasks", [])
         if not isinstance(raw_tasks, list):
             raise ValueError("Proposal tasks must be a list")
@@ -132,55 +212,146 @@ class ProposedRoleTasks:
         seen_keys: set[str] = set()
         parsed: list[ProposedTask] = []
         for i, td in enumerate(raw_tasks):
-            if not isinstance(td, dict):
-                raise ValueError(f"Proposal task {i} must be a mapping")
+            parsed.append(_parse_proposed_task(td, i, seen_keys))
 
-            for req in ("task_type", "role", "focus", "description"):
-                if req not in td:
-                    raise ValueError(f"Proposal task {i} missing required field: {req}")
+        brief_conflicts = _parse_brief_conflicts(data.get("brief_conflicts", []))
 
-            role = str(td["role"]).strip()
-            focus = str(td["focus"]).strip()
-            if not focus:
-                raise ValueError(f"Proposal task {i} focus must be non-empty")
-
-            key = focus_key(role, focus)
-            if key in seen_keys:
-                raise ValueError(
-                    f"Proposal task {i} focus collides with an earlier task: {key!r}. "
-                    "Proposers must use distinct focus values within a single proposal."
-                )
-            seen_keys.add(key)
-
-            depends_on_focus = td.get("depends_on_focus", [])
-            if not isinstance(depends_on_focus, list):
-                raise ValueError(f"Proposal task {i} depends_on_focus must be a list")
-            depends_on_focus = [str(x).strip() for x in depends_on_focus if str(x).strip()]
-
-            raw_criteria = td.get("acceptance_criteria", [])
-            if not isinstance(raw_criteria, list):
-                raise ValueError(f"Proposal task {i} acceptance_criteria must be a list")
-            criteria = _parse_acceptance_criteria(raw_criteria, i)
-
-            expected_artifacts = td.get("expected_artifacts", [])
-            if not isinstance(expected_artifacts, list):
-                raise ValueError(f"Proposal task {i} expected_artifacts must be a list")
-
-            parsed.append(
-                ProposedTask(
-                    task_type=str(td["task_type"]).strip(),
-                    role=role,
-                    focus=focus,
-                    description=str(td["description"]).strip(),
-                    expected_artifacts=[str(a) for a in expected_artifacts],
-                    acceptance_criteria=criteria,
-                    depends_on_focus=depends_on_focus,
-                )
-            )
-
-        return cls(version=version, proposing_role=proposing_role, tasks=parsed)
+        return cls(
+            version=version,
+            proposal_id=proposal_id,
+            source_brief_id=source_brief_id,
+            proposing_role=proposing_role,
+            scope_statement=scope_statement,
+            tasks=parsed,
+            brief_conflicts=brief_conflicts,
+            source_artifact_refs=_parse_str_list(data.get("source_artifact_refs", [])),
+            assumptions=_parse_str_list(data.get("assumptions", [])),
+            risks=_parse_str_list(data.get("risks", [])),
+            gaps_not_covered=_parse_str_list(data.get("gaps_not_covered", [])),
+            confidence=str(data.get("confidence", "")).strip(),
+        )
 
     def task_keys(self) -> list[str]:
         """Canonical keys for this proposal's tasks — used by the merger
         to resolve ``depends_on_focus`` references across proposals."""
         return [focus_key(t.role, t.focus) for t in self.tasks]
+
+
+def _parse_proposed_task(td: object, i: int, seen_keys: set[str]) -> ProposedTask:
+    """Parse a single ``ProposedTask`` entry, enforcing required fields,
+    focus_key uniqueness, and RC-24 (no integer ``depends_on_focus``).
+
+    Pulled out of ``ProposedRoleTasks.from_yaml`` so the parent parser
+    stays under ruff's C901 complexity bound.
+    """
+    if not isinstance(td, dict):
+        raise ValueError(f"Proposal task {i} must be a mapping")
+
+    for req in ("task_type", "role", "focus", "description"):
+        if req not in td:
+            raise ValueError(f"Proposal task {i} missing required field: {req}")
+
+    role = str(td["role"]).strip()
+    focus = str(td["focus"]).strip()
+    if not focus:
+        raise ValueError(f"Proposal task {i} focus must be non-empty")
+
+    key = focus_key(role, focus)
+    if key in seen_keys:
+        raise ValueError(
+            f"Proposal task {i} focus collides with an earlier task: {key!r}. "
+            "Proposers must use distinct focus values within a single proposal."
+        )
+    seen_keys.add(key)
+
+    depends_on_focus = td.get("depends_on_focus", [])
+    if not isinstance(depends_on_focus, list):
+        raise ValueError(f"Proposal task {i} depends_on_focus must be a list")
+    # RC-24: reject integer entries. Proposers don't know their numeric
+    # task_index — only the merger assigns those. An int here means the
+    # proposer leaked a numbering assumption from somewhere.
+    for j, entry in enumerate(depends_on_focus):
+        if isinstance(entry, bool) or isinstance(entry, int):
+            raise ValueError(
+                f"Proposal task {i} depends_on_focus[{j}] must be a "
+                f"focus_key string, not an integer (RC-24): {entry!r}"
+            )
+    depends_on_focus = [str(x).strip() for x in depends_on_focus if str(x).strip()]
+
+    raw_criteria = td.get("acceptance_criteria", [])
+    if not isinstance(raw_criteria, list):
+        raise ValueError(f"Proposal task {i} acceptance_criteria must be a list")
+    criteria = _parse_acceptance_criteria(raw_criteria, i)
+
+    expected_artifacts = td.get("expected_artifacts", [])
+    if not isinstance(expected_artifacts, list):
+        raise ValueError(f"Proposal task {i} expected_artifacts must be a list")
+
+    return ProposedTask(
+        task_type=str(td["task_type"]).strip(),
+        role=role,
+        focus=focus,
+        description=str(td["description"]).strip(),
+        expected_artifacts=[str(a) for a in expected_artifacts],
+        acceptance_criteria=criteria,
+        depends_on_focus=depends_on_focus,
+    )
+
+
+def _parse_str_list(raw: object) -> list[str]:
+    """Coerce an optional YAML scalar/list field to a list of strings.
+
+    Best-effort: scalar becomes single-element list; list elements get
+    stringified; anything else surfaces as a parse error so the merger
+    can drop the proposal cleanly.
+    """
+    if raw is None or raw == "":
+        return []
+    if isinstance(raw, list):
+        return [str(x).strip() for x in raw if str(x).strip()]
+    raise ValueError(
+        f"Optional list field must be a YAML list or null, got {type(raw).__name__}"
+    )
+
+
+def _parse_brief_conflicts(raw: object) -> list[BriefConflict]:
+    """Parse the optional ``brief_conflicts`` list (SIP-0093 §5.5)."""
+    if raw is None or raw == "":
+        return []
+    if not isinstance(raw, list):
+        raise ValueError(
+            f"brief_conflicts must be a YAML list, got {type(raw).__name__}"
+        )
+
+    parsed: list[BriefConflict] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ValueError(f"brief_conflicts[{i}] must be a mapping")
+
+        for req in ("brief_field", "proposed_change", "reason", "severity"):
+            if req not in entry:
+                raise ValueError(f"brief_conflicts[{i}] missing required field: {req}")
+
+        severity = str(entry["severity"]).strip().lower()
+        if severity not in _VALID_BRIEF_CONFLICT_SEVERITIES:
+            raise ValueError(
+                f"brief_conflicts[{i}] severity must be one of "
+                f"{sorted(_VALID_BRIEF_CONFLICT_SEVERITIES)}, got {entry['severity']!r}"
+            )
+
+        affected = entry.get("affected_proposal_task_keys", [])
+        if not isinstance(affected, list):
+            raise ValueError(
+                f"brief_conflicts[{i}] affected_proposal_task_keys must be a list"
+            )
+
+        parsed.append(
+            BriefConflict(
+                brief_field=str(entry["brief_field"]).strip(),
+                proposed_change=str(entry["proposed_change"]).strip(),
+                reason=str(entry["reason"]).strip(),
+                severity=severity,
+                affected_proposal_task_keys=[str(k).strip() for k in affected if str(k).strip()],
+            )
+        )
+    return parsed

--- a/tests/unit/cycles/test_merge_decisions.py
+++ b/tests/unit/cycles/test_merge_decisions.py
@@ -1,0 +1,355 @@
+"""Tests for ``MergeDecisions`` (SIP-0093 §5.7).
+
+The merger's audit artifact carries every load-bearing invariant for the
+post-cutover framing pipeline. The parser enforces them so downstream
+consumers (gate package, observability, M3 applier) can trust the shape
+without re-checking.
+
+Coverage:
+
+- Required-field surface enforced.
+- RC-26 invariant (``authoring_mode`` ⇔ ``sole_author_reason`` ⇔
+  ``proposal_completeness``) enforced in all four cross-product cells.
+- ``canonical_tasks.task_index`` is unique-and-contiguous from 0.
+- ``merge_action`` and ``disposition`` enum values bounded.
+- ``MissingProposal`` and ``BriefConflictDisposition`` parse with their
+  full required surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.merge_decisions import (
+    BriefConflictDisposition,
+    CanonicalTaskProvenance,
+    MergeDecisions,
+    MissingProposal,
+    _validate_rc26,
+)
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+
+_VALID_MULTI_ROLE = """\
+version: 1
+target_plan_id: plan-cyc-test
+brief_id: brief-test-001
+proposal_ids: [prop-dev-001, prop-qa-001]
+guidance_ids: [guidance-strategy-001]
+authoring_mode: multi_role
+sole_author_reason: null
+proposal_completeness: complete
+missing_proposals: []
+canonical_tasks:
+  - task_index: 0
+    source_proposal_task_keys: [dev:backend api]
+    proposed_by: [development]
+    merge_action: accepted
+    reason: "Single dev proposal, no conflicts."
+  - task_index: 1
+    source_proposal_task_keys: [qa:integration smoke]
+    proposed_by: [qa]
+    merge_action: accepted
+    reason: "Standalone qa task."
+brief_conflicts_disposition: []
+operator_notes: ""
+"""
+
+
+_VALID_SOLE_AUTHOR = """\
+version: 1
+target_plan_id: plan-cyc-test
+brief_id: brief-test-001
+proposal_ids: []
+guidance_ids: []
+authoring_mode: sole_author
+sole_author_reason: no_contributors_configured
+proposal_completeness: sole_author
+missing_proposals: []
+canonical_tasks:
+  - task_index: 0
+    source_proposal_task_keys: []
+    proposed_by: []
+    merge_action: gap_filled
+    reason: "Sole-author fallback via PlanAuthoringService."
+brief_conflicts_disposition: []
+operator_notes: ""
+"""
+
+
+# ---------------------------------------------------------------------------
+# Happy path — both authoring modes
+# ---------------------------------------------------------------------------
+
+
+class TestFromYAMLHappy:
+    def test_parses_multi_role_decisions(self):
+        md = MergeDecisions.from_yaml(_VALID_MULTI_ROLE)
+        assert md.version == 1
+        assert md.target_plan_id == "plan-cyc-test"
+        assert md.brief_id == "brief-test-001"
+        assert md.proposal_ids == ["prop-dev-001", "prop-qa-001"]
+        assert md.authoring_mode == "multi_role"
+        assert md.sole_author_reason is None
+        assert md.proposal_completeness == "complete"
+
+        assert len(md.canonical_tasks) == 2
+        t0 = md.canonical_tasks[0]
+        assert isinstance(t0, CanonicalTaskProvenance)
+        assert t0.task_index == 0
+        assert t0.source_proposal_task_keys == ["dev:backend api"]
+        assert t0.proposed_by == ["development"]
+        assert t0.merge_action == "accepted"
+
+    def test_parses_sole_author_decisions(self):
+        md = MergeDecisions.from_yaml(_VALID_SOLE_AUTHOR)
+        assert md.authoring_mode == "sole_author"
+        assert md.sole_author_reason == "no_contributors_configured"
+        assert md.proposal_completeness == "sole_author"
+        assert md.canonical_tasks[0].merge_action == "gap_filled"
+
+    def test_parses_with_missing_proposals(self):
+        """Partial-completeness multi_role records each role that failed,
+        so the operator console can surface "qa didn't propose" without
+        re-deriving it from artifact absence."""
+        yaml_doc = _VALID_MULTI_ROLE.replace(
+            "proposal_completeness: complete",
+            "proposal_completeness: partial",
+        ).replace(
+            "missing_proposals: []",
+            (
+                "missing_proposals:\n"
+                "  - role: qa\n"
+                "    failure_reason: llm_error\n"
+                "  - role: strategy\n"
+                "    failure_reason: timeout"
+            ),
+        )
+        md = MergeDecisions.from_yaml(yaml_doc)
+        assert len(md.missing_proposals) == 2
+        assert md.missing_proposals[0] == MissingProposal(
+            role="qa", failure_reason="llm_error"
+        )
+
+    def test_parses_with_brief_conflicts_disposition(self):
+        yaml_doc = _VALID_MULTI_ROLE.replace(
+            "brief_conflicts_disposition: []",
+            (
+                "brief_conflicts_disposition:\n"
+                "  - brief_field: accepted_stack\n"
+                "    severity: blocking\n"
+                "    disposition: escalated_to_operator\n"
+                "    reason: PRD requires persistence; conflict surfaced to operator."
+            ),
+        )
+        md = MergeDecisions.from_yaml(yaml_doc)
+        assert len(md.brief_conflicts_disposition) == 1
+        d = md.brief_conflicts_disposition[0]
+        assert isinstance(d, BriefConflictDisposition)
+        assert d.severity == "blocking"
+        assert d.disposition == "escalated_to_operator"
+
+
+# ---------------------------------------------------------------------------
+# RC-26 invariant enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestRC26Invariant:
+    """The four combinations the parser must distinguish:
+
+    1. multi_role + sole_author_reason=null + completeness in {complete, partial} → valid
+    2. multi_role + sole_author_reason=set → invalid (the rejection path tested below)
+    3. multi_role + completeness=sole_author → invalid
+    4. sole_author + sole_author_reason=null → invalid
+    5. sole_author + completeness != sole_author → invalid
+    6. sole_author + sole_author_reason in valid set + completeness=sole_author → valid
+
+    Each invalid combination is one rule the merger relies on at construction
+    time; testing each separately keeps regressions diagnostic."""
+
+    def test_multi_role_with_sole_author_reason_rejected(self):
+        yaml_doc = _VALID_MULTI_ROLE.replace(
+            "sole_author_reason: null",
+            "sole_author_reason: no_contributors_configured",
+        )
+        with pytest.raises(ValueError, match="multi_role.*sole_author_reason"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+    def test_multi_role_with_sole_author_completeness_rejected(self):
+        yaml_doc = _VALID_MULTI_ROLE.replace(
+            "proposal_completeness: complete",
+            "proposal_completeness: sole_author",
+        )
+        with pytest.raises(ValueError, match="multi_role.*proposal_completeness"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+    def test_sole_author_with_null_reason_rejected(self):
+        yaml_doc = _VALID_SOLE_AUTHOR.replace(
+            "sole_author_reason: no_contributors_configured",
+            "sole_author_reason: null",
+        )
+        with pytest.raises(ValueError, match="sole_author.*sole_author_reason"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+    def test_sole_author_with_non_sole_author_completeness_rejected(self):
+        yaml_doc = _VALID_SOLE_AUTHOR.replace(
+            "proposal_completeness: sole_author",
+            "proposal_completeness: partial",
+        )
+        with pytest.raises(ValueError, match="sole_author.*proposal_completeness"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+    @pytest.mark.parametrize("reason", ["unknown", "user_quit", "manual_override"])
+    def test_unknown_sole_author_reason_rejected(self, reason):
+        yaml_doc = _VALID_SOLE_AUTHOR.replace(
+            "sole_author_reason: no_contributors_configured",
+            f"sole_author_reason: {reason}",
+        )
+        with pytest.raises(ValueError, match="sole_author_reason"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+    def test_rc26_validator_callable_directly(self):
+        """The merger constructs MergeDecisions in code (PR 93.3); the
+        invariant function must be callable outside the parser so the
+        constructor path can pre-validate."""
+        # valid combinations don't raise
+        _validate_rc26("multi_role", None, "complete")
+        _validate_rc26("multi_role", None, "partial")
+        _validate_rc26("sole_author", "no_contributors_configured", "sole_author")
+        _validate_rc26("sole_author", "all_proposals_failed", "sole_author")
+
+        with pytest.raises(ValueError):
+            _validate_rc26("multi_role", "all_proposals_failed", "complete")
+
+
+# ---------------------------------------------------------------------------
+# task_index unique-and-contiguous from 0
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalTaskIndices:
+    def test_non_contiguous_indices_rejected(self):
+        yaml_doc = _VALID_MULTI_ROLE.replace(
+            "  - task_index: 0\n",
+            "  - task_index: 5\n",
+        )
+        with pytest.raises(ValueError, match="contiguous"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+    def test_duplicate_indices_rejected(self):
+        yaml_doc = _VALID_MULTI_ROLE.replace(
+            "  - task_index: 1\n",
+            "  - task_index: 0\n",
+        )
+        with pytest.raises(ValueError, match="contiguous"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+    def test_non_int_task_index_rejected(self):
+        yaml_doc = _VALID_MULTI_ROLE.replace(
+            "  - task_index: 0\n",
+            '  - task_index: "first"\n',
+        )
+        with pytest.raises(ValueError, match="task_index"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+    def test_empty_canonical_tasks_valid(self):
+        """An edge case: a sole-author cycle with no canonical tasks at all
+        (e.g., the merger ran and decided every proposal was redundant).
+        Parser should accept it; the merger surfaces the pathology
+        elsewhere if it's actually a problem."""
+        yaml_doc = _VALID_SOLE_AUTHOR.replace(
+            "canonical_tasks:\n  - task_index: 0\n    source_proposal_task_keys: []\n    proposed_by: []\n    merge_action: gap_filled\n    reason: \"Sole-author fallback via PlanAuthoringService.\"\n",
+            "canonical_tasks: []\n",
+        )
+        md = MergeDecisions.from_yaml(yaml_doc)
+        assert md.canonical_tasks == []
+
+
+# ---------------------------------------------------------------------------
+# Enum validations
+# ---------------------------------------------------------------------------
+
+
+class TestEnumValidation:
+    @pytest.mark.parametrize(
+        "bad_action", ["replaced", "rejected", "ACCEPTED", ""]
+    )
+    def test_unknown_merge_action_rejected(self, bad_action):
+        yaml_doc = _VALID_MULTI_ROLE.replace(
+            "    merge_action: accepted\n    reason: \"Single dev proposal, no conflicts.\"",
+            f"    merge_action: {bad_action}\n    reason: foo",
+        )
+        with pytest.raises(ValueError, match="merge_action"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+    @pytest.mark.parametrize(
+        "bad_disposition", ["deferred", "fixed", "ESCALATED"]
+    )
+    def test_unknown_disposition_rejected(self, bad_disposition):
+        yaml_doc = _VALID_MULTI_ROLE.replace(
+            "brief_conflicts_disposition: []",
+            (
+                "brief_conflicts_disposition:\n"
+                "  - brief_field: accepted_stack\n"
+                "    severity: warning\n"
+                f"    disposition: {bad_disposition}\n"
+                "    reason: x"
+            ),
+        )
+        with pytest.raises(ValueError, match="disposition"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+    @pytest.mark.parametrize("bad_severity", ["critical", "info", "ERROR"])
+    def test_unknown_severity_rejected(self, bad_severity):
+        yaml_doc = _VALID_MULTI_ROLE.replace(
+            "brief_conflicts_disposition: []",
+            (
+                "brief_conflicts_disposition:\n"
+                "  - brief_field: accepted_stack\n"
+                f"    severity: {bad_severity}\n"
+                "    disposition: rejected\n"
+                "    reason: x"
+            ),
+        )
+        with pytest.raises(ValueError, match="severity"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+
+# ---------------------------------------------------------------------------
+# Required-field surface
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredFields:
+    @pytest.mark.parametrize(
+        "missing_field",
+        ["version", "target_plan_id", "brief_id", "authoring_mode", "proposal_completeness"],
+    )
+    def test_required_field_missing_rejected(self, missing_field):
+        lines = _VALID_MULTI_ROLE.splitlines(keepends=True)
+        filtered = [line for line in lines if not line.startswith(f"{missing_field}:")]
+        bad = "".join(filtered)
+        with pytest.raises(ValueError, match=missing_field):
+            MergeDecisions.from_yaml(bad)
+
+    def test_canonical_task_missing_reason_rejected(self):
+        yaml_doc = _VALID_MULTI_ROLE.replace(
+            '    merge_action: accepted\n    reason: "Single dev proposal, no conflicts."',
+            "    merge_action: accepted",
+        )
+        with pytest.raises(ValueError, match="reason"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+    def test_missing_proposal_entry_missing_failure_reason_rejected(self):
+        yaml_doc = _VALID_MULTI_ROLE.replace(
+            "missing_proposals: []",
+            "missing_proposals:\n  - role: qa",
+        )
+        with pytest.raises(ValueError, match="failure_reason"):
+            MergeDecisions.from_yaml(yaml_doc)
+
+    def test_malformed_yaml_rejected(self):
+        with pytest.raises(ValueError, match="Malformed"):
+            MergeDecisions.from_yaml("version: 1\ntarget_plan_id: [unclosed")

--- a/tests/unit/cycles/test_plan_guidance.py
+++ b/tests/unit/cycles/test_plan_guidance.py
@@ -1,0 +1,188 @@
+"""Tests for ``PlanGuidance`` (SIP-0093 §5.4.2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.plan_guidance import PlanGuidance
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+
+_VALID_GUIDANCE = """\
+version: 1
+guidance_id: guidance-strategy-001
+source_brief_id: brief-test-001
+proposing_role: strategy
+priority_guidance:
+  - area: backend_api
+    priority: high
+    rationale: "API surface is the integration anchor."
+ordering_guidance:
+  - before: dev.repository
+    after: dev.api.routes
+    rationale: "Routes pin the contract before persistence shape lands."
+risk_guidance:
+  - target: dev.api.routes
+    risk: "Auth middleware not specified — assume Keycloak."
+time_budget_guidance:
+  - area: backend_api
+    budget_pct: 30
+scope_cut_guidance:
+  - "Defer admin dashboards to a follow-up cycle."
+must_not_skip:
+  - "Auth integration smoke test"
+defer_if_time_constrained:
+  - "Cosmetic frontend polish"
+confidence: medium
+"""
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestFromYAMLHappy:
+    def test_parses_valid_guidance(self):
+        g = PlanGuidance.from_yaml(_VALID_GUIDANCE)
+        assert g.version == 1
+        assert g.guidance_id == "guidance-strategy-001"
+        assert g.source_brief_id == "brief-test-001"
+        assert g.proposing_role == "strategy"
+
+        assert len(g.priority_guidance) == 1
+        assert g.priority_guidance[0]["area"] == "backend_api"
+        assert g.priority_guidance[0]["priority"] == "high"
+
+        assert g.ordering_guidance[0]["before"] == "dev.repository"
+        assert g.risk_guidance[0]["target"] == "dev.api.routes"
+        assert g.time_budget_guidance[0]["budget_pct"] == 30
+
+        assert g.scope_cut_guidance == ["Defer admin dashboards to a follow-up cycle."]
+        assert g.must_not_skip == ["Auth integration smoke test"]
+        assert g.defer_if_time_constrained == ["Cosmetic frontend polish"]
+        assert g.confidence == "medium"
+
+    def test_minimal_guidance_with_only_required_fields(self):
+        """An LLM that returns only the required fields parses cleanly; the
+        merger applies an empty overlay. Forcing optional fields to be
+        populated would push too much format burden on strategy LLMs that
+        legitimately have nothing to say in a given dimension."""
+        minimal = (
+            "version: 1\n"
+            "guidance_id: g-1\n"
+            "source_brief_id: b-1\n"
+            "proposing_role: strategy\n"
+        )
+        g = PlanGuidance.from_yaml(minimal)
+        assert g.priority_guidance == []
+        assert g.ordering_guidance == []
+        assert g.must_not_skip == []
+        assert g.confidence == ""
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestFromYAMLErrors:
+    @pytest.mark.parametrize(
+        "missing_field",
+        ["version", "guidance_id", "source_brief_id", "proposing_role"],
+    )
+    def test_required_field_missing_rejected(self, missing_field):
+        """Each required field must produce an error message that names it,
+        so a malformed strategy emission is diagnosable without re-running
+        the LLM call."""
+        full = {
+            "version": "1",
+            "guidance_id": "g-1",
+            "source_brief_id": "b-1",
+            "proposing_role": "strategy",
+        }
+        full.pop(missing_field)
+        yaml_doc = "\n".join(f"{k}: {v}" for k, v in full.items()) + "\n"
+        with pytest.raises(ValueError, match=missing_field):
+            PlanGuidance.from_yaml(yaml_doc)
+
+    @pytest.mark.parametrize(
+        "bad_role",
+        ["development", "qa", "lead", "STRATEGY"[1:], ""],
+    )
+    def test_non_strategy_proposing_role_rejected(self, bad_role):
+        """Strategy is the only Rev 1 contributor of guidance — a proposal
+        coming through with another role indicates pipeline corruption,
+        not a recoverable malformation."""
+        yaml_doc = (
+            "version: 1\n"
+            "guidance_id: g-1\n"
+            "source_brief_id: b-1\n"
+            f'proposing_role: "{bad_role}"\n'
+        )
+        with pytest.raises(ValueError, match="proposing_role"):
+            PlanGuidance.from_yaml(yaml_doc)
+
+    def test_strategy_role_case_normalized(self):
+        """``Strategy`` and ``strategy`` must both parse — LLM casing varies."""
+        yaml_doc = (
+            "version: 1\n"
+            "guidance_id: g-1\n"
+            "source_brief_id: b-1\n"
+            "proposing_role: Strategy\n"
+        )
+        g = PlanGuidance.from_yaml(yaml_doc)
+        assert g.proposing_role == "strategy"
+
+    def test_non_int_version_rejected(self):
+        yaml_doc = (
+            'version: "1"\n'
+            "guidance_id: g-1\n"
+            "source_brief_id: b-1\n"
+            "proposing_role: strategy\n"
+        )
+        with pytest.raises(ValueError, match="version"):
+            PlanGuidance.from_yaml(yaml_doc)
+
+    def test_priority_guidance_non_list_rejected(self):
+        """A scalar where a list is expected is a structural mismatch the
+        merger can't usefully recover from; surface at parse time."""
+        yaml_doc = (
+            "version: 1\n"
+            "guidance_id: g-1\n"
+            "source_brief_id: b-1\n"
+            "proposing_role: strategy\n"
+            'priority_guidance: "high"\n'
+        )
+        with pytest.raises(ValueError, match="priority_guidance"):
+            PlanGuidance.from_yaml(yaml_doc)
+
+    def test_priority_guidance_list_with_non_mapping_rejected(self):
+        """A list of scalars would be silently coerced to ``dict(entry)``
+        and explode at attribute access in the merger; reject at parse."""
+        yaml_doc = (
+            "version: 1\n"
+            "guidance_id: g-1\n"
+            "source_brief_id: b-1\n"
+            "proposing_role: strategy\n"
+            "priority_guidance:\n"
+            '  - "backend_api: high"\n'
+        )
+        with pytest.raises(ValueError, match="priority_guidance"):
+            PlanGuidance.from_yaml(yaml_doc)
+
+    def test_must_not_skip_must_be_list(self):
+        yaml_doc = (
+            "version: 1\n"
+            "guidance_id: g-1\n"
+            "source_brief_id: b-1\n"
+            "proposing_role: strategy\n"
+            'must_not_skip: "auth tests"\n'
+        )
+        with pytest.raises(ValueError, match="must_not_skip"):
+            PlanGuidance.from_yaml(yaml_doc)
+
+    def test_malformed_yaml_rejected(self):
+        with pytest.raises(ValueError, match="Malformed"):
+            PlanGuidance.from_yaml("version: 1\nguidance_id: g-1\nsource_brief_id: [unclosed")

--- a/tests/unit/cycles/test_proposed_role_tasks.py
+++ b/tests/unit/cycles/test_proposed_role_tasks.py
@@ -50,6 +50,10 @@ class TestFocusKey:
 _VALID_PROPOSAL = """\
 version: 1
 proposing_role: qa
+proposal_id: prop-qa-001
+source_brief_id: brief-test-001
+scope_statement: |
+  QA coverage for backend endpoints.
 tasks:
   - task_type: qa.test
     role: qa
@@ -91,7 +95,14 @@ class TestFromYAMLHappy:
         """A role that fails to find anything to propose returns an
         empty list. The merger absorbs the empty proposal (per
         SIP-0093 §5.4 fall-back) — the parser shouldn't reject it."""
-        proposal = ProposedRoleTasks.from_yaml("version: 1\nproposing_role: strat\ntasks: []\n")
+        proposal = ProposedRoleTasks.from_yaml(
+            "version: 1\n"
+            "proposing_role: strat\n"
+            "proposal_id: prop-strat-001\n"
+            "source_brief_id: brief-test-001\n"
+            "scope_statement: 'Strategy proposal — no tasks'\n"
+            "tasks: []\n"
+        )
         assert proposal.tasks == []
 
     def test_task_keys_round_trip(self):
@@ -120,11 +131,25 @@ class TestFromYAMLErrors:
 
     def test_empty_proposing_role_rejected(self):
         with pytest.raises(ValueError, match="proposing_role"):
-            ProposedRoleTasks.from_yaml('version: 1\nproposing_role: ""\ntasks: []\n')
+            ProposedRoleTasks.from_yaml(
+                'version: 1\n'
+                'proposing_role: ""\n'
+                'proposal_id: prop-1\n'
+                'source_brief_id: brief-1\n'
+                "scope_statement: 'x'\n"
+                'tasks: []\n'
+            )
 
     def test_non_int_version_rejected(self):
         with pytest.raises(ValueError, match="version"):
-            ProposedRoleTasks.from_yaml('version: "1"\nproposing_role: qa\ntasks: []\n')
+            ProposedRoleTasks.from_yaml(
+                'version: "1"\n'
+                'proposing_role: qa\n'
+                'proposal_id: prop-1\n'
+                'source_brief_id: brief-1\n'
+                "scope_statement: 'x'\n"
+                'tasks: []\n'
+            )
 
     def test_malformed_yaml_rejected(self):
         with pytest.raises(ValueError, match="Malformed proposal YAML"):
@@ -138,6 +163,9 @@ class TestFromYAMLErrors:
         bad = """\
 version: 1
 proposing_role: qa
+proposal_id: prop-1
+source_brief_id: brief-1
+scope_statement: x
 tasks:
   - task_type: qa.test
     role: qa
@@ -153,6 +181,9 @@ tasks:
         bad = """\
 version: 1
 proposing_role: dev
+proposal_id: prop-1
+source_brief_id: brief-1
+scope_statement: x
 tasks:
   - task_type: development.develop
     role: dev
@@ -170,6 +201,9 @@ tasks:
         bad = """\
 version: 1
 proposing_role: qa
+proposal_id: prop-1
+source_brief_id: brief-1
+scope_statement: x
 tasks:
   - task_type: qa.test
     role: qa
@@ -184,6 +218,9 @@ tasks:
         bad = """\
 version: 1
 proposing_role: qa
+proposal_id: prop-1
+source_brief_id: brief-1
+scope_statement: x
 tasks:
   - task_type: qa.test
     role: qa

--- a/tests/unit/cycles/test_proposed_role_tasks_v2.py
+++ b/tests/unit/cycles/test_proposed_role_tasks_v2.py
@@ -1,0 +1,259 @@
+"""Tests for SIP-0093 PR 93.1 extensions to ProposedRoleTasks.
+
+The existing test file covers the original PR #125 surface. This file covers
+the new required-field surface, brief-conflict parsing, and the RC-24
+integer-rejection rule on ``depends_on_focus``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.proposed_role_tasks import (
+    BriefConflict,
+    ProposedRoleTasks,
+)
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+
+# Minimal valid proposal that includes every Rev 1 required field, used as
+# the mutation base for each error test. Tasks list is empty so failures
+# surface against the field under test rather than against task structure.
+_BASE_VALID = """\
+version: 1
+proposing_role: dev
+proposal_id: prop-dev-001
+source_brief_id: brief-test-001
+scope_statement: |
+  Dev contributions for the user CRUD feature.
+tasks: []
+"""
+
+
+# ---------------------------------------------------------------------------
+# New required fields enforced
+# ---------------------------------------------------------------------------
+
+
+class TestNewRequiredFields:
+    """Each new Rev 1 required field must raise ValueError when missing
+    or when present-but-empty. These are the fields the merger relies on
+    to tie a proposal back to the immutable brief (RC-22) and to track
+    proposal provenance — silently parsing without them would leak
+    untraceable proposals into the merge."""
+
+    def test_missing_proposal_id_rejected(self):
+        bad = (
+            "version: 1\n"
+            "proposing_role: dev\n"
+            "source_brief_id: brief-1\n"
+            "scope_statement: x\n"
+            "tasks: []\n"
+        )
+        with pytest.raises(ValueError, match="proposal_id"):
+            ProposedRoleTasks.from_yaml(bad)
+
+    def test_missing_source_brief_id_rejected(self):
+        bad = (
+            "version: 1\n"
+            "proposing_role: dev\n"
+            "proposal_id: prop-1\n"
+            "scope_statement: x\n"
+            "tasks: []\n"
+        )
+        with pytest.raises(ValueError, match="source_brief_id"):
+            ProposedRoleTasks.from_yaml(bad)
+
+    def test_missing_scope_statement_rejected(self):
+        bad = (
+            "version: 1\n"
+            "proposing_role: dev\n"
+            "proposal_id: prop-1\n"
+            "source_brief_id: brief-1\n"
+            "tasks: []\n"
+        )
+        with pytest.raises(ValueError, match="scope_statement"):
+            ProposedRoleTasks.from_yaml(bad)
+
+    @pytest.mark.parametrize(
+        "field,bad_value,error_match",
+        [
+            ("proposal_id", '""', "proposal_id"),
+            ("source_brief_id", '""', "source_brief_id"),
+            ("scope_statement", '""', "scope_statement"),
+            ("scope_statement", '"   "', "scope_statement"),  # whitespace-only also rejected
+        ],
+    )
+    def test_empty_required_field_rejected(self, field, bad_value, error_match):
+        # Build YAML by replacing the field's value with the empty/blank version.
+        lines = _BASE_VALID.splitlines(keepends=True)
+        out_lines = []
+        for line in lines:
+            if line.startswith(f"{field}:") or line.startswith(f"{field} ") or line.startswith(f"{field}\n"):
+                continue
+            out_lines.append(line)
+        bad = "".join(out_lines) + f"{field}: {bad_value}\n"
+        with pytest.raises(ValueError, match=error_match):
+            ProposedRoleTasks.from_yaml(bad)
+
+
+# ---------------------------------------------------------------------------
+# Brief conflicts parsing
+# ---------------------------------------------------------------------------
+
+
+class TestBriefConflicts:
+    """Brief conflicts are how proposers escalate spec disagreements with the
+    shared brief (SIP-0093 §5.5). They must parse with both severities and
+    reject unknown severities — the merger's escalation behavior branches on
+    severity, so a typo there would silently downgrade a blocking conflict."""
+
+    def test_parses_warning_and_blocking(self):
+        yaml_doc = _BASE_VALID + """
+brief_conflicts:
+  - brief_field: accepted_stack
+    proposed_change: Use SQLite instead of in-memory
+    reason: PRD requires persistence across app restart
+    severity: blocking
+    affected_proposal_task_keys: [dev:repository, qa:persistence tests]
+  - brief_field: scope_cuts
+    proposed_change: Drop the typeahead suggestion feature
+    reason: Out of scope for MVP
+    severity: warning
+"""
+        proposal = ProposedRoleTasks.from_yaml(yaml_doc)
+        assert len(proposal.brief_conflicts) == 2
+
+        blocking = proposal.brief_conflicts[0]
+        assert isinstance(blocking, BriefConflict)
+        assert blocking.brief_field == "accepted_stack"
+        assert blocking.severity == "blocking"
+        assert blocking.affected_proposal_task_keys == [
+            "dev:repository",
+            "qa:persistence tests",
+        ]
+
+        warning = proposal.brief_conflicts[1]
+        assert warning.severity == "warning"
+        assert warning.affected_proposal_task_keys == []
+
+    def test_unknown_severity_rejected(self):
+        yaml_doc = _BASE_VALID + """
+brief_conflicts:
+  - brief_field: accepted_stack
+    proposed_change: foo
+    reason: bar
+    severity: critical
+"""
+        with pytest.raises(ValueError, match="severity"):
+            ProposedRoleTasks.from_yaml(yaml_doc)
+
+    def test_missing_brief_field_rejected(self):
+        yaml_doc = _BASE_VALID + """
+brief_conflicts:
+  - proposed_change: foo
+    reason: bar
+    severity: warning
+"""
+        with pytest.raises(ValueError, match="brief_field"):
+            ProposedRoleTasks.from_yaml(yaml_doc)
+
+    def test_default_empty_list(self):
+        proposal = ProposedRoleTasks.from_yaml(_BASE_VALID)
+        assert proposal.brief_conflicts == []
+
+
+# ---------------------------------------------------------------------------
+# RC-24: integer entries in depends_on_focus rejected
+# ---------------------------------------------------------------------------
+
+
+class TestDependsOnFocusRC24:
+    """Proposers must use ``{role}:{focus}`` strings — never raw integer
+    task indices. If a proposer leaked an integer, the merger's dependency
+    resolution would silently mis-wire because integers happen to coerce to
+    strings cleanly. Reject at parse time so the malformation surfaces."""
+
+    def test_integer_entry_rejected(self):
+        bad = (
+            _BASE_VALID.replace("tasks: []\n", "")
+            + """tasks:
+  - task_type: qa.test
+    role: qa
+    focus: integration smoke
+    description: smoke the running app
+    depends_on_focus: [3]
+"""
+        )
+        with pytest.raises(ValueError, match="RC-24"):
+            ProposedRoleTasks.from_yaml(bad)
+
+    def test_string_entry_parses(self):
+        good = (
+            _BASE_VALID.replace("tasks: []\n", "")
+            + """tasks:
+  - task_type: qa.test
+    role: qa
+    focus: integration smoke
+    description: smoke the running app
+    depends_on_focus: ["dev:backend api"]
+"""
+        )
+        proposal = ProposedRoleTasks.from_yaml(good)
+        assert proposal.tasks[0].depends_on_focus == ["dev:backend api"]
+
+    def test_bool_entry_rejected(self):
+        """``isinstance(True, int)`` is True in Python — without an explicit
+        bool guard, a YAML ``true`` would bypass the integer check."""
+        bad = (
+            _BASE_VALID.replace("tasks: []\n", "")
+            + """tasks:
+  - task_type: qa.test
+    role: qa
+    focus: integration smoke
+    description: smoke the running app
+    depends_on_focus: [true]
+"""
+        )
+        with pytest.raises(ValueError, match="RC-24"):
+            ProposedRoleTasks.from_yaml(bad)
+
+
+# ---------------------------------------------------------------------------
+# Optional Rev 1 fields round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestOptionalFieldsRoundTrip:
+    """Recommended optional fields must parse cleanly when present and
+    default to sensible empty values when absent. The merger relies on
+    presence-or-absence to know which dimensions a proposer surfaced."""
+
+    def test_optional_fields_default_empty(self):
+        proposal = ProposedRoleTasks.from_yaml(_BASE_VALID)
+        assert proposal.source_artifact_refs == []
+        assert proposal.assumptions == []
+        assert proposal.risks == []
+        assert proposal.gaps_not_covered == []
+        assert proposal.confidence == ""
+
+    def test_optional_fields_parse_when_present(self):
+        yaml_doc = _BASE_VALID + """
+source_artifact_refs:
+  - planning_artifact.md
+  - design.md
+assumptions:
+  - Auth provider is Keycloak per the brief.
+risks:
+  - Persistence layer choice unresolved.
+gaps_not_covered:
+  - Frontend smoke tests deferred to qa.
+confidence: medium
+"""
+        proposal = ProposedRoleTasks.from_yaml(yaml_doc)
+        assert proposal.source_artifact_refs == ["planning_artifact.md", "design.md"]
+        assert proposal.assumptions == ["Auth provider is Keycloak per the brief."]
+        assert proposal.risks == ["Persistence layer choice unresolved."]
+        assert proposal.gaps_not_covered == ["Frontend smoke tests deferred to qa."]
+        assert proposal.confidence == "medium"


### PR DESCRIPTION
## Summary

Second implementation PR for SIP-0093 (Multi-Role Plan Authoring). **Pure schema work.** No new handlers; no behavior change at runtime. Lets PR 93.2 (role proposer handlers) and PR 93.3 (cutover merger) layer on a stable schema surface.

Sequence after PR #139 (PR 93.0) merged.

## What this PR delivers (per `docs/plans/SIP-0093-multi-role-plan-authoring-plan.md`, PR 93.1 row)

### `ProposedRoleTasks` (extended, `src/squadops/cycles/proposed_role_tasks.py`)

- New required fields per SIP-0093 §5.4.1: `proposal_id`, `source_brief_id` (RC-22 linkage to the immutable brief), `scope_statement`.
- New `BriefConflict` frozen dataclass + parser for the optional `brief_conflicts` list (§5.5). Severity bounded to `{warning, blocking}`. Unknown severity raises.
- Recommended optional Rev 1 fields parsed if present, default-empty if absent: `source_artifact_refs`, `assumptions`, `risks`, `gaps_not_covered`, `confidence`.
- **RC-24 enforced:** `depends_on_focus` rejects integer entries (and bool, since `isinstance(True, int)` is `True`). Proposers don't know their numeric `task_index` — only the merger assigns those, so an integer here means a numbering assumption leaked.
- Per-task parsing extracted to `_parse_proposed_task(...)` so the parent `from_yaml` stays under ruff's C901 complexity bound.

### `PlanGuidance` (new, `src/squadops/cycles/plan_guidance.py`)

- Frozen dataclass + `from_yaml()` for strategy's overlay artifact (§5.4.2).
- Required: `version`, `guidance_id`, `source_brief_id`, `proposing_role` — `proposing_role` enforced to `"strategy"` (case-normalized so ``Strategy`` and ``strategy`` both parse, but ``development`` rejects).
- Optional: `priority_guidance`, `ordering_guidance`, `risk_guidance`, `time_budget_guidance`, `scope_cut_guidance`, `must_not_skip`, `defer_if_time_constrained`, `confidence`.
- Priority/ordering/risk/time-budget kept as `list[dict[str, Any]]` rather than typed sub-dataclasses. Over-typing pushes too much format burden onto a strategy LLM that legitimately returns partial overlays; the merger reads each list as advisory and handles missing dimensions per its own policy.

### `MergeDecisions` (new, `src/squadops/cycles/merge_decisions.py`)

The merger's auditable record (§5.7). Three companion dataclasses, all frozen:

- `CanonicalTaskProvenance` — per-task lineage (`task_index`, `source_proposal_task_keys`, `proposed_by`, `merge_action`, `reason`). `merge_action` bounded to `{accepted, merged, modified, gap_filled}`.
- `BriefConflictDisposition` — how the merger handled each proposer-raised conflict (`brief_field`, `severity`, `disposition`, `reason`). `disposition` bounded to `{accepted, rejected, escalated_to_operator}`.
- `MissingProposal` — `(role, failure_reason)` for proposals that didn't make it, surfaced to the operator console without re-deriving from artifact absence.

**RC-26 invariant enforced at parse time** in `_validate_rc26(...)` — extracted from the parser so PR 93.3's merger can pre-validate when constructing `MergeDecisions` in code:

- `authoring_mode == "multi_role"` ⇒ `sole_author_reason is None` AND `proposal_completeness in {complete, partial}`.
- `authoring_mode == "sole_author"` ⇒ `sole_author_reason in {no_contributors_configured, all_proposals_failed}` AND `proposal_completeness == "sole_author"`.

`canonical_tasks` `task_index` values must be unique-and-contiguous from 0 (enforces SIP-0092 M1 schema's canonical ordering).

## What this PR explicitly does not do

- No new handlers. The schemas exist but no production code path constructs them yet.
- No changes to `PLANNING_TASK_STEPS`. Framing pipeline byte-identical to today.
- No prompt registry work. (Cleanup tracked in issue #140.)
- No proposer LLM prompts. Those land in PR 93.2.
- No merger logic. Lands in PR 93.3.

## Tests

67 new tests, all in the regression suite. `./scripts/dev/run_regression_tests.sh`: **3882 passed, 1 skipped, 0 failed** (was 3815 on main; +67).

- `test_proposed_role_tasks_v2.py` (16): new-required-field enforcement, brief_conflicts warning+blocking parse, unknown-severity rejection, RC-24 integer + bool rejection on `depends_on_focus`, optional fields round-trip.
- `test_plan_guidance.py` (17): required-field enforcement, non-strategy role rejection (parametrized across `development`/`qa`/`lead`/empty), case normalization, list-vs-scalar shape validation, minimal-guidance happy path.
- `test_merge_decisions.py` (34): both authoring modes parse, RC-26 invariant enforced in all 4 invalid cross-product cells, `task_index` uniqueness + contiguity (including non-int rejection), enum bounding parametrized across `merge_action` / `severity` / `disposition`, per-class required-field surface.

Existing `test_proposed_role_tasks.py` (18 tests) YAML literals updated to include the three new required fields where the test isn't asserting on a missing-field error path. The `proposing_role` check order is preserved in the parser so existing error-tests' field-name matchers still hit their target field, not a new required field.

## Diff scope

```
src/squadops/cycles/merge_decisions.py                  | 357 +++ (new)
src/squadops/cycles/plan_guidance.py                    | 136 +++ (new)
src/squadops/cycles/proposed_role_tasks.py              | 244 +++  (extends)
tests/unit/cycles/test_merge_decisions.py               | 327 +++ (new)
tests/unit/cycles/test_plan_guidance.py                 | 178 +++ (new)
tests/unit/cycles/test_proposed_role_tasks.py           |  60 +-  (fence-post: new requireds in error-test YAML)
tests/unit/cycles/test_proposed_role_tasks_v2.py        | 245 +++ (new)
```

## Test plan

- [ ] Maintainer confirms `ProposedRoleTasks`'s new required fields match SIP-0093 §5.4.1 Rev 1 spec.
- [ ] Maintainer confirms `_validate_rc26(...)` correctly enforces the four invalid cross-product cells documented in SIP-0093 §5.9 and RC-26.
- [ ] Maintainer confirms `merge_decisions.canonical_tasks` `task_index` invariant (unique-and-contiguous from 0) matches the SIP-0092 M1 canonical-plan shape.
- [ ] Confirm `./scripts/dev/run_regression_tests.sh` passes locally (3882/0).

## Next

PR 93.2 — Role proposer handlers (`development.propose_plan_tasks`, `qa.propose_plan_tasks`, `strategy.propose_plan_guidance`). Schema-backed, registered but not yet wired into `PLANNING_TASK_STEPS`. Per the plan doc, Rev 1 ships sequential proposers; parallel fan-out is a Rev 2 follow-up.

## Related

- Issue #140 — prompt registry cleanup. Finding F3 (missing `task_type.governance.prepare_plan_authoring_brief.md`) must land before PR 93.3 cutover.
- `docs/plans/SIP-0093-multi-role-plan-authoring-plan.md` — implementation plan.
- `sips/accepted/SIP-0093-Multi-Role-Plan-Authoring.md` — full design (Rev 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)