### PR TITLE
fix(#195): sync prompt-fragment manifest hashes + prevent future drift (+ first CI gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+# Runs the lint + regression gate on every PR and on pushes to main, so a red
+# change (stale manifest, lint break, failing test) can't reach main once this
+# check is marked Required in branch protection. Closes the enforcement gap that
+# let a stale prompt-fragment manifest merge (issue #195).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: lint + regression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tests/requirements.txt
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install -r tests/requirements.txt
+
+      - name: Prompt-fragment manifest is in sync
+        run: python scripts/dev/regen_fragment_manifest.py --check
+
+      # Runs `ruff check .` (lint, fail-stop) + the test-quality lint + the full
+      # unit regression suite. NOTE: a repo-wide `ruff format --check .` is NOT
+      # gated here yet — 43 pre-existing files need formatting first (tracked
+      # separately); add the format gate once that sweep lands.
+      - name: Regression suite (ruff check + test-quality lint + pytest)
+        run: bash scripts/dev/run_regression_tests.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,15 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  # Keep the prompt-fragment manifest hashes in sync with the fragment bodies.
+  # Runs only when a fragment or the manifest changes; uses the active env's
+  # python (squadops must be `pip install -e .`). See issue #195.
+  - repo: local
+    hooks:
+      - id: fragment-manifest-check
+        name: prompt-fragment manifest hashes up to date
+        entry: python scripts/dev/regen_fragment_manifest.py --check
+        language: system
+        pass_filenames: false
+        files: ^src/squadops/prompts/fragments/
+

--- a/adapters/prompts/filesystem.py
+++ b/adapters/prompts/filesystem.py
@@ -45,6 +45,28 @@ class FileSystemPromptRepository(PromptRepository):
         re.MULTILINE | re.DOTALL,
     )
 
+    @classmethod
+    def extract_content(cls, raw_content: str) -> str:
+        """Return a fragment's hashable body: everything after the YAML
+        frontmatter block, stripped (or the whole file, stripped, when there is
+        no frontmatter).
+
+        This is the single definition of "a fragment's content" — shared by the
+        runtime integrity check, the manifest regenerator, and the tests so the
+        manifest sha256 can't drift between them (see issue #195).
+        """
+        header_match = cls.HEADER_PATTERN.match(raw_content)
+        if header_match:
+            return raw_content[header_match.end() :].strip()
+        return raw_content.strip()
+
+    @classmethod
+    def hash_fragment_file(cls, path: Path) -> str:
+        """Compute the canonical SHA256 recorded in the manifest for a fragment
+        file on disk."""
+        raw = Path(path).read_text(encoding="utf-8")
+        return PromptFragment.compute_hash(cls.extract_content(raw))
+
     def __init__(self, base_path: Path, manifest_path: Path | None = None):
         """
         Initialize filesystem repository.
@@ -178,13 +200,11 @@ class FileSystemPromptRepository(PromptRepository):
                 header = yaml.safe_load(header_yaml)
             except yaml.YAMLError:
                 header = {}
-
-            # Content is everything after the header
-            content = raw_content[header_match.end() :].strip()
         else:
-            # No header - use entire file as content
             header = {}
-            content = raw_content.strip()
+
+        # Content (and its hash) come from the shared canonical extractor.
+        content = self.extract_content(raw_content)
 
         # Extract metadata (prefer file header, fall back to manifest)
         fragment_id = header.get("fragment_id") or (

--- a/scripts/dev/regen_fragment_manifest.py
+++ b/scripts/dev/regen_fragment_manifest.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Verify or regenerate the prompt-fragment manifest sha256 entries.
+
+The manifest (``src/squadops/prompts/fragments/manifest.yaml``) records a
+``sha256`` for each fragment's body. Editing a fragment without updating its
+hash makes the runtime integrity check
+(:meth:`FileSystemPromptRepository.validate_integrity`) and the unit tests
+diverge, and a stale manifest lets the assembler raise ``HashMismatchError`` at
+runtime — exactly the drift behind issue #195.
+
+This is the single tool that keeps fragments and the manifest in sync:
+
+    python scripts/dev/regen_fragment_manifest.py --check   # CI / pre-commit: exit 1 if stale
+    python scripts/dev/regen_fragment_manifest.py --write   # recompute + update hashes in place
+
+Hashing is delegated to ``FileSystemPromptRepository`` so this script, the
+runtime, and the tests all agree on what a fragment's hash is.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+from adapters.prompts.filesystem import FileSystemPromptRepository
+
+FRAGMENTS_DIR = Path(__file__).resolve().parents[2] / "src" / "squadops" / "prompts" / "fragments"
+MANIFEST_PATH = FRAGMENTS_DIR / "manifest.yaml"
+
+_FILE_MISSING = "<file missing>"
+
+
+def _entries() -> list[dict]:
+    data = yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return data.get("fragments", []) if data else []
+
+
+def _drift() -> list[tuple[str, str, str, str]]:
+    """Return ``(fragment_id, path, stored, computed)`` for each drifted entry."""
+    out: list[tuple[str, str, str, str]] = []
+    for entry in _entries():
+        path = FRAGMENTS_DIR / entry["path"]
+        if not path.exists():
+            out.append((entry["fragment_id"], entry["path"], entry["sha256"], _FILE_MISSING))
+            continue
+        computed = FileSystemPromptRepository.hash_fragment_file(path)
+        if computed != entry["sha256"]:
+            out.append((entry["fragment_id"], entry["path"], entry["sha256"], computed))
+    return out
+
+
+def check() -> int:
+    drift = _drift()
+    total = len(_entries())
+    if not drift:
+        print(f"OK: all {total} fragment hashes match {MANIFEST_PATH.name}")
+        return 0
+    print(f"STALE: {len(drift)}/{total} fragment hash(es) out of date in {MANIFEST_PATH.name}:")
+    for fid, path, stored, computed in drift:
+        print(f"  - {fid} ({path})")
+        print(f"      stored:   {stored}")
+        print(f"      computed: {computed}")
+    print("\nFix: python scripts/dev/regen_fragment_manifest.py --write")
+    return 1
+
+
+def write() -> int:
+    drift = _drift()
+    missing = [d for d in drift if d[3] == _FILE_MISSING]
+    if missing:
+        for fid, path, _stored, _computed in missing:
+            print(f"ERROR: fragment file missing for {fid} ({path})", file=sys.stderr)
+        return 1
+    if not drift:
+        print(f"OK: manifest already current ({len(_entries())} fragments)")
+        return 0
+    # Minimal edit: replace only the changed (globally unique) hash strings so
+    # the diff is exactly the stale lines and all other formatting is preserved.
+    raw = MANIFEST_PATH.read_text(encoding="utf-8")
+    for fid, path, stored, computed in drift:
+        raw = raw.replace(stored, computed)
+        print(f"updated {fid} ({path})")
+    MANIFEST_PATH.write_text(raw, encoding="utf-8")
+    print(f"\nwrote {len(drift)} hash(es) to {MANIFEST_PATH}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true", help="exit 1 if any hash is stale (default)")
+    group.add_argument("--write", action="store_true", help="recompute and update hashes in place")
+    args = parser.parse_args()
+    return write() if args.write else check()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/squadops/prompts/fragments/manifest.yaml
+++ b/src/squadops/prompts/fragments/manifest.yaml
@@ -6,7 +6,7 @@ fragments:
   layer: identity
   roles:
   - comms
-  sha256: 4f2490b4bd0deedf2d00dea843e519601ee5582a200e98bc61ee64bb9030e654
+  sha256: 297f1a1be3bb46fa2a63335ef241a0588864f62872348447de4234302f8beaf1
 - fragment_id: identity
   path: roles/data/identity.md
   layer: identity
@@ -90,13 +90,13 @@ fragments:
   layer: task_type
   roles:
   - dev
-  sha256: 9cd6b929e7958f613eb976d96a411ddc3fb9e2bcb7df91b2321df7a6c134870c
+  sha256: 3a4b8b05523ab8680ff40beab23c285714d4df1f8bb07555c6d168b67238e44e
 - fragment_id: task_type.qa.propose_plan_tasks
   path: shared/task_type/task_type.qa.propose_plan_tasks.md
   layer: task_type
   roles:
   - qa
-  sha256: 3c6419ac1e93c159d3e665d0dfb0dd370849970f9c9fa485028597d74777cc9a
+  sha256: 41f1ebd5833c4bdbefa3166cc642839a7d64e2dccc944af52b55ab79f19759dd
 - fragment_id: task_type.strategy.propose_plan_guidance
   path: shared/task_type/task_type.strategy.propose_plan_guidance.md
   layer: task_type

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -40,7 +40,12 @@ pyyaml>=6.0  # YAML parsing
 # OpenTelemetry packages (for telemetry testing)
 opentelemetry-api>=1.22.0
 opentelemetry-sdk>=1.22.0
-opentelemetry-instrumentation-aiohttp>=0.43b0; platform_machine != "aarch64"
+# NB: `opentelemetry-instrumentation-aiohttp` does not exist on PyPI (the real
+# packages are `-aiohttp-client` / `-aiohttp-server`). It was masked locally by
+# a `platform_machine != "aarch64"` marker — our dev box (DGX Spark) is aarch64,
+# so it was skipped there but broke install on x86_64 CI. It is unused by the
+# code and the suite passes without it, so it is omitted. Add `-aiohttp-client`
+# if aiohttp client instrumentation is ever actually needed.
 opentelemetry-instrumentation-asyncpg>=0.43b0
 opentelemetry-instrumentation-aio-pika>=0.43b0
 opentelemetry-exporter-otlp-proto-grpc>=1.22.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -27,7 +27,12 @@ psycopg-binary>=3.0.0  # Binary PostgreSQL adapter (includes libpq, no system de
 aiofiles>=23.0.0  # Async file I/O (used by base_agent)
 aio-pika>=9.3.0  # RabbitMQ async client
 asyncpg>=0.29.0  # PostgreSQL async driver
-fastapi>=0.104.0  # API framework
+# Upper bound pins the test env to the FastAPI the project actually runs (0.135.x).
+# Starlette >=0.136 newly rejects including a router instance into more than one
+# app, which the console unit tests do via module-level singleton routers +
+# sys.modules re-imports. The production app is unaffected (single import/include);
+# this is a test-harness incompatibility. Lift the cap once #198 reworks those tests.
+fastapi>=0.104.0,<0.136  # API framework (see #198 before raising the cap)
 python-multipart>=0.0.6  # Required by FastAPI for form/file uploads
 uvicorn>=0.24.0  # ASGI server
 aiohttp>=3.9.0  # HTTP client

--- a/tests/unit/prompts/test_planning_fragments.py
+++ b/tests/unit/prompts/test_planning_fragments.py
@@ -7,12 +7,13 @@ Verifies that all 7 planning/refinement prompt fragments:
 - Assembler can resolve them via task_type parameter
 """
 
-import hashlib
 import re
 from pathlib import Path
 
 import pytest
 import yaml
+
+from adapters.prompts.filesystem import FileSystemPromptRepository
 
 pytestmark = [pytest.mark.domain_capabilities]
 
@@ -170,9 +171,11 @@ class TestPlanningFragmentsManifest:
         ids=[s["fragment_id"] for s in PLANNING_FRAGMENTS],
     )
     def test_content_hash_matches_manifest(self, spec):
-        """SHA256 of content (after frontmatter) matches manifest entry."""
-        _, content = _load_fragment(spec["path"])
-        actual_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        """Manifest sha256 matches the hash the runtime computes for the
+        fragment body. Uses the same hasher the repository's integrity check
+        and the regen script use, so a drift here is the exact failure the
+        assembler would raise at runtime (HashMismatchError) — see issue #195."""
+        actual_hash = FileSystemPromptRepository.hash_fragment_file(FRAGMENTS_DIR / spec["path"])
 
         manifest = _load_manifest()
         entry = next(
@@ -184,6 +187,15 @@ class TestPlanningFragmentsManifest:
             f"Hash mismatch for {spec['fragment_id']}: "
             f"computed={actual_hash}, manifest={entry['sha256']}"
         )
+
+    def test_full_manifest_integrity(self):
+        """Every manifest sha256 matches its fragment body across ALL fragments,
+        not just the planning ones parametrized above — catches drift in
+        identity/constraints/etc. that the per-fragment cases miss (e.g. the
+        comms identity hash, #195). Reuses the repository's own integrity sweep
+        so the test and the runtime check can't diverge."""
+        repo = FileSystemPromptRepository(base_path=FRAGMENTS_DIR)
+        assert repo.validate_integrity() is True
 
 
 class TestPlanningFragmentsContent:


### PR DESCRIPTION
## What & why

`main`'s regression suite was **not green**: `test_content_hash_matches_manifest` failed for `development.propose_plan_tasks` and `qa.propose_plan_tasks` because their fragment bodies were edited (in `e1d6452`, #189) without regenerating the manifest `sha256`. The content-hash guard did its job; nothing ran it at merge time.

While adding a whole-manifest check I found a **third** stale entry the planning-only test never covered: `roles/comms/identity.md` (latent since `57f6305`, SIP-0085 Joi). All three fragment edits are confirmed intentional — only the manifest was stale.

## The fix (3 hashes)

| fragment | drift origin |
|---|---|
| `task_type.development.propose_plan_tasks` | `e1d6452` (#189) |
| `task_type.qa.propose_plan_tasks` | `e1d6452` (#189) |
| `identity` / `roles/comms/identity.md` | `57f6305` (SIP-0085); never synced |

Manifest diff is exactly those 3 `sha256` lines — no formatting churn.

## Prevention — defense in depth

1. **Single-source hasher** — `adapters/prompts/filesystem.py` now exposes `extract_content` + `hash_fragment_file`. The runtime integrity check (`validate_integrity`), the regen tool, and the tests all compute a fragment's hash through the *same* code, so they can't diverge.
2. **`scripts/dev/regen_fragment_manifest.py`** — `--check` (exit 1 on drift; covers the **whole** manifest, not just planning fragments) and `--write` (minimal in-place hash update). No more hand-editing hashes.
3. **Tests** — `test_content_hash_matches_manifest` uses the shared hasher; new `test_full_manifest_integrity` guards **every** fragment via the repository's own sweep.
4. **Pre-commit hook** — `fragment-manifest-check` runs `--check` when a fragment/manifest changes.
5. **CI (new)** — `.github/workflows/ci.yml`: manifest check + the regression suite (`ruff check` + test-quality lint + 4044 unit tests) on every PR and push to `main`. **This is the first CI in the repo and closes #149.**

## Verification

- `regen --check` → `OK: all 30 fragment hashes match manifest.yaml`
- Full regression: **4044 passed, 1 skipped, 0 failed** (was 2 failed on `main`).

## Deliberately out of scope

- Repo-wide `ruff format --check` is **not** gated in CI yet — 43 pre-existing files need a `ruff format .` sweep first. Tracked in **#196**; adding the format gate is the closing step there. (Left a NOTE in `ci.yml`.)

## Action required after merge

CI only **blocks** merges once `CI / lint + regression` is marked **Required** in `main`'s branch protection (admin/UI). I can't set that from here.

Closes #195
Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)