### PR TITLE
refactor(SIP-0094): rename per-agent reply queue _results → _replies

### DIFF
--- a/adapters/comms/rabbitmq.py
+++ b/adapters/comms/rabbitmq.py
@@ -90,7 +90,7 @@ class RabbitMQAdapter(QueuePort):
 
         Thin wrapper over :meth:`_get_queue`, so the reply queue is declared
         with byte-identical args to the agent comms queue. Agents call this at
-        startup for their ``{agent_id}_results`` queue — which they only ever
+        startup for their ``{agent_id}_replies`` queue — which they only ever
         publish to, never consume from — so the lazy declaration on
         :meth:`consume` never creates it.
         """

--- a/docs/plans/1-0-x-build-reliability-hardening-plan.md
+++ b/docs/plans/1-0-x-build-reliability-hardening-plan.md
@@ -15,7 +15,7 @@ These are not part of the "stay coherent over time" axis below — they are the 
 
 | # | SIP | Status | Where | GitHub issue |
 |---|-----|--------|-------|--------------|
-| S1 | **Per-Agent Reply Queues + Long-Lived Subscription Model** — replace per-run `cycle_results_{run_id}` queues with per-agent `{agent_id}_results` queues (parallel to existing `{agent_id}_comms`), and replace `_publish_and_await` poll loop with a single orchestrator-startup subscription per agent feeding an in-process reply router. Eliminates orphan-queue leakage and consumer-tag-churn failure classes in one structural step. Tactical patch (PR #89, merged 2026-05-02) contains the bleeding. | accepted 2026-06-20 as SIP-0094 (PR #193); plan rev 2 (2026-06-21); PR 94.1 in progress | `sips/accepted/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md` · plan `docs/plans/SIP-0094-per-agent-reply-queues-plan.md` | #146 |
+| S1 | **Per-Agent Reply Queues + Long-Lived Subscription Model** — replace per-run `cycle_results_{run_id}` queues with per-agent `{agent_id}_replies` queues (parallel to existing `{agent_id}_comms`), and replace `_publish_and_await` poll loop with a single orchestrator-startup subscription per agent feeding an in-process reply router. Eliminates orphan-queue leakage and consumer-tag-churn failure classes in one structural step. Tactical patch (PR #89, merged 2026-05-02) contains the bleeding. | accepted 2026-06-20 as SIP-0094 (PR #193); plan rev 2 (2026-06-21); PR 94.1 in progress | `sips/accepted/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md` · plan `docs/plans/SIP-0094-per-agent-reply-queues-plan.md` | #146 |
 
 ## Build-reliability axis (priority order)
 
@@ -103,6 +103,7 @@ Everything else is either already in `sips/proposed/`, a follow-up to an accepte
 
 ## Revision history
 
+- **rev 6 (2026-06-21):** Renamed the per-agent reply queue `{agent_id}_results` → `{agent_id}_replies` (after 94.1 merged + deployed, while still inert). The queue names a channel, not a payload type; `_replies` parallels `{agent_id}_comms`, matches the SIP's own "reply" vocabulary (`ReplyRouter`, `reply_queue`), and stays correct for non-task replies under the SIP-0088+ run modes. (Earlier rev entries below intentionally keep the `_results` name they shipped with.)
 - **rev 5 (2026-06-21):** S1 moved proposed → accepted as SIP-0094 (PR #193, 2026-06-20); implementation plan rev 2 landed; PR 94.1 (agent-side `{agent_id}_results` declaration) in progress on `feature/sip-0094-per-agent-reply-queues`. S1 row repointed to the accepted SIP + plan.
 - **rev 4 (2026-05-02):** S1 reshaped to per-agent reply queues (`{agent_id}_results`) replacing per-run `cycle_results_*` queues. Eliminates the orphan-queue leakage class entirely instead of mitigating it via TTL + run-completion cleanup. Drain-before-retry dropped (no longer needed — the always-on consumer never misses a reply window). SIP rev bumped to 2.
 - **rev 3 (2026-05-02):** Added Runtime Substrate section with S1 (Reply-Channel Subscription Model) as a precondition to the build-reliability axis. Triggered by `cyc_c9ca088599c0` lost-reply incident. Tactical patch on PR #89; structural SIP in `sips/proposed/`.

--- a/docs/plans/SIP-0094-per-agent-reply-queues-plan.md
+++ b/docs/plans/SIP-0094-per-agent-reply-queues-plan.md
@@ -6,7 +6,7 @@ SIP-0094 replaces the orchestrator↔agent reply path. Today `_publish_and_await
 polls a per-run reply queue (`cycle_results_{run_id}`) with short-lived consumer
 subscriptions, which (a) loses replies in the gap between subscriptions and (b)
 leaks an orphan `cycle_results_*` queue per run. The fix mirrors the existing
-dispatch-queue design: per-agent reply queues (`{agent_id}_results`, parallel to
+dispatch-queue design: per-agent reply queues (`{agent_id}_replies`, parallel to
 `{agent_id}_comms`) plus a single long-lived subscription per agent, opened
 **lazily on first dispatch**, with an in-process `ReplyRouter` that resolves an
 `asyncio.Future` keyed by `task_id`.
@@ -29,7 +29,7 @@ promotion.
 
 | PR | Scope | Inert? | Deploy |
 |----|-------|--------|--------|
-| **94.1** | Agent-side `{agent_id}_results` declaration at startup | yes (extra unused queue) | agents first |
+| **94.1** | Agent-side `{agent_id}_replies` declaration at startup | yes (extra unused queue) | agents first |
 | **94.2** | `QueuePort.subscribe()` + `SubscriptionHandle` + RabbitMQ native override (+ default polling impl) | yes (nothing subscribes yet) | runtime-api + agents |
 | **94.3** | `ReplyRouter` + `_publish_and_await` rewrite + DI wiring + `reply_queue` value flip | **no — behavior changes** | runtime-api |
 | **94.4** | Soak, drop orphan `cycle_results_*` queues, promote SIP→implemented | — | ops |
@@ -37,7 +37,7 @@ promotion.
 > **94.2 may split if the adapter code grows** (D6/§7 is the riskiest part): **94.2a** = port shape, default `subscribe()`, `SubscriptionHandle` lifecycle; **94.2b** = RabbitMQ native `subscribe()` + channel-close recovery + integration tests. Keeps the risky adapter code isolated and reviewable.
 
 **Deploy ordering is a safety preference, not a correctness dependency** (see D9):
-deploy agents (94.1) before the runtime-api cutover (94.3) so `{agent_id}_results`
+deploy agents (94.1) before the runtime-api cutover (94.3) so `{agent_id}_replies`
 already exists, but the cutover declares idempotently regardless.
 
 ## Binding decisions
@@ -47,18 +47,18 @@ robustness gaps that a polling loop never had to handle.
 
 - **D1 — `on_message` is async.** The router awaits `queue.ack(msg)` inside it. `subscribe(queue_name, *, on_message: Callable[[QueueMessage], Awaitable[None]])`.
 - **D2 — Router does NOT survive runtime-api restart.** In-process futures vanish on restart; an in-flight reply is ack'd-and-dropped on next boot. Durable resume is the SIP-0079 resume-contract's job, out of scope here.
-- **D3 — `{agent_id}_results` is durable, non-exclusive, `auto_delete=False`** (same args as `{agent_id}_comms`). Exclusive would block multiple runtime-api instances behind a load balancer; single-consumer is enforced by convention. **Declaration args MUST be identical everywhere** — agent `ensure_queue`, orchestrator `subscribe`, and any manual creation — via a single shared constant/helper (e.g. `REPLY_QUEUE_DECLARE_ARGS`), since a mismatch on a durable queue causes broker `PRECONDITION_FAILED`. A unit test asserts the helper is the only source of declare args.
+- **D3 — `{agent_id}_replies` is durable, non-exclusive, `auto_delete=False`** (same args as `{agent_id}_comms`). Exclusive would block multiple runtime-api instances behind a load balancer; single-consumer is enforced by convention. **Declaration args MUST be identical everywhere** — agent `ensure_queue`, orchestrator `subscribe`, and any manual creation — via a single shared constant/helper (e.g. `REPLY_QUEUE_DECLARE_ARGS`), since a mismatch on a durable queue causes broker `PRECONDITION_FAILED`. A unit test asserts the helper is the only source of declare args.
 - **D4 — `ensure_subscribed` is guarded by an `asyncio.Lock`.** Dispatch is sequential within a run, but `_execute_fan_out` (`dispatched_flow_executor.py:2402`) can dispatch concurrently; two concurrent first-dispatches to one agent must not open two subscriptions.
 - **D5 — `consume()`/`consume_blocking()`/`invalidate_queue()` STAY on `QueuePort`** (SIP §6). Only the executor's *use* of `consume_blocking`+`invalidate_queue` in the reply path is removed in 94.3. This is what "supersedes, not layers on" the PR #89 patch means concretely.
 - **D6 — Default `subscribe()` polls `consume_blocking()`; the native RabbitMQ override is THE structural fix.** The default exists only for non-RabbitMQ adapters and tests — it is explicitly NOT the SIP-0094 fix and must not be treated as satisfying it. `NoOpQueuePort` inherits the default and never fires a callback (its `consume()` returns `[]`) — fine for tests.
 - **D7 — Observability ships in 94.3** (see Observability section). At minimum a late-drop counter, plus the metrics needed to make the channel-close recovery (the riskiest path) observable during soak.
 - **D8 — Harden `TaskResult.from_dict` to ignore unknown keys.** It currently does `cls(**data)` (`tasks/models.py:109`), unlike `TaskEnvelope.from_dict` which filters. A forward-incompatible result payload would otherwise raise inside `_handle_reply` and (without D11) could strand the consumer.
-- **D9 — 94.1 is a rollout-safety + observability step, NOT a correctness dependency.** `ReplyRouter.ensure_subscribed()` / `QueuePort.subscribe()` MUST declare `{agent_id}_results` idempotently before publishing, so the cutover never assumes the agent pre-declared the queue. A future implementer must not bake in that assumption.
+- **D9 — 94.1 is a rollout-safety + observability step, NOT a correctness dependency.** `ReplyRouter.ensure_subscribed()` / `QueuePort.subscribe()` MUST declare `{agent_id}_replies` idempotently before publishing, so the cutover never assumes the agent pre-declared the queue. A future implementer must not bake in that assumption.
 - **D10 — `register(task_id)` raises a typed `DuplicateRegistration` error if a future is already pending for that `task_id`.** It must never silently overwrite an existing future — that would strand the first waiter on the shared per-agent queue.
 - **D11 — `_handle_reply` must never strand the consumer.** Parse `json.loads(msg.payload)["payload"]["task_id"]`. On malformed payload (bad JSON / missing `task_id`): log, increment a malformed-reply counter, ack/drop (or nack-without-requeue per adapter capability). On unknown/late `task_id` (no pending future): ack, increment the late-drop counter. If `TaskResult.from_dict` fails: log, fail the matching future if one exists, drop the bad message — do not let the exception kill the long-lived consumer task.
 - **D12 — `subscribe()` isolates callback exceptions.** Both the native and default impls catch exceptions from `on_message`, log, apply the ack/nack policy, and **continue consuming**. A single bad callback invocation must not terminate the durable subscription.
 - **D13 — Graceful shutdown ordering.** Runtime shutdown stops accepting new dispatches before calling `ReplyRouter.stop()`. The router carries a `stopped` state: once stopping, `ensure_subscribed()` and `register()` fail fast (typed error), so a late dispatch can't register a future while subscriptions are being cancelled. Document the lifespan ordering in `main.py` if it already guarantees this; otherwise enforce via the stopped state.
-- **D14 — `task_id` is the global correlation key.** Per-queue subscription already gives per-agent isolation: a reply on `{agent_id}_results` came, by construction, from a dispatch to that agent. Global uniqueness across normal / repair / correction task_ids is the only requirement (tested per SIP Risk 2). An explicit agent-identity match in the reply is **optional defense-in-depth** and is deferred — the reply envelope (`TaskResult` + `{correlation_id}`) carries no `agent_id` today, so it would require a payload addition.
+- **D14 — `task_id` is the global correlation key.** Per-queue subscription already gives per-agent isolation: a reply on `{agent_id}_replies` came, by construction, from a dispatch to that agent. Global uniqueness across normal / repair / correction task_ids is the only requirement (tested per SIP Risk 2). An explicit agent-identity match in the reply is **optional defense-in-depth** and is deferred — the reply envelope (`TaskResult` + `{correlation_id}`) carries no `agent_id` today, so it would require a payload addition.
 
 ## Cross-cutting requirements (every PR)
 
@@ -70,27 +70,27 @@ robustness gaps that a polling loop never had to handle.
 
 ---
 
-## PR 94.1 — Agent-side `{agent_id}_results` declaration (deploy-first, inert)
+## PR 94.1 — Agent-side `{agent_id}_replies` declaration (deploy-first, inert)
 
-**Goal:** ensure each agent's `{agent_id}_results` queue exists before runtime-api
+**Goal:** ensure each agent's `{agent_id}_replies` queue exists before runtime-api
 ever addresses it — a **defensive rollout step (D9)**, not a correctness source.
 
 **Finding that shapes this PR:** agents do **not** explicitly declare their
 `{agent_id}_comms` queue today — declaration is lazy inside
 `RabbitMQAdapter._get_queue()` (`adapters/comms/rabbitmq.py:82`) on the first
 `consume()`. There is no existing explicit-declare line to sit beside, and the
-agent only *publishes* to (never consumes from) its `_results` queue, so lazy
+agent only *publishes* to (never consumes from) its `_replies` queue, so lazy
 declaration won't cover it.
 
 ### Modified / new files
 - `src/squadops/ports/comms/queue.py` — add `ensure_queue(self, queue_name: str) -> None` (concrete default = no-op so NoOp works). Add the shared `REPLY_QUEUE_DECLARE_ARGS` constant (D3).
 - `adapters/comms/rabbitmq.py` — implement `ensure_queue` as a thin wrapper over `_get_queue(queue_name)` using `REPLY_QUEUE_DECLARE_ARGS`.
 - `src/squadops/ports/comms/noop.py` — inherits the no-op default.
-- `src/squadops/agents/entrypoint.py` — at startup (in `start()` after the adapter is built at `:351-352`, or top of `_consume_tasks` after `:438`): `await self._queue.ensure_queue(f"{self.agent_id}_results")`.
+- `src/squadops/agents/entrypoint.py` — at startup (in `start()` after the adapter is built at `:351-352`, or top of `_consume_tasks` after `:438`): `await self._queue.ensure_queue(f"{self.agent_id}_replies")`.
 
 ### Tests
 - `tests/unit/comms/test_rabbitmq_adapter.py` — `ensure_queue` declares with the shared args; idempotent across channel swap (extend `TestQueueCacheInvalidation` `:30`).
-- `tests/unit/agents/test_entrypoint_task.py` — agent startup calls `ensure_queue("{agent_id}_results")` exactly once.
+- `tests/unit/agents/test_entrypoint_task.py` — agent startup calls `ensure_queue("{agent_id}_replies")` exactly once.
 - Deploy: `rebuild_and_deploy.sh agents` before 94.3.
 
 ---
@@ -119,8 +119,8 @@ riskiest part of the SIP — emit resubscribe metrics (D7) and test it directly.
 ### Tests
 - `tests/unit/adapters/test_queue_port.py` — default `subscribe()`: published message reaches `on_message`; `cancel()` stops delivery; **a raising `on_message` does not stop the loop** (D12).
 - `tests/unit/comms/test_rabbitmq_adapter.py` — native `subscribe()`: happy path; **channel-close triggers transparent re-subscribe** (simulate close, assert a post-reconnect message is delivered); `cancel()` cleans up the consumer tag; raising `on_message` does not kill the consumer (D12).
-- `tests/integration/adapters/test_rabbitmq_adapter.py` — **new (SIP §8):** publish 100 replies to one `{agent_id}_results` queue with a single held subscriber → all 100 routed, zero lost; compare against the legacy `consume()` path.
-- `tests/integration/adapters/test_rabbitmq_adapter.py` — **new (multi-agent, #12):** subscribe to ≥2 `{agent_id}_results` queues, publish interleaved replies to both, assert each future resolves exactly once with **no cross-agent delivery**.
+- `tests/integration/adapters/test_rabbitmq_adapter.py` — **new (SIP §8):** publish 100 replies to one `{agent_id}_replies` queue with a single held subscriber → all 100 routed, zero lost; compare against the legacy `consume()` path.
+- `tests/integration/adapters/test_rabbitmq_adapter.py` — **new (multi-agent, #12):** subscribe to ≥2 `{agent_id}_replies` queues, publish interleaved replies to both, assert each future resolves exactly once with **no cross-agent delivery**.
 
 ---
 
@@ -141,7 +141,7 @@ Confirmed shapes: `QueueMessage.payload` is a raw JSON string (`comms/queue_mess
 ### Rewrite — `adapters/cycles/dispatched_flow_executor.py:669-743`
 `_publish_and_await` before → after:
 - **Remove** `reply_queue = f"cycle_results_{run_id}"` (`:675`) and the entire `while`/`consume_blocking`/`invalidate_queue`/`asyncio.sleep` recovery block (`:697-743`).
-- **Add:** `await self._reply_router.ensure_subscribed(envelope.agent_id)` → `fut = self._reply_router.register(envelope.task_id)` → set `reply_queue = f"{envelope.agent_id}_results"` in the message metadata (`:680`) → `publish(f"{envelope.agent_id}_comms", ...)` → `await asyncio.wait_for(fut, timeout=self._task_timeout)`.
+- **Add:** `await self._reply_router.ensure_subscribed(envelope.agent_id)` → `fut = self._reply_router.register(envelope.task_id)` → set `reply_queue = f"{envelope.agent_id}_replies"` in the message metadata (`:680`) → `publish(f"{envelope.agent_id}_comms", ...)` → `await asyncio.wait_for(fut, timeout=self._task_timeout)`.
 - **Ordering (D14/#2):** `ensure_subscribed → register → publish` — the consumer is live before any reply can arrive (no first-dispatch race). A pre-existing message for the same `task_id` would be dropped before registration, which is impossible given global `task_id` uniqueness (covered by the cross-run test).
 - **Publish-failure cleanup (#10):** wrap `publish` so that if it raises *after* `register()`, the future is cancelled/removed before returning/raising — no pending-future leak when the agent never received the task.
 - **Pending-future leak invariant (#9):** on EVERY exit path — success, timeout (`cancel(task_id)`), publish failure, router failure, cancellation — `task_id` must not remain pending. Asserted by tests.
@@ -170,12 +170,12 @@ controllable future. Three helpers gate the bulk:
 - `mock_queue` fixture (`:109`) → add a `reply_router` fixture.
 - `_make_result_message` (`:42`, default `cycle_results_run_001`) → router-result helper.
 - pulse `_consume_side_effect` keyed on `startswith("cycle_results_")` (`:2565`) → re-key on the router.
-- **Obsolete:** `test_recovers_from_transient_consume_error` (`:609`, asserts `invalidate_queue` `:660`), `test_uses_long_block_consume_not_short_poll` (`:662`). `test_publishes_to_agent_comms_queue` (`:494`) updates its `reply_queue` assertion (`:548`) → `{agent_id}_results`.
+- **Obsolete:** `test_recovers_from_transient_consume_error` (`:609`, asserts `invalidate_queue` `:660`), `test_uses_long_block_consume_not_short_poll` (`:662`). `test_publishes_to_agent_comms_queue` (`:494`) updates its `reply_queue` assertion (`:548`) → `{agent_id}_replies`.
 
 ### New tests
 - `tests/unit/cycles/test_reply_router.py`: register/resolve by `task_id`; **duplicate `register()` raises typed error (D10)**; late reply → drop + counter (D11); **malformed payload → log+count, consumer survives (D11)**; `from_dict` failure → fails the future, consumer survives (D11); `stop()` fails pending futures with the typed error; `ensure_subscribed` idempotent + **concurrency-safe (D4)**; `ensure_subscribed`/`register` fail fast once stopped (D13).
 - `_publish_and_await`: registers before publishing; resolves on reply; timeout → cancels future + FAILED; **publish failure after register removes the pending future (#10)**; **no path leaves `task_id` pending (#9)**.
-- **Concurrent first-dispatch at executor level (#13):** two concurrent `_publish_and_await` for the same `agent_id` → exactly one subscription opened, both futures resolve, both publish to the same `{agent_id}_results`.
+- **Concurrent first-dispatch at executor level (#13):** two concurrent `_publish_and_await` for the same `agent_id` → exactly one subscription opened, both futures resolve, both publish to the same `{agent_id}_replies`.
 - **Cross-run / global uniqueness (SIP Risk 2 / D14):** two runs' `task-{run_id[:12]}-...` ids don't collide on a shared queue; cover a correction/repair id (`dispatched_flow_executor.py:2092,2259`) too.
 
 ---
@@ -183,25 +183,25 @@ controllable future. Three helpers gate the bulk:
 ## PR 94.4 — Soak, orphan cleanup, promote
 
 1. **Soak** in Spark dev for one full long-cycle build (SIP E2E): re-run a `group_run`
-   cycle; verify no `cycle_results_*` queues are created, `{agent_id}_results` queues
+   cycle; verify no `cycle_results_*` queues are created, `{agent_id}_replies` queues
    exist and drain to zero after the run, a late dispatch completes in peer wall time,
    and the **late-drop / malformed counters are zero or understood**.
 2. **Guarded orphan cleanup (#15):** before deleting, list queues and confirm —
    no active runtime-api is still on the legacy path; target queues have **zero
    consumers**; target queues are **older than the cutover timestamp**; names match
-   the **exact prefix `cycle_results_`**. **Never touch any `{agent_id}_results`
+   the **exact prefix `cycle_results_`**. **Never touch any `{agent_id}_replies`
    queue.** One-shot `rabbitmqctl`, not code.
 3. **Promote only when (#17):** soak passed, no new `cycle_results_*` created, all
-   `{agent_id}_results` drain to zero, late-drop/malformed counters zero-or-understood,
+   `{agent_id}_replies` drain to zero, late-drop/malformed counters zero-or-understood,
    the rollback window has passed, and orphan cleanup is done (or explicitly deferred
    with an owner + date). Then: `SQUADOPS_MAINTAINER=1 python scripts/maintainer/update_sip_status.py sips/accepted/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md implemented`.
 
 ## Rollback (#16)
 
 - **94.1 / 94.2 are inert** — leave them deployed; they're compatible with the legacy path.
-- **If 94.3 fails:** roll runtime-api back to the previous image. Agents carrying extra `{agent_id}_results` queues remain compatible with the old `cycle_results_{run_id}` path.
+- **If 94.3 fails:** roll runtime-api back to the previous image. Agents carrying extra `{agent_id}_replies` queues remain compatible with the old `cycle_results_{run_id}` path.
 - **Do not drop `cycle_results_*` queues until after soak AND the rollback window** — the legacy path needs them on rollback.
-- If rollback happens after some `{agent_id}_results` queues accumulated messages, inspect and purge **only after confirming no 94.3 runtime is active**.
+- If rollback happens after some `{agent_id}_replies` queues accumulated messages, inspect and purge **only after confirming no 94.3 runtime is active**.
 
 ## Risks & mitigations
 
@@ -221,7 +221,7 @@ controllable future. Three helpers gate the bulk:
 
 - **Unit/integration:** all new tests pass; the ~40 migrated executor tests pass against the router; the 100-reply single-subscriber and the multi-agent interleaved tests show zero loss / no cross-agent delivery; full regression green.
 - **Robustness invariants proven by test:** duplicate `task_id` registration fails fast (typed error); publish failure after registration removes the pending future; callback exceptions do not terminate the subscription; malformed reply payloads are logged, counted, and don't kill the subscription; concurrent first-dispatches to one agent create exactly one subscription; queue declare args are identical across agent startup and orchestrator subscribe; runtime shutdown prevents new future registration before router stop; no `_publish_and_await` exit path leaves a pending future.
-- **E2E (the original failure mode):** re-run the incident cycle on a clean stack — the previously-lost late reply is delivered within normal wall time; **no `cycle_results_*` queue is created**; `{agent_id}_results` queues exist and drain to zero after the run.
+- **E2E (the original failure mode):** re-run the incident cycle on a clean stack — the previously-lost late reply is delivered within normal wall time; **no `cycle_results_*` queue is created**; `{agent_id}_replies` queues exist and drain to zero after the run.
 - **Operational:** rollback from 94.3 to the legacy path is documented and validated; observability counters are emitted and checked during soak.
 - **No regression** to the per-task timeout, agent comms loop, or dispatch-message shape.
 
@@ -234,5 +234,6 @@ controllable future. Three helpers gate the bulk:
 
 ## Revision history
 
+- **2026-06-21 — Rev 3.** Renamed the per-agent reply queue `{agent_id}_results` → `{agent_id}_replies` (done after 94.1 merged + deployed, while still inert — empty queues, no consumers, no downstream code yet). The queue names a channel, not a payload type: `_replies` parallels `{agent_id}_comms`, matches this plan's own "reply" vocabulary (`ReplyRouter`, `reply_queue`, `_publish_and_await`), and stays correct for non-`TaskResult` replies under the SIP-0088+ run modes. Ops: redeploy agents to declare `_replies`; drop the orphan empty `_results` queues.
 - **2026-06-21 — Rev 2.** Incorporated review feedback: 94.1 reframed as defensive not load-bearing (D9); added duplicate-registration guard (D10), `_handle_reply` robustness (D11), callback exception isolation (D12), shutdown ordering/stopped-state (D13), global-key + per-queue isolation rationale (D14); shared declare-args helper (D3); native-is-the-fix caveat (D6); publish-failure cleanup + pending-future leak invariant in the rewrite; Observability, Rollback sections; multi-agent + concurrent-executor tests; guarded orphan cleanup + conditional promotion; optional 94.2 split.
 - **2026-06-20 — Rev 1.** Initial phased plan grounded in the current dispatch/reply code.

--- a/sips/accepted/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md
+++ b/sips/accepted/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md
@@ -17,7 +17,7 @@ updated_at: '2026-06-20T19:43:25.130339Z'
 
 ## 1. Abstract
 
-The orchestrator's request/reply path between `runtime-api` and agents has two structural problems: (a) it polls a per-run RabbitMQ reply queue with thousands of short-lived consumer subscriptions per long task, losing replies in the gap between subscriptions, and (b) it scopes the reply queue by run instead of by agent, so every completed run leaves an orphaned `cycle_results_*` queue that nobody ever cleans up. This SIP fixes both by mirroring the existing dispatch-channel design — replace per-run reply queues with per-agent reply queues (`{agent_id}_results`, parallel to the existing `{agent_id}_comms`), and replace the polling loop with a single long-lived subscription per agent, established lazily on first dispatch to each agent. The result eliminates the "agent succeeded but reply lost" failure class and the orphan-queue leakage class in one step. A tactical patch (PR #89, `fix/cycle-results-channel-recovery`, merged 2026-05-02) already lands cache-recovery and longer poll chunks that contain the bleeding; this SIP is the structural fix.
+The orchestrator's request/reply path between `runtime-api` and agents has two structural problems: (a) it polls a per-run RabbitMQ reply queue with thousands of short-lived consumer subscriptions per long task, losing replies in the gap between subscriptions, and (b) it scopes the reply queue by run instead of by agent, so every completed run leaves an orphaned `cycle_results_*` queue that nobody ever cleans up. This SIP fixes both by mirroring the existing dispatch-channel design — replace per-run reply queues with per-agent reply queues (`{agent_id}_replies`, parallel to the existing `{agent_id}_comms`), and replace the polling loop with a single long-lived subscription per agent, established lazily on first dispatch to each agent. The result eliminates the "agent succeeded but reply lost" failure class and the orphan-queue leakage class in one step. A tactical patch (PR #89, `fix/cycle-results-channel-recovery`, merged 2026-05-02) already lands cache-recovery and longer poll chunks that contain the bleeding; this SIP is the structural fix.
 
 ## 2. Problem Statement
 
@@ -39,7 +39,7 @@ The tactical fix on PR #89 introduces `consume_blocking()` (one consumer per chu
 
 ## 3. Goals
 
-1. Replace per-run reply queues (`cycle_results_{run_id}`) with per-agent reply queues (`{agent_id}_results`). One declaration per agent at orchestrator startup; durable; never cleaned up because they are the agent's permanent reply address (parallel structure to the existing `{agent_id}_comms` dispatch queue). Eliminates the orphan-queue class.
+1. Replace per-run reply queues (`cycle_results_{run_id}`) with per-agent reply queues (`{agent_id}_replies`). One declaration per agent at orchestrator startup; durable; never cleaned up because they are the agent's permanent reply address (parallel structure to the existing `{agent_id}_comms` dispatch queue). Eliminates the orphan-queue class.
 2. Replace `_publish_and_await`'s polling loop with a long-lived per-agent subscription established lazily on first dispatch to each agent (the squad roster isn't fixed at boot — profiles resolve per-run), plus an in-process router that resolves an `asyncio.Future` keyed by `task_id` when a matching reply arrives. Eliminates the consumer-tag-churn failure class.
 3. Define an explicit `subscribe()` primitive on `QueuePort` with callback/async-iterator semantics so reply consumption is no longer expressed as polling at any layer.
 
@@ -55,18 +55,18 @@ The tactical fix on PR #89 introduces `consume_blocking()` (one consumer per chu
 
 ### 5.1 Per-agent reply queue
 
-Each agent gets a permanent reply queue named `{agent_id}_results`, declared durable. Symmetric to the existing `{agent_id}_comms`:
+Each agent gets a permanent reply queue named `{agent_id}_replies`, declared durable. Symmetric to the existing `{agent_id}_comms`:
 
 | Direction | Queue | Writer | Reader |
 |---|---|---|---|
 | Dispatch | `{agent_id}_comms` | runtime-api | the named agent |
-| Reply (new) | `{agent_id}_results` | the named agent | runtime-api |
+| Reply (new) | `{agent_id}_replies` | the named agent | runtime-api |
 
 Declaration happens in two places:
-- **Orchestrator, on first dispatch to an agent**: `ReplyRouter.ensure_subscribed(agent_id)` opens the subscription, which declares `{agent_id}_results` (idempotent — broker no-ops on re-declare with same args). There is no boot-time roster to enumerate; the squad profile is resolved per-run and can be overridden per run (see §5.3).
-- **Agent startup**: also declares its own `{agent_id}_results` (defensive — if the orchestrator hasn't dispatched to it yet, the agent shouldn't fail its first reply).
+- **Orchestrator, on first dispatch to an agent**: `ReplyRouter.ensure_subscribed(agent_id)` opens the subscription, which declares `{agent_id}_replies` (idempotent — broker no-ops on re-declare with same args). There is no boot-time roster to enumerate; the squad profile is resolved per-run and can be overridden per run (see §5.3).
+- **Agent startup**: also declares its own `{agent_id}_replies` (defensive — if the orchestrator hasn't dispatched to it yet, the agent shouldn't fail its first reply).
 
-The `reply_queue` field in dispatch metadata becomes `{envelope.agent_id}_results` instead of `cycle_results_{run_id}`. Agents see no semantic change — they still publish wherever metadata says to publish.
+The `reply_queue` field in dispatch metadata becomes `{envelope.agent_id}_replies` instead of `cycle_results_{run_id}`. Agents see no semantic change — they still publish wherever metadata says to publish.
 
 ### 5.2 New port primitive
 
@@ -87,7 +87,7 @@ This shape is closer to "register a callback" than "wait for one message." It's 
 
 ### 5.3 Reply router
 
-A new `ReplyRouter` component in `adapters/cycles/`. It subscribes **lazily**: there is no fixed agent roster at orchestrator boot — squad profiles are resolved per-run via `SquadProfilePort.resolve_snapshot(profile_id)` and can be overridden per run, so the router cannot enumerate agents at startup. Instead the executor calls `ensure_subscribed(agent_id)` before each dispatch; the first call for a given agent opens that agent's `{agent_id}_results` subscription, and subsequent calls are no-ops. Once opened, a subscription lives for the process lifetime.
+A new `ReplyRouter` component in `adapters/cycles/`. It subscribes **lazily**: there is no fixed agent roster at orchestrator boot — squad profiles are resolved per-run via `SquadProfilePort.resolve_snapshot(profile_id)` and can be overridden per run, so the router cannot enumerate agents at startup. Instead the executor calls `ensure_subscribed(agent_id)` before each dispatch; the first call for a given agent opens that agent's `{agent_id}_replies` subscription, and subsequent calls are no-ops. Once opened, a subscription lives for the process lifetime.
 
 ```python
 class ReplyRouter:
@@ -101,7 +101,7 @@ class ReplyRouter:
         if agent_id in self._subscriptions:
             return
         self._subscriptions[agent_id] = await self._queue.subscribe(
-            f"{agent_id}_results",
+            f"{agent_id}_replies",
             on_message=self._handle_reply,
         )
 
@@ -144,7 +144,7 @@ Lifecycle: constructed at runtime-api boot, `stop()` at shutdown. No boot-time s
 ```python
 await self._reply_router.ensure_subscribed(envelope.agent_id)
 fut = self._reply_router.register(envelope.task_id)
-reply_queue = f"{envelope.agent_id}_results"
+reply_queue = f"{envelope.agent_id}_replies"
 message = {
     "action": "comms.task",
     "metadata": {"reply_queue": reply_queue, "correlation_id": envelope.correlation_id},
@@ -166,10 +166,10 @@ except asyncio.TimeoutError:
 
 ### 5.5 Migration
 
-The dispatch-side change (use `{agent_id}_results` as `reply_queue`) is invisible to agents because they read the address out of metadata. The cutover is therefore a runtime-api-only change once the agents have their `_results` queues declared. Order of operations:
+The dispatch-side change (use `{agent_id}_replies` as `reply_queue`) is invisible to agents because they read the address out of metadata. The cutover is therefore a runtime-api-only change once the agents have their `_replies` queues declared. Order of operations:
 
 1. Land tactical patch (PR #89, done).
-2. Add `_results` queue declaration to agent startup (`entrypoint.py`). Deploy agents first. Old runtime-api still uses `cycle_results_{run_id}`; agents now have an extra unused queue. No behavior change.
+2. Add `_replies` queue declaration to agent startup (`entrypoint.py`). Deploy agents first. Old runtime-api still uses `cycle_results_{run_id}`; agents now have an extra unused queue. No behavior change.
 3. Land `subscribe()` + `ReplyRouter` + executor wiring in runtime-api. Deploy.
 4. After one soak cycle, manually drop the historical `cycle_results_*` queues (one-shot rabbitmqctl command).
 
@@ -182,23 +182,23 @@ The dispatch-side change (use `{agent_id}_results` as `reply_queue`) is invisibl
 
 ## 7. Risks
 
-- **Long-lived consumer channel death**: if a `_results` consumer's channel closes (network blip, broker restart), in-flight waits are silently stranded until either the channel reconnects or the dispatch times out. Mitigation: `subscribe()` implementation must register channel-close callbacks, re-declare its queue on the new channel, and re-establish the consumer. Existing `_get_queue` channel-swap detection (already in tactical patch) covers re-declaration; subscription resumption is new code.
+- **Long-lived consumer channel death**: if a `_replies` consumer's channel closes (network blip, broker restart), in-flight waits are silently stranded until either the channel reconnects or the dispatch times out. Mitigation: `subscribe()` implementation must register channel-close callbacks, re-declare its queue on the new channel, and re-establish the consumer. Existing `_get_queue` channel-swap detection (already in tactical patch) covers re-declaration; subscription resumption is new code.
 - **Cross-run task_id collision**: per-agent queues are shared across runs, so task_id must be globally unique (not just per-run). Audit `TaskEnvelope.task_id` generation — currently UUID-based (`task-{run_short}-{m_idx}-{capability}`), which encodes the run prefix, so collision is unlikely but worth a deliberate test.
-- **Late-reply leakage**: if an agent's reply arrives after the orchestrator has timed out and given up on a task, the reply lands in `_results`, gets ack'd by the router, and is dropped with a warning log. Cost: zero broker-side leakage but a small observability gap. Mitigation: counter metric for late-drop events so we can detect a regression.
-- **Agent-orchestrator startup ordering**: largely dissolved by lazy subscription (§5.3). The orchestrator's `subscribe()` now happens on first dispatch, not at boot, and itself declares `{agent_id}_results` (idempotent), so it no longer depends on the agent having booted first. Both sides own their queue declarations; first-mover wins. Residual requirement: `subscribe()` must tolerate being the declarer (not assume the queue already exists).
+- **Late-reply leakage**: if an agent's reply arrives after the orchestrator has timed out and given up on a task, the reply lands in `_replies`, gets ack'd by the router, and is dropped with a warning log. Cost: zero broker-side leakage but a small observability gap. Mitigation: counter metric for late-drop events so we can detect a regression.
+- **Agent-orchestrator startup ordering**: largely dissolved by lazy subscription (§5.3). The orchestrator's `subscribe()` now happens on first dispatch, not at boot, and itself declares `{agent_id}_replies` (idempotent), so it no longer depends on the agent having booted first. Both sides own their queue declarations; first-mover wins. Residual requirement: `subscribe()` must tolerate being the declarer (not assume the queue already exists).
 
 ## 8. Test Plan
 
 - Unit: `ReplyRouter` registers/resolves futures by task_id; late replies (no awaiting future) are dropped with a warning; on shutdown, all pending futures are failed with a typed error.
 - Unit: `subscribe()` happy path; channel-close triggers re-subscribe transparently; cancel cleans up consumer tag.
 - Unit: `_publish_and_await` registers with router before publishing, resolves on reply, fails cleanly on timeout, and unregisters on timeout to avoid future-leak.
-- Integration (`tests/integration/adapters/test_rabbitmq_adapter.py`): publish 100 replies to one `{agent_id}_results` queue while a single subscriber is held — all 100 routed correctly to their futures, zero lost. Compare to the same load against the legacy `consume()` path to demonstrate the regression.
-- E2E: re-run the `group_run` cycle that surfaced this issue (`cyc_c9ca088599c0`) on a clean stack; verify dev[3] completes within the same wall time as dev[0–2]. Verify no `cycle_results_*` queues are created. Verify `{agent_id}_results` queues exist and have zero ready messages after the run completes.
+- Integration (`tests/integration/adapters/test_rabbitmq_adapter.py`): publish 100 replies to one `{agent_id}_replies` queue while a single subscriber is held — all 100 routed correctly to their futures, zero lost. Compare to the same load against the legacy `consume()` path to demonstrate the regression.
+- E2E: re-run the `group_run` cycle that surfaced this issue (`cyc_c9ca088599c0`) on a clean stack; verify dev[3] completes within the same wall time as dev[0–2]. Verify no `cycle_results_*` queues are created. Verify `{agent_id}_replies` queues exist and have zero ready messages after the run completes.
 
 ## 9. Rollout
 
 1. **Done**: tactical patch (`fix/cycle-results-channel-recovery`, PR #89, merged 2026-05-02). Contains the bleeding.
-2. Agent-side: declare `{agent_id}_results` queue at agent startup. Ship and deploy first so that when runtime-api starts using the new path, the queues exist. No behavior change in this step.
+2. Agent-side: declare `{agent_id}_replies` queue at agent startup. Ship and deploy first so that when runtime-api starts using the new path, the queues exist. No behavior change in this step.
 3. Runtime-api side: land `subscribe()` + `ReplyRouter` + dispatch-metadata change in one feature branch off main. Tests required per §8.
 4. Soak in Spark dev environment for one full long-cycle build.
 5. Drop historical `cycle_results_*` queues via one-shot rabbitmqctl command after soak.
@@ -208,4 +208,4 @@ The dispatch-side change (use `{agent_id}_results` as `reply_queue`) is invisibl
 
 - Should `subscribe()`'s `on_message` callback be sync or async? Async is required for the router (which calls `await queue.ack(msg)` inside it). Recommend async.
 - Should the router survive runtime-api restarts? If runtime-api restarts mid-task, in-process futures vanish and any reply already in flight will be ack'd-and-dropped on next boot. Out of scope for this SIP — that's the SIP-0079-style resume contract's job.
-- Should `{agent_id}_results` queues be declared with `auto_delete=False, exclusive=False` (current per-run default) or `exclusive=True` to enforce single-consumer semantics? Recommend non-exclusive — exclusive prevents the orchestrator from running multiple instances behind a load balancer. Single-consumer is enforced by convention, not broker.
+- Should `{agent_id}_replies` queues be declared with `auto_delete=False, exclusive=False` (current per-run default) or `exclusive=True` to enforce single-consumer semantics? Recommend non-exclusive — exclusive prevents the orchestrator from running multiple instances behind a load balancer. Single-consumer is enforced by convention, not broker.

--- a/src/squadops/agents/entrypoint.py
+++ b/src/squadops/agents/entrypoint.py
@@ -436,7 +436,7 @@ class AgentRunner:
 
         # Queue name for this agent's communications
         comms_queue = f"{self.agent_id}_comms"
-        results_queue = f"{self.agent_id}_results"
+        replies_queue = f"{self.agent_id}_replies"
 
         logger.info(
             "Starting task consumer",
@@ -444,10 +444,10 @@ class AgentRunner:
         )
 
         # SIP-0094 (D9): declare this agent's reply queue before the orchestrator
-        # ever addresses it. The agent only publishes to `{agent_id}_results`
+        # ever addresses it. The agent only publishes to `{agent_id}_replies`
         # (never consumes from it), so the lazy declaration that covers the comms
         # queue won't create it. Idempotent — safe to call on every boot.
-        await self._queue.ensure_queue(results_queue)
+        await self._queue.ensure_queue(replies_queue)
 
         while not self._shutdown_event.is_set():
             try:

--- a/src/squadops/ports/comms/queue.py
+++ b/src/squadops/ports/comms/queue.py
@@ -9,7 +9,7 @@ from typing import Any
 from squadops.comms.queue_message import QueueMessage
 
 # SIP-0094 D3: canonical declaration args for agent comms/reply queues
-# (`{agent_id}_comms`, `{agent_id}_results`). Every declaration of these queues
+# (`{agent_id}_comms`, `{agent_id}_replies`). Every declaration of these queues
 # — agent startup `ensure_queue`, orchestrator `subscribe`, manual creation —
 # MUST use these exact args. A mismatch on a durable queue makes the broker
 # reject the redeclare with PRECONDITION_FAILED, so this is single-sourced here
@@ -113,7 +113,7 @@ class QueuePort(ABC):
         Broker-backed adapters override this to declare with
         :data:`REPLY_QUEUE_DECLARE_ARGS` (SIP-0094 D3).
 
-        Agents call this at startup for their ``{agent_id}_results`` reply
+        Agents call this at startup for their ``{agent_id}_replies`` reply
         queue, which they only ever publish to (never consume from), so the
         lazy declaration that covers ``{agent_id}_comms`` never fires for it.
         """

--- a/tests/unit/agents/test_entrypoint_task.py
+++ b/tests/unit/agents/test_entrypoint_task.py
@@ -152,7 +152,7 @@ class TestHandleTaskEnvelope:
 
 
 class TestConsumeTasksEnsuresReplyQueue:
-    """`_consume_tasks` must declare the agent's `{agent_id}_results` reply
+    """`_consume_tasks` must declare the agent's `{agent_id}_replies` reply
     queue at startup (SIP-0094 D9) so the orchestrator never publishes a reply
     to a queue the agent never created."""
 
@@ -167,8 +167,8 @@ class TestConsumeTasksEnsuresReplyQueue:
             r._shutdown_event = MagicMock()
             return r
 
-    async def test_declares_results_queue_before_consuming(self) -> None:
-        """ensure_queue("{agent_id}_results") is awaited exactly once, ahead of
+    async def test_declares_replies_queue_before_consuming(self) -> None:
+        """ensure_queue("{agent_id}_replies") is awaited exactly once, ahead of
         the consume loop. With the loop short-circuited, a call count of one
         proves the declaration sits *before* the loop, not inside it (which
         would yield zero calls here and N calls in steady state)."""
@@ -177,6 +177,6 @@ class TestConsumeTasksEnsuresReplyQueue:
 
         await r._consume_tasks()
 
-        r._queue.ensure_queue.assert_awaited_once_with("neo_results")
+        r._queue.ensure_queue.assert_awaited_once_with("neo_replies")
         # The loop body never ran, so nothing was consumed this pass.
         r._queue.consume.assert_not_awaited()

--- a/tests/unit/comms/test_rabbitmq_adapter.py
+++ b/tests/unit/comms/test_rabbitmq_adapter.py
@@ -98,7 +98,7 @@ class TestQueueCacheInvalidation:
 
 class TestEnsureQueue:
     """``ensure_queue`` eagerly declares a queue the adapter would otherwise
-    only create lazily on first consume — needed for ``{agent_id}_results``
+    only create lazily on first consume — needed for ``{agent_id}_replies``
     reply queues, which agents publish to but never consume from (SIP-0094)."""
 
     async def test_declares_with_shared_args(self) -> None:
@@ -112,11 +112,11 @@ class TestEnsureQueue:
         ch.declare_queue = AsyncMock(return_value=declared)
 
         adapter = _make_adapter_with_channel(ch)
-        await adapter.ensure_queue("neo_results")
+        await adapter.ensure_queue("neo_replies")
 
-        ch.declare_queue.assert_awaited_once_with("neo_results", **REPLY_QUEUE_DECLARE_ARGS)
+        ch.declare_queue.assert_awaited_once_with("neo_replies", **REPLY_QUEUE_DECLARE_ARGS)
 
-    async def test_results_and_comms_declare_with_identical_args(self) -> None:
+    async def test_replies_and_comms_declare_with_identical_args(self) -> None:
         """D3 single-source invariant: the reply queue and the comms queue must
         be declared with byte-identical args. A drift between the two paths is
         exactly what causes the broker to reject a durable redeclare."""
@@ -132,11 +132,11 @@ class TestEnsureQueue:
         ch.declare_queue = AsyncMock(side_effect=_fresh_queue)
 
         adapter = _make_adapter_with_channel(ch)
-        await adapter.ensure_queue("neo_results")  # reply queue path
+        await adapter.ensure_queue("neo_replies")  # reply queue path
         await adapter._get_queue("neo_comms")  # comms queue path
 
         results_call, comms_call = ch.declare_queue.await_args_list
-        assert results_call.args == ("neo_results",)
+        assert results_call.args == ("neo_replies",)
         assert comms_call.args == ("neo_comms",)
         assert results_call.kwargs == comms_call.kwargs == REPLY_QUEUE_DECLARE_ARGS
 
@@ -151,7 +151,7 @@ class TestEnsureQueue:
         ch1.declare_queue = AsyncMock(return_value=q1)
 
         adapter = _make_adapter_with_channel(ch1)
-        await adapter.ensure_queue("neo_results")
+        await adapter.ensure_queue("neo_replies")
         ch1.declare_queue.assert_awaited_once()
 
         # RobustChannel reconnect: adapter now holds a fresh channel.
@@ -162,8 +162,8 @@ class TestEnsureQueue:
         ch2.declare_queue = AsyncMock(return_value=q2)
         adapter._channel = ch2
 
-        await adapter.ensure_queue("neo_results")
-        ch2.declare_queue.assert_awaited_once_with("neo_results", **REPLY_QUEUE_DECLARE_ARGS)
+        await adapter.ensure_queue("neo_replies")
+        ch2.declare_queue.assert_awaited_once_with("neo_replies", **REPLY_QUEUE_DECLARE_ARGS)
 
 
 class TestConsumeBlockingErrorWrapping:


### PR DESCRIPTION
## Why

The per-agent reply queue was named `{agent_id}_results` — but that names the queue by *today's* payload (a `TaskResult`), not by *what it is*: the agent's outbound reply channel.

`{agent_id}_replies` is better:
- **Channel, not payload** — parallels the inbound `{agent_id}_comms`.
- **Consistent with the SIP's own vocabulary** — `ReplyRouter`, `reply_queue`, `_publish_and_await`, `REPLY_QUEUE_DECLARE_ARGS`. `_results` was the odd term out.
- **Mode-agnostic** — under the SIP-0088+ duty/ambient/cycle run modes, an agent's outbound channel carries more than task results; `_results` would read wrong the moment a non-task reply flows.

## Why now

94.1 is **inert**: the `_results` queues are empty, have no consumers, and nothing downstream (94.2/94.3) references the name yet. So this is a near-free rename — versus painful once the cutover wires real traffic and code to it.

## Scope

- **Code:** `entrypoint.py` declaration, the D3 constant comment + docstrings in `ports/comms/queue.py` and `adapters/comms/rabbitmq.py`, and the two 94.1 tests.
- **Docs:** SIP body, implementation plan, and the hardening-plan S1 row. Earlier revision-history entries intentionally keep the `_results` name they shipped with.
- `cycle_results_*` (the legacy per-run queue) is **deliberately untouched** — verified by grep.

## Ops after merge

1. Redeploy agents (`rebuild_and_deploy.sh agents`) → they declare `_replies`.
2. Drop the orphan empty `_results` queues (created by the 94.1 deploy; inert, empty).

## Verification

- `tests/unit/comms/ tests/unit/agents/`: **79 passed**. ruff clean.
- Repo-wide grep confirms no agent-reply `_results` remain and `cycle_results_*` is intact.

Follows SIP-0094 94.1 (merged). Precedes 94.2.