### PR TITLE
fix(#189): normalize cross-proposal dependency keys (role display-name vs role-id)

### DIFF
--- a/src/squadops/capabilities/handlers/_plan_merger.py
+++ b/src/squadops/capabilities/handlers/_plan_merger.py
@@ -42,6 +42,7 @@ from squadops.cycles.plan_guidance import PlanGuidance
 from squadops.cycles.proposed_role_tasks import (
     ProposedRoleTasks,
     ProposedTask,
+    canonicalize_dep_ref,
     focus_key,
 )
 
@@ -53,6 +54,41 @@ logger = logging.getLogger(__name__)
 # lane); qa tasks proposed by dev are likewise dropped.
 _DEV_TASK_TYPES = frozenset({"development.develop", "builder.assemble"})
 _QA_TASK_TYPES = frozenset({"qa.test"})
+
+
+def _resolve_dependency_edges(
+    indexed_pairs: list[tuple[PlanTask, CanonicalTaskProvenance, ProposedTask]],
+    focus_to_index: dict[str, int],
+) -> tuple[list[tuple[PlanTask, CanonicalTaskProvenance]], list[tuple[int, str]]]:
+    """Resolve each task's ``depends_on_focus`` references to canonical
+    ``task_index`` edges (SIP-0093 rule 5).
+
+    References are normalized (#189) so a role display-name / case variant
+    (``development:Backend Models``) resolves against the produced role-id key
+    (``dev:backend models``). A reference that still misses after normalization
+    is a genuine gap (a focus no task produced) and is returned in
+    ``unresolved_deps`` keyed by its normalized form for the operator note.
+    """
+    resolved_pairs: list[tuple[PlanTask, CanonicalTaskProvenance]] = []
+    unresolved_deps: list[tuple[int, str]] = []  # (task_index, missing_key)
+    for task, prov, orig in indexed_pairs:
+        depends_on: list[int] = []
+        for dep_key in orig.depends_on_focus:
+            norm_key = canonicalize_dep_ref(dep_key)
+            if norm_key not in focus_to_index:
+                unresolved_deps.append((task.task_index, norm_key))
+                continue
+            if norm_key != dep_key:
+                logger.debug(
+                    "merge_plan: normalized cross-proposal dependency %r -> %r",
+                    dep_key,
+                    norm_key,
+                )
+            depends_on.append(focus_to_index[norm_key])
+        resolved_pairs.append(
+            (dataclasses.replace(task, depends_on=sorted(set(depends_on))), prov)
+        )
+    return resolved_pairs, unresolved_deps
 
 
 def merge_proposals(
@@ -138,18 +174,9 @@ def merge_proposals(
         for key in prov.source_proposal_task_keys:
             focus_to_index[key] = task.task_index
 
-    resolved_pairs: list[tuple[PlanTask, CanonicalTaskProvenance]] = []
-    unresolved_deps: list[tuple[int, str]] = []  # (task_index, missing_key)
-    for task, prov, orig in indexed_pairs:
-        depends_on: list[int] = []
-        for dep_key in orig.depends_on_focus:
-            if dep_key in focus_to_index:
-                depends_on.append(focus_to_index[dep_key])
-            else:
-                unresolved_deps.append((task.task_index, dep_key))
-        resolved_pairs.append(
-            (dataclasses.replace(task, depends_on=sorted(set(depends_on))), prov)
-        )
+    resolved_pairs, unresolved_deps = _resolve_dependency_edges(
+        indexed_pairs, focus_to_index
+    )
 
     canonical_tasks = [t for t, _ in resolved_pairs]
     provenance_entries = [p for _, p in resolved_pairs]

--- a/src/squadops/cycles/proposed_role_tasks.py
+++ b/src/squadops/cycles/proposed_role_tasks.py
@@ -46,9 +46,46 @@ def _normalize_focus(text: str) -> str:
     return _FOCUS_NORMALIZE_RE.sub(" ", text.strip().lower())
 
 
+# Role display-name → role-id. The proposer vocabulary uses display names
+# (``proposing_role: development``) while produced tasks carry role-ids
+# (``role: dev``). Dependency keys must collapse to the role-id form so a
+# ``development:`` reference resolves against the produced ``dev:`` task
+# (issue #189). Single source of truth: ``task_plan._PLAN_AUTHORING_PROPOSER_STEPS``
+# derives its role-id column from this map via :func:`role_to_id`.
+ROLE_NAME_TO_ID: dict[str, str] = {"development": "dev", "strategy": "strat"}
+
+
+def role_to_id(role: str) -> str:
+    """Collapse a role token (display-name or id) to its canonical role-id.
+
+    Unknown tokens pass through unchanged — ``qa``/``builder``/``data`` are
+    identical in both vocabularies, so only ``development`` and ``strategy``
+    are aliased."""
+    token = role.strip().lower()
+    return ROLE_NAME_TO_ID.get(token, token)
+
+
 def focus_key(role: str, focus: str) -> str:
-    """Canonical lookup key for cross-role dependencies."""
-    return f"{role.strip().lower()}:{_normalize_focus(focus)}"
+    """Canonical lookup key for cross-proposal dependencies.
+
+    Tolerant of role display-name vs role-id prefixes (issue #189):
+    ``development``/``strategy`` collapse to ``dev``/``strat`` so a proposer
+    that references ``development:Backend models`` resolves against the
+    produced ``dev:backend models`` task. Focus is whitespace-collapsed and
+    lowercased via :func:`_normalize_focus`."""
+    return f"{role_to_id(role)}:{_normalize_focus(focus)}"
+
+
+def canonicalize_dep_ref(dep_ref: str) -> str:
+    """Normalize a ``depends_on_focus`` ``"role:focus"`` reference the same
+    way :func:`focus_key` normalizes a produced task's key, so the resolve
+    side (raw reference string) and the produce side cannot drift (#189).
+
+    A bare string with no ``":"`` is treated as a focus with no role prefix."""
+    role, sep, focus = dep_ref.partition(":")
+    if not sep:
+        return _normalize_focus(dep_ref)
+    return focus_key(role, focus)
 
 
 @dataclass(frozen=True)

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -31,6 +31,7 @@ from squadops.cycles.models import (
     SquadProfile,
     WorkloadType,
 )
+from squadops.cycles.proposed_role_tasks import role_to_id
 from squadops.tasks.models import TaskEnvelope
 
 # Pinned task_type → role mapping (SIP-0066 §5.4)
@@ -73,11 +74,13 @@ PLANNING_TASK_STEPS: list[tuple[str, str]] = [
 
 # Per SIP-0093 §5.3: role → (task_type, role_id) mapping for the proposer
 # steps the framing sequence inserts between brief and merger when that
-# role is in ``plan_authoring_contributors``.
+# role is in ``plan_authoring_contributors``. The role-id column is derived
+# from ``proposed_role_tasks.role_to_id`` so it can't drift from the merger's
+# dependency-key normalization (issue #189).
 _PLAN_AUTHORING_PROPOSER_STEPS: dict[str, tuple[str, str]] = {
-    "development": ("development.propose_plan_tasks", "dev"),
-    "qa": ("qa.propose_plan_tasks", "qa"),
-    "strategy": ("strategy.propose_plan_guidance", "strat"),
+    "development": ("development.propose_plan_tasks", role_to_id("development")),
+    "qa": ("qa.propose_plan_tasks", role_to_id("qa")),
+    "strategy": ("strategy.propose_plan_guidance", role_to_id("strategy")),
 }
 
 # Rev 1 contributor vocabulary. ``build`` is reserved for Rev 2 (SIP-0093

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.development.propose_plan_tasks.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.development.propose_plan_tasks.md
@@ -51,10 +51,12 @@ Each task you propose must:
 - Be `focus`-unique within your proposal — duplicate focus values collide
   in the merger.
 - Be completable in roughly 2–10 minutes of focused LLM generation.
-- Declare cross-role dependencies via `depends_on_focus: ["{role}:{focus}"]`
+- Declare cross-role dependencies via `depends_on_focus: ["{role_id}:{focus}"]`
   strings — never via integer indices (you don't know your final
-  `task_index`; only the merger assigns those). Example: a dev task that
-  depends on builder packaging uses `["builder:package startup"]`.
+  `task_index`; only the merger assigns those). The prefix MUST be the
+  **role ID** (`dev`, `qa`, `strat`, `builder`), NOT the display name —
+  write `dev:`, never `development:`. Example: a dev endpoint task that
+  depends on your own data-model task uses `["dev:backend user model"]`.
 
 ### Acceptance-criteria discipline
 

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.qa.propose_plan_tasks.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.qa.propose_plan_tasks.md
@@ -58,9 +58,11 @@ Each task you propose must:
   `"Test everything"`). The `focus` is your task's identity within this
   proposal AND the dependency reference key other proposers use.
 - Be `focus`-unique within your proposal.
-- Declare cross-role dependencies via `depends_on_focus: ["{role}:{focus}"]`
-  strings, never via integer indices. Example: a qa test that depends
-  on Development's user-CRUD endpoint uses `["dev:user crud routes"]`.
+- Declare cross-role dependencies via `depends_on_focus: ["{role_id}:{focus}"]`
+  strings, never via integer indices. The prefix MUST be the **role ID**
+  (`dev`, `qa`, `strat`, `builder`), NOT the display name — write `dev:`,
+  never `development:`. Example: a qa test that depends on Development's
+  user-CRUD endpoint uses `["dev:user crud routes"]`.
 
 ### Acceptance-criteria discipline
 

--- a/tests/unit/capabilities/test_merge_plan_handler.py
+++ b/tests/unit/capabilities/test_merge_plan_handler.py
@@ -470,6 +470,119 @@ class TestDependencyResolution:
 
 
 # ---------------------------------------------------------------------------
+# Dependency-key normalization (issue #189): role display-name vs role-id
+# ---------------------------------------------------------------------------
+
+# Dev proposal with an INTRA-proposal dependency expressed via the role
+# DISPLAY name ("development:") rather than the role id ("dev:") — exactly the
+# shape the SIP-0093 dev proposer emitted in cyc_1bbe424095fc, which dropped
+# every dev->dev edge before the #189 fix.
+_DEV_PROPOSAL_DISPLAYNAME_DEP_YAML = """\
+version: 1
+proposal_id: prop-dev-189
+source_brief_id: brief-merge-001
+proposing_role: development
+scope_statement: |
+  Backend models + endpoint, endpoint depends on models.
+tasks:
+  - task_type: development.develop
+    role: dev
+    focus: "Backend models and schemas"
+    description: |
+      Pydantic models for the run domain.
+    expected_artifacts:
+      - "backend/models.py"
+    depends_on_focus: []
+  - task_type: development.develop
+    role: dev
+    focus: "FastAPI endpoints"
+    description: |
+      Wire endpoints; needs the models task.
+    expected_artifacts:
+      - "backend/main.py"
+    depends_on_focus:
+      - "development:Backend models and schemas"
+"""
+
+
+class TestDependencyKeyNormalization:
+    """#189: a ``depends_on_focus`` reference using the role DISPLAY name
+    (``development:``/``strategy:``) or a different case must still resolve
+    against the produced ``{role_id}:{focus.lower()}`` key. Only genuinely
+    absent focuses (hallucinated targets) stay gap_fill candidates."""
+
+    def test_intra_dev_display_name_self_reference_resolves(self, brief):
+        """The cyc_1bbe424095fc regression: dev's own endpoint task depends on
+        its own models task via ``development:Backend models and schemas``.
+        Before #189 this dropped to ``depends_on: []``; now it resolves."""
+        dev_proposal = ProposedRoleTasks.from_yaml(_DEV_PROPOSAL_DISPLAYNAME_DEP_YAML)
+        plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=None,
+            strategy_guidance=None,
+            project_id="p",
+            cycle_id="c",
+            prd_hash="h",
+            configured_contributors=["development"],
+            missing_proposals=[],
+        )
+        assert plan.tasks[0].focus == "Backend models and schemas"
+        assert plan.tasks[1].focus == "FastAPI endpoints"
+        # Endpoint task resolves its display-name dependency to the models index.
+        assert plan.tasks[1].depends_on == [0]
+        assert "Unresolved cross-proposal dependency" not in decisions.operator_notes
+
+    def test_cross_role_display_name_prefix_resolves(self, brief, dev_proposal):
+        """qa references the dev task as ``development:api join`` (display name)
+        — must resolve to the dev task index, not drop to a gap_fill note."""
+        qa_proposal_yaml = _QA_PROPOSAL_YAML.replace(
+            'depends_on_focus:\n      - "dev:api join"',
+            'depends_on_focus:\n      - "development:api join"',
+        )
+        qa_proposal = ProposedRoleTasks.from_yaml(qa_proposal_yaml)
+        plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=dev_proposal,
+            qa_proposal=qa_proposal,
+            strategy_guidance=None,
+            project_id="p",
+            cycle_id="c",
+            prd_hash="h",
+            configured_contributors=["development", "qa"],
+            missing_proposals=[],
+        )
+        assert plan.tasks[1].depends_on == [0]
+        assert "Unresolved cross-proposal dependency" not in decisions.operator_notes
+
+    def test_hallucinated_focus_gap_fills_with_normalized_key(self, brief):
+        """A truly absent focus stays a gap_fill candidate even when the
+        reference used a display-name prefix — and the operator note reports
+        the NORMALIZED ``dev:`` key, not the raw ``development:`` form, so the
+        note reads in the same vocabulary as the produced keys."""
+        qa_proposal_yaml = _QA_PROPOSAL_YAML.replace(
+            'depends_on_focus:\n      - "dev:api join"',
+            'depends_on_focus:\n      - "development:nonexistent"',
+        )
+        qa_proposal = ProposedRoleTasks.from_yaml(qa_proposal_yaml)
+        plan, decisions = merge_proposals(
+            brief=brief,
+            dev_proposal=None,
+            qa_proposal=qa_proposal,
+            strategy_guidance=None,
+            project_id="p",
+            cycle_id="c",
+            prd_hash="h",
+            configured_contributors=["qa"],
+            missing_proposals=[],
+        )
+        assert plan.tasks[0].depends_on == []
+        assert "Unresolved cross-proposal dependency" in decisions.operator_notes
+        assert "dev:nonexistent" in decisions.operator_notes
+        assert "development:nonexistent" not in decisions.operator_notes
+
+
+# ---------------------------------------------------------------------------
 # Domain-owner rule (§5.8 rule 2)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/cycles/test_proposed_role_tasks.py
+++ b/tests/unit/cycles/test_proposed_role_tasks.py
@@ -8,7 +8,9 @@ from squadops.cycles.implementation_plan import TypedCheck
 from squadops.cycles.proposed_role_tasks import (
     ProposedRoleTasks,
     ProposedTask,
+    canonicalize_dep_ref,
     focus_key,
+    role_to_id,
 )
 
 pytestmark = [pytest.mark.domain_orchestration]
@@ -40,6 +42,40 @@ class TestFocusKey:
 
     def test_distinct_roles_produce_distinct_keys(self):
         assert focus_key("dev", "tests") != focus_key("qa", "tests")
+
+    @pytest.mark.parametrize(
+        "display,role_id",
+        [("development", "dev"), ("strategy", "strat"), ("Development", "dev")],
+    )
+    def test_display_name_prefix_collapses_to_role_id(self, display, role_id):
+        # #189: a proposer that writes the role DISPLAY name must produce the
+        # same key as one that writes the role id, or dependency edges drop.
+        assert focus_key(display, "Backend Models") == focus_key(role_id, "Backend Models")
+
+    def test_role_id_and_unknown_role_pass_through(self):
+        # qa/builder/data are identical in both vocabularies — no aliasing.
+        assert role_to_id("qa") == "qa"
+        assert role_to_id("builder") == "builder"
+        assert role_to_id("development") == "dev"
+        assert role_to_id("strategy") == "strat"
+
+
+class TestCanonicalizeDepRef:
+    """#189: a raw ``depends_on_focus`` reference string must normalize the
+    same way :func:`focus_key` normalizes a produced task's key, so the
+    resolve side and produce side can't drift."""
+
+    def test_display_name_ref_matches_produced_key(self):
+        assert canonicalize_dep_ref("development:Backend Models") == focus_key(
+            "dev", "backend  models"
+        )
+
+    def test_already_canonical_ref_is_idempotent(self):
+        assert canonicalize_dep_ref("dev:backend api") == "dev:backend api"
+
+    def test_bare_string_without_colon_treated_as_focus(self):
+        # No role prefix → the whole string is a (normalized) focus.
+        assert canonicalize_dep_ref("Backend  Models") == "backend models"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

In SIP-0093 multi-role plan authoring, the merger built each produced task's canonical key with `focus_key()` (which lowercases the focus) but compared the **raw** `depends_on_focus` reference string against that index. So a proposer that wrote the role **display name** (`development:Backend models`) never matched the produced **role-id** key (`dev:backend models`) — the prefix never collapsed.

Result: every such dependency edge was flagged as a dangling "gap_fill candidate" in `merge_decisions.yaml` and the merged tasks landed with `depends_on: []`. This hit on every multi-role cycle once dev proposals started surviving the merge (`cyc_1bbe424095fc`), and it dropped even dev→dev *intra*-proposal edges. The dependency graph was silently discarded; plans only ran because sequential mode masks it.

The root cause is narrower than the issue first framed it: case was never the problem (`focus_key` already lowercases both sides) — it was purely the **role-token prefix** (`development` vs `dev`) plus a normalization **asymmetry** (produce side normalized, resolve side raw).

## Fix

One shared normalization, used by both the produce and resolve sides so they can't drift:

- **`role_to_id()` + `ROLE_NAME_TO_ID`** (`proposed_role_tasks.py`) collapse display-names (`development`→`dev`, `strategy`→`strat`) to role-ids; `qa`/`builder`/`data` pass through unchanged. `focus_key()` now runs the role through it.
- **`canonicalize_dep_ref()`** normalizes a raw `"role:focus"` reference the same way; `_plan_merger` resolves through it (extracted into `_resolve_dependency_edges`, which also keeps `merge_proposals` under the C901 complexity bound).
- **Class-2 (hallucinated targets)** — references to a focus no task produced (e.g. qa's `dev:run api endpoints`) still surface as gap_fill candidates, but the operator note now reports the **normalized** key so trivially-recoverable misses don't drown the real ones.
- **Single-sourcing:** `task_plan._PLAN_AUTHORING_PROPOSER_STEPS` derives its role-id column from `role_to_id`, so the proposer-step vocabulary can't drift from the merger's normalization.
- **Prompt fragments (dev + qa):** pin the dependency prefix to role-ids (`dev:`, never `development:`) to reduce malformed emissions at the source. Defense-in-depth — the code fix is load-bearing regardless of prompt.

## Tests

- Helper unit tests: display-name/case collapse, `canonicalize_dep_ref` idempotence on already-canonical input, bare-string-no-prefix edge.
- Merger regression tests: intra-dev display-name self-reference resolves (the exact `cyc_1bbe424095fc` shape), cross-role display-name resolves, and a hallucinated focus still gap_fills **with the normalized key**.
- Full `cycles` + `capabilities` suites: **2351 pass**, ruff clean.

## Deploy

- **runtime-api** rebuild for the merger fix (the executor/merger runs there).
- **agent-image** rebuild to pick up the prompt-fragment change.

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)