### PR TITLE
SIP-0094 94.3: ReplyRouter cutover — _publish_and_await onto per-agent reply queues

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -50,6 +50,7 @@ from squadops.telemetry.context import use_correlation_context, use_run_ids
 from squadops.telemetry.models import CorrelationContext
 
 if TYPE_CHECKING:
+    from adapters.cycles.reply_router import ReplyRouter
     from squadops.capabilities.acceptance import AcceptanceCheckEngine
     from squadops.capabilities.models import AcceptanceContext
     from squadops.cycles.models import GateDecision, SquadProfile
@@ -82,8 +83,10 @@ class DispatchedFlowExecutor(FlowExecutionPort):
     """Flow executor that dispatches tasks to agent containers via RabbitMQ.
 
     Uses a request/reply pattern: publishes a ``comms.task`` message to
-    ``{agent_id}_comms``, then consumes the ``TaskResult`` from a per-run
-    reply queue (``cycle_results_{run_id}``).
+    ``{agent_id}_comms``, then awaits the ``TaskResult`` via the
+    :class:`ReplyRouter`, which holds a long-lived subscription on the agent's
+    per-agent reply queue (``{agent_id}_replies``) and resolves a future keyed
+    by ``task_id`` (SIP-0094).
     """
 
     def __init__(
@@ -97,10 +100,12 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         llm_observability: LLMObservabilityPort | None = None,
         workflow_tracker: WorkflowTrackerPort | None = None,
         event_bus: CycleEventBusPort | None = None,
+        reply_router: ReplyRouter | None = None,
     ) -> None:
         self._cycle_registry = cycle_registry
         self._artifact_vault = artifact_vault
         self._queue = queue
+        self._reply_router = reply_router
         self._squad_profile = squad_profile
         self._project_registry = project_registry
         self._task_timeout = task_timeout
@@ -671,8 +676,32 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         envelope: TaskEnvelope,
         run_id: str,
     ) -> TaskResult:
-        """Dispatch over the queue and poll the reply queue for a result."""
-        reply_queue = f"cycle_results_{run_id}"
+        """Dispatch over ``{agent_id}_comms`` and await the reply via the router.
+
+        SIP-0094: replaces the per-run ``cycle_results_{run_id}`` polling loop
+        with a long-lived per-agent subscription. The reply for ``task_id`` is
+        delivered through :class:`ReplyRouter`, which resolves the future this
+        method awaits.
+
+        Invariants:
+        - **Ordering (D14/#2):** ``ensure_subscribed → register → publish`` — the
+          consumer is live before any reply can arrive (no first-dispatch race).
+        - **No pending-future leak (#9):** every exit path — success, timeout,
+          publish failure, router/await failure, cancellation — removes
+          ``task_id`` from the router so it never lingers.
+        """
+        if self._reply_router is None:
+            raise RuntimeError(
+                "DispatchedFlowExecutor requires a ReplyRouter to dispatch (SIP-0094)"
+            )
+
+        reply_queue = f"{envelope.agent_id}_replies"
+        queue_name = f"{envelope.agent_id}_comms"
+
+        # Open the agent's reply subscription and register our future BEFORE
+        # publishing, so a fast reply can't arrive before we're listening.
+        await self._reply_router.ensure_subscribed(envelope.agent_id)
+        fut = self._reply_router.register(envelope.task_id)
 
         message = {
             "action": "comms.task",
@@ -683,8 +712,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             "payload": envelope.to_dict(),
         }
 
-        queue_name = f"{envelope.agent_id}_comms"
-        await self._queue.publish(queue_name, json.dumps(message))
+        # #10: if publish fails after register(), the agent never got the task —
+        # drop the pending future so it doesn't leak.
+        try:
+            await self._queue.publish(queue_name, json.dumps(message))
+        except Exception:
+            self._reply_router.cancel(envelope.task_id)
+            raise
 
         logger.info(
             "Dispatched task %s (%s) to %s, awaiting reply on %s",
@@ -694,53 +728,28 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             reply_queue,
         )
 
-        deadline = time.monotonic() + self._task_timeout
-        # Block on the reply queue in long chunks so a single consumer
-        # registration covers each chunk — avoids the consumer-tag churn
-        # of poll-and-sleep that previously raced with arriving replies.
-        # Cap each chunk well below typical broker idle-disconnect windows.
-        chunk_seconds = 30.0
-
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                break
-            wait = min(chunk_seconds, remaining)
-
-            try:
-                messages = await self._queue.consume_blocking(
-                    reply_queue, timeout=wait, max_messages=1
-                )
-            except Exception as exc:
-                # Channel went stale or broker hiccup. Drop the cached
-                # queue handle and back off briefly before retrying so
-                # the next call re-declares against a fresh channel.
-                logger.warning(
-                    "consume_blocking on %s failed (%s); invalidating cache and retrying",
-                    reply_queue,
-                    exc,
-                )
-                try:
-                    await self._queue.invalidate_queue(reply_queue)
-                except Exception:
-                    logger.debug("invalidate_queue raised; continuing", exc_info=True)
-                await asyncio.sleep(min(1.0, max(0.0, deadline - time.monotonic())))
-                continue
-
-            for msg in messages:
-                data = json.loads(msg.payload)
-                result_data = data.get("payload", {})
-                if result_data.get("task_id") == envelope.task_id:
-                    await self._queue.ack(msg)
-                    return TaskResult.from_dict(result_data)
-                # Not our message — ack to avoid blocking
-                await self._queue.ack(msg)
-
-        return TaskResult(
-            task_id=envelope.task_id,
-            status="FAILED",
-            error=f"Timed out waiting for agent {envelope.agent_id} after {self._task_timeout}s",
-        )
+        try:
+            return await asyncio.wait_for(fut, timeout=self._task_timeout)
+        except asyncio.CancelledError:
+            self._reply_router.cancel(envelope.task_id)
+            raise
+        except TimeoutError:
+            self._reply_router.cancel(envelope.task_id)
+            return TaskResult(
+                task_id=envelope.task_id,
+                status="FAILED",
+                error=f"Timed out waiting for agent {envelope.agent_id} after {self._task_timeout}s",
+            )
+        except Exception as exc:
+            # Router-side failure surfaced via the future (e.g. a malformed
+            # reply that failed TaskResult.from_dict, or ReplyRouterStopped on
+            # shutdown). The future is already settled; just guard the leak.
+            self._reply_router.cancel(envelope.task_id)
+            return TaskResult(
+                task_id=envelope.task_id,
+                status="FAILED",
+                error=f"Reply wait for agent {envelope.agent_id} failed: {exc}",
+            )
 
     # ------------------------------------------------------------------
     # Execution strategies

--- a/adapters/cycles/factory.py
+++ b/adapters/cycles/factory.py
@@ -109,5 +109,6 @@ def create_flow_executor(
             llm_observability=kwargs.get("llm_observability"),
             workflow_tracker=workflow_tracker,
             event_bus=kwargs.get("event_bus"),
+            reply_router=kwargs.get("reply_router"),
         )
     raise ValueError(f"Unknown flow executor provider: {provider}")

--- a/adapters/cycles/reply_router.py
+++ b/adapters/cycles/reply_router.py
@@ -1,0 +1,175 @@
+"""In-process reply router for per-agent reply queues (SIP-0094 §5.3).
+
+The orchestrator dispatches a task to ``{agent_id}_comms`` and waits for the
+agent to publish a ``TaskResult`` to ``{agent_id}_replies``. This router holds
+one long-lived subscription per agent (opened lazily on first dispatch — the
+squad roster isn't fixed at boot) and resolves an ``asyncio.Future`` keyed by
+``task_id`` when the matching reply arrives. It replaces the old per-run
+``cycle_results_{run_id}`` polling loop, eliminating both the consumer-tag-churn
+reply loss and the orphan-queue leak.
+
+Ack ownership: the ``QueuePort.subscribe`` primitive (SIP-0094 94.2b) acks every
+delivery *after* the callback returns. So ``_handle_reply`` must NOT ack — a
+second ack on the same delivery is an AMQP error. "Dropping" a reply here means
+resolving/failing/ignoring its future and returning; the primitive acks it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from squadops.comms.queue_message import QueueMessage
+from squadops.ports.comms.queue import QueuePort, SubscriptionHandle
+from squadops.tasks.models import TaskResult
+
+logger = logging.getLogger(__name__)
+
+
+class DuplicateRegistration(Exception):
+    """Raised when ``register`` is called for a ``task_id`` already pending.
+
+    SIP-0094 D10: silently overwriting the future would strand the first waiter
+    on the shared per-agent queue. ``task_id`` is the global correlation key
+    (D14), so a duplicate is a programming error, not a normal condition.
+    """
+
+
+class ReplyRouterStopped(Exception):
+    """Raised by ``ensure_subscribed`` / ``register`` after ``stop()``.
+
+    SIP-0094 D13: once shutdown begins, a late dispatch must not register a
+    future while subscriptions are being torn down.
+    """
+
+
+class ReplyRouter:
+    """Routes agent replies on ``{agent_id}_replies`` to per-task futures."""
+
+    def __init__(self, queue: QueuePort):
+        self._queue = queue
+        self._futures: dict[str, asyncio.Future[TaskResult]] = {}
+        self._subscriptions: dict[str, SubscriptionHandle] = {}
+        # D4: opening a subscription is the one operation two concurrent
+        # first-dispatches to the same agent could race; guard it.
+        self._subscribe_lock = asyncio.Lock()
+        self._stopped = False
+        # D7/#6: observability counters (snapshot via metrics()).
+        self._subscriptions_opened = 0
+        self._late_drops = 0
+        self._malformed_replies = 0
+        self._from_dict_failures = 0
+
+    async def ensure_subscribed(self, agent_id: str) -> None:
+        """Open ``agent_id``'s reply subscription on first use (idempotent).
+
+        D4: lock-guarded so two concurrent first-dispatches open exactly one
+        subscription. D9: ``subscribe`` declares ``{agent_id}_replies`` before
+        consuming, so the orchestrator never assumes the agent pre-declared it.
+        D13: fails fast once stopped.
+        """
+        if self._stopped:
+            raise ReplyRouterStopped(f"router stopped; refusing to subscribe {agent_id}")
+        if agent_id in self._subscriptions:
+            return
+        async with self._subscribe_lock:
+            # Re-check inside the lock: another coroutine may have opened it
+            # while we awaited the lock.
+            if agent_id in self._subscriptions:
+                return
+            if self._stopped:
+                raise ReplyRouterStopped(f"router stopped; refusing to subscribe {agent_id}")
+            handle = await self._queue.subscribe(
+                f"{agent_id}_replies",
+                on_message=self._handle_reply,
+            )
+            self._subscriptions[agent_id] = handle
+            self._subscriptions_opened += 1
+            logger.info("reply-router: opened subscription for %s_replies", agent_id)
+
+    def register(self, task_id: str) -> asyncio.Future[TaskResult]:
+        """Register interest in a reply for ``task_id`` and return its future.
+
+        D10: raises :class:`DuplicateRegistration` if one is already pending —
+        never overwrites. D13: refuses once stopped. Must be called *before*
+        publishing (D14/#2) so the consumer is live before any reply arrives.
+        """
+        if self._stopped:
+            raise ReplyRouterStopped(f"router stopped; refusing to register {task_id}")
+        existing = self._futures.get(task_id)
+        if existing is not None and not existing.done():
+            raise DuplicateRegistration(f"a reply is already pending for task_id {task_id}")
+        fut: asyncio.Future[TaskResult] = asyncio.get_running_loop().create_future()
+        self._futures[task_id] = fut
+        return fut
+
+    def cancel(self, task_id: str) -> None:
+        """Drop a pending future (e.g. on dispatch timeout or publish failure).
+
+        #9: every non-success exit path calls this so ``task_id`` never lingers
+        in ``_futures`` (no pending-future leak).
+        """
+        self._futures.pop(task_id, None)
+
+    async def _handle_reply(self, msg: QueueMessage) -> None:
+        """Resolve the future for an incoming reply (D11: never strands the
+        consumer; never acks — the subscribe primitive owns ack)."""
+        try:
+            data = json.loads(msg.payload)
+            task_id = data["payload"]["task_id"]
+        except (ValueError, KeyError, TypeError) as exc:
+            self._malformed_replies += 1
+            logger.warning("reply-router: malformed reply dropped (%s)", exc)
+            return
+
+        fut = self._futures.pop(task_id, None)
+        if fut is None or fut.done():
+            self._late_drops += 1
+            logger.warning("reply-router: reply for unknown/late task %s — dropping", task_id)
+            return
+
+        try:
+            result = TaskResult.from_dict(data["payload"])
+        except Exception as exc:
+            # D11: bad result payload -> fail this waiter (so it doesn't hang to
+            # timeout) but keep the consumer alive for every other agent.
+            self._from_dict_failures += 1
+            logger.error("reply-router: TaskResult.from_dict failed for %s: %s", task_id, exc)
+            if not fut.done():
+                fut.set_exception(exc)
+            return
+
+        fut.set_result(result)
+
+    async def stop(self) -> None:
+        """Stop accepting work, cancel all subscriptions, fail pending futures.
+
+        D13: ``_stopped`` is set first so no new registration/subscription can
+        slip in. Subscriptions are cancelled before futures are failed so a
+        late reply can't race a future we're about to fail.
+        """
+        self._stopped = True
+        for agent_id, handle in list(self._subscriptions.items()):
+            try:
+                await handle.cancel()
+            except Exception:
+                logger.exception("reply-router: error cancelling subscription for %s", agent_id)
+        self._subscriptions.clear()
+
+        for task_id, fut in list(self._futures.items()):
+            if not fut.done():
+                fut.set_exception(ReplyRouterStopped(f"router stopped before reply for {task_id}"))
+        self._futures.clear()
+
+    def metrics(self) -> dict[str, Any]:
+        """Snapshot for soak/observability (SIP-0094 D7/#6)."""
+        return {
+            "subscriptions_open": len(self._subscriptions),
+            "subscriptions_opened_total": self._subscriptions_opened,
+            "pending_futures": len(self._futures),
+            "late_drops": self._late_drops,
+            "malformed_replies": self._malformed_replies,
+            "from_dict_failures": self._from_dict_failures,
+        }

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -139,6 +139,9 @@ rabbitmq_channel: aio_pika.Channel | None = None
 # Workflow tracker port for shutdown cleanup
 _workflow_tracker = None
 
+# Reply router for per-agent reply queues (SIP-0094); stopped on shutdown (D13)
+_reply_router = None
+
 # Log forwarder port for shutdown cleanup (SIP-0087)
 _log_forwarder = None
 
@@ -235,7 +238,7 @@ async def _init_log_forwarding(config) -> None:
 
 async def _init_cycle_subsystem(config, pool) -> None:
     """Initialize SIP-0064 cycle ports + SIP-0066 orchestrator."""
-    global _workflow_tracker
+    global _workflow_tracker, _reply_router
     try:
         from adapters.cycles.factory import (
             create_artifact_vault,
@@ -275,6 +278,13 @@ async def _init_cycle_subsystem(config, pool) -> None:
         queue_adapter = RabbitMQAdapter(url=RABBITMQ_URL)
         llm_obs = create_llm_observability_provider(config=config.langfuse)
 
+        # SIP-0094: per-agent reply-queue router. Holds one long-lived
+        # subscription per agent (opened lazily on first dispatch) and resolves
+        # task futures. Stopped during shutdown (D13).
+        from adapters.cycles.reply_router import ReplyRouter
+
+        _reply_router = ReplyRouter(queue_adapter)
+
         _workflow_tracker = create_workflow_tracker(config.prefect)
 
         from adapters.events.factory import create_cycle_event_bus
@@ -303,6 +313,7 @@ async def _init_cycle_subsystem(config, pool) -> None:
             llm_observability=llm_obs,
             workflow_tracker=_workflow_tracker,
             event_bus=event_bus,
+            reply_router=_reply_router,
         )
 
         set_cycle_ports(
@@ -445,6 +456,11 @@ async def shutdown_event():
         await rabbitmq_connection.close()
     if _log_forwarder is not None:
         await _log_forwarder.aclose()
+    # SIP-0094 D13: stop the reply router — once stopped it rejects new
+    # registrations, cancels its subscriptions, and fails any pending reply
+    # futures with ReplyRouterStopped (in-flight waits resolve as FAILED).
+    if _reply_router is not None:
+        await _reply_router.stop()
     if _workflow_tracker is not None:
         await _workflow_tracker.close()
 

--- a/src/squadops/tasks/models.py
+++ b/src/squadops/tasks/models.py
@@ -107,5 +107,12 @@ class TaskResult:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TaskResult:
-        """Deserialize from dict."""
-        return cls(**data)
+        """Deserialize from dict.
+
+        Unknown keys are dropped (SIP-0094 D8) so a result produced by a newer
+        agent deserializes cleanly on an older orchestrator — matching
+        :meth:`TaskEnvelope.from_dict`. Without this, a forward-incompatible
+        reply payload would raise inside the reply router's ``_handle_reply``.
+        """
+        known = {f.name for f in dataclasses.fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})

--- a/tests/integration/cycles/test_pulse_check_e2e.py
+++ b/tests/integration/cycles/test_pulse_check_e2e.py
@@ -14,7 +14,7 @@ Covers:
 
 from __future__ import annotations
 
-import json
+import asyncio
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
@@ -27,7 +27,6 @@ try:
 except ImportError:
     _has_runtime_deps = False
 
-from squadops.comms.queue_message import QueueMessage
 from squadops.cycles.models import (
     Cycle,
     RunStatus,
@@ -76,8 +75,6 @@ def _make_registry(cycle):
 
     registry = MemoryCycleRegistry()
     # Seed cycle and run synchronously via internals
-    import asyncio
-
     loop = asyncio.get_event_loop()
 
     async def _seed():
@@ -98,30 +95,34 @@ def _make_registry(cycle):
     return registry
 
 
-def _make_result_message(task_id, queue_name="cycle_results_run_e2e"):
-    result = TaskResult(
-        task_id=task_id,
-        status="SUCCEEDED",
-        outputs={"summary": "ok", "artifacts": []},
-    )
-    return QueueMessage(
-        queue_name=queue_name,
-        body=json.dumps(result.to_dict()).encode(),
-    )
+class _E2EReplyRouter:
+    """Minimal SIP-0094 ReplyRouter double for this file.
 
+    The shared ``FakeReplyRouter`` lives in ``tests/unit/conftest.py`` and isn't
+    importable from the integration tree, so this self-contained shim mirrors
+    the old always-succeed consume stub: every dispatched task resolves to a
+    SUCCEEDED reply.
+    """
 
-def _consume_factory(mock_queue):
-    async def _consume(queue_name, max_messages=1):
-        if not queue_name.startswith("cycle_results_"):
-            return []
-        last_call = mock_queue.publish.call_args
-        if last_call:
-            msg_data = json.loads(last_call.args[1])
-            task_id = msg_data["payload"]["task_id"]
-            return [_make_result_message(task_id, queue_name)]
-        return []
+    async def ensure_subscribed(self, agent_id):
+        pass
 
-    return _consume
+    def register(self, task_id):
+        fut = asyncio.get_running_loop().create_future()
+        fut.set_result(
+            TaskResult(
+                task_id=task_id,
+                status="SUCCEEDED",
+                outputs={"summary": "ok", "artifacts": []},
+            )
+        )
+        return fut
+
+    def cancel(self, task_id):
+        pass
+
+    async def stop(self):
+        pass
 
 
 def _make_executor(registry, cycle):
@@ -129,7 +130,6 @@ def _make_executor(registry, cycle):
 
     mock_vault = AsyncMock()
     mock_queue = AsyncMock()
-    mock_queue.consume.side_effect = _consume_factory(mock_queue)
 
     squad_profile = SquadProfile(
         profile_id="full-squad",
@@ -144,6 +144,7 @@ def _make_executor(registry, cycle):
         queue=mock_queue,
         squad_profile=mock_squad_profile,
         task_timeout=5.0,
+        reply_router=_E2EReplyRouter(),
     )
     return executor, mock_queue
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,9 +5,109 @@ This file contains fixtures specific to unit tests that mock external dependenci
 Integration tests use real services via tests/integration/conftest.py.
 """
 
+import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+from squadops.tasks.models import TaskResult
+
+# =============================================================================
+# SIP-0094 reply-router test double (shared by all executor tests)
+# =============================================================================
+
+
+class FakeReplyRouter:
+    """Shared test double for the SIP-0094 ReplyRouter
+    (``adapters/cycles/reply_router.py``).
+
+    Post-cutover the executor awaits this router instead of polling the queue.
+    It simulates the agent round-trip: :meth:`bind` wires a mock QueuePort so
+    that publishing a ``comms.task`` to ``{agent_id}_comms`` calls
+    :meth:`_autorespond`, which resolves the registered future with the
+    configured reply.
+
+    Configure the agent's reply per test:
+    - ``responder`` — callable(envelope_dict) -> TaskResult, the default reply
+      for every task (defaults to SUCCEEDED, empty outputs). Use a stateful
+      closure to reproduce a scripted per-dispatch reply sequence.
+    - ``results`` — ``{task_id: TaskResult}`` exact replies (resolve at
+      register time, so they work even if publish is intercepted).
+    - ``suppress`` — task_ids that never reply (drives a dispatch timeout).
+
+    Mirrors the real router's register/cancel/ensure_subscribed/stop surface so
+    the executor's ordering and pending-future-leak invariants are exercised.
+    """
+
+    def __init__(self) -> None:
+        self._futures: dict[str, asyncio.Future] = {}
+        self.subscribed: list[str] = []
+        self.registered: list[str] = []
+        self.cancelled: list[str] = []
+        self.results: dict[str, TaskResult] = {}
+        self.suppress: set[str] = set()
+        self.stopped = False
+        self.responder = lambda env: TaskResult(
+            task_id=env["task_id"], status="SUCCEEDED", outputs={}
+        )
+
+    async def ensure_subscribed(self, agent_id: str) -> None:
+        self.subscribed.append(agent_id)
+
+    def register(self, task_id: str):
+        self.registered.append(task_id)
+        fut = asyncio.get_running_loop().create_future()
+        self._futures[task_id] = fut
+        # A pre-seeded result resolves immediately, so tests that bypass the
+        # autoresponding publish (e.g. those overriding publish to capture the
+        # envelope) still receive their reply.
+        if task_id not in self.suppress and task_id in self.results:
+            fut.set_result(self.results[task_id])
+        return fut
+
+    def cancel(self, task_id: str) -> None:
+        self.cancelled.append(task_id)
+        self._futures.pop(task_id, None)
+
+    def _autorespond(self, envelope: dict) -> None:
+        """Called by the bound mock_queue.publish to simulate the agent reply."""
+        task_id = envelope["task_id"]
+        if task_id in self.suppress:
+            return  # no reply -> executor times out
+        result = self.results.get(task_id)
+        if result is None:
+            result = self.responder(envelope)
+        fut = self._futures.get(task_id)
+        if fut is not None and not fut.done():
+            fut.set_result(result)
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    def bind(self, mock_queue):
+        """Wire ``mock_queue.publish`` so dispatching a ``comms.task``
+        auto-delivers the agent's reply through this router. Returns the queue.
+        """
+        mock_queue.reply_router = self
+        router = self
+
+        async def _publish(queue_name, payload, delay_seconds=None):
+            data = json.loads(payload)
+            if queue_name.endswith("_comms") and data.get("action") == "comms.task":
+                router._autorespond(data["payload"])
+            return None
+
+        mock_queue.publish.side_effect = _publish
+        return mock_queue
+
+
+@pytest.fixture
+def reply_router():
+    """SIP-0094 reply-router test double; bind it to a mock queue with
+    ``reply_router.bind(mock_queue)``."""
+    return FakeReplyRouter()
+
 
 # =============================================================================
 # Mock Infrastructure Fixtures

--- a/tests/unit/cycles/conftest.py
+++ b/tests/unit/cycles/conftest.py
@@ -2,8 +2,6 @@
 Shared fixtures for SIP-0064 cycle domain tests.
 """
 
-import asyncio
-import json
 from datetime import UTC, datetime
 
 import pytest
@@ -19,100 +17,11 @@ from squadops.cycles.models import (
     SquadProfile,
     TaskFlowPolicy,
 )
-from squadops.tasks.models import TaskResult
+
+# NOTE: FakeReplyRouter + the `reply_router` fixture live in tests/unit/conftest.py
+# (shared by all executor tests, including tests/unit/events/).
 
 _NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
-
-
-class FakeReplyRouter:
-    """Shared test double for the SIP-0094 ReplyRouter
-    (``adapters/cycles/reply_router.py``).
-
-    Post-cutover the executor awaits this router instead of polling the queue.
-    It simulates the agent round-trip: :meth:`bind` wires a mock QueuePort so
-    that publishing a ``comms.task`` to ``{agent_id}_comms`` calls
-    :meth:`_autorespond`, which resolves the registered future with the
-    configured reply.
-
-    Configure the agent's reply per test:
-    - ``responder`` — callable(envelope_dict) -> TaskResult, the default reply
-      for every task (defaults to SUCCEEDED, empty outputs). Use a stateful
-      closure to reproduce a scripted per-dispatch reply sequence.
-    - ``results`` — ``{task_id: TaskResult}`` exact replies (resolve at
-      register time, so they work even if publish is intercepted).
-    - ``suppress`` — task_ids that never reply (drives a dispatch timeout).
-
-    Mirrors the real router's register/cancel/ensure_subscribed/stop surface so
-    the executor's ordering and pending-future-leak invariants are exercised.
-    """
-
-    def __init__(self) -> None:
-        self._futures: dict[str, asyncio.Future] = {}
-        self.subscribed: list[str] = []
-        self.registered: list[str] = []
-        self.cancelled: list[str] = []
-        self.results: dict[str, TaskResult] = {}
-        self.suppress: set[str] = set()
-        self.stopped = False
-        self.responder = lambda env: TaskResult(
-            task_id=env["task_id"], status="SUCCEEDED", outputs={}
-        )
-
-    async def ensure_subscribed(self, agent_id: str) -> None:
-        self.subscribed.append(agent_id)
-
-    def register(self, task_id: str):
-        self.registered.append(task_id)
-        fut = asyncio.get_running_loop().create_future()
-        self._futures[task_id] = fut
-        # A pre-seeded result resolves immediately, so tests that bypass the
-        # autoresponding publish (e.g. those overriding publish to capture the
-        # envelope) still receive their reply.
-        if task_id not in self.suppress and task_id in self.results:
-            fut.set_result(self.results[task_id])
-        return fut
-
-    def cancel(self, task_id: str) -> None:
-        self.cancelled.append(task_id)
-        self._futures.pop(task_id, None)
-
-    def _autorespond(self, envelope: dict) -> None:
-        """Called by the bound mock_queue.publish to simulate the agent reply."""
-        task_id = envelope["task_id"]
-        if task_id in self.suppress:
-            return  # no reply -> executor times out
-        result = self.results.get(task_id)
-        if result is None:
-            result = self.responder(envelope)
-        fut = self._futures.get(task_id)
-        if fut is not None and not fut.done():
-            fut.set_result(result)
-
-    async def stop(self) -> None:
-        self.stopped = True
-
-    def bind(self, mock_queue):
-        """Wire ``mock_queue.publish`` so dispatching a ``comms.task``
-        auto-delivers the agent's reply through this router. Returns the queue.
-        """
-        mock_queue.reply_router = self
-        router = self
-
-        async def _publish(queue_name, payload, delay_seconds=None):
-            data = json.loads(payload)
-            if queue_name.endswith("_comms") and data.get("action") == "comms.task":
-                router._autorespond(data["payload"])
-            return None
-
-        mock_queue.publish.side_effect = _publish
-        return mock_queue
-
-
-@pytest.fixture
-def reply_router():
-    """SIP-0094 reply-router test double; bind it to a mock queue with
-    ``reply_router.bind(mock_queue)``."""
-    return FakeReplyRouter()
 
 
 @pytest.fixture

--- a/tests/unit/cycles/conftest.py
+++ b/tests/unit/cycles/conftest.py
@@ -2,6 +2,8 @@
 Shared fixtures for SIP-0064 cycle domain tests.
 """
 
+import asyncio
+import json
 from datetime import UTC, datetime
 
 import pytest
@@ -17,8 +19,100 @@ from squadops.cycles.models import (
     SquadProfile,
     TaskFlowPolicy,
 )
+from squadops.tasks.models import TaskResult
 
 _NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+
+class FakeReplyRouter:
+    """Shared test double for the SIP-0094 ReplyRouter
+    (``adapters/cycles/reply_router.py``).
+
+    Post-cutover the executor awaits this router instead of polling the queue.
+    It simulates the agent round-trip: :meth:`bind` wires a mock QueuePort so
+    that publishing a ``comms.task`` to ``{agent_id}_comms`` calls
+    :meth:`_autorespond`, which resolves the registered future with the
+    configured reply.
+
+    Configure the agent's reply per test:
+    - ``responder`` — callable(envelope_dict) -> TaskResult, the default reply
+      for every task (defaults to SUCCEEDED, empty outputs). Use a stateful
+      closure to reproduce a scripted per-dispatch reply sequence.
+    - ``results`` — ``{task_id: TaskResult}`` exact replies (resolve at
+      register time, so they work even if publish is intercepted).
+    - ``suppress`` — task_ids that never reply (drives a dispatch timeout).
+
+    Mirrors the real router's register/cancel/ensure_subscribed/stop surface so
+    the executor's ordering and pending-future-leak invariants are exercised.
+    """
+
+    def __init__(self) -> None:
+        self._futures: dict[str, asyncio.Future] = {}
+        self.subscribed: list[str] = []
+        self.registered: list[str] = []
+        self.cancelled: list[str] = []
+        self.results: dict[str, TaskResult] = {}
+        self.suppress: set[str] = set()
+        self.stopped = False
+        self.responder = lambda env: TaskResult(
+            task_id=env["task_id"], status="SUCCEEDED", outputs={}
+        )
+
+    async def ensure_subscribed(self, agent_id: str) -> None:
+        self.subscribed.append(agent_id)
+
+    def register(self, task_id: str):
+        self.registered.append(task_id)
+        fut = asyncio.get_running_loop().create_future()
+        self._futures[task_id] = fut
+        # A pre-seeded result resolves immediately, so tests that bypass the
+        # autoresponding publish (e.g. those overriding publish to capture the
+        # envelope) still receive their reply.
+        if task_id not in self.suppress and task_id in self.results:
+            fut.set_result(self.results[task_id])
+        return fut
+
+    def cancel(self, task_id: str) -> None:
+        self.cancelled.append(task_id)
+        self._futures.pop(task_id, None)
+
+    def _autorespond(self, envelope: dict) -> None:
+        """Called by the bound mock_queue.publish to simulate the agent reply."""
+        task_id = envelope["task_id"]
+        if task_id in self.suppress:
+            return  # no reply -> executor times out
+        result = self.results.get(task_id)
+        if result is None:
+            result = self.responder(envelope)
+        fut = self._futures.get(task_id)
+        if fut is not None and not fut.done():
+            fut.set_result(result)
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    def bind(self, mock_queue):
+        """Wire ``mock_queue.publish`` so dispatching a ``comms.task``
+        auto-delivers the agent's reply through this router. Returns the queue.
+        """
+        mock_queue.reply_router = self
+        router = self
+
+        async def _publish(queue_name, payload, delay_seconds=None):
+            data = json.loads(payload)
+            if queue_name.endswith("_comms") and data.get("action") == "comms.task":
+                router._autorespond(data["payload"])
+            return None
+
+        mock_queue.publish.side_effect = _publish
+        return mock_queue
+
+
+@pytest.fixture
+def reply_router():
+    """SIP-0094 reply-router test double; bind it to a mock queue with
+    ``reply_router.bind(mock_queue)``."""
+    return FakeReplyRouter()
 
 
 @pytest.fixture

--- a/tests/unit/cycles/test_correction_protocol.py
+++ b/tests/unit/cycles/test_correction_protocol.py
@@ -13,7 +13,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from squadops.comms.queue_message import QueueMessage
 from squadops.cycles.models import (
     AgentProfileEntry,
     Cycle,
@@ -34,35 +33,6 @@ pytestmark = [pytest.mark.domain_orchestration]
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_result_message(
-    task_id: str,
-    status: str = "SUCCEEDED",
-    outputs: dict | None = None,
-    error: str | None = None,
-    queue_name: str = "cycle_results_run_001",
-) -> QueueMessage:
-    result = TaskResult(
-        task_id=task_id,
-        status=status,
-        outputs=outputs,
-        error=error,
-    )
-    payload = json.dumps(
-        {
-            "action": "comms.task.result",
-            "metadata": {"correlation_id": "corr"},
-            "payload": result.to_dict(),
-        }
-    )
-    return QueueMessage(
-        message_id=f"msg_{task_id}",
-        queue_name=queue_name,
-        payload=payload,
-        receipt_handle=f"rh_{task_id}",
-        attributes={},
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -102,18 +72,14 @@ def mock_vault():
 
 
 @pytest.fixture
-def mock_queue():
+def mock_queue(reply_router):
     mock = AsyncMock()
-    mock.publish.return_value = None
     mock.ack.return_value = None
     mock.invalidate_queue.return_value = None
     mock.consume.return_value = []
-
-    async def _consume_blocking(queue_name, timeout, max_messages=1):
-        return await mock.consume(queue_name, max_messages=max_messages)
-
-    mock.consume_blocking.side_effect = _consume_blocking
-    return mock
+    # SIP-0094: publishing a comms.task auto-delivers the agent reply via the
+    # reply router (the executor no longer polls a reply queue).
+    return reply_router.bind(mock)
 
 
 @pytest.fixture
@@ -194,50 +160,36 @@ def executor(
         queue=mock_queue,
         squad_profile=mock_squad_profile,
         task_timeout=5.0,
+        reply_router=mock_queue.reply_router,
     )
     ex._cycle_event_bus = mock_event_bus
     return ex
 
 
-def _build_scripted_consume(mock_queue, script):
-    """Build consume side_effect from a list of (status, outputs, error) tuples.
+def _script_replies(reply_router, script):
+    """Drive the reply router from a list of (status, outputs, error) tuples.
 
-    Each publish gets the next response from the script. After the script
-    is exhausted, returns SUCCEEDED with default outputs.
+    Each dispatch (in order) gets the next scripted reply, exactly as the old
+    scripted consume side_effect did. After the script is exhausted, replies
+    default to SUCCEEDED — same fallback as before.
     """
     idx = {"n": 0}
 
-    async def consume_side_effect(queue_name, max_messages=1):
-        if not queue_name.startswith("cycle_results_"):
-            return []
-        last_call = mock_queue.publish.call_args
-        if not last_call:
-            return []
-        msg_data = json.loads(last_call.args[1])
-        task_id = msg_data["payload"]["task_id"]
-
+    def responder(env):
         i = idx["n"]
         idx["n"] += 1
-
         if i < len(script):
             status, outputs, error = script[i]
         else:
-            status, outputs, error = (
-                "SUCCEEDED",
-                {"summary": "ok", "role": "strat"},
-                None,
-            )
-        return [
-            _make_result_message(
-                task_id=task_id,
-                status=status,
-                outputs=outputs,
-                error=error,
-                queue_name=queue_name,
-            )
-        ]
+            status, outputs, error = ("SUCCEEDED", {"summary": "ok", "role": "strat"}, None)
+        return TaskResult(
+            task_id=env["task_id"],
+            status=status,
+            outputs=outputs,
+            error=error,
+        )
 
-    return consume_side_effect
+    reply_router.responder = responder
 
 
 # ---------------------------------------------------------------------------
@@ -286,7 +238,7 @@ class TestCorrectionContinue:
             ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
             ("SUCCEEDED", {"summary": "ok", "role": "data"}, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -352,7 +304,7 @@ class TestCorrectionPatch:
             ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
             ("SUCCEEDED", {"summary": "ok", "role": "data"}, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -554,7 +506,7 @@ class TestCorrectionTaskArtifactStorage:
             ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
             ("SUCCEEDED", {"summary": "ok", "role": "data"}, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -630,7 +582,7 @@ class TestCorrectionTaskArtifactStorage:
             ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
             ("SUCCEEDED", {"summary": "ok", "role": "data"}, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -710,7 +662,7 @@ class TestCorrectionTerminalPaths:
             ),
             ("SUCCEEDED", correction_decision, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -775,7 +727,7 @@ class TestMaxCorrectionAttempts:
             ("FAILED", semantic_outputs_2, "bad again"),
             # max_correction_attempts=1 exhausted -> abort
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -838,7 +790,7 @@ class TestPlanDelta:
             ("SUCCEEDED", analyze_failure, None),
             ("SUCCEEDED", correction_decision, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -904,7 +856,7 @@ class TestPlanDelta:
             ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
             ("SUCCEEDED", {"summary": "ok", "role": "data"}, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -961,7 +913,7 @@ class TestCorrectionCheckpoints:
             # correction_decision succeeds -> checkpoint
             ("SUCCEEDED", correction_decision, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -987,7 +939,7 @@ class TestCorrectionCheckpoints:
             # correction_decision fails
             ("FAILED", None, "corr fail"),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -1037,7 +989,7 @@ class TestCorrectionEvents:
             ),
             ("SUCCEEDED", correction_decision, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -1093,7 +1045,7 @@ class TestCorrectionEvents:
             ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
             ("SUCCEEDED", {"summary": "ok", "role": "data"}, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -1194,7 +1146,7 @@ class TestCorrectionModelResolution:
             ),
             ("SUCCEEDED", decision, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -1255,7 +1207,7 @@ class TestCorrectionModelResolution:
             ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
             ("SUCCEEDED", {"summary": "ok", "role": "data"}, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -1370,7 +1322,7 @@ class TestCorrectionModelResolution:
             ("SUCCEEDED", {"summary": "ok", "role": "qa"}, None),
             ("SUCCEEDED", {"summary": "ok", "role": "data"}, None),
         ]
-        mock_queue.consume.side_effect = _build_scripted_consume(mock_queue, script)
+        _script_replies(mock_queue.reply_router, script)
 
         with (
             patch.object(exec_mod, "generate_task_plan", _gen_with_contract),

--- a/tests/unit/cycles/test_correction_repair_prefect_propagation.py
+++ b/tests/unit/cycles/test_correction_repair_prefect_propagation.py
@@ -79,7 +79,7 @@ def mock_prefect_reporter() -> AsyncMock:
     return reporter
 
 
-def _make_executor(mock_prefect_reporter):
+def _make_executor(mock_prefect_reporter, reply_router):
     """Build a minimally-wired executor for direct method calls."""
     from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
@@ -95,6 +95,7 @@ def _make_executor(mock_prefect_reporter):
         squad_profile=squad,
         task_timeout=5.0,
         workflow_tracker=mock_prefect_reporter,
+        reply_router=reply_router,
     )
     ex._cycle_event_bus = MagicMock()
     return ex
@@ -110,9 +111,9 @@ class TestCorrectionTaskRunPropagation:
     correction step and tag every emitted task event with both run IDs."""
 
     async def test_correction_steps_create_task_runs_and_emit_full_context(
-        self, mock_prefect_reporter, cycle, failed_envelope
+        self, mock_prefect_reporter, cycle, failed_envelope, reply_router
     ):
-        ex = _make_executor(mock_prefect_reporter)
+        ex = _make_executor(mock_prefect_reporter, reply_router)
 
         # Stub _dispatch_task: capture kwargs and return a "continue"
         # correction decision so the protocol terminates without entering
@@ -185,11 +186,11 @@ class TestCorrectionTaskRunPropagation:
             assert ctx["task_run_id"].startswith("tr_")
 
     async def test_correction_skips_task_run_creation_when_flow_run_id_missing(
-        self, mock_prefect_reporter, cycle, failed_envelope
+        self, mock_prefect_reporter, cycle, failed_envelope, reply_router
     ):
         """No Prefect flow context → no task_runs created (consistent with
         main path); event contexts carry empty-string IDs (not None)."""
-        ex = _make_executor(mock_prefect_reporter)
+        ex = _make_executor(mock_prefect_reporter, reply_router)
 
         async def succeed(envelope, *_a, **_k):
             if envelope.task_type == "governance.correction_decision":
@@ -236,9 +237,9 @@ class TestCorrectionPatchRepairTaskRunPropagation:
     correction protocol must also create per-step task_runs."""
 
     async def test_patch_repairs_create_task_runs_and_carry_full_context(
-        self, mock_prefect_reporter, cycle, failed_envelope
+        self, mock_prefect_reporter, cycle, failed_envelope, reply_router
     ):
-        ex = _make_executor(mock_prefect_reporter)
+        ex = _make_executor(mock_prefect_reporter, reply_router)
 
         seen_repair_dispatches: list[dict] = []
 
@@ -297,14 +298,14 @@ class TestPulseRepairTaskRunPropagation:
     """
 
     async def test_pulse_repair_dispatches_carry_run_ids(
-        self, mock_prefect_reporter, cycle, failed_envelope
+        self, mock_prefect_reporter, cycle, failed_envelope, reply_router
     ):
         from squadops.cycles.pulse_models import (
             PulseDecision,
             SuiteOutcome,
         )
 
-        ex = _make_executor(mock_prefect_reporter)
+        ex = _make_executor(mock_prefect_reporter, reply_router)
 
         # Stub the boundary verification: report FAIL on the first pass and
         # PASS on the second so the loop runs exactly one repair attempt.

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -2796,3 +2796,104 @@ class TestDispatchTaskPrefectLifecycle:
             if t.get_name().startswith("prefect-heartbeat-") and not t.done()
         ]
         assert leftover == []
+
+
+class TestPublishAndAwaitInvariants:
+    """SIP-0094 cutover invariants of _publish_and_await: ordering (D14/#2),
+    pending-future-leak safety on every exit path (#9/#10), concurrent
+    first-dispatch (#13), and global task_id uniqueness across runs (D14)."""
+
+    @staticmethod
+    def _env(task_id="t1", agent_id="neo"):
+        return TaskEnvelope(
+            task_id=task_id,
+            agent_id=agent_id,
+            cycle_id="cyc_001",
+            pulse_id="p1",
+            project_id="proj_001",
+            task_type="development.design",
+            correlation_id="corr",
+            causation_id="cause",
+            trace_id="trace",
+            span_id="span",
+            metadata={"role": "dev"},
+        )
+
+    async def test_subscribes_and_registers_before_publish(
+        self, executor, mock_queue, reply_router
+    ):
+        """D14/#2: ensure_subscribed + register happen BEFORE publish, so a fast
+        reply can't arrive before the consumer is live."""
+        seen = {}
+
+        async def _publish(queue_name, payload, delay_seconds=None):
+            data = json.loads(payload)
+            seen["registered"] = data["payload"]["task_id"] in reply_router.registered
+            seen["subscribed"] = "neo" in reply_router.subscribed
+            reply_router._autorespond(data["payload"])
+
+        mock_queue.publish.side_effect = _publish
+
+        await executor._publish_and_await(self._env(), "run_001")
+
+        assert seen == {"registered": True, "subscribed": True}
+
+    async def test_publish_failure_removes_pending_future(self, executor, mock_queue, reply_router):
+        """#10: if publish raises after register(), the pending future is dropped
+        (no leak) and the error propagates."""
+        mock_queue.publish.side_effect = RuntimeError("broker down")
+
+        with pytest.raises(RuntimeError, match="broker down"):
+            await executor._publish_and_await(self._env("t_fail"), "run_001")
+
+        assert "t_fail" in reply_router.cancelled
+        assert "t_fail" not in reply_router._futures
+
+    async def test_timeout_leaves_no_pending_future(self, executor, reply_router):
+        """#9: a timed-out dispatch cancels its future (no leak) and returns FAILED."""
+        reply_router.suppress.add("t_to")
+        executor._task_timeout = 0.1
+
+        result = await executor._publish_and_await(self._env("t_to"), "run_001")
+
+        assert result.status == "FAILED"
+        assert "t_to" in reply_router.cancelled
+        assert "t_to" not in reply_router._futures
+
+    async def test_concurrent_dispatch_same_agent_both_resolve(
+        self, executor, mock_queue, reply_router
+    ):
+        """#13: two concurrent dispatches to one agent both resolve to their own
+        results and both publish to that agent's comms queue."""
+        reply_router.results["ta"] = TaskResult(
+            task_id="ta", status="SUCCEEDED", outputs={"n": "a"}
+        )
+        reply_router.results["tb"] = TaskResult(
+            task_id="tb", status="SUCCEEDED", outputs={"n": "b"}
+        )
+
+        ra, rb = await asyncio.gather(
+            executor._publish_and_await(self._env("ta"), "run_001"),
+            executor._publish_and_await(self._env("tb"), "run_001"),
+        )
+
+        assert ra.outputs["n"] == "a"
+        assert rb.outputs["n"] == "b"
+        pub_queues = [c.args[0] for c in mock_queue.publish.call_args_list]
+        assert pub_queues.count("neo_comms") == 2
+
+    async def test_cross_run_task_ids_dont_collide(self, executor, reply_router):
+        """D14: globally-unique task_ids from different runs resolve to their own
+        results on the shared per-agent reply queue (no cross-run mixup)."""
+        reply_router.results["task-run_aaaa-1"] = TaskResult(
+            task_id="task-run_aaaa-1", status="SUCCEEDED", outputs={"r": "a"}
+        )
+        reply_router.results["task-run_bbbb-1"] = TaskResult(
+            task_id="task-run_bbbb-1", status="SUCCEEDED", outputs={"r": "b"}
+        )
+
+        r1 = await executor._publish_and_await(self._env("task-run_aaaa-1"), "run_aaaa")
+        r2 = await executor._publish_and_await(self._env("task-run_bbbb-1"), "run_bbbb")
+
+        assert r1.outputs["r"] == "a"
+        assert r2.outputs["r"] == "b"

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -16,7 +16,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from squadops.comms.queue_message import QueueMessage
 from squadops.cycles.models import (
     AgentProfileEntry,
     ArtifactRef,
@@ -39,39 +38,11 @@ pytestmark = [pytest.mark.domain_orchestration]
 # ---------------------------------------------------------------------------
 
 
-def _make_result_message(
-    task_id: str,
-    status: str = "SUCCEEDED",
-    outputs: dict | None = None,
-    error: str | None = None,
-    queue_name: str = "cycle_results_run_001",
-) -> QueueMessage:
-    """Build a QueueMessage containing a TaskResult."""
-    result = TaskResult(
-        task_id=task_id,
-        status=status,
-        outputs=outputs,
-        error=error,
-    )
-    payload = json.dumps(
-        {
-            "action": "comms.task.result",
-            "metadata": {"correlation_id": "corr"},
-            "payload": result.to_dict(),
-        }
-    )
-    return QueueMessage(
-        message_id=f"msg_{task_id}",
-        queue_name=queue_name,
-        payload=payload,
-        receipt_handle=f"rh_{task_id}",
-        attributes={},
-    )
-
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+# FakeReplyRouter + the `reply_router` fixture live in conftest.py (shared by
+# all executor test files post-SIP-0094 cutover).
 
 
 @pytest.fixture
@@ -107,22 +78,14 @@ def mock_vault():
 
 
 @pytest.fixture
-def mock_queue():
-    """Mock QueuePort that succeeds on publish and returns results on consume."""
+def mock_queue(reply_router):
+    """Mock QueuePort bound to the reply router: publishing a ``comms.task``
+    auto-delivers the agent's reply (SIP-0094 cutover)."""
     mock = AsyncMock()
-    mock.publish.return_value = None
     mock.ack.return_value = None
     mock.invalidate_queue.return_value = None
-    # Default: consume returns empty (override per-test)
     mock.consume.return_value = []
-
-    # Route consume_blocking through consume so tests that set
-    # consume.side_effect continue to work without modification.
-    async def _consume_blocking(queue_name, timeout, max_messages=1):
-        return await mock.consume(queue_name, max_messages=max_messages)
-
-    mock.consume_blocking.side_effect = _consume_blocking
-    return mock
+    return reply_router.bind(mock)
 
 
 @pytest.fixture
@@ -174,7 +137,7 @@ def run():
 
 
 @pytest.fixture
-def executor(mock_registry, mock_vault, mock_queue, mock_squad_profile, cycle, run):
+def executor(mock_registry, mock_vault, mock_queue, mock_squad_profile, reply_router, cycle, run):
     from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     mock_registry.get_cycle.return_value = cycle
@@ -185,6 +148,7 @@ def executor(mock_registry, mock_vault, mock_queue, mock_squad_profile, cycle, r
         queue=mock_queue,
         squad_profile=mock_squad_profile,
         task_timeout=5.0,  # Short timeout for tests
+        reply_router=reply_router,
     )
 
 
@@ -495,29 +459,7 @@ class TestDispatchTask:
         self, executor, mock_queue, mock_registry, cycle
     ) -> None:
         """Task is published to {agent_id}_comms with comms.task action."""
-        # Make consume return a result for the first task
-        call_count = 0
-
-        async def consume_side_effect(queue_name, max_messages=1):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1 and queue_name.startswith("cycle_results_"):
-                # Return result for whatever was last published
-                last_publish_call = mock_queue.publish.call_args
-                if last_publish_call:
-                    msg_data = json.loads(last_publish_call.args[1])
-                    task_id = msg_data["payload"]["task_id"]
-                    return [
-                        _make_result_message(
-                            task_id=task_id,
-                            outputs={"summary": "ok", "artifacts": []},
-                            queue_name=queue_name,
-                        )
-                    ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
-
+        # Default reply_router responder auto-succeeds the dispatched task.
         envelope = TaskEnvelope(
             task_id="task_abc",
             agent_id="neo",
@@ -545,17 +487,16 @@ class TestDispatchTask:
 
         published = json.loads(pub_args.args[1])
         assert published["action"] == "comms.task"
-        assert published["metadata"]["reply_queue"] == "cycle_results_run_001"
+        # SIP-0094: reply address is now the per-agent reply queue.
+        assert published["metadata"]["reply_queue"] == "neo_replies"
         assert published["payload"]["task_id"] == "task_abc"
 
-    async def test_consumes_result_from_reply_queue(self, executor, mock_queue) -> None:
-        """Result is consumed from cycle_results_{run_id}."""
-        result_msg = _make_result_message(
-            task_id="task_abc",
-            outputs={"summary": "implemented"},
-            queue_name="cycle_results_run_001",
+    async def test_returns_agent_result_from_router(self, executor, reply_router) -> None:
+        """The agent's TaskResult (delivered via the reply router) is returned
+        by _dispatch_task with its outputs intact (SIP-0094)."""
+        reply_router.results["task_abc"] = TaskResult(
+            task_id="task_abc", status="SUCCEEDED", outputs={"summary": "implemented"}
         )
-        mock_queue.consume.return_value = [result_msg]
 
         envelope = TaskEnvelope(
             task_id="task_abc",
@@ -576,11 +517,12 @@ class TestDispatchTask:
         assert result.task_id == "task_abc"
         assert result.status == "SUCCEEDED"
         assert result.outputs["summary"] == "implemented"
-        mock_queue.ack.assert_awaited_once_with(result_msg)
+        # The reply router/subscribe primitive owns ack now — not the executor
+        # (ack behavior is covered in test_reply_router.py).
 
-    async def test_timeout_returns_failed(self, executor, mock_queue) -> None:
-        """If no result arrives within timeout, returns FAILED TaskResult."""
-        mock_queue.consume.return_value = []  # Always empty
+    async def test_timeout_returns_failed(self, executor, reply_router) -> None:
+        """If the agent never replies within the timeout, returns FAILED."""
+        reply_router.suppress.add("task_abc")  # agent never replies
         executor._task_timeout = 0.1  # Very short
 
         envelope = TaskEnvelope(
@@ -597,111 +539,22 @@ class TestDispatchTask:
             metadata={"role": "dev"},
         )
 
-        with patch(
-            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
-            new_callable=AsyncMock,
-        ):
-            result = await executor._dispatch_task(envelope, "run_001")
+        # NOTE: do NOT patch asyncio.sleep here. The concurrent heartbeat loop
+        # (`while True: await asyncio.sleep(30)`) would then spin instantly and
+        # starve the event loop, so wait_for's 0.1s timer never fires. With real
+        # sleep the heartbeat parks for 30s and the timeout fires cleanly.
+        result = await executor._dispatch_task(envelope, "run_001")
 
         assert result.status == "FAILED"
         assert "Timed out" in result.error
 
-    async def test_recovers_from_transient_consume_error(self, executor, mock_queue) -> None:
-        """A transient QueueError must invalidate the cached queue handle and
-        the loop must keep waiting until the deadline — not fail the task.
-
-        Regression: prior to fix, a single ``Channel was not opened`` from
-        the broker would propagate out of ``_publish_and_await`` and fail an
-        otherwise-recoverable wait, even though the agent's reply was sitting
-        in the queue.
-        """
-        executor._task_timeout = 1.0
-
-        envelope = TaskEnvelope(
-            task_id="task_recover",
-            agent_id="neo",
-            cycle_id="cyc_001",
-            pulse_id="p1",
-            project_id="proj_001",
-            task_type="development.design",
-            correlation_id="corr",
-            causation_id="cause",
-            trace_id="trace",
-            span_id="span",
-            metadata={"role": "dev"},
-        )
-
-        # First consume_blocking raises (stale channel); second returns the
-        # reply that was waiting all along.
-        result_msg = _make_result_message(
-            task_id="task_recover",
-            outputs={"summary": "recovered", "artifacts": []},
-        )
-        call_count = {"n": 0}
-
-        async def flaky_consume_blocking(queue_name, timeout, max_messages=1):
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                raise RuntimeError("Channel was not opened")
-            return [result_msg]
-
-        mock_queue.consume_blocking.side_effect = flaky_consume_blocking
-
-        with patch(
-            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
-            new_callable=AsyncMock,
-        ):
-            result = await executor._dispatch_task(envelope, "run_001")
-
-        assert result.status == "SUCCEEDED"
-        assert result.outputs["summary"] == "recovered"
-        # Cache must be invalidated so the retry re-declares against a fresh
-        # channel rather than reusing the broken handle.
-        mock_queue.invalidate_queue.assert_awaited_with("cycle_results_run_001")
-
-    async def test_uses_long_block_consume_not_short_poll(self, executor, mock_queue) -> None:
-        """The wait must use ``consume_blocking`` (one consumer per chunk),
-        not the legacy ``consume`` poll-and-sleep that churned consumer tags.
-
-        Regression: the old loop opened ~3600 short-lived consumers per
-        30-min wait, racing with arriving messages. New loop must call
-        ``consume_blocking`` with a multi-second timeout.
-        """
-        executor._task_timeout = 0.05  # shortcut: single iteration
-
-        result_msg = _make_result_message(
-            task_id="task_blk",
-            outputs={"summary": "ok", "artifacts": []},
-        )
-        mock_queue.consume_blocking.side_effect = None
-        mock_queue.consume_blocking.return_value = [result_msg]
-
-        envelope = TaskEnvelope(
-            task_id="task_blk",
-            agent_id="neo",
-            cycle_id="cyc_001",
-            pulse_id="p1",
-            project_id="proj_001",
-            task_type="development.design",
-            correlation_id="corr",
-            causation_id="cause",
-            trace_id="trace",
-            span_id="span",
-            metadata={"role": "dev"},
-        )
-
-        result = await executor._dispatch_task(envelope, "run_001")
-
-        assert result.status == "SUCCEEDED"
-        # Must have called consume_blocking, not the short-poll consume.
-        assert mock_queue.consume_blocking.await_count >= 1
-        # Each call must request a meaningful blocking window so the
-        # consumer subscription is held long enough to receive a reply.
-        first_call = mock_queue.consume_blocking.await_args_list[0]
-        timeout_arg = first_call.kwargs.get("timeout")
-        if timeout_arg is None and len(first_call.args) >= 2:
-            timeout_arg = first_call.args[1]
-        assert timeout_arg is not None and timeout_arg > 0
+    # SIP-0094 removed the executor-side reply polling loop (consume_blocking +
+    # invalidate_queue recovery). Two tests that asserted that mechanism —
+    # transient-consume-error recovery and "uses long-block consume not short
+    # poll" — are deleted here; their coverage moved to the reply substrate:
+    # channel-close resubscribe is tested in tests/unit/comms/
+    # test_rabbitmq_adapter.py (94.2b) and the router resolve path in
+    # tests/unit/cycles/test_reply_router.py.
 
 
 # ---------------------------------------------------------------------------
@@ -713,42 +566,33 @@ class TestSequentialHappyPath:
     """Sequential mode: 5 tasks dispatched via queue, run completes."""
 
     @staticmethod
-    def _make_queue_side_effects(mock_queue):
-        """Build a consume side_effect that returns matching results."""
+    def _wire_canned_replies(mock_queue):
+        """Make every dispatched task reply SUCCEEDED with one artifact, so the
+        run progresses and artifacts get stored."""
 
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            # Return result matching the most recent publish
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={
-                            "summary": "stub output",
-                            "role": "strat",
-                            "artifacts": [
-                                {
-                                    "name": "output.md",
-                                    "content": "# Output",
-                                    "media_type": "text/markdown",
-                                    "type": "document",
-                                }
-                            ],
-                        },
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
+        def responder(env):
+            return TaskResult(
+                task_id=env["task_id"],
+                status="SUCCEEDED",
+                outputs={
+                    "summary": "stub output",
+                    "role": "strat",
+                    "artifacts": [
+                        {
+                            "name": "output.md",
+                            "content": "# Output",
+                            "media_type": "text/markdown",
+                            "type": "document",
+                        }
+                    ],
+                },
+            )
 
-        return consume_side_effect
+        mock_queue.reply_router.responder = responder
 
     async def test_run_completes(self, executor, mock_registry, mock_queue) -> None:
         """5 tasks dispatched; run transitions queued -> running -> completed."""
-        mock_queue.consume.side_effect = self._make_queue_side_effects(mock_queue)
+        self._wire_canned_replies(mock_queue)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -763,7 +607,7 @@ class TestSequentialHappyPath:
 
     async def test_publish_called_5_times(self, executor, mock_queue) -> None:
         """queue.publish called once per pipeline step (5 total)."""
-        mock_queue.consume.side_effect = self._make_queue_side_effects(mock_queue)
+        self._wire_canned_replies(mock_queue)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -775,7 +619,7 @@ class TestSequentialHappyPath:
 
     async def test_publishes_to_correct_agent_queues(self, executor, mock_queue) -> None:
         """Each task published to the correct agent's comms queue."""
-        mock_queue.consume.side_effect = self._make_queue_side_effects(mock_queue)
+        self._wire_canned_replies(mock_queue)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -794,7 +638,7 @@ class TestSequentialHappyPath:
 
     async def test_artifacts_stored(self, executor, mock_vault, mock_queue) -> None:
         """vault.store called for each task's artifacts."""
-        mock_queue.consume.side_effect = self._make_queue_side_effects(mock_queue)
+        self._wire_canned_replies(mock_queue)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -815,7 +659,7 @@ class TestFailFast:
     """Outcome routing: persistent failures retry, trigger correction, then abort."""
 
     async def test_persistent_failure_retries_then_aborts(
-        self, executor, mock_queue, mock_registry
+        self, executor, mock_queue, mock_registry, reply_router
     ) -> None:
         """All dispatches FAILED → retry + correction protocol → run FAILED.
 
@@ -826,25 +670,10 @@ class TestFailFast:
         4. Both correction tasks also fail → correction_path defaults to "abort"
         Total publishes: 2 (task retries) + 2 (correction tasks) = 4
         """
-
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        status="FAILED",
-                        error="boom",
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
+        # Every agent reply is a failure -> drives the retry/correction path.
+        reply_router.responder = lambda env: TaskResult(
+            task_id=env["task_id"], status="FAILED", error="boom"
+        )
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -900,36 +729,25 @@ class TestCancellation:
 class TestArtifactStorage:
     """Artifact ref creation from distributed results."""
 
-    async def test_artifact_ref_has_metadata(self, executor, mock_vault, mock_queue) -> None:
+    async def test_artifact_ref_has_metadata(self, executor, mock_vault, reply_router) -> None:
         """ArtifactRef passed to vault.store has task_id and role in metadata."""
-
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={
-                            "summary": "ok",
-                            "artifacts": [
-                                {
-                                    "name": "output.md",
-                                    "content": "# Output",
-                                    "media_type": "text/markdown",
-                                    "type": "document",
-                                }
-                            ],
-                        },
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
+        # Every task replies with one artifact so vault.store is exercised with
+        # task artifacts (not just the run report).
+        reply_router.responder = lambda env: TaskResult(
+            task_id=env["task_id"],
+            status="SUCCEEDED",
+            outputs={
+                "summary": "ok",
+                "artifacts": [
+                    {
+                        "name": "output.md",
+                        "content": "# Output",
+                        "media_type": "text/markdown",
+                        "type": "document",
+                    }
+                ],
+            },
+        )
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -981,24 +799,6 @@ class TestPulseVerificationBackwardCompat:
     async def test_no_pulse_checks_completes_normally(self, executor, mock_queue, mock_registry):
         """Run with no pulse_checks in applied_defaults completes as before."""
 
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -1028,6 +828,7 @@ class TestPulseVerificationMilestone:
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
+            reply_router=mock_queue.reply_router,
             squad_profile=mock_squad_profile,
             task_timeout=5.0,
         )
@@ -1056,24 +857,6 @@ class TestPulseVerificationMilestone:
             mock_squad_profile,
             cycle,
         )
-
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
 
         # Mock the engine to return PASS
         with (
@@ -1126,24 +909,6 @@ class TestPulseVerificationMilestone:
             cycle,
         )
 
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
-
         with (
             patch(
                 "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -1189,6 +954,7 @@ class TestPulseVerificationCadence:
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
+            reply_router=mock_queue.reply_router,
             squad_profile=mock_squad_profile,
             task_timeout=5.0,
         )
@@ -1217,24 +983,6 @@ class TestPulseVerificationCadence:
             mock_squad_profile,
             cycle,
         )
-
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
 
         with (
             patch(
@@ -1287,24 +1035,6 @@ class TestPulseVerificationCadence:
             mock_squad_profile,
             cycle,
         )
-
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
 
         with (
             patch(
@@ -1435,6 +1165,7 @@ class TestPulseVerificationTelemetry:
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
+            reply_router=mock_queue.reply_router,
             squad_profile=mock_squad_profile,
             task_timeout=5.0,
             llm_observability=obs,
@@ -1464,24 +1195,6 @@ class TestPulseVerificationTelemetry:
             mock_squad_profile,
             cycle,
         )
-
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
 
         with (
             patch(
@@ -1538,24 +1251,6 @@ class TestPulseVerificationTelemetry:
             cycle,
         )
 
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
-
         with (
             patch(
                 "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -1607,24 +1302,6 @@ class TestPulseVerificationTelemetry:
             cycle,
         )
 
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
-
         with (
             patch(
                 "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -1675,24 +1352,6 @@ class TestPulseVerificationTelemetry:
             cycle,
         )
 
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -1722,6 +1381,7 @@ class TestPulseVerificationCombined:
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
+            reply_router=mock_queue.reply_router,
             squad_profile=mock_squad_profile,
             task_timeout=5.0,
         )
@@ -1759,24 +1419,6 @@ class TestPulseVerificationCombined:
             mock_squad_profile,
             cycle,
         )
-
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
 
         with (
             patch(
@@ -1830,6 +1472,7 @@ class TestPulseVerificationRecordPersistence:
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
+            reply_router=mock_queue.reply_router,
             squad_profile=mock_squad_profile,
             task_timeout=5.0,
         )
@@ -1858,24 +1501,6 @@ class TestPulseVerificationRecordPersistence:
             mock_squad_profile,
             cycle,
         )
-
-        async def consume_side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
 
         with (
             patch(
@@ -1930,31 +1555,10 @@ class TestPulseRepairLoop:
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
+            reply_router=mock_queue.reply_router,
             squad_profile=mock_squad_profile,
             task_timeout=5.0,
         )
-
-    @staticmethod
-    def _consume_side_effect(mock_queue):
-        """Return success for every dispatched task (plan + repair)."""
-
-        async def _side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        return _side_effect
 
     async def test_fail_repair_pass_continues(
         self,
@@ -1982,7 +1586,6 @@ class TestPulseRepairLoop:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         # First call: FAIL; second call (after repair): PASS
         call_count = {"n": 0}
@@ -2003,9 +1606,7 @@ class TestPulseRepairLoop:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=run_pv_side_effect,
@@ -2045,7 +1646,6 @@ class TestPulseRepairLoop:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2061,9 +1661,7 @@ class TestPulseRepairLoop:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=always_fail,
@@ -2104,7 +1702,6 @@ class TestPulseRepairLoop:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2120,9 +1717,7 @@ class TestPulseRepairLoop:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=always_fail,
@@ -2166,7 +1761,6 @@ class TestPulseRepairLoop:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2195,9 +1789,7 @@ class TestPulseRepairLoop:
             return records
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=mixed_pv,
@@ -2243,7 +1835,6 @@ class TestPulseRepairLoop:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2259,9 +1850,7 @@ class TestPulseRepairLoop:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=always_fail,
@@ -2298,7 +1887,6 @@ class TestPulseRepairLoop:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2318,9 +1906,7 @@ class TestPulseRepairLoop:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side_effect,
@@ -2357,7 +1943,6 @@ class TestPulseRepairLoop:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2377,9 +1962,7 @@ class TestPulseRepairLoop:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
@@ -2429,7 +2012,6 @@ class TestPulseRepairLoop:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2449,9 +2031,7 @@ class TestPulseRepairLoop:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
@@ -2493,7 +2073,6 @@ class TestPulseRepairLoop:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2513,9 +2092,7 @@ class TestPulseRepairLoop:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
@@ -2554,30 +2131,11 @@ class TestPulseRepairTelemetry:
             cycle_registry=mock_registry,
             artifact_vault=mock_vault,
             queue=mock_queue,
+            reply_router=mock_queue.reply_router,
             squad_profile=mock_squad_profile,
             task_timeout=5.0,
             llm_observability=obs,
         ), obs
-
-    @staticmethod
-    def _consume_side_effect(mock_queue):
-        async def _side_effect(queue_name, max_messages=1):
-            if not queue_name.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        return _side_effect
 
     async def test_repair_started_event(
         self,
@@ -2605,7 +2163,6 @@ class TestPulseRepairTelemetry:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2625,9 +2182,7 @@ class TestPulseRepairTelemetry:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
@@ -2664,7 +2219,6 @@ class TestPulseRepairTelemetry:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2680,9 +2234,7 @@ class TestPulseRepairTelemetry:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=always_fail,
@@ -2729,7 +2281,6 @@ class TestPulseRepairTelemetry:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2745,9 +2296,7 @@ class TestPulseRepairTelemetry:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=always_fail,
@@ -2795,7 +2344,6 @@ class TestPulseRepairTelemetry:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2815,9 +2363,7 @@ class TestPulseRepairTelemetry:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
@@ -2864,7 +2410,6 @@ class TestPulseRepairTelemetry:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2884,9 +2429,7 @@ class TestPulseRepairTelemetry:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
@@ -2938,7 +2481,6 @@ class TestPulseRepairTelemetry:
             mock_squad_profile,
             cycle,
         )
-        mock_queue.consume.side_effect = self._consume_side_effect(mock_queue)
 
         from squadops.cycles.pulse_models import PulseVerificationRecord
 
@@ -2958,9 +2500,7 @@ class TestPulseRepairTelemetry:
             ]
 
         with (
-            patch(
-                "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
-            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
             patch(
                 "adapters.cycles.dispatched_flow_executor.run_pulse_verification",
                 side_effect=pv_side,
@@ -3022,27 +2562,16 @@ class TestDispatchTaskPrefectLifecycle:
 
         return DispatchedFlowExecutor(
             queue=mock_queue,
+            reply_router=mock_queue.reply_router,
             task_timeout=5.0,
             workflow_tracker=mock_reporter,
         )
 
     def _wire_success_reply(self, mock_queue, task_id: str):
-        call_count = 0
-
-        async def consume_side_effect(queue_name, max_messages=1):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return [
-                    _make_result_message(
-                        task_id=task_id,
-                        outputs={"summary": "ok", "artifacts": []},
-                        queue_name=queue_name,
-                    )
-                ]
-            return []
-
-        mock_queue.consume.side_effect = consume_side_effect
+        """Seed the reply router so the dispatched task gets a SUCCEEDED reply."""
+        mock_queue.reply_router.results[task_id] = TaskResult(
+            task_id=task_id, status="SUCCEEDED", outputs={"summary": "ok", "artifacts": []}
+        )
 
     async def test_creates_task_run_and_sets_running_when_prefect_enabled(
         self, mock_queue, mock_reporter, envelope

--- a/tests/unit/cycles/test_dispatched_flow_executor_observability.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor_observability.py
@@ -6,14 +6,12 @@ creation in execute_run().
 
 from __future__ import annotations
 
-import json
 import logging
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from squadops.comms.queue_message import QueueMessage
 from squadops.cycles.models import (
     AgentProfileEntry,
     Cycle,
@@ -22,72 +20,10 @@ from squadops.cycles.models import (
     SquadProfile,
     TaskFlowPolicy,
 )
-from squadops.tasks.models import TaskResult
 
 pytestmark = [pytest.mark.domain_orchestration]
 
 NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_result_message(
-    task_id: str,
-    status: str = "SUCCEEDED",
-    outputs: dict | None = None,
-    queue_name: str = "cycle_results_run_001",
-) -> QueueMessage:
-    result = TaskResult(task_id=task_id, status=status, outputs=outputs)
-    payload = json.dumps(
-        {
-            "action": "comms.task.result",
-            "metadata": {"correlation_id": "corr"},
-            "payload": result.to_dict(),
-        }
-    )
-    return QueueMessage(
-        message_id=f"msg_{task_id}",
-        queue_name=queue_name,
-        payload=payload,
-        receipt_handle=f"rh_{task_id}",
-        attributes={},
-    )
-
-
-def _make_queue_side_effects(mock_queue):
-    """Build a consume side_effect that returns matching results."""
-
-    async def consume_side_effect(queue_name, max_messages=1):
-        if not queue_name.startswith("cycle_results_"):
-            return []
-        last_call = mock_queue.publish.call_args
-        if last_call:
-            msg_data = json.loads(last_call.args[1])
-            task_id = msg_data["payload"]["task_id"]
-            return [
-                _make_result_message(
-                    task_id=task_id,
-                    outputs={
-                        "summary": "stub output",
-                        "role": "strat",
-                        "artifacts": [
-                            {
-                                "name": "output.md",
-                                "content": "# Output",
-                                "media_type": "text/markdown",
-                                "type": "document",
-                            }
-                        ],
-                    },
-                    queue_name=queue_name,
-                )
-            ]
-        return []
-
-    return consume_side_effect
 
 
 # ---------------------------------------------------------------------------
@@ -128,17 +64,14 @@ def mock_vault():
 
 
 @pytest.fixture
-def mock_queue():
+def mock_queue(reply_router):
     mock = AsyncMock()
     mock.publish.return_value = None
     mock.ack.return_value = None
     mock.invalidate_queue.return_value = None
-    mock.consume.return_value = []
-
-    async def _consume_blocking(queue_name, timeout, max_messages=1):
-        return await mock.consume(queue_name, max_messages=max_messages)
-
-    mock.consume_blocking.side_effect = _consume_blocking
+    # SIP-0094: wire the reply router so dispatching a comms.task auto-delivers
+    # the agent's reply (default: SUCCEEDED). Accessible as mock.reply_router.
+    reply_router.bind(mock)
     return mock
 
 
@@ -213,6 +146,7 @@ def executor(
         task_timeout=5.0,
         llm_observability=mock_llm_obs,
         workflow_tracker=mock_prefect,
+        reply_router=mock_queue.reply_router,
     )
 
 
@@ -227,6 +161,7 @@ def executor_no_obs(mock_registry, mock_vault, mock_queue, mock_squad_profile, c
         queue=mock_queue,
         squad_profile=mock_squad_profile,
         task_timeout=5.0,
+        reply_router=mock_queue.reply_router,
     )
 
 
@@ -239,8 +174,6 @@ class TestLangFuseCycleEvents:
     """Verify start_cycle_trace + end_cycle_trace called around execute_run."""
 
     async def test_emits_langfuse_cycle_events(self, executor, mock_queue, mock_llm_obs):
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -258,8 +191,6 @@ class TestLangFuseCycleEvents:
         assert "cycle.completed" in event_names
 
     async def test_langfuse_context_has_trace_id(self, executor, mock_queue, mock_llm_obs):
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -278,8 +209,6 @@ class TestWithoutObservability:
     async def test_no_langfuse_no_prefect_no_error(
         self, executor_no_obs, mock_queue, mock_registry
     ):
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -313,12 +242,8 @@ class TestFlowLevelCorrelationScope:
             PrefectLogHandler,
         )
 
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         forwarder = MagicMock(enqueue=MagicMock())
-        handler = PrefectLogHandler(
-            forwarder, filters=LogHandlerFilters(min_level=logging.INFO)
-        )
+        handler = PrefectLogHandler(forwarder, filters=LogHandlerFilters(min_level=logging.INFO))
         logging.getLogger().addHandler(handler)
         prior_levels = {n: logging.getLogger(n).level for n in ("squadops", "adapters")}
         logging.getLogger("squadops").setLevel(logging.INFO)
@@ -356,8 +281,6 @@ class TestPrefectFlowRun:
     """Verify Prefect flow run created at start."""
 
     async def test_creates_prefect_flow_run(self, executor, mock_queue, mock_prefect):
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -383,8 +306,6 @@ class TestPrefectTaskRuns:
     ):
         """Executor creates task runs + transitions to RUNNING directly so the
         ``task_run_id`` is available for the per-task log forwarder."""
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -394,9 +315,7 @@ class TestPrefectTaskRuns:
         # 5 sequential tasks → 5 create_task_run + 5 set_task_run_state(RUNNING)
         assert mock_prefect.create_task_run.await_count == 5
         running_calls = [
-            c
-            for c in mock_prefect.set_task_run_state.await_args_list
-            if c.args[1] == "RUNNING"
+            c for c in mock_prefect.set_task_run_state.await_args_list if c.args[1] == "RUNNING"
         ]
         assert len(running_calls) == 5
         # Terminal task states come through PrefectBridge events, not direct
@@ -411,8 +330,6 @@ class TestPrefectTaskRuns:
     async def test_emits_task_dispatched_events(self, executor, mock_queue, mock_prefect):
         """Executor emits TASK_DISPATCHED for each of the 5 sequential tasks."""
         from squadops.events.types import EventType
-
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
 
         emitted: list[str] = []
         original_emit = executor._cycle_event_bus.emit

--- a/tests/unit/cycles/test_executor_build_wiring.py
+++ b/tests/unit/cycles/test_executor_build_wiring.py
@@ -9,7 +9,7 @@ Part of Phase 2.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -49,13 +49,13 @@ def _make_artifact_ref(
 
 
 @pytest.fixture
-def executor():
+def executor(reply_router):
     """Create a DispatchedFlowExecutor with mocked ports."""
     from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     vault = AsyncMock()
     registry = AsyncMock()
-    queue = AsyncMock()
+    queue = reply_router.bind(AsyncMock())
     squad = AsyncMock()
     project = AsyncMock()
 
@@ -68,6 +68,7 @@ def executor():
         queue=queue,
         squad_profile=squad,
         project_registry=project,
+        reply_router=reply_router,
     )
     return ex
 
@@ -254,7 +255,7 @@ class TestProducingTaskTypeMetadata:
 
 
 class TestBuildOnlyValidation:
-    async def test_build_only_missing_refs_fails(self):
+    async def test_build_only_missing_refs_fails(self, reply_router):
         """Build-only cycle without plan_artifact_refs raises _ExecutionError."""
         from adapters.cycles.dispatched_flow_executor import (
             DispatchedFlowExecutor,
@@ -316,8 +317,9 @@ class TestBuildOnlyValidation:
         ex = DispatchedFlowExecutor(
             cycle_registry=registry,
             artifact_vault=AsyncMock(),
-            queue=AsyncMock(),
+            queue=reply_router.bind(AsyncMock()),
             squad_profile=squad,
+            reply_router=reply_router,
         )
 
         await ex.execute_run("cyc_001", "run_001")
@@ -367,7 +369,7 @@ class TestBuildOnlySeeding:
         assert "implementation_plan.md" in contents
         assert contents["implementation_plan.md"] == "Plan content here"
 
-    async def test_build_only_with_valid_refs_passes_validation(self):
+    async def test_build_only_with_valid_refs_passes_validation(self, reply_router):
         """Build-only cycle with plan_artifact_refs does not raise."""
         from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
@@ -433,35 +435,32 @@ class TestBuildOnlySeeding:
             )
         )
 
+        from squadops.tasks.models import TaskResult
+
+        reply_router.responder = lambda env: TaskResult(
+            task_id=env["task_id"],
+            status="SUCCEEDED",
+            outputs={
+                "summary": "done",
+                "role": env["metadata"].get("role"),
+                "artifacts": [
+                    {
+                        "name": "src/main.py",
+                        "content": "print(1)",
+                        "type": "source",
+                        "media_type": "text/x-python",
+                    },
+                ],
+            },
+        )
+
         ex = DispatchedFlowExecutor(
             cycle_registry=registry,
             artifact_vault=vault,
-            queue=AsyncMock(),
+            queue=reply_router.bind(AsyncMock()),
             squad_profile=squad,
+            reply_router=reply_router,
         )
-
-        # Mock dispatch to succeed
-        async def fake_dispatch(envelope, rid, **_kwargs):
-            from squadops.tasks.models import TaskResult
-
-            return TaskResult(
-                task_id=envelope.task_id,
-                status="SUCCEEDED",
-                outputs={
-                    "summary": "done",
-                    "role": envelope.metadata.get("role"),
-                    "artifacts": [
-                        {
-                            "name": "src/main.py",
-                            "content": "print(1)",
-                            "type": "source",
-                            "media_type": "text/x-python",
-                        },
-                    ],
-                },
-            )
-
-        ex._dispatch_task = fake_dispatch
 
         await ex.execute_run("cyc_001", "run_001")
 
@@ -476,7 +475,7 @@ class TestBuildOnlySeeding:
 class TestPlanOnlyCyclesUnaffected:
     """Regression: plan-only cycles still work as before."""
 
-    async def test_plan_only_cycle_no_build_validation(self):
+    async def test_plan_only_cycle_no_build_validation(self, reply_router):
         """Plan-only cycle doesn't trigger build-only validation."""
         from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
@@ -510,23 +509,6 @@ class TestPlanOnlyCyclesUnaffected:
         registry.get_latest_checkpoint = AsyncMock(return_value=None)
         registry.save_checkpoint = AsyncMock(return_value=None)
 
-        queue = AsyncMock()
-        # Simulate task results
-        msg = MagicMock()
-        import json
-
-        msg.payload = json.dumps(
-            {
-                "payload": {
-                    "task_id": "placeholder",
-                    "status": "SUCCEEDED",
-                    "outputs": {"summary": "done", "role": "strat"},
-                }
-            }
-        )
-        queue.consume = AsyncMock(return_value=[msg])
-        queue.ack = AsyncMock()
-
         vault = AsyncMock()
         vault.store = AsyncMock(side_effect=lambda ref, content: ref)
 
@@ -553,24 +535,21 @@ class TestPlanOnlyCyclesUnaffected:
             )
         )
 
+        from squadops.tasks.models import TaskResult
+
+        reply_router.responder = lambda env: TaskResult(
+            task_id=env["task_id"],
+            status="SUCCEEDED",
+            outputs={"summary": "done", "role": env["metadata"].get("role")},
+        )
+
         ex = DispatchedFlowExecutor(
             cycle_registry=registry,
             artifact_vault=vault,
-            queue=queue,
+            queue=reply_router.bind(AsyncMock()),
             squad_profile=squad,
+            reply_router=reply_router,
         )
-
-        # Mock _dispatch_task to return success for any task
-        async def fake_dispatch(envelope, rid, **_kwargs):
-            from squadops.tasks.models import TaskResult
-
-            return TaskResult(
-                task_id=envelope.task_id,
-                status="SUCCEEDED",
-                outputs={"summary": "done", "role": envelope.metadata.get("role")},
-            )
-
-        ex._dispatch_task = fake_dispatch
 
         await ex.execute_run("cyc_001", "run_001")
 

--- a/tests/unit/cycles/test_executor_checkpoint.py
+++ b/tests/unit/cycles/test_executor_checkpoint.py
@@ -18,7 +18,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from squadops.comms.queue_message import QueueMessage
 from squadops.cycles.checkpoint import RunCheckpoint
 from squadops.cycles.models import (
     AgentProfileEntry,
@@ -36,57 +35,6 @@ from squadops.tasks.models import TaskResult
 NOW = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
 
 pytestmark = [pytest.mark.domain_orchestration]
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_result_message(
-    task_id: str,
-    status: str = "SUCCEEDED",
-    outputs: dict | None = None,
-    error: str | None = None,
-    queue_name: str = "cycle_results_run_impl",
-) -> QueueMessage:
-    result = TaskResult(task_id=task_id, status=status, outputs=outputs, error=error)
-    payload = json.dumps(
-        {
-            "action": "comms.task.result",
-            "metadata": {"correlation_id": "corr"},
-            "payload": result.to_dict(),
-        }
-    )
-    return QueueMessage(
-        message_id=f"msg_{task_id}",
-        queue_name=queue_name,
-        payload=payload,
-        receipt_handle=f"rh_{task_id}",
-        attributes={},
-    )
-
-
-def _make_queue_side_effects(mock_queue, queue_name="cycle_results_run_impl"):
-    """Build consume side_effect that returns matching results."""
-
-    async def consume_side_effect(qn, max_messages=1):
-        if not qn.startswith("cycle_results_"):
-            return []
-        last_call = mock_queue.publish.call_args
-        if last_call:
-            msg_data = json.loads(last_call.args[1])
-            task_id = msg_data["payload"]["task_id"]
-            return [
-                _make_result_message(
-                    task_id=task_id,
-                    outputs={"summary": "ok", "artifacts": []},
-                    queue_name=qn,
-                )
-            ]
-        return []
-
-    return consume_side_effect
 
 
 # ---------------------------------------------------------------------------
@@ -129,17 +77,15 @@ def mock_vault():
 
 
 @pytest.fixture
-def mock_queue():
+def mock_queue(reply_router):
     mock = AsyncMock()
     mock.publish.return_value = None
     mock.ack.return_value = None
     mock.invalidate_queue.return_value = None
-    mock.consume.return_value = []
-
-    async def _consume_blocking(queue_name, timeout, max_messages=1):
-        return await mock.consume(queue_name, max_messages=max_messages)
-
-    mock.consume_blocking.side_effect = _consume_blocking
+    # SIP-0094: the executor dispatches over {agent_id}_comms and awaits the
+    # reply via the router instead of polling. bind() wires publish so each
+    # dispatched comms.task auto-delivers the agent's reply.
+    reply_router.bind(mock)
     return mock
 
 
@@ -198,6 +144,7 @@ def executor(mock_registry, mock_vault, mock_queue, mock_squad_profile, impl_cyc
         squad_profile=mock_squad_profile,
         task_timeout=5.0,
         event_bus=mock_event_bus,
+        reply_router=mock_queue.reply_router,
     )
 
 
@@ -211,8 +158,6 @@ class TestCheckpointOnSuccess:
 
     async def test_checkpoint_saved_per_task(self, executor, mock_registry, mock_queue) -> None:
         """save_checkpoint called once per successful task (3 for implementation)."""
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -223,8 +168,6 @@ class TestCheckpointOnSuccess:
 
     async def test_checkpoint_indices_increment(self, executor, mock_registry, mock_queue) -> None:
         """Each checkpoint has sequential checkpoint_index."""
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -239,8 +182,6 @@ class TestCheckpointOnSuccess:
         self, executor, mock_registry, mock_queue
     ) -> None:
         """Each checkpoint records all completed tasks so far."""
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -255,35 +196,26 @@ class TestCheckpointOnSuccess:
         self, executor, mock_registry, mock_queue
     ) -> None:
         """No checkpoint saved when a task fails."""
+        dispatch_count = 0
 
-        async def fail_second(qn, max_messages=1):
-            if not qn.startswith("cycle_results_"):
-                return []
-            last_call = mock_queue.publish.call_args
-            if last_call:
-                msg_data = json.loads(last_call.args[1])
-                task_id = msg_data["payload"]["task_id"]
-                # First task succeeds, second fails
-                if mock_queue.publish.call_count <= 1:
-                    return [
-                        _make_result_message(
-                            task_id=task_id,
-                            outputs={"summary": "ok", "artifacts": []},
-                            queue_name=qn,
-                        )
-                    ]
-                else:
-                    return [
-                        _make_result_message(
-                            task_id=task_id,
-                            status="FAILED",
-                            error="build error",
-                            queue_name=qn,
-                        )
-                    ]
-            return []
+        def fail_second(env):
+            nonlocal dispatch_count
+            dispatch_count += 1
+            # First task succeeds, every subsequent dispatch (including
+            # retries of the failing task) fails.
+            if dispatch_count == 1:
+                return TaskResult(
+                    task_id=env["task_id"],
+                    status="SUCCEEDED",
+                    outputs={"summary": "ok", "artifacts": []},
+                )
+            return TaskResult(
+                task_id=env["task_id"],
+                status="FAILED",
+                error="build error",
+            )
 
-        mock_queue.consume.side_effect = fail_second
+        mock_queue.reply_router.responder = fail_second
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -304,8 +236,6 @@ class TestCheckpointEvents:
     """CHECKPOINT_CREATED event emitted after each save."""
 
     async def test_checkpoint_created_event(self, executor, mock_event_bus, mock_queue) -> None:
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -320,8 +250,6 @@ class TestCheckpointEvents:
         assert len(checkpoint_events) == 3
 
     async def test_checkpoint_created_payload(self, executor, mock_event_bus, mock_queue) -> None:
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -361,8 +289,6 @@ class TestResumeFromCheckpoint:
             plan_delta_refs=(),
             created_at=NOW,
         )
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -384,8 +310,6 @@ class TestResumeFromCheckpoint:
             plan_delta_refs=(),
             created_at=NOW,
         )
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -422,8 +346,6 @@ class TestResumeFromCheckpoint:
             plan_delta_refs=(),
             created_at=NOW,
         )
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -452,8 +374,6 @@ class TestResumeFromCheckpoint:
             plan_delta_refs=(),
             created_at=NOW,
         )
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -481,8 +401,6 @@ class TestResumeFromCheckpoint:
             plan_delta_refs=(),
             created_at=NOW,
         )
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -497,8 +415,6 @@ class TestResumeFromCheckpoint:
         self, executor, mock_registry, mock_queue, mock_event_bus
     ) -> None:
         """Fresh run (no checkpoint) emits RUN_STARTED, not RUN_RESUMED."""
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -526,8 +442,6 @@ class TestTimeBudget:
 
         budget_cycle = dataclasses.replace(impl_cycle, applied_defaults={"time_budget_seconds": 0})
         mock_registry.get_cycle.return_value = budget_cycle
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -541,8 +455,6 @@ class TestTimeBudget:
 
     async def test_no_time_budget_no_enforcement(self, executor, mock_registry, mock_queue) -> None:
         """When time_budget_seconds is not set, no enforcement."""
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,
@@ -561,8 +473,6 @@ class TestTimeBudget:
 
         budget_cycle = dataclasses.replace(impl_cycle, applied_defaults={"time_budget_seconds": 0})
         mock_registry.get_cycle.return_value = budget_cycle
-        mock_queue.consume.side_effect = _make_queue_side_effects(mock_queue)
-
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
             new_callable=AsyncMock,

--- a/tests/unit/cycles/test_handle_gate_decisions.py
+++ b/tests/unit/cycles/test_handle_gate_decisions.py
@@ -71,7 +71,7 @@ def mock_event_bus():
 
 
 @pytest.fixture
-def executor(mock_registry, mock_event_bus):
+def executor(mock_registry, mock_event_bus, reply_router):
     from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
     exec_ = DispatchedFlowExecutor(
@@ -80,6 +80,7 @@ def executor(mock_registry, mock_event_bus):
         queue=AsyncMock(),
         squad_profile=AsyncMock(),
         task_timeout=5.0,
+        reply_router=reply_router,
     )
     exec_._cycle_event_bus = mock_event_bus
     return exec_
@@ -116,9 +117,7 @@ class TestHandleGateDecisions:
 
     async def test_approved_resumes_run(self, executor, mock_registry, mock_event_bus, cycle):
         """approved → update status to RUNNING, emit RUN_RESUMED."""
-        mock_registry.get_run.return_value = _run_with_gate_decision(
-            GateDecisionValue.APPROVED
-        )
+        mock_registry.get_run.return_value = _run_with_gate_decision(GateDecisionValue.APPROVED)
         mock_registry.update_run_status.return_value = None
 
         await executor._handle_gate("run_001", cycle, "plan_tasks")
@@ -149,9 +148,7 @@ class TestHandleGateDecisions:
         emit_types = [c[0][0] for c in emit_calls]
         assert EventType.RUN_RESUMED in emit_types
 
-    async def test_rejected_raises_execution_error(
-        self, executor, mock_registry, cycle
-    ):
+    async def test_rejected_raises_execution_error(self, executor, mock_registry, cycle):
         """rejected → raises _ExecutionError."""
         from adapters.cycles.dispatched_flow_executor import _ExecutionError
 

--- a/tests/unit/cycles/test_outcome_routing.py
+++ b/tests/unit/cycles/test_outcome_routing.py
@@ -7,13 +7,11 @@ NEEDS_REPLAN from contract aborts immediately, and the D5 fallback table.
 
 from __future__ import annotations
 
-import json
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from squadops.comms.queue_message import QueueMessage
 from squadops.cycles.models import (
     AgentProfileEntry,
     Cycle,
@@ -28,40 +26,6 @@ from squadops.tasks.models import TaskResult
 NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
 
 pytestmark = [pytest.mark.domain_orchestration]
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_result_message(
-    task_id: str,
-    status: str = "SUCCEEDED",
-    outputs: dict | None = None,
-    error: str | None = None,
-    queue_name: str = "cycle_results_run_001",
-) -> QueueMessage:
-    result = TaskResult(
-        task_id=task_id,
-        status=status,
-        outputs=outputs,
-        error=error,
-    )
-    payload = json.dumps(
-        {
-            "action": "comms.task.result",
-            "metadata": {"correlation_id": "corr"},
-            "payload": result.to_dict(),
-        }
-    )
-    return QueueMessage(
-        message_id=f"msg_{task_id}",
-        queue_name=queue_name,
-        payload=payload,
-        receipt_handle=f"rh_{task_id}",
-        attributes={},
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -101,18 +65,13 @@ def mock_vault():
 
 
 @pytest.fixture
-def mock_queue():
+def mock_queue(reply_router):
+    """Mock QueuePort bound to the reply router: publishing a ``comms.task``
+    auto-delivers the agent's reply (SIP-0094)."""
     mock = AsyncMock()
-    mock.publish.return_value = None
     mock.ack.return_value = None
     mock.invalidate_queue.return_value = None
-    mock.consume.return_value = []
-
-    async def _consume_blocking(queue_name, timeout, max_messages=1):
-        return await mock.consume(queue_name, max_messages=max_messages)
-
-    mock.consume_blocking.side_effect = _consume_blocking
-    return mock
+    return reply_router.bind(mock)
 
 
 @pytest.fixture
@@ -175,48 +134,41 @@ def executor(mock_registry, mock_vault, mock_queue, mock_squad_profile, cycle, r
         queue=mock_queue,
         squad_profile=mock_squad_profile,
         task_timeout=5.0,
+        reply_router=mock_queue.reply_router,
     )
 
 
 # ---------------------------------------------------------------------------
-# Helpers for side-effects
+# Helpers for scripted agent replies
 # ---------------------------------------------------------------------------
 
 
-def _build_consume_side_effect(mock_queue, responses):
-    """Build a consume side_effect that returns different results per publish.
+def _scripted_responder(responses):
+    """Build a reply-router responder that returns a different result per
+    dispatch (SIP-0094 equivalent of the old per-publish consume side_effect).
 
-    ``responses`` maps publish call index (0-based) to (status, outputs, error).
-    Missing indices get status="SUCCEEDED".
+    ``responses`` maps dispatch index (0-based, in publish order) to
+    (status, outputs, error). Missing indices get status="SUCCEEDED". The
+    responder is invoked once per ``comms.task`` publish, so the index advances
+    in lockstep with the executor's dispatch sequence — exactly as the old
+    consume side_effect's call counter did.
     """
     call_idx = {"n": 0}
 
-    async def consume_side_effect(queue_name, max_messages=1):
-        if not queue_name.startswith("cycle_results_"):
-            return []
-        last_call = mock_queue.publish.call_args
-        if not last_call:
-            return []
-        msg_data = json.loads(last_call.args[1])
-        task_id = msg_data["payload"]["task_id"]
-
+    def responder(env):
         idx = call_idx["n"]
         call_idx["n"] += 1
-
         status, outputs, error = responses.get(
             idx, ("SUCCEEDED", {"summary": "ok", "role": "strat"}, None)
         )
-        return [
-            _make_result_message(
-                task_id=task_id,
-                status=status,
-                outputs=outputs,
-                error=error,
-                queue_name=queue_name,
-            )
-        ]
+        return TaskResult(
+            task_id=env["task_id"],
+            status=status,
+            outputs=outputs,
+            error=error,
+        )
 
-    return consume_side_effect
+    return responder
 
 
 # ---------------------------------------------------------------------------
@@ -235,7 +187,7 @@ class TestRetryableFailure:
         responses = {
             0: ("FAILED", None, "transient"),
         }
-        mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
+        mock_queue.reply_router.responder = _scripted_responder(responses)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -262,7 +214,7 @@ class TestRetryableFailure:
 
         # All dispatches fail → attempt 1,2 = RETRYABLE, attempt 3 = SEMANTIC
         responses = {i: ("FAILED", None, "boom") for i in range(10)}
-        mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
+        mock_queue.reply_router.responder = _scripted_responder(responses)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -297,7 +249,7 @@ class TestSemanticFailure:
             1: ("FAILED", None, "correction failed"),
             2: ("FAILED", None, "correction failed"),
         }
-        mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
+        mock_queue.reply_router.responder = _scripted_responder(responses)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -326,7 +278,7 @@ class TestBlockedOutcome:
         responses = {
             0: ("FAILED", outputs_blocked, "blocked"),
         }
-        mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
+        mock_queue.reply_router.responder = _scripted_responder(responses)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -348,7 +300,7 @@ class TestSuccessOutcome:
     async def test_success_checkpoints(self, executor, mock_queue, mock_registry):
         """Each successful task triggers a checkpoint save."""
         # All 5 tasks succeed
-        mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, {})
+        mock_queue.reply_router.responder = _scripted_responder({})
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -364,7 +316,7 @@ class TestSuccessOutcome:
         responses = {
             0: ("FAILED", None, "transient"),
         }
-        mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
+        mock_queue.reply_router.responder = _scripted_responder(responses)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -396,7 +348,7 @@ class TestNeedReplanFromContract:
         responses = {
             0: ("FAILED", outputs_replan, "parse error"),
         }
-        mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
+        mock_queue.reply_router.responder = _scripted_responder(responses)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -421,7 +373,7 @@ class TestFallbackTable:
         responses = {
             0: ("FAILED", None, "transient"),
         }
-        mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
+        mock_queue.reply_router.responder = _scripted_responder(responses)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -438,7 +390,7 @@ class TestFallbackTable:
     async def test_exhausted_retries_becomes_semantic(self, executor, mock_queue, mock_registry):
         """All retries exhausted → SEMANTIC_FAILURE → correction → abort."""
         responses = {i: ("FAILED", None, "boom") for i in range(10)}
-        mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
+        mock_queue.reply_router.responder = _scripted_responder(responses)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
@@ -469,7 +421,7 @@ class TestNeedsRepairOutcome:
             1: ("FAILED", None, "corr"),
             2: ("FAILED", None, "corr"),
         }
-        mock_queue.consume.side_effect = _build_consume_side_effect(mock_queue, responses)
+        mock_queue.reply_router.responder = _scripted_responder(responses)
 
         with patch(
             "adapters.cycles.dispatched_flow_executor.asyncio.sleep",

--- a/tests/unit/cycles/test_reply_router.py
+++ b/tests/unit/cycles/test_reply_router.py
@@ -1,0 +1,233 @@
+"""Unit tests for the SIP-0094 ReplyRouter (cutover, 94.3).
+
+Covers the D-decisions: lazy/concurrency-safe subscribe (D4), duplicate-register
+guard (D10), robust _handle_reply that never strands the consumer (D11), shutdown
+that fails pending futures (D13), and the ack-ownership reconciliation — the
+subscribe primitive auto-acks, so the router must never ack (double-ack here
+raises, mimicking AMQP).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from adapters.cycles.reply_router import (
+    DuplicateRegistration,
+    ReplyRouter,
+    ReplyRouterStopped,
+)
+from squadops.comms.queue_message import QueueMessage
+from squadops.ports.comms.queue import QueuePort
+from squadops.tasks.models import TaskResult
+
+pytestmark = [pytest.mark.unit]
+
+
+def _reply(task_id: str, *, status: str = "SUCCEEDED", outputs=None, extra=None) -> str:
+    """Agent reply envelope (entrypoint.py shape): payload is the TaskResult."""
+    payload = {"task_id": task_id, "status": status}
+    if outputs is not None:
+        payload["outputs"] = outputs
+    if extra:
+        payload.update(extra)
+    return json.dumps(
+        {
+            "action": "comms.task.result",
+            "metadata": {"correlation_id": "c"},
+            "payload": payload,
+        }
+    )
+
+
+class _Handle:
+    """Duck-typed SubscriptionHandle the fake queue hands back."""
+
+    def __init__(self):
+        self.cancelled = False
+
+    @property
+    def active(self) -> bool:
+        return not self.cancelled
+
+    async def cancel(self) -> None:
+        self.cancelled = True
+
+
+class FakeQueue(QueuePort):
+    """Models the 94.2b subscribe primitive: captures the on_message callback,
+    and ``deliver`` hands a message to it then **acks exactly once** (as the
+    real primitive does). ``ack`` raises on a repeat so a router that wrongly
+    acked would blow up the test."""
+
+    def __init__(self):
+        self.handlers: dict[str, object] = {}
+        self.handles: dict[str, _Handle] = {}
+        self.acked: list[str] = []
+        self._tag = 0
+
+    async def subscribe(self, queue_name: str, *, on_message):
+        await asyncio.sleep(0)  # force a yield so D4 concurrency is exercised
+        self.handlers[queue_name] = on_message
+        handle = _Handle()
+        self.handles[queue_name] = handle
+        return handle
+
+    async def deliver(self, queue_name: str, payload: str) -> None:
+        """Simulate one broker delivery + the primitive's auto-ack."""
+        self._tag += 1
+        msg = QueueMessage(
+            message_id=str(self._tag),
+            queue_name=queue_name,
+            payload=payload,
+            receipt_handle=str(self._tag),
+            attributes={},
+        )
+        await self.handlers[queue_name](msg)  # router._handle_reply (must NOT ack)
+        await self.ack(msg)  # primitive auto-ack, exactly once
+
+    async def ack(self, message: QueueMessage) -> None:
+        if message.receipt_handle in self.acked:
+            raise RuntimeError(f"double-ack on delivery {message.receipt_handle}")
+        self.acked.append(message.receipt_handle)
+
+    # --- unused abstract surface ---
+    async def publish(self, queue_name, payload, delay_seconds=None):  # pragma: no cover
+        pass
+
+    async def consume(self, queue_name, max_messages=1):  # pragma: no cover
+        return []
+
+    async def retry(self, message, delay_seconds):  # pragma: no cover
+        pass
+
+    async def health(self):  # pragma: no cover
+        return {"status": "healthy"}
+
+    def capabilities(self):  # pragma: no cover
+        return {"delay": False, "fifo": True, "priority": False}
+
+
+async def test_register_and_resolve_by_task_id():
+    """Happy path: a reply resolves its future to the exact TaskResult, the
+    delivery is acked exactly once (by the primitive, not the router), and no
+    pending future is left behind."""
+    q = FakeQueue()
+    router = ReplyRouter(q)
+    await router.ensure_subscribed("neo")
+    fut = router.register("t1")
+
+    await q.deliver("neo_replies", _reply("t1", outputs={"x": 1}))
+    result = await asyncio.wait_for(fut, timeout=1.0)
+
+    assert result == TaskResult(task_id="t1", status="SUCCEEDED", outputs={"x": 1})
+    assert q.acked == ["1"]  # exactly one ack, from the primitive
+    assert router.metrics()["pending_futures"] == 0
+
+
+async def test_duplicate_register_raises():
+    """D10: a second register() for a pending task_id raises rather than
+    silently overwriting (which would strand the first waiter)."""
+    q = FakeQueue()
+    router = ReplyRouter(q)
+    router.register("t1")
+    with pytest.raises(DuplicateRegistration):
+        router.register("t1")
+
+
+async def test_late_reply_dropped_and_counted():
+    """D11: a reply with no pending future (timed-out/unknown) is dropped and
+    counted, the delivery still acked, and the consumer is unaffected."""
+    q = FakeQueue()
+    router = ReplyRouter(q)
+    await router.ensure_subscribed("neo")
+
+    await q.deliver("neo_replies", _reply("ghost"))
+
+    assert router.metrics()["late_drops"] == 1
+    assert q.acked == ["1"]
+
+
+async def test_malformed_reply_survives_consumer():
+    """D11: malformed payloads (bad JSON, missing task_id) are counted, not
+    raised — and a later valid reply still resolves (consumer survived)."""
+    q = FakeQueue()
+    router = ReplyRouter(q)
+    await router.ensure_subscribed("neo")
+
+    await q.deliver("neo_replies", "this is not json")
+    # well-formed envelope but payload has no task_id
+    await q.deliver("neo_replies", json.dumps({"payload": {"status": "SUCCEEDED"}}))
+
+    assert router.metrics()["malformed_replies"] == 2
+
+    fut = router.register("t9")
+    await q.deliver("neo_replies", _reply("t9"))
+    result = await asyncio.wait_for(fut, timeout=1.0)
+    assert result.task_id == "t9"
+
+
+async def test_from_dict_failure_fails_future_but_consumer_lives():
+    """D11: a reply whose payload can't build a TaskResult (missing required
+    status) fails *that* waiter instead of hanging it, and keeps the consumer
+    alive for other tasks."""
+    q = FakeQueue()
+    router = ReplyRouter(q)
+    await router.ensure_subscribed("neo")
+
+    bad_fut = router.register("t_bad")
+    await q.deliver(
+        "neo_replies",
+        json.dumps({"payload": {"task_id": "t_bad"}}),  # no status -> from_dict raises
+    )
+    with pytest.raises(TypeError):
+        await asyncio.wait_for(bad_fut, timeout=1.0)
+    assert router.metrics()["from_dict_failures"] == 1
+
+    # Consumer still healthy: a subsequent good reply resolves.
+    good_fut = router.register("t_ok")
+    await q.deliver("neo_replies", _reply("t_ok"))
+    assert (await asyncio.wait_for(good_fut, timeout=1.0)).task_id == "t_ok"
+
+
+async def test_stop_fails_pending_futures_and_cancels_subscriptions():
+    """D13: stop() fails every pending future with the typed error and cancels
+    each open subscription."""
+    q = FakeQueue()
+    router = ReplyRouter(q)
+    await router.ensure_subscribed("neo")
+    fut = router.register("t1")
+
+    await router.stop()
+
+    with pytest.raises(ReplyRouterStopped):
+        await asyncio.wait_for(fut, timeout=1.0)
+    assert q.handles["neo_replies"].cancelled is True
+    assert router.metrics()["pending_futures"] == 0
+
+
+async def test_ensure_subscribed_is_concurrency_safe():
+    """D4: five concurrent first-dispatches to one agent open exactly one
+    subscription (double-checked lock), not five."""
+    q = FakeQueue()
+    router = ReplyRouter(q)
+
+    await asyncio.gather(*(router.ensure_subscribed("neo") for _ in range(5)))
+
+    assert router.metrics()["subscriptions_opened_total"] == 1
+    assert list(q.handlers.keys()) == ["neo_replies"]
+
+
+async def test_fails_fast_once_stopped():
+    """D13: after stop(), both ensure_subscribed and register refuse with the
+    typed error so a late dispatch can't slip a future past shutdown."""
+    q = FakeQueue()
+    router = ReplyRouter(q)
+    await router.stop()
+
+    with pytest.raises(ReplyRouterStopped):
+        await router.ensure_subscribed("neo")
+    with pytest.raises(ReplyRouterStopped):
+        router.register("t1")

--- a/tests/unit/cycles/test_run_report.py
+++ b/tests/unit/cycles/test_run_report.py
@@ -89,7 +89,7 @@ def _make_plan(count: int = 3) -> list[TaskEnvelope]:
 
 
 @pytest.fixture
-def executor():
+def executor(reply_router):
     """Create a DispatchedFlowExecutor with mocked ports."""
     from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
@@ -102,6 +102,7 @@ def executor():
         artifact_vault=vault,
         queue=AsyncMock(),
         squad_profile=AsyncMock(),
+        reply_router=reply_router,
     )
     return ex
 

--- a/tests/unit/events/test_drift_detection.py
+++ b/tests/unit/events/test_drift_detection.py
@@ -11,14 +11,12 @@ CollectingSubscriber.
 
 from __future__ import annotations
 
-import json
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
 from adapters.events.in_process_cycle_event_bus import InProcessCycleEventBus
-from squadops.comms.queue_message import QueueMessage
 from squadops.cycles.models import (
     AgentProfileEntry,
     Cycle,
@@ -49,50 +47,17 @@ _STATUS_TO_EVENT: dict[RunStatus, str] = {
 # ---------------------------------------------------------------------------
 
 
-def _make_result_message(
-    task_id: str,
-    status: str = "SUCCEEDED",
-    outputs: dict | None = None,
-    queue_name: str = "cycle_results_run_001",
-) -> QueueMessage:
-    result = TaskResult(task_id=task_id, status=status, outputs=outputs)
-    payload = json.dumps(
-        {
-            "action": "comms.task.result",
-            "metadata": {"correlation_id": "corr"},
-            "payload": result.to_dict(),
-        }
-    )
-    return QueueMessage(
-        message_id=f"msg_{task_id}",
-        queue_name=queue_name,
-        payload=payload,
-        receipt_handle=f"rh_{task_id}",
-        attributes={},
-    )
+def _responder(status: str = "SUCCEEDED"):
+    """Build a reply-router responder that replies with the given status."""
 
+    def reply(env: dict) -> TaskResult:
+        return TaskResult(
+            task_id=env["task_id"],
+            status=status,
+            outputs={"summary": "stub", "artifacts": []},
+        )
 
-def _make_queue_consume(mock_queue, result_status="SUCCEEDED"):
-    """Build a consume side_effect that returns matching results."""
-
-    async def consume_side_effect(queue_name, max_messages=1):
-        if not queue_name.startswith("cycle_results_"):
-            return []
-        last_call = mock_queue.publish.call_args
-        if last_call:
-            msg_data = json.loads(last_call.args[1])
-            task_id = msg_data["payload"]["task_id"]
-            return [
-                _make_result_message(
-                    task_id=task_id,
-                    status=result_status,
-                    outputs={"summary": "stub", "artifacts": []},
-                    queue_name=queue_name,
-                )
-            ]
-        return []
-
-    return consume_side_effect
+    return reply
 
 
 # ---------------------------------------------------------------------------
@@ -143,17 +108,11 @@ def mock_vault():
 
 
 @pytest.fixture
-def mock_queue():
+def mock_queue(reply_router):
     mock = AsyncMock()
-    mock.publish.return_value = None
     mock.ack.return_value = None
     mock.invalidate_queue.return_value = None
-    mock.consume.return_value = []
-
-    async def _consume_blocking(queue_name, timeout, max_messages=1):
-        return await mock.consume(queue_name, max_messages=max_messages)
-
-    mock.consume_blocking.side_effect = _consume_blocking
+    reply_router.bind(mock)
     return mock
 
 
@@ -208,6 +167,7 @@ def executor(
         squad_profile=mock_squad_profile,
         task_timeout=5.0,
         event_bus=event_bus,
+        reply_router=mock_queue.reply_router,
     )
 
 
@@ -225,13 +185,9 @@ class TestHappyPathDrift:
     async def test_registry_transitions_match_events(
         self, executor, mock_registry, mock_queue, collector
     ) -> None:
-        mock_queue.consume.side_effect = _make_queue_consume(mock_queue)
+        mock_queue.reply_router.responder = _responder()
 
-        with patch(
-            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
-            new_callable=AsyncMock,
-        ):
-            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+        await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
 
         # Extract registry transitions
         status_calls = mock_registry.update_run_status.call_args_list
@@ -257,13 +213,9 @@ class TestHappyPathDrift:
         self, executor, mock_registry, mock_queue, collector
     ) -> None:
         """Every run event has a corresponding registry transition."""
-        mock_queue.consume.side_effect = _make_queue_consume(mock_queue)
+        mock_queue.reply_router.responder = _responder()
 
-        with patch(
-            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
-            new_callable=AsyncMock,
-        ):
-            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+        await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
 
         status_calls = mock_registry.update_run_status.call_args_list
         registry_statuses = {call.args[1] for call in status_calls}
@@ -290,13 +242,9 @@ class TestTaskFailureDrift:
     async def test_failure_transitions_match_events(
         self, executor, mock_registry, mock_queue, collector
     ) -> None:
-        mock_queue.consume.side_effect = _make_queue_consume(mock_queue, result_status="FAILED")
+        mock_queue.reply_router.responder = _responder(status="FAILED")
 
-        with patch(
-            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
-            new_callable=AsyncMock,
-        ):
-            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+        await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
 
         run_events = [e for e in collector.events if e.entity_type == "run"]
         run_event_types = [e.event_type for e in run_events]
@@ -307,13 +255,9 @@ class TestTaskFailureDrift:
     async def test_task_failed_precedes_run_failed(
         self, executor, mock_registry, mock_queue, collector
     ) -> None:
-        mock_queue.consume.side_effect = _make_queue_consume(mock_queue, result_status="FAILED")
+        mock_queue.reply_router.responder = _responder(status="FAILED")
 
-        with patch(
-            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
-            new_callable=AsyncMock,
-        ):
-            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+        await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
 
         all_types = [e.event_type for e in collector.events]
         task_failed_idx = all_types.index(EventType.TASK_FAILED)
@@ -328,13 +272,9 @@ class TestTaskEventsMatchDispatches:
     async def test_dispatch_count_matches_events(
         self, executor, mock_registry, mock_queue, collector
     ) -> None:
-        mock_queue.consume.side_effect = _make_queue_consume(mock_queue)
+        mock_queue.reply_router.responder = _responder()
 
-        with patch(
-            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
-            new_callable=AsyncMock,
-        ):
-            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+        await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
 
         dispatched_events = [
             e for e in collector.events if e.event_type == EventType.TASK_DISPATCHED

--- a/tests/unit/tasks/test_models_serialization.py
+++ b/tests/unit/tasks/test_models_serialization.py
@@ -137,3 +137,26 @@ class TestTaskResultSerialization:
         json_str = json.dumps(result.to_dict())
         rebuilt = TaskResult.from_dict(json.loads(json_str))
         assert rebuilt == result
+
+    def test_from_dict_drops_unknown_keys(self) -> None:
+        """SIP-0094 D8: a result from a newer agent carrying a field this
+        version doesn't know must deserialize (dropping the extra) instead of
+        raising ``TypeError`` inside the reply router's _handle_reply."""
+        payload = {
+            "task_id": "task_abc",
+            "status": "SUCCEEDED",
+            "outputs": {"summary": "ok"},
+            "future_field_we_dont_know": {"nested": 1},
+            "another_new_one": "x",
+        }
+        rebuilt = TaskResult.from_dict(payload)
+        assert rebuilt == TaskResult(
+            task_id="task_abc", status="SUCCEEDED", outputs={"summary": "ok"}
+        )
+
+    def test_from_dict_missing_required_field_raises(self) -> None:
+        """Edge: a payload missing the required ``status`` is a genuinely
+        malformed reply and must raise (caught + future-failed by the router),
+        not silently construct a bogus result."""
+        with pytest.raises(TypeError):
+            TaskResult.from_dict({"task_id": "task_abc"})


### PR DESCRIPTION
## What

**The behavior-changing cutover.** The orchestrator no longer polls a per-run `cycle_results_{run_id}` reply queue (thousands of short-lived consumers per long task, losing replies in the gaps, leaking an orphan queue per run). It now routes replies through the long-lived per-agent subscription built in 94.1/94.2.

`_publish_and_await` becomes: `ensure_subscribed(agent_id) → register(task_id) → publish to {agent_id}_comms → await the router future`. The reply address in dispatch metadata is now `{agent_id}_replies`.

## Pieces

- **`adapters/cycles/reply_router.py`** — `ReplyRouter` (SIP §5.3) holding one `{agent_id}_replies` subscription per agent, opened lazily on first dispatch, resolving an `asyncio.Future` keyed by `task_id`:
  - **D4** lock-guarded + double-checked `ensure_subscribed` (concurrent first-dispatch → one subscription).
  - **D9** declares the queue via `subscribe` before consuming.
  - **D10** `register` raises `DuplicateRegistration` rather than overwriting a pending future.
  - **D11** `_handle_reply` never strands the consumer — malformed/late replies counted+dropped, a `from_dict` failure fails only that future.
  - **D13** `stop()` sets stopped state (ensure_subscribed/register fail fast), cancels subscriptions, fails pending futures with `ReplyRouterStopped`.
  - **Ack reconciliation:** the 94.2b `subscribe` primitive auto-acks every delivery, so `_handle_reply` must **not** ack — the SIP §5.3 sketch's `await ack` would double-ack (an AMQP error). The router never acks; the test double enforces this (double-ack raises).
- **`TaskResult.from_dict`** hardened to drop unknown keys (**D8**) — a newer agent's reply payload can't crash `_handle_reply`.
- **`dispatched_flow_executor.py`** — `_publish_and_await` rewritten; `reply_router` constructor arg; every exit path (success, timeout, publish failure, router failure, cancellation) drops the pending future so `task_id` never leaks (**#9/#10**).
- **`api/runtime/main.py`** — construct `ReplyRouter(queue_adapter)`, inject into the executor, `stop()` it on shutdown (**D13**). **`factory.py`** threads it through.

## Tests

- **`test_reply_router.py`** (8): register/resolve, duplicate-register (D10), late/malformed drops + survival (D11), `from_dict` failure fails only that future, `stop()` (D13), concurrency-safe subscribe (D4), fail-fast once stopped.
- **`TestPublishAndAwaitInvariants`** (5, new): subscribe+register before publish (D14/#2), publish-failure removes pending future (#10), timeout leaves no pending future (#9), concurrent same-agent dispatch both resolve (#13), cross-run task_id isolation (D14).
- **Full executor-test migration (~12 files).** Replacing the reply mechanism breaks every test that drove a task to completion via the old `queue.consume` poll. Single-sourced a `FakeReplyRouter` double + `reply_router` fixture in `tests/unit/conftest.py`; `bind(mock_queue)` auto-delivers the agent reply on publish; replies configured via `responder`/`results`/`suppress`. Migrated **faithfully**: the real `register→publish→await` path is exercised, scripted per-dispatch sequences (outcome-routing's 7 scenarios, correction-protocol's continue/patch/rewind/abort) carried over **verbatim** via stateful responders, **no assertions changed**. Two tests deleted (their sole purpose was the deleted polling mechanism; coverage moved to 94.2b + `test_reply_router.py`); two would-be **vacuous passes** caught and fixed by re-supplying specific reply content.

## Verification

- `cycles` + `events` gated suites: **1483 passed**.
- Full regression gate (`run_regression_tests.sh`: `ruff check .` + test-quality lint + ~2900 tests): **green (exit 0)**. Prompt-fragment manifest in sync.

## Defect surfaced (filed, not fixed here)

- **#211** — pre-existing: `integration/test_pulse_check_e2e.py` seeds via `loop.run_until_complete()` inside an async test ("event loop is already running"). Confirmed failing on the pre-cutover file; it's in the un-gated integration tree. Its 94.3 reply-router migration is done; only the orthogonal seed bug remains.

## Next

**94.4** — soak on a real long-cycle build (no new `cycle_results_*`, `{agent_id}_replies` drain to zero, late-drop/malformed counters zero), guarded cleanup of the ~95 orphan `cycle_results_*` queues, promote SIP → implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)