### PR TITLE
ci: parallelize the regression suite with pytest-xdist -n auto (#216)

### DIFF
--- a/scripts/dev/run_regression_tests.sh
+++ b/scripts/dev/run_regression_tests.sh
@@ -48,5 +48,8 @@ echo "Running regression tests..."
 echo "Directories: ${REGRESSION_DIRS[*]}"
 echo ""
 
-# Run pytest with the new arch directories
-pytest "${REGRESSION_DIRS[@]}" "$@"
+# Run pytest across the regression directories.
+# #216: -n auto parallelizes across CPU cores (pytest-xdist). The suite is
+# isolation-clean under parallel workers (verified ~4460 tests green). Pass
+# `-n 0` via "$@" to force serial when debugging a single test.
+pytest -n auto "${REGRESSION_DIRS[@]}" "$@"


### PR DESCRIPTION
## What & why

Closes #216. The regression gate ran **serially** (~38s in CI). Add `-n auto` to the `pytest` invocation in `scripts/dev/run_regression_tests.sh` to fan out across CPU cores via pytest-xdist.

- Local full run: **~38s → ~8.4s** (20 workers).
- CI runs the same script, so CI gets the speedup too.

## Safety — isolation verified

The plan's acceptance was "green run = acceptance; M-effort if isolation collisions surface." Ran the full ~4460-test regression set under `-n auto`: **4463 passed, 1 skipped**, zero cross-worker state collisions. (pytest-benchmark auto-disables under xdist — expected; the gate checks correctness, not perf.)

## Dependency

`pytest-xdist` is **already declared** — `tests/requirements.txt` (`>=3.3.0`) and `ci-constraints.txt` (`==3.8.0`) — so no dep file changes. `-n 0` via `"$@"` still forces serial for single-test debugging.

## Lane coordination

Edits **only the pytest invocation line**, not the append-only `REGRESSION_DIRS` block the runtime lane appends to (announced before editing this shared file). Prereq #239 (OTel global-provider isolation) is merged, so parallel workers don't multiply the atexit traceback.

---
Lane S / Sprint 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)