### PR TITLE
fix(api): enforce cycles:read/write scopes on cycle routes (#150)

### DIFF
--- a/src/squadops/api/middleware/auth.py
+++ b/src/squadops/api/middleware/auth.py
@@ -18,6 +18,10 @@ from squadops.ports.auth.authentication import AuthPort
 
 logger = logging.getLogger(__name__)
 
+# One-time warning latch: #150 — surface a missing audit port instead of silently
+# dropping security audit events.
+_audit_unavailable_warned = False
+
 # Always allowlisted path prefixes (no token required)
 _ALWAYS_ALLOWLISTED_PREFIXES = ("/health",)
 
@@ -90,6 +94,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
             except Exception:
                 pass
         if audit_port is None:
+            global _audit_unavailable_warned
+            if not _audit_unavailable_warned:
+                logger.warning(
+                    "Audit port unavailable — security audit events (including token "
+                    "rejections) are not being recorded (#150)."
+                )
+                _audit_unavailable_warned = True
             return
         try:
             from squadops.auth.models import AuditEvent
@@ -237,46 +248,52 @@ def require_auth(auth_port_getter=None):
     return dependency
 
 
+async def _enforce_access(
+    request: Request, *, roles: list[str], scopes: list[str]
+) -> Identity | None:
+    """Shared authorization check for :func:`require_roles` / :func:`require_scopes`.
+
+    No-op when no authorization backend is configured — i.e. auth is disabled for
+    this deployment (``AuthMiddleware`` is itself only attached when auth is
+    enabled, so a protected route must not 401 in an auth-off deployment; this
+    matches the pre-#150 behaviour of leaving routes open when auth is off).
+    When authz IS configured: 401 without an identity, 403 without the required
+    roles/scopes (#150).
+    """
+    # Import here to avoid circular imports at module level
+    from squadops.api.runtime.deps import get_authz_port
+
+    authz = get_authz_port()
+    if authz is None:
+        return getattr(request.state, "identity", None)
+
+    identity: Identity | None = getattr(request.state, "identity", None)
+    if identity is None:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    ctx = authz.check_access(identity, required_roles=roles, required_scopes=scopes)
+    if not ctx.granted:
+        raise HTTPException(status_code=403, detail=ctx.denial_reason or "Forbidden")
+    return identity
+
+
 def require_roles(*roles: str) -> Callable:
-    """FastAPI dependency that checks identity has at least one of the required roles."""
+    """FastAPI dependency: identity has at least one of the required roles.
 
-    async def dependency(request: Request) -> Identity:
-        identity: Identity | None = getattr(request.state, "identity", None)
-        if identity is None:
-            raise HTTPException(status_code=401, detail="Not authenticated")
+    No-op when auth is disabled (no authorization backend configured)."""
 
-        # Import here to avoid circular imports at module level
-        from squadops.api.runtime.deps import get_authz_port
-
-        authz = get_authz_port()
-        if authz is None:
-            raise HTTPException(status_code=503, detail="Authorization service unavailable")
-
-        ctx = authz.check_access(identity, required_roles=list(roles), required_scopes=[])
-        if not ctx.granted:
-            raise HTTPException(status_code=403, detail=ctx.denial_reason or "Forbidden")
-        return identity
+    async def dependency(request: Request) -> Identity | None:
+        return await _enforce_access(request, roles=list(roles), scopes=[])
 
     return dependency
 
 
 def require_scopes(*scopes: str) -> Callable:
-    """FastAPI dependency that checks identity has all required scopes."""
+    """FastAPI dependency: identity has all of the required scopes.
 
-    async def dependency(request: Request) -> Identity:
-        identity: Identity | None = getattr(request.state, "identity", None)
-        if identity is None:
-            raise HTTPException(status_code=401, detail="Not authenticated")
+    No-op when auth is disabled (no authorization backend configured)."""
 
-        from squadops.api.runtime.deps import get_authz_port
-
-        authz = get_authz_port()
-        if authz is None:
-            raise HTTPException(status_code=503, detail="Authorization service unavailable")
-
-        ctx = authz.check_access(identity, required_roles=[], required_scopes=list(scopes))
-        if not ctx.granted:
-            raise HTTPException(status_code=403, detail=ctx.denial_reason or "Forbidden")
-        return identity
+    async def dependency(request: Request) -> Identity | None:
+        return await _enforce_access(request, roles=[], scopes=list(scopes))
 
     return dependency

--- a/src/squadops/api/routes/cycles/artifacts.py
+++ b/src/squadops/api/routes/cycles/artifacts.py
@@ -6,11 +6,13 @@ import hashlib
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 
+from squadops.api.middleware.auth import require_scopes
 from squadops.api.routes.cycles.dtos import BaselinePromoteRequest
 from squadops.api.routes.cycles.errors import handle_cycle_error
 from squadops.api.routes.cycles.mapping import artifact_to_response
+from squadops.auth.models import Scope
 from squadops.cycles.models import (
     ArtifactRef,
     BaselineNotAllowedError,
@@ -28,7 +30,10 @@ _MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 _VALID_PROMOTION_STATUSES = {PromotionStatus.WORKING, PromotionStatus.PROMOTED}
 
 
-@router.post("/projects/{project_id}/artifacts/ingest")
+@router.post(
+    "/projects/{project_id}/artifacts/ingest",
+    dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))],
+)
 async def ingest_artifact(
     project_id: str,
     file: UploadFile = File(...),
@@ -92,7 +97,7 @@ async def ingest_artifact(
         raise handle_cycle_error(e) from e
 
 
-@router.get("/artifacts/{artifact_id}")
+@router.get("/artifacts/{artifact_id}", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def get_artifact_metadata(artifact_id: str):
     from squadops.api.runtime.deps import get_artifact_vault
 
@@ -104,7 +109,9 @@ async def get_artifact_metadata(artifact_id: str):
         raise handle_cycle_error(e) from e
 
 
-@router.get("/artifacts/{artifact_id}/download")
+@router.get(
+    "/artifacts/{artifact_id}/download", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))]
+)
 async def download_artifact(artifact_id: str):
     from squadops.api.runtime.deps import get_artifact_vault
 
@@ -122,7 +129,9 @@ async def download_artifact(artifact_id: str):
         raise handle_cycle_error(e) from e
 
 
-@router.post("/artifacts/{artifact_id}/promote")
+@router.post(
+    "/artifacts/{artifact_id}/promote", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))]
+)
 async def promote_artifact(artifact_id: str):
     """Promote an artifact to cycle-scoped canonical status (SIP-0076 §9.5)."""
     from squadops.api.runtime.deps import get_artifact_vault
@@ -152,7 +161,9 @@ async def promote_artifact(artifact_id: str):
         raise handle_cycle_error(e) from e
 
 
-@router.get("/projects/{project_id}/artifacts")
+@router.get(
+    "/projects/{project_id}/artifacts", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))]
+)
 async def list_project_artifacts(
     project_id: str,
     artifact_type: str | None = None,
@@ -177,7 +188,10 @@ async def list_project_artifacts(
         raise handle_cycle_error(e) from e
 
 
-@router.get("/projects/{project_id}/cycles/{cycle_id}/artifacts")
+@router.get(
+    "/projects/{project_id}/cycles/{cycle_id}/artifacts",
+    dependencies=[Depends(require_scopes(Scope.CYCLES_READ))],
+)
 async def list_cycle_artifacts(
     project_id: str,
     cycle_id: str,
@@ -202,7 +216,10 @@ async def list_cycle_artifacts(
         raise handle_cycle_error(e) from e
 
 
-@router.get("/projects/{project_id}/cycles/{cycle_id}/runs/{run_id}/artifacts")
+@router.get(
+    "/projects/{project_id}/cycles/{cycle_id}/runs/{run_id}/artifacts",
+    dependencies=[Depends(require_scopes(Scope.CYCLES_READ))],
+)
 async def list_run_artifacts(
     project_id: str,
     cycle_id: str,
@@ -229,7 +246,10 @@ async def list_run_artifacts(
         raise handle_cycle_error(e) from e
 
 
-@router.post("/projects/{project_id}/baseline/{artifact_type}")
+@router.post(
+    "/projects/{project_id}/baseline/{artifact_type}",
+    dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))],
+)
 async def promote_baseline(project_id: str, artifact_type: str, body: BaselinePromoteRequest):
     """Promote an artifact as baseline (T6: enforcement here, not in vault)."""
     from squadops.api.runtime.deps import get_artifact_vault, get_cycle_registry
@@ -262,7 +282,10 @@ async def promote_baseline(project_id: str, artifact_type: str, body: BaselinePr
         raise handle_cycle_error(e) from e
 
 
-@router.get("/projects/{project_id}/baseline/{artifact_type}")
+@router.get(
+    "/projects/{project_id}/baseline/{artifact_type}",
+    dependencies=[Depends(require_scopes(Scope.CYCLES_READ))],
+)
 async def get_baseline(project_id: str, artifact_type: str):
     from squadops.api.runtime.deps import get_artifact_vault
 
@@ -278,7 +301,9 @@ async def get_baseline(project_id: str, artifact_type: str):
         raise handle_cycle_error(e) from e
 
 
-@router.get("/projects/{project_id}/baseline")
+@router.get(
+    "/projects/{project_id}/baseline", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))]
+)
 async def list_baselines(project_id: str):
     from squadops.api.runtime.deps import get_artifact_vault
 

--- a/src/squadops/api/routes/cycles/cycle_request_profiles.py
+++ b/src/squadops/api/routes/cycles/cycle_request_profiles.py
@@ -7,13 +7,15 @@ These are code/config-file-backed value objects that only change on redeploy.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
+from squadops.api.middleware.auth import require_scopes
 from squadops.api.routes.cycles.dtos import (
     CycleRequestProfileResponse,
     PromptMetaResponse,
 )
+from squadops.auth.models import Scope
 
 router = APIRouter(
     prefix="/api/v1/cycle-request-profiles",
@@ -42,7 +44,7 @@ def _profile_to_response(profile) -> dict:
     ).model_dump()
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def list_cycle_request_profiles():
     """Return all registered cycle request profiles with prompts metadata."""
     from squadops.contracts.cycle_request_profiles import list_profiles, load_profile
@@ -52,7 +54,7 @@ async def list_cycle_request_profiles():
     return JSONResponse(content=profiles, headers=_CACHE_HEADERS)
 
 
-@router.get("/{profile_name}")
+@router.get("/{profile_name}", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def get_cycle_request_profile(profile_name: str):
     """Return a single cycle request profile by name."""
     from squadops.contracts.cycle_request_profiles import load_profile

--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -5,11 +5,13 @@ Cycle API routes (SIP-0064 §9.3).
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, BackgroundTasks
+from fastapi import APIRouter, BackgroundTasks, Depends
 
+from squadops.api.middleware.auth import require_scopes
 from squadops.api.routes.cycles.dtos import CycleCreateRequest, CycleCreateResponse
 from squadops.api.routes.cycles.errors import handle_cycle_error
 from squadops.api.routes.cycles.mapping import cycle_to_response
+from squadops.auth.models import Scope
 from squadops.cycles.lifecycle import compute_config_hash
 from squadops.cycles.models import (
     Cycle,
@@ -23,7 +25,7 @@ from squadops.cycles.models import (
 router = APIRouter(prefix="/api/v1/projects/{project_id}/cycles", tags=["cycles"])
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def create_cycle(
     project_id: str, body: CycleCreateRequest, background_tasks: BackgroundTasks
 ):
@@ -144,7 +146,7 @@ async def create_cycle(
         raise handle_cycle_error(e) from e
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def list_cycles(project_id: str, status: CycleStatus | None = None):
     from squadops.api.runtime.deps import get_cycle_registry
 
@@ -160,7 +162,7 @@ async def list_cycles(project_id: str, status: CycleStatus | None = None):
         raise handle_cycle_error(e) from e
 
 
-@router.get("/{cycle_id}")
+@router.get("/{cycle_id}", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def get_cycle(project_id: str, cycle_id: str):
     from squadops.api.runtime.deps import get_cycle_registry
 
@@ -173,7 +175,7 @@ async def get_cycle(project_id: str, cycle_id: str):
         raise handle_cycle_error(e) from e
 
 
-@router.post("/{cycle_id}/cancel")
+@router.post("/{cycle_id}/cancel", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def cancel_cycle(project_id: str, cycle_id: str):
     from squadops.api.runtime.deps import get_cycle_registry
 

--- a/src/squadops/api/routes/cycles/models.py
+++ b/src/squadops/api/routes/cycles/models.py
@@ -10,15 +10,17 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
+from squadops.api.middleware.auth import require_scopes
 from squadops.api.routes.cycles.dtos import (
     ModelSpecResponse,
     PulledModelResponse,
     PullModelRequest,
     PullStatusResponse,
 )
+from squadops.auth.models import Scope
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +29,7 @@ router = APIRouter(prefix="/api/v1/models", tags=["models"])
 _CACHE_HEADERS = {"Cache-Control": "public, max-age=300"}
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def list_models():
     """Return all model registry entries."""
     from squadops.llm.model_registry import MODEL_SPECS
@@ -58,7 +60,7 @@ def _get_ollama_adapter():
     return port
 
 
-@router.get("/pulled")
+@router.get("/pulled", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def list_pulled_models():
     """List locally pulled models with active profile cross-reference."""
     from squadops.llm.model_registry import MODEL_SPECS
@@ -110,7 +112,7 @@ async def list_pulled_models():
     return results
 
 
-@router.post("/pull", status_code=202)
+@router.post("/pull", status_code=202, dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def pull_model(body: PullModelRequest):
     """Start pulling a model in the background. Returns 202 with pull_id."""
     from squadops.api.runtime.pull_tracker import (
@@ -138,7 +140,7 @@ async def pull_model(body: PullModelRequest):
     ).model_dump()
 
 
-@router.get("/pull/{pull_id}/status")
+@router.get("/pull/{pull_id}/status", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def pull_status(pull_id: str):
     """Poll the status of a model pull job."""
     from squadops.api.runtime.pull_tracker import get_pull_job
@@ -155,7 +157,7 @@ async def pull_status(pull_id: str):
     ).model_dump()
 
 
-@router.delete("/{model_name:path}")
+@router.delete("/{model_name:path}", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def delete_model(model_name: str):
     """Delete a locally pulled model."""
     from squadops.llm.exceptions import LLMConnectionError, LLMModelNotFoundError

--- a/src/squadops/api/routes/cycles/profiles.py
+++ b/src/squadops/api/routes/cycles/profiles.py
@@ -8,8 +8,9 @@ import logging
 from dataclasses import replace
 from datetime import UTC, datetime
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from squadops.api.middleware.auth import require_scopes
 from squadops.api.routes.cycles.dtos import (
     ProfileCloneRequest,
     ProfileCreateRequest,
@@ -18,6 +19,7 @@ from squadops.api.routes.cycles.dtos import (
 )
 from squadops.api.routes.cycles.errors import handle_cycle_error
 from squadops.api.routes.cycles.mapping import profile_to_response
+from squadops.auth.models import Scope
 from squadops.cycles.models import (
     AgentProfileEntry,
     CycleError,
@@ -93,7 +95,7 @@ async def _check_model_availability(agents: tuple[AgentProfileEntry, ...]) -> li
     return warnings
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def list_profiles():
     from squadops.api.runtime.deps import get_squad_profile_port
 
@@ -106,7 +108,7 @@ async def list_profiles():
         raise handle_cycle_error(e) from e
 
 
-@router.get("/active")
+@router.get("/active", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def get_active_profile():
     from squadops.api.runtime.deps import get_squad_profile_port
 
@@ -118,7 +120,7 @@ async def get_active_profile():
         raise handle_cycle_error(e) from e
 
 
-@router.post("/active")
+@router.post("/active", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def set_active_profile(body: SetActiveProfileRequest):
     from squadops.api.runtime.deps import get_squad_profile_port
 
@@ -130,7 +132,7 @@ async def set_active_profile(body: SetActiveProfileRequest):
         raise handle_cycle_error(e) from e
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def create_profile(body: ProfileCreateRequest):
     from squadops.api.runtime.deps import get_squad_profile_port
 
@@ -155,7 +157,7 @@ async def create_profile(body: ProfileCreateRequest):
         raise handle_cycle_error(e) from e
 
 
-@router.put("/{profile_id}")
+@router.put("/{profile_id}", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def update_profile(profile_id: str, body: ProfileUpdateRequest):
     from squadops.api.runtime.deps import get_squad_profile_port
 
@@ -182,7 +184,7 @@ async def update_profile(profile_id: str, body: ProfileUpdateRequest):
         raise handle_cycle_error(e) from e
 
 
-@router.post("/{profile_id}/clone")
+@router.post("/{profile_id}/clone", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def clone_profile(profile_id: str, body: ProfileCloneRequest):
     from squadops.api.runtime.deps import get_squad_profile_port
 
@@ -205,7 +207,7 @@ async def clone_profile(profile_id: str, body: ProfileCloneRequest):
         raise handle_cycle_error(e) from e
 
 
-@router.delete("/{profile_id}")
+@router.delete("/{profile_id}", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def delete_profile(profile_id: str):
     from squadops.api.runtime.deps import get_squad_profile_port
 
@@ -217,7 +219,7 @@ async def delete_profile(profile_id: str):
         raise handle_cycle_error(e) from e
 
 
-@router.post("/{profile_id}/activate")
+@router.post("/{profile_id}/activate", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def activate_profile(profile_id: str):
     from squadops.api.runtime.deps import get_squad_profile_port
 
@@ -229,7 +231,7 @@ async def activate_profile(profile_id: str):
         raise handle_cycle_error(e) from e
 
 
-@router.get("/{profile_id}")
+@router.get("/{profile_id}", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def get_profile(profile_id: str):
     from squadops.api.runtime.deps import get_squad_profile_port
 

--- a/src/squadops/api/routes/cycles/projects.py
+++ b/src/squadops/api/routes/cycles/projects.py
@@ -4,17 +4,19 @@ Project API routes (SIP-0064 §9.1).
 
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import PlainTextResponse
 
+from squadops.api.middleware.auth import require_scopes
 from squadops.api.routes.cycles.errors import handle_cycle_error
 from squadops.api.routes.cycles.mapping import project_to_response
+from squadops.auth.models import Scope
 from squadops.cycles.models import CycleError
 
 router = APIRouter(prefix="/api/v1/projects", tags=["projects"])
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def list_projects():
     from squadops.api.runtime.deps import get_project_registry
 
@@ -26,7 +28,7 @@ async def list_projects():
         raise handle_cycle_error(e) from e
 
 
-@router.get("/{project_id}")
+@router.get("/{project_id}", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def get_project(project_id: str):
     from squadops.api.runtime.deps import get_project_registry
 
@@ -38,7 +40,7 @@ async def get_project(project_id: str):
         raise handle_cycle_error(e) from e
 
 
-@router.get("/{project_id}/prd-content")
+@router.get("/{project_id}/prd-content", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def get_project_prd_content(project_id: str):
     """Read PRD file content for a project (SIP-0074 §3.5).
 

--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -6,8 +6,9 @@ import logging
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from squadops.api.middleware.auth import require_scopes
 from squadops.api.routes.cycles.dtos import (
     CheckpointSummaryResponse,
     GateDecisionRequest,
@@ -15,6 +16,7 @@ from squadops.api.routes.cycles.dtos import (
 )
 from squadops.api.routes.cycles.errors import handle_cycle_error
 from squadops.api.routes.cycles.mapping import compute_workload_progress, run_to_response
+from squadops.auth.models import Scope
 from squadops.cycles.lifecycle import compute_config_hash, resolve_cycle_status
 from squadops.cycles.models import (
     CycleError,
@@ -32,7 +34,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/projects/{project_id}/cycles/{cycle_id}/runs", tags=["runs"])
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def create_run(project_id: str, cycle_id: str, workload_type: str | None = None):
     """Create a new Run (retry) for an existing Cycle."""
     from squadops.api.runtime.deps import get_cycle_registry
@@ -82,7 +84,7 @@ async def create_run(project_id: str, cycle_id: str, workload_type: str | None =
         raise handle_cycle_error(e) from e
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def list_runs(project_id: str, cycle_id: str, workload_type: str | None = None):
     from squadops.api.runtime.deps import get_cycle_registry
 
@@ -94,7 +96,7 @@ async def list_runs(project_id: str, cycle_id: str, workload_type: str | None = 
         raise handle_cycle_error(e) from e
 
 
-@router.get("/{run_id}")
+@router.get("/{run_id}", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def get_run(project_id: str, cycle_id: str, run_id: str):
     from squadops.api.runtime.deps import get_cycle_registry
 
@@ -106,7 +108,7 @@ async def get_run(project_id: str, cycle_id: str, run_id: str):
         raise handle_cycle_error(e) from e
 
 
-@router.post("/{run_id}/cancel")
+@router.post("/{run_id}/cancel", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def cancel_run(project_id: str, cycle_id: str, run_id: str):
     from squadops.api.runtime.deps import get_cycle_registry
 
@@ -128,7 +130,9 @@ async def cancel_run(project_id: str, cycle_id: str, run_id: str):
         raise handle_cycle_error(e) from e
 
 
-@router.post("/{run_id}/gates/{gate_name}")
+@router.post(
+    "/{run_id}/gates/{gate_name}", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))]
+)
 async def gate_decision(
     project_id: str,
     cycle_id: str,
@@ -182,7 +186,7 @@ async def gate_decision(
         raise handle_cycle_error(e) from e
 
 
-@router.post("/{run_id}/resume")
+@router.post("/{run_id}/resume", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def resume_run(
     project_id: str,
     cycle_id: str,
@@ -247,7 +251,7 @@ async def resume_run(
         raise handle_cycle_error(e) from e
 
 
-@router.get("/{run_id}/checkpoints")
+@router.get("/{run_id}/checkpoints", dependencies=[Depends(require_scopes(Scope.CYCLES_READ))])
 async def list_checkpoints(project_id: str, cycle_id: str, run_id: str):
     """List checkpoints for a run (SIP-0079)."""
     from squadops.api.runtime.deps import get_cycle_registry

--- a/tests/unit/cycles/test_api_cycles.py
+++ b/tests/unit/cycles/test_api_cycles.py
@@ -270,3 +270,77 @@ class TestCancelCycle:
         assert resp.status_code == 200
         assert resp.json()["status"] == "cancelled"
         assert resp.json()["prefect_flow_runs_cancelled"] == 0
+
+
+class TestCycleRouteScopeEnforcement:
+    """#150: with auth enabled, cycle routes enforce cycles:read/write.
+
+    Proves the require_scopes guards are actually wired onto the real routes
+    (not merely that require_scopes works in isolation) — a request with an
+    insufficient scope is rejected before the handler runs."""
+
+    def _auth_app(self, identity):
+        from datetime import timedelta
+
+        from squadops.api.middleware.auth import AuthMiddleware, RequestIDMiddleware
+        from squadops.auth.models import TokenClaims
+
+        now = datetime.now(tz=UTC)
+        claims = TokenClaims(
+            subject=identity.user_id,
+            issuer="http://kc/realms/squadops",
+            audience="squadops-runtime",
+            expires_at=now + timedelta(hours=1),
+            issued_at=now,
+            roles=identity.roles,
+            scopes=identity.scopes,
+        )
+        auth_port = AsyncMock()
+        auth_port.validate_token = AsyncMock(return_value=claims)
+        auth_port.resolve_identity = AsyncMock(return_value=identity)
+
+        app = FastAPI()
+        app.add_middleware(
+            AuthMiddleware, auth_port=auth_port, provider="keycloak", expose_docs=False
+        )
+        app.add_middleware(RequestIDMiddleware)
+        app.include_router(router)
+        return app
+
+    def test_write_route_forbidden_without_write_scope(self):
+        """A read-only identity hitting a write route (cancel) gets 403."""
+        from unittest.mock import patch
+
+        from adapters.auth.keycloak.authz_adapter import KeycloakAuthzAdapter
+        from squadops.auth.models import Identity, Role, Scope
+
+        identity = Identity(
+            user_id="reader",
+            display_name="Reader",
+            roles=(Role.VIEWER,),
+            scopes=(Scope.CYCLES_READ,),
+        )
+        app = self._auth_app(identity)
+        with patch("squadops.api.runtime.deps.get_authz_port", return_value=KeycloakAuthzAdapter()):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/v1/projects/hello_squad/cycles/cyc_001/cancel",
+                headers={"Authorization": "Bearer t"},
+            )
+        assert resp.status_code == 403
+
+    def test_read_route_requires_authentication_when_auth_on(self):
+        """Auth enabled but no token → 401 even on a read route."""
+        from unittest.mock import patch
+
+        from adapters.auth.keycloak.authz_adapter import KeycloakAuthzAdapter
+        from squadops.auth.models import Identity, Role, Scope
+
+        identity = Identity(
+            user_id="x", display_name="x", roles=(Role.VIEWER,), scopes=(Scope.CYCLES_READ,)
+        )
+        app = self._auth_app(identity)
+        with patch("squadops.api.runtime.deps.get_authz_port", return_value=KeycloakAuthzAdapter()):
+            client = TestClient(app)
+            resp = client.get("/api/v1/projects/hello_squad/cycles", headers={})
+        assert resp.status_code == 401


### PR DESCRIPTION
Closes #150. **Release-gating security fix for 1.1.0** (fix-first per the release decision).

## The hole
SIP-0062 wired `require_scopes`/`require_roles` but **never applied them** (zero usages, verified). Any authenticated user could perform any cycle operation — create/cancel runs, decide gates, pull models, mutate squad profiles.

## Fix
- **All 40 routes in `routes/cycles/`** now carry a scope guard via `dependencies=[Depends(require_scopes(...))]` on the decorator: **GET → `cycles:read`, mutations → `cycles:write`** (cycles/runs/artifacts/profiles/projects/request-profiles/models).
- **Auth-disabled no-op (the critical safety property):** `require_scopes`/`require_roles` refactored to a shared `_enforce_access` that no-ops when no authz backend is configured. Auth-off deployments (and the entire serviceless test suite) keep routes open exactly as before; when auth is on, it enforces 401 (no identity) / 403 (missing scope). Net security gain, **zero regression** (authz-absent = open = prior behaviour).
- **#150 item 3:** `_emit_audit` logs a one-time warning when the audit port is unavailable, instead of silently dropping security events (token rejections).

## Verification
- New tests: **403** on a write route (`/cancel`) with a read-only identity, and **401** unauthenticated when auth is on — proving the guards are wired on the *real* routes, not just `require_scopes` in isolation.
- Existing `require_roles` tests + all cycle/api route tests pass (no-op-when-off holds).
- Full gate: **4435 passed, 0 failures**.

## Notes
- Scope granularity: `cycles:read/write` applied uniformly across the package (matches the issue's example). Finer admin-scoping for profile/model mutations is a reasonable follow-up.
- Residual edge (pre-existing, non-regression): if auth is *enabled* but the authz backend fails to initialize, enforcement no-ops (open) rather than failing closed — same as today's always-open. Hardening that to fail-closed via an explicit config flag could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)