### PR TITLE
feat(observability): per-role n/total Prefect task names + framing titles (#94)

### DIFF
--- a/adapters/cycles/task_naming.py
+++ b/adapters/cycles/task_naming.py
@@ -11,6 +11,18 @@ from __future__ import annotations
 from squadops.tasks.models import TaskEnvelope
 
 
+def _humanize_task_type(task_type: str) -> str:
+    """Title for a non-focused task, derived from its ``task_type``.
+
+    Takes the leaf segment and makes it read like a title:
+    ``strategy.frame_objective`` → ``Frame objective``,
+    ``qa.define_test_strategy`` → ``Define test strategy``. Falls back to the
+    raw ``task_type`` if it has no usable leaf.
+    """
+    leaf = task_type.rsplit(".", 1)[-1].replace("_", " ").replace("-", " ").strip()
+    return leaf[:1].upper() + leaf[1:] if leaf else task_type
+
+
 def build_task_name(envelope: TaskEnvelope) -> str:
     """Build a Gantt-friendly Prefect task name for a dispatched envelope.
 
@@ -22,17 +34,30 @@ def build_task_name(envelope: TaskEnvelope) -> str:
     leave it empty — and to ``"unknown"`` when neither is present. ``agent_id``
     comes from the squad profile, so the label stays profile-configurable.
 
-    Focused-mode envelopes (manifest-decomposed subtasks) render
-    ``prefix[idx]: focus`` so the Gantt distinguishes parallel subtasks instead
-    of showing N identical ``prefix: task_type`` rows. Non-focused envelopes
-    keep ``prefix: task_type``.
+    Planned-run envelopes (framing + implementation) carry per-agent
+    ``role_index``/``role_total`` (#94) and render ``prefix[n/total]: title`` —
+    1-based position within that agent's work, so "how far through dev work are
+    we" is answerable at a glance and the count reflects per-role progress, not a
+    global index. The title is the manifest ``subtask_focus`` when present, else
+    the humanized ``task_type`` (so framing tasks gain a readable title too).
+
+    Envelopes without per-agent counts (correction/repair, gate boundaries) keep
+    the legacy shape: ``prefix[idx]: focus`` for focused subtasks, else
+    ``prefix: task_type``.
     """
     role = envelope.metadata.get("role", "unknown") if envelope.metadata else "unknown"
     prefix = envelope.agent_id or role
     inputs = envelope.inputs or {}
     focus = inputs.get("subtask_focus")
+    title = str(focus)[:60] if focus else _humanize_task_type(envelope.task_type)
+
+    n = inputs.get("role_index")
+    total = inputs.get("role_total")
+    if n is not None and total is not None:
+        return f"{prefix}[{n}/{total}]: {title}"
+
+    # Legacy fallback for envelopes built outside the plan (no per-agent counts).
     idx = inputs.get("subtask_index")
     if focus:
-        focus_short = str(focus)[:60]
-        return f"{prefix}[{idx}]: {focus_short}" if idx is not None else f"{prefix}: {focus_short}"
+        return f"{prefix}[{idx}]: {title}" if idx is not None else f"{prefix}: {title}"
     return f"{prefix}: {envelope.task_type}"

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -14,6 +14,7 @@ Part of SIP-0066 Phase 4 + build capabilities extension + SIP-0071 + SIP-0078.
 
 from __future__ import annotations
 
+from collections import Counter
 from uuid import uuid4
 
 from squadops.capabilities.handlers.build_profiles import (
@@ -388,6 +389,16 @@ def generate_task_plan(
     envelopes: list[TaskEnvelope] = []
     prev_task_id: str | None = None
 
+    # #94: resolve each step's agent once and count per-agent (≈ per-role, since
+    # the squad maps one agent to one role) so the Prefect label can read
+    # "{agent}[{n}/{total}]" — position within that agent's work, not a global
+    # index. ``lane_seen`` advances in dispatch order to give the 1-based n.
+    step_resolutions = [
+        _resolve_agent_config(profile, s[1] if isinstance(s, tuple) else s.role) for s in steps
+    ]
+    lane_totals = Counter(r[0] for r in step_resolutions)
+    lane_seen: dict[str, int] = {}
+
     for step_index, step in enumerate(steps):
         # Steps are either (task_type, role) tuples or PlanTask objects
         if isinstance(step, tuple):
@@ -411,7 +422,7 @@ def generate_task_plan(
         span_id = uuid4().hex
         causation_id = prev_task_id or correlation_id
 
-        agent_id, agent_model, agent_overrides = _resolve_agent_config(profile, role)
+        agent_id, agent_model, agent_overrides = step_resolutions[step_index]
 
         metadata: dict = {
             "step_index": step_index,
@@ -432,6 +443,11 @@ def generate_task_plan(
             # constrain plan role choices to what the squad actually has.
             "profile_roles": sorted(profile_roles),
         }
+
+        # #94: per-agent position/total for the Prefect "{agent}[{n}/{total}]" label
+        lane_seen[agent_id] = lane_seen.get(agent_id, 0) + 1
+        inputs["role_index"] = lane_seen[agent_id]
+        inputs["role_total"] = lane_totals[agent_id]
 
         # SIP-0086: populate subtask fields from plan
         if plan_task is not None:

--- a/tests/unit/cycles/test_task_naming.py
+++ b/tests/unit/cycles/test_task_naming.py
@@ -89,3 +89,65 @@ class TestBuildTaskName:
         """Subtask index 0 must render as ``[0]`` — falsy but valid."""
         env = _envelope(agent_id="neo", inputs={"subtask_focus": "first", "subtask_index": 0})
         assert build_task_name(env) == "neo[0]: first"
+
+
+class TestPerRoleNumbering:
+    """#94: planned-run envelopes carry per-agent role_index/role_total and render
+    ``prefix[n/total]: title`` (1-based) for both framing and implementation."""
+
+    def test_implementation_focused_uses_per_role_count(self) -> None:
+        env = _envelope(
+            agent_id="neo",
+            inputs={
+                "subtask_focus": "Backend Pydantic models & in-memory repository",
+                "role_index": 1,
+                "role_total": 4,
+            },
+        )
+        assert build_task_name(env) == "neo[1/4]: Backend Pydantic models & in-memory repository"
+
+    def test_framing_non_focused_gets_humanized_title_and_count(self) -> None:
+        # The #94 win for framing: a numeric position AND a readable title derived
+        # from the task_type, instead of the bare "nat: strategy.frame_objective".
+        env = _envelope(
+            task_type="strategy.frame_objective",
+            agent_id="nat",
+            role="strat",
+            inputs={"role_index": 1, "role_total": 1},
+        )
+        assert build_task_name(env) == "nat[1/1]: Frame objective"
+
+    @pytest.mark.parametrize(
+        ("task_type", "expected_title"),
+        [
+            ("qa.define_test_strategy", "Define test strategy"),
+            ("governance.assess_readiness", "Assess readiness"),
+            ("data.research_context", "Research context"),
+            ("development.design_plan", "Design plan"),
+            ("noseparator", "Noseparator"),
+        ],
+    )
+    def test_humanized_title_from_task_type(self, task_type, expected_title) -> None:
+        env = _envelope(
+            task_type=task_type, agent_id="x", inputs={"role_index": 2, "role_total": 5}
+        )
+        assert build_task_name(env) == f"x[2/5]: {expected_title}"
+
+    def test_count_is_one_based(self) -> None:
+        """Per-role index is 1-based — the #94 fix for confusing 0-based UI labels."""
+        env = _envelope(
+            agent_id="neo", inputs={"subtask_focus": "first", "role_index": 1, "role_total": 2}
+        )
+        assert build_task_name(env) == "neo[1/2]: first"
+
+    def test_long_focus_still_truncates_with_count(self) -> None:
+        env = _envelope(
+            agent_id="neo", inputs={"subtask_focus": "X" * 100, "role_index": 2, "role_total": 4}
+        )
+        assert build_task_name(env) == f"neo[2/4]: {'X' * 60}"
+
+    def test_partial_count_falls_back_to_legacy(self) -> None:
+        """role_index without role_total (defensive) must not render ``[1/None]`` —
+        fall back to the legacy non-focused shape."""
+        env = _envelope(task_type="development.develop", agent_id="neo", inputs={"role_index": 1})
+        assert build_task_name(env) == "neo: development.develop"

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -135,6 +135,26 @@ class TestGenerateTaskPlanWithManifest:
         # 5 planning steps + 4 manifest build steps = 9
         assert len(envelopes) == 9
 
+    def test_per_agent_role_numbering(self):
+        """#94: each envelope carries a 1-based role_index + role_total counted
+        per agent (≈ per role), in dispatch order. With this manifest neo (dev)
+        runs 1 planning + 3 build tasks = 4 (numbered 1/4..4/4) and eve (qa) runs
+        1 planning + 1 build = 2 — the per-role progress the global index hid."""
+        from collections import defaultdict
+
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
+        envelopes = generate_task_plan(_make_cycle(), _make_run(), _make_profile(), plan=manifest)
+
+        by_agent: dict[str, list[tuple[int, int]]] = defaultdict(list)
+        for e in envelopes:
+            by_agent[e.agent_id].append((e.inputs["role_index"], e.inputs["role_total"]))
+
+        assert by_agent["neo"] == [(1, 4), (2, 4), (3, 4), (4, 4)]  # dev
+        assert by_agent["eve"] == [(1, 2), (2, 2)]  # qa
+        assert by_agent["max"] == [(1, 1)]  # lead
+        assert by_agent["nat"] == [(1, 1)]  # strat
+        assert by_agent["data"] == [(1, 1)]  # data
+
     def test_without_manifest_produces_static_steps(self):
         cycle = _make_cycle()
         run = _make_run()


### PR DESCRIPTION
Closes #94.

## Problem
Prefect/Gantt task labels used a **global** subtask index and gave framing tasks no index or title:
- `builder[4]` looked like the 5th builder task — it was the only one. `qa[5]` looked like the 6th qa task — it was the first.
- Framing showed `strat: strategy.frame_objective` — no position, no readable title.
- Indexes were 0-based (confusing in a human-facing UI).

## Fix
- `generate_task_plan` resolves each step's agent once and computes a **1-based `role_index` + `role_total` per agent** (≈ per role — the squad maps one agent to one role) across the whole plan, in dispatch order, stamping them on each envelope.
- `build_task_name` renders `prefix[n/total]: title` for planned envelopes. Title = the manifest `subtask_focus` when present, else a **humanized `task_type`** (`strategy.frame_objective` → "Frame objective"), so framing tasks gain a title too. Correction/repair/gate envelopes (no per-agent counts) keep the legacy shape.

Result:
```
nat[1/1]: Frame objective
neo[1/4]: Backend Pydantic models & in-memory repository
neo[2/4]: FastAPI endpoints & validation logic
builder[1/1]: Packaging, startup scripts & qa_handoff artifact
eve[1/2]: Backend pytest suite & validation checks
```

## One deviation from the issue (flagging)
The issue's mockups use a `dev[1/4]` (role) prefix; I kept the **agent** prefix (`neo[1/4]`), preserving the #185 decision that the agent identity is strictly more informative than the role (which duplicates the `task_type` domain segment). Since agents map 1:1 to roles, the per-agent count **is** the per-role progress the issue wants. One-line change if you'd rather show the role.

## Tests
- `build_task_name`: per-role count rendering, humanized titles (parametrized), 1-based, 60-char truncation with count, and a partial-count → legacy fallback.
- `generate_task_plan` integration: a 4-dev / 2-qa manifest asserts `neo == [1/4..4/4]`, `eve == [1/2, 2/2]`, singles `1/1`.
- The 8 existing `build_task_name` tests are unchanged (new format only triggers when per-agent counts are present). Full `tests/unit/cycles` green — **1346 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
