### PR TITLE
test(ci): add tests/unit/adapters/ to the regression gate (#207)

### DIFF
--- a/scripts/dev/run_regression_tests.sh
+++ b/scripts/dev/run_regression_tests.sh
@@ -30,6 +30,7 @@ REGRESSION_DIRS=(
     "tests/unit/contracts/"
     "tests/unit/runtime/"        # SIP-0089 runtime modes/assignments/scheduler (#220)
     "tests/unit/architecture/"   # D26 forbidden-imports + future architecture guards (#220)
+    "tests/unit/adapters/"       # mocked adapter unit tests (a2a, persistence, queue, chat) (#207)
 )
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
Closes #207.

## What

Adds `tests/unit/adapters/` to `REGRESSION_DIRS` in `scripts/dev/run_regression_tests.sh` — a one-line append after Mac's `runtime/` + `architecture/` entries (append-don't-rewrite convention preserved).

## Why it's safe for CI

The adapter suite is **92 mocked unit tests** (a2a client/server, postgres persistence, queue_port, chat cache/repo, prefect task adapter) with:
- **no live-service dependency** (confirmed: zero `@pytest.mark.database/redis/rabbitmq/docker` markers),
- **no integration markers**,

so they run on the serviceless x86_64 CI runner. The note in `tests/unit/conftest.py` confirms real-service tests live under `tests/integration/`.

The issue warned this could surface failures ("adapter tests have never run in the gate") — in practice **nothing surfaced**: the tests pass and the test-quality lint is clean.

## Verification

- Full gate (`run_regression_tests.sh`): **4378 passed, 1 skipped, 0 failures**.
- `ruff check .` clean.
- `lint_test_quality.py` clean on all 7 adapter test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)