### PR TITLE
fix(#276): build-acceptance — verify the frontend actually builds

### DIFF
--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -2242,6 +2242,7 @@ class QATestHandler(_CycleTaskHandler):
             TEST_FRAMEWORK_VITEST,
         )
         from squadops.capabilities.handlers.test_runner import (
+            run_frontend_build,
             run_fullstack_tests,
             run_generated_tests,
             run_node_tests,
@@ -2272,6 +2273,28 @@ class QATestHandler(_CycleTaskHandler):
                 timeout_seconds=test_timeout,
             )
 
+        # #276: vitest unit tests pass even when the app cannot build (e.g. a Vite
+        # app missing its root index.html), so a non-runnable frontend ships green.
+        # Verify the frontend actually builds and fold a build failure into the
+        # test outcome so the existing acceptance fold -> SEMANTIC_FAILURE ->
+        # correction loop handles it. A skip (no frontend / no node) is not a failure.
+        build_result = None
+        if capability.test_framework in (TEST_FRAMEWORK_VITEST, TEST_FRAMEWORK_BOTH):
+            build_result = await run_frontend_build(
+                source_file_records, timeout_seconds=test_timeout
+            )
+            if build_result.failed:
+                from dataclasses import replace
+
+                merged_error = "; ".join(
+                    part for part in (test_result.error, build_result.error) if part
+                )
+                test_result = replace(
+                    test_result,
+                    exit_code=test_result.exit_code or build_result.exit_code or 1,
+                    error=merged_error,
+                )
+
         report_lines = [
             "# Test Execution Report\n",
             f"**Result:** {test_result.summary}\n",
@@ -2279,6 +2302,15 @@ class QATestHandler(_CycleTaskHandler):
             f"**Test files:** {test_result.test_file_count}\n",
             f"**Source files:** {test_result.source_file_count}\n",
         ]
+        if build_result is not None:
+            if build_result.failed:
+                report_lines.append(f"\n**Frontend build:** FAILED — {build_result.error}\n")
+                if build_result.stderr:
+                    report_lines.append(f"\n## Build stderr\n\n```\n{build_result.stderr}\n```\n")
+            elif build_result.ran:
+                report_lines.append("\n**Frontend build:** passed\n")
+            else:
+                report_lines.append(f"\n**Frontend build:** skipped ({build_result.error})\n")
         if test_result.stdout:
             report_lines.append(f"\n## stdout\n\n```\n{test_result.stdout}\n```\n")
         if test_result.stderr:

--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -2236,64 +2236,26 @@ class QATestHandler(_CycleTaskHandler):
         sources: dict[str, str],
         extracted: list[dict],
     ) -> tuple[Any, dict]:
-        """Run test suite and return (test_result, report_artifact)."""
-        from squadops.capabilities.dev_capabilities import (
-            TEST_FRAMEWORK_BOTH,
-            TEST_FRAMEWORK_VITEST,
-        )
-        from squadops.capabilities.handlers.test_runner import (
-            run_frontend_build,
-            run_fullstack_tests,
-            run_generated_tests,
-            run_node_tests,
-        )
+        """Run the build-validation suite and return (result, report_artifact).
+
+        Framework dispatch (pytest/vitest/both) and the #276 frontend build check
+        live in ``test_runner`` (which owns test-framework knowledge). This handler
+        stays framework-agnostic — it passes ``capability.test_framework`` through
+        and reads only the generic ``RunTestsResult``.
+        """
+        from squadops.capabilities.handlers.test_runner import run_build_validation
 
         source_file_records = [{"path": p, "content": c} for p, c in sources.items()]
         test_file_records = [
             {"path": rec["filename"], "content": rec["content"]} for rec in extracted
         ]
-        test_timeout = capability.test_timeout_seconds
 
-        if capability.test_framework == TEST_FRAMEWORK_VITEST:
-            test_result = await run_node_tests(
-                source_file_records,
-                test_file_records,
-                timeout_seconds=test_timeout,
-            )
-        elif capability.test_framework == TEST_FRAMEWORK_BOTH:
-            test_result = await run_fullstack_tests(
-                source_file_records,
-                test_file_records,
-                timeout_seconds=test_timeout,
-            )
-        else:
-            test_result = await run_generated_tests(
-                source_file_records,
-                test_file_records,
-                timeout_seconds=test_timeout,
-            )
-
-        # #276: vitest unit tests pass even when the app cannot build (e.g. a Vite
-        # app missing its root index.html), so a non-runnable frontend ships green.
-        # Verify the frontend actually builds and fold a build failure into the
-        # test outcome so the existing acceptance fold -> SEMANTIC_FAILURE ->
-        # correction loop handles it. A skip (no frontend / no node) is not a failure.
-        build_result = None
-        if capability.test_framework in (TEST_FRAMEWORK_VITEST, TEST_FRAMEWORK_BOTH):
-            build_result = await run_frontend_build(
-                source_file_records, timeout_seconds=test_timeout
-            )
-            if build_result.failed:
-                from dataclasses import replace
-
-                merged_error = "; ".join(
-                    part for part in (test_result.error, build_result.error) if part
-                )
-                test_result = replace(
-                    test_result,
-                    exit_code=test_result.exit_code or build_result.exit_code or 1,
-                    error=merged_error,
-                )
+        test_result = await run_build_validation(
+            capability.test_framework,
+            source_file_records,
+            test_file_records,
+            timeout_seconds=capability.test_timeout_seconds,
+        )
 
         report_lines = [
             "# Test Execution Report\n",
@@ -2302,15 +2264,6 @@ class QATestHandler(_CycleTaskHandler):
             f"**Test files:** {test_result.test_file_count}\n",
             f"**Source files:** {test_result.source_file_count}\n",
         ]
-        if build_result is not None:
-            if build_result.failed:
-                report_lines.append(f"\n**Frontend build:** FAILED — {build_result.error}\n")
-                if build_result.stderr:
-                    report_lines.append(f"\n## Build stderr\n\n```\n{build_result.stderr}\n```\n")
-            elif build_result.ran:
-                report_lines.append("\n**Frontend build:** passed\n")
-            else:
-                report_lines.append(f"\n**Frontend build:** skipped ({build_result.error})\n")
         if test_result.stdout:
             report_lines.append(f"\n## stdout\n\n```\n{test_result.stdout}\n```\n")
         if test_result.stderr:

--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -282,6 +282,130 @@ async def run_node_tests(
         shutil.rmtree(workspace, ignore_errors=True)
 
 
+@dataclass(frozen=True)
+class BuildCheckResult:
+    """Outcome of a deliverable build/boot check (#276).
+
+    ``ran`` is False when the check was skipped (no build script, no npm, or no
+    frontend source) — a skip is not a failure. ``ok`` is True only when the
+    check actually ran and succeeded.
+    """
+
+    ran: bool
+    ok: bool = False
+    exit_code: int = -1
+    error: str = ""
+    stderr: str = ""
+
+    @property
+    def failed(self) -> bool:
+        """True only when the check ran and did not succeed (skips are not failures)."""
+        return self.ran and not self.ok
+
+
+async def run_frontend_build(
+    source_files: list[dict[str, str]],
+    target_dir: str | None = "frontend",
+    timeout_seconds: int = 120,
+) -> BuildCheckResult:
+    """Verify the frontend actually builds (#276).
+
+    Materializes the frontend source, ``npm install``s, then runs the package's
+    ``build`` script (falling back to ``npx vite build``). Catches deliverables
+    that pass vitest unit tests but cannot build — e.g. a Vite app missing its
+    root ``index.html`` (observed in cyc_2f415e43f9cf: ``vite build`` failed
+    immediately, yet the run shipped green).
+
+    Skips (``ran=False``) when there is no frontend source, no ``package.json``,
+    or Node is unavailable — a skip is never a failure. Never raises.
+    """
+    frontend_source = (
+        [rec for rec in source_files if rec["path"].startswith(f"{target_dir}/")]
+        if target_dir
+        else source_files
+    )
+    if not frontend_source:
+        return BuildCheckResult(ran=False, error="no frontend source")
+
+    workspace = tempfile.mkdtemp(prefix="qa_build_")
+    try:
+        _materialize_files(workspace, frontend_source)
+        cwd = os.path.join(workspace, target_dir) if target_dir else workspace
+
+        pkg_path = os.path.join(cwd, "package.json")
+        if not os.path.isfile(pkg_path):
+            return BuildCheckResult(ran=False, error="no package.json — cannot build")
+
+        # Prefer the package's own build script; fall back to vite build.
+        import json
+
+        try:
+            scripts = json.loads(open(pkg_path, encoding="utf-8").read()).get("scripts", {})
+        except (OSError, ValueError):
+            scripts = {}
+        build_cmd = ["npm", "run", "build"] if "build" in scripts else ["npx", "vite", "build"]
+
+        try:
+            install = await asyncio.create_subprocess_exec(
+                "npm",
+                "install",
+                "--no-audit",
+                "--no-fund",
+                cwd=cwd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                _, inst_err = await asyncio.wait_for(install.communicate(), timeout=timeout_seconds)
+            except TimeoutError:
+                install.kill()
+                await install.wait()
+                return BuildCheckResult(
+                    ran=False, error=f"npm install timed out after {timeout_seconds}s"
+                )
+            if install.returncode != 0:
+                return BuildCheckResult(
+                    ran=False,
+                    error="npm install failed (dependency resolution) — cannot assess build",
+                    stderr=inst_err.decode(errors="replace")[:_STDOUT_LIMIT],
+                )
+        except FileNotFoundError:
+            return BuildCheckResult(ran=False, error="npm not found — Node.js not installed")
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *build_cmd,
+                cwd=cwd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError:
+            return BuildCheckResult(
+                ran=False, error=f"{build_cmd[0]} not found — Node.js not installed"
+            )
+
+        try:
+            _, raw_stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return BuildCheckResult(ran=False, error=f"build timed out after {timeout_seconds}s")
+
+        exit_code = proc.returncode or 0
+        return BuildCheckResult(
+            ran=True,
+            ok=exit_code == 0,
+            exit_code=exit_code,
+            stderr=raw_stderr.decode(errors="replace")[:_STDOUT_LIMIT],
+            error="" if exit_code == 0 else f"frontend build failed (exit {exit_code})",
+        )
+    except Exception as exc:  # never raise — a runner error is a skip, not a failure
+        logger.warning("Frontend build check error: %s", exc, exc_info=True)
+        return BuildCheckResult(ran=False, error=str(exc))
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
 async def run_fullstack_tests(
     source_files: list[dict[str, str]],
     test_files: list[dict[str, str]],

--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -17,7 +17,7 @@ import os
 import shutil
 import sys
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 logger = logging.getLogger(__name__)
 
@@ -483,3 +483,49 @@ async def run_fullstack_tests(
         test_file_count=backend_result.test_file_count + frontend_result.test_file_count,
         source_file_count=backend_result.source_file_count + frontend_result.source_file_count,
     )
+
+
+async def run_build_validation(
+    test_framework: str,
+    source_files: list[dict[str, str]],
+    test_files: list[dict[str, str]],
+    timeout_seconds: int = 60,
+) -> RunTestsResult:
+    """Run the framework-appropriate test suite plus a build check, as one result.
+
+    Single entry point that owns all test-framework dispatch (pytest / vitest /
+    both) and the #276 frontend build check, so callers stay framework-agnostic.
+
+    A frontend *build* failure is BLOCKING (a non-building app is broken) even
+    where frontend unit tests are non-blocking (D13). A build *skip* — no
+    frontend, no ``package.json``, or no Node — never fails. Returns a
+    ``RunTestsResult`` — never raises.
+    """
+    from squadops.capabilities.dev_capabilities import (
+        TEST_FRAMEWORK_BOTH,
+        TEST_FRAMEWORK_VITEST,
+    )
+
+    if test_framework == TEST_FRAMEWORK_VITEST:
+        result = await run_node_tests(source_files, test_files, timeout_seconds=timeout_seconds)
+        build_target: str | None = None
+    elif test_framework == TEST_FRAMEWORK_BOTH:
+        result = await run_fullstack_tests(
+            source_files, test_files, timeout_seconds=timeout_seconds
+        )
+        build_target = "frontend"
+    else:
+        # pytest / backend-only: nothing to build
+        return await run_generated_tests(source_files, test_files, timeout_seconds=timeout_seconds)
+
+    build = await run_frontend_build(
+        source_files, target_dir=build_target, timeout_seconds=timeout_seconds
+    )
+    if build.failed:
+        merged_error = "; ".join(part for part in (result.error, build.error) if part)
+        result = replace(
+            result,
+            exit_code=result.exit_code or build.exit_code or 1,
+            error=merged_error,
+        )
+    return result

--- a/tests/unit/capabilities/test_frontend_build.py
+++ b/tests/unit/capabilities/test_frontend_build.py
@@ -1,0 +1,125 @@
+"""Tests for the frontend build-acceptance check (#276).
+
+Bug this guards: a Vite frontend can pass vitest unit tests yet fail to build
+(e.g. missing root ``index.html``), shipping a non-runnable deliverable green.
+``run_frontend_build`` must FAIL when the build ran and errored, and must SKIP
+(not fail) when it can't assess (no frontend, no package.json, no node).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from squadops.capabilities.handlers.test_runner import (
+    BuildCheckResult,
+    run_frontend_build,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_PKG_WITH_BUILD = '{"name": "fe", "scripts": {"build": "vite build"}}'
+
+
+class _FakeProc:
+    def __init__(self, returncode: int):
+        self.returncode = returncode
+
+    async def communicate(self):
+        return (b"", b"build output")
+
+    def kill(self):
+        pass
+
+    async def wait(self):
+        pass
+
+
+def _fake_exec(returncodes: list[int]):
+    """Return a create_subprocess_exec stand-in yielding the given exit codes."""
+    it = iter(returncodes)
+
+    async def _exec(*_args, **_kwargs):
+        return _FakeProc(next(it))
+
+    return _exec
+
+
+# --- BuildCheckResult.failed semantics (skips are not failures) ---------------
+
+
+@pytest.mark.parametrize(
+    "ran,ok,expected_failed",
+    [(True, False, True), (True, True, False), (False, False, False), (False, True, False)],
+)
+def test_failed_property(ran, ok, expected_failed):
+    assert BuildCheckResult(ran=ran, ok=ok).failed is expected_failed
+
+
+# --- Skip paths (no subprocess, deterministic) --------------------------------
+
+
+async def test_skips_when_no_frontend_source():
+    result = await run_frontend_build([{"path": "backend/main.py", "content": "x = 1"}])
+    assert result.ran is False and result.failed is False
+
+
+async def test_skips_when_no_package_json():
+    result = await run_frontend_build(
+        [{"path": "frontend/src/main.jsx", "content": "export default 1"}]
+    )
+    assert result.ran is False
+    assert "package.json" in result.error
+
+
+# --- Build outcome (mocked subprocess) ----------------------------------------
+
+
+async def test_build_failure_is_a_failure(monkeypatch):
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", _fake_exec([0, 1])
+    )  # install ok, build fails
+    result = await run_frontend_build(
+        [{"path": "frontend/package.json", "content": _PKG_WITH_BUILD}]
+    )
+    assert result.ran is True
+    assert result.ok is False
+    assert result.failed is True
+    assert result.exit_code == 1
+
+
+async def test_build_success(monkeypatch):
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", _fake_exec([0, 0])
+    )  # install ok, build ok
+    result = await run_frontend_build(
+        [{"path": "frontend/package.json", "content": _PKG_WITH_BUILD}]
+    )
+    assert result.ran is True
+    assert result.ok is True
+    assert result.failed is False
+
+
+async def test_install_failure_is_skip_not_failure(monkeypatch):
+    """A broken toolchain (npm install fails) can't assess the build — that's a
+    SKIP, not a deliverable failure (don't punish the app for our env)."""
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec([1]))  # install fails
+    result = await run_frontend_build(
+        [{"path": "frontend/package.json", "content": _PKG_WITH_BUILD}]
+    )
+    assert result.ran is False
+    assert result.failed is False
+    assert "install" in result.error
+
+
+async def test_missing_node_is_skip_not_failure(monkeypatch):
+    async def _raise(*_a, **_k):
+        raise FileNotFoundError("npm")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _raise)
+    result = await run_frontend_build(
+        [{"path": "frontend/package.json", "content": _PKG_WITH_BUILD}]
+    )
+    assert result.ran is False
+    assert result.failed is False

--- a/tests/unit/capabilities/test_frontend_build.py
+++ b/tests/unit/capabilities/test_frontend_build.py
@@ -12,8 +12,16 @@ import asyncio
 
 import pytest
 
+import squadops.capabilities.handlers.test_runner as tr
+from squadops.capabilities.dev_capabilities import (
+    TEST_FRAMEWORK_BOTH,
+    TEST_FRAMEWORK_PYTEST,
+    TEST_FRAMEWORK_VITEST,
+)
 from squadops.capabilities.handlers.test_runner import (
     BuildCheckResult,
+    RunTestsResult,
+    run_build_validation,
     run_frontend_build,
 )
 
@@ -123,3 +131,57 @@ async def test_missing_node_is_skip_not_failure(monkeypatch):
     )
     assert result.ran is False
     assert result.failed is False
+
+
+# --- run_build_validation: framework dispatch + blocking-build fold ------------
+# The QA handler is framework-agnostic; this orchestration lives in test_runner.
+
+
+async def test_build_validation_backend_only_skips_build(monkeypatch):
+    """pytest/backend-only capabilities have no frontend — never invoke a build."""
+    called = {"build": False}
+
+    async def _generated(*_a, **_k):
+        return RunTestsResult(executed=True, exit_code=0)
+
+    async def _build(*_a, **_k):
+        called["build"] = True
+        return BuildCheckResult(ran=True, ok=False)
+
+    monkeypatch.setattr(tr, "run_generated_tests", _generated)
+    monkeypatch.setattr(tr, "run_frontend_build", _build)
+    result = await run_build_validation(TEST_FRAMEWORK_PYTEST, [], [{"path": "t", "content": "x"}])
+    assert result.exit_code == 0
+    assert called["build"] is False
+
+
+async def test_build_validation_build_failure_blocks_even_when_tests_pass(monkeypatch):
+    """A frontend build failure is blocking even where fullstack tests passed (D13)."""
+
+    async def _fullstack(*_a, **_k):
+        return RunTestsResult(executed=True, exit_code=0)  # tests green
+
+    async def _build(*_a, **_k):
+        return BuildCheckResult(ran=True, ok=False, exit_code=2, error="vite build failed")
+
+    monkeypatch.setattr(tr, "run_fullstack_tests", _fullstack)
+    monkeypatch.setattr(tr, "run_frontend_build", _build)
+    result = await run_build_validation(TEST_FRAMEWORK_BOTH, [], [{"path": "t", "content": "x"}])
+    assert result.tests_passed is False
+    assert result.exit_code == 2
+    assert "vite build failed" in result.error
+
+
+async def test_build_validation_build_skip_does_not_fail(monkeypatch):
+    """A build skip (no node) must not turn a passing suite red."""
+
+    async def _node(*_a, **_k):
+        return RunTestsResult(executed=True, exit_code=0)
+
+    async def _build(*_a, **_k):
+        return BuildCheckResult(ran=False, error="npm not found")
+
+    monkeypatch.setattr(tr, "run_node_tests", _node)
+    monkeypatch.setattr(tr, "run_frontend_build", _build)
+    result = await run_build_validation(TEST_FRAMEWORK_VITEST, [], [{"path": "t", "content": "x"}])
+    assert result.tests_passed is True

--- a/tests/unit/capabilities/test_test_runner.py
+++ b/tests/unit/capabilities/test_test_runner.py
@@ -216,17 +216,25 @@ class TestRunGeneratedTestsTimeout:
 
 
 class TestRunGeneratedTestsCleanup:
-    async def test_workspace_cleaned_up_after_run(self):
+    async def test_workspace_cleaned_up_after_run(self, monkeypatch):
         source = [{"path": "a.py", "content": "x = 1"}]
         tests = [{"path": "test_a.py", "content": "def test_a():\n    assert True\n"}]
 
-        # We can't easily capture the workspace path, but we can verify
-        # that repeated runs don't accumulate temp dirs (smoke test).
-        import glob
+        # Capture the exact workspace this run creates and assert it's gone.
+        # (Globbing shared /tmp for qa_run_* is flaky under -n auto: a parallel
+        # worker's in-flight workspace leaks into the assertion.)
         import tempfile
 
-        before = set(glob.glob(os.path.join(tempfile.gettempdir(), "qa_run_*")))
+        created: list[str] = []
+        real_mkdtemp = tempfile.mkdtemp
+
+        def _capturing_mkdtemp(*args, **kwargs):
+            path = real_mkdtemp(*args, **kwargs)
+            created.append(path)
+            return path
+
+        monkeypatch.setattr(tempfile, "mkdtemp", _capturing_mkdtemp)
         await run_generated_tests(source, tests)
-        after = set(glob.glob(os.path.join(tempfile.gettempdir(), "qa_run_*")))
-        # No new dirs should remain
-        assert after - before == set()
+
+        assert created, "run_generated_tests did not create a workspace"
+        assert all(not os.path.exists(p) for p in created)


### PR DESCRIPTION
Build-acceptance increment for #276 (references #276; does not close it — deliverable-level `required_files` still needs a Mac seam, see below).

## Gap this closes
`cyc_2f415e43f9cf` run 1 shipped a **non-runnable frontend** green: the Vite app had no root `index.html`, so `vite build` failed — but **vitest unit tests pass without it**, so acceptance never noticed.

Reproduce-first refinement: **Part A (PR #289) already closed the *backend*-import gap** — by rejecting the `except ImportError` stub, a clean generated test imports `backend.main` directly, so a missing-import `NameError` fails pytest collection → the existing `tests_pass` fold catches it. So this increment adds only the genuinely-uncovered half (frontend build); an explicit backend-import check would be redundant.

## Change
- **`test_runner.run_frontend_build()`** — materialize frontend source, `npm install`, run the package's `build` script (fallback `npx vite build`). Returns `BuildCheckResult` where a **skip is not a failure**: no frontend / no `package.json` / no node / `npm install` failure all return `ran=False` (don't punish the app for our toolchain). Only a build that *ran and errored* fails.
- **`QATestHandler`** folds a build failure into the existing test outcome (`dataclasses.replace` on `exit_code`) → the current acceptance fold → `SEMANTIC_FAILURE` → SIP-0086 correction loop. Minimal `cycle_tasks.py` footprint; report surfaces the build result.
- **Fixed a pre-existing `-n auto` isolation flake** in `test_workspace_cleaned_up_after_run` (globbed shared `/tmp/qa_run_*`, catching a parallel worker's in-flight dir) — now captures this run's exact workspace via `mkdtemp` and asserts removal.

## Deferred: deliverable-level `required_files` (the Dockerfile gap)
The builder run's missing-`Dockerfile` case needs the **full emitted-artifact filename set**, which lives at the **executor** (`stored_artifacts` has filenames + the profile). The qa handler only receives a per-task *filtered* `artifact_contents` subset (`all_artifact_refs` are ID-only; filenames need heavy vault retrieval). So required_files enforcement is a **Mac-seam** item — flagged on #276 for coordination, not forced into a handler hack.

## Verification
- `test_frontend_build.py`: 10 tests (failed-property semantics; skip paths; build fail/success/install-fail/no-node via mocked subprocess).
- capabilities `1083 passed` (3× under `-n auto`, flake gone) + cycles `1352 passed`; ruff + test-quality lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)