### PR TITLE
feat(console): surface agent mode + runtime_status on the agent list (#230, #231)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,9 @@ squadops artifacts list <run-id>           # List artifacts for run
 ### Agent Squad
 6 agents when builder role is present: Max (Lead), Neo (Dev), Nat (Strategy), Bob (Builder), Eve (QA), Data (Analytics). The standard 5-agent squad (without Bob) remains the default via `full-squad` profile. Implementations in `src/squadops/agents/`.
 
+### Agent status vs runtime state
+Don't conflate the signals. **Health = `runtime_status`, posture = `mode`** (both from `agent_runtime_state`, SIP-0089); `lifecycle_state`/`network_status` on `agent_status` are heartbeat telemetry (`network_status` is legacy/deprecated). Canonical model + the rule surfaces must conform to: `docs/agent-runtime-status-model.md` (#231).
+
 ## Test Configuration
 
 - Tests auto-receive `unit`/`integration` markers based on file location (`tests/conftest.py`)

--- a/console/continuum-plugins/squadops.agents/ui/src/AgentsStatus.svelte
+++ b/console/continuum-plugins/squadops.agents/ui/src/AgentsStatus.svelte
@@ -10,7 +10,10 @@
   function mapAgent(a) {
     return {
       name: a.agent_name || a.agent_id || a.name,
-      status: a.network_status || a.lifecycle_state || a.status || 'unknown',
+      // Health = runtime_status (SIP-0089); network_status is the legacy fallback
+      // for an agent that has no runtime-state row yet (#230/#231).
+      status: a.runtime_status || a.network_status || a.lifecycle_state || a.status || 'unknown',
+      mode: a.mode || null,
       role: a.role_label || a.role || '',
       current_task: a.current_task_id || a.current_task || null,
     };
@@ -45,6 +48,13 @@
     if (s === 'busy') return 'busy';
     return 'unhealthy';
   }
+
+  function modeClass(mode) {
+    const m = (mode || '').toLowerCase();
+    if (m === 'duty') return 'mode-duty';
+    if (m === 'cycle') return 'mode-cycle';
+    return 'mode-ambient';
+  }
 </script>
 
 <div class="agents-status">
@@ -61,6 +71,9 @@
           <div class="agent-name">{agent.name}</div>
           <div class="agent-role">{agent.role}</div>
           <div class="agent-status {statusClass(agent.status)}">{agent.status}</div>
+          {#if agent.mode}
+            <div class="agent-mode {modeClass(agent.mode)}">{agent.mode}</div>
+          {/if}
           {#if agent.current_task}
             <div class="agent-task">{agent.current_task}</div>
           {/if}
@@ -95,6 +108,14 @@
   .healthy { background: rgba(34, 197, 94, 0.15); color: var(--continuum-accent-success, #22c55e); }
   .busy { background: rgba(99, 102, 241, 0.15); color: var(--continuum-accent-primary, #6366f1); }
   .unhealthy { background: rgba(148, 163, 184, 0.15); color: var(--continuum-text-muted, #94a3b8); }
+  .agent-mode {
+    font-size: var(--continuum-font-size-xs, 0.75rem);
+    padding: 2px 8px; border-radius: var(--continuum-radius-sm, 4px);
+    font-weight: 500; text-transform: uppercase;
+  }
+  .mode-duty { background: rgba(234, 179, 8, 0.15); color: var(--continuum-accent-warning, #eab308); }
+  .mode-cycle { background: rgba(99, 102, 241, 0.15); color: var(--continuum-accent-primary, #6366f1); }
+  .mode-ambient { background: rgba(148, 163, 184, 0.15); color: var(--continuum-text-muted, #94a3b8); }
   .agent-task { font-size: var(--continuum-font-size-xs, 0.75rem); color: var(--continuum-text-secondary, #cbd5e1); flex: 1; text-align: right; }
   .loading, .no-agents { color: var(--continuum-text-muted, #94a3b8); }
 </style>

--- a/docs/agent-runtime-status-model.md
+++ b/docs/agent-runtime-status-model.md
@@ -1,0 +1,57 @@
+# Agent Status vs Runtime State — Canonical Model
+
+**Status:** canonical reference (SIP-0089) · addresses the terminology half of #231.
+
+SquadOps tracks several overlapping signals about an agent. They are easy to
+conflate. This is the canonical model that surfaces (APIs, dashboard, CLI) MUST
+conform to. The remaining *consolidation* work (collapsing the legacy field,
+renaming the accessors) is tracked in #231.
+
+## The two tables
+
+| Table | Owns | Written by |
+|-------|------|-----------|
+| `agent_status` | heartbeat **telemetry**: `lifecycle_state`, `last_heartbeat`, `network_status`, `tps`, `memory_count`, `current_task_id` | the agent heartbeat flow (`update_agent_status_in_db`) |
+| `agent_runtime_state` (SIP-0089) | **runtime posture + health**: `mode`, `runtime_status`, `focus`, `current_runtime_activity_id`, `interruptibility`, `current_assignment_ref` | the `RuntimeCoordinator` only (D16) — the single mode-writer |
+
+They are intentionally separate (D17: the heartbeat is **non-authoritative** for
+runtime state). The health-checker reconciliation loop mirrors an agent that has
+gone offline (by heartbeat age) into `agent_runtime_state.runtime_status` so the
+coordinator's §11.3 `offline → duty` guard sees a fresh value.
+
+## The canonical signals
+
+- **Mode** (`mode`) — *work posture*: `ambient` | `cycle` | `duty`. What the agent
+  is currently doing. Source of truth: `agent_runtime_state.mode`. Only the
+  coordinator writes it.
+- **Runtime status** (`runtime_status`) — *health / availability*: `online` |
+  `degraded` | `recovering` | `offline`. **This is the canonical health signal.**
+  Source: `agent_runtime_state.runtime_status`. Whether an agent is "idle",
+  "busy", or "paused" is **derived** from FocusLease + RuntimeActivity (§10.5),
+  not stored here.
+- **Lifecycle state** (`lifecycle_state`, on `agent_status`) — the agent process /
+  heartbeat lifecycle (`READY`, etc.). It **feeds** health via
+  `runtime_status_from_lifecycle()`; it is not itself the health signal.
+- **`network_status`** (computed on `agent_status` from heartbeat age) — a legacy,
+  derived reachability flag. **Deprecated** in favour of `runtime_status`; kept
+  only for back-compat until the consolidation in #231 lands.
+
+## The rule for surfaces (APIs / dashboard / CLI)
+
+> **Health = `runtime_status`. Posture = `mode`.**
+> `lifecycle_state` feeds health; `agent_status` is telemetry; `network_status`
+> is legacy-derived — do not introduce new dependencies on it.
+
+Concretely:
+- A health pill/badge shows `runtime_status` (falling back to `network_status`
+  only for back-compat while an agent has no `agent_runtime_state` row yet).
+- A separate posture indicator shows `mode`.
+- `GET /health/agents` carries both `runtime_status` and `mode` per agent (plus
+  `network_status`/`lifecycle_state` for back-compat); `mode`/`runtime_status`
+  are `null` when an agent has no runtime-state row (#230).
+
+## Deferred (the rest of #231)
+
+A strangler, not a blocker: collapse `network_status` into `runtime_status` at the
+source, and reconcile the accessor names (`get_agent_status` telemetry vs
+`get_runtime_state` runtime) once every surface reads from this model.

--- a/src/squadops/api/runtime/health_checker.py
+++ b/src/squadops/api/runtime/health_checker.py
@@ -141,9 +141,15 @@ class HealthChecker:
         """Return agent status list, merging DB rows with instances.yaml metadata."""
         try:
             async with self.pg_pool.acquire() as conn:
+                # LEFT JOIN the SIP-0089 runtime row so the list carries posture
+                # (mode) and the canonical health signal (runtime_status). Both
+                # are NULL for an agent with no runtime-state row yet (#230).
                 rows = await conn.fetch(
-                    "SELECT agent_id, lifecycle_state, version, tps, memory_count, "
-                    "last_heartbeat, current_task_id FROM agent_status"
+                    "SELECT s.agent_id, s.lifecycle_state, s.version, s.tps, "
+                    "s.memory_count, s.last_heartbeat, s.current_task_id, "
+                    "r.mode, r.runtime_status "
+                    "FROM agent_status s "
+                    "LEFT JOIN agent_runtime_state r ON r.agent_id = s.agent_id"
                 )
 
             instances = self._load_instances()
@@ -167,6 +173,9 @@ class HealthChecker:
                     "role_label": get_role_label(role),
                     "network_status": network_status,
                     "lifecycle_state": lifecycle_state,
+                    # SIP-0089 posture + canonical health (None when no runtime row)
+                    "mode": row["mode"],
+                    "runtime_status": row["runtime_status"],
                     "version": row["version"] or "0.0.0",
                     "tps": row["tps"],
                     "memory_count": row["memory_count"] if row["memory_count"] is not None else 0,
@@ -195,6 +204,8 @@ class HealthChecker:
                     "role_label": get_role_label(info.get("role", "unknown")),
                     "network_status": "offline",
                     "lifecycle_state": "UNKNOWN",
+                    "mode": None,
+                    "runtime_status": None,
                     "version": "0.0.0",
                     "tps": 0,
                     "memory_count": 0,

--- a/tests/unit/api/test_health_checker.py
+++ b/tests/unit/api/test_health_checker.py
@@ -98,6 +98,8 @@ class TestGetAgentStatus:
             "memory_count": 10,
             "last_heartbeat": datetime.utcnow(),
             "current_task_id": None,
+            "mode": None,
+            "runtime_status": None,
         }[key]
 
         mock_conn = AsyncMock()
@@ -127,6 +129,8 @@ class TestGetAgentStatus:
             "memory_count": 10,
             "last_heartbeat": datetime.utcnow(),
             "current_task_id": None,
+            "mode": None,
+            "runtime_status": None,
         }[key]
 
         mock_conn = AsyncMock()
@@ -161,6 +165,8 @@ class TestGetAgentStatus:
             "memory_count": 10,
             "last_heartbeat": datetime.utcnow(),
             "current_task_id": None,
+            "mode": None,
+            "runtime_status": None,
         }[key]
 
         mock_conn = AsyncMock()
@@ -173,6 +179,52 @@ class TestGetAgentStatus:
         neo = [a for a in result if a["agent_id"] == "neo"][0]
         assert neo["role"] == "dev"
         assert neo["role_label"] == "Developer"
+
+
+class TestAgentStatusRuntimeMode:
+    """#230: the agent list LEFT JOINs agent_runtime_state to surface posture
+    (mode) and the canonical health signal (runtime_status)."""
+
+    def _row(self, **overrides):
+        data = {
+            "agent_id": "max",
+            "lifecycle_state": "READY",
+            "version": "0.9.7",
+            "tps": 5,
+            "memory_count": 10,
+            "last_heartbeat": datetime.utcnow(),
+            "current_task_id": None,
+            "mode": None,
+            "runtime_status": None,
+        }
+        data.update(overrides)
+        row = MagicMock()
+        row.__getitem__ = lambda _self, key: data[key]
+        return row
+
+    def _wire(self, mock_pg_pool, row):
+        conn = AsyncMock()
+        conn.fetch = AsyncMock(return_value=[row])
+        conn.__aenter__ = AsyncMock(return_value=conn)
+        conn.__aexit__ = AsyncMock(return_value=False)
+        mock_pg_pool.acquire.return_value = conn
+
+    @pytest.mark.asyncio
+    async def test_surfaces_mode_and_runtime_status(self, checker, mock_pg_pool):
+        """When a runtime row exists, its mode + runtime_status appear on the agent."""
+        self._wire(mock_pg_pool, self._row(mode="duty", runtime_status="online"))
+        agent = (await checker.get_agent_status())[0]
+        assert agent["mode"] == "duty"
+        assert agent["runtime_status"] == "online"
+
+    @pytest.mark.asyncio
+    async def test_no_runtime_row_yields_none(self, checker, mock_pg_pool):
+        """LEFT JOIN with no agent_runtime_state row → mode/runtime_status are None.
+        The keys are always present so a surface can render a fallback (#230)."""
+        self._wire(mock_pg_pool, self._row(mode=None, runtime_status=None))
+        agent = (await checker.get_agent_status())[0]
+        assert agent["mode"] is None
+        assert agent["runtime_status"] is None
 
 
 class TestUpdateAgentStatusInDb:


### PR DESCRIPTION
Closes #230. Addresses the doc step of #231 (full consolidation deferred).

## #231 — canonical model (doc step)
`docs/agent-runtime-status-model.md` documents the model every surface must conform to, to stop the `network_status` / `runtime_status` / `lifecycle_state` conflation:

> **Health = `runtime_status`. Posture = `mode`.** Both from `agent_runtime_state` (SIP-0089). `lifecycle_state` feeds health; `agent_status` is heartbeat telemetry; `network_status` is legacy-derived and **deprecated**.

A pointer was added to `CLAUDE.md` (Agent Squad section). The remaining *consolidation* — collapse `network_status` into `runtime_status` at the source, reconcile the `get_agent_status` vs `get_runtime_state` accessor names — stays open under **#231** as a strangler (not version-gating).

## #230 — mode on the agent list
- `get_agent_status()` now `LEFT JOIN`s `agent_runtime_state`, so `GET /health/agents` carries **`mode`** and the canonical **`runtime_status`** per agent (both `null` when an agent has no runtime-state row yet). `network_status`/`lifecycle_state` stay for back-compat.
- `AgentsStatus.svelte` renders the **status pill** (preferring `runtime_status`, falling back to `network_status`) **and** a new **mode pill** (`duty`/`cycle`/`ambient`).
- `dist/plugin.js` is gitignored and regenerated at deploy; I ran `vite build` to verify the source compiles (new pill present in the bundle) but there's no artifact to commit.

## Tests
- `mode`/`runtime_status` surfaced when a runtime row exists.
- Both `None` on the no-runtime-row `LEFT JOIN` (the key case — keys always present so the UI can fall back).
- Existing `get_agent_status` tests updated for the new columns. Full `tests/unit/api` green (163 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
