### PR TITLE
style+ci: repo-wide ruff format sweep + enforce format gate (#196)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,8 @@ jobs:
       - name: Prompt-fragment manifest is in sync
         run: python scripts/dev/regen_fragment_manifest.py --check
 
-      # Runs `ruff check .` (lint, fail-stop) + the test-quality lint + the full
-      # unit regression suite. NOTE: a repo-wide `ruff format --check .` is NOT
-      # gated here yet — 43 pre-existing files need formatting first (tracked
-      # separately); add the format gate once that sweep lands.
-      - name: Regression suite (ruff check + test-quality lint + pytest)
+      # Runs `ruff check .` + `ruff format --check .` (lint + format, fail-stop) +
+      # the test-quality lint + the full unit regression suite. The repo-wide
+      # format sweep landed in #196, so the format check is now gated here.
+      - name: Regression suite (ruff check + format + test-quality lint + pytest)
         run: bash scripts/dev/run_regression_tests.sh

--- a/scripts/dev/lint_test_quality.py
+++ b/scripts/dev/lint_test_quality.py
@@ -50,10 +50,20 @@ def _has_nontrivial_call(body: list[ast.stmt]) -> bool:
     Plain constructors (ClassName(...)) in assignments are just setup, not behavior.
     """
     # Builtins that inspect structure but don't exercise behavior
-    _PASSIVE_BUILTINS = frozenset({
-        "isinstance", "issubclass", "type", "len", "str",
-        "getattr", "hasattr", "setattr", "vars", "dir",
-    })
+    _PASSIVE_BUILTINS = frozenset(
+        {
+            "isinstance",
+            "issubclass",
+            "type",
+            "len",
+            "str",
+            "getattr",
+            "hasattr",
+            "setattr",
+            "vars",
+            "dir",
+        }
+    )
 
     for node in ast.walk(ast.Module(body=body, type_ignores=[])):
         if isinstance(node, ast.Await):
@@ -85,22 +95,24 @@ def _collect_asserts(body: list[ast.stmt]) -> list[ast.Assert]:
     return asserts
 
 
-_MOCK_ASSERT_METHODS = frozenset({
-    "assert_called",
-    "assert_called_once",
-    "assert_called_with",
-    "assert_called_once_with",
-    "assert_any_call",
-    "assert_has_calls",
-    "assert_not_called",
-    "assert_awaited",
-    "assert_awaited_once",
-    "assert_awaited_with",
-    "assert_awaited_once_with",
-    "assert_any_await",
-    "assert_has_awaits",
-    "assert_not_awaited",
-})
+_MOCK_ASSERT_METHODS = frozenset(
+    {
+        "assert_called",
+        "assert_called_once",
+        "assert_called_with",
+        "assert_called_once_with",
+        "assert_any_call",
+        "assert_has_calls",
+        "assert_not_called",
+        "assert_awaited",
+        "assert_awaited_once",
+        "assert_awaited_with",
+        "assert_awaited_once_with",
+        "assert_any_await",
+        "assert_has_awaits",
+        "assert_not_awaited",
+    }
+)
 
 
 def _has_mock_assertions(body: list[ast.stmt]) -> bool:

--- a/scripts/dev/run_regression_tests.sh
+++ b/scripts/dev/run_regression_tests.sh
@@ -34,8 +34,9 @@ REGRESSION_DIRS=(
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-echo "Running ruff lint (fail-stop)..."
+echo "Running ruff lint + format check (fail-stop)..."
 ruff check .
+ruff format --check .
 echo ""
 
 echo "Running test quality lint..."

--- a/scripts/maintainer/upload_prompts_to_langfuse.py
+++ b/scripts/maintainer/upload_prompts_to_langfuse.py
@@ -167,12 +167,14 @@ def upload_to_langfuse(
     errors = 0
 
     for entry in entries:
-        payload = json.dumps({
-            "name": entry.name,
-            "prompt": entry.content,
-            "labels": [environment],
-            "type": "text",
-        }).encode()
+        payload = json.dumps(
+            {
+                "name": entry.name,
+                "prompt": entry.content,
+                "labels": [environment],
+                "type": "text",
+            }
+        ).encode()
 
         req = urllib.request.Request(url, data=payload, method="POST")
         req.add_header("Content-Type", "application/json")
@@ -197,9 +199,9 @@ def upload_to_langfuse(
 
 def print_dry_run(entries: list[UploadEntry], environment: str) -> None:
     """Print what would be uploaded without making API calls."""
-    print(f"\n{'='*70}")
+    print(f"\n{'=' * 70}")
     print(f"DRY RUN — {len(entries)} assets would be uploaded (environment: {environment})")
-    print(f"{'='*70}\n")
+    print(f"{'=' * 70}\n")
 
     fragments = [e for e in entries if e.asset_type == "fragment"]
     templates = [e for e in entries if e.asset_type == "template"]

--- a/src/squadops/capabilities/handlers/_plan_merger.py
+++ b/src/squadops/capabilities/handlers/_plan_merger.py
@@ -85,9 +85,7 @@ def _resolve_dependency_edges(
                     norm_key,
                 )
             depends_on.append(focus_to_index[norm_key])
-        resolved_pairs.append(
-            (dataclasses.replace(task, depends_on=sorted(set(depends_on))), prov)
-        )
+        resolved_pairs.append((dataclasses.replace(task, depends_on=sorted(set(depends_on))), prov))
     return resolved_pairs, unresolved_deps
 
 
@@ -174,9 +172,7 @@ def merge_proposals(
         for key in prov.source_proposal_task_keys:
             focus_to_index[key] = task.task_index
 
-    resolved_pairs, unresolved_deps = _resolve_dependency_edges(
-        indexed_pairs, focus_to_index
-    )
+    resolved_pairs, unresolved_deps = _resolve_dependency_edges(indexed_pairs, focus_to_index)
 
     canonical_tasks = [t for t, _ in resolved_pairs]
     provenance_entries = [p for _, p in resolved_pairs]
@@ -199,9 +195,7 @@ def merge_proposals(
     configured_set = set(configured_contributors)
     completeness = "complete" if configured_set == successful_roles else "partial"
 
-    proposal_ids = [
-        p.proposal_id for p in (dev_proposal, qa_proposal) if p is not None
-    ]
+    proposal_ids = [p.proposal_id for p in (dev_proposal, qa_proposal) if p is not None]
     guidance_ids = [strategy_guidance.guidance_id] if strategy_guidance else []
 
     plan = _build_canonical_plan(
@@ -245,8 +239,7 @@ def build_sole_author_decisions(
     operator_notes_parts: list[str] = []
     if sole_author_reason == "all_proposals_failed":
         operator_notes_parts.append(
-            "Multi-role authoring degraded to sole-author: every "
-            "configured proposer failed."
+            "Multi-role authoring degraded to sole-author: every configured proposer failed."
         )
         # Per-role missing-proposal warnings still surface in degraded mode
         # so the operator can see which roles failed.
@@ -380,8 +373,7 @@ def _resolve_brief_conflicts(
                         severity="warning",
                         disposition="accepted",
                         reason=(
-                            f"Warning conflict from {proposal.proposing_role} accepted: "
-                            f"{bc.reason}"
+                            f"Warning conflict from {proposal.proposing_role} accepted: {bc.reason}"
                         ),
                     )
                 )
@@ -419,26 +411,20 @@ def _build_operator_notes(
 
     # §5.9 required missing-role warnings
     if "qa" in configured and "qa" not in successful:
-        parts.append(
-            "QA coverage warning: plan was authored without qa-domain input."
-        )
+        parts.append("QA coverage warning: plan was authored without qa-domain input.")
     if "development" in configured and "development" not in successful:
         parts.append(
-            "Implementation decomposition warning: plan was authored "
-            "without dev-domain input."
+            "Implementation decomposition warning: plan was authored without dev-domain input."
         )
     if "strategy" in configured and "strategy" not in successful:
         parts.append(
-            "Ordering/priority warning: plan ordering was assigned without "
-            "strategy guidance."
+            "Ordering/priority warning: plan ordering was assigned without strategy guidance."
         )
 
     # Escalated brief conflicts
     for d in brief_conflicts_disposition:
         if d.disposition == "escalated_to_operator":
-            parts.append(
-                f"Brief conflict escalated ({d.brief_field}): {d.reason}"
-            )
+            parts.append(f"Brief conflict escalated ({d.brief_field}): {d.reason}")
 
     # Unresolved cross-proposal dependencies (rule 7 gap-fill candidates).
     # Rev 1 surfaces these as operator notes rather than auto-filling — the

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -556,9 +556,7 @@ class GovernancePreparePlanAuthoringBriefHandler(_PlanningTaskHandler):
         )
         system_prompt = assembled.content
 
-        max_attempts = int(
-            resolved_config.get("brief_max_attempts", _BRIEF_MAX_ATTEMPTS_DEFAULT)
-        )
+        max_attempts = int(resolved_config.get("brief_max_attempts", _BRIEF_MAX_ATTEMPTS_DEFAULT))
         chat_kwargs = self._build_chat_kwargs(inputs)
 
         def parse_and_validate(
@@ -774,10 +772,7 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
         profile_roles = inputs.get("profile_roles") or []
         roles_section = ""
         if profile_roles:
-            roles_section = (
-                "## Available roles in this squad\n\n"
-                f"{', '.join(profile_roles)}\n\n"
-            )
+            roles_section = f"## Available roles in this squad\n\n{', '.join(profile_roles)}\n\n"
 
         builder_section = ""
         if "builder" in profile_roles and self._role != "builder":
@@ -998,7 +993,10 @@ class DevelopmentProposePlanTasksHandler(_ProposeBaseHandler):
         from squadops.cycles.proposed_role_tasks import ProposedRoleTasks
 
         if yaml_content is None:
-            return None, "No fenced YAML block found. Emit your proposal in a ```yaml:proposed_plan_tasks.yaml``` block."
+            return (
+                None,
+                "No fenced YAML block found. Emit your proposal in a ```yaml:proposed_plan_tasks.yaml``` block.",
+            )
         try:
             proposal = ProposedRoleTasks.from_yaml(yaml_content)
         except ValueError as exc:
@@ -1035,7 +1033,10 @@ class QaProposePlanTasksHandler(_ProposeBaseHandler):
         from squadops.cycles.proposed_role_tasks import ProposedRoleTasks
 
         if yaml_content is None:
-            return None, "No fenced YAML block found. Emit your proposal in a ```yaml:proposed_plan_tasks.yaml``` block."
+            return (
+                None,
+                "No fenced YAML block found. Emit your proposal in a ```yaml:proposed_plan_tasks.yaml``` block.",
+            )
         try:
             proposal = ProposedRoleTasks.from_yaml(yaml_content)
         except ValueError as exc:
@@ -1047,8 +1048,7 @@ class QaProposePlanTasksHandler(_ProposeBaseHandler):
             )
         if proposal.proposing_role != "qa":
             return None, (
-                f"proposing_role must be 'qa' for this handler, "
-                f"got {proposal.proposing_role!r}"
+                f"proposing_role must be 'qa' for this handler, got {proposal.proposing_role!r}"
             )
         return proposal, None
 
@@ -1072,7 +1072,10 @@ class StrategyProposePlanGuidanceHandler(_ProposeBaseHandler):
         from squadops.cycles.plan_guidance import PlanGuidance
 
         if yaml_content is None:
-            return None, "No fenced YAML block found. Emit your guidance in a ```yaml:plan_guidance.yaml``` block."
+            return (
+                None,
+                "No fenced YAML block found. Emit your guidance in a ```yaml:plan_guidance.yaml``` block.",
+            )
         try:
             guidance = PlanGuidance.from_yaml(yaml_content)
         except ValueError as exc:
@@ -1151,9 +1154,7 @@ class GovernanceMergePlanHandler(_CycleTaskHandler):
 
         prior_outputs = inputs.get("prior_outputs") or {}
         resolved_config = inputs.get("resolved_config") or {}
-        configured_contributors = list(
-            resolved_config.get("plan_authoring_contributors") or []
-        )
+        configured_contributors = list(resolved_config.get("plan_authoring_contributors") or [])
 
         # Brief is mandatory upstream — without it the merger has no
         # contract to anchor proposals against. Fail loudly if absent
@@ -1186,9 +1187,7 @@ class GovernanceMergePlanHandler(_CycleTaskHandler):
         dev_proposal, dev_missing = self._parse_proposal_outcome(
             dev_outcome, "development", ProposedRoleTasks
         )
-        qa_proposal, qa_missing = self._parse_proposal_outcome(
-            qa_outcome, "qa", ProposedRoleTasks
-        )
+        qa_proposal, qa_missing = self._parse_proposal_outcome(qa_outcome, "qa", ProposedRoleTasks)
         strategy_guidance, strat_missing = self._parse_proposal_outcome(
             strat_outcome, "strategy", PlanGuidance
         )
@@ -1199,9 +1198,7 @@ class GovernanceMergePlanHandler(_CycleTaskHandler):
                 missing_proposals.append(entry)
 
         successful_count = sum(
-            1
-            for p in (dev_proposal, qa_proposal, strategy_guidance)
-            if p is not None
+            1 for p in (dev_proposal, qa_proposal, strategy_guidance) if p is not None
         )
 
         prd = inputs.get("prd", "")
@@ -1334,9 +1331,7 @@ class GovernanceMergePlanHandler(_CycleTaskHandler):
         from squadops.cycles.implementation_plan import ImplementationPlan
 
         sole_author_reason = (
-            "no_contributors_configured"
-            if not configured_contributors
-            else "all_proposals_failed"
+            "no_contributors_configured" if not configured_contributors else "all_proposals_failed"
         )
 
         planning_content = self._build_planning_content_from_framing(prior_outputs)

--- a/src/squadops/cycles/merge_decisions.py
+++ b/src/squadops/cycles/merge_decisions.py
@@ -27,15 +27,11 @@ from dataclasses import dataclass
 import yaml
 
 _VALID_AUTHORING_MODES = frozenset({"multi_role", "sole_author"})
-_VALID_SOLE_AUTHOR_REASONS = frozenset(
-    {"no_contributors_configured", "all_proposals_failed"}
-)
+_VALID_SOLE_AUTHOR_REASONS = frozenset({"no_contributors_configured", "all_proposals_failed"})
 _VALID_PROPOSAL_COMPLETENESS = frozenset({"complete", "partial", "sole_author"})
 _VALID_MERGE_ACTIONS = frozenset({"accepted", "merged", "modified", "gap_filled"})
 _VALID_BRIEF_CONFLICT_SEVERITIES = frozenset({"warning", "blocking"})
-_VALID_CONFLICT_DISPOSITIONS = frozenset(
-    {"accepted", "rejected", "escalated_to_operator"}
-)
+_VALID_CONFLICT_DISPOSITIONS = frozenset({"accepted", "rejected", "escalated_to_operator"})
 
 
 @dataclass(frozen=True)
@@ -158,9 +154,7 @@ class MergeDecisions:
 
         version = data["version"]
         if not isinstance(version, int):
-            raise ValueError(
-                f"merge_decisions version must be int, got {type(version).__name__}"
-            )
+            raise ValueError(f"merge_decisions version must be int, got {type(version).__name__}")
 
         target_plan_id = str(data["target_plan_id"]).strip()
         brief_id = str(data["brief_id"]).strip()
@@ -243,8 +237,7 @@ def _validate_rc26(
     # sole_author
     if sole_author_reason is None:
         raise ValueError(
-            "merge_decisions: authoring_mode 'sole_author' requires "
-            "sole_author_reason to be set"
+            "merge_decisions: authoring_mode 'sole_author' requires sole_author_reason to be set"
         )
     if proposal_completeness != "sole_author":
         raise ValueError(
@@ -328,14 +321,11 @@ def _parse_canonical_tasks(raw: object) -> list[CanonicalTaskProvenance]:
         source_keys = entry.get("source_proposal_task_keys", [])
         if not isinstance(source_keys, list):
             raise ValueError(
-                f"merge_decisions canonical_tasks[{i}].source_proposal_task_keys "
-                "must be a list"
+                f"merge_decisions canonical_tasks[{i}].source_proposal_task_keys must be a list"
             )
         proposed_by = entry.get("proposed_by", [])
         if not isinstance(proposed_by, list):
-            raise ValueError(
-                f"merge_decisions canonical_tasks[{i}].proposed_by must be a list"
-            )
+            raise ValueError(f"merge_decisions canonical_tasks[{i}].proposed_by must be a list")
 
         parsed.append(
             CanonicalTaskProvenance(
@@ -367,9 +357,7 @@ def _parse_brief_conflicts_disposition(raw: object) -> list[BriefConflictDisposi
     parsed: list[BriefConflictDisposition] = []
     for i, entry in enumerate(raw):
         if not isinstance(entry, dict):
-            raise ValueError(
-                f"merge_decisions brief_conflicts_disposition[{i}] must be a mapping"
-            )
+            raise ValueError(f"merge_decisions brief_conflicts_disposition[{i}] must be a mapping")
         for req in ("brief_field", "severity", "disposition", "reason"):
             if req not in entry:
                 raise ValueError(
@@ -395,5 +383,3 @@ def _parse_brief_conflicts_disposition(raw: object) -> list[BriefConflictDisposi
             )
         )
     return parsed
-
-

--- a/src/squadops/cycles/plan_guidance.py
+++ b/src/squadops/cycles/plan_guidance.py
@@ -70,9 +70,7 @@ class PlanGuidance:
 
         version = data["version"]
         if not isinstance(version, int):
-            raise ValueError(
-                f"plan_guidance version must be int, got {type(version).__name__}"
-            )
+            raise ValueError(f"plan_guidance version must be int, got {type(version).__name__}")
 
         guidance_id = str(data["guidance_id"]).strip()
         if not guidance_id:

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -141,6 +141,7 @@ def build_planning_steps(
     )
     return steps
 
+
 # Refinement task steps (SIP-0078 §5.10)
 REFINEMENT_TASK_STEPS: list[tuple[str, str]] = [
     ("governance.incorporate_feedback", "lead"),

--- a/tests/integration/cycles/test_merge_plan.py
+++ b/tests/integration/cycles/test_merge_plan.py
@@ -310,8 +310,7 @@ def test_review_plan_handler_no_longer_calls_plan_authoring_service():
         "in the merger; this handler is sign-off only."
     )
     assert "produce_plan(" not in handler_source, (
-        "GovernanceReviewPlanHandler reintroduced an inline produce_plan "
-        "call — cutover regression."
+        "GovernanceReviewPlanHandler reintroduced an inline produce_plan call — cutover regression."
     )
     # The handler's _produce_plan method itself must be gone (not just unused)
     assert not hasattr(GovernanceReviewPlanHandler, "_produce_plan"), (

--- a/tests/unit/adapters/test_chat_cache.py
+++ b/tests/unit/adapters/test_chat_cache.py
@@ -90,10 +90,26 @@ class TestGetMessages:
     async def test_returns_parsed_messages(self):
         """Cached messages are JSON-parsed and returned."""
         redis = _make_redis()
-        redis.lrange = AsyncMock(return_value=[
-            json.dumps({"message_id": "m1", "role": "user", "content": "hi", "created_at": "2025-01-01T00:00:00"}),
-            json.dumps({"message_id": "m2", "role": "assistant", "content": "hello", "created_at": "2025-01-01T00:00:01"}),
-        ])
+        redis.lrange = AsyncMock(
+            return_value=[
+                json.dumps(
+                    {
+                        "message_id": "m1",
+                        "role": "user",
+                        "content": "hi",
+                        "created_at": "2025-01-01T00:00:00",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "message_id": "m2",
+                        "role": "assistant",
+                        "content": "hello",
+                        "created_at": "2025-01-01T00:00:01",
+                    }
+                ),
+            ]
+        )
         cache = ChatSessionCache(redis=redis)
 
         result = await cache.get_messages("s1")

--- a/tests/unit/agents/test_entrypoint_log_scoping.py
+++ b/tests/unit/agents/test_entrypoint_log_scoping.py
@@ -91,9 +91,7 @@ def installed_handler():
     handler = PrefectLogHandler(forwarder, filters=LogHandlerFilters(min_level=logging.INFO))
     logging.getLogger().addHandler(handler)
 
-    prior_levels = {
-        name: logging.getLogger(name).level for name in ("adapters", "squadops")
-    }
+    prior_levels = {name: logging.getLogger(name).level for name in ("adapters", "squadops")}
     logging.getLogger("adapters").setLevel(logging.INFO)
     logging.getLogger("squadops").setLevel(logging.INFO)
 

--- a/tests/unit/api/test_chat_routes.py
+++ b/tests/unit/api/test_chat_routes.py
@@ -61,9 +61,7 @@ def _setup_app(
     default_all = {"comms-agent": _DEFAULT_AGENT}
     default_msg = {"comms-agent": _DEFAULT_AGENT}
 
-    chat_routes_mod._all_agents = (
-        all_agents if all_agents is not None else default_all
-    )
+    chat_routes_mod._all_agents = all_agents if all_agents is not None else default_all
     chat_routes_mod._messaging_agents = (
         messaging_agents if messaging_agents is not None else default_msg
     )
@@ -142,10 +140,7 @@ class TestSendChatMessage:
             assert response.headers["content-type"].startswith("text/event-stream")
 
             # Parse SSE events
-            events = [
-                line for line in response.text.split("\n")
-                if line.startswith("data:")
-            ]
+            events = [line for line in response.text.split("\n") if line.startswith("data:")]
             assert len(events) >= 2  # at least chunk events + done event
 
             # Verify session_id is in response header
@@ -288,12 +283,11 @@ class TestSendChatMessage:
             )
             # Stream completes despite persistence failure
             assert response.status_code == 200
-            events = [
-                line for line in response.text.split("\n")
-                if line.startswith("data:")
-            ]
+            events = [line for line in response.text.split("\n") if line.startswith("data:")]
             # Should still have text chunks and done event
-            done_events = [e for e in events if '"done": true' in e.lower() or '"done":true' in e.lower()]
+            done_events = [
+                e for e in events if '"done": true' in e.lower() or '"done":true' in e.lower()
+            ]
             assert len(done_events) == 1
         finally:
             _teardown(originals)
@@ -325,16 +319,24 @@ class TestGetSessionMessages:
         """Messages returned in chronological order."""
         repo = _make_chat_repo()
         now = _now()
-        repo.get_session_messages = AsyncMock(return_value=[
-            ChatMessage(
-                message_id="m1", session_id="s1", role="user",
-                content="hello", created_at=now,
-            ),
-            ChatMessage(
-                message_id="m2", session_id="s1", role="assistant",
-                content="hi there", created_at=now,
-            ),
-        ])
+        repo.get_session_messages = AsyncMock(
+            return_value=[
+                ChatMessage(
+                    message_id="m1",
+                    session_id="s1",
+                    role="user",
+                    content="hello",
+                    created_at=now,
+                ),
+                ChatMessage(
+                    message_id="m2",
+                    session_id="s1",
+                    role="assistant",
+                    content="hi there",
+                    created_at=now,
+                ),
+            ]
+        )
         app, originals = _setup_app(chat_repo=repo)
         try:
             client = TestClient(app)
@@ -415,12 +417,16 @@ class TestListAgentSessions:
     def test_returns_sessions_for_agent(self):
         """Returns sessions for the agent+user pair."""
         repo = _make_chat_repo()
-        repo.list_sessions = AsyncMock(return_value=[
-            ChatSession(
-                session_id="s1", agent_id="comms-agent",
-                user_id="anonymous", started_at=_now(),
-            ),
-        ])
+        repo.list_sessions = AsyncMock(
+            return_value=[
+                ChatSession(
+                    session_id="s1",
+                    agent_id="comms-agent",
+                    user_id="anonymous",
+                    started_at=_now(),
+                ),
+            ]
+        )
         app, originals = _setup_app(chat_repo=repo)
         try:
             client = TestClient(app)
@@ -519,10 +525,22 @@ class TestLoadHistory:
     async def test_returns_from_redis_cache_on_hit(self):
         """Redis cache hit returns messages without hitting Postgres."""
         cache = _make_cache()
-        cache.get_messages = AsyncMock(return_value=[
-            {"message_id": "m1", "role": "user", "content": "hi", "created_at": "2025-01-01T00:00:00"},
-            {"message_id": "m2", "role": "assistant", "content": "hello", "created_at": "2025-01-01T00:00:01"},
-        ])
+        cache.get_messages = AsyncMock(
+            return_value=[
+                {
+                    "message_id": "m1",
+                    "role": "user",
+                    "content": "hi",
+                    "created_at": "2025-01-01T00:00:00",
+                },
+                {
+                    "message_id": "m2",
+                    "role": "assistant",
+                    "content": "hello",
+                    "created_at": "2025-01-01T00:00:01",
+                },
+            ]
+        )
         repo = _make_chat_repo()
 
         orig_cache = chat_routes_mod._chat_cache
@@ -549,12 +567,17 @@ class TestLoadHistory:
 
         now = _now()
         repo = _make_chat_repo()
-        repo.get_session_messages = AsyncMock(return_value=[
-            ChatMessage(
-                message_id="m1", session_id="s1", role="user",
-                content="hello", created_at=now,
-            ),
-        ])
+        repo.get_session_messages = AsyncMock(
+            return_value=[
+                ChatMessage(
+                    message_id="m1",
+                    session_id="s1",
+                    role="user",
+                    content="hello",
+                    created_at=now,
+                ),
+            ]
+        )
 
         orig_cache = chat_routes_mod._chat_cache
         orig_repo = chat_routes_mod._chat_repo

--- a/tests/unit/api/test_models_api.py
+++ b/tests/unit/api/test_models_api.py
@@ -42,11 +42,7 @@ def mock_squad_profile():
         name="Full Squad",
         description="All agents",
         version=1,
-        agents=(
-            AgentProfileEntry(
-                agent_id="neo", role="dev", model="qwen2.5:7b", enabled=True
-            ),
-        ),
+        agents=(AgentProfileEntry(agent_id="neo", role="dev", model="qwen2.5:7b", enabled=True),),
         created_at=NOW,
     )
     return mock

--- a/tests/unit/api/test_workload_canon_api.py
+++ b/tests/unit/api/test_workload_canon_api.py
@@ -186,9 +186,7 @@ class TestCreateRunWorkloadType:
         assert body["workload_type"] is None
 
     def test_create_run_with_workload_type(self, client):
-        resp = client.post(
-            "/api/v1/projects/hello_squad/cycles/cyc_001/runs?workload_type=framing"
-        )
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs?workload_type=framing")
         assert resp.status_code == 200
         body = resp.json()
         assert body["workload_type"] == "framing"

--- a/tests/unit/capabilities/handlers/test_focused_prompts.py
+++ b/tests/unit/capabilities/handlers/test_focused_prompts.py
@@ -76,17 +76,13 @@ class TestDevFocusedPrompt:
 
     def test_focused_prompt_no_acceptance_criteria_omits_section(self):
         handler = DevelopmentDevelopHandler()
-        prompt = handler._build_focused_prompt(
-            self._make_inputs(acceptance_criteria=[])
-        )
+        prompt = handler._build_focused_prompt(self._make_inputs(acceptance_criteria=[]))
 
         assert "### Acceptance Criteria" not in prompt
 
     def test_focused_prompt_no_prior_artifacts_omits_section(self):
         handler = DevelopmentDevelopHandler()
-        prompt = handler._build_focused_prompt(
-            self._make_inputs(artifact_contents={})
-        )
+        prompt = handler._build_focused_prompt(self._make_inputs(artifact_contents={}))
 
         assert "### Prior Artifacts" not in prompt
 

--- a/tests/unit/capabilities/handlers/test_output_validation.py
+++ b/tests/unit/capabilities/handlers/test_output_validation.py
@@ -136,8 +136,14 @@ class TestDevMonolithicValidation:
     async def test_fastapi_react_prd_expects_backend_and_frontend(self):
         h = self._handler()
         inputs = {"prd": "Build a FastAPI backend and React frontend app."}
-        artifacts = [_art("main.py"), _art("App.jsx"), _art("repo.py"),
-                     _art("index.html"), _art("package.json"), _art("routes.py")]
+        artifacts = [
+            _art("main.py"),
+            _art("App.jsx"),
+            _art("repo.py"),
+            _art("index.html"),
+            _art("package.json"),
+            _art("routes.py"),
+        ]
         result = await h._validate_output(inputs, artifacts)
 
         assert result.passed is True
@@ -275,7 +281,9 @@ class TestEstimateMinArtifacts:
 
     async def test_fullstack_higher_than_simple(self):
         simple = _estimate_min_artifacts("Build a CLI script")
-        fullstack = _estimate_min_artifacts("Build a FastAPI backend with React frontend and pytest tests")
+        fullstack = _estimate_min_artifacts(
+            "Build a FastAPI backend with React frontend and pytest tests"
+        )
         assert fullstack > simple
 
 
@@ -308,7 +316,7 @@ class TestOutcomeClassification:
         ctx = self._make_context()
 
         # LLM returns good artifacts matching expected
-        content = '```python:models.py\nclass RunEvent:\n    pass\n```'
+        content = "```python:models.py\nclass RunEvent:\n    pass\n```"
         resp = MagicMock()
         resp.content = content
         resp.tokens_per_second = None
@@ -338,7 +346,7 @@ class TestOutcomeClassification:
         ctx = self._make_context()
 
         # LLM returns wrong file (not matching expected)
-        content = '```python:wrong.py\nx = 1\n```'
+        content = "```python:wrong.py\nx = 1\n```"
         resp = MagicMock()
         resp.content = content
         resp.tokens_per_second = None
@@ -375,7 +383,8 @@ class TestOutcomeClassification:
 class TestBuildSelfEvalPrompt:
     async def test_includes_validation_summary(self):
         v = ValidationResult(
-            passed=False, summary="Missing files: models.py",
+            passed=False,
+            summary="Missing files: models.py",
             missing_components=["file:models.py"],
         )
         prompt = _CycleTaskHandler._build_self_eval_prompt(v, [_art("utils.py")])
@@ -384,7 +393,8 @@ class TestBuildSelfEvalPrompt:
 
     async def test_includes_missing_components(self):
         v = ValidationResult(
-            passed=False, summary="test",
+            passed=False,
+            summary="test",
             missing_components=["file:models.py", "file:routes.py"],
         )
         prompt = _CycleTaskHandler._build_self_eval_prompt(v, [])
@@ -402,9 +412,7 @@ class TestBuildSelfEvalPrompt:
 class TestMergeArtifacts:
     async def test_adds_new_files(self):
         evidence: dict = {}
-        result = _CycleTaskHandler._merge_artifacts(
-            [_art("a.py")], [_art("b.py")], evidence
-        )
+        result = _CycleTaskHandler._merge_artifacts([_art("a.py")], [_art("b.py")], evidence)
 
         assert len(result) == 2
         names = [a["name"] for a in result]
@@ -467,7 +475,7 @@ class TestSelfEvalLoop:
 
         # First call: missing models.py, produces wrong.py
         resp1 = MagicMock()
-        resp1.content = '```python:wrong.py\nx = 1\n```'
+        resp1.content = "```python:wrong.py\nx = 1\n```"
         resp1.tokens_per_second = None
         resp1.prompt_tokens = 10
         resp1.completion_tokens = 20
@@ -475,7 +483,7 @@ class TestSelfEvalLoop:
 
         # Self-eval call: produces models.py
         resp2 = MagicMock()
-        resp2.content = '```python:models.py\nclass RunEvent: pass\n```'
+        resp2.content = "```python:models.py\nclass RunEvent: pass\n```"
         resp2.tokens_per_second = None
         resp2.prompt_tokens = 10
         resp2.completion_tokens = 20
@@ -509,7 +517,7 @@ class TestSelfEvalLoop:
         ctx = self._make_context()
 
         resp = MagicMock()
-        resp.content = '```python:wrong.py\nx = 1\n```'
+        resp.content = "```python:wrong.py\nx = 1\n```"
         resp.tokens_per_second = None
         resp.prompt_tokens = 10
         resp.completion_tokens = 20
@@ -541,7 +549,7 @@ class TestSelfEvalLoop:
 
         # All responses produce wrong file
         bad_resp = MagicMock()
-        bad_resp.content = '```python:wrong.py\nx = 1\n```'
+        bad_resp.content = "```python:wrong.py\nx = 1\n```"
         bad_resp.tokens_per_second = None
         bad_resp.prompt_tokens = 10
         bad_resp.completion_tokens = 20
@@ -735,8 +743,7 @@ class TestQATestExecutionFoldsIntoOutcome:
         assert result.outputs["outcome_class"] == TaskOutcome.SEMANTIC_FAILURE
         val = result.outputs["validation_result"]
         assert any(
-            "tests_not_executed:runner_missing_pytest" in m
-            for m in val["missing_components"]
+            "tests_not_executed:runner_missing_pytest" in m for m in val["missing_components"]
         )
 
     async def test_validation_disabled_preserves_legacy_pass(self) -> None:

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -190,7 +190,9 @@ class TestDevBuildParseFailure:
 
 class TestDevBuildLLMError:
     async def test_dev_build_llm_error(self, mock_context, build_inputs):
-        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(side_effect=LLMConnectionError("timeout"))
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            side_effect=LLMConnectionError("timeout")
+        )
         handler = DevelopmentDevelopHandler()
         result = await handler.handle(mock_context, build_inputs)
 

--- a/tests/unit/capabilities/test_builder_assemble_handler.py
+++ b/tests/unit/capabilities/test_builder_assemble_handler.py
@@ -369,7 +369,7 @@ class TestTaskScopedRequiredFiles:
     LLM_MANIFESTS_ONLY = (
         "```dockerfile:Dockerfile\nFROM python:3.11-slim\n```\n\n"
         "```text:requirements.txt\nfastapi\n```\n\n"
-        "```json:package.json\n{\"name\":\"frontend\"}\n```\n"
+        '```json:package.json\n{"name":"frontend"}\n```\n'
     )
 
     async def test_manifest_task_passes_without_qa_handoff(self, mock_context, builder_inputs):
@@ -395,20 +395,14 @@ class TestTaskScopedRequiredFiles:
         artifact_names = {a["name"] for a in result.outputs["artifacts"]}
         assert "qa_handoff.md" not in artifact_names
 
-    async def test_qa_handoff_task_still_required_when_in_scope(
-        self, mock_context, builder_inputs
-    ):
+    async def test_qa_handoff_task_still_required_when_in_scope(self, mock_context, builder_inputs):
         # Task 9 in cycle 3's plan: qa_handoff is the scope. The validator
         # MUST still reject if Bob produces it without the required sections.
         mock_context.ports.llm.chat = AsyncMock(
-            return_value=ChatMessage(
-                role="assistant", content=LLM_QA_HANDOFF_MISSING_SECTION
-            ),
+            return_value=ChatMessage(role="assistant", content=LLM_QA_HANDOFF_MISSING_SECTION),
         )
         mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
-            return_value=ChatMessage(
-                role="assistant", content=LLM_QA_HANDOFF_MISSING_SECTION
-            ),
+            return_value=ChatMessage(role="assistant", content=LLM_QA_HANDOFF_MISSING_SECTION),
         )
         scoped_inputs = dict(builder_inputs)
         scoped_inputs["expected_artifacts"] = ["qa_handoff.md"]
@@ -776,9 +770,7 @@ class TestAssemblyInputsExpandedExtensions:
 
 
 class TestBuilderFailureOutcomeClass:
-    async def test_missing_qa_handoff_emits_semantic_failure(
-        self, mock_context, builder_inputs
-    ):
+    async def test_missing_qa_handoff_emits_semantic_failure(self, mock_context, builder_inputs):
         from squadops.cycles.task_outcome import FailureClassification, TaskOutcome
 
         mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
@@ -792,9 +784,7 @@ class TestBuilderFailureOutcomeClass:
         assert result.outputs["failure_classification"] == FailureClassification.WORK_PRODUCT
         assert "qa_handoff.md not found" in result.error
 
-    async def test_missing_required_file_emits_semantic_failure(
-        self, mock_context, builder_inputs
-    ):
+    async def test_missing_required_file_emits_semantic_failure(self, mock_context, builder_inputs):
         from squadops.cycles.task_outcome import FailureClassification, TaskOutcome
 
         mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
@@ -807,9 +797,7 @@ class TestBuilderFailureOutcomeClass:
         assert result.outputs["outcome_class"] == TaskOutcome.SEMANTIC_FAILURE
         assert result.outputs["failure_classification"] == FailureClassification.WORK_PRODUCT
 
-    async def test_no_fenced_blocks_emits_semantic_failure(
-        self, mock_context, builder_inputs
-    ):
+    async def test_no_fenced_blocks_emits_semantic_failure(self, mock_context, builder_inputs):
         """LLM responds with prose only — no fenced code blocks extractable."""
         from squadops.cycles.task_outcome import FailureClassification, TaskOutcome
 

--- a/tests/unit/capabilities/test_merge_plan_handler.py
+++ b/tests/unit/capabilities/test_merge_plan_handler.py
@@ -196,8 +196,7 @@ class TestWorkedExample:
         assert qa_task.focus == "backend join tests"
         assert qa_task.depends_on == [0]  # resolved from "dev:api join"
         assert any(
-            hasattr(c, "check") and c.check == "regex_match"
-            for c in qa_task.acceptance_criteria
+            hasattr(c, "check") and c.check == "regex_match" for c in qa_task.acceptance_criteria
         )
 
     def test_merge_decisions_provenance_recorded(self, brief, dev_proposal, qa_proposal):
@@ -326,9 +325,7 @@ class TestAuthoringModeInvariant:
         assert "QA coverage warning" in decisions.operator_notes
         assert "Ordering/priority warning" in decisions.operator_notes
 
-    def test_emitted_yaml_passes_rc26_parser_validation(
-        self, brief, dev_proposal, qa_proposal
-    ):
+    def test_emitted_yaml_passes_rc26_parser_validation(self, brief, dev_proposal, qa_proposal):
         """The merger's emitted merge_decisions.yaml must round-trip through
         MergeDecisions.from_yaml — which enforces RC-26 at parse time. This
         guards against the merger constructing internally-valid Python
@@ -363,7 +360,9 @@ class TestBriefConflicts:
     BriefConflictDisposition and (for blocking) an operator_notes entry."""
 
     def test_warning_brief_conflict_accepted(self, brief):
-        proposal_yaml = _DEV_PROPOSAL_YAML.rstrip("\n") + """
+        proposal_yaml = (
+            _DEV_PROPOSAL_YAML.rstrip("\n")
+            + """
 brief_conflicts:
   - brief_field: accepted_stack
     proposed_change: Use SQLite instead of in-memory.
@@ -371,6 +370,7 @@ brief_conflicts:
     severity: warning
     affected_proposal_task_keys: ["dev:api join"]
 """
+        )
         dev_proposal = ProposedRoleTasks.from_yaml(proposal_yaml)
         _plan, decisions = merge_proposals(
             brief=brief,
@@ -391,13 +391,16 @@ brief_conflicts:
         assert "escalated" not in decisions.operator_notes.lower()
 
     def test_blocking_brief_conflict_escalated_to_operator(self, brief):
-        proposal_yaml = _DEV_PROPOSAL_YAML.rstrip("\n") + """
+        proposal_yaml = (
+            _DEV_PROPOSAL_YAML.rstrip("\n")
+            + """
 brief_conflicts:
   - brief_field: must_cover_requirements
     proposed_change: PRD adds a requirement the brief omitted.
     reason: PRD says X; brief is missing it.
     severity: blocking
 """
+        )
         dev_proposal = ProposedRoleTasks.from_yaml(proposal_yaml)
         _plan, decisions = merge_proposals(
             brief=brief,

--- a/tests/unit/capabilities/test_prepare_plan_authoring_brief.py
+++ b/tests/unit/capabilities/test_prepare_plan_authoring_brief.py
@@ -43,10 +43,7 @@ risk_areas:
 # qwen3:27b actually emits (and the form that broke the cycle before the
 # retry/fence-strip wiring).
 _VALID_BRIEF_FENCED_RESPONSE = (
-    "Here's the brief.\n\n"
-    "```yaml:plan_authoring_brief.yaml\n"
-    f"{_VALID_BRIEF_YAML}"
-    "```\n"
+    f"Here's the brief.\n\n```yaml:plan_authoring_brief.yaml\n{_VALID_BRIEF_YAML}```\n"
 )
 
 
@@ -58,9 +55,7 @@ def _make_context(llm_response: str | list[str] = _VALID_BRIEF_FENCED_RESPONSE):
     """
     llm = AsyncMock()
     if isinstance(llm_response, list):
-        llm.chat_stream_with_usage.side_effect = [
-            MagicMock(content=r) for r in llm_response
-        ]
+        llm.chat_stream_with_usage.side_effect = [MagicMock(content=r) for r in llm_response]
     else:
         llm.chat_stream_with_usage.return_value = MagicMock(content=llm_response)
     llm.default_model = "test-model"
@@ -224,9 +219,7 @@ async def test_handler_returns_failure_when_brief_missing_required_field(seeded_
     )
     fenced_response = f"```yaml:plan_authoring_brief.yaml\n{missing_risk_areas}```\n"
     handler = GovernancePreparePlanAuthoringBriefHandler()
-    result = await handler.handle(
-        _make_context(llm_response=fenced_response), seeded_inputs
-    )
+    result = await handler.handle(_make_context(llm_response=fenced_response), seeded_inputs)
 
     assert result.success is False
     assert "risk_areas" in (result.error or "")

--- a/tests/unit/capabilities/test_propose_plan_tasks.py
+++ b/tests/unit/capabilities/test_propose_plan_tasks.py
@@ -218,9 +218,7 @@ class TestRegistration:
         ],
     )
     def test_handler_registered_with_correct_role(self, handler_cls, expected_roles):
-        registered = {
-            entry[0].__name__: entry[1] for entry in get_all_handlers()
-        }
+        registered = {entry[0].__name__: entry[1] for entry in get_all_handlers()}
         assert handler_cls.__name__ in registered, (
             f"{handler_cls.__name__} not in bootstrap handler registry"
         )

--- a/tests/unit/cli/test_bootstrap.py
+++ b/tests/unit/cli/test_bootstrap.py
@@ -59,7 +59,9 @@ class TestBootstrapCLI:
     @patch("subprocess.run")
     @patch("squadops.cli.commands.bootstrap._BOOTSTRAP_SCRIPT")
     @patch("squadops.cli.commands.bootstrap.load_bootstrap_profile")
-    def test_dry_run_no_state_written(self, mock_load, mock_script, mock_run, mock_checks, mock_write):
+    def test_dry_run_no_state_written(
+        self, mock_load, mock_script, mock_run, mock_checks, mock_write
+    ):
         """--dry-run doesn't write state file."""
         mock_load.return_value = _mock_profile()
         mock_script.is_file.return_value = True

--- a/tests/unit/cli/test_doctor.py
+++ b/tests/unit/cli/test_doctor.py
@@ -25,7 +25,12 @@ def _make_results(
 ) -> list[CheckResult]:
     """Build a list of CheckResults for testing."""
     results = [
-        CheckResult(name="python_version", category="python", passed=True, message="Python 3.11.14 via pyenv"),
+        CheckResult(
+            name="python_version",
+            category="python",
+            passed=True,
+            message="Python 3.11.14 via pyenv",
+        ),
         CheckResult(name="venv_exists", category="python", passed=True, message=".venv present"),
         CheckResult(name="platform", category="platform", passed=True, message="darwin 14.5"),
         CheckResult(name="tool:git", category="tools", passed=True, message="git found"),
@@ -33,16 +38,20 @@ def _make_results(
     if include_heuristic_warning:
         results.append(
             CheckResult(
-                name="gpu:ollama-access", category="gpu",
-                passed=False, message="Ollama GPU access not detected",
+                name="gpu:ollama-access",
+                category="gpu",
+                passed=False,
+                message="Ollama GPU access not detected",
                 heuristic=True,
             )
         )
     if include_failure:
         results.append(
             CheckResult(
-                name="docker:postgres", category="docker",
-                passed=False, message="postgres not listening on port 5432",
+                name="docker:postgres",
+                category="docker",
+                passed=False,
+                message="postgres not listening on port 5432",
                 fix_command="docker-compose up -d postgres",
                 auto_fixable=True,
             )

--- a/tests/unit/cli/test_gate_decision_values.py
+++ b/tests/unit/cli/test_gate_decision_values.py
@@ -62,9 +62,7 @@ class TestGateDecisionFlags:
         mock_client.post.return_value = {"status": "ok"}
         mock_client_cls.return_value = mock_client
 
-        result = runner.invoke(
-            app, ["gate", "proj", "cyc", "run", "g1", "--with-refinements"]
-        )
+        result = runner.invoke(app, ["gate", "proj", "cyc", "run", "g1", "--with-refinements"])
         assert result.exit_code == 0
         call_args = mock_client.post.call_args
         assert call_args[1]["json"]["decision"] == "approved_with_refinements"
@@ -77,9 +75,7 @@ class TestGateDecisionFlags:
         mock_client.post.return_value = {"status": "ok"}
         mock_client_cls.return_value = mock_client
 
-        result = runner.invoke(
-            app, ["gate", "proj", "cyc", "run", "g1", "--return-for-revision"]
-        )
+        result = runner.invoke(app, ["gate", "proj", "cyc", "run", "g1", "--return-for-revision"])
         assert result.exit_code == 0
         call_args = mock_client.post.call_args
         assert call_args[1]["json"]["decision"] == "returned_for_revision"
@@ -94,8 +90,6 @@ class TestGateFlagMutualExclusion:
         assert "must specify exactly one" in result.output
 
     def test_multiple_flags_exits_with_error(self):
-        result = runner.invoke(
-            app, ["gate", "proj", "cyc", "run", "g1", "--approve", "--reject"]
-        )
+        result = runner.invoke(app, ["gate", "proj", "cyc", "run", "g1", "--approve", "--reject"])
         assert result.exit_code == 2
         assert "must specify exactly one" in result.output

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -85,7 +85,10 @@ def fastapi_workspace(tmp_path: Path) -> Path:
 class TestEndpointDefined:
     async def test_all_present_passed(self, fastapi_workspace):
         result = await get_check("endpoint_defined").evaluate(
-            {"file": "main.py", "methods_paths": ["GET /users", "POST /items", "DELETE /users/{uid}"]},
+            {
+                "file": "main.py",
+                "methods_paths": ["GET /users", "POST /items", "DELETE /users/{uid}"],
+            },
             fastapi_workspace,
             stack="fastapi",
         )

--- a/tests/unit/cycles/test_api_resume.py
+++ b/tests/unit/cycles/test_api_resume.py
@@ -224,7 +224,7 @@ class TestResumeRun:
         mock_cycle_registry.get_run.return_value = failed_run
         mock_cycle_registry.list_runs.return_value = [
             _COMPLETED_RUN,  # run_001: completed planning
-            failed_run,       # run_002: failed impl (wants resume)
+            failed_run,  # run_002: failed impl (wants resume)
         ]
         resp = client.post(f"{_URL_PREFIX}/run_002/resume")
         assert resp.status_code == 200

--- a/tests/unit/cycles/test_executor_plan_loading.py
+++ b/tests/unit/cycles/test_executor_plan_loading.py
@@ -61,9 +61,7 @@ class _FakeSourceArtifactRef:
     artifact_id: str = "art_src"
     filename: str = "backend/models.py"
     artifact_type: str = "source"
-    metadata: dict = field(
-        default_factory=lambda: {"producing_task_type": "development.develop"}
-    )
+    metadata: dict = field(default_factory=lambda: {"producing_task_type": "development.develop"})
 
 
 @dataclass
@@ -71,9 +69,7 @@ class _FakeDocArtifactRef:
     artifact_id: str = "art_doc"
     filename: str = "strategy_analysis.md"
     artifact_type: str = "document"
-    metadata: dict = field(
-        default_factory=lambda: {"producing_task_type": "strategy.analyze_prd"}
-    )
+    metadata: dict = field(default_factory=lambda: {"producing_task_type": "strategy.analyze_prd"})
 
 
 # ---------------------------------------------------------------------------
@@ -247,9 +243,7 @@ class TestResolveArtifactContentsChaining:
             (dev_ref, b"models content"),
         ]
 
-        contents = await executor._resolve_artifact_contents(
-            "development.develop", stored
-        )
+        contents = await executor._resolve_artifact_contents("development.develop", stored)
 
         assert "strategy_analysis.md" in contents
         assert "backend/models.py" in contents

--- a/tests/unit/cycles/test_flow_execution_port_default.py
+++ b/tests/unit/cycles/test_flow_execution_port_default.py
@@ -18,9 +18,7 @@ class ConcreteExecutor(FlowExecutionPort):
     def __init__(self):
         self.execute_run_calls: list[tuple] = []
 
-    async def execute_run(
-        self, cycle_id: str, run_id: str, profile_id: str | None = None
-    ) -> None:
+    async def execute_run(self, cycle_id: str, run_id: str, profile_id: str | None = None) -> None:
         self.execute_run_calls.append((cycle_id, run_id, profile_id))
 
     async def cancel_run(self, run_id: str) -> None:

--- a/tests/unit/cycles/test_merge_decisions.py
+++ b/tests/unit/cycles/test_merge_decisions.py
@@ -128,9 +128,7 @@ class TestFromYAMLHappy:
         )
         md = MergeDecisions.from_yaml(yaml_doc)
         assert len(md.missing_proposals) == 2
-        assert md.missing_proposals[0] == MissingProposal(
-            role="qa", failure_reason="llm_error"
-        )
+        assert md.missing_proposals[0] == MissingProposal(role="qa", failure_reason="llm_error")
 
     def test_parses_with_brief_conflicts_disposition(self):
         yaml_doc = _VALID_MULTI_ROLE.replace(
@@ -260,7 +258,7 @@ class TestCanonicalTaskIndices:
         Parser should accept it; the merger surfaces the pathology
         elsewhere if it's actually a problem."""
         yaml_doc = _VALID_SOLE_AUTHOR.replace(
-            "canonical_tasks:\n  - task_index: 0\n    source_proposal_task_keys: []\n    proposed_by: []\n    merge_action: gap_filled\n    reason: \"Sole-author fallback via PlanAuthoringService.\"\n",
+            'canonical_tasks:\n  - task_index: 0\n    source_proposal_task_keys: []\n    proposed_by: []\n    merge_action: gap_filled\n    reason: "Sole-author fallback via PlanAuthoringService."\n',
             "canonical_tasks: []\n",
         )
         md = MergeDecisions.from_yaml(yaml_doc)
@@ -273,20 +271,16 @@ class TestCanonicalTaskIndices:
 
 
 class TestEnumValidation:
-    @pytest.mark.parametrize(
-        "bad_action", ["replaced", "rejected", "ACCEPTED", ""]
-    )
+    @pytest.mark.parametrize("bad_action", ["replaced", "rejected", "ACCEPTED", ""])
     def test_unknown_merge_action_rejected(self, bad_action):
         yaml_doc = _VALID_MULTI_ROLE.replace(
-            "    merge_action: accepted\n    reason: \"Single dev proposal, no conflicts.\"",
+            '    merge_action: accepted\n    reason: "Single dev proposal, no conflicts."',
             f"    merge_action: {bad_action}\n    reason: foo",
         )
         with pytest.raises(ValueError, match="merge_action"):
             MergeDecisions.from_yaml(yaml_doc)
 
-    @pytest.mark.parametrize(
-        "bad_disposition", ["deferred", "fixed", "ESCALATED"]
-    )
+    @pytest.mark.parametrize("bad_disposition", ["deferred", "fixed", "ESCALATED"])
     def test_unknown_disposition_rejected(self, bad_disposition):
         yaml_doc = _VALID_MULTI_ROLE.replace(
             "brief_conflicts_disposition: []",

--- a/tests/unit/cycles/test_plan_guidance.py
+++ b/tests/unit/cycles/test_plan_guidance.py
@@ -69,12 +69,7 @@ class TestFromYAMLHappy:
         merger applies an empty overlay. Forcing optional fields to be
         populated would push too much format burden on strategy LLMs that
         legitimately have nothing to say in a given dimension."""
-        minimal = (
-            "version: 1\n"
-            "guidance_id: g-1\n"
-            "source_brief_id: b-1\n"
-            "proposing_role: strategy\n"
-        )
+        minimal = "version: 1\nguidance_id: g-1\nsource_brief_id: b-1\nproposing_role: strategy\n"
         g = PlanGuidance.from_yaml(minimal)
         assert g.priority_guidance == []
         assert g.ordering_guidance == []
@@ -116,31 +111,20 @@ class TestFromYAMLErrors:
         coming through with another role indicates pipeline corruption,
         not a recoverable malformation."""
         yaml_doc = (
-            "version: 1\n"
-            "guidance_id: g-1\n"
-            "source_brief_id: b-1\n"
-            f'proposing_role: "{bad_role}"\n'
+            f'version: 1\nguidance_id: g-1\nsource_brief_id: b-1\nproposing_role: "{bad_role}"\n'
         )
         with pytest.raises(ValueError, match="proposing_role"):
             PlanGuidance.from_yaml(yaml_doc)
 
     def test_strategy_role_case_normalized(self):
         """``Strategy`` and ``strategy`` must both parse — LLM casing varies."""
-        yaml_doc = (
-            "version: 1\n"
-            "guidance_id: g-1\n"
-            "source_brief_id: b-1\n"
-            "proposing_role: Strategy\n"
-        )
+        yaml_doc = "version: 1\nguidance_id: g-1\nsource_brief_id: b-1\nproposing_role: Strategy\n"
         g = PlanGuidance.from_yaml(yaml_doc)
         assert g.proposing_role == "strategy"
 
     def test_non_int_version_rejected(self):
         yaml_doc = (
-            'version: "1"\n'
-            "guidance_id: g-1\n"
-            "source_brief_id: b-1\n"
-            "proposing_role: strategy\n"
+            'version: "1"\nguidance_id: g-1\nsource_brief_id: b-1\nproposing_role: strategy\n'
         )
         with pytest.raises(ValueError, match="version"):
             PlanGuidance.from_yaml(yaml_doc)

--- a/tests/unit/cycles/test_proposal_failure.py
+++ b/tests/unit/cycles/test_proposal_failure.py
@@ -52,19 +52,14 @@ class TestParserErrors:
 
     def test_empty_proposer_role_rejected(self):
         with pytest.raises(ValueError, match="proposer_role"):
-            ProposalFailure.from_yaml(
-                'proposer_role: ""\nfailure_reason: llm_error\n'
-            )
+            ProposalFailure.from_yaml('proposer_role: ""\nfailure_reason: llm_error\n')
 
     @pytest.mark.parametrize(
         "bad_reason",
         ["unknown", "BAD_REASON", "user_quit", "manual_override"],
     )
     def test_unknown_failure_reason_rejected(self, bad_reason):
-        yaml_doc = (
-            "proposer_role: development\n"
-            f"failure_reason: {bad_reason}\n"
-        )
+        yaml_doc = f"proposer_role: development\nfailure_reason: {bad_reason}\n"
         with pytest.raises(ValueError, match="failure_reason"):
             ProposalFailure.from_yaml(yaml_doc)
 
@@ -89,10 +84,6 @@ class TestParserErrors:
     def test_every_valid_reason_parses(self, valid_reason):
         """Each bounded reason must round-trip cleanly. Tracks the
         vocabulary against accidental shrinkage in the parser."""
-        yaml_doc = (
-            "proposer_role: development\n"
-            f"failure_reason: {valid_reason}\n"
-            "details: ok\n"
-        )
+        yaml_doc = f"proposer_role: development\nfailure_reason: {valid_reason}\ndetails: ok\n"
         parsed = ProposalFailure.from_yaml(yaml_doc)
         assert parsed.failure_reason == valid_reason

--- a/tests/unit/cycles/test_proposed_role_tasks.py
+++ b/tests/unit/cycles/test_proposed_role_tasks.py
@@ -168,23 +168,23 @@ class TestFromYAMLErrors:
     def test_empty_proposing_role_rejected(self):
         with pytest.raises(ValueError, match="proposing_role"):
             ProposedRoleTasks.from_yaml(
-                'version: 1\n'
+                "version: 1\n"
                 'proposing_role: ""\n'
-                'proposal_id: prop-1\n'
-                'source_brief_id: brief-1\n'
+                "proposal_id: prop-1\n"
+                "source_brief_id: brief-1\n"
                 "scope_statement: 'x'\n"
-                'tasks: []\n'
+                "tasks: []\n"
             )
 
     def test_non_int_version_rejected(self):
         with pytest.raises(ValueError, match="version"):
             ProposedRoleTasks.from_yaml(
                 'version: "1"\n'
-                'proposing_role: qa\n'
-                'proposal_id: prop-1\n'
-                'source_brief_id: brief-1\n'
+                "proposing_role: qa\n"
+                "proposal_id: prop-1\n"
+                "source_brief_id: brief-1\n"
                 "scope_statement: 'x'\n"
-                'tasks: []\n'
+                "tasks: []\n"
             )
 
     def test_malformed_yaml_rejected(self):

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -158,15 +158,9 @@ class TestGenerateTaskPlanWithManifest:
         assert len(manifest_envelopes) == 4
 
         # Check RC-2 deterministic ID format
-        assert manifest_envelopes[0].task_id == (
-            "task-run_abcdef12-m000-development.develop"
-        )
-        assert manifest_envelopes[1].task_id == (
-            "task-run_abcdef12-m001-development.develop"
-        )
-        assert manifest_envelopes[3].task_id == (
-            "task-run_abcdef12-m003-qa.test"
-        )
+        assert manifest_envelopes[0].task_id == ("task-run_abcdef12-m000-development.develop")
+        assert manifest_envelopes[1].task_id == ("task-run_abcdef12-m001-development.develop")
+        assert manifest_envelopes[3].task_id == ("task-run_abcdef12-m003-qa.test")
 
     def test_manifest_envelopes_have_subtask_focus(self):
         manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
@@ -245,18 +239,10 @@ class TestGenerateTaskPlanWithManifest:
             description="Missing QA",
             version=1,
             agents=[
-                AgentProfileEntry(
-                    agent_id="max", role="lead", model="test", enabled=True
-                ),
-                AgentProfileEntry(
-                    agent_id="neo", role="dev", model="test", enabled=True
-                ),
-                AgentProfileEntry(
-                    agent_id="nat", role="strat", model="test", enabled=True
-                ),
-                AgentProfileEntry(
-                    agent_id="data", role="data", model="test", enabled=True
-                ),
+                AgentProfileEntry(agent_id="max", role="lead", model="test", enabled=True),
+                AgentProfileEntry(agent_id="neo", role="dev", model="test", enabled=True),
+                AgentProfileEntry(agent_id="nat", role="strat", model="test", enabled=True),
+                AgentProfileEntry(agent_id="data", role="data", model="test", enabled=True),
             ],
             created_at=NOW,
         )

--- a/tests/unit/prompts/test_artifact_provenance.py
+++ b/tests/unit/prompts/test_artifact_provenance.py
@@ -59,7 +59,6 @@ class TestArtifactRefProvenance:
         assert ref.system_prompt_bundle_hash is None
 
 
-
 # ---------------------------------------------------------------------------
 # Vault round-trip
 # ---------------------------------------------------------------------------

--- a/tests/unit/prompts/test_asset_source_port.py
+++ b/tests/unit/prompts/test_asset_source_port.py
@@ -23,7 +23,9 @@ class TestPromptAssetSourcePortContract:
         """Partial implementation still raises TypeError."""
 
         class Incomplete(PromptAssetSourcePort):
-            async def resolve_system_fragment(self, fragment_id, role=None, environment="production"):
+            async def resolve_system_fragment(
+                self, fragment_id, role=None, environment="production"
+            ):
                 pass
 
         with pytest.raises(TypeError):
@@ -33,7 +35,9 @@ class TestPromptAssetSourcePortContract:
         """Fully implemented subclass can be constructed."""
 
         class Complete(PromptAssetSourcePort):
-            async def resolve_system_fragment(self, fragment_id, role=None, environment="production"):
+            async def resolve_system_fragment(
+                self, fragment_id, role=None, environment="production"
+            ):
                 return ResolvedAsset(
                     asset_id=fragment_id,
                     content="test",
@@ -61,7 +65,9 @@ class TestPromptAssetSourcePortContract:
         """Verify return type contract."""
 
         class Stub(PromptAssetSourcePort):
-            async def resolve_system_fragment(self, fragment_id, role=None, environment="production"):
+            async def resolve_system_fragment(
+                self, fragment_id, role=None, environment="production"
+            ):
                 return ResolvedAsset(
                     asset_id=fragment_id,
                     content="content",
@@ -72,8 +78,11 @@ class TestPromptAssetSourcePortContract:
 
             async def resolve_request_template(self, template_id, environment="production"):
                 return ResolvedAsset(
-                    asset_id=template_id, content="", version="1",
-                    environment=environment, content_hash=ResolvedAsset.compute_hash(""),
+                    asset_id=template_id,
+                    content="",
+                    version="1",
+                    environment=environment,
+                    content_hash=ResolvedAsset.compute_hash(""),
                 )
 
             async def get_asset_version(self, asset_id):
@@ -87,10 +96,15 @@ class TestPromptAssetSourcePortContract:
         """Verify return type contract for template resolution."""
 
         class Stub(PromptAssetSourcePort):
-            async def resolve_system_fragment(self, fragment_id, role=None, environment="production"):
+            async def resolve_system_fragment(
+                self, fragment_id, role=None, environment="production"
+            ):
                 return ResolvedAsset(
-                    asset_id=fragment_id, content="", version="1",
-                    environment=environment, content_hash=ResolvedAsset.compute_hash(""),
+                    asset_id=fragment_id,
+                    content="",
+                    version="1",
+                    environment=environment,
+                    content_hash=ResolvedAsset.compute_hash(""),
                 )
 
             async def resolve_request_template(self, template_id, environment="production"):
@@ -103,9 +117,7 @@ class TestPromptAssetSourcePortContract:
                 )
 
             async def get_asset_version(self, asset_id):
-                return AssetVersionInfo(
-                    asset_id=asset_id, version="2", environment="production"
-                )
+                return AssetVersionInfo(asset_id=asset_id, version="2", environment="production")
 
         stub = Stub()
         result = await stub.resolve_request_template("request.cycle_task_base")

--- a/tests/unit/prompts/test_cycle_prompt_cache.py
+++ b/tests/unit/prompts/test_cycle_prompt_cache.py
@@ -199,14 +199,7 @@ def _make_source(templates: dict[str, str]) -> AsyncMock:
     return source
 
 
-_TEMPLATE = (
-    "---\n"
-    "template_id: request.test\n"
-    "required_variables:\n"
-    "  - name\n"
-    "---\n"
-    "Hello {{name}}!\n"
-)
+_TEMPLATE = "---\ntemplate_id: request.test\nrequired_variables:\n  - name\n---\nHello {{name}}!\n"
 
 
 class TestRendererWithCycleCache:

--- a/tests/unit/prompts/test_manifest_completeness.py
+++ b/tests/unit/prompts/test_manifest_completeness.py
@@ -47,8 +47,11 @@ def test_every_fragment_file_is_registered_in_manifest():
 def test_every_manifest_entry_points_to_existing_file():
     """Every manifest entry's `path` must resolve to an existing file."""
     manifest = _load_manifest()
-    missing = [entry["path"] for entry in manifest["fragments"]
-               if not (FRAGMENTS_DIR / entry["path"]).exists()]
+    missing = [
+        entry["path"]
+        for entry in manifest["fragments"]
+        if not (FRAGMENTS_DIR / entry["path"]).exists()
+    ]
     assert not missing, f"Manifest references missing files: {missing}"
 
 

--- a/tests/unit/prompts/test_request_template_contracts.py
+++ b/tests/unit/prompts/test_request_template_contracts.py
@@ -36,7 +36,7 @@ def _load_all_templates() -> list[tuple[str, dict, str]]:
         match = _FRONTMATTER_PATTERN.match(raw)
         if match:
             header = yaml.safe_load(match.group(1)) or {}
-            body = raw[match.end():]
+            body = raw[match.end() :]
         else:
             header = {}
             body = raw
@@ -119,9 +119,7 @@ class TestPriorAnalysisOrdering:
             return  # No headings, nothing to check
 
         # Check if any heading contains "Prior Analysis"
-        prior_indices = [
-            i for i, h in enumerate(headings) if "Prior Analysis" in h
-        ]
+        prior_indices = [i for i, h in enumerate(headings) if "Prior Analysis" in h]
         if not prior_indices:
             return  # Template doesn't have prior analysis section
 
@@ -130,8 +128,7 @@ class TestPriorAnalysisOrdering:
         # Allow only static instruction content after prior analysis, not other ## sections
         # The {{prior_outputs}} placeholder following the heading is fine
         remaining_headings = [
-            h for i, h in enumerate(headings)
-            if i > last_prior and "Prior Analysis" not in h
+            h for i, h in enumerate(headings) if i > last_prior and "Prior Analysis" not in h
         ]
 
         # Special case: builder template has static instructions after prior_outputs

--- a/tests/unit/prompts/test_request_template_renderer.py
+++ b/tests/unit/prompts/test_request_template_renderer.py
@@ -233,8 +233,6 @@ class TestCaching:
         renderer = RequestTemplateRenderer(source)
 
         await renderer.render("request.test", {"prd": "A", "role": "dev"}, environment="staging")
-        await renderer.render(
-            "request.test", {"prd": "A", "role": "dev"}, environment="production"
-        )
+        await renderer.render("request.test", {"prd": "A", "role": "dev"}, environment="production")
 
         assert source.resolve_request_template.call_count == 2

--- a/tests/unit/prompts/test_upload_prompts_to_langfuse.py
+++ b/tests/unit/prompts/test_upload_prompts_to_langfuse.py
@@ -259,9 +259,7 @@ class TestUploadToLangfuse:
         mod = _import()
 
         def fake_urlopen(req):
-            raise urllib.error.HTTPError(
-                req.full_url, 500, "Internal Server Error", {}, None
-            )
+            raise urllib.error.HTTPError(req.full_url, 500, "Internal Server Error", {}, None)
 
         monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
 
@@ -413,14 +411,10 @@ class TestUploadResolveRoundTrip:
                 source_path="fragments/roles/dev/identity.md",
             ),
         ]
-        success, errors = mod.upload_to_langfuse(
-            entries, "http://fake", "pk", "sk", "production"
-        )
+        success, errors = mod.upload_to_langfuse(entries, "http://fake", "pk", "sk", "production")
         assert success == 1
 
-        adapter = LangfusePromptAssetAdapter(
-            public_key="pk", secret_key="sk", host="http://fake"
-        )
+        adapter = LangfusePromptAssetAdapter(public_key="pk", secret_key="sk", host="http://fake")
         resolved = await adapter.resolve_system_fragment("identity", role="dev")
 
         assert resolved.content == "You are Neo, the development agent."
@@ -446,14 +440,10 @@ class TestUploadResolveRoundTrip:
                 source_path="request_templates/request.cycle_task_base.md",
             ),
         ]
-        success, errors = mod.upload_to_langfuse(
-            entries, "http://fake", "pk", "sk", "staging"
-        )
+        success, errors = mod.upload_to_langfuse(entries, "http://fake", "pk", "sk", "staging")
         assert success == 1
 
-        adapter = LangfusePromptAssetAdapter(
-            public_key="pk", secret_key="sk", host="http://fake"
-        )
+        adapter = LangfusePromptAssetAdapter(public_key="pk", secret_key="sk", host="http://fake")
         resolved = await adapter.resolve_request_template(
             "request.cycle_task_base", environment="staging"
         )

--- a/tests/unit/runtime/test_coordinator.py
+++ b/tests/unit/runtime/test_coordinator.py
@@ -88,8 +88,12 @@ async def test_ambient_to_duty_applies_and_binds_assignment():
     coord = RuntimeCoordinator(port, events_publisher=pub)
 
     outcome = await coord.request_transition(
-        "max", "duty", reasons.DUTY_WINDOW_OPENED,
-        requester_kind="scheduler", owner_ref="assign-1", assignment_id="assign-1",
+        "max",
+        "duty",
+        reasons.DUTY_WINDOW_OPENED,
+        requester_kind="scheduler",
+        owner_ref="assign-1",
+        assignment_id="assign-1",
     )
 
     assert outcome.applied is True
@@ -107,8 +111,11 @@ async def test_duty_to_ambient_clears_assignment_ref():
     coord = RuntimeCoordinator(port, events_publisher=_RecordingPublisher())
 
     await coord.request_transition(
-        "max", "ambient", reasons.DUTY_WINDOW_CLOSED,
-        requester_kind="scheduler", owner_ref="assign-1",
+        "max",
+        "ambient",
+        reasons.DUTY_WINDOW_CLOSED,
+        requester_kind="scheduler",
+        owner_ref="assign-1",
     )
 
     assert port.upserts[-1].mode == "ambient"
@@ -123,8 +130,11 @@ async def test_same_mode_is_idempotent_noop_without_write_or_event():
     coord = RuntimeCoordinator(port, events_publisher=pub)
 
     outcome = await coord.request_transition(
-        "max", "duty", reasons.DUTY_WINDOW_OPENED,
-        requester_kind="scheduler", owner_ref="assign-1",
+        "max",
+        "duty",
+        reasons.DUTY_WINDOW_OPENED,
+        requester_kind="scheduler",
+        owner_ref="assign-1",
     )
 
     assert outcome.idempotent_skip is True and outcome.applied is False
@@ -140,8 +150,11 @@ async def test_offline_runtime_cannot_enter_duty():
     coord = RuntimeCoordinator(port, events_publisher=pub)
 
     outcome = await coord.request_transition(
-        "max", "duty", reasons.DUTY_WINDOW_OPENED,
-        requester_kind="scheduler", owner_ref="assign-1",
+        "max",
+        "duty",
+        reasons.DUTY_WINDOW_OPENED,
+        requester_kind="scheduler",
+        owner_ref="assign-1",
     )
 
     assert outcome.applied is False
@@ -156,7 +169,11 @@ async def test_missing_reason_code_rejected_before_state_load():
     coord = RuntimeCoordinator(port, events_publisher=_RecordingPublisher())
 
     outcome = await coord.request_transition(
-        "max", "duty", "", requester_kind="cli", owner_ref="op",
+        "max",
+        "duty",
+        "",
+        requester_kind="cli",
+        owner_ref="op",
     )
 
     assert outcome.applied is False
@@ -171,8 +188,11 @@ async def test_malformed_target_mode_rejected():
     coord = RuntimeCoordinator(port, events_publisher=_RecordingPublisher())
 
     outcome = await coord.request_transition(
-        "max", "paused", reasons.DUTY_WINDOW_OPENED,
-        requester_kind="external", owner_ref="x",
+        "max",
+        "paused",
+        reasons.DUTY_WINDOW_OPENED,
+        requester_kind="external",
+        owner_ref="x",
     )
 
     assert outcome.applied is False
@@ -210,8 +230,11 @@ async def test_applied_event_keeps_event_and_reason_distinct_d18():
     coord = RuntimeCoordinator(port, events_publisher=pub)
 
     await coord.request_transition(
-        "max", "cycle", reasons.CYCLE_RECRUITED,
-        requester_kind="coordinator", owner_ref="cyc-1",
+        "max",
+        "cycle",
+        reasons.CYCLE_RECRUITED,
+        requester_kind="coordinator",
+        owner_ref="cyc-1",
     )
 
     event_name, agent_id, reason_code, payload = pub.emitted[0]

--- a/tests/unit/telemetry/test_langfuse_adapter.py
+++ b/tests/unit/telemetry/test_langfuse_adapter.py
@@ -390,9 +390,7 @@ class TestPromptToGenerationLinkage:
             a._process_entry(_BufferEntry(_EventType.START_TASK, ctx, None))
 
             record = _make_record(prompt_name="request.cycle_task_base", prompt_version=2)
-            a._process_entry(
-                _BufferEntry(_EventType.GENERATION, ctx, (record, _make_layers()))
-            )
+            a._process_entry(_BufferEntry(_EventType.GENERATION, ctx, (record, _make_layers())))
 
             mock_client.get_prompt.assert_called_once_with(
                 name="request.cycle_task_base", version=2
@@ -416,9 +414,7 @@ class TestPromptToGenerationLinkage:
             a._process_entry(_BufferEntry(_EventType.START_TASK, ctx, None))
 
             record = _make_record()  # No prompt_name
-            a._process_entry(
-                _BufferEntry(_EventType.GENERATION, ctx, (record, _make_layers()))
-            )
+            a._process_entry(_BufferEntry(_EventType.GENERATION, ctx, (record, _make_layers())))
 
             mock_client.get_prompt.assert_not_called()
             tk = ctx.trace_id or ctx.cycle_id
@@ -443,9 +439,7 @@ class TestPromptToGenerationLinkage:
             a._process_entry(_BufferEntry(_EventType.START_TASK, ctx, None))
 
             record = _make_record(prompt_name="nonexistent.template")
-            a._process_entry(
-                _BufferEntry(_EventType.GENERATION, ctx, (record, _make_layers()))
-            )
+            a._process_entry(_BufferEntry(_EventType.GENERATION, ctx, (record, _make_layers())))
 
             mock_client.get_prompt.assert_called_once()
             tk = ctx.trace_id or ctx.cycle_id


### PR DESCRIPTION
Closes #196.

## Two commits, reviewable separately

1. **`style: ruff format repo`** — mechanical `ruff format .` over the 41 drifted files. **Whitespace/formatting only, zero logic change** (all 41 are `.py`; diff is pure reflow). This is the bulk; review as whitespace.
2. **`ci: enforce ruff format`** — adds `ruff format --check .` (fail-stop) beside `ruff check .` in `run_regression_tests.sh`, and removes the stale NOTE in `ci.yml`. Since CI runs that script, format drift now blocks merge.

## Coordination (the important part)

Landed in the **open window** confirmed with the runtime lane: SIP-0089 Phase 3 (#235) is merged, no Phase 4 branch exists, and the runtime lane is holding off `tests/unit/runtime/test_coordinator.py` until this merges. So the one runtime-zone file in the sweep reflows with **zero conflict** — Phase 4 will branch off already-formatted main.

## Note on overlap with #238 (#207)

Both touch `scripts/dev/run_regression_tests.sh` but in different regions (#238 adds a dir to `REGRESSION_DIRS`; this adds the `ruff format --check` line near `ruff check`). They auto-merge; whichever lands second needs no manual resolution.

## Verification

- `ruff format --check .` → 734 files already formatted (clean).
- `ruff check .` → clean.
- Full gate (`run_regression_tests.sh`): **4286 passed, 1 skipped, 0 failures**, with the new format check running green inside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)