### PR TITLE
test(ci): gate tests/unit/comms + tests/unit/agents in the regression suite (closes #200)

### DIFF
--- a/scripts/dev/run_regression_tests.sh
+++ b/scripts/dev/run_regression_tests.sh
@@ -20,6 +20,8 @@ REGRESSION_DIRS=(
     "tests/unit/prompts/"
     "tests/unit/tools/"
     "tests/unit/agent_foundation/"
+    "tests/unit/agents/"
+    "tests/unit/comms/"
     "tests/unit/capabilities/"
     "tests/unit/cycles/"
     "tests/unit/events/"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -59,7 +59,10 @@ opentelemetry-semantic-conventions>=0.43b0
 prometheus-client>=0.19.0
 
 # Additional agent dependencies
-a2a-sdk[http-server]>=0.3.0  # A2A protocol (used by chat executor)
+# Cap to the 0.3.x line the project runs: chat_executor.py imports
+# `new_agent_text_message` from `a2a.utils`, which a2a-sdk >=0.4 removed/renamed.
+# (Same unpinned-dep drift class as the fastapi cap — see #198 re: pinning deps.)
+a2a-sdk[http-server]>=0.3.0,<0.4  # A2A protocol (used by chat executor)
 beautifulsoup4>=4.12.0  # HTML parsing (used by qa skills)
 psutil>=5.9.0  # System utilities (used by lead agent)
 


### PR DESCRIPTION
## What

Adds `tests/unit/comms/` and `tests/unit/agents/` to `REGRESSION_DIRS` in `scripts/dev/run_regression_tests.sh`, so the regression suite and the CI gate actually exercise the comms-transport and agent-runtime domains.

## Why

These domains were silently ungated. SIP-0094 PR 94.1 (#199) adds tests in both dirs — they pass locally but the CI on #199 went green **without running them**. The whole S1 substrate track is comms/agents work, so this needs closing for CI to mean anything there.

## Safety check

Both dirs are pure mock-based unit tests:
- test-quality lint: clean
- no `@pytest.mark.{rabbitmq,database,redis,docker,integration}` markers
- no live connections (only a fake `amqp://test` URL against mocked channels)
- 75 tests, 0 skips

Local regression after adding them: **4119 passed, 0 failed**. CI (x86_64, serviceless) is the authoritative confirmation — see the check on this PR.

## Out of scope

Other excluded unit dirs (`auth`, `memory`, `adapters`, `runtime`, `config`, `core`, `observability`, `ports`, `architecture`, `bootstrap`) remain excluded — several need live services or are legacy. Evaluating them is a separate follow-up.

Closes #200