### PR TITLE
fix(comms): bounded retry/backoff for RabbitMQ publish() across reconnect window (#245)

### DIFF
--- a/adapters/comms/rabbitmq.py
+++ b/adapters/comms/rabbitmq.py
@@ -24,6 +24,15 @@ logger = logging.getLogger(__name__)
 # subscription, so a flapping channel doesn't spin a tight reconnect loop.
 _SUBSCRIBE_RECONNECT_BACKOFF = 0.5
 
+# #245: a publish issued inside connect_robust's reconnect window hits a stale
+# channel ("Channel was not opened") and, with a single attempt, lost the
+# message. Unlike subscribe (a long-lived loop), a publish is a bounded
+# operation: retry a small number of times with backoff — invalidating the
+# stale Queue handle between tries so the next attempt re-declares against the
+# live channel — then surface QueueError so the caller is never blocked forever.
+_PUBLISH_MAX_ATTEMPTS = 3
+_PUBLISH_RETRY_BACKOFF = 0.5
+
 
 class QueueError(Exception):
     """Base exception for queue operations."""
@@ -134,38 +143,73 @@ class RabbitMQAdapter(QueuePort):
         Raises:
             QueueError: If publishing fails
         """
-        try:
-            await self._ensure_connection()
-            queue = await self._get_queue(queue_name)
+        # Build the message once; only the transport send is retried. A bad
+        # payload fails here, before the loop, so it is never retried.
+        message_properties: dict[str, Any] = {
+            "delivery_mode": aio_pika.DeliveryMode.PERSISTENT,
+        }
 
-            # Create message with persistent delivery mode
-            message_properties = {
-                "delivery_mode": aio_pika.DeliveryMode.PERSISTENT,
-            }
+        # Handle delay using TTL and Dead Letter Exchange
+        # Note: For production, consider using rabbitmq-delayed-message-exchange plugin
+        if delay_seconds is not None and delay_seconds > 0:
+            # Use TTL with DLX for delayed delivery
+            # This is a simplified approach; full implementation would use delayed exchange plugin
+            # aio_pika expects expiration as int (milliseconds) or timedelta
+            message_properties["expiration"] = delay_seconds * 1000  # TTL in milliseconds
 
-            # Handle delay using TTL and Dead Letter Exchange
-            # Note: For production, consider using rabbitmq-delayed-message-exchange plugin
-            if delay_seconds is not None and delay_seconds > 0:
-                # Use TTL with DLX for delayed delivery
-                # This is a simplified approach; full implementation would use delayed exchange plugin
-                # aio_pika expects expiration as int (milliseconds) or timedelta
-                message_properties["expiration"] = delay_seconds * 1000  # TTL in milliseconds
+        message = Message(
+            body=payload.encode("utf-8"),
+            **message_properties,
+        )
 
-            message = Message(
-                body=payload.encode("utf-8"),
-                **message_properties,
-            )
+        last_exc: Exception | None = None
+        for attempt in range(1, _PUBLISH_MAX_ATTEMPTS + 1):
+            try:
+                await self._ensure_connection()
+                queue = await self._get_queue(queue_name)
 
-            await self._channel.default_exchange.publish(
-                message,
-                routing_key=queue.name,
-            )
+                await self._channel.default_exchange.publish(
+                    message,
+                    routing_key=queue.name,
+                )
 
-            logger.debug(f"Published message to queue: {queue.name}")
+                if attempt > 1:
+                    logger.info(
+                        "Published message to queue %s on attempt %d/%d",
+                        queue.name,
+                        attempt,
+                        _PUBLISH_MAX_ATTEMPTS,
+                    )
+                else:
+                    logger.debug("Published message to queue: %s", queue.name)
+                return
 
-        except Exception as e:
-            logger.error(f"Failed to publish message to queue {queue_name}: {e}")
-            raise QueueError(f"Failed to publish message: {e}") from e
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                # A drop inside connect_robust's reconnect window leaves a stale
+                # channel/Queue handle. Drop the cached handle so the next attempt
+                # re-declares against the live channel (the _get_queue channel-swap
+                # path), back off, and retry.
+                last_exc = e
+                await self.invalidate_queue(queue_name)
+                if attempt < _PUBLISH_MAX_ATTEMPTS:
+                    logger.warning(
+                        "publish to %s failed (attempt %d/%d): %s; retrying",
+                        queue_name,
+                        attempt,
+                        _PUBLISH_MAX_ATTEMPTS,
+                        e,
+                    )
+                    await asyncio.sleep(_PUBLISH_RETRY_BACKOFF * attempt)
+
+        logger.error(
+            "Failed to publish message to queue %s after %d attempts: %s",
+            queue_name,
+            _PUBLISH_MAX_ATTEMPTS,
+            last_exc,
+        )
+        raise QueueError(f"Failed to publish message: {last_exc}") from last_exc
 
     @staticmethod
     def _to_queue_message(

--- a/tests/unit/comms/test_rabbitmq_adapter.py
+++ b/tests/unit/comms/test_rabbitmq_adapter.py
@@ -197,6 +197,65 @@ class TestConsumeBlockingErrorWrapping:
         assert "Channel was not opened" in str(exc_info.value)
 
 
+class TestPublishRetry:
+    """#245: ``publish()`` must survive a connection/channel drop inside
+    ``connect_robust``'s reconnect window — bounded retry with backoff, dropping
+    the stale Queue handle between tries (mirrors the consume-side recovery) —
+    instead of failing the first attempt and losing the message."""
+
+    @staticmethod
+    def _publish_adapter(publish_side_effect) -> tuple[RabbitMQAdapter, MagicMock, MagicMock]:
+        """Adapter whose only live transport is ``default_exchange.publish``;
+        connection/declare/invalidate are stubbed so no broker is needed."""
+        ch = MagicMock()
+        ch.is_closed = False
+        ch.default_exchange.publish = AsyncMock(side_effect=publish_side_effect)
+        adapter = _make_adapter_with_channel(ch)
+
+        queue = MagicMock()
+        queue.name = "comms.work"
+        adapter._ensure_connection = AsyncMock()
+        adapter._get_queue = AsyncMock(return_value=queue)
+        adapter.invalidate_queue = AsyncMock()
+        return adapter, ch, queue
+
+    async def test_recovers_after_transient_channel_drop(self, monkeypatch) -> None:
+        """Regression: a publish that hit a dropped channel raised ``QueueError``
+        with no retry, losing the message. It must invalidate the stale queue,
+        reconnect, and re-publish — succeeding on the second attempt."""
+        monkeypatch.setattr(rabbitmq_mod.asyncio, "sleep", AsyncMock())
+        adapter, ch, _ = self._publish_adapter([RuntimeError("Channel was not opened"), None])
+
+        await adapter.publish("work", '{"x": 1}')
+
+        # Two transport sends: the dropped one, then the recovered one.
+        assert ch.default_exchange.publish.await_count == 2
+        # Stale handle dropped exactly once (after the failed attempt).
+        adapter.invalidate_queue.assert_awaited_once_with("work")
+
+    async def test_raises_queue_error_after_exhausting_retries(self, monkeypatch) -> None:
+        """A persistent broker failure is retried the bounded number of times,
+        then surfaced as a typed ``QueueError`` chaining the underlying cause —
+        never an infinite loop, never a leaky aio_pika exception."""
+        monkeypatch.setattr(rabbitmq_mod.asyncio, "sleep", AsyncMock())
+        adapter, ch, _ = self._publish_adapter(RuntimeError("broker down"))
+
+        with pytest.raises(QueueError, match="broker down"):
+            await adapter.publish("work", "{}")
+
+        assert ch.default_exchange.publish.await_count == rabbitmq_mod._PUBLISH_MAX_ATTEMPTS
+
+    async def test_first_attempt_success_does_not_retry(self) -> None:
+        """The happy path must publish exactly once and never invalidate the
+        queue — guards against a regression where the loop always retries."""
+        adapter, ch, _ = self._publish_adapter([None])
+
+        await adapter.publish("work", "{}")
+
+        ch.default_exchange.publish.assert_awaited_once()
+        adapter.invalidate_queue.assert_not_awaited()
+
+
 class _FakeIncoming:
     """Stand-in for an aio_pika incoming message with a trackable ack()."""
 


### PR DESCRIPTION
## What & why

Closes #245. `publish()` made a **single** attempt — a connection/channel drop inside `connect_robust`'s reconnect window raised `QueueError` with no retry, **silently losing the message**. The consume side (`consume`, `_get_queue`, `subscribe`) already recovers (invalidate cache + re-declare on channel swap); `publish` was the only unguarded path.

## Change

`adapters/comms/rabbitmq.py` — bounded retry loop around the transport send. Mirrors the consume-side recovery idiom but **finite** (a publish is one-shot, not a long-lived consumer):

- Build the `Message` **once, before the loop** — a bad payload fails fast and is never retried.
- On each transport failure: drop the stale `Queue` handle (`invalidate_queue` → next attempt re-declares against the live channel via the `_get_queue` channel-swap path), back off, retry.
- Surface `QueueError` (chaining the cause) only after `_PUBLISH_MAX_ATTEMPTS` (3) — never blocks the caller forever.
- `CancelledError` is re-raised, not retried.

New constants `_PUBLISH_MAX_ATTEMPTS` / `_PUBLISH_RETRY_BACKOFF` sit alongside the existing `_SUBSCRIBE_RECONNECT_BACKOFF`.

## Tests

`TestPublishRetry` (mirrors the #146 consume-recovery tests — MagicMock channels, no broker):
- transient drop → recovers on attempt 2 (2 sends, 1 invalidate)
- persistent failure → typed `QueueError` after exactly `_PUBLISH_MAX_ATTEMPTS` sends
- happy path → exactly one send, **no** invalidate (guards against always-retry regression)

Local: comms + adapters gate dirs **118 passed**, `ruff format --check` clean.

---
Lane S / Sprint 1, item 1. The only live reliability bug in the set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)