### PR TITLE
SIP-0094 94.2a: QueuePort.subscribe() primitive + SubscriptionHandle (inert)

### DIFF
--- a/src/squadops/ports/comms/queue.py
+++ b/src/squadops/ports/comms/queue.py
@@ -3,10 +3,17 @@ Port interface for queue providers.
 Defines the contract that any queue transport provider must satisfy.
 """
 
+import asyncio
+import inspect
+import logging
+import time
 from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from squadops.comms.queue_message import QueueMessage
+
+logger = logging.getLogger(__name__)
 
 # SIP-0094 D3: canonical declaration args for agent comms/reply queues
 # (`{agent_id}_comms`, `{agent_id}_replies`). Every declaration of these queues
@@ -15,6 +22,50 @@ from squadops.comms.queue_message import QueueMessage
 # reject the redeclare with PRECONDITION_FAILED, so this is single-sourced here
 # to keep the args from drifting across call sites.
 REPLY_QUEUE_DECLARE_ARGS: dict[str, Any] = {"durable": True}
+
+# SIP-0094 D6: how long the default poll-based `subscribe()` blocks on each
+# `consume_blocking()` iteration. This does NOT affect delivery latency — a
+# waiting message is returned the moment it arrives — it only bounds how often
+# an idle loop re-enters consume. The native RabbitMQ override (PR 94.2b)
+# holds a real long-lived consumer and ignores this value.
+_SUBSCRIBE_POLL_TIMEOUT = 5.0
+
+# A subscription callback may be sync or async; it receives one QueueMessage.
+# The reply-router cutover (PR 94.3) resolves a Future synchronously, so the
+# sync form must be supported, not just coroutines.
+SubscriptionCallback = Callable[[QueueMessage], Awaitable[None] | None]
+
+
+class SubscriptionHandle:
+    """Lifecycle handle for a long-lived queue subscription (SIP-0094 D6).
+
+    Returned by :meth:`QueuePort.subscribe`. Wraps the background task that
+    drives delivery; ``await handle.cancel()`` stops it. The handle is the only
+    thing a caller needs to retain to tear a subscription down — it never
+    exposes the underlying task directly.
+    """
+
+    def __init__(self, task: asyncio.Task, queue_name: str) -> None:
+        self._task = task
+        self.queue_name = queue_name
+
+    @property
+    def active(self) -> bool:
+        """True while the subscription's background task is still running."""
+        return not self._task.done()
+
+    async def cancel(self) -> None:
+        """Stop the subscription and wait for its task to unwind.
+
+        Idempotent: calling it on an already-finished subscription is a no-op.
+        """
+        if self._task.done():
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
 
 
 class QueuePort(ABC):
@@ -80,9 +131,6 @@ class QueuePort(ABC):
             QueueError: If consumption fails
         """
         # Default fallback: poll consume() until a message arrives or deadline.
-        import asyncio
-        import time
-
         deadline = time.monotonic() + timeout
         while True:
             messages = await self.consume(queue_name, max_messages=max_messages)
@@ -92,6 +140,85 @@ class QueuePort(ABC):
             if remaining <= 0:
                 return []
             await asyncio.sleep(min(0.5, remaining))
+
+    async def subscribe(
+        self,
+        queue_name: str,
+        *,
+        on_message: SubscriptionCallback,
+    ) -> SubscriptionHandle:
+        """Deliver every message on ``queue_name`` to ``on_message`` until
+        cancelled (SIP-0094 D6).
+
+        This **concrete default** drives a background task that loops on
+        :meth:`consume_blocking`, dispatching each delivery to ``on_message``
+        (awaited if it returns a coroutine) and acking it. It is the
+        subscription primitive for non-RabbitMQ adapters and tests — it is
+        explicitly **NOT** the SIP-0094 fix. The RabbitMQ adapter overrides
+        this with a native long-lived consumer (PR 94.2b); ``NoOpQueuePort``
+        inherits this default and never fires the callback (its ``consume``
+        returns no messages).
+
+        Callback exceptions are isolated (SIP-0094 D12): a raising
+        ``on_message`` is logged and the message is still acked — reply
+        messages are never redelivered, since a failing callback is a
+        waiter-side logic error rather than a transport fault, so requeuing
+        would only poison-loop — and the loop keeps consuming. A single bad
+        callback never terminates the subscription.
+
+        The queue is declared idempotently before consuming (SIP-0094 D9) so a
+        subscriber never assumes a peer pre-declared it.
+
+        Args:
+            queue_name: Queue to subscribe to.
+            on_message: Sync or async callable invoked with each QueueMessage.
+
+        Returns:
+            A :class:`SubscriptionHandle`; ``await handle.cancel()`` to stop.
+
+        Raises:
+            QueueError: If the queue cannot be declared.
+        """
+        await self.ensure_queue(queue_name)
+
+        async def _run() -> None:
+            while True:
+                try:
+                    messages = await self.consume_blocking(
+                        queue_name, timeout=_SUBSCRIBE_POLL_TIMEOUT, max_messages=1
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception("subscribe: consume failed on %s; retrying", queue_name)
+                    await asyncio.sleep(1.0)
+                    continue
+
+                for message in messages:
+                    # D12: isolate callback failures so the durable
+                    # subscription survives a single bad invocation.
+                    try:
+                        result = on_message(message)
+                        if inspect.isawaitable(result):
+                            await result
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        logger.exception(
+                            "subscribe: callback raised on %s; acking and continuing",
+                            queue_name,
+                        )
+                    # Ack after the delivery attempt (success OR failure):
+                    # reply messages are not redelivered.
+                    try:
+                        await self.ack(message)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        logger.exception("subscribe: ack failed on %s", queue_name)
+
+        task = asyncio.create_task(_run(), name=f"subscribe:{queue_name}")
+        return SubscriptionHandle(task, queue_name)
 
     async def invalidate_queue(self, queue_name: str) -> None:
         """Drop any cached handle for ``queue_name`` so subsequent operations

--- a/tests/unit/comms/test_queue_subscribe.py
+++ b/tests/unit/comms/test_queue_subscribe.py
@@ -1,0 +1,181 @@
+"""Unit tests for the default `QueuePort.subscribe()` primitive (SIP-0094 D6).
+
+These exercise the concrete default subscription loop directly: delivery,
+ack-after-delivery, queue declaration (D9), sync vs async callbacks, callback
+exception isolation (D12), cancellation, and the NoOp inheritance path. Pure
+comms-domain — no adapter/factory imports — so it runs in the gated `comms`
+regression dir.
+"""
+
+import asyncio
+
+import pytest
+
+from squadops.comms.queue_message import QueueMessage
+from squadops.ports.comms.noop import NoOpQueuePort
+from squadops.ports.comms.queue import QueuePort
+
+
+def _msg(i: int, queue: str = "agent-x_replies") -> QueueMessage:
+    """Build a QueueMessage with a recognizable id for delivery assertions."""
+    return QueueMessage(
+        message_id=f"m{i}",
+        queue_name=queue,
+        payload=f'{{"i":{i}}}',
+        receipt_handle=f"h{i}",
+        attributes={},
+    )
+
+
+class RecordingQueueProvider(QueuePort):
+    """QueuePort that drains a controllable inbox and records ack/declare calls.
+
+    Inherits the concrete default ``subscribe()`` / ``consume_blocking()`` from
+    QueuePort — that default loop is exactly what these tests exercise.
+    """
+
+    def __init__(self, to_deliver: list[QueueMessage] | None = None):
+        self._inbox: list[QueueMessage] = list(to_deliver or [])
+        self.acked: list[QueueMessage] = []
+        self.ensured: list[str] = []
+
+    async def publish(
+        self, queue_name: str, payload: str, delay_seconds: int | None = None
+    ) -> None:
+        self._inbox.append(
+            QueueMessage(
+                message_id=f"pub{len(self._inbox)}",
+                queue_name=queue_name,
+                payload=payload,
+                receipt_handle="r",
+                attributes={},
+            )
+        )
+
+    async def consume(self, queue_name: str, max_messages: int = 1) -> list[QueueMessage]:
+        out = self._inbox[:max_messages]
+        del self._inbox[:max_messages]
+        return out
+
+    async def ack(self, message: QueueMessage) -> None:
+        self.acked.append(message)
+
+    async def retry(self, message: QueueMessage, delay_seconds: int) -> None:
+        pass
+
+    async def health(self) -> dict:
+        return {"status": "healthy", "connected": True}
+
+    def capabilities(self) -> dict[str, bool]:
+        return {"delay": False, "fifo": True, "priority": False}
+
+    async def ensure_queue(self, queue_name: str) -> None:
+        self.ensured.append(queue_name)
+
+
+@pytest.mark.unit
+class TestQueuePortSubscribe:
+    """Default `subscribe()` primitive (SIP-0094 D6 poll loop, D12 isolation)."""
+
+    @pytest.mark.asyncio
+    async def test_subscribe_delivers_acks_and_declares_first(self):
+        """A queued message reaches the callback, is acked, and the queue is
+        declared (D9) before any consume happens."""
+        provider = RecordingQueueProvider([_msg(1)])
+        received: list[QueueMessage] = []
+        done = asyncio.Event()
+
+        async def on_message(m: QueueMessage) -> None:
+            received.append(m)
+            done.set()
+
+        handle = await provider.subscribe("agent-x_replies", on_message=on_message)
+        await asyncio.wait_for(done.wait(), timeout=2.0)
+        await handle.cancel()
+
+        assert [m.message_id for m in received] == ["m1"]
+        assert [m.message_id for m in provider.acked] == ["m1"]
+        # D9: ensure_queue ran before consuming so the subscriber never assumes
+        # a peer pre-declared the reply queue.
+        assert provider.ensured == ["agent-x_replies"]
+        assert handle.active is False
+
+    @pytest.mark.asyncio
+    async def test_subscribe_supports_sync_callback(self):
+        """A plain sync callback works — the cutover (94.3) resolves a Future
+        synchronously, so subscribe must not assume coroutines."""
+        provider = RecordingQueueProvider([_msg(7)])
+        received: list[QueueMessage] = []
+
+        handle = await provider.subscribe("q", on_message=lambda m: received.append(m))
+        for _ in range(40):
+            if received:
+                break
+            await asyncio.sleep(0.05)
+        await handle.cancel()
+
+        assert [m.message_id for m in received] == ["m7"]
+        assert [m.message_id for m in provider.acked] == ["m7"]
+
+    @pytest.mark.asyncio
+    async def test_subscribe_callback_exception_does_not_stop_loop(self):
+        """D12: a raising callback is isolated — the next message is still
+        delivered, and the failed message is acked (no poison redelivery)."""
+        provider = RecordingQueueProvider([_msg(1), _msg(2)])
+        received: list[QueueMessage] = []
+        second = asyncio.Event()
+
+        async def on_message(m: QueueMessage) -> None:
+            if m.message_id == "m1":
+                raise RuntimeError("boom")
+            received.append(m)
+            second.set()
+
+        handle = await provider.subscribe("q", on_message=on_message)
+        await asyncio.wait_for(second.wait(), timeout=2.0)
+        await handle.cancel()
+
+        # m2 delivered despite m1 raising -> loop survived the exception.
+        assert [m.message_id for m in received] == ["m2"]
+        # Both acked, including the one whose callback raised.
+        assert {m.message_id for m in provider.acked} == {"m1", "m2"}
+
+    @pytest.mark.asyncio
+    async def test_subscribe_cancel_stops_delivery(self):
+        """After cancel() the loop is gone: messages published afterward are
+        never delivered, and cancel() is idempotent."""
+        provider = RecordingQueueProvider([])
+        received: list[QueueMessage] = []
+
+        handle = await provider.subscribe("q", on_message=lambda m: received.append(m))
+        await asyncio.sleep(0.1)  # let the loop spin at least once
+        await handle.cancel()
+        assert handle.active is False
+
+        # Anything that arrives after cancellation must not be consumed.
+        provider._inbox.append(_msg(99))
+        await asyncio.sleep(0.6)
+        assert received == []
+        assert provider.acked == []
+
+        # Idempotent second cancel must not raise.
+        await handle.cancel()
+        assert handle.active is False
+
+    @pytest.mark.asyncio
+    async def test_noop_subscribe_never_delivers_and_cancels_clean(self):
+        """NoOpQueuePort inherits the default (D6): it never fires the callback
+        (its consume returns nothing) yet stays a usable, cancellable target."""
+        provider = NoOpQueuePort()
+        received: list[QueueMessage] = []
+
+        handle = await provider.subscribe(
+            "agent-x_replies", on_message=lambda m: received.append(m)
+        )
+        await asyncio.sleep(0.6)  # spans more than one poll cycle
+
+        assert received == []
+        assert handle.active is True
+
+        await handle.cancel()
+        assert handle.active is False


### PR DESCRIPTION
## What

Adds the long-lived subscription primitive for SIP-0094 — the dormant building block the cutover (94.3) routes per-agent replies through. **Inert: nothing subscribes yet.**

- **`SubscriptionHandle`** — lifecycle wrapper over the background delivery task; idempotent `async cancel()`, an `active` flag, never exposes the raw task.
- **`QueuePort.subscribe(queue_name, *, on_message) -> SubscriptionHandle`** — concrete default (**D6**): a background loop over `consume_blocking()` → `on_message`, acking each delivery.
  - Declares the queue first (**D9**) — a subscriber never assumes a peer pre-declared it.
  - Callback exceptions isolated (**D12**): a raising `on_message` is logged, the message is **still acked** (reply messages are never redelivered — a failed callback is a waiter-side logic error, not a transport fault), and the loop keeps consuming.
  - Supports **sync and async** callbacks (the 94.3 cutover resolves a `Future` synchronously).
- **`NoOpQueuePort`** inherits the default and never fires the callback (its `consume` returns nothing).

The native RabbitMQ override (real long-lived consumer + channel-close resubscribe, SIP §7) is **PR 94.2b** — kept separate so the risky adapter code is isolated.

## Tests

`tests/unit/comms/test_queue_subscribe.py` (5 tests): delivery+ack+declare-first (D9), sync-callback support, **callback-exception-doesn't-stop-loop + failed msg still acked** (D12), cancel-stops-delivery + idempotent cancel, NoOp-never-delivers-but-cancels-clean (D6).

Placed in the **already-gated** `tests/unit/comms/` dir (pure comms-domain, no adapter imports) rather than the ungated `tests/unit/adapters/` — see Notes.

## Notes — two pre-existing defects surfaced (filed, not fixed here)

- **#206** — `sqlalchemy` is an **undeclared dependency** (imported by `ports/db.py` + postgres runtime; absent from pyproject + `ci-constraints.txt`). Breaks clean install of postgres persistence; makes 3 adapter test files fail collection in lean envs.
- **#207** — `tests/unit/adapters/` is **not in the CI regression gate** (blocked by #206). That's why 94.2a's tests went into the gated `comms/` dir instead.

## Verification

- `pytest tests/unit/comms/` → 19 passed
- `ruff check` + `ruff format --check` clean on both files
- `lint_test_quality.py tests/unit/comms/` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)