### PR TITLE
feat(SIP-0094 PR 94.1): declare per-agent {agent_id}_results queue at startup (inert, deploy-first)

### DIFF
--- a/adapters/comms/rabbitmq.py
+++ b/adapters/comms/rabbitmq.py
@@ -10,7 +10,7 @@ import aio_pika
 from aio_pika import Connection, Message, Queue
 
 from squadops.comms.queue_message import QueueMessage
-from squadops.ports.comms.queue import QueuePort
+from squadops.ports.comms.queue import REPLY_QUEUE_DECLARE_ARGS, QueuePort
 
 logger = logging.getLogger(__name__)
 
@@ -79,10 +79,22 @@ class RabbitMQAdapter(QueuePort):
         if cached is not None and getattr(cached, "channel", None) is self._channel:
             return cached
 
-        queue = await self._channel.declare_queue(full_name, durable=True)
+        queue = await self._channel.declare_queue(full_name, **REPLY_QUEUE_DECLARE_ARGS)
         self._queues[full_name] = queue
         logger.debug(f"Declared queue: {full_name}")
         return queue
+
+    async def ensure_queue(self, queue_name: str) -> None:
+        """Idempotently declare ``queue_name`` with the shared
+        :data:`REPLY_QUEUE_DECLARE_ARGS` (SIP-0094 D3).
+
+        Thin wrapper over :meth:`_get_queue`, so the reply queue is declared
+        with byte-identical args to the agent comms queue. Agents call this at
+        startup for their ``{agent_id}_results`` queue — which they only ever
+        publish to, never consume from — so the lazy declaration on
+        :meth:`consume` never creates it.
+        """
+        await self._get_queue(queue_name)
 
     async def invalidate_queue(self, queue_name: str) -> None:
         """Drop the cached Queue handle for ``queue_name``.

--- a/docs/plans/1-0-x-build-reliability-hardening-plan.md
+++ b/docs/plans/1-0-x-build-reliability-hardening-plan.md
@@ -2,7 +2,7 @@
 
 **Created:** 2026-04-27
 **Updated:** 2026-06-14 (added GitHub-issue column to priority tables → issue #170; added Framework smoke integration test section → issue #176; rev 4 2026-05-02 — S1 reshaped to per-agent reply queues)
-**Status:** Active — #1 drafted, #2 next; substrate SIP S1 proposed
+**Status:** Active — #1 drafted, #2 next; substrate SIP S1 accepted (SIP-0094), 94.1 implementing
 **Scope:** SquadOps 1.0.x patch series (Spark lane); orthogonal to v1.1 work (SIP-0088+)
 
 ## Intent
@@ -15,7 +15,7 @@ These are not part of the "stay coherent over time" axis below — they are the 
 
 | # | SIP | Status | Where | GitHub issue |
 |---|-----|--------|-------|--------------|
-| S1 | **Per-Agent Reply Queues + Long-Lived Subscription Model** — replace per-run `cycle_results_{run_id}` queues with per-agent `{agent_id}_results` queues (parallel to existing `{agent_id}_comms`), and replace `_publish_and_await` poll loop with a single orchestrator-startup subscription per agent feeding an in-process reply router. Eliminates orphan-queue leakage and consumer-tag-churn failure classes in one structural step. Tactical patch (PR #89, merged 2026-05-02) contains the bleeding. | proposed rev 2 (2026-05-02); tactical patch merged via PR #89 | `sips/proposed/SIP-Reply-Channel-Subscription-Model.md` | #146 |
+| S1 | **Per-Agent Reply Queues + Long-Lived Subscription Model** — replace per-run `cycle_results_{run_id}` queues with per-agent `{agent_id}_results` queues (parallel to existing `{agent_id}_comms`), and replace `_publish_and_await` poll loop with a single orchestrator-startup subscription per agent feeding an in-process reply router. Eliminates orphan-queue leakage and consumer-tag-churn failure classes in one structural step. Tactical patch (PR #89, merged 2026-05-02) contains the bleeding. | accepted 2026-06-20 as SIP-0094 (PR #193); plan rev 2 (2026-06-21); PR 94.1 in progress | `sips/accepted/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md` · plan `docs/plans/SIP-0094-per-agent-reply-queues-plan.md` | #146 |
 
 ## Build-reliability axis (priority order)
 
@@ -103,6 +103,7 @@ Everything else is either already in `sips/proposed/`, a follow-up to an accepte
 
 ## Revision history
 
+- **rev 5 (2026-06-21):** S1 moved proposed → accepted as SIP-0094 (PR #193, 2026-06-20); implementation plan rev 2 landed; PR 94.1 (agent-side `{agent_id}_results` declaration) in progress on `feature/sip-0094-per-agent-reply-queues`. S1 row repointed to the accepted SIP + plan.
 - **rev 4 (2026-05-02):** S1 reshaped to per-agent reply queues (`{agent_id}_results`) replacing per-run `cycle_results_*` queues. Eliminates the orphan-queue leakage class entirely instead of mitigating it via TTL + run-completion cleanup. Drain-before-retry dropped (no longer needed — the always-on consumer never misses a reply window). SIP rev bumped to 2.
 - **rev 3 (2026-05-02):** Added Runtime Substrate section with S1 (Reply-Channel Subscription Model) as a precondition to the build-reliability axis. Triggered by `cyc_c9ca088599c0` lost-reply incident. Tactical patch on PR #89; structural SIP in `sips/proposed/`.
 - **rev 2 (2026-04-27):** Incorporated external review. Three structural changes: (1) split former #9 into #5a (minimal breakers, precondition for #5) and #9 (full operator surface, original slot); (2) swapped former #6 ↔ #7 — Defect Report now precedes Resume Contract, with Resume scoped to technical idempotency only; (3) added explicit Capability/Policy Boundaries section. Plus annotations on #4 (typed-not-soup), #6 (machine-actionable fields), #8 (duration AND risk), #10↔#2 link, #11 (empirical, revertible).

--- a/src/squadops/agents/entrypoint.py
+++ b/src/squadops/agents/entrypoint.py
@@ -436,11 +436,18 @@ class AgentRunner:
 
         # Queue name for this agent's communications
         comms_queue = f"{self.agent_id}_comms"
+        results_queue = f"{self.agent_id}_results"
 
         logger.info(
             "Starting task consumer",
             extra={"agent_id": self.agent_id, "role": self.role, "queue": comms_queue},
         )
+
+        # SIP-0094 (D9): declare this agent's reply queue before the orchestrator
+        # ever addresses it. The agent only publishes to `{agent_id}_results`
+        # (never consumes from it), so the lazy declaration that covers the comms
+        # queue won't create it. Idempotent — safe to call on every boot.
+        await self._queue.ensure_queue(results_queue)
 
         while not self._shutdown_event.is_set():
             try:

--- a/src/squadops/ports/comms/queue.py
+++ b/src/squadops/ports/comms/queue.py
@@ -8,6 +8,14 @@ from typing import Any
 
 from squadops.comms.queue_message import QueueMessage
 
+# SIP-0094 D3: canonical declaration args for agent comms/reply queues
+# (`{agent_id}_comms`, `{agent_id}_results`). Every declaration of these queues
+# — agent startup `ensure_queue`, orchestrator `subscribe`, manual creation —
+# MUST use these exact args. A mismatch on a durable queue makes the broker
+# reject the redeclare with PRECONDITION_FAILED, so this is single-sourced here
+# to keep the args from drifting across call sites.
+REPLY_QUEUE_DECLARE_ARGS: dict[str, Any] = {"durable": True}
+
 
 class QueuePort(ABC):
     """Abstract base class for queue transport providers."""
@@ -93,6 +101,21 @@ class QueuePort(ABC):
         re-declares the queue rather than reusing a stale, channel-bound
         handle. Default implementation is a no-op for adapters that don't
         cache.
+        """
+        return None
+
+    async def ensure_queue(self, queue_name: str) -> None:
+        """Idempotently declare ``queue_name`` so it exists before any peer
+        addresses it.
+
+        Concrete default is a no-op: adapters that declare lazily on first
+        consume (or have no broker at all, e.g. NoOp) need do nothing here.
+        Broker-backed adapters override this to declare with
+        :data:`REPLY_QUEUE_DECLARE_ARGS` (SIP-0094 D3).
+
+        Agents call this at startup for their ``{agent_id}_results`` reply
+        queue, which they only ever publish to (never consume from), so the
+        lazy declaration that covers ``{agent_id}_comms`` never fires for it.
         """
         return None
 

--- a/tests/unit/agents/test_entrypoint_task.py
+++ b/tests/unit/agents/test_entrypoint_task.py
@@ -149,3 +149,34 @@ class TestHandleTaskEnvelope:
 
         published = json.loads(runner._queue.publish.call_args.args[1])
         assert published["metadata"]["correlation_id"] == "corr_001"
+
+
+class TestConsumeTasksEnsuresReplyQueue:
+    """`_consume_tasks` must declare the agent's `{agent_id}_results` reply
+    queue at startup (SIP-0094 D9) so the orchestrator never publishes a reply
+    to a queue the agent never created."""
+
+    def _runner(self):
+        from squadops.agents.entrypoint import AgentRunner
+
+        with patch.object(AgentRunner, "__init__", lambda self, *a, **kw: None):
+            r = AgentRunner.__new__(AgentRunner)
+            r.agent_id = "neo"
+            r.role = "dev"
+            r._queue = AsyncMock()
+            r._shutdown_event = MagicMock()
+            return r
+
+    async def test_declares_results_queue_before_consuming(self) -> None:
+        """ensure_queue("{agent_id}_results") is awaited exactly once, ahead of
+        the consume loop. With the loop short-circuited, a call count of one
+        proves the declaration sits *before* the loop, not inside it (which
+        would yield zero calls here and N calls in steady state)."""
+        r = self._runner()
+        r._shutdown_event.is_set.return_value = True  # exit loop immediately
+
+        await r._consume_tasks()
+
+        r._queue.ensure_queue.assert_awaited_once_with("neo_results")
+        # The loop body never ran, so nothing was consumed this pass.
+        r._queue.consume.assert_not_awaited()

--- a/tests/unit/comms/test_rabbitmq_adapter.py
+++ b/tests/unit/comms/test_rabbitmq_adapter.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from adapters.comms.rabbitmq import QueueError, RabbitMQAdapter
+from squadops.ports.comms.queue import REPLY_QUEUE_DECLARE_ARGS
 
 pytestmark = [pytest.mark.unit]
 
@@ -93,6 +94,76 @@ class TestQueueCacheInvalidation:
         # Must not raise, even though no cache entry exists.
         await adapter.invalidate_queue("never_cached")
         assert "never_cached" not in adapter._queues
+
+
+class TestEnsureQueue:
+    """``ensure_queue`` eagerly declares a queue the adapter would otherwise
+    only create lazily on first consume — needed for ``{agent_id}_results``
+    reply queues, which agents publish to but never consume from (SIP-0094)."""
+
+    async def test_declares_with_shared_args(self) -> None:
+        """``ensure_queue`` declares the named queue using the single-sourced
+        ``REPLY_QUEUE_DECLARE_ARGS`` — not a hardcoded arg set that could drift
+        and trip a durable-queue ``PRECONDITION_FAILED`` redeclare."""
+        ch = MagicMock()
+        ch.is_closed = False
+        declared = MagicMock()
+        declared.channel = ch
+        ch.declare_queue = AsyncMock(return_value=declared)
+
+        adapter = _make_adapter_with_channel(ch)
+        await adapter.ensure_queue("neo_results")
+
+        ch.declare_queue.assert_awaited_once_with("neo_results", **REPLY_QUEUE_DECLARE_ARGS)
+
+    async def test_results_and_comms_declare_with_identical_args(self) -> None:
+        """D3 single-source invariant: the reply queue and the comms queue must
+        be declared with byte-identical args. A drift between the two paths is
+        exactly what causes the broker to reject a durable redeclare."""
+        ch = MagicMock()
+        ch.is_closed = False
+
+        def _fresh_queue(name, **_kw):
+            q = MagicMock()
+            q.channel = ch
+            q.name = name
+            return q
+
+        ch.declare_queue = AsyncMock(side_effect=_fresh_queue)
+
+        adapter = _make_adapter_with_channel(ch)
+        await adapter.ensure_queue("neo_results")  # reply queue path
+        await adapter._get_queue("neo_comms")  # comms queue path
+
+        results_call, comms_call = ch.declare_queue.await_args_list
+        assert results_call.args == ("neo_results",)
+        assert comms_call.args == ("neo_comms",)
+        assert results_call.kwargs == comms_call.kwargs == REPLY_QUEUE_DECLARE_ARGS
+
+    async def test_redeclares_after_channel_swap(self) -> None:
+        """Edge: after a RobustChannel reconnect the reply queue is cached on a
+        dead channel. ``ensure_queue`` must re-declare on the live channel — the
+        stale-handle failure class SIP-0094 eliminates."""
+        ch1 = MagicMock()
+        ch1.is_closed = False
+        q1 = MagicMock()
+        q1.channel = ch1
+        ch1.declare_queue = AsyncMock(return_value=q1)
+
+        adapter = _make_adapter_with_channel(ch1)
+        await adapter.ensure_queue("neo_results")
+        ch1.declare_queue.assert_awaited_once()
+
+        # RobustChannel reconnect: adapter now holds a fresh channel.
+        ch2 = MagicMock()
+        ch2.is_closed = False
+        q2 = MagicMock()
+        q2.channel = ch2
+        ch2.declare_queue = AsyncMock(return_value=q2)
+        adapter._channel = ch2
+
+        await adapter.ensure_queue("neo_results")
+        ch2.declare_queue.assert_awaited_once_with("neo_results", **REPLY_QUEUE_DECLARE_ARGS)
 
 
 class TestConsumeBlockingErrorWrapping:


### PR DESCRIPTION
## What & why

**PR 94.1 of the SIP-0094 sequence** (S1 — Per-Agent Reply Queues). This is the deploy-first, **inert** rollout-safety step (decision **D9**): each agent declares its own `{agent_id}_results` reply queue at startup, so the orchestrator never addresses a queue the agent hasn't created.

Agents only ever *publish* to `{agent_id}_results` (never consume from it), so the lazy declaration that covers `{agent_id}_comms` never creates it — it must be declared explicitly.

**Nothing consumes from the new queue yet.** The reply path doesn't change until the 94.3 cutover. The only observable effect of this PR is one extra (idle) queue per agent.

- Plan: `docs/plans/SIP-0094-per-agent-reply-queues-plan.md`
- SIP: `sips/accepted/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md`
- Motivating incident: `cyc_c9ca088599c0` (reply lost in the poll-loop gap, orphan `cycle_results_*` queue leaked)

## Changes

- `ports/comms/queue.py` — `QueuePort.ensure_queue()` (concrete no-op default) + single-sourced `REPLY_QUEUE_DECLARE_ARGS` constant (**D3**: declare args must be identical everywhere or a durable redeclare hits `PRECONDITION_FAILED`).
- `adapters/comms/rabbitmq.py` — `ensure_queue()` as a thin wrapper over `_get_queue()`; the sole `declare_queue` call routed through `REPLY_QUEUE_DECLARE_ARGS` so comms + results declare byte-identically.
- `agents/entrypoint.py` — `ensure_queue("{agent_id}_results")` once before the consume loop.
- Tests: `ensure_queue` declares with shared args; results/comms args identical (D3); re-declares after channel swap; entrypoint declares the results queue exactly once.
- Docs: hardening-plan S1 row repointed to the accepted SIP + plan.

## Verification

- `tests/unit/comms/ tests/unit/agents/`: **79 passed**.
- Full regression suite: **4044 passed, 0 failed**.

> ⚠️ **CI coverage note:** `scripts/dev/run_regression_tests.sh` (and therefore the new CI gate) does **not** include `tests/unit/comms/` or `tests/unit/agents/`, so this PR's tests are verified locally but are **not** exercised by CI. Worth evaluating adding those dirs to the gate (separately — they may surface pre-existing issues, as `console/` did under newer deps).

## Deploy & rollback

- **Deploy-first:** rebuild + redeploy agents (`rebuild_and_deploy.sh agents`) so `{agent_id}_results` exists before the 94.3 runtime-api cutover. Idempotent declare (D9) means the cutover never assumes the agent pre-declared it.
- **Rollback:** inert — safe to leave deployed; fully compatible with the current `cycle_results_{run_id}` path.

Part of S1 / #146. Followed by 94.2 (subscribe primitive), 94.3 (cutover), 94.4 (soak + cleanup).