### PR TITLE
feat: SIP-0089 Phase 1 — Minimal runtime state

### DIFF
--- a/adapters/persistence/runtime/__init__.py
+++ b/adapters/persistence/runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Runtime persistence adapters (SIP-0089)."""
+
+from adapters.persistence.runtime.state_postgres import PostgresRuntimeState
+
+__all__ = ["PostgresRuntimeState"]

--- a/adapters/persistence/runtime/state_postgres.py
+++ b/adapters/persistence/runtime/state_postgres.py
@@ -96,33 +96,37 @@ class PostgresRuntimeState(RuntimeStatePort):
         *,
         runtime_status: str | None = None,
     ) -> AgentRuntimeState:
-        await self.ensure_state(agent_id)
+        """Mirror a heartbeat in a single upsert: create the row if absent, then
+        bump ``last_heartbeat_at`` (and ``runtime_status`` when provided).
+
+        D17: the ON CONFLICT branch only writes the heartbeat-owned columns
+        (``last_heartbeat_at``, ``runtime_status``) — never the coordinator-owned
+        fields — so a heartbeat can never clobber a coordinator transition. The
+        ``COALESCE`` keeps the stored ``runtime_status`` when no status is given.
+        """
         now = datetime.now(UTC)
+        insert_status = runtime_status if runtime_status is not None else _DEFAULT_RUNTIME_STATUS
         async with self._pool.acquire() as conn:
-            if runtime_status is not None:
-                row = await conn.fetchrow(
-                    "UPDATE agent_runtime_state "
-                    "SET last_heartbeat_at = $2, runtime_status = $3, "
-                    "updated_at = now() "
-                    "WHERE agent_id = $1 "
-                    "RETURNING agent_id, mode, runtime_status, focus, "
-                    "current_runtime_activity_id, interruptibility, "
-                    "last_heartbeat_at, current_assignment_ref",
-                    agent_id,
-                    now,
-                    runtime_status,
-                )
-            else:
-                row = await conn.fetchrow(
-                    "UPDATE agent_runtime_state "
-                    "SET last_heartbeat_at = $2, updated_at = now() "
-                    "WHERE agent_id = $1 "
-                    "RETURNING agent_id, mode, runtime_status, focus, "
-                    "current_runtime_activity_id, interruptibility, "
-                    "last_heartbeat_at, current_assignment_ref",
-                    agent_id,
-                    now,
-                )
+            row = await conn.fetchrow(
+                "INSERT INTO agent_runtime_state ("
+                "agent_id, mode, runtime_status, focus, interruptibility, "
+                "last_heartbeat_at"
+                ") VALUES ($1,$2,$3,$4,$5,$6) "
+                "ON CONFLICT (agent_id) DO UPDATE SET "
+                "last_heartbeat_at = EXCLUDED.last_heartbeat_at, "
+                "runtime_status = COALESCE($7, agent_runtime_state.runtime_status), "
+                "updated_at = now() "
+                "RETURNING agent_id, mode, runtime_status, focus, "
+                "current_runtime_activity_id, interruptibility, "
+                "last_heartbeat_at, current_assignment_ref",
+                agent_id,
+                _DEFAULT_MODE,
+                insert_status,
+                _DEFAULT_FOCUS,
+                _DEFAULT_INTERRUPTIBILITY,
+                now,
+                runtime_status,
+            )
         return _row_to_state(row)
 
 

--- a/adapters/persistence/runtime/state_postgres.py
+++ b/adapters/persistence/runtime/state_postgres.py
@@ -1,0 +1,139 @@
+"""Postgres-backed runtime-state adapter (SIP-0089 §1.3).
+
+Implements `RuntimeStatePort` via the existing asyncpg connection pool used
+by the cycle registry. All writes hit `agent_runtime_state` (migration
+`1100_agent_runtime_state.sql`).
+
+`ensure_state` and `update_heartbeat` preserve D17's non-authoritative
+semantics: heartbeat never overwrites coordinator-owned fields
+(`mode`, `focus`, `current_assignment_ref`, `current_runtime_activity_id`).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import asyncpg
+
+from squadops.ports.runtime.state import RuntimeStatePort
+from squadops.runtime.models import AgentRuntimeState
+
+_DEFAULT_MODE = "ambient"
+_DEFAULT_RUNTIME_STATUS = "online"
+_DEFAULT_INTERRUPTIBILITY = "high"
+_DEFAULT_FOCUS = ""
+
+
+class PostgresRuntimeState(RuntimeStatePort):
+    """Postgres-backed `RuntimeStatePort` implementation."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def get_state(self, agent_id: str) -> AgentRuntimeState | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT agent_id, mode, runtime_status, focus, "
+                "current_runtime_activity_id, interruptibility, "
+                "last_heartbeat_at, current_assignment_ref "
+                "FROM agent_runtime_state WHERE agent_id = $1",
+                agent_id,
+            )
+        return _row_to_state(row) if row else None
+
+    async def upsert_state(self, state: AgentRuntimeState) -> AgentRuntimeState:
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO agent_runtime_state ("
+                "agent_id, mode, runtime_status, focus, "
+                "current_runtime_activity_id, interruptibility, "
+                "last_heartbeat_at, current_assignment_ref"
+                ") VALUES ($1,$2,$3,$4,$5,$6,$7,$8) "
+                "ON CONFLICT (agent_id) DO UPDATE SET "
+                "mode = EXCLUDED.mode, "
+                "runtime_status = EXCLUDED.runtime_status, "
+                "focus = EXCLUDED.focus, "
+                "current_runtime_activity_id = EXCLUDED.current_runtime_activity_id, "
+                "interruptibility = EXCLUDED.interruptibility, "
+                "last_heartbeat_at = EXCLUDED.last_heartbeat_at, "
+                "current_assignment_ref = EXCLUDED.current_assignment_ref, "
+                "updated_at = now()",
+                state.agent_id,
+                state.mode,
+                state.runtime_status,
+                state.focus,
+                state.current_runtime_activity_id,
+                state.interruptibility,
+                state.last_heartbeat_at,
+                state.current_assignment_ref,
+            )
+        return state
+
+    async def ensure_state(self, agent_id: str) -> AgentRuntimeState:
+        now = datetime.now(UTC)
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "INSERT INTO agent_runtime_state ("
+                "agent_id, mode, runtime_status, focus, interruptibility, "
+                "last_heartbeat_at"
+                ") VALUES ($1,$2,$3,$4,$5,$6) "
+                "ON CONFLICT (agent_id) DO UPDATE SET agent_id = EXCLUDED.agent_id "
+                "RETURNING agent_id, mode, runtime_status, focus, "
+                "current_runtime_activity_id, interruptibility, "
+                "last_heartbeat_at, current_assignment_ref",
+                agent_id,
+                _DEFAULT_MODE,
+                _DEFAULT_RUNTIME_STATUS,
+                _DEFAULT_FOCUS,
+                _DEFAULT_INTERRUPTIBILITY,
+                now,
+            )
+        return _row_to_state(row)
+
+    async def update_heartbeat(
+        self,
+        agent_id: str,
+        *,
+        runtime_status: str | None = None,
+    ) -> AgentRuntimeState:
+        await self.ensure_state(agent_id)
+        now = datetime.now(UTC)
+        async with self._pool.acquire() as conn:
+            if runtime_status is not None:
+                row = await conn.fetchrow(
+                    "UPDATE agent_runtime_state "
+                    "SET last_heartbeat_at = $2, runtime_status = $3, "
+                    "updated_at = now() "
+                    "WHERE agent_id = $1 "
+                    "RETURNING agent_id, mode, runtime_status, focus, "
+                    "current_runtime_activity_id, interruptibility, "
+                    "last_heartbeat_at, current_assignment_ref",
+                    agent_id,
+                    now,
+                    runtime_status,
+                )
+            else:
+                row = await conn.fetchrow(
+                    "UPDATE agent_runtime_state "
+                    "SET last_heartbeat_at = $2, updated_at = now() "
+                    "WHERE agent_id = $1 "
+                    "RETURNING agent_id, mode, runtime_status, focus, "
+                    "current_runtime_activity_id, interruptibility, "
+                    "last_heartbeat_at, current_assignment_ref",
+                    agent_id,
+                    now,
+                )
+        return _row_to_state(row)
+
+
+def _row_to_state(row: asyncpg.Record) -> AgentRuntimeState:
+    return AgentRuntimeState(
+        agent_id=row["agent_id"],
+        mode=row["mode"],
+        runtime_status=row["runtime_status"],
+        focus=row["focus"],
+        current_runtime_activity_id=row["current_runtime_activity_id"],
+        interruptibility=row["interruptibility"],
+        last_heartbeat_at=row["last_heartbeat_at"],
+        current_assignment_ref=row["current_assignment_ref"],
+    )

--- a/docs/plans/SIP-0089-phase-1-spike-notes.md
+++ b/docs/plans/SIP-0089-phase-1-spike-notes.md
@@ -1,0 +1,79 @@
+# SIP-0089 Phase 1 — Pre-implementation Spike Notes
+
+Working artifact for plan §1.0. Two spikes required before any code; output gets pasted into the Phase 1 PR body.
+
+---
+
+## Spike 1 — Entrypoint integration (D8)
+
+**Question:** Where is the narrowest place to enrich heartbeat payloads with runtime-state without changing agent lifecycle semantics?
+
+**Findings** (`src/squadops/agents/entrypoint.py`, 833 lines, last touched by SIP-0087 cleanup):
+
+- `HealthCheckHttpReporter` is constructed in `AgentRunner.start()` at line 156, *before* `_create_system()` builds the ports bundle. It currently takes no constructor arguments and reports only `agent_id`, `lifecycle_state`, and `version` (line 770).
+- `_send_heartbeat()` (line 763) is a thin wrapper around `reporter.send_status(...)`. It has no access to `self.system.ports` because the call signature is fixed and the reporter is owned by the runner, not the system.
+- `_heartbeat_loop()` (line 738) does not start until line 172 — *after* `_create_system()`. So the reporter is constructed before ports exist, but it does not actually run until after they do.
+
+**Decision:**
+
+Reorder construction in `start()` so the heartbeat reporter is created **after** `_create_system()`, then pass `RuntimeStatePort` to its constructor:
+
+```python
+self.system = await self._create_system()
+# NEW: pass runtime_state port to the reporter
+self._heartbeat_reporter = HealthCheckHttpReporter(
+    runtime_state=self.system.ports.runtime_state,
+)
+```
+
+`HealthCheckHttpReporter.send_status()` then calls `ensure_state(agent_id)` on first heartbeat (idempotent per D17) and `update_heartbeat(agent_id, runtime_status=..., last_heartbeat_at=now)` on every subsequent tick. **It never writes `mode`, `focus`, `current_assignment_ref`, or `current_runtime_activity_id`** — those are coordinator-owned (D16/D17).
+
+**Impact on lifecycle semantics:** none. The reporter still produces the same HTTP heartbeat to the dashboard; it just additionally upserts into `agent_runtime_state` via the new port. If the port is absent or returns an error, the HTTP heartbeat must still succeed (heartbeat is non-authoritative — D17).
+
+**Risk:** the existing `HealthCheckHttpReporter` is in `adapters/observability/healthcheck_http.py`. The port must be an injected dependency, not imported in adapter code (D26 forbidden-import test will catch violations).
+
+---
+
+## Spike 2 — Events bridge routing (D22)
+
+**Question:** Do runtime-state events route through the existing `events/bridges/workflow_tracker.py`, or warrant a dedicated `runtime_state` bridge?
+
+**Findings** (`src/squadops/events/bridges/workflow_tracker.py`, 86 lines, last refactored 2026-04-25 in SIP-0087 c3):
+
+- The bridge is structurally **cycle/run/task-shaped, not generic**:
+  - `_RUN_STATE_MAP` translates `RUN_STARTED → ("RUNNING", "Running")`, `RUN_COMPLETED → ("COMPLETED", "Completed")`, etc.
+  - `_TASK_STATE_MAP` translates `TASK_SUCCEEDED`/`TASK_FAILED` to terminal task-run states.
+  - It depends on `flow_run_id` and `task_run_id` in `event.context` — Prefect-specific correlation identifiers.
+- The class name was generalized in SIP-0087 c3 (`PrefectBridge` → `WorkflowTrackerBridge`), but the *behavior* remains run/task lifecycle for Prefect tracking. Routing `runtime_state.mode_transition` or `focus_lease.granted` events through it would mean either fabricating run states for non-run concepts, or adding type-discriminating branches that bypass the existing state maps entirely. Both options dilute the bridge's single concern.
+
+**Decision:**
+
+**Dedicated `src/squadops/events/bridges/runtime_state.py` bridge.**
+
+The plan's default rule (D22: "default to dedicated `runtime_state` bridge unless `workflow_tracker` is intentionally generic") applies. The current `workflow_tracker` is not intentionally generic — it's a Prefect-flavored state translator that was renamed to look generic.
+
+The new bridge subscribes to runtime-state events emitted by `src/squadops/runtime/coordinator.py` via the existing `EventPublisherPort`. Initial implementation is minimal: forward events to the event log (postgres) and attach to the active `CorrelationContext` when present (D15). Future SIPs (0090, 0091) extend its subscriber set without touching the workflow_tracker.
+
+**Boundary preserved:** `runtime/coordinator.py` depends on `EventPublisherPort`, not on the bridge directly (D22). The bridge is wired in infrastructure (`src/squadops/events/factory.py` or equivalent) and subscribes to runtime-event types.
+
+**Initial event vocabulary** (locked at end of §1.0, per D14):
+
+| Event name | Reason code examples |
+|---|---|
+| `runtime_state.mode_transition` | `duty_window_opened`, `duty_window_closed`, `cycle_recruited`, `cycle_completed` |
+| `runtime_state.heartbeat_initialized` | (no reason — informational) |
+| `runtime_state.heartbeat_recovered` | `runtime_status_changed_to_online` |
+
+Events for `FocusLease` and `Assignment` are deferred to Phases 2/3 but will follow the same event/reason separation (D18).
+
+---
+
+## Pre-Phase-1 checklist
+
+- [x] §1.0 spikes complete (this document)
+- [ ] §1.1 — Create `src/squadops/runtime/` package skeleton
+- [ ] §1.2 — Migration `1100_agent_runtime_state.sql` + `infra/migrations/README.md` with range registry (per D11)
+- [ ] §1.3 — `adapters/persistence/runtime/state_postgres.py`
+- [ ] §1.4 — Heartbeat reporter extension per Spike 1 decision
+- [ ] §1.5 — `squadops agent state <agent-id>` CLI command
+- [ ] §1.6 — Tests including `tests/unit/architecture/test_forbidden_imports.py` (new per D26)

--- a/docs/plans/SIP-0089-phase-1-spike-notes.md
+++ b/docs/plans/SIP-0089-phase-1-spike-notes.md
@@ -4,33 +4,41 @@ Working artifact for plan §1.0. Two spikes required before any code; output get
 
 ---
 
-## Spike 1 — Entrypoint integration (D8)
+## Spike 1 — Heartbeat integration (D8) — revised
 
-**Question:** Where is the narrowest place to enrich heartbeat payloads with runtime-state without changing agent lifecycle semantics?
+**Question:** Where is the narrowest place to enrich the heartbeat path with runtime-state without changing agent lifecycle semantics?
 
-**Findings** (`src/squadops/agents/entrypoint.py`, 833 lines, last touched by SIP-0087 cleanup):
+**Initial finding (incorrect):** The first read of `agents/entrypoint.py` suggested injecting `RuntimeStatePort` into `HealthCheckHttpReporter` agent-side, then reordering `AgentRunner.start()` to construct the reporter after the system.
 
-- `HealthCheckHttpReporter` is constructed in `AgentRunner.start()` at line 156, *before* `_create_system()` builds the ports bundle. It currently takes no constructor arguments and reports only `agent_id`, `lifecycle_state`, and `version` (line 770).
-- `_send_heartbeat()` (line 763) is a thin wrapper around `reporter.send_status(...)`. It has no access to `self.system.ports` because the call signature is fixed and the reporter is owned by the runner, not the system.
-- `_heartbeat_loop()` (line 738) does not start until line 172 — *after* `_create_system()`. So the reporter is constructed before ports exist, but it does not actually run until after they do.
+**Why that was wrong:** Agents have no direct Postgres dependency today. `HealthCheckHttpReporter` POSTs to `{SQUADOPS_RUNTIME_API_URL}/health/agents/status` over HTTP; only the runtime-api service owns the asyncpg pool. Wiring `RuntimeStatePort` into the agent would have added a brand-new postgres dependency to every agent container — a much larger architectural change than D8 implies.
 
-**Decision:**
+**Revised decision:**
 
-Reorder construction in `start()` so the heartbeat reporter is created **after** `_create_system()`, then pass `RuntimeStatePort` to its constructor:
+The integration point is **server-side**, at `POST /agents/status` in `src/squadops/api/routes/platform_health.py` (line 121). The handler already calls `hc.update_agent_status_in_db(...)`; we add a parallel call to `RuntimeStatePort.update_heartbeat(agent_id, runtime_status=...)` against the existing asyncpg pool already held by `HealthChecker`.
 
-```python
-self.system = await self._create_system()
-# NEW: pass runtime_state port to the reporter
-self._heartbeat_reporter = HealthCheckHttpReporter(
-    runtime_state=self.system.ports.runtime_state,
-)
-```
+Concretely:
 
-`HealthCheckHttpReporter.send_status()` then calls `ensure_state(agent_id)` on first heartbeat (idempotent per D17) and `update_heartbeat(agent_id, runtime_status=..., last_heartbeat_at=now)` on every subsequent tick. **It never writes `mode`, `focus`, `current_assignment_ref`, or `current_runtime_activity_id`** — those are coordinator-owned (D16/D17).
+1. **No changes to the agent.** `HealthCheckHttpReporter.send_status()` keeps its current payload (agent_id, lifecycle_state, version, tps, memory_count). The reporter does not import or depend on `RuntimeStatePort`.
+2. **`HealthChecker` (`src/squadops/api/runtime/health_checker.py`) gains a `runtime_state: RuntimeStatePort` constructor argument.** Wired via the existing health-checker singleton in `api/runtime/deps.py`.
+3. **`update_agent_status_in_db` additionally calls `runtime_state.update_heartbeat(agent_id, runtime_status=mapped)`** where `mapped` is derived from `lifecycle_state` via a small helper.
+4. **Lifecycle → runtime_status mapping** (locked at end of §1.0):
 
-**Impact on lifecycle semantics:** none. The reporter still produces the same HTTP heartbeat to the dashboard; it just additionally upserts into `agent_runtime_state` via the new port. If the port is absent or returns an error, the HTTP heartbeat must still succeed (heartbeat is non-authoritative — D17).
+   | `lifecycle_state` | `runtime_status` |
+   |---|---|
+   | `STARTING` | `recovering` |
+   | `READY` | `online` |
+   | `WORKING` | `online` |
+   | `BLOCKED` | `degraded` |
+   | `CRASHED` | `offline` |
+   | `STOPPING` | `recovering` |
 
-**Risk:** the existing `HealthCheckHttpReporter` is in `adapters/observability/healthcheck_http.py`. The port must be an injected dependency, not imported in adapter code (D26 forbidden-import test will catch violations).
+   Server-side timeout detection (the agent has not heartbeated for N seconds) → `offline` is Phase-1 in-scope only if trivial to add to the existing reconciliation loop; otherwise deferred.
+
+5. **Coordinator-owned fields stay untouched** (D17). The heartbeat handler calls `update_heartbeat` which writes only `last_heartbeat_at` + `runtime_status`. `ensure_state` is called transparently inside `update_heartbeat`, so the first heartbeat from a new agent creates the row with defaults (`mode=ambient`, `interruptibility=high`).
+
+**Impact on lifecycle semantics:** none. The HTTP heartbeat behaves exactly as today; runtime-api just additionally upserts into `agent_runtime_state`. Failures in the runtime-state write must be isolated (logged, not raised) so they cannot break the existing health-status flow.
+
+**Forbidden-import implication:** `src/squadops/api/runtime/health_checker.py` may import `RuntimeStatePort` (a port). It must NOT import `adapters.persistence.runtime.state_postgres` directly — wiring happens in the bootstrap path, which is the only place adapter imports are permitted. The D26 forbidden-import test will codify this for `health_checker.py` once added.
 
 ---
 

--- a/infra/migrations/1100_agent_runtime_state.sql
+++ b/infra/migrations/1100_agent_runtime_state.sql
@@ -1,0 +1,25 @@
+-- 1100_agent_runtime_state.sql
+-- SIP-0089 Phase 1 §1.2: agent_runtime_state table.
+-- All DDL is idempotent (CREATE ... IF NOT EXISTS).
+--
+-- Field semantics mirror src/squadops/runtime/models.py::AgentRuntimeState.
+-- Enum-shaped columns carry CHECK constraints matching the Literal types
+-- in code (D3). `mode`, `focus`, `current_runtime_activity_id`, and
+-- `current_assignment_ref` are coordinator-owned (D16); heartbeat may
+-- write only `last_heartbeat_at` and `runtime_status` (D17).
+
+CREATE TABLE IF NOT EXISTS agent_runtime_state (
+    agent_id                       TEXT PRIMARY KEY,
+    mode                           TEXT NOT NULL
+        CHECK (mode IN ('duty', 'cycle', 'ambient')),
+    runtime_status                 TEXT NOT NULL
+        CHECK (runtime_status IN ('online', 'degraded', 'recovering', 'offline')),
+    focus                          TEXT NOT NULL DEFAULT '',
+    current_runtime_activity_id    TEXT,
+    interruptibility               TEXT NOT NULL
+        CHECK (interruptibility IN ('none', 'low', 'medium', 'high')),
+    last_heartbeat_at              TIMESTAMPTZ NOT NULL,
+    current_assignment_ref         TEXT,
+    created_at                     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at                     TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/infra/migrations/README.md
+++ b/infra/migrations/README.md
@@ -1,0 +1,26 @@
+# Postgres Migrations
+
+Postgres DDL migrations applied at runtime-api startup.
+
+All migrations are idempotent (`CREATE ... IF NOT EXISTS`) and apply in lexicographic filename order.
+
+## Numbering ranges
+
+Numeric ranges are reserved to keep parallel work streams from colliding. SIP-0089 plan binding decision **D11** establishes the scheme; the existing `001`–`006` migrations predate the range scheme and remain at their original three-digit prefixes.
+
+| Range | Owner | Status |
+|---|---|---|
+| `001–006` | Pre-range-scheme (cycle registry, pulse, squad profiles, workload canon, run checkpoints, chat tables) | In place |
+| `1000–1099` | 1.0.x hardening (Spark) | Reserved |
+| `1100–1199` | SIP-0089 Agent Runtime State (v1.1) | In use — see `1100_agent_runtime_state.sql` |
+| `1200–1299` | SIP-0090 Agent Embodiment Substrate (v1.2) | Reserved (tentative) |
+| `1300–1399` | SIP-0091 Duty Durability via Temporal (v1.3) | Reserved (tentative) |
+
+If your work doesn't fit a reserved range, pick the next free hundred and add a row here in the same PR.
+
+## Authoring rules
+
+- **Idempotent DDL only** — use `CREATE TABLE IF NOT EXISTS`, `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, etc.
+- **One concern per file** — don't bundle unrelated schema changes.
+- **Header comment** — first line is the filename; second line names the SIP and section.
+- **CHECK constraints** for enum-shaped columns must match the `Literal` types in the corresponding Python model (D3).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,8 @@ markers = [
     "domain_pulse_checks: Pulse check verification domain tests",
     # Cycle Event System (SIP-0077)
     "domain_events: Cycle lifecycle event system tests",
+    # Runtime Modes (SIP-0089)
+    "domain_runtime: Agent runtime state, modes, and coordinator tests",
 ]
 
 ###########################

--- a/src/squadops/api/routes/platform_health.py
+++ b/src/squadops/api/routes/platform_health.py
@@ -127,7 +127,9 @@ async def get_agent_runtime_state(agent_id: str):
     """
     hc = _get_health_checker()
     try:
-        state = await hc.get_runtime_state(agent_id)
+        # Normalize case to match the sibling /agents/status/{agent_id} route,
+        # which lower-cases agent_id; rows are stored lower-cased.
+        state = await hc.get_runtime_state(agent_id.lower())
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to read runtime state: {e}") from e
     if state is None:

--- a/src/squadops/api/routes/platform_health.py
+++ b/src/squadops/api/routes/platform_health.py
@@ -118,6 +118,26 @@ async def get_agent_status_by_id(agent_id: str):
         raise HTTPException(status_code=500, detail=f"Failed to get agent status: {e}") from e
 
 
+@router.get("/agents/{agent_id}/runtime-state")
+async def get_agent_runtime_state(agent_id: str):
+    """Return the SIP-0089 AgentRuntimeState for an agent.
+
+    Returns 404 if no row exists yet (agent has not heartbeated since the
+    runtime-state migration applied).
+    """
+    hc = _get_health_checker()
+    try:
+        state = await hc.get_runtime_state(agent_id)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to read runtime state: {e}") from e
+    if state is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No runtime state for agent_id={agent_id}",
+        )
+    return state
+
+
 @router.post("/agents/status")
 async def create_or_update_agent_status(agent_status: AgentStatusCreate):
     """Create or update agent status (heartbeat endpoint)."""

--- a/src/squadops/api/runtime/health_checker.py
+++ b/src/squadops/api/runtime/health_checker.py
@@ -19,6 +19,8 @@ import httpx
 import yaml
 
 from squadops.api.runtime.agent_labels import get_role_label
+from squadops.ports.runtime.state import RuntimeStatePort
+from squadops.runtime.lifecycle_status import runtime_status_from_lifecycle
 
 logger = logging.getLogger(__name__)
 
@@ -32,10 +34,12 @@ class HealthChecker:
         pg_pool: asyncpg.Pool,
         redis_client: Any | None = None,
         config: Any,
+        runtime_state: RuntimeStatePort | None = None,
     ) -> None:
         self.pg_pool = pg_pool
         self.redis_client = redis_client
         self._config = config
+        self._runtime_state = runtime_state
         self._instances_cache: dict[str, dict[str, Any]] | None = None
         self._instances_cache_mtime: float | None = None
         self._reconciliation_running = True
@@ -221,7 +225,29 @@ class HealthChecker:
                 agent_status.get("memory_count", 0) or 0,
                 now,
             )
+        await self._update_runtime_state_heartbeat(
+            agent_status["agent_id"], agent_status["lifecycle_state"]
+        )
         return {"status": "updated", "agent_id": agent_status["agent_id"]}
+
+    async def _update_runtime_state_heartbeat(self, agent_id: str, lifecycle_state: str) -> None:
+        """Mirror the heartbeat into agent_runtime_state (SIP-0089 §1.4).
+
+        Failures are isolated — runtime-state writes must not break the
+        existing agent_status heartbeat flow (D17 non-authoritative).
+        """
+        if self._runtime_state is None:
+            return
+        runtime_status = runtime_status_from_lifecycle(lifecycle_state)
+        if runtime_status is None:
+            return
+        try:
+            await self._runtime_state.update_heartbeat(agent_id, runtime_status=runtime_status)
+        except Exception as exc:
+            logger.warning(
+                "runtime_state_heartbeat_failed",
+                extra={"agent_id": agent_id, "error": str(exc)},
+            )
 
     # ── Reconciliation loop ─────────────────────────────────────────────
 

--- a/src/squadops/api/runtime/health_checker.py
+++ b/src/squadops/api/runtime/health_checker.py
@@ -230,6 +230,30 @@ class HealthChecker:
         )
         return {"status": "updated", "agent_id": agent_status["agent_id"]}
 
+    async def get_runtime_state(self, agent_id: str) -> dict[str, Any] | None:
+        """Return the SIP-0089 AgentRuntimeState for an agent, or None.
+
+        Pure read; never mutates. Returns a JSON-serialisable dict so the
+        FastAPI route does not need to know about the dataclass.
+        """
+        if self._runtime_state is None:
+            return None
+        state = await self._runtime_state.get_state(agent_id)
+        if state is None:
+            return None
+        return {
+            "agent_id": state.agent_id,
+            "mode": state.mode,
+            "runtime_status": state.runtime_status,
+            "focus": state.focus,
+            "current_runtime_activity_id": state.current_runtime_activity_id,
+            "interruptibility": state.interruptibility,
+            "last_heartbeat_at": (
+                state.last_heartbeat_at.isoformat() if state.last_heartbeat_at else None
+            ),
+            "current_assignment_ref": state.current_assignment_ref,
+        }
+
     async def _update_runtime_state_heartbeat(self, agent_id: str, lifecycle_state: str) -> None:
         """Mirror the heartbeat into agent_runtime_state (SIP-0089 §1.4).
 

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -336,6 +336,7 @@ async def _init_monitoring(config, pool) -> None:
     try:
         import redis.asyncio as aioredis
 
+        from adapters.persistence.runtime import PostgresRuntimeState
         from squadops.api.runtime.health_checker import HealthChecker
 
         redis_url = config.comms.redis.url
@@ -344,6 +345,7 @@ async def _init_monitoring(config, pool) -> None:
             pg_pool=pool,
             redis_client=_redis_client,
             config=config,
+            runtime_state=PostgresRuntimeState(pool),
         )
         await _health_checker_instance.init_connections()
         set_health_checker(_health_checker_instance)

--- a/src/squadops/cli/commands/agent.py
+++ b/src/squadops/cli/commands/agent.py
@@ -40,8 +40,10 @@ def state(
 
     try:
         client = _get_client(ctx)
-        data = client.get(f"/health/agents/{agent_id}/runtime-state")
-        client.close()
+        try:
+            data = client.get(f"/health/agents/{agent_id}/runtime-state")
+        finally:
+            client.close()
     except CLIError as e:
         print_error(str(e))
         raise typer.Exit(code=e.exit_code) from e

--- a/src/squadops/cli/commands/agent.py
+++ b/src/squadops/cli/commands/agent.py
@@ -1,0 +1,55 @@
+"""Agent commands (SIP-0089 §1.5).
+
+`squadops agent state <agent-id>` reads the SIP-0089 AgentRuntimeState
+for an agent and renders it as a table or `--json`.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from squadops.cli.client import APIClient, CLIError
+from squadops.cli.config import load_config
+from squadops.cli.output import print_detail, print_error, print_json
+
+app = typer.Typer(name="agent", help="Inspect agent runtime state (SIP-0089)")
+
+
+def _get_client(ctx: typer.Context) -> APIClient:
+    config = load_config()
+    return APIClient(config)
+
+
+def _derived_availability(state: dict) -> str:
+    """Compute idle/busy/paused for display only (per D6 — never stored)."""
+    if state.get("current_runtime_activity_id"):
+        return "busy"
+    if state.get("interruptibility") == "none":
+        return "paused"
+    return "idle"
+
+
+@app.command("state")
+def state(
+    ctx: typer.Context,
+    agent_id: str = typer.Argument(..., help="Agent identifier (e.g. max, neo)"),
+):
+    """Show runtime state for an agent: mode, focus, heartbeat, assignments."""
+    fmt = ctx.obj.get("format", "table") if ctx.obj else "table"
+    quiet = ctx.obj.get("quiet", False) if ctx.obj else False
+
+    try:
+        client = _get_client(ctx)
+        data = client.get(f"/health/agents/{agent_id}/runtime-state")
+        client.close()
+    except CLIError as e:
+        print_error(str(e))
+        raise typer.Exit(code=e.exit_code) from e
+
+    if fmt == "json":
+        print_json(data)
+        return
+
+    display = dict(data)
+    display["availability"] = _derived_availability(data)
+    print_detail(display, quiet=quiet)

--- a/src/squadops/cli/main.py
+++ b/src/squadops/cli/main.py
@@ -20,6 +20,7 @@ if "pytest" not in sys.modules:
     _repo_root = Path(__file__).resolve().parents[3]
     load_dotenv(_repo_root / ".env", override=False)
 
+from squadops.cli.commands.agent import app as agent_app
 from squadops.cli.commands.artifacts import artifacts_app, baseline_app
 from squadops.cli.commands.auth import auth_app, login, logout
 from squadops.cli.commands.bootstrap import bootstrap
@@ -99,3 +100,4 @@ app.add_typer(baseline_app, name="baseline")
 app.add_typer(auth_app, name="auth")
 app.add_typer(request_profiles_app, name="request-profiles")  # SIP-0074
 app.add_typer(models_app, name="models")  # SIP-0074
+app.add_typer(agent_app, name="agent")  # SIP-0089

--- a/src/squadops/ports/runtime/__init__.py
+++ b/src/squadops/ports/runtime/__init__.py
@@ -1,0 +1,10 @@
+"""
+Runtime ports (SIP-0089).
+
+Matches the namespace pattern of `squadops.ports.cycles` and
+`squadops.ports.observability` (established in 1.0.5).
+"""
+
+from squadops.ports.runtime.state import RuntimeStatePort
+
+__all__ = ["RuntimeStatePort"]

--- a/src/squadops/ports/runtime/state.py
+++ b/src/squadops/ports/runtime/state.py
@@ -1,0 +1,57 @@
+"""
+RuntimeStatePort — abstract interface for agent runtime-state persistence (SIP-0089 §10.1).
+
+Phase 1 surface. Phases 2–4 add `AssignmentPort`, `FocusLeasePort`, and
+`RuntimeActivityPort` alongside this one.
+
+Operations preserve D17's non-authoritative-heartbeat semantics:
+`ensure_state` initializes a missing row with safe defaults; `update_heartbeat`
+must not overwrite coordinator-owned fields (`mode`, `focus`,
+`current_assignment_ref`, `current_runtime_activity_id`).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from squadops.runtime.models import AgentRuntimeState
+
+
+class RuntimeStatePort(ABC):
+    """Port for `AgentRuntimeState` CRUD and heartbeat updates."""
+
+    @abstractmethod
+    async def get_state(self, agent_id: str) -> AgentRuntimeState | None:
+        """Return the current state for `agent_id`, or `None` if no row exists."""
+
+    @abstractmethod
+    async def upsert_state(self, state: AgentRuntimeState) -> AgentRuntimeState:
+        """Persist `state` (insert or update by `agent_id`) and return it.
+
+        Coordinator-owned writes go through this method. Heartbeat must not.
+        """
+
+    @abstractmethod
+    async def ensure_state(self, agent_id: str) -> AgentRuntimeState:
+        """Initialize default state for `agent_id` if no row exists; idempotent.
+
+        Default values: `mode=ambient`, `runtime_status=online`,
+        `interruptibility=high`, `focus=""`, all activity/assignment refs null.
+        Calling on an existing row returns the existing row unchanged.
+        """
+
+    @abstractmethod
+    async def update_heartbeat(
+        self,
+        agent_id: str,
+        *,
+        runtime_status: str | None = None,
+    ) -> AgentRuntimeState:
+        """Apply a heartbeat update (non-authoritative per D17).
+
+        Always updates `last_heartbeat_at`. Optionally updates `runtime_status`
+        (health only). Never writes `mode`, `focus`, `current_assignment_ref`,
+        or `current_runtime_activity_id` — those are coordinator-owned (D16).
+
+        Calls `ensure_state` first if no row exists.
+        """

--- a/src/squadops/runtime/__init__.py
+++ b/src/squadops/runtime/__init__.py
@@ -1,0 +1,12 @@
+"""
+Agent runtime state — SIP-0089.
+
+Pure coordination layer for `RuntimeMode`, `RuntimeActivity`, `FocusLease`,
+`Assignment`, and `DutyWindow`. Depends on `squadops.ports.*`; never on
+`adapters.*` (D1, enforced by `tests/unit/architecture/test_forbidden_imports.py`
+per D26).
+"""
+
+from squadops.runtime.models import AgentRuntimeState
+
+__all__ = ["AgentRuntimeState"]

--- a/src/squadops/runtime/events.py
+++ b/src/squadops/runtime/events.py
@@ -1,0 +1,21 @@
+"""
+Canonical runtime-state event names (SIP-0089, D14, D18).
+
+Events describe **what happened**. Reasons (in `reasons.py`) describe **why**.
+The two vocabularies are deliberately separate — see D18. Both are locked
+v1.1 constants after the §1.0 spike normalization pass.
+
+Initial v1.1 vocabulary. Phases 2/3 extend this set for assignments and
+focus leases; new names go through the same normalization step.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Mode transitions (Phase 1)
+MODE_TRANSITION: Final[str] = "runtime_state.mode_transition"
+
+# Heartbeat lifecycle (Phase 1)
+HEARTBEAT_INITIALIZED: Final[str] = "runtime_state.heartbeat_initialized"
+HEARTBEAT_RECOVERED: Final[str] = "runtime_state.heartbeat_recovered"

--- a/src/squadops/runtime/lifecycle_status.py
+++ b/src/squadops/runtime/lifecycle_status.py
@@ -1,0 +1,33 @@
+"""
+Map agent lifecycle_state → runtime_status for SIP-0089 heartbeat integration.
+
+`lifecycle_state` is the existing agent-status vocabulary used by
+`HealthChecker` and the `/health/agents/status` endpoint. `runtime_status`
+is the SIP-0089 §10.5 health vocabulary on `agent_runtime_state`.
+
+The mapping is locked v1.1 per §1.0 spike normalization. Server-side
+timeout detection (last_heartbeat_at older than N seconds → offline) is
+handled by the existing reconciliation loop, not this mapper.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+_LIFECYCLE_TO_RUNTIME_STATUS: Final[dict[str, str]] = {
+    "STARTING": "recovering",
+    "READY": "online",
+    "WORKING": "online",
+    "BLOCKED": "degraded",
+    "CRASHED": "offline",
+    "STOPPING": "recovering",
+}
+
+
+def runtime_status_from_lifecycle(lifecycle_state: str) -> str | None:
+    """Return the SIP-0089 `runtime_status` for an agent `lifecycle_state`.
+
+    Returns `None` for unknown values so callers can skip the runtime-state
+    update entirely rather than write a default that would mask drift.
+    """
+    return _LIFECYCLE_TO_RUNTIME_STATUS.get(lifecycle_state)

--- a/src/squadops/runtime/models.py
+++ b/src/squadops/runtime/models.py
@@ -1,0 +1,37 @@
+"""
+Runtime state dataclasses for SIP-0089 Phase 1.
+
+`AgentRuntimeState` mirrors SIP-0089 §10.1. Frozen dataclass; mutate via
+`dataclasses.replace()`. `Literal` types in code; matching `CHECK` constraints
+at the DB level (D3).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+RuntimeMode = Literal["duty", "cycle", "ambient"]
+RuntimeStatus = Literal["online", "degraded", "recovering", "offline"]
+Interruptibility = Literal["none", "low", "medium", "high"]
+
+
+@dataclass(frozen=True)
+class AgentRuntimeState:
+    """Observable runtime state for a single agent.
+
+    `mode`, `focus`, `current_runtime_activity_id`, and `current_assignment_ref`
+    are coordinator-owned (D16). Heartbeat may initialize a missing row and
+    update `last_heartbeat_at` + `runtime_status`, but must not overwrite
+    coordinator-owned fields (D17).
+    """
+
+    agent_id: str
+    mode: RuntimeMode
+    runtime_status: RuntimeStatus
+    focus: str
+    current_runtime_activity_id: str | None
+    interruptibility: Interruptibility
+    last_heartbeat_at: datetime
+    current_assignment_ref: str | None

--- a/src/squadops/runtime/reasons.py
+++ b/src/squadops/runtime/reasons.py
@@ -1,0 +1,22 @@
+"""
+Canonical runtime-state reason codes (SIP-0089, D14, D18).
+
+Reasons describe **why** a decision happened. Events (in `events.py`)
+describe **what happened**. The two vocabularies are deliberately separate —
+see D18. Both are locked v1.1 constants after the §1.0 spike normalization pass.
+
+Phases 2/3 extend this set for assignment scheduling and focus-lease decisions.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Mode-transition reasons (Phase 1)
+DUTY_WINDOW_OPENED: Final[str] = "duty_window_opened"
+DUTY_WINDOW_CLOSED: Final[str] = "duty_window_closed"
+CYCLE_RECRUITED: Final[str] = "cycle_recruited"
+CYCLE_COMPLETED: Final[str] = "cycle_completed"
+
+# Heartbeat-recovery reasons (Phase 1)
+RUNTIME_STATUS_CHANGED_TO_ONLINE: Final[str] = "runtime_status_changed_to_online"

--- a/tests/unit/architecture/test_forbidden_imports.py
+++ b/tests/unit/architecture/test_forbidden_imports.py
@@ -1,0 +1,145 @@
+"""Hexagonal-boundary architecture tests for SIP-0089 (D26).
+
+These tests enforce dependency direction by AST-parsing source files and
+asserting that the imports they declare do not cross forbidden boundaries.
+They run in the regression suite so violations fail CI, not just review.
+
+Rules currently encoded (D26):
+
+1. `src/squadops/runtime/` does not import any `adapters.*` module,
+   CLI modules, embodiment-specific modules, or Temporal-specific modules.
+2. `src/squadops/runtime/coordinator.py` (when it exists, Phase 2+) does
+   not import `events/bridges/*` directly — must depend on a port (D22).
+3. `src/squadops/capabilities/handlers/` does not import runtime persistence
+   adapters directly.
+4. `src/squadops/cli/` does not import Postgres runtime adapters directly.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.domain_runtime]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC = REPO_ROOT / "src" / "squadops"
+
+
+def _collect_imports(py_file: Path) -> list[str]:
+    """Return every fully-qualified module name imported by `py_file`."""
+    tree = ast.parse(py_file.read_text(), filename=str(py_file))
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                out.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                # Relative imports cannot reach `adapters.*` or `squadops.cli`.
+                continue
+            if node.module:
+                out.append(node.module)
+                for alias in node.names:
+                    out.append(f"{node.module}.{alias.name}")
+    return out
+
+
+def _iter_py(root: Path):
+    for p in root.rglob("*.py"):
+        if "__pycache__" in p.parts:
+            continue
+        yield p
+
+
+def test_runtime_layer_does_not_import_adapters():
+    """D1/D26: `src/squadops/runtime/` is a pure coordination layer. Importing
+    `adapters.*` from there would couple runtime semantics to a specific
+    infrastructure choice and break the hex boundary.
+
+    Bug class: if an implementer reaches for an adapter to 'just get the pool'
+    inside runtime/coordinator.py, this test fails immediately."""
+    runtime_dir = SRC / "runtime"
+    assert runtime_dir.is_dir(), "src/squadops/runtime/ must exist"
+
+    violations: list[tuple[str, str]] = []
+    for py in _iter_py(runtime_dir):
+        for imp in _collect_imports(py):
+            if imp == "adapters" or imp.startswith("adapters."):
+                violations.append((py.relative_to(REPO_ROOT).as_posix(), imp))
+
+    assert not violations, (
+        f"src/squadops/runtime/ must not import adapters.*. Violations: {violations}"
+    )
+
+
+def test_runtime_layer_does_not_import_cli():
+    """D1/D26: runtime is a domain layer; CLI is a delivery layer.
+    Bug class: importing CLI rendering helpers into runtime would invert
+    the dependency direction and make headless runtime use impossible."""
+    runtime_dir = SRC / "runtime"
+    violations: list[tuple[str, str]] = []
+    for py in _iter_py(runtime_dir):
+        for imp in _collect_imports(py):
+            if imp == "squadops.cli" or imp.startswith("squadops.cli."):
+                violations.append((py.relative_to(REPO_ROOT).as_posix(), imp))
+    assert not violations, f"runtime must not import squadops.cli: {violations}"
+
+
+def test_runtime_coordinator_does_not_import_event_bridges_directly():
+    """D22: runtime/coordinator.py (when added in Phase 2+) must emit events
+    through an injected EventPublisherPort, not by importing a specific bridge.
+    Bug class: a direct bridge import couples runtime to the workflow_tracker /
+    runtime_state bridge implementation, blocking swap-in of NoOp or alternatives.
+
+    No-op today because coordinator.py does not yet exist; the test wakes up
+    automatically when Phase 2/3 lands the file."""
+    coordinator = SRC / "runtime" / "coordinator.py"
+    if not coordinator.exists():
+        pytest.skip("runtime/coordinator.py not yet implemented (Phase 2+)")
+    violations = [
+        imp
+        for imp in _collect_imports(coordinator)
+        if imp == "squadops.events.bridges" or imp.startswith("squadops.events.bridges.")
+    ]
+    assert not violations, (
+        "runtime/coordinator.py must not import event bridges directly (D22). "
+        f"Violations: {violations}"
+    )
+
+
+def test_capabilities_handlers_do_not_import_runtime_persistence():
+    """D26: handlers depend on ports, not on `adapters.persistence.runtime.*`.
+    Bug class: a handler that imports the postgres adapter directly cannot be
+    unit-tested without postgres, and bypasses the coordinator authority (D16)."""
+    handlers_dir = SRC / "capabilities" / "handlers"
+    violations: list[tuple[str, str]] = []
+    for py in _iter_py(handlers_dir):
+        for imp in _collect_imports(py):
+            if imp == "adapters.persistence.runtime" or imp.startswith(
+                "adapters.persistence.runtime."
+            ):
+                violations.append((py.relative_to(REPO_ROOT).as_posix(), imp))
+    assert not violations, (
+        f"capabilities/handlers/ must not import adapters.persistence.runtime.*: {violations}"
+    )
+
+
+def test_cli_does_not_import_runtime_persistence():
+    """D26: CLI talks to the runtime over HTTP, not by importing the postgres
+    adapter directly. Bug class: a CLI command that imported the adapter would
+    not work outside the deployment (no DSN, no pool) but would still pass
+    unit tests against a mock — breaking when shipped to operators."""
+    cli_dir = SRC / "cli"
+    violations: list[tuple[str, str]] = []
+    for py in _iter_py(cli_dir):
+        for imp in _collect_imports(py):
+            if imp == "adapters.persistence.runtime" or imp.startswith(
+                "adapters.persistence.runtime."
+            ):
+                violations.append((py.relative_to(REPO_ROOT).as_posix(), imp))
+    assert not violations, (
+        f"squadops.cli must not import adapters.persistence.runtime.*: {violations}"
+    )

--- a/tests/unit/cli/test_agent_state_command.py
+++ b/tests/unit/cli/test_agent_state_command.py
@@ -1,0 +1,117 @@
+"""Unit tests for `squadops agent state` (SIP-0089 §1.5).
+
+What bugs would these catch?
+- Wrong endpoint URL → operator command silently hits the wrong service.
+- `--json` output silently including the derived `availability` field would
+  violate D6 (display-only, never stored/transported).
+- A 404 from the API path not propagating a non-zero exit code would break
+  scripting workflows.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from squadops.cli.commands.agent import _derived_availability
+from squadops.cli.main import app
+
+pytestmark = [pytest.mark.domain_cli]
+
+NOW_ISO = datetime(2026, 5, 17, 12, 0, 0, tzinfo=UTC).isoformat()
+
+
+def _state_payload(**overrides) -> dict:
+    base = {
+        "agent_id": "max",
+        "mode": "ambient",
+        "runtime_status": "online",
+        "focus": "",
+        "current_runtime_activity_id": None,
+        "interruptibility": "high",
+        "last_heartbeat_at": NOW_ISO,
+        "current_assignment_ref": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _patched_client(payload):
+    mock_client = MagicMock()
+    mock_client.get.return_value = payload
+    return mock_client
+
+
+@pytest.mark.parametrize(
+    ("state_overrides", "expected_availability"),
+    [
+        ({}, "idle"),
+        ({"current_runtime_activity_id": "act-1"}, "busy"),
+        ({"interruptibility": "none"}, "paused"),
+        # busy wins over interruptibility=none because an active activity is
+        # the strongest signal — sanity-check the precedence.
+        (
+            {"current_runtime_activity_id": "act-1", "interruptibility": "none"},
+            "busy",
+        ),
+    ],
+)
+def test_derived_availability_precedence(state_overrides, expected_availability):
+    """Bug class: a wrong precedence between `current_runtime_activity_id` and
+    `interruptibility=none` would mislabel a working agent as paused (or vice
+    versa) on every operator dashboard."""
+    assert _derived_availability(_state_payload(**state_overrides)) == expected_availability
+
+
+def test_json_output_does_not_include_derived_availability():
+    """Bug class (D6): `availability` is computed for display only. Leaking it
+    into the `--json` payload would let downstream tooling persist it as if it
+    were authoritative."""
+    runner = CliRunner()
+    payload = _state_payload()
+    with patch("squadops.cli.commands.agent._get_client", return_value=_patched_client(payload)):
+        # --json is the global flag handled by the top-level Typer callback;
+        # it must precede the subcommand path.
+        result = runner.invoke(app, ["--json", "agent", "state", "max"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.stdout
+    # Find the JSON body — print_json may add leading/trailing whitespace.
+    text = result.stdout.strip()
+    parsed = json.loads(text)
+    assert "availability" not in parsed
+    assert parsed["agent_id"] == "max"
+    assert parsed["mode"] == "ambient"
+
+
+def test_state_command_calls_correct_endpoint():
+    """Bug class: an endpoint typo (e.g. `/agents/state/{id}` vs
+    `/agents/{id}/runtime-state`) would compile, pass type checks, and only
+    fail at runtime when an operator runs the command."""
+    runner = CliRunner()
+    mock_client = _patched_client(_state_payload())
+    with patch("squadops.cli.commands.agent._get_client", return_value=mock_client):
+        result = runner.invoke(app, ["agent", "state", "max"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.stdout
+    mock_client.get.assert_called_once_with("/health/agents/max/runtime-state")
+
+
+def test_state_command_propagates_404_as_nonzero_exit():
+    """Bug class: a CLI that silently exits 0 on 'agent not found' breaks every
+    operator script that pipes `squadops agent state` into conditional logic.
+    The API returns 404 when no runtime-state row exists — the CLI must surface
+    that as a non-zero exit code."""
+    from squadops.cli import exit_codes
+    from squadops.cli.client import CLIError
+
+    runner = CliRunner()
+    mock_client = MagicMock()
+    mock_client.get.side_effect = CLIError("Agent 'ghost' not found", exit_codes.NOT_FOUND)
+    with patch("squadops.cli.commands.agent._get_client", return_value=mock_client):
+        result = runner.invoke(app, ["agent", "state", "ghost"], catch_exceptions=False)
+
+    assert result.exit_code == exit_codes.NOT_FOUND

--- a/tests/unit/runtime/test_agent_runtime_state.py
+++ b/tests/unit/runtime/test_agent_runtime_state.py
@@ -1,0 +1,249 @@
+"""Unit tests for SIP-0089 Phase 1 runtime-state primitives.
+
+Covers:
+- `runtime_status_from_lifecycle` mapper (pure logic — every branch).
+- `PostgresRuntimeState` adapter behaviors that protect D17
+  non-authoritative heartbeat semantics (the real concurrency bug class
+  this design exists to prevent).
+
+Each test answers: what bug would it catch?
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from adapters.persistence.runtime.state_postgres import PostgresRuntimeState
+from squadops.runtime.lifecycle_status import runtime_status_from_lifecycle
+from squadops.runtime.models import AgentRuntimeState
+
+pytestmark = [pytest.mark.domain_runtime]
+
+NOW = datetime(2026, 5, 17, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# lifecycle_status mapper — parametrized
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("lifecycle", "expected"),
+    [
+        ("STARTING", "recovering"),
+        ("READY", "online"),
+        ("WORKING", "online"),
+        ("BLOCKED", "degraded"),
+        ("CRASHED", "offline"),
+        ("STOPPING", "recovering"),
+    ],
+)
+def test_lifecycle_status_known_values_map_correctly(lifecycle, expected):
+    """Bug class: silent drift if a lifecycle_state maps to the wrong health bucket."""
+    assert runtime_status_from_lifecycle(lifecycle) == expected
+
+
+@pytest.mark.parametrize("lifecycle", ["", "UNKNOWN", "running", "online", "duty"])
+def test_lifecycle_status_unknown_returns_none(lifecycle):
+    """Bug class: defaulting unknown values to a real status would mask drift
+    (e.g. a typo or future lifecycle vocab change writing `online` for everything).
+    Returning None forces the caller to skip the update."""
+    assert runtime_status_from_lifecycle(lifecycle) is None
+
+
+# ---------------------------------------------------------------------------
+# asyncpg pool/connection fakes — pattern matches test_postgres_cycle_registry
+# ---------------------------------------------------------------------------
+
+
+class _AcquireCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _make_pool(conn):
+    pool = MagicMock()
+    pool.acquire.return_value = _AcquireCtx(conn)
+    return pool
+
+
+def _state_row(**overrides) -> dict:
+    base = {
+        "agent_id": "max",
+        "mode": "ambient",
+        "runtime_status": "online",
+        "focus": "",
+        "current_runtime_activity_id": None,
+        "interruptibility": "high",
+        "last_heartbeat_at": NOW,
+        "current_assignment_ref": None,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Adapter behaviors that protect D17
+# ---------------------------------------------------------------------------
+
+
+async def test_get_state_returns_none_when_no_row():
+    """Bug class: callers must distinguish 'agent has never heartbeated' from 'agent
+    is in default state'. Raising or returning a synthetic default would erase that
+    distinction."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = None
+    adapter = PostgresRuntimeState(_make_pool(conn))
+
+    assert await adapter.get_state("missing-agent") is None
+
+
+async def test_get_state_maps_row_to_dataclass():
+    """Bug class: a row→dataclass mapper that silently drops fields would degrade
+    observability without failing tests."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _state_row(
+        mode="duty",
+        focus="customer_support",
+        current_assignment_ref="assign-42",
+    )
+    adapter = PostgresRuntimeState(_make_pool(conn))
+
+    state = await adapter.get_state("max")
+
+    assert state == AgentRuntimeState(
+        agent_id="max",
+        mode="duty",
+        runtime_status="online",
+        focus="customer_support",
+        current_runtime_activity_id=None,
+        interruptibility="high",
+        last_heartbeat_at=NOW,
+        current_assignment_ref="assign-42",
+    )
+
+
+async def test_update_heartbeat_without_status_sends_only_last_heartbeat_at():
+    """Bug class (D17): if update_heartbeat's no-status branch slipped a status default
+    into the UPDATE, every heartbeat would overwrite the coordinator's runtime_status.
+    The query string must contain `last_heartbeat_at` but not `runtime_status`."""
+    conn = AsyncMock()
+    # First call (inside ensure_state) returns a row; second call (UPDATE) returns row.
+    conn.fetchrow.side_effect = [_state_row(), _state_row()]
+    adapter = PostgresRuntimeState(_make_pool(conn))
+
+    await adapter.update_heartbeat("max")
+
+    update_call = conn.fetchrow.call_args_list[1]
+    query = update_call.args[0]
+    # Split on RETURNING so the column list it specifies (read-side) isn't
+    # confused with the SET clause (write-side).
+    set_clause = query.split("RETURNING", 1)[0]
+    assert "last_heartbeat_at = $2" in set_clause
+    assert "runtime_status" not in set_clause, (
+        "Heartbeat without explicit status must not write runtime_status (D17)"
+    )
+    # Two positional args after the query: agent_id, now
+    assert len(update_call.args) == 3
+
+
+async def test_update_heartbeat_with_status_does_not_touch_coordinator_fields():
+    """Bug class (D17 — the load-bearing one): if anyone adds mode/focus/
+    current_assignment_ref/current_runtime_activity_id to the UPDATE, heartbeat
+    can race the coordinator and corrupt state. This is the regression test."""
+    conn = AsyncMock()
+    conn.fetchrow.side_effect = [_state_row(), _state_row(runtime_status="degraded")]
+    adapter = PostgresRuntimeState(_make_pool(conn))
+
+    await adapter.update_heartbeat("max", runtime_status="degraded")
+
+    update_call = conn.fetchrow.call_args_list[1]
+    query = update_call.args[0]
+    set_clause = query.split("RETURNING", 1)[0]
+    # Each forbidden column listed as `column =` (the SET-clause assignment
+    # form) — bare names appear in the RETURNING list and are legitimate.
+    forbidden = (
+        "mode =",
+        "focus =",
+        "current_assignment_ref =",
+        "current_runtime_activity_id =",
+    )
+    for tok in forbidden:
+        assert tok not in set_clause, f"Heartbeat UPDATE must not write {tok!r} (D17)"
+
+
+async def test_update_heartbeat_calls_ensure_state_first():
+    """Bug class: removing the ensure_state call would mean an agent that never
+    had a row simply never gets one — heartbeats would no-op silently and
+    `squadops agent state` would 404 forever."""
+    conn = AsyncMock()
+    conn.fetchrow.side_effect = [_state_row(), _state_row()]
+    adapter = PostgresRuntimeState(_make_pool(conn))
+
+    await adapter.update_heartbeat("max")
+
+    # Two fetchrow calls: first is the ensure_state INSERT...ON CONFLICT,
+    # second is the heartbeat UPDATE. The INSERT must come first.
+    first_query = conn.fetchrow.call_args_list[0].args[0]
+    assert "INSERT INTO agent_runtime_state" in first_query
+
+
+async def test_ensure_state_returns_existing_row_unchanged():
+    """Bug class: if ensure_state used INSERT...ON CONFLICT DO NOTHING + a separate
+    SELECT, a race could return None for an existing row. INSERT...ON CONFLICT DO
+    UPDATE agent_id RETURNING * fetches the row in one statement either way."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _state_row(
+        mode="duty",
+        focus="nightly_research",
+    )
+    adapter = PostgresRuntimeState(_make_pool(conn))
+
+    state = await adapter.ensure_state("max")
+
+    # The mock row reflects the *existing* state; ensure_state must surface
+    # that rather than the ambient/online defaults baked into the INSERT.
+    assert state.mode == "duty"
+    assert state.focus == "nightly_research"
+
+
+async def test_upsert_state_writes_all_fields_including_coordinator_owned():
+    """Bug class: upsert is the coordinator's path for transitions. If the UPDATE
+    branch silently omits a field (typo, copy-paste), a transition would persist
+    partially. The test asserts the SQL parameter count and the EXCLUDED clauses."""
+    conn = AsyncMock()
+    adapter = PostgresRuntimeState(_make_pool(conn))
+    state = AgentRuntimeState(
+        agent_id="max",
+        mode="duty",
+        runtime_status="online",
+        focus="customer_support",
+        current_runtime_activity_id="act-1",
+        interruptibility="low",
+        last_heartbeat_at=NOW,
+        current_assignment_ref="assign-1",
+    )
+
+    await adapter.upsert_state(state)
+
+    args = conn.execute.call_args.args
+    # 1 query + 8 columns of AgentRuntimeState
+    assert len(args) == 9
+    query = args[0]
+    for col in (
+        "mode = EXCLUDED.mode",
+        "focus = EXCLUDED.focus",
+        "current_runtime_activity_id = EXCLUDED.current_runtime_activity_id",
+        "current_assignment_ref = EXCLUDED.current_assignment_ref",
+        "interruptibility = EXCLUDED.interruptibility",
+    ):
+        assert col in query, f"upsert UPDATE branch missing: {col}"

--- a/tests/unit/runtime/test_agent_runtime_state.py
+++ b/tests/unit/runtime/test_agent_runtime_state.py
@@ -132,43 +132,40 @@ async def test_get_state_maps_row_to_dataclass():
     )
 
 
-async def test_update_heartbeat_without_status_sends_only_last_heartbeat_at():
-    """Bug class (D17): if update_heartbeat's no-status branch slipped a status default
-    into the UPDATE, every heartbeat would overwrite the coordinator's runtime_status.
-    The query string must contain `last_heartbeat_at` but not `runtime_status`."""
+async def test_update_heartbeat_without_status_preserves_stored_runtime_status():
+    """Bug class (D16/D17): a heartbeat with no explicit status must not overwrite
+    the stored runtime_status. The single upsert COALESCEs the (NULL) status bind
+    param against the stored value, so the existing status wins."""
     conn = AsyncMock()
-    # First call (inside ensure_state) returns a row; second call (UPDATE) returns row.
-    conn.fetchrow.side_effect = [_state_row(), _state_row()]
+    conn.fetchrow.return_value = _state_row()
     adapter = PostgresRuntimeState(_make_pool(conn))
 
     await adapter.update_heartbeat("max")
 
-    update_call = conn.fetchrow.call_args_list[1]
-    query = update_call.args[0]
-    # Split on RETURNING so the column list it specifies (read-side) isn't
-    # confused with the SET clause (write-side).
-    set_clause = query.split("RETURNING", 1)[0]
-    assert "last_heartbeat_at = $2" in set_clause
-    assert "runtime_status" not in set_clause, (
-        "Heartbeat without explicit status must not write runtime_status (D17)"
-    )
-    # Two positional args after the query: agent_id, now
-    assert len(update_call.args) == 3
+    call = conn.fetchrow.call_args_list[0]
+    # Isolate the ON CONFLICT SET clause from the RETURNING column list.
+    set_clause = call.args[0].split("DO UPDATE SET", 1)[1].split("RETURNING", 1)[0]
+    assert "last_heartbeat_at = EXCLUDED.last_heartbeat_at" in set_clause
+    # runtime_status is COALESCEd against the stored value, never force-written.
+    assert "runtime_status = COALESCE(" in set_clause
+    # The COALESCE status bind param (last positional arg) is None for a
+    # no-status heartbeat, so the stored value is preserved.
+    assert call.args[-1] is None
 
 
-async def test_update_heartbeat_with_status_does_not_touch_coordinator_fields():
+async def test_update_heartbeat_does_not_touch_coordinator_fields():
     """Bug class (D17 — the load-bearing one): if anyone adds mode/focus/
-    current_assignment_ref/current_runtime_activity_id to the UPDATE, heartbeat
-    can race the coordinator and corrupt state. This is the regression test."""
+    current_assignment_ref/current_runtime_activity_id to the ON CONFLICT SET,
+    a heartbeat can race the coordinator and corrupt state. This is the
+    regression test."""
     conn = AsyncMock()
-    conn.fetchrow.side_effect = [_state_row(), _state_row(runtime_status="degraded")]
+    conn.fetchrow.return_value = _state_row(runtime_status="degraded")
     adapter = PostgresRuntimeState(_make_pool(conn))
 
     await adapter.update_heartbeat("max", runtime_status="degraded")
 
-    update_call = conn.fetchrow.call_args_list[1]
-    query = update_call.args[0]
-    set_clause = query.split("RETURNING", 1)[0]
+    call = conn.fetchrow.call_args_list[0]
+    set_clause = call.args[0].split("DO UPDATE SET", 1)[1].split("RETURNING", 1)[0]
     # Each forbidden column listed as `column =` (the SET-clause assignment
     # form) — bare names appear in the RETURNING list and are legitimate.
     forbidden = (
@@ -178,23 +175,24 @@ async def test_update_heartbeat_with_status_does_not_touch_coordinator_fields():
         "current_runtime_activity_id =",
     )
     for tok in forbidden:
-        assert tok not in set_clause, f"Heartbeat UPDATE must not write {tok!r} (D17)"
+        assert tok not in set_clause, f"Heartbeat upsert must not write {tok!r} (D17)"
+    # An explicit status flows through as the COALESCE bind param.
+    assert call.args[-1] == "degraded"
 
 
-async def test_update_heartbeat_calls_ensure_state_first():
-    """Bug class: removing the ensure_state call would mean an agent that never
-    had a row simply never gets one — heartbeats would no-op silently and
-    `squadops agent state` would 404 forever."""
+async def test_update_heartbeat_creates_row_when_absent():
+    """Bug class: an agent that never had a row must still get one from a heartbeat,
+    else `squadops agent state` 404s forever. The single statement is an
+    INSERT...ON CONFLICT, so it inserts when absent and updates when present."""
     conn = AsyncMock()
-    conn.fetchrow.side_effect = [_state_row(), _state_row()]
+    conn.fetchrow.return_value = _state_row()
     adapter = PostgresRuntimeState(_make_pool(conn))
 
     await adapter.update_heartbeat("max")
 
-    # Two fetchrow calls: first is the ensure_state INSERT...ON CONFLICT,
-    # second is the heartbeat UPDATE. The INSERT must come first.
-    first_query = conn.fetchrow.call_args_list[0].args[0]
-    assert "INSERT INTO agent_runtime_state" in first_query
+    query = conn.fetchrow.call_args_list[0].args[0]
+    assert "INSERT INTO agent_runtime_state" in query
+    assert "ON CONFLICT (agent_id) DO UPDATE" in query
 
 
 async def test_ensure_state_returns_existing_row_unchanged():


### PR DESCRIPTION
## Summary

Implements **SIP-0089 Phase 1** per `docs/plans/SIP-0089-agent-runtime-state-plan.md`, delivering the minimal runtime-state primitives the rest of v1.1 builds on:

- New `src/squadops/runtime/` package: `AgentRuntimeState` frozen dataclass (SIP-0089 §10.1), canonical `events.py` / `reasons.py` constants kept distinct per D18.
- New `src/squadops/ports/runtime/` namespace matching the `ports/cycles/` and `ports/observability/` pattern from 1.0.5; `RuntimeStatePort` with `get_state` / `upsert_state` / `ensure_state` / `update_heartbeat`.
- Migration `1100_agent_runtime_state.sql` with `CHECK` constraints matching the `Literal` types (D3); `infra/migrations/README.md` establishes the **D11 range registry** (1000–1099 reserved for 1.0.x hardening, 1100–1199 for SIP-0089, 1200–1299/1300–1399 reserved for SIP-0090/0091).
- `PostgresRuntimeState` adapter using the existing asyncpg pool (no new DB dependency).
- **Server-side heartbeat mirror** inside `HealthChecker.update_agent_status_in_db` — see Spike 1 below.
- `GET /health/agents/{id}/runtime-state` endpoint + `squadops agent state <id>` CLI command. Derived `availability` (idle/busy/paused) is computed for display only, never persisted (D6).
- Tests: parametrized lifecycle→runtime_status mapping, adapter behaviors that protect D17 non-authoritative semantics, CLI rendering and exit-code propagation, plus a new D26 architecture test `tests/unit/architecture/test_forbidden_imports.py` that rejects forbidden import directions across the runtime layer.

29 tests pass + 1 forward-looking skip (the coordinator forbidden-import test wakes up automatically when Phase 2/3 lands `runtime/coordinator.py`).

## Spike outputs (§1.0)

Captured in `docs/plans/SIP-0089-phase-1-spike-notes.md`.

- **Entrypoint / heartbeat (D8) — revised mid-implementation.** Original plan implied injecting `RuntimeStatePort` into the agent-side `HealthCheckHttpReporter`. Reading the entrypoint revealed agents have **no direct Postgres dependency** — they POST heartbeats to runtime-api over HTTP. Wiring a port into the agent would have added a brand-new postgres coupling to every agent container. Revised to mirror the heartbeat **server-side** inside `HealthChecker.update_agent_status_in_db`. **Zero agent-side code changes** in this PR (`agents/entrypoint.py`, `base_agent.py`, `healthcheck_http.py` all untouched).
- **Events bridge (D22).** Dedicated `runtime_state` bridge, not `workflow_tracker`. The renamed-but-still-Prefect-shaped `workflow_tracker` is not intentionally generic; the plan's default rule applies.

## What this PR explicitly does NOT do

- No `RuntimeMode` transitions (coordinator authority is Phase 2/3).
- No `RuntimeActivity` records on cycle work (Phase 4).
- No embodiment, no Temporal (SIP-0090 / SIP-0091).
- No agent-side code modifications, no changes to cycle execution path.
- No `pyproject.toml` version bump (1.0.x stays on 1.0.5+ until Phase 4 closes, per plan §133).

## Plan PR boundary checklist (§135)

- [x] Does this PR introduce a new execution path? **No.**
- [x] Does this PR use `RuntimeActivity` only as observation/control state? **N/A — Phase 4.**
- [x] Does this PR keep `RuntimeMode` transitions coordinator-owned? **No mode transitions yet — Phase 2/3.**
- [x] Does this PR avoid embodiment and Temporal concerns? **Yes.**
- [x] Does this PR separate event names (what happened) from reason codes (why)? **Yes — `runtime/events.py` vs `runtime/reasons.py`.**
- [x] Does this PR use canonical names (`RuntimeMode`, `RuntimeActivity`, etc.) from the first commit? **Yes.**

## Coordination with Spark (1.0.x parallel work)

Plan §"Coordination with Spark" hot zones intentionally avoided in Phase 1:

- `src/squadops/agents/entrypoint.py` — untouched (see Spike 1 revision)
- `src/squadops/agents/base_agent.py` — untouched
- `src/squadops/capabilities/handlers/cycle_tasks.py` — untouched (Phase 4 work)
- Migration ranges disjoint per D11 (this PR uses 1100, Spark hardening uses 1000–1099)

This PR should rebase cleanly against ongoing Spark hardening.

## Test plan

- [x] `pytest tests/unit/runtime/ tests/unit/architecture/ tests/unit/cli/test_agent_state_command.py -v` → 29 pass, 1 skip
- [x] `ruff check` + `ruff format --check` clean across all new files
- [x] Rebuilt runtime-api locally (`./scripts/dev/ops/rebuild_and_deploy.sh runtime-api`) and verified:
  - Migration `1100_agent_runtime_state.sql` applied at startup
  - All 7 agents have rows in `agent_runtime_state` created by their first heartbeat
  - `squadops agent state max` returns the row with derived `availability: idle`
  - Heartbeats keep updating `last_heartbeat_at` and `runtime_status` only
- [x] **Smoke cycle on rebuilt runtime-api**: `cyc_4b8867e809fa` completed in 59.8s with 7 artifacts — Phase 1 changes do not regress cycle execution.

## Field notes

Two pre-existing bugs surfaced while validating this PR are tracked separately and **not addressed here**:

- **#146** — RabbitMQ consume loop has no channel-recovery (filed today; 6-day Nat queue blackout caused our first smoke attempt to time out).
- **#77** — `cycles cancel` does not propagate to Prefect flow run or to the run-row in the registry; added a comment with today's reproduction and expanded blast radius.

## References

- SIP-0088 — Agent Runtime Modes (umbrella)
- SIP-0089 — Agent Runtime State (this scope)
- `docs/plans/SIP-0089-agent-runtime-state-plan.md` — implementation plan rev 4
- `docs/plans/SIP-0089-phase-1-spike-notes.md` — §1.0 spike outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)