### PR TITLE
SIP-0089 §2.4: activate the in-process duty scheduler (+ close-sweep fix, #226)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,13 @@ SQUADOPS_PROFILE=dev  # Options: dev, local, lab, cloud
 # Runtime API
 # SQUADOPS__RUNTIME__API__URL=http://runtime-api:8001
 
+# Duty-transition scheduler (SIP-0089 §2.4) — opt-in. When enabled, the
+# runtime-api process runs an in-process scheduler that opens/closes duty
+# windows by writing agent mode (ambient<->duty). Run exactly one runtime-api
+# instance with this enabled (single central mode-writer; no leader election).
+# SQUADOPS__RUNTIME__SCHEDULER__ENABLED=false
+# SQUADOPS__RUNTIME__SCHEDULER__POLL_INTERVAL_SECONDS=30
+
 # Prefect Configuration
 # SQUADOPS__PREFECT__API__URL=http://prefect-server:4200/api
 

--- a/adapters/events/runtime_event_publisher.py
+++ b/adapters/events/runtime_event_publisher.py
@@ -1,0 +1,53 @@
+"""Logging-backed `RuntimeEventPublisher` adapter (SIP-0089 §2.6).
+
+The `RuntimeCoordinator` and `DutyScheduler` emit runtime-state events
+(`runtime_state.mode_transition`, `assignment.window.skipped`, …) through the
+`RuntimeEventPublisher` port. This adapter records each one as a structured log
+record so an activated scheduler's transitions are observable in runtime-api
+logs (which SIP-0087 forwards) without coupling the runtime layer to any
+particular sink.
+
+Runtime-state events are a **separate vocabulary** from the locked cycle-event
+taxonomy (D14/D18), so they are deliberately *not* bridged onto
+`CycleEventBusPort`. A durable/console sink can replace this adapter behind the
+same port later.
+
+Per the port contract, `emit` is best-effort and never raises to the caller —
+a logging failure must not turn a successful mode transition into an error.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from squadops.ports.runtime.event_publisher import RuntimeEventPublisher
+
+logger = logging.getLogger("squadops.runtime.events")
+
+
+class LoggingRuntimeEventPublisher(RuntimeEventPublisher):
+    """Emit runtime-state events as structured log records (best-effort)."""
+
+    def emit(
+        self,
+        event_name: str,
+        *,
+        agent_id: str,
+        reason_code: str,
+        payload: dict | None = None,
+    ) -> None:
+        try:
+            logger.info(
+                "runtime event %s for %s (reason=%s)",
+                event_name,
+                agent_id,
+                reason_code,
+                extra={
+                    "runtime_event": event_name,
+                    "agent_id": agent_id,
+                    "reason_code": reason_code,
+                    "payload": payload or {},
+                },
+            )
+        except Exception:  # best-effort (D22): emission must never break the caller
+            logger.debug("runtime event emission failed", exc_info=True)

--- a/adapters/persistence/runtime/assignments_postgres.py
+++ b/adapters/persistence/runtime/assignments_postgres.py
@@ -27,6 +27,11 @@ _COLUMNS = (
     "allowed_off_window_modes, active"
 )
 
+# Same columns qualified with the `a` alias, for the close-sweep JOIN. asyncpg
+# names result columns by the bare column (alias stripped), so `_row_to_assignment`
+# still indexes by name.
+_A_COLUMNS = ", ".join(f"a.{col.strip()}" for col in _COLUMNS.split(","))
+
 
 class PostgresAssignment(AssignmentPort):
     """Postgres-backed `AssignmentPort` implementation."""
@@ -72,6 +77,24 @@ class PostgresAssignment(AssignmentPort):
                 "AND $1 >= window_start - reserve_before_window "
                 "AND $1 <  window_end "
                 "ORDER BY window_start",
+                now,
+            )
+        return [_row_to_assignment(r) for r in rows]
+
+    async def list_assignments_to_close(self, now: datetime) -> list[Assignment]:
+        # Join to the agent's live state: a duty assignment whose serving agent is
+        # still in mode='duty' bound to it, and whose window has fully ended
+        # (now >= window_end + reserve_after_window). This is the close path for
+        # windows that left the active set before a tick observed in_reserve_after
+        # (notably reserve_after_window = 0; #226). Disjoint from the active set.
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                f"SELECT {_A_COLUMNS} FROM agent_assignments a "
+                "JOIN agent_runtime_state s ON s.current_assignment_ref = a.assignment_id "
+                "WHERE s.mode = 'duty' "
+                "AND a.assignment_type = 'duty' "
+                "AND $1 >= a.window_end + a.reserve_after_window "
+                "ORDER BY a.window_end",
                 now,
             )
         return [_row_to_assignment(r) for r in rows]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,6 +189,11 @@ services:
       # LLM (SIP-0066: cycle task handlers)
       SQUADOPS__LLM__MODEL: "llama3.1:8b"
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
+      # Duty-transition scheduler (SIP-0089 §2.4). runtime-api is the single
+      # central writer of agent mode (D16) — keep this enabled on exactly one
+      # runtime-api instance (no leader election yet).
+      SQUADOPS__RUNTIME__SCHEDULER__ENABLED: "true"
+      SQUADOPS__RUNTIME__SCHEDULER__POLL_INTERVAL_SECONDS: "10"
     volumes:
       - ./data/artifacts:/app/data/artifacts
     networks:

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -155,6 +155,9 @@ _redis_client = None
 _health_checker_instance = None
 _reconciliation_task = None
 
+# SIP-0089 §2.4: in-process duty-transition scheduler (opt-in; stopped on shutdown)
+_duty_scheduler = None
+
 
 async def _init_auth_subsystem(config) -> None:
     """Initialize auth, audit, and service token adapters (SIP-0062)."""
@@ -430,6 +433,27 @@ async def _init_monitoring(config, pool) -> None:
         logger.error(f"Failed to initialize chat ports: {e}")
 
 
+async def _init_duty_scheduler(config, pool) -> None:
+    """Start the duty-transition scheduler when enabled (SIP-0089 §2.4).
+
+    The scheduler is the live driver of ambient↔duty transitions: it polls duty
+    assignments and requests window open/close through the coordinator (the sole
+    writer of mode, D16). Opt-in via `runtime.scheduler.enabled`; a clean
+    shutdown path is provided in `shutdown_event` (mirrors the reconciliation
+    loop). See `scheduler_bootstrap` for the single-writer constraint.
+    """
+    global _duty_scheduler
+    try:
+        from squadops.api.runtime.scheduler_bootstrap import create_duty_scheduler
+
+        _duty_scheduler = create_duty_scheduler(config, pool)
+        if _duty_scheduler is not None:
+            await _duty_scheduler.start()
+            logger.info("Duty scheduler started")
+    except Exception as e:
+        logger.error("Failed to start duty scheduler: %s", e)
+
+
 @app.on_event("startup")
 async def startup_event():
     """Initialize database and message queue connections."""
@@ -454,12 +478,17 @@ async def startup_event():
     await _init_log_forwarding(config)
     await _init_cycle_subsystem(config, pool)
     await _init_monitoring(config, pool)
+    await _init_duty_scheduler(config, pool)
 
 
 @app.on_event("shutdown")
 async def shutdown_event():
     """Clean up connections."""
     global pool, rabbitmq_connection
+    # SIP-0089 §2.4: stop the duty scheduler before the pool closes so its final
+    # tick can't race a closing connection.
+    if _duty_scheduler is not None:
+        await _duty_scheduler.stop()
     if _health_checker_instance:
         _health_checker_instance._reconciliation_running = False
     if _reconciliation_task:

--- a/src/squadops/api/runtime/scheduler_bootstrap.py
+++ b/src/squadops/api/runtime/scheduler_bootstrap.py
@@ -1,0 +1,76 @@
+"""Duty-scheduler bootstrap (SIP-0089 §2.4 activation).
+
+Composition-root helper that assembles the `DutyScheduler` graph for the
+runtime-api process. Kept out of `main.py` so the activation gate (the
+`runtime.scheduler.enabled` decision and the pool precondition) is unit-testable
+without standing up FastAPI.
+
+This is the composition root — it is allowed to import adapters (unlike
+`src/squadops/runtime/*`, which D26 keeps adapter-free). It wires:
+
+    PostgresRuntimeState ─┐
+    PostgresAssignment ───┼─→ RuntimeCoordinator ─→ DutyScheduler
+    LoggingRuntimeEventPublisher ─┘
+
+**Single-writer constraint:** the `RuntimeCoordinator` is the sole writer of
+`AgentRuntimeState.mode` (D16). This is safe only while a *single* runtime-api
+instance runs the loop — today's deployment. If runtime-api is ever scaled to
+multiple replicas, two schedulers would both write modes; that needs leader
+election (e.g. a Postgres advisory lock) before scaling. Deferred while
+single-instance; the `enabled` flag keeps activation deliberate.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import asyncpg
+
+from squadops.config.schema import AppConfig
+from squadops.runtime.coordinator import RuntimeCoordinator
+from squadops.runtime.scheduler import DutyScheduler
+
+logger = logging.getLogger(__name__)
+
+
+def create_duty_scheduler(config: AppConfig, pool: asyncpg.Pool | None) -> DutyScheduler | None:
+    """Build the duty scheduler, or return ``None`` when it should not run.
+
+    Returns ``None`` (and the caller starts nothing) when the scheduler is
+    disabled by config, or when no Postgres pool is available — the assignment
+    and runtime-state tables both live in Postgres, so without a pool there is
+    nothing to schedule against.
+    """
+    if not config.runtime.scheduler.enabled:
+        logger.info("Duty scheduler disabled (runtime.scheduler.enabled=false)")
+        return None
+
+    if pool is None:
+        logger.warning("Duty scheduler enabled but no Postgres pool — scheduler not started")
+        return None
+
+    # Imported here (not at module top) so importing this module never pulls the
+    # asyncpg adapter stack into processes that only need the factory signature.
+    from adapters.events.runtime_event_publisher import LoggingRuntimeEventPublisher
+    from adapters.persistence.runtime import PostgresRuntimeState
+    from adapters.persistence.runtime.assignments_postgres import PostgresAssignment
+
+    state = PostgresRuntimeState(pool)
+    assignments = PostgresAssignment(pool)
+    publisher = LoggingRuntimeEventPublisher()
+    coordinator = RuntimeCoordinator(state, events_publisher=publisher)
+
+    poll_interval = config.runtime.scheduler.poll_interval_seconds
+    logger.warning(
+        "Duty scheduler ACTIVE (poll=%ss). The coordinator is the single writer "
+        "of agent runtime mode; run exactly one runtime-api instance with the "
+        "scheduler enabled (no leader election yet).",
+        poll_interval,
+    )
+    return DutyScheduler(
+        assignments,
+        coordinator,
+        state,
+        events_publisher=publisher,
+        poll_interval_seconds=poll_interval,
+    )

--- a/src/squadops/config/schema.py
+++ b/src/squadops/config/schema.py
@@ -411,6 +411,37 @@ class CyclesConfig(BaseModel):
     )
 
 
+class SchedulerConfig(BaseModel):
+    """Duty-transition scheduler configuration (SIP-0089 §2.4).
+
+    The in-process `DutyScheduler` opens/closes duty windows by requesting
+    transitions through the `RuntimeCoordinator`. It is **opt-in** (`enabled`
+    defaults false) so a deployment activates duty mode deliberately. The
+    scheduler is a single central writer of `mode`; running more than one
+    runtime-api instance with it enabled would create two writers (see the
+    single-writer note at the bootstrap call site).
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Activate the in-process duty-transition scheduler (SIP-0089 §2.4)",
+    )
+    poll_interval_seconds: int = Field(
+        default=30,
+        ge=1,
+        description="Seconds between duty-window scheduler ticks",
+    )
+
+
+class RuntimeConfig(BaseModel):
+    """Agent runtime-state configuration (SIP-0089)."""
+
+    scheduler: SchedulerConfig = Field(
+        default_factory=SchedulerConfig,
+        description="Duty-transition scheduler configuration (SIP-0089 §2.4)",
+    )
+
+
 class PrefectConfig(BaseModel):
     """Prefect orchestration configuration."""
 
@@ -644,6 +675,11 @@ class AppConfig(BaseModel):
     # Cycles
     cycles: CyclesConfig = Field(
         default_factory=CyclesConfig, description="Cycle registry configuration"
+    )
+
+    # Runtime (SIP-0089: agent runtime state, duty scheduler)
+    runtime: RuntimeConfig = Field(
+        default_factory=RuntimeConfig, description="Agent runtime-state configuration (SIP-0089)"
     )
 
     # Orchestration

--- a/src/squadops/ports/runtime/assignments.py
+++ b/src/squadops/ports/runtime/assignments.py
@@ -55,5 +55,19 @@ class AssignmentPort(ABC):
         """
 
     @abstractmethod
+    async def list_assignments_to_close(self, now: datetime) -> list[Assignment]:
+        """Return duty assignments whose serving agent should return to ambient.
+
+        A duty assignment where an agent is currently in `mode = 'duty'` bound to
+        it (`current_assignment_ref`) and whose window has fully ended:
+        `now >= window_end + reserve_after_window`. This is the close-sweep the
+        scheduler (§2.4) uses for windows that leave the active set before a tick
+        can observe `in_reserve_after` — notably hard duty with the default
+        `reserve_after_window = 0`, where the active-set upper bound and the close
+        instant coincide (#226). Disjoint from `list_active_assignments` at the
+        `window_end + reserve_after_window` boundary.
+        """
+
+    @abstractmethod
     async def upsert_assignment(self, assignment: Assignment) -> Assignment:
         """Insert or update `assignment` by `assignment_id`; return it."""

--- a/src/squadops/runtime/scheduler.py
+++ b/src/squadops/runtime/scheduler.py
@@ -71,10 +71,20 @@ class DutyScheduler:
         """Evaluate all active duty assignments once. Returns transitions requested."""
         at = now if now is not None else self._clock()
         outcomes: list[TransitionOutcome] = []
+        # Pass 1: assignments currently in the active span — open, late-open per
+        # MissedWindowPolicy, or close (when reserve_after keeps them active past
+        # window_end so the tick sees in_reserve_after).
         for assignment in await self._assignments.list_active_assignments(at):
             if assignment.assignment_type != "duty":
                 continue  # reserve / cycle_eligibility don't drive mode transitions
             outcome = await self._evaluate(assignment, at)
+            if outcome is not None:
+                outcomes.append(outcome)
+        # Pass 2: close-sweep for windows that left the active set before a tick
+        # could observe in_reserve_after — an agent still in duty whose window has
+        # fully ended (notably reserve_after = 0; #226). Disjoint from pass 1.
+        for assignment in await self._assignments.list_assignments_to_close(at):
+            outcome = await self._close(assignment)
             if outcome is not None:
                 outcomes.append(outcome)
         return outcomes

--- a/tests/unit/api/test_scheduler_bootstrap.py
+++ b/tests/unit/api/test_scheduler_bootstrap.py
@@ -1,0 +1,68 @@
+"""Unit tests for SIP-0089 §2.4 activation gate — `create_duty_scheduler`.
+
+This factory is the whole point of "activating" the scheduler: it decides, from
+config + pool, whether a live `DutyScheduler` exists at all. The bug classes it
+guards:
+- accidental activation: a disabled config (the opt-in default) must yield no
+  scheduler, even when a pool is present;
+- a missing precondition: enabled but pool-less must not return a scheduler that
+  would then NPE against absent assignment/state tables;
+- lifecycle: the factory must hand back an INERT scheduler (not yet polling) so
+  the composition root owns `start()`/`stop()` — per the plan, "must not start
+  implicitly".
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from squadops.api.runtime.scheduler_bootstrap import create_duty_scheduler
+from squadops.config.schema import (
+    AppConfig,
+    AuthConfig,
+    CommsConfig,
+    DBConfig,
+    RabbitMQConfig,
+    RedisConfig,
+)
+from squadops.runtime.scheduler import DutyScheduler
+
+pytestmark = [pytest.mark.domain_runtime]
+
+
+def _config(*, enabled: bool, poll: int = 30) -> AppConfig:
+    return AppConfig(
+        db=DBConfig(url="postgresql://u@localhost:5432/db"),
+        comms=CommsConfig(
+            rabbitmq=RabbitMQConfig(url="amqp://u@localhost:5672/"),
+            redis=RedisConfig(url="redis://localhost:6379/0"),
+        ),
+        auth=AuthConfig(enabled=False),
+        runtime={"scheduler": {"enabled": enabled, "poll_interval_seconds": poll}},
+    )
+
+
+def test_disabled_config_returns_no_scheduler_even_with_pool():
+    """Bug class: the opt-in default must not be overridable by mere presence of
+    a pool. Disabled means no scheduler, full stop."""
+    assert create_duty_scheduler(_config(enabled=False), MagicMock()) is None
+
+
+def test_enabled_without_pool_returns_none():
+    """Bug class: assignments + runtime state both live in Postgres. Returning a
+    scheduler with no pool would defer the failure to the first tick (an NPE
+    against a None pool). Refuse to build it instead."""
+    assert create_duty_scheduler(_config(enabled=True), None) is None
+
+
+def test_enabled_with_pool_builds_inert_scheduler_with_configured_interval():
+    """Bug class: activation must produce a real DutyScheduler carrying the
+    configured poll interval, and it must be INERT — the factory hands ownership
+    of start()/stop() to the composition root (no implicit background ticking)."""
+    scheduler = create_duty_scheduler(_config(enabled=True, poll=7), MagicMock())
+
+    assert isinstance(scheduler, DutyScheduler)
+    assert scheduler._poll_interval_seconds == 7
+    assert scheduler._task is None  # not started by the factory

--- a/tests/unit/events/test_runtime_event_publisher.py
+++ b/tests/unit/events/test_runtime_event_publisher.py
@@ -1,0 +1,69 @@
+"""Unit tests for SIP-0089 §2.6 — LoggingRuntimeEventPublisher.
+
+The coordinator/scheduler depend on the publisher being **best-effort** (D22):
+a logging failure must never propagate and turn a successful mode transition
+into an application error. The structured fields it records are also the only
+observability an activated scheduler has, so they are asserted exactly.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from adapters.events.runtime_event_publisher import LoggingRuntimeEventPublisher
+from squadops.runtime import events, reasons
+
+pytestmark = [pytest.mark.domain_runtime]
+
+
+def test_emit_records_structured_transition_fields(caplog):
+    """Bug class: a publisher that dropped any of event_name/agent_id/reason_code/
+    payload would blind the only observability path for live transitions. Assert
+    each canonical field lands on the log record exactly."""
+    pub = LoggingRuntimeEventPublisher()
+    with caplog.at_level(logging.INFO, logger="squadops.runtime.events"):
+        pub.emit(
+            events.MODE_TRANSITION,
+            agent_id="max",
+            reason_code=reasons.DUTY_WINDOW_OPENED,
+            payload={"from_mode": "ambient", "to_mode": "duty"},
+        )
+
+    [record] = [r for r in caplog.records if r.name == "squadops.runtime.events"]
+    assert record.runtime_event == "runtime_state.mode_transition"
+    assert record.agent_id == "max"
+    assert record.reason_code == "duty_window_opened"
+    assert record.payload == {"from_mode": "ambient", "to_mode": "duty"}
+
+
+def test_emit_normalizes_missing_payload_to_empty_dict(caplog):
+    """Bug class: callers may omit payload (e.g. a bare window-skip). It must log
+    as an empty dict, never `None`, so downstream parsing never hits a NoneType."""
+    pub = LoggingRuntimeEventPublisher()
+    with caplog.at_level(logging.INFO, logger="squadops.runtime.events"):
+        pub.emit(
+            events.ASSIGNMENT_WINDOW_SKIPPED,
+            agent_id="neo",
+            reason_code=reasons.DUTY_WINDOW_MISSED,
+        )
+
+    [record] = [r for r in caplog.records if r.name == "squadops.runtime.events"]
+    assert record.payload == {}
+
+
+def test_emit_never_raises_when_logging_fails(monkeypatch):
+    """Bug class (D22 best-effort): if the sink raises, emit must swallow it.
+    A propagated logging error would abort the coordinator's transition AFTER the
+    mode was already written, desyncing state from its event stream. Force the
+    info() call to raise and assert emit still returns cleanly."""
+    pub = LoggingRuntimeEventPublisher()
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("sink down")
+
+    monkeypatch.setattr("adapters.events.runtime_event_publisher.logger.info", _boom)
+
+    # Must not raise.
+    pub.emit(events.MODE_TRANSITION, agent_id="max", reason_code=reasons.DUTY_WINDOW_OPENED)

--- a/tests/unit/runtime/test_assignments_postgres.py
+++ b/tests/unit/runtime/test_assignments_postgres.py
@@ -168,6 +168,27 @@ async def test_list_claimable_windows_filters_duty_and_ends_at_window_close():
     assert args == [NOW]
 
 
+async def test_list_assignments_to_close_joins_duty_state_and_filters_ended_windows():
+    """Bug class (#226): an agent in duty whose window fully ended (now >=
+    window_end + reserve_after) must be returned for closing even after it left
+    the active set — otherwise reserve_after=0 hard duty strands the agent in
+    duty. Assert the JOIN to agent_runtime_state, the duty-mode filter, the
+    ended-window predicate, and the sole `now` binding."""
+    conn = AsyncMock()
+    conn.fetch.return_value = [_row()]
+    adapter = PostgresAssignment(_make_pool(conn))
+
+    result = await adapter.list_assignments_to_close(NOW)
+
+    assert [a.assignment_id for a in result] == ["a-1"]
+    sql, *args = conn.fetch.call_args.args
+    assert "JOIN agent_runtime_state s ON s.current_assignment_ref = a.assignment_id" in sql
+    assert "s.mode = 'duty'" in sql
+    assert "a.assignment_type = 'duty'" in sql
+    assert "$1 >= a.window_end + a.reserve_after_window" in sql
+    assert args == [NOW]  # `now` is the sole bind param
+
+
 async def test_upsert_assignment_flattens_window_and_binds_array_as_list():
     """Bug class: the nested DutyWindow must flatten to the window_start/_end/
     timezone binds, and the tuple field must bind as a list — asyncpg array

--- a/tests/unit/runtime/test_scheduler.py
+++ b/tests/unit/runtime/test_scheduler.py
@@ -61,19 +61,21 @@ def _duty(
 
 
 def _agent_state(mode="ambient", assignment_ref=None) -> AgentRuntimeState:
-    return AgentRuntimeState(
-        "max", mode, "online", "", None, "high", WIN_START, assignment_ref
-    )
+    return AgentRuntimeState("max", mode, "online", "", None, "high", WIN_START, assignment_ref)
 
 
 class _FakeAssignments:
-    def __init__(self, items: list[Assignment]) -> None:
+    def __init__(self, items: list[Assignment], to_close: list[Assignment] | None = None) -> None:
         self._items = items
+        self._to_close = to_close or []
         self.calls = 0
 
     async def list_active_assignments(self, now):
         self.calls += 1
         return list(self._items)
+
+    async def list_assignments_to_close(self, now):
+        return list(self._to_close)
 
 
 class _RecordingCoordinator:
@@ -81,10 +83,16 @@ class _RecordingCoordinator:
         self.requests: list[dict] = []
 
     async def request_transition(self, agent_id, target_mode, reason_code, **kwargs):
-        self.requests.append({"agent_id": agent_id, "target_mode": target_mode, "reason_code": reason_code, **kwargs})
+        self.requests.append(
+            {"agent_id": agent_id, "target_mode": target_mode, "reason_code": reason_code, **kwargs}
+        )
         return TransitionOutcome(
-            applied=True, agent_id=agent_id, from_mode=None,
-            to_mode=target_mode, reason_code=reason_code, event_name=events.MODE_TRANSITION,
+            applied=True,
+            agent_id=agent_id,
+            from_mode=None,
+            to_mode=target_mode,
+            reason_code=reason_code,
+            event_name=events.MODE_TRANSITION,
         )
 
 
@@ -143,6 +151,40 @@ async def test_window_close_fires_for_serving_agent_after_window():
     r = coord.requests[0]
     assert (r["target_mode"], r["reason_code"]) == ("ambient", reasons.DUTY_WINDOW_CLOSED)
     assert r["scheduled_at"] == WIN_END
+
+
+async def test_close_sweep_fires_after_assignment_leaves_active_set():
+    """Bug class (#226): with reserve_after=0 a served window leaves the active
+    set at window_end, so pass 1 never observes in_reserve_after and the agent
+    would stay stuck in duty. The close-sweep (pass 2) must still request the
+    duty->ambient close, scheduled at window_end, for an agent still in duty —
+    even when the active set is empty."""
+    coord = _RecordingCoordinator()
+    state = _FakeStatePort(_agent_state(mode="duty", assignment_ref="assign-1"))
+    # Active set empty (assignment dropped out at window_end); close-sweep returns it.
+    sched = DutyScheduler(_FakeAssignments([], to_close=[_duty()]), coord, state)
+
+    await sched.tick(now=_at(7, 0))  # well past window_end
+
+    assert len(coord.requests) == 1
+    r = coord.requests[0]
+    assert (r["target_mode"], r["reason_code"]) == ("ambient", reasons.DUTY_WINDOW_CLOSED)
+    assert r["scheduled_at"] == WIN_END
+    assert r["assignment_id"] == "assign-1"
+    assert state.upserts == []  # D21: requested via coordinator, never written directly
+
+
+async def test_close_sweep_empty_requests_no_transition():
+    """Bug class: the close-sweep must not invent closes. With nothing to close
+    (and no active assignments) the tick requests nothing, even though an agent
+    row exists in duty — closing is driven by the sweep query, not by state."""
+    coord = _RecordingCoordinator()
+    state = _FakeStatePort(_agent_state(mode="duty", assignment_ref="assign-1"))
+    sched = DutyScheduler(_FakeAssignments([], to_close=[]), coord, state)
+
+    outcomes = await sched.tick(now=_at(7, 0))
+
+    assert outcomes == [] and coord.requests == []
 
 
 async def test_scheduler_never_writes_state_directly():
@@ -214,7 +256,9 @@ async def test_skip_policy_does_not_open_late_window():
     coord = _RecordingCoordinator()
     pub = _RecordingPublisher()
     sched = DutyScheduler(
-        _FakeAssignments([_duty(policy="skip")]), coord, _FakeStatePort(None),
+        _FakeAssignments([_duty(policy="skip")]),
+        coord,
+        _FakeStatePort(None),
         events_publisher=pub,
     )
 
@@ -228,8 +272,10 @@ async def test_require_operator_review_flags_instead_of_transitioning():
     coord = _RecordingCoordinator()
     pub = _RecordingPublisher()
     sched = DutyScheduler(
-        _FakeAssignments([_duty(policy="require_operator_review")]), coord,
-        _FakeStatePort(None), events_publisher=pub,
+        _FakeAssignments([_duty(policy="require_operator_review")]),
+        coord,
+        _FakeStatePort(None),
+        events_publisher=pub,
     )
 
     await sched.tick(now=_at(1, 10))
@@ -243,7 +289,9 @@ async def test_missed_window_after_end_enacts_skip():
     coord = _RecordingCoordinator()
     pub = _RecordingPublisher()
     sched = DutyScheduler(
-        _FakeAssignments([_duty(policy="skip")]), coord, _FakeStatePort(None),
+        _FakeAssignments([_duty(policy="skip")]),
+        coord,
+        _FakeStatePort(None),
         events_publisher=pub,
     )
 

--- a/tests/unit/runtime/test_scheduler_config.py
+++ b/tests/unit/runtime/test_scheduler_config.py
@@ -1,0 +1,70 @@
+"""Unit tests for SIP-0089 §2.4 scheduler config (`runtime.scheduler`).
+
+The activation gate reads `config.runtime.scheduler.{enabled,poll_interval_seconds}`,
+so two bug classes matter here:
+- the new `runtime` section must actually be wired into `AppConfig` (a default
+  that silently dropped it would make every deployment un-activatable, or worse,
+  read a stale default), and
+- `poll_interval_seconds` must reject non-positive values — a 0s interval turns
+  the poll loop into an unthrottled hot spin.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from squadops.config.schema import (
+    AppConfig,
+    AuthConfig,
+    CommsConfig,
+    DBConfig,
+    RabbitMQConfig,
+    RedisConfig,
+    SchedulerConfig,
+)
+
+pytestmark = [pytest.mark.domain_runtime]
+
+
+def _app_config(runtime: dict | None = None) -> AppConfig:
+    """Build a minimal valid AppConfig, optionally overriding the runtime section."""
+    kwargs: dict = {
+        "db": DBConfig(url="postgresql://u@localhost:5432/db"),
+        "comms": CommsConfig(
+            rabbitmq=RabbitMQConfig(url="amqp://u@localhost:5672/"),
+            redis=RedisConfig(url="redis://localhost:6379/0"),
+        ),
+        "auth": AuthConfig(enabled=False),
+    }
+    if runtime is not None:
+        kwargs["runtime"] = runtime
+    return AppConfig(**kwargs)
+
+
+def test_runtime_scheduler_defaults_to_disabled_when_section_omitted():
+    """Bug class: if the `runtime` field were not wired into AppConfig (or its
+    default_factory dropped), activation would read the wrong default. Omitting
+    the section entirely must still yield the opt-in-safe default: disabled,
+    30s poll. A regression to enabled-by-default would auto-activate the single
+    central mode-writer in every deployment."""
+    cfg = _app_config()
+    assert cfg.runtime.scheduler.enabled is False
+    assert cfg.runtime.scheduler.poll_interval_seconds == 30
+
+
+def test_runtime_scheduler_override_nests_into_app_config():
+    """Bug class: a mis-wired nested field would ignore the override and keep the
+    default. An explicit override must reach `runtime.scheduler`."""
+    cfg = _app_config(runtime={"scheduler": {"enabled": True, "poll_interval_seconds": 5}})
+    assert cfg.runtime.scheduler.enabled is True
+    assert cfg.runtime.scheduler.poll_interval_seconds == 5
+
+
+@pytest.mark.parametrize("bad_interval", [0, -1])
+def test_poll_interval_rejects_non_positive(bad_interval):
+    """Bug class: a 0s (or negative) interval would make the scheduler poll loop
+    spin without throttling. The `ge=1` constraint must reject it at load time,
+    not at runtime."""
+    with pytest.raises(ValidationError):
+        SchedulerConfig(poll_interval_seconds=bad_interval)


### PR DESCRIPTION
## Summary

Activates the SIP-0089 §2.4 **duty scheduler** — the dormant `DutyScheduler` + `RuntimeCoordinator` (built and unit-tested in #221 but constructed nowhere outside tests) are now wired into the runtime-api process so duty windows drive **live ambient↔duty mode transitions**. Validated end-to-end on the dev stack.

Live activation also exposed a latent bug in the merged §2.4 scheduler — agents stranded in `duty` when `reserve_after_window=0` (the hard-duty default) — fixed here as a second commit.

**Closes #226.**

## What's in it

**Activation (`9ec1ddc`)**
- `runtime.scheduler.{enabled,poll_interval_seconds}` config (`SchedulerConfig`/`RuntimeConfig`). **Opt-in** — `enabled` defaults `false` so a deployment activates duty mode deliberately. Verified the new nested `runtime` model doesn't collide with the flat `runtime_api_url` env path.
- `LoggingRuntimeEventPublisher` (`adapters/events/`) — records runtime-state events (`mode_transition`, `window.skipped/review_required`) as structured logs. Best-effort per D22 (never raises). Deliberately **not** bridged onto the locked cycle-event taxonomy (separate vocabulary).
- `create_duty_scheduler(config, pool)` (`api/runtime/scheduler_bootstrap.py`) — the composition-root activation gate (returns `None` when disabled or pool-less). `main.py` starts the loop in `startup` (background asyncio task, same pattern as the health reconciliation loop) and `stop()`s it first in `shutdown`.

**Close-sweep fix — #226 (`0b5f2a1`)**
- **Bug:** with `reserve_after_window=0`, an opened agent never closed. `tick()` only iterated `list_active_assignments(now)`, whose upper bound is `now < window_end + reserve_after`; at `reserve_after=0` the assignment leaves the active set the instant `window_end` passes — before any tick observes `window_state == in_reserve_after` — so the close branch was unreachable. Unit tests missed it (they drove `tick()` with the assignment already in the mocked active set).
- **Fix:** a disjoint **pass-2 close-sweep**. New `AssignmentPort.list_assignments_to_close(now)` (PostgresAssignment JOINs `agent_runtime_state` for `mode='duty'` + `now >= window_end + reserve_after`); `DutyScheduler.tick()` closes each via the coordinator (D21 — requests, never writes). Complementary to the active-set upper bound, so the two passes never overlap. Also acts as a catch-up if a `reserve_after>0` close was missed during downtime.

**Enable in dev stack (`f70d82e`)**
- `docker-compose.yml` runtime-api env: `SQUADOPS__RUNTIME__SCHEDULER__ENABLED=true`, 10s poll. runtime-api is the **single central writer** of agent mode (D16).

## Live validation (dev stack, real agents)
- `ambient → duty` on window open ✓
- `duty → ambient` on close — both *with* a reserve buffer **and** with the `reserve_after=0` default (the #226 case) ✓
- Other agents stay `ambient`; heartbeats don't revert mode (D17) ✓

## Tests
- 14 new tests: config gate + `ge=1` poll constraint; publisher structured-fields + best-effort contract; activation gate (disabled/no-pool/inert-on-build); close-sweep (fires `duty→ambient` from an empty active set; empty sweep is a no-op); adapter JOIN/predicate/binding.
- 87 runtime + architecture tests green locally; D26 forbidden-imports + test-quality linter clean. Full regression runs in CI (local 3.11 can't, per #217).

## Single-writer constraint (deferred)
The coordinator is the sole writer of `mode` (D16) — safe with **one** runtime-api instance (today's deployment). Scaling to multiple replicas would need leader election (a Postgres advisory lock). Deferred while single-instance and gated behind the `enabled` flag; documented at the bootstrap call site and `.env.example`.

## Follow-ups
- Closes #226.
- **#222** — scheduler auto-resume of duty-deferred PAUSED runs on window close is a natural close-sweep follow-up (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)