### PR TITLE
SIP-0089 Phase 2 — Agent Runtime State (assignments, scheduler, coordinator, reserve guard)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,12 +205,19 @@ python scripts/maintainer/update_sip_status.py sips/accepted/SIP-0067-My-Feature
 **Proactive guidance**: If you observe a workflow or code best practice being bypassed, call it out early — don't wait to be asked. Examples:
 - Workflow: developing on main instead of a feature branch, skipping tests, hardcoding secrets
 - Code structure: copy-pasted logic that should be a shared helper, inconsistent patterns across similar modules, missing registry updates when adding new entries, constants duplicated across files instead of single-sourced
+- Cross-cutting surface drift: adding a new HTTP route prefix, API error shape, event type, or `SQUADOPS__*` config-var convention that diverges from the existing standard — flag it and conform; never justify a new variant by "it doesn't collide" or "it's easy" (this is exactly how the runtime-api drifted into 4 URL conventions — see API Conventions below, #218)
 
 ## Repository Rules
 
 **Read-Only Areas**:
 - Never modify `dist/` or generated metadata (`manifest.json`, `agent_info.json`)
 - Version bumps via `scripts/maintainer/version_cli.py` only
+
+**API Conventions** (runtime-api HTTP surface):
+- Before adding or moving any route, read the **whole** existing surface — do not reason only about the neighborhood. Conform to the lane standard; if no standard covers your case, surface the gap and propose it **before** adding (#218).
+- **Lanes:** authenticated, managed REST resources → `/api/v1/<resource>` (default home for anything new). `/health/*` = read-only, unauthenticated operational probes/heartbeats **only** — never a writable business resource (it's the only no-auth lane). `/auth/*` = identity. **Do not add `/api/v2`** — extend v1.
+- A new prefix/variant is a deliberate, justified decision, never a default. "It doesn't collide" is not a justification.
+- Known deviations under cleanup: unversioned `/api/chat`+`/api/agents` (#219); `/health`+`/auth` plain-string error bodies vs the standard `{"error": {...}}` envelope (#218). Don't add to these.
 
 **Structure**:
 - Permanent utilities: `scripts/dev/`

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -45,6 +45,7 @@ from squadops.cycles.task_outcome import TaskOutcome
 from squadops.cycles.task_plan import generate_task_plan
 from squadops.events.types import EventType
 from squadops.ports.cycles.flow_execution import FlowExecutionPort
+from squadops.runtime.recruitment import reserve_buffer_decision
 from squadops.tasks.models import TaskEnvelope, TaskResult
 from squadops.telemetry.context import use_correlation_context, use_run_ids
 from squadops.telemetry.models import CorrelationContext
@@ -62,6 +63,7 @@ if TYPE_CHECKING:
     from squadops.ports.cycles.squad_profile import SquadProfilePort
     from squadops.ports.cycles.workflow_tracker import WorkflowTrackerPort
     from squadops.ports.events.cycle_event_bus import CycleEventBusPort
+    from squadops.ports.runtime.assignments import AssignmentPort
     from squadops.ports.telemetry.llm_observability import LLMObservabilityPort
 
 logger = logging.getLogger(__name__)
@@ -77,6 +79,20 @@ class _CancellationError(Exception):
 
 class _PausedError(Exception):
     """Internal: run paused due to BLOCKED outcome."""
+
+
+class _RecruitmentRejectedError(Exception):
+    """Internal: cycle recruitment deferred (SIP-0089 §2.5/§11.4).
+
+    A participating agent is committed to — or about to start — a hard duty
+    window, so the run is paused (a *deferral*, not a failure). Re-attempt via
+    ``squadops runs resume`` once the window closes.
+    """
+
+    def __init__(self, agent_id: str | None, reason: str | None) -> None:
+        super().__init__(f"recruitment rejected for agent {agent_id}: {reason}")
+        self.agent_id = agent_id
+        self.reason = reason
 
 
 class DispatchedFlowExecutor(FlowExecutionPort):
@@ -101,6 +117,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         workflow_tracker: WorkflowTrackerPort | None = None,
         event_bus: CycleEventBusPort | None = None,
         reply_router: ReplyRouter | None = None,
+        assignment_port: AssignmentPort | None = None,
     ) -> None:
         self._cycle_registry = cycle_registry
         self._artifact_vault = artifact_vault
@@ -111,6 +128,10 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         self._task_timeout = task_timeout
         self._llm_observability = llm_observability
         self._workflow_tracker = workflow_tracker
+        # SIP-0089 §2.5: reserve-buffer guard dependency. Opt-in — when None,
+        # the guard is skipped entirely (safe no-op until an AssignmentPort is
+        # wired in the composition root).
+        self._assignment_port = assignment_port
         self._cancelled: set[str] = set()
 
         # SIP-0077: Cycle event bus (defaults to NoOp if not provided)
@@ -182,6 +203,23 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             implementation_plan = await self._load_plan_for_run(cycle, run)
 
             plan = generate_task_plan(cycle, run, profile, plan=implementation_plan)
+
+            # SIP-0089 §2.5: reserve-buffer guard. The plan now names every
+            # agent this run would recruit. If one is committed to — or about to
+            # start — a hard duty window (§11.4), defer the run rather than pull
+            # the agent into cycle work. Opt-in: skipped when no AssignmentPort
+            # is wired. Decision is pure (time-injected) and lives in the runtime
+            # domain; we only enforce it here.
+            if self._assignment_port is not None:
+                guard_now = datetime.now(UTC)
+                active_assignments = await self._assignment_port.list_active_assignments(guard_now)
+                decision = reserve_buffer_decision(
+                    active_assignments,
+                    {e.agent_id for e in plan},
+                    guard_now,
+                )
+                if not decision.allowed:
+                    raise _RecruitmentRejectedError(decision.blocking_agent_id, decision.reason)
 
             # Build-only validation (D6): require plan_artifact_refs
             include_plan = bool(cycle.applied_defaults.get("plan_tasks", True))
@@ -283,6 +321,27 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 context={"cycle_id": cycle_id, "run_id": run_id},
             )
             logger.info("Run %s cancelled", run_id)
+
+        except _RecruitmentRejectedError as exc:
+            # SIP-0089 §2.5: deferral, not failure. PAUSED has a first-class
+            # resume affordance (squadops runs resume → RUN_RESUMED); the reason
+            # rides in the payload so operators can distinguish a duty deferral
+            # from a BLOCKED-outcome pause.
+            terminal_status = "PAUSED"
+            await self._safe_transition(run_id, RunStatus.PAUSED)
+            self._cycle_event_bus.emit(
+                EventType.RUN_PAUSED,
+                entity_type="run",
+                entity_id=run_id,
+                context={"cycle_id": cycle_id, "run_id": run_id},
+                payload={"reason": exc.reason, "deferred_for_agent": exc.agent_id},
+            )
+            logger.info(
+                "Run %s paused — recruitment deferred (agent=%s, reason=%s)",
+                run_id,
+                exc.agent_id,
+                exc.reason,
+            )
 
         except _PausedError:
             terminal_status = "PAUSED"

--- a/adapters/cycles/factory.py
+++ b/adapters/cycles/factory.py
@@ -110,5 +110,6 @@ def create_flow_executor(
             workflow_tracker=workflow_tracker,
             event_bus=kwargs.get("event_bus"),
             reply_router=kwargs.get("reply_router"),
+            assignment_port=kwargs.get("assignment_port"),
         )
     raise ValueError(f"Unknown flow executor provider: {provider}")

--- a/adapters/persistence/__init__.py
+++ b/adapters/persistence/__init__.py
@@ -1,8 +1,29 @@
-"""
-Persistence adapters package.
+"""Persistence adapters package.
+
+`get_db_runtime` / `PostgresRuntime` are resolved lazily (PEP 562). Importing a
+sibling asyncpg adapter under `adapters.persistence.runtime.*` must not drag in
+the sqlalchemy-based postgres backend (and its optional `sqlalchemy` dependency)
+merely to load this package — that eager coupling made the asyncpg adapter unit
+tests uncollectable in the minimal CI env (#220). The names stay importable on
+demand, so `from adapters.persistence import get_db_runtime` still works.
 """
 
-from adapters.persistence.factory import get_db_runtime
-from adapters.persistence.postgres import PostgresRuntime
+from typing import TYPE_CHECKING
 
 __all__ = ["get_db_runtime", "PostgresRuntime"]
+
+if TYPE_CHECKING:
+    from adapters.persistence.factory import get_db_runtime
+    from adapters.persistence.postgres import PostgresRuntime
+
+
+def __getattr__(name: str):
+    if name == "get_db_runtime":
+        from adapters.persistence.factory import get_db_runtime
+
+        return get_db_runtime
+    if name == "PostgresRuntime":
+        from adapters.persistence.postgres import PostgresRuntime
+
+        return PostgresRuntime
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/adapters/persistence/runtime/assignments_postgres.py
+++ b/adapters/persistence/runtime/assignments_postgres.py
@@ -1,0 +1,146 @@
+"""Postgres-backed Assignment adapter (SIP-0089 §2.3).
+
+Implements `AssignmentPort` via the asyncpg pool shared with the cycle registry
+and runtime-state adapter. All rows hit `agent_assignments` (migration
+`1110_assignments.sql`).
+
+The flat `window_start`/`window_end`/`timezone` columns are reassembled into the
+nested `DutyWindow` on read; INTERVAL columns map to `timedelta` and the
+`allowed_off_window_modes` TEXT[] maps to a tuple (the dataclass is frozen).
+The reserve-buffer interval arithmetic for the active/claimable queries runs in
+SQL so callers never over-fetch.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import asyncpg
+
+from squadops.ports.runtime.assignments import AssignmentPort
+from squadops.runtime.models import Assignment, DutyWindow
+
+_COLUMNS = (
+    "assignment_id, agent_id, assignment_type, assigned_role, priority, "
+    "strictness, window_start, window_end, timezone, reserve_before_window, "
+    "reserve_after_window, recall_policy, graceful_window, missed_window_policy, "
+    "allowed_off_window_modes, active"
+)
+
+
+class PostgresAssignment(AssignmentPort):
+    """Postgres-backed `AssignmentPort` implementation."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def get_assignment(self, assignment_id: str) -> Assignment | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"SELECT {_COLUMNS} FROM agent_assignments WHERE assignment_id = $1",
+                assignment_id,
+            )
+        return _row_to_assignment(row) if row else None
+
+    async def list_assignments_for_agent(self, agent_id: str) -> list[Assignment]:
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                f"SELECT {_COLUMNS} FROM agent_assignments "
+                "WHERE agent_id = $1 ORDER BY window_start",
+                agent_id,
+            )
+        return [_row_to_assignment(r) for r in rows]
+
+    async def list_active_assignments(self, now: datetime) -> list[Assignment]:
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                f"SELECT {_COLUMNS} FROM agent_assignments "
+                "WHERE active = TRUE "
+                "AND $1 >= window_start - reserve_before_window "
+                "AND $1 <  window_end + reserve_after_window "
+                "ORDER BY window_start",
+                now,
+            )
+        return [_row_to_assignment(r) for r in rows]
+
+    async def list_claimable_windows(self, now: datetime) -> list[Assignment]:
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                f"SELECT {_COLUMNS} FROM agent_assignments "
+                "WHERE active = TRUE "
+                "AND assignment_type = 'duty' "
+                "AND $1 >= window_start - reserve_before_window "
+                "AND $1 <  window_end "
+                "ORDER BY window_start",
+                now,
+            )
+        return [_row_to_assignment(r) for r in rows]
+
+    async def upsert_assignment(self, assignment: Assignment) -> Assignment:
+        a = assignment
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO agent_assignments ("
+                "assignment_id, agent_id, assignment_type, assigned_role, priority, "
+                "strictness, window_start, window_end, timezone, reserve_before_window, "
+                "reserve_after_window, recall_policy, graceful_window, missed_window_policy, "
+                "allowed_off_window_modes, active"
+                ") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16) "
+                "ON CONFLICT (assignment_id) DO UPDATE SET "
+                "agent_id = EXCLUDED.agent_id, "
+                "assignment_type = EXCLUDED.assignment_type, "
+                "assigned_role = EXCLUDED.assigned_role, "
+                "priority = EXCLUDED.priority, "
+                "strictness = EXCLUDED.strictness, "
+                "window_start = EXCLUDED.window_start, "
+                "window_end = EXCLUDED.window_end, "
+                "timezone = EXCLUDED.timezone, "
+                "reserve_before_window = EXCLUDED.reserve_before_window, "
+                "reserve_after_window = EXCLUDED.reserve_after_window, "
+                "recall_policy = EXCLUDED.recall_policy, "
+                "graceful_window = EXCLUDED.graceful_window, "
+                "missed_window_policy = EXCLUDED.missed_window_policy, "
+                "allowed_off_window_modes = EXCLUDED.allowed_off_window_modes, "
+                "active = EXCLUDED.active, "
+                "updated_at = now()",
+                a.assignment_id,
+                a.agent_id,
+                a.assignment_type,
+                a.assigned_role,
+                a.priority,
+                a.strictness,
+                a.active_window.start,
+                a.active_window.end,
+                a.active_window.timezone,
+                a.reserve_before_window,
+                a.reserve_after_window,
+                a.recall_policy,
+                a.graceful_window,
+                a.missed_window_policy,
+                list(a.allowed_off_window_modes),
+                a.active,
+            )
+        return a
+
+
+def _row_to_assignment(row: asyncpg.Record) -> Assignment:
+    return Assignment(
+        assignment_id=row["assignment_id"],
+        agent_id=row["agent_id"],
+        assignment_type=row["assignment_type"],
+        assigned_role=row["assigned_role"],
+        priority=row["priority"],
+        strictness=row["strictness"],
+        active_window=DutyWindow(
+            start=row["window_start"],
+            end=row["window_end"],
+            timezone=row["timezone"],
+        ),
+        reserve_before_window=row["reserve_before_window"],
+        reserve_after_window=row["reserve_after_window"],
+        recall_policy=row["recall_policy"],
+        graceful_window=row["graceful_window"],
+        missed_window_policy=row["missed_window_policy"],
+        allowed_off_window_modes=tuple(row["allowed_off_window_modes"]),
+        active=row["active"],
+    )

--- a/docs/plans/SIP-0089-agent-runtime-state-plan.md
+++ b/docs/plans/SIP-0089-agent-runtime-state-plan.md
@@ -337,6 +337,8 @@ No `--watch` flag in v1.1; defer to a follow-up if needed.
 
 Identify the exact cycle recruitment seam in `src/squadops/orchestration/` (or wherever it lives post-1.0.5). Document the file/function in the Phase 2 PR body before coding the reserve-buffer integration.
 
+> **Note (post-SIP-0094):** The reply transport was restructured by SIP-0094 (implemented 2026-06-21) — the per-run `cycle_results_{run_id}` poll loop is gone, replaced by the in-process `ReplyRouter` over per-agent `{agent_id}_replies` queues (`adapters/cycles/reply_router.py`, rewritten `_publish_and_await`). Map the recruitment seam against that current path; do **not** assume the old poll loop. A key thing for the spike to settle: whether recruitment is an explicit orchestration-layer step or implicit at task-dispatch time — that determines where the §2.5 reserve guard attaches.
+
 ### 2.1 Models
 
 In `src/squadops/runtime/models.py`:

--- a/docs/plans/SIP-0089-phase-2-spike-notes.md
+++ b/docs/plans/SIP-0089-phase-2-spike-notes.md
@@ -1,0 +1,126 @@
+# SIP-0089 Phase 2 — §2.0 Pre-Implementation Spike Notes
+
+**Status:** Read-only spike complete (2026-06-23). No code changed.
+**Scope:** Identify the cycle **recruitment seam** against the **current** dispatch
+path (post-SIP-0094) so the §2.5 reserve-buffer guard attaches in the right place.
+**Lane:** `track:macbook` · branch `feature/sip-0089-phase-2-assignments`.
+
+All line citations below were verified against `main` @ `af6c308` + the doc-alignment
+commit on this branch.
+
+---
+
+## Verdict (headline answers the spike had to settle)
+
+1. **Recruitment is IMPLICIT and bound at *plan-generation* time — not explicit, and
+   not at dispatch.** No function "recruits" a roster. Each planned task carries a
+   `role`; the role is resolved to a concrete `agent_id` (first *enabled* agent for
+   that role in the squad profile) when the task plan is generated. The materialized
+   roster lives only as `agent_id` on the `TaskEnvelope`s — there is **no
+   `participating_agents` field on `Cycle` or `Run`.**
+
+2. **The dispatch path has no admission/eligibility gate.** The executor publishes
+   unconditionally to `{agent_id}_comms`. The only existing "eligibility" filter is the
+   profile-level `enabled` flag applied during planning. Heartbeat status is
+   observability-only and never blocks dispatch.
+
+3. **Therefore §2.5 is greenfield**, and the right seam is the
+   **plan-generation → dispatch boundary inside `execute_run()`**, *after* the roster
+   materializes but *before* the dispatch loop — **not** inside the (synchronous, pure)
+   domain planner.
+
+---
+
+## 1. Dispatch path (post-SIP-0094) — confirmed
+
+The SIP-0094 cutover is live: the old per-run `cycle_results_{run_id}` poll loop is
+gone, replaced by a long-lived per-agent subscription via `ReplyRouter`.
+
+| Step | Where | What |
+|------|-------|------|
+| Resolve target agent | `src/squadops/cycles/task_plan.py:413` → `:225` | `_resolve_agent_config(profile, role)` → `agent_id` (first `enabled` agent for the role) |
+| Build envelopes | `task_plan.py:328` `generate_task_plan(...)` | **synchronous, pure domain fn**; called *without* `await` at `dispatched_flow_executor.py:184` |
+| Dispatch | `dispatched_flow_executor.py:619` `_dispatch_task` → `:674` `_publish_and_await` | telemetry/heartbeat wrapper, then publish+await |
+| Subscribe / register / publish | `:703` `ensure_subscribed` → `:704` `register(task_id)` → publish to `:699` `f"{agent_id}_comms"` (reply via `:698` `f"{agent_id}_replies"`) | ordering `ensure_subscribed → register → publish` (D14) |
+| Correlate reply | `reply_router.py:65` `ensure_subscribed`, `:92` `register`, `:121` `data["payload"]["task_id"]` → `set_result` | **`task_id` is the sole correlation key** (not `correlation_id`); one long-lived subscription per agent on `{agent_id}_replies` |
+
+**No pre-publish admission check exists.** Closest gate is run-level
+`_check_task_preconditions` (cancelled / time-budget / checkpoint-skip) — not per-agent
+availability.
+
+## 2. Recruitment model — implicit, profile-driven
+
+- Cycle creation stores only the profile id + snapshot hash
+  (`src/squadops/api/routes/cycles/cycles.py` `create_cycle`); it does **not** materialize
+  a roster.
+- The roster materializes at `execute_run()` time:
+  `dispatched_flow_executor.py:146` resolves the profile snapshot, `:184` calls
+  `generate_task_plan(...)`, which emits one `TaskEnvelope` per planned step with
+  `agent_id` set.
+- Enabled-role filter: `task_plan.py:354` (`{a.role for a in profile.agents if a.enabled}`).
+
+## 3. Existing eligibility / availability gates
+
+- **Profile `enabled` flag** — the *only* gate in the main path (`task_plan.py:354`).
+- **Heartbeat** (`src/squadops/ports/observability/heartbeat.py`) — lifecycle status for
+  observability; **does not** block dispatch.
+- **Plan/role validation** (`src/squadops/cycles/implementation_plan.py` `validate_against_profile`)
+  — authoring-time (SIP-0092), not recruitment-time.
+- **No** capacity, duty-window, reserve-buffer, or interruptibility check exists.
+
+## 4. Recommended §2.5 attachment seam
+
+**Primary:** inside `DispatchedFlowExecutor.execute_run()`
+(`adapters/cycles/dispatched_flow_executor.py:134`), **immediately after** the plan is
+generated at `:184` and **before** the dispatch loop.
+
+```
+plan = generate_task_plan(cycle, run, profile, plan=implementation_plan)
+# §2.5 reserve-buffer admission check goes HERE:
+#   - distinct agent_ids = {e.agent_id for e in plan.envelopes}
+#   - assignments = await self._assignment_port.list_active_assignments(now)
+#   - for each participating agent with a HARD duty window in `in_reserve_before`/`active`
+#     (per §2.1 window_state): reject → emit cycle.recruitment.rejected
+#     (reason `upcoming_hard_duty_window`, per D18); soft duty may permit per recall_policy
+# then proceed to dispatch
+```
+
+**Why here, not inside `generate_task_plan()` (the subagent's first pick):**
+
+- `generate_task_plan()` is **synchronous and pure**, in the domain layer
+  (`src/squadops/cycles/`). The reserve check requires an **async Postgres lookup** via
+  `AssignmentPort`. Injecting an adapter + `await` into the domain planner breaks the
+  hexagonal boundary the repo enforces (ports/adapters do I/O; domain stays pure).
+- `execute_run()` is already `async`, already constructs/holds ports, and is the
+  natural owner of the run-start admission decision and `cycle.recruitment.rejected`
+  emission.
+- The §2.5 "recruitment ordering" maps cleanly: **enabled-filter** (in the planner) →
+  **reserve check** (`execute_run`) → **FocusLease** (Phase 3, also `execute_run`).
+
+**Granularity:** one `list_active_assignments(now)` query, then filter to the run's
+distinct participating `agent_id`s — avoids N per-agent round trips.
+
+## 5. Greenfield checklist (what Phase 2 must create to land §2.5)
+
+1. **`AssignmentPort` + adapter** (§2.3) — not present in the executor today.
+2. **Wire the port into the executor** — add `assignment_port: AssignmentPort | None = None`
+   to `DispatchedFlowExecutor.__init__` (near `:103`, alongside the existing
+   `reply_router` injection) and through the factory (`adapters/cycles/factory.py`).
+3. **`window_state()` helper** (§2.1) — drives the reserve decision; keep the
+   reject/permit logic reading it rather than re-deriving interval math at the seam.
+4. **Events/reasons** — `cycle.recruitment.rejected` + reason `upcoming_hard_duty_window`
+   (D18: event ≠ reason).
+
+## 6. Observations / follow-ups (not blocking §2.5)
+
+- **DRY debt:** `_resolve_agent_config` is duplicated — domain copy at
+  `task_plan.py:225`, mirrored static copy at `dispatched_flow_executor.py:1855` (used by
+  correction paths `:2102`, `:2269`, per issue #110). If the reserve check ever needs to
+  run on correction-spawned tasks too, both call sites matter. Out of scope for §2.5 but
+  worth tracking.
+- **`now` source:** the seam needs a clock. Prefer injecting a time source rather than
+  calling `datetime.now()` inline, to keep the check testable (mirrors how the scheduler
+  in §2.4 will need the same).
+- **Soft-duty semantics** (§2.5 step: soft duty may permit if cycle `can_pause` matches
+  `recall_policy`) need the cycle's pause capability surfaced at the seam — confirm it's
+  reachable from `cycle`/`run` at `execute_run` time during implementation.

--- a/docs/plans/v1.1-runtime-track-roadmap.md
+++ b/docs/plans/v1.1-runtime-track-roadmap.md
@@ -58,8 +58,12 @@ in #170.
 
 - **Migration ranges:** this lane uses `1100–1199` (`1110` next); Spark uses `1000–1099`.
 - **Shared hot file:** `src/squadops/agents/entrypoint.py` — coordinate edits.
-- **Executor dispatch chokepoint:** the Spark's S1 (per-agent reply queues,
-  `SIP-Reply-Channel-Subscription-Model`) and Phase 2's §2.5 reserve guard both
-  touch `_publish_and_await` in `adapters/cycles/dispatched_flow_executor.py`.
-  **Sequence S1 first** (see `1-0-x-build-reliability-hardening-plan.md`); Phase 2's
-  guard lands last, onto the restructured dispatch path.
+- **Executor dispatch chokepoint (S1 landed):** the Spark's S1 — per-agent reply
+  queues, now **SIP-0094** (implemented 2026-06-21) — restructured the reply
+  transport: the per-run `cycle_results_{run_id}` poll loop in
+  `adapters/cycles/dispatched_flow_executor.py` is replaced by the in-process
+  `ReplyRouter` over per-agent `{agent_id}_replies` queues
+  (`adapters/cycles/reply_router.py`). **"Sequence S1 first" is satisfied.**
+  Phase 2's §2.5 reserve guard attaches at the *recruitment* seam (an
+  orchestration-layer admission decision), not necessarily a `_publish_and_await`
+  edit — the §2.0 spike confirms the seam against the post-SIP-0094 path.

--- a/infra/migrations/1110_assignments.sql
+++ b/infra/migrations/1110_assignments.sql
@@ -1,0 +1,53 @@
+-- 1110_assignments.sql
+-- SIP-0089 Phase 2 §2.2: agent_assignments table.
+-- All DDL is idempotent (CREATE ... IF NOT EXISTS).
+--
+-- Field semantics mirror src/squadops/runtime/models.py::Assignment +
+-- DutyWindow (the nested active_window flattens to window_start/window_end/
+-- timezone here). Enum-shaped columns carry CHECK constraints matching the
+-- Literal types in code (D3). Durations are stored as INTERVAL.
+--
+-- agent_id is the holder of the assignment. It is indexed (the port queries
+-- assignments by agent) but intentionally NOT a hard FK to agent_runtime_state:
+-- that row is created lazily by heartbeat (Phase 1 ensure_state), so an
+-- assignment may legitimately be written before the agent has heartbeated.
+
+CREATE TABLE IF NOT EXISTS agent_assignments (
+    assignment_id              TEXT PRIMARY KEY,
+    agent_id                   TEXT NOT NULL,
+    assignment_type            TEXT NOT NULL
+        CHECK (assignment_type IN ('duty', 'reserve', 'cycle_eligibility')),
+    assigned_role              TEXT NOT NULL,
+    priority                   INTEGER NOT NULL,
+    strictness                 TEXT NOT NULL
+        CHECK (strictness IN ('hard', 'soft')),
+    window_start               TIMESTAMPTZ NOT NULL,
+    window_end                 TIMESTAMPTZ NOT NULL,
+    timezone                   TEXT NOT NULL,
+    reserve_before_window      INTERVAL NOT NULL,
+    reserve_after_window       INTERVAL NOT NULL,
+    recall_policy              TEXT NOT NULL
+        CHECK (recall_policy IN ('immediate', 'graceful', 'none')),
+    graceful_window            INTERVAL NOT NULL,
+    missed_window_policy       TEXT NOT NULL
+        CHECK (missed_window_policy IN (
+            'skip', 'start_late_within_grace', 'require_operator_review'
+        )),
+    -- Literal-element membership ('ambient'|'cycle'|'duty') is enforced in code;
+    -- Postgres array-element CHECKs are omitted to match the Phase 1 convention
+    -- of CHECKing scalar enum columns only.
+    allowed_off_window_modes   TEXT[] NOT NULL,
+    active                     BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (window_end > window_start)
+);
+
+-- list_assignments_for_agent(agent_id)
+CREATE INDEX IF NOT EXISTS idx_agent_assignments_agent_id
+    ON agent_assignments (agent_id);
+
+-- list_active_assignments(now) / list_claimable_windows(now): scan active rows
+-- by window bounds.
+CREATE INDEX IF NOT EXISTS idx_agent_assignments_active_window
+    ON agent_assignments (active, window_start, window_end);

--- a/scripts/dev/run_regression_tests.sh
+++ b/scripts/dev/run_regression_tests.sh
@@ -28,6 +28,8 @@ REGRESSION_DIRS=(
     "tests/unit/cli/"
     "tests/unit/console/"
     "tests/unit/contracts/"
+    "tests/unit/runtime/"        # SIP-0089 runtime modes/assignments/scheduler (#220)
+    "tests/unit/architecture/"   # D26 forbidden-imports + future architecture guards (#220)
 )
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/src/squadops/api/routes/assignments.py
+++ b/src/squadops/api/routes/assignments.py
@@ -1,0 +1,212 @@
+"""Assignment routes (SIP-0089 §2.7).
+
+REST surface for duty `Assignment`s on the versioned resource lane (`/api/v1`),
+per the runtime-api prefix standard (#218): authenticated, managed resources
+live under `/api/v1`; `/health` is reserved for read-only, unauthenticated
+probes, so a writable resource must not live there. The CLI cannot import the
+Postgres adapter directly (D26 forbidden-imports), so the ``squadops assignment
+...`` commands reach assignments through these routes — mirroring how Phase-1
+``agent state`` reads runtime-state over HTTP.
+
+Serialization lives here in the DTO layer (DTO-purity): timedeltas cross the
+wire as integer seconds (`*_seconds`), `DutyWindow` as a nested object, and the
+`allowed_off_window_modes` tuple as a list.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field, model_validator
+
+from squadops.runtime.models import (
+    Assignment,
+    AssignmentType,
+    DutyWindow,
+    MissedWindowPolicy,
+    RecallPolicy,
+    RuntimeMode,
+    Strictness,
+    default_reserve_before_window,
+)
+
+router = APIRouter(prefix="/api/v1", tags=["assignments"])
+
+
+def _get_assignment_port():
+    from squadops.api.runtime.deps import get_assignment_port
+
+    return get_assignment_port()
+
+
+def _not_found(assignment_id: str) -> HTTPException:
+    """404 in the resource-lane error envelope the CLI client parses."""
+    return HTTPException(
+        status_code=404,
+        detail={
+            "error": {
+                "code": "ASSIGNMENT_NOT_FOUND",
+                "message": f"No assignment with id={assignment_id}",
+                "details": None,
+            }
+        },
+    )
+
+
+class DutyWindowDTO(BaseModel):
+    """Wire form of `runtime.models.DutyWindow` (§10.3)."""
+
+    start: datetime
+    end: datetime
+    timezone: str
+
+
+class AssignmentResponse(BaseModel):
+    """Wire form of `runtime.models.Assignment` (§10.2).
+
+    `timedelta` fields are serialized as integer seconds; the reserve buffers and
+    graceful window are minute-granularity policy, so seconds are lossless.
+    """
+
+    assignment_id: str
+    agent_id: str
+    assignment_type: AssignmentType
+    assigned_role: str
+    priority: int
+    strictness: Strictness
+    active_window: DutyWindowDTO
+    reserve_before_window_seconds: int
+    reserve_after_window_seconds: int
+    recall_policy: RecallPolicy
+    graceful_window_seconds: int
+    missed_window_policy: MissedWindowPolicy
+    allowed_off_window_modes: list[RuntimeMode]
+    active: bool
+
+    @classmethod
+    def from_domain(cls, a: Assignment) -> AssignmentResponse:
+        return cls(
+            assignment_id=a.assignment_id,
+            agent_id=a.agent_id,
+            assignment_type=a.assignment_type,
+            assigned_role=a.assigned_role,
+            priority=a.priority,
+            strictness=a.strictness,
+            active_window=DutyWindowDTO(
+                start=a.active_window.start,
+                end=a.active_window.end,
+                timezone=a.active_window.timezone,
+            ),
+            reserve_before_window_seconds=int(a.reserve_before_window.total_seconds()),
+            reserve_after_window_seconds=int(a.reserve_after_window.total_seconds()),
+            recall_policy=a.recall_policy,
+            graceful_window_seconds=int(a.graceful_window.total_seconds()),
+            missed_window_policy=a.missed_window_policy,
+            allowed_off_window_modes=list(a.allowed_off_window_modes),
+            active=a.active,
+        )
+
+
+class AssignmentCreate(BaseModel):
+    """Create-request body for `POST /api/v1/assignments`.
+
+    EXPERIMENTAL/INTERNAL in v1.1 (plan §2.7) — not a public operator command.
+    Reserve fields are optional: when omitted, the D7/§11.4 strictness defaults
+    are applied (15m before-window for hard duty, 0 for soft; 0 after-window
+    always). Every persisted Assignment still carries explicit reserve values.
+    """
+
+    agent_id: str
+    assigned_role: str
+    window_start: datetime
+    window_end: datetime
+    timezone: str = "UTC"
+    assignment_id: str | None = None
+    assignment_type: AssignmentType = "duty"
+    priority: int = 0
+    strictness: Strictness = "hard"
+    reserve_before_window_seconds: int | None = None
+    reserve_after_window_seconds: int | None = None
+    recall_policy: RecallPolicy = "graceful"
+    graceful_window_seconds: int = 0
+    missed_window_policy: MissedWindowPolicy = "skip"
+    allowed_off_window_modes: list[RuntimeMode] = Field(default_factory=list)
+    active: bool = True
+
+    @model_validator(mode="after")
+    def _check_window(self) -> AssignmentCreate:
+        # Half-open [start, end): an empty or inverted window is never valid and
+        # the DB CHECK (§2.2 / D3) would reject it — surface it as 422 here.
+        if self.window_end <= self.window_start:
+            raise ValueError("window_end must be after window_start")
+        if (
+            self.reserve_before_window_seconds is not None
+            and self.reserve_before_window_seconds < 0
+        ):
+            raise ValueError("reserve_before_window_seconds must be non-negative")
+        if self.reserve_after_window_seconds is not None and self.reserve_after_window_seconds < 0:
+            raise ValueError("reserve_after_window_seconds must be non-negative")
+        return self
+
+    def to_domain(self) -> Assignment:
+        reserve_before = (
+            timedelta(seconds=self.reserve_before_window_seconds)
+            if self.reserve_before_window_seconds is not None
+            else default_reserve_before_window(self.strictness)
+        )
+        reserve_after = (
+            timedelta(seconds=self.reserve_after_window_seconds)
+            if self.reserve_after_window_seconds is not None
+            else timedelta()
+        )
+        return Assignment(
+            assignment_id=self.assignment_id or str(uuid4()),
+            agent_id=self.agent_id,
+            assignment_type=self.assignment_type,
+            assigned_role=self.assigned_role,
+            priority=self.priority,
+            strictness=self.strictness,
+            active_window=DutyWindow(
+                start=self.window_start,
+                end=self.window_end,
+                timezone=self.timezone,
+            ),
+            reserve_before_window=reserve_before,
+            reserve_after_window=reserve_after,
+            recall_policy=self.recall_policy,
+            graceful_window=timedelta(seconds=self.graceful_window_seconds),
+            missed_window_policy=self.missed_window_policy,
+            allowed_off_window_modes=tuple(self.allowed_off_window_modes),
+            active=self.active,
+        )
+
+
+@router.get("/agents/{agent_id}/assignments", response_model=list[AssignmentResponse])
+async def list_agent_assignments(agent_id: str) -> list[AssignmentResponse]:
+    """List every assignment held by an agent (active and inactive), window-start order."""
+    port = _get_assignment_port()
+    assignments = await port.list_assignments_for_agent(agent_id)
+    return [AssignmentResponse.from_domain(a) for a in assignments]
+
+
+@router.get("/assignments/{assignment_id}", response_model=AssignmentResponse)
+async def get_assignment(assignment_id: str) -> AssignmentResponse:
+    """Show one assignment by id; 404 if no row exists."""
+    port = _get_assignment_port()
+    assignment = await port.get_assignment(assignment_id)
+    if assignment is None:
+        raise _not_found(assignment_id)
+    return AssignmentResponse.from_domain(assignment)
+
+
+@router.post("/assignments", response_model=AssignmentResponse, status_code=201)
+async def create_assignment(body: AssignmentCreate) -> AssignmentResponse:
+    """Create (upsert) an assignment. EXPERIMENTAL/INTERNAL in v1.1 — not a
+    public operator command. Applies the D7/§11.4 reserve-buffer defaults when
+    the reserve fields are omitted, then persists via the AssignmentPort.
+    """
+    port = _get_assignment_port()
+    saved = await port.upsert_assignment(body.to_domain())
+    return AssignmentResponse.from_domain(saved)

--- a/src/squadops/api/runtime/deps.py
+++ b/src/squadops/api/runtime/deps.py
@@ -17,6 +17,7 @@ from squadops.ports.cycles.project_registry import ProjectRegistryPort
 from squadops.ports.cycles.squad_profile import SquadProfilePort
 from squadops.ports.events.cycle_event_bus import CycleEventBusPort
 from squadops.ports.llm.provider import LLMPort
+from squadops.ports.runtime.assignments import AssignmentPort
 
 if TYPE_CHECKING:
     from squadops.api.runtime.health_checker import HealthChecker
@@ -40,6 +41,9 @@ _cycle_event_bus_warned: bool = False
 
 # SIP-0075: LLM port for model management endpoints
 _llm_port: LLMPort | None = None
+
+# SIP-0089 §2.7: Assignment port for the assignment REST surface
+_assignment_port: AssignmentPort | None = None
 
 
 def set_auth_ports(
@@ -205,6 +209,28 @@ def get_llm_port() -> LLMPort:
     if _llm_port is None:
         raise RuntimeError("LLMPort not configured")
     return _llm_port
+
+
+# =============================================================================
+# SIP-0089 §2.7: Assignment port
+# =============================================================================
+
+
+def set_assignment_port(port: AssignmentPort) -> None:
+    """Set the AssignmentPort instance for the assignment REST surface."""
+    global _assignment_port
+    _assignment_port = port
+
+
+def get_assignment_port() -> AssignmentPort:
+    """Return the AssignmentPort instance.
+
+    Raises RuntimeError if unconfigured — assignments require a Postgres pool,
+    so a missing port at a route call site is a wiring error, not a no-op.
+    """
+    if _assignment_port is None:
+        raise RuntimeError("AssignmentPort not configured")
+    return _assignment_port
 
 
 # =============================================================================

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -302,6 +302,15 @@ async def _init_cycle_subsystem(config, pool) -> None:
         )
         set_cycle_event_bus(event_bus)
 
+        # SIP-0089 §2.5: wire the reserve-buffer guard live when a Postgres pool
+        # is available (the agent_assignments table lives there, migration 1110).
+        # Without a pool the guard stays unwired and recruitment is never gated.
+        assignment_port = None
+        if pool is not None:
+            from adapters.persistence.runtime.assignments_postgres import PostgresAssignment
+
+            assignment_port = PostgresAssignment(pool)
+
         flow_executor = create_flow_executor(
             "dispatched",
             cycle_registry=cycle_registry,
@@ -314,6 +323,7 @@ async def _init_cycle_subsystem(config, pool) -> None:
             workflow_tracker=_workflow_tracker,
             event_bus=event_bus,
             reply_router=_reply_router,
+            assignment_port=assignment_port,
         )
 
         set_cycle_ports(

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -117,6 +117,11 @@ app.include_router(artifacts_router)
 app.include_router(cycle_request_profiles_router)  # SIP-0074
 app.include_router(models_router)  # SIP-0074
 
+# SIP-0089 §2.7: Assignment routes (versioned resource lane, /api/v1)
+from squadops.api.routes.assignments import router as assignments_router  # noqa: E402
+
+app.include_router(assignments_router)
+
 # Platform health routes (replaces legacy health-check service)
 from squadops.api.routes.platform_health import router as platform_health_router  # noqa: E402
 
@@ -308,8 +313,11 @@ async def _init_cycle_subsystem(config, pool) -> None:
         assignment_port = None
         if pool is not None:
             from adapters.persistence.runtime.assignments_postgres import PostgresAssignment
+            from squadops.api.runtime.deps import set_assignment_port
 
             assignment_port = PostgresAssignment(pool)
+            # SIP-0089 §2.7: same adapter backs the assignment REST surface.
+            set_assignment_port(assignment_port)
 
         flow_executor = create_flow_executor(
             "dispatched",

--- a/src/squadops/cli/commands/assignment.py
+++ b/src/squadops/cli/commands/assignment.py
@@ -1,0 +1,188 @@
+"""Assignment commands (SIP-0089 §2.7).
+
+`squadops assignment list <agent-id>` and `squadops assignment show
+<assignment-id>` are operator read commands; `squadops assignment create ...`
+is EXPERIMENTAL/INTERNAL in v1.1 (not a public operator command).
+
+All three reach the runtime-api over HTTP on the versioned resource lane
+(`/api/v1/...`) — the CLI is forbidden from importing the Postgres adapter
+directly (D26), mirroring how `agent state` reads runtime-state over HTTP.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from squadops.cli.client import APIClient, CLIError
+from squadops.cli.config import load_config
+from squadops.cli.output import (
+    print_detail,
+    print_error,
+    print_json,
+    print_success,
+    print_table,
+)
+
+app = typer.Typer(name="assignment", help="Inspect and manage duty assignments (SIP-0089)")
+
+
+def _get_client(ctx: typer.Context) -> APIClient:
+    config = load_config()
+    return APIClient(config)
+
+
+def _window_field(assignment: dict, key: str) -> str:
+    """Pull a nested active_window field for table display."""
+    window = assignment.get("active_window") or {}
+    return str(window.get(key, "") or "")
+
+
+@app.command("list")
+def list_assignments(
+    ctx: typer.Context,
+    agent_id: str = typer.Argument(..., help="Agent identifier (e.g. max, neo)"),
+):
+    """List all assignments held by an agent (active and inactive)."""
+    fmt = ctx.obj.get("format", "table") if ctx.obj else "table"
+    quiet = ctx.obj.get("quiet", False) if ctx.obj else False
+
+    try:
+        client = _get_client(ctx)
+        try:
+            data = client.get(f"/api/v1/agents/{agent_id}/assignments")
+        finally:
+            client.close()
+    except CLIError as e:
+        print_error(str(e))
+        raise typer.Exit(code=e.exit_code) from e
+
+    if fmt == "json":
+        print_json(data)
+        return
+
+    rows = [
+        [
+            a["assignment_id"],
+            a["assignment_type"],
+            a["assigned_role"],
+            a["strictness"],
+            _window_field(a, "start"),
+            _window_field(a, "end"),
+            str(a["active"]),
+        ]
+        for a in data
+    ]
+    print_table(
+        ["Assignment ID", "Type", "Role", "Strictness", "Window Start", "Window End", "Active"],
+        rows,
+        quiet=quiet,
+    )
+
+
+@app.command("show")
+def show_assignment(
+    ctx: typer.Context,
+    assignment_id: str = typer.Argument(..., help="Assignment identifier"),
+):
+    """Show one assignment by id."""
+    fmt = ctx.obj.get("format", "table") if ctx.obj else "table"
+    quiet = ctx.obj.get("quiet", False) if ctx.obj else False
+
+    try:
+        client = _get_client(ctx)
+        try:
+            data = client.get(f"/api/v1/assignments/{assignment_id}")
+        finally:
+            client.close()
+    except CLIError as e:
+        print_error(str(e))
+        raise typer.Exit(code=e.exit_code) from e
+
+    if fmt == "json":
+        print_json(data)
+    else:
+        print_detail(data, quiet=quiet)
+
+
+@app.command("create")
+def create_assignment(
+    ctx: typer.Context,
+    agent_id: str = typer.Argument(..., help="Agent identifier (holder of the assignment)"),
+    role: str = typer.Option(..., "--role", help="Assigned role"),
+    window_start: str = typer.Option(..., "--window-start", help="Window start (ISO 8601)"),
+    window_end: str = typer.Option(..., "--window-end", help="Window end (ISO 8601)"),
+    timezone: str = typer.Option("UTC", "--timezone", help="Civil timezone of the window"),
+    assignment_id: str | None = typer.Option(
+        None, "--assignment-id", help="Explicit id (upsert target); generated if omitted"
+    ),
+    assignment_type: str = typer.Option("duty", "--type", help="duty|reserve|cycle_eligibility"),
+    priority: int = typer.Option(0, "--priority", help="Scheduling priority"),
+    strictness: str = typer.Option("hard", "--strictness", help="hard|soft"),
+    reserve_before_seconds: int | None = typer.Option(
+        None,
+        "--reserve-before-seconds",
+        help="Pre-window reserve buffer; omitted = D7 default (900 hard / 0 soft)",
+    ),
+    reserve_after_seconds: int | None = typer.Option(
+        None, "--reserve-after-seconds", help="Trailing reserve buffer; omitted = 0"
+    ),
+    recall_policy: str = typer.Option(
+        "graceful", "--recall-policy", help="immediate|graceful|none"
+    ),
+    graceful_window_seconds: int = typer.Option(0, "--graceful-window-seconds"),
+    missed_window_policy: str = typer.Option(
+        "skip",
+        "--missed-window-policy",
+        help="skip|start_late_within_grace|require_operator_review",
+    ),
+    off_window_mode: list[str] = typer.Option(
+        [], "--off-window-mode", help="Allowed off-window mode (repeatable): duty|cycle|ambient"
+    ),
+    active: bool = typer.Option(
+        True, "--active/--inactive", help="Whether the assignment is active"
+    ),
+):
+    """Create (upsert) an assignment. EXPERIMENTAL/INTERNAL — not a public operator command.
+
+    Reserve buffers are optional: omit them to apply the SIP-0089 §11.4 defaults
+    (15 minutes before a hard duty window, 0 for soft).
+    """
+    fmt = ctx.obj.get("format", "table") if ctx.obj else "table"
+
+    body: dict = {
+        "agent_id": agent_id,
+        "assigned_role": role,
+        "window_start": window_start,
+        "window_end": window_end,
+        "timezone": timezone,
+        "assignment_type": assignment_type,
+        "priority": priority,
+        "strictness": strictness,
+        "recall_policy": recall_policy,
+        "graceful_window_seconds": graceful_window_seconds,
+        "missed_window_policy": missed_window_policy,
+        "allowed_off_window_modes": off_window_mode,
+        "active": active,
+    }
+    if assignment_id is not None:
+        body["assignment_id"] = assignment_id
+    # Only send reserve overrides when provided, so the server applies D7 defaults.
+    if reserve_before_seconds is not None:
+        body["reserve_before_window_seconds"] = reserve_before_seconds
+    if reserve_after_seconds is not None:
+        body["reserve_after_window_seconds"] = reserve_after_seconds
+
+    try:
+        client = _get_client(ctx)
+        try:
+            data = client.post("/api/v1/assignments", json=body)
+        finally:
+            client.close()
+    except CLIError as e:
+        print_error(str(e))
+        raise typer.Exit(code=e.exit_code) from e
+
+    if fmt == "json":
+        print_json(data)
+    else:
+        print_success(f"Assignment {data.get('assignment_id', '')} created")

--- a/src/squadops/cli/main.py
+++ b/src/squadops/cli/main.py
@@ -22,6 +22,7 @@ if "pytest" not in sys.modules:
 
 from squadops.cli.commands.agent import app as agent_app
 from squadops.cli.commands.artifacts import artifacts_app, baseline_app
+from squadops.cli.commands.assignment import app as assignment_app
 from squadops.cli.commands.auth import auth_app, login, logout
 from squadops.cli.commands.bootstrap import bootstrap
 from squadops.cli.commands.cycles import app as cycles_app
@@ -101,3 +102,4 @@ app.add_typer(auth_app, name="auth")
 app.add_typer(request_profiles_app, name="request-profiles")  # SIP-0074
 app.add_typer(models_app, name="models")  # SIP-0074
 app.add_typer(agent_app, name="agent")  # SIP-0089
+app.add_typer(assignment_app, name="assignment")  # SIP-0089 §2.7

--- a/src/squadops/ports/runtime/__init__.py
+++ b/src/squadops/ports/runtime/__init__.py
@@ -6,6 +6,7 @@ Matches the namespace pattern of `squadops.ports.cycles` and
 """
 
 from squadops.ports.runtime.assignments import AssignmentPort
+from squadops.ports.runtime.event_publisher import RuntimeEventPublisher
 from squadops.ports.runtime.state import RuntimeStatePort
 
-__all__ = ["AssignmentPort", "RuntimeStatePort"]
+__all__ = ["AssignmentPort", "RuntimeEventPublisher", "RuntimeStatePort"]

--- a/src/squadops/ports/runtime/__init__.py
+++ b/src/squadops/ports/runtime/__init__.py
@@ -5,6 +5,7 @@ Matches the namespace pattern of `squadops.ports.cycles` and
 `squadops.ports.observability` (established in 1.0.5).
 """
 
+from squadops.ports.runtime.assignments import AssignmentPort
 from squadops.ports.runtime.state import RuntimeStatePort
 
-__all__ = ["RuntimeStatePort"]
+__all__ = ["AssignmentPort", "RuntimeStatePort"]

--- a/src/squadops/ports/runtime/assignments.py
+++ b/src/squadops/ports/runtime/assignments.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import TYPE_CHECKING
 
-from squadops.runtime.models import Assignment
+if TYPE_CHECKING:
+    from squadops.runtime.models import Assignment
 
 
 class AssignmentPort(ABC):

--- a/src/squadops/ports/runtime/assignments.py
+++ b/src/squadops/ports/runtime/assignments.py
@@ -1,0 +1,57 @@
+"""
+AssignmentPort — abstract interface for duty Assignment persistence (SIP-0089 §10.2).
+
+Phase 2 surface (§2.3). The query methods are intentionally specific so the
+scheduler (§2.4) and the cycle reserve-buffer guard (§2.5) push time/agent
+filtering into SQL rather than fetching all assignments and filtering in memory.
+
+Window semantics referenced below match `runtime.models.window_state`:
+"active or in reserve" means `now ∈ [window_start - reserve_before_window,
+window_end + reserve_after_window)`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+from squadops.runtime.models import Assignment
+
+
+class AssignmentPort(ABC):
+    """Port for `Assignment` persistence and the scheduler/guard read queries."""
+
+    @abstractmethod
+    async def get_assignment(self, assignment_id: str) -> Assignment | None:
+        """Return the assignment by id, or `None` if no row exists."""
+
+    @abstractmethod
+    async def list_assignments_for_agent(self, agent_id: str) -> list[Assignment]:
+        """Return all assignments held by `agent_id`, ordered by window start.
+
+        Returns active and inactive rows; callers filter on `active` as needed.
+        """
+
+    @abstractmethod
+    async def list_active_assignments(self, now: datetime) -> list[Assignment]:
+        """Return active assignments whose window is active or in reserve at `now`.
+
+        i.e. `now ∈ [window_start - reserve_before_window, window_end +
+        reserve_after_window)` and `active = TRUE`. This is the broad
+        "currently relevant" set; the §2.5 guard refines it (e.g. to hard duties
+        in `in_reserve_before`/`active`) via `window_state`.
+        """
+
+    @abstractmethod
+    async def list_claimable_windows(self, now: datetime) -> list[Assignment]:
+        """Return active duty assignments whose window is currently claimable.
+
+        Claimable = `assignment_type = 'duty'`, `active = TRUE`, and `now ∈
+        [window_start - reserve_before_window, window_end)` — from when the
+        pre-duty reserve buffer opens until the window closes. The scheduler
+        (§2.4) decides per row whether a transition request is still needed.
+        """
+
+    @abstractmethod
+    async def upsert_assignment(self, assignment: Assignment) -> Assignment:
+        """Insert or update `assignment` by `assignment_id`; return it."""

--- a/src/squadops/ports/runtime/event_publisher.py
+++ b/src/squadops/ports/runtime/event_publisher.py
@@ -1,0 +1,32 @@
+"""
+RuntimeEventPublisher — abstract seam for runtime-state event publication (SIP-0089 D22).
+
+The coordinator (§2.6) emits mode-transition events through this port rather than
+importing an event bridge directly (D26 forbids `runtime/* → events/bridges/*`).
+Mirrors the best-effort contract of `CycleEventBusPort`: `emit` is non-blocking
+and not part of the caller's success criteria — emission failure is never an
+application error.
+
+`event_name` comes from `squadops.runtime.events`; `reason_code` from
+`squadops.runtime.reasons`. The two are kept as separate arguments because D18
+requires events (what happened) and reasons (why) to stay distinct.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class RuntimeEventPublisher(ABC):
+    """Port for runtime-state event publication (best-effort)."""
+
+    @abstractmethod
+    def emit(
+        self,
+        event_name: str,
+        *,
+        agent_id: str,
+        reason_code: str,
+        payload: dict | None = None,
+    ) -> None:
+        """Publish a runtime event for `agent_id`. Best-effort; never raises to the caller."""

--- a/src/squadops/ports/runtime/state.py
+++ b/src/squadops/ports/runtime/state.py
@@ -13,8 +13,10 @@ must not overwrite coordinator-owned fields (`mode`, `focus`,
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-from squadops.runtime.models import AgentRuntimeState
+if TYPE_CHECKING:
+    from squadops.runtime.models import AgentRuntimeState
 
 
 class RuntimeStatePort(ABC):

--- a/src/squadops/runtime/__init__.py
+++ b/src/squadops/runtime/__init__.py
@@ -23,11 +23,13 @@ from squadops.runtime.models import (
     WindowState,
     window_state,
 )
+from squadops.runtime.scheduler import DutyScheduler
 
 __all__ = [
     "AgentRuntimeState",
     "Assignment",
     "AssignmentType",
+    "DutyScheduler",
     "DutyWindow",
     "MissedWindowPolicy",
     "RecallPolicy",

--- a/src/squadops/runtime/__init__.py
+++ b/src/squadops/runtime/__init__.py
@@ -23,6 +23,7 @@ from squadops.runtime.models import (
     WindowState,
     window_state,
 )
+from squadops.runtime.recruitment import RecruitmentDecision, reserve_buffer_decision
 from squadops.runtime.scheduler import DutyScheduler
 
 __all__ = [
@@ -33,10 +34,12 @@ __all__ = [
     "DutyWindow",
     "MissedWindowPolicy",
     "RecallPolicy",
+    "RecruitmentDecision",
     "RequesterKind",
     "RuntimeCoordinator",
     "Strictness",
     "TransitionOutcome",
     "WindowState",
+    "reserve_buffer_decision",
     "window_state",
 ]

--- a/src/squadops/runtime/__init__.py
+++ b/src/squadops/runtime/__init__.py
@@ -7,6 +7,11 @@ Pure coordination layer for `RuntimeMode`, `RuntimeActivity`, `FocusLease`,
 per D26).
 """
 
+from squadops.runtime.coordinator import (
+    RequesterKind,
+    RuntimeCoordinator,
+    TransitionOutcome,
+)
 from squadops.runtime.models import (
     AgentRuntimeState,
     Assignment,
@@ -26,7 +31,10 @@ __all__ = [
     "DutyWindow",
     "MissedWindowPolicy",
     "RecallPolicy",
+    "RequesterKind",
+    "RuntimeCoordinator",
     "Strictness",
+    "TransitionOutcome",
     "WindowState",
     "window_state",
 ]

--- a/src/squadops/runtime/__init__.py
+++ b/src/squadops/runtime/__init__.py
@@ -7,6 +7,26 @@ Pure coordination layer for `RuntimeMode`, `RuntimeActivity`, `FocusLease`,
 per D26).
 """
 
-from squadops.runtime.models import AgentRuntimeState
+from squadops.runtime.models import (
+    AgentRuntimeState,
+    Assignment,
+    AssignmentType,
+    DutyWindow,
+    MissedWindowPolicy,
+    RecallPolicy,
+    Strictness,
+    WindowState,
+    window_state,
+)
 
-__all__ = ["AgentRuntimeState"]
+__all__ = [
+    "AgentRuntimeState",
+    "Assignment",
+    "AssignmentType",
+    "DutyWindow",
+    "MissedWindowPolicy",
+    "RecallPolicy",
+    "Strictness",
+    "WindowState",
+    "window_state",
+]

--- a/src/squadops/runtime/coordinator.py
+++ b/src/squadops/runtime/coordinator.py
@@ -1,0 +1,223 @@
+"""
+Runtime state coordinator — the sole authority for RuntimeMode transitions
+(SIP-0089 §2.6, D16).
+
+Every mode change flows through `request_transition`. The coordinator is the
+only writer of `AgentRuntimeState.mode` (D16); schedulers, CLI, and external
+callers *request* transitions and the coordinator validates and applies them.
+
+Phase 2 gates:
+- a reason code is required (§11.2);
+- target == current is an idempotent no-op;
+- the (from, to) pair must be an allowed transition (§11.1 lists all six ordered
+  pairs among the three modes, so this mainly rejects malformed `target_mode`
+  strings that bypass the type hint);
+- an `offline` runtime may not enter `duty` directly (§11.3);
+- D12 idempotency: a transition tagged `(assignment_id, scheduled_at)` applies at
+  most once, so repeated scheduler ticks within a window never duplicate it.
+
+FocusLease (Phase 3, §10.4) and RuntimeActivity (Phase 4) resolution are
+deliberately stubbed seams here — see the precondition comments in
+`request_transition`. On apply, a canonical event is emitted with a *separate*
+reason code (D14/D18) through the injected `RuntimeEventPublisher`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+from squadops.ports.runtime.event_publisher import RuntimeEventPublisher
+from squadops.ports.runtime.state import RuntimeStatePort
+from squadops.runtime import events, reasons
+from squadops.runtime.models import RuntimeMode
+
+RequesterKind = Literal["scheduler", "coordinator", "cli", "external"]
+
+# §11.1 allowed mode transitions. All six ordered pairs among the three modes are
+# permitted (some policy-gated — cycle→duty preemption, duty→cycle window-ended —
+# whose deeper checks land with FocusLease in Phase 3 / RuntimeActivity in
+# Phase 4). Kept explicit so a malformed `target_mode` is rejected, not applied.
+_ALLOWED_TRANSITIONS: frozenset[tuple[RuntimeMode, RuntimeMode]] = frozenset(
+    {
+        ("ambient", "cycle"),
+        ("ambient", "duty"),
+        ("cycle", "ambient"),
+        ("cycle", "duty"),
+        ("duty", "ambient"),
+        ("duty", "cycle"),
+    }
+)
+
+
+@dataclass(frozen=True)
+class TransitionOutcome:
+    """Result of a `request_transition` call.
+
+    Exactly one of three shapes: applied (`applied=True`, `event_name` set),
+    idempotent no-op (`idempotent_skip=True`), or rejected (`rejected_reason`
+    set). `reason_code` echoes the requested reason in all cases.
+    """
+
+    applied: bool
+    agent_id: str
+    from_mode: RuntimeMode | None
+    to_mode: str
+    reason_code: str
+    event_name: str | None = None
+    rejected_reason: str | None = None
+    idempotent_skip: bool = False
+
+
+class RuntimeCoordinator:
+    """Validates and applies RuntimeMode transitions; emits reason-coded events."""
+
+    def __init__(
+        self,
+        state: RuntimeStatePort,
+        *,
+        events_publisher: RuntimeEventPublisher | None = None,
+    ) -> None:
+        self._state = state
+        self._events = events_publisher
+        # D12 idempotency ledger. In-process for v1.1 (single in-process scheduler);
+        # durable persistence is a refinement for the SIP-0091 Temporal adapter.
+        self._applied_keys: set[str] = set()
+
+    async def request_transition(
+        self,
+        agent_id: str,
+        target_mode: str,
+        reason_code: str,
+        *,
+        requester_kind: RequesterKind,
+        owner_ref: str,
+        assignment_id: str | None = None,
+        scheduled_at: datetime | None = None,
+    ) -> TransitionOutcome:
+        # (1 §11.2) a reason code is mandatory.
+        if not reason_code:
+            return TransitionOutcome(
+                applied=False,
+                agent_id=agent_id,
+                from_mode=None,
+                to_mode=target_mode,
+                reason_code=reason_code,
+                rejected_reason=reasons.MISSING_REASON_CODE,
+            )
+
+        # (D12) repeated request for the same scheduled window is a no-op.
+        idem_key = _idem_key(agent_id, assignment_id, scheduled_at, target_mode)
+        if idem_key is not None and idem_key in self._applied_keys:
+            return TransitionOutcome(
+                applied=False,
+                agent_id=agent_id,
+                from_mode=target_mode if target_mode in ("duty", "cycle", "ambient") else None,
+                to_mode=target_mode,
+                reason_code=reason_code,
+                idempotent_skip=True,
+            )
+
+        state = await self._state.get_state(agent_id)
+        if state is None:
+            state = await self._state.ensure_state(agent_id)
+        current = state.mode
+
+        # target == current: nothing to do.
+        if current == target_mode:
+            if idem_key is not None:
+                self._applied_keys.add(idem_key)
+            return TransitionOutcome(
+                applied=False,
+                agent_id=agent_id,
+                from_mode=current,
+                to_mode=target_mode,
+                reason_code=reason_code,
+                idempotent_skip=True,
+            )
+
+        # (4 §11.1) structural allow-list — also rejects malformed target modes.
+        if (current, target_mode) not in _ALLOWED_TRANSITIONS:
+            return self._reject(agent_id, current, target_mode, reason_code, reasons.INVALID_MODE_TRANSITION)
+
+        # (4 §11.3) an offline runtime must reach online/recovering before duty.
+        if target_mode == "duty" and state.runtime_status == "offline":
+            return self._reject(
+                agent_id, current, target_mode, reason_code, reasons.OFFLINE_CANNOT_ENTER_DUTY
+            )
+
+        # (2) FocusLease decision — Phase 3 (§10.4) wires arbitration here.
+        # (3) RuntimeActivity decision — Phase 4 wires pause/resume/abort here.
+        # Both are intentional no-ops in Phase 2.
+
+        # (5 D16) apply — the coordinator is the sole writer of `mode`. Entering
+        # duty binds the active assignment; leaving duty clears it.
+        new_state = dataclasses.replace(
+            state,
+            mode=target_mode,
+            current_assignment_ref=(assignment_id if target_mode == "duty" else None),
+        )
+        await self._state.upsert_state(new_state)
+
+        # (5 D14/D18) emit the canonical event with a separate reason code.
+        if self._events is not None:
+            self._events.emit(
+                events.MODE_TRANSITION,
+                agent_id=agent_id,
+                reason_code=reason_code,
+                payload={
+                    "from_mode": current,
+                    "to_mode": target_mode,
+                    "assignment_id": assignment_id,
+                    "requester_kind": requester_kind,
+                    "owner_ref": owner_ref,
+                },
+            )
+
+        # (6) record idempotency key only after a successful apply.
+        if idem_key is not None:
+            self._applied_keys.add(idem_key)
+
+        return TransitionOutcome(
+            applied=True,
+            agent_id=agent_id,
+            from_mode=current,
+            to_mode=target_mode,
+            reason_code=reason_code,
+            event_name=events.MODE_TRANSITION,
+        )
+
+    @staticmethod
+    def _reject(
+        agent_id: str,
+        from_mode: RuntimeMode,
+        to_mode: str,
+        reason_code: str,
+        rejected_reason: str,
+    ) -> TransitionOutcome:
+        return TransitionOutcome(
+            applied=False,
+            agent_id=agent_id,
+            from_mode=from_mode,
+            to_mode=to_mode,
+            reason_code=reason_code,
+            rejected_reason=rejected_reason,
+        )
+
+
+def _idem_key(
+    agent_id: str,
+    assignment_id: str | None,
+    scheduled_at: datetime | None,
+    target_mode: str,
+) -> str | None:
+    """Idempotency key for a scheduled transition, or None when untagged.
+
+    Requires both `assignment_id` and `scheduled_at` — ad-hoc (CLI/external)
+    transitions are not deduplicated.
+    """
+    if assignment_id is None or scheduled_at is None:
+        return None
+    return f"{agent_id}|{assignment_id}|{scheduled_at.isoformat()}|{target_mode}"

--- a/src/squadops/runtime/events.py
+++ b/src/squadops/runtime/events.py
@@ -19,3 +19,7 @@ MODE_TRANSITION: Final[str] = "runtime_state.mode_transition"
 # Heartbeat lifecycle (Phase 1)
 HEARTBEAT_INITIALIZED: Final[str] = "runtime_state.heartbeat_initialized"
 HEARTBEAT_RECOVERED: Final[str] = "runtime_state.heartbeat_recovered"
+
+# Assignment window lifecycle (Phase 2 §2.4 — scheduler-emitted, non-transition)
+ASSIGNMENT_WINDOW_SKIPPED: Final[str] = "assignment.window.skipped"
+ASSIGNMENT_WINDOW_REVIEW_REQUIRED: Final[str] = "assignment.window.review_required"

--- a/src/squadops/runtime/models.py
+++ b/src/squadops/runtime/models.py
@@ -110,6 +110,22 @@ class Assignment:
     active: bool = True
 
 
+def default_reserve_before_window(strictness: Strictness) -> timedelta:
+    """Return the strictness-dependent pre-duty reserve buffer (SIP-0089 §11.4 / D7).
+
+    Hard duty reserves the 15 minutes before its window (cycle recruitment is
+    rejected during that buffer so the agent is free when duty opens); soft duty
+    reserves nothing (the scheduler handles soft recall when the window opens, so
+    there is no pre-duty hold). The trailing `reserve_after_window` default is
+    always zero, so it has no helper — callers pass ``timedelta()``.
+
+    Applied at Assignment creation time (the API create route), never inside the
+    dataclass: per D7 every Assignment carries explicit reserve values, so this
+    only fills the gap when a caller omits them.
+    """
+    return timedelta(minutes=15) if strictness == "hard" else timedelta()
+
+
 def window_state(
     assignment: Assignment,
     now: datetime,

--- a/src/squadops/runtime/models.py
+++ b/src/squadops/runtime/models.py
@@ -1,15 +1,19 @@
 """
-Runtime state dataclasses for SIP-0089 Phase 1.
+Runtime state dataclasses for SIP-0089.
 
-`AgentRuntimeState` mirrors SIP-0089 §10.1. Frozen dataclass; mutate via
-`dataclasses.replace()`. `Literal` types in code; matching `CHECK` constraints
-at the DB level (D3).
+Phase 1: `AgentRuntimeState` mirrors SIP-0089 §10.1.
+Phase 2 (§2.1): `Assignment` + `DutyWindow` mirror §10.2/§10.3, plus the
+`window_state()` time classifier used by the scheduler (§2.4) and the cycle
+reserve-buffer guard (§2.5).
+
+All models are frozen dataclasses; mutate via `dataclasses.replace()`. `Literal`
+types in code mirror the DB `CHECK` constraints (D3).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Literal
 
 RuntimeMode = Literal["duty", "cycle", "ambient"]
@@ -35,3 +39,113 @@ class AgentRuntimeState:
     interruptibility: Interruptibility
     last_heartbeat_at: datetime
     current_assignment_ref: str | None
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 (§2.1) — Assignments and Duty Windows
+# ---------------------------------------------------------------------------
+
+AssignmentType = Literal["duty", "reserve", "cycle_eligibility"]
+Strictness = Literal["hard", "soft"]
+RecallPolicy = Literal["immediate", "graceful", "none"]
+MissedWindowPolicy = Literal["skip", "start_late_within_grace", "require_operator_review"]
+WindowState = Literal[
+    "before_window",
+    "in_reserve_before",
+    "active",
+    "in_reserve_after",
+    "closed",
+    "missed",
+]
+
+
+@dataclass(frozen=True)
+class DutyWindow:
+    """The time range an Assignment is active, plus its civil timezone.
+
+    Per SIP-0089 §10.3, window fields live inside the Assignment rather than in a
+    separate table for v1.1. `start`/`end` are absolute, timezone-aware instants;
+    `timezone` is the civil tz (e.g. ``America/New_York``) the window was authored
+    in, retained for display and recurrence reasoning. Half-open ``[start, end)``:
+    `start` is inside the window, `end` is the first instant after it.
+    """
+
+    start: datetime
+    end: datetime
+    timezone: str
+
+
+@dataclass(frozen=True)
+class Assignment:
+    """A durable commitment that may claim an agent during its DutyWindow.
+
+    Mirrors SIP-0089 §10.2. Frozen; mutate via ``dataclasses.replace()``. An agent
+    may hold multiple Assignments but exactly one current RuntimeMode (§10.2);
+    conflicts are resolved by scheduling policy before a focus claim is attempted.
+
+    `reserve_before_window`/`reserve_after_window` are first-class v1.1 policy
+    (§11.4): the pre-duty buffer during which cycle recruitment is rejected.
+    Strictness-dependent defaults (15m hard / 0m soft) are applied at creation
+    time, not here — every Assignment carries explicit values (D7).
+    """
+
+    assignment_id: str
+    assignment_type: AssignmentType
+    assigned_role: str
+    priority: int
+    strictness: Strictness
+    active_window: DutyWindow
+    reserve_before_window: timedelta
+    reserve_after_window: timedelta
+    recall_policy: RecallPolicy
+    graceful_window: timedelta
+    missed_window_policy: MissedWindowPolicy
+    allowed_off_window_modes: tuple[RuntimeMode, ...]
+    active: bool = True
+
+
+def window_state(
+    assignment: Assignment,
+    now: datetime,
+    *,
+    entered_active: bool = True,
+) -> WindowState:
+    """Classify where ``now`` falls relative to ``assignment``'s duty window.
+
+    The five time-geometry states derive purely from the window and its reserve
+    buffers (all bounds half-open, inclusive-start / exclusive-end):
+
+        before_window      before the pre-duty reserve buffer opens
+        in_reserve_before  inside the pre-duty reserve buffer, before the window (§11.4)
+        active             inside the window itself
+        in_reserve_after   after the window, inside the trailing reserve buffer
+        closed             past the trailing reserve buffer
+
+    The sixth state, ``missed``, is NOT derivable from time alone — it requires
+    knowing the agent never entered duty. The scheduler (§2.4) tracks that and
+    passes ``entered_active=False``; only once the window has *ended* without entry
+    does the result become ``missed`` (it never pre-empts ``active``, since the
+    agent could still enter while the window is open). The default ``True`` makes
+    the documented ``window_state(assignment, now)`` a pure time classifier — all
+    the §2.5 reserve guard needs, since it acts only on ``in_reserve_before`` and
+    ``active``.
+
+    All datetimes must be timezone-aware; mixing aware/naive raises ``TypeError``
+    from the comparison, which is the desired fail-fast.
+    """
+    window = assignment.active_window
+    reserve_before_start = window.start - assignment.reserve_before_window
+    reserve_after_end = window.end + assignment.reserve_after_window
+
+    if now < reserve_before_start:
+        return "before_window"
+    if now < window.start:
+        return "in_reserve_before"
+    if now < window.end:
+        return "active"
+    # The window has ended.
+    if not entered_active:
+        return "missed"
+    if now < reserve_after_end:
+        return "in_reserve_after"
+    return "closed"

--- a/src/squadops/runtime/models.py
+++ b/src/squadops/runtime/models.py
@@ -83,6 +83,11 @@ class Assignment:
     may hold multiple Assignments but exactly one current RuntimeMode (§10.2);
     conflicts are resolved by scheduling policy before a focus claim is attempted.
 
+    `agent_id` (the holder) is not in the §10.2 field sketch but is required by the
+    §2.2 table and the §2.3 port: `list_active_assignments(now)` returns rows across
+    agents, and the §2.5 reserve guard filters them to a run's participating agents,
+    so each Assignment must carry its holder.
+
     `reserve_before_window`/`reserve_after_window` are first-class v1.1 policy
     (§11.4): the pre-duty buffer during which cycle recruitment is rejected.
     Strictness-dependent defaults (15m hard / 0m soft) are applied at creation
@@ -90,6 +95,7 @@ class Assignment:
     """
 
     assignment_id: str
+    agent_id: str
     assignment_type: AssignmentType
     assigned_role: str
     priority: int

--- a/src/squadops/runtime/reasons.py
+++ b/src/squadops/runtime/reasons.py
@@ -20,3 +20,8 @@ CYCLE_COMPLETED: Final[str] = "cycle_completed"
 
 # Heartbeat-recovery reasons (Phase 1)
 RUNTIME_STATUS_CHANGED_TO_ONLINE: Final[str] = "runtime_status_changed_to_online"
+
+# Transition-rejection reasons (Phase 2 §2.6 — coordinator)
+MISSING_REASON_CODE: Final[str] = "missing_reason_code"
+INVALID_MODE_TRANSITION: Final[str] = "invalid_mode_transition"
+OFFLINE_CANNOT_ENTER_DUTY: Final[str] = "offline_cannot_enter_duty"

--- a/src/squadops/runtime/reasons.py
+++ b/src/squadops/runtime/reasons.py
@@ -30,3 +30,6 @@ OFFLINE_CANNOT_ENTER_DUTY: Final[str] = "offline_cannot_enter_duty"
 DUTY_WINDOW_STARTED_LATE: Final[str] = "duty_window_started_late"
 DUTY_WINDOW_MISSED: Final[str] = "duty_window_missed"
 DUTY_WINDOW_MISSED_OPERATOR_REVIEW: Final[str] = "duty_window_missed_operator_review"
+
+# Cycle recruitment-guard reasons (Phase 2 §2.5 — reserve buffer)
+UPCOMING_HARD_DUTY_WINDOW: Final[str] = "upcoming_hard_duty_window"

--- a/src/squadops/runtime/reasons.py
+++ b/src/squadops/runtime/reasons.py
@@ -25,3 +25,8 @@ RUNTIME_STATUS_CHANGED_TO_ONLINE: Final[str] = "runtime_status_changed_to_online
 MISSING_REASON_CODE: Final[str] = "missing_reason_code"
 INVALID_MODE_TRANSITION: Final[str] = "invalid_mode_transition"
 OFFLINE_CANNOT_ENTER_DUTY: Final[str] = "offline_cannot_enter_duty"
+
+# Duty-window scheduling reasons (Phase 2 §2.4 — scheduler)
+DUTY_WINDOW_STARTED_LATE: Final[str] = "duty_window_started_late"
+DUTY_WINDOW_MISSED: Final[str] = "duty_window_missed"
+DUTY_WINDOW_MISSED_OPERATOR_REVIEW: Final[str] = "duty_window_missed_operator_review"

--- a/src/squadops/runtime/recruitment.py
+++ b/src/squadops/runtime/recruitment.py
@@ -1,0 +1,86 @@
+"""
+Cycle recruitment guard — SIP-0089 §2.5 (reserve-buffer protection).
+
+Pure policy. Given the active duty assignments and the agents a cycle run is
+about to recruit, decide whether recruitment may proceed or must be deferred
+because a participating agent is committed to — or about to start — a hard duty
+window (§11.4).
+
+This is the runtime-domain *decision*. Enforcement (pausing the run, emitting
+the deferral event) lives in the cycle executor (``adapters/cycles``). The
+module depends only on ``runtime.models`` and ``runtime.reasons`` — never on
+``adapters.*`` (D26) — so the executor (an adapter) imports *down* into the
+domain, never the reverse.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from squadops.runtime import reasons
+from squadops.runtime.models import window_state
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from datetime import datetime
+
+    from squadops.runtime.models import Assignment
+
+
+@dataclass(frozen=True)
+class RecruitmentDecision:
+    """Outcome of the reserve-buffer guard.
+
+    ``allowed=True`` → the run may dispatch. ``allowed=False`` → defer (pause):
+    a participating agent holds a hard duty assignment in its pre-duty reserve
+    buffer or active window. ``blocking_agent_id`` / ``reason`` are populated
+    only when ``allowed=False``.
+    """
+
+    allowed: bool
+    blocking_agent_id: str | None = None
+    reason: str | None = None
+
+
+def reserve_buffer_decision(
+    assignments: Iterable[Assignment],
+    participating_agent_ids: set[str],
+    now: datetime,
+) -> RecruitmentDecision:
+    """Reject cycle recruitment when a participating agent is reserved for duty.
+
+    Rejects iff some ``assignment`` is, at ``now``:
+
+      * held by a participating agent (``agent_id in participating_agent_ids``),
+      * a ``duty`` assignment with ``hard`` strictness, and
+      * ``in_reserve_before`` or ``active`` per :func:`window_state` (§11.4).
+
+    Soft duties do not gate recruitment in v1.1: a soft window yields to the
+    scheduler's recall when it opens (§2.4), so starting cycle work alongside it
+    is safe. The trailing ``in_reserve_after`` buffer also does not block — duty
+    is winding down, not starting. The earliest-starting blocking assignment is
+    reported (deterministic; ties broken by ``assignment_id``).
+
+    Pure and time-injected (``now``) so the executor stays unit-testable without
+    a clock.
+    """
+    blocking = sorted(
+        (
+            a
+            for a in assignments
+            if a.assignment_type == "duty"
+            and a.strictness == "hard"
+            and a.agent_id in participating_agent_ids
+            and window_state(a, now) in ("in_reserve_before", "active")
+        ),
+        key=lambda a: (a.active_window.start, a.assignment_id),
+    )
+    if blocking:
+        first = blocking[0]
+        return RecruitmentDecision(
+            allowed=False,
+            blocking_agent_id=first.agent_id,
+            reason=reasons.UPCOMING_HARD_DUTY_WINDOW,
+        )
+    return RecruitmentDecision(allowed=True)

--- a/src/squadops/runtime/scheduler.py
+++ b/src/squadops/runtime/scheduler.py
@@ -1,0 +1,188 @@
+"""
+In-process duty transition scheduler (SIP-0089 §2.4).
+
+A polling scheduler that opens and closes duty windows by **requesting**
+transitions through the `RuntimeCoordinator`. Per D21 it is a *claimant, not an
+authority*: it reads assignments and agent state but never writes
+`AgentRuntimeState` directly — only the coordinator does.
+
+Per-tick, for each active **duty** assignment:
+- `window_state == active` and the agent is not yet on duty for it → open the
+  window (on time → `duty_window_opened`; late → governed by `MissedWindowPolicy`);
+- agent on duty for it and `window_state ∈ {in_reserve_after, closed}` → close it
+  (`duty_window_closed`);
+- `window_state == missed` (window ended, never entered) → enact the policy
+  (skip → `assignment.window.skipped`; review → `assignment.window.review_required`).
+
+Idempotency (D12/D21): open requests carry `scheduled_at = window_start` and
+close requests `scheduled_at = window_end`, so the coordinator dedupes repeated
+ticks within the same window.
+
+Lifecycle: construction does nothing. `start()` launches the poll loop; bootstrap
+calls it **only when `runtime.scheduler.enabled`**. It must not auto-start — unit
+tests drive `tick()` directly. The v1.3 Temporal scheduler (SIP-0091) will sit
+behind the same seam.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+
+from squadops.ports.runtime.assignments import AssignmentPort
+from squadops.ports.runtime.event_publisher import RuntimeEventPublisher
+from squadops.ports.runtime.state import RuntimeStatePort
+from squadops.runtime import events, reasons
+from squadops.runtime.coordinator import RuntimeCoordinator, TransitionOutcome
+from squadops.runtime.models import Assignment, window_state
+
+logger = logging.getLogger(__name__)
+
+# Config: runtime.scheduler.poll_interval_seconds (default 30); the scheduler is
+# constructed/started by bootstrap only when runtime.scheduler.enabled is true.
+_DEFAULT_POLL_INTERVAL_SECONDS = 30.0
+
+
+class DutyScheduler:
+    """Polls duty assignments and requests window-open/close transitions."""
+
+    def __init__(
+        self,
+        assignments: AssignmentPort,
+        coordinator: RuntimeCoordinator,
+        state: RuntimeStatePort,
+        *,
+        events_publisher: RuntimeEventPublisher | None = None,
+        poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._assignments = assignments
+        self._coordinator = coordinator
+        self._state = state
+        self._events = events_publisher
+        self._poll_interval_seconds = poll_interval_seconds
+        self._clock = clock or (lambda: datetime.now(UTC))
+        self._task: asyncio.Task | None = None
+
+    async def tick(self, now: datetime | None = None) -> list[TransitionOutcome]:
+        """Evaluate all active duty assignments once. Returns transitions requested."""
+        at = now if now is not None else self._clock()
+        outcomes: list[TransitionOutcome] = []
+        for assignment in await self._assignments.list_active_assignments(at):
+            if assignment.assignment_type != "duty":
+                continue  # reserve / cycle_eligibility don't drive mode transitions
+            outcome = await self._evaluate(assignment, at)
+            if outcome is not None:
+                outcomes.append(outcome)
+        return outcomes
+
+    async def _evaluate(self, a: Assignment, now: datetime) -> TransitionOutcome | None:
+        state = await self._state.get_state(a.agent_id)
+        in_duty = (
+            state is not None
+            and state.mode == "duty"
+            and state.current_assignment_ref == a.assignment_id
+        )
+        st = window_state(a, now, entered_active=in_duty)
+
+        if st == "active":
+            if in_duty:
+                return None  # already serving this window
+            late = now - a.active_window.start
+            if late <= timedelta(0):
+                return await self._open(a, reasons.DUTY_WINDOW_OPENED)
+            return await self._open_late(a, late)
+
+        if st in ("in_reserve_after", "closed"):
+            # window_state only yields these when in_duty is True (entered_active),
+            # so this is the close path for an agent currently serving the window.
+            return await self._close(a)
+
+        if st == "missed":
+            self._enact_missed(a)
+            return None
+
+        return None  # before_window / in_reserve_before — reserve is §2.5's concern
+
+    async def _open(self, a: Assignment, reason: str) -> TransitionOutcome:
+        return await self._coordinator.request_transition(
+            a.agent_id,
+            "duty",
+            reason,
+            requester_kind="scheduler",
+            owner_ref=a.assignment_id,
+            assignment_id=a.assignment_id,
+            scheduled_at=a.active_window.start,
+        )
+
+    async def _open_late(self, a: Assignment, late: timedelta) -> TransitionOutcome | None:
+        policy = a.missed_window_policy
+        if policy == "require_operator_review":
+            self._emit_review(a)
+            return None
+        if policy == "start_late_within_grace" and late <= a.graceful_window:
+            return await self._open(a, reasons.DUTY_WINDOW_STARTED_LATE)
+        # 'skip', or 'start_late_within_grace' past the grace window.
+        self._emit_skipped(a)
+        return None
+
+    async def _close(self, a: Assignment) -> TransitionOutcome:
+        return await self._coordinator.request_transition(
+            a.agent_id,
+            "ambient",
+            reasons.DUTY_WINDOW_CLOSED,
+            requester_kind="scheduler",
+            owner_ref=a.assignment_id,
+            assignment_id=a.assignment_id,
+            scheduled_at=a.active_window.end,
+        )
+
+    def _enact_missed(self, a: Assignment) -> None:
+        if a.missed_window_policy == "require_operator_review":
+            self._emit_review(a)
+        else:
+            self._emit_skipped(a)
+
+    def _emit_skipped(self, a: Assignment) -> None:
+        if self._events is not None:
+            self._events.emit(
+                events.ASSIGNMENT_WINDOW_SKIPPED,
+                agent_id=a.agent_id,
+                reason_code=reasons.DUTY_WINDOW_MISSED,
+                payload={"assignment_id": a.assignment_id},
+            )
+
+    def _emit_review(self, a: Assignment) -> None:
+        if self._events is not None:
+            self._events.emit(
+                events.ASSIGNMENT_WINDOW_REVIEW_REQUIRED,
+                agent_id=a.agent_id,
+                reason_code=reasons.DUTY_WINDOW_MISSED_OPERATOR_REVIEW,
+                payload={"assignment_id": a.assignment_id},
+            )
+
+    # -- poll loop (started by bootstrap only when enabled) --
+
+    async def start(self) -> None:
+        """Launch the background poll loop. Idempotent."""
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Cancel the poll loop and await its clean shutdown."""
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+
+    async def _run(self) -> None:
+        while True:
+            try:
+                await self.tick()
+            except Exception:  # one bad tick must not kill the loop
+                logger.exception("duty scheduler tick failed")
+            await asyncio.sleep(self._poll_interval_seconds)

--- a/tests/unit/api/test_assignment_routes.py
+++ b/tests/unit/api/test_assignment_routes.py
@@ -1,0 +1,176 @@
+"""Unit tests for the SIP-0089 §2.7 assignment route DTOs.
+
+These deliberately avoid `TestClient` (blocked locally per #217) and test the
+serialization layer directly: the `Assignment` <-> wire-DTO mapping and the
+D7/§11.4 reserve-buffer defaults applied at create time. The HTTP wiring itself
+(routing, 404 envelope) is exercised by the CLI command tests via an injected
+client.
+
+Each test answers: what bug would it catch?
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from squadops.api.routes.assignments import (
+    AssignmentCreate,
+    AssignmentResponse,
+)
+from squadops.runtime.models import Assignment, DutyWindow
+
+pytestmark = [pytest.mark.domain_api]
+
+WIN_START = datetime(2026, 6, 24, 1, 0, tzinfo=UTC)
+WIN_END = datetime(2026, 6, 24, 6, 0, tzinfo=UTC)
+
+
+def _assignment(**overrides) -> Assignment:
+    base = dict(
+        assignment_id="a-1",
+        agent_id="max",
+        assignment_type="duty",
+        assigned_role="support",
+        priority=10,
+        strictness="hard",
+        active_window=DutyWindow(start=WIN_START, end=WIN_END, timezone="America/New_York"),
+        reserve_before_window=timedelta(minutes=15),
+        reserve_after_window=timedelta(minutes=10),
+        recall_policy="graceful",
+        graceful_window=timedelta(minutes=5),
+        missed_window_policy="require_operator_review",
+        allowed_off_window_modes=("ambient", "cycle"),
+        active=True,
+    )
+    base.update(overrides)
+    return Assignment(**base)  # type: ignore[arg-type]
+
+
+def _create_from_response(resp: AssignmentResponse) -> AssignmentCreate:
+    """Rebuild a create-request from a response, passing reserve buffers
+    explicitly so no defaults are re-applied — this makes the trip lossless."""
+    return AssignmentCreate(
+        agent_id=resp.agent_id,
+        assigned_role=resp.assigned_role,
+        window_start=resp.active_window.start,
+        window_end=resp.active_window.end,
+        timezone=resp.active_window.timezone,
+        assignment_id=resp.assignment_id,
+        assignment_type=resp.assignment_type,
+        priority=resp.priority,
+        strictness=resp.strictness,
+        reserve_before_window_seconds=resp.reserve_before_window_seconds,
+        reserve_after_window_seconds=resp.reserve_after_window_seconds,
+        recall_policy=resp.recall_policy,
+        graceful_window_seconds=resp.graceful_window_seconds,
+        missed_window_policy=resp.missed_window_policy,
+        allowed_off_window_modes=resp.allowed_off_window_modes,
+        active=resp.active,
+    )
+
+
+def test_dto_round_trip_preserves_all_fields():
+    """Bug class: a dropped or mistyped field in `from_domain`/`to_domain` (e.g.
+    forgetting the timezone, coercing the tuple to a list, or losing a reserve
+    buffer) would silently corrupt an assignment as it crosses the API. A full
+    round-trip equality is the only assertion that catches every such omission."""
+    original = _assignment()
+    rebuilt = _create_from_response(AssignmentResponse.from_domain(original)).to_domain()
+    assert rebuilt == original
+    # Spot-check the easy-to-lose nested/typed members explicitly.
+    assert rebuilt.active_window.timezone == "America/New_York"
+    assert rebuilt.allowed_off_window_modes == ("ambient", "cycle")
+    assert isinstance(rebuilt.allowed_off_window_modes, tuple)
+    assert rebuilt.reserve_before_window == timedelta(minutes=15)
+
+
+def test_response_serializes_timedeltas_as_integer_seconds():
+    """Bug class: using `.seconds` instead of `.total_seconds()`, or emitting a
+    `timedelta`/float, would break every JSON consumer. Pin the exact integers."""
+    resp = AssignmentResponse.from_domain(_assignment())
+    assert resp.reserve_before_window_seconds == 900
+    assert resp.reserve_after_window_seconds == 600
+    assert resp.graceful_window_seconds == 300
+    assert isinstance(resp.reserve_before_window_seconds, int)
+
+
+@pytest.mark.parametrize(
+    ("strictness", "expected_before"),
+    [
+        ("hard", timedelta(minutes=15)),
+        ("soft", timedelta(0)),
+    ],
+)
+def test_create_applies_reserve_defaults_when_omitted(strictness, expected_before):
+    """Bug class (§11.4/D7): if `to_domain` failed to apply the strictness default
+    when the operator omits the reserve fields, a hard duty would persist with a
+    0-minute buffer and the §2.5 recruitment guard would never gate it."""
+    body = AssignmentCreate(
+        agent_id="max",
+        assigned_role="support",
+        window_start=WIN_START,
+        window_end=WIN_END,
+        strictness=strictness,
+    )
+    domain = body.to_domain()
+    assert domain.reserve_before_window == expected_before
+    assert domain.reserve_after_window == timedelta(0)
+
+
+def test_create_explicit_zero_reserve_is_not_overridden_by_default():
+    """Bug class: distinguishing 'omitted' (apply default) from 'explicitly 0'
+    (honor it) matters — a hard duty that the operator deliberately set to a
+    0-minute buffer must NOT silently get the 15-minute default back."""
+    body = AssignmentCreate(
+        agent_id="max",
+        assigned_role="support",
+        window_start=WIN_START,
+        window_end=WIN_END,
+        strictness="hard",
+        reserve_before_window_seconds=0,
+    )
+    assert body.to_domain().reserve_before_window == timedelta(0)
+
+
+def test_create_generates_id_when_omitted():
+    """Bug class: the upsert is keyed by assignment_id; if create left it empty,
+    every created assignment would collide on the same row."""
+    body = AssignmentCreate(
+        agent_id="max",
+        assigned_role="support",
+        window_start=WIN_START,
+        window_end=WIN_END,
+    )
+    assert body.to_domain().assignment_id
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"window_start": WIN_END, "window_end": WIN_START},  # inverted
+        {"window_start": WIN_START, "window_end": WIN_START},  # empty
+    ],
+)
+def test_create_rejects_non_positive_window(kwargs):
+    """Bug class: an inverted or empty window passes type-checking but is rejected
+    by the DB CHECK (§2.2/D3) as a 500. Validating it as a 422 at the DTO turns a
+    server error into a clear client error."""
+    with pytest.raises(ValidationError):
+        AssignmentCreate(agent_id="max", assigned_role="support", **kwargs)
+
+
+def test_create_rejects_negative_reserve():
+    """Bug class: a negative reserve buffer would make `window_state` open the
+    reserve window *after* the duty start — nonsensical geometry the guard relies
+    on. Reject it at the edge."""
+    with pytest.raises(ValidationError):
+        AssignmentCreate(
+            agent_id="max",
+            assigned_role="support",
+            window_start=WIN_START,
+            window_end=WIN_END,
+            reserve_before_window_seconds=-60,
+        )

--- a/tests/unit/cli/test_assignment_command.py
+++ b/tests/unit/cli/test_assignment_command.py
@@ -1,0 +1,178 @@
+"""Unit tests for `squadops assignment ...` (SIP-0089 §2.7).
+
+What bugs would these catch?
+- Wrong endpoint URL → the operator command silently hits the wrong service.
+- `create` sending reserve buffers it shouldn't → the server would never apply
+  the D7/§11.4 strictness defaults (a hard duty would persist with no buffer).
+- A 404 from `show` not propagating a non-zero exit → breaks operator scripts.
+
+Mirrors `test_agent_state_command.py`: CliRunner + a patched `_get_client`, so no
+network and no TestClient (blocked locally per #217).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from squadops.cli.main import app
+
+pytestmark = [pytest.mark.domain_cli]
+
+WIN_START = "2026-06-24T01:00:00+00:00"
+WIN_END = "2026-06-24T06:00:00+00:00"
+
+
+def _assignment_payload(**overrides) -> dict:
+    base = {
+        "assignment_id": "a-1",
+        "agent_id": "max",
+        "assignment_type": "duty",
+        "assigned_role": "support",
+        "priority": 10,
+        "strictness": "hard",
+        "active_window": {"start": WIN_START, "end": WIN_END, "timezone": "UTC"},
+        "reserve_before_window_seconds": 900,
+        "reserve_after_window_seconds": 0,
+        "recall_policy": "graceful",
+        "graceful_window_seconds": 0,
+        "missed_window_policy": "skip",
+        "allowed_off_window_modes": ["ambient", "cycle"],
+        "active": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def _client_returning(*, get=None, post=None) -> MagicMock:
+    mock = MagicMock()
+    if get is not None:
+        mock.get.return_value = get
+    if post is not None:
+        mock.post.return_value = post
+    return mock
+
+
+def test_list_calls_correct_endpoint():
+    """Bug class: an endpoint typo (`/api/v1/assignments/agents/...`) compiles and
+    only fails when an operator runs it."""
+    runner = CliRunner()
+    mock_client = _client_returning(get=[_assignment_payload()])
+    with patch("squadops.cli.commands.assignment._get_client", return_value=mock_client):
+        result = runner.invoke(app, ["assignment", "list", "max"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.stdout
+    mock_client.get.assert_called_once_with("/api/v1/agents/max/assignments")
+
+
+def test_list_json_emits_raw_payload():
+    """Bug class: the `--json` path must pass the API payload through untouched so
+    downstream tooling sees the canonical shape (incl. the nested active_window)."""
+    runner = CliRunner()
+    payload = [_assignment_payload()]
+    mock_client = _client_returning(get=payload)
+    with patch("squadops.cli.commands.assignment._get_client", return_value=mock_client):
+        result = runner.invoke(app, ["--json", "assignment", "list", "max"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.stdout
+    parsed = json.loads(result.stdout.strip())
+    assert parsed == payload
+    assert parsed[0]["active_window"]["timezone"] == "UTC"
+
+
+def test_show_calls_correct_endpoint():
+    runner = CliRunner()
+    mock_client = _client_returning(get=_assignment_payload())
+    with patch("squadops.cli.commands.assignment._get_client", return_value=mock_client):
+        result = runner.invoke(app, ["assignment", "show", "a-1"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.stdout
+    mock_client.get.assert_called_once_with("/api/v1/assignments/a-1")
+
+
+def test_show_propagates_404_as_nonzero_exit():
+    """Bug class: a CLI that exits 0 on 'not found' breaks every operator script
+    that branches on `squadops assignment show`."""
+    from squadops.cli import exit_codes
+    from squadops.cli.client import CLIError
+
+    runner = CliRunner()
+    mock_client = MagicMock()
+    mock_client.get.side_effect = CLIError("not found — ghost", exit_codes.NOT_FOUND)
+    with patch("squadops.cli.commands.assignment._get_client", return_value=mock_client):
+        result = runner.invoke(app, ["assignment", "show", "ghost"], catch_exceptions=False)
+
+    assert result.exit_code == exit_codes.NOT_FOUND
+
+
+def test_create_posts_minimal_body_without_reserve_overrides():
+    """Bug class: if `create` always sent reserve_*_window_seconds, the server
+    could never apply the §11.4 strictness defaults — a hard duty would persist
+    with whatever the CLI defaulted to. The omitted keys are load-bearing."""
+    runner = CliRunner()
+    mock_client = _client_returning(post=_assignment_payload())
+    with patch("squadops.cli.commands.assignment._get_client", return_value=mock_client):
+        result = runner.invoke(
+            app,
+            [
+                "assignment",
+                "create",
+                "max",
+                "--role",
+                "support",
+                "--window-start",
+                WIN_START,
+                "--window-end",
+                WIN_END,
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.stdout
+    mock_client.post.assert_called_once()
+    path, kwargs = mock_client.post.call_args[0], mock_client.post.call_args[1]
+    assert path == ("/api/v1/assignments",)
+    body = kwargs["json"]
+    assert body["agent_id"] == "max"
+    assert body["assigned_role"] == "support"
+    assert body["window_start"] == WIN_START
+    assert body["strictness"] == "hard"
+    # Defaults must be left to the server — these keys must be absent.
+    assert "reserve_before_window_seconds" not in body
+    assert "reserve_after_window_seconds" not in body
+    assert "assignment_id" not in body
+
+
+def test_create_passes_explicit_reserve_override_through():
+    """Bug class: when the operator *does* set a reserve buffer, it must reach the
+    server verbatim (incl. an explicit 0, which must not be dropped as falsy)."""
+    runner = CliRunner()
+    mock_client = _client_returning(post=_assignment_payload())
+    with patch("squadops.cli.commands.assignment._get_client", return_value=mock_client):
+        result = runner.invoke(
+            app,
+            [
+                "assignment",
+                "create",
+                "max",
+                "--role",
+                "support",
+                "--window-start",
+                WIN_START,
+                "--window-end",
+                WIN_END,
+                "--reserve-before-seconds",
+                "0",
+                "--strictness",
+                "soft",
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.stdout
+    body = mock_client.post.call_args[1]["json"]
+    assert body["reserve_before_window_seconds"] == 0
+    assert body["strictness"] == "soft"

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -26,6 +26,7 @@ from squadops.cycles.models import (
     TaskFlowPolicy,
 )
 from squadops.cycles.pulse_models import CADENCE_BOUNDARY_ID, SuiteOutcome
+from squadops.events.types import EventType
 from squadops.tasks.models import TaskEnvelope, TaskResult
 
 NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
@@ -719,6 +720,183 @@ class TestCancellation:
         status_calls = mock_registry.update_run_status.call_args_list
         terminal_statuses = [c.args[1] for c in status_calls]
         assert RunStatus.CANCELLED in terminal_statuses
+
+
+# ---------------------------------------------------------------------------
+# SIP-0089 §2.5 — reserve-buffer recruitment guard
+# ---------------------------------------------------------------------------
+
+
+class TestReserveBufferGuard:
+    """A participating agent's imminent/active hard duty window defers the run.
+
+    The guard fires after plan generation (the plan names every recruited agent)
+    and before dispatch: on conflict the run is PAUSED (a deferral, resumable via
+    ``squadops runs resume``), no task is published, and the RUN_PAUSED event
+    carries the duty-deferral reason so it is distinguishable from a BLOCKED
+    pause. The opposite bug — a wired guard false-positively blocking a clean
+    run — is guarded by the no-conflict case.
+    """
+
+    @staticmethod
+    def _assignment_port(assignments):
+        port = AsyncMock()
+        port.list_active_assignments.return_value = assignments
+        return port
+
+    @staticmethod
+    def _hard_duty(agent_id):
+        from squadops.runtime.models import Assignment, DutyWindow
+
+        # Window spans a wide range so window_state == "active" at wall-clock now
+        # (the guard reads datetime.now(UTC); this avoids coupling to real time).
+        return Assignment(
+            assignment_id=f"duty-{agent_id}",
+            agent_id=agent_id,
+            assignment_type="duty",
+            assigned_role="support",
+            priority=10,
+            strictness="hard",
+            active_window=DutyWindow(
+                start=datetime(2000, 1, 1, tzinfo=UTC),
+                end=datetime(2100, 1, 1, tzinfo=UTC),
+                timezone="UTC",
+            ),
+            reserve_before_window=timedelta(minutes=15),
+            reserve_after_window=timedelta(minutes=10),
+            recall_policy="graceful",
+            graceful_window=timedelta(minutes=5),
+            missed_window_policy="skip",
+            allowed_off_window_modes=("ambient", "cycle"),
+        )
+
+    def _build(
+        self,
+        *,
+        mock_registry,
+        mock_vault,
+        mock_queue,
+        mock_squad_profile,
+        reply_router,
+        cycle,
+        run,
+        event_bus,
+        assignment_port,
+    ):
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+        mock_registry.get_cycle.return_value = cycle
+        mock_registry.get_run.return_value = run
+        return DispatchedFlowExecutor(
+            cycle_registry=mock_registry,
+            artifact_vault=mock_vault,
+            queue=mock_queue,
+            squad_profile=mock_squad_profile,
+            task_timeout=5.0,
+            reply_router=reply_router,
+            event_bus=event_bus,
+            assignment_port=assignment_port,
+        )
+
+    async def test_imminent_hard_duty_pauses_run_before_dispatch(
+        self,
+        mock_registry,
+        mock_vault,
+        mock_queue,
+        mock_squad_profile,
+        reply_router,
+        cycle,
+        run,
+    ) -> None:
+        event_bus = MagicMock()
+        # "neo" is a participating agent (development.design step).
+        port = self._assignment_port([self._hard_duty("neo")])
+        executor = self._build(
+            mock_registry=mock_registry,
+            mock_vault=mock_vault,
+            mock_queue=mock_queue,
+            mock_squad_profile=mock_squad_profile,
+            reply_router=reply_router,
+            cycle=cycle,
+            run=run,
+            event_bus=event_bus,
+            assignment_port=port,
+        )
+
+        with patch(
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        # Deferred, not dispatched.
+        statuses = [c.args[1] for c in mock_registry.update_run_status.call_args_list]
+        assert statuses[0] == RunStatus.RUNNING
+        assert statuses[-1] == RunStatus.PAUSED
+        assert mock_queue.publish.call_count == 0
+
+        # RUN_PAUSED carries the duty-deferral reason + the blocking agent.
+        paused = [
+            c for c in event_bus.emit.call_args_list if c.args and c.args[0] == EventType.RUN_PAUSED
+        ]
+        assert len(paused) == 1
+        payload = paused[0].kwargs["payload"]
+        assert payload["reason"] == "upcoming_hard_duty_window"
+        assert payload["deferred_for_agent"] == "neo"
+
+    async def test_no_conflicting_assignment_lets_run_proceed(
+        self,
+        mock_registry,
+        mock_vault,
+        mock_queue,
+        mock_squad_profile,
+        reply_router,
+        cycle,
+        run,
+    ) -> None:
+        """Guard wired but the active set is empty → no false positive: the run
+        dispatches all 5 tasks and completes."""
+        event_bus = MagicMock()
+        port = self._assignment_port([])
+        executor = self._build(
+            mock_registry=mock_registry,
+            mock_vault=mock_vault,
+            mock_queue=mock_queue,
+            mock_squad_profile=mock_squad_profile,
+            reply_router=reply_router,
+            cycle=cycle,
+            run=run,
+            event_bus=event_bus,
+            assignment_port=port,
+        )
+        reply_router.responder = lambda env: TaskResult(
+            task_id=env["task_id"],
+            status="SUCCEEDED",
+            outputs={
+                "summary": "ok",
+                "role": "strat",
+                "artifacts": [
+                    {
+                        "name": "o.md",
+                        "content": "# o",
+                        "media_type": "text/markdown",
+                        "type": "document",
+                    }
+                ],
+            },
+        )
+
+        # NB: asyncio.sleep is intentionally NOT patched here. The per-task
+        # heartbeat is a `while True: await asyncio.sleep(...)` loop; patching
+        # sleep to a non-yielding AsyncMock turns it into a busy-spin that
+        # starves the event loop (the same reason TestSequentialHappyPath can
+        # hang locally). With real sleep, the heartbeat task is created and
+        # cancelled before its first 30s tick, and replies resolve synchronously.
+        await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        statuses = [c.args[1] for c in mock_registry.update_run_status.call_args_list]
+        assert statuses[-1] == RunStatus.COMPLETED
+        assert mock_queue.publish.call_count == 5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/events/test_event_emission.py
+++ b/tests/unit/events/test_event_emission.py
@@ -221,8 +221,14 @@ class TestEmitCallSitePayloadFields:
         assert with_payload >= 38
 
     def test_total_emit_call_count(self) -> None:
-        """Sanity check: 40 executor + 7 route = 47 total emit calls."""
+        """Sanity check: 41 executor + 7 route = 48 total emit calls.
+
+        The 41st executor emit is the SIP-0089 §2.5 reserve-buffer deferral —
+        `EventType.RUN_PAUSED` with payload reason `upcoming_hard_duty_window`,
+        raised from the `_RecruitmentRejectedError` handler. Reusing RUN_PAUSED
+        (rather than minting a new EventType) keeps the locked cycle taxonomy
+        intact, so this count — not the taxonomy size — is what moves."""
         total = 0
         for path in _ALL_EMISSION_FILES:
             total += len(self._extract_emit_calls(path))
-        assert total == 47
+        assert total == 48

--- a/tests/unit/runtime/test_assignments.py
+++ b/tests/unit/runtime/test_assignments.py
@@ -32,6 +32,7 @@ def _assignment(
 ) -> Assignment:
     return Assignment(
         assignment_id="a-1",
+        agent_id="max",
         assignment_type="duty",
         assigned_role="support",
         priority=10,

--- a/tests/unit/runtime/test_assignments.py
+++ b/tests/unit/runtime/test_assignments.py
@@ -1,0 +1,119 @@
+"""Unit tests for SIP-0089 Phase 2 §2.1 — Assignment / DutyWindow / window_state.
+
+These exercise `window_state()`, the pure time classifier the scheduler (§2.4)
+and the cycle reserve-buffer guard (§2.5) both depend on. The bug class they
+guard against is off-by-one / boundary errors in the reserve-buffer geometry —
+the kind that would let a cycle be recruited one second inside a hard duty's
+reserve window, or mark a window `closed` while it is still `active`.
+
+Each test answers: what bug would it catch?
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from squadops.runtime.models import Assignment, DutyWindow, window_state
+
+pytestmark = [pytest.mark.domain_runtime]
+
+# Window: 01:00–06:00 UTC, 15m pre-buffer (→ opens 00:45), 10m post-buffer (→ closes 06:10).
+WIN_START = datetime(2026, 6, 24, 1, 0, tzinfo=UTC)
+WIN_END = datetime(2026, 6, 24, 6, 0, tzinfo=UTC)
+
+
+def _assignment(
+    *,
+    reserve_before: timedelta = timedelta(minutes=15),
+    reserve_after: timedelta = timedelta(minutes=10),
+    strictness: str = "hard",
+) -> Assignment:
+    return Assignment(
+        assignment_id="a-1",
+        assignment_type="duty",
+        assigned_role="support",
+        priority=10,
+        strictness=strictness,  # type: ignore[arg-type]
+        active_window=DutyWindow(start=WIN_START, end=WIN_END, timezone="UTC"),
+        reserve_before_window=reserve_before,
+        reserve_after_window=reserve_after,
+        recall_policy="graceful",
+        graceful_window=timedelta(minutes=5),
+        missed_window_policy="require_operator_review",
+        allowed_off_window_modes=("ambient", "cycle"),
+    )
+
+
+def _at(hour: int, minute: int) -> datetime:
+    return datetime(2026, 6, 24, hour, minute, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    ("now", "expected"),
+    [
+        (_at(0, 30), "before_window"),  # before the 00:45 reserve opens
+        (_at(0, 45), "in_reserve_before"),  # reserve-start instant is inside the buffer
+        (_at(0, 55), "in_reserve_before"),
+        (_at(1, 0), "active"),  # window-start instant is active (inclusive)
+        (_at(3, 0), "active"),
+        (_at(6, 0), "in_reserve_after"),  # window-end instant is already past (exclusive)
+        (_at(6, 5), "in_reserve_after"),
+        (_at(6, 10), "closed"),  # reserve-after-end instant is closed (exclusive)
+        (_at(7, 0), "closed"),
+    ],
+)
+def test_window_state_time_geometry(now, expected):
+    """Bug class: a boundary off-by-one would misclassify the reserve buffer — e.g.
+    treating 00:45 as `before_window` would let a cycle in during a hard duty's
+    reserve, the exact conflict §11.4 exists to prevent."""
+    assert window_state(_assignment(), now) == expected
+
+
+def test_window_state_default_never_returns_missed_after_close():
+    """Bug class: the default call must be a pure time classifier. If `missed`
+    leaked into the default path, a normally-completed window would be mislabeled
+    long after the fact."""
+    assert window_state(_assignment(), _at(7, 0)) == "closed"
+
+
+@pytest.mark.parametrize(
+    ("now", "expected"),
+    [
+        (_at(0, 55), "in_reserve_before"),  # not missed yet — window hasn't opened
+        (_at(3, 0), "active"),  # still open: the agent can still enter, so not missed
+        (_at(6, 0), "missed"),  # window just ended and was never entered
+        (_at(7, 0), "missed"),  # missed supersedes closed when never entered
+    ],
+)
+def test_window_state_missed_requires_window_ended_without_entry(now, expected):
+    """Bug class: `missed` must not pre-empt `active` (an agent entering late is
+    not a miss), and must override the post-window states once the window closes
+    unentered — otherwise the scheduler can't tell a no-show from a clean finish."""
+    assert window_state(_assignment(), now, entered_active=False) == expected
+
+
+@pytest.mark.parametrize(
+    ("now", "expected"),
+    [
+        (_at(0, 59), "before_window"),  # no pre-buffer → straight from before to active
+        (_at(1, 0), "active"),
+        (_at(5, 59), "active"),
+        (_at(6, 0), "closed"),  # no post-buffer → no in_reserve_after state at all
+    ],
+)
+def test_window_state_zero_buffers_collapse_reserve_states(now, expected):
+    """Bug class (soft-duty default = 0m buffers, §11.4): with zero reserve, the
+    `in_reserve_before`/`in_reserve_after` states must vanish rather than swallow
+    a zero-width interval and momentarily report a reserve state."""
+    a = _assignment(reserve_before=timedelta(0), reserve_after=timedelta(0), strictness="soft")
+    assert window_state(a, now) == expected
+
+
+def test_window_state_rejects_naive_now():
+    """Bug class: comparing a naive `now` against tz-aware window bounds silently
+    'works' in some Python versions and raises in others. We want fail-fast, not a
+    timezone-blind classification, so a naive datetime must raise."""
+    with pytest.raises(TypeError):
+        window_state(_assignment(), datetime(2026, 6, 24, 3, 0))  # noqa: DTZ001 — intentional

--- a/tests/unit/runtime/test_assignments.py
+++ b/tests/unit/runtime/test_assignments.py
@@ -15,7 +15,12 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from squadops.runtime.models import Assignment, DutyWindow, window_state
+from squadops.runtime.models import (
+    Assignment,
+    DutyWindow,
+    default_reserve_before_window,
+    window_state,
+)
 
 pytestmark = [pytest.mark.domain_runtime]
 
@@ -118,3 +123,19 @@ def test_window_state_rejects_naive_now():
     timezone-blind classification, so a naive datetime must raise."""
     with pytest.raises(TypeError):
         window_state(_assignment(), datetime(2026, 6, 24, 3, 0))  # noqa: DTZ001 — intentional
+
+
+@pytest.mark.parametrize(
+    ("strictness", "expected"),
+    [
+        ("hard", timedelta(minutes=15)),
+        ("soft", timedelta(0)),
+    ],
+)
+def test_default_reserve_before_window(strictness, expected):
+    """Bug class (§2.7 create / §11.4 / D7): the reserve-buffer default is what
+    decides whether an upcoming hard duty gates cycle recruitment. If hard duty
+    defaulted to 0 (or soft to 15m), the §2.5 guard would either never fire or
+    fire spuriously — and the value must be an exact 15-minute timedelta, not
+    just 'truthy', since `window_state` does interval arithmetic with it."""
+    assert default_reserve_before_window(strictness) == expected  # type: ignore[arg-type]

--- a/tests/unit/runtime/test_assignments_postgres.py
+++ b/tests/unit/runtime/test_assignments_postgres.py
@@ -108,6 +108,31 @@ async def test_get_assignment_returns_none_when_absent():
     assert await adapter.get_assignment("missing") is None
 
 
+async def test_list_assignments_for_agent_returns_all_of_an_agents_assignments():
+    """Bug class (§10.2 cardinality — an agent may hold MULTIPLE assignments): a
+    query that collapsed to one row per agent (e.g. fetchrow, DISTINCT ON
+    agent_id, or a stray LIMIT) would silently hide an agent's other commitments,
+    so the scheduler would never open the second window. Assert both rows survive,
+    keyed to the same agent, filtered by agent_id and ordered by window_start."""
+    later_start = WIN_START + timedelta(days=1)
+    conn = AsyncMock()
+    conn.fetch.return_value = [
+        _row(assignment_id="a-1"),
+        _row(assignment_id="a-2", window_start=later_start),
+    ]
+    adapter = PostgresAssignment(_make_pool(conn))
+
+    result = await adapter.list_assignments_for_agent("max")
+
+    assert [a.assignment_id for a in result] == ["a-1", "a-2"]
+    assert {a.agent_id for a in result} == {"max"}
+    sql, *args = conn.fetch.call_args.args
+    assert "WHERE agent_id = $1" in sql
+    assert "ORDER BY window_start" in sql
+    assert "LIMIT" not in sql.upper()  # never truncate an agent's commitments
+    assert args == ["max"]
+
+
 async def test_list_active_assignments_predicate_and_binding():
     """Bug class: the active set must be `active = TRUE` AND now inside the full
     reserve span [start - before, end + after). Dropping either buffer term would

--- a/tests/unit/runtime/test_assignments_postgres.py
+++ b/tests/unit/runtime/test_assignments_postgres.py
@@ -1,0 +1,163 @@
+"""Unit tests for SIP-0089 §2.3 — PostgresAssignment adapter.
+
+Two bug classes are guarded:
+- Row→dataclass mapping drift: the flat window columns must reassemble into the
+  nested `DutyWindow`, and the TEXT[] must become a tuple (a frozen-dataclass
+  field) — a list would silently break equality/hashing.
+- Time-predicate drift in the scheduler/guard queries: the reserve-buffer
+  interval arithmetic is the whole point of pushing these into SQL, so the
+  predicates and the `now` binding are asserted directly.
+
+asyncpg-mock pattern mirrors test_agent_runtime_state.py.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from adapters.persistence.runtime.assignments_postgres import PostgresAssignment
+from squadops.runtime.models import Assignment, DutyWindow
+
+pytestmark = [pytest.mark.domain_runtime]
+
+WIN_START = datetime(2026, 6, 24, 1, 0, tzinfo=UTC)
+WIN_END = datetime(2026, 6, 24, 6, 0, tzinfo=UTC)
+NOW = datetime(2026, 6, 24, 3, 0, tzinfo=UTC)
+
+
+class _AcquireCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _make_pool(conn):
+    pool = MagicMock()
+    pool.acquire.return_value = _AcquireCtx(conn)
+    return pool
+
+
+def _row(**overrides) -> dict:
+    base = {
+        "assignment_id": "a-1",
+        "agent_id": "max",
+        "assignment_type": "duty",
+        "assigned_role": "support",
+        "priority": 10,
+        "strictness": "hard",
+        "window_start": WIN_START,
+        "window_end": WIN_END,
+        "timezone": "UTC",
+        "reserve_before_window": timedelta(minutes=15),
+        "reserve_after_window": timedelta(minutes=10),
+        "recall_policy": "graceful",
+        "graceful_window": timedelta(minutes=5),
+        "missed_window_policy": "require_operator_review",
+        "allowed_off_window_modes": ["ambient", "cycle"],  # asyncpg returns a list
+        "active": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def _assignment() -> Assignment:
+    return Assignment(
+        assignment_id="a-1",
+        agent_id="max",
+        assignment_type="duty",
+        assigned_role="support",
+        priority=10,
+        strictness="hard",
+        active_window=DutyWindow(start=WIN_START, end=WIN_END, timezone="UTC"),
+        reserve_before_window=timedelta(minutes=15),
+        reserve_after_window=timedelta(minutes=10),
+        recall_policy="graceful",
+        graceful_window=timedelta(minutes=5),
+        missed_window_policy="require_operator_review",
+        allowed_off_window_modes=("ambient", "cycle"),
+        active=True,
+    )
+
+
+async def test_get_assignment_maps_row_including_nested_window_and_tuple():
+    """Bug class: a mapper that left the window columns flat, or kept the TEXT[]
+    as a list, would not equal the canonical dataclass — and the list would make
+    the frozen Assignment unhashable. This asserts the full reconstruction."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _row()
+    adapter = PostgresAssignment(_make_pool(conn))
+
+    assert await adapter.get_assignment("a-1") == _assignment()
+
+
+async def test_get_assignment_returns_none_when_absent():
+    """Bug class: callers must distinguish 'no such assignment' from a default;
+    a synthetic default row would corrupt scheduling decisions."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = None
+    adapter = PostgresAssignment(_make_pool(conn))
+
+    assert await adapter.get_assignment("missing") is None
+
+
+async def test_list_active_assignments_predicate_and_binding():
+    """Bug class: the active set must be `active = TRUE` AND now inside the full
+    reserve span [start - before, end + after). Dropping either buffer term would
+    make the §2.5 guard miss a reserve conflict."""
+    conn = AsyncMock()
+    conn.fetch.return_value = [_row()]
+    adapter = PostgresAssignment(_make_pool(conn))
+
+    result = await adapter.list_active_assignments(NOW)
+
+    assert [a.assignment_id for a in result] == ["a-1"]
+    sql, *args = conn.fetch.call_args.args
+    assert "active = TRUE" in sql
+    assert "$1 >= window_start - reserve_before_window" in sql
+    assert "$1 <  window_end + reserve_after_window" in sql
+    assert args == [NOW]  # `now` is the sole bind param
+
+
+async def test_list_claimable_windows_filters_duty_and_ends_at_window_close():
+    """Bug class: claimable must be duty-only and end at window close, NOT at the
+    trailing reserve buffer — including the after-buffer would keep requesting a
+    transition for a window that has already ended."""
+    conn = AsyncMock()
+    conn.fetch.return_value = []
+    adapter = PostgresAssignment(_make_pool(conn))
+
+    await adapter.list_claimable_windows(NOW)
+
+    sql, *args = conn.fetch.call_args.args
+    assert "assignment_type = 'duty'" in sql
+    assert "$1 <  window_end " in sql
+    assert "window_end + reserve_after_window" not in sql  # claim ends at close
+    assert args == [NOW]
+
+
+async def test_upsert_assignment_flattens_window_and_binds_array_as_list():
+    """Bug class: the nested DutyWindow must flatten to the window_start/_end/
+    timezone binds, and the tuple field must bind as a list — asyncpg array
+    params reject a tuple, so a silent type slip would fail only at runtime."""
+    conn = AsyncMock()
+    adapter = PostgresAssignment(_make_pool(conn))
+    a = _assignment()
+
+    returned = await adapter.upsert_assignment(a)
+
+    assert returned is a
+    sql, *args = conn.execute.call_args.args
+    assert "ON CONFLICT (assignment_id) DO UPDATE" in sql
+    assert args[6] == WIN_START  # $7 window_start
+    assert args[7] == WIN_END  # $8 window_end
+    assert args[8] == "UTC"  # $9 timezone
+    assert args[14] == ["ambient", "cycle"]  # $15 TEXT[] bound as list
+    assert isinstance(args[14], list)

--- a/tests/unit/runtime/test_coordinator.py
+++ b/tests/unit/runtime/test_coordinator.py
@@ -1,0 +1,218 @@
+"""Unit tests for SIP-0089 §2.6 — RuntimeCoordinator (the D16 transition authority).
+
+Bug classes guarded:
+- the coordinator silently applying a transition it should reject (offline→duty,
+  malformed mode, missing reason) — each would corrupt runtime state or hide a
+  scheduling bug;
+- a non-idempotent coordinator letting a repeated scheduler tick (D12/D21) open
+  the same window twice — duplicate transitions/events;
+- mode/assignment writes drifting (entering duty must bind the assignment;
+  leaving duty must clear it);
+- event/reason collapse (D18) — the emitted event name and the reason code must
+  be distinct values.
+
+Uses an in-memory RuntimeStatePort + a recording publisher rather than mocks, so
+assertions are on resulting state, not call shapes.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from squadops.ports.runtime.event_publisher import RuntimeEventPublisher
+from squadops.ports.runtime.state import RuntimeStatePort
+from squadops.runtime import events, reasons
+from squadops.runtime.coordinator import RuntimeCoordinator
+from squadops.runtime.models import AgentRuntimeState
+
+pytestmark = [pytest.mark.domain_runtime]
+
+NOW = datetime(2026, 6, 24, 1, 0, tzinfo=UTC)
+
+
+def _state(mode="ambient", runtime_status="online") -> AgentRuntimeState:
+    return AgentRuntimeState(
+        agent_id="max",
+        mode=mode,
+        runtime_status=runtime_status,
+        focus="",
+        current_runtime_activity_id=None,
+        interruptibility="high",
+        last_heartbeat_at=NOW,
+        current_assignment_ref=None,
+    )
+
+
+class _FakeStatePort(RuntimeStatePort):
+    def __init__(self, initial: AgentRuntimeState | None = None) -> None:
+        self._rows: dict[str, AgentRuntimeState] = {}
+        if initial is not None:
+            self._rows[initial.agent_id] = initial
+        self.upserts: list[AgentRuntimeState] = []
+
+    async def get_state(self, agent_id):
+        return self._rows.get(agent_id)
+
+    async def upsert_state(self, state):
+        self._rows[state.agent_id] = state
+        self.upserts.append(state)
+        return state
+
+    async def ensure_state(self, agent_id):
+        if agent_id not in self._rows:
+            self._rows[agent_id] = _state()
+        return self._rows[agent_id]
+
+    async def update_heartbeat(self, agent_id, *, runtime_status=None):  # unused here
+        return await self.ensure_state(agent_id)
+
+
+class _RecordingPublisher(RuntimeEventPublisher):
+    def __init__(self) -> None:
+        self.emitted: list[tuple] = []
+
+    def emit(self, event_name, *, agent_id, reason_code, payload=None):
+        self.emitted.append((event_name, agent_id, reason_code, payload))
+
+
+async def test_ambient_to_duty_applies_and_binds_assignment():
+    """Bug class: entering duty must persist mode=duty AND bind the active
+    assignment, else recall/scheduling can't tell which duty the agent serves."""
+    port = _FakeStatePort(_state(mode="ambient"))
+    pub = _RecordingPublisher()
+    coord = RuntimeCoordinator(port, events_publisher=pub)
+
+    outcome = await coord.request_transition(
+        "max", "duty", reasons.DUTY_WINDOW_OPENED,
+        requester_kind="scheduler", owner_ref="assign-1", assignment_id="assign-1",
+    )
+
+    assert outcome.applied is True
+    assert (outcome.from_mode, outcome.to_mode) == ("ambient", "duty")
+    assert port.upserts[-1].mode == "duty"
+    assert port.upserts[-1].current_assignment_ref == "assign-1"
+
+
+async def test_duty_to_ambient_clears_assignment_ref():
+    """Bug class: leaving duty must clear current_assignment_ref — a stale ref
+    would make an ambient agent look like it's still on duty."""
+    port = _FakeStatePort(
+        AgentRuntimeState("max", "duty", "online", "", None, "high", NOW, "assign-1")
+    )
+    coord = RuntimeCoordinator(port, events_publisher=_RecordingPublisher())
+
+    await coord.request_transition(
+        "max", "ambient", reasons.DUTY_WINDOW_CLOSED,
+        requester_kind="scheduler", owner_ref="assign-1",
+    )
+
+    assert port.upserts[-1].mode == "ambient"
+    assert port.upserts[-1].current_assignment_ref is None
+
+
+async def test_same_mode_is_idempotent_noop_without_write_or_event():
+    """Bug class: a no-op transition must not write or emit — spurious events
+    would pollute the audit trail and a needless upsert could race."""
+    port = _FakeStatePort(_state(mode="duty"))
+    pub = _RecordingPublisher()
+    coord = RuntimeCoordinator(port, events_publisher=pub)
+
+    outcome = await coord.request_transition(
+        "max", "duty", reasons.DUTY_WINDOW_OPENED,
+        requester_kind="scheduler", owner_ref="assign-1",
+    )
+
+    assert outcome.idempotent_skip is True and outcome.applied is False
+    assert port.upserts == []
+    assert pub.emitted == []
+
+
+async def test_offline_runtime_cannot_enter_duty():
+    """Bug class (§11.3): an offline agent transitioning straight to duty would
+    schedule work onto an unreachable runtime."""
+    port = _FakeStatePort(_state(mode="ambient", runtime_status="offline"))
+    pub = _RecordingPublisher()
+    coord = RuntimeCoordinator(port, events_publisher=pub)
+
+    outcome = await coord.request_transition(
+        "max", "duty", reasons.DUTY_WINDOW_OPENED,
+        requester_kind="scheduler", owner_ref="assign-1",
+    )
+
+    assert outcome.applied is False
+    assert outcome.rejected_reason == reasons.OFFLINE_CANNOT_ENTER_DUTY
+    assert port.upserts == [] and pub.emitted == []
+
+
+async def test_missing_reason_code_rejected_before_state_load():
+    """Bug class (§11.2): an unreasoned transition is unexplainable in the audit
+    trail and must be refused outright."""
+    port = _FakeStatePort(_state())
+    coord = RuntimeCoordinator(port, events_publisher=_RecordingPublisher())
+
+    outcome = await coord.request_transition(
+        "max", "duty", "", requester_kind="cli", owner_ref="op",
+    )
+
+    assert outcome.applied is False
+    assert outcome.rejected_reason == reasons.MISSING_REASON_CODE
+    assert port.upserts == []
+
+
+async def test_malformed_target_mode_rejected():
+    """Bug class: the allow-list catches a target_mode string that slipped past
+    the type hint (e.g. a typo), rather than persisting an invalid mode."""
+    port = _FakeStatePort(_state(mode="ambient"))
+    coord = RuntimeCoordinator(port, events_publisher=_RecordingPublisher())
+
+    outcome = await coord.request_transition(
+        "max", "paused", reasons.DUTY_WINDOW_OPENED,
+        requester_kind="external", owner_ref="x",
+    )
+
+    assert outcome.applied is False
+    assert outcome.rejected_reason == reasons.INVALID_MODE_TRANSITION
+    assert port.upserts == []
+
+
+async def test_repeated_scheduled_transition_is_deduped_d12():
+    """Bug class (D12/D21): a repeated scheduler tick for the same
+    (assignment, scheduled_at) must not open the window twice."""
+    port = _FakeStatePort(_state(mode="ambient"))
+    pub = _RecordingPublisher()
+    coord = RuntimeCoordinator(port, events_publisher=pub)
+    kwargs = {
+        "requester_kind": "scheduler",
+        "owner_ref": "assign-1",
+        "assignment_id": "assign-1",
+        "scheduled_at": NOW,
+    }
+
+    first = await coord.request_transition("max", "duty", reasons.DUTY_WINDOW_OPENED, **kwargs)
+    second = await coord.request_transition("max", "duty", reasons.DUTY_WINDOW_OPENED, **kwargs)
+
+    assert first.applied is True
+    assert second.applied is False and second.idempotent_skip is True
+    assert len(port.upserts) == 1  # applied exactly once
+    assert len(pub.emitted) == 1
+
+
+async def test_applied_event_keeps_event_and_reason_distinct_d18():
+    """Bug class (D18): the emitted event name and the reason code must be
+    different values — collapsing them loses the what/why distinction."""
+    port = _FakeStatePort(_state(mode="ambient"))
+    pub = _RecordingPublisher()
+    coord = RuntimeCoordinator(port, events_publisher=pub)
+
+    await coord.request_transition(
+        "max", "cycle", reasons.CYCLE_RECRUITED,
+        requester_kind="coordinator", owner_ref="cyc-1",
+    )
+
+    event_name, agent_id, reason_code, payload = pub.emitted[0]
+    assert event_name == events.MODE_TRANSITION
+    assert reason_code == reasons.CYCLE_RECRUITED
+    assert event_name != reason_code
+    assert payload["from_mode"] == "ambient" and payload["to_mode"] == "cycle"

--- a/tests/unit/runtime/test_recruitment.py
+++ b/tests/unit/runtime/test_recruitment.py
@@ -1,0 +1,159 @@
+"""Unit tests for SIP-0089 §2.5 — ``reserve_buffer_decision`` (pure guard).
+
+Bug classes guarded:
+- a hard duty in its pre-duty reserve buffer NOT rejecting recruitment (the core
+  §11.4 guarantee: an agent about to start duty gets pulled into a cycle anyway);
+- a hard duty *active* window not rejecting (agent already serving duty recruited);
+- over-rejecting on windows that should be permissive — before the reserve buffer
+  opens, the trailing reserve-after buffer, soft duties, and non-duty assignments;
+- rejecting on an assignment held by an agent the run does NOT recruit;
+- non-deterministic blocking-agent selection when several windows conflict;
+- the wrong reason code on rejection.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from squadops.runtime import reasons
+from squadops.runtime.models import Assignment, DutyWindow
+from squadops.runtime.recruitment import reserve_buffer_decision
+
+pytestmark = [pytest.mark.domain_runtime]
+
+NOW = datetime(2026, 6, 25, 12, 0, tzinfo=UTC)
+
+
+def _assignment(
+    *,
+    agent_id: str = "neo",
+    assignment_type: str = "duty",
+    strictness: str = "hard",
+    start: datetime,
+    end: datetime,
+    reserve_before: timedelta = timedelta(minutes=15),
+    reserve_after: timedelta = timedelta(minutes=10),
+) -> Assignment:
+    return Assignment(
+        assignment_id=f"a-{agent_id}-{start.hour:02d}{start.minute:02d}",
+        agent_id=agent_id,
+        assignment_type=assignment_type,  # type: ignore[arg-type]
+        assigned_role="support",
+        priority=10,
+        strictness=strictness,  # type: ignore[arg-type]
+        active_window=DutyWindow(start=start, end=end, timezone="UTC"),
+        reserve_before_window=reserve_before,
+        reserve_after_window=reserve_after,
+        recall_policy="graceful",
+        graceful_window=timedelta(minutes=5),
+        missed_window_policy="skip",
+        allowed_off_window_modes=("ambient", "cycle"),
+    )
+
+
+def test_hard_duty_in_reserve_before_rejects():
+    """Window opens in 5 min, 15-min reserve → in_reserve_before → defer."""
+    a = _assignment(start=NOW + timedelta(minutes=5), end=NOW + timedelta(hours=1))
+
+    decision = reserve_buffer_decision([a], {"neo"}, NOW)
+
+    assert decision.allowed is False
+    assert decision.blocking_agent_id == "neo"
+    assert decision.reason == reasons.UPCOMING_HARD_DUTY_WINDOW
+
+
+def test_hard_duty_active_rejects():
+    a = _assignment(start=NOW - timedelta(minutes=30), end=NOW + timedelta(minutes=30))
+
+    decision = reserve_buffer_decision([a], {"neo"}, NOW)
+
+    assert decision.allowed is False
+    assert decision.blocking_agent_id == "neo"
+
+
+def test_before_reserve_buffer_allows():
+    """Window is 1 h out; the 15-min reserve hasn't opened yet → allow."""
+    a = _assignment(start=NOW + timedelta(hours=1), end=NOW + timedelta(hours=2))
+
+    decision = reserve_buffer_decision([a], {"neo"}, NOW)
+
+    assert decision.allowed is True
+    assert decision.blocking_agent_id is None
+    assert decision.reason is None
+
+
+def test_trailing_reserve_after_does_not_block():
+    """Window ended 5 min ago, inside the 10-min trailing buffer → duty is
+    winding down, not starting → recruitment allowed."""
+    a = _assignment(start=NOW - timedelta(hours=2), end=NOW - timedelta(minutes=5))
+
+    decision = reserve_buffer_decision([a], {"neo"}, NOW)
+
+    assert decision.allowed is True
+
+
+def test_soft_duty_active_does_not_block():
+    """Soft windows yield to the scheduler's recall (§2.4); they do not gate
+    recruitment in v1.1 even while active."""
+    a = _assignment(
+        strictness="soft",
+        start=NOW - timedelta(minutes=30),
+        end=NOW + timedelta(minutes=30),
+    )
+
+    decision = reserve_buffer_decision([a], {"neo"}, NOW)
+
+    assert decision.allowed is True
+
+
+def test_non_duty_assignment_does_not_block():
+    """Only `duty` assignments claim the agent; a hard, active cycle_eligibility
+    row must not defer recruitment."""
+    a = _assignment(
+        assignment_type="cycle_eligibility",
+        start=NOW - timedelta(minutes=30),
+        end=NOW + timedelta(minutes=30),
+    )
+
+    decision = reserve_buffer_decision([a], {"neo"}, NOW)
+
+    assert decision.allowed is True
+
+
+def test_assignment_for_non_participating_agent_does_not_block():
+    """A blocking hard duty held by an agent the run never recruits is ignored."""
+    a = _assignment(
+        agent_id="bob",
+        start=NOW - timedelta(minutes=30),
+        end=NOW + timedelta(minutes=30),
+    )
+
+    decision = reserve_buffer_decision([a], {"neo", "max"}, NOW)
+
+    assert decision.allowed is True
+
+
+def test_empty_assignments_allows():
+    assert reserve_buffer_decision([], {"neo"}, NOW).allowed is True
+
+
+def test_reports_earliest_starting_blocking_assignment():
+    """Two participating agents both conflict; the earliest-starting window is
+    reported deterministically (so the deferral reason is stable across runs)."""
+    later = _assignment(
+        agent_id="max",
+        start=NOW - timedelta(minutes=10),
+        end=NOW + timedelta(hours=1),
+    )
+    earlier = _assignment(
+        agent_id="neo",
+        start=NOW - timedelta(minutes=45),
+        end=NOW + timedelta(hours=1),
+    )
+
+    decision = reserve_buffer_decision([later, earlier], {"neo", "max"}, NOW)
+
+    assert decision.allowed is False
+    assert decision.blocking_agent_id == "neo"

--- a/tests/unit/runtime/test_scheduler.py
+++ b/tests/unit/runtime/test_scheduler.py
@@ -1,0 +1,270 @@
+"""Unit tests for SIP-0089 §2.4 — DutyScheduler.
+
+Bug classes guarded:
+- the scheduler writing AgentRuntimeState directly instead of requesting via the
+  coordinator (violates D21 claimant-not-authority);
+- window-open / window-close firing at the wrong window_state boundary;
+- MissedWindowPolicy mis-enacted (a missed hard duty silently opening, or a
+  within-grace late start being skipped);
+- the scheduler polling on construction (must be started explicitly — D-note in
+  §2.4 forbids implicit background activation in tests);
+- repeated ticks within one window duplicating the open transition (D12/D21).
+
+Fakes (recording coordinator + controllable state) keep assertions on what the
+scheduler *requests*, not on a live coordinator's side effects.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from squadops.ports.runtime.event_publisher import RuntimeEventPublisher
+from squadops.ports.runtime.state import RuntimeStatePort
+from squadops.runtime import events, reasons
+from squadops.runtime.coordinator import RuntimeCoordinator, TransitionOutcome
+from squadops.runtime.models import AgentRuntimeState, Assignment, DutyWindow
+from squadops.runtime.scheduler import DutyScheduler
+
+pytestmark = [pytest.mark.domain_runtime]
+
+WIN_START = datetime(2026, 6, 24, 1, 0, tzinfo=UTC)
+WIN_END = datetime(2026, 6, 24, 6, 0, tzinfo=UTC)
+
+
+def _at(hour: int, minute: int) -> datetime:
+    return datetime(2026, 6, 24, hour, minute, tzinfo=UTC)
+
+
+def _duty(
+    *,
+    policy: str = "skip",
+    graceful: timedelta = timedelta(minutes=5),
+    assignment_type: str = "duty",
+) -> Assignment:
+    return Assignment(
+        assignment_id="assign-1",
+        agent_id="max",
+        assignment_type=assignment_type,  # type: ignore[arg-type]
+        assigned_role="support",
+        priority=10,
+        strictness="hard",
+        active_window=DutyWindow(start=WIN_START, end=WIN_END, timezone="UTC"),
+        reserve_before_window=timedelta(minutes=15),
+        reserve_after_window=timedelta(minutes=10),
+        recall_policy="graceful",
+        graceful_window=graceful,
+        missed_window_policy=policy,  # type: ignore[arg-type]
+        allowed_off_window_modes=("ambient", "cycle"),
+    )
+
+
+def _agent_state(mode="ambient", assignment_ref=None) -> AgentRuntimeState:
+    return AgentRuntimeState(
+        "max", mode, "online", "", None, "high", WIN_START, assignment_ref
+    )
+
+
+class _FakeAssignments:
+    def __init__(self, items: list[Assignment]) -> None:
+        self._items = items
+        self.calls = 0
+
+    async def list_active_assignments(self, now):
+        self.calls += 1
+        return list(self._items)
+
+
+class _RecordingCoordinator:
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    async def request_transition(self, agent_id, target_mode, reason_code, **kwargs):
+        self.requests.append({"agent_id": agent_id, "target_mode": target_mode, "reason_code": reason_code, **kwargs})
+        return TransitionOutcome(
+            applied=True, agent_id=agent_id, from_mode=None,
+            to_mode=target_mode, reason_code=reason_code, event_name=events.MODE_TRANSITION,
+        )
+
+
+class _FakeStatePort(RuntimeStatePort):
+    def __init__(self, initial: AgentRuntimeState | None = None) -> None:
+        self._row = initial
+        self.upserts: list[AgentRuntimeState] = []
+
+    async def get_state(self, agent_id):
+        return self._row
+
+    async def upsert_state(self, state):
+        self._row = state
+        self.upserts.append(state)
+        return state
+
+    async def ensure_state(self, agent_id):
+        if self._row is None:
+            self._row = _agent_state()
+        return self._row
+
+    async def update_heartbeat(self, agent_id, *, runtime_status=None):
+        return await self.ensure_state(agent_id)
+
+
+class _RecordingPublisher(RuntimeEventPublisher):
+    def __init__(self) -> None:
+        self.emitted: list[tuple] = []
+
+    def emit(self, event_name, *, agent_id, reason_code, payload=None):
+        self.emitted.append((event_name, agent_id, reason_code, payload))
+
+
+async def test_window_open_fires_on_time():
+    coord = _RecordingCoordinator()
+    sched = DutyScheduler(_FakeAssignments([_duty()]), coord, _FakeStatePort(None))
+
+    await sched.tick(now=WIN_START)
+
+    assert len(coord.requests) == 1
+    r = coord.requests[0]
+    assert (r["target_mode"], r["reason_code"]) == ("duty", reasons.DUTY_WINDOW_OPENED)
+    assert r["scheduled_at"] == WIN_START
+    assert r["assignment_id"] == "assign-1"
+    assert r["requester_kind"] == "scheduler"
+
+
+async def test_window_close_fires_for_serving_agent_after_window():
+    coord = _RecordingCoordinator()
+    state = _FakeStatePort(_agent_state(mode="duty", assignment_ref="assign-1"))
+    sched = DutyScheduler(_FakeAssignments([_duty()]), coord, state)
+
+    await sched.tick(now=_at(6, 5))  # in_reserve_after, agent serving
+
+    assert len(coord.requests) == 1
+    r = coord.requests[0]
+    assert (r["target_mode"], r["reason_code"]) == ("ambient", reasons.DUTY_WINDOW_CLOSED)
+    assert r["scheduled_at"] == WIN_END
+
+
+async def test_scheduler_never_writes_state_directly():
+    """D21: the scheduler may read state but only the coordinator writes it."""
+    coord = _RecordingCoordinator()
+    state = _FakeStatePort(None)
+    sched = DutyScheduler(_FakeAssignments([_duty()]), coord, state)
+
+    await sched.tick(now=WIN_START)
+
+    assert state.upserts == []  # scheduler requested, never wrote
+    assert len(coord.requests) == 1
+
+
+async def test_non_duty_assignment_is_ignored():
+    coord = _RecordingCoordinator()
+    sched = DutyScheduler(
+        _FakeAssignments([_duty(assignment_type="cycle_eligibility")]),
+        coord,
+        _FakeStatePort(None),
+    )
+
+    outcomes = await sched.tick(now=WIN_START)
+
+    assert outcomes == [] and coord.requests == []
+
+
+async def test_construction_does_not_poll():
+    """No implicit background activation — only start() polls."""
+    provider = _FakeAssignments([_duty()])
+    DutyScheduler(provider, _RecordingCoordinator(), _FakeStatePort(None))
+
+    assert provider.calls == 0
+
+
+async def test_late_start_within_grace_opens_late():
+    coord = _RecordingCoordinator()
+    sched = DutyScheduler(
+        _FakeAssignments([_duty(policy="start_late_within_grace", graceful=timedelta(minutes=5))]),
+        coord,
+        _FakeStatePort(None),
+    )
+
+    await sched.tick(now=_at(1, 3))  # 3 min late, within 5-min grace
+
+    assert len(coord.requests) == 1
+    assert coord.requests[0]["reason_code"] == reasons.DUTY_WINDOW_STARTED_LATE
+    assert coord.requests[0]["target_mode"] == "duty"
+
+
+async def test_late_start_past_grace_skips_even_under_start_late_policy():
+    coord = _RecordingCoordinator()
+    pub = _RecordingPublisher()
+    sched = DutyScheduler(
+        _FakeAssignments([_duty(policy="start_late_within_grace", graceful=timedelta(minutes=5))]),
+        coord,
+        _FakeStatePort(None),
+        events_publisher=pub,
+    )
+
+    await sched.tick(now=_at(1, 10))  # 10 min late, past grace
+
+    assert coord.requests == []  # no transition
+    assert pub.emitted[0][0] == events.ASSIGNMENT_WINDOW_SKIPPED
+    assert pub.emitted[0][2] == reasons.DUTY_WINDOW_MISSED
+
+
+async def test_skip_policy_does_not_open_late_window():
+    coord = _RecordingCoordinator()
+    pub = _RecordingPublisher()
+    sched = DutyScheduler(
+        _FakeAssignments([_duty(policy="skip")]), coord, _FakeStatePort(None),
+        events_publisher=pub,
+    )
+
+    await sched.tick(now=_at(1, 1))  # 1 min late
+
+    assert coord.requests == []
+    assert pub.emitted[0][0] == events.ASSIGNMENT_WINDOW_SKIPPED
+
+
+async def test_require_operator_review_flags_instead_of_transitioning():
+    coord = _RecordingCoordinator()
+    pub = _RecordingPublisher()
+    sched = DutyScheduler(
+        _FakeAssignments([_duty(policy="require_operator_review")]), coord,
+        _FakeStatePort(None), events_publisher=pub,
+    )
+
+    await sched.tick(now=_at(1, 10))
+
+    assert coord.requests == []
+    assert pub.emitted[0][0] == events.ASSIGNMENT_WINDOW_REVIEW_REQUIRED
+    assert pub.emitted[0][2] == reasons.DUTY_WINDOW_MISSED_OPERATOR_REVIEW
+
+
+async def test_missed_window_after_end_enacts_skip():
+    coord = _RecordingCoordinator()
+    pub = _RecordingPublisher()
+    sched = DutyScheduler(
+        _FakeAssignments([_duty(policy="skip")]), coord, _FakeStatePort(None),
+        events_publisher=pub,
+    )
+
+    await sched.tick(now=_at(6, 5))  # past window end, never entered → missed
+
+    assert coord.requests == []
+    assert pub.emitted[0][0] == events.ASSIGNMENT_WINDOW_SKIPPED
+    assert pub.emitted[0][2] == reasons.DUTY_WINDOW_MISSED
+
+
+async def test_repeated_ticks_open_window_exactly_once_with_real_coordinator():
+    """D12/D21 end-to-end: two ticks within the same window → one open. The first
+    applies; the second sees the agent already on duty (and the coordinator's
+    idempotency key would also dedupe), so no second transition is written."""
+    state = _FakeStatePort(_agent_state(mode="ambient"))
+    coord = RuntimeCoordinator(state, events_publisher=_RecordingPublisher())
+    sched = DutyScheduler(_FakeAssignments([_duty()]), coord, state)
+
+    await sched.tick(now=WIN_START)
+    await sched.tick(now=_at(1, 1))
+
+    duty_upserts = [s for s in state.upserts if s.mode == "duty"]
+    assert len(duty_upserts) == 1
+    assert state.upserts[-1].current_assignment_ref == "assign-1"


### PR DESCRIPTION
## SIP-0089 Phase 2 — Agent Runtime State

Implements Phase 2 of SIP-0089: durable **Assignments** with duty windows, the scheduler/coordinator that act on them, and the cycle reserve-buffer guard — plus the operator CLI/REST surface to inspect and (experimentally) create them. Targets v1.1.0 (no version bump until Phase 4 per the plan).

Branch starts from the accepted SIP on `main`; 11 incremental commits, one per phase section.

### What's included (§2.0–§2.8)

| § | Commit | Summary |
|---|---|---|
| 2.0 | `59fd93c` | Spike: recruitment seam vs. the post-SIP-0094 dispatch path |
| 2.1 | `f653b52` | `Assignment`/`DutyWindow` models + `window_state()` 6-state classifier |
| 2.2 | `041bd5c` | `agent_assignments` migration (1110) + `agent_id` holder on `Assignment` |
| 2.3 | `31b5c35` | `AssignmentPort` + `PostgresAssignment` adapter (time filtering pushed into SQL) |
| 2.6 | `ef964fc` | `RuntimeCoordinator` — the D16 sole mode-transition authority (idempotent per D12, event/reason distinct per D18) |
| 2.4 | `61aeb39` | `DutyScheduler` — polling claimant (D21), opens/closes windows via coordinator, full missed-window policy table; inert until `start()` |
| 2.5 | `45d8d48` | Reserve-buffer recruitment guard — an upcoming **hard** duty window defers cycle recruitment (`RUN_PAUSED` + typed payload `reason=upcoming_hard_duty_window`; no new event type minted) |
| 2.7 | `00b6399` | `squadops assignment list/show/create` CLI + `/api/v1` REST surface |
| 2.8 | `f133f78` | Close-out: gate the new test dirs in CI + cardinality acceptance test |

### API surface + a prefix-standard decision

§2.7 needed an HTTP route because the CLI is forbidden from importing Postgres adapters directly (D26). Choosing where to put it surfaced that the runtime-api had drifted into **four** URL-prefix conventions with no owning standard. Rather than add a fifth, we adopted a lane standard:

- **`/api/v1/<resource>`** — authenticated, managed REST resources (where assignments live).
- **`/health/*`** — read-only, *unauthenticated* operational probes only (so a writable `POST` must not live here — it'd be unauthenticated).
- **`/auth/*`** — identity. **No `/api/v2`** — extend v1.

Assignments therefore sit on `/api/v1`: `GET /api/v1/agents/{id}/assignments`, `GET /api/v1/assignments/{id}`, `POST /api/v1/assignments` (experimental/internal). The standard is enforced going forward by a new **CLAUDE.md API-conventions rule** (`f67e98e`); the rest of the standardization (an executable architecture test, chat-route normalization, error-shape envelope) is tracked in **#218** / **#219**.

### Testing

- **DTO-purity:** serialization lives in the API layer (timedeltas → integer seconds, `DutyWindow` nested, modes tuple→list); round-trip preserves every field.
- **Reserve defaults (§11.4/D7):** 15m hard / 0 soft applied at create; explicit-zero is honored, not overridden.
- **CI gate (#220):** added `tests/unit/runtime/` + `tests/unit/architecture/` to `REGRESSION_DIRS` — previously these (the whole SIP-0089 suite + the D26 forbidden-imports test) did **not** run on PRs. Both dirs are green (78 tests) and pass the test-quality linter.
- **Acceptance audit:** 14/15 §2.8 items were already covered; the one gap (cardinality — an agent may hold multiple assignments) is now tested.

### Note on the full regression suite

The local Python 3.11 venv cannot produce a clean full-suite green — `TestClient`-based route tests break under the drifted deps, and there's a 3.11-specific asyncio hang in `tests/unit/cycles/test_correction_protocol.py`. Both are pre-existing and tracked in **#217**; neither is caused by this work. CI (pinned deps) is the authoritative gate, and the newly-gated dirs were verified green locally without `TestClient`.

### Linked issues

- **Closes #220** — the CI gate for `tests/unit/runtime/` + `tests/unit/architecture/` is fully contained in this PR.
- Follow-up (track:spark, not closed here): #218 (API prefix standard + enforcement), #219 (chat-route normalization).
- Context: #217 (local↔CI env reconciliation), #186 (executor decomposition — follow-up, not in scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
