### PR TITLE
SIP-0089 Phase 4: RuntimeActivity

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -45,6 +45,7 @@ from squadops.cycles.task_outcome import TaskOutcome
 from squadops.cycles.task_plan import generate_task_plan
 from squadops.events.types import EventType
 from squadops.ports.cycles.flow_execution import FlowExecutionPort
+from squadops.runtime import reasons
 from squadops.runtime.recruitment import reserve_buffer_decision
 from squadops.tasks.models import TaskEnvelope, TaskResult
 from squadops.telemetry.context import use_correlation_context, use_run_ids
@@ -63,6 +64,7 @@ if TYPE_CHECKING:
     from squadops.ports.cycles.squad_profile import SquadProfilePort
     from squadops.ports.cycles.workflow_tracker import WorkflowTrackerPort
     from squadops.ports.events.cycle_event_bus import CycleEventBusPort
+    from squadops.ports.runtime.activity import RuntimeActivityPort
     from squadops.ports.runtime.assignments import AssignmentPort
     from squadops.ports.telemetry.llm_observability import LLMObservabilityPort
 
@@ -118,6 +120,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         event_bus: CycleEventBusPort | None = None,
         reply_router: ReplyRouter | None = None,
         assignment_port: AssignmentPort | None = None,
+        activity_port: RuntimeActivityPort | None = None,
     ) -> None:
         self._cycle_registry = cycle_registry
         self._artifact_vault = artifact_vault
@@ -132,6 +135,11 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # the guard is skipped entirely (safe no-op until an AssignmentPort is
         # wired in the composition root).
         self._assignment_port = assignment_port
+        # SIP-0089 §4.4 (executor-side instrumentation): opt-in RuntimeActivityPort.
+        # When wired, each dispatched task opens a RuntimeActivity (start on
+        # dispatch, complete/fail on reply) so an agent's current task is
+        # observable. Best-effort — never breaks dispatch; None disables it.
+        self._activity_port = activity_port
         self._cancelled: set[str] = set()
 
         # SIP-0077: Cycle event bus (defaults to NoOp if not provided)
@@ -721,14 +729,72 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 self._task_heartbeat(envelope, interval=heartbeat_interval),
                 name=f"prefect-heartbeat-{envelope.task_id}",
             )
+            # SIP-0089 §4.4: open a RuntimeActivity for this task (best-effort).
+            activity_id = await self._start_task_activity(envelope)
             try:
-                return await self._publish_and_await(envelope, run_id)
+                result = await self._publish_and_await(envelope, run_id)
+            except BaseException:
+                # Reply wait raised (rare — _publish_and_await usually returns a
+                # FAILED TaskResult): record the task activity as failed.
+                await self._finish_task_activity(activity_id, None)
+                raise
+            else:
+                await self._finish_task_activity(activity_id, result)
+                return result
             finally:
                 heartbeat.cancel()
                 try:
                     await heartbeat
                 except asyncio.CancelledError:
                     pass
+
+    async def _start_task_activity(self, envelope: TaskEnvelope) -> str | None:
+        """Open a RuntimeActivity for a dispatched cycle task (§4.4, executor-side).
+
+        Best-effort: returns the activity id, or None when disabled/failed — it
+        must never raise, so observability can't break dispatch. D9 (one active
+        activity per agent) is enforced by the partial unique index; a leftover
+        active row from a prior crashed task makes this conflict, which we swallow.
+        """
+        if self._activity_port is None:
+            return None
+        try:
+            activity = await self._activity_port.start_activity(
+                envelope.agent_id,
+                mode="cycle",
+                activity_type=envelope.task_type,
+                goal=envelope.task_name or f"{envelope.task_type} ({envelope.cycle_id})",
+                source_kind="cycle_task",
+                source_ref=envelope.task_id,
+                cycle_id=envelope.cycle_id,
+                task_id=envelope.task_id,
+            )
+            return activity.runtime_activity_id
+        except Exception:
+            logger.warning(
+                "best-effort start_activity failed for task %s", envelope.task_id, exc_info=True
+            )
+            return None
+
+    async def _finish_task_activity(
+        self, activity_id: str | None, result: TaskResult | None
+    ) -> None:
+        """Terminate a task's RuntimeActivity (§4.4, executor-side, best-effort).
+
+        SUCCEEDED → complete; anything else (FAILED/CANCELED/raised/None) → fail.
+        Never raises. `update_state`'s active-only guard makes this safe even if
+        the activity was already terminalized elsewhere.
+        """
+        if self._activity_port is None or activity_id is None:
+            return
+        try:
+            if result is not None and result.status == "SUCCEEDED":
+                await self._activity_port.complete_activity(activity_id)
+            else:
+                reason = (result.error if result is not None else None) or reasons.ACTIVITY_FAILED
+                await self._activity_port.fail_activity(activity_id, reason)
+        except Exception:
+            logger.warning("best-effort finish_activity failed for %s", activity_id, exc_info=True)
 
     async def _publish_and_await(
         self,

--- a/adapters/cycles/factory.py
+++ b/adapters/cycles/factory.py
@@ -111,5 +111,6 @@ def create_flow_executor(
             event_bus=kwargs.get("event_bus"),
             reply_router=kwargs.get("reply_router"),
             assignment_port=kwargs.get("assignment_port"),
+            activity_port=kwargs.get("activity_port"),
         )
     raise ValueError(f"Unknown flow executor provider: {provider}")

--- a/adapters/persistence/runtime/__init__.py
+++ b/adapters/persistence/runtime/__init__.py
@@ -1,6 +1,7 @@
 """Runtime persistence adapters (SIP-0089)."""
 
+from adapters.persistence.runtime.activity_postgres import PostgresRuntimeActivity
 from adapters.persistence.runtime.focus_lease_postgres import PostgresFocusLease
 from adapters.persistence.runtime.state_postgres import PostgresRuntimeState
 
-__all__ = ["PostgresFocusLease", "PostgresRuntimeState"]
+__all__ = ["PostgresFocusLease", "PostgresRuntimeActivity", "PostgresRuntimeState"]

--- a/adapters/persistence/runtime/activity_postgres.py
+++ b/adapters/persistence/runtime/activity_postgres.py
@@ -1,0 +1,168 @@
+"""Postgres-backed RuntimeActivity adapter (SIP-0089 §4.3).
+
+Implements `RuntimeActivityPort` via the asyncpg pool shared with the cycle
+registry and the other runtime adapters. All rows hit `runtime_activities`
+(migration `1130_runtime_activities.sql`).
+
+`start_activity` inserts a `running` activity; the §4.2 partial unique index
+enforces the single-active-activity invariant (D9), so a second active start for
+the same agent raises `UniqueViolationError` — the §4.4 instrumentation treats
+activity calls as best-effort and swallows it so observability never breaks a
+real task. `update_state` manages the lifecycle timestamps; the terminal helpers
+are thin wrappers over it (their reason/evidence is event-surfaced, not stored).
+
+JSONB columns (`completion_conditions`/`evidence_requirements`) follow the cycle
+registry convention: `json.dumps` on write, decode on read.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+import asyncpg
+
+from squadops.ports.runtime.activity import RuntimeActivityPort
+from squadops.runtime.models import (
+    ActivitySourceKind,
+    ActivityState,
+    RuntimeActivity,
+    RuntimeMode,
+    is_terminal_activity_state,
+)
+
+_COLUMNS = (
+    "runtime_activity_id, agent_id, mode, activity_type, goal, priority, state, "
+    "source_kind, cycle_id, workload_id, task_id, source_ref, can_pause, can_resume, "
+    "can_abort, completion_conditions, evidence_requirements, started_at, paused_at, ended_at"
+)
+
+
+class PostgresRuntimeActivity(RuntimeActivityPort):
+    """Postgres-backed `RuntimeActivityPort` implementation."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def start_activity(
+        self,
+        agent_id: str,
+        *,
+        mode: RuntimeMode,
+        activity_type: str,
+        goal: str,
+        source_kind: ActivitySourceKind,
+        source_ref: str,
+        priority: int = 0,
+        cycle_id: str | None = None,
+        workload_id: str | None = None,
+        task_id: str | None = None,
+        can_pause: bool = False,
+        can_resume: bool = False,
+        can_abort: bool = True,
+        completion_conditions: tuple[dict, ...] = (),
+        evidence_requirements: tuple[dict, ...] = (),
+    ) -> RuntimeActivity:
+        activity_id = uuid.uuid4().hex
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "INSERT INTO runtime_activities ("
+                "runtime_activity_id, agent_id, mode, activity_type, goal, priority, state, "
+                "source_kind, cycle_id, workload_id, task_id, source_ref, can_pause, can_resume, "
+                "can_abort, completion_conditions, evidence_requirements, started_at"
+                ") VALUES ($1,$2,$3,$4,$5,$6,'running',$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17) "
+                f"RETURNING {_COLUMNS}",
+                activity_id,
+                agent_id,
+                mode,
+                activity_type,
+                goal,
+                priority,
+                source_kind,
+                cycle_id,
+                workload_id,
+                task_id,
+                source_ref,
+                can_pause,
+                can_resume,
+                can_abort,
+                json.dumps(list(completion_conditions)),
+                json.dumps(list(evidence_requirements)),
+                datetime.now(UTC),
+            )
+        return _row_to_activity(row)
+
+    async def update_state(self, activity_id: str, state: ActivityState) -> RuntimeActivity | None:
+        # Timestamp management is intrinsic to the state being entered: pausing
+        # stamps paused_at, a terminal state stamps ended_at, and (re)entering
+        # running ensures started_at is set without clobbering the original.
+        sets = ["state = $2", "updated_at = now()"]
+        if state == "paused":
+            sets.append("paused_at = now()")
+        elif is_terminal_activity_state(state):
+            sets.append("ended_at = now()")
+        elif state == "running":
+            sets.append("started_at = COALESCE(started_at, now())")
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"UPDATE runtime_activities SET {', '.join(sets)} "
+                f"WHERE runtime_activity_id = $1 RETURNING {_COLUMNS}",
+                activity_id,
+                state,
+            )
+        return _row_to_activity(row) if row else None
+
+    async def complete_activity(
+        self, activity_id: str, *, evidence_ref: str | None = None
+    ) -> RuntimeActivity | None:
+        return await self.update_state(activity_id, "completed")
+
+    async def fail_activity(self, activity_id: str, reason_code: str) -> RuntimeActivity | None:
+        return await self.update_state(activity_id, "failed")
+
+    async def abort_activity(self, activity_id: str, reason_code: str) -> RuntimeActivity | None:
+        return await self.update_state(activity_id, "aborted")
+
+    async def get_current_activity(self, agent_id: str) -> RuntimeActivity | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"SELECT {_COLUMNS} FROM runtime_activities "
+                "WHERE agent_id = $1 AND state IN ('pending', 'running', 'paused')",
+                agent_id,
+            )
+        return _row_to_activity(row) if row else None
+
+
+def _loads_jsonb(value) -> list:
+    """Decode a JSONB column value (asyncpg returns str by default)."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return json.loads(value)
+    return value  # already decoded (e.g. with a custom codec)
+
+
+def _row_to_activity(row: asyncpg.Record) -> RuntimeActivity:
+    return RuntimeActivity(
+        runtime_activity_id=row["runtime_activity_id"],
+        agent_id=row["agent_id"],
+        mode=row["mode"],
+        activity_type=row["activity_type"],
+        goal=row["goal"],
+        priority=row["priority"],
+        state=row["state"],
+        source_kind=row["source_kind"],
+        source_ref=row["source_ref"],
+        cycle_id=row["cycle_id"],
+        workload_id=row["workload_id"],
+        task_id=row["task_id"],
+        can_pause=row["can_pause"],
+        can_resume=row["can_resume"],
+        can_abort=row["can_abort"],
+        completion_conditions=tuple(_loads_jsonb(row["completion_conditions"])),
+        evidence_requirements=tuple(_loads_jsonb(row["evidence_requirements"])),
+        started_at=row["started_at"],
+        paused_at=row["paused_at"],
+        ended_at=row["ended_at"],
+    )

--- a/adapters/persistence/runtime/activity_postgres.py
+++ b/adapters/persistence/runtime/activity_postgres.py
@@ -104,10 +104,16 @@ class PostgresRuntimeActivity(RuntimeActivityPort):
             sets.append("ended_at = now()")
         elif state == "running":
             sets.append("started_at = COALESCE(started_at, now())")
+        # Only an ACTIVE activity may transition: terminal states are final, so a
+        # terminal row never moves again. This makes terminalization race-safe —
+        # if the owning handler completes an activity the coordinator just aborted
+        # (or vice versa), the second writer matches no row and gets None.
         async with self._pool.acquire() as conn:
             row = await conn.fetchrow(
                 f"UPDATE runtime_activities SET {', '.join(sets)} "
-                f"WHERE runtime_activity_id = $1 RETURNING {_COLUMNS}",
+                "WHERE runtime_activity_id = $1 "
+                "AND state IN ('pending', 'running', 'paused') "
+                f"RETURNING {_COLUMNS}",
                 activity_id,
                 state,
             )

--- a/infra/migrations/1130_runtime_activities.sql
+++ b/infra/migrations/1130_runtime_activities.sql
@@ -1,0 +1,62 @@
+-- 1130_runtime_activities.sql
+-- SIP-0089 Phase 4 §4.2: runtime_activities table.
+-- All DDL is idempotent (CREATE ... IF NOT EXISTS).
+--
+-- Field semantics mirror src/squadops/runtime/models.py::RuntimeActivity (§10.6).
+-- Enum-shaped columns carry CHECK constraints matching the Literal types in code
+-- (D3). Source identity is explicit: cycle_id/workload_id/task_id are queryable
+-- columns; source_ref is opaque adapter detail core never parses (§4.1).
+--
+-- agent_id is the holder. It is indexed (the port looks up the current activity by
+-- agent) but intentionally NOT a hard FK to agent_runtime_state: that row is
+-- created lazily by heartbeat (Phase 1 ensure_state), so an activity may be
+-- written before the agent has heartbeated (mirrors 1110/1120).
+
+CREATE TABLE IF NOT EXISTS runtime_activities (
+    runtime_activity_id    TEXT PRIMARY KEY,
+    agent_id               TEXT NOT NULL,
+    mode                   TEXT NOT NULL
+        CHECK (mode IN ('duty', 'cycle', 'ambient')),
+    activity_type          TEXT NOT NULL,
+    goal                   TEXT NOT NULL,
+    priority               INTEGER NOT NULL,
+    state                  TEXT NOT NULL
+        CHECK (state IN ('pending', 'running', 'paused', 'completed', 'aborted', 'failed')),
+    source_kind            TEXT NOT NULL
+        CHECK (source_kind IN (
+            'cycle_task', 'workload', 'duty_handler', 'ambient_observation', 'embodied_action'
+        )),
+    cycle_id               TEXT,
+    workload_id            TEXT,
+    task_id                TEXT,
+    source_ref             TEXT NOT NULL,
+    can_pause              BOOLEAN NOT NULL,
+    can_resume             BOOLEAN NOT NULL,
+    can_abort              BOOLEAN NOT NULL,
+    completion_conditions  JSONB NOT NULL DEFAULT '[]'::jsonb,
+    evidence_requirements  JSONB NOT NULL DEFAULT '[]'::jsonb,
+    started_at             TIMESTAMPTZ,
+    paused_at              TIMESTAMPTZ,
+    ended_at               TIMESTAMPTZ,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Single active-activity invariant (D9 / §4.2): at most one row per agent in a
+-- non-terminal state. A partial unique index lets terminal rows accumulate freely
+-- while guaranteeing one current unit of work per agent.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_runtime_activities_one_active_per_agent
+    ON runtime_activities (agent_id)
+    WHERE state IN ('pending', 'running', 'paused');
+
+-- get_current_activity(agent_id): look up the active activity for an agent.
+CREATE INDEX IF NOT EXISTS idx_runtime_activities_agent_id
+    ON runtime_activities (agent_id);
+
+-- Explicit source-identity columns are queryable (history-by-X), so index them.
+CREATE INDEX IF NOT EXISTS idx_runtime_activities_cycle_id
+    ON runtime_activities (cycle_id);
+CREATE INDEX IF NOT EXISTS idx_runtime_activities_workload_id
+    ON runtime_activities (workload_id);
+CREATE INDEX IF NOT EXISTS idx_runtime_activities_task_id
+    ON runtime_activities (task_id);

--- a/src/squadops/api/routes/platform_health.py
+++ b/src/squadops/api/routes/platform_health.py
@@ -140,6 +140,26 @@ async def get_agent_runtime_state(agent_id: str):
     return state
 
 
+@router.get("/agents/{agent_id}/activity")
+async def get_agent_current_activity(agent_id: str):
+    """Return the agent's current (active) RuntimeActivity (SIP-0089 §4.7).
+
+    Returns 404 when the agent has no active activity (idle), or when the
+    runtime-api has no RuntimeActivityPort wired.
+    """
+    hc = _get_health_checker()
+    try:
+        activity = await hc.get_current_activity(agent_id.lower())
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to read activity: {e}") from e
+    if activity is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No active activity for agent_id={agent_id}",
+        )
+    return activity
+
+
 @router.post("/agents/status")
 async def create_or_update_agent_status(agent_status: AgentStatusCreate):
     """Create or update agent status (heartbeat endpoint)."""

--- a/src/squadops/api/runtime/health_checker.py
+++ b/src/squadops/api/runtime/health_checker.py
@@ -19,6 +19,7 @@ import httpx
 import yaml
 
 from squadops.api.runtime.agent_labels import get_role_label
+from squadops.ports.runtime.activity import RuntimeActivityPort
 from squadops.ports.runtime.state import RuntimeStatePort
 from squadops.runtime.lifecycle_status import runtime_status_from_lifecycle
 
@@ -35,11 +36,13 @@ class HealthChecker:
         redis_client: Any | None = None,
         config: Any,
         runtime_state: RuntimeStatePort | None = None,
+        activity: RuntimeActivityPort | None = None,
     ) -> None:
         self.pg_pool = pg_pool
         self.redis_client = redis_client
         self._config = config
         self._runtime_state = runtime_state
+        self._activity = activity
         self._instances_cache: dict[str, dict[str, Any]] | None = None
         self._instances_cache_mtime: float | None = None
         self._reconciliation_running = True
@@ -252,6 +255,39 @@ class HealthChecker:
                 state.last_heartbeat_at.isoformat() if state.last_heartbeat_at else None
             ),
             "current_assignment_ref": state.current_assignment_ref,
+        }
+
+    async def get_current_activity(self, agent_id: str) -> dict[str, Any] | None:
+        """Return the agent's current (active) RuntimeActivity as a dict, or None.
+
+        Pure read (SIP-0089 §4.7); never mutates. Returns a JSON-serialisable dict
+        so the FastAPI route stays dataclass-agnostic. `None` means either no
+        activity port is wired or the agent has no active activity.
+        """
+        if self._activity is None:
+            return None
+        activity = await self._activity.get_current_activity(agent_id)
+        if activity is None:
+            return None
+        return {
+            "runtime_activity_id": activity.runtime_activity_id,
+            "agent_id": activity.agent_id,
+            "mode": activity.mode,
+            "activity_type": activity.activity_type,
+            "goal": activity.goal,
+            "priority": activity.priority,
+            "state": activity.state,
+            "source_kind": activity.source_kind,
+            "source_ref": activity.source_ref,
+            "cycle_id": activity.cycle_id,
+            "workload_id": activity.workload_id,
+            "task_id": activity.task_id,
+            "can_pause": activity.can_pause,
+            "can_resume": activity.can_resume,
+            "can_abort": activity.can_abort,
+            "started_at": activity.started_at.isoformat() if activity.started_at else None,
+            "paused_at": activity.paused_at.isoformat() if activity.paused_at else None,
+            "ended_at": activity.ended_at.isoformat() if activity.ended_at else None,
         }
 
     async def _update_runtime_state_heartbeat(self, agent_id: str, lifecycle_state: str) -> None:

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -375,7 +375,7 @@ async def _init_monitoring(config, pool) -> None:
     try:
         import redis.asyncio as aioredis
 
-        from adapters.persistence.runtime import PostgresRuntimeState
+        from adapters.persistence.runtime import PostgresRuntimeActivity, PostgresRuntimeState
         from squadops.api.runtime.health_checker import HealthChecker
 
         redis_url = config.comms.redis.url
@@ -385,6 +385,8 @@ async def _init_monitoring(config, pool) -> None:
             redis_client=_redis_client,
             config=config,
             runtime_state=PostgresRuntimeState(pool),
+            # SIP-0089 §4.7: backs GET /health/agents/{id}/activity.
+            activity=PostgresRuntimeActivity(pool),
         )
         await _health_checker_instance.init_connections()
         set_health_checker(_health_checker_instance)

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -314,13 +314,19 @@ async def _init_cycle_subsystem(config, pool) -> None:
         # is available (the agent_assignments table lives there, migration 1110).
         # Without a pool the guard stays unwired and recruitment is never gated.
         assignment_port = None
+        activity_port = None
         if pool is not None:
+            from adapters.persistence.runtime.activity_postgres import PostgresRuntimeActivity
             from adapters.persistence.runtime.assignments_postgres import PostgresAssignment
             from squadops.api.runtime.deps import set_assignment_port
 
             assignment_port = PostgresAssignment(pool)
             # SIP-0089 §2.7: same adapter backs the assignment REST surface.
             set_assignment_port(assignment_port)
+            # SIP-0089 §4.4: executor-side task-activity instrumentation. The
+            # runtime-api process owns the asyncpg pool, so RuntimeActivity is
+            # written here (not in agents) as each task is dispatched/replied.
+            activity_port = PostgresRuntimeActivity(pool)
 
         flow_executor = create_flow_executor(
             "dispatched",
@@ -335,6 +341,7 @@ async def _init_cycle_subsystem(config, pool) -> None:
             event_bus=event_bus,
             reply_router=_reply_router,
             assignment_port=assignment_port,
+            activity_port=activity_port,
         )
 
         set_cycle_ports(

--- a/src/squadops/api/runtime/scheduler_bootstrap.py
+++ b/src/squadops/api/runtime/scheduler_bootstrap.py
@@ -10,13 +10,16 @@ This is the composition root — it is allowed to import adapters (unlike
 
     PostgresRuntimeState ─┐
     PostgresAssignment ───┤
-    PostgresFocusLease ───┼─→ RuntimeCoordinator ─→ DutyScheduler
+    PostgresFocusLease ───┤
+    PostgresRuntimeActivity ─┼─→ RuntimeCoordinator ─→ DutyScheduler
     LoggingRuntimeEventPublisher ─┘
 
 The `PostgresFocusLease` makes the coordinator's §3.4 lease arbitration live:
 opening a duty window acquires the agent's duty FocusLease (preempting a held
 cycle lease), and closing it releases the lease (§3.4). lease ≠ mode — the
-coordinator still owns the authoritative `mode` write.
+coordinator still owns the authoritative `mode` write. `PostgresRuntimeActivity`
+wires the §4.5 seam (abort an activity orphaned by a mode change); it is a no-op
+in v1.1 until handlers emit activities (§4.4), but kept wired for consistency.
 
 **Single-writer constraint:** the `RuntimeCoordinator` is the sole writer of
 `AgentRuntimeState.mode` (D16). This is safe only while a *single* runtime-api
@@ -58,14 +61,21 @@ def create_duty_scheduler(config: AppConfig, pool: asyncpg.Pool | None) -> DutyS
     # Imported here (not at module top) so importing this module never pulls the
     # asyncpg adapter stack into processes that only need the factory signature.
     from adapters.events.runtime_event_publisher import LoggingRuntimeEventPublisher
-    from adapters.persistence.runtime import PostgresFocusLease, PostgresRuntimeState
+    from adapters.persistence.runtime import (
+        PostgresFocusLease,
+        PostgresRuntimeActivity,
+        PostgresRuntimeState,
+    )
     from adapters.persistence.runtime.assignments_postgres import PostgresAssignment
 
     state = PostgresRuntimeState(pool)
     assignments = PostgresAssignment(pool)
     focus_lease = PostgresFocusLease(pool)
+    activity = PostgresRuntimeActivity(pool)
     publisher = LoggingRuntimeEventPublisher()
-    coordinator = RuntimeCoordinator(state, events_publisher=publisher, focus_lease=focus_lease)
+    coordinator = RuntimeCoordinator(
+        state, events_publisher=publisher, focus_lease=focus_lease, activity=activity
+    )
 
     poll_interval = config.runtime.scheduler.poll_interval_seconds
     logger.warning(

--- a/src/squadops/cli/commands/agent.py
+++ b/src/squadops/cli/commands/agent.py
@@ -1,13 +1,15 @@
-"""Agent commands (SIP-0089 §1.5).
+"""Agent commands (SIP-0089 §1.5 / §4.7).
 
-`squadops agent state <agent-id>` reads the SIP-0089 AgentRuntimeState
-for an agent and renders it as a table or `--json`.
+`squadops agent state <agent-id>` reads the SIP-0089 AgentRuntimeState for an
+agent; `squadops agent activity <agent-id>` reads its current RuntimeActivity
+(what the agent is working on right now). Both render as a table or `--json`.
 """
 
 from __future__ import annotations
 
 import typer
 
+from squadops.cli import exit_codes
 from squadops.cli.client import APIClient, CLIError
 from squadops.cli.config import load_config
 from squadops.cli.output import print_detail, print_error, print_json
@@ -55,3 +57,38 @@ def state(
     display = dict(data)
     display["availability"] = _derived_availability(data)
     print_detail(display, quiet=quiet)
+
+
+@app.command("activity")
+def activity(
+    ctx: typer.Context,
+    agent_id: str = typer.Argument(..., help="Agent identifier (e.g. max, neo)"),
+):
+    """Show the agent's current RuntimeActivity: what it's working on right now."""
+    fmt = ctx.obj.get("format", "table") if ctx.obj else "table"
+    quiet = ctx.obj.get("quiet", False) if ctx.obj else False
+
+    try:
+        client = _get_client(ctx)
+        try:
+            data = client.get(f"/health/agents/{agent_id}/activity")
+        finally:
+            client.close()
+    except CLIError as e:
+        # A 404 means the agent is idle (no active activity) — report it plainly
+        # rather than as an error, mirroring how operators read `agent state`.
+        if e.exit_code == exit_codes.NOT_FOUND:
+            if fmt == "json":
+                print_json({"agent_id": agent_id, "current_activity": None})
+            else:
+                print_detail(
+                    {"agent_id": agent_id, "current_activity": "(idle — none)"}, quiet=quiet
+                )
+            return
+        print_error(str(e))
+        raise typer.Exit(code=e.exit_code) from e
+
+    if fmt == "json":
+        print_json(data)
+        return
+    print_detail(data, quiet=quiet)

--- a/src/squadops/ports/runtime/__init__.py
+++ b/src/squadops/ports/runtime/__init__.py
@@ -5,9 +5,16 @@ Matches the namespace pattern of `squadops.ports.cycles` and
 `squadops.ports.observability` (established in 1.0.5).
 """
 
+from squadops.ports.runtime.activity import RuntimeActivityPort
 from squadops.ports.runtime.assignments import AssignmentPort
 from squadops.ports.runtime.event_publisher import RuntimeEventPublisher
 from squadops.ports.runtime.focus_lease import FocusLeasePort
 from squadops.ports.runtime.state import RuntimeStatePort
 
-__all__ = ["AssignmentPort", "FocusLeasePort", "RuntimeEventPublisher", "RuntimeStatePort"]
+__all__ = [
+    "AssignmentPort",
+    "FocusLeasePort",
+    "RuntimeActivityPort",
+    "RuntimeEventPublisher",
+    "RuntimeStatePort",
+]

--- a/src/squadops/ports/runtime/activity.py
+++ b/src/squadops/ports/runtime/activity.py
@@ -1,0 +1,89 @@
+"""
+RuntimeActivityPort — abstract interface for RuntimeActivity persistence
+(SIP-0089 §10.6, Phase 4 §4.3).
+
+A RuntimeActivity is the observable unit of work an agent performs within a mode.
+At most one *active* (`pending`/`running`/`paused`) activity per agent (D9),
+enforced by the §4.2 partial unique index — `start_activity` raises if one
+already exists. Handlers/workloads emit these at task granularity (D19); the
+coordinator (§4.5) pauses/aborts the current activity during a mode transition.
+
+The terminal helpers (`complete`/`fail`/`abort`) and their `evidence_ref` /
+`reason_code` are surfaced on the canonical `runtime_activity.*` event (D18); the
+reason is not persisted as a column in v1.1 — `state` + `ended_at` are.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from squadops.runtime.models import (
+        ActivitySourceKind,
+        ActivityState,
+        RuntimeActivity,
+        RuntimeMode,
+    )
+
+
+class RuntimeActivityPort(ABC):
+    """Port for `RuntimeActivity` persistence and lifecycle transitions."""
+
+    @abstractmethod
+    async def start_activity(
+        self,
+        agent_id: str,
+        *,
+        mode: RuntimeMode,
+        activity_type: str,
+        goal: str,
+        source_kind: ActivitySourceKind,
+        source_ref: str,
+        priority: int = 0,
+        cycle_id: str | None = None,
+        workload_id: str | None = None,
+        task_id: str | None = None,
+        can_pause: bool = False,
+        can_resume: bool = False,
+        can_abort: bool = True,
+        completion_conditions: tuple[dict, ...] = (),
+        evidence_requirements: tuple[dict, ...] = (),
+    ) -> RuntimeActivity:
+        """Create a new `running` activity for `agent_id` and return it.
+
+        Mints the id and sets `started_at`. Raises if the agent already holds an
+        active activity (D9 — the partial unique index rejects a second). Source
+        identity is explicit (`cycle_id`/`workload_id`/`task_id`); `source_ref` is
+        opaque and never parsed by core.
+        """
+
+    @abstractmethod
+    async def update_state(self, activity_id: str, state: ActivityState) -> RuntimeActivity | None:
+        """Transition an activity to `state`, managing timestamps automatically.
+
+        `paused` stamps `paused_at`; a terminal state stamps `ended_at`; `running`
+        ensures `started_at` is set (resume keeps the original). Returns the updated
+        activity, or `None` if no such activity exists.
+        """
+
+    @abstractmethod
+    async def complete_activity(
+        self, activity_id: str, *, evidence_ref: str | None = None
+    ) -> RuntimeActivity | None:
+        """Terminal helper: mark the activity `completed`. `evidence_ref` is
+        event-surfaced (proof of completion), not persisted in v1.1."""
+
+    @abstractmethod
+    async def fail_activity(self, activity_id: str, reason_code: str) -> RuntimeActivity | None:
+        """Terminal helper: mark the activity `failed`. `reason_code` is
+        event-surfaced (D18), not persisted in v1.1."""
+
+    @abstractmethod
+    async def abort_activity(self, activity_id: str, reason_code: str) -> RuntimeActivity | None:
+        """Terminal helper: mark the activity `aborted` (non-cooperative stop).
+        `reason_code` is event-surfaced (D18), not persisted in v1.1."""
+
+    @abstractmethod
+    async def get_current_activity(self, agent_id: str) -> RuntimeActivity | None:
+        """Return the agent's current (active) activity, or `None`."""

--- a/src/squadops/runtime/__init__.py
+++ b/src/squadops/runtime/__init__.py
@@ -13,6 +13,8 @@ from squadops.runtime.coordinator import (
     TransitionOutcome,
 )
 from squadops.runtime.models import (
+    ActivitySourceKind,
+    ActivityState,
     AgentRuntimeState,
     Assignment,
     AssignmentType,
@@ -26,8 +28,11 @@ from squadops.runtime.models import (
     OwnerType,
     RecallPolicy,
     RenewalPolicy,
+    RuntimeActivity,
     Strictness,
     WindowState,
+    is_active_activity_state,
+    is_terminal_activity_state,
     owner_type_outranks,
     window_state,
 )
@@ -35,6 +40,8 @@ from squadops.runtime.recruitment import RecruitmentDecision, reserve_buffer_dec
 from squadops.runtime.scheduler import DutyScheduler
 
 __all__ = [
+    "ActivitySourceKind",
+    "ActivityState",
     "AgentRuntimeState",
     "Assignment",
     "AssignmentType",
@@ -51,10 +58,13 @@ __all__ = [
     "RecruitmentDecision",
     "RenewalPolicy",
     "RequesterKind",
+    "RuntimeActivity",
     "RuntimeCoordinator",
     "Strictness",
     "TransitionOutcome",
     "WindowState",
+    "is_active_activity_state",
+    "is_terminal_activity_state",
     "owner_type_outranks",
     "reserve_buffer_decision",
     "window_state",

--- a/src/squadops/runtime/coordinator.py
+++ b/src/squadops/runtime/coordinator.py
@@ -21,9 +21,14 @@ Phase 3 (§3.4) wires FocusLease arbitration: entering a focus-bearing mode
 step 4 precedes step 6), and **lease ≠ mode** — a granted lease never changes
 `RuntimeMode`; the upsert is authoritative. Phase 3 uses best-effort compensation
 (a lease acquired for a transition is rolled back if the mode write fails — no
-stranded leases); D25's single-Postgres-transaction wrapping of the lease + mode
-writes lands in Phase 4 (§4.5) alongside RuntimeActivity. With `focus_lease=None`
-the coordinator behaves exactly as in Phase 2.
+stranded leases). With `focus_lease=None` the coordinator behaves as in Phase 2.
+
+Phase 4 (§4.5, thin v1.1 seam) wires a RuntimeActivity action: a mode change
+orphans any activity bound to the previous mode, so it is aborted best-effort
+*after* the mode write. The full §4.5 transition order (activity before mode) and
+D25's single-Postgres-transaction wrapping of lease+activity+mode are deferred to
+#244 (gated on recruitment #233) — in v1.1 the path is unexercised. With
+`activity=None` there is no activity bookkeeping.
 
 On apply, a canonical mode-transition event plus the relevant `focus_lease.*`
 events are emitted, each with a *separate* reason code (D14/D18) through the
@@ -33,10 +38,12 @@ injected `RuntimeEventPublisher`.
 from __future__ import annotations
 
 import dataclasses
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
 
+from squadops.ports.runtime.activity import RuntimeActivityPort
 from squadops.ports.runtime.event_publisher import RuntimeEventPublisher
 from squadops.ports.runtime.focus_lease import FocusLeasePort
 from squadops.ports.runtime.state import RuntimeStatePort
@@ -48,6 +55,8 @@ from squadops.runtime.models import (
     OwnerType,
     RuntimeMode,
 )
+
+logger = logging.getLogger(__name__)
 
 RequesterKind = Literal["scheduler", "coordinator", "cli", "external"]
 
@@ -123,11 +132,14 @@ class RuntimeCoordinator:
         *,
         events_publisher: RuntimeEventPublisher | None = None,
         focus_lease: FocusLeasePort | None = None,
+        activity: RuntimeActivityPort | None = None,
     ) -> None:
         self._state = state
         self._events = events_publisher
         # FocusLease arbitration (§3.4). None → Phase-2 behavior (no lease gate).
         self._focus_lease = focus_lease
+        # RuntimeActivity seam (§4.5, thin v1.1). None → no activity bookkeeping.
+        self._activity = activity
         # D12 idempotency ledger. In-process for v1.1 (single in-process scheduler);
         # durable persistence is a refinement for the SIP-0091 Temporal adapter.
         self._applied_keys: set[str] = set()
@@ -231,7 +243,7 @@ class RuntimeCoordinator:
 
         # (2/4 §4.5) FocusLease arbitration before the mode write. A rejected
         # lease blocks the transition (prior mode stays authoritative).
-        # (3) RuntimeActivity decision — Phase 4 wires pause/resume/abort here.
+        # (5 §4.5) the RuntimeActivity action runs post-write — see below.
         arb: _LeaseArbitration | None = None
         if self._focus_lease is not None:
             arb = await self._arbitrate_lease(agent_id, current, target_mode, owner_ref)
@@ -276,6 +288,13 @@ class RuntimeCoordinator:
             self._emit_arbitration_events(
                 arb, agent_id, from_mode=current, to_mode=target_mode, owner_ref=owner_ref
             )
+
+        # (5 §4.5, thin v1.1 seam) RuntimeActivity action: a mode change orphans any
+        # activity bound to the *previous* mode — abort it so it doesn't linger as
+        # the agent's "current work". Best-effort, post-write: an activity is
+        # observability, never a reason to fail an applied transition.
+        if self._activity is not None:
+            await self._abort_orphaned_activity(agent_id, target_mode)
 
         # (7 D14/D18) emit the canonical mode-transition event with its own reason.
         if self._events is not None:
@@ -441,6 +460,48 @@ class RuntimeCoordinator:
                 from_mode=from_mode,
                 to_mode=to_mode,
                 owner_ref=owner_ref,
+            )
+
+    async def _abort_orphaned_activity(self, agent_id: str, target_mode: str) -> None:
+        """Abort the agent's current activity if a mode change orphaned it (§4.5).
+
+        An activity belongs to a mode; once the agent leaves that mode the activity
+        can't continue, so it's aborted. An activity already in the target mode
+        (e.g. a handler started it for the mode we're entering) is left alone.
+        Wholly best-effort: any failure is logged, never propagated — observability
+        must not break an applied transition. `update_state`'s active-only guard
+        makes this race-safe against the owning handler terminalizing first.
+
+        NOTE (§4.5/D25): in v1.1 this path is effectively unexercised — scheduler
+        ambient↔duty transitions have no live activity, and cycle activities are
+        owned/terminated by their handler (§4.4). The §4.5 single-Postgres-transaction
+        wrapping of lease+activity+mode (D25) is therefore deferred to #244 (gated
+        on recruitment #233); v1.1 keeps the best-effort post-write abort here.
+        """
+        assert self._activity is not None  # guarded by the caller
+        try:
+            current = await self._activity.get_current_activity(agent_id)
+            if current is None or current.mode == target_mode:
+                return
+            aborted = await self._activity.abort_activity(
+                current.runtime_activity_id, reasons.ACTIVITY_PREEMPTED_BY_MODE_CHANGE
+            )
+            if aborted is not None and self._events is not None:
+                self._events.emit(
+                    events.RUNTIME_ACTIVITY_ABORTED,
+                    agent_id=agent_id,
+                    reason_code=reasons.ACTIVITY_PREEMPTED_BY_MODE_CHANGE,
+                    payload={
+                        "runtime_activity_id": current.runtime_activity_id,
+                        "from_mode": current.mode,
+                        "to_mode": target_mode,
+                    },
+                )
+        except Exception:
+            logger.warning(
+                "best-effort abort of orphaned activity failed for agent %s",
+                agent_id,
+                exc_info=True,
             )
 
 

--- a/src/squadops/runtime/events.py
+++ b/src/squadops/runtime/events.py
@@ -31,3 +31,10 @@ FOCUS_LEASE_GRANTED: Final[str] = "focus_lease.granted"
 FOCUS_LEASE_REJECTED: Final[str] = "focus_lease.rejected"
 FOCUS_LEASE_PREEMPTED: Final[str] = "focus_lease.preempted"
 FOCUS_LEASE_RELEASED: Final[str] = "focus_lease.released"
+
+# Runtime-activity lifecycle (Phase 4 §4.4 handler-emitted, §4.5 coordinator-emitted).
+# Every activity transition emits a `runtime_activity.*` event (D14/D22).
+RUNTIME_ACTIVITY_STARTED: Final[str] = "runtime_activity.started"
+RUNTIME_ACTIVITY_COMPLETED: Final[str] = "runtime_activity.completed"
+RUNTIME_ACTIVITY_FAILED: Final[str] = "runtime_activity.failed"
+RUNTIME_ACTIVITY_ABORTED: Final[str] = "runtime_activity.aborted"

--- a/src/squadops/runtime/models.py
+++ b/src/squadops/runtime/models.py
@@ -8,6 +8,8 @@ reserve-buffer guard (§2.5).
 Phase 3 (§3.1): `FocusLease` mirrors §10.4, plus the `LeaseDecision` union
 (`LeaseGranted` / `LeaseRejected` / `LeasePreempting`) returned by the
 `FocusLeasePort`. Queueing (`LeaseQueued`) is deferred to v1.2+ (§3.0/D20).
+Phase 4 (§4.1): `RuntimeActivity` mirrors §10.6 — the observable unit of work an
+agent performs within a mode, with at most one *active* activity per agent (D9).
 
 All models are frozen dataclasses; mutate via `dataclasses.replace()`. `Literal`
 types in code mirror the DB `CHECK` constraints (D3).
@@ -267,3 +269,69 @@ class LeasePreempting:
 # Discriminated union of v1.1 lease outcomes. `LeaseQueued` is a recognized
 # v1.2+ outcome (§3.0/D20) and is deliberately absent here.
 LeaseDecision = LeaseGranted | LeaseRejected | LeasePreempting
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 (§4.1) — Runtime activities
+# ---------------------------------------------------------------------------
+
+ActivityState = Literal["pending", "running", "paused", "completed", "aborted", "failed"]
+ActivitySourceKind = Literal[
+    "cycle_task", "workload", "duty_handler", "ambient_observation", "embodied_action"
+]
+
+# An activity occupies the agent's single active slot (D9) while in one of these
+# states; the complement are terminal. The §4.2 partial unique index enforces at
+# most one active row per agent.
+_ACTIVE_ACTIVITY_STATES: frozenset[ActivityState] = frozenset({"pending", "running", "paused"})
+_TERMINAL_ACTIVITY_STATES: frozenset[ActivityState] = frozenset({"completed", "aborted", "failed"})
+
+
+def is_active_activity_state(state: ActivityState) -> bool:
+    """True while the activity holds the agent's single active slot (D9)."""
+    return state in _ACTIVE_ACTIVITY_STATES
+
+
+def is_terminal_activity_state(state: ActivityState) -> bool:
+    """True once the activity has ended (`completed`/`aborted`/`failed`)."""
+    return state in _TERMINAL_ACTIVITY_STATES
+
+
+@dataclass(frozen=True)
+class RuntimeActivity:
+    """An observable unit of work an agent performs within a mode (§10.6).
+
+    Makes current work visible without digging through prompt history. At most one
+    *active* (`pending`/`running`/`paused`) activity per agent (D9), enforced by the
+    §4.2 partial unique index. RuntimeActivities don't perform work — handlers and
+    workloads do, emitting these at task granularity (D19); `pending` is short-lived.
+
+    Source identity is explicit and queryable: `cycle_id` / `workload_id` /
+    `task_id` are first-class columns. `source_ref` is opaque adapter detail that
+    **core never parses** (§4.1) — history-by-X queries use the explicit columns.
+
+    Frozen; mutate via `dataclasses.replace()`. `completion_conditions` /
+    `evidence_requirements` carry decoded JSONB payloads (opaque in v1.1); they make
+    the instance unhashable, which is fine — runtime activities are never hashed.
+    """
+
+    runtime_activity_id: str
+    agent_id: str
+    mode: RuntimeMode
+    activity_type: str
+    goal: str
+    priority: int
+    state: ActivityState
+    source_kind: ActivitySourceKind
+    source_ref: str
+    cycle_id: str | None
+    workload_id: str | None
+    task_id: str | None
+    can_pause: bool
+    can_resume: bool
+    can_abort: bool
+    completion_conditions: tuple[dict, ...] = ()
+    evidence_requirements: tuple[dict, ...] = ()
+    started_at: datetime | None = None
+    paused_at: datetime | None = None
+    ended_at: datetime | None = None

--- a/src/squadops/runtime/policy.py
+++ b/src/squadops/runtime/policy.py
@@ -1,0 +1,89 @@
+"""
+Ambient irreversibility policy seam (SIP-0089 §4.6).
+
+The v1.2 embodiment hook. Per §10.4/§10.5, an Ambient agent may observe, idle, or
+respond lightly, but may **not** perform an irreversible external action (mutate
+external systems, spend material compute) unless it holds **both** a granted
+FocusLease and a started RuntimeActivity. `AmbientPolicy.assert_action_permitted`
+enforces that, evaluated against the *ports* (not in-memory agent fields) so it
+works unchanged once embodiment adapters arrive.
+
+In v1.1 this gate has **no real callers** — no embodied actions exist yet. It
+exists so v1.2 plugs into a working policy seam without a redesign.
+
+Reconciliation note: §4.6's sketch reads "raises if ... no FocusLease AND no
+RuntimeActivity", but the canonical invariant (§10.4) requires *both* a lease and
+an activity to act. This implements the stricter, spec-faithful rule: an ambient
+agent is refused an irreversible action unless it holds a lease **and** an
+activity (i.e. either one missing → refused).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from squadops.runtime import reasons
+
+if TYPE_CHECKING:
+    from squadops.ports.runtime.activity import RuntimeActivityPort
+    from squadops.ports.runtime.focus_lease import FocusLeasePort
+    from squadops.ports.runtime.state import RuntimeStatePort
+
+
+class AmbientActionForbidden(Exception):
+    """An ambient agent attempted an irreversible action without the required
+    FocusLease + RuntimeActivity (§4.6 / §10.4)."""
+
+    def __init__(self, agent_id: str, action_kind: str) -> None:
+        self.agent_id = agent_id
+        self.action_kind = action_kind
+        self.reason_code = reasons.AMBIENT_IRREVERSIBLE_ACTION_FORBIDDEN
+        super().__init__(
+            f"ambient agent {agent_id!r} may not perform irreversible action "
+            f"{action_kind!r} without an active focus lease and runtime activity"
+        )
+
+
+class AmbientPolicy:
+    """Gate irreversible actions for ambient agents against the runtime ports."""
+
+    def __init__(
+        self,
+        state: RuntimeStatePort,
+        focus_lease: FocusLeasePort,
+        activity: RuntimeActivityPort,
+    ) -> None:
+        self._state = state
+        self._focus_lease = focus_lease
+        self._activity = activity
+
+    async def assert_action_permitted(
+        self,
+        agent_id: str,
+        action_kind: str,
+        *,
+        irreversible: bool,
+    ) -> None:
+        """Raise `AmbientActionForbidden` if the action is not permitted.
+
+        Reversible actions are always permitted. Irreversible actions are gated
+        only for ambient agents (duty/cycle agents are already doing claimed work);
+        an agent with no runtime-state row is treated as ambient (most restrictive).
+        `irreversible` is supplied by the caller — v1.1 does not classify every
+        possible action.
+        """
+        if not irreversible:
+            return
+
+        state = await self._state.get_state(agent_id)
+        # Only ambient is gated. A missing row (never heartbeated) → treat as
+        # ambient so the seam fails closed rather than open.
+        if state is not None and state.mode != "ambient":
+            return
+
+        lease = await self._focus_lease.get_current_lease(agent_id)
+        activity = await self._activity.get_current_activity(agent_id)
+        if lease is not None and activity is not None:
+            return
+
+        raise AmbientActionForbidden(agent_id, action_kind)

--- a/src/squadops/runtime/reasons.py
+++ b/src/squadops/runtime/reasons.py
@@ -45,3 +45,10 @@ CURRENT_ACTIVITY_CANNOT_PAUSE: Final[str] = "current_activity_cannot_pause"
 AGENT_RUNTIME_STATUS_UNAVAILABLE: Final[str] = "agent_runtime_status_unavailable"
 # Deferred-queue rejection (§3.0/D20): a request that would have queued in v1.2.
 FOCUS_LEASE_QUEUEING_NOT_SUPPORTED: Final[str] = "focus_lease_queueing_not_supported_in_v1.1"
+
+# Runtime-activity reasons (Phase 4 §4.4/§4.5)
+ACTIVITY_STARTED: Final[str] = "activity_started"
+ACTIVITY_COMPLETED: Final[str] = "activity_completed"
+ACTIVITY_FAILED: Final[str] = "activity_failed"
+# The coordinator aborts an activity orphaned by a mode change (§4.5 thin seam).
+ACTIVITY_PREEMPTED_BY_MODE_CHANGE: Final[str] = "activity_preempted_by_mode_change"

--- a/src/squadops/runtime/reasons.py
+++ b/src/squadops/runtime/reasons.py
@@ -52,3 +52,6 @@ ACTIVITY_COMPLETED: Final[str] = "activity_completed"
 ACTIVITY_FAILED: Final[str] = "activity_failed"
 # The coordinator aborts an activity orphaned by a mode change (§4.5 thin seam).
 ACTIVITY_PREEMPTED_BY_MODE_CHANGE: Final[str] = "activity_preempted_by_mode_change"
+
+# Ambient irreversibility policy (Phase 4 §4.6 — v1.2 embodiment seam, no v1.1 callers)
+AMBIENT_IRREVERSIBLE_ACTION_FORBIDDEN: Final[str] = "ambient_irreversible_action_forbidden"

--- a/tests/unit/api/test_health_checker.py
+++ b/tests/unit/api/test_health_checker.py
@@ -313,3 +313,63 @@ class TestReconcileOnce:
         await checker._reconcile_once()
 
         runtime_state.mark_offline.assert_not_awaited()
+
+
+class TestGetCurrentActivity:
+    """SIP-0089 §4.7: HealthChecker.get_current_activity maps the dataclass to a
+    JSON-serialisable dict for the route, or None."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_activity_port(self, mock_config):
+        """Bug class: with no RuntimeActivityPort wired, the read must yield None
+        (→ 404 idle), not raise."""
+        checker = HealthChecker(pg_pool=MagicMock(), redis_client=None, config=mock_config)
+        assert await checker.get_current_activity("max") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_agent_idle(self, mock_config):
+        """Bug class: an idle agent (port returns None) must surface as None."""
+        port = AsyncMock()
+        port.get_current_activity.return_value = None
+        checker = HealthChecker(
+            pg_pool=MagicMock(), redis_client=None, config=mock_config, activity=port
+        )
+        assert await checker.get_current_activity("max") is None
+
+    @pytest.mark.asyncio
+    async def test_maps_activity_with_iso_timestamps(self, mock_config):
+        """Bug class: a mapper that drops a field or emits a raw datetime would
+        break the JSON route. Assert key fields + ISO-formatted started_at."""
+        from squadops.runtime.models import RuntimeActivity
+
+        started = datetime(2026, 6, 28, 12, 0, 0)
+        port = AsyncMock()
+        port.get_current_activity.return_value = RuntimeActivity(
+            runtime_activity_id="act-9",
+            agent_id="max",
+            mode="cycle",
+            activity_type="strategy.analyze_prd",
+            goal="Analyze the PRD",
+            priority=0,
+            state="running",
+            source_kind="cycle_task",
+            source_ref="t1",
+            cycle_id="cyc-1",
+            workload_id=None,
+            task_id="t1",
+            can_pause=False,
+            can_resume=False,
+            can_abort=True,
+            started_at=started,
+        )
+        checker = HealthChecker(
+            pg_pool=MagicMock(), redis_client=None, config=mock_config, activity=port
+        )
+
+        result = await checker.get_current_activity("max")
+
+        assert result["runtime_activity_id"] == "act-9"
+        assert result["state"] == "running" and result["mode"] == "cycle"
+        assert result["task_id"] == "t1" and result["cycle_id"] == "cyc-1"
+        assert result["started_at"] == started.isoformat()
+        assert result["ended_at"] is None

--- a/tests/unit/api/test_platform_health_routes.py
+++ b/tests/unit/api/test_platform_health_routes.py
@@ -198,3 +198,39 @@ class TestUpdateAgentStatus:
             },
         )
         assert resp.status_code == 404
+
+
+class TestAgentCurrentActivity:
+    """SIP-0089 §4.7: GET /health/agents/{id}/activity."""
+
+    def test_activity_found_returns_200(self, client, mock_health_checker):
+        """Bug class: a working agent's current activity must be served as 200 with
+        the activity body (the read the CLI/console render)."""
+        mock_health_checker.get_current_activity = AsyncMock(
+            return_value={"runtime_activity_id": "act-1", "state": "running", "mode": "cycle"}
+        )
+
+        resp = client.get("/health/agents/max/activity")
+
+        assert resp.status_code == 200
+        assert resp.json()["runtime_activity_id"] == "act-1"
+        # agent_id is lower-cased to match how rows are stored.
+        mock_health_checker.get_current_activity.assert_awaited_once_with("max")
+
+    def test_activity_absent_returns_404(self, client, mock_health_checker):
+        """Bug class: an idle agent (no active activity) must be a clean 404, which
+        the CLI maps to 'idle' — not a 200 with a null body or a 500."""
+        mock_health_checker.get_current_activity = AsyncMock(return_value=None)
+
+        resp = client.get("/health/agents/idle/activity")
+
+        assert resp.status_code == 404
+
+    def test_activity_id_is_lowercased(self, client, mock_health_checker):
+        """Bug class: rows are stored lower-cased; an upper-case path arg must be
+        normalized or it would 404 against a row that exists."""
+        mock_health_checker.get_current_activity = AsyncMock(return_value=None)
+
+        client.get("/health/agents/MAX/activity")
+
+        mock_health_checker.get_current_activity.assert_awaited_once_with("max")

--- a/tests/unit/api/test_scheduler_bootstrap.py
+++ b/tests/unit/api/test_scheduler_bootstrap.py
@@ -68,12 +68,13 @@ def test_enabled_with_pool_builds_inert_scheduler_with_configured_interval():
     assert scheduler._task is None  # not started by the factory
 
 
-def test_enabled_scheduler_coordinator_has_focus_lease_wired():
-    """Bug class (§3.4 activation): the coordinator must be built WITH a
-    FocusLeasePort, else duty transitions silently skip lease arbitration (the
-    Phase-2 no-lease path) even though Phase 3 shipped. Guards against the wiring
-    regressing back to `RuntimeCoordinator(state, events_publisher=...)`."""
+def test_enabled_scheduler_coordinator_has_focus_lease_and_activity_wired():
+    """Bug class (§3.4/§4.5 activation): the coordinator must be built WITH both a
+    FocusLeasePort and a RuntimeActivityPort, else duty transitions silently skip
+    lease arbitration / the activity seam even though Phase 3/4 shipped. Guards
+    against the wiring regressing to a bare `RuntimeCoordinator(state, ...)`."""
     scheduler = create_duty_scheduler(_config(enabled=True), MagicMock())
 
     assert scheduler is not None
     assert scheduler._coordinator._focus_lease is not None
+    assert scheduler._coordinator._activity is not None

--- a/tests/unit/cli/test_agent_activity_command.py
+++ b/tests/unit/cli/test_agent_activity_command.py
@@ -1,0 +1,115 @@
+"""Unit tests for `squadops agent activity` (SIP-0089 §4.7).
+
+What bugs would these catch?
+- Wrong endpoint URL → the operator command silently hits the wrong service.
+- A 404 (agent idle — no active activity) being surfaced as an ERROR / non-zero
+  exit would make "is this agent busy?" scripts treat *idle* as *failure*. Unlike
+  `agent state`, idle is a normal answer here, so 404 must report idle at exit 0.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from squadops.cli import exit_codes
+from squadops.cli.client import CLIError
+from squadops.cli.main import app
+
+pytestmark = [pytest.mark.domain_cli]
+
+NOW_ISO = datetime(2026, 6, 28, 12, 0, 0, tzinfo=UTC).isoformat()
+
+
+def _activity_payload(**overrides) -> dict:
+    base = {
+        "runtime_activity_id": "act-1",
+        "agent_id": "max",
+        "mode": "cycle",
+        "activity_type": "strategy.analyze_prd",
+        "goal": "Analyze the PRD",
+        "priority": 0,
+        "state": "running",
+        "source_kind": "cycle_task",
+        "source_ref": "t1",
+        "cycle_id": "cyc-1",
+        "workload_id": None,
+        "task_id": "t1",
+        "can_pause": False,
+        "can_resume": False,
+        "can_abort": True,
+        "started_at": NOW_ISO,
+        "paused_at": None,
+        "ended_at": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_activity_command_calls_correct_endpoint():
+    """Bug class: an endpoint typo would only fail at runtime for an operator."""
+    runner = CliRunner()
+    client = MagicMock()
+    client.get.return_value = _activity_payload()
+    with patch("squadops.cli.commands.agent._get_client", return_value=client):
+        result = runner.invoke(app, ["agent", "activity", "max"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.stdout
+    client.get.assert_called_once_with("/health/agents/max/activity")
+
+
+def test_activity_success_renders_activity():
+    """Bug class: a working agent's activity must actually render (the value of the
+    command). The running cycle task's type should appear."""
+    runner = CliRunner()
+    client = MagicMock()
+    client.get.return_value = _activity_payload()
+    with patch("squadops.cli.commands.agent._get_client", return_value=client):
+        result = runner.invoke(app, ["agent", "activity", "max"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "strategy.analyze_prd" in result.stdout
+
+
+def test_activity_404_reports_idle_at_zero_exit():
+    """Bug class (the load-bearing one): idle (no active activity → 404) is a
+    NORMAL answer, not an error. The command must exit 0 and say idle, NOT
+    propagate a non-zero exit like `agent state` does."""
+    runner = CliRunner()
+    client = MagicMock()
+    client.get.side_effect = CLIError("No active activity", exit_codes.NOT_FOUND)
+    with patch("squadops.cli.commands.agent._get_client", return_value=client):
+        result = runner.invoke(app, ["agent", "activity", "max"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.stdout
+    assert "idle" in result.stdout.lower()
+
+
+def test_activity_404_json_reports_null_current_activity():
+    """Bug class: scripted `--json` callers need a stable idle shape, not an error
+    blob. Idle must serialize as current_activity: null at exit 0."""
+    runner = CliRunner()
+    client = MagicMock()
+    client.get.side_effect = CLIError("No active activity", exit_codes.NOT_FOUND)
+    with patch("squadops.cli.commands.agent._get_client", return_value=client):
+        result = runner.invoke(app, ["--json", "agent", "activity", "max"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.stdout
+    parsed = json.loads(result.stdout.strip())
+    assert parsed == {"agent_id": "max", "current_activity": None}
+
+
+def test_activity_non_404_error_propagates_nonzero():
+    """Bug class: a real failure (e.g. 500) must NOT be swallowed as idle — only
+    404 maps to idle; other errors keep their non-zero exit."""
+    runner = CliRunner()
+    client = MagicMock()
+    client.get.side_effect = CLIError("server boom", exit_codes.GENERAL_ERROR)
+    with patch("squadops.cli.commands.agent._get_client", return_value=client):
+        result = runner.invoke(app, ["agent", "activity", "max"], catch_exceptions=False)
+
+    assert result.exit_code == exit_codes.GENERAL_ERROR

--- a/tests/unit/cycles/test_executor_activity_instrumentation.py
+++ b/tests/unit/cycles/test_executor_activity_instrumentation.py
@@ -1,0 +1,215 @@
+"""Unit tests for SIP-0089 §4.4 — executor-side RuntimeActivity instrumentation.
+
+The DispatchedFlowExecutor opens a RuntimeActivity per dispatched task (start on
+dispatch, complete/fail on reply) so an agent's current task is observable. Bug
+classes guarded:
+- a dispatched task not opening an activity (no observability) or opening one with
+  the wrong identity (mode/source_kind/refs);
+- a SUCCEEDED task not completing its activity, or a FAILED/raised task not
+  failing it (stale "running" activity);
+- the instrumentation breaking dispatch when the activity port errors (must be
+  best-effort);
+- activity calls firing when the port is unwired (opt-in).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+from squadops.ports.runtime.activity import RuntimeActivityPort
+from squadops.runtime.models import RuntimeActivity
+from squadops.tasks.models import TaskEnvelope, TaskResult
+
+
+def _envelope(task_id="t1", agent_id="max", cycle_id="cyc-1", task_type="strategy.analyze_prd"):
+    return TaskEnvelope(
+        task_id=task_id,
+        agent_id=agent_id,
+        cycle_id=cycle_id,
+        pulse_id="p1",
+        project_id="proj",
+        task_type=task_type,
+        correlation_id="c",
+        causation_id="ca",
+        trace_id="tr",
+        span_id="sp",
+        task_name="Analyze the PRD",
+    )
+
+
+def _activity(activity_id="act-1") -> RuntimeActivity:
+    return RuntimeActivity(
+        runtime_activity_id=activity_id,
+        agent_id="max",
+        mode="cycle",
+        activity_type="strategy.analyze_prd",
+        goal="Analyze the PRD",
+        priority=0,
+        state="running",
+        source_kind="cycle_task",
+        source_ref="t1",
+        cycle_id="cyc-1",
+        workload_id=None,
+        task_id="t1",
+        can_pause=False,
+        can_resume=False,
+        can_abort=True,
+    )
+
+
+class _FakeActivityPort(RuntimeActivityPort):
+    def __init__(self, *, start_raises: bool = False) -> None:
+        self.start_raises = start_raises
+        self.started: list[dict] = []
+        self.completed: list[str] = []
+        self.failed: list[tuple[str, str]] = []
+
+    async def start_activity(self, agent_id, **kwargs):
+        if self.start_raises:
+            raise RuntimeError("db down")
+        self.started.append({"agent_id": agent_id, **kwargs})
+        return _activity()
+
+    async def update_state(self, activity_id, state):
+        raise NotImplementedError
+
+    async def complete_activity(self, activity_id, *, evidence_ref=None):
+        self.completed.append(activity_id)
+        return None
+
+    async def fail_activity(self, activity_id, reason_code):
+        self.failed.append((activity_id, reason_code))
+        return None
+
+    async def abort_activity(self, activity_id, reason_code):
+        raise NotImplementedError
+
+    async def get_current_activity(self, agent_id):
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# _start_task_activity
+# ---------------------------------------------------------------------------
+
+
+async def test_start_task_activity_opens_cycle_activity_with_task_identity():
+    """Bug class: a dispatched task must open a `cycle` / `cycle_task` activity
+    carrying the task's identity (source_ref, cycle_id, task_id) so it's queryable
+    and attributable. Returns the minted activity id."""
+    act = _FakeActivityPort()
+    ex = DispatchedFlowExecutor(activity_port=act)
+
+    activity_id = await ex._start_task_activity(_envelope())
+
+    assert activity_id == "act-1"
+    started = act.started[0]
+    assert started["agent_id"] == "max"
+    assert started["mode"] == "cycle"
+    assert started["source_kind"] == "cycle_task"
+    assert started["source_ref"] == "t1"
+    assert started["cycle_id"] == "cyc-1"
+    assert started["task_id"] == "t1"
+    assert started["activity_type"] == "strategy.analyze_prd"
+
+
+async def test_start_task_activity_disabled_when_no_port():
+    """Bug class: instrumentation is opt-in. With no activity port, dispatch must
+    not attempt any activity work — returns None, no calls."""
+    ex = DispatchedFlowExecutor()  # no activity_port
+
+    assert await ex._start_task_activity(_envelope()) is None
+
+
+async def test_start_task_activity_swallows_errors():
+    """Bug class (best-effort): a failure opening the activity must NOT propagate
+    (it would break dispatch). Returns None so finish becomes a no-op."""
+    act = _FakeActivityPort(start_raises=True)
+    ex = DispatchedFlowExecutor(activity_port=act)
+
+    assert await ex._start_task_activity(_envelope()) is None
+
+
+# ---------------------------------------------------------------------------
+# _finish_task_activity
+# ---------------------------------------------------------------------------
+
+
+async def test_finish_completes_on_succeeded_result():
+    """Bug class: a SUCCEEDED task must complete its activity (not fail it)."""
+    act = _FakeActivityPort()
+    ex = DispatchedFlowExecutor(activity_port=act)
+
+    await ex._finish_task_activity("act-1", TaskResult(task_id="t1", status="SUCCEEDED"))
+
+    assert act.completed == ["act-1"] and act.failed == []
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        TaskResult(task_id="t1", status="FAILED", error="boom"),
+        TaskResult(task_id="t1", status="CANCELED"),
+        None,  # reply wait raised
+    ],
+)
+async def test_finish_fails_on_non_success(result):
+    """Bug class: a FAILED/CANCELED/raised task must fail its activity, never leave
+    it running or mark it complete."""
+    act = _FakeActivityPort()
+    ex = DispatchedFlowExecutor(activity_port=act)
+
+    await ex._finish_task_activity("act-1", result)
+
+    assert act.completed == []
+    assert len(act.failed) == 1 and act.failed[0][0] == "act-1"
+
+
+async def test_finish_noop_without_activity_id():
+    """Bug class: if start was disabled/failed (activity_id None) finish must be a
+    no-op — never call complete/fail with a missing id."""
+    act = _FakeActivityPort()
+    ex = DispatchedFlowExecutor(activity_port=act)
+
+    await ex._finish_task_activity(None, TaskResult(task_id="t1", status="SUCCEEDED"))
+
+    assert act.completed == [] and act.failed == []
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_task wrapping (integration)
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_task_starts_then_completes_activity_on_success():
+    """Bug class (the end-to-end wrap): dispatching a task must open an activity
+    before the reply wait and complete it after a SUCCEEDED reply."""
+    act = _FakeActivityPort()
+    ex = DispatchedFlowExecutor(activity_port=act)
+    ex._create_task_run_if_enabled = AsyncMock(return_value=None)
+    ex._publish_and_await = AsyncMock(return_value=TaskResult(task_id="t1", status="SUCCEEDED"))
+
+    result = await ex._dispatch_task(_envelope(), "run-1", heartbeat_interval=999)
+
+    assert result.status == "SUCCEEDED"
+    assert len(act.started) == 1
+    assert act.completed == ["act-1"] and act.failed == []
+
+
+async def test_dispatch_task_fails_activity_on_failed_reply():
+    """Bug class: a FAILED reply must fail the task's activity (not complete it),
+    so a failed task never shows as completed work."""
+    act = _FakeActivityPort()
+    ex = DispatchedFlowExecutor(activity_port=act)
+    ex._create_task_run_if_enabled = AsyncMock(return_value=None)
+    ex._publish_and_await = AsyncMock(
+        return_value=TaskResult(task_id="t1", status="FAILED", error="timeout")
+    )
+
+    result = await ex._dispatch_task(_envelope(), "run-1", heartbeat_interval=999)
+
+    assert result.status == "FAILED"
+    assert act.completed == [] and len(act.failed) == 1

--- a/tests/unit/runtime/test_ambient_policy.py
+++ b/tests/unit/runtime/test_ambient_policy.py
@@ -1,0 +1,94 @@
+"""Unit tests for SIP-0089 §4.6 — AmbientPolicy irreversibility gate.
+
+Bug classes guarded:
+- a reversible action being gated (it must always pass, without even touching the
+  ports);
+- a duty/cycle agent being blocked from irreversible work (only ambient is gated);
+- the gate permitting an ambient irreversible action when only ONE of the
+  required {lease, activity} is held — the canonical invariant (§10.4) requires
+  BOTH, so either missing must refuse (this distinguishes the spec-faithful rule
+  from §4.6's looser "neither" phrasing);
+- failing OPEN for an agent with no runtime-state row (must fail closed).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from squadops.runtime import reasons
+from squadops.runtime.models import AgentRuntimeState
+from squadops.runtime.policy import AmbientActionForbidden, AmbientPolicy
+
+pytestmark = [pytest.mark.domain_runtime]
+
+NOW = datetime(2026, 6, 28, 1, 0, tzinfo=UTC)
+
+
+def _state(mode: str) -> AgentRuntimeState:
+    return AgentRuntimeState("max", mode, "online", "", None, "high", NOW, None)
+
+
+def _policy(*, mode: str | None, has_lease: bool, has_activity: bool) -> AmbientPolicy:
+    state = AsyncMock()
+    state.get_state.return_value = _state(mode) if mode is not None else None
+    focus_lease = AsyncMock()
+    focus_lease.get_current_lease.return_value = object() if has_lease else None
+    activity = AsyncMock()
+    activity.get_current_activity.return_value = object() if has_activity else None
+    return AmbientPolicy(state, focus_lease, activity)
+
+
+async def test_reversible_action_is_always_permitted_without_touching_ports():
+    """Bug class: a reversible action must never be gated — and the gate should
+    short-circuit before any port lookup."""
+    policy = _policy(mode="ambient", has_lease=False, has_activity=False)
+
+    await policy.assert_action_permitted("max", "observe", irreversible=False)
+
+    policy._state.get_state.assert_not_awaited()  # short-circuited
+
+
+@pytest.mark.parametrize("mode", ["duty", "cycle"])
+async def test_non_ambient_agent_permitted_for_irreversible_action(mode):
+    """Bug class: only ambient is gated. A duty/cycle agent is already doing
+    claimed work and must be permitted even with no lease/activity visible here."""
+    policy = _policy(mode=mode, has_lease=False, has_activity=False)
+
+    await policy.assert_action_permitted("max", "deploy", irreversible=True)  # no raise
+
+
+async def test_ambient_with_both_lease_and_activity_is_permitted():
+    """Bug class: the legitimate path — ambient holding BOTH a lease and an
+    activity may act irreversibly (§10.4)."""
+    policy = _policy(mode="ambient", has_lease=True, has_activity=True)
+
+    await policy.assert_action_permitted("max", "deploy", irreversible=True)  # no raise
+
+
+@pytest.mark.parametrize(
+    ("has_lease", "has_activity"),
+    [(True, False), (False, True), (False, False)],
+)
+async def test_ambient_missing_either_requirement_is_forbidden(has_lease, has_activity):
+    """Bug class (the load-bearing one): §10.4 requires BOTH a lease and an
+    activity. Holding only one (or neither) must refuse — a gate that allowed the
+    single-held case would violate the invariant."""
+    policy = _policy(mode="ambient", has_lease=has_lease, has_activity=has_activity)
+
+    with pytest.raises(AmbientActionForbidden) as exc:
+        await policy.assert_action_permitted("max", "deploy", irreversible=True)
+
+    assert exc.value.reason_code == reasons.AMBIENT_IRREVERSIBLE_ACTION_FORBIDDEN
+    assert exc.value.agent_id == "max" and exc.value.action_kind == "deploy"
+
+
+async def test_missing_state_row_fails_closed():
+    """Bug class: an agent that never heartbeated (no state row) must be treated
+    as ambient and refused, not permitted by default — fail closed, not open."""
+    policy = _policy(mode=None, has_lease=False, has_activity=False)
+
+    with pytest.raises(AmbientActionForbidden):
+        await policy.assert_action_permitted("ghost", "deploy", irreversible=True)

--- a/tests/unit/runtime/test_coordinator_with_activity.py
+++ b/tests/unit/runtime/test_coordinator_with_activity.py
@@ -1,0 +1,204 @@
+"""Unit tests for SIP-0089 §4.5 (thin v1.1 seam) — coordinator RuntimeActivity action.
+
+A mode change orphans any activity bound to the *previous* mode; the coordinator
+aborts it best-effort, post-write. Bug classes guarded:
+- an activity left running after its mode ended (stale "current work");
+- aborting an activity that belongs to the mode being ENTERED (false abort);
+- the activity action breaking an otherwise-applied transition (it must be
+  best-effort — observability never fails a mode change);
+- emitting/aborting when there is no current activity.
+
+The full §4.5 transition order + D25 single transaction are deferred to #244; these
+tests pin the v1.1 seam behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+
+import pytest
+
+from squadops.ports.runtime.activity import RuntimeActivityPort
+from squadops.ports.runtime.event_publisher import RuntimeEventPublisher
+from squadops.ports.runtime.state import RuntimeStatePort
+from squadops.runtime import events, reasons
+from squadops.runtime.coordinator import RuntimeCoordinator
+from squadops.runtime.models import AgentRuntimeState, RuntimeActivity
+
+pytestmark = [pytest.mark.domain_runtime]
+
+NOW = datetime(2026, 6, 28, 1, 0, tzinfo=UTC)
+
+
+def _state(mode="cycle") -> AgentRuntimeState:
+    return AgentRuntimeState("max", mode, "online", "", None, "high", NOW, None)
+
+
+def _activity(mode="cycle", activity_id="act-1") -> RuntimeActivity:
+    return RuntimeActivity(
+        runtime_activity_id=activity_id,
+        agent_id="max",
+        mode=mode,
+        activity_type="design",
+        goal="g",
+        priority=5,
+        state="running",
+        source_kind="cycle_task",
+        source_ref="task-1",
+        cycle_id="cyc-1",
+        workload_id=None,
+        task_id="task-1",
+        can_pause=False,
+        can_resume=False,
+        can_abort=True,
+    )
+
+
+class _FakeStatePort(RuntimeStatePort):
+    def __init__(self, initial: AgentRuntimeState) -> None:
+        self._rows = {initial.agent_id: initial}
+        self.upserts: list[AgentRuntimeState] = []
+
+    async def get_state(self, agent_id):
+        return self._rows.get(agent_id)
+
+    async def upsert_state(self, state):
+        self._rows[state.agent_id] = state
+        self.upserts.append(state)
+        return state
+
+    async def ensure_state(self, agent_id):
+        return self._rows[agent_id]
+
+    async def update_heartbeat(self, agent_id, *, runtime_status=None):
+        return self._rows[agent_id]
+
+    async def mark_offline(self, agent_id):
+        return self._rows.get(agent_id)
+
+
+class _FakeActivityPort(RuntimeActivityPort):
+    def __init__(
+        self, current: RuntimeActivity | None = None, *, abort_raises: bool = False
+    ) -> None:
+        self._current = current
+        self.abort_raises = abort_raises
+        self.aborted: list[tuple[str, str]] = []
+
+    async def start_activity(self, agent_id, **kwargs):  # unused here
+        raise NotImplementedError
+
+    async def update_state(self, activity_id, state):  # unused here
+        raise NotImplementedError
+
+    async def complete_activity(self, activity_id, *, evidence_ref=None):  # unused here
+        raise NotImplementedError
+
+    async def fail_activity(self, activity_id, reason_code):  # unused here
+        raise NotImplementedError
+
+    async def abort_activity(self, activity_id, reason_code):
+        if self.abort_raises:
+            raise RuntimeError("boom")
+        self.aborted.append((activity_id, reason_code))
+        cur = self._current
+        self._current = None
+        return replace(cur, state="aborted") if cur is not None else None
+
+    async def get_current_activity(self, agent_id):
+        return self._current
+
+
+class _RecordingPublisher(RuntimeEventPublisher):
+    def __init__(self) -> None:
+        self.emitted: list[tuple] = []
+
+    def emit(self, event_name, *, agent_id, reason_code, payload=None):
+        self.emitted.append((event_name, agent_id, reason_code, payload))
+
+    def names(self) -> list[str]:
+        return [e[0] for e in self.emitted]
+
+
+async def test_orphaned_activity_is_aborted_and_event_emitted():
+    """Bug class: leaving a mode must abort the activity bound to it, else it
+    lingers as stale current work. cycle→ambient aborts the cycle activity and
+    emits runtime_activity.aborted with the preemption reason."""
+    state = _FakeStatePort(_state(mode="cycle"))
+    pub = _RecordingPublisher()
+    act = _FakeActivityPort(_activity(mode="cycle", activity_id="act-9"))
+    coord = RuntimeCoordinator(state, events_publisher=pub, activity=act)
+
+    outcome = await coord.request_transition(
+        "max", "ambient", reasons.CYCLE_COMPLETED, requester_kind="coordinator", owner_ref="cyc-1"
+    )
+
+    assert outcome.applied is True and state.upserts[-1].mode == "ambient"
+    assert act.aborted == [("act-9", reasons.ACTIVITY_PREEMPTED_BY_MODE_CHANGE)]
+    assert events.RUNTIME_ACTIVITY_ABORTED in pub.names()
+
+
+async def test_activity_in_target_mode_is_not_aborted():
+    """Bug class: an activity belonging to the mode being ENTERED must NOT be
+    aborted (a duty handler may have already opened its activity). ambient→duty
+    with a duty activity present leaves it running."""
+    state = _FakeStatePort(_state(mode="ambient"))
+    pub = _RecordingPublisher()
+    act = _FakeActivityPort(_activity(mode="duty"))
+    coord = RuntimeCoordinator(state, events_publisher=pub, activity=act)
+
+    await coord.request_transition(
+        "max", "duty", reasons.DUTY_WINDOW_OPENED, requester_kind="scheduler", owner_ref="assign-1"
+    )
+
+    assert act.aborted == []
+    assert events.RUNTIME_ACTIVITY_ABORTED not in pub.names()
+
+
+async def test_no_current_activity_is_a_noop():
+    """Bug class: with no current activity the seam must do nothing — no abort, no
+    runtime_activity event."""
+    state = _FakeStatePort(_state(mode="cycle"))
+    pub = _RecordingPublisher()
+    act = _FakeActivityPort(None)
+    coord = RuntimeCoordinator(state, events_publisher=pub, activity=act)
+
+    await coord.request_transition(
+        "max", "ambient", reasons.CYCLE_COMPLETED, requester_kind="coordinator", owner_ref="cyc-1"
+    )
+
+    assert act.aborted == []
+    assert events.RUNTIME_ACTIVITY_ABORTED not in pub.names()
+
+
+async def test_activity_abort_failure_does_not_break_transition():
+    """Bug class (best-effort): the activity action is observability — a failure
+    aborting the activity must NOT fail an already-applied mode transition. The
+    mode is written, the transition reports applied, no abort event is emitted."""
+    state = _FakeStatePort(_state(mode="cycle"))
+    pub = _RecordingPublisher()
+    act = _FakeActivityPort(_activity(mode="cycle"), abort_raises=True)
+    coord = RuntimeCoordinator(state, events_publisher=pub, activity=act)
+
+    outcome = await coord.request_transition(
+        "max", "ambient", reasons.CYCLE_COMPLETED, requester_kind="coordinator", owner_ref="cyc-1"
+    )
+
+    assert outcome.applied is True and state.upserts[-1].mode == "ambient"
+    assert events.RUNTIME_ACTIVITY_ABORTED not in pub.names()  # abort failed → no event
+
+
+async def test_no_activity_port_keeps_prior_behavior():
+    """Bug class: activity=None must keep the pre-Phase-4 path — a plain mode write
+    with no activity interaction and no runtime_activity events."""
+    state = _FakeStatePort(_state(mode="cycle"))
+    pub = _RecordingPublisher()
+    coord = RuntimeCoordinator(state, events_publisher=pub)  # no activity
+
+    outcome = await coord.request_transition(
+        "max", "ambient", reasons.CYCLE_COMPLETED, requester_kind="coordinator", owner_ref="cyc-1"
+    )
+
+    assert outcome.applied is True
+    assert pub.names() == [events.MODE_TRANSITION]

--- a/tests/unit/runtime/test_runtime_activity.py
+++ b/tests/unit/runtime/test_runtime_activity.py
@@ -201,6 +201,22 @@ async def test_update_state_returns_none_when_activity_absent():
     assert await adapter.update_state("ghost", "completed") is None
 
 
+async def test_update_state_guards_on_active_states_so_terminal_is_final():
+    """Bug class (race-safety): terminal states are final. The WHERE must restrict
+    to active states so a terminal activity never re-transitions — the
+    coordinator's abort and the handler's complete can't double-terminalize (the
+    loser matches no row → None)."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = None  # terminal row matched nothing
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    result = await adapter.update_state("already-terminal", "completed")
+
+    assert result is None
+    where = conn.fetchrow.await_args.args[0].split("WHERE", 1)[1]
+    assert "state IN ('pending', 'running', 'paused')" in where
+
+
 # ---------------------------------------------------------------------------
 # terminal helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/test_runtime_activity.py
+++ b/tests/unit/runtime/test_runtime_activity.py
@@ -1,0 +1,282 @@
+"""Unit tests for SIP-0089 Phase 4 — RuntimeActivity model + adapter.
+
+Bug classes guarded:
+- `is_active_/is_terminal_activity_state` mis-bucketing a state (e.g. `paused`
+  treated as terminal) — would corrupt the single-active-activity invariant (D9)
+  and the get_current_activity filter;
+- `start_activity` not opening in `running` / not stamping `started_at` — the
+  activity would be invisible as the agent's current work;
+- `update_state` stamping the wrong lifecycle timestamp (pause→ended_at, etc.);
+- a terminal helper mapping to the wrong state (complete→failed);
+- `get_current_activity` returning a terminal activity as "current";
+- JSONB payloads silently dropped on the row→dataclass round-trip.
+
+asyncpg fakes mirror `test_focus_lease.py`.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from adapters.persistence.runtime.activity_postgres import PostgresRuntimeActivity
+from squadops.runtime.models import (
+    RuntimeActivity,
+    is_active_activity_state,
+    is_terminal_activity_state,
+)
+
+pytestmark = [pytest.mark.domain_runtime]
+
+NOW = datetime(2026, 6, 28, 12, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# state classifiers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("state", "active", "terminal"),
+    [
+        ("pending", True, False),
+        ("running", True, False),
+        ("paused", True, False),
+        ("completed", False, True),
+        ("aborted", False, True),
+        ("failed", False, True),
+    ],
+)
+def test_activity_state_classifiers(state, active, terminal):
+    """Bug class: a mis-bucketed state breaks the D9 single-active invariant and
+    the active/terminal split. active and terminal must partition the 6 states."""
+    assert is_active_activity_state(state) is active
+    assert is_terminal_activity_state(state) is terminal
+    assert active != terminal  # exactly one bucket
+
+
+# ---------------------------------------------------------------------------
+# asyncpg fakes
+# ---------------------------------------------------------------------------
+
+
+class _AcquireCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _make_pool(conn):
+    pool = MagicMock()
+    pool.acquire.return_value = _AcquireCtx(conn)
+    return pool
+
+
+def _activity_row(**overrides) -> dict:
+    base = {
+        "runtime_activity_id": "act-1",
+        "agent_id": "max",
+        "mode": "cycle",
+        "activity_type": "design",
+        "goal": "build the thing",
+        "priority": 5,
+        "state": "running",
+        "source_kind": "cycle_task",
+        "cycle_id": "cyc-1",
+        "workload_id": None,
+        "task_id": "task-7",
+        "source_ref": "task-7",
+        "can_pause": True,
+        "can_resume": True,
+        "can_abort": True,
+        "completion_conditions": "[]",
+        "evidence_requirements": "[]",
+        "started_at": NOW,
+        "paused_at": None,
+        "ended_at": None,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# start_activity
+# ---------------------------------------------------------------------------
+
+
+async def test_start_activity_opens_running_with_started_at_and_minted_id():
+    """Bug class: a new activity must open in `running` with a stamped
+    `started_at` and a minted id, or it won't register as the agent's current
+    work. JSONB payloads are serialized via json.dumps."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _activity_row()
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    activity = await adapter.start_activity(
+        "max",
+        mode="cycle",
+        activity_type="design",
+        goal="build the thing",
+        source_kind="cycle_task",
+        source_ref="task-7",
+        task_id="task-7",
+        cycle_id="cyc-1",
+        completion_conditions=({"kind": "tests_pass"},),
+    )
+
+    assert isinstance(activity, RuntimeActivity)
+    args = conn.fetchrow.await_args.args
+    query = args[0]
+    assert "INSERT INTO runtime_activities" in query
+    assert "'running'" in query  # state literal, not a bind param
+    assert len(args[1]) == 32  # uuid4().hex minted id
+    # completion_conditions serialized as JSON text (param order: ...,$15,$16,$17)
+    assert json.loads(args[15]) == [{"kind": "tests_pass"}]
+    assert isinstance(args[-1], datetime)  # started_at stamped
+
+
+# ---------------------------------------------------------------------------
+# update_state — timestamp management
+# ---------------------------------------------------------------------------
+
+
+async def test_update_state_pause_stamps_paused_at_only():
+    """Bug class: pausing must stamp paused_at, NOT ended_at (a paused activity
+    isn't terminal). started_at must be left alone."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _activity_row(state="paused", paused_at=NOW)
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    await adapter.update_state("act-1", "paused")
+
+    set_clause = conn.fetchrow.await_args.args[0].split("SET", 1)[1].split("WHERE", 1)[0]
+    assert "paused_at = now()" in set_clause
+    assert "ended_at" not in set_clause
+    assert "started_at" not in set_clause
+
+
+async def test_update_state_terminal_stamps_ended_at():
+    """Bug class: a terminal transition must stamp ended_at so duration/terminality
+    is recorded, and must not stamp paused_at."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _activity_row(state="completed", ended_at=NOW)
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    await adapter.update_state("act-1", "completed")
+
+    set_clause = conn.fetchrow.await_args.args[0].split("SET", 1)[1].split("WHERE", 1)[0]
+    assert "ended_at = now()" in set_clause
+    assert "paused_at" not in set_clause
+
+
+async def test_update_state_running_preserves_original_started_at():
+    """Bug class: resuming to running must NOT reset started_at (it's the original
+    start) — COALESCE keeps the stored value while initializing if somehow null."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _activity_row(state="running")
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    await adapter.update_state("act-1", "running")
+
+    set_clause = conn.fetchrow.await_args.args[0].split("SET", 1)[1].split("WHERE", 1)[0]
+    assert "started_at = COALESCE(started_at, now())" in set_clause
+    assert "ended_at" not in set_clause
+
+
+async def test_update_state_returns_none_when_activity_absent():
+    """Bug class: updating an unknown activity must report None, not raise — the
+    instrumentation path is best-effort."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = None
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    assert await adapter.update_state("ghost", "completed") is None
+
+
+# ---------------------------------------------------------------------------
+# terminal helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs", "expected_state"),
+    [
+        ("complete_activity", {"evidence_ref": "art-9"}, "completed"),
+        ("fail_activity", {"reason_code": "boom"}, "failed"),
+        ("abort_activity", {"reason_code": "preempted"}, "aborted"),
+    ],
+)
+async def test_terminal_helpers_map_to_correct_state(method, kwargs, expected_state):
+    """Bug class: a terminal helper wired to the wrong state (complete→failed)
+    would mislabel outcomes. Each helper must drive its own terminal state."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _activity_row(state=expected_state, ended_at=NOW)
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    result = await getattr(adapter, method)("act-1", **kwargs)
+
+    assert result is not None and result.state == expected_state
+    # state bind param (the 2nd positional after the query) carries the terminal state
+    assert conn.fetchrow.await_args.args[2] == expected_state
+
+
+# ---------------------------------------------------------------------------
+# get_current_activity + row mapping
+# ---------------------------------------------------------------------------
+
+
+async def test_get_current_activity_filters_to_active_states():
+    """Bug class: 'current' must mean an ACTIVE activity. The query must restrict
+    to pending/running/paused so a finished activity is never returned as current."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = None
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    assert await adapter.get_current_activity("idle") is None
+    query = conn.fetchrow.await_args.args[0]
+    assert "state IN ('pending', 'running', 'paused')" in query
+
+
+async def test_row_to_activity_decodes_jsonb_and_maps_all_fields():
+    """Bug class: a row→dataclass mapper that drops a field or fails to decode the
+    JSONB payloads would degrade observability silently."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _activity_row(
+        completion_conditions='[{"kind": "tests_pass"}]',
+        evidence_requirements='[{"artifact": "report"}]',
+        workload_id="wl-3",
+    )
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    activity = await adapter.get_current_activity("max")
+
+    assert activity == RuntimeActivity(
+        runtime_activity_id="act-1",
+        agent_id="max",
+        mode="cycle",
+        activity_type="design",
+        goal="build the thing",
+        priority=5,
+        state="running",
+        source_kind="cycle_task",
+        source_ref="task-7",
+        cycle_id="cyc-1",
+        workload_id="wl-3",
+        task_id="task-7",
+        can_pause=True,
+        can_resume=True,
+        can_abort=True,
+        completion_conditions=({"kind": "tests_pass"},),
+        evidence_requirements=({"artifact": "report"},),
+        started_at=NOW,
+        paused_at=None,
+        ended_at=None,
+    )


### PR DESCRIPTION
## Summary

Implements SIP-0089 **Phase 4 — RuntimeActivity**: make an agent's current work observable as a first-class record instead of hidden in prompt history. Built in plan order (§4.1–§4.7) on the new Python 3.12 dev venv (#236/#217), off already-formatted main (#196).

## What landed

- **§4.1 model** — `RuntimeActivity` frozen dataclass (§10.6) + `ActivityState`/`ActivitySourceKind` + `is_active_/is_terminal_activity_state`. Explicit, queryable `cycle_id`/`workload_id`/`task_id`; `source_ref` opaque (core never parses it).
- **§4.2 migration** `1130_runtime_activities.sql` — single-active-activity invariant (D9) via a partial unique index (`agent_id WHERE state IN pending/running/paused`) + indexed source-identity columns. **Live-validated** in a rolled-back txn.
- **§4.3 port + adapter** — `RuntimeActivityPort` + `PostgresRuntimeActivity` (start/update_state/complete/fail/abort/get_current). `update_state` manages lifecycle timestamps and **guards on active states** so terminal is final — race-safe against double-terminalization.
- **§4.5 coordinator seam (thin)** — a mode change best-effort aborts an activity orphaned by the change (post-write, swallows errors — observability never fails a transition). Wired into the scheduler's coordinator. **D25 single-Postgres-transaction (lease+activity+mode) deferred → #244** (gated on recruitment #233): in v1.1 this path is unexercised, so building the unit-of-work transaction now is premature.
- **§4.4 instrumentation — EXECUTOR-SIDE (a reasoned, approved deviation).** The handler runs in the agent processes, which use SQLAlchemy DbRuntime (not asyncpg) and have generated composition roots — so the plan's handler-side seam would need a second DB pool in agents + build-template changes + live-agent-path risk. Instead the `DispatchedFlowExecutor` (runtime-api process, already owns the asyncpg pool, brackets dispatch→reply) opens a `cycle`/`cycle_task` activity on dispatch and completes/fails it on reply. Opt-in `activity_port`, wholly best-effort, no new cycle EventType (the record is the observability; locked taxonomy untouched).
- **§4.6 policy seam** — `AmbientPolicy.assert_action_permitted`: the v1.2 embodiment hook (ambient + irreversible requires both a lease and an activity; fails closed). No v1.1 callers.
- **§4.7 CLI + API** — `GET /health/agents/{id}/activity` (read-only probe lane) + `squadops agent activity <id>`. Idle = 404 → CLI reports "idle" at exit 0; real errors keep non-zero exit.

## Live validation (dev stack)

Ran real `smoke` cycles end-to-end. Each dispatched task wrote a `cycle`/`cycle_task` RuntimeActivity, `running` on dispatch → `completed` on reply, one active per agent (D9), correct `task_id`/`activity_type`/`cycle_id`. A completed cycle left **zero stranded `running`** activities. `squadops agent activity <id>` rendered both the **running** activity (mid-cycle) and **idle** (after).

## Tests

- New: model+adapter, coordinator activity seam, ambient policy, executor instrumentation (helper + real `_dispatch_task` wrap), activity CLI, activity route, health_checker mapping.
- **Full canonical regression suite: 4429 passed, 1 skipped** locally on 3.12 (the CI gate, now reproducible post-#217). Format gate clean.

## Not bumping the version

Per the 2026-06-28 decision, the 1.1.0 bump is gated on **1.0.x hardening-lane completeness**, not on Phase 4 — this PR keeps the version at 1.0.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)