### PR TITLE
feat(cycles): lite profile + filter builder-only task types by squad capability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ squadops artifacts list <run-id>           # List artifacts for run
   - `secrets/` - env, file, docker_secret providers
   - `comms/` - RabbitMQ adapter
   - `persistence/` - PostgreSQL runtime with connection pooling
-  - `cycles/` - DistributedFlowExecutor, MemoryCycleRegistry, PostgresCycleRegistry, factory
+  - `cycles/` - DispatchedFlowExecutor, MemoryCycleRegistry, PostgresCycleRegistry, factory
   - `telemetry/` - LangFuse adapter (buffered, with redaction) and factory
   - `auth/` - Keycloak adapter, JWT middleware
   - `llm/` - Ollama adapter

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Comprehensive documentation and protocols are available in `/docs/`:
 ├── secrets/          # env, file, docker_secret providers
 ├── comms/            # RabbitMQ adapter
 ├── persistence/      # PostgreSQL runtime
-├── cycles/           # DistributedFlowExecutor, MemoryCycleRegistry, PostgresCycleRegistry
+├── cycles/           # DispatchedFlowExecutor, MemoryCycleRegistry, PostgresCycleRegistry
 ├── telemetry/        # LangFuse adapter with buffering, flush, redaction
 ├── auth/             # Keycloak adapter, JWT middleware
 ├── capabilities/     # Filesystem repository, ACI executor

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 ### Cycle Execution Pipeline (SIP-0064/0066/0068/0076–0080/0083)
 - **Cycle API** – Create, monitor, and manage execution cycles via REST API
 - **Task Planning** – Automatic task plan generation from PRD references
-- **Distributed Flow Executor** – Sequential task dispatch to agent containers via RabbitMQ
+- **Dispatched Flow Executor** – Sequential task dispatch to agent containers via RabbitMQ
 - **Gate Decisions** – Human-in-the-loop approval gates between pipeline stages
 - **Artifact Management** – Typed artifact ingestion and retrieval per run with promotion model
 - **Build Capabilities** – Agents produce executable source code, tests, and config from plans (SIP-0068)

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1,5 +1,5 @@
 """
-Distributed flow executor adapter.
+Dispatched flow executor adapter.
 
 Dispatches cycle tasks to agent containers via RabbitMQ instead of
 executing them in-process.  Each agent handles its own task using

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -209,7 +209,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             flow_ctx = CorrelationContext(cycle_id=cycle_id, flow_run_id=flow_run_id)
             with use_correlation_context(flow_ctx):
                 logger.info(
-                    "Executing run %s for cycle %s (%d tasks, mode=%s, dispatch=distributed)",
+                    "Executing run %s for cycle %s (%d tasks, mode=%s, dispatch=dispatched)",
                     run_id,
                     cycle_id,
                     len(plan),
@@ -1711,7 +1711,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 obs_ctx,
                 StructuredEvent(
                     name="cycle.started",
-                    message=f"Cycle {cycle_id} started ({len(plan)} tasks, distributed)",
+                    message=f"Cycle {cycle_id} started ({len(plan)} tasks, dispatched)",
                 ),
             )
 

--- a/config/squad-profiles.yaml
+++ b/config/squad-profiles.yaml
@@ -45,4 +45,16 @@ profiles:
       - { agent_id: eve, role: qa, model: "qwen3.6:27b", enabled: true }
       - { agent_id: data, role: data, model: "qwen3.6:27b", enabled: true }
 
+  - profile_id: lite
+    name: "Lite Squad"
+    description: "All 6 roles incl. builder on qwen2.5:7b — lightweight end-to-end framework validation. Exercises the full build path (incl. builder.assemble) cheaply; small but structured-output-capable. For plumbing/clean-framework checks, NOT reasoning-quality signal."
+    version: 1
+    agents:
+      - { agent_id: max, role: lead, model: "qwen2.5:7b", enabled: true }
+      - { agent_id: neo, role: dev, model: "qwen2.5:7b", enabled: true }
+      - { agent_id: nat, role: strat, model: "qwen2.5:7b", enabled: true }
+      - { agent_id: bob, role: builder, model: "qwen2.5:7b", enabled: true }
+      - { agent_id: eve, role: qa, model: "qwen2.5:7b", enabled: true }
+      - { agent_id: data, role: data, model: "qwen2.5:7b", enabled: true }
+
 active_profile: full-squad

--- a/src/squadops/capabilities/handlers/_plan_authoring_service.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring_service.py
@@ -27,8 +27,8 @@ from squadops.capabilities.handlers.cycle_tasks import (
 )
 from squadops.capabilities.handlers.fenced_parser import extract_fenced_files
 from squadops.cycles.implementation_plan import (
-    _KNOWN_BUILD_TASK_TYPES,
     ImplementationPlan,
+    planner_build_task_types,
 )
 from squadops.llm.models import ChatMessage
 
@@ -62,19 +62,23 @@ async def produce_plan(
     prd = inputs.get("prd", "")
 
     profile_roles = inputs.get("profile_roles") or []
+    has_builder = "builder" in profile_roles
     roles_section = (
         f"Available roles (use ONLY these; do NOT invent new ones): {', '.join(profile_roles)}\n\n"
         if profile_roles
         else ""
     )
 
-    allowed_task_types = sorted(_KNOWN_BUILD_TASK_TYPES)
+    # Only offer task types the squad can actually execute: builder.assemble
+    # needs the builder role, so a builder-less squad must not be offered it
+    # (else the LLM authors a task that aborts at dispatch with
+    # "No handler for capability: builder.assemble").
+    allowed_task_types = sorted(planner_build_task_types(has_builder=has_builder))
     task_types_section = (
         f"Available task_types (use ONLY these; do NOT invent new ones): "
         f"{', '.join(allowed_task_types)}\n\n"
     )
 
-    has_builder = "builder" in profile_roles
     if has_builder:
         builder_guideline = (
             "- Route packaging, entrypoints, requirements.txt/package.json, "

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -35,6 +35,26 @@ _KNOWN_BUILD_TASK_TYPES = {
     "builder.assemble",
 }
 
+# Build task types only the builder role (bob) can execute. The plan author
+# must not offer these to a squad without a builder, or the LLM can author a
+# task that aborts at dispatch with "No handler for capability: builder.assemble".
+# The plan *validator* still accepts the full set above — it validates plans
+# regardless of the authoring squad.
+_BUILDER_ROLE_BUILD_TASK_TYPES = {"builder.assemble"}
+
+
+def planner_build_task_types(*, has_builder: bool) -> set[str]:
+    """Build task types the plan-authoring prompt may offer for a given squad.
+
+    Returns the full known set when the squad has a builder role; otherwise
+    drops builder-only task types so packaging/scaffolding is routed to a role
+    the squad actually has (e.g. ``development.develop``) instead of producing a
+    ``builder.assemble`` task no agent can handle.
+    """
+    if has_builder:
+        return set(_KNOWN_BUILD_TASK_TYPES)
+    return _KNOWN_BUILD_TASK_TYPES - _BUILDER_ROLE_BUILD_TASK_TYPES
+
 
 @dataclass(frozen=True)
 class TypedCheck:
@@ -178,9 +198,7 @@ class ImplementationPlan:
 
             raw_criteria = td.get("acceptance_criteria", [])
             if not isinstance(raw_criteria, list):
-                raise ValueError(
-                    f"Task {task_index}: acceptance_criteria must be a list"
-                )
+                raise ValueError(f"Task {task_index}: acceptance_criteria must be a list")
             criteria = _parse_acceptance_criteria(raw_criteria, task_index)
 
             tasks.append(
@@ -242,9 +260,7 @@ class ImplementationPlan:
         errors: list[str] = []
         for task in self.tasks:
             if task.role not in available_roles:
-                errors.append(
-                    f"Task {task.task_index}: role '{task.role}' not in profile"
-                )
+                errors.append(f"Task {task.task_index}: role '{task.role}' not in profile")
         return errors
 
     def to_dict(self) -> dict:
@@ -308,9 +324,7 @@ def _serialize_acceptance_criterion(c: str | TypedCheck) -> str | dict:
     return flat
 
 
-def _parse_acceptance_criteria(
-    raw: list, task_index: int
-) -> list[str | TypedCheck]:
+def _parse_acceptance_criteria(raw: list, task_index: int) -> list[str | TypedCheck]:
     """Parse a mixed acceptance_criteria list per SIP-0092 M1.
 
     Accepts:
@@ -352,8 +366,7 @@ def _parse_acceptance_criteria(
         check_name = item["check"]
         if not isinstance(check_name, str):
             raise ValueError(
-                f"Task {task_index}.acceptance_criteria[{j}]: "
-                f"'check' must be a string"
+                f"Task {task_index}.acceptance_criteria[{j}]: 'check' must be a string"
             )
         if check_name not in CHECK_SPECS:
             raise ValueError(
@@ -425,9 +438,7 @@ def _parse_acceptance_criteria(
         # Path-traversal pre-eval rejection
         for path_key in spec.path_params:
             if path_key in params:
-                _reject_unsafe_path(
-                    params[path_key], path_key, task_index, j, check_name
-                )
+                _reject_unsafe_path(params[path_key], path_key, task_index, j, check_name)
 
         parsed.append(
             TypedCheck(

--- a/src/squadops/ports/cycles/workflow_tracker.py
+++ b/src/squadops/ports/cycles/workflow_tracker.py
@@ -1,6 +1,6 @@
 """WorkflowTrackerPort — per-task workflow tracking abstraction.
 
-Used by the distributed flow executor and the cycle event bridges to record
+Used by the dispatched flow executor and the cycle event bridges to record
 flow runs, task runs, and their state transitions on an external workflow UI
 (today: Prefect; tomorrow: anything else with a comparable concept).
 

--- a/tests/unit/capabilities/test_plan_authoring_service.py
+++ b/tests/unit/capabilities/test_plan_authoring_service.py
@@ -437,3 +437,49 @@ async def test_produce_plan_inline_fallback_when_renderer_absent(seeded_inputs):
     user_prompt = next(m.content for m in messages if m.role == "user")
     assert "## PRD" in user_prompt
     assert "implementation_plan.yaml" in user_prompt
+
+
+async def test_produce_plan_filters_builder_assemble_by_squad_capability():
+    """End-to-end guard for the capability filter (cyc_0024e1a0b6b5 failure).
+
+    The plan-authoring prompt must NOT offer ``builder.assemble`` when the
+    squad has no builder role — otherwise the LLM authors a builder.assemble
+    task that aborts at dispatch with 'No handler for capability:
+    builder.assemble', as happened on full-squad. A builder-equipped squad
+    must still be offered it. The rendered template variables (which carry
+    the available-task-types list and builder example) are the surface.
+    """
+    base = {
+        "prd": "Build a simple user-CRUD API",
+        "resolved_config": {
+            "implementation_plan": True,
+            "min_build_subtasks": 3,
+            "max_build_subtasks": 15,
+        },
+    }
+
+    ctx_no_builder = _make_context()
+    await produce_plan(
+        ctx_no_builder,
+        {**base, "profile_roles": ["lead", "dev", "qa"]},
+        planning_content="## Plan",
+        resolved_config=base["resolved_config"],
+        role="lead",
+        handler_name="test_harness",
+        chat_kwargs={},
+    )
+    no_builder_render = str(ctx_no_builder.ports.request_renderer.render.call_args)
+    assert "builder.assemble" not in no_builder_render
+
+    ctx_builder = _make_context()
+    await produce_plan(
+        ctx_builder,
+        {**base, "profile_roles": ["lead", "dev", "builder", "qa"]},
+        planning_content="## Plan",
+        resolved_config=base["resolved_config"],
+        role="lead",
+        handler_name="test_harness",
+        chat_kwargs={},
+    )
+    builder_render = str(ctx_builder.ports.request_renderer.render.call_args)
+    assert "builder.assemble" in builder_render

--- a/tests/unit/capabilities/test_planning_handlers.py
+++ b/tests/unit/capabilities/test_planning_handlers.py
@@ -1065,16 +1065,24 @@ class TestProduceManifestRetry:
         assert "dev" in user_prompt and "qa" in user_prompt and "lead" in user_prompt
 
     async def test_allowed_task_types_injected_into_prompt(self):
-        """Known build task_types appear in the prompt so the LLM doesn't invent them."""
+        """Known build task_types appear in the prompt so the LLM doesn't invent
+        them. builder.assemble is gated on the squad having a builder role, so it
+        is NOT offered here (no builder present) — otherwise the LLM can author a
+        builder.assemble task that aborts at dispatch with 'No handler for
+        capability: builder.assemble' (the cyc_0024e1a0b6b5 failure). See
+        test_builder_guidance_* for the with/without-builder split."""
         ctx = _make_context(_VALID_MANIFEST_YAML)
-        await self._call_produce(ctx)
+        await self._call_produce(ctx)  # no profile_roles -> builder-less squad
 
         messages = ctx.ports.llm.chat_stream_with_usage.await_args_list[0].args[0]
         user_prompt = messages[1].content
         assert "Available task_types" in user_prompt
         assert "development.develop" in user_prompt
         assert "qa.test" in user_prompt
-        assert "builder.assemble" in user_prompt
+        # Builder-only capability is filtered out of the offered list for a
+        # builder-less squad (complements the example-row check in
+        # test_builder_guidance_absent_when_builder_role_missing).
+        assert "builder.assemble" not in user_prompt
 
     async def test_invented_role_triggers_retry_with_role_list(self):
         """Manifest with role outside profile_roles must retry with a specific error."""

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass
 import pytest
 
 from squadops.cycles.acceptance_check_spec import CHECK_SPECS
-from squadops.cycles.implementation_plan import ImplementationPlan, TypedCheck
+from squadops.cycles.implementation_plan import (
+    ImplementationPlan,
+    TypedCheck,
+    planner_build_task_types,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -282,9 +286,7 @@ class TestValidateAgainstProfile:
 
     def test_disabled_agent_treated_as_missing(self):
         manifest = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
-        profile = _FakeProfile(
-            agents=[_FakeAgent("dev"), _FakeAgent("qa", enabled=False)]
-        )
+        profile = _FakeProfile(agents=[_FakeAgent("dev"), _FakeAgent("qa", enabled=False)])
 
         errors = manifest.validate_against_profile(profile)
 
@@ -537,3 +539,34 @@ class TestTypedCheckRegistryCoverage:
                 f"CHECK_SPECS[{name!r}].path_params declares "
                 f"{stragglers} which are not in required ∪ optional params"
             )
+
+
+class TestPlannerBuildTaskTypes:
+    """Bug this guards: the plan author offering ``builder.assemble`` to a
+    builder-less squad. In production (cyc_0024e1a0b6b5) that produced a plan
+    whose first task aborted at dispatch with 'No handler for capability:
+    builder.assemble', failing the whole implementation run 9 minutes in. The
+    planner must only offer task types the squad can actually execute.
+    """
+
+    def test_builder_squad_gets_full_known_set(self):
+        assert planner_build_task_types(has_builder=True) == {
+            "development.develop",
+            "qa.test",
+            "builder.assemble",
+        }
+
+    def test_builderless_squad_drops_builder_assemble_but_keeps_build_path(self):
+        offered = planner_build_task_types(has_builder=False)
+        # The offending capability is gone...
+        assert "builder.assemble" not in offered
+        # ...but the dev/qa build path remains, so builder-less squads still build.
+        assert offered == {"development.develop", "qa.test"}
+
+    def test_result_is_a_fresh_set_callers_cannot_corrupt_constants(self):
+        """Returning the module constant itself would let one caller's mutation
+        leak into the next cycle's offered task types."""
+        result = planner_build_task_types(has_builder=True)
+        result.add("bogus.capability")
+        assert "bogus.capability" not in planner_build_task_types(has_builder=True)
+        assert "bogus.capability" not in planner_build_task_types(has_builder=False)


### PR DESCRIPTION
## Summary
Fixes the root cause of the `cyc_0024e1a0b6b5` implementation failure (full-squad aborted at task 2/8 with `No handler for capability: builder.assemble`) and adds a cheap builder-equipped profile for end-to-end framework validation.

## Changes
**1. Planner capability filter (root cause)**
`produce_plan` now offers the LLM only task types the squad can execute. `builder.assemble` is dropped from the allowed list when the squad has no `builder` role, so the planner can't author a task no agent can handle — packaging/scaffolding routes to `development.develop` instead, and **builder-less squads build successfully**. New `planner_build_task_types()` in `implementation_plan.py` is the single source (co-located with `_KNOWN_BUILD_TASK_TYPES`). The plan *validator* still accepts the full set — it validates plans regardless of authoring squad.

**2. New `lite` squad profile**
All 6 roles incl. builder on `qwen2.5:7b` — a lightweight, builder-equipped squad for cheap end-to-end framework validation (exercises the full build path, including `builder.assemble`, without large models). First profile under the no-`-with-builder`-suffix convention (see #173).

## Tests
- `planner_build_task_types` unit tests: both branches (exact sets) + mutation-safety (returns a fresh set).
- `produce_plan` behavioral test: `builder.assemble` is offered **iff** the squad has a builder role.
- Updated `test_allowed_task_types_injected_into_prompt` — its old assertion encoded the bug (builder.assemble always offered); now asserts the capability-filtered behavior.
- Regression: **3999 passed, 1 skipped, 0 failed**; test-quality lint clean.

## Scope / follow-ups (deliberately not here)
- **#172** — gate-time plan↔squad capability pre-flight (defense-in-depth; `ImplementationPlan.validate_against_profile` may already cover most of it — needs wiring).
- **#173** — profile-name consolidation (drop `-with-builder`, collapse `full`/`spark`, reconcile `smoke`/`lite`/`full`). Breaking; needs a DB migration + doc sweep.
