### PR TITLE
fix(cycles): resume mid-sequence runs at the right workload index (#257)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -427,8 +427,15 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             await self.execute_run(cycle_id, first_run_id, profile_id)
             return
 
+        # #257: support resuming mid-sequence. first_run_id may be a later
+        # workload's run (a resumed/deferred run), not the position-0 run. Start
+        # the loop at that run's workload index so earlier, already-completed
+        # workloads aren't re-run and the resumed run isn't double-executed.
+        # Cycle-create passes the first run, which resolves to index 0.
+        start_index = await self._starting_workload_index(cycle_id, first_run_id)
         current_run_id = first_run_id
-        for i, workload_entry in enumerate(workload_sequence):
+        for i in range(start_index, len(workload_sequence)):
+            workload_entry = workload_sequence[i]
             await self.execute_run(cycle_id, current_run_id, profile_id)
 
             # Check terminal status (compare persisted string values)
@@ -539,6 +546,26 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 context={"cycle_id": cycle_id, "run_id": current_run_id},
                 payload={"workload_type": next_workload.get("type")},
             )
+
+    async def _starting_workload_index(self, cycle_id: str, first_run_id: str) -> int:
+        """Workload-sequence index that ``first_run_id`` occupies (#257).
+
+        Runs map positionally to workloads — one run per position, created in
+        sequence order (D14) — so a run's index among the cycle's non-cancelled
+        runs (sorted by run_number) is its workload position. This lets
+        execute_cycle resume mid-sequence without re-running earlier completed
+        workloads or double-executing the resumed run. Returns 0 when the run is
+        the first/only one (the cycle-create entry) or is not found.
+        """
+        all_runs = await self._cycle_registry.list_runs(cycle_id)
+        non_cancelled = sorted(
+            (r for r in all_runs if r.status != RunStatus.CANCELLED.value),
+            key=lambda r: r.run_number,
+        )
+        for index, run in enumerate(non_cancelled):
+            if run.run_id == first_run_id:
+                return index
+        return 0
 
     async def _poll_inter_workload_gate(
         self, run_id: str, cycle: Cycle, gate_name: str

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -116,6 +116,9 @@ def executor(mock_registry, mock_event_bus):
     exec_._cycle_event_bus = mock_event_bus
     # Patch execute_run to track calls without real dispatch
     exec_.execute_run = AsyncMock()
+    # Default to the cycle-create entry (first run = position 0). Resume tests
+    # override this; the real lookup is covered by TestStartingWorkloadIndex.
+    exec_._starting_workload_index = AsyncMock(return_value=0)
     return exec_
 
 
@@ -225,6 +228,104 @@ class TestMultiWorkloadOrchestration:
 
         assert executor.execute_run.await_count == 3
         assert mock_registry.create_run.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Mid-sequence resume (#257)
+# ---------------------------------------------------------------------------
+
+
+class TestStartingWorkloadIndex:
+    """#257: _starting_workload_index maps a run to its workload position so
+    execute_cycle can resume mid-sequence instead of always starting at 0."""
+
+    def _bare_executor(self, registry):
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+        return DispatchedFlowExecutor(
+            cycle_registry=registry,
+            artifact_vault=AsyncMock(),
+            queue=AsyncMock(),
+            squad_profile=AsyncMock(),
+            task_timeout=5.0,
+        )
+
+    @pytest.mark.parametrize(
+        ("run_id", "expected"),
+        [("run_001", 0), ("run_002", 1), ("run_003", 2)],
+    )
+    async def test_index_matches_run_position(self, mock_registry, run_id, expected):
+        """A run's index is its position among non-cancelled runs (run_number order)."""
+        mock_registry.list_runs.return_value = [
+            _make_run("run_001", 1, "completed", "framing"),
+            _make_run("run_002", 2, "paused", "implementation"),
+            _make_run("run_003", 3, "queued", "wrapup"),
+        ]
+        ex = self._bare_executor(mock_registry)
+        assert await ex._starting_workload_index("cyc_001", run_id) == expected
+
+    async def test_cancelled_runs_are_skipped(self, mock_registry):
+        """A cancelled run occupies no workload position — later runs shift down."""
+        mock_registry.list_runs.return_value = [
+            _make_run("run_001", 1, "completed", "framing"),
+            _make_run("run_cx", 2, "cancelled", "implementation"),
+            _make_run("run_003", 3, "paused", "implementation"),
+        ]
+        ex = self._bare_executor(mock_registry)
+        # run_003 is the 2nd non-cancelled run → index 1, not 2
+        assert await ex._starting_workload_index("cyc_001", "run_003") == 1
+
+    async def test_unknown_run_defaults_to_zero(self, mock_registry):
+        """A run not among the cycle's runs falls back to the start (index 0)."""
+        mock_registry.list_runs.return_value = [_make_run("run_001", 1, "completed")]
+        ex = self._bare_executor(mock_registry)
+        assert await ex._starting_workload_index("cyc_001", "ghost") == 0
+
+
+class TestResumeMidSequence:
+    """#257: resuming a later workload's run starts the loop at its position.
+
+    The bug #256 made reachable (wiring resume → execute_cycle): with the old
+    `enumerate` loop, resuming run_002 ran it as workload 0, double-executed it,
+    and re-polled the framing→impl gate. The fix starts at the run's index.
+    """
+
+    async def test_resume_at_index_one_skips_completed_first_workload(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        cycle = _make_cycle(
+            workload_sequence=[
+                {"type": "framing"},
+                {"type": "implementation"},
+                {"type": "wrapup"},
+            ]
+        )
+        mock_registry.get_cycle.return_value = cycle
+
+        run1 = _make_run("run_001", 1, "completed", "framing")
+        run2 = _make_run("run_002", 2, "completed", "implementation")
+        run3 = _make_run("run_003", 3, "completed", "wrapup")
+
+        # Resume the implementation run (position 1); run_003 already exists (reused).
+        executor._starting_workload_index = AsyncMock(return_value=1)
+        mock_registry.get_run.side_effect = [run2, run3]
+        mock_registry.list_runs.return_value = [run1, run2, run3]
+
+        await executor.execute_cycle("cyc_001", "run_002")
+
+        # Only the resumed impl run and wrapup execute — framing (already done) is
+        # NOT re-run, and the resumed run runs exactly once.
+        executed = [c[0][1] for c in executor.execute_run.call_args_list]
+        assert executed == ["run_002", "run_003"]
+        assert "run_001" not in executed
+        mock_registry.create_run.assert_not_called()
+        # Workloads are labeled by their true position (no framing mislabel).
+        completed_types = [
+            c[1]["payload"]["workload_type"]
+            for c in mock_event_bus.emit.call_args_list
+            if c[0][0] == EventType.WORKLOAD_COMPLETED
+        ]
+        assert completed_types == ["implementation", "wrapup"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #257. Follow-up to #222 / #256.

## Problem
`execute_cycle`'s workload loop assumed `first_run_id` was the position-0 run and advanced by positional index:

```python
for i, workload_entry in enumerate(workload_sequence):   # always starts at 0
    await self.execute_run(cycle_id, current_run_id, profile_id)
    ...
    current_run_id = non_cancelled[i + 1].run_id
```

True for the cycle-create entry, but **#256** wired `runs resume` to call `execute_cycle(cycle_id, run_id)`. Resuming a run paused on a **later** workload (e.g. a SIP-0089 §2.5 duty deferral on the implementation run) then started the loop at `i=0` — re-running the resumed run as workload 0, **double-executing it**, and re-polling the wrong inter-workload gate.

## Fix
Add `_starting_workload_index(cycle_id, first_run_id)` — a run's index among the cycle's non-cancelled runs (sorted by `run_number`; one run per workload position, D14) — and iterate `for i in range(start_index, len(workload_sequence))`. Cycle-create's first run resolves to index 0, so that path is unchanged; single/first-workload resume was already correct (fast path / i=0).

## Tests
- `_starting_workload_index`: position mapping, cancelled-run skip, unknown→0.
- Resume at index 1 in a 3-workload cycle: the completed first workload is **not** re-run, the resumed run executes **once**, `run_003` (wrapup) follows, and `WORKLOAD_COMPLETED` is labeled by true position (`implementation`, `wrapup` — no framing mislabel).
- Existing `execute_cycle` tests unchanged: the shared fixture stubs the index to 0 (matching the cycle-create entry they model), so the brittle call-sequence tests stay valid. Full `tests/unit/cycles/` green (1331 passed).

## Note
This is the multi-workload edge; the common #222 case (single-workload selftest deferral, or a first-workload deferral) was already correct. #258 (live E2E validation) still covers the real executor round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
