### PR TITLE
feat(SIP-0093 PR 93.2): role proposer handlers + RC-23 failure records

### DIFF
--- a/src/squadops/bootstrap/handlers.py
+++ b/src/squadops/bootstrap/handlers.py
@@ -52,12 +52,15 @@ from squadops.capabilities.handlers.impl.repair_handlers import (
 from squadops.capabilities.handlers.planning_tasks import (
     DataResearchContextHandler,
     DevelopmentDesignPlanHandler,
+    DevelopmentProposePlanTasksHandler,
     GovernanceIncorporateFeedbackHandler,
     GovernancePreparePlanAuthoringBriefHandler,
     GovernanceReviewPlanHandler,
     QADefineTestStrategyHandler,
+    QaProposePlanTasksHandler,
     QAValidateRefinementHandler,
     StrategyFrameObjectiveHandler,
+    StrategyProposePlanGuidanceHandler,
 )
 from squadops.capabilities.handlers.qa import (
     TestExecutionHandler,
@@ -141,6 +144,12 @@ HANDLER_CONFIGS: list[tuple[type[CapabilityHandler], tuple[str, ...]]] = [
     # SIP-0093 PR 93.0: brief handler registered but not yet wired into
     # PLANNING_TASK_STEPS (cutover happens in PR 93.3).
     (GovernancePreparePlanAuthoringBriefHandler, ("lead",)),
+    # SIP-0093 PR 93.2: proposer handlers registered but not yet wired into
+    # PLANNING_TASK_STEPS (cutover happens in PR 93.3). Each is
+    # invocable via direct dispatch / tests.
+    (DevelopmentProposePlanTasksHandler, ("dev",)),
+    (QaProposePlanTasksHandler, ("qa",)),
+    (StrategyProposePlanGuidanceHandler, ("strat",)),
     # Refinement handlers (SIP-0078: Planning Workload Protocol)
     (GovernanceIncorporateFeedbackHandler, ("lead",)),
     (QAValidateRefinementHandler, ("qa",)),

--- a/src/squadops/capabilities/handlers/_plan_authoring.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring.py
@@ -9,9 +9,9 @@ Multi-role plan authoring routes through three handler families:
   + ``planning_artifact.md``.
 
 Each handler runs a retry-with-corrective-feedback LLM loop and emits
-fenced YAML in a known filename. The loop body, fenced extraction,
-and prompt-building are shared between all three so behavior stays
-aligned and a fix to one path doesn't drift away from the others.
+fenced YAML in a known filename. ``retry_yaml_call`` below is the shared
+loop body; handlers plug in their own parse/validate via the
+``parse_and_validate`` callback.
 
 This module is intentionally function-style (no service class). The
 handlers are the agents; this module is their toolbox.
@@ -20,35 +20,14 @@ handlers are the agents; this module is their toolbox.
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from squadops.capabilities.handlers.fenced_parser import extract_fenced_files
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
 
 logger = logging.getLogger(__name__)
-
-
-def extract_named_yaml(content: str, filename: str) -> str | None:
-    """Pull the first fenced ``yaml:filename`` block from a response.
-
-    Falls back to a tag-less ``yaml`` block if no filename-tagged one
-    is found — the LLM occasionally drops the tag and we don't want
-    to throw away an otherwise-valid proposal.
-    """
-    extracted = extract_fenced_files(content)
-    matches = [f for f in extracted if f["filename"] == filename]
-    if matches:
-        return matches[0]["content"]
-
-    import re
-
-    pattern = r"```yaml\s*\n(.*?)```"
-    for match in re.finditer(pattern, content, re.DOTALL):
-        block = match.group(1).strip()
-        if block:
-            return block
-    return None
 
 
 async def retry_yaml_call(
@@ -143,153 +122,3 @@ def _first_yaml_block_or_none(content: str) -> str | None:
         if block:
             return block
     return None
-
-
-# ---------------------------------------------------------------------------
-# Propose-prompt construction
-# ---------------------------------------------------------------------------
-
-
-_PROPOSE_BASE_INSTRUCTIONS = """\
-You are proposing the build-phase tasks that fall within YOUR role's
-domain. Other roles will propose their own tasks in parallel; the
-governance lead will merge all proposals into the canonical
-implementation plan.
-
-Constraints on YOUR proposal:
-
-- Propose ONLY tasks for the listed task_type(s) below — leave other
-  domains to their owning roles.
-- Each task must have a clear, narrow ``focus`` (e.g. "Backend models"
-  not "Build the app"). The ``focus`` is your task's identity and
-  serves as the dependency reference key for other proposers.
-- ``focus`` must be unique within your proposal.
-- For cross-role dependencies (e.g. your QA test depends on a dev
-  task), reference them by ``"{role}:{focus}"`` in
-  ``depends_on_focus`` — e.g. ``"dev:backend api"``. The merger will
-  resolve these to numeric task_indices after combining all proposals.
-- Acceptance criteria: prefer machine-evaluable typed checks (SIP-0092
-  M1 vocabulary) over prose strings. Each typed check is a flat YAML
-  map with ``check`` plus check-specific keys.
-- Be concrete about file paths in ``expected_artifacts``. Filename
-  drift across proposers is the merger's biggest source of conflict.
-"""
-
-
-_TYPED_ACCEPTANCE_HINT = """\
-
-## Typed Acceptance Criteria (SIP-0092 vocabulary)
-
-Each typed check is a flat YAML map. Examples (one per shape):
-
-```yaml
-- check: regex_match
-  description: "At least three test functions exist"
-  file: tests/test_users.py
-  pattern: "def test_"
-  count_min: 3
-
-- check: endpoint_defined
-  description: "Backend exposes the user CRUD routes"
-  file: backend/main.py
-  methods_paths: ["GET /users", "POST /users", "DELETE /users/{uid}"]
-
-- check: field_present
-  description: "User model carries id and email"
-  file: backend/models.py
-  class_name: User
-  fields: [id, email]
-
-- check: import_present
-  description: "Pydantic is wired in for request models"
-  file: backend/main.py
-  module: pydantic
-  symbol: BaseModel
-```
-
-Strings (e.g. ``"Backend runs cleanly"``) stay as informational prose
-and never block validation. Typed checks with ``severity: error``
-(default) DO block the build when failed.
-"""
-
-
-_PROPOSE_OUTPUT_SHAPE = """\
-
-Output ONLY a fenced YAML block tagged ``proposed_plan_tasks.yaml``
-with this shape:
-
-```yaml:proposed_plan_tasks.yaml
-version: 1
-proposing_role: {proposing_role}
-tasks:
-  - task_type: {primary_task_type}
-    role: {proposing_role}
-    focus: "Short identity for this task"
-    description: |
-      Detailed description.
-    expected_artifacts:
-      - "path/to/file"
-    acceptance_criteria:
-      - check: regex_match
-        file: "path/to/file"
-        pattern: "..."
-        count_min: 1
-    depends_on_focus: []
-```
-
-If you have nothing to propose for your role (e.g. the build is so
-simple your role has no testable surface), emit ``tasks: []`` — the
-merger will absorb the empty proposal and proceed.
-"""
-
-
-def build_propose_prompt(
-    *,
-    role: str,
-    primary_task_type: str,
-    role_domain_description: str,
-    prd: str,
-    planning_content: str,
-    profile_roles: list[str],
-    profile_has_builder: bool,
-) -> str:
-    """Assemble the per-role propose-task prompt.
-
-    ``role_domain_description`` is the role-specific scope sentence
-    (e.g. "Decompose the build's QA work into focused test
-    subtasks") — provided by each propose handler so the shared body
-    can stay generic.
-    """
-    builder_section = ""
-    if profile_has_builder and role != "builder":
-        builder_section = (
-            "\n\n## Builder role present\n\n"
-            "This squad includes a dedicated builder role. Do NOT propose "
-            "packaging, requirements files, Dockerfile, startup scripts, or "
-            "qa_handoff.md tasks — those are the builder's domain. Reference "
-            "builder tasks via ``depends_on_focus`` if your tasks need their "
-            "outputs."
-        )
-
-    roles_section = ""
-    if profile_roles:
-        roles_section = (
-            f"\n\n## Available roles in this squad\n\n"
-            f"{', '.join(profile_roles)}\n\n"
-            f"You are proposing as the **{role}** role. Reference other "
-            f"roles by id when expressing cross-role dependencies."
-        )
-
-    return (
-        f"{_PROPOSE_BASE_INSTRUCTIONS}"
-        f"\n\n## Your scope\n\n"
-        f"{role_domain_description} Restrict your proposed tasks to "
-        f"task_type ``{primary_task_type}``."
-        f"{roles_section}"
-        f"{builder_section}"
-        f"\n\n## PRD\n\n{prd}\n"
-        f"\n## Planning artifacts (from upstream framing tasks)\n\n"
-        f"{planning_content}\n"
-        f"{_TYPED_ACCEPTANCE_HINT}"
-        f"{_PROPOSE_OUTPUT_SHAPE.format(proposing_role=role, primary_task_type=primary_task_type)}"
-    )

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -578,6 +578,431 @@ class GovernancePreparePlanAuthoringBriefHandler(_PlanningTaskHandler):
 
 
 # ---------------------------------------------------------------------------
+# 3 Proposer handlers (SIP-0093 PR 93.2)
+#
+# Three handlers that contribute domain-scoped plan-authoring artifacts:
+# development.propose_plan_tasks, qa.propose_plan_tasks, and
+# strategy.propose_plan_guidance. Registered but NOT wired into
+# PLANNING_TASK_STEPS — cutover happens in PR 93.3. The handlers are
+# reachable via direct dispatch and in tests until then.
+#
+# Each handler:
+#   1. Reads plan_authoring_brief.yaml from prior_outputs["artifact_contents"]
+#      (RC-22: brief is immutable upstream context).
+#   2. Renders its user prompt from a registered template that surfaces the
+#      brief content, planning_content, proposal_id, source_brief_id.
+#   3. Assembles its system prompt via prompt_service.assemble(..., task_type=
+#      self._capability_id) — task-type fragments live in
+#      src/squadops/prompts/fragments/shared/task_type/.
+#   4. Runs retry_yaml_call (SIP-0093 _plan_authoring helper) for up to
+#      manifest_max_attempts attempts with corrective feedback on each
+#      parse failure.
+#   5. Enforces source_brief_id matching the upstream brief's brief_id.
+#   6. On success: emits the parseable artifact (proposed_plan_tasks.yaml or
+#      plan_guidance.yaml).
+#   7. On exhausted failure: emits a ProposalFailure artifact (RC-23) rather
+#      than an exception that kills the cycle. The merger (PR 93.3) reads
+#      these as "this role's proposal is missing."
+# ---------------------------------------------------------------------------
+
+
+_PROPOSAL_MAX_ATTEMPTS_DEFAULT = 2
+
+
+def _extract_brief_id_from_prior_outputs(prior_outputs: dict[str, Any] | None) -> str | None:
+    """Pull the upstream brief_id out of a pre-resolved artifact-contents map.
+
+    The pipeline pre-resolver (wired by PR 93.3 cutover) puts the brief's
+    YAML content into ``prior_outputs["artifact_contents"]["plan_authoring_brief.yaml"]``.
+    Returns ``None`` if the brief isn't in prior_outputs (caller decides
+    whether that's a hard failure or an empty-context proposer call).
+    """
+    if not prior_outputs:
+        return None
+    contents = prior_outputs.get("artifact_contents")
+    if not isinstance(contents, dict):
+        return None
+    brief_yaml = contents.get("plan_authoring_brief.yaml")
+    if not brief_yaml:
+        return None
+    try:
+        from squadops.cycles.plan_authoring_brief import PlanAuthoringBrief
+
+        return PlanAuthoringBrief.from_yaml(brief_yaml).brief_id
+    except ValueError:
+        return None
+
+
+def _format_planning_content(prior_outputs: dict[str, Any] | None) -> str:
+    """Concatenate non-brief planning artifacts for the user-prompt context.
+
+    Filters out the brief itself (surfaced separately as ``brief_content``)
+    and the artifact_contents key. Renders remaining role outputs as
+    Markdown sections so the proposer sees the framing artifacts as a
+    single narrative.
+    """
+    if not prior_outputs:
+        return "(no upstream framing artifacts)"
+    parts: list[str] = []
+
+    contents = prior_outputs.get("artifact_contents")
+    if isinstance(contents, dict):
+        for name, content in contents.items():
+            if name == "plan_authoring_brief.yaml":
+                continue
+            parts.append(f"### {name}\n{content}")
+
+    for key, value in prior_outputs.items():
+        if key in ("artifact_contents",):
+            continue
+        if isinstance(value, dict) and "summary" in value:
+            parts.append(f"### {key}\n{value['summary']}")
+
+    return "\n\n".join(parts) if parts else "(no upstream framing artifacts)"
+
+
+class _ProposeBaseHandler(_PlanningTaskHandler):
+    """Shared shape for the three SIP-0093 proposer handlers.
+
+    Subclasses pin ``_capability_id``, ``_role``, ``_request_template_id``,
+    ``_proposer_role`` (the value that appears in ``proposing_role`` of the
+    parsed artifact), and implement ``_parse_and_validate``. The base
+    drives the retry loop, surfaces the parsed artifact on success, and
+    emits a ``ProposalFailure`` artifact on exhaustion (RC-23).
+    """
+
+    _success_artifact_name: str = ""  # subclasses override
+    _success_artifact_type: str = ""  # subclasses override
+    _proposer_role: str = ""  # subclasses override — appears as proposing_role in YAML
+
+    def _failure_artifact_name(self) -> str:
+        # capability_id with dots → underscores, plus _failure.yaml — a
+        # filename the merger can pattern-match without parsing.
+        return self._capability_id.replace(".", "_") + "_failure.yaml"
+
+    def _parse_and_validate(
+        self,
+        yaml_content: str | None,
+        expected_brief_id: str | None,
+    ) -> tuple[Any | None, str | None]:
+        """Subclass-specific parse + validate.
+
+        Returns ``(parsed_obj, error_msg)``. ``error_msg is None`` means
+        accept; otherwise the message becomes corrective feedback for the
+        next retry attempt.
+        """
+        raise NotImplementedError
+
+    def _build_render_variables(
+        self,
+        prd: str,
+        prior_outputs: dict[str, Any] | None,
+        inputs: dict[str, Any],
+    ) -> dict[str, str]:
+        import uuid
+
+        brief_content = "(brief not yet provided — direct-invocation context)"
+        if prior_outputs:
+            contents = prior_outputs.get("artifact_contents")
+            if isinstance(contents, dict):
+                brief_content = contents.get("plan_authoring_brief.yaml", brief_content)
+
+        brief_id = _extract_brief_id_from_prior_outputs(prior_outputs) or "(unknown)"
+        proposal_id = inputs.get("proposal_id") or f"prop-{uuid.uuid4().hex[:8]}"
+
+        profile_roles = inputs.get("profile_roles") or []
+        roles_section = ""
+        if profile_roles:
+            roles_section = (
+                "## Available roles in this squad\n\n"
+                f"{', '.join(profile_roles)}\n\n"
+            )
+
+        builder_section = ""
+        if "builder" in profile_roles and self._role != "builder":
+            builder_section = (
+                "## Builder role present\n\n"
+                "This squad includes a dedicated builder role. Do NOT propose "
+                "packaging, requirements files, Dockerfile, startup scripts, "
+                "or qa_handoff.md tasks — those are the builder's domain. "
+                "Reference builder tasks via ``depends_on_focus`` if your "
+                "tasks need their outputs.\n\n"
+            )
+
+        return {
+            "brief_content": brief_content,
+            "planning_content": _format_planning_content(prior_outputs),
+            "proposal_id": proposal_id,
+            "source_brief_id": brief_id,
+            "prd": prd,
+            "roles_section": roles_section,
+            "builder_section": builder_section,
+            "typed_acceptance_vocabulary": "",  # task-type fragment carries the vocabulary
+        }
+
+    async def handle(
+        self,
+        context: ExecutionContext,
+        inputs: dict[str, Any],
+    ) -> HandlerResult:
+        from squadops.capabilities.handlers._plan_authoring import retry_yaml_call
+
+        start_time = time.perf_counter()
+
+        prd = inputs.get("prd", "")
+        prior_outputs = inputs.get("prior_outputs")
+        resolved_config = inputs.get("resolved_config", {})
+        expected_brief_id = _extract_brief_id_from_prior_outputs(prior_outputs)
+
+        # Render user prompt via the registered template (SIP-0084).
+        renderer = getattr(context.ports, "request_renderer", None)
+        if renderer is None:
+            # No renderer in test contexts: emit a structured failure rather
+            # than constructing an inline duplicate. This handler family is
+            # new (PR 93.2) — tests inject a renderer mock, no migration
+            # baggage to accommodate.
+            return self._build_failure_result(
+                start_time,
+                inputs,
+                "llm_error",
+                f"{self._handler_name} requires request_renderer port",
+            )
+
+        variables = self._build_render_variables(prd, prior_outputs, inputs)
+        rendered = await renderer.render(self._request_template_id, variables)
+        user_prompt = rendered.content
+
+        assembled = context.ports.prompt_service.assemble(
+            role=self._role,
+            hook="agent_start",
+            task_type=self._capability_id,
+        )
+        system_prompt = assembled.content
+
+        max_attempts = int(
+            resolved_config.get("proposal_max_attempts", _PROPOSAL_MAX_ATTEMPTS_DEFAULT)
+        )
+        chat_kwargs = self._build_chat_kwargs(inputs)
+
+        def parse_and_validate(yaml_or_none: str | None) -> tuple[Any | None, str | None]:
+            return self._parse_and_validate(yaml_or_none, expected_brief_id)
+
+        parsed, last_yaml, last_error = await retry_yaml_call(
+            llm=context.ports.llm,
+            chat_kwargs=chat_kwargs,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            parse_and_validate=parse_and_validate,
+            max_attempts=max_attempts,
+            handler_name=self._handler_name,
+        )
+
+        if parsed is None:
+            failure_reason = self._classify_failure(last_error, last_yaml)
+            return self._build_failure_result(
+                start_time,
+                inputs,
+                failure_reason,
+                last_error or "exhausted retry budget without parseable output",
+            )
+
+        return self._build_success_result(start_time, inputs, last_yaml or "")
+
+    def _classify_failure(self, last_error: str | None, last_yaml: str | None) -> str:
+        """Map the retry loop's last error to a ProposalFailure failure_reason."""
+        if not last_error:
+            return "malformed_yaml" if not last_yaml else "schema_validation_error"
+        lowered = last_error.lower()
+        if "brief" in lowered and "mismatch" in lowered:
+            return "mismatched_brief_id"
+        if "malformed" in lowered or "yaml" in lowered:
+            return "malformed_yaml"
+        if last_yaml is None:
+            return "malformed_yaml"
+        return "schema_validation_error"
+
+    def _build_success_result(
+        self,
+        start_time: float,
+        inputs: dict[str, Any],
+        yaml_content: str,
+    ) -> HandlerResult:
+        outputs = {
+            "summary": f"[{self._role}] proposal produced for {self._capability_id}",
+            "role": self._role,
+            "artifacts": [
+                {
+                    "name": self._success_artifact_name,
+                    "content": yaml_content,
+                    "media_type": "text/yaml",
+                    "type": self._success_artifact_type,
+                },
+            ],
+        }
+        duration_ms = (time.perf_counter() - start_time) * 1000
+        evidence = HandlerEvidence.create(
+            handler_name=self._handler_name,
+            capability_id=self._capability_id,
+            duration_ms=duration_ms,
+            inputs_hash=self._hash_dict(inputs),
+            outputs_hash=self._hash_dict(outputs),
+        )
+        return HandlerResult(success=True, outputs=outputs, _evidence=evidence)
+
+    def _build_failure_result(
+        self,
+        start_time: float,
+        inputs: dict[str, Any],
+        failure_reason: str,
+        details: str,
+    ) -> HandlerResult:
+        """Emit a ProposalFailure artifact (RC-23) — the cycle continues.
+
+        Returns ``HandlerResult(success=True, ...)`` so the cycle pipeline
+        keeps moving and the merger gets a chance to read this artifact.
+        The "failure" is captured inside the artifact, not at the
+        HandlerResult layer.
+        """
+        from squadops.cycles.proposal_failure import ProposalFailure
+
+        failure = ProposalFailure(
+            proposer_role=self._proposer_role,
+            failure_reason=failure_reason,
+            details=details,
+        )
+        outputs = {
+            "summary": (
+                f"[{self._role}] proposal failed ({failure_reason}) — "
+                f"failure record emitted for merger"
+            ),
+            "role": self._role,
+            "artifacts": [
+                {
+                    "name": self._failure_artifact_name(),
+                    "content": failure.to_yaml(),
+                    "media_type": "text/yaml",
+                    "type": "proposal_failure",
+                },
+            ],
+        }
+        duration_ms = (time.perf_counter() - start_time) * 1000
+        evidence = HandlerEvidence.create(
+            handler_name=self._handler_name,
+            capability_id=self._capability_id,
+            duration_ms=duration_ms,
+            inputs_hash=self._hash_dict(inputs),
+            outputs_hash=self._hash_dict(outputs),
+        )
+        return HandlerResult(success=True, outputs=outputs, _evidence=evidence)
+
+
+class DevelopmentProposePlanTasksHandler(_ProposeBaseHandler):
+    """SIP-0093 PR 93.2: development-domain plan-task proposer."""
+
+    _handler_name = "development_propose_plan_tasks_handler"
+    _capability_id = "development.propose_plan_tasks"
+    _role = "dev"
+    _request_template_id = "request.development_propose_plan_tasks"
+    _success_artifact_name = "proposed_plan_tasks.yaml"
+    _success_artifact_type = "proposed_plan_tasks"
+    _proposer_role = "development"
+
+    def _parse_and_validate(
+        self,
+        yaml_content: str | None,
+        expected_brief_id: str | None,
+    ) -> tuple[Any | None, str | None]:
+        from squadops.cycles.proposed_role_tasks import ProposedRoleTasks
+
+        if yaml_content is None:
+            return None, "No fenced YAML block found. Emit your proposal in a ```yaml:proposed_plan_tasks.yaml``` block."
+        try:
+            proposal = ProposedRoleTasks.from_yaml(yaml_content)
+        except ValueError as exc:
+            return None, f"proposed_plan_tasks.yaml failed to parse: {exc}"
+        if expected_brief_id and proposal.source_brief_id != expected_brief_id:
+            return None, (
+                f"brief_id mismatch: proposal cites {proposal.source_brief_id!r}, "
+                f"upstream brief is {expected_brief_id!r}. Use the upstream brief_id verbatim."
+            )
+        if proposal.proposing_role not in ("development", "dev"):
+            return None, (
+                f"proposing_role must be 'development' for this handler, "
+                f"got {proposal.proposing_role!r}"
+            )
+        return proposal, None
+
+
+class QaProposePlanTasksHandler(_ProposeBaseHandler):
+    """SIP-0093 PR 93.2: qa-domain plan-task proposer."""
+
+    _handler_name = "qa_propose_plan_tasks_handler"
+    _capability_id = "qa.propose_plan_tasks"
+    _role = "qa"
+    _request_template_id = "request.qa_propose_plan_tasks"
+    _success_artifact_name = "proposed_plan_tasks.yaml"
+    _success_artifact_type = "proposed_plan_tasks"
+    _proposer_role = "qa"
+
+    def _parse_and_validate(
+        self,
+        yaml_content: str | None,
+        expected_brief_id: str | None,
+    ) -> tuple[Any | None, str | None]:
+        from squadops.cycles.proposed_role_tasks import ProposedRoleTasks
+
+        if yaml_content is None:
+            return None, "No fenced YAML block found. Emit your proposal in a ```yaml:proposed_plan_tasks.yaml``` block."
+        try:
+            proposal = ProposedRoleTasks.from_yaml(yaml_content)
+        except ValueError as exc:
+            return None, f"proposed_plan_tasks.yaml failed to parse: {exc}"
+        if expected_brief_id and proposal.source_brief_id != expected_brief_id:
+            return None, (
+                f"brief_id mismatch: proposal cites {proposal.source_brief_id!r}, "
+                f"upstream brief is {expected_brief_id!r}. Use the upstream brief_id verbatim."
+            )
+        if proposal.proposing_role != "qa":
+            return None, (
+                f"proposing_role must be 'qa' for this handler, "
+                f"got {proposal.proposing_role!r}"
+            )
+        return proposal, None
+
+
+class StrategyProposePlanGuidanceHandler(_ProposeBaseHandler):
+    """SIP-0093 PR 93.2: strategy plan-authoring guidance proposer."""
+
+    _handler_name = "strategy_propose_plan_guidance_handler"
+    _capability_id = "strategy.propose_plan_guidance"
+    _role = "strat"
+    _request_template_id = "request.strategy_propose_plan_guidance"
+    _success_artifact_name = "plan_guidance.yaml"
+    _success_artifact_type = "plan_guidance"
+    _proposer_role = "strategy"
+
+    def _parse_and_validate(
+        self,
+        yaml_content: str | None,
+        expected_brief_id: str | None,
+    ) -> tuple[Any | None, str | None]:
+        from squadops.cycles.plan_guidance import PlanGuidance
+
+        if yaml_content is None:
+            return None, "No fenced YAML block found. Emit your guidance in a ```yaml:plan_guidance.yaml``` block."
+        try:
+            guidance = PlanGuidance.from_yaml(yaml_content)
+        except ValueError as exc:
+            return None, f"plan_guidance.yaml failed to parse: {exc}"
+        if expected_brief_id and guidance.source_brief_id != expected_brief_id:
+            return None, (
+                f"brief_id mismatch: guidance cites {guidance.source_brief_id!r}, "
+                f"upstream brief is {expected_brief_id!r}. Use the upstream brief_id verbatim."
+            )
+        return guidance, None
+
+
+# ---------------------------------------------------------------------------
 # 2 Refinement handlers (SIP-0078 §5.10)
 # ---------------------------------------------------------------------------
 

--- a/src/squadops/cycles/proposal_failure.py
+++ b/src/squadops/cycles/proposal_failure.py
@@ -1,0 +1,107 @@
+"""ProposalFailure — structured failure record from a proposer handler (SIP-0093 RC-23).
+
+When a role proposer fails (LLM error, retry-budget exhaustion, malformed YAML
+that survives retries, brief-id mismatch), the handler emits a structured
+failure record into the cycle artifact stream rather than raising an exception
+that kills the cycle. The merger (PR 93.3) reads these records as "this
+role's proposal is missing" and produces a `MissingProposal` entry in
+`merge_decisions.yaml` accordingly.
+
+This is distinct from `merge_decisions.MissingProposal`:
+
+- ``ProposalFailure`` is what the *proposer* emits when it fails.
+- ``MissingProposal`` is what the *merger* records about missing proposals
+  in its audit artifact. The merger constructs `MissingProposal` entries
+  from `ProposalFailure` artifacts it finds in the artifact stream.
+
+The two have a structural overlap (role + failure_reason) but live at
+different layers — proposer-side artifact vs merger-side audit record.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import yaml
+
+_VALID_FAILURE_REASONS = frozenset(
+    {
+        "llm_error",
+        "timeout",
+        "malformed_yaml",
+        "mismatched_brief_id",
+        "schema_validation_error",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ProposalFailure:
+    """A proposer's structured failure record.
+
+    Attributes:
+        proposer_role: role ID of the proposer that failed
+            (``development``, ``qa``, ``strategy``, ``builder``).
+        failure_reason: bounded tag explaining why the proposal failed.
+            One of: ``llm_error`` (transport-level LLM failure),
+            ``timeout`` (call exceeded its budget), ``malformed_yaml``
+            (retry budget exhausted on bad YAML), ``mismatched_brief_id``
+            (parsed proposal cites a brief other than the upstream one),
+            ``schema_validation_error`` (parsed but failed parser
+            invariants — e.g., RC-24 integer-in-depends_on_focus).
+        details: free-form diagnostic text for operators — typically the
+            last error message from the retry loop or the validation
+            failure description.
+    """
+
+    proposer_role: str
+    failure_reason: str
+    details: str = ""
+
+    def to_yaml(self) -> str:
+        """Emit the failure record as a YAML document the merger can parse."""
+        return yaml.safe_dump(
+            {
+                "proposer_role": self.proposer_role,
+                "failure_reason": self.failure_reason,
+                "details": self.details,
+            },
+            sort_keys=False,
+        )
+
+    @classmethod
+    def from_yaml(cls, content: str) -> ProposalFailure:
+        """Parse a ``proposed_plan_tasks_failure.yaml`` document.
+
+        Raises:
+            ValueError: malformed YAML, missing required fields, or
+                unknown ``failure_reason``.
+        """
+        try:
+            data = yaml.safe_load(content)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Malformed ProposalFailure YAML: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise ValueError("ProposalFailure must be a YAML mapping at the top level")
+
+        for key in ("proposer_role", "failure_reason"):
+            if key not in data:
+                raise ValueError(f"ProposalFailure missing required field: {key}")
+
+        proposer_role = str(data["proposer_role"]).strip()
+        if not proposer_role:
+            raise ValueError("ProposalFailure proposer_role must be non-empty")
+
+        failure_reason = str(data["failure_reason"]).strip()
+        if failure_reason not in _VALID_FAILURE_REASONS:
+            raise ValueError(
+                f"ProposalFailure failure_reason must be one of "
+                f"{sorted(_VALID_FAILURE_REASONS)}, got {failure_reason!r}"
+            )
+
+        return cls(
+            proposer_role=proposer_role,
+            failure_reason=failure_reason,
+            details=str(data.get("details", "")).strip(),
+        )

--- a/src/squadops/prompts/fragments/manifest.yaml
+++ b/src/squadops/prompts/fragments/manifest.yaml
@@ -1,5 +1,5 @@
-version: 0.9.20
-updated_at: '2026-05-16T00:00:00.000000Z'
+version: 0.9.21
+updated_at: '2026-05-16T14:30:00.000000Z'
 fragments:
 - fragment_id: identity
   path: roles/comms/identity.md
@@ -85,6 +85,24 @@ fragments:
   roles:
   - qa
   sha256: 51e353106e276a8486f9f01d1755830d7ad531cc891bc6f30525e08232286d5e
+- fragment_id: task_type.development.propose_plan_tasks
+  path: shared/task_type/task_type.development.propose_plan_tasks.md
+  layer: task_type
+  roles:
+  - dev
+  sha256: 9cd6b929e7958f613eb976d96a411ddc3fb9e2bcb7df91b2321df7a6c134870c
+- fragment_id: task_type.qa.propose_plan_tasks
+  path: shared/task_type/task_type.qa.propose_plan_tasks.md
+  layer: task_type
+  roles:
+  - qa
+  sha256: 3c6419ac1e93c159d3e665d0dfb0dd370849970f9c9fa485028597d74777cc9a
+- fragment_id: task_type.strategy.propose_plan_guidance
+  path: shared/task_type/task_type.strategy.propose_plan_guidance.md
+  layer: task_type
+  roles:
+  - strat
+  sha256: b1fbebc9aad1a56370f5320dd4d3733c5b0487b73b7676044bb30498bdf966e0
 - fragment_id: task_type.governance.review_plan
   path: shared/task_type/task_type.governance.review_plan.md
   layer: task_type

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.development.propose_plan_tasks.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.development.propose_plan_tasks.md
@@ -1,0 +1,92 @@
+---
+fragment_id: task_type.development.propose_plan_tasks
+layer: task_type
+version: "0.9.21"
+roles: ["dev"]
+---
+## Development Plan-Task Proposal (SIP-0093)
+
+You are proposing the **development-domain** subtasks for this cycle's
+build. Your proposal is one of several role contributions; the governance
+lead's merger combines yours with QA's proposal and Strategy's guidance to
+produce the canonical `implementation_plan.yaml`. You do NOT produce the
+canonical plan — you propose your slice of it.
+
+### Domain ownership
+
+You own proposals for implementation tasks (`development.develop`), the
+dev-side typed acceptance criteria on those tasks, and the dependency
+edges among them. Adjacent role boundaries:
+
+- **QA tasks** (`qa.test`) belong to QA's proposal — do not include them.
+- **Build/packaging tasks** belong to the builder role's proposal (when
+  the squad includes a builder) — do not include them.
+- **Cross-cutting guidance** (priority, ordering, time budget) belongs to
+  Strategy — do not encode it as tasks.
+
+### Brief is authoritative (RC-22)
+
+You receive `plan_authoring_brief.yaml` as untrusted-input-shaped read-only
+context. You must:
+
+- Honor every entry in `must_cover_requirements` — every requirement gets
+  at least one of your proposed tasks (typically via `acceptance_criteria`).
+- Respect `accepted_stack` — propose tasks for the stack the brief pins,
+  not the stack you'd choose.
+- Treat `scope_cuts` as out-of-bounds — don't propose tasks for deferred
+  scope.
+- Direct diligence toward `risk_areas` when defining acceptance criteria.
+
+**You may NOT edit the brief.** If you believe it contradicts the PRD or
+omits a requirement, raise a structured `brief_conflicts` entry (see
+output shape) — never silently diverge.
+
+### Task discipline
+
+Each task you propose must:
+
+- Have a clear, narrow `focus` (e.g., `"Backend user model"`, not
+  `"Build the app"`). The `focus` is your task's identity within this
+  proposal AND the dependency reference key other proposers use.
+- Be `focus`-unique within your proposal — duplicate focus values collide
+  in the merger.
+- Be completable in roughly 2–10 minutes of focused LLM generation.
+- Declare cross-role dependencies via `depends_on_focus: ["{role}:{focus}"]`
+  strings — never via integer indices (you don't know your final
+  `task_index`; only the merger assigns those). Example: a dev task that
+  depends on builder packaging uses `["builder:package startup"]`.
+
+### Acceptance-criteria discipline
+
+Prefer **typed checks** (SIP-0092 M1 vocabulary) over prose strings.
+Typed checks block validation when failed; prose entries are
+informational only. The user prompt lists the vocabulary with examples
+— use them for dev-domain assertions:
+
+- `field_present` for model fields
+- `import_present` for module/symbol wiring
+- `regex_match` for code pattern presence
+- `endpoint_defined` for HTTP route presence
+- `command_exit_zero` for static checkers (argv-only safelist)
+- `count_at_least` for glob match counts
+
+### Output shape
+
+Emit your proposal as a single fenced YAML block tagged
+`proposed_plan_tasks.yaml`. Do not emit prose outside the block. The
+parser (`ProposedRoleTasks.from_yaml`) is strict on the required field
+surface — `version`, `proposal_id`, `source_brief_id`,
+`proposing_role`, `scope_statement`, `tasks`.
+
+`source_brief_id` MUST match the `brief_id` of the
+`plan_authoring_brief.yaml` you were given. A mismatch causes the merger
+to drop your proposal as compromised.
+
+### What this prompt is NOT
+
+- Not a place to debate the brief's content. Conflicts go through
+  `brief_conflicts`, not by editing requirements out of the proposal.
+- Not a place to produce the canonical plan or assign final task
+  indices.
+- Not a place to encode strategy's job. Priority and ordering are
+  strategy's contribution; you propose tasks.

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.qa.propose_plan_tasks.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.qa.propose_plan_tasks.md
@@ -1,0 +1,95 @@
+---
+fragment_id: task_type.qa.propose_plan_tasks
+layer: task_type
+version: "0.9.21"
+roles: ["qa"]
+---
+## QA Plan-Task Proposal (SIP-0093)
+
+You are proposing the **qa-domain** subtasks for this cycle's build.
+Your proposal is one of several role contributions; the governance lead's
+merger combines yours with Development's proposal and Strategy's guidance
+to produce the canonical `implementation_plan.yaml`. You do NOT produce
+the canonical plan — you propose your slice of it.
+
+### Domain ownership
+
+You own proposals for test, acceptance, validation, and evidence tasks
+(`qa.test`), and the qa-side typed acceptance criteria that test dev
+artifacts. Adjacent role boundaries:
+
+- **Implementation tasks** (`development.develop`) belong to
+  Development's proposal — do not include them. Reference them by
+  `depends_on_focus` if your tests depend on their outputs.
+- **Build/packaging tasks** belong to the builder role's proposal — do
+  not include them.
+- **Cross-cutting guidance** (priority, ordering, time budget) belongs
+  to Strategy.
+
+**QA holds the gap-catching pen.** If the brief's
+`must_cover_requirements` lists an item Development's proposal won't
+verify, propose a qa task that does. This is the single most important
+reason multi-role authoring exists: QA proposes tasks Development
+omitted, the merger absorbs them, and the canonical plan is more
+complete than any single role would have authored alone.
+
+### Brief is authoritative (RC-22)
+
+You receive `plan_authoring_brief.yaml` as read-only context. You must:
+
+- Honor every entry in `must_cover_requirements` — propose qa tasks
+  that verify them where they aren't already covered by acceptance
+  criteria on dev tasks.
+- Treat `scope_cuts` as out-of-bounds — don't propose tests for
+  deferred scope.
+- Direct test diligence toward `risk_areas` — that's the brief's signal
+  about where verification matters most.
+
+**You may NOT edit the brief.** If you believe it contradicts the PRD,
+omits a verification requirement, or pins an inappropriate stack, raise
+a structured `brief_conflicts` entry (see output shape) — never
+silently diverge.
+
+### Task discipline
+
+Each task you propose must:
+
+- Have a clear, narrow `focus` (e.g., `"Backend pytest suite"`, not
+  `"Test everything"`). The `focus` is your task's identity within this
+  proposal AND the dependency reference key other proposers use.
+- Be `focus`-unique within your proposal.
+- Declare cross-role dependencies via `depends_on_focus: ["{role}:{focus}"]`
+  strings, never via integer indices. Example: a qa test that depends
+  on Development's user-CRUD endpoint uses `["dev:user crud routes"]`.
+
+### Acceptance-criteria discipline
+
+Prefer **typed checks** for qa assertions:
+
+- `regex_match` for test-function presence (e.g.,
+  `pattern: "def test_", count_min: N`)
+- `count_at_least` for test-file/spec-file counts via glob
+- `command_exit_zero` for invoking a test runner (argv-only safelist:
+  `python -m py_compile`, `ruff check`, `tsc --noEmit`, etc.)
+- `import_present` to verify a test file imports the production module
+  it should be exercising
+
+### Output shape
+
+Emit your proposal as a single fenced YAML block tagged
+`proposed_plan_tasks.yaml`. Do not emit prose outside the block. The
+parser (`ProposedRoleTasks.from_yaml`) is strict on the required field
+surface — `version`, `proposal_id`, `source_brief_id`,
+`proposing_role`, `scope_statement`, `tasks`.
+
+`source_brief_id` MUST match the `brief_id` of the
+`plan_authoring_brief.yaml` you were given. A mismatch causes the
+merger to drop your proposal.
+
+### What this prompt is NOT
+
+- Not a place to propose implementation tasks. Tests reference
+  implementation tasks via `depends_on_focus`; they don't replace them.
+- Not a place to debate the brief. Conflicts go through
+  `brief_conflicts`.
+- Not a place to assign final `task_index` values.

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.strategy.propose_plan_guidance.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.strategy.propose_plan_guidance.md
@@ -1,0 +1,88 @@
+---
+fragment_id: task_type.strategy.propose_plan_guidance
+layer: task_type
+version: "0.9.21"
+roles: ["strat"]
+---
+## Strategy Plan-Authoring Guidance (SIP-0093)
+
+You are proposing **cross-cutting guidance** that shapes how Development
+and QA's task proposals get assembled into the canonical plan. Your
+proposal is one of several role contributions; the governance lead's
+merger applies your guidance during merge — to ordering, priority,
+time-budget allocation, and risk callouts — without changing task
+content or ownership.
+
+### What you produce — and what you do NOT produce
+
+- **You produce** `plan_guidance.yaml`: priority hints by area,
+  ordering edges across symbolic dependency keys, risk callouts,
+  time-budget allocations, scope-cut additions, items that must not be
+  skipped under budget pressure, and items that may be deferred first.
+- **You do NOT produce** plan tasks. Strategy's value is priority,
+  ordering, and tradeoff framing — not task decomposition. Forcing
+  strategy into `PlanTask` shape would produce fake implementation
+  tasks and merge noise. Development and QA propose tasks; you guide
+  how they get assembled.
+
+### Brief is authoritative (RC-22)
+
+You receive `plan_authoring_brief.yaml` as read-only context. Your
+guidance must operate within the brief's frame:
+
+- `must_cover_requirements` are non-negotiable — your guidance can
+  raise their priority but cannot remove them.
+- `scope_cuts` are already decided — your `scope_cut_guidance` can add
+  to the list, but proposers will treat any item there as out-of-scope.
+- `risk_areas` are the dimensions the brief flagged for diligence —
+  your `risk_guidance` should sharpen them, not contradict them.
+
+**You may NOT edit the brief.** Strategy's guidance overlays the
+brief; it never replaces it.
+
+### Guidance fields and how the merger uses them
+
+- `priority_guidance: [{area, priority, rationale}]` — biases which
+  areas get higher sufficiency targets and earlier scheduling.
+- `ordering_guidance: [{before, after, rationale}]` — `before` and
+  `after` are symbolic dependency keys (`{role}:{focus}`). Used as
+  ordering hints when the merger has scheduling flexibility.
+- `risk_guidance: [{target, risk}]` — `target` is a symbolic key or an
+  area name. The merger surfaces these in `operator_notes` at gate.
+- `time_budget_guidance: [{area, budget_pct}]` — rough percentage
+  allocations summing to ≤100. Informs whether a proposal's task count
+  is over-/under-budget for its area.
+- `scope_cut_guidance: ["..."]` — items proposers should treat as
+  cut beyond the brief's own `scope_cuts`.
+- `must_not_skip: ["..."]` — items that must survive merge regardless
+  of time pressure. Often a subset of `must_cover_requirements` you
+  want the merger to treat as load-bearing.
+- `defer_if_time_constrained: ["..."]` — items the merger may drop
+  first when budget pressure forces cuts.
+
+### Output shape
+
+Emit your guidance as a single fenced YAML block tagged
+`plan_guidance.yaml`. Do not emit prose outside the block. The parser
+(`PlanGuidance.from_yaml`) is strict on the required field surface —
+`version`, `guidance_id`, `source_brief_id`, `proposing_role: strategy`.
+
+Optional fields default to empty when omitted. **It is fine to emit
+guidance that's mostly empty** — partial overlays are useful and
+expected. Don't fabricate priority hints to fill out the shape.
+
+`source_brief_id` MUST match the `brief_id` of the
+`plan_authoring_brief.yaml` you were given. A mismatch causes the
+merger to drop your guidance.
+
+### What this prompt is NOT
+
+- Not a place to propose tasks. Tasks are Development's and QA's.
+- Not a place to encode `must_cover_requirements` as guidance entries
+  — those are in the brief already. `must_not_skip` is for items you
+  want to elevate as load-bearing within the merger's pressure-cut
+  logic, not a duplicate of the brief.
+- Not a place to assign final `task_index` values or pin numeric
+  scheduling decisions.
+- Not a place to decide stack, scope, or risk dimensions — those are
+  brief-level decisions.

--- a/src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md
+++ b/src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md
@@ -1,0 +1,69 @@
+---
+template_id: request.development_propose_plan_tasks
+version: "1"
+required_variables:
+  - brief_content
+  - planning_content
+  - proposal_id
+  - source_brief_id
+optional_variables:
+  - prd
+  - roles_section
+  - builder_section
+  - typed_acceptance_vocabulary
+---
+You are proposing development-domain plan tasks for the upcoming build.
+
+## Authoritative brief (read-only — RC-22)
+
+The brief below was authored upstream and is immutable. Your proposal must operate within its frame. Disagreements surface via `brief_conflicts` (see output shape), never by editing requirements out of your proposal.
+
+```yaml:plan_authoring_brief.yaml
+{{brief_content}}
+```
+
+{{roles_section}}{{builder_section}}## PRD
+
+{{prd}}
+
+## Planning artifacts (upstream framing)
+
+{{planning_content}}
+
+{{typed_acceptance_vocabulary}}
+## Your task
+
+Decompose the development work for this build into focused tasks (`task_type: development.develop`) that, together with QA's test proposal and Strategy's guidance, will assemble into a complete implementation plan. Restrict your proposal to dev-domain tasks. Use the typed-acceptance vocabulary above where applicable.
+
+Pre-filled identifiers below — copy verbatim:
+
+```yaml:proposed_plan_tasks.yaml
+version: 1
+proposal_id: {{proposal_id}}
+source_brief_id: {{source_brief_id}}
+proposing_role: development
+scope_statement: |
+  One-paragraph self-assessment of what this proposal covers.
+tasks:
+  - task_type: development.develop
+    role: dev
+    focus: "Backend user model"
+    description: |
+      Detailed description of what this task produces and why.
+    expected_artifacts:
+      - "backend/models.py"
+    acceptance_criteria:
+      - check: field_present
+        file: backend/models.py
+        class_name: User
+        fields: [id, email]
+        severity: error
+    depends_on_focus: []
+brief_conflicts: []  # Raise structured disagreements here if needed (see SIP-0093 §5.5).
+# Optional Rev 1 fields — include only if you have substantive content.
+source_artifact_refs: []
+assumptions: []
+risks: []
+gaps_not_covered: []
+confidence: ""  # low | medium | high
+```

--- a/src/squadops/prompts/request_templates/request.qa_propose_plan_tasks.md
+++ b/src/squadops/prompts/request_templates/request.qa_propose_plan_tasks.md
@@ -1,0 +1,71 @@
+---
+template_id: request.qa_propose_plan_tasks
+version: "1"
+required_variables:
+  - brief_content
+  - planning_content
+  - proposal_id
+  - source_brief_id
+optional_variables:
+  - prd
+  - roles_section
+  - builder_section
+  - typed_acceptance_vocabulary
+---
+You are proposing QA-domain plan tasks for the upcoming build.
+
+## Authoritative brief (read-only — RC-22)
+
+The brief below was authored upstream and is immutable. Your proposal must operate within its frame. Your role is the gap-catching pen: if `must_cover_requirements` lists items Development's proposal won't verify, propose qa tasks that do. Disagreements with the brief surface via `brief_conflicts` (see output shape), never by silent divergence.
+
+```yaml:plan_authoring_brief.yaml
+{{brief_content}}
+```
+
+{{roles_section}}{{builder_section}}## PRD
+
+{{prd}}
+
+## Planning artifacts (upstream framing)
+
+{{planning_content}}
+
+{{typed_acceptance_vocabulary}}
+## Your task
+
+Decompose the QA work for this build into focused tasks (`task_type: qa.test`) that verify the brief's `must_cover_requirements`. Where a requirement isn't already covered by acceptance criteria on a development task, propose a qa task that covers it explicitly. Restrict your proposal to qa-domain tasks. Reference development tasks via `depends_on_focus: ["dev:..."]` strings.
+
+Pre-filled identifiers below — copy verbatim:
+
+```yaml:proposed_plan_tasks.yaml
+version: 1
+proposal_id: {{proposal_id}}
+source_brief_id: {{source_brief_id}}
+proposing_role: qa
+scope_statement: |
+  One-paragraph self-assessment of what this proposal covers.
+tasks:
+  - task_type: qa.test
+    role: qa
+    focus: "Backend user-CRUD pytest suite"
+    description: |
+      Cover the user CRUD endpoints with pytest functions exercising
+      create / read / update / delete and duplicate-handling.
+    expected_artifacts:
+      - "backend/tests/test_users.py"
+    acceptance_criteria:
+      - check: regex_match
+        file: backend/tests/test_users.py
+        pattern: "def test_"
+        count_min: 5
+        severity: error
+    depends_on_focus:
+      - "dev:user crud routes"
+brief_conflicts: []  # Raise structured disagreements here if needed (see SIP-0093 §5.5).
+# Optional Rev 1 fields — include only if you have substantive content.
+source_artifact_refs: []
+assumptions: []
+risks: []
+gaps_not_covered: []
+confidence: ""  # low | medium | high
+```

--- a/src/squadops/prompts/request_templates/request.strategy_propose_plan_guidance.md
+++ b/src/squadops/prompts/request_templates/request.strategy_propose_plan_guidance.md
@@ -1,0 +1,65 @@
+---
+template_id: request.strategy_propose_plan_guidance
+version: "1"
+required_variables:
+  - brief_content
+  - planning_content
+  - guidance_id
+  - source_brief_id
+optional_variables:
+  - prd
+  - roles_section
+---
+You are proposing cross-cutting plan-authoring guidance for the upcoming build.
+
+## Authoritative brief (read-only — RC-22)
+
+The brief below was authored upstream and is immutable. Your guidance overlays the brief; it does not replace any of its fields. Disagreements surface only through the brief's own escalation paths — your role contributes priority/ordering/risk overlay, not brief edits.
+
+```yaml:plan_authoring_brief.yaml
+{{brief_content}}
+```
+
+{{roles_section}}## PRD
+
+{{prd}}
+
+## Planning artifacts (upstream framing)
+
+{{planning_content}}
+
+## Your task
+
+Produce `plan_guidance.yaml` capturing the cross-cutting priorities and tradeoffs Development and QA's proposers should be biased toward. Strategy's value is priority, ordering, and risk framing — NOT task decomposition. Do NOT propose plan tasks.
+
+Partial guidance is fine. If you don't have substantive content for a field, omit it or leave the list empty; the merger handles empty overlays cleanly. Fabricating priority hints to fill the shape adds merge noise.
+
+Pre-filled identifiers below — copy verbatim:
+
+```yaml:plan_guidance.yaml
+version: 1
+guidance_id: {{guidance_id}}
+source_brief_id: {{source_brief_id}}
+proposing_role: strategy
+priority_guidance:
+  - area: backend_api
+    priority: high
+    rationale: |
+      Brief calls API surface the integration anchor; prioritize it.
+ordering_guidance:
+  - before: "dev:repository layer"
+    after: "dev:user crud routes"
+    rationale: |
+      Routes pin the contract before persistence shape lands.
+risk_guidance:
+  - target: "dev:user crud routes"
+    risk: |
+      Brief flagged auth as a risk area — make sure routes propose typed auth checks.
+time_budget_guidance:
+  - area: backend_api
+    budget_pct: 30
+scope_cut_guidance: []        # Items proposers should treat as out-of-scope beyond brief's own cuts.
+must_not_skip: []             # Items the merger must preserve under budget pressure.
+defer_if_time_constrained: [] # Items the merger may drop first under pressure.
+confidence: ""                # low | medium | high
+```

--- a/tests/unit/capabilities/test_propose_plan_tasks.py
+++ b/tests/unit/capabilities/test_propose_plan_tasks.py
@@ -1,0 +1,479 @@
+"""Tests for SIP-0093 PR 93.2 proposer handlers.
+
+Three handlers, three failure surfaces, one happy path each. The handlers
+share a base (``_ProposeBaseHandler``), so the structural assertions
+(registration, brief-id matching, RC-23 failure shape, parse retries)
+test the base behavior once per concrete handler rather than testing the
+base class directly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.bootstrap.handlers import get_all_handlers
+from squadops.capabilities.handlers.planning_tasks import (
+    DevelopmentProposePlanTasksHandler,
+    QaProposePlanTasksHandler,
+    StrategyProposePlanGuidanceHandler,
+)
+from squadops.cycles.plan_guidance import PlanGuidance
+from squadops.cycles.proposal_failure import ProposalFailure
+from squadops.cycles.proposed_role_tasks import ProposedRoleTasks
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+_BRIEF_YAML = """\
+version: 1
+brief_id: brief-test-001
+objective_summary: |
+  Build a simple user-CRUD API with backend persistence and a basic UI.
+accepted_stack:
+  frontend: "React+Vite"
+  backend: "FastAPI+SQLite"
+must_cover_requirements:
+  - "POST /users creates a new user and returns 201"
+  - "GET /users/{id} returns 404 when not found"
+scope_cuts:
+  - "Admin dashboards deferred to follow-up cycle"
+risk_areas:
+  - "auth integration"
+  - "data integrity on concurrent writes"
+"""
+
+
+_DEV_PROPOSAL_RESPONSE = """\
+Looking at the brief, here are the dev tasks:
+
+```yaml:proposed_plan_tasks.yaml
+version: 1
+proposal_id: prop-dev-001
+source_brief_id: brief-test-001
+proposing_role: development
+scope_statement: |
+  Backend implementation: user model, CRUD routes.
+tasks:
+  - task_type: development.develop
+    role: dev
+    focus: "Backend user model"
+    description: |
+      Define the User Pydantic model with id and email fields.
+    expected_artifacts:
+      - "backend/models.py"
+    acceptance_criteria:
+      - check: field_present
+        file: backend/models.py
+        class_name: User
+        fields: [id, email]
+        severity: error
+    depends_on_focus: []
+  - task_type: development.develop
+    role: dev
+    focus: "User CRUD routes"
+    description: |
+      Implement POST / GET / DELETE user endpoints.
+    expected_artifacts:
+      - "backend/main.py"
+    acceptance_criteria:
+      - check: endpoint_defined
+        file: backend/main.py
+        methods_paths:
+          - ["POST", "/users"]
+          - ["GET", "/users/{id}"]
+        severity: error
+    depends_on_focus:
+      - "dev:backend user model"
+```
+"""
+
+
+_QA_PROPOSAL_RESPONSE = """\
+```yaml:proposed_plan_tasks.yaml
+version: 1
+proposal_id: prop-qa-001
+source_brief_id: brief-test-001
+proposing_role: qa
+scope_statement: |
+  Test coverage for user CRUD endpoints including 404 path.
+tasks:
+  - task_type: qa.test
+    role: qa
+    focus: "User CRUD pytest suite"
+    description: |
+      pytest functions exercising POST, GET, DELETE, and 404 on missing id.
+    expected_artifacts:
+      - "backend/tests/test_users.py"
+    acceptance_criteria:
+      - check: regex_match
+        file: backend/tests/test_users.py
+        pattern: "def test_"
+        count_min: 4
+        severity: error
+    depends_on_focus:
+      - "dev:user crud routes"
+```
+"""
+
+
+_STRATEGY_GUIDANCE_RESPONSE = """\
+```yaml:plan_guidance.yaml
+version: 1
+guidance_id: guidance-strategy-001
+source_brief_id: brief-test-001
+proposing_role: strategy
+priority_guidance:
+  - area: backend_api
+    priority: high
+    rationale: "API surface is the integration anchor for this build."
+must_not_skip:
+  - "404 handling on GET /users/{id}"
+defer_if_time_constrained:
+  - "frontend polish"
+```
+"""
+
+
+def _make_context(llm_response: str):
+    """Build a minimal ExecutionContext mock with a renderer mock.
+
+    Proposer handlers (PR 93.2) require ``request_renderer`` — no inline
+    fallback (no migration baggage from older test contexts). The renderer
+    mock returns a deterministic ``RenderedRequest`` so the LLM call
+    receives a stable user prompt regardless of variable contents; tests
+    assert on inputs via ``render.call_args`` and on outputs via the
+    parsed proposal/guidance artifact.
+    """
+    llm = AsyncMock()
+    llm.chat_stream_with_usage.return_value = MagicMock(content=llm_response)
+    llm.default_model = "test-model"
+
+    prompt_service = MagicMock()
+    assembled = MagicMock()
+    assembled.content = "system prompt for proposer"
+    assembled.assembly_hash = "deadbeef"
+    prompt_service.assemble.return_value = assembled
+
+    renderer = AsyncMock()
+    rendered = MagicMock()
+    rendered.content = "user prompt (rendered)"
+    rendered.template_id = "request.placeholder"
+    rendered.template_version = "1"
+    renderer.render.return_value = rendered
+
+    ports = MagicMock()
+    ports.llm = llm
+    ports.prompt_service = prompt_service
+    ports.llm_observability = None
+    ports.request_renderer = renderer
+
+    ctx = MagicMock()
+    ctx.ports = ports
+    ctx.correlation_context = None
+    ctx.project_id = "test_proj"
+    ctx.cycle_id = "cyc_test"
+    return ctx
+
+
+def _seeded_inputs(prior_outputs_extra: dict | None = None) -> dict:
+    prior_outputs = {
+        "artifact_contents": {
+            "plan_authoring_brief.yaml": _BRIEF_YAML,
+            "planning_artifact.md": "## Plan\n\nLooks good.",
+        },
+    }
+    if prior_outputs_extra:
+        prior_outputs.update(prior_outputs_extra)
+    return {
+        "prd": "Build a simple user-CRUD API",
+        "profile_roles": ["lead", "dev", "qa", "strat"],
+        "prior_outputs": prior_outputs,
+        "resolved_config": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    """Each proposer handler must be registered in bootstrap so direct
+    dispatch resolves it. PR 93.3's cutover only adds the steps to
+    PLANNING_TASK_STEPS; registration is here in PR 93.2."""
+
+    @pytest.mark.parametrize(
+        "handler_cls,expected_roles",
+        [
+            (DevelopmentProposePlanTasksHandler, ("dev",)),
+            (QaProposePlanTasksHandler, ("qa",)),
+            (StrategyProposePlanGuidanceHandler, ("strat",)),
+        ],
+    )
+    def test_handler_registered_with_correct_role(self, handler_cls, expected_roles):
+        registered = {
+            entry[0].__name__: entry[1] for entry in get_all_handlers()
+        }
+        assert handler_cls.__name__ in registered, (
+            f"{handler_cls.__name__} not in bootstrap handler registry"
+        )
+        assert registered[handler_cls.__name__] == expected_roles
+
+
+# ---------------------------------------------------------------------------
+# Happy path: each handler produces its expected artifact for a seeded LLM response
+# ---------------------------------------------------------------------------
+
+
+async def test_dev_proposer_emits_parseable_proposal():
+    ctx = _make_context(_DEV_PROPOSAL_RESPONSE)
+    handler = DevelopmentProposePlanTasksHandler()
+
+    result = await handler.handle(ctx, _seeded_inputs())
+
+    assert result.success is True
+    artifact = result.outputs["artifacts"][0]
+    assert artifact["name"] == "proposed_plan_tasks.yaml"
+    assert artifact["media_type"] == "text/yaml"
+    assert artifact["type"] == "proposed_plan_tasks"
+
+    parsed = ProposedRoleTasks.from_yaml(artifact["content"])
+    assert parsed.proposing_role == "development"
+    assert parsed.source_brief_id == "brief-test-001"
+    assert len(parsed.tasks) == 2
+    assert parsed.tasks[0].focus == "Backend user model"
+    assert parsed.tasks[1].depends_on_focus == ["dev:backend user model"]
+
+
+async def test_qa_proposer_emits_parseable_proposal():
+    ctx = _make_context(_QA_PROPOSAL_RESPONSE)
+    handler = QaProposePlanTasksHandler()
+
+    result = await handler.handle(ctx, _seeded_inputs())
+
+    assert result.success is True
+    artifact = result.outputs["artifacts"][0]
+    assert artifact["name"] == "proposed_plan_tasks.yaml"
+    parsed = ProposedRoleTasks.from_yaml(artifact["content"])
+    assert parsed.proposing_role == "qa"
+    assert parsed.source_brief_id == "brief-test-001"
+    assert parsed.tasks[0].depends_on_focus == ["dev:user crud routes"]
+
+
+async def test_strategy_proposer_emits_parseable_guidance():
+    ctx = _make_context(_STRATEGY_GUIDANCE_RESPONSE)
+    handler = StrategyProposePlanGuidanceHandler()
+
+    result = await handler.handle(ctx, _seeded_inputs())
+
+    assert result.success is True
+    artifact = result.outputs["artifacts"][0]
+    assert artifact["name"] == "plan_guidance.yaml"
+    assert artifact["type"] == "plan_guidance"
+
+    parsed = PlanGuidance.from_yaml(artifact["content"])
+    assert parsed.proposing_role == "strategy"
+    assert parsed.source_brief_id == "brief-test-001"
+    assert parsed.must_not_skip == ["404 handling on GET /users/{id}"]
+
+
+# ---------------------------------------------------------------------------
+# RC-23: structured failure record, not exception, on retry exhaustion
+# ---------------------------------------------------------------------------
+
+
+class TestRC23FailureRecord:
+    """When a proposer can't produce a parseable artifact within the retry
+    budget, it must emit a structured ProposalFailure artifact rather than
+    raising. The cycle continues; the merger reads the failure record as
+    'this role's proposal is missing' and produces a MissingProposal entry
+    in merge_decisions.yaml accordingly."""
+
+    @pytest.mark.parametrize(
+        "handler_cls,proposer_role,failure_artifact_name",
+        [
+            (
+                DevelopmentProposePlanTasksHandler,
+                "development",
+                "development_propose_plan_tasks_failure.yaml",
+            ),
+            (
+                QaProposePlanTasksHandler,
+                "qa",
+                "qa_propose_plan_tasks_failure.yaml",
+            ),
+            (
+                StrategyProposePlanGuidanceHandler,
+                "strategy",
+                "strategy_propose_plan_guidance_failure.yaml",
+            ),
+        ],
+    )
+    async def test_unparseable_response_emits_failure_record(
+        self, handler_cls, proposer_role, failure_artifact_name
+    ):
+        ctx = _make_context("No fenced YAML at all here.")
+        handler = handler_cls()
+        inputs = _seeded_inputs()
+        inputs["resolved_config"]["proposal_max_attempts"] = 1  # don't burn time retrying
+
+        result = await handler.handle(ctx, inputs)
+
+        # HandlerResult.success is True — the cycle keeps moving. The failure
+        # is captured inside the artifact, not at the HandlerResult layer.
+        assert result.success is True
+        artifact = result.outputs["artifacts"][0]
+        assert artifact["name"] == failure_artifact_name
+        assert artifact["type"] == "proposal_failure"
+
+        failure = ProposalFailure.from_yaml(artifact["content"])
+        assert failure.proposer_role == proposer_role
+        assert failure.failure_reason in {"malformed_yaml", "schema_validation_error"}
+        assert failure.details  # non-empty
+
+    @pytest.mark.parametrize(
+        "handler_cls",
+        [
+            DevelopmentProposePlanTasksHandler,
+            QaProposePlanTasksHandler,
+            StrategyProposePlanGuidanceHandler,
+        ],
+    )
+    async def test_no_exception_on_repeated_failure(self, handler_cls):
+        """Multiple retries that all fail must not propagate as an exception
+        — the entire point of RC-23 is that proposer failure doesn't kill
+        the cycle."""
+        ctx = _make_context("garbage response that won't parse")
+        handler = handler_cls()
+        inputs = _seeded_inputs()
+        inputs["resolved_config"]["proposal_max_attempts"] = 3
+
+        # Must not raise.
+        result = await handler.handle(ctx, inputs)
+        assert result.success is True
+        assert result.outputs["artifacts"][0]["type"] == "proposal_failure"
+
+
+# ---------------------------------------------------------------------------
+# Brief-id matching (RC-22 immutability invariant at proposer layer)
+# ---------------------------------------------------------------------------
+
+
+class TestBriefIdMatching:
+    """The merger relies on every proposal citing the same brief_id as the
+    upstream brief. A mismatch indicates either a corrupted proposal or a
+    proposer running against a stale brief — either way, drop it cleanly
+    rather than merging a divergent worldview."""
+
+    @pytest.mark.parametrize(
+        "handler_cls,response",
+        [
+            (DevelopmentProposePlanTasksHandler, _DEV_PROPOSAL_RESPONSE),
+            (QaProposePlanTasksHandler, _QA_PROPOSAL_RESPONSE),
+            (StrategyProposePlanGuidanceHandler, _STRATEGY_GUIDANCE_RESPONSE),
+        ],
+    )
+    async def test_brief_id_mismatch_produces_failure_record(self, handler_cls, response):
+        # Tamper with the response to cite a different brief_id than the upstream.
+        tampered = response.replace("brief-test-001", "brief-fake-999")
+        ctx = _make_context(tampered)
+        handler = handler_cls()
+        inputs = _seeded_inputs()
+        inputs["resolved_config"]["proposal_max_attempts"] = 1
+
+        result = await handler.handle(ctx, inputs)
+        assert result.success is True
+
+        artifact = result.outputs["artifacts"][0]
+        assert artifact["type"] == "proposal_failure"
+        failure = ProposalFailure.from_yaml(artifact["content"])
+        assert failure.failure_reason == "mismatched_brief_id"
+        assert "brief-test-001" in failure.details
+        assert "brief-fake-999" in failure.details
+
+
+# ---------------------------------------------------------------------------
+# Prompt registry integration (the issue #140 discipline applied to PR 93.2)
+# ---------------------------------------------------------------------------
+
+
+class TestPromptRegistryIntegration:
+    """PR 93.2 was authored after issue #140's prompt-registry cleanup
+    lesson. These tests guard against future drift back toward inline
+    prompts. Each handler MUST route its user prompt through the registry
+    and assemble its system prompt with the appropriate task_type
+    fragment."""
+
+    @pytest.mark.parametrize(
+        "handler_cls,expected_template,expected_task_type",
+        [
+            (
+                DevelopmentProposePlanTasksHandler,
+                "request.development_propose_plan_tasks",
+                "development.propose_plan_tasks",
+            ),
+            (
+                QaProposePlanTasksHandler,
+                "request.qa_propose_plan_tasks",
+                "qa.propose_plan_tasks",
+            ),
+            (
+                StrategyProposePlanGuidanceHandler,
+                "request.strategy_propose_plan_guidance",
+                "strategy.propose_plan_guidance",
+            ),
+        ],
+    )
+    async def test_handler_uses_registered_template_and_task_type(
+        self, handler_cls, expected_template, expected_task_type
+    ):
+        ctx = _make_context(_DEV_PROPOSAL_RESPONSE)  # response unused for these assertions
+        handler = handler_cls()
+
+        await handler.handle(ctx, _seeded_inputs())
+
+        ctx.ports.request_renderer.render.assert_called_once()
+        template_id = ctx.ports.request_renderer.render.call_args.args[0]
+        assert template_id == expected_template
+
+        ctx.ports.prompt_service.assemble.assert_called_once_with(
+            role=handler._role,
+            hook="agent_start",
+            task_type=expected_task_type,
+        )
+
+    async def test_brief_content_surfaced_to_template(self):
+        ctx = _make_context(_DEV_PROPOSAL_RESPONSE)
+        handler = DevelopmentProposePlanTasksHandler()
+
+        await handler.handle(ctx, _seeded_inputs())
+
+        variables = ctx.ports.request_renderer.render.call_args.args[1]
+        assert "brief_content" in variables
+        assert "brief_id: brief-test-001" in variables["brief_content"]
+        assert variables["source_brief_id"] == "brief-test-001"
+        assert variables["proposal_id"]  # non-empty
+
+    async def test_renderer_required_no_inline_fallback(self):
+        """No silent fall-through to inline construction (lesson from #140)."""
+        ctx = _make_context(_DEV_PROPOSAL_RESPONSE)
+        ctx.ports.request_renderer = None
+        handler = DevelopmentProposePlanTasksHandler()
+
+        result = await handler.handle(ctx, _seeded_inputs())
+
+        # Surfaces as a structured failure rather than raising or silently
+        # constructing an inline prompt.
+        assert result.success is True
+        artifact = result.outputs["artifacts"][0]
+        assert artifact["type"] == "proposal_failure"
+        failure = ProposalFailure.from_yaml(artifact["content"])
+        assert failure.failure_reason == "llm_error"
+        assert "request_renderer" in failure.details

--- a/tests/unit/cycles/test_proposal_failure.py
+++ b/tests/unit/cycles/test_proposal_failure.py
@@ -1,0 +1,98 @@
+"""Tests for ``ProposalFailure`` (SIP-0093 PR 93.2 RC-23 record)."""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.proposal_failure import ProposalFailure
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+
+class TestRoundTrip:
+    """The merger (PR 93.3) reads ProposalFailure artifacts from the cycle
+    stream. The to_yaml → from_yaml round-trip must preserve the three
+    fields the merger cares about — proposer_role, failure_reason,
+    details — so the merger's MissingProposal construction has its
+    inputs intact."""
+
+    def test_round_trip_preserves_fields(self):
+        original = ProposalFailure(
+            proposer_role="qa",
+            failure_reason="malformed_yaml",
+            details="retry budget exhausted after 2 attempts",
+        )
+        parsed = ProposalFailure.from_yaml(original.to_yaml())
+        assert parsed == original
+
+    def test_round_trip_with_empty_details(self):
+        original = ProposalFailure(
+            proposer_role="strategy",
+            failure_reason="timeout",
+        )
+        parsed = ProposalFailure.from_yaml(original.to_yaml())
+        assert parsed == original
+        assert parsed.details == ""
+
+
+class TestParserErrors:
+    @pytest.mark.parametrize(
+        "missing_field",
+        ["proposer_role", "failure_reason"],
+    )
+    def test_missing_required_field_rejected(self, missing_field):
+        full = {
+            "proposer_role": "development",
+            "failure_reason": "llm_error",
+        }
+        full.pop(missing_field)
+        yaml_doc = "\n".join(f"{k}: {v}" for k, v in full.items()) + "\n"
+        with pytest.raises(ValueError, match=missing_field):
+            ProposalFailure.from_yaml(yaml_doc)
+
+    def test_empty_proposer_role_rejected(self):
+        with pytest.raises(ValueError, match="proposer_role"):
+            ProposalFailure.from_yaml(
+                'proposer_role: ""\nfailure_reason: llm_error\n'
+            )
+
+    @pytest.mark.parametrize(
+        "bad_reason",
+        ["unknown", "BAD_REASON", "user_quit", "manual_override"],
+    )
+    def test_unknown_failure_reason_rejected(self, bad_reason):
+        yaml_doc = (
+            "proposer_role: development\n"
+            f"failure_reason: {bad_reason}\n"
+        )
+        with pytest.raises(ValueError, match="failure_reason"):
+            ProposalFailure.from_yaml(yaml_doc)
+
+    def test_malformed_yaml_rejected(self):
+        with pytest.raises(ValueError, match="Malformed"):
+            ProposalFailure.from_yaml("proposer_role: [unclosed")
+
+    def test_non_mapping_rejected(self):
+        with pytest.raises(ValueError, match="mapping"):
+            ProposalFailure.from_yaml("- just\n- a\n- list\n")
+
+    @pytest.mark.parametrize(
+        "valid_reason",
+        [
+            "llm_error",
+            "timeout",
+            "malformed_yaml",
+            "mismatched_brief_id",
+            "schema_validation_error",
+        ],
+    )
+    def test_every_valid_reason_parses(self, valid_reason):
+        """Each bounded reason must round-trip cleanly. Tracks the
+        vocabulary against accidental shrinkage in the parser."""
+        yaml_doc = (
+            "proposer_role: development\n"
+            f"failure_reason: {valid_reason}\n"
+            "details: ok\n"
+        )
+        parsed = ProposalFailure.from_yaml(yaml_doc)
+        assert parsed.failure_reason == valid_reason

--- a/tests/unit/prompts/test_planning_fragments.py
+++ b/tests/unit/prompts/test_planning_fragments.py
@@ -58,6 +58,24 @@ PLANNING_FRAGMENTS = [
         "roles": ["lead"],
     },
     {
+        "fragment_id": "task_type.development.propose_plan_tasks",
+        "path": "shared/task_type/task_type.development.propose_plan_tasks.md",
+        "layer": "task_type",
+        "roles": ["dev"],
+    },
+    {
+        "fragment_id": "task_type.qa.propose_plan_tasks",
+        "path": "shared/task_type/task_type.qa.propose_plan_tasks.md",
+        "layer": "task_type",
+        "roles": ["qa"],
+    },
+    {
+        "fragment_id": "task_type.strategy.propose_plan_guidance",
+        "path": "shared/task_type/task_type.strategy.propose_plan_guidance.md",
+        "layer": "task_type",
+        "roles": ["strat"],
+    },
+    {
         "fragment_id": "task_type.governance.incorporate_feedback",
         "path": "shared/task_type/task_type.governance.incorporate_feedback.md",
         "layer": "task_type",
@@ -179,11 +197,13 @@ class TestPlanningFragmentsContent:
         assert len(content) > 50, f"Fragment content too short: {len(content)} chars"
 
     def test_task_type_fragments_total(self):
-        """Exactly 17 task_type fragments exist:
+        """Exactly 20 task_type fragments exist:
         5 planning + 2 refinement + 5 wrap-up + 3 SIP-0079 impl
         (analyze_failure, correction_decision, establish_contract —
         moved out of hardcoded constants in impl/*.py) +
-        2 SIP-0093 (prepare_plan_authoring_brief, review_plan_manifest)."""
+        5 SIP-0093 (prepare_plan_authoring_brief, review_plan_manifest,
+        development.propose_plan_tasks, qa.propose_plan_tasks,
+        strategy.propose_plan_guidance)."""
         task_type_dir = FRAGMENTS_DIR / "shared" / "task_type"
         md_files = list(task_type_dir.glob("*.md"))
-        assert len(md_files) == 17
+        assert len(md_files) == 20


### PR DESCRIPTION
## Summary

Third implementation PR for SIP-0093 (Multi-Role Plan Authoring). Adds the three role proposers (development, qa, strategy) and the structured-failure record they emit on retry exhaustion. **Registered in bootstrap; NOT wired into `PLANNING_TASK_STEPS`** — that's the cutover PR (93.3). Cycle behavior unchanged at runtime.

Authored after issue #140's prompt-registry cleanup lesson — every LLM call routes through the registered template + task-type fragment from day one. No inline prompts.

## Handlers (`src/squadops/capabilities/handlers/planning_tasks.py`)

All three subclass a new `_ProposeBaseHandler` that drives the retry-with-corrective-feedback LLM loop via `retry_yaml_call` (`_plan_authoring` helper), enforces `source_brief_id` matching against the upstream brief (RC-22), and emits a `ProposalFailure` artifact on exhaustion rather than raising (RC-23). `HandlerResult.success` stays `True` on failure — the cycle keeps moving, the merger reads the failure artifact as "this role's proposal is missing."

- **`DevelopmentProposePlanTasksHandler`** (`development.propose_plan_tasks`) — reads brief from `prior_outputs["artifact_contents"]`; emits `proposed_plan_tasks.yaml` parsed by `ProposedRoleTasks.from_yaml`.
- **`QaProposePlanTasksHandler`** (`qa.propose_plan_tasks`) — same shape, qa-scoped. SIP-0093 design: QA is the gap-catching pen — proposes tasks Development omitted.
- **`StrategyProposePlanGuidanceHandler`** (`strategy.propose_plan_guidance`) — emits `plan_guidance.yaml` parsed by `PlanGuidance.from_yaml`. Strategy proposes cross-cutting overlay (priority, ordering, time-budget guidance), not tasks. Per SIP-0093 §5.3.

Rev 1 ships sequential (per plan-doc Spark amendment from #143): parallel fan-out wouldn't deliver wall-clock savings on bandwidth-bound hardware.

## Prompt registry (issue #140 discipline applied from day one)

- **3 task-type fragments** registered: `task_type.development.propose_plan_tasks`, `task_type.qa.propose_plan_tasks`, `task_type.strategy.propose_plan_guidance`. Each role-scoped, each pinning brief immutability (RC-22), domain boundaries (no cross-domain task proposals), and output-shape discipline.
- **3 request templates** registered: `request.development_propose_plan_tasks`, `request.qa_propose_plan_tasks`, `request.strategy_propose_plan_guidance`. Full variable surface declared; pre-filled identifiers for `proposal_id` / `source_brief_id` so proposers can't fabricate them.
- Manifest version bumped `0.9.20` → `0.9.21`.

## RC-23 failure schema (`src/squadops/cycles/proposal_failure.py`)

`ProposalFailure` frozen dataclass + `from_yaml/to_yaml`. Bounded `failure_reason` vocabulary: `llm_error`, `timeout`, `malformed_yaml`, `mismatched_brief_id`, `schema_validation_error`. Distinct from `MissingProposal` in `merge_decisions.py` — `ProposalFailure` is what the *proposer* emits; `MissingProposal` is what the *merger* records in its audit (the merger reads the former to produce the latter in PR 93.3).

## Dead-code cleanup (`src/squadops/capabilities/handlers/_plan_authoring.py`)

PR 93.0 left some inline-prompt scaffolding for the proposers — `build_propose_prompt` and its `_PROPOSE_BASE_INSTRUCTIONS` / `_TYPED_ACCEPTANCE_HINT` / `_PROPOSE_OUTPUT_SHAPE` constants. Issue #140's lesson made that approach obsolete; PR 93.2 went straight to registered templates. The dead scaffolding is removed in this PR rather than left as a lazy-shortcut attractor for a future contributor. Also removed `extract_named_yaml` (unused).

The module now contains only `retry_yaml_call` + its internal `_first_yaml_block_or_none` helper.

## Tests (72 new, all in regression suite)

- **`tests/unit/capabilities/test_propose_plan_tasks.py`** (20):
  - Registration in bootstrap (parametrized × 3 handlers).
  - Happy path for each handler: parseable artifact emitted from seeded LLM response.
  - RC-23: unparseable LLM response → `ProposalFailure` artifact, not exception (parametrized × 3 handlers × 2 cases each).
  - Brief-id mismatch (RC-22) → `ProposalFailure` with `failure_reason: mismatched_brief_id` and both ids in details (parametrized × 3).
  - **Prompt-registry integration regression anchors**: each handler uses its registered `template_id` + assembles with its `task_type`; renderer-absent surfaces as a structured failure (lesson from #140).
- **`tests/unit/cycles/test_proposal_failure.py`** (16): round-trip preservation, required-field surface, bounded `failure_reason` vocabulary, malformed-YAML rejection.

`PLANNING_FRAGMENTS` parametrized test list extended to cover all three new task-type fragments; total task_type fragment count assertion bumped `17` → `20`.

## Regression

**3969 passed**, 1 skipped, 0 failed (was 3897 on main; +72 new tests).

## Diff scope

```
src/squadops/bootstrap/handlers.py                                                   |   8 +-
src/squadops/capabilities/handlers/_plan_authoring.py                                | 169 +-
src/squadops/capabilities/handlers/planning_tasks.py                                 | 357 +++++
src/squadops/cycles/proposal_failure.py                                              | 108 +++ (new)
src/squadops/prompts/fragments/manifest.yaml                                         |  20 +
src/squadops/prompts/fragments/shared/task_type/task_type.development.propose_plan_tasks.md | 81 ++ (new)
src/squadops/prompts/fragments/shared/task_type/task_type.qa.propose_plan_tasks.md          | 84 ++ (new)
src/squadops/prompts/fragments/shared/task_type/task_type.strategy.propose_plan_guidance.md | 89 ++ (new)
src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md            | 56 + (new)
src/squadops/prompts/request_templates/request.qa_propose_plan_tasks.md                     | 65 + (new)
src/squadops/prompts/request_templates/request.strategy_propose_plan_guidance.md            | 60 + (new)
tests/unit/capabilities/test_propose_plan_tasks.py                                          | 386 +++ (new)
tests/unit/cycles/test_proposal_failure.py                                                  |  98 + (new)
tests/unit/prompts/test_planning_fragments.py                                               |  31 +-
```

## Test plan

- [ ] Maintainer confirms the three handler `_capability_id` values match SIP-0093 §5.3 (`development.propose_plan_tasks`, `qa.propose_plan_tasks`, `strategy.propose_plan_guidance`).
- [ ] Maintainer confirms the RC-23 failure-vs-success path: `HandlerResult.success=True` on failure with a `ProposalFailure` artifact, so the cycle pipeline keeps moving.
- [ ] Maintainer confirms each handler routes through its registered template + task-type fragment, no inline prompts (issue #140 discipline).
- [ ] Maintainer confirms `_plan_authoring.py` dead-code removal doesn't break any consumer (`build_propose_prompt`, `extract_named_yaml` had no callers).
- [ ] Confirm `./scripts/dev/run_regression_tests.sh` passes locally (3969/0).

## Sequencing

After this PR merges, PR 93.3 (cutover) is the next step. PR 93.3:

- Adds `GovernanceMergePlanHandler` (the merger).
- Rewires `PLANNING_TASK_STEPS` to include brief → proposers → merger → review_plan (sign-off).
- Removes inline `PlanAuthoringService.produce_plan` invocation from `GovernanceReviewPlanHandler` — that handler becomes sign-off only.
- Sole-author mode (empty contributors, or all proposals failed) flows through the same chain via `PlanAuthoringService`.

The merger will consume `ProposalFailure` artifacts emitted by this PR's handlers to construct `MissingProposal` entries in `merge_decisions.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)