### PR TITLE
fix(capabilities): strip <think> before fenced parsing + log zero-extraction raw (#130)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -448,6 +448,23 @@ class _CycleTaskHandler(CapabilityHandler):
             error=error,
         )
 
+    def _log_no_fenced_blocks(self, content: str, *, excerpt: int = 1000) -> None:
+        """Log the truncated raw LLM response when fenced extraction found
+        nothing (#130).
+
+        The build/QA handlers otherwise only persist the raw into a
+        ``build_warnings.md`` artifact, so a zero-extraction failure leaves no
+        signal in the agent logs. The raw is the only way to distinguish a
+        thinking-mode token blowout from a prompt/scope formatting failure.
+        """
+        logger.warning(
+            "%s: no fenced code blocks extracted from a %d-char response; raw[:%d]=%r",
+            self._handler_name,
+            len(content),
+            excerpt,
+            content[:excerpt],
+        )
+
     def _resolve_model_budget(
         self,
         inputs: dict[str, Any],
@@ -1766,6 +1783,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         extracted = extract_fenced_files(content)
 
         if not extracted:
+            self._log_no_fenced_blocks(content)
             return self._fail_result(
                 start_time,
                 inputs,
@@ -2416,6 +2434,7 @@ class QATestHandler(_CycleTaskHandler):
 
         extracted = extract_fenced_files(content)
         if not extracted:
+            self._log_no_fenced_blocks(content)
             return self._fail_result(
                 start_time,
                 inputs,
@@ -3100,6 +3119,7 @@ class BuilderAssembleHandler(_CycleTaskHandler):
         if not extracted:
             from squadops.cycles.task_outcome import FailureClassification, TaskOutcome
 
+            self._log_no_fenced_blocks(content)
             return self._fail_result(
                 start_time,
                 inputs,

--- a/src/squadops/capabilities/handlers/fenced_parser.py
+++ b/src/squadops/capabilities/handlers/fenced_parser.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 import re
 
+from squadops.capabilities.handlers.impl._json_extraction import _strip_think_blocks
+
 # Strict format header: ```<lang>:<path>
 _STRICT_HEADER_RE = re.compile(r"^```(\w+):(\S+)\s*$", re.MULTILINE)
 
@@ -142,6 +144,12 @@ def extract_fenced_files(response: str) -> list[dict]:
     """
     if not response:
         return []
+
+    # #130: strip Qwen3-family <think>...</think> reasoning blocks before
+    # scanning for fences. Thinking-mode traces can contain stray ``` fences
+    # (false matches) or consume the response budget entirely; stripping them
+    # first is what PR #128's JSON extractor already does for impl handlers.
+    response = _strip_think_blocks(response)
 
     results: list[dict] = []
     pos = 0

--- a/tests/unit/capabilities/test_fenced_parser.py
+++ b/tests/unit/capabilities/test_fenced_parser.py
@@ -40,6 +40,82 @@ class TestSingleFence:
         assert "main()" in result[0]["content"]
 
 
+class TestThinkBlockStripping:
+    """#130: Qwen3-family ``<think>...</think>`` reasoning blocks are stripped
+    before fence scanning. Thinking-mode traces routinely contain stray fenced
+    blocks (or consume the whole response), which corrupted extraction."""
+
+    def test_fence_inside_think_block_is_ignored(self):
+        """A throwaway fenced file inside the reasoning trace must NOT be
+        extracted — only the real file outside the think block."""
+        response = (
+            "<think>\n"
+            "Let me sketch it first:\n"
+            "```python:scratch/draft.py\n"
+            "x = 1  # throwaway\n"
+            "```\n"
+            "</think>\n"
+            "```python:src/main.py\n"
+            "print('real')\n"
+            "```\n"
+        )
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "src/main.py"
+        assert result[0]["content"] == "print('real')"
+
+    def test_response_that_is_only_a_think_block_yields_nothing(self):
+        """The exact #130 failure: thinking mode emits a fence but no real
+        output. After stripping the trace, there are no files to extract — the
+        handler can then fail cleanly instead of using throwaway reasoning."""
+        response = (
+            "<think>\n"
+            "I should build a FastAPI app...\n"
+            "```python:plan.py\n"
+            "# just thinking out loud\n"
+            "```\n"
+            "</think>\n"
+        )
+        assert extract_fenced_files(response) == []
+
+    def test_think_prose_before_real_file_does_not_break_extraction(self):
+        """Reasoning prose ahead of the real output is fine, and the tag match
+        is case-insensitive (models emit <think> and <THINK>)."""
+        response = "<THINK>weighing the design</THINK>\n```python:app.py\nprint('ok')\n```\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "app.py"
+        assert result[0]["content"] == "print('ok')"
+
+
+class TestNoFencedBlocksLogging:
+    """#130: a zero-extraction failure must surface the raw LLM response in the
+    agent logs (truncated) — otherwise it's only buried in a build_warnings.md
+    artifact, leaving no signal to triage thinking-mode vs prompt/scope failure."""
+
+    def test_logs_truncated_raw_response(self, caplog):
+        import logging
+
+        from squadops.capabilities.handlers.cycle_tasks import DevelopmentDevelopHandler
+
+        handler = DevelopmentDevelopHandler()
+        raw = ("A" * 1500) + "TAIL_MARKER_BEYOND_EXCERPT"
+
+        with caplog.at_level(logging.WARNING):
+            handler._log_no_fenced_blocks(raw, excerpt=1000)
+
+        warnings = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "no fenced code blocks extracted" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+        msg = warnings[0]
+        assert "AAAA" in msg  # the raw prefix is captured
+        assert "TAIL_MARKER" not in msg  # ...but truncated to the excerpt window
+        assert str(len(raw)) in msg  # full response length reported
+
+
 class TestMultipleFences:
     def test_multiple_fences(self):
         response = (


### PR DESCRIPTION
## What & why

Closes #130. `development.develop` (and `builder.assemble` / `qa.test`) parse multi-file output through `extract_fenced_files`. Under spark-squad models, two modes produced a 0-byte `build_warnings.md` that routed through the correction protocol as `task_failure:development.develop`:

1. **Qwen3 `<think>…</think>` traces** were fed straight into the fence scanner. Thinking-mode traces can contain stray ``` fences (false matches) or consume the whole response so no real files are emitted.
2. **Zero-extraction was invisible** — the raw response went only into a `build_warnings.md` artifact, never the agent logs, so there was no way to triage thinking-mode vs prompt/scope failure.

## Change

- **`fenced_parser.extract_fenced_files` strips `<think>` blocks first** — reuses `_strip_think_blocks` from `impl/_json_extraction` (the same defense PR #128 added for the JSON impl handlers). Helps **every** caller (develop/assemble/qa/repair/plan-authoring), not just develop.
- **`_CycleTaskHandler._log_no_fenced_blocks()`** logs the truncated raw (`raw[:1000]`) + the full response length, wired into the develop / qa / assemble zero-extraction paths.

## Tests (`test_fenced_parser.py`)
- fence **inside** a `<think>` block is ignored (only the real file is extracted)
- a **think-only** response yields no files — the exact #130 failure
- think prose before a real file is fine (case-insensitive `<think>`/`<THINK>`)
- zero-extraction logs a **truncated, length-reporting** warning (tail beyond the excerpt is dropped)

41 fenced-parser tests + 1062 capabilities tests pass; ruff clean; no import cycle.

Implements the issue's ranked fixes #1 (raw logging) and #3 (`<think>` strip). Prompt-tuning (#2) and scope-bounding (#4) remain open as separate follow-ups if the logging shows they're needed.

---
Lane S / Sprint 1, item 7 — **completes the Sprint 1 cluster.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)