### PR TITLE
fix(tests): restore green regression baseline on main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ markers = [
     "domain_events: Cycle lifecycle event system tests",
     # Runtime Modes (SIP-0089)
     "domain_runtime: Agent runtime state, modes, and coordinator tests",
+    "domain_cycles: Cycle/run/gate execution domain tests",
 ]
 
 ###########################

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -110,19 +110,22 @@ def _safe_resolve(path_str: str, workspace_root: Path) -> Path:
     except ValueError as exc:
         raise _SafetyError("path_escapes_workspace") from exc
 
-    # Symlink escape: any symlink in the chain pointing outside the workspace.
+    # Symlink escape: any symlink WITHIN the user-supplied path (at or below
+    # workspace_root) whose target lies outside the workspace. Strict ancestors
+    # of workspace_root are trusted and skipped — they are frequently symlinked
+    # (e.g. /var -> /private/var on macOS, symlinked mount points on Linux) and
+    # are not attacker-controlled, so walking into them produces false escapes.
     cur = workspace_root / path_str
-    walked = []
-    while cur != cur.parent:
-        walked.append(cur)
-        cur = cur.parent
-    for node in walked:
-        if node.is_symlink():
-            target = node.resolve()
+    while True:
+        if cur.is_symlink():
+            target = cur.resolve()
             try:
                 target.relative_to(root_resolved)
             except ValueError as exc:
                 raise _SafetyError("path_escapes_workspace") from exc
+        if cur == workspace_root or cur == cur.parent:
+            break
+        cur = cur.parent
     return candidate
 
 
@@ -162,10 +165,7 @@ def _exact_then_one_path(*prefix: str) -> Callable[[list[str]], bool]:
     prefix_list = list(prefix)
 
     def matcher(argv: list[str]) -> bool:
-        return (
-            len(argv) == len(prefix_list) + 1
-            and list(argv[: len(prefix_list)]) == prefix_list
-        )
+        return len(argv) == len(prefix_list) + 1 and list(argv[: len(prefix_list)]) == prefix_list
 
     return matcher
 
@@ -188,7 +188,9 @@ def _argv0_with_args(name: str) -> Callable[[list[str]], bool]:
 
 # Order matters only for human readability; the matcher is `any(...)`.
 _COMMAND_SAFELIST: tuple[_CommandPattern, ...] = (
-    _CommandPattern("python -m py_compile <file>", _exact_then_one_path("python", "-m", "py_compile")),
+    _CommandPattern(
+        "python -m py_compile <file>", _exact_then_one_path("python", "-m", "py_compile")
+    ),
     _CommandPattern("python -m mypy <args...>", _prefix_with_args("python", "-m", "mypy")),
     _CommandPattern("node --check <file>", _exact_then_one_path("node", "--check")),
     _CommandPattern("ruff check <args...>", _prefix_with_args("ruff", "check")),
@@ -335,9 +337,7 @@ class EndpointDefinedCheck(BaseCheck):
         except _SafetyError as exc:
             return CheckOutcome.error(reason=exc.reason)
         if not file_path.is_file():
-            return CheckOutcome.failed(
-                reason="file_not_found", file=str(params["file"])
-            )
+            return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
         try:
             source = file_path.read_text(encoding="utf-8", errors="replace")
         except OSError:
@@ -364,9 +364,7 @@ class EndpointDefinedCheck(BaseCheck):
             else:
                 expected.append(parsed)
         if malformed:
-            return CheckOutcome.error(
-                reason="malformed_methods_paths", malformed=malformed
-            )
+            return CheckOutcome.error(reason="malformed_methods_paths", malformed=malformed)
 
         missing = [f"{m} {p}" for (m, p) in expected if (m, p) not in found]
         found_strs = sorted(f"{m} {p}" for (m, p) in found)
@@ -600,9 +598,7 @@ class CountAtLeastCheck(BaseCheck):
         count = len(matches)
         if count >= min_count:
             return CheckOutcome.passed(count=count, min_count=min_count)
-        return CheckOutcome.failed(
-            reason="count_below_minimum", count=count, min_count=min_count
-        )
+        return CheckOutcome.failed(reason="count_below_minimum", count=count, min_count=min_count)
 
 
 def _tail(text: str, max_chars: int = 1024) -> str:
@@ -658,9 +654,7 @@ class CommandExitZeroCheck(BaseCheck):
             return CheckOutcome.error(reason="command_spawn_failed", detail=str(exc))
 
         try:
-            stdout_b, stderr_b = await asyncio.wait_for(
-                proc.communicate(), timeout=timeout_s
-            )
+            stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
         except asyncio.TimeoutError:
             proc.kill()
             try:

--- a/tests/unit/adapters/test_a2a_client.py
+++ b/tests/unit/adapters/test_a2a_client.py
@@ -255,10 +255,10 @@ class TestSendMessageStream:
 
 
 class TestBuildSendPayload:
-    """Tests for _build_send_payload static method."""
+    """Tests for _build_payload static method."""
 
     def test_basic_payload(self):
-        payload = A2AClientAdapter._build_send_payload("hello")
+        payload = A2AClientAdapter._build_payload("hello")
         assert payload["jsonrpc"] == "2.0"
         assert payload["method"] == "message/send"
         assert payload["params"]["message"]["role"] == "user"
@@ -267,7 +267,7 @@ class TestBuildSendPayload:
         ]
 
     def test_payload_with_context_and_task(self):
-        payload = A2AClientAdapter._build_send_payload(
+        payload = A2AClientAdapter._build_payload(
             "hello",
             context_id="ctx-1",
             task_id="task-1",
@@ -276,7 +276,7 @@ class TestBuildSendPayload:
         assert payload["params"]["message"]["taskId"] == "task-1"
 
     def test_payload_without_optional_ids(self):
-        payload = A2AClientAdapter._build_send_payload("hello")
+        payload = A2AClientAdapter._build_payload("hello")
         assert "contextId" not in payload["params"]["message"]
         assert "taskId" not in payload["params"]["message"]
 

--- a/tests/unit/auth/test_keycloak_operational_config.py
+++ b/tests/unit/auth/test_keycloak_operational_config.py
@@ -363,11 +363,13 @@ class TestRealmLintFunction:
             "adminEventsEnabled": True,
             "bruteForceProtected": True,
             "authenticationFlows": [{"alias": "squadops-browser-with-mfa"}],
+            "loginTheme": "squadops",
             "clients": [
                 {
                     "clientId": "squadops-console",
                     "redirectUris": ["https://console.local.example/*"],
                     "webOrigins": ["https://console.local.example"],
+                    "attributes": {"post.logout.redirect.uris": "https://console.local.example/*"},
                 }
             ],
         }


### PR DESCRIPTION
## Why
While scoping SIP-0089 Phase 2, found the merge gate (`run_regression_tests.sh`) was **red on main** — it halted at collection — and the broader `pytest tests/unit` had 21 failures. Distinct from #148 (httpx 0.28 drift, now resolved). Fixes #160.

## Root causes & fixes
| # | Cluster | Verdict | Fix |
|---|---------|---------|-----|
| 1 | `domain_cycles` marker unregistered | **Gate-blocking** — strict-markers collection error interrupts the whole suite | Register the marker in `pyproject.toml` |
| 2 | `_safe_resolve` symlink-escape (8 typed-acceptance tests) | **Real code bug** | Stop the symlink walk at `workspace_root`; trusted symlinked ancestors (`/var → /private/var` on macOS, symlinked mounts on Linux) no longer trip `path_escapes_workspace`. Escape detection for absolute / `..` / in-path symlinks preserved |
| 3 | a2a `_build_send_payload` (3 tests) | **Test stale** | Rename to `_build_payload` (the actual method name since the initial commit) |
| 4 | keycloak realm-lint fixture (2 tests) | **Test stale** | Add `loginTheme` + `squadops-console` `post.logout.redirect.uris` (lint rules added in 0497720; the fixture predated them) |

Triaged each cluster code-vs-test via git history before fixing — only #2 was a code change; #3/#4 were stale tests updated to match intended behavior (not weakened).

## Verification
- `./scripts/dev/run_regression_tests.sh`: **green, 3987 passed** (was halting at collection).
- `pytest tests/unit`: **21 → 8 failures**. The remaining 8 are telemetry **cumulative test-pollution** (pass in isolation and in the gate; only fail in full `tests/unit`) — not gate-blocking, tracked separately in **#161**.
- `ruff check` clean on changed lines; `ruff format` applied to touched files.

## Not in scope
- #161 — telemetry cumulative pollution (test-infra; pairs naturally with #149 CI).
- #148 — httpx drift, already resolved; this is the residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)