### PR TITLE
SIP-0089: mirror offline runtime_status in reconciliation so the duty guard sees dead agents (#159)

### DIFF
--- a/adapters/persistence/runtime/state_postgres.py
+++ b/adapters/persistence/runtime/state_postgres.py
@@ -129,6 +129,23 @@ class PostgresRuntimeState(RuntimeStatePort):
             )
         return _row_to_state(row)
 
+    async def mark_offline(self, agent_id: str) -> AgentRuntimeState | None:
+        """Set runtime_status='offline' only — never bump last_heartbeat_at or
+        coordinator-owned fields (D17/D16), and never INSERT (an agent that never
+        heartbeated has no row). The `runtime_status != 'offline'` guard makes
+        repeated reconciliation ticks idempotent (already-offline → no row → None).
+        """
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "UPDATE agent_runtime_state SET runtime_status = 'offline', updated_at = now() "
+                "WHERE agent_id = $1 AND runtime_status != 'offline' "
+                "RETURNING agent_id, mode, runtime_status, focus, "
+                "current_runtime_activity_id, interruptibility, "
+                "last_heartbeat_at, current_assignment_ref",
+                agent_id,
+            )
+        return _row_to_state(row) if row else None
+
 
 def _row_to_state(row: asyncpg.Record) -> AgentRuntimeState:
     return AgentRuntimeState(

--- a/src/squadops/api/runtime/health_checker.py
+++ b/src/squadops/api/runtime/health_checker.py
@@ -281,45 +281,71 @@ class HealthChecker:
         while self._reconciliation_running:
             try:
                 await asyncio.sleep(interval)
-                timeout = self._config.agent.heartbeat_timeout_window
-                now = datetime.utcnow()
-
-                async with self.pg_pool.acquire() as conn:
-                    rows = await conn.fetch(
-                        "SELECT agent_id, last_heartbeat, lifecycle_state, network_status "
-                        "FROM agent_status"
-                    )
-                    for row in rows:
-                        hb = row["last_heartbeat"]
-                        computed = (
-                            "online" if hb and (now - hb).total_seconds() <= timeout else "offline"
-                        )
-                        stored = row.get("network_status")
-                        need_lifecycle = (
-                            computed == "offline" and row.get("lifecycle_state") != "UNKNOWN"
-                        )
-
-                        if computed != stored or need_lifecycle:
-                            if need_lifecycle:
-                                await conn.execute(
-                                    "UPDATE agent_status SET network_status=$1, lifecycle_state=$2, "
-                                    "updated_at=$3 WHERE agent_id=$4",
-                                    computed,
-                                    "UNKNOWN",
-                                    now,
-                                    row["agent_id"],
-                                )
-                            else:
-                                await conn.execute(
-                                    "UPDATE agent_status SET network_status=$1, updated_at=$2 "
-                                    "WHERE agent_id=$3",
-                                    computed,
-                                    now,
-                                    row["agent_id"],
-                                )
+                await self._reconcile_once()
             except Exception as e:
                 logger.error("Reconciliation loop error: %s", e, exc_info=True)
                 await asyncio.sleep(10)
+
+    async def _reconcile_once(self) -> None:
+        """One reconciliation pass: recompute network_status from heartbeat age,
+        update agent_status, and mirror offline agents into agent_runtime_state
+        (SIP-0089 #159) so the coordinator's §11.3 offline guard sees them."""
+        timeout = self._config.agent.heartbeat_timeout_window
+        now = datetime.utcnow()
+        offline_agents: list[str] = []
+
+        async with self.pg_pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT agent_id, last_heartbeat, lifecycle_state, network_status FROM agent_status"
+            )
+            for row in rows:
+                hb = row["last_heartbeat"]
+                computed = "online" if hb and (now - hb).total_seconds() <= timeout else "offline"
+                stored = row.get("network_status")
+                need_lifecycle = computed == "offline" and row.get("lifecycle_state") != "UNKNOWN"
+
+                if computed != stored or need_lifecycle:
+                    if need_lifecycle:
+                        await conn.execute(
+                            "UPDATE agent_status SET network_status=$1, lifecycle_state=$2, "
+                            "updated_at=$3 WHERE agent_id=$4",
+                            computed,
+                            "UNKNOWN",
+                            now,
+                            row["agent_id"],
+                        )
+                    else:
+                        await conn.execute(
+                            "UPDATE agent_status SET network_status=$1, updated_at=$2 "
+                            "WHERE agent_id=$3",
+                            computed,
+                            now,
+                            row["agent_id"],
+                        )
+                if computed == "offline":
+                    offline_agents.append(row["agent_id"])
+
+        # Mirror offline agents into runtime-state after releasing the read conn, so
+        # the coordinator's §11.3 offline->duty rejection sees a crashed agent (#159).
+        for agent_id in offline_agents:
+            await self._mark_runtime_state_offline(agent_id)
+
+    async def _mark_runtime_state_offline(self, agent_id: str) -> None:
+        """Best-effort mirror of an offline transition into agent_runtime_state.
+
+        Non-authoritative (D17): sets only runtime_status, never last_heartbeat_at
+        or coordinator-owned fields. Failures are isolated like the heartbeat
+        mirror — a runtime-state write must not break reconciliation.
+        """
+        if self._runtime_state is None:
+            return
+        try:
+            await self._runtime_state.mark_offline(agent_id)
+        except Exception as exc:
+            logger.warning(
+                "runtime_state_offline_mirror_failed",
+                extra={"agent_id": agent_id, "error": str(exc)},
+            )
 
     # ── Infrastructure health probes ────────────────────────────────────
 

--- a/src/squadops/ports/runtime/state.py
+++ b/src/squadops/ports/runtime/state.py
@@ -57,3 +57,18 @@ class RuntimeStatePort(ABC):
 
         Calls `ensure_state` first if no row exists.
         """
+
+    @abstractmethod
+    async def mark_offline(self, agent_id: str) -> AgentRuntimeState | None:
+        """Mark a timed-out agent `offline` (health-only, non-authoritative per D17).
+
+        Sets `runtime_status = 'offline'` and nothing else: it must NOT touch
+        `last_heartbeat_at` (a dead agent's last heartbeat is meaningful) nor any
+        coordinator-owned field (`mode`, `focus`, `current_assignment_ref`,
+        `current_runtime_activity_id`). Unlike `update_heartbeat` it never creates
+        a row — an agent that never heartbeated has no runtime state to mark.
+
+        Returns the updated row, or `None` when no row exists or it was already
+        `offline` (idempotent no-op). Used by the reconciliation loop so the
+        coordinator's offline→duty rejection (§11.3) sees a crashed agent.
+        """

--- a/tests/unit/api/test_health_checker.py
+++ b/tests/unit/api/test_health_checker.py
@@ -245,3 +245,71 @@ class TestCheckPostgres:
         mock_pg_pool.acquire.side_effect = Exception("Connection refused")
         result = await checker.check_postgres()
         assert result["status"] == "offline"
+
+
+class TestReconcileOnce:
+    """SIP-0089 #159: a reconciliation pass mirrors offline agents into
+    agent_runtime_state so the coordinator's §11.3 offline->duty guard sees them."""
+
+    def _checker(self, mock_config):
+        conn = AsyncMock()
+        conn.__aenter__ = AsyncMock(return_value=conn)
+        conn.__aexit__ = AsyncMock(return_value=False)
+        pool = MagicMock()
+        pool.acquire.return_value = conn
+        runtime_state = AsyncMock()
+        checker = HealthChecker(
+            pg_pool=pool, redis_client=None, config=mock_config, runtime_state=runtime_state
+        )
+        return checker, conn, runtime_state
+
+    @pytest.mark.asyncio
+    async def test_timed_out_agent_is_mirrored_offline(self, mock_config):
+        """Bug class (#159): a crashed/timed-out agent must be marked offline in
+        agent_runtime_state. Without it the coordinator reads a stale 'online'
+        forever and could open a duty window for a dead agent. Only the timed-out
+        agent is mirrored — the live one is not."""
+        checker, conn, runtime_state = self._checker(mock_config)
+        now = datetime.utcnow()
+        conn.fetch = AsyncMock(
+            return_value=[
+                {
+                    "agent_id": "dead",
+                    "last_heartbeat": now - timedelta(seconds=200),  # > 90s timeout
+                    "lifecycle_state": "READY",
+                    "network_status": "online",
+                },
+                {
+                    "agent_id": "alive",
+                    "last_heartbeat": now - timedelta(seconds=10),
+                    "lifecycle_state": "READY",
+                    "network_status": "online",
+                },
+            ]
+        )
+
+        await checker._reconcile_once()
+
+        runtime_state.mark_offline.assert_awaited_once_with("dead")
+
+    @pytest.mark.asyncio
+    async def test_all_online_agents_not_mirrored(self, mock_config):
+        """Bug class: the mirror must be driven by computed offline status, never
+        fire for a healthy agent — a spurious mark_offline would wrongly trip the
+        coordinator's offline guard against a live agent."""
+        checker, conn, runtime_state = self._checker(mock_config)
+        now = datetime.utcnow()
+        conn.fetch = AsyncMock(
+            return_value=[
+                {
+                    "agent_id": "alive",
+                    "last_heartbeat": now - timedelta(seconds=5),
+                    "lifecycle_state": "READY",
+                    "network_status": "online",
+                },
+            ]
+        )
+
+        await checker._reconcile_once()
+
+        runtime_state.mark_offline.assert_not_awaited()

--- a/tests/unit/runtime/test_agent_runtime_state.py
+++ b/tests/unit/runtime/test_agent_runtime_state.py
@@ -245,3 +245,36 @@ async def test_upsert_state_writes_all_fields_including_coordinator_owned():
         "interruptibility = EXCLUDED.interruptibility",
     ):
         assert col in query, f"upsert UPDATE branch missing: {col}"
+
+
+async def test_mark_offline_sets_only_status_not_heartbeat_or_coordinator_fields():
+    """Bug class (#159 + D17/D16): the reconciliation loop must record a crashed
+    agent as offline WITHOUT bumping last_heartbeat_at (a dead agent's last beat is
+    evidence) or clobbering coordinator-owned fields (a duty agent that crashed is
+    still bound to its window). The UPDATE must set only runtime_status, and the
+    `!= 'offline'` guard makes repeated ticks idempotent."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _state_row(mode="duty", runtime_status="offline")
+    adapter = PostgresRuntimeState(_make_pool(conn))
+
+    state = await adapter.mark_offline("max")
+
+    query = conn.fetchrow.call_args.args[0]
+    set_clause = query.split("SET", 1)[1].split("WHERE", 1)[0]
+    assert "runtime_status = 'offline'" in set_clause
+    for forbidden in ("last_heartbeat_at =", "mode =", "focus =", "current_assignment_ref ="):
+        assert forbidden not in set_clause, f"mark_offline must not write {forbidden!r}"
+    assert "runtime_status != 'offline'" in query  # idempotent guard
+    assert "INSERT" not in query  # never fabricates a row for a never-seen agent
+    assert state is not None and state.mode == "duty"  # coordinator field preserved
+
+
+async def test_mark_offline_returns_none_when_no_row_or_already_offline():
+    """Bug class: an agent with no runtime-state row (never heartbeated) or already
+    offline yields no updated row. mark_offline must return None, not raise — the
+    reconciliation mirror is best-effort."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = None
+    adapter = PostgresRuntimeState(_make_pool(conn))
+
+    assert await adapter.mark_offline("ghost") is None

--- a/tests/unit/runtime/test_coordinator.py
+++ b/tests/unit/runtime/test_coordinator.py
@@ -68,6 +68,9 @@ class _FakeStatePort(RuntimeStatePort):
     async def update_heartbeat(self, agent_id, *, runtime_status=None):  # unused here
         return await self.ensure_state(agent_id)
 
+    async def mark_offline(self, agent_id):  # unused here
+        return self._rows.get(agent_id)
+
 
 class _RecordingPublisher(RuntimeEventPublisher):
     def __init__(self) -> None:

--- a/tests/unit/runtime/test_scheduler.py
+++ b/tests/unit/runtime/test_scheduler.py
@@ -117,6 +117,9 @@ class _FakeStatePort(RuntimeStatePort):
     async def update_heartbeat(self, agent_id, *, runtime_status=None):
         return await self.ensure_state(agent_id)
 
+    async def mark_offline(self, agent_id):  # unused here
+        return self._row
+
 
 class _RecordingPublisher(RuntimeEventPublisher):
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary

Fixes **#159**: a crashed/timed-out agent's `agent_runtime_state.runtime_status` stayed frozen at `online`, because the heartbeat mirror only fires on an **inbound** heartbeat and the reconciliation loop (which marks dead agents offline in `agent_status`) never touched `agent_runtime_state`.

This now matters more than at Phase 1: the coordinator's §11.3 **"offline can't enter duty"** guard reads the *stored* `runtime_status`, and the duty scheduler went live in #227. With the field stuck at `online`, the scheduler could open a duty window for a **dead agent**.

## Fix (Option 1 — mirror parity)
- **`RuntimeStatePort.mark_offline(agent_id)`** — sets `runtime_status='offline'` and nothing else. It must NOT bump `last_heartbeat_at` (a dead agent's last beat is evidence) or touch coordinator-owned fields (`mode`, `focus`, `current_assignment_ref`, `current_runtime_activity_id`) — D17/D16. `PostgresRuntimeState` implements it as a guarded `UPDATE ... WHERE runtime_status != 'offline'` (idempotent; never `INSERT`s a row for an agent that never heartbeated). Returns the row, or `None` when absent/already-offline.
- **`health_checker`** — extracted the reconciliation body into a testable `_reconcile_once()`, which now mirrors every offline agent via `mark_offline` after releasing the read connection. Best-effort + failure-isolated, exactly like the existing heartbeat mirror.

## Live validation (dev stack)
Rebuilt runtime-api, stopped the `data` agent at `20:33:14Z`; at `20:34:59Z` (~105s, within the 90s timeout + ≤45s reconcile) `agent_runtime_state` flipped to **`mode=ambient, runtime_status=offline`** — status mirrored, `mode` preserved (D17 held). Restarted it → recovered to `online` in ~6s via the heartbeat path.

## Tests
- Adapter: `mark_offline` writes only `runtime_status` (not heartbeat/mode/assignment_ref), carries the idempotent guard, and returns `None` when absent/already-offline.
- Reconciliation: a timed-out agent is mirrored offline; a live agent is not.
- Updated the two `RuntimeStatePort` test fakes for the new method.
- 106 runtime + health-checker + architecture tests green locally; D26 + test-quality linter clean. Full regression in CI.

Closes #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)