### PR TITLE
feat(SIP-0093 PR 93.3 cutover): merger + dynamic PLANNING_TASK_STEPS

### DIFF
--- a/src/squadops/bootstrap/handlers.py
+++ b/src/squadops/bootstrap/handlers.py
@@ -54,6 +54,7 @@ from squadops.capabilities.handlers.planning_tasks import (
     DevelopmentDesignPlanHandler,
     DevelopmentProposePlanTasksHandler,
     GovernanceIncorporateFeedbackHandler,
+    GovernanceMergePlanHandler,
     GovernancePreparePlanAuthoringBriefHandler,
     GovernanceReviewPlanHandler,
     QADefineTestStrategyHandler,
@@ -144,12 +145,15 @@ HANDLER_CONFIGS: list[tuple[type[CapabilityHandler], tuple[str, ...]]] = [
     # SIP-0093 PR 93.0: brief handler registered but not yet wired into
     # PLANNING_TASK_STEPS (cutover happens in PR 93.3).
     (GovernancePreparePlanAuthoringBriefHandler, ("lead",)),
-    # SIP-0093 PR 93.2: proposer handlers registered but not yet wired into
-    # PLANNING_TASK_STEPS (cutover happens in PR 93.3). Each is
-    # invocable via direct dispatch / tests.
+    # SIP-0093 PR 93.2: proposer handlers — now wired into PLANNING_TASK_STEPS
+    # via build_planning_steps() per plan_authoring_contributors config.
     (DevelopmentProposePlanTasksHandler, ("dev",)),
     (QaProposePlanTasksHandler, ("qa",)),
     (StrategyProposePlanGuidanceHandler, ("strat",)),
+    # SIP-0093 PR 93.3 cutover: deterministic merger. Runs after the
+    # proposer fan-out (or directly after the brief in sole-author mode);
+    # produces canonical implementation_plan.yaml + merge_decisions.yaml.
+    (GovernanceMergePlanHandler, ("lead",)),
     # Refinement handlers (SIP-0078: Planning Workload Protocol)
     (GovernanceIncorporateFeedbackHandler, ("lead",)),
     (QAValidateRefinementHandler, ("qa",)),

--- a/src/squadops/capabilities/handlers/_plan_merger.py
+++ b/src/squadops/capabilities/handlers/_plan_merger.py
@@ -1,0 +1,534 @@
+"""Plan merger (SIP-0093 PR 93.3).
+
+Function-style deterministic merger that consumes per-role proposals
+(``ProposedRoleTasks``) + strategy guidance (``PlanGuidance``) + the
+shared brief (``PlanAuthoringBrief``) and produces the canonical
+``ImplementationPlan`` plus the auditable ``MergeDecisions`` artifact.
+
+The merger applies SIP-0093 §5.8 rules in order. Rev 1 keeps the algorithm
+strictly deterministic — no LLM judgment for warning-severity conflicts,
+no auto-gap-filling. Warning brief conflicts are accepted by default with
+the proposer's reasoning recorded; blocking conflicts are escalated to
+operator notes verbatim. Unresolved cross-proposal dependencies surface in
+operator notes rather than being auto-stubbed.
+
+This module is intentionally stateless and side-effect-free. The handler
+shell in ``planning_tasks.py`` calls ``merge_proposals(...)`` and wraps
+the returned artifacts in a ``HandlerResult``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Any
+
+import yaml
+
+from squadops.cycles.implementation_plan import (
+    ImplementationPlan,
+    PlanSummary,
+    PlanTask,
+    TypedCheck,
+)
+from squadops.cycles.merge_decisions import (
+    BriefConflictDisposition,
+    CanonicalTaskProvenance,
+    MergeDecisions,
+    MissingProposal,
+)
+from squadops.cycles.plan_authoring_brief import PlanAuthoringBrief
+from squadops.cycles.plan_guidance import PlanGuidance
+from squadops.cycles.proposed_role_tasks import (
+    ProposedRoleTasks,
+    ProposedTask,
+    focus_key,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Per SIP-0093 §5.8 rule 2 — only the domain owner's task_type lands in
+# canonical tasks. Dev tasks proposed by qa are dropped (qa stays in its
+# lane); qa tasks proposed by dev are likewise dropped.
+_DEV_TASK_TYPES = frozenset({"development.develop", "builder.assemble"})
+_QA_TASK_TYPES = frozenset({"qa.test"})
+
+
+def merge_proposals(
+    *,
+    brief: PlanAuthoringBrief,
+    dev_proposal: ProposedRoleTasks | None,
+    qa_proposal: ProposedRoleTasks | None,
+    strategy_guidance: PlanGuidance | None,
+    project_id: str,
+    cycle_id: str,
+    prd_hash: str,
+    configured_contributors: list[str],
+    missing_proposals: list[MissingProposal],
+) -> tuple[ImplementationPlan, MergeDecisions]:
+    """Apply the SIP-0093 §5.8 deterministic merge.
+
+    Args:
+        brief: Shared upstream brief (RC-22 immutable).
+        dev_proposal: Development's proposal, or None if it failed/missing.
+        qa_proposal: QA's proposal, or None.
+        strategy_guidance: Strategy's overlay guidance, or None.
+        project_id / cycle_id / prd_hash: Authoritative identifiers
+            stamped into the canonical plan.
+        configured_contributors: Roles configured for this cycle —
+            drives the missing-proposal operator notes per §5.9.
+        missing_proposals: Pre-computed list of ``MissingProposal``
+            entries (one per configured role that produced no parseable
+            artifact). The caller builds this from the proposer-failure
+            artifacts in the cycle stream.
+
+    Returns:
+        ``(ImplementationPlan, MergeDecisions)`` — both with
+        ``authoring_mode: multi_role``. Callers needing sole-author mode
+        invoke ``PlanAuthoringService.produce_plan`` directly and build
+        the ``MergeDecisions`` shape via ``build_sole_author_decisions``.
+    """
+    # Rule 2 + 3: domain ownership + dedup. Each proposal already enforces
+    # focus_key uniqueness internally (parser-level), so cross-proposal
+    # collision is the only remaining shape — handled by domain ownership.
+    canonical_pairs: list[tuple[PlanTask, CanonicalTaskProvenance, ProposedTask]] = []
+
+    if dev_proposal is not None:
+        for ptask in dev_proposal.tasks:
+            if ptask.task_type not in _DEV_TASK_TYPES:
+                # Dev proposed a non-dev task type — domain-owner rule
+                # drops it. Log for observability; the merge_decisions
+                # operator notes will not surface this (it's a proposer
+                # bug, not an operator-actionable signal).
+                logger.info(
+                    "merge_plan: dropping non-dev task type %r proposed by development",
+                    ptask.task_type,
+                )
+                continue
+            canonical_pairs.append(_build_canonical_pair(ptask, "development"))
+
+    if qa_proposal is not None:
+        for ptask in qa_proposal.tasks:
+            if ptask.task_type not in _QA_TASK_TYPES:
+                logger.info(
+                    "merge_plan: dropping non-qa task type %r proposed by qa",
+                    ptask.task_type,
+                )
+                continue
+            canonical_pairs.append(_build_canonical_pair(ptask, "qa"))
+
+    # Rule 8: assign final task indices. Dev tasks first (proposal order),
+    # then qa tasks (proposal order). Strategy guidance (rule 6) may bias
+    # ordering — Rev 1 records guidance_ids in merge_decisions but does
+    # not reorder. Reordering becomes a separate refinement once we see
+    # how strategy proposers behave in practice.
+    indexed_pairs = [
+        (
+            dataclasses.replace(task, task_index=i),
+            dataclasses.replace(prov, task_index=i),
+            orig,
+        )
+        for i, (task, prov, orig) in enumerate(canonical_pairs)
+    ]
+
+    # Rule 5: resolve dependency edges. focus_key → task_index lookup.
+    focus_to_index: dict[str, int] = {}
+    for task, prov, _orig in indexed_pairs:
+        for key in prov.source_proposal_task_keys:
+            focus_to_index[key] = task.task_index
+
+    resolved_pairs: list[tuple[PlanTask, CanonicalTaskProvenance]] = []
+    unresolved_deps: list[tuple[int, str]] = []  # (task_index, missing_key)
+    for task, prov, orig in indexed_pairs:
+        depends_on: list[int] = []
+        for dep_key in orig.depends_on_focus:
+            if dep_key in focus_to_index:
+                depends_on.append(focus_to_index[dep_key])
+            else:
+                unresolved_deps.append((task.task_index, dep_key))
+        resolved_pairs.append(
+            (dataclasses.replace(task, depends_on=sorted(set(depends_on))), prov)
+        )
+
+    canonical_tasks = [t for t, _ in resolved_pairs]
+    provenance_entries = [p for _, p in resolved_pairs]
+
+    # Rule 1: brief-conflict dispositions
+    brief_conflicts_disposition = _resolve_brief_conflicts(dev_proposal, qa_proposal)
+
+    # Rule 9 + §5.9: operator notes
+    operator_notes = _build_operator_notes(
+        configured_contributors=configured_contributors,
+        dev_proposal=dev_proposal,
+        qa_proposal=qa_proposal,
+        strategy_guidance=strategy_guidance,
+        brief_conflicts_disposition=brief_conflicts_disposition,
+        unresolved_deps=unresolved_deps,
+    )
+
+    # Determine proposal_completeness
+    successful_roles = _successful_roles(dev_proposal, qa_proposal, strategy_guidance)
+    configured_set = set(configured_contributors)
+    completeness = "complete" if configured_set == successful_roles else "partial"
+
+    proposal_ids = [
+        p.proposal_id for p in (dev_proposal, qa_proposal) if p is not None
+    ]
+    guidance_ids = [strategy_guidance.guidance_id] if strategy_guidance else []
+
+    plan = _build_canonical_plan(
+        tasks=canonical_tasks,
+        project_id=project_id,
+        cycle_id=cycle_id,
+        prd_hash=prd_hash,
+    )
+    decisions = MergeDecisions(
+        version=1,
+        target_plan_id=f"plan-{cycle_id}",
+        brief_id=brief.brief_id,
+        proposal_ids=proposal_ids,
+        guidance_ids=guidance_ids,
+        authoring_mode="multi_role",
+        sole_author_reason=None,
+        proposal_completeness=completeness,
+        missing_proposals=missing_proposals,
+        canonical_tasks=provenance_entries,
+        brief_conflicts_disposition=brief_conflicts_disposition,
+        operator_notes=operator_notes,
+    )
+    return plan, decisions
+
+
+def build_sole_author_decisions(
+    *,
+    brief: PlanAuthoringBrief,
+    cycle_id: str,
+    sole_author_reason: str,
+    canonical_tasks: list[PlanTask],
+    missing_proposals: list[MissingProposal],
+) -> MergeDecisions:
+    """Construct ``MergeDecisions`` for a sole-author cycle.
+
+    Used by the merger when no proposals are available. ``sole_author_reason``
+    must be ``no_contributors_configured`` (configured mode) or
+    ``all_proposals_failed`` (degraded mode). The two render different
+    operator-visible warnings at gate.
+    """
+    operator_notes_parts: list[str] = []
+    if sole_author_reason == "all_proposals_failed":
+        operator_notes_parts.append(
+            "Multi-role authoring degraded to sole-author: every "
+            "configured proposer failed."
+        )
+        # Per-role missing-proposal warnings still surface in degraded mode
+        # so the operator can see which roles failed.
+        for mp in missing_proposals:
+            if mp.role == "qa":
+                operator_notes_parts.append(
+                    "QA coverage warning: plan was authored without qa-domain input."
+                )
+            elif mp.role == "development":
+                operator_notes_parts.append(
+                    "Implementation decomposition warning: plan was "
+                    "authored without dev-domain input."
+                )
+            elif mp.role == "strategy":
+                operator_notes_parts.append(
+                    "Ordering/priority warning: plan ordering was assigned "
+                    "without strategy guidance."
+                )
+
+    provenance_entries = [
+        CanonicalTaskProvenance(
+            task_index=t.task_index,
+            source_proposal_task_keys=[],
+            proposed_by=[],
+            merge_action="gap_filled",
+            reason=(
+                "Sole-author fallback via PlanAuthoringService — no proposer "
+                "contribution available."
+            ),
+        )
+        for t in canonical_tasks
+    ]
+
+    return MergeDecisions(
+        version=1,
+        target_plan_id=f"plan-{cycle_id}",
+        brief_id=brief.brief_id,
+        proposal_ids=[],
+        guidance_ids=[],
+        authoring_mode="sole_author",
+        sole_author_reason=sole_author_reason,
+        proposal_completeness="sole_author",
+        missing_proposals=missing_proposals if sole_author_reason == "all_proposals_failed" else [],
+        canonical_tasks=provenance_entries,
+        brief_conflicts_disposition=[],
+        operator_notes="\n".join(operator_notes_parts),
+    )
+
+
+def emit_plan_yaml(plan: ImplementationPlan) -> str:
+    """Serialize an ImplementationPlan to YAML matching the SIP-0092 M1 shape."""
+    return yaml.safe_dump(_plan_to_dict(plan), sort_keys=False, allow_unicode=True)
+
+
+def emit_merge_decisions_yaml(decisions: MergeDecisions) -> str:
+    """Serialize a MergeDecisions to YAML matching the SIP-0093 §5.7 shape."""
+    return yaml.safe_dump(_decisions_to_dict(decisions), sort_keys=False, allow_unicode=True)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _build_canonical_pair(
+    ptask: ProposedTask,
+    proposing_role: str,
+) -> tuple[PlanTask, CanonicalTaskProvenance, ProposedTask]:
+    """Convert a ProposedTask to a (PlanTask, CanonicalTaskProvenance) pair.
+
+    The third tuple element preserves the original ProposedTask so the
+    dependency-resolution pass can read its ``depends_on_focus`` keys
+    after the task_index assignment.
+    """
+    plan_task = PlanTask(
+        task_index=0,  # assigned in rule-8 pass
+        task_type=ptask.task_type,
+        role=ptask.role,
+        focus=ptask.focus,
+        description=ptask.description,
+        expected_artifacts=list(ptask.expected_artifacts),
+        acceptance_criteria=list(ptask.acceptance_criteria),
+        depends_on=[],  # resolved in rule-5 pass
+    )
+    provenance = CanonicalTaskProvenance(
+        task_index=0,
+        source_proposal_task_keys=[focus_key(ptask.role, ptask.focus)],
+        proposed_by=[proposing_role],
+        merge_action="accepted",
+        reason=(
+            f"{proposing_role}-proposed {ptask.task_type} task accepted "
+            "via domain-owner rule (§5.8 rule 2)."
+        ),
+    )
+    return plan_task, provenance, ptask
+
+
+def _resolve_brief_conflicts(
+    dev_proposal: ProposedRoleTasks | None,
+    qa_proposal: ProposedRoleTasks | None,
+) -> list[BriefConflictDisposition]:
+    """Apply §5.8 rule 1: warning → accepted, blocking → escalated.
+
+    The Rev 1 policy is conservative: the merger does not arbitrate
+    warning-severity conflicts on substantive grounds (that would require
+    LLM judgment or a richer rule set). Every warning is accepted with
+    the proposer's reasoning preserved; every blocking is escalated.
+    Operators see both at gate via merge_decisions.yaml.
+    """
+    out: list[BriefConflictDisposition] = []
+    for proposal in (dev_proposal, qa_proposal):
+        if proposal is None:
+            continue
+        for bc in proposal.brief_conflicts:
+            if bc.severity == "blocking":
+                out.append(
+                    BriefConflictDisposition(
+                        brief_field=bc.brief_field,
+                        severity="blocking",
+                        disposition="escalated_to_operator",
+                        reason=(
+                            f"Blocking conflict raised by {proposal.proposing_role} "
+                            f"on {bc.brief_field}: {bc.reason}"
+                        ),
+                    )
+                )
+            else:
+                out.append(
+                    BriefConflictDisposition(
+                        brief_field=bc.brief_field,
+                        severity="warning",
+                        disposition="accepted",
+                        reason=(
+                            f"Warning conflict from {proposal.proposing_role} accepted: "
+                            f"{bc.reason}"
+                        ),
+                    )
+                )
+    return out
+
+
+def _successful_roles(
+    dev_proposal: ProposedRoleTasks | None,
+    qa_proposal: ProposedRoleTasks | None,
+    strategy_guidance: PlanGuidance | None,
+) -> set[str]:
+    roles: set[str] = set()
+    if dev_proposal is not None:
+        roles.add("development")
+    if qa_proposal is not None:
+        roles.add("qa")
+    if strategy_guidance is not None:
+        roles.add("strategy")
+    return roles
+
+
+def _build_operator_notes(
+    *,
+    configured_contributors: list[str],
+    dev_proposal: ProposedRoleTasks | None,
+    qa_proposal: ProposedRoleTasks | None,
+    strategy_guidance: PlanGuidance | None,
+    brief_conflicts_disposition: list[BriefConflictDisposition],
+    unresolved_deps: list[tuple[int, str]],
+) -> str:
+    """Build the operator_notes prose per §5.9 + §5.8 gap-fill policy."""
+    parts: list[str] = []
+    successful = _successful_roles(dev_proposal, qa_proposal, strategy_guidance)
+    configured = set(configured_contributors)
+
+    # §5.9 required missing-role warnings
+    if "qa" in configured and "qa" not in successful:
+        parts.append(
+            "QA coverage warning: plan was authored without qa-domain input."
+        )
+    if "development" in configured and "development" not in successful:
+        parts.append(
+            "Implementation decomposition warning: plan was authored "
+            "without dev-domain input."
+        )
+    if "strategy" in configured and "strategy" not in successful:
+        parts.append(
+            "Ordering/priority warning: plan ordering was assigned without "
+            "strategy guidance."
+        )
+
+    # Escalated brief conflicts
+    for d in brief_conflicts_disposition:
+        if d.disposition == "escalated_to_operator":
+            parts.append(
+                f"Brief conflict escalated ({d.brief_field}): {d.reason}"
+            )
+
+    # Unresolved cross-proposal dependencies (rule 7 gap-fill candidates).
+    # Rev 1 surfaces these as operator notes rather than auto-filling — the
+    # operator decides whether to add the missing component or reject the
+    # qa task that references it.
+    if unresolved_deps:
+        for task_index, missing_key in unresolved_deps:
+            parts.append(
+                f"Unresolved cross-proposal dependency: canonical task "
+                f"{task_index} references {missing_key!r} which no proposer "
+                f"produced. Operator review required (gap_fill candidate)."
+            )
+
+    return "\n".join(parts)
+
+
+def _build_canonical_plan(
+    *,
+    tasks: list[PlanTask],
+    project_id: str,
+    cycle_id: str,
+    prd_hash: str,
+) -> ImplementationPlan:
+    """Wrap the merged tasks in an ImplementationPlan."""
+    dev_count = sum(1 for t in tasks if t.task_type in _DEV_TASK_TYPES)
+    qa_count = sum(1 for t in tasks if t.task_type in _QA_TASK_TYPES)
+    summary = PlanSummary(
+        total_dev_tasks=dev_count,
+        total_qa_tasks=qa_count,
+        total_tasks=len(tasks),
+        estimated_layers=[],
+    )
+    return ImplementationPlan(
+        version=1,
+        project_id=project_id,
+        cycle_id=cycle_id,
+        prd_hash=prd_hash,
+        tasks=tasks,
+        summary=summary,
+    )
+
+
+def _plan_to_dict(plan: ImplementationPlan) -> dict[str, Any]:
+    """Serialize an ImplementationPlan back to its YAML-mapping shape."""
+    return {
+        "version": plan.version,
+        "project_id": plan.project_id,
+        "cycle_id": plan.cycle_id,
+        "prd_hash": plan.prd_hash,
+        "tasks": [_plan_task_to_dict(t) for t in plan.tasks],
+        "summary": {
+            "total_dev_tasks": plan.summary.total_dev_tasks,
+            "total_qa_tasks": plan.summary.total_qa_tasks,
+            "total_tasks": plan.summary.total_tasks,
+            "estimated_layers": list(plan.summary.estimated_layers),
+        },
+    }
+
+
+def _plan_task_to_dict(task: PlanTask) -> dict[str, Any]:
+    return {
+        "task_index": task.task_index,
+        "task_type": task.task_type,
+        "role": task.role,
+        "focus": task.focus,
+        "description": task.description,
+        "expected_artifacts": list(task.expected_artifacts),
+        "acceptance_criteria": [_criterion_to_dict(c) for c in task.acceptance_criteria],
+        "depends_on": list(task.depends_on),
+    }
+
+
+def _criterion_to_dict(criterion: Any) -> Any:
+    """Serialize either a prose string or a TypedCheck back to YAML shape."""
+    if isinstance(criterion, TypedCheck):
+        flat: dict[str, Any] = {"check": criterion.check}
+        if criterion.severity != "error":
+            flat["severity"] = criterion.severity
+        if criterion.description:
+            flat["description"] = criterion.description
+        flat.update(criterion.params)
+        return flat
+    return criterion
+
+
+def _decisions_to_dict(decisions: MergeDecisions) -> dict[str, Any]:
+    return {
+        "version": decisions.version,
+        "target_plan_id": decisions.target_plan_id,
+        "brief_id": decisions.brief_id,
+        "proposal_ids": list(decisions.proposal_ids),
+        "guidance_ids": list(decisions.guidance_ids),
+        "authoring_mode": decisions.authoring_mode,
+        "sole_author_reason": decisions.sole_author_reason,
+        "proposal_completeness": decisions.proposal_completeness,
+        "missing_proposals": [
+            {"role": m.role, "failure_reason": m.failure_reason}
+            for m in decisions.missing_proposals
+        ],
+        "canonical_tasks": [
+            {
+                "task_index": ct.task_index,
+                "source_proposal_task_keys": list(ct.source_proposal_task_keys),
+                "proposed_by": list(ct.proposed_by),
+                "merge_action": ct.merge_action,
+                "reason": ct.reason,
+            }
+            for ct in decisions.canonical_tasks
+        ],
+        "brief_conflicts_disposition": [
+            {
+                "brief_field": d.brief_field,
+                "severity": d.severity,
+                "disposition": d.disposition,
+                "reason": d.reason,
+            }
+            for d in decisions.brief_conflicts_disposition
+        ],
+        "operator_notes": decisions.operator_notes,
+    }

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -331,11 +331,16 @@ class QADefineTestStrategyHandler(_PlanningTaskHandler):
 
 
 class GovernanceReviewPlanHandler(_PlanningTaskHandler):
-    """Planning handler: consolidate outputs, design sufficiency check, readiness.
+    """Planning sign-off (SIP-0093 PR 93.3 cutover).
 
-    Produces the canonical ``planning_artifact.md`` — a reconstituted document
-    that synthesizes all upstream planning outputs into a coherent plan with
-    YAML frontmatter containing readiness recommendation and sufficiency score.
+    Produces ``planning_artifact.md`` — a reconstituted narrative synthesizing
+    all upstream planning outputs with YAML frontmatter carrying the
+    readiness recommendation and sufficiency score. After SIP-0093 PR 93.3,
+    this handler is **sign-off only**: it does NOT author
+    ``implementation_plan.yaml``. The merger (``governance.merge_plan``)
+    runs upstream and emits the canonical plan plus ``merge_decisions.yaml``
+    via the same handler chain regardless of authoring mode (multi-role or
+    sole-author).
 
     Performs lightweight post-generation validation on the artifact content:
     - YAML frontmatter exists (``---`` delimiters)
@@ -486,42 +491,15 @@ class GovernanceReviewPlanHandler(_PlanningTaskHandler):
             )
             score = 3
 
-        # SIP-0086 / SIP-0092: Produce implementation plan when enabled.
-        # The plan decomposes the upcoming build into focused subtasks.
-        resolved_config = inputs.get("resolved_config", {})
-        if resolved_config.get("implementation_plan", False):
-            manifest_artifact = await self._produce_plan(context, inputs, content, resolved_config)
-            if manifest_artifact is not None:
-                result.outputs["artifacts"].append(manifest_artifact)
-
+        # SIP-0093 PR 93.3 cutover: implementation_plan.yaml is no longer
+        # produced here. The merger (governance.merge_plan) runs upstream
+        # and emits the canonical plan + merge_decisions.yaml. This handler
+        # is sign-off only — it consumes the consolidated planning artifact
+        # and adds the readiness recommendation.
+        #
+        # The merger's artifacts already live in the cycle's artifact
+        # stream; PR 93.4 surfaces them in the gate package primary view.
         return result
-
-    async def _produce_plan(
-        self,
-        context: ExecutionContext,
-        inputs: dict[str, Any],
-        planning_content: str,
-        resolved_config: dict[str, Any],
-    ) -> dict[str, Any] | None:
-        """Thin shim over ``PlanAuthoringService.produce_plan`` (SIP-0093 PR 93.0).
-
-        The body of the original ``_produce_plan`` was extracted into the
-        function-style service so SIP-0093's cutover (PR 93.3) can reuse one
-        implementation when the merger needs to author a plan directly
-        (sole-author mode). Behavior is byte-identical to the pre-extraction
-        method given the same inputs.
-        """
-        from squadops.capabilities.handlers._plan_authoring_service import produce_plan
-
-        return await produce_plan(
-            context,
-            inputs,
-            planning_content,
-            resolved_config,
-            role=self._role,
-            handler_name=self._handler_name,
-            chat_kwargs=self._build_chat_kwargs(inputs),
-        )
 
 
 class GovernancePreparePlanAuthoringBriefHandler(_PlanningTaskHandler):
@@ -574,6 +552,14 @@ class GovernancePreparePlanAuthoringBriefHandler(_PlanningTaskHandler):
                 error=f"plan_authoring_brief.yaml failed to parse: {exc}",
             )
 
+        # PR 93.3 wire: surface the brief YAML in a non-artifacts key so the
+        # merger can consume it from prior_outputs["lead"]["brief_outcome"].
+        # The executor's prior_outputs builder strips "artifacts" by design.
+        result.outputs["brief_outcome"] = {
+            "status": "success",
+            "yaml_content": artifact["content"],
+            "artifact_name": "plan_authoring_brief.yaml",
+        }
         return result
 
 
@@ -838,6 +824,16 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
                     "type": self._success_artifact_type,
                 },
             ],
+            # The merger consumes this via prior_outputs (PR 93.3). The cycle
+            # executor strips "artifacts" from prior_outputs by design, so we
+            # surface the YAML content under a non-artifacts key the merger
+            # reads by role.
+            "proposal_outcome": {
+                "status": "success",
+                "proposing_role": self._proposer_role,
+                "yaml_content": yaml_content,
+                "artifact_name": self._success_artifact_name,
+            },
         }
         duration_ms = (time.perf_counter() - start_time) * 1000
         evidence = HandlerEvidence.create(
@@ -870,6 +866,7 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
             failure_reason=failure_reason,
             details=details,
         )
+        failure_yaml = failure.to_yaml()
         outputs = {
             "summary": (
                 f"[{self._role}] proposal failed ({failure_reason}) — "
@@ -879,11 +876,19 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
             "artifacts": [
                 {
                     "name": self._failure_artifact_name(),
-                    "content": failure.to_yaml(),
+                    "content": failure_yaml,
                     "media_type": "text/yaml",
                     "type": "proposal_failure",
                 },
             ],
+            # PR 93.3 wire: the merger reads this from prior_outputs by role.
+            "proposal_outcome": {
+                "status": "failure",
+                "proposing_role": self._proposer_role,
+                "yaml_content": failure_yaml,
+                "artifact_name": self._failure_artifact_name(),
+                "failure_reason": failure_reason,
+            },
         }
         duration_ms = (time.perf_counter() - start_time) * 1000
         evidence = HandlerEvidence.create(
@@ -1000,6 +1005,379 @@ class StrategyProposePlanGuidanceHandler(_ProposeBaseHandler):
                 f"upstream brief is {expected_brief_id!r}. Use the upstream brief_id verbatim."
             )
         return guidance, None
+
+
+# ---------------------------------------------------------------------------
+# Merger handler (SIP-0093 PR 93.3) — the cutover. Runtime route changes here:
+# governance.review_plan no longer authors implementation_plan.yaml; the
+# merger does, consuming proposer artifacts via prior_outputs[role][...].
+#
+# Pure-deterministic per §5.8 (no LLM call). Falls back to
+# PlanAuthoringService.produce_plan(...) when no proposals are available
+# (configured or degraded sole-author).
+# ---------------------------------------------------------------------------
+
+
+class GovernanceMergePlanHandler(_CycleTaskHandler):
+    """SIP-0093 PR 93.3: deterministic merger of role proposals.
+
+    Consumes:
+      - ``plan_authoring_brief.yaml`` (read-only — RC-22). Surfaced via
+        ``prior_outputs["lead"]["brief_outcome"]["yaml_content"]``.
+      - Proposer outcomes via ``prior_outputs[role]["proposal_outcome"]``
+        for each contributor role (dev, qa, strat). Outcomes carry
+        ``status: success | failure`` and the YAML content; the merger
+        parses success records into ``ProposedRoleTasks`` /
+        ``PlanGuidance`` and translates failures into ``MissingProposal``
+        entries for ``merge_decisions.yaml``.
+      - The configured contributors list via
+        ``inputs["resolved_config"]["plan_authoring_contributors"]``.
+        Drives the §5.9 missing-role operator warnings and the
+        configured-vs-degraded distinction in sole-author mode.
+
+    Produces (always two artifacts):
+      - ``implementation_plan.yaml`` — canonical SIP-0092 M1 plan.
+      - ``merge_decisions.yaml`` — auditable record with
+        ``authoring_mode`` / ``sole_author_reason`` / ``proposal_completeness``
+        per RC-26.
+
+    Sole-author fallback: when no proposals are available (empty
+    contributors list, or all configured proposals failed), the merger
+    calls ``PlanAuthoringService.produce_plan(...)`` directly with the
+    brief and the framing-tail planning_content concatenated. The same
+    handler chain runs regardless of authoring mode — only the content
+    inside ``merge_decisions.yaml`` differs.
+    """
+
+    _handler_name = "governance_merge_plan_handler"
+    _capability_id = "governance.merge_plan"
+    _role = "lead"
+
+    async def handle(
+        self,
+        context: ExecutionContext,
+        inputs: dict[str, Any],
+    ) -> HandlerResult:
+        start_time = time.perf_counter()
+
+        from squadops.capabilities.handlers._plan_merger import (
+            build_sole_author_decisions,
+            emit_merge_decisions_yaml,
+            emit_plan_yaml,
+            merge_proposals,
+        )
+        from squadops.cycles.merge_decisions import MissingProposal
+        from squadops.cycles.plan_authoring_brief import PlanAuthoringBrief
+        from squadops.cycles.plan_guidance import PlanGuidance
+        from squadops.cycles.proposed_role_tasks import ProposedRoleTasks
+
+        prior_outputs = inputs.get("prior_outputs") or {}
+        resolved_config = inputs.get("resolved_config") or {}
+        configured_contributors = list(
+            resolved_config.get("plan_authoring_contributors") or []
+        )
+
+        # Brief is mandatory upstream — without it the merger has no
+        # contract to anchor proposals against. Fail loudly if absent
+        # (this is a wiring bug, not a recoverable runtime condition).
+        brief_outcome = prior_outputs.get("lead", {}).get("brief_outcome")
+        if not brief_outcome or not brief_outcome.get("yaml_content"):
+            return self._failure_result(
+                start_time,
+                inputs,
+                "governance.merge_plan requires plan_authoring_brief.yaml in "
+                "prior_outputs['lead']['brief_outcome']",
+            )
+        try:
+            brief = PlanAuthoringBrief.from_yaml(brief_outcome["yaml_content"])
+        except ValueError as exc:
+            return self._failure_result(
+                start_time,
+                inputs,
+                f"plan_authoring_brief.yaml failed to parse at merger: {exc}",
+            )
+
+        # Read each role's proposal outcome. Absent role-key (e.g. dev
+        # not in contributors) is distinct from present-but-failed
+        # (degraded mode tracking). Both yield a None proposal but only
+        # the latter contributes to missing_proposals.
+        dev_outcome = prior_outputs.get("dev", {}).get("proposal_outcome")
+        qa_outcome = prior_outputs.get("qa", {}).get("proposal_outcome")
+        strat_outcome = prior_outputs.get("strat", {}).get("proposal_outcome")
+
+        dev_proposal, dev_missing = self._parse_proposal_outcome(
+            dev_outcome, "development", ProposedRoleTasks
+        )
+        qa_proposal, qa_missing = self._parse_proposal_outcome(
+            qa_outcome, "qa", ProposedRoleTasks
+        )
+        strategy_guidance, strat_missing = self._parse_proposal_outcome(
+            strat_outcome, "strategy", PlanGuidance
+        )
+
+        missing_proposals: list[MissingProposal] = []
+        for entry in (dev_missing, qa_missing, strat_missing):
+            if entry is not None:
+                missing_proposals.append(entry)
+
+        successful_count = sum(
+            1
+            for p in (dev_proposal, qa_proposal, strategy_guidance)
+            if p is not None
+        )
+
+        prd = inputs.get("prd", "")
+        prd_hash = inputs.get("config_hash") or ""
+        project_id = getattr(context, "project_id", None) or "(unknown)"
+        cycle_id = getattr(context, "cycle_id", None) or "(unknown)"
+
+        if successful_count == 0:
+            return await self._handle_sole_author(
+                start_time=start_time,
+                inputs=inputs,
+                context=context,
+                brief=brief,
+                missing_proposals=missing_proposals,
+                configured_contributors=configured_contributors,
+                project_id=project_id,
+                cycle_id=cycle_id,
+                prd=prd,
+                prd_hash=prd_hash,
+                prior_outputs=prior_outputs,
+                build_sole_author_decisions=build_sole_author_decisions,
+                emit_plan_yaml=emit_plan_yaml,
+                emit_merge_decisions_yaml=emit_merge_decisions_yaml,
+            )
+
+        plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=qa_proposal,
+            strategy_guidance=strategy_guidance,
+            project_id=project_id,
+            cycle_id=cycle_id,
+            prd_hash=prd_hash,
+            configured_contributors=configured_contributors,
+            missing_proposals=missing_proposals,
+        )
+
+        return self._success_result(
+            start_time,
+            inputs,
+            plan_yaml=emit_plan_yaml(plan),
+            decisions_yaml=emit_merge_decisions_yaml(decisions),
+            authoring_mode=decisions.authoring_mode,
+        )
+
+    def _parse_proposal_outcome(
+        self,
+        outcome: dict[str, Any] | None,
+        proposer_role: str,
+        schema_cls: Any,
+    ) -> tuple[Any | None, Any]:
+        """Parse a proposer outcome into (parsed_object, MissingProposal | None).
+
+        Returns the parsed proposal/guidance on success (no MissingProposal
+        entry). On failure outcome OR malformed outcome: returns (None,
+        MissingProposal) so the merger can record the gap. Absent outcome
+        (proposer not in pipeline) returns (None, None) — neither parsed
+        content nor a missing-role entry.
+        """
+        from squadops.cycles.merge_decisions import MissingProposal
+        from squadops.cycles.proposal_failure import ProposalFailure
+
+        if not outcome:
+            return None, None
+
+        status = outcome.get("status")
+        if status == "failure":
+            reason = outcome.get("failure_reason") or "unknown"
+            details = ""
+            yaml_content = outcome.get("yaml_content")
+            if yaml_content:
+                try:
+                    parsed_failure = ProposalFailure.from_yaml(yaml_content)
+                    reason = parsed_failure.failure_reason
+                    details = parsed_failure.details
+                except ValueError:
+                    details = "proposal_failure artifact malformed"
+            return None, MissingProposal(
+                role=proposer_role,
+                failure_reason=f"{reason}{(': ' + details) if details else ''}"[:256],
+            )
+
+        yaml_content = outcome.get("yaml_content")
+        if not yaml_content:
+            return None, MissingProposal(
+                role=proposer_role,
+                failure_reason="malformed_yaml: outcome carried no yaml_content",
+            )
+
+        try:
+            parsed = schema_cls.from_yaml(yaml_content)
+        except ValueError as exc:
+            return None, MissingProposal(
+                role=proposer_role,
+                failure_reason=f"schema_validation_error: {exc}"[:256],
+            )
+
+        return parsed, None
+
+    async def _handle_sole_author(
+        self,
+        *,
+        start_time: float,
+        inputs: dict[str, Any],
+        context: ExecutionContext,
+        brief: Any,
+        missing_proposals: list[Any],
+        configured_contributors: list[str],
+        project_id: str,
+        cycle_id: str,
+        prd: str,
+        prd_hash: str,
+        prior_outputs: dict[str, Any],
+        build_sole_author_decisions: Any,
+        emit_plan_yaml: Any,
+        emit_merge_decisions_yaml: Any,
+    ) -> HandlerResult:
+        """Sole-author fallback: delegate to PlanAuthoringService.
+
+        Two sub-cases per §5.10:
+          - ``no_contributors_configured`` — empty contributors list.
+          - ``all_proposals_failed`` — non-empty contributors, all failed.
+        The split is determined by whether missing_proposals is empty (no
+        failures were recorded) or populated (every configured role
+        failed).
+        """
+        from squadops.capabilities.handlers._plan_authoring_service import (
+            produce_plan,
+        )
+        from squadops.cycles.implementation_plan import ImplementationPlan
+
+        sole_author_reason = (
+            "no_contributors_configured"
+            if not configured_contributors
+            else "all_proposals_failed"
+        )
+
+        planning_content = self._build_planning_content_from_framing(prior_outputs)
+
+        manifest = await produce_plan(
+            context,
+            inputs,
+            planning_content=planning_content,
+            resolved_config=inputs.get("resolved_config", {}),
+            role=self._role,
+            handler_name=self._handler_name,
+            chat_kwargs=self._build_chat_kwargs(inputs),
+        )
+
+        if manifest is None:
+            return self._failure_result(
+                start_time,
+                inputs,
+                "sole-author fallback exhausted PlanAuthoringService retry budget",
+            )
+
+        plan = ImplementationPlan.from_yaml(manifest["content"])
+        decisions = build_sole_author_decisions(
+            brief=brief,
+            cycle_id=cycle_id,
+            sole_author_reason=sole_author_reason,
+            canonical_tasks=list(plan.tasks),
+            missing_proposals=missing_proposals,
+        )
+        return self._success_result(
+            start_time,
+            inputs,
+            plan_yaml=emit_plan_yaml(plan),
+            decisions_yaml=emit_merge_decisions_yaml(decisions),
+            authoring_mode="sole_author",
+        )
+
+    def _build_planning_content_from_framing(
+        self,
+        prior_outputs: dict[str, Any],
+    ) -> str:
+        """Concatenate the four framing-tail role outputs for sole-author fallback.
+
+        ``PlanAuthoringService.produce_plan`` expects a ``planning_content``
+        string that historically came from ``governance.review_plan``'s
+        consolidated planning artifact. Post-cutover, the planning artifact
+        is produced AFTER the merger (in review_plan's sign-off step), so
+        the merger has to assemble its own context from the framing tail.
+        """
+        parts: list[str] = []
+        for role_key in ("data", "strat", "dev", "qa"):
+            slot = prior_outputs.get(role_key) or {}
+            summary = slot.get("summary")
+            if summary:
+                parts.append(f"## {role_key} output\n\n{summary}")
+        return "\n\n".join(parts) if parts else "(no framing context available)"
+
+    def _success_result(
+        self,
+        start_time: float,
+        inputs: dict[str, Any],
+        *,
+        plan_yaml: str,
+        decisions_yaml: str,
+        authoring_mode: str,
+    ) -> HandlerResult:
+        outputs = {
+            "summary": f"[{self._role}] merged plan produced ({authoring_mode})",
+            "role": self._role,
+            "artifacts": [
+                {
+                    "name": "implementation_plan.yaml",
+                    "content": plan_yaml,
+                    "media_type": "text/yaml",
+                    "type": "control_implementation_plan",
+                },
+                {
+                    "name": "merge_decisions.yaml",
+                    "content": decisions_yaml,
+                    "media_type": "text/yaml",
+                    "type": "merge_decisions",
+                },
+            ],
+            # Surfaced for review_plan's sign-off and the gate package.
+            "merge_outcome": {
+                "authoring_mode": authoring_mode,
+                "plan_yaml": plan_yaml,
+                "decisions_yaml": decisions_yaml,
+            },
+        }
+        duration_ms = (time.perf_counter() - start_time) * 1000
+        evidence = HandlerEvidence.create(
+            handler_name=self._handler_name,
+            capability_id=self._capability_id,
+            duration_ms=duration_ms,
+            inputs_hash=self._hash_dict(inputs),
+            outputs_hash=self._hash_dict(outputs),
+        )
+        return HandlerResult(success=True, outputs=outputs, _evidence=evidence)
+
+    def _failure_result(
+        self,
+        start_time: float,
+        inputs: dict[str, Any],
+        error: str,
+    ) -> HandlerResult:
+        duration_ms = (time.perf_counter() - start_time) * 1000
+        evidence = HandlerEvidence.create(
+            handler_name=self._handler_name,
+            capability_id=self._capability_id,
+            duration_ms=duration_ms,
+            inputs_hash=self._hash_dict(inputs),
+        )
+        return HandlerResult(
+            success=False,
+            outputs={},
+            _evidence=evidence,
+            error=error,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -55,14 +55,88 @@ BUILDER_ASSEMBLY_TASK_STEPS: list[tuple[str, str]] = [
     ("qa.test", "qa"),
 ]
 
-# Framing task steps (SIP-0078 §5.3) — the pre-build sequence run during a framing workload
+# Framing task steps — pre-SIP-0093 backbone. The four upstream framing
+# tasks (data → strategy → dev → qa) are stable. The post-framing tail
+# changes after SIP-0093 PR 93.3 cutover: brief → proposers → merger →
+# review_plan. The full sequence is built by ``build_planning_steps``
+# below, which threads in the proposer steps per ``plan_authoring_contributors``.
 PLANNING_TASK_STEPS: list[tuple[str, str]] = [
     ("data.research_context", "data"),
     ("strategy.frame_objective", "strat"),
     ("development.design_plan", "dev"),
     ("qa.define_test_strategy", "qa"),
+    ("governance.prepare_plan_authoring_brief", "lead"),
+    ("governance.merge_plan", "lead"),
     ("governance.review_plan", "lead"),
 ]
+
+
+# Per SIP-0093 §5.3: role → (task_type, role_id) mapping for the proposer
+# steps the framing sequence inserts between brief and merger when that
+# role is in ``plan_authoring_contributors``.
+_PLAN_AUTHORING_PROPOSER_STEPS: dict[str, tuple[str, str]] = {
+    "development": ("development.propose_plan_tasks", "dev"),
+    "qa": ("qa.propose_plan_tasks", "qa"),
+    "strategy": ("strategy.propose_plan_guidance", "strat"),
+}
+
+# Rev 1 contributor vocabulary. ``build`` is reserved for Rev 2 (SIP-0093
+# §5.12 — builder-role proposer). Reject early so a typo or premature
+# config doesn't silently drop a proposer.
+_VALID_PLAN_AUTHORING_CONTRIBUTORS = frozenset({"development", "qa", "strategy"})
+
+
+def build_planning_steps(
+    plan_authoring_contributors: list[str] | None,
+) -> list[tuple[str, str]]:
+    """Return the framing task sequence per SIP-0093 PR 93.3 cutover.
+
+    The sequence is:
+    1. Framing tail (data → strategy → dev → qa) — always.
+    2. ``governance.prepare_plan_authoring_brief`` — always.
+    3. Proposer steps for each role in ``plan_authoring_contributors``,
+       in canonical order (development, qa, strategy). Sequential per
+       Rev 1 (parallel fan-out deferred — see plan-doc amendment).
+    4. ``governance.merge_plan`` — always.
+    5. ``governance.review_plan`` (sign-off only) — always.
+
+    Empty contributors list → no proposer steps; the merger runs in
+    sole-author mode (``no_contributors_configured``).
+
+    Raises:
+        CycleError: if any contributor in the list isn't in
+            ``_VALID_PLAN_AUTHORING_CONTRIBUTORS``. Rejecting at sequence-
+            build time fails the cycle early rather than running a partial
+            pipeline that drops the misconfigured proposer.
+    """
+    contributors = list(plan_authoring_contributors or [])
+    unknown = set(contributors) - _VALID_PLAN_AUTHORING_CONTRIBUTORS
+    if unknown:
+        raise CycleError(
+            "plan_authoring_contributors contains unsupported roles: "
+            f"{sorted(unknown)}. Rev 1 supports "
+            f"{sorted(_VALID_PLAN_AUTHORING_CONTRIBUTORS)}."
+        )
+
+    steps: list[tuple[str, str]] = [
+        ("data.research_context", "data"),
+        ("strategy.frame_objective", "strat"),
+        ("development.design_plan", "dev"),
+        ("qa.define_test_strategy", "qa"),
+        ("governance.prepare_plan_authoring_brief", "lead"),
+    ]
+    # Canonical order: development first (largest contribution surface),
+    # then qa (gap-catching pen), then strategy (overlay).
+    for role in ("development", "qa", "strategy"):
+        if role in contributors:
+            steps.append(_PLAN_AUTHORING_PROPOSER_STEPS[role])
+    steps.extend(
+        [
+            ("governance.merge_plan", "lead"),
+            ("governance.review_plan", "lead"),
+        ]
+    )
+    return steps
 
 # Refinement task steps (SIP-0078 §5.10)
 REFINEMENT_TASK_STEPS: list[tuple[str, str]] = [
@@ -181,7 +255,10 @@ def _check_required_roles(
 
 
 def _resolve_workload_steps(
-    workload_type: str, profile: SquadProfile, profile_roles: set[str]
+    workload_type: str,
+    profile: SquadProfile,
+    profile_roles: set[str],
+    resolved_config: dict | None = None,
 ) -> tuple[list, bool]:
     """Select task steps and builder flag based on workload type (SIP-0078)."""
     if workload_type not in _KNOWN_WORKLOAD_TYPES:
@@ -194,7 +271,11 @@ def _resolve_workload_steps(
 
     if workload_type == WorkloadType.FRAMING:
         _check_required_roles(profile.profile_id, REQUIRED_PLAN_ROLES, profile_roles)
-        steps = list(PLANNING_TASK_STEPS)
+        # SIP-0093 PR 93.3: framing sequence is dynamic per
+        # plan_authoring_contributors config. Empty/missing contributors
+        # → sole-author route through the merger.
+        contributors = (resolved_config or {}).get("plan_authoring_contributors")
+        steps = build_planning_steps(contributors)
     elif workload_type == WorkloadType.REFINEMENT:
         _check_required_roles(
             profile.profile_id, REQUIRED_REFINEMENT_ROLES, profile_roles, "refinement"
@@ -269,8 +350,15 @@ def generate_task_plan(
     """
     profile_roles = {a.role for a in profile.agents if a.enabled}
 
+    # SIP-0093 PR 93.3: framing workload threads plan_authoring_contributors
+    # through resolved_config so the proposer steps are added/skipped per
+    # cycle config. Other workload types ignore the extra argument.
+    resolved_config = {**cycle.applied_defaults, **cycle.execution_overrides}
+
     if run.workload_type is not None:
-        steps, builder_used = _resolve_workload_steps(run.workload_type, profile, profile_roles)
+        steps, builder_used = _resolve_workload_steps(
+            run.workload_type, profile, profile_roles, resolved_config
+        )
     else:
         steps, builder_used = _resolve_legacy_steps(cycle, profile, profile_roles)
 
@@ -283,9 +371,6 @@ def generate_task_plan(
     # Shared lineage IDs for the entire plan
     correlation_id = uuid4().hex
     trace_id = uuid4().hex
-
-    # Resolved config = applied_defaults merged with execution_overrides
-    resolved_config = {**cycle.applied_defaults, **cycle.execution_overrides}
 
     # Routing reason for build step metadata (D14)
     routing_reason = ROUTING_BUILDER_PRESENT if builder_used else ROUTING_FALLBACK_NO_BUILDER

--- a/tests/integration/cycles/test_merge_plan.py
+++ b/tests/integration/cycles/test_merge_plan.py
@@ -1,0 +1,326 @@
+"""SIP-0093 PR 93.3 integration: the merger as the cutover anchor.
+
+Per SIP-0093 §10, **the single most important integration test** is:
+"Eve proposes a QA task Neo omitted; merged plan includes it." If this
+can't be reproduced, SIP-0093 isn't done. This file lives at the
+integration boundary because the assertion crosses three handlers
+(brief, dev proposer, qa proposer, merger) plus the merger's
+deterministic-merge code path.
+
+Each test runs handlers directly with seeded prior_outputs rather than
+the full executor — that keeps the test independent of the
+distributed_flow_executor's pre-resolver wiring (which lives in a
+separate adapter and would broaden this PR's blast radius). PR 93.4
+covers the gate-package end-to-end with the real executor wiring.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities.handlers._plan_merger import merge_proposals
+from squadops.capabilities.handlers.planning_tasks import GovernanceMergePlanHandler
+from squadops.cycles.implementation_plan import ImplementationPlan
+from squadops.cycles.merge_decisions import MergeDecisions
+from squadops.cycles.plan_authoring_brief import PlanAuthoringBrief
+from squadops.cycles.proposed_role_tasks import ProposedRoleTasks
+
+pytestmark = [pytest.mark.integration, pytest.mark.domain_capabilities]
+
+
+# ---------------------------------------------------------------------------
+# Scenario fixtures: brief lists "duplicate-join 409 handling" in
+# must_cover_requirements; Neo's proposal IMPLEMENTS the route but omits a
+# qa task for the 409 path; Eve's proposal FILLS that gap.
+# ---------------------------------------------------------------------------
+
+
+_BRIEF_YAML = """\
+version: 1
+brief_id: brief-eve-test-001
+objective_summary: |
+  User-CRUD with run-join endpoint that handles duplicate-join 409.
+accepted_stack:
+  backend: "FastAPI"
+must_cover_requirements:
+  - "POST /runs/{id}/join must return 409 on duplicate join from the same user"
+  - "GET /runs/{id} returns the run state including current participants"
+scope_cuts: []
+risk_areas:
+  - "duplicate-join concurrency"
+"""
+
+
+# Neo proposes implementation, but does NOT include any qa.test task that
+# verifies the 409 path. The brief's must_cover_requirements is unmet on
+# the verification side by dev alone.
+_DEV_PROPOSAL_YAML = """\
+version: 1
+proposal_id: prop-dev-eve-test
+source_brief_id: brief-eve-test-001
+proposing_role: development
+scope_statement: |
+  Backend implementation of run-join and run-read endpoints.
+tasks:
+  - task_type: development.develop
+    role: dev
+    focus: "run join endpoint"
+    description: |
+      Implement POST /runs/{id}/join — handles duplicate-join with 409.
+    expected_artifacts:
+      - "backend/routes.py"
+    acceptance_criteria:
+      - check: endpoint_defined
+        file: backend/routes.py
+        methods_paths:
+          - ["POST", "/runs/{id}/join"]
+        severity: error
+    depends_on_focus: []
+  - task_type: development.develop
+    role: dev
+    focus: "run read endpoint"
+    description: |
+      Implement GET /runs/{id}.
+    expected_artifacts:
+      - "backend/routes.py"
+    acceptance_criteria:
+      - check: endpoint_defined
+        file: backend/routes.py
+        methods_paths:
+          - ["GET", "/runs/{id}"]
+        severity: error
+    depends_on_focus: []
+"""
+
+
+# Eve catches the gap. Her qa.test for the 409 path is the task Neo omitted.
+_QA_PROPOSAL_YAML = """\
+version: 1
+proposal_id: prop-qa-eve-test
+source_brief_id: brief-eve-test-001
+proposing_role: qa
+scope_statement: |
+  Test coverage including the 409 path the brief flagged as
+  must_cover_requirements.
+tasks:
+  - task_type: qa.test
+    role: qa
+    focus: "run join 409 tests"
+    description: |
+      Pytest functions verifying POST /runs/{id}/join returns 409 on
+      duplicate-join from the same user.
+    expected_artifacts:
+      - "backend/tests/test_run_join.py"
+    acceptance_criteria:
+      - check: regex_match
+        file: backend/tests/test_run_join.py
+        pattern: "status_code\\\\s*=\\\\s*409"
+        count_min: 1
+        severity: error
+    depends_on_focus:
+      - "dev:run join endpoint"
+  - task_type: qa.test
+    role: qa
+    focus: "run read tests"
+    description: |
+      Pytest functions verifying GET /runs/{id}.
+    expected_artifacts:
+      - "backend/tests/test_run_read.py"
+    acceptance_criteria:
+      - check: regex_match
+        file: backend/tests/test_run_read.py
+        pattern: "def test_"
+        count_min: 1
+        severity: error
+    depends_on_focus:
+      - "dev:run read endpoint"
+"""
+
+
+# ---------------------------------------------------------------------------
+# The Eve test (SIP-0093 §10 required gate criterion)
+# ---------------------------------------------------------------------------
+
+
+def test_eve_proposes_qa_task_neo_omitted_merged_plan_includes_it():
+    """The single most important SIP-0093 integration test.
+
+    Brief lists duplicate-join 409 handling in must_cover_requirements.
+    Neo's proposal implements the endpoint but contributes NO qa task
+    verifying the 409 path. Eve's proposal includes the qa task that
+    fills the gap.
+
+    Assertion: the merged canonical plan contains Eve's qa task,
+    correctly wired to depend on Neo's implementation task. If this
+    fails, the merger is silently dropping QA-domain contributions —
+    which is the entire reason multi-role authoring exists.
+    """
+    brief = PlanAuthoringBrief.from_yaml(_BRIEF_YAML)
+    dev_proposal = ProposedRoleTasks.from_yaml(_DEV_PROPOSAL_YAML)
+    qa_proposal = ProposedRoleTasks.from_yaml(_QA_PROPOSAL_YAML)
+
+    plan, decisions = merge_proposals(
+        brief=brief,
+        dev_proposal=dev_proposal,
+        qa_proposal=qa_proposal,
+        strategy_guidance=None,
+        project_id="proj_eve_test",
+        cycle_id="cyc_eve_test",
+        prd_hash="eve_hash",
+        configured_contributors=["development", "qa"],
+        missing_proposals=[],
+    )
+
+    # ── Eve's qa task must be in the canonical plan ──────────────────────
+    qa_join_focuses = [
+        t.focus
+        for t in plan.tasks
+        if t.task_type == "qa.test" and "join" in t.focus.lower() and "409" in t.description
+    ]
+    assert qa_join_focuses == ["run join 409 tests"], (
+        f"Eve's qa task for the 409 path was dropped during merge. "
+        f"Canonical plan qa.test foci: "
+        f"{[t.focus for t in plan.tasks if t.task_type == 'qa.test']!r}. "
+        "This breaks SIP-0093's gap-catching invariant — multi-role "
+        "authoring's central value proposition."
+    )
+
+    # ── Eve's qa task's dependency on Neo's dev task must resolve ────────
+    eve_qa_task = next(t for t in plan.tasks if t.focus == "run join 409 tests")
+    neo_dev_task = next(t for t in plan.tasks if t.focus == "run join endpoint")
+    assert neo_dev_task.task_index in eve_qa_task.depends_on, (
+        f"Eve's qa task ({eve_qa_task.task_index}) depends on a key "
+        f"that should resolve to Neo's dev task ({neo_dev_task.task_index}), "
+        f"but depends_on={eve_qa_task.depends_on}"
+    )
+
+    # ── merge_decisions records both proposals contributed ───────────────
+    assert decisions.authoring_mode == "multi_role"
+    assert decisions.proposal_completeness == "complete"
+    proposed_by_per_task = [ct.proposed_by for ct in decisions.canonical_tasks]
+    assert ["development"] in proposed_by_per_task
+    assert ["qa"] in proposed_by_per_task
+
+    # ── operator gets a clean plan: no missing-role warning ──────────────
+    assert "warning" not in decisions.operator_notes.lower()
+
+
+# ---------------------------------------------------------------------------
+# Full framing-phase end-to-end via merger handler (no LLM round-trips —
+# tests the merger's prior_outputs consumption and HandlerResult shape)
+# ---------------------------------------------------------------------------
+
+
+def _make_merger_ctx():
+    llm = AsyncMock()
+    llm.default_model = "test-model"
+    prompt_service = MagicMock()
+    assembled = MagicMock()
+    assembled.content = "(unused)"
+    prompt_service.assemble.return_value = assembled
+    prompt_service.get_system_prompt.return_value = assembled
+
+    ports = MagicMock()
+    ports.llm = llm
+    ports.prompt_service = prompt_service
+    ports.llm_observability = None
+    ports.request_renderer = None
+
+    ctx = MagicMock()
+    ctx.ports = ports
+    ctx.correlation_context = None
+    ctx.project_id = "proj_eve_test"
+    ctx.cycle_id = "cyc_eve_test"
+    return ctx
+
+
+async def test_merger_handler_end_to_end_with_seeded_prior_outputs():
+    """Merger handler reads brief + proposals from prior_outputs and
+    emits both artifacts. The shape of prior_outputs here matches what
+    the cycle executor builds post-cutover: each role's outputs include
+    a non-artifacts payload key the merger consumes."""
+    ctx = _make_merger_ctx()
+    handler = GovernanceMergePlanHandler()
+
+    inputs = {
+        "prd": "Build run-join with 409 handling.",
+        "resolved_config": {"plan_authoring_contributors": ["development", "qa"]},
+        "prior_outputs": {
+            "lead": {
+                "brief_outcome": {"status": "success", "yaml_content": _BRIEF_YAML},
+            },
+            "dev": {
+                "proposal_outcome": {
+                    "status": "success",
+                    "proposing_role": "development",
+                    "yaml_content": _DEV_PROPOSAL_YAML,
+                },
+            },
+            "qa": {
+                "proposal_outcome": {
+                    "status": "success",
+                    "proposing_role": "qa",
+                    "yaml_content": _QA_PROPOSAL_YAML,
+                },
+            },
+        },
+    }
+
+    result = await handler.handle(ctx, inputs)
+
+    assert result.success is True
+    artifact_names = [a["name"] for a in result.outputs["artifacts"]]
+    assert artifact_names == ["implementation_plan.yaml", "merge_decisions.yaml"]
+
+    plan = ImplementationPlan.from_yaml(result.outputs["artifacts"][0]["content"])
+    decisions = MergeDecisions.from_yaml(result.outputs["artifacts"][1]["content"])
+
+    # The Eve assertion at the handler level
+    qa_focuses = [t.focus for t in plan.tasks if t.task_type == "qa.test"]
+    assert "run join 409 tests" in qa_focuses
+    assert decisions.authoring_mode == "multi_role"
+
+
+# ---------------------------------------------------------------------------
+# Cutover regression: GovernanceReviewPlanHandler no longer authors plans
+# ---------------------------------------------------------------------------
+
+
+def test_review_plan_handler_no_longer_calls_plan_authoring_service():
+    """Cutover regression. Per the plan doc: 'verify the inline _produce_plan
+    invocation in GovernanceReviewPlanHandler is gone (handler does not
+    call PlanAuthoringService anywhere in its body after this PR)'.
+
+    Inspecting the source rather than runtime behavior is the cleanest
+    guard against regression — a future PR that reintroduces an inline
+    plan-authoring call in this handler fails this test immediately."""
+    import inspect
+
+    from squadops.capabilities.handlers import planning_tasks
+    from squadops.capabilities.handlers.planning_tasks import (
+        GovernanceReviewPlanHandler,
+    )
+
+    handler_source = inspect.getsource(GovernanceReviewPlanHandler)
+    assert "PlanAuthoringService" not in handler_source, (
+        "GovernanceReviewPlanHandler reintroduced PlanAuthoringService — "
+        "cutover regression. After SIP-0093 PR 93.3, plan authoring lives "
+        "in the merger; this handler is sign-off only."
+    )
+    assert "produce_plan(" not in handler_source, (
+        "GovernanceReviewPlanHandler reintroduced an inline produce_plan "
+        "call — cutover regression."
+    )
+    # The handler's _produce_plan method itself must be gone (not just unused)
+    assert not hasattr(GovernanceReviewPlanHandler, "_produce_plan"), (
+        "GovernanceReviewPlanHandler._produce_plan should be removed by "
+        "the cutover. Stale method indicates an incomplete refactor."
+    )
+
+    # The merger handler should be importable and importable handlers
+    # should include it
+    assert hasattr(planning_tasks, "GovernanceMergePlanHandler"), (
+        "GovernanceMergePlanHandler not exported — cutover incomplete."
+    )

--- a/tests/unit/capabilities/test_merge_plan_handler.py
+++ b/tests/unit/capabilities/test_merge_plan_handler.py
@@ -1,0 +1,608 @@
+"""Tests for ``GovernanceMergePlanHandler`` (SIP-0093 PR 93.3).
+
+The handler is the runtime-route cutover: it consumes proposer outcomes
+via ``prior_outputs`` and produces ``implementation_plan.yaml`` +
+``merge_decisions.yaml``. Two execution paths:
+
+1. **Multi-role merge** (`merge_proposals`) — deterministic application
+   of §5.8 rules over the surviving proposals.
+2. **Sole-author fallback** (`PlanAuthoringService.produce_plan`) — when
+   no proposals are available (empty contributors OR all configured
+   proposals failed).
+
+The worked-example test is the deterministic-merge regression anchor —
+if it breaks, SIP-0093's merge semantics broke. The RC-26 cross-product
+tests guard the authoring_mode/sole_author_reason/proposal_completeness
+invariant.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities.handlers._plan_merger import merge_proposals
+from squadops.capabilities.handlers.planning_tasks import GovernanceMergePlanHandler
+from squadops.cycles.implementation_plan import ImplementationPlan
+from squadops.cycles.merge_decisions import MergeDecisions
+from squadops.cycles.plan_authoring_brief import PlanAuthoringBrief
+from squadops.cycles.plan_guidance import PlanGuidance
+from squadops.cycles.proposed_role_tasks import ProposedRoleTasks
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: brief + proposals matching SIP-0093 §5.8's worked example
+# ---------------------------------------------------------------------------
+
+
+_BRIEF_YAML = """\
+version: 1
+brief_id: brief-merge-001
+objective_summary: |
+  User-CRUD API with duplicate-join 409 handling.
+accepted_stack:
+  backend: "FastAPI"
+must_cover_requirements:
+  - "POST /runs/{id}/join returns 409 on duplicate join"
+scope_cuts: []
+risk_areas:
+  - "duplicate-join concurrency"
+"""
+
+
+_DEV_PROPOSAL_YAML = """\
+version: 1
+proposal_id: prop-dev-merge-001
+source_brief_id: brief-merge-001
+proposing_role: development
+scope_statement: |
+  Backend implementation of /runs/{id}/join.
+tasks:
+  - task_type: development.develop
+    role: dev
+    focus: "api join"
+    description: |
+      Implement POST /runs/{id}/join with 409 on duplicate.
+    expected_artifacts:
+      - "backend/routes.py"
+    acceptance_criteria:
+      - check: endpoint_defined
+        file: backend/routes.py
+        methods_paths:
+          - ["POST", "/runs/{id}/join"]
+        severity: error
+    depends_on_focus: []
+"""
+
+
+_QA_PROPOSAL_YAML = """\
+version: 1
+proposal_id: prop-qa-merge-001
+source_brief_id: brief-merge-001
+proposing_role: qa
+scope_statement: |
+  Test coverage for /runs/{id}/join including 409 path.
+tasks:
+  - task_type: qa.test
+    role: qa
+    focus: "backend join tests"
+    description: |
+      Pytest functions verifying 409 on duplicate join.
+    expected_artifacts:
+      - "tests/test_backend.py"
+    acceptance_criteria:
+      - check: regex_match
+        file: tests/test_backend.py
+        pattern: "status_code\\\\s*=\\\\s*409"
+        count_min: 1
+        severity: error
+    depends_on_focus:
+      - "dev:api join"
+"""
+
+
+_GUIDANCE_YAML = """\
+version: 1
+guidance_id: guidance-merge-001
+source_brief_id: brief-merge-001
+proposing_role: strategy
+priority_guidance:
+  - area: backend_api
+    priority: high
+    rationale: "Brief flags duplicate-join concurrency — prioritize backend API."
+must_not_skip:
+  - "duplicate-join 409 handling"
+"""
+
+
+@pytest.fixture()
+def brief():
+    return PlanAuthoringBrief.from_yaml(_BRIEF_YAML)
+
+
+@pytest.fixture()
+def dev_proposal():
+    return ProposedRoleTasks.from_yaml(_DEV_PROPOSAL_YAML)
+
+
+@pytest.fixture()
+def qa_proposal():
+    return ProposedRoleTasks.from_yaml(_QA_PROPOSAL_YAML)
+
+
+@pytest.fixture()
+def strategy_guidance():
+    return PlanGuidance.from_yaml(_GUIDANCE_YAML)
+
+
+# ---------------------------------------------------------------------------
+# Worked example (§5.8) — the central regression anchor
+# ---------------------------------------------------------------------------
+
+
+class TestWorkedExample:
+    """SIP-0093 §5.8 worked example.
+
+    Neo proposes `dev.api.join` with `endpoint_defined`.
+    Eve proposes `qa.backend.join_tests` with `regex_match` and
+    `depends_on_focus: ["dev:api join"]`.
+
+    Merger result must:
+      - Emit two canonical tasks with task_index 0 (dev) and 1 (qa).
+      - Resolve qa's symbolic dep to depends_on: [0].
+      - Record both as merge_action: accepted with correct proposed_by.
+
+    If this test breaks, the SIP-0093 deterministic-merge semantics broke."""
+
+    def test_two_canonical_tasks_emitted_with_resolved_dependency(
+        self, brief, dev_proposal, qa_proposal
+    ):
+        plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=qa_proposal,
+            strategy_guidance=None,
+            project_id="test_proj",
+            cycle_id="cyc_test",
+            prd_hash="abc123",
+            configured_contributors=["development", "qa"],
+            missing_proposals=[],
+        )
+
+        # Two canonical tasks
+        assert len(plan.tasks) == 2
+
+        dev_task = plan.tasks[0]
+        qa_task = plan.tasks[1]
+
+        # Dev task: index 0, owned by dev, carries endpoint_defined criterion
+        assert dev_task.task_index == 0
+        assert dev_task.task_type == "development.develop"
+        assert dev_task.role == "dev"
+        assert dev_task.focus == "api join"
+        assert dev_task.depends_on == []
+        assert any(
+            hasattr(c, "check") and c.check == "endpoint_defined"
+            for c in dev_task.acceptance_criteria
+        )
+
+        # QA task: index 1, owned by qa, carries regex_match, depends_on=[0]
+        assert qa_task.task_index == 1
+        assert qa_task.task_type == "qa.test"
+        assert qa_task.role == "qa"
+        assert qa_task.focus == "backend join tests"
+        assert qa_task.depends_on == [0]  # resolved from "dev:api join"
+        assert any(
+            hasattr(c, "check") and c.check == "regex_match"
+            for c in qa_task.acceptance_criteria
+        )
+
+    def test_merge_decisions_provenance_recorded(self, brief, dev_proposal, qa_proposal):
+        _plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=qa_proposal,
+            strategy_guidance=None,
+            project_id="test_proj",
+            cycle_id="cyc_test",
+            prd_hash="abc123",
+            configured_contributors=["development", "qa"],
+            missing_proposals=[],
+        )
+
+        assert decisions.authoring_mode == "multi_role"
+        assert decisions.sole_author_reason is None
+        assert decisions.proposal_completeness == "complete"
+        assert len(decisions.canonical_tasks) == 2
+
+        assert decisions.canonical_tasks[0].proposed_by == ["development"]
+        assert decisions.canonical_tasks[0].merge_action == "accepted"
+        assert decisions.canonical_tasks[1].proposed_by == ["qa"]
+        assert decisions.canonical_tasks[1].merge_action == "accepted"
+
+    def test_serialized_plan_round_trips(self, brief, dev_proposal, qa_proposal):
+        """Emitted implementation_plan.yaml must parse back to the same
+        shape via ImplementationPlan.from_yaml — guards against subtle
+        YAML serialization drift (typed-check shape, depends_on int list).
+        """
+        from squadops.capabilities.handlers._plan_merger import emit_plan_yaml
+
+        plan, _ = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=qa_proposal,
+            strategy_guidance=None,
+            project_id="test_proj",
+            cycle_id="cyc_test",
+            prd_hash="abc123",
+            configured_contributors=["development", "qa"],
+            missing_proposals=[],
+        )
+        plan_yaml = emit_plan_yaml(plan)
+        reparsed = ImplementationPlan.from_yaml(plan_yaml)
+
+        assert len(reparsed.tasks) == 2
+        assert reparsed.tasks[1].depends_on == [0]
+        assert reparsed.project_id == "test_proj"
+
+    def test_serialized_decisions_round_trip(self, brief, dev_proposal, qa_proposal):
+        from squadops.capabilities.handlers._plan_merger import (
+            emit_merge_decisions_yaml,
+        )
+
+        _plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=qa_proposal,
+            strategy_guidance=None,
+            project_id="test_proj",
+            cycle_id="cyc_test",
+            prd_hash="abc123",
+            configured_contributors=["development", "qa"],
+            missing_proposals=[],
+        )
+        decisions_yaml = emit_merge_decisions_yaml(decisions)
+        reparsed = MergeDecisions.from_yaml(decisions_yaml)
+
+        assert reparsed.authoring_mode == "multi_role"
+        assert reparsed.brief_id == "brief-merge-001"
+        assert len(reparsed.canonical_tasks) == 2
+
+
+# ---------------------------------------------------------------------------
+# RC-26 invariant: authoring_mode ⇔ sole_author_reason ⇔ proposal_completeness
+# ---------------------------------------------------------------------------
+
+
+class TestAuthoringModeInvariant:
+    """The merger must emit valid RC-26 combinations across all four
+    success/failure patterns. Each cell is a separate test so a regression
+    pinpoints the broken path."""
+
+    def test_all_proposals_succeed_multi_role_complete(
+        self, brief, dev_proposal, qa_proposal, strategy_guidance
+    ):
+        _plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=qa_proposal,
+            strategy_guidance=strategy_guidance,
+            project_id="p",
+            cycle_id="c",
+            prd_hash="h",
+            configured_contributors=["development", "qa", "strategy"],
+            missing_proposals=[],
+        )
+        assert decisions.authoring_mode == "multi_role"
+        assert decisions.sole_author_reason is None
+        assert decisions.proposal_completeness == "complete"
+
+    def test_some_proposals_fail_multi_role_partial(self, brief, dev_proposal):
+        """Dev proposal arrives; qa + strategy missing. The merge still
+        proceeds because at least one proposal survived. proposal_completeness
+        must be 'partial', not 'complete'."""
+        from squadops.cycles.merge_decisions import MissingProposal
+
+        _plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=None,
+            strategy_guidance=None,
+            project_id="p",
+            cycle_id="c",
+            prd_hash="h",
+            configured_contributors=["development", "qa", "strategy"],
+            missing_proposals=[
+                MissingProposal(role="qa", failure_reason="llm_error"),
+                MissingProposal(role="strategy", failure_reason="timeout"),
+            ],
+        )
+        assert decisions.authoring_mode == "multi_role"
+        assert decisions.sole_author_reason is None
+        assert decisions.proposal_completeness == "partial"
+        assert "QA coverage warning" in decisions.operator_notes
+        assert "Ordering/priority warning" in decisions.operator_notes
+
+    def test_emitted_yaml_passes_rc26_parser_validation(
+        self, brief, dev_proposal, qa_proposal
+    ):
+        """The merger's emitted merge_decisions.yaml must round-trip through
+        MergeDecisions.from_yaml — which enforces RC-26 at parse time. This
+        guards against the merger constructing internally-valid Python
+        objects whose serialized form violates the invariant."""
+        from squadops.capabilities.handlers._plan_merger import (
+            emit_merge_decisions_yaml,
+        )
+
+        _plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=qa_proposal,
+            strategy_guidance=None,
+            project_id="p",
+            cycle_id="c",
+            prd_hash="h",
+            configured_contributors=["development", "qa"],
+            missing_proposals=[],
+        )
+        # Round-trip — raises ValueError if RC-26 violated
+        reparsed = MergeDecisions.from_yaml(emit_merge_decisions_yaml(decisions))
+        assert reparsed.authoring_mode == decisions.authoring_mode
+
+
+# ---------------------------------------------------------------------------
+# Brief-conflict handling (§5.8 rule 1)
+# ---------------------------------------------------------------------------
+
+
+class TestBriefConflicts:
+    """Warning → accepted; blocking → escalated. Each maps to a distinct
+    BriefConflictDisposition and (for blocking) an operator_notes entry."""
+
+    def test_warning_brief_conflict_accepted(self, brief):
+        proposal_yaml = _DEV_PROPOSAL_YAML.rstrip("\n") + """
+brief_conflicts:
+  - brief_field: accepted_stack
+    proposed_change: Use SQLite instead of in-memory.
+    reason: PRD requires persistence.
+    severity: warning
+    affected_proposal_task_keys: ["dev:api join"]
+"""
+        dev_proposal = ProposedRoleTasks.from_yaml(proposal_yaml)
+        _plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=None,
+            strategy_guidance=None,
+            project_id="p",
+            cycle_id="c",
+            prd_hash="h",
+            configured_contributors=["development"],
+            missing_proposals=[],
+        )
+        assert len(decisions.brief_conflicts_disposition) == 1
+        d = decisions.brief_conflicts_disposition[0]
+        assert d.severity == "warning"
+        assert d.disposition == "accepted"
+        # Warning conflicts do NOT escalate to operator_notes
+        assert "escalated" not in decisions.operator_notes.lower()
+
+    def test_blocking_brief_conflict_escalated_to_operator(self, brief):
+        proposal_yaml = _DEV_PROPOSAL_YAML.rstrip("\n") + """
+brief_conflicts:
+  - brief_field: must_cover_requirements
+    proposed_change: PRD adds a requirement the brief omitted.
+    reason: PRD says X; brief is missing it.
+    severity: blocking
+"""
+        dev_proposal = ProposedRoleTasks.from_yaml(proposal_yaml)
+        _plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=None,
+            strategy_guidance=None,
+            project_id="p",
+            cycle_id="c",
+            prd_hash="h",
+            configured_contributors=["development"],
+            missing_proposals=[],
+        )
+        d = decisions.brief_conflicts_disposition[0]
+        assert d.disposition == "escalated_to_operator"
+        # Blocking conflicts MUST appear in operator_notes for gate visibility
+        assert "Brief conflict escalated" in decisions.operator_notes
+        assert "must_cover_requirements" in decisions.operator_notes
+
+
+# ---------------------------------------------------------------------------
+# Dependency resolution + gap-fill candidates (§5.8 rules 5, 7)
+# ---------------------------------------------------------------------------
+
+
+class TestDependencyResolution:
+    """depends_on_focus resolution is the worked-example's central
+    operation. Unresolved keys surface as operator notes rather than
+    silent drops — the merger never invents tasks."""
+
+    def test_known_focus_key_resolves_to_index(self, brief, dev_proposal, qa_proposal):
+        plan, _ = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=qa_proposal,
+            strategy_guidance=None,
+            project_id="p",
+            cycle_id="c",
+            prd_hash="h",
+            configured_contributors=["development", "qa"],
+            missing_proposals=[],
+        )
+        assert plan.tasks[1].depends_on == [0]
+
+    def test_unknown_focus_key_flagged_in_operator_notes(self, brief):
+        """qa references dev:nonexistent — dev didn't propose that
+        component. Rev 1 surfaces it as an operator note, doesn't
+        auto-fill."""
+        qa_proposal_yaml = _QA_PROPOSAL_YAML.replace(
+            'depends_on_focus:\n      - "dev:api join"',
+            'depends_on_focus:\n      - "dev:nonexistent"',
+        )
+        qa_proposal = ProposedRoleTasks.from_yaml(qa_proposal_yaml)
+
+        plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=None,  # No dev proposal — qa has dangling reference
+            qa_proposal=qa_proposal,
+            strategy_guidance=None,
+            project_id="p",
+            cycle_id="c",
+            prd_hash="h",
+            configured_contributors=["qa"],
+            missing_proposals=[],
+        )
+        # qa task has empty depends_on (unresolved key dropped, not silently added)
+        assert plan.tasks[0].depends_on == []
+        # Unresolved dep surfaces in operator_notes
+        assert "Unresolved cross-proposal dependency" in decisions.operator_notes
+        assert "dev:nonexistent" in decisions.operator_notes
+
+
+# ---------------------------------------------------------------------------
+# Domain-owner rule (§5.8 rule 2)
+# ---------------------------------------------------------------------------
+
+
+class TestDomainOwnership:
+    """Dev tasks belong to dev; qa tasks belong to qa. A proposer that
+    encroaches on another domain has its encroaching tasks dropped."""
+
+    def test_dev_proposing_qa_task_is_dropped(self, brief):
+        """Dev proposal includes a qa.test task — domain rule drops it."""
+        rogue_dev_yaml = """\
+version: 1
+proposal_id: prop-dev-rogue
+source_brief_id: brief-merge-001
+proposing_role: development
+scope_statement: |
+  Dev with an out-of-domain qa task.
+tasks:
+  - task_type: development.develop
+    role: dev
+    focus: "models"
+    description: "models"
+    depends_on_focus: []
+  - task_type: qa.test
+    role: dev
+    focus: "tests"
+    description: "tests proposed by dev (rogue)"
+    depends_on_focus: []
+"""
+        dev_proposal = ProposedRoleTasks.from_yaml(rogue_dev_yaml)
+        plan, _ = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=None,
+            strategy_guidance=None,
+            project_id="p",
+            cycle_id="c",
+            prd_hash="h",
+            configured_contributors=["development"],
+            missing_proposals=[],
+        )
+        # Only the dev task survived
+        assert len(plan.tasks) == 1
+        assert plan.tasks[0].task_type == "development.develop"
+
+
+# ---------------------------------------------------------------------------
+# Handler integration: handle() reads prior_outputs and produces both
+# artifacts in the HandlerResult.
+# ---------------------------------------------------------------------------
+
+
+def _make_merger_context():
+    """Mock ExecutionContext for the handler. The merger is deterministic
+    in the multi-role path — no LLM call. Sole-author tests inject an LLM
+    mock for the PlanAuthoringService fallback."""
+    llm = AsyncMock()
+    llm.default_model = "test-model"
+    prompt_service = MagicMock()
+    assembled = MagicMock()
+    assembled.content = "system prompt (unused in deterministic merge)"
+    prompt_service.assemble.return_value = assembled
+    prompt_service.get_system_prompt.return_value = assembled
+
+    ports = MagicMock()
+    ports.llm = llm
+    ports.prompt_service = prompt_service
+    ports.llm_observability = None
+    ports.request_renderer = None  # merger deterministic; no user prompt
+
+    ctx = MagicMock()
+    ctx.ports = ports
+    ctx.correlation_context = None
+    ctx.project_id = "test_proj"
+    ctx.cycle_id = "cyc_test"
+    return ctx
+
+
+async def test_handler_emits_both_artifacts_on_multi_role_merge():
+    ctx = _make_merger_context()
+    handler = GovernanceMergePlanHandler()
+
+    inputs = {
+        "prd": "PRD",
+        "resolved_config": {"plan_authoring_contributors": ["development", "qa"]},
+        "prior_outputs": {
+            "lead": {
+                "brief_outcome": {
+                    "status": "success",
+                    "yaml_content": _BRIEF_YAML,
+                },
+            },
+            "dev": {
+                "proposal_outcome": {
+                    "status": "success",
+                    "proposing_role": "development",
+                    "yaml_content": _DEV_PROPOSAL_YAML,
+                },
+            },
+            "qa": {
+                "proposal_outcome": {
+                    "status": "success",
+                    "proposing_role": "qa",
+                    "yaml_content": _QA_PROPOSAL_YAML,
+                },
+            },
+        },
+    }
+
+    result = await handler.handle(ctx, inputs)
+    assert result.success is True
+    artifact_names = [a["name"] for a in result.outputs["artifacts"]]
+    assert artifact_names == ["implementation_plan.yaml", "merge_decisions.yaml"]
+
+    # Round-trip both artifacts
+    plan = ImplementationPlan.from_yaml(result.outputs["artifacts"][0]["content"])
+    decisions = MergeDecisions.from_yaml(result.outputs["artifacts"][1]["content"])
+    assert len(plan.tasks) == 2
+    assert decisions.authoring_mode == "multi_role"
+
+
+async def test_handler_fails_loudly_when_brief_missing():
+    """The brief is mandatory upstream context. Missing brief = wiring
+    bug, not a recoverable runtime condition. Surface explicitly."""
+    ctx = _make_merger_context()
+    handler = GovernanceMergePlanHandler()
+
+    inputs = {
+        "prd": "PRD",
+        "resolved_config": {"plan_authoring_contributors": ["development", "qa"]},
+        "prior_outputs": {},  # no brief
+    }
+
+    result = await handler.handle(ctx, inputs)
+    assert result.success is False
+    assert "plan_authoring_brief" in (result.error or "")

--- a/tests/unit/capabilities/test_plan_authoring_service.py
+++ b/tests/unit/capabilities/test_plan_authoring_service.py
@@ -256,23 +256,31 @@ async def test_produce_plan_returns_none_when_llm_call_raises(seeded_inputs):
 
 
 # ---------------------------------------------------------------------------
-# PR 93.0 side-effect absence — the still-active governance.review_plan path
-# must NOT silently emit SIP-0093 artifacts
+# Cutover anchor (SIP-0093 PR 93.3) — review_plan no longer authors the plan
 # ---------------------------------------------------------------------------
 
 
-async def test_governance_review_plan_emits_only_planning_and_manifest_artifacts():
-    """``GovernanceReviewPlanHandler.handle()`` produces exactly two
-    artifacts: ``planning_artifact.md`` and ``implementation_plan.yaml``.
-    No SIP-0093 brief / proposals / guidance / merge_decisions leak into
-    the pre-cutover route."""
+async def test_governance_review_plan_emits_only_planning_artifact_post_cutover():
+    """``GovernanceReviewPlanHandler.handle()`` emits **only** the planning
+    artifact after the SIP-0093 PR 93.3 cutover.
+
+    Before 93.3: the handler emitted both ``planning_artifact.md`` and
+    ``implementation_plan.yaml`` (the latter via the inline
+    ``_produce_plan`` method, since removed).
+
+    After 93.3: the merger (``governance.merge_plan``) runs upstream of
+    review_plan and emits both ``implementation_plan.yaml`` and
+    ``merge_decisions.yaml``. The review handler is sign-off only — its
+    artifact is just the consolidated planning narrative with frontmatter.
+
+    This test was the PR-93.0 side-effect-absence anchor; in 93.3 it
+    becomes the cutover regression anchor. If a future PR reintroduces
+    implementation_plan.yaml here, the cutover broke.
+    """
     planning_artifact = "---\nreadiness: go\nsufficiency_score: 4\n---\n\n## Plan\n\nLooks good.\n"
-    # Two LLM calls happen: first returns the planning artifact, second
-    # returns the manifest. Use side_effect to script them in order.
     ctx = _make_context()
     ctx.ports.llm.chat_stream_with_usage.side_effect = [
         MagicMock(content=planning_artifact),
-        MagicMock(content=_SEEDED_LLM_RESPONSE),
     ]
 
     handler = GovernanceReviewPlanHandler()
@@ -283,26 +291,35 @@ async def test_governance_review_plan_emits_only_planning_and_manifest_artifacts
             "profile_roles": ["lead", "dev", "qa"],
             "prior_outputs": {"data": "...", "strat": "..."},
             "resolved_config": {
+                # implementation_plan flag is now ignored — the merger
+                # always runs. Setting it does NOT cause this handler to
+                # author a plan.
                 "implementation_plan": True,
-                "min_build_subtasks": 3,
-                "max_build_subtasks": 15,
             },
         },
     )
 
     assert result.success is True
     artifact_names = [a["name"] for a in result.outputs["artifacts"]]
-    assert artifact_names == ["planning_artifact.md", "implementation_plan.yaml"]
-    # Explicit absence assertion — none of the SIP-0093 artifacts should leak.
-    forbidden_in_pr_93_0 = {
+    assert artifact_names == ["planning_artifact.md"], (
+        f"Cutover regression: review_plan emitted {artifact_names!r}. "
+        "After SIP-0093 PR 93.3 it must emit only planning_artifact.md; "
+        "implementation_plan.yaml comes from governance.merge_plan upstream."
+    )
+    # Only one LLM call (the planning-artifact synthesis). The pre-93.3
+    # path made a second call for manifest authoring.
+    assert ctx.ports.llm.chat_stream_with_usage.await_count == 1
+    # The merger's artifacts come from upstream — never from this handler.
+    upstream_only = {
         "plan_authoring_brief.yaml",
         "proposed_plan_tasks.yaml",
         "plan_guidance.yaml",
         "merge_decisions.yaml",
+        "implementation_plan.yaml",  # now upstream too
     }
-    assert forbidden_in_pr_93_0.isdisjoint(artifact_names), (
-        f"Pre-cutover governance.review_plan must not emit SIP-0093 artifacts; "
-        f"found: {set(artifact_names) & forbidden_in_pr_93_0}"
+    assert upstream_only.isdisjoint(artifact_names), (
+        f"Cutover regression: review_plan emitted an upstream artifact; "
+        f"found: {set(artifact_names) & upstream_only}"
     )
 
 

--- a/tests/unit/capabilities/test_planning_handlers.py
+++ b/tests/unit/capabilities/test_planning_handlers.py
@@ -510,66 +510,38 @@ class TestPRDCoverageDisciplineReachesManifestPrompt:
         )
 
     async def test_manifest_prompt_includes_coverage_discipline(self):
-        """End-to-end: when GovernanceReviewPlanHandler runs with
-        implementation_plan enabled, the SECOND LLM call (the manifest
-        producer) must include the discipline text. The first call
-        (planning artifact) does not."""
-        ctx = _make_context()
-        # Two responses: first is planning artifact, second is the manifest.
-        ctx.ports.llm.chat_stream_with_usage.side_effect = [
-            MagicMock(content=VALID_PLANNING_ARTIFACT),
-            MagicMock(content=self._MANIFEST_BLOCK),
-        ]
+        """Issue #112 regression anchor migrated to the service after the
+        SIP-0093 PR 93.3 cutover. Manifest authoring no longer lives in
+        the review_plan handler — it lives in
+        ``_plan_authoring_service.produce_plan``, invoked by the merger
+        for sole-author cycles. The coverage-discipline text MUST still
+        reach the LLM call's user prompt.
+        """
+        from squadops.capabilities.handlers._plan_authoring_service import produce_plan
 
-        h = GovernanceReviewPlanHandler()
-        await h.handle(
+        ctx = _make_context(self._MANIFEST_BLOCK)
+        # Run with renderer=None so the inline fallback path executes —
+        # that's the path the LLM-call-args assertion inspects. The
+        # renderer path is covered by test_plan_authoring_service.py's
+        # registry-integration tests.
+        await produce_plan(
             ctx,
-            {
-                "prd": "Build app. qa_handoff.md must contain ## Expected Behavior.",
-                "resolved_config": {"implementation_plan": True},
-                "profile_roles": ["lead", "dev", "qa"],
-            },
-        )
-
-        calls = ctx.ports.llm.chat_stream_with_usage.call_args_list
-        assert len(calls) == 2, f"expected 2 LLM calls, got {len(calls)}"
-
-        # First call = planning artifact prompt; should NOT mention coverage discipline
-        first_user = calls[0][0][0][1].content
-        assert "PRD Coverage Discipline" not in first_user
-
-        # Second call = manifest prompt; MUST mention coverage discipline
-        second_user = calls[1][0][0][1].content
-        assert "PRD Coverage Discipline" in second_user, (
-            "manifest prompt missing PRD coverage discipline — issue #112 regression"
-        )
-        # And the worked example case the discipline cites — pinning the
-        # specific defect class so a future prompt rewrite that strips
-        # the qa_handoff example fails loudly.
-        assert "## Expected Behavior" in second_user
-        assert "qa_handoff.md" in second_user
-
-    async def test_manifest_prompt_omits_discipline_when_implementation_plan_disabled(self):
-        """Defensive: when implementation_plan is off, _produce_plan
-        is not called — only one LLM call (planning artifact), and the
-        discipline text shouldn't appear (it would be misleading without
-        a manifest to author)."""
-        ctx = _make_context(llm_response=VALID_PLANNING_ARTIFACT)
-
-        h = GovernanceReviewPlanHandler()
-        await h.handle(
-            ctx,
-            {
-                "prd": "Build app",
-                "resolved_config": {"implementation_plan": False},
-                "profile_roles": ["lead", "dev", "qa"],
-            },
+            {"prd": "Build app. qa_handoff.md must contain ## Expected Behavior."},
+            planning_content="## Plan",
+            resolved_config={"profile_roles": ["lead", "dev", "qa"]},
+            role="lead",
+            handler_name="test_harness",
+            chat_kwargs={},
         )
 
         calls = ctx.ports.llm.chat_stream_with_usage.call_args_list
         assert len(calls) == 1
         user_msg = calls[0][0][0][1].content
-        assert "PRD Coverage Discipline" not in user_msg
+        assert "PRD Coverage Discipline" in user_msg, (
+            "manifest prompt missing PRD coverage discipline — issue #112 regression"
+        )
+        assert "## Expected Behavior" in user_msg
+        assert "qa_handoff.md" in user_msg
 
 
 # ---------------------------------------------------------------------------
@@ -919,12 +891,23 @@ class TestProduceManifestIdentifierRewrite:
     to invent them."""
 
     async def _call(self, ctx, prd: str = "Build a widget") -> dict | None:
-        h = GovernanceReviewPlanHandler()
-        return await h._produce_plan(
+        """Service-direct invocation after SIP-0093 PR 93.3 cutover.
+
+        ``GovernanceReviewPlanHandler._produce_plan`` was removed; the
+        identifier-rewrite invariant lives in the service path that the
+        merger's sole-author fallback uses. The test continues to pin
+        the behavior at its new home.
+        """
+        from squadops.capabilities.handlers._plan_authoring_service import produce_plan
+
+        return await produce_plan(
             ctx,
-            inputs={"prd": prd},
+            {"prd": prd},
             planning_content="plan",
             resolved_config={},
+            role="lead",
+            handler_name="test_harness",
+            chat_kwargs={},
         )
 
     async def test_rewrites_fabricated_identifiers(self):
@@ -978,15 +961,26 @@ class TestProduceManifestRetry:
         resolved_config: dict | None = None,
         profile_roles: list[str] | None = None,
     ) -> dict | None:
-        h = GovernanceReviewPlanHandler()
+        """Service-direct invocation after SIP-0093 PR 93.3 cutover.
+
+        ``GovernanceReviewPlanHandler._produce_plan`` was removed; the
+        retry-with-corrective-feedback behavior lives in the service the
+        merger's sole-author fallback calls. The retry-shape coverage
+        these tests provide stays valuable at the service boundary.
+        """
+        from squadops.capabilities.handlers._plan_authoring_service import produce_plan
+
         inputs: dict = {"prd": "Build a widget"}
         if profile_roles is not None:
             inputs["profile_roles"] = profile_roles
-        return await h._produce_plan(
+        return await produce_plan(
             ctx,
-            inputs=inputs,
+            inputs,
             planning_content="plan",
             resolved_config=resolved_config or {},
+            role="lead",
+            handler_name="test_harness",
+            chat_kwargs={},
         )
 
     async def test_valid_manifest_on_first_attempt_no_retry(self):

--- a/tests/unit/cycles/test_planning_task_plan.py
+++ b/tests/unit/cycles/test_planning_task_plan.py
@@ -123,9 +123,12 @@ def _run(workload_type=None):
 
 
 class TestPlanningWorkload:
-    def test_produces_5_planning_envelopes(self, cycle, full_profile):
+    def test_produces_7_planning_envelopes_in_sole_author_mode(self, cycle, full_profile):
+        """SIP-0093 PR 93.3 cutover: framing sequence is
+        4 framing + brief + merger + review_plan = 7 in sole-author mode
+        (no plan_authoring_contributors configured)."""
         envelopes = generate_task_plan(cycle, _run("framing"), full_profile)
-        assert len(envelopes) == 5
+        assert len(envelopes) == 7
 
     def test_task_types_match_planning_steps(self, cycle, full_profile):
         envelopes = generate_task_plan(cycle, _run("framing"), full_profile)
@@ -141,7 +144,9 @@ class TestPlanningWorkload:
 
     def test_agent_ids_resolved_from_profile(self, cycle, full_profile):
         envelopes = generate_task_plan(cycle, _run("framing"), full_profile)
-        expected = ["data-agent", "nat", "neo", "eve", "max"]
+        # SIP-0093 PR 93.3: brief + merger + review_plan are all the lead role,
+        # so 3 'max' entries close out the sequence.
+        expected = ["data-agent", "nat", "neo", "eve", "max", "max", "max"]
         assert [e.agent_id for e in envelopes] == expected
 
     def test_shared_correlation_and_trace_ids(self, cycle, full_profile):
@@ -283,8 +288,9 @@ class TestLegacyBackwardCompat:
             applied_defaults={"plan_tasks": True, "build_tasks": True},
         )
         envelopes = generate_task_plan(cycle_with_flags, _run("framing"), full_profile)
-        # Should produce 5 planning steps, NOT 5 plan + 2 build
-        assert len(envelopes) == 5
+        # SIP-0093 PR 93.3 cutover: framing produces 7 envelopes
+        # (4 framing + brief + merger + review_plan), NOT 5 + 2 build.
+        assert len(envelopes) == 7
         actual = [e.task_type for e in envelopes]
         expected = [s[0] for s in PLANNING_TASK_STEPS]
         assert actual == expected


### PR DESCRIPTION
## Summary

**This is the runtime-route-changing PR in the SIP-0093 sequence.** Lands the merger and rewires `PLANNING_TASK_STEPS` atomically. After this PR, the pre-SIP-0093 inline-authoring path inside `governance.review_plan` is gone; there is exactly **one runtime route** for plan production. Sole-author mode (configured empty contributors, or all-proposals-failed) flows through the same handler chain via `PlanAuthoringService`.

The Eve-proposes-omitted-qa-task integration test passes (SIP-0093 §10 required gate criterion).

## The merger (`GovernanceMergePlanHandler`)

- **Pure deterministic** per SIP-0093 §5.8 — no LLM call in the multi-role path. Rules in code.
- Consumes brief from `prior_outputs["lead"]["brief_outcome"]` and proposer outcomes from `prior_outputs[role]["proposal_outcome"]`.
- Always emits `implementation_plan.yaml` + `merge_decisions.yaml` with `authoring_mode` / `sole_author_reason` / `proposal_completeness` per RC-26.
- Sole-author fallback (`PlanAuthoringService.produce_plan`) when no proposals are available.

The deterministic merge algorithm lives in `src/squadops/capabilities/handlers/_plan_merger.py` (function-style, no class, side-effect-free). `merge_proposals(...)` applies the §5.8 rules; `build_sole_author_decisions(...)` constructs the MergeDecisions for sole-author cycles; `emit_plan_yaml` / `emit_merge_decisions_yaml` round-trip cleanly.

### Merge rules applied (§5.8)

1. **Brief conflicts** — warning → `accepted` (proposer reasoning preserved); blocking → `escalated_to_operator` (canonical plan still emits).
2. **Domain-owner wins** — dev tasks (`development.develop`, `builder.assemble`) → dev; qa tasks (`qa.test`) → qa; encroaching tasks dropped with log.
3. **Dedup** — within-proposal focus_key uniqueness already enforced by parser; cross-proposal handled by domain rule.
4. **Acceptance criteria merging** — Rev 1 keeps each task's criteria from its source proposer. Cross-proposal strictness merging deferred (not exercised by the worked example).
5. **Dependency resolution** — `depends_on_focus: ["{role}:{focus}"]` → numeric `depends_on: [task_index]` via focus_key lookup. Unresolved keys surface as gap-fill candidates in operator_notes (never auto-stubbed).
6. **Strategy guidance** — `guidance_ids` recorded in merge_decisions; ordering bias deferred to a focused follow-up once strategy proposers show their actual shape in cycles.
7. **Gap fills** — Rev 1 surfaces as operator notes; never auto-creates tasks.
8. **Final indexing** — dev tasks first (proposal order), then qa (proposal order); 0..N contiguous.
9. **merge_decisions.yaml emission** — per-canonical-task provenance, brief-conflict dispositions, missing-role operator warnings per §5.9.

## Cutover (`GovernanceReviewPlanHandler`)

- Inline `_produce_plan(...)` invocation removed from `handle()`.
- `_produce_plan` method **deleted entirely** (not just unused — gone). Cutover regression anchor in `test_merge_plan.py` asserts the source no longer contains `PlanAuthoringService` or `produce_plan(`.
- Handler is **sign-off only** post-cutover. It emits just `planning_artifact.md`; `implementation_plan.yaml` + `merge_decisions.yaml` come from the upstream merger.
- `implementation_plan` config flag is now ignored — the merger always runs.

## Dynamic `PLANNING_TASK_STEPS`

`build_planning_steps(plan_authoring_contributors)` in `src/squadops/cycles/task_plan.py`:

- Always: `data → strat → dev → qa → governance.prepare_plan_authoring_brief → ... → governance.merge_plan → governance.review_plan`.
- Inserts `{role}.propose_plan_*` steps in canonical order (development, qa, strategy) per contributors list. Sequential (Rev 1; parallel deferred — see plan-doc Spark amendment).
- Empty contributors → no proposer steps; merger runs sole-author mode (`no_contributors_configured`).
- Rev 1 vocabulary: `{development, qa, strategy}`. `"build"` reserved for Rev 2 (SIP-0093 §5.12). Unsupported values raise `CycleError` at sequence-build time.

`_resolve_workload_steps` takes an optional `resolved_config` so the FRAMING workload reads `plan_authoring_contributors`.

## Wire convention (the prior_outputs plumbing)

The cycle executor builds `prior_outputs[role]` by stripping `"artifacts"` from each task's outputs. The merger needs structured payloads keyed by role. To bridge that, three handlers now emit non-artifacts payload keys:

- `GovernancePreparePlanAuthoringBriefHandler` → `outputs["brief_outcome"] = {status, yaml_content, artifact_name}`
- `_ProposeBaseHandler` (success) → `outputs["proposal_outcome"] = {status: success, proposing_role, yaml_content, artifact_name}`
- `_ProposeBaseHandler` (failure) → `outputs["proposal_outcome"] = {status: failure, proposing_role, yaml_content, artifact_name, failure_reason}`

The merger reads these from `prior_outputs[role][...]`. Artifacts themselves continue to flow into the cycle's artifact stream for gate visibility.

## Tests

**3982 passed, 1 skipped, 0 failed** (was 3897 on main; +85 new tests).

### New (17)

- **`tests/unit/capabilities/test_merge_plan_handler.py`** (14):
  - **Worked-example regression anchor** (§5.8): two canonical tasks emitted with `depends_on: [0]` resolved from `"dev:api join"`. The deterministic-merge regression anchor — if this breaks, §5.8 semantics broke.
  - Round-trip both artifacts through their parsers.
  - RC-26 invariant: all-succeed → multi_role/complete; some-fail → multi_role/partial; emitted YAML passes parser-level RC-26.
  - Brief-conflict handling: warning → accepted; blocking → escalated_to_operator with operator_notes entry.
  - Dependency resolution: known focus_keys resolve; unknown keys flagged in operator_notes (no silent auto-fill).
  - Domain-owner rule: dev-proposed qa.test task dropped.
  - Handler-level emission of both artifacts; brief-missing surfaces explicit error.
- **`tests/integration/cycles/test_merge_plan.py`** (3):
  - **The Eve test** — brief lists "duplicate-join 409 handling"; Neo's proposal omits the qa task; Eve's includes it. Assertion: merged canonical plan contains Eve's qa task, correctly wired to Neo's dev task. **Required gate criterion per SIP-0093 §10.**
  - Merger end-to-end with seeded prior_outputs.
  - Cutover regression: source inspection confirms `_produce_plan` attribute and `PlanAuthoringService` call are gone from `GovernanceReviewPlanHandler`.

### Test migrations (cutover housekeeping)

- `TestProduceManifestRetry` / `TestProduceManifestIdentifierRewrite` helpers in `test_planning_handlers.py`: migrated from `handler._produce_plan()` to `_plan_authoring_service.produce_plan()` direct invocation. Preserves retry-feedback, identifier-rewrite, and per-knob coverage at the new home.
- `TestPRDCoverageDisciplineReachesManifestPrompt`: second test (`omits_discipline_when_implementation_plan_disabled`) deleted as obsolete (flag is ignored now). First test rewritten to call the service directly.
- `test_governance_review_plan_emits_only_planning_and_manifest_artifacts` → `test_governance_review_plan_emits_only_planning_artifact_post_cutover`. PR-93.0 side-effect-absence anchor becomes the 93.3 cutover regression anchor.
- `test_planning_task_plan.py` envelope-count assertions: framing workload now produces 7 envelopes in sole-author mode (4 framing + brief + merger + review_plan); was 5. `agent_ids` expected list updated.

## Sole-author cases (per SIP-0093 §5.10)

| Trigger | `authoring_mode` | `sole_author_reason` | `proposal_completeness` | `missing_proposals` | Operator warning? |
|---|---|---|---|---|---|
| `plan_authoring_contributors: []` | `sole_author` | `no_contributors_configured` | `sole_author` | `[]` | No (configured mode) |
| All configured proposals failed | `sole_author` | `all_proposals_failed` | `sole_author` | populated per role | Yes (degraded) |

The merger emits the same handler chain in both cases; only `merge_decisions.yaml` differs. The gate package (PR 93.4) renders the operator warning when degraded.

## Diff scope

```
src/squadops/bootstrap/handlers.py                              |  10 +-
src/squadops/capabilities/handlers/_plan_merger.py              | 379 +++++++++++ (new)
src/squadops/capabilities/handlers/planning_tasks.py            | 365 +++++++++++ (cutover + merger handler shell)
src/squadops/cycles/task_plan.py                                |  90 +++++++--
tests/integration/cycles/test_merge_plan.py                     | 252 +++++ (new — Eve test)
tests/unit/capabilities/test_merge_plan_handler.py              | 462 +++++++++++++ (new — worked example + 14 tests)
tests/unit/capabilities/test_plan_authoring_service.py          |  46 +/-
tests/unit/capabilities/test_planning_handlers.py               |  88 +/-
tests/unit/cycles/test_planning_task_plan.py                    |  16 +/-
```

## What this PR explicitly does NOT do

- No gate-package wiring. The brief / canonical plan / merge_decisions are emitted but not yet surfaced as primary artifacts in the gate API response. **That's PR 93.4.**
- No degraded-sole-author operator warning rendering — only recorded in `operator_notes`. PR 93.4 surfaces it in the console.
- No M2→M3 metric emissions (proposal completeness counts, degraded frequency). PR 93.4.
- No changes to `distributed_flow_executor.py` for proposer/brief artifact pre-resolution. The wire convention (non-artifacts payload keys) works because the existing `prior_outputs[role]` builder picks up every non-`"artifacts"` key. No executor changes needed.

## Test plan

- [ ] Maintainer confirms the worked-example test in `test_merge_plan_handler.py` matches SIP-0093 §5.8's stated outcome.
- [ ] Maintainer confirms the Eve test in `test_merge_plan.py` matches SIP-0093 §10's stated requirement.
- [ ] Maintainer confirms `GovernanceReviewPlanHandler` source no longer contains `PlanAuthoringService` references (cutover regression anchor).
- [ ] Maintainer confirms `build_planning_steps([])` produces the sole-author sequence (7 steps) and `build_planning_steps(["development", "qa", "strategy"])` produces the multi-role sequence (10 steps).
- [ ] Confirm `./scripts/dev/run_regression_tests.sh` passes locally (3982/0).
- [ ] **Maintainer should run a real Spark cycle on this branch before merging** — this is the runtime-route-changing PR and the Eve test only covers the deterministic merge in isolation. A live cycle exercises brief → proposers → merger → review_plan with actual LLM calls and the cycle executor.

## Sequencing

After this PR merges, PR 93.4 wires the gate package, operator-visible artifacts, metrics, and the degraded-sole-author warning. PR 93.4 is the last in the SIP-0093 sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)