### PR TITLE
chore(cycles): finish DispatchedFlowExecutor rename in docstrings + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ squadops artifacts list <run-id>           # List artifacts for run
   - `secrets/` - env, file, docker_secret providers
   - `comms/` - RabbitMQ adapter
   - `persistence/` - PostgreSQL runtime with connection pooling
-  - `cycles/` - DistributedFlowExecutor, MemoryCycleRegistry, PostgresCycleRegistry, factory
+  - `cycles/` - DispatchedFlowExecutor, MemoryCycleRegistry, PostgresCycleRegistry, factory
   - `telemetry/` - LangFuse adapter (buffered, with redaction) and factory
   - `auth/` - Keycloak adapter, JWT middleware
   - `llm/` - Ollama adapter

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Comprehensive documentation and protocols are available in `/docs/`:
 ├── secrets/          # env, file, docker_secret providers
 ├── comms/            # RabbitMQ adapter
 ├── persistence/      # PostgreSQL runtime
-├── cycles/           # DistributedFlowExecutor, MemoryCycleRegistry, PostgresCycleRegistry
+├── cycles/           # DispatchedFlowExecutor, MemoryCycleRegistry, PostgresCycleRegistry
 ├── telemetry/        # LangFuse adapter with buffering, flush, redaction
 ├── auth/             # Keycloak adapter, JWT middleware
 ├── capabilities/     # Filesystem repository, ACI executor

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 ### Cycle Execution Pipeline (SIP-0064/0066/0068/0076–0080/0083)
 - **Cycle API** – Create, monitor, and manage execution cycles via REST API
 - **Task Planning** – Automatic task plan generation from PRD references
-- **Distributed Flow Executor** – Sequential task dispatch to agent containers via RabbitMQ
+- **Dispatched Flow Executor** – Sequential task dispatch to agent containers via RabbitMQ
 - **Gate Decisions** – Human-in-the-loop approval gates between pipeline stages
 - **Artifact Management** – Typed artifact ingestion and retrieval per run with promotion model
 - **Build Capabilities** – Agents produce executable source code, tests, and config from plans (SIP-0068)

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1,5 +1,5 @@
 """
-Distributed flow executor adapter.
+Dispatched flow executor adapter.
 
 Dispatches cycle tasks to agent containers via RabbitMQ instead of
 executing them in-process.  Each agent handles its own task using

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -209,7 +209,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             flow_ctx = CorrelationContext(cycle_id=cycle_id, flow_run_id=flow_run_id)
             with use_correlation_context(flow_ctx):
                 logger.info(
-                    "Executing run %s for cycle %s (%d tasks, mode=%s, dispatch=distributed)",
+                    "Executing run %s for cycle %s (%d tasks, mode=%s, dispatch=dispatched)",
                     run_id,
                     cycle_id,
                     len(plan),
@@ -1711,7 +1711,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 obs_ctx,
                 StructuredEvent(
                     name="cycle.started",
-                    message=f"Cycle {cycle_id} started ({len(plan)} tasks, distributed)",
+                    message=f"Cycle {cycle_id} started ({len(plan)} tasks, dispatched)",
                 ),
             )
 

--- a/src/squadops/ports/cycles/workflow_tracker.py
+++ b/src/squadops/ports/cycles/workflow_tracker.py
@@ -1,6 +1,6 @@
 """WorkflowTrackerPort — per-task workflow tracking abstraction.
 
-Used by the distributed flow executor and the cycle event bridges to record
+Used by the dispatched flow executor and the cycle event bridges to record
 flow runs, task runs, and their state transitions on an external workflow UI
 (today: Prefect; tomorrow: anything else with a comparable concept).
 


### PR DESCRIPTION
## Summary
Follow-up to PR #164 (`c185d14`), which renamed `DistributedFlowExecutor` → `DispatchedFlowExecutor` and `distributed_flow_executor.py` → `dispatched_flow_executor.py`. The symbol rename was functionally complete (no Python identifier/import referenced the old class), but stale `Distributed` references survived in docstrings, living docs, and runtime strings. This PR clears them — strings/comments/markdown only, **zero logic**.

## Changes
**Commit 1 — docstrings + living docs**
- `adapters/cycles/dispatched_flow_executor.py` — module docstring title
- `src/squadops/ports/cycles/workflow_tracker.py` — port docstring prose
- `CLAUDE.md`, `README.md:108` — architecture sections

**Commit 2 — cross-terminal audit follow-up** (a case-insensitive re-audit caught what the token-scoped first pass missed)
- `README.md:35` — "Distributed Flow Executor" prose heading (a CamelCase/snake grep can't match prose)
- `dispatched_flow_executor.py` — log line `dispatch=distributed` and the `cycle.started` event message now read `dispatched`, matching the canonical mode word the codebase already uses (class, filename, **and** factory provider key `create_flow_executor("dispatched")`). Initially kept as topology descriptors; the factory-key evidence shows the project settled on "dispatched" for this mode, so consistency wins.

## Deliberately left (describe the system, not the class — avoids over-correction)
- "Distributed Execution" / "distributed cycle execution pipeline" prose (`README` L6/25/176/182/194) — topology/capability description
- **SIP-0066 "Distributed Cycle Execution Pipeline"** proper name (`CLAUDE.md:180`, `ROADMAP`, `README`)
- "Distributed tracing" (OpenTelemetry term) in `telemetry/`, `core/lineage.py`, `ports/telemetry/`
- The explainer comment in `tests/unit/cycles/test_flow_executor_factory.py` that documents the rename

## Out of scope → tracked in #168
Forward-looking `docs/plans/SIP-*-plan.md` references, plus a **broken doc example** surfaced by the audit (`docs/reviews/continuum-control-plane-context.md:437` calls `create_flow_executor("distributed")`, which now raises `ValueError` since the provider key is `"dispatched"`). Structural decomposition of the executor is #151.

## Test
Ruff clean on changed files. No test asserts on the changed log/event strings. No behavior change — strings/markdown only.
