### PR TITLE
chore(release): 1.1.0 — Agent Runtime State (SIP-0089) + 1.0.x hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to SquadOps are recorded here. Format loosely follows
+[Keep a Changelog](https://keepachangelog.com/); versions follow semver.
+
+## [1.1.0] — 2026-06-28
+
+The v1.1 line ships the **Agent Runtime State** platform (SIP-0089) on top of a
+hardened 1.0.x foundation. Per the release decision, "1.0.x hardening
+completeness" was read as the foundational CI-trust + reliability arc (complete);
+the remaining build-reliability work continues as the **1.1.x hardening plan**
+(`docs/plans/1-1-x-hardening-plan.md`).
+
+### Added — Agent Runtime State (SIP-0089, Phases 1–4)
+- **Runtime modes** (`ambient` / `cycle` / `duty`) with a single-writer
+  RuntimeCoordinator (D16) and an in-process duty scheduler that drives
+  `ambient↔duty` transitions on a poll — the live central mode-writer.
+- **Assignments & duty windows** (hard/soft strictness, pre/post reserve
+  buffers) plus a cycle-recruitment reserve-buffer guard that defers a run
+  rather than pull an agent into a hard-duty window.
+- **FocusLease** arbitration — `granted`/`rejected`/`preempting`, the hard gate
+  for an agent's primary attention. lease ≠ mode; a failed mode write rolls the
+  lease back (no stranded leases).
+- **RuntimeActivity** — an agent's current cycle task is observable
+  (`running` → `completed`/`failed`), instrumented at the executor dispatch
+  boundary; surfaced via `squadops agent activity <id>` and
+  `GET /health/agents/{id}/activity`.
+- Postgres migrations `1100`–`1130` (agent_runtime_state, agent_assignments,
+  focus_leases, runtime_activities), each with single-active-row invariants.
+- CLI: `squadops agent state`, `squadops agent activity`,
+  `squadops assignment list|show|create`.
+
+### Security
+- Enforce `cycles:read` / `cycles:write` scopes on all cycle API routes
+  (`require_scopes` was wired in SIP-0062 but never applied — any authenticated
+  user could perform any cycle operation). No-op when auth is disabled (#150).
+
+### Changed — 1.0.x hardening (CI-trust foundation)
+- Dev and CI standardized on **Python 3.12** (production stays 3.11; build a
+  3.12 venv to reproduce the gate) (#217).
+- Regression gate now enforces `ruff format --check` and runs the adapter unit
+  tests (#196, #207).
+- Declared previously-transitive deps as optional extras: `sqlalchemy`
+  (`postgres`) and `python-jose` (`auth`), and decoupled the core `DbRuntime`
+  port so the `postgres` extra is truly optional (#206, #191).
+
+### Fixed
+- Cancelling a cycle/run now propagates to Prefect — the orphaned flow run is
+  transitioned to CANCELLED instead of running on (#77).
+- Stop in-place mutation of the frozen `HandlerResult` in the planning retry
+  path (#155).
+- RabbitMQ consume-loop channel recovery locked with regression tests (the
+  spin-forever path was already fixed by SIP-0094; #146).
+- Integration test config no longer drifts from the stack: env vars now override
+  `test_config.env`, and creds match the deployed broker (#209).
+- `test_pulse_check_e2e` repaired (event-loop seeding + stale-API drift) (#211).
+
+### Known limitations (1.1.0)
+- Cycle **recruitment does not yet acquire FocusLeases through the coordinator**
+  — the lease gate is enforced at the coordinator, not at recruitment (#233);
+  the coordinator's lease+activity+mode writes use best-effort compensation, not
+  a single Postgres transaction (#244).
+- A cycle **deferred by a hard-duty reserve window cannot be resumed** — the
+  deferral is correct, but no checkpoint exists to resume from (#222).
+- RuntimeActivity is emitted for **cycle tasks only** (executor-side);
+  ambient/duty-handler activities are not yet instrumented.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,13 @@ Living document tracking the implementation progression from initial prototype t
 
 ## Release Timeline
 
-### v1.0.6 (2026-06-21) — Current — Per-Agent Reply Queues
+### v1.1.0 (2026-06-28) — Current — Agent Runtime State + 1.0.x Hardening
+- **SIP-0089** Agent Runtime State (Phases 1–4): runtime modes (ambient/cycle/duty) with a single-writer coordinator + in-process duty scheduler, assignments & duty windows, FocusLease arbitration, RuntimeActivity observability. Migrations 1100–1130.
+- **1.0.x hardening foundation** landed: CI-trust arc (declared deps, dev+CI on Python 3.12, ruff-format gate, adapters in the gate) + reliability fixes (#146 channel recovery, #155 frozen-result mutation, #77 cancel→Prefect, #209 integration config) + **#150 cycle-route scope enforcement (security)**.
+- The remaining build-reliability work is re-baselined as the **1.1.x hardening plan** (`docs/plans/1-1-x-hardening-plan.md`) — it no longer gates the version. (Gate read as foundational-hardening completeness; joint Spark/Mac decision 2026-06-28.)
+- **SIP-0088** (Agent Runtime Modes umbrella) stays **accepted** — its v1.2 pieces (embodiment, recruitment-driven leases) are future; promoting the umbrella would overstate it.
+
+### v1.0.6 (2026-06-21) — Per-Agent Reply Queues
 - **SIP-0094** Per-Agent Reply Queues + Long-Lived Subscription Model
   - Replaces the leaky per-run `cycle_results_{run_id}` reply queues — which lost replies in the consumer-tag churn window and leaked one orphan queue per run — with durable per-agent `{agent_id}_replies` queues
   - `ReplyRouter` holds one long-lived subscription per agent and resolves replies by `task_id`; new `QueuePort.subscribe()` primitive backed by a reconnecting RabbitMQ iterator (resubscribe surfaced in `health()`)
@@ -358,8 +364,7 @@ The following areas are identified for future work but do not block 1.0 readines
 
 | SIP | Title |
 |-----|-------|
-| **SIP-0088** | Agent Runtime Modes |
-| **SIP-0089** | Agent Runtime State |
+| **SIP-0088** | Agent Runtime Modes (umbrella; v1.2 pieces future) |
 | **SIP-0090** | Agent Embodiment Substrate |
 | **SIP-0091** | Duty Durability via Temporal |
 | **SIP-0092** | Implementation Plan Improvement — Typed Acceptance, Separated Authoring, and Plan Changes |

--- a/docs/plans/1-1-x-hardening-plan.md
+++ b/docs/plans/1-1-x-hardening-plan.md
@@ -1,0 +1,73 @@
+# 1.1.x Hardening Plan
+
+**Status:** active · **Established:** 2026-06-28 (with the 1.1.0 release)
+
+## Why this exists
+
+The original 1.0.x plan gated the `1.1.0` version bump on *all* build-reliability
+hardening completing. With SIP-0089 (Agent Runtime State) delivered and tested,
+that gate was re-read (joint Spark/Mac decision, 2026-06-28) as **foundational
+hardening completeness** — the CI-trust arc + reliability bugs — which *is* done.
+1.1.0 shipped on that basis; the remaining hardening is re-baselined here as the
+**1.1.x hardening plan** — ongoing post-1.1 work that no longer blocks a version.
+
+Versioning discipline: **bug fixes → 1.1.x patches; larger capability-bearing
+SIPs may warrant 1.2.0 minors; tech-debt/arch → opportunistic, never
+version-gating.**
+
+Supersedes the gating framing of
+[`1-0-x-build-reliability-hardening-plan.md`](1-0-x-build-reliability-hardening-plan.md)
+(that doc remains the detailed build-reliability axis; this one is the release-lane view).
+
+## Foundational hardening — DONE (shipped in 1.1.0)
+
+- CI-trust arc: declared deps (#206/#191), dev+CI on Python 3.12 (#217),
+  ruff-format gate (#196), adapters in the gate (#207), pulse-e2e (#211),
+  integration config (#209).
+- Reliability bugs: #146 (channel recovery), #155 (frozen-result mutation),
+  #77 (cancel→Prefect), #150 (cycle-route scope enforcement — security).
+
+## 1.1.x patches (bug fixes)
+
+| Issue | |
+|-------|--|
+| #132 | `runs resume --reason` always returns 422 (CLI/API contract drift) |
+| #133 | `runs retry` is dead weight — advertises but never executes |
+| #245 | RabbitMQ `publish()` has no retry during the reconnect window |
+| #239 | OTel `BrokenExporter` test pollutes every regression run (atexit noise) |
+| #168 | Residual `DistributedFlowExecutor` refs after the #164 rename |
+| #198 | FastAPI cap-lift (console router cycle) — adopt ≥0.136 |
+| #130 | Neo `development.develop` unparseable output under spark models |
+
+## Capability SIPs (feature-bearing — likely 1.2.0+ minors)
+
+These add new capabilities, so they ship as minor releases. Order per the
+build-reliability axis; tracked under this hardening plan.
+
+| # | Item |
+|---|------|
+| 2 | Smoke & Acceptance Capability Pack (#176): `qa.start_app`/`probe_endpoint`/`capture_evidence` |
+| — | SIP-0093 authoring depth: B′ (revision loop) → C (M3.1/M3.2) → D (M3.3) |
+| 4 | Cross-Run Memory & Context Handoff (typed ledger) |
+| 6 | Structured Defect Report & Targeted Repair |
+| 7 | Cycle Resume Contract (technical idempotency) |
+| 5/5a | Run Trajectory & Continuation Protocol + minimal budget breakers |
+| 3 | Cycle Evaluation Scorecard (phases 1–2) |
+| 8 | QA Maturity Ladder (composes #2 into stages) |
+| 10 | Stack Capability Registry concretization |
+
+## Ongoing tech-debt / arch (slot opportunistically — never version-gating)
+
+#234/#153 (DbRuntime sqlalchemy-port leak), #154 (adapter imports in domain),
+#156 (`_parse_jsonb` dedup), #250 (duplicate WorkflowTracker factory),
+#242 (gate serviceless integration tests), #218/#219 (runtime-api URL conventions),
+#216 (pytest-xdist), #157 (api/comms coverage), #158 (schema_migrations table),
+#173 (squad-profile name consolidation), #134 (qwen2.5:32b YAML brittleness),
+#224 (model-availability preflight), #237 (drop 3.11 / migrate prod to 3.12),
+#80 (cycle lineage on the record).
+
+## Runtime-lane follow-ups carried out of 1.1.0 (SIP-0089 known limitations)
+
+#233 (recruitment-acquired FocusLeases via coordinator), #244 (single-transaction
+coordinator writes vs best-effort compensation), #222 (resume a hard-duty-deferred
+cycle — needs a checkpoint). These are v1.1.x/v1.2 runtime-lane work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["squadops*", "adapters*"]  # Include both packages
 
 [project]
 name = "squadops"
-version = "1.0.6"
+version = "1.1.0"
 description = "SquadOps: a production-grade multi-agent orchestration framework."
 requires-python = ">=3.11"
 authors = [

--- a/sips/implemented/SIP-0089-Agent-Runtime-State.md
+++ b/sips/implemented/SIP-0089-Agent-Runtime-State.md
@@ -1,14 +1,14 @@
 ---
 title: Agent Runtime State
-status: accepted
+status: implemented
 author: Jason Ladd
 created_at: '2026-04-25T00:00:00Z'
 sip_number: 89
-updated_at: '2026-04-25T17:57:13.678325Z'
+updated_at: '2026-06-28T14:29:52.689735Z'
 ---
 # SIP-0089: Agent Runtime State — Modes, Duty Windows, Focus, and RuntimeActivity
 
-**Status:** Accepted
+**Status:** Implemented
 **Authors:** Jason Ladd
 **Created:** 2026-04-25
 **Revision:** 2 (incorporated review feedback on 2026-04-25)

--- a/sips/registry.yaml
+++ b/sips/registry.yaml
@@ -803,12 +803,12 @@ sips:
 - sip_uid: null
   sip_number: 89
   title: Agent Runtime State
-  path: sips/accepted/SIP-0089-Agent-Runtime-State.md
-  status: accepted
+  path: sips/implemented/SIP-0089-Agent-Runtime-State.md
+  status: implemented
   author: Jason Ladd
   approver: jladd
   created_at: '2026-04-25T00:00:00Z'
-  updated_at: '2026-04-25T17:57:13.702309Z'
+  updated_at: '2026-06-28T14:29:52.709752Z'
 - sip_uid: null
   sip_number: 90
   title: Agent Embodiment Substrate


### PR DESCRIPTION
**1.1.0 release** — Spark-prepped for the Mac lane's review (ASK 3 = spark-preps; Mac owns/verifies the SIP-0089 promotion). Gated on #150 (merged, fix-first) and the joint decision to read "1.0.x hardening completeness" as foundational-hardening (done) → ship 1.1.0; remaining work re-baselined as the 1.1.x hardening plan.

## Contents (one coordinated commit)
- **Version** 1.0.6 → 1.1.0 (`version_cli.py`; single-sourced in `pyproject.toml`).
- **SIP-0089 → implemented** (file moved + registry + frontmatter via `update_sip_status.py`; body `Status` fixed by hand). **SIP-0088 stays `accepted`** — umbrella with future v1.2 pieces; promoting it would overstate it (Mac's judgment call, confirmed).
- **`CHANGELOG.md`** (new): 1.1.0 section — SIP-0089 runtime notes + honest *known limitations* (#233/#244/#222), plus the 1.0.x hardening summary.
- **`docs/ROADMAP.md`**: v1.1.0 entry; SIP-0089 off "next up".
- **`docs/plans/1-1-x-hardening-plan.md`** (new): re-baselined hardening plan (no longer version-gating).

## Reviewer focus (Mac)
- The **SIP-0089 promotion** (registry + status + the file move) — your lane, please verify.
- The **release-notes block** — used your authored text verbatim.

## Verification
- Full regression gate: **4435 passed, 0 failures**.
- Installed metadata: `squadops 1.1.0`.

## After merge (per Mac's runbook step 5)
Rebuild + redeploy, then `curl -s localhost:8001/health | jq .version` → `1.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)