### PR TITLE
sip: accept SIP-0094 — Per-Agent Reply Queues + Long-Lived Subscription Model

### DIFF
--- a/sips/accepted/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md
+++ b/sips/accepted/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md
@@ -1,6 +1,14 @@
-# SIP-0XXX: Per-Agent Reply Queues + Long-Lived Subscription Model
+---
+title: Per-Agent Reply Queues + Long-Lived Subscription Model
+status: accepted
+author: SquadOps Architecture
+created_at: '2026-05-02T00:00:00Z'
+sip_number: 94
+updated_at: '2026-06-20T19:43:25.130339Z'
+---
+# SIP-0094: Per-Agent Reply Queues + Long-Lived Subscription Model
 
-**Status:** Proposed
+**Status:** Accepted
 **Authors:** SquadOps Architecture
 **Created:** 2026-05-02
 **Revision:** 3

--- a/sips/registry.yaml
+++ b/sips/registry.yaml
@@ -1,4 +1,4 @@
-last_assigned: 93
+last_assigned: 94
 sips:
 - sip_uid: null
   sip_number: null
@@ -846,3 +846,12 @@ sips:
   approver: jladd
   created_at: '2026-04-30T00:00:00Z'
   updated_at: '2026-05-05T14:50:27.244405Z'
+- sip_uid: null
+  sip_number: 94
+  title: Per-Agent Reply Queues + Long-Lived Subscription Model
+  path: sips/accepted/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md
+  status: accepted
+  author: SquadOps Architecture
+  approver: jladd
+  created_at: '2026-05-02T00:00:00Z'
+  updated_at: '2026-06-20T19:43:25.157766Z'


### PR DESCRIPTION
Promotes the reply-channel subscription-model SIP from **proposed → accepted** (the S1 runtime-substrate precondition in the 1.0.x build-reliability hardening plan). Per the SIP workflow, **acceptance is a design commitment on `main`, not an implementation artifact** — merging this lets the implementation branch start from an approved spec.

## What this PR does

- Runs `scripts/maintainer/update_sip_status.py … accepted`, which **assigned SIP-0094 from the registry** (`last_assigned` 93 → 94), moved + renamed the file to `sips/accepted/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md`, and recorded the registry entry. The number came from the script, not a hand-pick.
- Added the YAML frontmatter the proposal was missing (it used markdown-bold headers the tooling can't parse) so the script could read it.
- Synced the body's H1 (`SIP-0XXX` → `SIP-0094`) and `**Status:**` line — the script's frontmatter-only updater leaves the prose untouched (matches the SIP-0093 dual-label convention).

No code changes; SIP doc + registry only.

## Design review summary

Sound and complete — recommend acceptance:
- Grounded in a concrete incident (`cyc_c9ca088599c0` / `run_edc1d0dc7bf4`): reply published but lost in the polling gap, task FAILED at the 1800s timeout, replies stuck in an orphan queue.
- Two isolated root causes: (A) `consume()` iterator-churn anti-pattern (~3600 short-lived consumer subscriptions per 30-min wait), (B) per-run `cycle_results_{run_id}` queue scoping that leaks orphan queues.
- Fix mirrors the existing `{agent_id}_comms` dispatch pattern: per-agent `{agent_id}_results` queues + a **lazy** per-agent `ReplyRouter` subscription (Rev 3 — no boot-time roster, since profiles resolve per-run).
- Full spec: `QueuePort.subscribe()` primitive, executor wiring, migration ordering (agents declare `_results` first → runtime-api cutover → drop orphans), compatibility, risks-with-mitigations, test plan, rollout, open questions.

## Implementation-phase notes (not acceptance blockers, carry into the impl branch)

1. Guard `ensure_subscribed` against concurrent first-dispatch to one agent (matters only if fan-out ever dispatches to a single agent in parallel).
2. `subscribe()`'s default impl still polls `consume_blocking()` — only RabbitMQAdapter gets the native long-iterator.
3. Wire the late-drop counter metric from Risk 3 for observability.

## Coordination

- Overlaps the **#186** dispatch-transport seam (`_publish_and_await` / `_dispatch_task`). Plan: implement S1 in place; let #186 extract `TaskDispatcher` around the new subscription model later (S1 actually pins down that boundary).
- Supersedes the tactical patch (PR #89, `fix/cycle-results-channel-recovery`) — confirm during implementation that the structural model removes the workaround rather than layering on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)