### PR TITLE
refactor(adapters): extract one parse_jsonb helper, dedup 3 copies (#156)

### DIFF
--- a/adapters/cycles/postgres_cycle_registry.py
+++ b/adapters/cycles/postgres_cycle_registry.py
@@ -12,6 +12,7 @@ import logging
 
 import asyncpg
 
+from adapters.jsonb import parse_jsonb
 from squadops.cycles.checkpoint import RunCheckpoint
 from squadops.cycles.lifecycle import (
     GATE_REJECTED_STATES,
@@ -304,7 +305,7 @@ class PostgresCycleRegistry(CycleRegistryPort):
                 )
                 if cycle_row is None:
                     raise CycleNotFoundError(f"Cycle not found: {run_row['cycle_id']}")
-                policy = self._parse_jsonb(cycle_row["task_flow_policy"])
+                policy = parse_jsonb(cycle_row["task_flow_policy"])
                 gate_names = {g["name"] for g in policy.get("gates", ())}
                 if decision.gate_name not in gate_names:
                     raise ValidationError(
@@ -435,16 +436,9 @@ class PostgresCycleRegistry(CycleRegistryPort):
 
     # --- Internal helpers ---
 
-    @staticmethod
-    def _parse_jsonb(value):
-        """Decode a JSONB column value (asyncpg returns str by default)."""
-        if isinstance(value, str):
-            return json.loads(value)
-        return value  # already a dict (e.g. in tests or with custom codec)
-
     def _row_to_cycle(self, row: asyncpg.Record) -> Cycle:
         """Reconstruct frozen Cycle from asyncpg Record."""
-        tfp = self._parse_jsonb(row["task_flow_policy"])
+        tfp = parse_jsonb(row["task_flow_policy"])
         gates = tuple(
             Gate(
                 name=g["name"],
@@ -453,9 +447,9 @@ class PostgresCycleRegistry(CycleRegistryPort):
             )
             for g in tfp.get("gates", ())
         )
-        applied = self._parse_jsonb(row["applied_defaults"]) or {}
-        overrides = self._parse_jsonb(row["execution_overrides"]) or {}
-        experiment = self._parse_jsonb(row["experiment_context"]) or {}
+        applied = parse_jsonb(row["applied_defaults"]) or {}
+        overrides = parse_jsonb(row["execution_overrides"]) or {}
+        experiment = parse_jsonb(row["experiment_context"]) or {}
         return Cycle(
             cycle_id=row["cycle_id"],
             project_id=row["project_id"],
@@ -506,10 +500,10 @@ class PostgresCycleRegistry(CycleRegistryPort):
         return RunCheckpoint(
             run_id=row["run_id"],
             checkpoint_index=row["checkpoint_index"],
-            completed_task_ids=tuple(self._parse_jsonb(row["completed_task_ids"])),
-            prior_outputs=self._parse_jsonb(row["prior_outputs"]),
-            artifact_refs=tuple(self._parse_jsonb(row["artifact_refs"])),
-            plan_delta_refs=tuple(self._parse_jsonb(row["plan_delta_refs"])),
+            completed_task_ids=tuple(parse_jsonb(row["completed_task_ids"])),
+            prior_outputs=parse_jsonb(row["prior_outputs"]),
+            artifact_refs=tuple(parse_jsonb(row["artifact_refs"])),
+            plan_delta_refs=tuple(parse_jsonb(row["plan_delta_refs"])),
             created_at=row["created_at"],
         )
 

--- a/adapters/cycles/postgres_squad_profile.py
+++ b/adapters/cycles/postgres_squad_profile.py
@@ -11,6 +11,7 @@ import logging
 
 import asyncpg
 
+from adapters.jsonb import parse_jsonb
 from squadops.cycles.lifecycle import compute_profile_snapshot_hash
 from squadops.cycles.models import (
     ActiveProfileDeletionError,
@@ -210,13 +211,6 @@ class PostgresSquadProfile(SquadProfilePort):
     # --- Helpers ---
 
     @staticmethod
-    def _parse_jsonb(value):
-        """Decode a JSONB column value (asyncpg returns str by default)."""
-        if isinstance(value, str):
-            return json.loads(value)
-        return value
-
-    @staticmethod
     def _agents_to_dicts(agents: tuple[AgentProfileEntry, ...]) -> list[dict]:
         """Serialize AgentProfileEntry tuples to list of dicts for JSONB."""
         return [
@@ -232,7 +226,7 @@ class PostgresSquadProfile(SquadProfilePort):
 
     def _row_to_profile(self, row: asyncpg.Record) -> SquadProfile:
         """Reconstruct SquadProfile from asyncpg Record."""
-        agents_data = self._parse_jsonb(row["agents"])
+        agents_data = parse_jsonb(row["agents"])
         agents = tuple(
             AgentProfileEntry(
                 agent_id=a["agent_id"],

--- a/adapters/jsonb.py
+++ b/adapters/jsonb.py
@@ -1,0 +1,27 @@
+"""Shared helper for decoding JSONB column values from asyncpg.
+
+asyncpg returns JSONB columns as a JSON ``str`` by default (no custom codec is
+registered), but in tests — or with a custom codec — they may already be
+decoded. Every postgres-backed adapter decodes the same way through this single
+helper, so the behavior can't drift between adapters (#156).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def parse_jsonb(value: Any) -> Any:
+    """Decode a JSONB column value.
+
+    asyncpg returns JSONB as a JSON ``str`` by default; decode it. If it was
+    already decoded — a ``dict``/``list``, or ``None`` for SQL NULL (e.g. in
+    tests or with a custom codec) — return it unchanged.
+
+    Callers that need ``None`` coerced to ``{}`` (e.g. a nullable metadata
+    column) should apply ``or {}`` at the call site.
+    """
+    if isinstance(value, str):
+        return json.loads(value)
+    return value

--- a/adapters/persistence/chat_repository.py
+++ b/adapters/persistence/chat_repository.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     import asyncpg
 
+from adapters.jsonb import parse_jsonb
 from squadops.comms.models import ChatMessage, ChatSession, SessionNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -150,15 +151,6 @@ class ChatRepository:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _parse_jsonb(value: Any) -> dict:
-        """Decode a JSONB column value (asyncpg returns strings)."""
-        if isinstance(value, str):
-            return json.loads(value)
-        if value is None:
-            return {}
-        return value
-
     def _assemble_session(self, row: Any) -> ChatSession:
         """Reconstruct a ChatSession from a database row."""
         return ChatSession(
@@ -167,7 +159,9 @@ class ChatRepository:
             user_id=row["user_id"],
             started_at=row["started_at"],
             ended_at=row["ended_at"],
-            metadata=self._parse_jsonb(row["metadata"]),
+            # `or {}`: a nullable metadata column decodes to None — coerce to {}
+            # (preserved from the old _parse_jsonb None branch).
+            metadata=parse_jsonb(row["metadata"]) or {},
         )
 
     def _assemble_message(self, row: Any) -> ChatMessage:
@@ -178,5 +172,5 @@ class ChatRepository:
             role=row["role"],
             content=row["content"],
             created_at=row["created_at"],
-            metadata=self._parse_jsonb(row["metadata"]),
+            metadata=parse_jsonb(row["metadata"]) or {},
         )

--- a/tests/unit/adapters/test_chat_repository.py
+++ b/tests/unit/adapters/test_chat_repository.py
@@ -234,20 +234,48 @@ class TestChatRepositoryListSessions:
         assert "ORDER BY started_at DESC" in sql
 
 
-class TestChatRepositoryJsonb:
-    """JSONB parsing edge cases."""
+class TestChatRepositoryMetadataDecoding:
+    """ChatRepository decodes JSONB metadata via the shared ``parse_jsonb``
+    helper, and (preserved from the old ``_parse_jsonb``) coerces a NULL
+    metadata column to an empty dict at the call site so consumers always get a
+    dict (#156)."""
 
-    def test_parse_jsonb_handles_string(self):
-        """asyncpg returns JSONB as string — parser decodes it."""
-        result = ChatRepository._parse_jsonb('{"key": "value"}')
-        assert result == {"key": "value"}
+    @staticmethod
+    def _session_row(metadata):
+        return {
+            "session_id": "s1",
+            "agent_id": "a1",
+            "user_id": "u1",
+            "started_at": _now(),
+            "ended_at": None,
+            "metadata": metadata,
+        }
 
-    def test_parse_jsonb_handles_dict(self):
-        """Already-decoded dict passes through."""
-        result = ChatRepository._parse_jsonb({"key": "value"})
-        assert result == {"key": "value"}
+    @staticmethod
+    def _message_row(metadata):
+        return {
+            "message_id": "m1",
+            "session_id": "s1",
+            "role": "user",
+            "content": "hi",
+            "created_at": _now(),
+            "metadata": metadata,
+        }
 
-    def test_parse_jsonb_handles_none(self):
-        """None returns empty dict."""
-        result = ChatRepository._parse_jsonb(None)
-        assert result == {}
+    def test_session_decodes_string_metadata(self):
+        """asyncpg returns JSONB as a string — it is decoded into a dict."""
+        repo = ChatRepository(pool=_make_pool()[0])
+        session = repo._assemble_session(self._session_row('{"k": "v"}'))
+        assert session.metadata == {"k": "v"}
+
+    def test_session_null_metadata_becomes_empty_dict(self):
+        """Preserved None→{}: a NULL metadata column surfaces as {} (not None)."""
+        repo = ChatRepository(pool=_make_pool()[0])
+        session = repo._assemble_session(self._session_row(None))
+        assert session.metadata == {}
+
+    def test_message_null_metadata_becomes_empty_dict(self):
+        """Same None→{} preservation on the message-assembly path."""
+        repo = ChatRepository(pool=_make_pool()[0])
+        message = repo._assemble_message(self._message_row(None))
+        assert message.metadata == {}

--- a/tests/unit/adapters/test_jsonb.py
+++ b/tests/unit/adapters/test_jsonb.py
@@ -1,0 +1,45 @@
+"""Tests for the shared asyncpg JSONB decode helper (#156).
+
+Single-sources the decode used by every postgres-backed adapter; this locks the
+contract so the behavior can't drift back into per-adapter copies.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from adapters.jsonb import parse_jsonb
+
+
+def test_decodes_json_object_string():
+    """asyncpg returns JSONB as a JSON string by default — decode it to a dict."""
+    assert parse_jsonb('{"key": "value"}') == {"key": "value"}
+
+
+def test_decodes_json_array_string():
+    """A JSONB array column decodes to a list (e.g. the *_refs / id columns in
+    the cycle registry)."""
+    assert parse_jsonb('["a", "b"]') == ["a", "b"]
+
+
+def test_passes_through_already_decoded_value():
+    """An already-decoded value (tests, or a registered custom codec) is
+    returned unchanged — same object, not a re-encoded copy."""
+    value = {"key": "value"}
+    assert parse_jsonb(value) is value
+
+
+def test_none_passes_through_as_none():
+    """None (SQL NULL) is returned as-is. The None→{} coercion is deliberately
+    NOT baked into the helper — callers that need it apply ``or {}`` at the call
+    site (e.g. chat metadata)."""
+    assert parse_jsonb(None) is None
+
+
+def test_invalid_json_string_raises():
+    """A malformed JSON string surfaces a decode error rather than being
+    silently swallowed."""
+    with pytest.raises(json.JSONDecodeError):
+        parse_jsonb("{not valid json}")


### PR DESCRIPTION
## What & why

Closes #156. `_parse_jsonb` was copy-pasted as a private static method in three adapters:
- `adapters/persistence/chat_repository.py` (with a `None → {}` branch)
- `adapters/cycles/postgres_squad_profile.py`
- `adapters/cycles/postgres_cycle_registry.py`

(the latter two byte-identical). A single decode, three copies that could drift.

## Change

New **`adapters/jsonb.py`** → `parse_jsonb(value)`: `str → json.loads`, otherwise passthrough (incl. `None`). All three adapters route through it.

- **`chat_repository`'s `None → {}` is preserved at the call sites** (`parse_jsonb(row["metadata"]) or {}`) — *not* baked into the shared helper — so nullable metadata still surfaces as `{}` while the helper stays a pure decode for adapters (cycle registry) that need `None` passed through.
- Helper lives at the **top-level `adapters` package** (not under `persistence`) so the `cycles` adapters don't take a dependency on the `persistence` subpackage. `test_forbidden_imports` stays green.

## Tests
- New `tests/unit/adapters/test_jsonb.py` locks the helper contract: object/array decode, already-decoded passthrough (same object), `None → None`, invalid-JSON raises `JSONDecodeError`.
- The old direct-`_parse_jsonb` chat tests (which broke when the method was removed) are replaced with **call-site** tests through `_assemble_session` / `_assemble_message` that lock the preserved `None → {}` behavior — testing the real path, not the deleted method.

Local: `adapters` + `cycles` suites **1353 passed / 2 skipped**, arch forbidden-imports green, ruff clean.

---
Lane S / Sprint 1, item 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)