### PR TITLE
fix(sip-0093): enable multi-role plan authoring via plan_authoring_contributors

### DIFF
--- a/src/squadops/contracts/cycle_request_profiles/profiles/validation-multirole.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/validation-multirole.yaml
@@ -1,0 +1,49 @@
+name: validation-multirole
+description: >
+  SIP-0093 multi-role plan authoring validation. Same framing → gate →
+  implementation shape as `validation`, but turns ON the multi-role authoring
+  path by setting `plan_authoring_contributors`, so development, qa, and
+  strategy each emit `*.propose_plan_tasks` and `governance.merge_plan`
+  reconciles them into the canonical `implementation_plan.yaml` +
+  `merge_decisions.yaml`. Without contributors the merger runs sole-author and
+  the multi-role path is never exercised — this profile is the first one that
+  actually activates it. Pauses at the `progress_plan_review` gate after framing
+  so the merged plan + merge decisions can be inspected before (optionally)
+  proceeding to implementation.
+defaults:
+  build_strategy: fresh
+  # SIP-0093 activation — the whole point of this profile.
+  plan_authoring_contributors:
+    - development
+    - qa
+    - strategy
+  task_flow_policy:
+    mode: sequential
+    gates:
+      - name: progress_plan_review
+        description: Review the merged plan + merge_decisions before implementation begins.
+        after_task_types:
+          - governance.review_plan
+  expected_artifact_types:
+    - document
+    - source
+    - test
+    - config
+  workload_sequence:
+    - type: framing
+      gate: progress_plan_review
+    - type: implementation
+      gate: null
+  build_tasks: true
+  implementation_plan: true
+  output_validation: true
+  # Implementation-profile depth, matching `validation`.
+  max_self_eval_passes: 2
+  max_correction_attempts: 3
+  max_build_subtasks: 15
+  # SIP-0092 M1 active (typed acceptance), same as `validation`.
+  typed_acceptance: true
+  command_acceptance_checks: true
+  time_budget_seconds: 7200
+  experiment_context: {}
+  notes: "SIP-0093 multi-role plan authoring validation (B closure)"

--- a/src/squadops/contracts/cycle_request_profiles/schema.py
+++ b/src/squadops/contracts/cycle_request_profiles/schema.py
@@ -40,10 +40,16 @@ _APPLIED_DEFAULTS_EXTRA_KEYS = {
     "min_artifact_count",
     "stub_threshold_bytes",
     # SIP-0092 M1.3 typed acceptance
-    "typed_acceptance",            # master flag (default true)
-    "command_acceptance_checks",   # gate command_exit_zero independently
-    "command_check_safelist",      # operator-controlled extension to argv safelist
-    "stack",                       # resolved stack identity for typed-check evaluators
+    "typed_acceptance",  # master flag (default true)
+    "command_acceptance_checks",  # gate command_exit_zero independently
+    "command_check_safelist",  # operator-controlled extension to argv safelist
+    "stack",  # resolved stack identity for typed-check evaluators
+    # SIP-0093: multi-role plan authoring activation. Selects which roles emit
+    # ``*.propose_plan_tasks`` before ``governance.merge_plan``; empty/absent
+    # → the merger runs sole-author. Consumed by task_plan.build_planning_steps
+    # via resolved_config. Valid roles: development, qa, strategy (build reserved
+    # for Rev 2). Without this entry no request profile can turn the path on.
+    "plan_authoring_contributors",
 }
 
 _ALL_ALLOWED_KEYS = _ALLOWED_DEFAULT_KEYS | _APPLIED_DEFAULTS_EXTRA_KEYS

--- a/tests/unit/contracts/test_validation_multirole_profile.py
+++ b/tests/unit/contracts/test_validation_multirole_profile.py
@@ -1,0 +1,64 @@
+"""Unit tests for the validation-multirole cycle request profile (SIP-0093).
+
+This profile is the first one to set `plan_authoring_contributors`, which is
+what actually activates the multi-role plan authoring path (per-role
+`*.propose_plan_tasks` → `governance.merge_plan`). Before this profile existed,
+no request profile could turn the path on, so the merger always ran in
+sole-author mode. These tests guard that activation.
+"""
+
+import pytest
+
+from squadops.contracts.cycle_request_profiles import list_profiles, load_profile
+from squadops.contracts.cycle_request_profiles.schema import (
+    _ALL_ALLOWED_KEYS,
+    CycleRequestProfile,
+)
+
+pytestmark = [pytest.mark.domain_contracts]
+
+
+class TestValidationMultiroleProfile:
+    def test_profile_loads(self):
+        profile = load_profile("validation-multirole")
+        assert isinstance(profile, CycleRequestProfile)
+        assert profile.name == "validation-multirole"
+
+    def test_profile_appears_in_listing(self):
+        assert "validation-multirole" in list_profiles()
+
+    def test_contributors_activate_all_three_authoring_roles(self):
+        """The load-bearing assertion: the profile must enable dev, qa, and
+        strategy as plan authors. If this key is dropped (or the schema
+        allow-list rejects it), the merger silently falls back to sole-author
+        and the multi-role path the profile exists to exercise never runs."""
+        profile = load_profile("validation-multirole")
+        assert profile.defaults["plan_authoring_contributors"] == [
+            "development",
+            "qa",
+            "strategy",
+        ]
+
+    def test_plan_authoring_contributors_is_an_allowed_default_key(self):
+        """Regression guard for the activation wiring: without this key in the
+        CRP allow-list, `load_profile` raises and no profile can enable
+        multi-role authoring."""
+        assert "plan_authoring_contributors" in _ALL_ALLOWED_KEYS
+
+    def test_workload_is_framing_then_implementation_with_gate(self):
+        """B's output (merged plan + merge_decisions) is produced during
+        framing; the gate must pause after framing so it can be inspected
+        before any implementation work runs."""
+        profile = load_profile("validation-multirole")
+        sequence = profile.defaults["workload_sequence"]
+        assert [entry["type"] for entry in sequence] == ["framing", "implementation"]
+        assert sequence[0]["gate"] == "progress_plan_review"
+
+    def test_distinct_from_validation_profile_on_authoring(self):
+        """The stock `validation` profile does NOT set contributors (it runs
+        sole-author); `validation-multirole` is precisely the one that adds the
+        activation. If they ever converge, the multi-role distinction is lost."""
+        validation = load_profile("validation")
+        multirole = load_profile("validation-multirole")
+        assert "plan_authoring_contributors" not in validation.defaults
+        assert "plan_authoring_contributors" in multirole.defaults

--- a/tests/unit/cycles/test_planning_task_plan.py
+++ b/tests/unit/cycles/test_planning_task_plan.py
@@ -130,6 +130,50 @@ class TestPlanningWorkload:
         envelopes = generate_task_plan(cycle, _run("framing"), full_profile)
         assert len(envelopes) == 7
 
+    def test_contributors_configured_inserts_proposer_steps(self, cycle, full_profile):
+        """SIP-0093 activation: with plan_authoring_contributors set, the framing
+        sequence gains one proposer step per role between the brief and the
+        merger — 7 sole-author + 3 proposers = 10, in canonical
+        (development, qa, strategy) order. Guards the request → resolved_config
+        → build_planning_steps wiring that lets a request profile actually turn
+        multi-role authoring on (the path the validation-multirole profile and
+        the SIP-0093 schema allow-list entry exist to enable)."""
+        multirole = replace(
+            cycle,
+            applied_defaults={
+                "build_strategy": "fresh",
+                "plan_authoring_contributors": ["development", "qa", "strategy"],
+            },
+        )
+        envelopes = generate_task_plan(multirole, _run("framing"), full_profile)
+        assert [e.task_type for e in envelopes] == [
+            "data.research_context",
+            "strategy.frame_objective",
+            "development.design_plan",
+            "qa.define_test_strategy",
+            "governance.prepare_plan_authoring_brief",
+            "development.propose_plan_tasks",
+            "qa.propose_plan_tasks",
+            "strategy.propose_plan_guidance",
+            "governance.merge_plan",
+            "governance.review_plan",
+        ]
+
+    def test_unknown_contributor_raises_cycle_error(self, cycle, full_profile):
+        """A typo'd or premature contributor (e.g. `build`, reserved for Rev 2)
+        must fail the cycle at plan generation rather than silently dropping a
+        proposer. Without this, a misconfigured profile would run a partial
+        authoring pipeline and look like it succeeded."""
+        bad = replace(
+            cycle,
+            applied_defaults={
+                "build_strategy": "fresh",
+                "plan_authoring_contributors": ["development", "build"],
+            },
+        )
+        with pytest.raises(CycleError, match="unsupported roles"):
+            generate_task_plan(bad, _run("framing"), full_profile)
+
     def test_task_types_match_planning_steps(self, cycle, full_profile):
         envelopes = generate_task_plan(cycle, _run("framing"), full_profile)
         actual = [e.task_type for e in envelopes]


### PR DESCRIPTION
## Problem
SIP-0093's per-role proposer handlers + `governance.merge_plan` merger merged (#144/#145/#165), but the **activation key** — `plan_authoring_contributors` — was never registered as an allowed CRP default. So no request profile could load with it set, and the merger has been running **sole-author in every cycle**. The multi-role authoring code is effectively dormant: SIP-0093-B has never actually run in multi-role mode.

The key already survives the full request path unchanged — `applied_defaults` → JSONB → `resolved_config = {**applied_defaults, **execution_overrides}` (task_plan.py) → `build_planning_steps` — exactly like `build_tasks`. Only the client-side CRP allow-list entry was missing.

## Change
- **schema**: add `plan_authoring_contributors` to `_APPLIED_DEFAULTS_EXTRA_KEYS`.
- **profiles**: add `validation-multirole` — the first request profile that activates the path (framing → `progress_plan_review` gate → implementation; contributors = development/qa/strategy).
- **tests**: contributors-configured framing sequence (proposer steps in canonical order), unknown-contributor `CycleError`, and profile-load guards.

## Verification
New tests pass; ruff clean. Activates the path that lets a validation cycle finally exercise multi-role authoring + merge_decisions.yaml end-to-end.

## Merge order
Branched off main **before** #179 (the regression-suite green-up). Rebase onto main after #179 merges so this PR sits on a green baseline. Files are disjoint from #179 — no conflict.

Part of closing the SIP-0093 partial (multi-role plan authoring core → validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)