### PR TITLE
fix(cli,api): make `runs retry` actually execute; correct stale execution docstrings (#133, #205)

### DIFF
--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -35,8 +35,17 @@ router = APIRouter(prefix="/api/v1/projects/{project_id}/cycles/{cycle_id}/runs"
 
 
 @router.post("", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
-async def create_run(project_id: str, cycle_id: str, workload_type: str | None = None):
-    """Create a new Run (retry) for an existing Cycle."""
+async def create_run(
+    project_id: str,
+    cycle_id: str,
+    background_tasks: BackgroundTasks,
+    workload_type: str | None = None,
+):
+    """Create a new Run (retry) for an existing Cycle and enqueue its execution.
+
+    Mirrors ``cycles create`` / ``resume_run``: the new run is dispatched
+    server-side (not just recorded), so a retry actually re-runs (#133).
+    """
     from squadops.api.runtime.deps import get_cycle_registry
 
     try:
@@ -77,6 +86,19 @@ async def create_run(project_id: str, cycle_id: str, workload_type: str | None =
                 "initiated_by": created.initiated_by,
                 "workload_type": created.workload_type,
             },
+        )
+
+        # Enqueue execution so the retry run actually proceeds (#133) — creating
+        # the run record alone never ran it (only cycle-create/resume dispatched).
+        # Mirrors resume_run; execute_cycle re-runs the §2.5 duty guard, so a
+        # still-active hard-duty window simply re-defers.
+        from squadops.api.runtime.deps import get_flow_executor
+
+        background_tasks.add_task(
+            get_flow_executor().execute_cycle,
+            cycle_id,
+            created.run_id,
+            cycle.squad_profile_id,
         )
 
         return run_to_response(created)

--- a/src/squadops/cli/commands/cycles.py
+++ b/src/squadops/cli/commands/cycles.py
@@ -98,10 +98,11 @@ def create_cycle(
     set_flags: list[str] | None = typer.Option(None, "--set", help="Override: key=value"),
     notes: str | None = typer.Option(None, "--notes", help="Experiment notes"),
 ):
-    """Create a new experiment cycle.
+    """Create a new experiment cycle and start its run.
 
-    Creates an experiment record. Does not trigger task execution
-    (deferred to a future release).
+    Persists the cycle and enqueues its run for execution server-side
+    (SIP-0066/0083) — real (LLM-cost) work begins immediately, no separate
+    trigger needed.
     """
     fmt = ctx.obj.get("format", "table") if ctx.obj else "table"
 

--- a/src/squadops/cli/commands/runs.py
+++ b/src/squadops/cli/commands/runs.py
@@ -136,10 +136,10 @@ def retry_run(
     project_id: str = typer.Argument(...),
     cycle_id: str = typer.Argument(...),
 ):
-    """Create a new run (retry) for a cycle.
+    """Create a new run (retry) for a cycle and enqueue it for execution.
 
-    Creates an execution record. Does not trigger task execution
-    (deferred to a future release).
+    The new run is dispatched server-side — the same as `cycles create` and
+    `runs resume`.
     """
     fmt = ctx.obj.get("format", "table") if ctx.obj else "table"
 

--- a/tests/unit/api/test_workload_canon_api.py
+++ b/tests/unit/api/test_workload_canon_api.py
@@ -150,6 +150,8 @@ def client(mock_cycle_registry, monkeypatch):
     import squadops.api.runtime.deps as deps_mod
 
     monkeypatch.setattr(deps_mod, "_cycle_registry", mock_cycle_registry)
+    # create_run now enqueues execution (#133), so a flow executor must be wired.
+    monkeypatch.setattr(deps_mod, "_flow_executor", AsyncMock())
     return TestClient(app)
 
 

--- a/tests/unit/cycles/test_api_runs.py
+++ b/tests/unit/cycles/test_api_runs.py
@@ -65,13 +65,19 @@ def mock_artifact_vault():
 
 
 @pytest.fixture
-def client(mock_cycle_registry, mock_artifact_vault, monkeypatch):
+def mock_flow_executor():
+    return AsyncMock()
+
+
+@pytest.fixture
+def client(mock_cycle_registry, mock_artifact_vault, mock_flow_executor, monkeypatch):
     app = FastAPI()
     app.include_router(router)
     import squadops.api.runtime.deps as deps_mod
 
     monkeypatch.setattr(deps_mod, "_cycle_registry", mock_cycle_registry)
     monkeypatch.setattr(deps_mod, "_artifact_vault", mock_artifact_vault)
+    monkeypatch.setattr(deps_mod, "_flow_executor", mock_flow_executor)
     return TestClient(app)
 
 
@@ -83,6 +89,18 @@ class TestCreateRun:
         assert body["run_number"] == 2
         assert body["initiated_by"] == "retry"
         assert body["status"] == "queued"
+
+    def test_retry_run_is_dispatched_for_execution(self, client, mock_flow_executor):
+        """#133: a retry must actually run — the route enqueues execute_cycle for
+        the new run (not just create a queued record that never executes).
+        TestClient runs background tasks after the response."""
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs")
+        assert resp.status_code == 200
+        new_run_id = resp.json()["run_id"]
+
+        mock_flow_executor.execute_cycle.assert_awaited_once_with(
+            "cyc_001", new_run_id, "full-squad"
+        )
 
 
 class TestListRuns:


### PR DESCRIPTION
## What & why

Closes **#133** and **#205**. Reproduce-first turned up a discrepancy between the two issues:

- **`cycles create` — #205 correct:** POST `/cycles` enqueues `execute_cycle` (SIP-0066/0083), but the CLI help said *"Does not trigger task execution (deferred to a future release)."* → **fixed**.
- **`runs retry` — #205 wrong / #133 correct:** `create_run` builds a `status="queued"`, `initiated_by="retry"` run, emits `RUN_CREATED`, and returns **with no dispatch** (`resume_run` even documents *"only cycle-create enqueues it"*). The retry run never ran — #133's "dead weight." So the docstring #205 proposed (*"enqueues it for execution"*) would have been a **new** false claim. (Corrective note posted on #205.)

## Change

Rather than make the retry docstring honest-but-useless, take #133's preferred option (1) — **wire `create_run` to dispatch**, mirroring `resume_run`:

```python
background_tasks.add_task(get_flow_executor().execute_cycle, cycle_id, created.run_id, cycle.squad_profile_id)
```

`execute_cycle` re-runs the SIP-0089 §2.5 duty guard, so a still-active hard-duty window simply re-defers — consistent with resume.

**Verified safe (no double-dispatch):** internal/workload runs are created via `registry.create_run` *directly* (`dispatched_flow_executor.py:659`, `initiated_by="system"`); the HTTP `create_run` route is only the external retry path, so auto-dispatch can't double-fire workload runs.

Both CLI docstrings now state execution is enqueued — true for both commands.

## Tests
- `test_retry_run_is_dispatched_for_execution` — the retry route enqueues `execute_cycle(cycle_id, new_run_id, squad_profile_id)` (TestClient runs background tasks post-response).
- `client` fixture now provides a flow-executor mock.
- `tests/unit/cycles/` **1336 passed**, CLI **207 passed**, ruff clean.

## Note (lane coordination)
Touches `api/routes/cycles/runs.py` `create_run` (lines ~37–95). Lane M's #222 edits `resume_run` (~212) in the same file — different function, ~150 lines apart, so clean auto-merge expected.

---
Lane S / Sprint 1, item 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)