### PR TITLE
refactor(governance): rename establish_contract → define_done (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to SquadOps are recorded here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions follow semver.
 
+## [Unreleased]
+
+### Changed
+- Renamed the `governance.establish_contract` capability → **`governance.define_done`**
+  and its `run_contract.json` artifact → **`definition_of_done.json`** (the fields
+  are a standard Definition of Done, not a "contract"). Internal rename, no
+  behaviour change; historical artifacts on disk are left as-is (#79).
+
 ## [1.1.0] — 2026-06-28
 
 The v1.1 line ships the **Agent Runtime State** platform (SIP-0089) on top of a

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1597,10 +1597,10 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
         # SEMANTIC_FAILURE / NEEDS_REPAIR / NEEDS_REPLAN → correction
 
-        # D9: contract task failure → immediate abort, no correction
-        if envelope.task_type == "governance.establish_contract":
+        # D9: definition-of-done task failure → immediate abort, no correction
+        if envelope.task_type == "governance.define_done":
             raise _ExecutionError(
-                f"Contract task {envelope.task_id} failed (no correction): {result.error}"
+                f"Definition-of-done task {envelope.task_id} failed (no correction): {result.error}"
             )
 
         # Trigger correction protocol

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -76,7 +76,7 @@ Release milestone, not a new SIP. 13 SIPs landed between v0.9.0 and v1.0.0 (auth
   - Implementation/correction/repair task steps with deterministic IDs
   - 6 bounded execution CRP schema keys (`max_task_retries`, `max_task_seconds`, `max_consecutive_failures`, `max_correction_attempts`, `time_budget_seconds`, `implementation_pulse_checks`)
   - Executor checkpoint/resume, time budget enforcement, `_PausedError`
-  - Correction protocol handlers (analyze_failure, correction_decision, establish_contract, repair handlers)
+  - Correction protocol handlers (analyze_failure, correction_decision, define_done, repair handlers)
   - Outcome routing with `outcome_class` on TaskResult
   - Resume and checkpoints API routes (`POST /{run_id}/resume`, `GET /{run_id}/checkpoints`)
   - Resume and checkpoints CLI commands (`squadops runs resume`, `squadops runs checkpoints`)

--- a/sips/implemented/SIP-0079-Implementation-Run-Contract-Correction.md
+++ b/sips/implemented/SIP-0079-Implementation-Run-Contract-Correction.md
@@ -14,6 +14,12 @@ updated_at: '2026-03-05T19:38:22.120040Z'
 **Updated:** 2026-03-04
 **Revision:** 3
 
+> **Renamed (#79):** the capability `governance.establish_contract` and its
+> artifact `run_contract.json` described below are now **`governance.define_done`**
+> / **`definition_of_done.json`** (handler `GovernanceDefineDoneHandler`, model
+> `DefinitionOfDone`). The fields are a standard Definition of Done, not a
+> "contract". This SIP body keeps the original names as historical record.
+
 ---
 
 ## 1. Abstract

--- a/src/squadops/bootstrap/handlers.py
+++ b/src/squadops/bootstrap/handlers.py
@@ -41,8 +41,8 @@ from squadops.capabilities.handlers.impl.analyze_failure import (
 from squadops.capabilities.handlers.impl.correction_decision import (
     GovernanceCorrectionDecisionHandler,
 )
-from squadops.capabilities.handlers.impl.establish_contract import (
-    GovernanceEstablishContractHandler,
+from squadops.capabilities.handlers.impl.define_done import (
+    GovernanceDefineDoneHandler,
 )
 from squadops.capabilities.handlers.impl.repair_handlers import (
     BuilderAssembleRepairHandler,
@@ -126,7 +126,7 @@ HANDLER_CONFIGS: list[tuple[type[CapabilityHandler], tuple[str, ...]]] = [
     (StrategyCorrectivePlanHandler, ("strat",)),
     (DevelopmentRepairHandler, ("dev",)),
     # Implementation handlers (SIP-0079: Implementation Run Contract)
-    (GovernanceEstablishContractHandler, ("lead",)),
+    (GovernanceDefineDoneHandler, ("lead",)),
     (DataAnalyzeFailureHandler, ("data",)),
     (GovernanceCorrectionDecisionHandler, ("lead",)),
     # Correction-loop repair pair (SIP-0079 §7.7). Distinct from the

--- a/src/squadops/capabilities/handlers/impl/_json_extraction.py
+++ b/src/squadops/capabilities/handlers/impl/_json_extraction.py
@@ -1,6 +1,6 @@
 """Robust JSON extraction for SIP-0079 impl handlers.
 
-The three SIP-0079 implementation handlers (establish_contract,
+The three SIP-0079 implementation handlers (define_done,
 correction_decision, analyze_failure) ask the LLM to return a JSON
 object as the entire response. Strict-from-start parsing is brittle —
 LLMs commonly emit:

--- a/src/squadops/capabilities/handlers/impl/define_done.py
+++ b/src/squadops/capabilities/handlers/impl/define_done.py
@@ -1,7 +1,7 @@
-"""Governance establish_contract handler (SIP-0079 §7.2).
+"""Governance define_done handler (SIP-0079 §7.2).
 
 Extracts the planning artifact from prior outputs and asks the LLM
-to produce a structured RunContract (objective, acceptance criteria,
+to produce a structured DefinitionOfDone (objective, acceptance criteria,
 stop conditions, etc.). On parse failure returns NEEDS_REPLAN.
 """
 
@@ -31,13 +31,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class GovernanceEstablishContractHandler(_CycleTaskHandler):
-    """Establish a run contract before implementation begins."""
+class GovernanceDefineDoneHandler(_CycleTaskHandler):
+    """Define the run's definition of done before implementation begins."""
 
-    _handler_name = "governance_establish_contract_handler"
-    _capability_id = "governance.establish_contract"
+    _handler_name = "governance_define_done_handler"
+    _capability_id = "governance.define_done"
     _role = "lead"
-    _artifact_name = "run_contract.json"
+    _artifact_name = "definition_of_done.json"
 
     async def handle(
         self,
@@ -96,7 +96,7 @@ class GovernanceEstablishContractHandler(_CycleTaskHandler):
 
         content = response.content
 
-        # Parse JSON contract from LLM response. Tolerates <think>
+        # Parse the JSON definition of done from the LLM response. Tolerates <think>
         # blocks, code fences, and prose preamble around the JSON —
         # every impl handler is one model tantrum away from a "char 0"
         # parse error otherwise. Logs a truncated raw response on
@@ -106,7 +106,7 @@ class GovernanceEstablishContractHandler(_CycleTaskHandler):
             contract_data = extract_first_json_object(content)
         except JSONExtractionError as exc:
             logger.warning(
-                "%s: failed to parse run contract JSON: %s | raw[:500]=%r",
+                "%s: failed to parse definition of done JSON: %s | raw[:500]=%r",
                 self._handler_name,
                 exc,
                 exc.raw_excerpt,
@@ -122,7 +122,7 @@ class GovernanceEstablishContractHandler(_CycleTaskHandler):
                 success=False,
                 outputs={"outcome_class": TaskOutcome.NEEDS_REPLAN},
                 _evidence=evidence,
-                error=f"Failed to parse run contract: {exc}",
+                error=f"Failed to parse definition of done: {exc}",
             )
 
         duration_ms = (time.perf_counter() - start_time) * 1000
@@ -137,7 +137,7 @@ class GovernanceEstablishContractHandler(_CycleTaskHandler):
 
         outputs = {
             "summary": (
-                f"[lead] Run contract established: {contract_data.get('objective', '')[:60]}"
+                f"[lead] Definition of done established: {contract_data.get('objective', '')[:60]}"
             ),
             "role": self._role,
             "contract": contract_data,
@@ -146,7 +146,7 @@ class GovernanceEstablishContractHandler(_CycleTaskHandler):
                     "name": self._artifact_name,
                     "content": json.dumps(contract_data, indent=2),
                     "media_type": "application/json",
-                    "type": "run_contract",
+                    "type": "definition_of_done",
                 },
             ],
             "prompt_provenance": provenance,

--- a/src/squadops/contracts/cycle_request_profiles/profiles/implementation.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/implementation.yaml
@@ -34,9 +34,9 @@ defaults:
         - qa.validate_repair
       checks:
         - check_type: plan_alignment
-          target: "{run_root}/run_contract.json"
+          target: "{run_root}/definition_of_done.json"
         - check_type: acceptance_progress
-          target: "{run_root}/run_contract.json"
+          target: "{run_root}/definition_of_done.json"
         - check_type: regression_check
           target: "{run_root}/test_results/"
       max_suite_seconds: 30
@@ -48,7 +48,7 @@ defaults:
         - check_type: forward_progress
           target: "{run_root}/checkpoint_latest.json"
         - check_type: scope_drift
-          target: "{run_root}/run_contract.json"
+          target: "{run_root}/definition_of_done.json"
         - check_type: failure_pattern
           target: "{run_root}/plan_deltas/"
       max_suite_seconds: 30

--- a/src/squadops/cycles/definition_of_done.py
+++ b/src/squadops/cycles/definition_of_done.py
@@ -1,8 +1,8 @@
-"""Run Contract model — durable execution contract for implementation runs (SIP-0079 §7.1).
+"""Definition of Done model — durable execution definition for implementation runs (SIP-0079 §7.1).
 
-The run contract captures objective, acceptance criteria, non-goals, time budget,
-stop conditions, and required artifacts. Stored as a run-level artifact of type
-``run_contract`` and referenced by all pulse checks and correction decisions.
+The definition of done captures objective, acceptance criteria, non-goals, time
+budget, stop conditions, and required artifacts. Stored as a run-level artifact of
+type ``definition_of_done`` and referenced by all pulse checks and correction decisions.
 """
 
 from __future__ import annotations
@@ -13,8 +13,8 @@ from typing import Any
 
 
 @dataclass(frozen=True)
-class RunContract:
-    """Durable execution contract for an implementation run."""
+class DefinitionOfDone:
+    """Durable definition of done for an implementation run."""
 
     objective: str
     acceptance_criteria: tuple[str, ...]
@@ -30,7 +30,7 @@ class RunContract:
         return dataclasses.asdict(self)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> RunContract:
+    def from_dict(cls, data: dict[str, Any]) -> DefinitionOfDone:
         """Deserialize from dict.
 
         Converts list fields to tuples for frozen dataclass compatibility.

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -150,7 +150,7 @@ REFINEMENT_TASK_STEPS: list[tuple[str, str]] = [
 
 # Implementation task steps (SIP-0079 §7.2): contract + build steps
 IMPLEMENTATION_TASK_STEPS: list[tuple[str, str]] = [
-    ("governance.establish_contract", "lead"),
+    ("governance.define_done", "lead"),
     ("development.develop", "dev"),
     ("qa.test", "qa"),
 ]

--- a/src/squadops/prompts/fragments/manifest.yaml
+++ b/src/squadops/prompts/fragments/manifest.yaml
@@ -163,12 +163,12 @@ fragments:
   roles:
   - lead
   sha256: 91af4ac066ce276fb60d7a049321c9f2743e5e32da671de40c9c7476fab0d28a
-- fragment_id: task_type.governance.establish_contract
-  path: shared/task_type/task_type.governance.establish_contract.md
+- fragment_id: task_type.governance.define_done
+  path: shared/task_type/task_type.governance.define_done.md
   layer: task_type
   roles:
   - lead
-  sha256: 737da7b531599a8bedf7c811394af4cae50e3506512244b6309cd646111b8bcb
+  sha256: 7e9a5144762828089f7ec8fdfcc6ad661fa0dcf4dd962bad3160227f826b6e08
 - fragment_id: task_type.governance.correction_decision
   path: shared/task_type/task_type.governance.correction_decision.md
   layer: task_type

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.governance.define_done.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.governance.define_done.md
@@ -1,12 +1,12 @@
 ---
-fragment_id: task_type.governance.establish_contract
+fragment_id: task_type.governance.define_done
 layer: task_type
 version: "1.0.0"
 roles: ["lead"]
 ---
-## Establish Run Contract (SIP-0079)
+## Define the Definition of Done (SIP-0079)
 
-Given the planning artifacts and PRD, produce a JSON run contract with
+Given the planning artifacts and PRD, produce a JSON definition of done with
 these fields:
 
 - `objective` (string): one-sentence goal

--- a/tests/unit/capabilities/handlers/test_json_extraction.py
+++ b/tests/unit/capabilities/handlers/test_json_extraction.py
@@ -3,7 +3,7 @@
 The pre-existing parse pattern (strip-leading-fence then ``json.loads``)
 fails on every common LLM-output shape that isn't pure JSON: thinking
 blocks, prose preamble, json-in-fence-after-prose. This regression hit
-``governance.establish_contract`` on cyc_a4e6dc3afe7a (2026-05-05) and
+``governance.define_done`` on cyc_a4e6dc3afe7a (2026-05-05) and
 silently aborted the implementation phase in ~4 minutes. The tolerant
 extractor below is the load-bearing fix.
 """

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -1,6 +1,6 @@
 """Tests for SIP-0079 implementation handlers.
 
-Covers GovernanceEstablishContractHandler, DataAnalyzeFailureHandler,
+Covers GovernanceDefineDoneHandler, DataAnalyzeFailureHandler,
 GovernanceCorrectionDecisionHandler, DevelopmentCorrectionRepairHandler,
 QAValidateRepairHandler.
 """
@@ -18,8 +18,8 @@ from squadops.capabilities.handlers.impl.analyze_failure import (
 from squadops.capabilities.handlers.impl.correction_decision import (
     GovernanceCorrectionDecisionHandler,
 )
-from squadops.capabilities.handlers.impl.establish_contract import (
-    GovernanceEstablishContractHandler,
+from squadops.capabilities.handlers.impl.define_done import (
+    GovernanceDefineDoneHandler,
 )
 from squadops.capabilities.handlers.impl.repair_handlers import (
     BuilderAssembleRepairHandler,
@@ -58,7 +58,7 @@ def mock_context():
     assembled.assembly_hash = "sha256:test"
     ctx.ports.prompt_service.get_system_prompt = MagicMock(return_value=assembled)
     # Externalized impl-handler system prompts (correction_decision /
-    # analyze_failure / establish_contract) call assemble_task_only(role,
+    # analyze_failure / define_done) call assemble_task_only(role,
     # task_type) — the task_type fragment with NO role-identity prepend.
     # Mock both forms so the auto-attribute MagicMock doesn't return a
     # non-string.
@@ -70,7 +70,7 @@ def mock_context():
 
 
 # ---------------------------------------------------------------------------
-# GovernanceEstablishContractHandler
+# GovernanceDefineDoneHandler
 # ---------------------------------------------------------------------------
 
 
@@ -89,15 +89,15 @@ class TestEstablishContract:
             return_value=ChatMessage(role="assistant", content=json.dumps(contract)),
         )
 
-        h = GovernanceEstablishContractHandler()
+        h = GovernanceDefineDoneHandler()
         result = await h.handle(mock_context, {"prd": "Build a CLI tool"})
 
         assert result.success is True
         assert result.outputs["contract"]["objective"] == "Build CLI tool"
         assert result.outputs["contract"]["acceptance_criteria"] == ["Passes tests"]
         assert result.outputs["contract"]["time_budget_seconds"] == 3600
-        assert result.outputs["artifacts"][0]["type"] == "run_contract"
-        assert result.outputs["artifacts"][0]["name"] == "run_contract.json"
+        assert result.outputs["artifacts"][0]["type"] == "definition_of_done"
+        assert result.outputs["artifacts"][0]["name"] == "definition_of_done.json"
 
     async def test_parse_failure_returns_needs_replan(self, mock_context):
         _set_llm_mock(
@@ -105,7 +105,7 @@ class TestEstablishContract:
             return_value=ChatMessage(role="assistant", content="not valid json"),
         )
 
-        h = GovernanceEstablishContractHandler()
+        h = GovernanceDefineDoneHandler()
         result = await h.handle(mock_context, {"prd": "test"})
 
         assert result.success is False
@@ -117,7 +117,7 @@ class TestEstablishContract:
             side_effect=LLMConnectionError("timeout"),
         )
 
-        h = GovernanceEstablishContractHandler()
+        h = GovernanceDefineDoneHandler()
         result = await h.handle(mock_context, {"prd": "test"})
 
         assert result.success is False
@@ -131,7 +131,7 @@ class TestEstablishContract:
             return_value=ChatMessage(role="assistant", content=fenced),
         )
 
-        h = GovernanceEstablishContractHandler()
+        h = GovernanceDefineDoneHandler()
         result = await h.handle(mock_context, {"prd": "test"})
 
         assert result.success is True
@@ -163,7 +163,7 @@ class TestEstablishContract:
             return_value=ChatMessage(role="assistant", content=thinking_response),
         )
 
-        h = GovernanceEstablishContractHandler()
+        h = GovernanceDefineDoneHandler()
         result = await h.handle(mock_context, {"prd": "test"})
 
         assert result.success is True
@@ -186,7 +186,7 @@ class TestEstablishContract:
             return_value=ChatMessage(role="assistant", content=response),
         )
 
-        h = GovernanceEstablishContractHandler()
+        h = GovernanceDefineDoneHandler()
         result = await h.handle(mock_context, {"prd": "test"})
 
         assert result.success is True
@@ -380,7 +380,7 @@ class TestAnalyzeFailure:
 
 class TestImplHandlerSystemPromptExternalization:
     """The three SIP-0079 impl handlers (analyze_failure,
-    correction_decision, establish_contract) used to hardcode their
+    correction_decision, define_done) used to hardcode their
     system prompts as Python string constants, bypassing PromptService
     and missing LangFuse version tracking.
 
@@ -409,9 +409,9 @@ class TestImplHandlerSystemPromptExternalization:
                 "governance.correction_decision",
             ),
             (
-                GovernanceEstablishContractHandler,
+                GovernanceDefineDoneHandler,
                 "lead",
-                "governance.establish_contract",
+                "governance.define_done",
             ),
         ],
         ids=lambda x: x.__name__ if isinstance(x, type) else x,
@@ -438,7 +438,7 @@ class TestImplHandlerSystemPromptExternalization:
                     "affected_task_types": [],
                 }
             )
-        else:  # GovernanceEstablishContractHandler
+        else:  # GovernanceDefineDoneHandler
             payload = json.dumps(
                 {
                     "objective": "Build a thing",
@@ -481,7 +481,7 @@ class TestImplHandlerSystemPromptExternalization:
         assert not hasattr(_mod, "_ANALYSIS_SYSTEM_PROMPT")
 
     async def test_contract_constant_removed(self):
-        from squadops.capabilities.handlers.impl import establish_contract as _mod
+        from squadops.capabilities.handlers.impl import define_done as _mod
 
         assert not hasattr(_mod, "_CONTRACT_SYSTEM_PROMPT")
 

--- a/tests/unit/cycles/test_definition_of_done.py
+++ b/tests/unit/cycles/test_definition_of_done.py
@@ -1,15 +1,15 @@
-"""Tests for RunContract frozen dataclass (SIP-0079 §7.1)."""
+"""Tests for DefinitionOfDone frozen dataclass (SIP-0079 §7.1)."""
 
 import dataclasses
 
 import pytest
 
-from squadops.cycles.run_contract import RunContract
+from squadops.cycles.definition_of_done import DefinitionOfDone
 
 pytestmark = [pytest.mark.domain_orchestration]
 
 
-def _make_contract(**overrides) -> RunContract:
+def _make_contract(**overrides) -> DefinitionOfDone:
     defaults = {
         "objective": "Build the auth module",
         "acceptance_criteria": ("tests pass", "code reviewed"),
@@ -20,10 +20,10 @@ def _make_contract(**overrides) -> RunContract:
         "plan_artifact_ref": "art-plan-001",
     }
     defaults.update(overrides)
-    return RunContract(**defaults)
+    return DefinitionOfDone(**defaults)
 
 
-class TestRunContract:
+class TestDefinitionOfDone:
     def test_frozen_immutability(self):
         rc = _make_contract()
         with pytest.raises(dataclasses.FrozenInstanceError):
@@ -50,7 +50,7 @@ class TestRunContract:
     def test_to_dict_round_trip(self):
         rc = _make_contract(source_gate_decision="approved")
         d = rc.to_dict()
-        restored = RunContract.from_dict(d)
+        restored = DefinitionOfDone.from_dict(d)
         assert restored == rc
 
     def test_from_dict_coerces_lists_to_tuples(self):
@@ -63,7 +63,7 @@ class TestRunContract:
             "required_artifacts": ["code"],
             "plan_artifact_ref": "art-001",
         }
-        rc = RunContract.from_dict(d)
+        rc = DefinitionOfDone.from_dict(d)
         assert isinstance(rc.acceptance_criteria, tuple)
         assert isinstance(rc.non_goals, tuple)
         assert isinstance(rc.stop_conditions, tuple)

--- a/tests/unit/cycles/test_executor_checkpoint.py
+++ b/tests/unit/cycles/test_executor_checkpoint.py
@@ -283,7 +283,7 @@ class TestResumeFromCheckpoint:
         mock_registry.get_latest_checkpoint.return_value = RunCheckpoint(
             run_id="run_impl",
             checkpoint_index=1,
-            completed_task_ids=("task-run_impl-000-governance.establish_contract",),
+            completed_task_ids=("task-run_impl-000-governance.define_done",),
             prior_outputs={"lead": {"summary": "contract established"}},
             artifact_refs=(),
             plan_delta_refs=(),
@@ -304,7 +304,7 @@ class TestResumeFromCheckpoint:
         mock_registry.get_latest_checkpoint.return_value = RunCheckpoint(
             run_id="run_impl",
             checkpoint_index=1,
-            completed_task_ids=("task-run_impl-000-governance.establish_contract",),
+            completed_task_ids=("task-run_impl-000-governance.define_done",),
             prior_outputs=prior,
             artifact_refs=(),
             plan_delta_refs=(),
@@ -340,7 +340,7 @@ class TestResumeFromCheckpoint:
         mock_registry.get_latest_checkpoint.return_value = RunCheckpoint(
             run_id="run_impl",
             checkpoint_index=1,
-            completed_task_ids=("task-run_impl-000-governance.establish_contract",),
+            completed_task_ids=("task-run_impl-000-governance.define_done",),
             prior_outputs={},
             artifact_refs=("art_001",),
             plan_delta_refs=(),
@@ -366,7 +366,7 @@ class TestResumeFromCheckpoint:
             run_id="run_impl",
             checkpoint_index=2,
             completed_task_ids=(
-                "task-run_impl-000-governance.establish_contract",
+                "task-run_impl-000-governance.define_done",
                 "task-run_impl-001-development.develop",
             ),
             prior_outputs={},
@@ -395,7 +395,7 @@ class TestResumeFromCheckpoint:
         mock_registry.get_latest_checkpoint.return_value = RunCheckpoint(
             run_id="run_impl",
             checkpoint_index=1,
-            completed_task_ids=("task-run_impl-000-governance.establish_contract",),
+            completed_task_ids=("task-run_impl-000-governance.define_done",),
             prior_outputs={},
             artifact_refs=(),
             plan_delta_refs=(),

--- a/tests/unit/cycles/test_outcome_routing.py
+++ b/tests/unit/cycles/test_outcome_routing.py
@@ -329,7 +329,7 @@ class TestSuccessOutcome:
 
 
 class TestNeedReplanFromContract:
-    """NEEDS_REPLAN from governance.establish_contract → immediate abort (D9)."""
+    """NEEDS_REPLAN from governance.define_done → immediate abort (D9)."""
 
     async def test_contract_failure_aborts_immediately(
         self, executor, mock_queue, mock_registry, run

--- a/tests/unit/cycles/test_planning_task_plan.py
+++ b/tests/unit/cycles/test_planning_task_plan.py
@@ -270,7 +270,7 @@ class TestImplementationWorkload:
     def test_builder_present_produces_contract_plus_assembly_steps(self, cycle, builder_profile):
         envelopes = generate_task_plan(cycle, _run("implementation"), builder_profile)
         actual = [e.task_type for e in envelopes]
-        # SIP-0079: governance.establish_contract prepended before builder assembly steps
+        # SIP-0079: governance.define_done prepended before builder assembly steps
         expected = [s[0] for s in IMPLEMENTATION_TASK_STEPS[:1]] + [
             s[0] for s in BUILDER_ASSEMBLY_TASK_STEPS
         ]

--- a/tests/unit/cycles/test_task_plan_implementation.py
+++ b/tests/unit/cycles/test_task_plan_implementation.py
@@ -92,14 +92,14 @@ def legacy_run():
 class TestImplementationTaskSteps:
     def test_constants_defined(self):
         assert len(IMPLEMENTATION_TASK_STEPS) == 3
-        assert IMPLEMENTATION_TASK_STEPS[0] == ("governance.establish_contract", "lead")
+        assert IMPLEMENTATION_TASK_STEPS[0] == ("governance.define_done", "lead")
         assert IMPLEMENTATION_TASK_STEPS[1] == ("development.develop", "dev")
         assert IMPLEMENTATION_TASK_STEPS[2] == ("qa.test", "qa")
 
     def test_prepends_contract_before_build(self, impl_cycle, impl_run, profile):
         plan = generate_task_plan(impl_cycle, impl_run, profile)
         task_types = [e.task_type for e in plan]
-        assert task_types[0] == "governance.establish_contract"
+        assert task_types[0] == "governance.define_done"
         assert "development.develop" in task_types
         assert "qa.test" in task_types
 
@@ -170,6 +170,6 @@ class TestDeterministicTaskIds:
 
     def test_deterministic_ids_include_task_type(self, impl_cycle, impl_run, profile):
         plan = generate_task_plan(impl_cycle, impl_run, profile)
-        assert plan[0].task_id.endswith("governance.establish_contract")
+        assert plan[0].task_id.endswith("governance.define_done")
         assert plan[1].task_id.endswith("development.develop")
         assert plan[2].task_id.endswith("qa.test")

--- a/tests/unit/prompts/test_manifest_completeness.py
+++ b/tests/unit/prompts/test_manifest_completeness.py
@@ -1,12 +1,12 @@
 """Regression: prompt manifest must register every fragment file on disk.
 
 Bug it catches: PR #126 added three task_type fragment files
-(`task_type.governance.establish_contract`, `task_type.governance.correction_decision`,
+(`task_type.governance.define_done`, `task_type.governance.correction_decision`,
 `task_type.data.analyze_failure`) but did not register them in
 `fragments/manifest.yaml`. PR #129 then made them mandatory via
 `assemble_task_only`, which failed at runtime with
 `MandatoryLayerMissingError` on the first impl task of every cycle (Max's
-`governance.establish_contract`).
+`governance.define_done`).
 
 The shared-fragment lookup goes through the manifest, so an unregistered
 fragment is invisible regardless of whether the file exists.
@@ -60,7 +60,7 @@ def test_impl_handler_task_type_fragments_registered():
     manifest = _load_manifest()
     registered_ids = {entry["fragment_id"] for entry in manifest["fragments"]}
     required = {
-        "task_type.governance.establish_contract",
+        "task_type.governance.define_done",
         "task_type.governance.correction_decision",
         "task_type.data.analyze_failure",
     }

--- a/tests/unit/prompts/test_migration_validation.py
+++ b/tests/unit/prompts/test_migration_validation.py
@@ -30,8 +30,8 @@ from squadops.capabilities.handlers.impl.analyze_failure import (
 from squadops.capabilities.handlers.impl.correction_decision import (
     GovernanceCorrectionDecisionHandler,
 )
-from squadops.capabilities.handlers.impl.establish_contract import (
-    GovernanceEstablishContractHandler,
+from squadops.capabilities.handlers.impl.define_done import (
+    GovernanceDefineDoneHandler,
 )
 from squadops.capabilities.handlers.planning_tasks import (
     DataResearchContextHandler,
@@ -229,7 +229,7 @@ class TestCustomHandlerTemplateIdCoverage:
                 {"failure_analysis": {"error": "test"}},
             ),
             (
-                GovernanceEstablishContractHandler,
+                GovernanceDefineDoneHandler,
                 "request.cycle_task_base",
                 {},
             ),

--- a/tests/unit/prompts/test_planning_fragments.py
+++ b/tests/unit/prompts/test_planning_fragments.py
@@ -211,7 +211,7 @@ class TestPlanningFragmentsContent:
     def test_task_type_fragments_total(self):
         """Exactly 20 task_type fragments exist:
         5 planning + 2 refinement + 5 wrap-up + 3 SIP-0079 impl
-        (analyze_failure, correction_decision, establish_contract —
+        (analyze_failure, correction_decision, define_done —
         moved out of hardcoded constants in impl/*.py) +
         5 SIP-0093 (prepare_plan_authoring_brief, review_plan_manifest,
         development.propose_plan_tasks, qa.propose_plan_tasks,


### PR DESCRIPTION
Closes #79.

## What
Rename the misnamed SIP-0079 governance capability + artifact. The fields (`objective`, `acceptance_criteria`, `non_goals`, `time_budget_seconds`, `stop_conditions`, `required_artifacts`) are a standard **Definition of Done**, and "contract" is overloaded (API contract, design-by-contract, …).

| Old | New |
|-----|-----|
| capability `governance.establish_contract` | `governance.define_done` |
| artifact `run_contract.json` (type `run_contract`) | `definition_of_done.json` (type `definition_of_done`) |
| `GovernanceEstablishContractHandler` (`establish_contract.py`) | `GovernanceDefineDoneHandler` (`define_done.py`) |
| `RunContract` (`run_contract.py`) | `DefinitionOfDone` (`definition_of_done.py`) |
| fragment `task_type.governance.establish_contract.md` | `…define_done.md` (manifest hashes regenerated) |

Also updated: the executor's D9 abort special-case, the `IMPLEMENTATION_TASK_STEPS` step, and the profile's pulse-check `target` paths. No behaviour change.

## Back-compat decision (flagging — differs from the issue)
The issue floated a deprecation period (dual-register the old capability ID, dual-read the old filename). **I did a clean rename instead**, because the analysis showed near-zero back-compat value:
- `console/`, `infra/`, `scripts/` have **zero** references — every consumer is internal and renames atomically.
- **Nothing reads the artifact by filename**; the only "reader" is the profile's pulse-check `target`, which moves with the writer.
- The capability ID is **regenerated per run** (task plans), so no persisted plan pins the old string across a redeploy in a way that matters.

So the shims would mean keeping a parallel prompt fragment + handler alias alive for no real consumer. Historical artifacts on disk (`run_contract.json` in past runs) are **left untouched** (immutable evidence). If you'd prefer the deprecation period anyway, say so and I'll add the alias + dual-read.

## Docs
- `sips/implemented/SIP-0079-*` gets a **non-destructive** forward-pointer note (body keeps the original names as historical record).
- `CHANGELOG.md` (Unreleased) + `docs/ROADMAP.md` updated.

## Tests
- All identifiers swapped across the 19 touchpoints (handler, model, registry, task_plan, executor, profile, fragment + their tests); prompt-manifest hashes regenerated via `scripts/dev/regen_fragment_manifest.py --write`.
- Functional smoke: the registry serves `governance.define_done` and the old ID is gone; `DefinitionOfDone` imports/round-trips.
- Full `tests/unit/{capabilities,cycles,prompts,bootstrap}` green — **2833 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
