### PR TITLE
fix(cycles): resume re-attempts duty-deferred runs + actually re-executes (#222)

### DIFF
--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends
 
 from squadops.api.middleware.auth import require_scopes
 from squadops.api.routes.cycles.dtos import (
@@ -191,9 +191,16 @@ async def resume_run(
     project_id: str,
     cycle_id: str,
     run_id: str,
+    background_tasks: BackgroundTasks,
     body: RunResumeRequest | None = None,
 ):
-    """Resume a paused or failed run from its latest checkpoint (SIP-0079)."""
+    """Resume a paused or failed run (SIP-0079).
+
+    Resumes from the latest checkpoint when one exists; a run PAUSED before any
+    task ran (e.g. a SIP-0089 §2.5 duty deferral, #222) is re-attempted from the
+    start. Re-execution is enqueued so the run actually proceeds — flipping status
+    alone does not re-run the executor.
+    """
     from squadops.api.runtime.deps import get_cycle_registry
 
     try:
@@ -208,9 +215,12 @@ async def resume_run(
                 f"Cannot resume run in status {run.status!r} — must be paused or failed"
             )
 
-        # 3. Must have at least one checkpoint
+        # 3. Resume source: a checkpoint (resume mid-plan), or — for a run PAUSED
+        #    before any task ran (e.g. a §2.5 duty deferral, #222) — a re-attempt
+        #    from the start. A checkpoint-less FAILED run still can't be resumed
+        #    (no progress and no deliberate pause → create a fresh run).
         latest_cp = await registry.get_latest_checkpoint(run_id)
-        if latest_cp is None:
+        if latest_cp is None and run.status != RunStatus.PAUSED.value:
             raise ValidationError("Cannot resume run without a checkpoint")
 
         # 4. Parent cycle must not be terminal
@@ -242,8 +252,22 @@ async def resume_run(
             },
             payload={
                 "resume_reason": resume_reason,
-                "checkpoint_index": latest_cp.checkpoint_index,
+                "checkpoint_index": latest_cp.checkpoint_index if latest_cp else None,
             },
+        )
+
+        # Re-attempt execution. Flipping status to RUNNING alone does not re-run
+        # the executor — only cycle-create enqueues it. execute_run self-detects
+        # the resume source: it resumes from the latest checkpoint if one exists,
+        # else restarts the plan from the beginning, and re-runs the §2.5 duty
+        # guard (a still-active hard-duty window simply re-defers).
+        from squadops.api.runtime.deps import get_flow_executor
+
+        background_tasks.add_task(
+            get_flow_executor().execute_cycle,
+            cycle_id,
+            run_id,
+            cycle.squad_profile_id,
         )
 
         return run_to_response(updated)

--- a/tests/unit/cycles/test_api_resume.py
+++ b/tests/unit/cycles/test_api_resume.py
@@ -123,12 +123,18 @@ def mock_cycle_registry():
 
 
 @pytest.fixture
-def client(mock_cycle_registry, monkeypatch):
+def mock_flow_executor():
+    return AsyncMock()
+
+
+@pytest.fixture
+def client(mock_cycle_registry, mock_flow_executor, monkeypatch):
     app = FastAPI()
     app.include_router(router)
     import squadops.api.runtime.deps as deps_mod
 
     monkeypatch.setattr(deps_mod, "_cycle_registry", mock_cycle_registry)
+    monkeypatch.setattr(deps_mod, "_flow_executor", mock_flow_executor)
     return TestClient(app)
 
 
@@ -149,12 +155,38 @@ class TestResumeRun:
         assert resp.status_code == 200
         assert resp.json()["status"] == "running"
 
-    def test_resume_without_checkpoint(self, client, mock_cycle_registry):
-        """Resume without any checkpoint returns 422."""
+    def test_resume_enqueues_reexecution(self, client, mock_flow_executor):
+        """Resume must re-trigger the executor — flipping status to running alone
+        never re-executes the run. execute_run resumes-from-checkpoint or restarts
+        internally, so the route enqueues execute_cycle unconditionally."""
+        resp = client.post(f"{_URL_PREFIX}/run_001/resume")
+        assert resp.status_code == 200
+        mock_flow_executor.execute_cycle.assert_called_once_with("cyc_001", "run_001", "full-squad")
+
+    def test_resume_paused_without_checkpoint_reattempts(
+        self, client, mock_cycle_registry, mock_flow_executor
+    ):
+        """#222: a PAUSED run with no checkpoint (e.g. a SIP-0089 §2.5 duty
+        deferral, which pauses before any task runs) must resume and re-attempt the
+        plan from the start — NOT 422. Re-execution is enqueued from the start."""
+        mock_cycle_registry.get_latest_checkpoint.return_value = None
+        resp = client.post(f"{_URL_PREFIX}/run_001/resume")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "running"
+        mock_flow_executor.execute_cycle.assert_called_once_with("cyc_001", "run_001", "full-squad")
+
+    def test_resume_failed_without_checkpoint_still_rejected(
+        self, client, mock_cycle_registry, mock_flow_executor
+    ):
+        """A FAILED run with no checkpoint still cannot be resumed — 422 (the
+        relaxation is scoped to PAUSED). No re-execution is enqueued."""
+        mock_cycle_registry.get_run.return_value = _FAILED_RUN
+        mock_cycle_registry.list_runs.return_value = [_FAILED_RUN]
         mock_cycle_registry.get_latest_checkpoint.return_value = None
         resp = client.post(f"{_URL_PREFIX}/run_001/resume")
         assert resp.status_code == 422
         assert resp.json()["detail"]["error"]["code"] == "VALIDATION_ERROR"
+        mock_flow_executor.execute_cycle.assert_not_called()
 
     def test_resume_completed_run(self, client, mock_cycle_registry):
         """Completed run cannot be resumed — 409."""


### PR DESCRIPTION
Closes #222.

## Problem
A run deferred by the SIP-0089 §2.5 reserve-buffer guard pauses **before any task runs** (no Prefect flow, no checkpoint), with `RUN_PAUSED` payload `reason=upcoming_hard_duty_window`. But the documented re-attempt path (`squadops runs resume`) **422'd** it: the resume route hard-required a checkpoint (`runs.py` step 3, "Cannot resume run without a checkpoint"). Surfaced by live Tier-2 verification, not unit tests (which mocked the registry).

While fixing it I found a **second, latent gap**: the resume route only flipped status to RUNNING and emitted `RUN_RESUMED` — it **never re-invoked the executor**. Repo-wide, the only caller of `execute_cycle`/`execute_run` is cycle-create's background task, so resume (for *any* case, including SIP-0079 checkpoint-resume) silently never re-executed.

## Fix (resume route only)
1. **Relax the checkpoint guard for PAUSED runs** — a checkpoint-less PAUSED run re-attempts the plan from the start (option 2 in #222). A FAILED run without a checkpoint still 422s (scoped — create a fresh run).
2. **Enqueue `execute_cycle` on resume** (mirrors cycle-create). `execute_run` already self-detects the resume source — it resumes from the latest checkpoint if one exists, else restarts from the beginning, and re-runs the §2.5 duty guard, so a still-active hard-duty window simply re-defers. This makes resume actually proceed, for the deferral case **and** the previously-dead checkpoint-resume path.

## Tests (`test_api_resume.py`)
- PAUSED + no checkpoint → 200 + re-attempt enqueued (the #222 case)
- FAILED + no checkpoint → 422, no enqueue (scoped relaxation)
- resume enqueues `execute_cycle` (the re-execution wiring)
- existing resume / terminal / cycle-status cases unchanged

Full `tests/unit/cycles/` suite green (1325 passed, 2 skipped).

## Note for review
The re-execution wiring (#2) is broader than the literal #222 title but is required to make "re-attempt from the start" actually work, and it was the same one-line gap for checkpoint-resume — so I wired it uniformly rather than ship an incoherent half-fix. Happy to split #2 into its own issue if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
