### PR TITLE
fix(cycles): propagate cycle/run cancel to Prefect (#77)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -26,6 +26,7 @@ from uuid import uuid4
 from adapters.cycles.task_naming import build_task_name
 from squadops.cycles.checkpoint import RunCheckpoint
 from squadops.cycles.models import ArtifactRef, Cycle, GateDecisionValue, Run, RunStatus
+from squadops.cycles.naming import flow_run_name
 from squadops.cycles.plan_delta import PlanDelta
 from squadops.cycles.pulse_models import (
     CADENCE_BOUNDARY_ID,
@@ -1772,7 +1773,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 flow_id = await self._workflow_tracker.ensure_flow()
                 flow_run_id = await self._workflow_tracker.create_flow_run(
                     flow_id,
-                    run_name=f"{cycle.project_id}/{cycle_id[:12]}/{run_id[:12]}",
+                    run_name=flow_run_name(cycle.project_id, cycle_id, run_id),
                     parameters={
                         "cycle_id": cycle_id,
                         "run_id": run_id,

--- a/adapters/cycles/factory.py
+++ b/adapters/cycles/factory.py
@@ -95,9 +95,9 @@ def create_flow_executor(
 
         workflow_tracker = kwargs.get("workflow_tracker")
         if not workflow_tracker and kwargs.get("prefect_api_url"):
-            from adapters.cycles.prefect_reporter import PrefectReporter
+            from adapters.cycles.prefect_workflow_tracker import PrefectWorkflowTracker
 
-            workflow_tracker = PrefectReporter(api_url=kwargs["prefect_api_url"])
+            workflow_tracker = PrefectWorkflowTracker(api_url=kwargs["prefect_api_url"])
 
         return DispatchedFlowExecutor(
             cycle_registry=cycle_registry,

--- a/adapters/cycles/noop_workflow_tracker.py
+++ b/adapters/cycles/noop_workflow_tracker.py
@@ -40,6 +40,9 @@ class NoOpWorkflowTracker(WorkflowTrackerPort):
     ) -> str:
         return self._placeholder()
 
+    async def find_active_flow_run_ids(self, run_names: list[str]) -> list[str]:
+        return []
+
     async def set_flow_run_state(
         self,
         flow_run_id: str,

--- a/adapters/cycles/prefect_reporter.py
+++ b/adapters/cycles/prefect_reporter.py
@@ -115,6 +115,39 @@ class PrefectReporter(WorkflowTrackerPort):
             logger.warning("Prefect create_task_run failed", exc_info=True)
             return f"unknown-{uuid4().hex[:8]}"
 
+    async def find_active_flow_run_ids(self, run_names: list[str]) -> list[str]:
+        """Find non-terminal flow runs by exact name so they can be cancelled (#77).
+
+        Best-effort: returns [] on transport failure or when nothing matches.
+        """
+        if not run_names:
+            return []
+        try:
+            resp = await self._client.post(
+                f"{self._api_url}/flow_runs/filter",
+                json={
+                    "flow_runs": {
+                        "name": {"any_": run_names},
+                        "state": {
+                            "type": {
+                                "any_": [
+                                    "SCHEDULED",
+                                    "PENDING",
+                                    "RUNNING",
+                                    "PAUSED",
+                                    "CANCELLING",
+                                ]
+                            }
+                        },
+                    }
+                },
+            )
+            resp.raise_for_status()
+            return [fr["id"] for fr in resp.json()]
+        except Exception:
+            logger.warning("Prefect find_active_flow_run_ids failed", exc_info=True)
+            return []
+
     async def set_flow_run_state(self, flow_run_id: str, state_type: str, state_name: str) -> None:
         """Update flow run state (RUNNING, COMPLETED, FAILED, CANCELLED)."""
         try:

--- a/adapters/cycles/prefect_workflow_tracker.py
+++ b/adapters/cycles/prefect_workflow_tracker.py
@@ -22,7 +22,7 @@ from squadops.ports.cycles import WorkflowTrackerPort
 logger = logging.getLogger(__name__)
 
 
-class PrefectReporter(WorkflowTrackerPort):
+class PrefectWorkflowTracker(WorkflowTrackerPort):
     """Prefect-backed :class:`WorkflowTrackerPort`.
 
     Best-effort: all methods catch exceptions and log warnings. Execution

--- a/adapters/cycles/workflow_tracker_factory.py
+++ b/adapters/cycles/workflow_tracker_factory.py
@@ -3,7 +3,7 @@
 Selects a concrete adapter based on configuration. Mirrors the selection
 recipe established by SIP-0061 (LangFuse) and SIP-0087 (log forwarder):
 
-- Prefect-shaped config with ``api_url`` set → :class:`PrefectReporter`.
+- Prefect-shaped config with ``api_url`` set → :class:`PrefectWorkflowTracker`.
 - Anything else → :class:`NoOpWorkflowTracker`.
 
 The returned port is always non-None — callers never null-check.
@@ -25,9 +25,9 @@ def create_workflow_tracker(prefect_cfg: PrefectConfig | None) -> WorkflowTracke
     if prefect_cfg is None or not prefect_cfg.api_url:
         return NoOpWorkflowTracker()
     try:
-        from adapters.cycles.prefect_reporter import PrefectReporter
+        from adapters.cycles.prefect_workflow_tracker import PrefectWorkflowTracker
 
-        tracker = PrefectReporter(api_url=prefect_cfg.api_url)
+        tracker = PrefectWorkflowTracker(api_url=prefect_cfg.api_url)
         logger.info(
             "Workflow tracker initialized (backend=prefect, api_url=%s)",
             prefect_cfg.api_url,

--- a/src/squadops/api/routes/cycles/cancellation.py
+++ b/src/squadops/api/routes/cycles/cancellation.py
@@ -1,0 +1,47 @@
+"""#77: propagate a cycle/run cancellation to Prefect.
+
+Cancelling a cycle/run flips registry status, but without this the corresponding
+Prefect flow run keeps executing (orphaned GPU/LLM work). We reconstruct the
+flow-run name(s) for the cancelled run(s) — via the same ``flow_run_name`` the
+executor wrote — find the still-running flow run(s) in Prefect, and transition
+them to CANCELLED so workers stop.
+
+Best-effort: registry cancellation is the source of truth; this never raises, so
+the cancel route always reports the cycle/run as cancelled even if Prefect is
+unreachable (the failure is logged).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from squadops.api.runtime.deps import get_workflow_tracker
+from squadops.cycles.naming import flow_run_name
+
+logger = logging.getLogger(__name__)
+
+
+async def cancel_orphaned_flow_runs(project_id: str, cycle_id: str, run_ids: list[str]) -> int:
+    """Transition still-running Prefect flow runs for the given cycle runs to
+    CANCELLED. Returns the number cancelled (0 if none active / Prefect off)."""
+    if not run_ids:
+        return 0
+    try:
+        tracker = get_workflow_tracker()
+        names = [flow_run_name(project_id, cycle_id, rid) for rid in run_ids]
+        flow_run_ids = await tracker.find_active_flow_run_ids(names)
+        for flow_run_id in flow_run_ids:
+            await tracker.set_flow_run_state(flow_run_id, "CANCELLED", "Cancelled")
+        if flow_run_ids:
+            logger.info(
+                "#77: cancelled %d orphaned Prefect flow run(s) for cycle %s (runs=%s)",
+                len(flow_run_ids),
+                cycle_id,
+                run_ids,
+            )
+        return len(flow_run_ids)
+    except Exception:
+        logger.warning(
+            "#77: Prefect cancel propagation failed for cycle %s", cycle_id, exc_info=True
+        )
+        return 0

--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -193,6 +193,17 @@ async def cancel_cycle(project_id: str, cycle_id: str):
             payload={"project_id": project_id},
         )
 
-        return {"status": "cancelled", "cycle_id": cycle_id}
+        # #77: stop the orphaned Prefect flow run(s) for this cycle's runs so
+        # workers don't keep executing a logically-cancelled cycle.
+        from squadops.api.routes.cycles.cancellation import cancel_orphaned_flow_runs
+
+        run_ids = [run.run_id for run in await registry.list_runs(cycle_id)]
+        cancelled = await cancel_orphaned_flow_runs(project_id, cycle_id, run_ids)
+
+        return {
+            "status": "cancelled",
+            "cycle_id": cycle_id,
+            "prefect_flow_runs_cancelled": cancelled,
+        }
     except CycleError as e:
         raise handle_cycle_error(e) from e

--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -113,7 +113,17 @@ async def cancel_run(project_id: str, cycle_id: str, run_id: str):
     try:
         registry = get_cycle_registry()
         await registry.cancel_run(run_id)
-        return {"status": "cancelled", "run_id": run_id}
+
+        # #77: stop the orphaned Prefect flow run for this run.
+        from squadops.api.routes.cycles.cancellation import cancel_orphaned_flow_runs
+
+        cancelled = await cancel_orphaned_flow_runs(project_id, cycle_id, [run_id])
+
+        return {
+            "status": "cancelled",
+            "run_id": run_id,
+            "prefect_flow_runs_cancelled": cancelled,
+        }
     except CycleError as e:
         raise handle_cycle_error(e) from e
 

--- a/src/squadops/api/runtime/deps.py
+++ b/src/squadops/api/runtime/deps.py
@@ -15,6 +15,7 @@ from squadops.ports.cycles.cycle_registry import CycleRegistryPort
 from squadops.ports.cycles.flow_execution import FlowExecutionPort
 from squadops.ports.cycles.project_registry import ProjectRegistryPort
 from squadops.ports.cycles.squad_profile import SquadProfilePort
+from squadops.ports.cycles.workflow_tracker import WorkflowTrackerPort
 from squadops.ports.events.cycle_event_bus import CycleEventBusPort
 from squadops.ports.llm.provider import LLMPort
 from squadops.ports.runtime.assignments import AssignmentPort
@@ -38,6 +39,9 @@ _flow_executor: FlowExecutionPort | None = None
 # SIP-0077: Cycle event bus
 _cycle_event_bus: CycleEventBusPort | None = None
 _cycle_event_bus_warned: bool = False
+
+_workflow_tracker: WorkflowTrackerPort | None = None
+_workflow_tracker_warned: bool = False
 
 # SIP-0075: LLM port for model management endpoints
 _llm_port: LLMPort | None = None
@@ -191,6 +195,42 @@ def get_cycle_event_bus() -> CycleEventBusPort:
     from adapters.events.noop_cycle_event_bus import NoOpCycleEventBus
 
     return NoOpCycleEventBus()
+
+
+# =============================================================================
+# #77: Workflow tracker (Prefect) — used by cancel routes to stop orphaned runs
+# =============================================================================
+
+
+def set_workflow_tracker(tracker: WorkflowTrackerPort) -> None:
+    """Set the WorkflowTrackerPort instance (#77: cancel propagation)."""
+    global _workflow_tracker
+    _workflow_tracker = tracker
+
+
+def get_workflow_tracker() -> WorkflowTrackerPort:
+    """Return the WorkflowTrackerPort instance.
+
+    Best-effort like the event bus: returns NoOpWorkflowTracker instead of
+    raising when unconfigured, so cancel routes never fail because workflow
+    tracking is off. Warns once per process on fallback.
+    """
+    global _workflow_tracker_warned
+    if _workflow_tracker is not None:
+        return _workflow_tracker
+
+    if not _workflow_tracker_warned:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "WorkflowTrackerPort not configured — using NoOpWorkflowTracker. "
+            "Cancellations will not propagate to Prefect."
+        )
+        _workflow_tracker_warned = True
+
+    from adapters.cycles.noop_workflow_tracker import NoOpWorkflowTracker
+
+    return NoOpWorkflowTracker()
 
 
 # =============================================================================

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -294,6 +294,11 @@ async def _init_cycle_subsystem(config, pool) -> None:
         _reply_router = ReplyRouter(queue_adapter)
 
         _workflow_tracker = create_workflow_tracker(config.prefect)
+        # #77: expose the tracker to the cancel routes so cancelling a cycle/run
+        # propagates to Prefect (stops the orphaned flow run).
+        from squadops.api.runtime.deps import set_workflow_tracker
+
+        set_workflow_tracker(_workflow_tracker)
 
         from adapters.events.factory import create_cycle_event_bus
         from squadops.api.runtime.deps import set_cycle_event_bus

--- a/src/squadops/cycles/naming.py
+++ b/src/squadops/cycles/naming.py
@@ -1,0 +1,15 @@
+"""Canonical names for cycle-execution artifacts.
+
+Single source of truth for names that are *written* by one component and
+*reconstructed* by another. Today: the Prefect flow-run name — produced by the
+dispatched flow executor and reconstructed by the cancel routes to find the
+flow run to cancel (#77). Keeping the format here means producer and consumer
+can never silently drift apart.
+"""
+
+from __future__ import annotations
+
+
+def flow_run_name(project_id: str, cycle_id: str, run_id: str) -> str:
+    """Prefect flow-run name for a cycle run: ``<project>/<cyc[:12]>/<run[:12]>``."""
+    return f"{project_id}/{cycle_id[:12]}/{run_id[:12]}"

--- a/src/squadops/ports/cycles/workflow_tracker.py
+++ b/src/squadops/ports/cycles/workflow_tracker.py
@@ -53,6 +53,12 @@ class WorkflowTrackerPort(ABC):
         """Create a task run inside the given flow run. Returns ``task_run_id``."""
 
     @abstractmethod
+    async def find_active_flow_run_ids(self, run_names: list[str]) -> list[str]:
+        """Return the ids of flow runs with the given exact names that are still
+        in a non-terminal state (so they can be cancelled). Best-effort:
+        returns ``[]`` on transport failure or when nothing matches (#77)."""
+
+    @abstractmethod
     async def set_flow_run_state(
         self,
         flow_run_id: str,

--- a/tests/unit/cycles/test_api_cycles.py
+++ b/tests/unit/cycles/test_api_cycles.py
@@ -209,3 +209,64 @@ class TestCancelCycle:
         resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/cancel")
         assert resp.status_code == 200
         assert resp.json()["status"] == "cancelled"
+
+    def test_cancel_propagates_to_prefect(self, client, mock_cycle_registry, monkeypatch):
+        """#77: cancelling a cycle transitions its still-running Prefect flow
+        run(s) to CANCELLED so workers stop executing the orphaned cycle."""
+        import squadops.api.runtime.deps as deps_mod
+        from squadops.cycles.models import Run
+
+        mock_cycle_registry.cancel_cycle.return_value = None
+        mock_cycle_registry.list_runs.return_value = [
+            Run(
+                run_id="run_001",
+                cycle_id="cyc_001",
+                run_number=1,
+                status="running",
+                initiated_by="api",
+                resolved_config_hash="x",
+            ),
+        ]
+        fake_tracker = AsyncMock()
+        fake_tracker.find_active_flow_run_ids.return_value = ["flowrun-xyz"]
+        monkeypatch.setattr(deps_mod, "_workflow_tracker", fake_tracker)
+
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/cancel")
+
+        assert resp.status_code == 200
+        assert resp.json()["prefect_flow_runs_cancelled"] == 1
+        # Found by the reconstructed flow-run name (single-sourced with the executor)
+        # and transitioned to CANCELLED.
+        fake_tracker.find_active_flow_run_ids.assert_awaited_once_with(
+            ["hello_squad/cyc_001/run_001"]
+        )
+        fake_tracker.set_flow_run_state.assert_awaited_once_with(
+            "flowrun-xyz", "CANCELLED", "Cancelled"
+        )
+
+    def test_cancel_survives_prefect_failure(self, client, mock_cycle_registry, monkeypatch):
+        """Registry cancellation is the source of truth: if Prefect propagation
+        fails, the cycle is still reported cancelled (best-effort, #77)."""
+        import squadops.api.runtime.deps as deps_mod
+        from squadops.cycles.models import Run
+
+        mock_cycle_registry.cancel_cycle.return_value = None
+        mock_cycle_registry.list_runs.return_value = [
+            Run(
+                run_id="run_001",
+                cycle_id="cyc_001",
+                run_number=1,
+                status="running",
+                initiated_by="api",
+                resolved_config_hash="x",
+            ),
+        ]
+        fake_tracker = AsyncMock()
+        fake_tracker.find_active_flow_run_ids.side_effect = RuntimeError("prefect down")
+        monkeypatch.setattr(deps_mod, "_workflow_tracker", fake_tracker)
+
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/cancel")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "cancelled"
+        assert resp.json()["prefect_flow_runs_cancelled"] == 0

--- a/tests/unit/cycles/test_api_runs.py
+++ b/tests/unit/cycles/test_api_runs.py
@@ -112,6 +112,26 @@ class TestCancelRun:
         assert resp.status_code == 200
         assert resp.json()["status"] == "cancelled"
 
+    def test_cancel_propagates_to_prefect(self, client, monkeypatch):
+        """#77: cancelling a single run transitions its still-running Prefect
+        flow run to CANCELLED."""
+        import squadops.api.runtime.deps as deps_mod
+
+        fake_tracker = AsyncMock()
+        fake_tracker.find_active_flow_run_ids.return_value = ["flowrun-abc"]
+        monkeypatch.setattr(deps_mod, "_workflow_tracker", fake_tracker)
+
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs/run_001/cancel")
+
+        assert resp.status_code == 200
+        assert resp.json()["prefect_flow_runs_cancelled"] == 1
+        fake_tracker.find_active_flow_run_ids.assert_awaited_once_with(
+            ["hello_squad/cyc_001/run_001"]
+        )
+        fake_tracker.set_flow_run_state.assert_awaited_once_with(
+            "flowrun-abc", "CANCELLED", "Cancelled"
+        )
+
 
 class TestGateDecision:
     def test_approve_gate(self, client, mock_cycle_registry):

--- a/tests/unit/cycles/test_correction_repair_prefect_propagation.py
+++ b/tests/unit/cycles/test_correction_repair_prefect_propagation.py
@@ -65,8 +65,8 @@ def failed_envelope() -> TaskEnvelope:
 
 
 @pytest.fixture
-def mock_prefect_reporter() -> AsyncMock:
-    """``PrefectReporter`` test double; ``create_task_run`` returns sequential IDs."""
+def mock_prefect_workflow_tracker() -> AsyncMock:
+    """``PrefectWorkflowTracker`` test double; ``create_task_run`` returns sequential IDs."""
     reporter = AsyncMock()
     counter = {"n": 0}
 
@@ -79,7 +79,7 @@ def mock_prefect_reporter() -> AsyncMock:
     return reporter
 
 
-def _make_executor(mock_prefect_reporter, reply_router):
+def _make_executor(mock_prefect_workflow_tracker, reply_router):
     """Build a minimally-wired executor for direct method calls."""
     from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 
@@ -94,7 +94,7 @@ def _make_executor(mock_prefect_reporter, reply_router):
         queue=queue,
         squad_profile=squad,
         task_timeout=5.0,
-        workflow_tracker=mock_prefect_reporter,
+        workflow_tracker=mock_prefect_workflow_tracker,
         reply_router=reply_router,
     )
     ex._cycle_event_bus = MagicMock()
@@ -111,9 +111,9 @@ class TestCorrectionTaskRunPropagation:
     correction step and tag every emitted task event with both run IDs."""
 
     async def test_correction_steps_create_task_runs_and_emit_full_context(
-        self, mock_prefect_reporter, cycle, failed_envelope, reply_router
+        self, mock_prefect_workflow_tracker, cycle, failed_envelope, reply_router
     ):
-        ex = _make_executor(mock_prefect_reporter, reply_router)
+        ex = _make_executor(mock_prefect_workflow_tracker, reply_router)
 
         # Stub _dispatch_task: capture kwargs and return a "continue"
         # correction decision so the protocol terminates without entering
@@ -164,7 +164,7 @@ class TestCorrectionTaskRunPropagation:
         )
 
         # Each correction step gets its own Prefect task_run.
-        assert mock_prefect_reporter.create_task_run.await_count == len(captured)
+        assert mock_prefect_workflow_tracker.create_task_run.await_count == len(captured)
         assert all(c["flow_run_id"] == "fr_main" for c in captured)
         assert all(
             c["task_run_id"] is not None and c["task_run_id"].startswith("tr_") for c in captured
@@ -186,11 +186,11 @@ class TestCorrectionTaskRunPropagation:
             assert ctx["task_run_id"].startswith("tr_")
 
     async def test_correction_skips_task_run_creation_when_flow_run_id_missing(
-        self, mock_prefect_reporter, cycle, failed_envelope, reply_router
+        self, mock_prefect_workflow_tracker, cycle, failed_envelope, reply_router
     ):
         """No Prefect flow context → no task_runs created (consistent with
         main path); event contexts carry empty-string IDs (not None)."""
-        ex = _make_executor(mock_prefect_reporter, reply_router)
+        ex = _make_executor(mock_prefect_workflow_tracker, reply_router)
 
         async def succeed(envelope, *_a, **_k):
             if envelope.task_type == "governance.correction_decision":
@@ -217,7 +217,7 @@ class TestCorrectionTaskRunPropagation:
             flow_run_id=None,
         )
 
-        mock_prefect_reporter.create_task_run.assert_not_awaited()
+        mock_prefect_workflow_tracker.create_task_run.assert_not_awaited()
         for call in ex._cycle_event_bus.emit.call_args_list:
             event_type = call.args[0] if call.args else call.kwargs.get("event_type")
             if event_type != EventType.TASK_DISPATCHED:
@@ -237,9 +237,9 @@ class TestCorrectionPatchRepairTaskRunPropagation:
     correction protocol must also create per-step task_runs."""
 
     async def test_patch_repairs_create_task_runs_and_carry_full_context(
-        self, mock_prefect_reporter, cycle, failed_envelope, reply_router
+        self, mock_prefect_workflow_tracker, cycle, failed_envelope, reply_router
     ):
-        ex = _make_executor(mock_prefect_reporter, reply_router)
+        ex = _make_executor(mock_prefect_workflow_tracker, reply_router)
 
         seen_repair_dispatches: list[dict] = []
 
@@ -298,14 +298,14 @@ class TestPulseRepairTaskRunPropagation:
     """
 
     async def test_pulse_repair_dispatches_carry_run_ids(
-        self, mock_prefect_reporter, cycle, failed_envelope, reply_router
+        self, mock_prefect_workflow_tracker, cycle, failed_envelope, reply_router
     ):
         from squadops.cycles.pulse_models import (
             PulseDecision,
             SuiteOutcome,
         )
 
-        ex = _make_executor(mock_prefect_reporter, reply_router)
+        ex = _make_executor(mock_prefect_workflow_tracker, reply_router)
 
         # Stub the boundary verification: report FAIL on the first pass and
         # PASS on the second so the loop runs exactly one repair attempt.

--- a/tests/unit/cycles/test_prefect_workflow_tracker.py
+++ b/tests/unit/cycles/test_prefect_workflow_tracker.py
@@ -1,4 +1,4 @@
-"""Tests for PrefectReporter (adapters/cycles/prefect_reporter.py).
+"""Tests for PrefectWorkflowTracker (adapters/cycles/prefect_workflow_tracker.py).
 
 Covers ensure_flow (create + find existing), create_flow_run,
 create_task_run, set_state methods, and graceful degradation.
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock
 import httpx
 import pytest
 
-from adapters.cycles.prefect_reporter import PrefectReporter
+from adapters.cycles.prefect_workflow_tracker import PrefectWorkflowTracker
 
 pytestmark = [pytest.mark.domain_orchestration]
 
@@ -42,7 +42,7 @@ def _mock_response(status_code: int = 200, json_data: dict | list | None = None)
 
 class TestEnsureFlow:
     async def test_creates_flow_when_none_exists(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
 
         # First call: filter returns empty
@@ -69,7 +69,7 @@ class TestEnsureFlow:
         assert "/flows/" in create_call.args[0]
 
     async def test_finds_existing_flow(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
 
         reporter._client.post = AsyncMock(
@@ -82,7 +82,7 @@ class TestEnsureFlow:
         reporter._client.post.assert_called_once()  # Only filter, no create
 
     async def test_returns_cached_flow_id(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._flow_id = "cached-flow-789"
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
 
@@ -94,7 +94,7 @@ class TestEnsureFlow:
 
 class TestCreateFlowRun:
     async def test_creates_flow_run(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
         reporter._client.post = AsyncMock(return_value=_mock_response(201, {"id": "run-abc"}))
 
@@ -114,7 +114,7 @@ class TestCreateFlowRun:
 
 class TestCreateTaskRun:
     async def test_creates_task_run(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
         reporter._client.post = AsyncMock(return_value=_mock_response(201, {"id": "taskrun-xyz"}))
 
@@ -134,7 +134,7 @@ class TestCreateTaskRun:
 
 class TestSetStateMethods:
     async def test_set_flow_run_state(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
         reporter._client.post = AsyncMock(return_value=_mock_response(200, {"status": "ok"}))
 
@@ -147,7 +147,7 @@ class TestSetStateMethods:
         assert body["state"]["name"] == "Running"
 
     async def test_set_task_run_state(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
         reporter._client.post = AsyncMock(return_value=_mock_response(200, {"status": "ok"}))
 
@@ -163,7 +163,7 @@ class TestGracefulDegradation:
     """Prefect down -> warning logged, no exception raised."""
 
     async def test_ensure_flow_handles_connection_error(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
         reporter._client.post = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
 
@@ -172,7 +172,7 @@ class TestGracefulDegradation:
         assert flow_id  # Returns a placeholder
 
     async def test_create_flow_run_handles_error(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
         reporter._client.post = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
 
@@ -180,7 +180,7 @@ class TestGracefulDegradation:
         assert run_id  # Returns a placeholder
 
     async def test_create_task_run_handles_error(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
         reporter._client.post = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
 
@@ -188,7 +188,7 @@ class TestGracefulDegradation:
         assert task_run_id  # Returns a placeholder
 
     async def test_set_flow_run_state_handles_error(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
         reporter._client.post = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
 
@@ -196,7 +196,7 @@ class TestGracefulDegradation:
         await reporter.set_flow_run_state("run-1", "RUNNING", "Running")
 
     async def test_set_task_run_state_handles_error(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
         reporter._client.post = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
 
@@ -204,7 +204,7 @@ class TestGracefulDegradation:
         await reporter.set_task_run_state("taskrun-1", "FAILED", "Failed")
 
     async def test_http_500_does_not_raise(self):
-        reporter = PrefectReporter(api_url=PREFECT_URL)
+        reporter = PrefectWorkflowTracker(api_url=PREFECT_URL)
         reporter._client = AsyncMock(spec=httpx.AsyncClient)
         reporter._client.post = AsyncMock(
             return_value=_mock_response(500, {"detail": "Internal Server Error"})

--- a/tests/unit/cycles/test_workflow_tracker_factory.py
+++ b/tests/unit/cycles/test_workflow_tracker_factory.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from adapters.cycles.noop_workflow_tracker import NoOpWorkflowTracker
-from adapters.cycles.prefect_reporter import PrefectReporter
+from adapters.cycles.prefect_workflow_tracker import PrefectWorkflowTracker
 from adapters.cycles.workflow_tracker_factory import create_workflow_tracker
 from squadops.config.schema import PrefectConfig
 from squadops.ports.cycles import WorkflowTrackerPort
@@ -38,15 +38,15 @@ def test_returns_noop_when_api_url_unset():
     assert isinstance(tracker, NoOpWorkflowTracker)
 
 
-def test_returns_prefect_reporter_when_configured():
+def test_returns_prefect_workflow_tracker_when_configured():
     tracker = create_workflow_tracker(_cfg())
-    assert isinstance(tracker, PrefectReporter)
+    assert isinstance(tracker, PrefectWorkflowTracker)
     assert isinstance(tracker, WorkflowTrackerPort)
 
 
 def test_falls_back_to_noop_on_init_failure():
     with patch(
-        "adapters.cycles.prefect_reporter.PrefectReporter",
+        "adapters.cycles.prefect_workflow_tracker.PrefectWorkflowTracker",
         side_effect=RuntimeError("boom"),
     ):
         tracker = create_workflow_tracker(_cfg())

--- a/tests/unit/events/test_bridge_parity.py
+++ b/tests/unit/events/test_bridge_parity.py
@@ -123,7 +123,7 @@ class TestLangFuseParity:
 
 @pytest.mark.domain_events
 class TestPrefectParity:
-    """Bridge state transitions match executor's direct PrefectReporter calls."""
+    """Bridge state transitions match executor's direct PrefectWorkflowTracker calls."""
 
     def test_run_started_state_matches(self):
         """Executor: set_flow_run_state(frid, 'RUNNING', 'Running')"""


### PR DESCRIPTION
Closes #77.

## Bug (confirmed live)
`cycles cancel` / `runs cancel` flipped registry status but **never cancelled the Prefect flow run** — the flow kept executing tasks (GPU/LLM) against a logically-cancelled cycle. Reproduce-first confirmed the cancel routes only touched the registry + emitted an event.

## Approach B (query Prefect by correlation)
Chosen over persisting `flow_run_id` (which needs a schema migration + executor/registry changes in the #186 god-class). Self-contained to the cancel routes + tracker adapter:

- **`WorkflowTrackerPort.find_active_flow_run_ids(names)`** — ids of non-terminal flow runs matching exact names, via Prefect `/flow_runs/filter`. Impl in `prefect_reporter`, `[]` in noop. Best-effort.
- **`squadops.cycles.naming.flow_run_name()`** — single-sources the flow-run name so the **executor (producer)** and **cancel routes (consumer)** can't drift apart (the executor now calls it instead of an inline f-string). A format drift would silently break cancellation, so this is the safety mechanism.
- **`deps.get_workflow_tracker()`** — NoOp-fallback getter (mirrors the event bus), wired in `main`.
- **Both cancel routes** reconstruct the run name(s) from the registry, find the live flow run(s), and set them `CANCELLED`. Response now includes `prefect_flow_runs_cancelled`.

**Best-effort by design:** the registry cancel is the source of truth; Prefect propagation never fails the request (it's logged), so a cycle is still reported `cancelled` if Prefect is unreachable.

## Verification
- Cancel-route tests (cycle + run) assert `find_active_flow_run_ids` is called with the exact reconstructed name and each match is set `CANCELLED`; plus a best-effort-survival test (Prefect failure → still `cancelled`, count 0).
- Full regression gate: **4382 passed, 0 failures**.
- The `/flow_runs/filter` request shape **validated against the live Prefect server** (HTTP 200, correct empty result for a non-existent name) — the one thing mocks can't cover.

## Note
Only the WorkflowTrackerPort gained a method; noop + prefect are the only implementers (verified). No schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)