### PR TITLE
fix(maintainer): rewrite body **Status:** line on SIP promotion (#253)

### DIFF
--- a/scripts/maintainer/update_sip_status.py
+++ b/scripts/maintainer/update_sip_status.py
@@ -124,6 +124,71 @@ def update_sip_file_metadata(file_path: Path, updates: dict[str, Any]) -> bool:
         return False
 
 
+# Status keywords that may appear in a SIP body status-declaration line. Used to
+# anchor the body rewrite so prose/code/table mentions of "status" are never touched.
+_STATUS_WORDS = (
+    "Proposed",
+    "Draft",
+    "Accepted",
+    "Approved",
+    "Implemented",
+    "Deprecated",
+    "Rejected",
+    "Withdrawn",
+)
+
+# Matches the canonical body status line, e.g. "**Status:** Accepted",
+# "**Status**: Draft", "- **Status:** Accepted", "*Status: Draft*". `prefix`
+# captures everything up to and including the colon + emphasis; `word` is the
+# status keyword. Only horizontal whitespace is allowed so the match cannot span
+# lines. Anything after `word` (trailing emphasis, "(umbrella / vision)") is left
+# untouched by the caller's count=1 substitution.
+_BODY_STATUS_RE = re.compile(
+    r"^(?P<prefix>[ \t]{0,3}(?:[-*>][ \t]+)?\*{0,2}[ \t]*Status[ \t]*\*{0,2}[ \t]*:[ \t]*\*{0,2}[ \t]*)"
+    r"(?P<word>" + "|".join(_STATUS_WORDS) + r")",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def update_sip_body_status(file_path: Path, new_status: str) -> bool:
+    """Rewrite the human-readable body ``**Status:**`` line to match new_status.
+
+    The frontmatter ``status:`` is handled by :func:`update_sip_file_metadata`;
+    this updates the *body* declaration so the document doesn't silently disagree
+    with its frontmatter/registry after a promotion. Only the first status line in
+    the body is rewritten, and only the status word — the line's markdown and any
+    trailing annotation (e.g. ``(umbrella / vision)``) are preserved.
+
+    Returns True if a body status line was found and rewritten, False otherwise
+    (caller should warn so the maintainer can update it by hand).
+    """
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            content = f.read()
+    except Exception as e:
+        print(f"Warning: could not read {file_path} to update body status: {e}")
+        return False
+
+    # Isolate the frontmatter so the body regex can never touch it.
+    frontmatter_match = re.match(r"^---\s*\n.*?\n---\s*\n", content, re.DOTALL)
+    head = frontmatter_match.group(0) if frontmatter_match else ""
+    body = content[len(head) :]
+
+    canonical = new_status.capitalize()
+    new_body, count = _BODY_STATUS_RE.subn(lambda m: m.group("prefix") + canonical, body, count=1)
+    if count == 0:
+        return False
+
+    try:
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(head + new_body)
+    except Exception as e:
+        print(f"Warning: could not write {file_path} to update body status: {e}")
+        return False
+
+    return True
+
+
 def normalize_filename(sip_number: int, title: str) -> str:
     """Generate normalized filename with maximum 4 words."""
     # Clean title for filename
@@ -422,6 +487,13 @@ def update_sip_status(sip_file: Path, new_status: str) -> bool:
         if not update_sip_file_metadata(sip_file, {"sip_number": sip_number, "status": new_status}):
             return False
 
+        # Update the human-readable body status line to match the frontmatter.
+        if not update_sip_body_status(sip_file, new_status):
+            print(
+                "Warning: no body **Status:** line found to update; "
+                "check the document body manually."
+            )
+
         # Generate new filename
         new_filename = normalize_filename(sip_number, title)
         target_dir = STATUS_TO_FOLDER[new_status]
@@ -605,6 +677,13 @@ def update_sip_status(sip_file: Path, new_status: str) -> bool:
         # Update file metadata
         if not update_sip_file_metadata(sip_file, {"status": new_status}):
             return False
+
+        # Update the human-readable body status line to match the frontmatter.
+        if not update_sip_body_status(sip_file, new_status):
+            print(
+                "Warning: no body **Status:** line found to update; "
+                "check the document body manually."
+            )
 
         # Move file to new lifecycle folder using explicit copy+delete for reliability
         target_dir = STATUS_TO_FOLDER[new_status]

--- a/tests/unit/maintainer/test_update_sip_status.py
+++ b/tests/unit/maintainer/test_update_sip_status.py
@@ -1,0 +1,136 @@
+"""Unit tests for the body status-line rewrite in update_sip_status.py (#253).
+
+The script already updates the frontmatter ``status:`` field; the bug was that the
+human-readable body ``**Status:**`` line was left stale, so a promoted SIP's body
+silently disagreed with its frontmatter/registry. ``update_sip_body_status`` closes
+that gap. Bug classes guarded:
+
+- the body status line not being rewritten at all (the original bug);
+- a rewrite that clobbers the line's markdown or a trailing annotation
+  (e.g. ``(umbrella / vision)``);
+- the body regex reaching into the frontmatter and corrupting the YAML
+  ``status:`` value (it must operate on the body only);
+- replacing *every* "Status:" occurrence, mangling prose/historical notes — only
+  the first declaration must change;
+- silently "succeeding" (or corrupting the file) when there is no recognizable
+  body status line.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "maintainer" / "update_sip_status.py"
+
+_spec = importlib.util.spec_from_file_location("update_sip_status", _SCRIPT)
+update_sip_status = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(update_sip_status)
+
+update_sip_body_status = update_sip_status.update_sip_body_status
+
+
+_FRONTMATTER = "---\nsip_number: 89\nstatus: accepted\ntitle: Demo\n---\n\n"
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    f = tmp_path / "SIP-0089-Demo.md"
+    f.write_text(_FRONTMATTER + body, encoding="utf-8")
+    return f
+
+
+def test_rewrites_canonical_body_line_without_touching_frontmatter(tmp_path):
+    """The reported bug: accepted→implemented must flip the body line. The
+    frontmatter ``status: accepted`` must be left exactly as-is (it's handled
+    elsewhere and the body pass must not reach into it)."""
+    f = _write(tmp_path, "# Demo\n\n**Status:** Accepted\n\nBody text.\n")
+
+    assert update_sip_body_status(f, "implemented") is True
+
+    content = f.read_text(encoding="utf-8")
+    assert "**Status:** Implemented\n" in content
+    assert "**Status:** Accepted" not in content
+    # frontmatter value is lowercase and must be untouched by the body pass
+    assert "status: accepted\n" in content
+
+
+def test_preserves_trailing_annotation(tmp_path):
+    """A trailing annotation (SIP-0088's ``(umbrella / vision)``) must survive —
+    only the status word changes, never the rest of the line."""
+    f = _write(tmp_path, "**Status:** Accepted (umbrella / vision)\n")
+
+    assert update_sip_body_status(f, "implemented") is True
+    assert "**Status:** Implemented (umbrella / vision)\n" in f.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("line", "new_status", "expected"),
+    [
+        ("**Status**: Draft", "accepted", "**Status**: Accepted"),
+        ("- **Status:** Accepted", "implemented", "- **Status:** Implemented"),
+        ("*Status: Draft*", "accepted", "*Status: Accepted*"),
+        ("status: Proposed", "accepted", "status: Accepted"),
+    ],
+)
+def test_preserves_line_formatting_variants(tmp_path, line, new_status, expected):
+    """Bug class: the rewrite must recognize the formatting variants in the corpus
+    and preserve their markdown (bold/italic/list prefix, trailing emphasis),
+    changing only the status word."""
+    f = _write(tmp_path, f"{line}\n\nMore body.\n")
+
+    assert update_sip_body_status(f, new_status) is True
+    assert f"{expected}\n" in f.read_text(encoding="utf-8")
+
+
+def test_only_first_status_line_changes(tmp_path):
+    """Bug class: replacing every match would corrupt later mentions. A historical
+    note further down that also looks like a status line must be left intact."""
+    f = _write(
+        tmp_path,
+        "**Status:** Accepted\n\n## History\n\n> Earlier this was **Status:** Draft (2024).\n",
+    )
+
+    assert update_sip_body_status(f, "implemented") is True
+    content = f.read_text(encoding="utf-8")
+    assert "**Status:** Implemented\n" in content
+    assert "**Status:** Draft (2024)." in content  # historical note untouched
+
+
+def test_prose_mentions_of_status_are_not_matched(tmp_path):
+    """Bug class: prose/code lines containing the word "status" must not be
+    mistaken for the declaration. With no real status line, return False and leave
+    the file byte-for-byte unchanged."""
+    body = (
+        "# Demo\n\n"
+        "This SIP tracks deployment status across agents.\n"
+        "    if response.status != 200:\n"
+    )
+    f = _write(tmp_path, body)
+    before = f.read_text(encoding="utf-8")
+
+    assert update_sip_body_status(f, "implemented") is False
+    assert f.read_text(encoding="utf-8") == before
+
+
+def test_header_only_status_is_noop(tmp_path):
+    """Bug class: a ``## Status`` header with no inline ``<keyword>`` has nothing to
+    rewrite — must report False (so the caller warns) and not alter the file."""
+    f = _write(tmp_path, "## 📌 Status\n\nSome explanation, not a keyword.\n")
+    before = f.read_text(encoding="utf-8")
+
+    assert update_sip_body_status(f, "implemented") is False
+    assert f.read_text(encoding="utf-8") == before
+
+
+def test_frontmatter_status_is_never_rewritten_as_body(tmp_path):
+    """Critical: when the body has no status line, the frontmatter ``status:``
+    must NOT be picked up and rewritten (which would corrupt the YAML casing to
+    ``Implemented`` and double-source the value). Returns False, file unchanged."""
+    f = _write(tmp_path, "# Demo\n\nNo status declaration in the body at all.\n")
+    before = f.read_text(encoding="utf-8")
+
+    assert update_sip_body_status(f, "implemented") is False
+    assert f.read_text(encoding="utf-8") == before


### PR DESCRIPTION
Closes #253.

## Problem
`scripts/maintainer/update_sip_status.py` updates the frontmatter `status:`, moves the file to the right lifecycle folder, and updates `sips/registry.yaml` — but leaves the human-readable **body** `**Status:**` line stale. So after every promotion the maintainer had to hand-edit the body line, and the doc body could silently disagree with its frontmatter/registry. Hit during the SIP-0089 → implemented promotion for 1.1.0.

## Fix
- Add `update_sip_body_status()`, called from **both** transition branches right after the frontmatter update (so the moved copy carries both changes).
- Rewrites only the **first** status-declaration line in the document **body**, changing just the status *word* and preserving:
  - line markdown: `**Status:**`, `**Status**:`, `- **Status:**`, `*Status: …*`
  - any trailing annotation, e.g. `**Status:** Accepted (umbrella / vision)`
- Never touches the frontmatter (isolated before the body search) or prose/code/table mentions of "status".
- When no recognizable body line exists, it **warns and continues** rather than failing the promotion.

## Tests
New `tests/unit/maintainer/test_update_sip_status.py` (10 cases): canonical accepted→implemented rewrite, trailing-annotation preservation, formatting-variant preservation, first-line-only (historical notes intact), prose/header no-op, and the critical frontmatter-never-rewritten-as-body case. Also verified end-to-end through a full `update_sip_status` promotion in a temp sandbox (frontmatter + body both flip, file moves, no stale value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)