### PR TITLE
chore(release): cut 1.1.1 — post-1.1.0 runtime-lane hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,60 @@ All notable changes to SquadOps are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [1.1.1] — 2026-06-28
+
+Hardening patch on the 1.1.0 runtime line. The runtime lane (SIP-0089) was
+live-validated end-to-end after 1.1.0, surfacing two regressions the unit
+suites couldn't catch (#270, #272); both are fixed here alongside the resume
+and reliability work from the 1.1.x hardening plan. No new SIPs — the additive
+items are backward-compatible and the one rename (#79) is internal.
+
+### Added
+- Per-role Prefect task names: tasks render as `{role} [{n}/{total}]: {title}`
+  so a role appearing multiple times in a plan is distinguishable in the
+  Prefect UI (#94).
+- Agent **`mode`** and **`runtime_status`** are now surfaced on the agent-list
+  API and the console agent view, alongside the heartbeat fields — health is
+  `runtime_status`, posture is `mode` (see
+  `docs/agent-runtime-status-model.md`) (#230, #231).
+
+### Fixed
+- **Auth:** cycle API routes returned 403 for every authenticated user — #150
+  applied `cycles:read`/`cycles:write` scope checks, but the role-centric
+  Keycloak realm issues *roles*, not those scopes. Bridge realm roles to their
+  implied scopes in `resolve_identity` so role-bearing tokens authorize as
+  intended (#270).
+- **Duty scheduler:** duty windows never auto-opened under the default
+  `missed_window_policy="skip"` — the poll-cadence lag before the first
+  observing tick was misread as a missed window. A just-active window is now
+  treated as on-time within one poll interval (plus jitter margin) (#272).
+- **Resume:** a duty-deferred run is now re-attempted *and* actually
+  re-executed on resume — the resume route never re-invoked the executor
+  before (#222).
+- **Resume:** mid-sequence runs resume at the correct workload index instead of
+  re-running from workload 0 (#257).
+- **Comms:** `publish()` now retries with bounded backoff across the RabbitMQ
+  reconnect window instead of failing the first send after a drop (#245).
+- **Capabilities:** strip `<think>` blocks before fenced-code parsing, and log
+  the raw output on zero extraction so empty parses are diagnosable (#130).
+- **CLI/API:** `runs retry` now actually executes the run (it previously
+  no-op'd); corrected stale docstrings (#133, #205).
+- **Telemetry:** the `BrokenExporter` test no longer leaks a global OTel
+  provider into sibling tests (#239).
+
 ### Changed
 - Renamed the `governance.establish_contract` capability → **`governance.define_done`**
   and its `run_contract.json` artifact → **`definition_of_done.json`** (the fields
   are a standard Definition of Done, not a "contract"). Internal rename, no
   behaviour change; historical artifacts on disk are left as-is (#79).
+
+### Internal / tooling
+- Regression suite runs in parallel via `pytest-xdist -n auto` (#216).
+- `update_sip_status.py` now rewrites the body `**Status:**` line on promotion,
+  not just the frontmatter (#253).
+- Deduplicated three copies of the JSONB-parsing helper into one (#156); routed
+  the dispatched-flow factory through `create_workflow_tracker` (#250); corrected
+  stale flow-executor references in the control-plane context doc (#168).
 
 ## [1.1.0] — 2026-06-28
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 SquadOps is a multi-agent orchestration framework for software development. It uses a hexagonal architecture (ports & adapters) with dependency injection for testability.
 
-**Framework Version**: 1.0.5 (single-sourced via `importlib.metadata.version("squadops")`)
+**Framework Version**: 1.1.1 (single-sourced via `importlib.metadata.version("squadops")`)
 **Python Requirement**: 3.11+ (production runs 3.11); develop and test on **Python 3.12** to match CI
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 **SquadOps** is an AI agent collaboration framework for software development. The system implements a role-based agent architecture where specialized agents handle different aspects of development tasks, from requirements analysis to application deployment.
 
-**Current Status**: v1.0.5 — Production-ready framework with hexagonal architecture, distributed cycle execution pipeline, multi-run cycle orchestration, workload protocols (planning, implementation, wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, build convergence loop with dynamic task decomposition (SIP-0086), Prefect task-scoped log streaming (SIP-0087), Postgres-backed persistence, LangFuse observability, Keycloak authentication, CLI tooling, test quality enforcement, and 3,460+ passing tests.
+**Current Status**: v1.1.1 — Production-ready framework with hexagonal architecture, the Agent Runtime State platform (SIP-0089: runtime modes ambient/cycle/duty, single-writer coordinator, duty scheduler, FocusLease arbitration, RuntimeActivity observability), distributed cycle execution pipeline, multi-run cycle orchestration, workload protocols (planning, implementation, wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, build convergence loop with dynamic task decomposition (SIP-0086), Prefect task-scoped log streaming (SIP-0087), Postgres-backed persistence, LangFuse observability, Keycloak authentication, CLI tooling, test quality enforcement, and 4,470+ passing tests.
 
 ---
 
@@ -173,13 +173,13 @@ See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for full setup instructio
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for the full release timeline.
 
-**Current**: v1.0.5 — Post-1.0 stable; distributed cycle execution, multi-run orchestration, correction protocol, build convergence loop (SIP-0086), and Prefect task-scoped log streaming (SIP-0087) shipped
+**Current**: v1.1.1 — Agent Runtime State (SIP-0089) on a hardened 1.0.x foundation; distributed cycle execution, multi-run orchestration, correction protocol, build convergence loop (SIP-0086), and Prefect task-scoped log streaming (SIP-0087) shipped
 
 ---
 
 ## Current Status
-**Framework Version**: 1.0.5
-**Development Status**: Post-1.0 stable multi-agent orchestration with console UI, distributed cycle execution, multi-run cycle orchestration, workload protocols (planning → implementation → wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, Prefect task-scoped log streaming, durable persistence, authentication, CLI tooling, profile-driven bootstrap, test quality enforcement, and full observability stack.
+**Framework Version**: 1.1.1
+**Development Status**: Post-1.1 stable multi-agent orchestration with the Agent Runtime State platform (SIP-0089: runtime modes, duty scheduler, FocusLease, RuntimeActivity), console UI, distributed cycle execution, multi-run cycle orchestration, workload protocols (planning → implementation → wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, Prefect task-scoped log streaming, durable persistence, authentication, CLI tooling, profile-driven bootstrap, test quality enforcement, and full observability stack.
 
 ### Project Statistics
 - **~39,000 lines** of Python source code

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,16 @@ Living document tracking the implementation progression from initial prototype t
 
 ## Release Timeline
 
-### v1.1.0 (2026-06-28) — Current — Agent Runtime State + 1.0.x Hardening
+### v1.1.1 (2026-06-28) — Current — Runtime Lane Hardening
+- **Live-validated the runtime lane (SIP-0089) end-to-end** after 1.1.0, which surfaced two regressions the unit suites couldn't catch:
+  - **#270** cycle API routes 403'd every authenticated user — #150's `cycles:*` scope checks didn't account for the role-centric Keycloak realm (issues roles, not scopes); fixed with a role→scope bridge in `resolve_identity`.
+  - **#272** duty windows never auto-opened under the default `missed_window_policy="skip"` — poll-cadence lag was misread as a missed window; fixed with an on-time grace of one poll interval.
+- **Resume reliability:** duty-deferred runs now actually re-execute on resume (#222); mid-sequence runs resume at the correct workload index (#257).
+- **Reliability:** bounded RabbitMQ publish retry/backoff (#245); `runs retry` actually executes (#133, #205); strip `<think>` before fenced parsing (#130); OTel provider test leak fixed (#239).
+- **Additive (backward-compatible):** per-role Prefect task names (#94); agent `mode` + `runtime_status` on the agent list / console (#230, #231).
+- **Internal:** `establish_contract` → `define_done` rename (#79); regression suite parallelized via pytest-xdist (#216); SIP-status script rewrites the body status line (#253).
+
+### v1.1.0 (2026-06-28) — Agent Runtime State + 1.0.x Hardening
 - **SIP-0089** Agent Runtime State (Phases 1–4): runtime modes (ambient/cycle/duty) with a single-writer coordinator + in-process duty scheduler, assignments & duty windows, FocusLease arbitration, RuntimeActivity observability. Migrations 1100–1130.
 - **1.0.x hardening foundation** landed: CI-trust arc (declared deps, dev+CI on Python 3.12, ruff-format gate, adapters in the gate) + reliability fixes (#146 channel recovery, #155 frozen-result mutation, #77 cancel→Prefect, #209 integration config) + **#150 cycle-route scope enforcement (security)**.
 - The remaining build-reliability work is re-baselined as the **1.1.x hardening plan** (`docs/plans/1-1-x-hardening-plan.md`) — it no longer gates the version. (Gate read as foundational-hardening completeness; joint Spark/Mac decision 2026-06-28.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["squadops*", "adapters*"]  # Include both packages
 
 [project]
 name = "squadops"
-version = "1.1.0"
+version = "1.1.1"
 description = "SquadOps: a production-grade multi-agent orchestration framework."
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
Cuts **1.1.1**, bundling the 16 PRs merged since 1.1.0 (`baa0e82`) into a patch release. Closes #274.

## Why patch, not minor
14 of 16 merged PRs are bug fixes / refactors / CI / docs. The two additive `feat` commits (#94, #230/#231) are backward-compatible new fields, and the one rename (#79) is internal orchestration plumbing — documented explicitly as **Changed/Renamed**. Consistent with the semver rule set at 1.1.0 ship: 1.1.x = hardening, 1.2.0 = next feature SIP.

## Highlights
The runtime lane (SIP-0089) was **live-validated end-to-end** after 1.1.0, surfacing two regressions the unit suites couldn't catch — both fixed here:
- **#270** — cycle API routes 403'd every authenticated user (#150's `cycles:*` scopes vs the role-centric Keycloak realm). Role→scope bridge in `resolve_identity`.
- **#272** — duty windows never auto-opened under the default `missed_window_policy="skip"` (poll-cadence lag misread as a missed window). On-time grace of one poll interval.

Plus resume reliability (#222 re-execute, #257 mid-sequence index), comms retry (#245), `runs retry` actually executing (#133/#205), and the additive observability (#94, #230/#231).

## Changes
- Version bump `1.1.0 → 1.1.1` via `version_cli.py` (pyproject single source)
- CHANGELOG 1.1.1 section — Added / Fixed / Changed / Internal (the #79 rename called out, not buried)
- Fixed stale `1.0.5` version markers in **CLAUDE.md** and **README.md** (neither got bumped at 1.1.0)
- ROADMAP v1.1.1 entry

## Verification
- Regression suite: **4476 passed, 1 skipped** (xdist, ~9s)
- Post-merge: rebuild runtime-api + agents, verify `/health` → 1.1.1

## Included PRs
Fixes/hardening: #270 #272 #222 #257 #245 #239 #130 #133 #205 #156 #250 #253
CI/docs: #216 #168
Additive: #94 #230 #231
Rename: #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)
