### PR TITLE
refactor(cycles): route dispatched factory through create_workflow_tracker (#250)

### DIFF
--- a/adapters/cycles/factory.py
+++ b/adapters/cycles/factory.py
@@ -95,9 +95,16 @@ def create_flow_executor(
 
         workflow_tracker = kwargs.get("workflow_tracker")
         if not workflow_tracker and kwargs.get("prefect_api_url"):
-            from adapters.cycles.prefect_workflow_tracker import PrefectWorkflowTracker
+            # Route through the shared factory so the NoOp-fallback and init
+            # logging apply here too (instead of inline-building the adapter and
+            # raising on construction failure). Only build when a Prefect URL is
+            # configured — when it isn't, workflow_tracker stays None, unchanged.
+            from adapters.cycles.workflow_tracker_factory import create_workflow_tracker
+            from squadops.config.schema import PrefectConfig
 
-            workflow_tracker = PrefectWorkflowTracker(api_url=kwargs["prefect_api_url"])
+            workflow_tracker = create_workflow_tracker(
+                PrefectConfig(api_url=kwargs["prefect_api_url"])
+            )
 
         return DispatchedFlowExecutor(
             cycle_registry=cycle_registry,

--- a/tests/unit/cycles/test_flow_executor_factory.py
+++ b/tests/unit/cycles/test_flow_executor_factory.py
@@ -29,3 +29,52 @@ def test_provider_key_resolves_to_expected_executor(provider, expected):
 def test_unknown_provider_raises():
     with pytest.raises(ValueError, match="Unknown flow executor provider"):
         create_flow_executor("bogus")
+
+
+class TestDispatchedWorkflowTrackerWiring:
+    """#250: the dispatched branch routes ``prefect_api_url`` through the shared
+    ``create_workflow_tracker`` (NoOp-fallback + init logging) instead of
+    inline-building ``PrefectWorkflowTracker`` — without changing the no-URL or
+    explicit-tracker paths."""
+
+    def test_prefect_url_builds_prefect_tracker(self):
+        """A configured Prefect URL yields a real PrefectWorkflowTracker on the
+        executor (the routing actually constructs the adapter)."""
+        from adapters.cycles.prefect_workflow_tracker import PrefectWorkflowTracker
+
+        executor = create_flow_executor("dispatched", prefect_api_url="http://prefect:4200/api")
+        assert isinstance(executor._workflow_tracker, PrefectWorkflowTracker)
+
+    def test_no_prefect_url_leaves_tracker_none(self):
+        """Behavior preserved: with no URL and no explicit tracker, the executor
+        gets ``None`` (NOT a NoOp) — exactly as before the refactor."""
+        executor = create_flow_executor("dispatched")
+        assert executor._workflow_tracker is None
+
+    def test_prefect_construction_failure_falls_back_to_noop(self, monkeypatch):
+        """The gain: because the branch now routes through the shared factory, a
+        PrefectWorkflowTracker construction failure falls back to a
+        NoOpWorkflowTracker instead of raising out of the factory and breaking
+        executor wiring (the old inline build would propagate the error)."""
+        import adapters.cycles.prefect_workflow_tracker as pwt
+        from adapters.cycles.noop_workflow_tracker import NoOpWorkflowTracker
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("prefect unreachable at construction")
+
+        monkeypatch.setattr(pwt, "PrefectWorkflowTracker", _boom)
+        executor = create_flow_executor("dispatched", prefect_api_url="http://prefect:4200/api")
+        assert isinstance(executor._workflow_tracker, NoOpWorkflowTracker)
+
+    def test_explicit_tracker_takes_precedence_over_url(self):
+        """An explicitly injected tracker is used as-is even when a URL is also
+        present — the ``if not workflow_tracker`` guard is preserved."""
+        from adapters.cycles.noop_workflow_tracker import NoOpWorkflowTracker
+
+        sentinel = NoOpWorkflowTracker()
+        executor = create_flow_executor(
+            "dispatched",
+            workflow_tracker=sentinel,
+            prefect_api_url="http://prefect:4200/api",
+        )
+        assert executor._workflow_tracker is sentinel


### PR DESCRIPTION
## What & why

Closes #250. The dispatched branch of `create_flow_executor` (`adapters/cycles/factory.py`) **inline-built** `PrefectWorkflowTracker(api_url=...)`, bypassing the shared `create_workflow_tracker` factory. It therefore missed:
- the **NoOp-fallback** (construction failure propagated out of the factory, breaking executor wiring),
- the **init logging** (`backend=prefect, api_url=...`).

## Change

Route the build through `create_workflow_tracker(PrefectConfig(api_url=kwargs["prefect_api_url"]))`.

**Behavior preserved** — the build still only happens when a Prefect URL is configured, so:
- no URL → `workflow_tracker` stays `None` (not NoOp), unchanged;
- an explicit `workflow_tracker` kwarg still wins (the `if not workflow_tracker` guard).

The **only** new behavior is the intended one: a configured-but-failing Prefect URL now falls back to `NoOpWorkflowTracker` (+ logs) instead of raising.

## Tests (`TestDispatchedWorkflowTrackerWiring`)
- URL → executor gets a real `PrefectWorkflowTracker`
- no URL → `None` (preserved)
- construction failure → `NoOpWorkflowTracker` fallback (**the gain** — old inline build raised)
- explicit tracker → takes precedence over URL

7 passed in the factory file; `workflow_tracker` + `prefect_workflow_tracker` suites green; ruff clean.

---
Lane S / Sprint 1, item 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)