### PR TITLE
fix: single-quote proposer acceptance-check examples so regex patterns parse

### DIFF
--- a/src/squadops/capabilities/handlers/_plan_authoring_service.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring_service.py
@@ -147,7 +147,9 @@ async def produce_plan(
         "- check: regex_match\n"
         '  description: "At least three test functions exist"\n'
         "  file: tests/test_users.py\n"
-        '  pattern: "def test_"\n'
+        # Single-quote regex patterns: double quotes interpret backslash escapes
+        # (\w, \.) and break yaml.safe_load. See acceptance_check_spec.CHECK_SPECS.
+        "  pattern: 'def test_\\w+'\n"
         "  count_min: 3\n"
         "\n"
         "# count_at_least — glob match count under workspace (stack-agnostic)\n"

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -120,7 +120,10 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         supported_stacks=frozenset(),
         requires_stack_context=False,
         path_params=frozenset({"file"}),
-        example={"file": "tests/test_runs.py", "pattern": "def test_", "count_min": 5},
+        # pattern carries a backslash escape on purpose: the rendered example
+        # must teach proposers the single-quote style for real regexes, since
+        # double-quoting \w / \. is exactly what broke YAML parsing in #182's wake.
+        example={"file": "tests/test_runs.py", "pattern": r"def test_\w+", "count_min": 5},
     ),
     "count_at_least": CheckSpec(
         name="count_at_least",
@@ -174,9 +177,18 @@ def _type_label(spec: CheckSpec, param: str) -> str:
 
 
 def _format_example_value(value: object) -> str:
-    """Render an example param value as inline YAML (strings quoted)."""
+    """Render an example param value as inline YAML, strings SINGLE-quoted.
+
+    The quote style is load-bearing: proposers copy whatever style the example
+    uses, and single-quoted YAML scalars do not process backslash escapes — a
+    regex like ``\\.length`` round-trips literally. Double quotes would read
+    ``\\.`` as an escape sequence and ``yaml.safe_load`` raises "unknown escape
+    character", which drops the entire proposal (observed in cyc_82c9b3f5a2c1,
+    the #182 follow-up regression). Embedded single quotes are escaped as ``''``
+    per the YAML single-quoted scalar rule.
+    """
     if isinstance(value, str):
-        return f'"{value}"'
+        return "'" + value.replace("'", "''") + "'"
     if isinstance(value, list):
         return "[" + ", ".join(_format_example_value(v) for v in value) + "]"
     return str(value)

--- a/tests/unit/cycles/test_typed_acceptance_vocabulary.py
+++ b/tests/unit/cycles/test_typed_acceptance_vocabulary.py
@@ -13,9 +13,11 @@ that it can never silently regress to the empty/under-specified state.
 """
 
 import pytest
+import yaml
 
 from squadops.cycles.acceptance_check_spec import (
     CHECK_SPECS,
+    _format_example_value,
     render_typed_acceptance_vocabulary,
 )
 from squadops.cycles.implementation_plan import TypedCheck, _parse_acceptance_criteria
@@ -67,3 +69,61 @@ def test_rendered_vocabulary_is_not_empty():
     assert rendered.strip()
     # Sanity: every check is represented, so length scales with the registry.
     assert rendered.count("- check:") == len(CHECK_SPECS)
+
+
+def _yaml_example_blocks(rendered: str) -> list[str]:
+    """Pull the fenced ```yaml example blocks out of the rendered vocabulary."""
+    blocks: list[str] = []
+    current: list[str] = []
+    inside = False
+    for line in rendered.splitlines():
+        if line.strip() == "```yaml":
+            inside, current = True, []
+        elif inside and line.strip() == "```":
+            blocks.append("\n".join(current))
+            inside = False
+        elif inside:
+            current.append(line)
+    return blocks
+
+
+def test_format_example_value_backslash_regex_round_trips():
+    """The #182-follow-up dev-proposer failure (cyc_82c9b3f5a2c1): a regex value
+    with a backslash escape must survive yaml.safe_load to the SAME string.
+    Double-quoting made YAML read \\. / \\w as escape sequences and raise
+    'unknown escape character', which dropped the entire proposal. Single-quoted
+    scalars don't process backslashes, so they round-trip."""
+    pattern = r"participant|participants?.*length|\.length"
+    loaded = yaml.safe_load(f"value: {_format_example_value(pattern)}")
+    assert loaded["value"] == pattern
+
+
+def test_format_example_value_escapes_embedded_single_quote():
+    """A value containing a single quote must stay parseable — YAML single-quoted
+    scalars escape ' by doubling it. Without the escaping the scalar terminates
+    early and the loaded value is corrupted."""
+    value = "can't stop"
+    loaded = yaml.safe_load(f"value: {_format_example_value(value)}")
+    assert loaded["value"] == value
+
+
+def test_rendered_vocabulary_examples_all_parse_as_yaml():
+    """Integration guard: every fenced example we hand proposers must round-trip
+    through the same yaml.safe_load the merger runs on proposals. The regex_match
+    example now carries a backslash escape, so a regression to double-quoting
+    fails here with the exact error that dropped the dev proposal."""
+    blocks = _yaml_example_blocks(render_typed_acceptance_vocabulary())
+    assert len(blocks) == len(CHECK_SPECS)
+    for block in blocks:
+        loaded = yaml.safe_load(block)
+        assert isinstance(loaded, list) and len(loaded) == 1
+        assert "check" in loaded[0]
+
+
+def test_regex_example_demonstrates_a_backslash_in_single_quotes():
+    """The regex_match exemplar must show a real backslash escape in single
+    quotes — that is what teaches proposers the safe style. A backslash-free or
+    double-quoted exemplar would silently re-teach the broken pattern."""
+    rendered = render_typed_acceptance_vocabulary()
+    assert r"pattern: 'def test_\w+'" in rendered
+    assert r'pattern: "def test_\w+"' not in rendered


### PR DESCRIPTION
## Problem

The SIP-0093 B re-validation cycle `cyc_82c9b3f5a2c1` (the re-run after #182) was meant to produce a non-empty multi-role plan. The **development proposer failed again** — but for a *different* reason than #182:

```
Malformed proposal YAML: while scanning a double-quoted scalar
  pattern: "participant|participants?.*length|\.length"
                                               ^
found unknown escape character '.'
```

Result: `proposal_completeness: partial`, dev proposal dropped, merged plan was **QA-only (0 dev tasks)** with 8 dangling `dev:*` dependencies — unbuildable.

## Root cause

The typed-acceptance vocabulary handed to proposers renders every string example with **double quotes** via `_format_example_value` (`acceptance_check_spec.py`). Double-quoted YAML scalars interpret backslash escapes, but regex patterns are made of them (`\.`, `\w`, `\d`, `\b`). Proposers copy the exemplar's quote style, so the moment one writes a realistic regex, `yaml.safe_load` raises *unknown escape character* and the whole proposal is discarded.

Ironically the **same #182 PR** that fixed the `count_at_least` empty-param bug introduced this renderer and picked the one quote style that breaks regexes. The `retry_yaml_call` path can't recover, because the bad exemplar steers the model right back to double quotes on every retry.

Trace:
1. `acceptance_check_spec.py` `_format_example_value` → `return f'"{value}"'`
2. `render_typed_acceptance_vocabulary()` renders the `regex_match` example double-quoted
3. injected into the proposer prompt at `planning_tasks.py:804` (`typed_acceptance_vocabulary`)
4. proposer LLM (`planning_tasks.py:185`) copies the style for its own regex
5. merge `yaml.safe_load` (`proposed_role_tasks.py:168-170`) raises `Malformed proposal YAML`

## Fix

- **`_format_example_value` → single quotes.** Single-quoted YAML scalars don't process backslash escapes, so `'\.length'` round-trips literally. Embedded `'` escaped as `''`.
- **`regex_match` example now carries a real backslash** (`def test_\w+`), so the rendered exemplar actively teaches the safe style instead of a backslash-free `def test_`.
- **Fixed the duplicate hardcoded exemplar** in `_plan_authoring_service.py` (the merge-author path) the same way — same bug class, second proposer-facing prompt.

## Tests

`tests/unit/cycles/test_typed_acceptance_vocabulary.py`:
- backslash-bearing regex round-trips through `yaml.safe_load` (the exact failure)
- embedded single-quote escaping (`''`)
- every fenced `\`\`\`yaml` example in the rendered vocabulary parses via `yaml.safe_load`
- the regex exemplar keeps its backslash **and** single quotes

243 passing across the affected planning/proposer/merge suites.

## What this validates / leaves open

- #182's `count_at_least` fix is **confirmed** (QA proposed cleanly in `cyc_82c9b3f5a2c1`); this PR removes the *second* blocker.
- A full multi-role (dev+qa+strategy) merge still needs a clean re-run to demonstrate B closure.

## Follow-up (not in this PR)

`_plan_authoring_service.py` hand-maintains a **second full copy** of the typed-acceptance vocabulary that duplicates `CHECK_SPECS`. It should be single-sourced onto `render_typed_acceptance_vocabulary()` so exemplars can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)