### PR TITLE
fix(runtime): open duty windows on-time within the poll cadence (#272)

### DIFF
--- a/src/squadops/runtime/scheduler.py
+++ b/src/squadops/runtime/scheduler.py
@@ -45,6 +45,11 @@ logger = logging.getLogger(__name__)
 # constructed/started by bootstrap only when runtime.scheduler.enabled is true.
 _DEFAULT_POLL_INTERVAL_SECONDS = 30.0
 
+# #272: tick-processing jitter absorbed on top of the poll interval when deciding
+# whether a just-active window is on-time. The poll cadence already bounds how
+# late the first observing tick can be; this covers the tick's own run time.
+_ON_TIME_GRACE_MARGIN_SECONDS = 2.0
+
 
 class DutyScheduler:
     """Polls duty assignments and requests window-open/close transitions."""
@@ -64,6 +69,12 @@ class DutyScheduler:
         self._state = state
         self._events = events_publisher
         self._poll_interval_seconds = poll_interval_seconds
+        # #272: a window is "on-time" if observed within one poll interval (plus a
+        # small jitter margin) of window_start — that lag is the scheduler's own
+        # cadence, not a missed window.
+        self._on_time_grace = timedelta(
+            seconds=poll_interval_seconds + _ON_TIME_GRACE_MARGIN_SECONDS
+        )
         self._clock = clock or (lambda: datetime.now(UTC))
         self._task: asyncio.Task | None = None
 
@@ -102,7 +113,12 @@ class DutyScheduler:
             if in_duty:
                 return None  # already serving this window
             late = now - a.active_window.start
-            if late <= timedelta(0):
+            # #272: the scheduler only observes a window at a tick boundary, so the
+            # first tick to see it active lags window_start by up to one poll
+            # interval (+ tick run time). That cadence lag is on-time — open it.
+            # missed_window_policy governs lateness *beyond* the grace (agent
+            # offline, scheduler stalled, ticks skipped), not the inherent poll lag.
+            if late <= self._on_time_grace:
                 return await self._open(a, reasons.DUTY_WINDOW_OPENED)
             return await self._open_late(a, late)
 

--- a/tests/unit/runtime/test_scheduler.py
+++ b/tests/unit/runtime/test_scheduler.py
@@ -271,6 +271,49 @@ async def test_skip_policy_does_not_open_late_window():
     assert pub.emitted[0][0] == events.ASSIGNMENT_WINDOW_SKIPPED
 
 
+async def test_poll_cadence_lateness_opens_on_time_under_skip():
+    """#272: a window observed a few seconds after window_start (the scheduler's
+    own poll-cadence lag) opens on-time even under the default skip policy. Before
+    the fix this skipped, so a default duty assignment never actually opened."""
+    coord = _RecordingCoordinator()
+    pub = _RecordingPublisher()
+    sched = DutyScheduler(
+        _FakeAssignments([_duty(policy="skip")]),
+        coord,
+        _FakeStatePort(None),
+        events_publisher=pub,
+        poll_interval_seconds=10,
+    )
+
+    # 5s after window_start — within one 10s poll interval.
+    await sched.tick(now=WIN_START + timedelta(seconds=5))
+
+    assert len(coord.requests) == 1
+    assert coord.requests[0]["target_mode"] == "duty"
+    assert coord.requests[0]["reason_code"] == reasons.DUTY_WINDOW_OPENED
+    assert pub.emitted == []  # not skipped
+
+
+async def test_lateness_beyond_poll_grace_still_skips():
+    """The on-time grace is bounded by the poll interval — lateness well beyond it
+    is a genuinely missed window and still honors skip."""
+    coord = _RecordingCoordinator()
+    pub = _RecordingPublisher()
+    sched = DutyScheduler(
+        _FakeAssignments([_duty(policy="skip")]),
+        coord,
+        _FakeStatePort(None),
+        events_publisher=pub,
+        poll_interval_seconds=10,
+    )
+
+    # 60s late, far beyond the ~12s grace for a 10s poll — genuinely missed.
+    await sched.tick(now=WIN_START + timedelta(seconds=60))
+
+    assert coord.requests == []
+    assert pub.emitted[0][0] == events.ASSIGNMENT_WINDOW_SKIPPED
+
+
 async def test_require_operator_review_flags_instead_of_transitioning():
     coord = _RecordingCoordinator()
     pub = _RecordingPublisher()


### PR DESCRIPTION
Closes #272.

## Problem
The duty scheduler never auto-opened a duty window under the default `missed_window_policy="skip"`. `_evaluate` treated **any** positive lateness as a missed window → `_open_late` → `skip` → no transition. But the scheduler only observes a window at a tick boundary, so the first tick to see a window active is always a few seconds late (up to one poll interval). With `skip`+`grace=0`, that cadence lag meant **default duty assignments never opened** — the agent stayed `ambient` the whole window.

## Fix
Treat lateness within one poll interval (+ a small tick-jitter margin) as **on-time**:
- `DutyScheduler.__init__`: `self._on_time_grace = poll_interval + 2s`.
- `_evaluate`: open via `_open` (`duty_window_opened`) when `late <= self._on_time_grace`; reserve `_open_late`/`missed_window_policy` for lateness **beyond** the cadence (agent offline, scheduler stalled, ticks skipped).

So `missed_window_policy` now governs *genuinely* missed windows, not the scheduler's own poll lag.

## Why it was masked
Unit tests drive `tick()` with on-time or minute-scale-late `now` values, so the seconds-scale poll-cadence case was never exercised. Added in this PR.

## Tests
- `test_poll_cadence_lateness_opens_on_time_under_skip`: 5s late, `poll=10s`, `skip` policy → opens `ambient→duty` with `duty_window_opened` (was skipped before).
- `test_lateness_beyond_poll_grace_still_skips`: 60s late, `poll=10s` → still skips (grace is bounded by the poll interval).
- Existing late-start tests unaffected (minute-scale lateness ≫ the seconds-scale grace). Runtime suite **142 passed**.

## Live evidence (from the #272 diagnosis)
A default-policy hard-duty assignment stayed `ambient` (`tick outcomes: []`); confirmed the coordinator/transition path itself is sound (flipping to `start_late_within_grace` opened `ambient→duty`, and the close-sweep closed it). Rebuilt runtime-api here to re-verify the default-policy open end-to-end. owner: track:macbook (SIP-0089).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
