### PR TITLE
fix(deps): declare sqlalchemy and python-jose (unblock unit collection)

### DIFF
--- a/ci-constraints.txt
+++ b/ci-constraints.txt
@@ -41,6 +41,7 @@ deprecation==2.1.0
 Django==6.0.6
 docker==7.1.0
 docutils==0.22.4
+ecdsa==0.19.2
 execnet==2.1.2
 factory_boy==3.3.3
 Faker==40.23.0
@@ -53,6 +54,7 @@ fsspec==2026.6.0
 google-api-core==2.31.0
 google-auth==2.55.0
 googleapis-common-protos==1.75.0
+greenlet==3.5.3
 grpcio==1.81.1
 h11==0.16.0
 hf-xet==1.5.1
@@ -146,6 +148,7 @@ pytest-redis==4.0.0
 pytest-xdist==3.8.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
+python-jose==3.5.0
 python-multipart==0.0.32
 pytokens==0.4.1
 PyYAML==6.0.3
@@ -157,6 +160,7 @@ responses==0.26.1
 rich==15.0.0
 roman-numerals==4.1.0
 rpds-py==2026.5.1
+rsa==4.9.1
 ruff==0.15.18
 safetensors==0.8.0
 scikit-learn==1.9.0
@@ -176,6 +180,7 @@ sphinxcontrib-jquery==4.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
+SQLAlchemy==2.0.51
 sqlparse==0.5.5
 sse-starlette==3.4.5
 starlette==1.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,11 @@ squadops = "squadops.cli.main:app"
 langfuse = ["langfuse>=2.0"]
 cli = ["typer>=0.9", "httpx>=0.25", "rich>=13.0"]
 pulse = ["jsonschema>=4.0", "httpx>=0.25"]
+# Adapter-specific deps. Previously undeclared and pulled in only transitively
+# (via Prefect in the Docker images), so minimal/CI envs failed to import the
+# adapters and unit collection aborted. See issues #206 / #191.
+postgres = ["sqlalchemy>=2.0"]            # adapters/persistence/postgres (Engine/sessionmaker)
+auth = ["python-jose[cryptography]>=3.3"] # adapters/auth/keycloak (JWT validation)
 
 #######################################
 # Ruff - Linting & basic code hygiene #

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -27,6 +27,8 @@ psycopg-binary>=3.0.0  # Binary PostgreSQL adapter (includes libpq, no system de
 aiofiles>=23.0.0  # Async file I/O (used by base_agent)
 aio-pika>=9.3.0  # RabbitMQ async client
 asyncpg>=0.29.0  # PostgreSQL async driver
+sqlalchemy>=2.0  # Sync Engine/sessionmaker used by adapters/persistence/postgres (issue #206)
+python-jose[cryptography]>=3.3  # JWT validation used by adapters/auth/keycloak (issue #191)
 # Upper bound pins the test env to the FastAPI the project actually runs (0.135.x).
 # Starlette >=0.136 newly rejects including a router instance into more than one
 # app, which the console unit tests do via module-level singleton routers +


### PR DESCRIPTION
## Problem (closes #206, #191)

`sqlalchemy` (`adapters/persistence/postgres/runtime.py` — `create_engine`/`sessionmaker`) and `python-jose` (`adapters/auth/keycloak/auth_adapter.py` — JWT validation) are **production imports** that were declared **nowhere** — not in `pyproject.toml`, `ci-constraints.txt`, or `tests/requirements.txt`. They were satisfied only **transitively** (via Prefect in the Docker images), so in a minimal or CI environment the adapters fail to import and `pytest tests/unit` **aborts at collection**:

```
ERROR tests/unit/adapters/test_persistence.py      - No module named 'sqlalchemy'
ERROR tests/unit/auth/test_keycloak_adapter.py     - No module named 'jose'
Interrupted: 2 errors during collection
```

Adapter unit tests aren't in the CI regression gate (#207), so CI never surfaced this — only a clean checkout / fresh venv hits it.

## Fix

Declare both explicitly across all three layers:

| Layer | Change |
|---|---|
| `pyproject.toml` | new `postgres` / `auth` optional-dependency extras |
| `tests/requirements.txt` | `sqlalchemy>=2.0`, `python-jose[cryptography]>=3.3` |
| `ci-constraints.txt` | pin 2 direct + 3 transitive: `SQLAlchemy==2.0.51`, `python-jose==3.5.0`, `ecdsa==0.19.2`, `rsa==4.9.1`, `greenlet==3.5.3` |

Declared as **adapter extras** (not core deps) because they're adapter-specific — consistent with the existing `langfuse`/`cli`/`pulse` extras and the hexagonal layering. The `sqlalchemy` leak into the domain port `ports/db.py` is a separate cleanup (#153); declaring the dep here doesn't bless it.

Pins were resolved from a clean install; all are pure-Python except `greenlet` (version-identical across platforms), so the local resolution matches what x86_64 CI installs.

## Validation

- `pytest tests/unit --collect-only`: **2 errors → 0** (4617 → 4650 collected; +33 = the now-runnable adapter/auth tests)
- the 33 formerly-aborting adapter/auth tests **pass**
- regression suite **green** (4253 passed, 1 skipped)
- `pip install ... -c ci-constraints.txt` resolves the new deps to exactly the pinned versions (no conflicts; `cryptography==49.0.0` already pinned satisfies `python-jose[cryptography]`)

## Lane / sequencing

First step of the Spark CI-trust arc (#206+#191 → #198 → #217 → #196 → #207 → #211/#209). Touches shared files (`pyproject.toml`, `ci-constraints.txt`, `tests/requirements.txt`) — additive only, no edits to MacBook-lane `runtime/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)