### PR TITLE
fix(tests): retarget builder-squad tests to spark-squad-with-builder (green the regression suite)

### DIFF
--- a/tests/unit/cycles/test_builder_bootstrap_verification.py
+++ b/tests/unit/cycles/test_builder_bootstrap_verification.py
@@ -2,7 +2,7 @@
 
 Tests that the builder role bootstraps cleanly in the handler and skill
 registries, and that dry-run plan generation emits builder.assemble tasks
-when the full-squad-with-builder profile is used.
+when the spark-squad-with-builder profile is used.
 """
 
 from __future__ import annotations
@@ -76,7 +76,7 @@ class TestDryRunPlanGeneration:
 
     async def test_plan_emits_builder_assemble(self, provider):
         """Plan generation with builder profile should emit builder.assemble."""
-        profile = await provider.get_profile("full-squad-with-builder")
+        profile = await provider.get_profile("spark-squad-with-builder")
         assert _has_builder_role(profile)
 
         cycle = Cycle(
@@ -85,7 +85,7 @@ class TestDryRunPlanGeneration:
             created_at=NOW,
             created_by="system",
             prd_ref="Build a CLI tool",
-            squad_profile_id="full-squad-with-builder",
+            squad_profile_id="spark-squad-with-builder",
             squad_profile_snapshot_ref="sha256:abc",
             task_flow_policy=TaskFlowPolicy(mode="sequential"),
             build_strategy="fresh",

--- a/tests/unit/cycles/test_builder_e2e_validation.py
+++ b/tests/unit/cycles/test_builder_e2e_validation.py
@@ -41,7 +41,7 @@ CONFIG_PATH = Path(__file__).resolve().parents[3] / "config" / "squad-profiles.y
 @pytest.fixture
 def builder_profile():
     return SquadProfile(
-        profile_id="full-squad-with-builder",
+        profile_id="spark-squad-with-builder",
         name="Full Squad with Builder",
         description="6 agents",
         version=1,
@@ -76,7 +76,7 @@ def run():
 
 def _make_cycle(
     applied_defaults: dict,
-    squad_profile_id: str = "full-squad-with-builder",
+    squad_profile_id: str = "spark-squad-with-builder",
 ) -> Cycle:
     return Cycle(
         cycle_id="cyc_e2e_001",
@@ -280,21 +280,21 @@ class TestYAMLProfileBuilderIntegration:
         return ConfigSquadProfile(yaml_path=CONFIG_PATH)
 
     async def test_builder_profile_has_six_agents(self, provider):
-        profile = await provider.get_profile("full-squad-with-builder")
+        profile = await provider.get_profile("spark-squad-with-builder")
         assert len(profile.agents) == 6
 
     async def test_builder_profile_has_builder_role(self, provider):
-        profile = await provider.get_profile("full-squad-with-builder")
+        profile = await provider.get_profile("spark-squad-with-builder")
         assert _has_builder_role(profile)
 
     async def test_builder_profile_bob_is_builder(self, provider):
-        profile = await provider.get_profile("full-squad-with-builder")
+        profile = await provider.get_profile("spark-squad-with-builder")
         bob = next(a for a in profile.agents if a.agent_id == "bob")
         assert bob.role == "builder"
         assert bob.enabled is True
 
     async def test_builder_profile_plan_emits_builder_assemble(self, provider, run):
-        profile = await provider.get_profile("full-squad-with-builder")
+        profile = await provider.get_profile("spark-squad-with-builder")
         cycle = _make_cycle(
             {
                 "build_tasks": ["builder.assemble", "qa.test"],
@@ -305,7 +305,7 @@ class TestYAMLProfileBuilderIntegration:
         assert "builder.assemble" in task_types
 
     async def test_builder_profile_routing_reason(self, provider, run):
-        profile = await provider.get_profile("full-squad-with-builder")
+        profile = await provider.get_profile("spark-squad-with-builder")
         cycle = _make_cycle(
             {
                 "build_tasks": ["builder.assemble", "qa.test"],

--- a/tests/unit/cycles/test_squad_profile_builder.py
+++ b/tests/unit/cycles/test_squad_profile_builder.py
@@ -1,7 +1,12 @@
-"""Tests for full-squad-with-builder squad profile (SIP-0071 Phase 2).
+"""Tests for the builder-equipped squad profile (SIP-0071 Phase 2).
 
-Validates that the squad profile with builder agent loads correctly,
+Validates that the squad profile carrying a builder agent loads correctly,
 resolves all 6 agents, and has the builder role properly configured.
+
+The original `full-squad-with-builder` profile was removed in PR #175; the
+surviving builder profile is `spark-squad-with-builder`, so these tests target
+it. (Broader squad-profile name consolidation is tracked in issue #173 — this
+change only re-points the stale assertions at the profile that still exists.)
 """
 
 from __future__ import annotations
@@ -22,37 +27,38 @@ def provider():
     return ConfigSquadProfile(yaml_path=CONFIG_PATH)
 
 
-class TestFullSquadWithBuilderProfile:
+class TestSparkSquadWithBuilderProfile:
     async def test_profile_loads(self, provider):
-        profile = await provider.get_profile("full-squad-with-builder")
-        assert profile.profile_id == "full-squad-with-builder"
+        profile = await provider.get_profile("spark-squad-with-builder")
+        assert profile.profile_id == "spark-squad-with-builder"
 
     async def test_has_six_agents(self, provider):
-        profile = await provider.get_profile("full-squad-with-builder")
+        profile = await provider.get_profile("spark-squad-with-builder")
         assert len(profile.agents) == 6
 
     async def test_builder_agent_present(self, provider):
-        profile = await provider.get_profile("full-squad-with-builder")
+        profile = await provider.get_profile("spark-squad-with-builder")
         builder_agents = [a for a in profile.agents if a.role == "builder"]
         assert len(builder_agents) == 1
 
     async def test_builder_agent_is_bob(self, provider):
-        profile = await provider.get_profile("full-squad-with-builder")
+        profile = await provider.get_profile("spark-squad-with-builder")
         builder_agents = [a for a in profile.agents if a.role == "builder"]
         assert builder_agents[0].agent_id == "bob"
 
     async def test_builder_agent_enabled(self, provider):
-        profile = await provider.get_profile("full-squad-with-builder")
+        profile = await provider.get_profile("spark-squad-with-builder")
         builder_agents = [a for a in profile.agents if a.role == "builder"]
         assert builder_agents[0].enabled is True
 
-    async def test_all_original_roles_present(self, provider):
-        profile = await provider.get_profile("full-squad-with-builder")
+    async def test_all_roles_present(self, provider):
+        profile = await provider.get_profile("spark-squad-with-builder")
         roles = {a.role for a in profile.agents}
         assert roles == {"lead", "dev", "strat", "builder", "qa", "data"}
 
-    async def test_original_full_squad_unchanged(self, provider):
-        """Original full-squad profile should still have 5 agents."""
+    async def test_full_squad_has_no_builder(self, provider):
+        """The non-builder `full-squad` profile still has 5 agents and no builder
+        role — the distinction the builder profile exists to add."""
         profile = await provider.get_profile("full-squad")
         assert len(profile.agents) == 5
         roles = {a.role for a in profile.agents}
@@ -62,4 +68,4 @@ class TestFullSquadWithBuilderProfile:
         profiles = await provider.list_profiles()
         ids = {p.profile_id for p in profiles}
         assert "full-squad" in ids
-        assert "full-squad-with-builder" in ids
+        assert "spark-squad-with-builder" in ids

--- a/tests/unit/cycles/test_task_plan_builder.py
+++ b/tests/unit/cycles/test_task_plan_builder.py
@@ -33,8 +33,8 @@ NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
 @pytest.fixture
 def profile_with_builder():
     return SquadProfile(
-        profile_id="full-squad-with-builder",
-        name="Full Squad with Builder",
+        profile_id="spark-squad-with-builder",
+        name="Spark Squad with Builder",
         description="6 agents",
         version=1,
         agents=(


### PR DESCRIPTION
## Problem
PR #175 removed the `full-squad-with-builder` squad profile but left **four** test files asserting it loads from `config/squad-profiles.yaml`. The regression suite has been red — **13 failures** — for ~6 days, which degrades the "2900+ always pass" signal every subsequent change relies on.

Affected files:
- `tests/unit/cycles/test_squad_profile_builder.py`
- `tests/unit/cycles/test_builder_e2e_validation.py`
- `tests/unit/cycles/test_builder_bootstrap_verification.py`
- `tests/unit/cycles/test_task_plan_builder.py` (cosmetic inline label only)

## Fix
Re-point the config-loading tests at the surviving builder profile, `spark-squad-with-builder` (identical 6-agent shape: lead/dev/strat/builder/qa/data, bob=builder). This **preserves the SIP-0071 builder-profile coverage** rather than deleting it. Inline cosmetic `profile_id` labels updated for consistency; the removed profile is now only referenced in an explanatory docstring.

## Verification
Regression: **3999 passed, 1 skipped, 0 failed** (was 13 failed).

## Notes
- Fallout from #175; broader squad-profile name consolidation is tracked in #173 — this PR only re-points stale assertions, it does not rename anything.
- Process note: #175 pruned a profile without updating its tests and shipped a red suite — worth catching at review next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)