### PR TITLE
SIP-0094 94.2b: native RabbitMQ subscribe() + channel-close resubscribe

### DIFF
--- a/adapters/comms/rabbitmq.py
+++ b/adapters/comms/rabbitmq.py
@@ -3,6 +3,7 @@ RabbitMQ adapter implementation for QueuePort.
 """
 
 import asyncio
+import inspect
 import logging
 from typing import Any
 
@@ -10,9 +11,18 @@ import aio_pika
 from aio_pika import Connection, Message, Queue
 
 from squadops.comms.queue_message import QueueMessage
-from squadops.ports.comms.queue import REPLY_QUEUE_DECLARE_ARGS, QueuePort
+from squadops.ports.comms.queue import (
+    REPLY_QUEUE_DECLARE_ARGS,
+    QueuePort,
+    SubscriptionCallback,
+    SubscriptionHandle,
+)
 
 logger = logging.getLogger(__name__)
+
+# SIP-0094 D6/§7: pause before re-establishing a dropped long-lived
+# subscription, so a flapping channel doesn't spin a tight reconnect loop.
+_SUBSCRIBE_RECONNECT_BACKOFF = 0.5
 
 
 class QueueError(Exception):
@@ -46,6 +56,10 @@ class RabbitMQAdapter(QueuePort):
         self._connection: Connection | None = None
         self._channel: aio_pika.Channel | None = None
         self._queues: dict[str, Queue] = {}
+        # SIP-0094 D7: count of times a long-lived subscription had to
+        # re-establish after its channel dropped. Surfaced via health() so a
+        # flapping reply channel is observable rather than silent.
+        self._resubscribe_total = 0
 
     async def _ensure_connection(self) -> None:
         """Ensure RabbitMQ connection and channel are established."""
@@ -153,6 +167,31 @@ class RabbitMQAdapter(QueuePort):
             logger.error(f"Failed to publish message to queue {queue_name}: {e}")
             raise QueueError(f"Failed to publish message: {e}") from e
 
+    @staticmethod
+    def _to_queue_message(
+        message: aio_pika.abc.AbstractIncomingMessage, queue_name: str
+    ) -> QueueMessage:
+        """Build a canonical :class:`QueueMessage` from an aio_pika delivery.
+
+        Single-sources the field/attribute mapping shared by :meth:`consume`,
+        :meth:`consume_blocking`, and :meth:`subscribe`. The raw aio_pika
+        message is stashed in ``attributes["message"]`` so :meth:`ack` /
+        :meth:`retry` can act on it later.
+        """
+        return QueueMessage(
+            message_id=str(message.delivery_tag),
+            queue_name=queue_name,
+            payload=message.body.decode("utf-8"),
+            receipt_handle=str(message.delivery_tag),
+            attributes={
+                "delivery_tag": message.delivery_tag,
+                "routing_key": message.routing_key,
+                "exchange": message.exchange,
+                "redelivered": message.redelivered,
+                "message": message,  # Store message object for ack
+            },
+        )
+
     async def consume(self, queue_name: str, max_messages: int = 1) -> list[QueueMessage]:
         """
         Consume messages from a queue.
@@ -178,28 +217,7 @@ class RabbitMQAdapter(QueuePort):
             async def collect_messages():
                 async with queue.iterator(no_ack=False) as queue_iter:
                     async for message in queue_iter:
-                        # Extract message data
-                        payload = message.body.decode("utf-8")
-                        receipt_handle = str(message.delivery_tag)
-
-                        # Store message reference for ack/retry
-                        message_attributes = {
-                            "delivery_tag": message.delivery_tag,
-                            "routing_key": message.routing_key,
-                            "exchange": message.exchange,
-                            "redelivered": message.redelivered,
-                            "message": message,  # Store message object for ack
-                        }
-
-                        queue_message = QueueMessage(
-                            message_id=str(message.delivery_tag),
-                            queue_name=queue_name,
-                            payload=payload,
-                            receipt_handle=receipt_handle,
-                            attributes=message_attributes,
-                        )
-
-                        messages.append(queue_message)
+                        messages.append(self._to_queue_message(message, queue_name))
 
                         # Break after getting max_messages
                         if len(messages) >= max_messages:
@@ -241,24 +259,7 @@ class RabbitMQAdapter(QueuePort):
             async def collect_messages():
                 async with queue.iterator(no_ack=False) as queue_iter:
                     async for message in queue_iter:
-                        payload = message.body.decode("utf-8")
-                        receipt_handle = str(message.delivery_tag)
-                        message_attributes = {
-                            "delivery_tag": message.delivery_tag,
-                            "routing_key": message.routing_key,
-                            "exchange": message.exchange,
-                            "redelivered": message.redelivered,
-                            "message": message,
-                        }
-                        messages.append(
-                            QueueMessage(
-                                message_id=str(message.delivery_tag),
-                                queue_name=queue_name,
-                                payload=payload,
-                                receipt_handle=receipt_handle,
-                                attributes=message_attributes,
-                            )
-                        )
+                        messages.append(self._to_queue_message(message, queue_name))
                         if len(messages) >= max_messages:
                             break
 
@@ -273,6 +274,114 @@ class RabbitMQAdapter(QueuePort):
         except Exception as e:
             logger.error(f"Failed to consume_blocking from queue {queue_name}: {e}")
             raise QueueError(f"Failed to consume_blocking: {e}") from e
+
+    async def subscribe(
+        self,
+        queue_name: str,
+        *,
+        on_message: SubscriptionCallback,
+    ) -> SubscriptionHandle:
+        """Native long-lived subscription on ``queue_name`` (SIP-0094 §7).
+
+        This is **the** SIP-0094 fix: instead of opening a fresh short-lived
+        consumer per reply wait (which races arriving messages against
+        consumer-tag teardown), it holds a single ``queue.iterator`` consumer
+        for the whole subscription and routes every delivery to ``on_message``.
+
+        **Channel-close resubscribe (the riskiest part).** The shared
+        RobustChannel can be replaced under us on reconnect, which strands a
+        long-lived consumer bound to the dead channel. The reconnect loop here
+        treats any termination of the iterator — an exception from a dropped
+        channel, or a clean end — as a signal to re-establish: it invalidates
+        the cached (stale) Queue handle, re-declares against the live channel
+        (the ``_get_queue`` channel-swap path), and re-opens the consumer,
+        bumping :attr:`_resubscribe_total` (D7) so flapping is observable. The
+        iterator surfacing the channel failure is what drives this, which is
+        why a separate ``add_close_callback`` re-consume isn't used — that would
+        race RobustChannel's own consumer restoration and double-subscribe.
+
+        Callback exceptions are isolated (D12): a raising ``on_message`` is
+        logged, the message is still acked (reply messages are never
+        redelivered), and the consumer keeps running. The queue is declared
+        before consuming (D9).
+
+        Args:
+            queue_name: Queue to subscribe to.
+            on_message: Sync or async callable invoked with each QueueMessage.
+
+        Returns:
+            A :class:`SubscriptionHandle`; ``await handle.cancel()`` cancels the
+            consumer and tears down the loop.
+        """
+        await self.ensure_queue(queue_name)
+
+        async def _run() -> None:
+            first_attempt = True
+            while True:
+                if not first_attempt:
+                    # Re-establishing after a drop or clean end: drop the stale
+                    # cached handle, back off, and count the resubscribe.
+                    self._resubscribe_total += 1
+                    await self.invalidate_queue(queue_name)
+                    logger.info(
+                        "subscribe: re-establishing subscription to %s (resubscribe #%d)",
+                        queue_name,
+                        self._resubscribe_total,
+                    )
+                    await asyncio.sleep(_SUBSCRIBE_RECONNECT_BACKOFF)
+                first_attempt = False
+
+                try:
+                    await self._ensure_connection()
+                    queue = await self._get_queue(queue_name)
+                    async with queue.iterator(no_ack=False) as queue_iter:
+                        async for message in queue_iter:
+                            await self._dispatch_subscription_delivery(
+                                message, on_message, queue_name
+                            )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "subscribe: subscription to %s dropped (%s); will resubscribe",
+                        queue_name,
+                        exc,
+                    )
+                    continue
+                # Iterator ended without error (consumer cancelled server-side):
+                # loop back to re-establish rather than silently stop.
+                logger.info("subscribe: iterator on %s ended; will resubscribe", queue_name)
+
+        task = asyncio.create_task(_run(), name=f"rabbitmq-subscribe:{queue_name}")
+        return SubscriptionHandle(task, queue_name)
+
+    async def _dispatch_subscription_delivery(
+        self,
+        message: aio_pika.abc.AbstractIncomingMessage,
+        on_message: SubscriptionCallback,
+        queue_name: str,
+    ) -> None:
+        """Route one native delivery to the callback (D12 isolation), then ack.
+
+        Mirrors the default ``subscribe`` policy: callback failures are logged
+        and the message is acked anyway (reply messages are not redelivered),
+        so a single bad invocation never tears down the consumer.
+        """
+        queue_message = self._to_queue_message(message, queue_name)
+        try:
+            result = on_message(queue_message)
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("subscribe: callback raised on %s; acking and continuing", queue_name)
+        try:
+            await message.ack()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("subscribe: ack failed on %s", queue_name)
 
     async def ack(self, message: QueueMessage) -> None:
         """
@@ -345,6 +454,7 @@ class RabbitMQAdapter(QueuePort):
                 "connected": is_connected,
                 "channel_ready": has_channel,
                 "provider": "rabbitmq",
+                "resubscribe_total": self._resubscribe_total,
             }
 
         except Exception as e:

--- a/tests/integration/adapters/test_rabbitmq_adapter.py
+++ b/tests/integration/adapters/test_rabbitmq_adapter.py
@@ -3,6 +3,7 @@ Integration tests for RabbitMQ adapter.
 Tests RabbitMQ roundtrip, namespace verification, and health checks.
 """
 
+import asyncio
 import json
 
 import pytest
@@ -230,3 +231,108 @@ class TestRabbitMQAdapter:
         # Acknowledge all messages
         for message in messages:
             await rabbitmq_adapter.ack(message)
+
+
+async def _drain(adapter: RabbitMQAdapter, name: str) -> None:
+    """Declare + purge so a rerun starts from an empty queue.
+
+    Uses purge (not delete) on purpose: deleting a queue on the shared channel
+    races RobustChannel's reopen and trips ``expected 'channel.open'``. Purge
+    leaves the durable queue in place and just clears residual messages.
+    """
+    try:
+        await adapter.ensure_queue(name)
+        queue = await adapter._get_queue(name)
+        await queue.purge()
+    except Exception:
+        pass
+
+
+@pytest.mark.integration
+class TestNativeSubscribeIntegration:
+    """SIP-0094 94.2b: native long-lived subscribe() against a real broker.
+
+    These are the zero-loss / no-cross-delivery guarantees the per-agent reply
+    queues rely on (SIP §8, #12) — the legacy per-call consume() poll path
+    could drop replies dispatched during consumer-tag churn.
+    """
+
+    @pytest_asyncio.fixture
+    async def adapter(self, rabbitmq_container):
+        a = RabbitMQAdapter(url=rabbitmq_container.get_connection_url(), namespace=None)
+        yield a
+        await a.close()
+
+    @pytest.mark.asyncio
+    async def test_held_subscription_loses_no_replies(self, adapter):
+        """Publish 100 replies to one reply queue with a single held
+        subscription -> all 100 are routed exactly once, none lost."""
+        queue_name = "sip0094_2b_soak_replies"
+        await _drain(adapter, queue_name)
+
+        total = 100
+        received: list[str] = []
+        all_in = asyncio.Event()
+
+        async def on_message(m):
+            received.append(m.payload)
+            if len(received) >= total:
+                all_in.set()
+
+        handle = await adapter.subscribe(queue_name, on_message=on_message)
+        try:
+            for i in range(total):
+                await adapter.publish(queue_name, json.dumps({"i": i}))
+            await asyncio.wait_for(all_in.wait(), timeout=30.0)
+        finally:
+            await handle.cancel()
+
+        assert len(received) == total, f"lost replies: only {len(received)}/{total} arrived"
+        # Exactly-once and complete: every published index shows up once.
+        assert sorted(json.loads(p)["i"] for p in received) == list(range(total))
+        assert adapter._resubscribe_total == 0  # stable channel -> no resubscribe
+
+    @pytest.mark.asyncio
+    async def test_two_reply_queues_no_cross_delivery(self, adapter):
+        """Two held subscriptions on distinct reply queues with interleaved
+        publishes -> each gets only its own messages, exactly once."""
+        q_alpha = "sip0094_2b_alpha_replies"
+        q_beta = "sip0094_2b_beta_replies"
+        per_queue = 15
+        for q in (q_alpha, q_beta):
+            await _drain(adapter, q)
+
+        alpha: list[str] = []
+        beta: list[str] = []
+        done = asyncio.Event()
+
+        def _check_done():
+            if len(alpha) >= per_queue and len(beta) >= per_queue:
+                done.set()
+
+        async def on_alpha(m):
+            alpha.append(m.payload)
+            _check_done()
+
+        async def on_beta(m):
+            beta.append(m.payload)
+            _check_done()
+
+        h_alpha = await adapter.subscribe(q_alpha, on_message=on_alpha)
+        h_beta = await adapter.subscribe(q_beta, on_message=on_beta)
+        try:
+            for i in range(per_queue):
+                await adapter.publish(q_alpha, json.dumps({"who": "alpha", "i": i}))
+                await adapter.publish(q_beta, json.dumps({"who": "beta", "i": i}))
+            await asyncio.wait_for(done.wait(), timeout=30.0)
+        finally:
+            await h_alpha.cancel()
+            await h_beta.cancel()
+
+        assert len(alpha) == per_queue and len(beta) == per_queue
+        # No cross-agent delivery: each queue only ever saw its own tag.
+        assert all(json.loads(p)["who"] == "alpha" for p in alpha)
+        assert all(json.loads(p)["who"] == "beta" for p in beta)
+        # Exactly-once within each queue.
+        assert sorted(json.loads(p)["i"] for p in alpha) == list(range(per_queue))
+        assert sorted(json.loads(p)["i"] for p in beta) == list(range(per_queue))

--- a/tests/unit/comms/test_rabbitmq_adapter.py
+++ b/tests/unit/comms/test_rabbitmq_adapter.py
@@ -8,10 +8,12 @@ no broker is required.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import adapters.comms.rabbitmq as rabbitmq_mod
 from adapters.comms.rabbitmq import QueueError, RabbitMQAdapter
 from squadops.ports.comms.queue import REPLY_QUEUE_DECLARE_ARGS
 
@@ -193,3 +195,161 @@ class TestConsumeBlockingErrorWrapping:
             await adapter.consume_blocking("reply_q", timeout=0.05, max_messages=1)
 
         assert "Channel was not opened" in str(exc_info.value)
+
+
+class _FakeIncoming:
+    """Stand-in for an aio_pika incoming message with a trackable ack()."""
+
+    def __init__(self, tag: int, body: str):
+        self.delivery_tag = tag
+        self.body = body.encode("utf-8")
+        self.routing_key = "rk"
+        self.exchange = ""
+        self.redelivered = False
+        self.acked = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+
+class _FakeIterator:
+    """Async context-manager + async-iterator over a fixed message list.
+
+    After the list drains it either raises ``raise_exc`` (to simulate a
+    channel-close mid-subscription) or blocks until the task is cancelled
+    (to simulate a healthy, idle long-lived consumer). Records enter/exit so
+    tests can assert the consumer was torn down on cancel.
+    """
+
+    def __init__(self, messages, *, raise_exc: BaseException | None = None):
+        self._messages = list(messages)
+        self._raise_exc = raise_exc
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self) -> _FakeIterator:
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *_exc) -> bool:
+        self.exited = True
+        return False
+
+    def __aiter__(self) -> _FakeIterator:
+        return self
+
+    async def __anext__(self):
+        if self._messages:
+            return self._messages.pop(0)
+        if self._raise_exc is not None:
+            exc, self._raise_exc = self._raise_exc, None
+            raise exc
+        # Healthy idle consumer: block until cancelled by handle.cancel().
+        await asyncio.sleep(3600)
+        raise StopAsyncIteration
+
+
+def _subscribe_adapter(iterators: list[_FakeIterator]) -> RabbitMQAdapter:
+    """Adapter wired so subscribe()'s loop pulls successive fake iterators,
+    with connection/declare/invalidate stubbed out (no broker)."""
+    adapter = RabbitMQAdapter(url="amqp://test", namespace=None)
+    adapter._ensure_connection = AsyncMock()
+    adapter.ensure_queue = AsyncMock()
+    adapter.invalidate_queue = AsyncMock()
+
+    fake_queue = MagicMock()
+    fake_queue.iterator = MagicMock(side_effect=iterators)
+    adapter._get_queue = AsyncMock(return_value=fake_queue)
+    return adapter
+
+
+class TestNativeSubscribe:
+    """Native long-lived ``subscribe()`` — the SIP-0094 fix (D6/D9/D12, §7)."""
+
+    async def test_delivers_and_acks(self) -> None:
+        """A message on the queue reaches the callback and is acked via the
+        underlying aio_pika message — the happy-path long-lived consumer."""
+        msg = _FakeIncoming(1, '{"reply":"a"}')
+        adapter = _subscribe_adapter([_FakeIterator([msg])])
+        received: list = []
+        got = asyncio.Event()
+
+        async def on_message(m):
+            received.append(m)
+            got.set()
+
+        handle = await adapter.subscribe("neo_replies", on_message=on_message)
+        await asyncio.wait_for(got.wait(), timeout=2.0)
+        await handle.cancel()
+
+        assert [m.payload for m in received] == ['{"reply":"a"}']
+        assert received[0].queue_name == "neo_replies"
+        assert msg.acked is True
+        assert adapter._resubscribe_total == 0  # no drop -> no resubscribe
+
+    async def test_callback_exception_does_not_kill_consumer(self) -> None:
+        """D12: a raising callback is isolated — the next delivery still
+        arrives, both messages are acked, and the consumer never resubscribes."""
+        m1 = _FakeIncoming(1, "boom")
+        m2 = _FakeIncoming(2, "ok")
+        adapter = _subscribe_adapter([_FakeIterator([m1, m2])])
+        received: list = []
+        second = asyncio.Event()
+
+        async def on_message(m):
+            if m.message_id == "1":
+                raise RuntimeError("callback boom")
+            received.append(m)
+            second.set()
+
+        handle = await adapter.subscribe("neo_replies", on_message=on_message)
+        await asyncio.wait_for(second.wait(), timeout=2.0)
+        await handle.cancel()
+
+        assert [m.payload for m in received] == ["ok"]
+        assert m1.acked is True and m2.acked is True
+        assert adapter._resubscribe_total == 0
+
+    async def test_channel_close_triggers_transparent_resubscribe(self, monkeypatch) -> None:
+        """§7 core: when the iterator dies (channel close), the loop
+        re-declares + re-consumes and a post-reconnect message is delivered,
+        bumping the resubscribe metric and invalidating the stale handle."""
+        monkeypatch.setattr(rabbitmq_mod, "_SUBSCRIBE_RECONNECT_BACKOFF", 0.01)
+
+        dead = _FakeIterator([], raise_exc=RuntimeError("Channel was not opened"))
+        post = _FakeIncoming(9, "after-reconnect")
+        alive = _FakeIterator([post])
+        adapter = _subscribe_adapter([dead, alive])
+        received: list = []
+        got = asyncio.Event()
+
+        async def on_message(m):
+            received.append(m)
+            got.set()
+
+        handle = await adapter.subscribe("neo_replies", on_message=on_message)
+        await asyncio.wait_for(got.wait(), timeout=2.0)
+        await handle.cancel()
+
+        assert [m.payload for m in received] == ["after-reconnect"]
+        assert post.acked is True
+        assert adapter._resubscribe_total == 1
+        # Stale Queue handle dropped before re-declaring on the live channel.
+        adapter.invalidate_queue.assert_awaited_with("neo_replies")
+
+    async def test_cancel_tears_down_consumer(self) -> None:
+        """cancel() stops the loop and exits the iterator context so the
+        broker-side consumer is released; the handle reports inactive."""
+        it = _FakeIterator([])  # no messages -> blocks until cancelled
+        adapter = _subscribe_adapter([it])
+
+        handle = await adapter.subscribe("neo_replies", on_message=lambda m: None)
+        await asyncio.sleep(0.05)  # let the loop enter the iterator
+        assert it.entered is True
+        assert handle.active is True
+
+        await handle.cancel()
+
+        assert handle.active is False
+        assert it.exited is True  # consumer context torn down
+        assert adapter._resubscribe_total == 0


### PR DESCRIPTION
## What

The native long-lived consumer that the reply-router cutover (94.3) will route per-agent replies through — **THE SIP-0094 fix** (the riskiest part, SIP §7). Still **inert**: nothing subscribes yet.

Overrides the default poll-based `subscribe()` (from 94.2a) with a native consumer that holds **one** `queue.iterator` for the whole subscription, instead of opening a fresh short-lived consumer per reply wait. The per-call path races arriving replies against consumer-tag teardown — that's the reply loss SIP-0094 eliminates.

### Channel-close resubscribe (the hard part)

The shared `RobustChannel` can be swapped under a long-lived consumer on reconnect, stranding it on a dead channel. The reconnect loop treats **any** iterator termination (a channel-close exception, or a clean end) as a re-establish signal:
1. invalidate the stale cached `Queue` handle,
2. re-declare against the live channel (the `_get_queue` channel-swap path),
3. re-open the consumer,
4. bump `_resubscribe_total` (**D7**), surfaced via `health()` so a flapping reply channel is observable.

**Design note:** I deliberately did *not* add a separate `add_close_callback` re-consume. That would race aio_pika's own RobustChannel consumer restoration and double-subscribe. Letting the iterator surface the failure keeps a single consumer and is directly testable.

### Other behavior
- **D12** callback isolation: a raising `on_message` is logged, the message is acked anyway (reply messages are never redelivered), the consumer keeps running.
- Queue declared before consuming (**D9**); sync + async callbacks supported.
- Killed copy-paste: extracted the `QueueMessage` construction shared by `consume`/`consume_blocking` into `_to_queue_message` (now also used by `subscribe`).

## Tests

**Unit** (mocked, no broker — gated `tests/unit/comms/`): happy-path delivery+ack · D12 callback survives + both acked · **channel-close → transparent resubscribe** (`resubscribe_total==1`, stale handle invalidated, post-reconnect message delivered) · cancel tears down the iterator/consumer.

**Integration** (live broker, `tests/integration/adapters/`): **100 replies → one held subscription → zero loss, exactly-once** · **two reply queues, interleaved publishes → no cross-agent delivery, exactly-once**. Both pass locally against the running `squadops-rabbitmq`. They need a broker, so they don't run in the current CI gate (unit-only) — validated locally.

## Verification

- `pytest tests/unit/comms/` → 23 passed; `ruff check`/`format --check` clean; test-quality lint clean.
- `pytest tests/integration/adapters/...TestNativeSubscribeIntegration` → 2 passed (live broker).

## Defect surfaced (filed, not fixed here)

- **#209** — `tests/integration/test_config.env` credentials drift from the deployed broker (`squadops123` vs `squadops-dev`) **and** shadow env overrides, so all rabbitmq/postgres integration tests fail auth by default. (Validated 94.2b's tests by temporarily correcting the password; the file was restored unchanged.)

## Next

**94.3 — CUTOVER**: `ReplyRouter` + rewrite `_publish_and_await` onto `{agent_id}_replies` + DI wiring. Behavior changes there; this PR stays dormant until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)