### PR TITLE
fix(observability): raw task_type + keep focus in Prefect task names (#277)

### DIFF
--- a/adapters/cycles/task_naming.py
+++ b/adapters/cycles/task_naming.py
@@ -10,54 +10,57 @@ from __future__ import annotations
 
 from squadops.tasks.models import TaskEnvelope
 
-
-def _humanize_task_type(task_type: str) -> str:
-    """Title for a non-focused task, derived from its ``task_type``.
-
-    Takes the leaf segment and makes it read like a title:
-    ``strategy.frame_objective`` → ``Frame objective``,
-    ``qa.define_test_strategy`` → ``Define test strategy``. Falls back to the
-    raw ``task_type`` if it has no usable leaf.
-    """
-    leaf = task_type.rsplit(".", 1)[-1].replace("_", " ").replace("-", " ").strip()
-    return leaf[:1].upper() + leaf[1:] if leaf else task_type
+# Separates the structural task_type from a subtask's free-text focus, e.g.
+# ``development.develop — implement POST /runs``.
+_FOCUS_SEPARATOR = " — "
+_FOCUS_MAX_LEN = 60
 
 
 def build_task_name(envelope: TaskEnvelope) -> str:
     """Build a Gantt-friendly Prefect task name for a dispatched envelope.
 
-    Prefixes with the **agent** that ran the task (``envelope.agent_id``) rather
-    than the role: the role already duplicates the ``task_type`` domain segment
-    (``qa: qa.define_test_strategy``), whereas the agent identity is strictly
-    more informative (``eve: qa.define_test_strategy``). Falls back to the role
-    when ``agent_id`` is unset — correction/repair and gate-boundary envelopes
-    leave it empty — and to ``"unknown"`` when neither is present. ``agent_id``
-    comes from the squad profile, so the label stays profile-configurable.
+    Shape: ``{agent} [{n}/{total}]: {task_type}[ — {focus}]``.
 
-    Planned-run envelopes (framing + implementation) carry per-agent
-    ``role_index``/``role_total`` (#94) and render ``prefix[n/total]: title`` —
-    1-based position within that agent's work, so "how far through dev work are
-    we" is answerable at a glance and the count reflects per-role progress, not a
-    global index. The title is the manifest ``subtask_focus`` when present, else
-    the humanized ``task_type`` (so framing tasks gain a readable title too).
+    **Prefix** — the *agent* that ran the task (``envelope.agent_id``), falling
+    back to the role (``metadata["role"]``) when ``agent_id`` is unset
+    (correction/repair and gate-boundary envelopes leave it empty), then to
+    ``"unknown"``. ``agent_id`` comes from the squad profile, so the label stays
+    profile-configurable.
 
-    Envelopes without per-agent counts (correction/repair, gate boundaries) keep
-    the legacy shape: ``prefix[idx]: focus`` for focused subtasks, else
-    ``prefix: task_type``.
+    **Descriptor** — the raw ``task_type`` (#277). Its domain segment is the
+    role (``qa.define_test_strategy``), so the raw value restores the role
+    identity the agent prefix alone would lose, *and* keeps the verb — strictly
+    more information than a humanized leaf (``qa.define_test_strategy`` →
+    "Test"). When a subtask carries a free-text ``subtask_focus`` (build
+    subtasks, e.g. "implement POST /runs"), it is appended after an em dash and
+    truncated to keep the label Gantt-sized; the ``task_type`` spine stays so the
+    label is uniform and greppable.
+
+    **Count** — planned-run envelopes (framing + implementation) carry per-agent
+    ``role_index``/``role_total`` (#94) and render ``[n/total]`` — 1-based
+    position within *that agent's* work, so "how far through dev work are we" is
+    answerable at a glance. The bracket is spaced off the prefix (``neo [2/5]``,
+    not ``neo[2/5]``) so it doesn't read as an array subscript (#277). Envelopes
+    built outside the plan (correction/repair, gate boundaries) carry no per-agent
+    count; a legacy ``subtask_index`` still renders as ``[idx]``, otherwise the
+    count is omitted.
     """
     role = envelope.metadata.get("role", "unknown") if envelope.metadata else "unknown"
     prefix = envelope.agent_id or role
     inputs = envelope.inputs or {}
+
+    descriptor = envelope.task_type
     focus = inputs.get("subtask_focus")
-    title = str(focus)[:60] if focus else _humanize_task_type(envelope.task_type)
+    if focus:
+        descriptor = f"{envelope.task_type}{_FOCUS_SEPARATOR}{str(focus)[:_FOCUS_MAX_LEN]}"
 
     n = inputs.get("role_index")
     total = inputs.get("role_total")
     if n is not None and total is not None:
-        return f"{prefix}[{n}/{total}]: {title}"
+        return f"{prefix} [{n}/{total}]: {descriptor}"
 
     # Legacy fallback for envelopes built outside the plan (no per-agent counts).
     idx = inputs.get("subtask_index")
-    if focus:
-        return f"{prefix}[{idx}]: {title}" if idx is not None else f"{prefix}: {title}"
-    return f"{prefix}: {envelope.task_type}"
+    if idx is not None:
+        return f"{prefix} [{idx}]: {descriptor}"
+    return f"{prefix}: {descriptor}"

--- a/tests/unit/cycles/test_task_naming.py
+++ b/tests/unit/cycles/test_task_naming.py
@@ -1,9 +1,11 @@
-"""Tests for build_task_name (adapters/cycles/task_naming.py, #185).
+"""Tests for build_task_name (adapters/cycles/task_naming.py, #185 / #277).
 
-The Prefect/Gantt task label prefixes with the agent that ran the task
-(``envelope.agent_id``) rather than the role, falling back to the role when
-``agent_id`` is unset (correction/repair, gate boundaries). Focused-mode
-envelopes additionally carry the manifest focus + index.
+The Prefect/Gantt task label is ``{agent} [{n}/{total}]: {task_type}[ — focus]``:
+prefix with the agent that ran the task (``envelope.agent_id``), falling back to
+the role when ``agent_id`` is unset (correction/repair, gate boundaries); the
+descriptor is the raw ``task_type`` (#277) with any free-text ``subtask_focus``
+appended; planned runs carry a 1-based per-agent ``[n/total]`` count (#94),
+spaced off the prefix so it doesn't read as an array subscript.
 """
 
 from __future__ import annotations
@@ -40,12 +42,12 @@ def _envelope(
 
 class TestBuildTaskName:
     """Gantt-friendly Prefect labels: prefix with the agent that ran the task,
-    not the role (role duplicates the task_type's own domain segment)."""
+    descriptor is the raw task_type (#277)."""
 
     def test_prefixes_with_agent_name_not_role(self) -> None:
-        # agent_id 'eve' wins over role 'qa' — the whole point of #185. Before
-        # the change this rendered "qa: qa.define_test_strategy" (role repeats
-        # the task_type domain).
+        # agent_id 'eve' wins over role 'qa'. The raw task_type already carries
+        # the role in its domain segment, so the label reads
+        # "eve: qa.define_test_strategy" — agent identity + role + verb, no dup.
         env = _envelope(task_type="qa.define_test_strategy", agent_id="eve", role="qa")
         assert build_task_name(env) == "eve: qa.define_test_strategy"
 
@@ -59,92 +61,126 @@ class TestBuildTaskName:
         env = _envelope(task_type="governance.review", agent_id="", role=None)
         assert build_task_name(env) == "unknown: governance.review"
 
-    def test_focused_envelope_uses_agent_focus_and_index(self) -> None:
+    def test_focused_envelope_appends_focus_to_task_type(self) -> None:
+        # #277: focus is appended to the raw task_type, not used in its place —
+        # the task_type spine stays so the label is uniform and greppable.
         env = _envelope(
             agent_id="neo",
+            task_type="development.develop",
             inputs={
                 "subtask_focus": "Backend data models and in-memory repository",
                 "subtask_index": 0,
             },
         )
-        assert build_task_name(env) == "neo[0]: Backend data models and in-memory repository"
+        assert build_task_name(env) == (
+            "neo [0]: development.develop — Backend data models and in-memory repository"
+        )
 
     def test_focused_envelope_without_index_omits_brackets(self) -> None:
         env = _envelope(
-            agent_id="neo", inputs={"subtask_focus": "FastAPI endpoints and validation"}
+            agent_id="neo",
+            task_type="development.develop",
+            inputs={"subtask_focus": "FastAPI endpoints and validation"},
         )
-        assert build_task_name(env) == "neo: FastAPI endpoints and validation"
+        assert build_task_name(env) == (
+            "neo: development.develop — FastAPI endpoints and validation"
+        )
 
     def test_non_focused_envelope_falls_back_to_task_type(self) -> None:
         env = _envelope(task_type="development.develop", agent_id="neo", inputs={})
         assert build_task_name(env) == "neo: development.develop"
 
     def test_long_focus_truncates_at_60_chars(self) -> None:
-        env = _envelope(agent_id="neo", inputs={"subtask_focus": "X" * 100, "subtask_index": 3})
+        env = _envelope(
+            agent_id="neo",
+            task_type="development.develop",
+            inputs={"subtask_focus": "X" * 100, "subtask_index": 3},
+        )
         name = build_task_name(env)
-        assert name == f"neo[3]: {'X' * 60}"
-        assert len(name.split(": ", 1)[1]) == 60
+        assert name == f"neo [3]: development.develop — {'X' * 60}"
+        # only the focus portion is truncated; the task_type spine is untouched.
+        assert name.split(" — ", 1)[1] == "X" * 60
 
     def test_index_zero_renders_as_zero_not_omitted(self) -> None:
         """Subtask index 0 must render as ``[0]`` — falsy but valid."""
-        env = _envelope(agent_id="neo", inputs={"subtask_focus": "first", "subtask_index": 0})
-        assert build_task_name(env) == "neo[0]: first"
+        env = _envelope(
+            agent_id="neo",
+            task_type="development.develop",
+            inputs={"subtask_focus": "first", "subtask_index": 0},
+        )
+        assert build_task_name(env) == "neo [0]: development.develop — first"
 
 
 class TestPerRoleNumbering:
-    """#94: planned-run envelopes carry per-agent role_index/role_total and render
-    ``prefix[n/total]: title`` (1-based) for both framing and implementation."""
+    """#94/#277: planned-run envelopes carry per-agent role_index/role_total and
+    render ``prefix [n/total]: task_type[ — focus]`` (1-based, spaced bracket)."""
 
     def test_implementation_focused_uses_per_role_count(self) -> None:
         env = _envelope(
             agent_id="neo",
+            task_type="development.develop",
             inputs={
                 "subtask_focus": "Backend Pydantic models & in-memory repository",
                 "role_index": 1,
                 "role_total": 4,
             },
         )
-        assert build_task_name(env) == "neo[1/4]: Backend Pydantic models & in-memory repository"
+        assert build_task_name(env) == (
+            "neo [1/4]: development.develop — Backend Pydantic models & in-memory repository"
+        )
 
-    def test_framing_non_focused_gets_humanized_title_and_count(self) -> None:
-        # The #94 win for framing: a numeric position AND a readable title derived
-        # from the task_type, instead of the bare "nat: strategy.frame_objective".
+    def test_framing_non_focused_uses_raw_task_type_and_count(self) -> None:
+        # #277: framing tasks show the raw task_type (role + verb), not a
+        # humanized leaf that drops the domain ("strategy.frame_objective", not
+        # "Frame objective").
         env = _envelope(
             task_type="strategy.frame_objective",
             agent_id="nat",
             role="strat",
             inputs={"role_index": 1, "role_total": 1},
         )
-        assert build_task_name(env) == "nat[1/1]: Frame objective"
+        assert build_task_name(env) == "nat [1/1]: strategy.frame_objective"
 
     @pytest.mark.parametrize(
-        ("task_type", "expected_title"),
+        "task_type",
         [
-            ("qa.define_test_strategy", "Define test strategy"),
-            ("governance.assess_readiness", "Assess readiness"),
-            ("data.research_context", "Research context"),
-            ("development.design_plan", "Design plan"),
-            ("noseparator", "Noseparator"),
+            "qa.define_test_strategy",
+            "governance.assess_readiness",
+            "data.research_context",
+            "development.design_plan",
+            "noseparator",
         ],
     )
-    def test_humanized_title_from_task_type(self, task_type, expected_title) -> None:
+    def test_raw_task_type_is_the_descriptor(self, task_type) -> None:
         env = _envelope(
             task_type=task_type, agent_id="x", inputs={"role_index": 2, "role_total": 5}
         )
-        assert build_task_name(env) == f"x[2/5]: {expected_title}"
+        assert build_task_name(env) == f"x [2/5]: {task_type}"
 
     def test_count_is_one_based(self) -> None:
         """Per-role index is 1-based — the #94 fix for confusing 0-based UI labels."""
         env = _envelope(
-            agent_id="neo", inputs={"subtask_focus": "first", "role_index": 1, "role_total": 2}
+            agent_id="neo",
+            task_type="development.develop",
+            inputs={"subtask_focus": "first", "role_index": 1, "role_total": 2},
         )
-        assert build_task_name(env) == "neo[1/2]: first"
+        assert build_task_name(env) == "neo [1/2]: development.develop — first"
+
+    def test_bracket_is_spaced_off_prefix(self) -> None:
+        """#277: the count bracket must be spaced (``neo [1/2]``) so it doesn't
+        read as an array subscript (``neo[1]``)."""
+        env = _envelope(agent_id="neo", inputs={"role_index": 1, "role_total": 2})
+        name = build_task_name(env)
+        assert " [1/2]:" in name
+        assert "neo[" not in name
 
     def test_long_focus_still_truncates_with_count(self) -> None:
         env = _envelope(
-            agent_id="neo", inputs={"subtask_focus": "X" * 100, "role_index": 2, "role_total": 4}
+            agent_id="neo",
+            task_type="development.develop",
+            inputs={"subtask_focus": "X" * 100, "role_index": 2, "role_total": 4},
         )
-        assert build_task_name(env) == f"neo[2/4]: {'X' * 60}"
+        assert build_task_name(env) == f"neo [2/4]: development.develop — {'X' * 60}"
 
     def test_partial_count_falls_back_to_legacy(self) -> None:
         """role_index without role_total (defensive) must not render ``[1/None]`` —


### PR DESCRIPTION
Closes #277.

#94's per-agent `[n/total]` count was a win and stays — but it over-corrected on the **descriptor**, dropping the role identity and collapsing task names to ~one word. This restores both.

## What changed
`build_task_name` (`adapters/cycles/task_naming.py`):
- **Descriptor is the raw `task_type`** instead of a humanized leaf. `qa.define_test_strategy` → "Test" threw away the `domain.verb` structure; the domain segment *is* the role, so the raw value restores the role identity (lost by #94's agent-only prefix) **and** keeps the verb — no duplication, since the prefix is the agent (`eve`), not the role (`qa`).
- **`subtask_focus` is appended, not substituted** — build subtasks keep their specificity while every label keeps a uniform, greppable `task_type` spine.
- **Count bracket spaced off the prefix** (`neo [1/2]`, not `neo[1/2]`) so it doesn't read as an array subscript.
- `_humanize_task_type` removed (now dead).

## Before → after
```
neo[2/5]: Develop                  →  neo [2/5]: development.develop — implement POST /runs
eve[1/2]: Test                     →  eve [1/2]: qa.define_test_strategy
nat[1/1]: Frame objective          →  nat [1/1]: strategy.frame_objective
```

## Decision on the open question (build subtask `focus`)
Went with **(b) keep the focus**, appended after an em dash — dropping it for format uniformity (option (a)) would have been a second over-correction in the opposite direction. `subtask_focus` is the most information-dense field available for build subtasks.

## Tests
`tests/unit/cycles/test_task_naming.py` updated to the new `agent [n/total]: task_type[ — focus]` shape; added a test asserting the bracket is spaced (no `neo[` subscript form). Full regression: **4477 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
