### PR TITLE
fix(#182): generate proposer typed-acceptance vocabulary from CHECK_SPECS

### DIFF
--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -30,6 +30,7 @@ from squadops.capabilities.handlers.base import (
 from squadops.capabilities.handlers.cycle_tasks import (
     _CycleTaskHandler,
 )
+from squadops.cycles.acceptance_check_spec import render_typed_acceptance_vocabulary
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
 
@@ -797,7 +798,10 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
             "prd": prd,
             "roles_section": roles_section,
             "builder_section": builder_section,
-            "typed_acceptance_vocabulary": "",  # task-type fragment carries the vocabulary
+            # Generated from CHECK_SPECS so the proposer sees exact param names
+            # + a parser-valid example per check (issue #182 — was "", which let
+            # models guess param names and fail count_at_least validation).
+            "typed_acceptance_vocabulary": render_typed_acceptance_vocabulary(),
         }
 
     async def handle(

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -8,6 +8,9 @@ entry. It is consumed by:
   malformed values at plan-parse time.
 - The evaluator framework in ``acceptance_checks.py`` (M1.2, not yet shipped)
   to declare the per-check evaluator implementation against the same spec.
+- ``render_typed_acceptance_vocabulary()`` (issue #182) to generate the
+  proposer-prompt vocabulary reference, so proposers are told the exact param
+  names + a parser-valid example for every check instead of guessing.
 
 Adding a new check means adding one entry to ``CHECK_SPECS`` here plus one
 evaluator class registration in M1.2 — no separate ``_KNOWN_CHECKS`` table
@@ -55,6 +58,11 @@ class CheckSpec:
             paths, ``..`` traversal) on these so authoring-time errors don't
             slip through to evaluation. Full chrooting and symlink rejection
             still happens at evaluation time (M1.2).
+        example: A representative, parser-valid param dict for this check
+            (params only — no ``check``/``severity`` wrapper). Rendered into the
+            proposer vocabulary so models see the exact flat-YAML shape. Kept in
+            sync with the spec by test (must include every required param and
+            only allowed params, with correct types).
     """
 
     name: str
@@ -64,6 +72,7 @@ class CheckSpec:
     supported_stacks: frozenset[str] = frozenset()
     requires_stack_context: bool = False
     path_params: frozenset[str] = frozenset()
+    example: dict[str, object] = field(default_factory=dict)
 
 
 # Allowed severity values. Anything else → ValueError at parse time.
@@ -71,7 +80,9 @@ ALLOWED_SEVERITIES: frozenset[str] = frozenset({"error", "warning", "info"})
 
 
 # Rev 1 vocabulary. Each entry's evaluator implementation lands in M1.2;
-# the parser already rejects authoring errors against this spec.
+# the parser already rejects authoring errors against this spec. The ``example``
+# on each entry is rendered into the proposer prompt (issue #182) and is
+# asserted parser-valid by test.
 CHECK_SPECS: dict[str, CheckSpec] = {
     "endpoint_defined": CheckSpec(
         name="endpoint_defined",
@@ -80,6 +91,7 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         supported_stacks=frozenset({"fastapi"}),
         requires_stack_context=True,
         path_params=frozenset({"file"}),
+        example={"file": "app/main.py", "methods_paths": ["GET /runs", "POST /runs"]},
     ),
     "import_present": CheckSpec(
         name="import_present",
@@ -89,6 +101,7 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         supported_stacks=frozenset({"python", "javascript", "typescript"}),
         requires_stack_context=False,
         path_params=frozenset({"file"}),
+        example={"file": "app/main.py", "module": "app.models", "symbol": "RunEvent"},
     ),
     "field_present": CheckSpec(
         name="field_present",
@@ -97,6 +110,7 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         supported_stacks=frozenset({"python"}),
         requires_stack_context=True,
         path_params=frozenset({"file"}),
+        example={"file": "app/models.py", "class_name": "RunEvent", "fields": ["id", "title"]},
     ),
     "regex_match": CheckSpec(
         name="regex_match",
@@ -106,6 +120,7 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         supported_stacks=frozenset(),
         requires_stack_context=False,
         path_params=frozenset({"file"}),
+        example={"file": "tests/test_runs.py", "pattern": "def test_", "count_min": 5},
     ),
     "count_at_least": CheckSpec(
         name="count_at_least",
@@ -114,6 +129,7 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         supported_stacks=frozenset(),
         requires_stack_context=False,
         path_params=frozenset({"glob"}),
+        example={"glob": "tests/test_*.py", "min_count": 3},
     ),
     "command_exit_zero": CheckSpec(
         name="command_exit_zero",
@@ -126,6 +142,7 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         # validates argv shapes pattern-by-pattern. cwd is path-checked at
         # evaluation time, not here.
         path_params=frozenset(),
+        example={"argv": ["python", "-m", "py_compile", "app/main.py"]},
     ),
 }
 
@@ -137,3 +154,72 @@ def reserved_keys_for(check_name: str) -> frozenset[str]:
     authored dict minus these keys.
     """
     return frozenset({"check", "severity", "description"})
+
+
+_PARAM_TYPE_NAMES: dict[type, str] = {
+    str: "string",
+    int: "integer",
+    list: "list",
+    bool: "boolean",
+}
+
+
+def _type_label(spec: CheckSpec, param: str) -> str:
+    """Human-readable type name(s) for a param, from the spec's param_types."""
+    declared = spec.param_types.get(param)
+    if declared is None:
+        return "value"
+    types = declared if isinstance(declared, tuple) else (declared,)
+    return " | ".join(_PARAM_TYPE_NAMES.get(t, getattr(t, "__name__", "value")) for t in types)
+
+
+def _format_example_value(value: object) -> str:
+    """Render an example param value as inline YAML (strings quoted)."""
+    if isinstance(value, str):
+        return f'"{value}"'
+    if isinstance(value, list):
+        return "[" + ", ".join(_format_example_value(v) for v in value) + "]"
+    return str(value)
+
+
+def render_typed_acceptance_vocabulary() -> str:
+    """Render the typed acceptance-criteria vocabulary for proposer prompts.
+
+    Generated from ``CHECK_SPECS`` so it can never drift from the parser's
+    contract. Fixes issue #182: proposers were given only check *names* (in the
+    task-type fragments) with no params or examples — the ``count_at_least``
+    check (the only one with two required params) failed validation because
+    models guessed param names. This emits, for every check, the exact required
+    and optional param names with types plus a parser-valid flat-YAML example.
+    """
+    out: list[str] = [
+        "## Typed acceptance-criteria vocabulary",
+        "",
+        "Each entry under a task's `acceptance_criteria` is either an "
+        "informational string or a typed-check mapping: a `check:` key, its "
+        "params inline (flat — not nested under `params:`), and an optional "
+        "`severity:` (`error` | `warning` | `info`, default `error`). Use the "
+        "EXACT param names shown below — a missing, misnamed, or extra param "
+        "fails plan validation and drops the entire proposal.",
+        "",
+    ]
+    for name, spec in CHECK_SPECS.items():
+        out.append(f"### `{name}`")
+        required = ", ".join(
+            f"`{p}` ({_type_label(spec, p)})" for p in sorted(spec.required_params)
+        )
+        out.append(f"- Required: {required}")
+        if spec.optional_params:
+            optional = ", ".join(
+                f"`{p}` ({_type_label(spec, p)})" for p in sorted(spec.optional_params)
+            )
+            out.append(f"- Optional: {optional}")
+        out.append("- Example:")
+        out.append("  ```yaml")
+        out.append(f"  - check: {name}")
+        for key, value in spec.example.items():
+            out.append(f"    {key}: {_format_example_value(value)}")
+        out.append("    severity: error")
+        out.append("  ```")
+        out.append("")
+    return "\n".join(out).rstrip() + "\n"

--- a/tests/unit/cycles/test_typed_acceptance_vocabulary.py
+++ b/tests/unit/cycles/test_typed_acceptance_vocabulary.py
@@ -1,0 +1,69 @@
+"""Tests for the proposer typed-acceptance vocabulary renderer (issue #182).
+
+Background: SIP-0093 proposers were handed only check *names* (via task-type
+fragments) with no params or examples, and `{{typed_acceptance_vocabulary}}`
+was injected as an empty string. Models guessed param names and `count_at_least`
+(the only check with two required params) failed plan validation, dropping the
+whole proposal → empty plan.
+
+`render_typed_acceptance_vocabulary()` now generates the vocabulary from
+`CHECK_SPECS` so the proposer sees exact param names + a parser-valid example
+per check. These tests guard that the rendered content is actually correct and
+that it can never silently regress to the empty/under-specified state.
+"""
+
+import pytest
+
+from squadops.cycles.acceptance_check_spec import (
+    CHECK_SPECS,
+    render_typed_acceptance_vocabulary,
+)
+from squadops.cycles.implementation_plan import TypedCheck, _parse_acceptance_criteria
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+
+@pytest.mark.parametrize("check_name", sorted(CHECK_SPECS))
+def test_every_check_example_is_parser_valid(check_name):
+    """The example we show proposers for each check must parse cleanly through
+    the real validator. If it doesn't, we'd be teaching models malformed YAML —
+    exactly the failure mode of issue #182. This is the load-bearing guarantee
+    and fails loudly if a new check is added without a valid example."""
+    spec = CHECK_SPECS[check_name]
+    assert spec.example, f"{check_name} has no example to render"
+
+    criterion = {"check": check_name, **spec.example, "severity": "error"}
+    parsed = _parse_acceptance_criteria([criterion], task_index=0)
+
+    assert len(parsed) == 1
+    assert isinstance(parsed[0], TypedCheck)
+    assert parsed[0].check == check_name
+
+
+@pytest.mark.parametrize("check_name", sorted(CHECK_SPECS))
+def test_rendered_vocabulary_shows_each_check_and_its_required_params(check_name):
+    """The whole point of the fix: the model must see the check name AND its
+    exact required param names. Listing the name without params is what caused
+    #182 (models guessed `count`/`count_min` instead of `glob`/`min_count`)."""
+    rendered = render_typed_acceptance_vocabulary()
+    assert f"`{check_name}`" in rendered
+    for param in CHECK_SPECS[check_name].required_params:
+        assert param in rendered, f"required param {param!r} of {check_name} not shown"
+
+
+def test_count_at_least_shows_both_required_params():
+    """Direct regression for #182: count_at_least must surface BOTH glob and
+    min_count (the params dev and qa proposers each omitted)."""
+    rendered = render_typed_acceptance_vocabulary()
+    assert "count_at_least" in rendered
+    assert "glob" in rendered
+    assert "min_count" in rendered
+
+
+def test_rendered_vocabulary_is_not_empty():
+    """The literal #182 root cause was the variable being injected as "".
+    A non-trivial rendered block guards against regressing to that state."""
+    rendered = render_typed_acceptance_vocabulary()
+    assert rendered.strip()
+    # Sanity: every check is represented, so length scales with the registry.
+    assert rendered.count("- check:") == len(CHECK_SPECS)


### PR DESCRIPTION
Fixes the root-cause prompt gap behind #182.

## Problem
SIP-0093 proposers (`development.propose_plan_tasks`, `qa.propose_plan_tasks`) are told to use the SIP-0092 typed-acceptance vocabulary, but they only ever saw check **names** (in the task-type fragments) — never the param schema. The `{{typed_acceptance_vocabulary}}` placeholder that both proposer templates already render was being fed the **empty string** (`planning_tasks.py:800`, with a comment that wrongly claimed "the fragment carries the vocabulary"). Models guessed param names; `count_at_least` (the only check with two required params, `glob`+`min_count`) failed validation, and because the parser is all-or-nothing, one bad criterion dropped the whole proposal.

Observed in `cyc_05d25747c7d2`: both dev and qa proposers failed identically → merged `implementation_plan.yaml` had `tasks: []`.

## Fix
Generate the vocabulary from `CHECK_SPECS` (the existing single source of truth) and inject it into the slot that was empty. Each check now renders with its exact **required + optional params (with types)** and a **parser-valid flat-YAML example**:

```yaml
### `count_at_least`
- Required: `glob` (string), `min_count` (integer)
- Example:
  - check: count_at_least
    glob: "tests/test_*.py"
    min_count: 3
    severity: error
```

Because it's generated from the registry, it fixes **every** check at once and **cannot drift** from the parser contract — no hand-maintained param prose duplicated in prompt files.

## Changes
- `cycles/acceptance_check_spec.py` — add `example` to `CheckSpec` (populated for all 6 checks) + `render_typed_acceptance_vocabulary()`.
- `capabilities/handlers/planning_tasks.py` — feed the renderer into `{{typed_acceptance_vocabulary}}` (was `""`).
- `tests/unit/cycles/test_typed_acceptance_vocabulary.py` — new:
  - every check's example round-trips through the real `_parse_acceptance_criteria` (guarantees we never show models malformed YAML),
  - every check + its required params appear in the rendered block,
  - `count_at_least` shows both `glob` and `min_count` (direct #182 regression),
  - non-empty guard (against regressing to `""`).

## Verification
Regression: **4023 passed, 1 skipped, 0 failed.**

## Out of scope (tracked elsewhere)
- Parser leniency (skip a malformed criterion instead of dropping the whole proposal) — belongs to **SIP-0093 B′** (the revision loop should re-prompt a failed proposer), not authoring-time validation weakening.
- The empirical acceptance gate — a `validation-multirole` cycle producing a non-empty merged plan — is the close criterion for #182; this PR is the fix, re-validation confirms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
