### PR TITLE
fix(tests): use asyncio.run in telemetry health tests (#161)

### DIFF
--- a/tests/unit/telemetry/test_adapters.py
+++ b/tests/unit/telemetry/test_adapters.py
@@ -220,7 +220,7 @@ class TestNoOpLLMObservabilityAdapter:
         import asyncio
 
         adapter = NoOpLLMObservabilityAdapter()
-        result = asyncio.get_event_loop().run_until_complete(adapter.health())
+        result = asyncio.run(adapter.health())
         assert result["status"] == "ok"
         assert result["backend"] == "noop"
         assert result["details"] == {}
@@ -231,6 +231,6 @@ class TestNoOpLLMObservabilityAdapter:
         adapter = NoOpLLMObservabilityAdapter(
             health_status="degraded", health_reason="langfuse SDK not installed"
         )
-        result = asyncio.get_event_loop().run_until_complete(adapter.health())
+        result = asyncio.run(adapter.health())
         assert result["status"] == "degraded"
         assert result["details"]["reason"] == "langfuse SDK not installed"

--- a/tests/unit/telemetry/test_factory.py
+++ b/tests/unit/telemetry/test_factory.py
@@ -120,7 +120,7 @@ class TestCreateLlmObservabilityProvider:
         import asyncio
 
         adapter = create_llm_observability_provider(config=None)
-        result = asyncio.get_event_loop().run_until_complete(adapter.health())
+        result = asyncio.run(adapter.health())
         assert result["status"] == "ok"
 
     def test_returns_langfuse_adapter_when_enabled(self):
@@ -176,7 +176,7 @@ class TestCreateLlmObservabilityProvider:
             sys.modules.pop("adapters.telemetry.langfuse.adapter", None)
             adapter = create_llm_observability_provider(config=config)
             assert isinstance(adapter, NoOpLLMObservabilityAdapter)
-            result = asyncio.get_event_loop().run_until_complete(adapter.health())
+            result = asyncio.run(adapter.health())
             assert result["status"] == "degraded"
             assert "SDK not installed" in result["details"]["reason"]
         finally:

--- a/tests/unit/telemetry/test_langfuse_adapter.py
+++ b/tests/unit/telemetry/test_langfuse_adapter.py
@@ -154,7 +154,7 @@ class TestBufferOverflow:
         for _ in range(12):
             adapter.start_cycle_trace(ctx)
 
-        result = asyncio.get_event_loop().run_until_complete(adapter.health())
+        result = asyncio.run(adapter.health())
         assert result["details"]["dropped_events"] == 2
 
     def test_health_includes_buffer_size(self, adapter):
@@ -164,7 +164,7 @@ class TestBufferOverflow:
         for _ in range(5):
             adapter.start_cycle_trace(ctx)
 
-        result = asyncio.get_event_loop().run_until_complete(adapter.health())
+        result = asyncio.run(adapter.health())
         assert result["details"]["buffer_size"] == 5
 
 
@@ -334,7 +334,7 @@ class TestHealthStatus:
     def test_health_ok_when_reachable(self, adapter):
         import asyncio
 
-        result = asyncio.get_event_loop().run_until_complete(adapter.health())
+        result = asyncio.run(adapter.health())
         assert result["status"] == "ok"
         assert result["backend"] == "langfuse"
         assert "buffer_size" in result["details"]
@@ -353,7 +353,7 @@ class TestHealthStatus:
 
             a = LangFuseAdapter(_make_config())
             try:
-                result = asyncio.get_event_loop().run_until_complete(a.health())
+                result = asyncio.run(a.health())
                 assert result["status"] == "down"
                 assert "error" in result["details"]
             finally:


### PR DESCRIPTION
## Why
The 8 telemetry failures tracked in #161 — they failed **only** in a full `pytest tests/unit` run, passing in isolation and in the regression gate.

## Root cause (not what #161 first suspected)
Not OTel/langfuse global-state pollution. The real error was `RuntimeError: There is no current event loop in thread 'MainThread'` on every `health()` test. These **sync** tests called the async `health()` via `asyncio.get_event_loop().run_until_complete(...)`. In isolation a current loop exists; in the full suite an earlier async test leaves the main-thread loop closed/cleared, and Python 3.11's `get_event_loop()` raises instead of auto-creating one. The adapters' `health()` is correct — only the test invocation was fragile.

## Fix
Replace all 8 occurrences with `asyncio.run(...)` (creates/tears down its own loop, immune to prior loop-state). All assertions preserved; surgical 8-line diff across the 3 telemetry test files.

## Verification
- Full `pytest tests/unit`: **4480 passed, 0 failed** (was 8 failed), deterministic across repeated runs.
- Telemetry in isolation: still 139 passed.
- `ruff check` clean.

Fixes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)