### PR TITLE
docs: correct stale flow-executor refs in control-plane context doc (#168)

### DIFF
--- a/docs/reviews/continuum-control-plane-context.md
+++ b/docs/reviews/continuum-control-plane-context.md
@@ -36,11 +36,11 @@
 ## Cycle Execution Adapters
 - `adapters/cycles/memory_cycle_registry.py` — in-memory `CycleRegistryPort` (current default)
 - `adapters/cycles/filesystem_artifact_vault.py` — filesystem `ArtifactVaultPort`
-- `adapters/cycles/distributed_flow_executor.py` — RabbitMQ-dispatched `FlowExecutionPort`
+- `adapters/cycles/dispatched_flow_executor.py` — RabbitMQ-dispatched `FlowExecutionPort`
 - `adapters/cycles/in_process_flow_executor.py` — local `FlowExecutionPort`
 - `adapters/cycles/config_project_registry.py` — YAML-file `ProjectRegistryPort`
 - `adapters/cycles/config_squad_profile.py` — YAML-file `SquadProfilePort`
-- `adapters/cycles/prefect_reporter.py` — Prefect REST API reporter (flow naming, task spans)
+- `adapters/cycles/prefect_workflow_tracker.py` — Prefect REST API workflow tracker (flow naming, task spans)
 - `adapters/cycles/factory.py` — factory functions for all cycle adapters
 
 ## Domain Models
@@ -369,8 +369,8 @@ adapters/
 ├── capabilities/   (factory.py, filesystem.py, aci_executor.py)
 ├── comms/          (factory.py, rabbitmq.py)
 ├── cycles/         (factory.py, memory_cycle_registry.py, filesystem_artifact_vault.py,
-│                    distributed_flow_executor.py, in_process_flow_executor.py,
-│                    config_project_registry.py, config_squad_profile.py, prefect_reporter.py)
+│                    dispatched_flow_executor.py, in_process_flow_executor.py,
+│                    config_project_registry.py, config_squad_profile.py, prefect_workflow_tracker.py)
 ├── embeddings/     (factory.py, ollama.py)
 ├── llm/            (factory.py, ollama.py)
 ├── memory/         (factory.py, lancedb.py)
@@ -434,7 +434,7 @@ project_registry = create_project_registry("config")
 cycle_registry = create_cycle_registry("memory")     # <-- in-memory!
 squad_profile = create_squad_profile_port("config")
 artifact_vault = create_artifact_vault("filesystem")
-flow_executor = create_flow_executor("distributed", cycle_registry=..., queue=..., ...)
+flow_executor = create_flow_executor("dispatched", cycle_registry=..., queue=..., ...)
 set_cycle_ports(project_registry=..., cycle_registry=..., ...)
 ```
 


### PR DESCRIPTION
## What & why

Closes #168. The #164 rename `DistributedFlowExecutor → DispatchedFlowExecutor` is **clean in code** — a broad sweep (case-insensitive, all `*.py`) finds zero stale code refs; the only hit is an intentional historical docstring in `test_flow_executor_factory.py`. So #168 is docs-only (corrective comment posted on the issue).

## Change — `docs/reviews/continuum-control-plane-context.md` only
- `create_flow_executor("distributed")` → `"dispatched"` — this was a **broken example** (the provider key is `dispatched`; the old string raises `Unknown flow executor provider`).
- `distributed_flow_executor.py` filename refs → `dispatched_flow_executor.py`.
- Adjacent stale `prefect_reporter.py` → `prefect_workflow_tracker.py` (same renamed-file class, same active doc — found in the sweep).

## Deliberately left (point-in-time records)
`docs/plans/SIP-*.md` implementation plans, the dated `2026-06-11-architectural-review.md` (which *discusses* the rename), and triage/hardening-plan docs. Rewriting historical planning artifacts to current filenames is cosmetic and erases the record — same reasoning as not touching frozen `sips/`.

No code changes; nothing to test beyond "no broken `create_flow_executor` example remains" (verified).

---
Lane S / Sprint 1, item 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)