### PR TITLE
docs: v1.1 runtime track roadmap (MacBook lane)

### DIFF
--- a/docs/plans/v1.1-runtime-track-roadmap.md
+++ b/docs/plans/v1.1-runtime-track-roadmap.md
@@ -1,0 +1,65 @@
+# v1.1 Runtime Track — Roadmap (MacBook lane / `track:macbook`)
+
+**Status:** Active — SIP-0089 Phase 1 merged (PR #147); Phase 2 next.
+**Scope:** v1.1 runtime work. This is the counterpart to the Spark lane's
+`1-0-x-build-reliability-hardening-plan.md`. The two run in parallel and are
+**orthogonal** — this lane builds features on the runtime substrate; the Spark
+lane does 1.0.x hardening.
+**Label:** issues/PRs in this lane carry `track:macbook`.
+
+## What this lane is — and is NOT
+
+Agent **runtime state and operating modes**:
+`RuntimeMode = Literal["duty", "cycle", "ambient"]` — *when* an agent does
+scheduled duty work vs. runs in a bounded cycle vs. idles in ambient presence —
+plus assignments, duty windows, focus leases, and RuntimeActivity. It is a
+coordination / state layer.
+
+- **NOT "multi-modal"** (input modalities like text/image/audio). The "modes"
+  word is not "modalities."
+- **NOT "multi-model"** (multiple LLM providers) and **NOT a "2.0" effort.**
+  This is **v1.1**. Model-independence is a separate, future vision item.
+
+## Two arcs
+
+### Runtime arc (the spine)
+
+| SIP | What | Status | Detail |
+|-----|------|--------|--------|
+| 0088 Agent Runtime Modes | Vision/index — the primitives everything attaches to ("why first: everything else depends on these") | accepted; vision doc, **realized by 0089** | `sips/accepted/SIP-0088-Agent-Runtime-Modes.md` |
+| **0089 Agent Runtime State** | The buildable core: modes, duty windows, focus, RuntimeActivity | **in progress** | `docs/plans/SIP-0089-agent-runtime-state-plan.md` |
+| 0090 Agent Embodiment Substrate | v1.2 candidate — depends on 0089, lands after | accepted, queued | `sips/accepted/SIP-0090-Agent-Embodiment-Substrate.md` |
+| 0091 Duty Durability via Temporal | v1.3 — depends on 0089; durable scheduler behind `DutyDurabilityPort` | accepted, queued | `sips/accepted/SIP-0091-Duty-Durability-via-Temporal.md` |
+
+### Planning arc (parallel concern, same lane)
+
+| SIP | What | Status |
+|-----|------|--------|
+| 0092 Implementation Plan Improvement | Typed acceptance, separated authoring, plan changes | accepted |
+| 0093 Multi-Role Plan Authoring | Multi-role plan authoring | accepted |
+
+## SIP-0089 phase status (current focus)
+
+- Phase 0 — acceptance & numbering — ✅
+- Phase 1 — minimal runtime state (state model, heartbeat mirror, CLI, migration `1100`) — ✅ merged (PR #147)
+- **Phase 2 — Assignments & Duty Windows — NEXT.** §2.1 models, §2.2 migration `1110`, §2.3 `AssignmentPort` + adapter, §2.4 in-process scheduler, §2.5 reserve-buffer guard (at the executor dispatch chokepoint), §2.6 runtime coordinator. Detail in the SIP-0089 plan.
+- Phases 3–4 — focus leases, ambient irreversibility hooks — pending.
+- Version bumps to **1.1.0 at Phase 4** (no bump before).
+
+## Tracking convention
+
+This lane is **SIP + plan + per-phase PR** driven (not issue-driven like the
+Spark lane). One PR per SIP-0089 phase (Phase 1 = #147); label PRs
+`track:macbook`. The only standing GitHub issue in this lane is **#159**
+(offline-status mirror — a Phase 2/3 carry-over). Cross-system wiring is tracked
+in #170.
+
+## Coordination with the Spark lane
+
+- **Migration ranges:** this lane uses `1100–1199` (`1110` next); Spark uses `1000–1099`.
+- **Shared hot file:** `src/squadops/agents/entrypoint.py` — coordinate edits.
+- **Executor dispatch chokepoint:** the Spark's S1 (per-agent reply queues,
+  `SIP-Reply-Channel-Subscription-Model`) and Phase 2's §2.5 reserve guard both
+  touch `_publish_and_await` in `adapters/cycles/dispatched_flow_executor.py`.
+  **Sequence S1 first** (see `1-0-x-build-reliability-hardening-plan.md`); Phase 2's
+  guard lands last, onto the restructured dispatch path.


### PR DESCRIPTION
Adds `docs/plans/v1.1-runtime-track-roadmap.md` — the MacBook lane's roadmap, the missing counterpart to the Spark lane's `1-0-x-build-reliability-hardening-plan.md`.

It's a thin **index/roadmap** (points to the detailed SIP plans rather than duplicating them): the runtime arc (SIP-0088 vision → **0089 in progress** → 0090/0091 queued), the planning arc (0092/0093), SIP-0089 phase status (Phase 1 merged #147, Phase 2 next), the SIP+plan+per-phase-PR tracking convention, and cross-lane coordination (migration ranges, the `_publish_and_await` chokepoint sequencing vs the Spark's S1).

Also pins the terminology so it stops drifting: this is **runtime state/modes (v1.1)** — not multi-modal, not multi-model.

Docs only; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)