### PR TITLE
refactor(cycles): rename DistributedFlowExecutor -> DispatchedFlowExecutor (#82)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -77,7 +77,7 @@ class _PausedError(Exception):
     """Internal: run paused due to BLOCKED outcome."""
 
 
-class DistributedFlowExecutor(FlowExecutionPort):
+class DispatchedFlowExecutor(FlowExecutionPort):
     """Flow executor that dispatches tasks to agent containers via RabbitMQ.
 
     Uses a request/reply pattern: publishes a ``comms.task`` message to

--- a/adapters/cycles/factory.py
+++ b/adapters/cycles/factory.py
@@ -90,8 +90,8 @@ def create_flow_executor(
             squad_profile=squad_profile,
             project_registry=project_registry,
         )
-    elif provider == "distributed":
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    elif provider == "dispatched":
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         workflow_tracker = kwargs.get("workflow_tracker")
         if not workflow_tracker and kwargs.get("prefect_api_url"):
@@ -99,7 +99,7 @@ def create_flow_executor(
 
             workflow_tracker = PrefectReporter(api_url=kwargs["prefect_api_url"])
 
-        return DistributedFlowExecutor(
+        return DispatchedFlowExecutor(
             cycle_registry=cycle_registry,
             artifact_vault=artifact_vault,
             queue=kwargs.get("queue"),

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -293,7 +293,7 @@ async def _init_cycle_subsystem(config, pool) -> None:
         set_cycle_event_bus(event_bus)
 
         flow_executor = create_flow_executor(
-            "distributed",
+            "dispatched",
             cycle_registry=cycle_registry,
             artifact_vault=artifact_vault,
             squad_profile=squad_profile,

--- a/src/squadops/events/bridges/workflow_tracker.py
+++ b/src/squadops/events/bridges/workflow_tracker.py
@@ -2,7 +2,7 @@
 
 Maps run lifecycle events to flow-run state changes. As of SIP-0087,
 task-run lifecycle (creation + state transitions) lives in
-``DistributedFlowExecutor._dispatch_task`` where the ``task_run_id`` is
+``DispatchedFlowExecutor._dispatch_task`` where the ``task_run_id`` is
 available for correlation-context scoping and the long-task heartbeat.
 The bridge still forwards terminal task-state transitions when a
 ``task_run_id`` is carried in the event context, but it no longer creates

--- a/tests/integration/cycles/test_merge_plan.py
+++ b/tests/integration/cycles/test_merge_plan.py
@@ -9,7 +9,7 @@ deterministic-merge code path.
 
 Each test runs handlers directly with seeded prior_outputs rather than
 the full executor — that keeps the test independent of the
-distributed_flow_executor's pre-resolver wiring (which lives in a
+dispatched_flow_executor's pre-resolver wiring (which lives in a
 separate adapter and would broaden this PR's blast radius). PR 93.4
 covers the gate-package end-to-end with the real executor wiring.
 """

--- a/tests/integration/cycles/test_pulse_check_e2e.py
+++ b/tests/integration/cycles/test_pulse_check_e2e.py
@@ -125,7 +125,7 @@ def _consume_factory(mock_queue):
 
 
 def _make_executor(registry, cycle):
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     mock_vault = AsyncMock()
     mock_queue = AsyncMock()
@@ -138,7 +138,7 @@ def _make_executor(registry, cycle):
     mock_squad_profile = AsyncMock()
     mock_squad_profile.get_profile.return_value = squad_profile
 
-    executor = DistributedFlowExecutor(
+    executor = DispatchedFlowExecutor(
         cycle_registry=registry,
         artifact_vault=mock_vault,
         queue=mock_queue,
@@ -161,7 +161,7 @@ class TestPulseCheckE2E:
         executor, mock_queue = _make_executor(registry, cycle)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_e2e", run_id="run_e2e")
@@ -201,11 +201,11 @@ class TestPulseCheckE2E:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=all_pass,
             ),
         ):
@@ -250,11 +250,11 @@ class TestPulseCheckE2E:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=fail_then_pass,
             ),
         ):
@@ -295,11 +295,11 @@ class TestPulseCheckE2E:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=always_fail,
             ),
         ):
@@ -340,11 +340,11 @@ class TestPulseCheckE2E:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=all_pass,
             ),
         ):

--- a/tests/unit/cycles/test_correction_protocol.py
+++ b/tests/unit/cycles/test_correction_protocol.py
@@ -1,4 +1,4 @@
-"""Tests for SIP-0079 correction protocol in DistributedFlowExecutor.
+"""Tests for SIP-0079 correction protocol in DispatchedFlowExecutor.
 
 Covers all 4 correction paths (continue, patch, rewind, abort),
 plan delta storage, max_correction_attempts, correction task checkpointing,
@@ -184,11 +184,11 @@ def executor(
     cycle,
     run,
 ):
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     mock_registry.get_cycle.return_value = cycle
     mock_registry.get_run.return_value = run
-    ex = DistributedFlowExecutor(
+    ex = DispatchedFlowExecutor(
         cycle_registry=mock_registry,
         artifact_vault=mock_vault,
         queue=mock_queue,
@@ -289,7 +289,7 @@ class TestCorrectionContinue:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -355,7 +355,7 @@ class TestCorrectionPatch:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -557,7 +557,7 @@ class TestCorrectionTaskArtifactStorage:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -633,7 +633,7 @@ class TestCorrectionTaskArtifactStorage:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -713,7 +713,7 @@ class TestCorrectionTerminalPaths:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -778,7 +778,7 @@ class TestMaxCorrectionAttempts:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -841,7 +841,7 @@ class TestPlanDelta:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -907,7 +907,7 @@ class TestPlanDelta:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -964,7 +964,7 @@ class TestCorrectionCheckpoints:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -990,7 +990,7 @@ class TestCorrectionCheckpoints:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -1040,7 +1040,7 @@ class TestCorrectionEvents:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -1096,7 +1096,7 @@ class TestCorrectionEvents:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -1197,7 +1197,7 @@ class TestCorrectionModelResolution:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -1258,7 +1258,7 @@ class TestCorrectionModelResolution:
         mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -1298,7 +1298,7 @@ class TestCorrectionModelResolution:
         # Wrap generate_task_plan so the failed task carries a real plan
         # contract. (The static plan generator only sets these when an
         # ImplementationPlan is supplied — the path under test here.)
-        import adapters.cycles.distributed_flow_executor as exec_mod
+        import adapters.cycles.dispatched_flow_executor as exec_mod
         from squadops.cycles.task_plan import generate_task_plan as real_gen
 
         def _gen_with_contract(*args, **kwargs):
@@ -1375,7 +1375,7 @@ class TestCorrectionModelResolution:
         with (
             patch.object(exec_mod, "generate_task_plan", _gen_with_contract),
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
         ):
@@ -1402,7 +1402,7 @@ class TestCorrectionModelResolution:
         roles upstream), but the fallback exists so a misconfigured profile
         can't crash the correction loop.
         """
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         class _ProfileStub:
             agents = (
@@ -1415,7 +1415,7 @@ class TestCorrectionModelResolution:
                 ),
             )
 
-        agent_id, model, overrides = DistributedFlowExecutor._resolve_agent_config(
+        agent_id, model, overrides = DispatchedFlowExecutor._resolve_agent_config(
             "data", _ProfileStub()
         )
         assert agent_id == "data"

--- a/tests/unit/cycles/test_correction_repair_prefect_propagation.py
+++ b/tests/unit/cycles/test_correction_repair_prefect_propagation.py
@@ -81,14 +81,14 @@ def mock_prefect_reporter() -> AsyncMock:
 
 def _make_executor(mock_prefect_reporter):
     """Build a minimally-wired executor for direct method calls."""
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     registry = AsyncMock()
     vault = AsyncMock()
     vault.store.side_effect = lambda ref, _content: ref
     queue = AsyncMock()
     squad = AsyncMock()
-    ex = DistributedFlowExecutor(
+    ex = DispatchedFlowExecutor(
         cycle_registry=registry,
         artifact_vault=vault,
         queue=queue,

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -1,4 +1,4 @@
-"""Tests for DistributedFlowExecutor (adapters/cycles/distributed_flow_executor.py).
+"""Tests for DispatchedFlowExecutor (adapters/cycles/dispatched_flow_executor.py).
 
 Covers dispatch via RabbitMQ publish/consume, sequential happy path,
 fail-fast, cancellation, artifact storage, output chaining, and timeout.
@@ -175,11 +175,11 @@ def run():
 
 @pytest.fixture
 def executor(mock_registry, mock_vault, mock_queue, mock_squad_profile, cycle, run):
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     mock_registry.get_cycle.return_value = cycle
     mock_registry.get_run.return_value = run
-    return DistributedFlowExecutor(
+    return DispatchedFlowExecutor(
         cycle_registry=mock_registry,
         artifact_vault=mock_vault,
         queue=mock_queue,
@@ -201,7 +201,7 @@ class TestBuildFailureEvidence:
     rewind on patchable content failures (cyc_4178f25a0dff delta_2 →
     cyc_d1c1a259c983 delta_0 had to guess the failure shape)."""
 
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     def _envelope(self, task_type: str) -> TaskEnvelope:
         return TaskEnvelope(
@@ -244,7 +244,7 @@ class TestBuildFailureEvidence:
             },
         )
 
-        evidence = self.DistributedFlowExecutor._build_failure_evidence(
+        evidence = self.DispatchedFlowExecutor._build_failure_evidence(
             envelope, result, prior_plan_deltas_count=0
         )
 
@@ -268,7 +268,7 @@ class TestBuildFailureEvidence:
             },
         )
 
-        evidence = self.DistributedFlowExecutor._build_failure_evidence(
+        evidence = self.DispatchedFlowExecutor._build_failure_evidence(
             envelope, result, prior_plan_deltas_count=2
         )
 
@@ -286,7 +286,7 @@ class TestBuildFailureEvidence:
         envelope = self._envelope("development.develop")
         result = TaskResult(task_id="t-7", status="FAILED", outputs=None, error="connection reset")
 
-        evidence = self.DistributedFlowExecutor._build_failure_evidence(
+        evidence = self.DispatchedFlowExecutor._build_failure_evidence(
             envelope, result, prior_plan_deltas_count=0
         )
 
@@ -309,7 +309,7 @@ class TestComposeFailureTrigger:
     prose. Non-typed-check failures (LLM crash, RabbitMQ timeout) keep the
     legacy `task_failure:<task_type>` shape so consumers handle both."""
 
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     @staticmethod
     def _envelope(task_type: str = "builder.assemble") -> TaskEnvelope:
@@ -349,7 +349,7 @@ class TestComposeFailureTrigger:
                 },
             ]
         )
-        trigger = self.DistributedFlowExecutor._compose_failure_trigger(
+        trigger = self.DispatchedFlowExecutor._compose_failure_trigger(
             self._envelope("builder.assemble"), evidence
         )
         assert trigger == "typed_check_failed:builder.assemble:5:2"
@@ -371,7 +371,7 @@ class TestComposeFailureTrigger:
                 },
             ]
         )
-        trigger = self.DistributedFlowExecutor._compose_failure_trigger(
+        trigger = self.DispatchedFlowExecutor._compose_failure_trigger(
             self._envelope("development.develop"), evidence
         )
         assert trigger == "task_failure:development.develop"
@@ -386,7 +386,7 @@ class TestComposeFailureTrigger:
                 {"check": "stack_coverage_heuristic", "passed": False},
             ]
         )
-        trigger = self.DistributedFlowExecutor._compose_failure_trigger(
+        trigger = self.DispatchedFlowExecutor._compose_failure_trigger(
             self._envelope("qa.test"), evidence
         )
         assert trigger == "task_failure:qa.test"
@@ -407,7 +407,7 @@ class TestComposeFailureTrigger:
                 },
             ]
         )
-        trigger = self.DistributedFlowExecutor._compose_failure_trigger(
+        trigger = self.DispatchedFlowExecutor._compose_failure_trigger(
             self._envelope("builder.assemble"), evidence
         )
         assert trigger == "task_failure:builder.assemble"
@@ -441,7 +441,7 @@ class TestComposeFailureTrigger:
                 },
             ]
         )
-        trigger = self.DistributedFlowExecutor._compose_failure_trigger(
+        trigger = self.DispatchedFlowExecutor._compose_failure_trigger(
             self._envelope("builder.assemble"), evidence
         )
         assert trigger == "typed_check_failed:builder.assemble:1:1"
@@ -462,13 +462,13 @@ class TestComposeFailureTrigger:
                 },
             ]
         )
-        trigger = self.DistributedFlowExecutor._compose_failure_trigger(
+        trigger = self.DispatchedFlowExecutor._compose_failure_trigger(
             self._envelope("builder.assemble"), evidence
         )
         assert trigger == "task_failure:builder.assemble"
 
     def test_empty_evidence_falls_back_to_legacy(self):
-        trigger = self.DistributedFlowExecutor._compose_failure_trigger(
+        trigger = self.DispatchedFlowExecutor._compose_failure_trigger(
             self._envelope("development.develop"), {}
         )
         assert trigger == "task_failure:development.develop"
@@ -477,7 +477,7 @@ class TestComposeFailureTrigger:
         # Defensive: a row that's not a dict (corrupt validation_result)
         # must not crash the trigger composer. Fall through to legacy.
         evidence = self._evidence(["not a dict", None, 42])  # type: ignore[list-item]
-        trigger = self.DistributedFlowExecutor._compose_failure_trigger(
+        trigger = self.DispatchedFlowExecutor._compose_failure_trigger(
             self._envelope("qa.test"), evidence
         )
         assert trigger == "task_failure:qa.test"
@@ -507,7 +507,7 @@ class TestBuildTaskName:
         )
 
     def test_focused_envelope_uses_focus_and_index(self) -> None:
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         env = self._envelope(
             inputs={
@@ -515,40 +515,40 @@ class TestBuildTaskName:
                 "subtask_index": 0,
             }
         )
-        assert DistributedFlowExecutor._build_task_name("dev", env) == (
+        assert DispatchedFlowExecutor._build_task_name("dev", env) == (
             "dev[0]: Backend data models and in-memory repository"
         )
 
     def test_focused_envelope_without_index_omits_brackets(self) -> None:
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         env = self._envelope(inputs={"subtask_focus": "FastAPI endpoints and validation"})
         assert (
-            DistributedFlowExecutor._build_task_name("dev", env)
+            DispatchedFlowExecutor._build_task_name("dev", env)
             == "dev: FastAPI endpoints and validation"
         )
 
     def test_non_focused_envelope_falls_back_to_task_type(self) -> None:
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         env = self._envelope(task_type="development.develop", inputs={})
-        assert DistributedFlowExecutor._build_task_name("dev", env) == "dev: development.develop"
+        assert DispatchedFlowExecutor._build_task_name("dev", env) == "dev: development.develop"
 
     def test_long_focus_truncates_at_60_chars(self) -> None:
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         long_focus = "X" * 100
         env = self._envelope(inputs={"subtask_focus": long_focus, "subtask_index": 3})
-        name = DistributedFlowExecutor._build_task_name("dev", env)
+        name = DispatchedFlowExecutor._build_task_name("dev", env)
         assert name == f"dev[3]: {'X' * 60}"
         assert len(name.split(": ", 1)[1]) == 60
 
     def test_index_zero_renders_as_zero_not_omitted(self) -> None:
         """Subtask index 0 must render as ``[0]`` — falsy but valid."""
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         env = self._envelope(inputs={"subtask_focus": "first", "subtask_index": 0})
-        assert DistributedFlowExecutor._build_task_name("dev", env) == "dev[0]: first"
+        assert DispatchedFlowExecutor._build_task_name("dev", env) == "dev[0]: first"
 
 
 # ---------------------------------------------------------------------------
@@ -601,7 +601,7 @@ class TestDispatchTask:
         )
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor._dispatch_task(envelope, "run_001")
@@ -666,7 +666,7 @@ class TestDispatchTask:
         )
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             result = await executor._dispatch_task(envelope, "run_001")
@@ -716,7 +716,7 @@ class TestDispatchTask:
         mock_queue.consume_blocking.side_effect = flaky_consume_blocking
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             result = await executor._dispatch_task(envelope, "run_001")
@@ -819,7 +819,7 @@ class TestSequentialHappyPath:
         mock_queue.consume.side_effect = self._make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -834,7 +834,7 @@ class TestSequentialHappyPath:
         mock_queue.consume.side_effect = self._make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -846,7 +846,7 @@ class TestSequentialHappyPath:
         mock_queue.consume.side_effect = self._make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -865,7 +865,7 @@ class TestSequentialHappyPath:
         mock_queue.consume.side_effect = self._make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -915,7 +915,7 @@ class TestFailFast:
         mock_queue.consume.side_effect = consume_side_effect
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -1000,7 +1000,7 @@ class TestArtifactStorage:
         mock_queue.consume.side_effect = consume_side_effect
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -1068,7 +1068,7 @@ class TestPulseVerificationBackwardCompat:
         mock_queue.consume.side_effect = consume_side_effect
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -1088,11 +1088,11 @@ class TestPulseVerificationMilestone:
         mock_squad_profile,
         cycle,
     ):
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         mock_registry.get_cycle.return_value = cycle
         mock_registry.record_pulse_verification.return_value = mock_registry.get_run.return_value
-        return DistributedFlowExecutor(
+        return DispatchedFlowExecutor(
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
@@ -1146,11 +1146,11 @@ class TestPulseVerificationMilestone:
         # Mock the engine to return PASS
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
             ) as mock_run_pv,
         ):
             from squadops.cycles.pulse_models import PulseVerificationRecord
@@ -1214,11 +1214,11 @@ class TestPulseVerificationMilestone:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
             ) as mock_run_pv,
         ):
             from squadops.cycles.pulse_models import PulseVerificationRecord
@@ -1249,11 +1249,11 @@ class TestPulseVerificationCadence:
         mock_squad_profile,
         cycle,
     ):
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         mock_registry.get_cycle.return_value = cycle
         mock_registry.record_pulse_verification.return_value = mock_registry.get_run.return_value
-        return DistributedFlowExecutor(
+        return DispatchedFlowExecutor(
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
@@ -1306,11 +1306,11 @@ class TestPulseVerificationCadence:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
             ) as mock_run_pv,
         ):
             from squadops.cycles.pulse_models import PulseVerificationRecord
@@ -1376,11 +1376,11 @@ class TestPulseVerificationCadence:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
             ) as mock_run_pv,
         ):
             from squadops.cycles.pulse_models import PulseVerificationRecord
@@ -1455,11 +1455,11 @@ class TestPulseVerificationCadence:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.time.monotonic",
+                "adapters.cycles.dispatched_flow_executor.time.monotonic",
                 side_effect=fake_monotonic,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
             ) as mock_run_pv,
         ):
             from squadops.cycles.pulse_models import PulseVerificationRecord
@@ -1494,12 +1494,12 @@ class TestPulseVerificationTelemetry:
         mock_squad_profile,
         cycle,
     ):
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         mock_registry.get_cycle.return_value = cycle
         mock_registry.record_pulse_verification.return_value = mock_registry.get_run.return_value
         obs = MagicMock()
-        return DistributedFlowExecutor(
+        return DispatchedFlowExecutor(
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
@@ -1553,11 +1553,11 @@ class TestPulseVerificationTelemetry:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
             ) as mock_run_pv,
         ):
             from squadops.cycles.pulse_models import PulseVerificationRecord
@@ -1626,11 +1626,11 @@ class TestPulseVerificationTelemetry:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
             ) as mock_run_pv,
         ):
             from squadops.cycles.pulse_models import PulseVerificationRecord
@@ -1695,11 +1695,11 @@ class TestPulseVerificationTelemetry:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
             ) as mock_run_pv,
         ):
             from squadops.cycles.pulse_models import PulseVerificationRecord
@@ -1762,7 +1762,7 @@ class TestPulseVerificationTelemetry:
         mock_queue.consume.side_effect = consume_side_effect
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -1782,11 +1782,11 @@ class TestPulseVerificationCombined:
         mock_squad_profile,
         cycle,
     ):
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         mock_registry.get_cycle.return_value = cycle
         mock_registry.record_pulse_verification.return_value = mock_registry.get_run.return_value
-        return DistributedFlowExecutor(
+        return DispatchedFlowExecutor(
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
@@ -1848,11 +1848,11 @@ class TestPulseVerificationCombined:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
             ) as mock_run_pv,
         ):
             from squadops.cycles.pulse_models import PulseVerificationRecord
@@ -1890,11 +1890,11 @@ class TestPulseVerificationRecordPersistence:
         mock_squad_profile,
         cycle,
     ):
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         mock_registry.get_cycle.return_value = cycle
         mock_registry.record_pulse_verification.return_value = mock_registry.get_run.return_value
-        return DistributedFlowExecutor(
+        return DispatchedFlowExecutor(
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
@@ -1947,11 +1947,11 @@ class TestPulseVerificationRecordPersistence:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
             ) as mock_run_pv,
         ):
             from squadops.cycles.pulse_models import PulseVerificationRecord
@@ -1990,11 +1990,11 @@ class TestPulseRepairLoop:
         mock_squad_profile,
         cycle,
     ):
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         mock_registry.get_cycle.return_value = cycle
         mock_registry.record_pulse_verification.return_value = mock_registry.get_run.return_value
-        return DistributedFlowExecutor(
+        return DispatchedFlowExecutor(
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
@@ -2072,10 +2072,10 @@ class TestPulseRepairLoop:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=run_pv_side_effect,
             ),
         ):
@@ -2130,10 +2130,10 @@ class TestPulseRepairLoop:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=always_fail,
             ),
         ):
@@ -2189,10 +2189,10 @@ class TestPulseRepairLoop:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=always_fail,
             ),
         ):
@@ -2264,10 +2264,10 @@ class TestPulseRepairLoop:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=mixed_pv,
             ),
         ):
@@ -2328,10 +2328,10 @@ class TestPulseRepairLoop:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=always_fail,
             ),
         ):
@@ -2387,10 +2387,10 @@ class TestPulseRepairLoop:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side_effect,
             ),
         ):
@@ -2446,10 +2446,10 @@ class TestPulseRepairLoop:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
             ),
         ):
@@ -2518,10 +2518,10 @@ class TestPulseRepairLoop:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
             ),
         ):
@@ -2582,10 +2582,10 @@ class TestPulseRepairLoop:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
             ),
         ):
@@ -2612,13 +2612,13 @@ class TestPulseRepairTelemetry:
         mock_squad_profile,
         cycle,
     ):
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         mock_registry.get_cycle.return_value = cycle
         mock_registry.record_pulse_verification.return_value = mock_registry.get_run.return_value
 
         obs = MagicMock()
-        return DistributedFlowExecutor(
+        return DispatchedFlowExecutor(
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
@@ -2694,10 +2694,10 @@ class TestPulseRepairTelemetry:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
             ),
         ):
@@ -2749,10 +2749,10 @@ class TestPulseRepairTelemetry:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=always_fail,
             ),
         ):
@@ -2814,10 +2814,10 @@ class TestPulseRepairTelemetry:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=always_fail,
             ),
         ):
@@ -2884,10 +2884,10 @@ class TestPulseRepairTelemetry:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
             ),
         ):
@@ -2953,10 +2953,10 @@ class TestPulseRepairTelemetry:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
             ),
         ):
@@ -3027,10 +3027,10 @@ class TestPulseRepairTelemetry:
 
         with (
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep", new_callable=AsyncMock
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
             ),
             patch(
-                "adapters.cycles.distributed_flow_executor.run_pulse_verification",
+                "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
             ),
         ):
@@ -3086,9 +3086,9 @@ class TestDispatchTaskPrefectLifecycle:
         return reporter
 
     def _build_executor(self, mock_queue, mock_reporter=None):
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
-        return DistributedFlowExecutor(
+        return DispatchedFlowExecutor(
             queue=mock_queue,
             task_timeout=5.0,
             workflow_tracker=mock_reporter,
@@ -3119,7 +3119,7 @@ class TestDispatchTaskPrefectLifecycle:
         executor = self._build_executor(mock_queue, mock_reporter)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor._dispatch_task(envelope, "run_001", flow_run_id="fr_abc")
@@ -3134,7 +3134,7 @@ class TestDispatchTaskPrefectLifecycle:
         executor = self._build_executor(mock_queue, mock_reporter=None)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             result = await executor._dispatch_task(envelope, "run_001", flow_run_id="fr_abc")
@@ -3148,7 +3148,7 @@ class TestDispatchTaskPrefectLifecycle:
         executor = self._build_executor(mock_queue, mock_reporter)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor._dispatch_task(envelope, "run_001", flow_run_id=None)
@@ -3166,7 +3166,7 @@ class TestDispatchTaskPrefectLifecycle:
         executor = self._build_executor(mock_queue, mock_reporter)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor._dispatch_task(
@@ -3190,7 +3190,7 @@ class TestDispatchTaskPrefectLifecycle:
         executor = self._build_executor(mock_queue, mock_reporter)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor._dispatch_task(
@@ -3214,7 +3214,7 @@ class TestDispatchTaskPrefectLifecycle:
         executor = self._build_executor(mock_queue, mock_reporter=None)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor._dispatch_task(envelope, "run_001")
@@ -3242,7 +3242,7 @@ class TestDispatchTaskPrefectLifecycle:
         executor = self._build_executor(mock_queue, mock_reporter)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor._dispatch_task(
@@ -3264,7 +3264,7 @@ class TestDispatchTaskPrefectLifecycle:
         the live correlation context so records are tagged for Prefect."""
         import logging as stdlog
 
-        import adapters.cycles.distributed_flow_executor as dfe
+        import adapters.cycles.dispatched_flow_executor as dfe
         from squadops.telemetry.context import (
             get_correlation_context,
             use_correlation_context,
@@ -3320,7 +3320,7 @@ class TestDispatchTaskPrefectLifecycle:
         executor = self._build_executor(mock_queue, mock_reporter)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor._dispatch_task(

--- a/tests/unit/cycles/test_dispatched_flow_executor_observability.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor_observability.py
@@ -1,4 +1,4 @@
-"""Tests for observability wiring in DistributedFlowExecutor.
+"""Tests for observability wiring in DispatchedFlowExecutor.
 
 Covers LangFuse cycle lifecycle events and Prefect flow/task run
 creation in execute_run().
@@ -202,10 +202,10 @@ def executor(
     mock_llm_obs,
     mock_prefect,
 ):
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     mock_registry.get_cycle.return_value = cycle
-    return DistributedFlowExecutor(
+    return DispatchedFlowExecutor(
         cycle_registry=mock_registry,
         artifact_vault=mock_vault,
         queue=mock_queue,
@@ -218,10 +218,10 @@ def executor(
 
 @pytest.fixture
 def executor_no_obs(mock_registry, mock_vault, mock_queue, mock_squad_profile, cycle):
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     mock_registry.get_cycle.return_value = cycle
-    return DistributedFlowExecutor(
+    return DispatchedFlowExecutor(
         cycle_registry=mock_registry,
         artifact_vault=mock_vault,
         queue=mock_queue,
@@ -242,7 +242,7 @@ class TestLangFuseCycleEvents:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -261,7 +261,7 @@ class TestLangFuseCycleEvents:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -281,7 +281,7 @@ class TestWithoutObservability:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor_no_obs.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -326,7 +326,7 @@ class TestFlowLevelCorrelationScope:
 
         try:
             with patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ):
                 await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -359,7 +359,7 @@ class TestPrefectFlowRun:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -386,7 +386,7 @@ class TestPrefectTaskRuns:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -424,7 +424,7 @@ class TestPrefectTaskRuns:
         executor._cycle_event_bus.emit = capture_emit
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -102,11 +102,11 @@ def mock_event_bus():
 
 @pytest.fixture
 def executor(mock_registry, mock_event_bus):
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     vault = AsyncMock()
     vault.list_artifacts.return_value = []  # Default: no promoted artifacts
-    exec_ = DistributedFlowExecutor(
+    exec_ = DispatchedFlowExecutor(
         cycle_registry=mock_registry,
         artifact_vault=vault,
         queue=AsyncMock(),
@@ -662,7 +662,7 @@ class TestPollInterWorkloadGate:
 
     async def test_cancellation_during_poll_raises(self, executor, mock_registry):
         """Cancellation check during polling raises _CancellationError."""
-        from adapters.cycles.distributed_flow_executor import _CancellationError
+        from adapters.cycles.dispatched_flow_executor import _CancellationError
 
         cycle = _make_cycle()
         # _is_cancelled returns True

--- a/tests/unit/cycles/test_executor_build_wiring.py
+++ b/tests/unit/cycles/test_executor_build_wiring.py
@@ -1,7 +1,7 @@
 """Tests for executor build task wiring (SIP-Enhanced-Agent-Build-Capabilities).
 
 Tests artifact content pre-resolution, build-only validation, and
-producing_task_type metadata tracking in DistributedFlowExecutor.
+producing_task_type metadata tracking in DispatchedFlowExecutor.
 
 Part of Phase 2.
 """
@@ -50,8 +50,8 @@ def _make_artifact_ref(
 
 @pytest.fixture
 def executor():
-    """Create a DistributedFlowExecutor with mocked ports."""
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    """Create a DispatchedFlowExecutor with mocked ports."""
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     vault = AsyncMock()
     registry = AsyncMock()
@@ -62,7 +62,7 @@ def executor():
     registry.get_latest_checkpoint.return_value = None
     registry.save_checkpoint.return_value = None
 
-    ex = DistributedFlowExecutor(
+    ex = DispatchedFlowExecutor(
         cycle_registry=registry,
         artifact_vault=vault,
         queue=queue,
@@ -256,8 +256,8 @@ class TestProducingTaskTypeMetadata:
 class TestBuildOnlyValidation:
     async def test_build_only_missing_refs_fails(self):
         """Build-only cycle without plan_artifact_refs raises _ExecutionError."""
-        from adapters.cycles.distributed_flow_executor import (
-            DistributedFlowExecutor,
+        from adapters.cycles.dispatched_flow_executor import (
+            DispatchedFlowExecutor,
         )
 
         cycle = Cycle(
@@ -313,7 +313,7 @@ class TestBuildOnlyValidation:
             )
         )
 
-        ex = DistributedFlowExecutor(
+        ex = DispatchedFlowExecutor(
             cycle_registry=registry,
             artifact_vault=AsyncMock(),
             queue=AsyncMock(),
@@ -369,7 +369,7 @@ class TestBuildOnlySeeding:
 
     async def test_build_only_with_valid_refs_passes_validation(self):
         """Build-only cycle with plan_artifact_refs does not raise."""
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         ref_plan = _make_artifact_ref("art_plan_001", "implementation_plan.md", "document")
 
@@ -433,7 +433,7 @@ class TestBuildOnlySeeding:
             )
         )
 
-        ex = DistributedFlowExecutor(
+        ex = DispatchedFlowExecutor(
             cycle_registry=registry,
             artifact_vault=vault,
             queue=AsyncMock(),
@@ -478,7 +478,7 @@ class TestPlanOnlyCyclesUnaffected:
 
     async def test_plan_only_cycle_no_build_validation(self):
         """Plan-only cycle doesn't trigger build-only validation."""
-        from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
         cycle = Cycle(
             cycle_id="cyc_001",
@@ -553,7 +553,7 @@ class TestPlanOnlyCyclesUnaffected:
             )
         )
 
-        ex = DistributedFlowExecutor(
+        ex = DispatchedFlowExecutor(
             cycle_registry=registry,
             artifact_vault=vault,
             queue=queue,

--- a/tests/unit/cycles/test_executor_checkpoint.py
+++ b/tests/unit/cycles/test_executor_checkpoint.py
@@ -188,10 +188,10 @@ def mock_event_bus():
 
 @pytest.fixture
 def executor(mock_registry, mock_vault, mock_queue, mock_squad_profile, impl_cycle, mock_event_bus):
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     mock_registry.get_cycle.return_value = impl_cycle
-    return DistributedFlowExecutor(
+    return DispatchedFlowExecutor(
         cycle_registry=mock_registry,
         artifact_vault=mock_vault,
         queue=mock_queue,
@@ -214,7 +214,7 @@ class TestCheckpointOnSuccess:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -226,7 +226,7 @@ class TestCheckpointOnSuccess:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -242,7 +242,7 @@ class TestCheckpointOnSuccess:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -286,7 +286,7 @@ class TestCheckpointOnSuccess:
         mock_queue.consume.side_effect = fail_second
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -307,7 +307,7 @@ class TestCheckpointEvents:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -323,7 +323,7 @@ class TestCheckpointEvents:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -364,7 +364,7 @@ class TestResumeFromCheckpoint:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -387,7 +387,7 @@ class TestResumeFromCheckpoint:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -425,7 +425,7 @@ class TestResumeFromCheckpoint:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -455,7 +455,7 @@ class TestResumeFromCheckpoint:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -484,7 +484,7 @@ class TestResumeFromCheckpoint:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -500,7 +500,7 @@ class TestResumeFromCheckpoint:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -529,7 +529,7 @@ class TestTimeBudget:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -544,7 +544,7 @@ class TestTimeBudget:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -564,7 +564,7 @@ class TestTimeBudget:
         mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
@@ -589,12 +589,12 @@ class TestPausedHandler:
         self, executor, mock_registry, mock_queue, mock_event_bus
     ) -> None:
         """_PausedError in _execute_sequential → run PAUSED."""
-        from adapters.cycles.distributed_flow_executor import _PausedError
+        from adapters.cycles.dispatched_flow_executor import _PausedError
 
         with (
             patch.object(executor, "_execute_sequential", side_effect=_PausedError("blocked")),
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
         ):
@@ -609,12 +609,12 @@ class TestPausedHandler:
     async def test_paused_emits_run_paused_event(
         self, executor, mock_registry, mock_queue, mock_event_bus
     ) -> None:
-        from adapters.cycles.distributed_flow_executor import _PausedError
+        from adapters.cycles.dispatched_flow_executor import _PausedError
 
         with (
             patch.object(executor, "_execute_sequential", side_effect=_PausedError("blocked")),
             patch(
-                "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+                "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
                 new_callable=AsyncMock,
             ),
         ):

--- a/tests/unit/cycles/test_executor_plan_loading.py
+++ b/tests/unit/cycles/test_executor_plan_loading.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
 
 # ---------------------------------------------------------------------------
@@ -84,8 +84,8 @@ class _FakeDocArtifactRef:
 
 
 class TestLoadManifestForRun:
-    def _make_executor(self) -> DistributedFlowExecutor:
-        executor = DistributedFlowExecutor.__new__(DistributedFlowExecutor)
+    def _make_executor(self) -> DispatchedFlowExecutor:
+        executor = DispatchedFlowExecutor.__new__(DispatchedFlowExecutor)
         executor._artifact_vault = MagicMock()
         executor._artifact_vault.retrieve = AsyncMock()
         return executor
@@ -205,31 +205,31 @@ class TestLoadManifestForRun:
 class TestBuildArtifactFilterChaining:
     def test_dev_develop_filter_includes_prior_dev_develop(self):
         """development.develop must see artifacts from prior development.develop tasks."""
-        filt = DistributedFlowExecutor._BUILD_ARTIFACT_FILTER["development.develop"]
+        filt = DispatchedFlowExecutor._BUILD_ARTIFACT_FILTER["development.develop"]
         assert "development.develop" in filt["by_producing_task"]
 
     def test_dev_develop_filter_includes_planning_artifacts(self):
         """development.develop must also see strategy and design artifacts."""
-        filt = DistributedFlowExecutor._BUILD_ARTIFACT_FILTER["development.develop"]
+        filt = DispatchedFlowExecutor._BUILD_ARTIFACT_FILTER["development.develop"]
         assert "strategy.analyze_prd" in filt["by_producing_task"]
         assert "development.design" in filt["by_producing_task"]
 
     def test_qa_test_filter_includes_dev_develop(self):
         """qa.test must see artifacts from development.develop subtasks."""
-        filt = DistributedFlowExecutor._BUILD_ARTIFACT_FILTER["qa.test"]
+        filt = DispatchedFlowExecutor._BUILD_ARTIFACT_FILTER["qa.test"]
         assert "development.develop" in filt["by_producing_task"]
 
     def test_builder_assemble_unchanged(self):
         """builder.assemble filter should still work as before."""
-        filt = DistributedFlowExecutor._BUILD_ARTIFACT_FILTER["builder.assemble"]
+        filt = DispatchedFlowExecutor._BUILD_ARTIFACT_FILTER["builder.assemble"]
         assert "development.develop" in filt["by_producing_task"]
 
 
 class TestResolveArtifactContentsChaining:
     """Verify _resolve_artifact_contents chains dev→dev artifacts."""
 
-    def _make_executor(self) -> DistributedFlowExecutor:
-        executor = DistributedFlowExecutor.__new__(DistributedFlowExecutor)
+    def _make_executor(self) -> DispatchedFlowExecutor:
+        executor = DispatchedFlowExecutor.__new__(DispatchedFlowExecutor)
         executor._artifact_vault = MagicMock()
         executor._artifact_vault.retrieve = AsyncMock()
         return executor

--- a/tests/unit/cycles/test_flow_executor_factory.py
+++ b/tests/unit/cycles/test_flow_executor_factory.py
@@ -1,0 +1,31 @@
+"""Factory resolution for the flow executor.
+
+DistributedFlowExecutor was renamed to DispatchedFlowExecutor; the provider
+key is ``"dispatched"``.
+"""
+
+import pytest
+
+from adapters.cycles.factory import create_flow_executor
+
+pytestmark = pytest.mark.domain_cycles
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [
+        ("in_process", "InProcessFlowExecutor"),
+        ("dispatched", "DispatchedFlowExecutor"),
+    ],
+)
+def test_provider_key_resolves_to_expected_executor(provider, expected):
+    """Bug class: a regression in the factory's provider routing would send a
+    valid key to the wrong executor (or fail to construct), breaking cycle
+    execution wiring."""
+    executor = create_flow_executor(provider)
+    assert type(executor).__name__ == expected
+
+
+def test_unknown_provider_raises():
+    with pytest.raises(ValueError, match="Unknown flow executor provider"):
+        create_flow_executor("bogus")

--- a/tests/unit/cycles/test_handle_gate_decisions.py
+++ b/tests/unit/cycles/test_handle_gate_decisions.py
@@ -72,9 +72,9 @@ def mock_event_bus():
 
 @pytest.fixture
 def executor(mock_registry, mock_event_bus):
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
-    exec_ = DistributedFlowExecutor(
+    exec_ = DispatchedFlowExecutor(
         cycle_registry=mock_registry,
         artifact_vault=AsyncMock(),
         queue=AsyncMock(),
@@ -153,7 +153,7 @@ class TestHandleGateDecisions:
         self, executor, mock_registry, cycle
     ):
         """rejected → raises _ExecutionError."""
-        from adapters.cycles.distributed_flow_executor import _ExecutionError
+        from adapters.cycles.dispatched_flow_executor import _ExecutionError
 
         mock_registry.get_run.return_value = _run_with_gate_decision(
             GateDecisionValue.REJECTED, notes="not ready"
@@ -166,7 +166,7 @@ class TestHandleGateDecisions:
         self, executor, mock_registry, cycle
     ):
         """returned_for_revision → raises _ExecutionError explaining manual retry is needed."""
-        from adapters.cycles.distributed_flow_executor import _ExecutionError
+        from adapters.cycles.dispatched_flow_executor import _ExecutionError
 
         mock_registry.get_run.return_value = _run_with_gate_decision(
             GateDecisionValue.RETURNED_FOR_REVISION, notes="needs more detail"

--- a/tests/unit/cycles/test_outcome_routing.py
+++ b/tests/unit/cycles/test_outcome_routing.py
@@ -1,4 +1,4 @@
-"""Tests for SIP-0079 outcome routing in DistributedFlowExecutor.
+"""Tests for SIP-0079 outcome routing in DispatchedFlowExecutor.
 
 Covers TaskOutcome-based routing: RETRYABLE_FAILURE retries, SEMANTIC_FAILURE
 triggers correction, BLOCKED pauses, SUCCESS resets and checkpoints,
@@ -165,11 +165,11 @@ def run():
 
 @pytest.fixture
 def executor(mock_registry, mock_vault, mock_queue, mock_squad_profile, cycle, run):
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     mock_registry.get_cycle.return_value = cycle
     mock_registry.get_run.return_value = run
-    return DistributedFlowExecutor(
+    return DispatchedFlowExecutor(
         cycle_registry=mock_registry,
         artifact_vault=mock_vault,
         queue=mock_queue,
@@ -238,7 +238,7 @@ class TestRetryableFailure:
         mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -265,7 +265,7 @@ class TestRetryableFailure:
         mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -300,7 +300,7 @@ class TestSemanticFailure:
         mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -329,7 +329,7 @@ class TestBlockedOutcome:
         mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -351,7 +351,7 @@ class TestSuccessOutcome:
         mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, {})
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -367,7 +367,7 @@ class TestSuccessOutcome:
         mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -399,7 +399,7 @@ class TestNeedReplanFromContract:
         mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -424,7 +424,7 @@ class TestFallbackTable:
         mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -441,7 +441,7 @@ class TestFallbackTable:
         mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -472,7 +472,7 @@ class TestNeedsRepairOutcome:
         mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")

--- a/tests/unit/cycles/test_run_report.py
+++ b/tests/unit/cycles/test_run_report.py
@@ -90,14 +90,14 @@ def _make_plan(count: int = 3) -> list[TaskEnvelope]:
 
 @pytest.fixture
 def executor():
-    """Create a DistributedFlowExecutor with mocked ports."""
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    """Create a DispatchedFlowExecutor with mocked ports."""
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     vault = AsyncMock()
     vault.store = AsyncMock(side_effect=lambda ref, content: ref)
     registry = AsyncMock()
 
-    ex = DistributedFlowExecutor(
+    ex = DispatchedFlowExecutor(
         cycle_registry=registry,
         artifact_vault=vault,
         queue=AsyncMock(),

--- a/tests/unit/events/bridges/test_workflow_tracker_bridge.py
+++ b/tests/unit/events/bridges/test_workflow_tracker_bridge.py
@@ -2,7 +2,7 @@
 
 As of SIP-0087 the bridge handles only flow-level state transitions and
 terminal task-state transitions — task-run creation + RUNNING is done in
-``DistributedFlowExecutor._dispatch_task``. The bridge therefore expects
+``DispatchedFlowExecutor._dispatch_task``. The bridge therefore expects
 ``task_run_id`` to be carried in the event context for TASK_SUCCEEDED /
 TASK_FAILED events.
 """

--- a/tests/unit/events/test_drift_detection.py
+++ b/tests/unit/events/test_drift_detection.py
@@ -197,11 +197,11 @@ def cycle():
 def executor(
     mock_registry, mock_vault, mock_queue, mock_squad_profile, cycle, event_bus, collector
 ):
-    from adapters.cycles.distributed_flow_executor import DistributedFlowExecutor
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     event_bus.subscribe(collector)
     mock_registry.get_cycle.return_value = cycle
-    return DistributedFlowExecutor(
+    return DispatchedFlowExecutor(
         cycle_registry=mock_registry,
         artifact_vault=mock_vault,
         queue=mock_queue,
@@ -228,7 +228,7 @@ class TestHappyPathDrift:
         mock_queue.consume.side_effect = _make_queue_consume(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -260,7 +260,7 @@ class TestHappyPathDrift:
         mock_queue.consume.side_effect = _make_queue_consume(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -293,7 +293,7 @@ class TestTaskFailureDrift:
         mock_queue.consume.side_effect = _make_queue_consume(mock_queue, result_status="FAILED")
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -310,7 +310,7 @@ class TestTaskFailureDrift:
         mock_queue.consume.side_effect = _make_queue_consume(mock_queue, result_status="FAILED")
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
@@ -331,7 +331,7 @@ class TestTaskEventsMatchDispatches:
         mock_queue.consume.side_effect = _make_queue_consume(mock_queue)
 
         with patch(
-            "adapters.cycles.distributed_flow_executor.asyncio.sleep",
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")

--- a/tests/unit/events/test_event_emission.py
+++ b/tests/unit/events/test_event_emission.py
@@ -49,7 +49,7 @@ def _find_event_type_refs_in_file(filepath: Path) -> set[str]:
 
 
 # Source files that contain emit() calls
-_EXECUTOR_PATH = Path("adapters/cycles/distributed_flow_executor.py")
+_EXECUTOR_PATH = Path("adapters/cycles/dispatched_flow_executor.py")
 _CYCLES_ROUTE = Path("src/squadops/api/routes/cycles/cycles.py")
 _RUNS_ROUTE = Path("src/squadops/api/routes/cycles/runs.py")
 _ARTIFACTS_ROUTE = Path("src/squadops/api/routes/cycles/artifacts.py")

--- a/tests/unit/tasks/test_models_serialization.py
+++ b/tests/unit/tasks/test_models_serialization.py
@@ -1,7 +1,7 @@
 """Tests for TaskEnvelope / TaskResult JSON serialization round-trip.
 
 Verifies to_dict() and from_dict() preserve all fields across
-JSON transport (used by DistributedFlowExecutor).
+JSON transport (used by DispatchedFlowExecutor).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Why
`DistributedFlowExecutor` overpromised — it dispatches tasks to agent containers over RabbitMQ, not distributed in the multi-node sense. Fixes #82. Lands **ahead of SIP-0089 Phase 2**, which adds a reserve-buffer guard at the executor's dispatch chokepoint (per the §2.0 spike on #82).

## What changed
- **Class + file renamed** (`git mv`, history preserved): `distributed_flow_executor.py` → `dispatched_flow_executor.py`, plus the two dedicated test files. All ~95 code/test references updated.
- **Provider key is now `"dispatched"` — clean cut, no alias.** A codebase-wide search found **zero usages** of the old `"distributed"` key in code, config, `.env`, `instances.yaml`, compose, or bootstrap profiles — nothing in the wild selects it — so no backward-compat shim is warranted. `api/runtime/main.py` uses `"dispatched"`.
- **New factory tests** (`tests/unit/cycles/test_flow_executor_factory.py`): `in_process` and `dispatched` route to their respective executors; unknown provider raises. (`create_flow_executor` had no test before.)

## Deliberately out of scope
- **Decomposition (#151)** — independent; the §2.0 spike confirmed it is **not** a Phase 2 prerequisite (all dispatch funnels through one chokepoint).
- **Historical SIP records** under `sips/` keep the original name (point-in-time records).
- Pre-existing `C901` on `execute_run` is unchanged (decomposition territory).

## Verification
- Full `pytest tests/unit`: **4483 passed**, 0 failed.
- `ruff` clean; touched files formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)