### PR TITLE
fix(#187): tolerate malformed optional sections in proposer parser

### DIFF
--- a/src/squadops/cycles/proposed_role_tasks.py
+++ b/src/squadops/cycles/proposed_role_tasks.py
@@ -22,6 +22,7 @@ fails, the merger falls back to sole-broker authoring per SIP-0093 §5.4.
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
 
@@ -31,6 +32,8 @@ from squadops.cycles.implementation_plan import (
     TypedCheck,
     _parse_acceptance_criteria,
 )
+
+logger = logging.getLogger(__name__)
 
 _FOCUS_NORMALIZE_RE = re.compile(r"\s+")
 
@@ -135,6 +138,12 @@ class ProposedRoleTasks:
     populate inconsistently even when required (per SIP-0093 §5.4.1) — kept
     optional so a proposer that fails to surface its assumptions doesn't
     invalidate an otherwise good proposal.
+
+    Optional sections degrade gracefully (issue #187): a malformed
+    ``brief_conflicts`` entry or wrong-typed advisory list is dropped (warn +
+    recorded in ``degraded_sections``) instead of discarding the proposal's
+    load-bearing ``tasks``. ``tasks`` and the required header fields stay
+    strict — a problem there still raises and the merger drops the proposal.
     """
 
     version: int
@@ -149,6 +158,10 @@ class ProposedRoleTasks:
     risks: list[str] = field(default_factory=list)
     gaps_not_covered: list[str] = field(default_factory=list)
     confidence: str = ""
+    # Optional sections dropped during tolerant parsing (issue #187). Empty for
+    # a clean proposal; e.g. ``["brief_conflicts[0]"]`` when one conflict entry
+    # was skipped. The merger can surface these without re-deriving them.
+    degraded_sections: list[str] = field(default_factory=list)
 
     @classmethod
     def from_yaml(cls, content: str) -> ProposedRoleTasks:
@@ -159,10 +172,17 @@ class ProposedRoleTasks:
         proceeds with the survivors), so we surface the specific
         failure rather than abort the whole framing phase.
 
+        Optional/advisory sections (``brief_conflicts`` and the str-list
+        fields) degrade rather than raise (issue #187): a malformed entry is
+        dropped and noted in ``degraded_sections`` so one fumbled annotation
+        can't discard the load-bearing ``tasks``. Only the required header
+        fields and the ``tasks`` list still raise.
+
         Raises:
-            ValueError: if the YAML is malformed or required fields
-                are missing. Caller decides whether to absorb the
-                failure (merger does) or escalate.
+            ValueError: if the YAML is malformed, required header fields
+                are missing, or a ``tasks`` entry is malformed. Caller
+                decides whether to absorb the failure (merger does) or
+                escalate.
         """
         try:
             data = yaml.safe_load(content)
@@ -214,7 +234,11 @@ class ProposedRoleTasks:
         for i, td in enumerate(raw_tasks):
             parsed.append(_parse_proposed_task(td, i, seen_keys))
 
-        brief_conflicts = _parse_brief_conflicts(data.get("brief_conflicts", []))
+        # Optional sections degrade rather than raise (issue #187): each helper
+        # appends the names of dropped sections to ``degraded`` instead of
+        # failing the whole proposal.
+        degraded: list[str] = []
+        brief_conflicts = _parse_brief_conflicts(data.get("brief_conflicts", []), degraded)
 
         return cls(
             version=version,
@@ -224,11 +248,16 @@ class ProposedRoleTasks:
             scope_statement=scope_statement,
             tasks=parsed,
             brief_conflicts=brief_conflicts,
-            source_artifact_refs=_parse_str_list(data.get("source_artifact_refs", [])),
-            assumptions=_parse_str_list(data.get("assumptions", [])),
-            risks=_parse_str_list(data.get("risks", [])),
-            gaps_not_covered=_parse_str_list(data.get("gaps_not_covered", [])),
+            source_artifact_refs=_parse_str_list(
+                data.get("source_artifact_refs", []), "source_artifact_refs", degraded
+            ),
+            assumptions=_parse_str_list(data.get("assumptions", []), "assumptions", degraded),
+            risks=_parse_str_list(data.get("risks", []), "risks", degraded),
+            gaps_not_covered=_parse_str_list(
+                data.get("gaps_not_covered", []), "gaps_not_covered", degraded
+            ),
             confidence=str(data.get("confidence", "")).strip(),
+            degraded_sections=degraded,
         )
 
     def task_keys(self) -> list[str]:
@@ -298,60 +327,85 @@ def _parse_proposed_task(td: object, i: int, seen_keys: set[str]) -> ProposedTas
     )
 
 
-def _parse_str_list(raw: object) -> list[str]:
-    """Coerce an optional YAML scalar/list field to a list of strings.
+def _parse_str_list(raw: object, section: str, degraded: list[str]) -> list[str]:
+    """Coerce an optional YAML list field to a list of strings.
 
-    Best-effort: scalar becomes single-element list; list elements get
-    stringified; anything else surfaces as a parse error so the merger
-    can drop the proposal cleanly.
+    Tolerant (issue #187): a wrong-typed advisory section is an LLM-output
+    annotation, not load-bearing — so it's dropped (warn + recorded in
+    ``degraded``) rather than failing the whole proposal. ``None``/empty →
+    ``[]``; a list gets stringified element-wise.
     """
     if raw is None or raw == "":
         return []
     if isinstance(raw, list):
         return [str(x).strip() for x in raw if str(x).strip()]
-    raise ValueError(
-        f"Optional list field must be a YAML list or null, got {type(raw).__name__}"
+    logger.warning(
+        "Proposal: dropping malformed optional section %r — expected a YAML list, got %s",
+        section,
+        type(raw).__name__,
     )
+    degraded.append(section)
+    return []
 
 
-def _parse_brief_conflicts(raw: object) -> list[BriefConflict]:
-    """Parse the optional ``brief_conflicts`` list (SIP-0093 §5.5)."""
+def _parse_brief_conflicts(raw: object, degraded: list[str]) -> list[BriefConflict]:
+    """Parse the optional ``brief_conflicts`` list (SIP-0093 §5.5).
+
+    Tolerant per-entry (issue #187): a malformed conflict entry is skipped
+    (warn + recorded in ``degraded`` as ``brief_conflicts[i]``), preserving the
+    valid entries and the proposal's load-bearing ``tasks``. A wrong-typed
+    section is dropped whole. This is an *advisory* section — the dev proposer
+    repeatedly fumbled a single sub-field here and lost its entire proposal
+    (cyc_ee7a5dfcdb16); one bad annotation must no longer discard real work.
+    """
     if raw is None or raw == "":
         return []
     if not isinstance(raw, list):
-        raise ValueError(
-            f"brief_conflicts must be a YAML list, got {type(raw).__name__}"
+        logger.warning(
+            "Proposal: dropping malformed 'brief_conflicts' — expected a YAML list, got %s",
+            type(raw).__name__,
         )
+        degraded.append("brief_conflicts")
+        return []
 
     parsed: list[BriefConflict] = []
     for i, entry in enumerate(raw):
-        if not isinstance(entry, dict):
-            raise ValueError(f"brief_conflicts[{i}] must be a mapping")
-
-        for req in ("brief_field", "proposed_change", "reason", "severity"):
-            if req not in entry:
-                raise ValueError(f"brief_conflicts[{i}] missing required field: {req}")
-
-        severity = str(entry["severity"]).strip().lower()
-        if severity not in _VALID_BRIEF_CONFLICT_SEVERITIES:
-            raise ValueError(
-                f"brief_conflicts[{i}] severity must be one of "
-                f"{sorted(_VALID_BRIEF_CONFLICT_SEVERITIES)}, got {entry['severity']!r}"
-            )
-
-        affected = entry.get("affected_proposal_task_keys", [])
-        if not isinstance(affected, list):
-            raise ValueError(
-                f"brief_conflicts[{i}] affected_proposal_task_keys must be a list"
-            )
-
-        parsed.append(
-            BriefConflict(
-                brief_field=str(entry["brief_field"]).strip(),
-                proposed_change=str(entry["proposed_change"]).strip(),
-                reason=str(entry["reason"]).strip(),
-                severity=severity,
-                affected_proposal_task_keys=[str(k).strip() for k in affected if str(k).strip()],
-            )
-        )
+        try:
+            parsed.append(_parse_one_brief_conflict(entry, i))
+        except ValueError as exc:
+            logger.warning("Proposal: skipping malformed brief_conflicts[%d] — %s", i, exc)
+            degraded.append(f"brief_conflicts[{i}]")
     return parsed
+
+
+def _parse_one_brief_conflict(entry: object, i: int) -> BriefConflict:
+    """Parse + validate a single ``brief_conflicts`` entry (strict).
+
+    Raises ``ValueError`` on any shape problem; the caller decides whether to
+    skip (it does) or propagate.
+    """
+    if not isinstance(entry, dict):
+        raise ValueError(f"brief_conflicts[{i}] must be a mapping")
+
+    for req in ("brief_field", "proposed_change", "reason", "severity"):
+        if req not in entry:
+            raise ValueError(f"brief_conflicts[{i}] missing required field: {req}")
+
+    severity = str(entry["severity"]).strip().lower()
+    if severity not in _VALID_BRIEF_CONFLICT_SEVERITIES:
+        raise ValueError(
+            f"brief_conflicts[{i}] severity must be one of "
+            f"{sorted(_VALID_BRIEF_CONFLICT_SEVERITIES)}, got {entry['severity']!r}"
+        )
+
+    affected = entry.get("affected_proposal_task_keys", [])
+    if not isinstance(affected, list):
+        raise ValueError(f"brief_conflicts[{i}] affected_proposal_task_keys must be a list")
+
+    return BriefConflict(
+        brief_field=str(entry["brief_field"]).strip(),
+        proposed_change=str(entry["proposed_change"]).strip(),
+        reason=str(entry["reason"]).strip(),
+        severity=severity,
+        affected_proposal_task_keys=[str(k).strip() for k in affected if str(k).strip()],
+    )

--- a/tests/unit/cycles/test_proposed_role_tasks_v2.py
+++ b/tests/unit/cycles/test_proposed_role_tasks_v2.py
@@ -56,11 +56,7 @@ class TestNewRequiredFields:
 
     def test_missing_source_brief_id_rejected(self):
         bad = (
-            "version: 1\n"
-            "proposing_role: dev\n"
-            "proposal_id: prop-1\n"
-            "scope_statement: x\n"
-            "tasks: []\n"
+            "version: 1\nproposing_role: dev\nproposal_id: prop-1\nscope_statement: x\ntasks: []\n"
         )
         with pytest.raises(ValueError, match="source_brief_id"):
             ProposedRoleTasks.from_yaml(bad)
@@ -90,7 +86,11 @@ class TestNewRequiredFields:
         lines = _BASE_VALID.splitlines(keepends=True)
         out_lines = []
         for line in lines:
-            if line.startswith(f"{field}:") or line.startswith(f"{field} ") or line.startswith(f"{field}\n"):
+            if (
+                line.startswith(f"{field}:")
+                or line.startswith(f"{field} ")
+                or line.startswith(f"{field}\n")
+            ):
                 continue
             out_lines.append(line)
         bad = "".join(out_lines) + f"{field}: {bad_value}\n"
@@ -103,14 +103,33 @@ class TestNewRequiredFields:
 # ---------------------------------------------------------------------------
 
 
+_BASE_VALID_WITH_TASK = """\
+version: 1
+proposing_role: dev
+proposal_id: prop-dev-001
+source_brief_id: brief-test-001
+scope_statement: |
+  Dev contributions for the user CRUD feature.
+tasks:
+  - task_type: development.develop
+    role: dev
+    focus: Backend repository
+    description: In-memory repo + Pydantic models
+"""
+
+
 class TestBriefConflicts:
     """Brief conflicts are how proposers escalate spec disagreements with the
-    shared brief (SIP-0093 §5.5). They must parse with both severities and
-    reject unknown severities — the merger's escalation behavior branches on
-    severity, so a typo there would silently downgrade a blocking conflict."""
+    shared brief (SIP-0093 §5.5). Valid entries parse with both severities. A
+    *malformed* entry is an advisory annotation, not load-bearing: per issue
+    #187 it's skipped and recorded in ``degraded_sections`` rather than failing
+    the whole proposal — the dev proposer kept losing its entire task set over a
+    single fumbled sub-field here (cyc_ee7a5dfcdb16)."""
 
     def test_parses_warning_and_blocking(self):
-        yaml_doc = _BASE_VALID + """
+        yaml_doc = (
+            _BASE_VALID
+            + """
 brief_conflicts:
   - brief_field: accepted_stack
     proposed_change: Use SQLite instead of in-memory
@@ -122,8 +141,10 @@ brief_conflicts:
     reason: Out of scope for MVP
     severity: warning
 """
+        )
         proposal = ProposedRoleTasks.from_yaml(yaml_doc)
         assert len(proposal.brief_conflicts) == 2
+        assert proposal.degraded_sections == []
 
         blocking = proposal.brief_conflicts[0]
         assert isinstance(blocking, BriefConflict)
@@ -138,30 +159,105 @@ brief_conflicts:
         assert warning.severity == "warning"
         assert warning.affected_proposal_task_keys == []
 
-    def test_unknown_severity_rejected(self):
-        yaml_doc = _BASE_VALID + """
+    def test_unknown_severity_entry_skipped_not_fatal(self):
+        yaml_doc = (
+            _BASE_VALID
+            + """
 brief_conflicts:
   - brief_field: accepted_stack
     proposed_change: foo
     reason: bar
     severity: critical
 """
-        with pytest.raises(ValueError, match="severity"):
-            ProposedRoleTasks.from_yaml(yaml_doc)
+        )
+        proposal = ProposedRoleTasks.from_yaml(yaml_doc)
+        # Bad-severity entry dropped, not raised; recorded for visibility.
+        assert proposal.brief_conflicts == []
+        assert proposal.degraded_sections == ["brief_conflicts[0]"]
 
-    def test_missing_brief_field_rejected(self):
-        yaml_doc = _BASE_VALID + """
+    def test_missing_required_field_entry_skipped(self):
+        # The exact cyc_ee7a5dfcdb16 failure: a brief_conflict missing
+        # proposed_change used to drop the whole proposal. Now it's skipped.
+        yaml_doc = (
+            _BASE_VALID
+            + """
 brief_conflicts:
-  - proposed_change: foo
+  - brief_field: accepted_stack
     reason: bar
     severity: warning
 """
-        with pytest.raises(ValueError, match="brief_field"):
-            ProposedRoleTasks.from_yaml(yaml_doc)
+        )
+        proposal = ProposedRoleTasks.from_yaml(yaml_doc)
+        assert proposal.brief_conflicts == []
+        assert proposal.degraded_sections == ["brief_conflicts[0]"]
+
+    def test_malformed_entry_preserves_valid_siblings_and_tasks(self):
+        # Per-entry tolerance is the load-bearing #187 guarantee: a single bad
+        # conflict must not take down the valid sibling conflict OR the real
+        # task. Entry 0 is missing proposed_change; entry 1 is well-formed.
+        yaml_doc = (
+            _BASE_VALID_WITH_TASK
+            + """
+brief_conflicts:
+  - brief_field: accepted_stack
+    reason: missing proposed_change here
+    severity: blocking
+  - brief_field: scope_cuts
+    proposed_change: Drop typeahead
+    reason: Out of scope for MVP
+    severity: warning
+"""
+        )
+        proposal = ProposedRoleTasks.from_yaml(yaml_doc)
+        # The valid sibling survives; the malformed one is dropped + recorded.
+        assert len(proposal.brief_conflicts) == 1
+        assert proposal.brief_conflicts[0].brief_field == "scope_cuts"
+        assert proposal.degraded_sections == ["brief_conflicts[0]"]
+        # And the load-bearing task is untouched.
+        assert len(proposal.tasks) == 1
+        assert proposal.tasks[0].focus == "Backend repository"
 
     def test_default_empty_list(self):
         proposal = ProposedRoleTasks.from_yaml(_BASE_VALID)
         assert proposal.brief_conflicts == []
+        assert proposal.degraded_sections == []
+
+
+class TestAdvisoryListTolerance:
+    """The advisory str-list sections (assumptions/risks/gaps_not_covered/
+    source_artifact_refs) are LLM-output annotations. A wrong-typed section is
+    dropped and recorded (issue #187), never fatal — same rationale as
+    brief_conflicts."""
+
+    def test_wrong_typed_section_dropped_and_recorded(self):
+        # A mapping where a list is expected used to raise and drop the whole
+        # proposal. Now the section is dropped, the rest survives.
+        yaml_doc = (
+            _BASE_VALID_WITH_TASK
+            + """
+assumptions:
+  not: a list
+"""
+        )
+        proposal = ProposedRoleTasks.from_yaml(yaml_doc)
+        assert proposal.assumptions == []
+        assert proposal.degraded_sections == ["assumptions"]
+        assert len(proposal.tasks) == 1
+
+    def test_only_offending_section_is_dropped(self):
+        # risks is malformed; assumptions is a valid list and must be kept.
+        yaml_doc = (
+            _BASE_VALID_WITH_TASK
+            + """
+assumptions:
+  - pytest is the backend runner
+risks: 42
+"""
+        )
+        proposal = ProposedRoleTasks.from_yaml(yaml_doc)
+        assert proposal.assumptions == ["pytest is the backend runner"]
+        assert proposal.risks == []
+        assert proposal.degraded_sections == ["risks"]
 
 
 # ---------------------------------------------------------------------------
@@ -239,7 +335,9 @@ class TestOptionalFieldsRoundTrip:
         assert proposal.confidence == ""
 
     def test_optional_fields_parse_when_present(self):
-        yaml_doc = _BASE_VALID + """
+        yaml_doc = (
+            _BASE_VALID
+            + """
 source_artifact_refs:
   - planning_artifact.md
   - design.md
@@ -251,6 +349,7 @@ gaps_not_covered:
   - Frontend smoke tests deferred to qa.
 confidence: medium
 """
+        )
         proposal = ProposedRoleTasks.from_yaml(yaml_doc)
         assert proposal.source_artifact_refs == ["planning_artifact.md", "design.md"]
         assert proposal.assumptions == ["Auth provider is Keycloak per the brief."]


### PR DESCRIPTION
Closes #187.

## Problem

`ProposedRoleTasks.from_yaml` (`src/squadops/cycles/proposed_role_tasks.py`) was **all-or-nothing**: any `ValueError` while parsing an *advisory* section aborted the whole proposal, discarding every valid task. The SIP-0093 multi-role dev proposer hit this **three cycles running**, each on a different field:

| Cycle | Dev proposer failure | Fix |
|---|---|---|
| — | `count_at_least` params | #182 / #183 |
| `cyc_82c9b3f5a2c1` | regex backslash in `"..."` YAML | #184 |
| `cyc_ee7a5dfcdb16` | `brief_conflicts[0]` missing `proposed_change` | **this PR** |

Each time the dev proposal was discarded → QA-only, unbuildable plan (`total_dev_tasks: 0`). `brief_conflicts` is *optional/advisory* (the QA proposer left it `[]`); one fumbled sub-field shouldn't nuke real work.

## Fix (structural — option B from #187)

Optional sections degrade instead of raising; `tasks` and required header fields stay strict.

- **`brief_conflicts`: per-entry tolerance** — a malformed conflict is skipped, valid siblings preserved (extracted `_parse_one_brief_conflict`).
- **str-list sections** (`assumptions` / `risks` / `gaps_not_covered` / `source_artifact_refs`): a wrong-typed section is dropped whole.
- Dropped sections are `logger.warning`'d **and recorded** in a new `ProposedRoleTasks.degraded_sections` field — not silent, so the merger can surface them.
- **`tasks` + required header fields unchanged** — a problem there still raises and the merger drops the proposal (load-bearing stays strict).

## Tests

- Rewrote the two brief_conflict "rejected" tests to the new resilient contract (skipped + recorded, not fatal).
- Added: malformed entry **preserves valid sibling + the load-bearing task**; str-list wrong-type dropped + only-offending-section dropped.
- 2341 unit tests pass; ruff clean.

## Follow-up (not in this PR)

#187 sub-item **(A)**: document the `brief_conflicts` schema in the proposer prompt (à la #182's `render_typed_acceptance_vocabulary`) to reduce how often it's emitted malformed. **(B)** here makes it non-fatal regardless, so this is frequency-reduction, not correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)