### PR TITLE
chore(release): bump to v1.0.6 + document SIP-0094

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,22 @@ Living document tracking the implementation progression from initial prototype t
 
 ## Release Timeline
 
-### v1.0.3 (2026-04) — Current
+### v1.0.6 (2026-06-21) — Current — Per-Agent Reply Queues
+- **SIP-0094** Per-Agent Reply Queues + Long-Lived Subscription Model
+  - Replaces the leaky per-run `cycle_results_{run_id}` reply queues — which lost replies in the consumer-tag churn window and leaked one orphan queue per run — with durable per-agent `{agent_id}_replies` queues
+  - `ReplyRouter` holds one long-lived subscription per agent and resolves replies by `task_id`; new `QueuePort.subscribe()` primitive backed by a reconnecting RabbitMQ iterator (resubscribe surfaced in `health()`)
+  - `TaskResult.from_dict` hardened to drop unknown keys (forward-compat across rolling agent deploys)
+  - Substrate precondition for the 1.0.x build-reliability hardening line
+
+### v1.0.5 (2026-04-24) — Prefect Task Log Streaming
+- **SIP-0087** Prefect Task-Scoped Log Streaming
+  - Per-task log forwarding to the Prefect UI with heartbeats
+
+### v1.0.4 (2026-04-19) — Build Convergence Loop
+- **SIP-0086** Build Convergence Loop
+  - Dynamic task decomposition, output validation, and correction activation
+
+### v1.0.3 (2026-04) — Post-1.0 Hardening
 Post-1.0 patch line. Docs hygiene, complexity tightening (C901 threshold 15→12), streaming LLM chat path (`chat_stream_with_usage()`).
 
 ### v1.0.2 (2026-03-15) — Console Messaging
@@ -341,9 +356,14 @@ The following areas are identified for future work but do not block 1.0 readines
 
 ## Accepted (Next Up)
 
-| SIP | Title | Accepted |
-|-----|-------|----------|
-| **SIP-0086** | Build Convergence Loop — Dynamic Task Decomposition, Output Validation & Correction Activation | 2026-04 |
+| SIP | Title |
+|-----|-------|
+| **SIP-0088** | Agent Runtime Modes |
+| **SIP-0089** | Agent Runtime State |
+| **SIP-0090** | Agent Embodiment Substrate |
+| **SIP-0091** | Duty Durability via Temporal |
+| **SIP-0092** | Implementation Plan Improvement — Typed Acceptance, Separated Authoring, and Plan Changes |
+| **SIP-0093** | Multi-Role Plan Authoring |
 
 ## Proposals (Backlog)
 
@@ -373,8 +393,8 @@ The following areas are identified for future work but do not block 1.0 readines
 
 ## Stats
 
-- **Framework version**: 1.0.3
-- **SIPs**: 54 implemented, 1 accepted (SIP-0086), 13 proposed, 20 deprecated (~88 total)
+- **Framework version**: 1.0.6
+- **SIPs**: 57 implemented, 6 accepted (SIP-0088–0093), 8 proposed, 20 deprecated (~91 total)
 - **Tests**: 3,030+ passing in the regression suite
 - **Python source**: ~39,000 lines (~51,000 test lines, ~84,000 doc lines)
 - **~6 months** from initial repo (2025-09-20) to 1.0.0 release (2026-03-10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["squadops*", "adapters*"]  # Include both packages
 
 [project]
 name = "squadops"
-version = "1.0.5"
+version = "1.0.6"
 description = "SquadOps: a production-grade multi-agent orchestration framework."
 requires-python = ">=3.11"
 authors = [

--- a/scripts/maintainer/version_cli.py
+++ b/scripts/maintainer/version_cli.py
@@ -2,7 +2,9 @@
 """
 SquadOps Version Management CLI
 
-Manages framework version across pyproject.toml and src/squadops/__init__.py.
+Manages the single-sourced framework version in pyproject.toml. The package
+exposes it at runtime via ``squadops.__version__`` (derived from
+``importlib.metadata``), so there is nothing else to stamp.
 Agent configurations are managed via agents/instances/instances.yaml.
 
 Usage:
@@ -21,7 +23,6 @@ import yaml
 # Resolve paths relative to repo root
 REPO_ROOT = Path(__file__).parent.parent.parent
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
-INIT_PATH = REPO_ROOT / "src" / "squadops" / "__init__.py"
 INSTANCES_PATH = REPO_ROOT / "agents" / "instances" / "instances.yaml"
 
 
@@ -106,7 +107,11 @@ def show_agent_details(agent_id: str):
 
 
 def bump_version(new_version: str):
-    """Bump framework version in pyproject.toml and __init__.py."""
+    """Bump the single-sourced framework version in pyproject.toml.
+
+    ``squadops.__version__`` derives from package metadata at runtime, so
+    pyproject.toml is the only place the version is written.
+    """
     old_version = get_framework_version()
 
     # Validate version format
@@ -136,24 +141,6 @@ def bump_version(new_version: str):
     else:
         errors.append("pyproject.toml: file not found")
 
-    # Update src/squadops/__init__.py
-    if INIT_PATH.exists():
-        content = INIT_PATH.read_text()
-
-        # Update __version__
-        new_content = re.sub(r'(__version__\s*=\s*")[^"]+(")', rf"\g<1>{new_version}\g<2>", content)
-
-        # Update docstring version
-        new_content = re.sub(r"(Framework Version:\s*)\S+", rf"\g<1>{new_version}", new_content)
-
-        if new_content != content:
-            INIT_PATH.write_text(new_content)
-            print("  Updated: src/squadops/__init__.py")
-        else:
-            errors.append("__init__.py: version pattern not found")
-    else:
-        errors.append("src/squadops/__init__.py: file not found")
-
     if errors:
         print()
         print("Warnings:")
@@ -164,7 +151,7 @@ def bump_version(new_version: str):
     print(f"Version bumped: {old_version} -> {new_version}")
     print()
     print("Next steps:")
-    print("  git add pyproject.toml src/squadops/__init__.py")
+    print("  git add pyproject.toml")
     print(f"  git commit -m 'chore: bump framework version to {new_version}'")
 
     return True


### PR DESCRIPTION
## What

Closes out the SIP-0094 (per-agent reply queues) release. The promote-to-implemented PR (#213) merged **without** the version bump + ROADMAP entry that every prior implemented SIP carries, so the framework was left pinned at 1.0.5 with a stale roadmap.

## Changes

- **Version bump → 1.0.6** (`pyproject.toml`). This is the single source — `squadops.__version__` (what agents and runtime-api report) derives from package metadata, so there's nothing else to stamp. Patch bump, consistent with how every prior implemented SIP was released (0084→1.0.1, 0085→1.0.2, 0086→1.0.4, 0087→1.0.5).
- **ROADMAP** — add the **v1.0.6 (SIP-0094)** entry and backfill the two timeline entries that were also missed: **v1.0.5 (SIP-0087)** and **v1.0.4 (SIP-0086)**. Refresh the *Accepted (Next Up)* table (SIP-0086 was listed there but is implemented; the real accepted set is SIP-0088–0093) and the *Stats* block (version + 57 implemented / 6 accepted / 8 proposed from the registry).
- **`version_cli.py`** — drop the dead `__init__.py` rewrite. `__version__` is now derived dynamically, so the regex never matched and every bump emitted a misleading `version pattern not found` warning. pyproject is the only place the version is written.

## Verification

- `version_cli.py bump 1.0.6` updates pyproject cleanly (no warnings after the cleanup).
- After `pip install -e .`, both `version_cli.py version` and `python -c "import squadops; print(squadops.__version__)"` report **1.0.6**.
- `ruff check scripts/maintainer/version_cli.py` passes.

## Follow-up

Deployed agent + runtime-api images report 1.0.5 until rebuilt — a `rebuild_and_deploy.sh all` on merge will pick up 1.0.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)