### PR TITLE
feat(runtime): route cycle recruitment through the coordinator (SIP-0089 §3.5, #233)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -428,9 +428,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # agent's future recruitment, so this must run before anything that can
             # raise. Empty (and skipped) when the run recruited no one.
             if self._coordinator is not None and recruited_agent_ids:
-                await release_participants(
-                    self._coordinator, recruited_agent_ids, owner_ref=run_id
-                )
+                await release_participants(self._coordinator, recruited_agent_ids, owner_ref=run_id)
             await self._finalize_run(
                 cycle_id,
                 run_id,

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -47,6 +47,7 @@ from squadops.cycles.task_plan import generate_task_plan
 from squadops.events.types import EventType
 from squadops.ports.cycles.flow_execution import FlowExecutionPort
 from squadops.runtime import reasons
+from squadops.runtime.admission import admit_participants, release_participants
 from squadops.runtime.recruitment import reserve_buffer_decision
 from squadops.tasks.models import TaskEnvelope, TaskResult
 from squadops.telemetry.context import use_correlation_context, use_run_ids
@@ -68,6 +69,7 @@ if TYPE_CHECKING:
     from squadops.ports.runtime.activity import RuntimeActivityPort
     from squadops.ports.runtime.assignments import AssignmentPort
     from squadops.ports.telemetry.llm_observability import LLMObservabilityPort
+    from squadops.runtime.coordinator import RuntimeCoordinator
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +124,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         reply_router: ReplyRouter | None = None,
         assignment_port: AssignmentPort | None = None,
         activity_port: RuntimeActivityPort | None = None,
+        coordinator: RuntimeCoordinator | None = None,
     ) -> None:
         self._cycle_registry = cycle_registry
         self._artifact_vault = artifact_vault
@@ -141,6 +144,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # dispatch, complete/fail on reply) so an agent's current task is
         # observable. Best-effort — never breaks dispatch; None disables it.
         self._activity_port = activity_port
+        # SIP-0089 §3.5 (#233): opt-in RuntimeCoordinator. When wired, recruitment
+        # routes each participant ambient→cycle through the coordinator (acquiring
+        # the cycle FocusLease) after the §2.5 guard passes, and releases them on
+        # finalize. When None (memory registry / lite local cycles), recruitment
+        # falls back to §2.5-only — a cycle never hard-fails for missing runtime
+        # infra.
+        self._coordinator = coordinator
         self._cancelled: set[str] = set()
 
         # SIP-0077: Cycle event bus (defaults to NoOp if not provided)
@@ -169,6 +179,11 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         self._pulse_report_entries = []
         cycle = None
         plan = None
+        # SIP-0089 §3.5 (#233): agents this run transitioned ambient→cycle, to be
+        # returned to ambient (releasing their cycle lease) in the finally. Stays
+        # empty when recruitment defers (admission rolls its own recruits back) or
+        # when no coordinator is wired.
+        recruited_agent_ids: tuple[str, ...] = ()
 
         try:
             cycle, run_root = await self._prepare_cycle_for_run(cycle_id, run_id)
@@ -212,6 +227,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             implementation_plan = await self._load_plan_for_run(cycle, run)
 
             plan = generate_task_plan(cycle, run, profile, plan=implementation_plan)
+            participating_agent_ids = {e.agent_id for e in plan}
 
             # SIP-0089 §2.5: reserve-buffer guard. The plan now names every
             # agent this run would recruit. If one is committed to — or about to
@@ -224,11 +240,29 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 active_assignments = await self._assignment_port.list_active_assignments(guard_now)
                 decision = reserve_buffer_decision(
                     active_assignments,
-                    {e.agent_id for e in plan},
+                    participating_agent_ids,
                     guard_now,
                 )
                 if not decision.allowed:
                     raise _RecruitmentRejectedError(decision.blocking_agent_id, decision.reason)
+
+            # SIP-0089 §3.5 (#233): having cleared the reserve-buffer guard, route
+            # recruitment through the coordinator — each participant transitions
+            # ambient→cycle, acquiring its cycle FocusLease (§3.4). A lease
+            # conflict is a deferral, not a failure: it rides the same
+            # _RecruitmentRejectedError → RUN_PAUSED path with a typed focus_lease_*
+            # reason (no new EventType). admission rolls back any agents it already
+            # recruited before deferring, so a paused run strands no one in cycle.
+            # Opt-in: skipped when no coordinator is wired (§2.5-only fallback).
+            if self._coordinator is not None:
+                admission = await admit_participants(
+                    self._coordinator,
+                    participating_agent_ids,
+                    owner_ref=run_id,
+                )
+                if not admission.admitted:
+                    raise _RecruitmentRejectedError(admission.blocking_agent_id, admission.reason)
+                recruited_agent_ids = admission.recruited_agent_ids
 
             # Build-only validation (D6): require plan_artifact_refs
             include_plan = bool(cycle.applied_defaults.get("plan_tasks", True))
@@ -388,6 +422,15 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             logger.exception("Run %s failed with unexpected error: %s", run_id, exc)
 
         finally:
+            # SIP-0089 §3.5 (#233): release the cycle leases this run acquired,
+            # whatever the outcome (completed/failed/paused/cancelled). Best-effort
+            # and isolated per agent — a stranded cycle lease would block all of an
+            # agent's future recruitment, so this must run before anything that can
+            # raise. Empty (and skipped) when the run recruited no one.
+            if self._coordinator is not None and recruited_agent_ids:
+                await release_participants(
+                    self._coordinator, recruited_agent_ids, owner_ref=run_id
+                )
             await self._finalize_run(
                 cycle_id,
                 run_id,

--- a/adapters/cycles/factory.py
+++ b/adapters/cycles/factory.py
@@ -119,5 +119,6 @@ def create_flow_executor(
             reply_router=kwargs.get("reply_router"),
             assignment_port=kwargs.get("assignment_port"),
             activity_port=kwargs.get("activity_port"),
+            coordinator=kwargs.get("coordinator"),
         )
     raise ValueError(f"Unknown flow executor provider: {provider}")

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -157,6 +157,9 @@ _reconciliation_task = None
 
 # SIP-0089 §2.4: in-process duty-transition scheduler (opt-in; stopped on shutdown)
 _duty_scheduler = None
+# SIP-0089 §3.5 (#233): the single-writer RuntimeCoordinator (D16), built once in
+# the cycle subsystem and shared by the executor (recruitment) and the scheduler.
+_runtime_coordinator = None
 
 
 async def _init_auth_subsystem(config) -> None:
@@ -246,7 +249,7 @@ async def _init_log_forwarding(config) -> None:
 
 async def _init_cycle_subsystem(config, pool) -> None:
     """Initialize SIP-0064 cycle ports + SIP-0066 orchestrator."""
-    global _workflow_tracker, _reply_router
+    global _workflow_tracker, _reply_router, _runtime_coordinator
     try:
         from adapters.cycles.factory import (
             create_artifact_vault,
@@ -333,6 +336,14 @@ async def _init_cycle_subsystem(config, pool) -> None:
             # written here (not in agents) as each task is dispatched/replied.
             activity_port = PostgresRuntimeActivity(pool)
 
+        # SIP-0089 §3.5 (#233): the single-writer coordinator (D16), built once
+        # here and reused by the duty scheduler (see _init_duty_scheduler) so the
+        # executor's recruitment and the scheduler drive the same mode-writer.
+        # None when pool-less → recruitment falls back to the §2.5 guard only.
+        from squadops.api.runtime.scheduler_bootstrap import create_runtime_coordinator
+
+        _runtime_coordinator = create_runtime_coordinator(pool)
+
         flow_executor = create_flow_executor(
             "dispatched",
             cycle_registry=cycle_registry,
@@ -347,6 +358,7 @@ async def _init_cycle_subsystem(config, pool) -> None:
             reply_router=_reply_router,
             assignment_port=assignment_port,
             activity_port=activity_port,
+            coordinator=_runtime_coordinator,
         )
 
         set_cycle_ports(
@@ -460,7 +472,9 @@ async def _init_duty_scheduler(config, pool) -> None:
     try:
         from squadops.api.runtime.scheduler_bootstrap import create_duty_scheduler
 
-        _duty_scheduler = create_duty_scheduler(config, pool)
+        # Reuse the single-writer coordinator built in _init_cycle_subsystem (D16);
+        # the scheduler builds its own only if that wiring was skipped.
+        _duty_scheduler = create_duty_scheduler(config, pool, coordinator=_runtime_coordinator)
         if _duty_scheduler is not None:
             await _duty_scheduler.start()
             logger.info("Duty scheduler started")

--- a/src/squadops/api/runtime/scheduler_bootstrap.py
+++ b/src/squadops/api/runtime/scheduler_bootstrap.py
@@ -42,13 +42,57 @@ from squadops.runtime.scheduler import DutyScheduler
 logger = logging.getLogger(__name__)
 
 
-def create_duty_scheduler(config: AppConfig, pool: asyncpg.Pool | None) -> DutyScheduler | None:
+def create_runtime_coordinator(pool: asyncpg.Pool | None) -> RuntimeCoordinator | None:
+    """Build the single Postgres-backed ``RuntimeCoordinator``, or ``None`` without a pool.
+
+    This is the **one** coordinator instance the composition root shares between
+    the cycle executor (recruitment lease acquisition, §3.5/#233) and the duty
+    scheduler. Both must drive the *same* instance because the coordinator is the
+    sole writer of ``AgentRuntimeState.mode`` (D16) — building a second one would
+    create two mode-writers.
+
+    NOT gated on ``scheduler.enabled``: recruitment acquires cycle leases whether
+    or not duty scheduling runs. Returns ``None`` only when no pool is available —
+    the focus-lease and runtime-state tables both live in Postgres.
+    """
+    if pool is None:
+        return None
+
+    # Imported here (not at module top) so importing this module never pulls the
+    # asyncpg adapter stack into processes that only need the factory signature.
+    from adapters.events.runtime_event_publisher import LoggingRuntimeEventPublisher
+    from adapters.persistence.runtime import (
+        PostgresFocusLease,
+        PostgresRuntimeActivity,
+        PostgresRuntimeState,
+    )
+
+    state = PostgresRuntimeState(pool)
+    focus_lease = PostgresFocusLease(pool)
+    activity = PostgresRuntimeActivity(pool)
+    publisher = LoggingRuntimeEventPublisher()
+    return RuntimeCoordinator(
+        state, events_publisher=publisher, focus_lease=focus_lease, activity=activity
+    )
+
+
+def create_duty_scheduler(
+    config: AppConfig,
+    pool: asyncpg.Pool | None,
+    *,
+    coordinator: RuntimeCoordinator | None = None,
+) -> DutyScheduler | None:
     """Build the duty scheduler, or return ``None`` when it should not run.
 
     Returns ``None`` (and the caller starts nothing) when the scheduler is
     disabled by config, or when no Postgres pool is available — the assignment
     and runtime-state tables both live in Postgres, so without a pool there is
     nothing to schedule against.
+
+    ``coordinator`` lets the composition root inject the shared single-writer
+    coordinator (D16) so the executor and scheduler drive the same instance. When
+    omitted (standalone use / unit tests) the scheduler builds its own via
+    :func:`create_runtime_coordinator`.
     """
     if not config.runtime.scheduler.enabled:
         logger.info("Duty scheduler disabled (runtime.scheduler.enabled=false)")
@@ -61,21 +105,16 @@ def create_duty_scheduler(config: AppConfig, pool: asyncpg.Pool | None) -> DutyS
     # Imported here (not at module top) so importing this module never pulls the
     # asyncpg adapter stack into processes that only need the factory signature.
     from adapters.events.runtime_event_publisher import LoggingRuntimeEventPublisher
-    from adapters.persistence.runtime import (
-        PostgresFocusLease,
-        PostgresRuntimeActivity,
-        PostgresRuntimeState,
-    )
+    from adapters.persistence.runtime import PostgresRuntimeState
     from adapters.persistence.runtime.assignments_postgres import PostgresAssignment
 
     state = PostgresRuntimeState(pool)
     assignments = PostgresAssignment(pool)
-    focus_lease = PostgresFocusLease(pool)
-    activity = PostgresRuntimeActivity(pool)
     publisher = LoggingRuntimeEventPublisher()
-    coordinator = RuntimeCoordinator(
-        state, events_publisher=publisher, focus_lease=focus_lease, activity=activity
-    )
+    # Share the composition root's single-writer coordinator (D16) when injected;
+    # otherwise build one — the standalone path keeps the §3.4/§4.5 wiring intact.
+    if coordinator is None:
+        coordinator = create_runtime_coordinator(pool)
 
     poll_interval = config.runtime.scheduler.poll_interval_seconds
     logger.warning(

--- a/src/squadops/runtime/__init__.py
+++ b/src/squadops/runtime/__init__.py
@@ -7,6 +7,11 @@ Pure coordination layer for `RuntimeMode`, `RuntimeActivity`, `FocusLease`,
 per D26).
 """
 
+from squadops.runtime.admission import (
+    AdmissionResult,
+    admit_participants,
+    release_participants,
+)
 from squadops.runtime.coordinator import (
     RequesterKind,
     RuntimeCoordinator,
@@ -42,6 +47,7 @@ from squadops.runtime.scheduler import DutyScheduler
 __all__ = [
     "ActivitySourceKind",
     "ActivityState",
+    "AdmissionResult",
     "AgentRuntimeState",
     "Assignment",
     "AssignmentType",
@@ -63,9 +69,11 @@ __all__ = [
     "Strictness",
     "TransitionOutcome",
     "WindowState",
+    "admit_participants",
     "is_active_activity_state",
     "is_terminal_activity_state",
     "owner_type_outranks",
+    "release_participants",
     "reserve_buffer_decision",
     "window_state",
 ]

--- a/src/squadops/runtime/admission.py
+++ b/src/squadops/runtime/admission.py
@@ -1,0 +1,138 @@
+"""
+Cycle recruitment admission through the coordinator — SIP-0089 §3.5.
+
+After the §2.5 reserve-buffer guard (:func:`squadops.runtime.recruitment.reserve_buffer_decision`)
+admits a run, this module routes each participating agent through the
+:class:`~squadops.runtime.coordinator.RuntimeCoordinator` to transition
+``ambient → cycle``. The cycle FocusLease rides that mode write (§3.4,
+``_owner_type_for_mode("cycle")``), so recruitment never touches the lease
+directly — the coordinator stays the sole lease arbiter and mode writer (D16).
+
+A lease conflict **defers** the run: the coordinator returns a typed
+``focus_lease_*`` reason, which the executor surfaces on the existing
+``RUN_PAUSED`` payload — no new ``cycle.recruitment.rejected`` EventType (the
+§2.5 / #222 locked-taxonomy precedent).
+
+Partial admission is rolled back. If agent *N* conflicts after agents *1..N-1*
+already entered ``cycle``, those are returned to ``ambient`` before deferring, so
+a deferred run never strands an agent in ``cycle`` mode. Release is symmetric:
+on run finalize the executor releases exactly the agents it recruited
+(``applied`` transitions only — an agent already in ``cycle`` for another run is
+left alone). Both paths are **best-effort** compensation in v1.1; the
+single-Postgres-transaction wrapping (D25) is #244, gated on this work.
+
+Pure orchestration: depends only on the coordinator (a runtime-domain object) and
+``runtime.reasons`` — never on ``adapters.*`` (D26). The executor (an adapter)
+imports *down* into this module, never the reverse.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from squadops.runtime import reasons
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from squadops.runtime.coordinator import RuntimeCoordinator
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AdmissionResult:
+    """Outcome of routing a run's participants through the coordinator.
+
+    ``admitted=True`` → every participant holds a cycle lease (or already did);
+    ``recruited_agent_ids`` are the agents this call transitioned ``ambient →
+    cycle`` and therefore the agents the caller must release on finalize.
+
+    ``admitted=False`` → a participant's lease conflicts; the run defers.
+    ``blocking_agent_id`` / ``reason`` are populated and any agents recruited
+    earlier in the same call have already been rolled back to ``ambient``
+    (so ``recruited_agent_ids`` is empty).
+    """
+
+    admitted: bool
+    blocking_agent_id: str | None = None
+    reason: str | None = None
+    recruited_agent_ids: tuple[str, ...] = field(default_factory=tuple)
+
+
+async def admit_participants(
+    coordinator: RuntimeCoordinator,
+    participating_agent_ids: Sequence[str],
+    *,
+    owner_ref: str,
+) -> AdmissionResult:
+    """Acquire a cycle FocusLease for each participant via an ``ambient → cycle`` transition.
+
+    Agents are processed in a deterministic (sorted) order so a conflict reports
+    the same blocking agent across retries. Per agent:
+
+      * ``applied`` → recruited (release it on finalize);
+      * ``idempotent_skip`` → already in ``cycle`` (replay or another owner) —
+        admitted, but **not** recorded as recruited-by-us, so finalize won't
+        release a lease we didn't take;
+      * rejected → defer: roll back everyone recruited so far, then return the
+        coordinator's typed reason (a ``focus_lease_*`` code).
+
+    ``owner_ref`` identifies the lease owner (the run/cycle id); the coordinator
+    derives a stable lease idem key from it, so retrying the same run replays the
+    same leases rather than minting duplicates.
+    """
+    recruited: list[str] = []
+    for agent_id in sorted(participating_agent_ids):
+        outcome = await coordinator.request_transition(
+            agent_id,
+            "cycle",
+            reasons.CYCLE_RECRUITED,
+            requester_kind="external",
+            owner_ref=owner_ref,
+        )
+        if outcome.applied:
+            recruited.append(agent_id)
+        elif outcome.idempotent_skip:
+            continue
+        else:
+            await release_participants(coordinator, recruited, owner_ref=owner_ref)
+            return AdmissionResult(
+                admitted=False,
+                blocking_agent_id=agent_id,
+                reason=outcome.rejected_reason or reasons.FOCUS_LEASE_CONFLICT,
+            )
+    return AdmissionResult(admitted=True, recruited_agent_ids=tuple(recruited))
+
+
+async def release_participants(
+    coordinator: RuntimeCoordinator,
+    agent_ids: Sequence[str],
+    *,
+    owner_ref: str,
+) -> None:
+    """Return recruited agents to ``ambient`` (``cycle → ambient``, releasing the lease).
+
+    Called on run finalize (completed/failed/paused) and for partial-admission
+    rollback. Best-effort and per-agent isolated: a failure releasing one agent
+    is logged and never blocks releasing the rest, since a stranded cycle lease
+    would block *all* of that agent's future recruitment.
+    """
+    for agent_id in agent_ids:
+        try:
+            await coordinator.request_transition(
+                agent_id,
+                "ambient",
+                reasons.CYCLE_COMPLETED,
+                requester_kind="external",
+                owner_ref=owner_ref,
+            )
+        except Exception:
+            logger.warning(
+                "best-effort release of cycle recruitment failed for agent %s (owner_ref=%s)",
+                agent_id,
+                owner_ref,
+                exc_info=True,
+            )

--- a/src/squadops/runtime/coordinator.py
+++ b/src/squadops/runtime/coordinator.py
@@ -26,9 +26,10 @@ stranded leases). With `focus_lease=None` the coordinator behaves as in Phase 2.
 Phase 4 (§4.5, thin v1.1 seam) wires a RuntimeActivity action: a mode change
 orphans any activity bound to the previous mode, so it is aborted best-effort
 *after* the mode write. The full §4.5 transition order (activity before mode) and
-D25's single-Postgres-transaction wrapping of lease+activity+mode are deferred to
-#244 (gated on recruitment #233) — in v1.1 the path is unexercised. With
-`activity=None` there is no activity bookkeeping.
+D25's single-Postgres-transaction wrapping of lease+activity+mode remain a
+follow-up in #244 (now unblocked — recruitment #233 has landed); the
+activity-orphan path stays unexercised in v1.1. With `activity=None` there is no
+activity bookkeeping.
 
 On apply, a canonical mode-transition event plus the relevant `focus_lease.*`
 events are emitted, each with a *separate* reason code (D14/D18) through the
@@ -474,9 +475,12 @@ class RuntimeCoordinator:
 
         NOTE (§4.5/D25): in v1.1 this path is effectively unexercised — scheduler
         ambient↔duty transitions have no live activity, and cycle activities are
-        owned/terminated by their handler (§4.4). The §4.5 single-Postgres-transaction
-        wrapping of lease+activity+mode (D25) is therefore deferred to #244 (gated
-        on recruitment #233); v1.1 keeps the best-effort post-write abort here.
+        owned/terminated by their handler (§4.4). Recruitment #233 now drives
+        ambient↔cycle through the coordinator but acquires/releases only the lease
+        (no live activity to orphan), so the abort path stays unexercised. The
+        §4.5 single-Postgres-transaction wrapping of lease+activity+mode (D25)
+        remains a follow-up in #244 (unblocked now that #233 has landed); v1.1
+        keeps the best-effort post-write abort here.
         """
         assert self._activity is not None  # guarded by the caller
         try:

--- a/tests/unit/api/test_scheduler_bootstrap.py
+++ b/tests/unit/api/test_scheduler_bootstrap.py
@@ -18,7 +18,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from squadops.api.runtime.scheduler_bootstrap import create_duty_scheduler
+from squadops.api.runtime.scheduler_bootstrap import (
+    create_duty_scheduler,
+    create_runtime_coordinator,
+)
 from squadops.config.schema import (
     AppConfig,
     AuthConfig,
@@ -27,6 +30,7 @@ from squadops.config.schema import (
     RabbitMQConfig,
     RedisConfig,
 )
+from squadops.runtime.coordinator import RuntimeCoordinator
 from squadops.runtime.scheduler import DutyScheduler
 
 pytestmark = [pytest.mark.domain_runtime]
@@ -78,3 +82,33 @@ def test_enabled_scheduler_coordinator_has_focus_lease_and_activity_wired():
     assert scheduler is not None
     assert scheduler._coordinator._focus_lease is not None
     assert scheduler._coordinator._activity is not None
+
+
+def test_create_runtime_coordinator_without_pool_returns_none():
+    """Bug class: the focus-lease + runtime-state tables live in Postgres, so a
+    pool-less coordinator can't function. Recruitment must fall back to the §2.5
+    guard (executor wires coordinator=None), not get a half-built coordinator."""
+    assert create_runtime_coordinator(None) is None
+
+
+def test_create_runtime_coordinator_wires_focus_lease_and_activity():
+    """The shared coordinator (used by the executor for recruitment) must carry
+    the same §3.4/§4.5 wiring as the scheduler's — a bare coordinator would skip
+    lease arbitration on recruitment."""
+    coordinator = create_runtime_coordinator(MagicMock())
+
+    assert isinstance(coordinator, RuntimeCoordinator)
+    assert coordinator._focus_lease is not None
+    assert coordinator._activity is not None
+
+
+def test_injected_coordinator_is_shared_not_rebuilt():
+    """D16 single-writer: when the composition root injects its coordinator, the
+    scheduler must drive THAT instance, not build a second mode-writer. A rebuild
+    here would silently create two writers of AgentRuntimeState.mode."""
+    shared = create_runtime_coordinator(MagicMock())
+
+    scheduler = create_duty_scheduler(_config(enabled=True), MagicMock(), coordinator=shared)
+
+    assert scheduler is not None
+    assert scheduler._coordinator is shared

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -27,6 +27,8 @@ from squadops.cycles.models import (
 )
 from squadops.cycles.pulse_models import CADENCE_BOUNDARY_ID, SuiteOutcome
 from squadops.events.types import EventType
+from squadops.runtime import reasons
+from squadops.runtime.coordinator import TransitionOutcome
 from squadops.tasks.models import TaskEnvelope, TaskResult
 
 NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
@@ -897,6 +899,205 @@ class TestReserveBufferGuard:
         statuses = [c.args[1] for c in mock_registry.update_run_status.call_args_list]
         assert statuses[-1] == RunStatus.COMPLETED
         assert mock_queue.publish.call_count == 5
+
+
+# ---------------------------------------------------------------------------
+# SIP-0089 §3.5 (#233) — recruitment routed through the coordinator
+# ---------------------------------------------------------------------------
+
+
+class _RecordingCoordinator:
+    """Fake RuntimeCoordinator: scripts ``ambient→cycle`` outcomes, records transitions.
+
+    Only ``request_transition`` is exercised by the executor. A clean
+    ``ambient→cycle`` (or any release) returns ``applied``; an agent in ``reject``
+    returns a rejected lease outcome carrying the given ``focus_lease_*`` reason.
+    """
+
+    def __init__(self, *, reject: dict[str, str] | None = None) -> None:
+        self._reject = reject or {}
+        # each entry: (agent_id, target_mode, reason_code)
+        self.transitions: list[tuple[str, str, str]] = []
+
+    async def request_transition(
+        self,
+        agent_id,
+        target_mode,
+        reason_code,
+        *,
+        requester_kind,
+        owner_ref,
+        assignment_id=None,
+        scheduled_at=None,
+    ):
+        self.transitions.append((agent_id, target_mode, reason_code))
+        if target_mode == "cycle" and agent_id in self._reject:
+            return TransitionOutcome(
+                applied=False,
+                agent_id=agent_id,
+                from_mode="ambient",
+                to_mode="cycle",
+                reason_code=reason_code,
+                rejected_reason=self._reject[agent_id],
+            )
+        from_mode = "ambient" if target_mode == "cycle" else "cycle"
+        return TransitionOutcome(
+            applied=True,
+            agent_id=agent_id,
+            from_mode=from_mode,
+            to_mode=target_mode,
+            reason_code=reason_code,
+            event_name="agent.mode.transition",
+        )
+
+    def recruited(self) -> set[str]:
+        return {a for a, mode, _ in self.transitions if mode == "cycle"}
+
+    def released(self) -> set[str]:
+        return {a for a, mode, _ in self.transitions if mode == "ambient"}
+
+
+class TestRecruitmentCoordinatorAdmission:
+    """Recruitment routes each participant ``ambient→cycle`` via the coordinator.
+
+    A lease conflict defers the run (RUN_PAUSED, typed ``focus_lease_*`` reason,
+    no dispatch) on the same path as the §2.5 guard. On any finalize the agents
+    the run recruited return to ``ambient`` so no cycle lease strands — the
+    acceptance criterion. Wired independently of the §2.5 guard (no
+    AssignmentPort here) so this isolates the coordinator admission step.
+    """
+
+    def _build(
+        self,
+        *,
+        mock_registry,
+        mock_vault,
+        mock_queue,
+        mock_squad_profile,
+        reply_router,
+        cycle,
+        run,
+        event_bus,
+        coordinator,
+    ):
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+        mock_registry.get_cycle.return_value = cycle
+        mock_registry.get_run.return_value = run
+        return DispatchedFlowExecutor(
+            cycle_registry=mock_registry,
+            artifact_vault=mock_vault,
+            queue=mock_queue,
+            squad_profile=mock_squad_profile,
+            task_timeout=5.0,
+            reply_router=reply_router,
+            event_bus=event_bus,
+            coordinator=coordinator,
+        )
+
+    async def test_lease_conflict_defers_run_before_dispatch(
+        self,
+        mock_registry,
+        mock_vault,
+        mock_queue,
+        mock_squad_profile,
+        reply_router,
+        cycle,
+        run,
+    ) -> None:
+        event_bus = MagicMock()
+        # "neo" is a participating agent; its cycle lease conflicts.
+        coordinator = _RecordingCoordinator(reject={"neo": reasons.FOCUS_LEASE_CONFLICT})
+        executor = self._build(
+            mock_registry=mock_registry,
+            mock_vault=mock_vault,
+            mock_queue=mock_queue,
+            mock_squad_profile=mock_squad_profile,
+            reply_router=reply_router,
+            cycle=cycle,
+            run=run,
+            event_bus=event_bus,
+            coordinator=coordinator,
+        )
+
+        with patch(
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        # Deferred, not dispatched.
+        statuses = [c.args[1] for c in mock_registry.update_run_status.call_args_list]
+        assert statuses[-1] == RunStatus.PAUSED
+        assert mock_queue.publish.call_count == 0
+
+        # RUN_PAUSED rides the lease-conflict reason + the blocking agent — no new
+        # EventType, same payload shape as the §2.5 deferral.
+        paused = [
+            c for c in event_bus.emit.call_args_list if c.args and c.args[0] == EventType.RUN_PAUSED
+        ]
+        assert len(paused) == 1
+        payload = paused[0].kwargs["payload"]
+        assert payload["reason"] == reasons.FOCUS_LEASE_CONFLICT
+        assert payload["deferred_for_agent"] == "neo"
+
+    async def test_clean_admission_dispatches_then_releases_every_recruit(
+        self,
+        mock_registry,
+        mock_vault,
+        mock_queue,
+        mock_squad_profile,
+        reply_router,
+        cycle,
+        run,
+    ) -> None:
+        """No conflict → run completes and every recruited agent is released to
+        ambient (no stranded cycle leases), with the canonical recruit/complete
+        reason codes."""
+        event_bus = MagicMock()
+        coordinator = _RecordingCoordinator()
+        executor = self._build(
+            mock_registry=mock_registry,
+            mock_vault=mock_vault,
+            mock_queue=mock_queue,
+            mock_squad_profile=mock_squad_profile,
+            reply_router=reply_router,
+            cycle=cycle,
+            run=run,
+            event_bus=event_bus,
+            coordinator=coordinator,
+        )
+        reply_router.responder = lambda env: TaskResult(
+            task_id=env["task_id"],
+            status="SUCCEEDED",
+            outputs={
+                "summary": "ok",
+                "role": "strat",
+                "artifacts": [
+                    {
+                        "name": "o.md",
+                        "content": "# o",
+                        "media_type": "text/markdown",
+                        "type": "document",
+                    }
+                ],
+            },
+        )
+
+        # Real asyncio.sleep (see the §2.5 no-conflict test note: patching it to a
+        # non-yielding AsyncMock busy-spins the per-task heartbeat loop).
+        await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        statuses = [c.args[1] for c in mock_registry.update_run_status.call_args_list]
+        assert statuses[-1] == RunStatus.COMPLETED
+        # Recruitment actually ran, and every agent it put in cycle came back to
+        # ambient on finalize — the no-strand guarantee.
+        assert coordinator.recruited()  # non-empty: not vacuously passing
+        assert coordinator.released() == coordinator.recruited()
+        recruit_reasons = {r for _, mode, r in coordinator.transitions if mode == "cycle"}
+        release_reasons = {r for _, mode, r in coordinator.transitions if mode == "ambient"}
+        assert recruit_reasons == {reasons.CYCLE_RECRUITED}
+        assert release_reasons == {reasons.CYCLE_COMPLETED}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/test_admission.py
+++ b/tests/unit/runtime/test_admission.py
@@ -1,0 +1,165 @@
+"""
+Unit tests for cycle recruitment admission — SIP-0089 §3.5 (#233).
+
+Exercises :func:`squadops.runtime.admission.admit_participants` /
+:func:`release_participants` against a fake coordinator that records every
+``request_transition`` call and returns scripted outcomes. The bugs these guard
+against: stranding agents in ``cycle`` mode when a later participant's lease
+conflicts, releasing a lease the run never acquired, and a single release failure
+stranding the remaining agents' leases.
+"""
+
+from __future__ import annotations
+
+from squadops.runtime import reasons
+from squadops.runtime.admission import (
+    AdmissionResult,
+    admit_participants,
+    release_participants,
+)
+from squadops.runtime.coordinator import TransitionOutcome
+
+
+def _applied(agent_id: str, from_mode: str, to_mode: str) -> TransitionOutcome:
+    return TransitionOutcome(
+        applied=True,
+        agent_id=agent_id,
+        from_mode=from_mode,  # type: ignore[arg-type]
+        to_mode=to_mode,
+        reason_code=reasons.CYCLE_RECRUITED,
+        event_name="agent.mode.transition",
+    )
+
+
+def _rejected(agent_id: str, rejected_reason: str | None) -> TransitionOutcome:
+    return TransitionOutcome(
+        applied=False,
+        agent_id=agent_id,
+        from_mode="ambient",
+        to_mode="cycle",
+        reason_code=reasons.CYCLE_RECRUITED,
+        rejected_reason=rejected_reason,
+    )
+
+
+def _idempotent(agent_id: str) -> TransitionOutcome:
+    return TransitionOutcome(
+        applied=False,
+        agent_id=agent_id,
+        from_mode="cycle",
+        to_mode="cycle",
+        reason_code=reasons.CYCLE_RECRUITED,
+        idempotent_skip=True,
+    )
+
+
+class FakeCoordinator:
+    """Records transitions; scripts the ``ambient → cycle`` outcome per agent."""
+
+    def __init__(
+        self,
+        *,
+        cycle_outcomes: dict[str, TransitionOutcome] | None = None,
+        raise_on_release: set[str] | None = None,
+    ) -> None:
+        self._cycle_outcomes = cycle_outcomes or {}
+        self._raise_on_release = raise_on_release or set()
+        # each entry: (agent_id, target_mode, reason_code, owner_ref, requester_kind)
+        self.calls: list[tuple[str, str, str, str, str]] = []
+
+    async def request_transition(
+        self,
+        agent_id: str,
+        target_mode: str,
+        reason_code: str,
+        *,
+        requester_kind: str,
+        owner_ref: str,
+        assignment_id: str | None = None,
+        scheduled_at: object | None = None,
+    ) -> TransitionOutcome:
+        self.calls.append((agent_id, target_mode, reason_code, owner_ref, requester_kind))
+        if target_mode == "ambient":
+            if agent_id in self._raise_on_release:
+                raise RuntimeError(f"release blew up for {agent_id}")
+            return _applied(agent_id, "cycle", "ambient")
+        return self._cycle_outcomes.get(agent_id, _applied(agent_id, "ambient", "cycle"))
+
+    def cycle_calls(self) -> list[tuple[str, str, str, str, str]]:
+        return [c for c in self.calls if c[1] == "cycle"]
+
+    def release_calls(self) -> list[tuple[str, str, str, str, str]]:
+        return [c for c in self.calls if c[1] == "ambient"]
+
+
+async def test_admit_all_participants_recruits_each_to_cycle_in_sorted_order():
+    coord = FakeCoordinator()
+
+    result = await admit_participants(coord, ["neo", "bob", "max"], owner_ref="run-1")
+
+    assert result == AdmissionResult(admitted=True, recruited_agent_ids=("bob", "max", "neo"))
+    # one ambient→cycle per agent, deterministic sorted order, correct reason/owner/requester
+    assert [(c[0], c[2], c[3], c[4]) for c in coord.cycle_calls()] == [
+        ("bob", reasons.CYCLE_RECRUITED, "run-1", "external"),
+        ("max", reasons.CYCLE_RECRUITED, "run-1", "external"),
+        ("neo", reasons.CYCLE_RECRUITED, "run-1", "external"),
+    ]
+    assert coord.release_calls() == []  # nobody released on a clean admit
+
+
+async def test_lease_conflict_defers_and_rolls_back_prior_recruits():
+    # sorted order is bob, max, neo → bob+max admit, neo conflicts.
+    coord = FakeCoordinator(cycle_outcomes={"neo": _rejected("neo", reasons.FOCUS_LEASE_CONFLICT)})
+
+    result = await admit_participants(coord, ["neo", "bob", "max"], owner_ref="run-1")
+
+    assert result.admitted is False
+    assert result.blocking_agent_id == "neo"
+    assert result.reason == reasons.FOCUS_LEASE_CONFLICT
+    assert result.recruited_agent_ids == ()
+    # the two agents already in cycle are rolled back to ambient (no strands)…
+    assert sorted(c[0] for c in coord.release_calls()) == ["bob", "max"]
+    assert all(c[2] == reasons.CYCLE_COMPLETED for c in coord.release_calls())
+    # …and the blocking agent, never recruited, is never released
+    assert "neo" not in [c[0] for c in coord.release_calls()]
+
+
+async def test_agent_already_in_cycle_is_admitted_but_not_recorded_as_recruited():
+    coord = FakeCoordinator(cycle_outcomes={"neo": _idempotent("neo")})
+
+    result = await admit_participants(coord, ["max", "neo"], owner_ref="run-1")
+
+    assert result.admitted is True
+    # neo was already in cycle for someone else — we must NOT release it on finalize
+    assert result.recruited_agent_ids == ("max",)
+    assert coord.release_calls() == []
+
+
+async def test_release_participants_is_best_effort_across_a_failure():
+    # max's release raises; neo and bob must still be released or their leases strand.
+    coord = FakeCoordinator(raise_on_release={"max"})
+
+    await release_participants(coord, ["max", "neo", "bob"], owner_ref="run-1")
+
+    released = [c[0] for c in coord.release_calls()]
+    assert released == ["max", "neo", "bob"]  # loop continued past the failure
+    assert all(c[2] == reasons.CYCLE_COMPLETED for c in coord.release_calls())
+
+
+async def test_empty_participants_admits_with_no_transitions():
+    coord = FakeCoordinator()
+
+    result = await admit_participants(coord, [], owner_ref="run-1")
+
+    assert result == AdmissionResult(admitted=True, recruited_agent_ids=())
+    assert coord.calls == []
+
+
+async def test_rejection_without_a_reason_falls_back_to_focus_lease_conflict():
+    coord = FakeCoordinator(cycle_outcomes={"max": _rejected("max", None)})
+
+    result = await admit_participants(coord, ["max"], owner_ref="run-1")
+
+    assert result.admitted is False
+    assert result.blocking_agent_id == "max"
+    assert result.reason == reasons.FOCUS_LEASE_CONFLICT


### PR DESCRIPTION
Completes the SIP-0089 runtime arc shipped with a known limitation in 1.1.0: cycle recruitment now acquires a **FocusLease** through the `RuntimeCoordinator` (§3.5), rather than the lease gate living only at the coordinator with no recruitment admission step.

Closes #233.

## Design decision (the #233 open question)

Recruited agents **transition `ambient → cycle`** through the coordinator, rather than holding a cycle lease while staying `ambient`. The `cycle` RuntimeMode exists for exactly this; `CYCLE_RECRUITED`/`CYCLE_COMPLETED` reasons were pre-minted; the cycle FocusLease rides the mode write via `_arbitrate_lease` (§3.4); and the ambient-lease alternative would need new coordinator surface and violate §10.4 ("ambient holds no primary lease in v1.1").

## What changed (4 slices)

1. **Domain admission** (`runtime/admission.py`) — `admit_participants` / `release_participants`. Routes each participant through `request_transition(..., "cycle", CYCLE_RECRUITED)`; a lease conflict defers with the coordinator's typed `focus_lease_*` reason. **Partial admission is rolled back** (a later conflict returns earlier recruits to `ambient` — no one strands in `cycle`); `idempotent_skip` (already in cycle) is admitted but not recorded as recruited; release is best-effort/per-agent isolated.
2. **Executor wiring** — `DispatchedFlowExecutor` gains an opt-in coordinator. After the §2.5 reserve-buffer guard passes, recruitment admits via the coordinator; a conflict rides the existing `_RecruitmentRejectedError → RUN_PAUSED` path (**no new EventType** — the §2.5/#222 locked-taxonomy precedent). The `finally` releases recruited leases on **every** terminal outcome.
3. **Composition root (D16)** — the coordinator must be the **sole writer of `mode`**, and one already exists for the duty scheduler, so the executor **shares that instance**. `create_runtime_coordinator(pool)` builds it once in `_init_cycle_subsystem`; `create_duty_scheduler` accepts the injected coordinator (back-compat fallback preserved). Pool-less → `coordinator=None` → recruitment degrades to the §2.5 guard, so a cycle never hard-fails for missing runtime infra.
4. **Docs** — coordinator notes updated: D25/#244 is no longer "gated on #233" but the **unblocked follow-up**.

## Acceptance (per the issue)

- ✅ Recruitment that conflicts with a held focus lease defers the run with a distinct, observable reason code (`focus_lease_*` on `RUN_PAUSED`).
- ✅ No stranded cycle leases across run completion/failure/pause (released in `finally`; partial admission rolled back).
- ✅ No new cycle EventType; deferral rides `RUN_PAUSED` payload.

## Tests

- `tests/unit/runtime/test_admission.py` — 6 tests: sorted recruit, partial-rollback on conflict, idempotent-skip, best-effort release across a failure, empty, reason fallback.
- `tests/unit/cycles/test_dispatched_flow_executor.py::TestRecruitmentCoordinatorAdmission` — conflict defers before dispatch with the right payload; clean admission completes and releases every recruit.
- `tests/unit/api/test_scheduler_bootstrap.py` — `create_runtime_coordinator` None-without-pool + §3.4/§4.5 wiring; injected coordinator shared, not rebuilt (the D16 guard).
- Full regression: **4488 passed / 1 skipped**.

## Follow-ups (out of scope)

- **#244** (single-Postgres-transaction wrapping of lease+activity+mode, D25) is now unblocked.
- **#286** (filed during this work): `main.py` loads+validates config at module-import time — pre-existing import side-effect, tech-debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)