### PR TITLE
fix(handlers): stop in-place mutation of frozen HandlerResult in planning retry (#155)

### DIFF
--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import re
 import time
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -435,7 +436,14 @@ class GovernanceReviewPlanHandler(_PlanningTaskHandler):
             retry_content = await self._retry_without_frontmatter(context, inputs, content)
             if retry_content is not None:
                 content = retry_content
-                result.outputs["artifacts"][0]["content"] = content
+                # #155: `result` is a frozen HandlerResult. Rebuild it with the
+                # retry content instead of mutating its nested `outputs` dict in
+                # place — `frozen=True` does not freeze nested containers, and the
+                # original result may be shared/cached/retried elsewhere.
+                artifacts = result.outputs["artifacts"]
+                new_artifacts = [{**artifacts[0], "content": content}, *artifacts[1:]]
+                new_outputs = {**result.outputs, "artifacts": new_artifacts}
+                result = replace(result, outputs=new_outputs)
                 m = _FRONTMATTER_RE.match(content)
 
             if not m:

--- a/tests/unit/capabilities/test_planning_handlers.py
+++ b/tests/unit/capabilities/test_planning_handlers.py
@@ -11,7 +11,7 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -28,6 +28,7 @@ from squadops.capabilities.handlers.planning_tasks import (
     _build_refinement_time_budget_section,
     _build_time_budget_section,
     _format_time_budget,
+    _PlanningTaskHandler,
 )
 from squadops.llm.exceptions import LLMError
 
@@ -710,6 +711,39 @@ class TestGovernanceAssessReadinessValidation:
         assert content.startswith("---\n")
         assert "readiness: go" in content
         assert ctx.ports.llm.chat_stream_with_usage.await_count == 2
+
+    async def test_retry_recovery_does_not_mutate_source_result(self):
+        """#155: the frontmatter retry must rebuild the result immutably, not
+        mutate the nested ``outputs`` dict of the frozen HandlerResult that
+        super().handle() returned (frozen does not freeze nested containers;
+        the original may be shared/cached/retried)."""
+        recovered = "---\nreadiness: go\nsufficiency_score: 4\n---\n\n## Body\n"
+        ctx = _make_context()
+        ctx.ports.llm.chat_stream_with_usage.side_effect = [
+            MagicMock(content="No frontmatter on first response"),
+            MagicMock(content=recovered),
+        ]
+        h = GovernanceReviewPlanHandler()
+
+        # Capture the frozen result (and its nested artifact dict) produced by
+        # super().handle(), so we can assert the retry leaves it untouched.
+        captured = {}
+        orig_handle = _PlanningTaskHandler.handle
+
+        async def _capturing_handle(self, context, inputs):
+            r = await orig_handle(self, context, inputs)
+            captured["artifact0"] = r.outputs["artifacts"][0]
+            return r
+
+        with patch.object(_PlanningTaskHandler, "handle", _capturing_handle):
+            result = await h.handle(ctx, {"prd": "Build a widget"})
+
+        # Retry content reached the returned result...
+        assert result.success is True
+        assert "readiness: go" in result.outputs["artifacts"][0]["content"]
+        # ...but the source result's nested dict was NOT mutated in place
+        # (it would read `recovered` if the handler still mutated outputs in place).
+        assert captured["artifact0"]["content"] == "No frontmatter on first response"
 
     async def test_retry_corrective_message_targets_frontmatter(self):
         """The retry's corrective message must call out the missing


### PR DESCRIPTION
Closes #155.

## What
`GovernanceReviewPlanHandler.handle()`'s YAML-frontmatter retry path mutated the nested `outputs["artifacts"][0]["content"]` of the **frozen** `HandlerResult` returned by `super().handle()` in place (`frozen=True` doesn't freeze nested containers). Replaced with an immutable rebuild via `dataclasses.replace()`.

## Scope (reproduce-first)
A broad sweep — `grep -rE '\.outputs\[[^]]+\] *=' src/squadops/` — shows **this was the only remaining in-place mutation**. The other sites #155 cited (`brief_outcome` in planning, the `wrapup_tasks` ones) were already refactored to reads. So this is a targeted fix rather than the general `update_result_output()` helper the issue proposed (one nested site doesn't warrant a helper).

## Why it matters
The in-place mutation currently produces *correct* output (super's result is discarded after), so it's a **latent** landmine — it only corrupts once a result is shared/cached/retried. That's exactly the immutability contract the frozen dataclass promises.

## Regression test
`test_retry_recovery_does_not_mutate_source_result` spies on `super().handle()` and asserts its frozen result is left untouched. It's **distinguishing** — verified it FAILS against the old in-place code (`assert '...## Body' == 'No frontmatter...'`) and PASSES on the rebuild. It lives in `tests/unit/capabilities/`, so it **runs in the CI gate** (unlike integration-only tests).

## Verification
- `test_planning_handlers.py` → 187 passed; capabilities domain → 1058 passed.
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)