### PR TITLE
fix(#185): prefix Prefect task labels with agent name; extract task_naming module

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -23,6 +23,7 @@ from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from adapters.cycles.task_naming import build_task_name
 from squadops.cycles.checkpoint import RunCheckpoint
 from squadops.cycles.models import ArtifactRef, Cycle, GateDecisionValue, Run, RunStatus
 from squadops.cycles.plan_delta import PlanDelta
@@ -567,23 +568,6 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
     # SIP-0087: task-run lifecycle lives here (moved out of WorkflowTrackerBridge) so
     # the task_run_id is known before the agent starts producing logs.
-    @staticmethod
-    def _build_task_name(role: str, envelope: TaskEnvelope) -> str:
-        """Build a Gantt-friendly Prefect task name.
-
-        Focused-mode envelopes (manifest-decomposed subtasks) get
-        ``role[idx]: focus`` so the Gantt distinguishes parallel subtasks
-        instead of showing N identical ``role: task_type`` rows.
-        Legacy / non-focused envelopes keep ``role: task_type``.
-        """
-        inputs = envelope.inputs or {}
-        focus = inputs.get("subtask_focus")
-        idx = inputs.get("subtask_index")
-        if focus:
-            focus_short = str(focus)[:60]
-            return f"{role}[{idx}]: {focus_short}" if idx is not None else f"{role}: {focus_short}"
-        return f"{role}: {envelope.task_type}"
-
     async def _create_task_run_if_enabled(
         self,
         flow_run_id: str | None,
@@ -592,8 +576,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         """Create a Prefect task_run + set RUNNING. Returns task_run_id or None."""
         if self._workflow_tracker is None or not flow_run_id:
             return None
-        role = envelope.metadata.get("role", "unknown") if envelope.metadata else "unknown"
-        task_name = self._build_task_name(role, envelope)
+        task_name = build_task_name(envelope)
         task_run_id = await self._workflow_tracker.create_task_run(
             flow_run_id, envelope.task_id, task_name
         )
@@ -970,7 +953,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 },
                 payload={
                     "task_type": envelope.task_type,
-                    "task_name": f"{envelope.metadata.get('role', 'unknown')}: {envelope.task_type}",
+                    "task_name": build_task_name(envelope),
                 },
             )
 
@@ -2432,7 +2415,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 },
                 payload={
                     "task_type": envelope.task_type,
-                    "task_name": f"{envelope.metadata.get('role', 'unknown')}: {envelope.task_type}",
+                    "task_name": build_task_name(envelope),
                 },
             )
             enriched = dataclasses.replace(

--- a/adapters/cycles/task_naming.py
+++ b/adapters/cycles/task_naming.py
@@ -1,0 +1,38 @@
+"""Prefect task-name formatting (extracted from DispatchedFlowExecutor, #185).
+
+The Gantt/flow-graph label for a dispatched task. Kept as a pure function in
+its own module so it can be unit-tested in isolation and shared by the three
+sites that previously each inlined a divergent copy. This is the first
+strangler slice of the executor decomposition (#186).
+"""
+
+from __future__ import annotations
+
+from squadops.tasks.models import TaskEnvelope
+
+
+def build_task_name(envelope: TaskEnvelope) -> str:
+    """Build a Gantt-friendly Prefect task name for a dispatched envelope.
+
+    Prefixes with the **agent** that ran the task (``envelope.agent_id``) rather
+    than the role: the role already duplicates the ``task_type`` domain segment
+    (``qa: qa.define_test_strategy``), whereas the agent identity is strictly
+    more informative (``eve: qa.define_test_strategy``). Falls back to the role
+    when ``agent_id`` is unset — correction/repair and gate-boundary envelopes
+    leave it empty — and to ``"unknown"`` when neither is present. ``agent_id``
+    comes from the squad profile, so the label stays profile-configurable.
+
+    Focused-mode envelopes (manifest-decomposed subtasks) render
+    ``prefix[idx]: focus`` so the Gantt distinguishes parallel subtasks instead
+    of showing N identical ``prefix: task_type`` rows. Non-focused envelopes
+    keep ``prefix: task_type``.
+    """
+    role = envelope.metadata.get("role", "unknown") if envelope.metadata else "unknown"
+    prefix = envelope.agent_id or role
+    inputs = envelope.inputs or {}
+    focus = inputs.get("subtask_focus")
+    idx = inputs.get("subtask_index")
+    if focus:
+        focus_short = str(focus)[:60]
+        return f"{prefix}[{idx}]: {focus_short}" if idx is not None else f"{prefix}: {focus_short}"
+    return f"{prefix}: {envelope.task_type}"

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -483,74 +483,6 @@ class TestComposeFailureTrigger:
         assert trigger == "task_failure:qa.test"
 
 
-class TestBuildTaskName:
-    """Gantt-friendly Prefect task names: focused-mode envelopes show the
-    manifest focus and index instead of N identical role:task_type rows."""
-
-    @staticmethod
-    def _envelope(
-        task_type: str = "development.develop", inputs: dict | None = None
-    ) -> TaskEnvelope:
-        return TaskEnvelope(
-            task_id="task_abc",
-            agent_id="neo",
-            cycle_id="cyc_001",
-            pulse_id="p1",
-            project_id="proj_001",
-            task_type=task_type,
-            correlation_id="corr",
-            causation_id="cause",
-            trace_id="trace",
-            span_id="span",
-            inputs=inputs or {},
-            metadata={"role": "dev"},
-        )
-
-    def test_focused_envelope_uses_focus_and_index(self) -> None:
-        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
-
-        env = self._envelope(
-            inputs={
-                "subtask_focus": "Backend data models and in-memory repository",
-                "subtask_index": 0,
-            }
-        )
-        assert DispatchedFlowExecutor._build_task_name("dev", env) == (
-            "dev[0]: Backend data models and in-memory repository"
-        )
-
-    def test_focused_envelope_without_index_omits_brackets(self) -> None:
-        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
-
-        env = self._envelope(inputs={"subtask_focus": "FastAPI endpoints and validation"})
-        assert (
-            DispatchedFlowExecutor._build_task_name("dev", env)
-            == "dev: FastAPI endpoints and validation"
-        )
-
-    def test_non_focused_envelope_falls_back_to_task_type(self) -> None:
-        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
-
-        env = self._envelope(task_type="development.develop", inputs={})
-        assert DispatchedFlowExecutor._build_task_name("dev", env) == "dev: development.develop"
-
-    def test_long_focus_truncates_at_60_chars(self) -> None:
-        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
-
-        long_focus = "X" * 100
-        env = self._envelope(inputs={"subtask_focus": long_focus, "subtask_index": 3})
-        name = DispatchedFlowExecutor._build_task_name("dev", env)
-        assert name == f"dev[3]: {'X' * 60}"
-        assert len(name.split(": ", 1)[1]) == 60
-
-    def test_index_zero_renders_as_zero_not_omitted(self) -> None:
-        """Subtask index 0 must render as ``[0]`` — falsy but valid."""
-        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
-
-        env = self._envelope(inputs={"subtask_focus": "first", "subtask_index": 0})
-        assert DispatchedFlowExecutor._build_task_name("dev", env) == "dev[0]: first"
-
-
 # ---------------------------------------------------------------------------
 # Dispatch mechanics
 # ---------------------------------------------------------------------------
@@ -3124,8 +3056,10 @@ class TestDispatchTaskPrefectLifecycle:
         ):
             await executor._dispatch_task(envelope, "run_001", flow_run_id="fr_abc")
 
+        # #185: label prefixes with the agent (envelope.agent_id="neo"), not
+        # the role ("dev") — proves the executor wires build_task_name through.
         mock_reporter.create_task_run.assert_awaited_once_with(
-            "fr_abc", "task_abc", "dev: development.design"
+            "fr_abc", "task_abc", "neo: development.design"
         )
         mock_reporter.set_task_run_state.assert_awaited_once_with("tr_new", "RUNNING", "Running")
 

--- a/tests/unit/cycles/test_task_naming.py
+++ b/tests/unit/cycles/test_task_naming.py
@@ -1,0 +1,91 @@
+"""Tests for build_task_name (adapters/cycles/task_naming.py, #185).
+
+The Prefect/Gantt task label prefixes with the agent that ran the task
+(``envelope.agent_id``) rather than the role, falling back to the role when
+``agent_id`` is unset (correction/repair, gate boundaries). Focused-mode
+envelopes additionally carry the manifest focus + index.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from adapters.cycles.task_naming import build_task_name
+from squadops.tasks.models import TaskEnvelope
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+
+def _envelope(
+    task_type: str = "development.develop",
+    inputs: dict | None = None,
+    agent_id: str = "neo",
+    role: str | None = "dev",
+) -> TaskEnvelope:
+    return TaskEnvelope(
+        task_id="task_abc",
+        agent_id=agent_id,
+        cycle_id="cyc_001",
+        pulse_id="p1",
+        project_id="proj_001",
+        task_type=task_type,
+        correlation_id="corr",
+        causation_id="cause",
+        trace_id="trace",
+        span_id="span",
+        inputs=inputs or {},
+        metadata={"role": role} if role is not None else {},
+    )
+
+
+class TestBuildTaskName:
+    """Gantt-friendly Prefect labels: prefix with the agent that ran the task,
+    not the role (role duplicates the task_type's own domain segment)."""
+
+    def test_prefixes_with_agent_name_not_role(self) -> None:
+        # agent_id 'eve' wins over role 'qa' — the whole point of #185. Before
+        # the change this rendered "qa: qa.define_test_strategy" (role repeats
+        # the task_type domain).
+        env = _envelope(task_type="qa.define_test_strategy", agent_id="eve", role="qa")
+        assert build_task_name(env) == "eve: qa.define_test_strategy"
+
+    def test_falls_back_to_role_when_agent_id_empty(self) -> None:
+        # Correction/repair + gate-boundary envelopes leave agent_id="" — the
+        # label must degrade to the role, not a blank prefix.
+        env = _envelope(task_type="development.develop", agent_id="", role="dev")
+        assert build_task_name(env) == "dev: development.develop"
+
+    def test_falls_back_to_unknown_when_no_agent_and_no_role(self) -> None:
+        env = _envelope(task_type="governance.review", agent_id="", role=None)
+        assert build_task_name(env) == "unknown: governance.review"
+
+    def test_focused_envelope_uses_agent_focus_and_index(self) -> None:
+        env = _envelope(
+            agent_id="neo",
+            inputs={
+                "subtask_focus": "Backend data models and in-memory repository",
+                "subtask_index": 0,
+            },
+        )
+        assert build_task_name(env) == "neo[0]: Backend data models and in-memory repository"
+
+    def test_focused_envelope_without_index_omits_brackets(self) -> None:
+        env = _envelope(
+            agent_id="neo", inputs={"subtask_focus": "FastAPI endpoints and validation"}
+        )
+        assert build_task_name(env) == "neo: FastAPI endpoints and validation"
+
+    def test_non_focused_envelope_falls_back_to_task_type(self) -> None:
+        env = _envelope(task_type="development.develop", agent_id="neo", inputs={})
+        assert build_task_name(env) == "neo: development.develop"
+
+    def test_long_focus_truncates_at_60_chars(self) -> None:
+        env = _envelope(agent_id="neo", inputs={"subtask_focus": "X" * 100, "subtask_index": 3})
+        name = build_task_name(env)
+        assert name == f"neo[3]: {'X' * 60}"
+        assert len(name.split(": ", 1)[1]) == 60
+
+    def test_index_zero_renders_as_zero_not_omitted(self) -> None:
+        """Subtask index 0 must render as ``[0]`` — falsy but valid."""
+        env = _envelope(agent_id="neo", inputs={"subtask_focus": "first", "subtask_index": 0})
+        assert build_task_name(env) == "neo[0]: first"


### PR DESCRIPTION
## Problem

The Prefect graph/Gantt task label prefixed with the **role**, which duplicates the `task_type`'s own domain segment and hides which agent actually ran the task:

```
qa: qa.define_test_strategy          # role repeats the "qa." already in task_type
```

The agent name is strictly more informative and removes the redundancy:

```
eve: qa.define_test_strategy
```

`envelope.agent_id` is already on every dispatched envelope (routing keys on it — `queue_name = f"{envelope.agent_id}_comms"`), and it comes from the squad profile, so the label stays profile-configurable. No new resolution/plumbing.

## What changed

- **New `adapters/cycles/task_naming.py::build_task_name(envelope)`** — a pure function that derives the prefix as `envelope.agent_id or role` (role fallback for correction/repair and gate-boundary envelopes that leave `agent_id` empty; `"unknown"` when neither is present), preserving the focused-subtask `prefix[idx]: focus` formatting.
- **Resolved a triple-duplication.** The label logic existed in **three** sites that drifted independently — the canonical `_build_task_name` staticmethod plus inlined copies in `_execute_sequential` **and `_execute_fan_out`** (the issue only flagged two). All three now route through the one helper. The staticmethod is deleted.

## Why this shape

This is the natural **first strangler slice of #186** (executor decomposition): the naming logic was already a pure staticmethod, so extracting it proves the pattern at near-zero risk. The module is shaped so **#94**'s `{n/total}` numbering (`{agent_id}[n/total]: {title}`) lands as edits to `task_naming.py` rather than re-rewriting the executor.

## Tests

- Moved the 5 naming tests to `tests/unit/cycles/test_task_naming.py`, re-pointed at the helper with agent-name expectations.
- Added cases: agent-name wins over role, `agent_id`-empty falls back to role, no-agent-and-no-role falls back to `"unknown"`.
- Updated the Prefect lifecycle integration assertion to the agent-name label (proves the executor wires the helper end-to-end).
- **4451 unit tests pass**, ruff clean.

> Note: the run excludes 5 pre-existing collection errors (missing `sqlalchemy`/`python-jose` in `tests/requirements.txt`) that reproduce on clean `main` — filed separately as #191, not caused by this change.

## Blast radius

Label-only — routing already uses `agent_id`, so execution is untouched. Deploy = rebuild **runtime-api** only (the executor runs there, not in agent images).

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)