### PR TITLE
chore(profiles): remove stale full-squad-with-builder profile

### DIFF
--- a/config/squad-profiles.yaml
+++ b/config/squad-profiles.yaml
@@ -21,18 +21,6 @@ profiles:
       - { agent_id: eve, role: qa, model: "qwen3.6:27b", enabled: true }
       - { agent_id: data, role: data, model: "qwen3.6:27b", enabled: true }
 
-  - profile_id: full-squad-with-builder
-    name: "Full Squad with Builder"
-    description: "6 agents including dedicated builder"
-    version: 1
-    agents:
-      - { agent_id: max, role: lead, model: "qwen2.5:32b", enabled: true }
-      - { agent_id: neo, role: dev, model: "qwen2.5:7b", enabled: true }
-      - { agent_id: nat, role: strat, model: "qwen2.5:7b", enabled: true }
-      - { agent_id: bob, role: builder, model: "qwen2.5:7b", enabled: true }
-      - { agent_id: eve, role: qa, model: "qwen2.5:3b-instruct", enabled: true }
-      - { agent_id: data, role: data, model: "qwen2.5:3b-instruct", enabled: true }
-
   - profile_id: spark-squad-with-builder
     name: "Spark Squad with Builder"
     description: "6 agents on DGX Spark — all roles on qwen3.6:27b (uniform, single loaded model, max reasoning depth)"


### PR DESCRIPTION
Removes the `full-squad-with-builder` squad profile.

**Why:** its mixed-model composition (qwen2.5 32b lead / 7b mid / 3b qa+data) is the model-swap-overhead anti-pattern on single-GPU Spark — the whole reason the uniform profiles exist. It's fully superseded by:
- `spark-squad-with-builder` — uniform qwen3.6:27b (reasoning + builder)
- `lite` — uniform qwen2.5:7b (cheap full-build-path plumbing)

**Safety:** referenced only in historical `docs/plans/` (SIP-0071/0073). No code, config, scripts, or test references, so removal is runtime-safe.

Leaves a clean profile set: `smoke` (3b), `lite` (7b+builder), `full-squad` (27b), `spark-squad-with-builder` (27b+builder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)