### PR TITLE
fix(deps): make the postgres extra truly optional — TYPE_CHECKING-guard sqlalchemy in ports/db.py (#206)

### DIFF
--- a/src/squadops/ports/db.py
+++ b/src/squadops/ports/db.py
@@ -5,10 +5,15 @@ Defines the contract that any database runtime implementation must satisfy.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-from sqlalchemy import Engine
-from sqlalchemy.orm import sessionmaker
+if TYPE_CHECKING:
+    # Type-only: the sqlalchemy `Engine`/`sessionmaker` types appear solely in the
+    # annotations below. `sqlalchemy` is the legacy/alternate persistence backend
+    # (the active runtime path is asyncpg), so it is declared as the optional
+    # `postgres` extra — importing this core port must NOT require it at runtime.
+    from sqlalchemy import Engine
+    from sqlalchemy.orm import sessionmaker
 
 
 @dataclass
@@ -25,7 +30,7 @@ class DbRuntime(ABC):
 
     @property
     @abstractmethod
-    def engine(self) -> Engine:
+    def engine(self) -> "Engine":
         """
         Return the SQLAlchemy engine instance.
 
@@ -36,7 +41,7 @@ class DbRuntime(ABC):
 
     @property
     @abstractmethod
-    def session_factory(self) -> sessionmaker:
+    def session_factory(self) -> "sessionmaker":
         """
         Return the SQLAlchemy sessionmaker instance.
 


### PR DESCRIPTION
## Why

Follow-up to #229. That PR declared `sqlalchemy` as the optional `postgres` extra, and the lazy persistence `__init__` (ce160d9/#220) decoupled the *adapter*. But the **core port** `squadops.ports.db` still imported sqlalchemy at module top level — used only for the `Engine`/`sessionmaker` return annotations on the abstract `engine`/`session_factory` properties.

Net effect: importing core ports required sqlalchemy **at runtime**, so the "optional extra" was dishonest. CI only stayed green because `tests/requirements.txt` installs it; a plain `pip install squadops` (no extras) would `ModuleNotFoundError` on importing the port. This is the core-vs-optional question raised in review of #229 — the code answered "de-facto core, by accident."

## What

- Move `from sqlalchemy import Engine` / `from sqlalchemy.orm import sessionmaker` behind `TYPE_CHECKING`.
- Stringify the two return annotations (`-> "Engine"`, `-> "sessionmaker"`).

sqlalchemy is the legacy/alternate backend; the active runtime path is asyncpg (`adapters/persistence/runtime/`, zero sqlalchemy). The sqlalchemy-typed `DbRuntime` is implemented only by `adapters/persistence/postgres/runtime.py`.

## Verification

- **Decoupling proof:** importing `squadops.ports.db` with sqlalchemy blocked (`sys.modules['sqlalchemy'] = None`, simulating a minimal env without the `postgres` extra) now succeeds — it raised `ModuleNotFoundError` before this change.
- `ruff check` + `ruff format --check` clean.
- `tests/unit/architecture/` (5) and `tests/unit/adapters/test_persistence.py` (18) pass.

## Follow-up (not in this PR)

Deeper hex-arch smell tracked separately: the port leaks vendor types (`Engine`/`sessionmaker`) and is shaped to the one legacy sqlalchemy backend while the active path is asyncpg with separate ports. Filed as a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)