### PR TITLE
fix(#276): fail qa acceptance on stub-fallback tests that mask a broken entrypoint (Part 1)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -2554,6 +2554,40 @@ class QATestHandler(_CycleTaskHandler):
                 validation.coverage_ratio = passed_count / len(validation.checks)
 
         if output_validation_enabled:
+            # #276: a generated test that hides a broken entrypoint import behind
+            # an ImportError fallback validates a stub app, not the deliverable —
+            # so `tests_passed` above can be falsely green (the stub collects and
+            # passes). Flag it so acceptance fails and the correction loop
+            # regenerates the test against the real module.
+            from squadops.capabilities.handlers.stub_detection import (
+                detect_stub_fallback_tests,
+            )
+
+            stub_offenders = detect_stub_fallback_tests(artifacts)
+            if stub_offenders:
+                validation.checks.append(
+                    {
+                        "check": "no_stub_fallback_tests",
+                        "offenders": stub_offenders,
+                        "passed": False,
+                    }
+                )
+                validation.passed = False
+                validation.missing_components.append(
+                    f"stub_fallback_tests:{','.join(stub_offenders)}"
+                )
+                note = (
+                    "Generated test masks the real entrypoint behind an "
+                    f"ImportError stub: {', '.join(stub_offenders)}"
+                )
+                validation.summary = (
+                    note
+                    if validation.summary in ("", "All checks passed")
+                    else f"{validation.summary}; {note}"
+                )
+                passed_count = sum(1 for c in validation.checks if c["passed"])
+                validation.coverage_ratio = passed_count / len(validation.checks)
+
             evidence_extra["validation_result"] = {
                 "passed": validation.passed,
                 "checks": validation.checks,

--- a/src/squadops/capabilities/handlers/stub_detection.py
+++ b/src/squadops/capabilities/handlers/stub_detection.py
@@ -1,0 +1,76 @@
+"""Detect stub-fallback anti-patterns in generated test files (#276).
+
+A generated test that wraps the entrypoint import in ``except ImportError:`` and
+reconstructs the application inline silently validates a **stub** instead of the
+delivered module. A structurally broken deliverable (e.g. ``backend/main.py``
+missing ``from pydantic import BaseModel``) then passes ``qa.test`` green,
+because pytest collects and runs the inline fallback app rather than failing on
+the import. This masks the exact class of defect acceptance exists to catch.
+
+This module flags that pattern so the qa acceptance path can fail the task
+(triggering the SIP-0086 correction loop to regenerate the test without the
+fallback) rather than green-lighting a non-runnable deliverable.
+
+The check is a deliberately conservative heuristic: a test file is flagged only
+when it *both* guards an import with ``except ImportError``/``ModuleNotFoundError``
+*and* constructs a web-app object in the file (the fallback re-implementation).
+That combination is the stub-fallback pattern; a test that merely catches an
+optional-dependency ImportError without rebuilding an app is not flagged.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Web-app constructors whose presence alongside an import guard signals that the
+# test rebuilt the app inline as a fallback (the stub).
+_APP_CONSTRUCTORS: tuple[str, ...] = (
+    "FastAPI(",
+    "Flask(",
+    "APIRouter(",
+    "Starlette(",
+    "express(",
+)
+
+# Matches `except ImportError`, `except ModuleNotFoundError`, and the tuple forms
+# `except (ImportError, ...)` / `except (ModuleNotFoundError, ...)`.
+_IMPORT_GUARD = re.compile(r"except\s*\(?\s*(?:ImportError|ModuleNotFoundError)\b")
+
+
+def _is_test_file(path: str) -> bool:
+    """True for python test files (``test_*.py`` / ``*_test.py``)."""
+    name = path.replace("\\", "/").rsplit("/", 1)[-1]
+    if not name.endswith(".py"):
+        return False
+    return name.startswith("test_") or name.endswith("_test.py")
+
+
+def _file_field(f: dict) -> tuple[str, str]:
+    """Extract (path, content) from an artifact/extracted-file dict.
+
+    Handles both the extracted-file shape (``filename``) and the artifact shape
+    (``name``); falls back to ``path``.
+    """
+    path = f.get("filename") or f.get("path") or f.get("name") or ""
+    return path, (f.get("content") or "")
+
+
+def detect_stub_fallback_tests(files: list[dict]) -> list[str]:
+    """Return the paths of generated test files that hide a broken entrypoint
+    import behind an ``ImportError`` fallback that reconstructs the app.
+
+    Args:
+        files: extracted-file or artifact dicts (each with a name/filename/path
+            and ``content``).
+
+    Returns:
+        Sorted list of offending file paths (empty when none are found).
+    """
+    offenders: list[str] = []
+    for f in files:
+        path, content = _file_field(f)
+        if not path or not _is_test_file(path):
+            continue
+        if _IMPORT_GUARD.search(content) and any(ctor in content for ctor in _APP_CONSTRUCTORS):
+            offenders.append(path)
+    return sorted(offenders)

--- a/tests/unit/capabilities/test_stub_detection.py
+++ b/tests/unit/capabilities/test_stub_detection.py
@@ -1,0 +1,110 @@
+"""Tests for stub-fallback test detection (#276).
+
+Bug this guards: a generated test that wraps the entrypoint import in
+``except ImportError:`` and rebuilds the app inline validates a stub, so a
+non-runnable deliverable (broken import) passes qa green. The detector must
+flag that pattern and must NOT flag legitimate tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.handlers.stub_detection import detect_stub_fallback_tests
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+_STUB_FALLBACK = """\
+try:
+    from backend.main import app
+except ImportError:
+    # Fallback inline app guarantees pytest collection succeeds.
+    from fastapi import FastAPI
+    app = FastAPI()
+
+    @app.get("/health")
+    def health():
+        return {"ok": True}
+
+
+def test_health():
+    assert app is not None
+"""
+
+_CLEAN_TEST = """\
+from backend.main import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+
+def test_health():
+    assert client.get("/health").status_code == 200
+"""
+
+
+def test_flags_import_error_fallback_with_fastapi():
+    offenders = detect_stub_fallback_tests(
+        [{"name": "backend/tests/test_api.py", "content": _STUB_FALLBACK}]
+    )
+    assert offenders == ["backend/tests/test_api.py"]
+
+
+def test_flags_module_not_found_and_flask():
+    content = "try:\n    from app import app\nexcept ModuleNotFoundError:\n    from flask import Flask\n    app = Flask(__name__)\n"
+    offenders = detect_stub_fallback_tests([{"filename": "test_app.py", "content": content}])
+    assert offenders == ["test_app.py"]
+
+
+def test_flags_tuple_except_form():
+    content = (
+        "try:\n    from backend.main import app\n"
+        "except (ImportError, AttributeError):\n"
+        "    from fastapi import FastAPI\n    app = FastAPI()\n"
+    )
+    offenders = detect_stub_fallback_tests([{"name": "test_x.py", "content": content}])
+    assert offenders == ["test_x.py"]
+
+
+def test_clean_test_not_flagged():
+    assert detect_stub_fallback_tests([{"name": "test_api.py", "content": _CLEAN_TEST}]) == []
+
+
+def test_import_guard_without_app_constructor_not_flagged():
+    """Catching an optional-dependency ImportError without rebuilding an app is
+    legitimate — must not be flagged (false-positive guard)."""
+    content = (
+        "try:\n    import ujson as json\nexcept ImportError:\n    import json\n\n"
+        "def test_parse():\n    assert json.loads('{}') == {}\n"
+    )
+    assert detect_stub_fallback_tests([{"name": "test_parse.py", "content": content}]) == []
+
+
+def test_non_test_file_ignored():
+    """The real deliverable (main.py) is not a test file — even if it constructs
+    an app and (hypothetically) guards an import, it must not be flagged."""
+    content = "from fastapi import FastAPI\ntry:\n    import x\nexcept ImportError:\n    pass\napp = FastAPI()\n"
+    assert detect_stub_fallback_tests([{"name": "backend/main.py", "content": content}]) == []
+
+
+def test_multiple_offenders_sorted():
+    files = [
+        {"name": "test_b.py", "content": _STUB_FALLBACK},
+        {"name": "test_a.py", "content": _STUB_FALLBACK},
+        {"name": "test_ok.py", "content": _CLEAN_TEST},
+    ]
+    assert detect_stub_fallback_tests(files) == ["test_a.py", "test_b.py"]
+
+
+@pytest.mark.parametrize(
+    "files",
+    [
+        [],
+        [{"name": "test_empty.py", "content": ""}],
+        [{"name": "", "content": _STUB_FALLBACK}],
+        [{"content": _STUB_FALLBACK}],  # missing name/filename/path
+    ],
+)
+def test_empty_or_nameless_inputs_do_not_crash(files):
+    assert detect_stub_fallback_tests(files) == []


### PR DESCRIPTION
**Part 1 of #276** (Slice 1a). References #276; does **not** close it — deliverable-level `required_files` enforcement (Part B) and build/boot-the-deliverable (Slice 2, pairs with #176) still to come.

## The bug
A `validation`-profile cycle completed **green** with a backend that doesn't run (`backend/main.py` used `BaseModel` with no `from pydantic import BaseModel`). Root cause: the generated `test_api.py` did

```python
try:
    from backend.main import app
except ImportError:
    from fastapi import FastAPI
    app = FastAPI()  # ~70-line inline re-implementation
```

so pytest collected and ran the **stub**, not the deliverable — exit 0, qa green. The existing `tests_pass` fold can't catch this (the stub *makes* the tests pass), which is exactly why the import defect was invisible to the correction loop.

## Fix
- **New `capabilities/handlers/stub_detection.py`** — `detect_stub_fallback_tests()` flags a test file only when it **both** guards an import with `except ImportError`/`ModuleNotFoundError` **and** constructs a web-app object inline (`FastAPI(`/`Flask(`/…). Conservative by design: catching an optional-dependency `ImportError` *without* rebuilding an app is **not** flagged (false-positive guard, tested).
- **`QATestHandler`** folds the result into `validation` in the output-validation path → `SEMANTIC_FAILURE`, so the SIP-0086 correction loop regenerates the test against the real module. Detection lives in its own module; the `cycle_tasks.py` change is a small block inside the *existing* acceptance branch.

## Why minimal `cycle_tasks.py` footprint
This file is the one true cross-lane code hot spot (Mac #114 typed-eval, #152 split). Keeping the edit to a ~30-line block in the existing branch + a separate helper module. Heads-up already posted on #114/#152; **I'll comment there when this merges.**

## Verification
- New `test_stub_detection.py`: 11 tests (pattern detected across FastAPI/Flask/tuple-except forms; clean tests, optional-dep imports, and the real `main.py` **not** flagged; multi-file sort; empty/nameless inputs safe).
- Full `capabilities/` + `cycles/` suites: **2423 passed**. ruff + test-quality lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)