### PR TITLE
chore(SIP-0092): wire ruff into regression as fail-stop + clear lint debt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,20 @@ max-complexity = 12
 "tests/**" = [
   "B",
 ]
+# SIP-0092 M1 follow-up: ruff was wired into regression at the same time
+# as the cycle_tasks.py complexity cleanup. The functions listed below
+# were already over the C901=12 budget when the gate landed; they are
+# tracked as follow-up cleanup rather than blocking that PR. Newly
+# added code in any file (including these) is still gated.
+"adapters/cycles/distributed_flow_executor.py" = ["C901"]
+"scripts/dev/lint_realm_exports.py" = ["C901"]
+"scripts/maintainer/audit_sip_registry.py" = ["C901"]
+"scripts/maintainer/cleanup_sip_registry.py" = ["C901"]
+"scripts/maintainer/update_sip_status.py" = ["C901"]
+"src/squadops/cycles/acceptance_checks.py" = ["C901"]
+"src/squadops/cycles/implementation_plan.py" = ["C901"]
+"tests/integration/test_agent_model_validation.py" = ["C901"]
+"tests/unit/config/test_secrets_enforcement.py" = ["C901"]
 
 ##########################
 # Black - Code formatter #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,12 +65,14 @@ max-complexity = 12
 "tests/**" = [
   "B",
 ]
-# SIP-0092 M1 follow-up: ruff was wired into regression at the same time
-# as the cycle_tasks.py complexity cleanup. The functions listed below
-# were already over the C901=12 budget when the gate landed; they are
-# tracked as follow-up cleanup rather than blocking that PR. Newly
-# added code in any file (including these) is still gated.
-"adapters/cycles/distributed_flow_executor.py" = ["C901"]
+# SIP-0092 M1 follow-up: ruff is wired into regression as a fail-stop. The
+# functions in the files listed below were already over the C901=12 budget
+# when the gate landed; they are tracked as follow-up cleanup (the
+# cycle_tasks.py handle() decomposition is deferred to its own PR) rather
+# than blocking the gate. Newly added code in any file (including these)
+# is still gated.
+"adapters/cycles/dispatched_flow_executor.py" = ["C901"]
+"src/squadops/capabilities/handlers/cycle_tasks.py" = ["C901"]
 "scripts/dev/lint_realm_exports.py" = ["C901"]
 "scripts/maintainer/audit_sip_registry.py" = ["C901"]
 "scripts/maintainer/cleanup_sip_registry.py" = ["C901"]

--- a/scripts/dev/run_regression_tests.sh
+++ b/scripts/dev/run_regression_tests.sh
@@ -30,6 +30,10 @@ REGRESSION_DIRS=(
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+echo "Running ruff lint (fail-stop)..."
+ruff check .
+echo ""
+
 echo "Running test quality lint..."
 python "$SCRIPT_DIR/lint_test_quality.py" "${REGRESSION_DIRS[@]}"
 echo ""

--- a/src/squadops/capabilities/handlers/impl/_json_extraction.py
+++ b/src/squadops/capabilities/handlers/impl/_json_extraction.py
@@ -33,7 +33,6 @@ import json
 import re
 from typing import Any
 
-
 _THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
 
 

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -655,7 +655,7 @@ class CommandExitZeroCheck(BaseCheck):
 
         try:
             stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             proc.kill()
             try:
                 await proc.wait()

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -19,7 +19,6 @@ import dataclasses
 import hashlib
 import json
 from dataclasses import dataclass, field
-from typing import Union
 
 import yaml
 
@@ -28,7 +27,6 @@ from squadops.cycles.acceptance_check_spec import (
     CHECK_SPECS,
     reserved_keys_for,
 )
-
 
 # Known task types that may appear in plan tasks.
 _KNOWN_BUILD_TASK_TYPES = {
@@ -92,7 +90,7 @@ class PlanTask:
     # Mixed list: prose strings stay informational; TypedCheck instances are
     # machine-evaluated by the M1.2 framework. The parser normalizes flat-YAML
     # typed entries into TypedCheck (see ImplementationPlan.from_yaml).
-    acceptance_criteria: list[Union[str, TypedCheck]] = field(default_factory=list)
+    acceptance_criteria: list[str | TypedCheck] = field(default_factory=list)
     depends_on: list[int] = field(default_factory=list)
 
 
@@ -260,7 +258,7 @@ class ImplementationPlan:
         canonical-hashing helper SIP-0092 M3 introduces.
         """
         result = dataclasses.asdict(self)
-        for task_dict, task in zip(result["tasks"], self.tasks):
+        for task_dict, task in zip(result["tasks"], self.tasks, strict=True):
             task_dict["acceptance_criteria"] = [
                 _serialize_acceptance_criterion(c) for c in task.acceptance_criteria
             ]
@@ -293,7 +291,7 @@ def _check_dependency_dag(tasks: list[PlanTask]) -> None:
         _visit(task.task_index)
 
 
-def _serialize_acceptance_criterion(c: Union[str, TypedCheck]) -> Union[str, dict]:
+def _serialize_acceptance_criterion(c: str | TypedCheck) -> str | dict:
     """Inverse of the parser's flat-YAML normalization.
 
     str entries pass through unchanged. TypedCheck entries become flat dicts
@@ -312,7 +310,7 @@ def _serialize_acceptance_criterion(c: Union[str, TypedCheck]) -> Union[str, dic
 
 def _parse_acceptance_criteria(
     raw: list, task_index: int
-) -> list[Union[str, TypedCheck]]:
+) -> list[str | TypedCheck]:
     """Parse a mixed acceptance_criteria list per SIP-0092 M1.
 
     Accepts:
@@ -333,7 +331,7 @@ def _parse_acceptance_criteria(
     Returns:
         Mixed list of str and TypedCheck instances, preserving authored order.
     """
-    parsed: list[Union[str, TypedCheck]] = []
+    parsed: list[str | TypedCheck] = []
     for j, item in enumerate(raw):
         if isinstance(item, str):
             parsed.append(item)

--- a/tests/unit/capabilities/handlers/test_focused_prompts.py
+++ b/tests/unit/capabilities/handlers/test_focused_prompts.py
@@ -4,13 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from squadops.capabilities.handlers.cycle_tasks import (
     DevelopmentDevelopHandler,
     QATestHandler,
 )
-
 
 # ---------------------------------------------------------------------------
 # DevelopmentDevelopHandler focused prompt (Phase 4a)

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -9,7 +9,6 @@ Coverage:
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
@@ -501,7 +500,6 @@ class TestCommandExitZero:
 
     async def test_timeout_clamped_below_max(self, tmp_path, monkeypatch):
         # Verify the clamp logic works without invoking a real long process.
-        from squadops.cycles import acceptance_checks as ac
 
         captured: dict = {}
 

--- a/tests/unit/cycles/test_executor_plan_loading.py
+++ b/tests/unit/cycles/test_executor_plan_loading.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
-
 
 # ---------------------------------------------------------------------------
 # Lightweight fakes

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -9,7 +9,6 @@ import pytest
 from squadops.cycles.acceptance_check_spec import CHECK_SPECS
 from squadops.cycles.implementation_plan import ImplementationPlan, TypedCheck
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import pytest
+from datetime import UTC, datetime
 
-from datetime import datetime, timezone
+import pytest
 
 from squadops.cycles.implementation_plan import ImplementationPlan
 from squadops.cycles.models import (
@@ -16,7 +16,7 @@ from squadops.cycles.models import (
 )
 from squadops.cycles.task_plan import generate_task_plan
 
-NOW = datetime(2026, 3, 31, tzinfo=timezone.utc)
+NOW = datetime(2026, 3, 31, tzinfo=UTC)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Salvages the safe, still-wanted half of the (now-closed) PR #166, re-applied cleanly against current `main`. The `handle()` decomposition from that branch was stale against ~12 main-side fixes to `cycle_tasks.py` and is deferred to its own PR (see below).

- **`ruff` fail-stop** — `scripts/dev/run_regression_tests.sh` now runs `ruff check .` before tests, so lint debt can't accumulate silently (cherry-picked clean from the closed branch).
- **Fresh repo-wide `ruff check --fix`** against current main: import sorting, `datetime.UTC` alias, `asyncio.TimeoutError` → `TimeoutError`, explicit `zip(..., strict=True)`.
- **Refreshed C901 tracked-debt ignore list**: updated for the `DistributedFlowExecutor` → `DispatchedFlowExecutor` rename (#164), and added `cycle_tasks.py` since its `handle()` decomposition is deferred.

## Deferred (follow-up)

The `cycle_tasks.py` `handle()` decomposition + typed-acceptance extraction from PR #166 is still wanted but must be **re-authored against current main** — the original was written before #83/#114/RC-9b and other typed-acceptance fixes landed, so rebasing it would have regressed them. Tracked via the `C901` ignore entry on `cycle_tasks.py`.

## Testing

`./scripts/dev/run_regression_tests.sh` → **3992 passed, 1 skipped**; `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)