### PR TITLE
sip: promote SIP-0094 → implemented (per-agent reply queues)

### DIFF
--- a/sips/implemented/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md
+++ b/sips/implemented/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md
@@ -1,14 +1,14 @@
 ---
 title: Per-Agent Reply Queues + Long-Lived Subscription Model
-status: accepted
+status: implemented
 author: SquadOps Architecture
 created_at: '2026-05-02T00:00:00Z'
 sip_number: 94
-updated_at: '2026-06-20T19:43:25.130339Z'
+updated_at: '2026-06-21T18:10:41.937582Z'
 ---
 # SIP-0094: Per-Agent Reply Queues + Long-Lived Subscription Model
 
-**Status:** Accepted
+**Status:** Implemented
 **Authors:** SquadOps Architecture
 **Created:** 2026-05-02
 **Revision:** 3

--- a/sips/registry.yaml
+++ b/sips/registry.yaml
@@ -849,9 +849,9 @@ sips:
 - sip_uid: null
   sip_number: 94
   title: Per-Agent Reply Queues + Long-Lived Subscription Model
-  path: sips/accepted/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md
-  status: accepted
+  path: sips/implemented/SIP-0094-Per-Agent-Reply-Queues-Long-Lived.md
+  status: implemented
   author: SquadOps Architecture
   approver: jladd
   created_at: '2026-05-02T00:00:00Z'
-  updated_at: '2026-06-20T19:43:25.157766Z'
+  updated_at: '2026-06-21T18:10:41.938458Z'


### PR DESCRIPTION
Promotes **SIP-0094 (Per-Agent Reply Queues + Long-Lived Subscription Model)** from accepted → implemented. S1 of the 1.0.x build-reliability hardening is complete.

## What shipped
The orchestrator's request/reply path now runs on long-lived per-agent `{agent_id}_replies` subscriptions resolved by an in-process `ReplyRouter`, replacing the per-run `cycle_results_{run_id}` polling loop. This eliminates the two structural failure classes the SIP targeted:
- **Reply loss** from consumer-tag churn (thousands of short-lived consumers per long task).
- **Orphan-queue leak** (one durable `cycle_results_*` left behind per run).

Landed across: #199 (94.1 declare reply queues), #208 (94.2a `subscribe()` primitive), #210 (94.2b native RabbitMQ subscribe + channel-close resubscribe), #212 (94.3 ReplyRouter cutover).

## Soak validation (cyc_2bba7d0729dd, play_game full build)
- ✅ Completed in ~30 min with **6 artifacts across all roles** → every dispatch got its reply (no losses → no timeouts).
- ✅ **Zero `cycle_results_*` created** (count steady at 95 throughout).
- ✅ `_replies` subscriptions held **live (`consumers=1`)** and drained to zero post-run.
- ✅ Router error counters **zero** (malformed / unknown-late / from_dict).

## Orphan cleanup
93 empty orphan `cycle_results_*` queues guard-deleted (`--if-empty --if-unused`). 2 non-empty relics holding stuck pre-cutover replies were preserved by the guard (harmless dead data; the exact failure the SIP fixes).

## Changes
- `sips/accepted/…SIP-0094…` → `sips/implemented/…`
- frontmatter + body Status → Implemented
- `sips/registry.yaml` status → implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)