### PR TITLE
fix(SIP-0093): plan-authoring brief handler retries + fence-stripping (PR 93.3 follow-on)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ data/
 # Bootstrap state (written by squadops CLI)
 .squadops/
 .claude/scheduled_tasks.lock
+.claude/worktrees/

--- a/config/squad-profiles.yaml
+++ b/config/squad-profiles.yaml
@@ -12,14 +12,14 @@ profiles:
 
   - profile_id: full-squad
     name: "Full Squad"
-    description: "All 5 agents with per-role models"
-    version: 1
+    description: "All 5 agents on qwen3.6:27b — uniform single-loaded-model on Spark, no swap overhead, max reasoning depth at 16 tps ceiling"
+    version: 2
     agents:
-      - { agent_id: max, role: lead, model: "qwen2.5:32b", enabled: true }
-      - { agent_id: neo, role: dev, model: "qwen2.5:7b", enabled: true }
-      - { agent_id: nat, role: strat, model: "qwen2.5:7b", enabled: true }
-      - { agent_id: eve, role: qa, model: "qwen2.5:3b-instruct", enabled: true }
-      - { agent_id: data, role: data, model: "qwen2.5:3b-instruct", enabled: true }
+      - { agent_id: max, role: lead, model: "qwen3.6:27b", enabled: true }
+      - { agent_id: neo, role: dev, model: "qwen3.6:27b", enabled: true }
+      - { agent_id: nat, role: strat, model: "qwen3.6:27b", enabled: true }
+      - { agent_id: eve, role: qa, model: "qwen3.6:27b", enabled: true }
+      - { agent_id: data, role: data, model: "qwen3.6:27b", enabled: true }
 
   - profile_id: full-squad-with-builder
     name: "Full Squad with Builder"

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -502,6 +502,9 @@ class GovernanceReviewPlanHandler(_PlanningTaskHandler):
         return result
 
 
+_BRIEF_MAX_ATTEMPTS_DEFAULT = 2
+
+
 class GovernancePreparePlanAuthoringBriefHandler(_PlanningTaskHandler):
     """SIP-0093 PR 93.0: produce ``plan_authoring_brief.yaml``.
 
@@ -510,9 +513,10 @@ class GovernancePreparePlanAuthoringBriefHandler(_PlanningTaskHandler):
     frame. The merger consumes it (RC-22 immutability) regardless of whether
     proposers ran or sole-author mode kicks in.
 
-    Registered in this PR but **not** wired into ``PLANNING_TASK_STEPS`` —
-    that's the cutover PR (93.3). The handler is reachable in tests and via
-    direct invocation only.
+    Runs an LLM call with up to ``brief_max_attempts`` retries; each attempt's
+    raw response is fence-stripped via ``retry_yaml_call`` before
+    ``PlanAuthoringBrief.from_yaml`` validates it. Mirrors the proposer
+    handlers in this module.
     """
 
     _handler_name = "governance_prepare_plan_authoring_brief_handler"
@@ -525,42 +529,112 @@ class GovernancePreparePlanAuthoringBriefHandler(_PlanningTaskHandler):
         context: ExecutionContext,
         inputs: dict[str, Any],
     ) -> HandlerResult:
-        result = await super().handle(context, inputs)
-        if not result.success:
-            return result
-
-        # Override the artifact shape produced by the base — the brief is YAML,
-        # not markdown — and validate that the LLM emitted a parseable brief.
+        from squadops.capabilities.handlers._plan_authoring import retry_yaml_call
         from squadops.cycles.plan_authoring_brief import PlanAuthoringBrief
 
-        artifact = result.outputs["artifacts"][0]
-        artifact["media_type"] = "text/yaml"
-        artifact["type"] = "plan_authoring_brief"
+        start_time = time.perf_counter()
 
-        try:
-            PlanAuthoringBrief.from_yaml(artifact["content"])
-        except ValueError as exc:
-            logger.warning(
-                "%s: LLM produced an unparseable brief: %s",
-                self._handler_name,
-                exc,
+        prd = inputs.get("prd", "")
+        prior_outputs = inputs.get("prior_outputs")
+        resolved_config = inputs.get("resolved_config", {})
+        raw_budget = resolved_config.get("time_budget_seconds")
+        time_budget_seconds = int(raw_budget) if raw_budget is not None else None
+
+        renderer = getattr(context.ports, "request_renderer", None)
+        if renderer is not None:
+            variables = self._build_render_variables(prd, prior_outputs, inputs)
+            rendered = await renderer.render(self._request_template_id, variables)
+            user_prompt = rendered.content
+        else:
+            user_prompt = self._build_user_prompt(prd, prior_outputs, time_budget_seconds)
+
+        assembled = context.ports.prompt_service.assemble(
+            role=self._role,
+            hook="agent_start",
+            task_type=self._capability_id,
+        )
+        system_prompt = assembled.content
+
+        max_attempts = int(
+            resolved_config.get("brief_max_attempts", _BRIEF_MAX_ATTEMPTS_DEFAULT)
+        )
+        chat_kwargs = self._build_chat_kwargs(inputs)
+
+        def parse_and_validate(
+            yaml_or_none: str | None,
+        ) -> tuple[Any | None, str | None]:
+            if yaml_or_none is None:
+                return None, (
+                    "No YAML brief found. Emit your output as a fenced block: "
+                    "```yaml:plan_authoring_brief.yaml ... ``` (or ```yaml ... ```)."
+                )
+            try:
+                brief = PlanAuthoringBrief.from_yaml(yaml_or_none)
+            except ValueError as exc:
+                return None, f"plan_authoring_brief.yaml failed to parse: {exc}"
+            return brief, None
+
+        parsed, last_yaml, last_error = await retry_yaml_call(
+            llm=context.ports.llm,
+            chat_kwargs=chat_kwargs,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            parse_and_validate=parse_and_validate,
+            max_attempts=max_attempts,
+            handler_name=self._handler_name,
+        )
+
+        duration_ms = (time.perf_counter() - start_time) * 1000
+
+        if parsed is None:
+            evidence = HandlerEvidence.create(
+                handler_name=self._handler_name,
+                capability_id=self._capability_id,
+                duration_ms=duration_ms,
+                inputs_hash=self._hash_dict(inputs),
             )
             return HandlerResult(
                 success=False,
                 outputs={},
-                _evidence=result._evidence,
-                error=f"plan_authoring_brief.yaml failed to parse: {exc}",
+                _evidence=evidence,
+                error=(
+                    f"plan_authoring_brief.yaml failed to parse: "
+                    f"{last_error or 'exhausted retry budget without parseable output'}"
+                ),
             )
 
-        # PR 93.3 wire: surface the brief YAML in a non-artifacts key so the
-        # merger can consume it from prior_outputs["lead"]["brief_outcome"].
-        # The executor's prior_outputs builder strips "artifacts" by design.
-        result.outputs["brief_outcome"] = {
-            "status": "success",
-            "yaml_content": artifact["content"],
-            "artifact_name": "plan_authoring_brief.yaml",
+        # ``last_yaml`` is the fence-extracted body; persist that as the
+        # artifact content so downstream callers (merger, gate package) get
+        # raw YAML without code-fence wrappers.
+        assert last_yaml is not None  # invariant: parsed is not None → yaml was extracted
+        outputs = {
+            "summary": f"[{self._role}] plan_authoring_brief produced",
+            "role": self._role,
+            "artifacts": [
+                {
+                    "name": self._artifact_name,
+                    "content": last_yaml,
+                    "media_type": "text/yaml",
+                    "type": "plan_authoring_brief",
+                },
+            ],
+            # PR 93.3 wire: surface the brief YAML in a non-artifacts key so
+            # the merger can consume it from prior_outputs["lead"]["brief_outcome"].
+            # The executor's prior_outputs builder strips "artifacts" by design.
+            "brief_outcome": {
+                "status": "success",
+                "yaml_content": last_yaml,
+                "artifact_name": self._artifact_name,
+            },
         }
-        return result
+        evidence = HandlerEvidence.create(
+            handler_name=self._handler_name,
+            capability_id=self._capability_id,
+            duration_ms=duration_ms,
+            inputs_hash=self._hash_dict(inputs),
+            outputs_hash=self._hash_dict(outputs),
+        )
+        return HandlerResult(success=True, outputs=outputs, _evidence=evidence)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/capabilities/test_prepare_plan_authoring_brief.py
+++ b/tests/unit/capabilities/test_prepare_plan_authoring_brief.py
@@ -1,9 +1,9 @@
 """Tests for ``GovernancePreparePlanAuthoringBriefHandler`` (SIP-0093 PR 93.0).
 
-The handler is registered in this PR but not yet wired into
-``PLANNING_TASK_STEPS`` (cutover happens in 93.3). These tests exercise it
-in isolation: brief production from seeded LLM responses, parse-failure
-handling, and the artifact's YAML media-type / type.
+The handler runs an LLM call with ``retry_yaml_call`` (mirroring the proposer
+handlers): each attempt is fence-stripped before ``PlanAuthoringBrief.from_yaml``
+validates it. These tests exercise the success path, the fence-stripping that
+production LLMs require, retry-then-succeed, and exhaustion failure modes.
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ from squadops.cycles.plan_authoring_brief import PlanAuthoringBrief
 pytestmark = [pytest.mark.domain_capabilities]
 
 
-_VALID_BRIEF_LLM_RESPONSE = """\
+_VALID_BRIEF_YAML = """\
 version: 1
 brief_id: br_seeded_001
 objective_summary: |
@@ -39,10 +39,30 @@ risk_areas:
   - "Concurrent create/delete races"
 """
 
+# Production-shape LLM response: YAML inside a typed fence. This is the form
+# qwen3:27b actually emits (and the form that broke the cycle before the
+# retry/fence-strip wiring).
+_VALID_BRIEF_FENCED_RESPONSE = (
+    "Here's the brief.\n\n"
+    "```yaml:plan_authoring_brief.yaml\n"
+    f"{_VALID_BRIEF_YAML}"
+    "```\n"
+)
 
-def _make_context(llm_response: str = _VALID_BRIEF_LLM_RESPONSE):
+
+def _make_context(llm_response: str | list[str] = _VALID_BRIEF_FENCED_RESPONSE):
+    """Build a stub ExecutionContext.
+
+    ``llm_response`` accepts a string (returned every call) or a list of
+    strings (consumed one per call, for retry tests).
+    """
     llm = AsyncMock()
-    llm.chat_stream_with_usage.return_value = MagicMock(content=llm_response)
+    if isinstance(llm_response, list):
+        llm.chat_stream_with_usage.side_effect = [
+            MagicMock(content=r) for r in llm_response
+        ]
+    else:
+        llm.chat_stream_with_usage.return_value = MagicMock(content=llm_response)
     llm.default_model = "test-model"
 
     prompt_service = MagicMock()
@@ -80,11 +100,6 @@ def seeded_inputs():
     }
 
 
-# ---------------------------------------------------------------------------
-# Class attributes (kept tight per CLAUDE.md guidance — paired with behavior tests)
-# ---------------------------------------------------------------------------
-
-
 def test_handler_registered_in_bootstrap():
     """Without registration the cutover PR (93.3) couldn't dispatch the
     handler. Confirms the import + HANDLER_CONFIGS entry both landed."""
@@ -93,24 +108,25 @@ def test_handler_registered_in_bootstrap():
 
 
 # ---------------------------------------------------------------------------
-# Behavior
+# Success: fenced output is the production shape; bare YAML inside a typed
+# fence (``yaml:plan_authoring_brief.yaml``) is what real LLMs emit and what
+# broke the cycle pre-fix.
 # ---------------------------------------------------------------------------
 
 
-async def test_handler_produces_parseable_brief_artifact(seeded_inputs):
-    """A seeded LLM response produces an artifact that parses round-trip
-    via ``PlanAuthoringBrief.from_yaml``."""
+async def test_handler_extracts_yaml_from_typed_fence(seeded_inputs):
+    """The LLM wraps YAML in ```yaml:plan_authoring_brief.yaml``` — the
+    artifact's stored content must be the unwrapped YAML (no leading fence
+    line) so downstream callers can ``from_yaml`` it directly."""
     handler = GovernancePreparePlanAuthoringBriefHandler()
     result = await handler.handle(_make_context(), seeded_inputs)
 
     assert result.success is True
-    artifacts = result.outputs["artifacts"]
-    assert len(artifacts) == 1
-
-    artifact = artifacts[0]
+    artifact = result.outputs["artifacts"][0]
     assert artifact["name"] == "plan_authoring_brief.yaml"
     assert artifact["media_type"] == "text/yaml"
     assert artifact["type"] == "plan_authoring_brief"
+    assert not artifact["content"].startswith("```")
 
     brief = PlanAuthoringBrief.from_yaml(artifact["content"])
     assert brief.brief_id == "br_seeded_001"
@@ -120,28 +136,84 @@ async def test_handler_produces_parseable_brief_artifact(seeded_inputs):
     ]
     assert brief.accepted_stack["framework"] == "fastapi"
 
+    # brief_outcome carries the same unwrapped content for the merger.
+    assert result.outputs["brief_outcome"]["status"] == "success"
+    assert result.outputs["brief_outcome"]["yaml_content"] == artifact["content"]
 
-async def test_handler_returns_failure_on_unparseable_llm_response(seeded_inputs):
-    """When the LLM emits something that can't parse as a brief, the
-    handler returns a structured failure naming ``plan_authoring_brief.yaml``
-    so the cycle's correction loop has a specific signal — not a silent
-    pass with garbage content."""
-    bad_response = "This isn't a YAML brief — just prose.\n"
+
+async def test_handler_extracts_yaml_from_bare_yaml_fence(seeded_inputs):
+    """LLMs sometimes drop the filename slot and emit just ```yaml``` —
+    the handler must still extract the body."""
+    bare_fenced = f"```yaml\n{_VALID_BRIEF_YAML}```\n"
     handler = GovernancePreparePlanAuthoringBriefHandler()
-    result = await handler.handle(_make_context(llm_response=bad_response), seeded_inputs)
+    result = await handler.handle(_make_context(llm_response=bare_fenced), seeded_inputs)
+
+    assert result.success is True
+    brief = PlanAuthoringBrief.from_yaml(result.outputs["artifacts"][0]["content"])
+    assert brief.brief_id == "br_seeded_001"
+
+
+# ---------------------------------------------------------------------------
+# Retry: a malformed first attempt followed by a valid second attempt should
+# succeed without the cycle seeing the failure.
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_retries_after_unparseable_first_attempt(seeded_inputs):
+    """First attempt: prose, no fenced YAML → retry. Second attempt: valid
+    fenced brief → success. Confirms retry budget actually buys recovery."""
+    responses = [
+        "I forgot to fence the YAML, sorry.",
+        _VALID_BRIEF_FENCED_RESPONSE,
+    ]
+    ctx = _make_context(llm_response=responses)
+    handler = GovernancePreparePlanAuthoringBriefHandler()
+    result = await handler.handle(ctx, seeded_inputs)
+
+    assert result.success is True
+    assert ctx.ports.llm.chat_stream_with_usage.call_count == 2
+    brief = PlanAuthoringBrief.from_yaml(result.outputs["artifacts"][0]["content"])
+    assert brief.brief_id == "br_seeded_001"
+
+
+async def test_handler_respects_configured_max_attempts(seeded_inputs):
+    """``brief_max_attempts`` from resolved_config caps retries. Setting it
+    to 1 means a single bad emission is terminal."""
+    seeded_inputs["resolved_config"]["brief_max_attempts"] = 1
+    ctx = _make_context(llm_response="not yaml at all")
+    handler = GovernancePreparePlanAuthoringBriefHandler()
+    result = await handler.handle(ctx, seeded_inputs)
+
+    assert result.success is False
+    assert ctx.ports.llm.chat_stream_with_usage.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Hard failures: the retry budget runs out, or the LLM call itself fails.
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_returns_failure_when_no_fenced_yaml_in_any_attempt(seeded_inputs):
+    """When every attempt emits prose with no fenced YAML, the handler
+    returns ``success=False`` naming the artifact so the cycle's
+    correction loop has a specific signal (not silent garbage)."""
+    handler = GovernancePreparePlanAuthoringBriefHandler()
+    result = await handler.handle(
+        _make_context(llm_response="This isn't a YAML brief — just prose.\n"),
+        seeded_inputs,
+    )
 
     assert result.success is False
     assert result.outputs == {}
     assert "plan_authoring_brief.yaml" in (result.error or "")
 
 
-async def test_handler_returns_failure_on_missing_required_field(seeded_inputs):
-    """A YAML response missing a required brief field surfaces the field
-    name in the failure error, not just a generic 'parse error'."""
+async def test_handler_returns_failure_when_brief_missing_required_field(seeded_inputs):
+    """YAML parses but omits a required field. The error surfaces the
+    field name (``risk_areas``) so the corrective feedback is actionable."""
     missing_risk_areas = "\n".join(
-        line for line in _VALID_BRIEF_LLM_RESPONSE.splitlines() if not line.startswith("risk_areas")
+        line for line in _VALID_BRIEF_YAML.splitlines() if not line.startswith("risk_areas")
     )
-    # Drop the bullet list under risk_areas too.
     missing_risk_areas = (
         "\n".join(
             line
@@ -150,18 +222,22 @@ async def test_handler_returns_failure_on_missing_required_field(seeded_inputs):
         )
         + "\n"
     )
-
+    fenced_response = f"```yaml:plan_authoring_brief.yaml\n{missing_risk_areas}```\n"
     handler = GovernancePreparePlanAuthoringBriefHandler()
-    result = await handler.handle(_make_context(llm_response=missing_risk_areas), seeded_inputs)
+    result = await handler.handle(
+        _make_context(llm_response=fenced_response), seeded_inputs
+    )
 
     assert result.success is False
     assert "risk_areas" in (result.error or "")
 
 
-async def test_handler_propagates_llm_failure_without_attempting_parse(seeded_inputs):
-    """If the underlying LLM call fails (network/timeout), the base
-    handler's failure surfaces unchanged — the brief-parse step never
-    runs and doesn't mask the real error."""
+async def test_handler_returns_failure_on_llm_error(seeded_inputs):
+    """If the LLM call itself raises (network/timeout), the handler
+    returns a structured failure. The retry loop swallows the LLMError
+    on each attempt, so the surfaced error is the retry-exhausted form
+    rather than the raw exception — but the artifact name is still in it
+    so the cycle can route correctly."""
     from squadops.llm.exceptions import LLMError
 
     ctx = _make_context()
@@ -171,6 +247,5 @@ async def test_handler_propagates_llm_failure_without_attempting_parse(seeded_in
     result = await handler.handle(ctx, seeded_inputs)
 
     assert result.success is False
-    # Surfaced as the LLM error, not a brief-parse error.
+    assert "plan_authoring_brief.yaml" in (result.error or "")
     assert "network timeout" in (result.error or "")
-    assert "plan_authoring_brief.yaml" not in (result.error or "")


### PR DESCRIPTION
## Summary

Follow-on fixes for SIP-0093 (Multi-Role Plan Authoring), riding on top of the already-merged PR 3 cutover (#145).

- **`fix(SIP-0093)`** — brief handler retries + fence-stripping in `planning_tasks.py`, so the plan-authoring brief survives transient LLM failures and strips code-fence wrappers from model output.
- **`chore(squad-profiles)`** — `full-squad` profile now runs on a uniform `qwen3.6:27b` across roles.
- **`chore`** — gitignore `.claude/worktrees/` (agent scratch checkouts).

## Testing

`pytest tests/unit/capabilities/` → **1053 passed**. Branch is based on current `main` (includes SIP-0089 phase 1 and the `DispatchedFlowExecutor` rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)