### PR TITLE
feat(runtime): RuntimeTransaction UoW — atomic coordinator lease+activity+mode (SIP-0089 §4.5/D25, #244)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2297,7 +2297,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
             # Issue #110: propagate squad-profile model + overrides so
             # correction-loop reasoning runs on the cycle's specified model
-            # (e.g. spark-squad-with-builder pins data/lead to qwen3.6:27b)
+            # (e.g. the `full` profile pins data/lead to qwen3.6:27b)
             # rather than the agent container's instance default.
             corr_inputs: dict[str, Any] = {
                 "prd": cycle.prd_ref,

--- a/adapters/persistence/runtime/__init__.py
+++ b/adapters/persistence/runtime/__init__.py
@@ -3,5 +3,11 @@
 from adapters.persistence.runtime.activity_postgres import PostgresRuntimeActivity
 from adapters.persistence.runtime.focus_lease_postgres import PostgresFocusLease
 from adapters.persistence.runtime.state_postgres import PostgresRuntimeState
+from adapters.persistence.runtime.transaction_postgres import PostgresRuntimeTransaction
 
-__all__ = ["PostgresFocusLease", "PostgresRuntimeActivity", "PostgresRuntimeState"]
+__all__ = [
+    "PostgresFocusLease",
+    "PostgresRuntimeActivity",
+    "PostgresRuntimeState",
+    "PostgresRuntimeTransaction",
+]

--- a/adapters/persistence/runtime/_conn.py
+++ b/adapters/persistence/runtime/_conn.py
@@ -1,0 +1,36 @@
+"""
+Shared connection helper for the runtime persistence adapters (SIP-0089 §4.5/D25).
+
+A runtime port method either runs inside a caller-supplied unit-of-work
+connection — the ``conn=`` the coordinator threads from
+:meth:`RuntimeTransactionPort.begin` so several writes commit atomically — or, when
+none is given, acquires its own connection from the pool. This helper centralizes
+that either/or so every adapter stays backward-compatible when not part of a
+transaction and never opens its own (auto-committing) connection over a
+caller's open transaction.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    import asyncpg
+
+
+@asynccontextmanager
+async def acquire(pool: asyncpg.Pool, conn: Any | None) -> AsyncIterator[Any]:
+    """Yield ``conn`` if the caller supplied one (UoW-shared), else one from ``pool``.
+
+    A supplied ``conn`` is *not* closed here — the unit of work that opened it
+    owns its lifecycle (commit/abort). A pool-acquired connection is released on
+    exit as usual.
+    """
+    if conn is not None:
+        yield conn
+    else:
+        async with pool.acquire() as owned:
+            yield owned

--- a/adapters/persistence/runtime/activity_postgres.py
+++ b/adapters/persistence/runtime/activity_postgres.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 import json
 import uuid
 from datetime import UTC, datetime
+from typing import Any
 
 import asyncpg
 
+from adapters.persistence.runtime._conn import acquire
 from squadops.ports.runtime.activity import RuntimeActivityPort
 from squadops.runtime.models import (
     ActivitySourceKind,
@@ -93,7 +95,9 @@ class PostgresRuntimeActivity(RuntimeActivityPort):
             )
         return _row_to_activity(row)
 
-    async def update_state(self, activity_id: str, state: ActivityState) -> RuntimeActivity | None:
+    async def update_state(
+        self, activity_id: str, state: ActivityState, *, conn: Any = None
+    ) -> RuntimeActivity | None:
         # Timestamp management is intrinsic to the state being entered: pausing
         # stamps paused_at, a terminal state stamps ended_at, and (re)entering
         # running ensures started_at is set without clobbering the original.
@@ -108,7 +112,7 @@ class PostgresRuntimeActivity(RuntimeActivityPort):
         # terminal row never moves again. This makes terminalization race-safe —
         # if the owning handler completes an activity the coordinator just aborted
         # (or vice versa), the second writer matches no row and gets None.
-        async with self._pool.acquire() as conn:
+        async with acquire(self._pool, conn) as conn:
             row = await conn.fetchrow(
                 f"UPDATE runtime_activities SET {', '.join(sets)} "
                 "WHERE runtime_activity_id = $1 "
@@ -127,11 +131,15 @@ class PostgresRuntimeActivity(RuntimeActivityPort):
     async def fail_activity(self, activity_id: str, reason_code: str) -> RuntimeActivity | None:
         return await self.update_state(activity_id, "failed")
 
-    async def abort_activity(self, activity_id: str, reason_code: str) -> RuntimeActivity | None:
-        return await self.update_state(activity_id, "aborted")
+    async def abort_activity(
+        self, activity_id: str, reason_code: str, *, conn: Any = None
+    ) -> RuntimeActivity | None:
+        return await self.update_state(activity_id, "aborted", conn=conn)
 
-    async def get_current_activity(self, agent_id: str) -> RuntimeActivity | None:
-        async with self._pool.acquire() as conn:
+    async def get_current_activity(
+        self, agent_id: str, *, conn: Any = None
+    ) -> RuntimeActivity | None:
+        async with acquire(self._pool, conn) as conn:
             row = await conn.fetchrow(
                 f"SELECT {_COLUMNS} FROM runtime_activities "
                 "WHERE agent_id = $1 AND state IN ('pending', 'running', 'paused')",

--- a/adapters/persistence/runtime/focus_lease_postgres.py
+++ b/adapters/persistence/runtime/focus_lease_postgres.py
@@ -19,9 +19,11 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import asyncpg
 
+from adapters.persistence.runtime._conn import acquire
 from squadops.ports.runtime.focus_lease import FocusLeasePort
 from squadops.runtime import reasons
 from squadops.runtime.models import (
@@ -62,8 +64,9 @@ class PostgresFocusLease(FocusLeasePort):
         recall_policy: RecallPolicy = "graceful",
         preemption_grace: timedelta = timedelta(),
         wait: bool = False,
+        conn: Any = None,
     ) -> LeaseDecision:
-        async with self._pool.acquire() as conn:
+        async with acquire(self._pool, conn) as conn:
             # (D12) idempotent replay: a still-active lease with this key wins,
             # so a retried acquire never creates a duplicate.
             existing = await self._active_lease_by_key(conn, idempotency_key)
@@ -132,22 +135,22 @@ class PostgresFocusLease(FocusLeasePort):
         # asyncpg returns e.g. "UPDATE 1"; "UPDATE 0" means no active lease matched.
         return result.split()[-1] != "0"
 
-    async def release_lease(self, lease_id: str, reason_code: str) -> None:
-        await self._mark_released(lease_id)
+    async def release_lease(self, lease_id: str, reason_code: str, *, conn: Any = None) -> None:
+        await self._mark_released(lease_id, conn=conn)
 
-    async def revoke_lease(self, lease_id: str, reason_code: str) -> None:
-        await self._mark_released(lease_id)
+    async def revoke_lease(self, lease_id: str, reason_code: str, *, conn: Any = None) -> None:
+        await self._mark_released(lease_id, conn=conn)
 
-    async def get_current_lease(self, agent_id: str) -> FocusLease | None:
-        async with self._pool.acquire() as conn:
+    async def get_current_lease(self, agent_id: str, *, conn: Any = None) -> FocusLease | None:
+        async with acquire(self._pool, conn) as conn:
             return await self._current_lease(conn, agent_id)
 
-    async def _mark_released(self, lease_id: str) -> None:
+    async def _mark_released(self, lease_id: str, *, conn: Any = None) -> None:
         """Free the active-lease slot. Shared by release (cooperative) and revoke
         (non-cooperative) — the storage effect is identical in v1.1; the audit
         distinction is carried by the coordinator's reason/event, not a column.
         The `released_at IS NULL` guard makes a repeated release/revoke a no-op."""
-        async with self._pool.acquire() as conn:
+        async with acquire(self._pool, conn) as conn:
             await conn.execute(
                 "UPDATE focus_leases SET released_at = now(), updated_at = now() "
                 "WHERE lease_id = $1 AND released_at IS NULL",

--- a/adapters/persistence/runtime/state_postgres.py
+++ b/adapters/persistence/runtime/state_postgres.py
@@ -12,9 +12,11 @@ semantics: heartbeat never overwrites coordinator-owned fields
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
 import asyncpg
 
+from adapters.persistence.runtime._conn import acquire
 from squadops.ports.runtime.state import RuntimeStatePort
 from squadops.runtime.models import AgentRuntimeState
 
@@ -41,8 +43,10 @@ class PostgresRuntimeState(RuntimeStatePort):
             )
         return _row_to_state(row) if row else None
 
-    async def upsert_state(self, state: AgentRuntimeState) -> AgentRuntimeState:
-        async with self._pool.acquire() as conn:
+    async def upsert_state(
+        self, state: AgentRuntimeState, *, conn: Any = None
+    ) -> AgentRuntimeState:
+        async with acquire(self._pool, conn) as conn:
             await conn.execute(
                 "INSERT INTO agent_runtime_state ("
                 "agent_id, mode, runtime_status, focus, "

--- a/adapters/persistence/runtime/transaction_postgres.py
+++ b/adapters/persistence/runtime/transaction_postgres.py
@@ -1,0 +1,34 @@
+"""
+Asyncpg RuntimeTransaction adapter (SIP-0089 §4.5/D25).
+
+Implements :class:`RuntimeTransactionPort` over the same asyncpg pool the other
+runtime adapters share. ``begin()`` acquires a connection and opens a
+``conn.transaction()`` block, yielding the connection as the opaque unit-of-work
+handle. Because every participating adapter runs its statement on that same
+connection (via ``conn=``), the writes share one transaction: normal exit
+commits, an exception aborts and rolls them all back.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+from squadops.ports.runtime.transaction import RuntimeTransactionPort
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    import asyncpg
+
+
+class PostgresRuntimeTransaction(RuntimeTransactionPort):
+    """Postgres-backed unit of work over the shared asyncpg pool."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    @asynccontextmanager
+    async def begin(self) -> AsyncIterator[asyncpg.Connection]:
+        async with self._pool.acquire() as conn, conn.transaction():
+            yield conn

--- a/src/squadops/api/runtime/scheduler_bootstrap.py
+++ b/src/squadops/api/runtime/scheduler_bootstrap.py
@@ -65,14 +65,22 @@ def create_runtime_coordinator(pool: asyncpg.Pool | None) -> RuntimeCoordinator 
         PostgresFocusLease,
         PostgresRuntimeActivity,
         PostgresRuntimeState,
+        PostgresRuntimeTransaction,
     )
 
     state = PostgresRuntimeState(pool)
     focus_lease = PostgresFocusLease(pool)
     activity = PostgresRuntimeActivity(pool)
     publisher = LoggingRuntimeEventPublisher()
+    # §4.5/D25: the UoW makes the transition's lease+activity+mode writes atomic —
+    # a mode-write failure aborts the transaction rather than best-effort compensating.
+    transaction = PostgresRuntimeTransaction(pool)
     return RuntimeCoordinator(
-        state, events_publisher=publisher, focus_lease=focus_lease, activity=activity
+        state,
+        events_publisher=publisher,
+        focus_lease=focus_lease,
+        activity=activity,
+        transaction=transaction,
     )
 
 

--- a/src/squadops/ports/runtime/activity.py
+++ b/src/squadops/ports/runtime/activity.py
@@ -16,7 +16,7 @@ reason is not persisted as a column in v1.1 — `state` + `ended_at` are.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from squadops.runtime.models import (
@@ -59,12 +59,16 @@ class RuntimeActivityPort(ABC):
         """
 
     @abstractmethod
-    async def update_state(self, activity_id: str, state: ActivityState) -> RuntimeActivity | None:
+    async def update_state(
+        self, activity_id: str, state: ActivityState, *, conn: Any = None
+    ) -> RuntimeActivity | None:
         """Transition an activity to `state`, managing timestamps automatically.
 
         `paused` stamps `paused_at`; a terminal state stamps `ended_at`; `running`
         ensures `started_at` is set (resume keeps the original). Returns the updated
         activity, or `None` if no such activity exists.
+
+        `conn` (§4.5/D25): run on the caller's unit-of-work connection when given.
         """
 
     @abstractmethod
@@ -80,10 +84,18 @@ class RuntimeActivityPort(ABC):
         event-surfaced (D18), not persisted in v1.1."""
 
     @abstractmethod
-    async def abort_activity(self, activity_id: str, reason_code: str) -> RuntimeActivity | None:
+    async def abort_activity(
+        self, activity_id: str, reason_code: str, *, conn: Any = None
+    ) -> RuntimeActivity | None:
         """Terminal helper: mark the activity `aborted` (non-cooperative stop).
-        `reason_code` is event-surfaced (D18), not persisted in v1.1."""
+        `reason_code` is event-surfaced (D18), not persisted in v1.1.
+
+        `conn` (§4.5/D25): run on the caller's unit-of-work connection when given."""
 
     @abstractmethod
-    async def get_current_activity(self, agent_id: str) -> RuntimeActivity | None:
-        """Return the agent's current (active) activity, or `None`."""
+    async def get_current_activity(
+        self, agent_id: str, *, conn: Any = None
+    ) -> RuntimeActivity | None:
+        """Return the agent's current (active) activity, or `None`.
+
+        `conn` (§4.5/D25): read on the caller's unit-of-work connection when given."""

--- a/src/squadops/ports/runtime/focus_lease.py
+++ b/src/squadops/ports/runtime/focus_lease.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from squadops.runtime.models import (
@@ -52,6 +52,7 @@ class FocusLeasePort(ABC):
         recall_policy: RecallPolicy = "graceful",
         preemption_grace: timedelta = timedelta(),
         wait: bool = False,
+        conn: Any = None,
     ) -> LeaseDecision:
         """Attempt to acquire the agent's primary focus; resolve to one outcome.
 
@@ -76,23 +77,31 @@ class FocusLeasePort(ABC):
         """
 
     @abstractmethod
-    async def release_lease(self, lease_id: str, reason_code: str) -> None:
+    async def release_lease(self, lease_id: str, reason_code: str, *, conn: Any = None) -> None:
         """Cooperatively complete a lease (the owner finished its focus work).
 
         Marks `released_at`, freeing the single-active-lease slot. `reason_code`
         is surfaced by the coordinator's `focus_lease.released` event (D18); it is
         not persisted as a column in v1.1. A no-op for an already-released lease.
+
+        `conn` (§4.5/D25): run on the caller's unit-of-work connection when given.
         """
 
     @abstractmethod
-    async def revoke_lease(self, lease_id: str, reason_code: str) -> None:
+    async def revoke_lease(self, lease_id: str, reason_code: str, *, conn: Any = None) -> None:
         """Non-cooperatively remove a lease (preemption / forced reclaim).
 
         Same storage effect as `release_lease` (marks `released_at`); the
         distinction is audit-only — revoke is initiated by a displacing owner, not
         the holder, and is surfaced via the `focus_lease.preempted` reason/event.
+
+        `conn` (§4.5/D25): run on the caller's unit-of-work connection when given.
         """
 
     @abstractmethod
-    async def get_current_lease(self, agent_id: str) -> FocusLease | None:
-        """Return the agent's current (un-released) lease, or `None`."""
+    async def get_current_lease(self, agent_id: str, *, conn: Any = None) -> FocusLease | None:
+        """Return the agent's current (un-released) lease, or `None`.
+
+        `conn` (§4.5/D25): read on the caller's unit-of-work connection when given,
+        so the coordinator sees a consistent snapshot within its transaction.
+        """

--- a/src/squadops/ports/runtime/state.py
+++ b/src/squadops/ports/runtime/state.py
@@ -13,7 +13,7 @@ must not overwrite coordinator-owned fields (`mode`, `focus`,
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from squadops.runtime.models import AgentRuntimeState
@@ -27,10 +27,16 @@ class RuntimeStatePort(ABC):
         """Return the current state for `agent_id`, or `None` if no row exists."""
 
     @abstractmethod
-    async def upsert_state(self, state: AgentRuntimeState) -> AgentRuntimeState:
+    async def upsert_state(
+        self, state: AgentRuntimeState, *, conn: Any = None
+    ) -> AgentRuntimeState:
         """Persist `state` (insert or update by `agent_id`) and return it.
 
         Coordinator-owned writes go through this method. Heartbeat must not.
+
+        `conn` (§4.5/D25): when supplied, the write runs on that unit-of-work
+        connection so it commits atomically with the coordinator's lease/activity
+        writes; when omitted, the adapter acquires its own connection.
         """
 
     @abstractmethod

--- a/src/squadops/ports/runtime/transaction.py
+++ b/src/squadops/ports/runtime/transaction.py
@@ -1,0 +1,49 @@
+"""
+RuntimeTransactionPort — unit-of-work for atomic multi-port runtime writes
+(SIP-0089 §4.5/D25).
+
+The coordinator's transition applies up to three writes across separate ports —
+a FocusLease acquisition/release, a RuntimeActivity transition, and the
+`AgentRuntimeState.mode` write. Phase 3/4 shipped these as best-effort
+compensation (roll a just-acquired lease back if the mode write fails). D25
+prescribes wrapping them in **one** Postgres transaction where the ports share a
+pool, so a partial failure becomes a transaction *abort* — no stranded leases, no
+orphaned activity transitions.
+
+`begin()` yields an **opaque** connection handle to pass as ``conn=`` to the
+participating port methods (`RuntimeStatePort.upsert_state`,
+`FocusLeasePort.request/release/revoke/get_current_lease`,
+`RuntimeActivityPort.get_current_activity/update_state/abort_activity`). Exiting
+the context normally commits; raising inside it aborts and rolls back every write
+made on the handle. The handle is deliberately untyped here (`Any`) so the port
+layer stays driver-agnostic (D26) — only the asyncpg adapter knows it is a
+`Connection`.
+
+When no transaction port is wired (or `conn` is omitted), the ports acquire their
+own connection and the coordinator keeps its Phase-3/4 compensation behavior — so
+this is additive and opt-in.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from contextlib import AbstractAsyncContextManager
+from typing import Any
+
+
+class RuntimeTransactionPort(ABC):
+    """Unit of work spanning the runtime persistence ports (§4.5/D25)."""
+
+    @abstractmethod
+    def begin(self) -> AbstractAsyncContextManager[Any]:
+        """Open a transaction and yield its opaque connection handle.
+
+        Usage::
+
+            async with transaction.begin() as conn:
+                await state.upsert_state(new_state, conn=conn)
+                ...  # raising here rolls the whole thing back
+
+        Normal exit commits; an exception aborts (rolls back all writes on the
+        handle).
+        """

--- a/src/squadops/runtime/coordinator.py
+++ b/src/squadops/runtime/coordinator.py
@@ -19,17 +19,21 @@ Phase 2 gates:
 Phase 3 (§3.4) wires FocusLease arbitration: entering a focus-bearing mode
 (`cycle`/`duty`) must secure the owner's lease *before* the mode write (§4.5
 step 4 precedes step 6), and **lease ≠ mode** — a granted lease never changes
-`RuntimeMode`; the upsert is authoritative. Phase 3 uses best-effort compensation
-(a lease acquired for a transition is rolled back if the mode write fails — no
-stranded leases). With `focus_lease=None` the coordinator behaves as in Phase 2.
+`RuntimeMode`; the upsert is authoritative. With `focus_lease=None` the
+coordinator behaves as in Phase 2.
 
-Phase 4 (§4.5, thin v1.1 seam) wires a RuntimeActivity action: a mode change
-orphans any activity bound to the previous mode, so it is aborted best-effort
-*after* the mode write. The full §4.5 transition order (activity before mode) and
-D25's single-Postgres-transaction wrapping of lease+activity+mode remain a
-follow-up in #244 (now unblocked — recruitment #233 has landed); the
-activity-orphan path stays unexercised in v1.1. With `activity=None` there is no
-activity bookkeeping.
+Phase 4 (§4.5) wires a RuntimeActivity action: a mode change orphans any activity
+bound to the previous mode, so it is aborted as part of the transition. With
+`activity=None` there is no activity bookkeeping.
+
+#244/D25 realizes the full §4.5 order and atomicity: `_apply_transition` runs
+lease (step 4) → activity abort (step 5) → mode write (step 6) inside a
+`RuntimeTransactionPort.begin()` unit of work. With a real UoW a failure at any
+step *aborts the transaction*, rolling back the lease acquisition and the activity
+abort (no stranded leases, no orphaned activity); with the default null UoW
+(no transaction port) the writes use their own connections and best-effort
+compensation (release the just-acquired lease on a failed mode write) stands in.
+Events are emitted only *after* the unit of work commits.
 
 On apply, a canonical mode-transition event plus the relevant `focus_lease.*`
 events are emitted, each with a *separate* reason code (D14/D18) through the

--- a/src/squadops/runtime/coordinator.py
+++ b/src/squadops/runtime/coordinator.py
@@ -40,20 +40,23 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 from squadops.ports.runtime.activity import RuntimeActivityPort
 from squadops.ports.runtime.event_publisher import RuntimeEventPublisher
 from squadops.ports.runtime.focus_lease import FocusLeasePort
 from squadops.ports.runtime.state import RuntimeStatePort
+from squadops.ports.runtime.transaction import RuntimeTransactionPort
 from squadops.runtime import events, reasons
 from squadops.runtime.models import (
     AgentRuntimeState,
     LeaseGranted,
     LeasePreempting,
     OwnerType,
+    RuntimeActivity,
     RuntimeMode,
 )
 
@@ -124,6 +127,35 @@ def _owner_type_for_mode(mode: str) -> OwnerType | None:
     return mode if mode in ("cycle", "duty") else None  # type: ignore[return-value]
 
 
+class _TransitionRejected(Exception):
+    """Internal: a lease conflict aborts the transition's unit of work (§4.5/D25).
+
+    Raised inside the `RuntimeTransactionPort.begin()` block so any partial
+    arbitration writes (e.g. a preempt-revoke that then failed to re-grant) roll
+    back with the transaction. The coordinator catches it and returns a *reject*
+    outcome — a rejection, not an error.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class _NullTransaction(RuntimeTransactionPort):
+    """Default no-op unit of work: yields no connection (§4.5/D25).
+
+    With `conn=None`, each runtime port write acquires its own auto-committing
+    connection — the exact Phase-3/4 behavior — and the coordinator's compensation
+    (release a just-acquired lease on a failed mode write) stands in for a real
+    transaction rollback. Used when the coordinator is built without a
+    `RuntimeTransactionPort`.
+    """
+
+    @asynccontextmanager
+    async def begin(self) -> Any:
+        yield None
+
+
 class RuntimeCoordinator:
     """Validates and applies RuntimeMode transitions; emits reason-coded events."""
 
@@ -134,6 +166,7 @@ class RuntimeCoordinator:
         events_publisher: RuntimeEventPublisher | None = None,
         focus_lease: FocusLeasePort | None = None,
         activity: RuntimeActivityPort | None = None,
+        transaction: RuntimeTransactionPort | None = None,
     ) -> None:
         self._state = state
         self._events = events_publisher
@@ -141,6 +174,10 @@ class RuntimeCoordinator:
         self._focus_lease = focus_lease
         # RuntimeActivity seam (§4.5, thin v1.1). None → no activity bookkeeping.
         self._activity = activity
+        # RuntimeTransaction UoW (§4.5/D25). None → _NullTransaction: each write
+        # uses its own connection and compensation stands in for a rollback (the
+        # Phase-3/4 behavior). A real UoW makes lease+activity+mode atomic.
+        self._transaction: RuntimeTransactionPort = transaction or _NullTransaction()
         # D12 idempotency ledger. In-process for v1.1 (single in-process scheduler);
         # durable persistence is a refinement for the SIP-0091 Temporal adapter.
         self._applied_keys: set[str] = set()
@@ -233,71 +270,92 @@ class RuntimeCoordinator:
         assignment_id: str | None,
         idem_key: str | None,
     ) -> TransitionOutcome:
-        """Arbitrate the lease, write the mode, and emit events (§4.5 steps 4–7).
+        """Apply lease → activity → mode as one unit of work, then emit (§4.5/D25).
 
-        Reached only after every validation gate passes. lease ≠ mode: a lease
-        secured here is rolled back if the mode write fails (§3.4 compensation),
-        and the leaving-mode lease is released only after the write succeeds so a
-        failure can never strand state.
+        Reached only after every validation gate passes. The three writes run in
+        `RuntimeTransactionPort.begin()` in §4.5 order (lease step 4 → activity
+        step 5 → mode step 6): with a real UoW a failure at any step aborts the
+        transaction, rolling back the lease acquisition and the activity abort;
+        with the default null UoW the writes use their own connections and the
+        compensation below stands in for a rollback. lease ≠ mode throughout.
+
+        Events are emitted only *after* the unit of work commits, so an aborted
+        transition (lease conflict or write failure) emits nothing.
         """
         current = state.mode
-
-        # (2/4 §4.5) FocusLease arbitration before the mode write. A rejected
-        # lease blocks the transition (prior mode stays authoritative).
-        # (5 §4.5) the RuntimeActivity action runs post-write — see below.
         arb: _LeaseArbitration | None = None
-        if self._focus_lease is not None:
-            arb = await self._arbitrate_lease(agent_id, current, target_mode, owner_ref)
-            if not arb.ok:
-                rejected = arb.rejected_reason or reasons.FOCUS_LEASE_CONFLICT
-                self._emit_lease_event(
-                    events.FOCUS_LEASE_REJECTED,
-                    agent_id,
-                    rejected,
-                    from_mode=current,
-                    to_mode=target_mode,
-                    owner_ref=owner_ref,
-                )
-                return self._reject(agent_id, current, target_mode, reason_code, rejected)
-
-        # (6 D16) apply — the coordinator is the sole writer of `mode`. Entering
-        # duty binds the active assignment; leaving duty clears it.
+        aborted_activity: RuntimeActivity | None = None
+        # (6 D16) the sole `mode` write. Entering duty binds the active assignment;
+        # leaving duty clears it. Built up front; written last, inside the UoW.
         new_state = dataclasses.replace(
             state,
             mode=target_mode,
             current_assignment_ref=(assignment_id if target_mode == "duty" else None),
         )
         try:
-            await self._state.upsert_state(new_state)
+            async with self._transaction.begin() as conn:
+                # (4 §4.5) FocusLease arbitration. A rejected lease aborts the unit
+                # of work (undoing any partial preempt-revoke) via _TransitionRejected.
+                if self._focus_lease is not None:
+                    arb = await self._arbitrate_lease(
+                        agent_id, current, target_mode, owner_ref, conn=conn
+                    )
+                    if not arb.ok:
+                        raise _TransitionRejected(
+                            arb.rejected_reason or reasons.FOCUS_LEASE_CONFLICT
+                        )
+                # (5 §4.5) RuntimeActivity action BEFORE the mode write, inside the
+                # transaction: abort an activity orphaned by this transition.
+                if self._activity is not None:
+                    aborted_activity = await self._abort_orphaned_activity(
+                        agent_id, target_mode, conn=conn
+                    )
+                # (6 §4.5/D16) the mode write.
+                await self._state.upsert_state(new_state, conn=conn)
+                # Release the leaving-mode lease (entering ambient) within the same
+                # unit of work, so it commits atomically with the mode write.
+                if arb is not None and arb.release_after_lease_id is not None:
+                    await self._focus_lease.release_lease(
+                        arb.release_after_lease_id, reasons.FOCUS_LEASE_RELEASED, conn=conn
+                    )
+        except _TransitionRejected as rej:
+            # A lease conflict — the unit of work rolled back; prior mode is authoritative.
+            self._emit_lease_event(
+                events.FOCUS_LEASE_REJECTED,
+                agent_id,
+                rej.reason,
+                from_mode=current,
+                to_mode=target_mode,
+                owner_ref=owner_ref,
+            )
+            return self._reject(agent_id, current, target_mode, reason_code, rej.reason)
         except Exception:
-            # Compensation (§3.4): a lease acquired for this transition must not
-            # outlive a failed mode write. Prior mode remains authoritative.
+            # Unexpected failure. A real UoW already rolled back the lease acquisition;
+            # for the null-UoW path this compensation (§3.4) ensures a lease acquired
+            # for this transition never outlives the failed write. Harmless no-op when
+            # already rolled back (the row matches no active lease).
             if arb is not None and arb.acquired_lease_id is not None:
                 await self._focus_lease.release_lease(
                     arb.acquired_lease_id, reasons.FOCUS_LEASE_RELEASED
                 )
             raise
 
-        # Post-write lease bookkeeping: release the leaving-mode lease (entering
-        # ambient) only now that the mode write succeeded, then emit focus_lease.*
-        # events for what the arbitration did (D18 — distinct from the reason).
+        # Committed. Emit events post-commit (D14/D18): arbitration → activity → mode.
         if arb is not None:
-            if arb.release_after_lease_id is not None:
-                await self._focus_lease.release_lease(
-                    arb.release_after_lease_id, reasons.FOCUS_LEASE_RELEASED
-                )
             self._emit_arbitration_events(
                 arb, agent_id, from_mode=current, to_mode=target_mode, owner_ref=owner_ref
             )
-
-        # (5 §4.5, thin v1.1 seam) RuntimeActivity action: a mode change orphans any
-        # activity bound to the *previous* mode — abort it so it doesn't linger as
-        # the agent's "current work". Best-effort, post-write: an activity is
-        # observability, never a reason to fail an applied transition.
-        if self._activity is not None:
-            await self._abort_orphaned_activity(agent_id, target_mode)
-
-        # (7 D14/D18) emit the canonical mode-transition event with its own reason.
+        if aborted_activity is not None and self._events is not None:
+            self._events.emit(
+                events.RUNTIME_ACTIVITY_ABORTED,
+                agent_id=agent_id,
+                reason_code=reasons.ACTIVITY_PREEMPTED_BY_MODE_CHANGE,
+                payload={
+                    "runtime_activity_id": aborted_activity.runtime_activity_id,
+                    "from_mode": aborted_activity.mode,
+                    "to_mode": target_mode,
+                },
+            )
         if self._events is not None:
             self._events.emit(
                 events.MODE_TRANSITION,
@@ -348,10 +406,14 @@ class RuntimeCoordinator:
         current: RuntimeMode,
         target_mode: str,
         owner_ref: str,
+        *,
+        conn: Any = None,
     ) -> _LeaseArbitration:
         """Secure (or clear) the FocusLease for a `current → target_mode` move.
 
-        Never writes `mode` (lease ≠ mode). Resolution by case:
+        Never writes `mode` (lease ≠ mode). All reads/writes run on the caller's
+        unit-of-work `conn` (§4.5/D25) so they roll back with the transition on a
+        later failure. Resolution by case:
         - entering ambient → no acquire; defer releasing the leaving-mode lease
           to after the mode write;
         - entering cycle/duty with no conflict → acquire (`granted`);
@@ -366,7 +428,7 @@ class RuntimeCoordinator:
         assert fl is not None  # guarded by the caller
         new_owner = _owner_type_for_mode(target_mode)
         leaving_owner = _owner_type_for_mode(current)
-        old_lease = await fl.get_current_lease(agent_id)
+        old_lease = await fl.get_current_lease(agent_id, conn=conn)
         holds_leaving_lease = old_lease is not None and old_lease.owner_type == leaving_owner
 
         if new_owner is None:
@@ -378,15 +440,15 @@ class RuntimeCoordinator:
         # Stable idem key: repeated requests for the same (owner, agent) replay the
         # same lease (D12) rather than minting duplicates across scheduler ticks.
         idem = f"{new_owner}:{owner_ref}:{agent_id}"
-        decision = await fl.request_lease(agent_id, new_owner, owner_ref, idem)
+        decision = await fl.request_lease(agent_id, new_owner, owner_ref, idem, conn=conn)
 
         if isinstance(decision, LeaseGranted):
             return _LeaseArbitration(ok=True, acquired_lease_id=decision.lease_id, granted=True)
 
         if isinstance(decision, LeasePreempting):
             if old_lease is not None:
-                await fl.revoke_lease(old_lease.lease_id, reasons.FOCUS_LEASE_PREEMPTED)
-            regrant = await fl.request_lease(agent_id, new_owner, owner_ref, idem)
+                await fl.revoke_lease(old_lease.lease_id, reasons.FOCUS_LEASE_PREEMPTED, conn=conn)
+            regrant = await fl.request_lease(agent_id, new_owner, owner_ref, idem, conn=conn)
             if isinstance(regrant, LeaseGranted):
                 return _LeaseArbitration(
                     ok=True, acquired_lease_id=regrant.lease_id, granted=True, preempted=True
@@ -396,8 +458,8 @@ class RuntimeCoordinator:
         # LeaseRejected. If our own leaving-mode lease is what blocks us, release
         # it (the agent is done with that focus) and retry once.
         if holds_leaving_lease and old_lease is not None:
-            await fl.release_lease(old_lease.lease_id, reasons.FOCUS_LEASE_RELEASED)
-            regrant = await fl.request_lease(agent_id, new_owner, owner_ref, idem)
+            await fl.release_lease(old_lease.lease_id, reasons.FOCUS_LEASE_RELEASED, conn=conn)
+            regrant = await fl.request_lease(agent_id, new_owner, owner_ref, idem, conn=conn)
             if isinstance(regrant, LeaseGranted):
                 return _LeaseArbitration(
                     ok=True, acquired_lease_id=regrant.lease_id, granted=True, released=True
@@ -463,50 +525,36 @@ class RuntimeCoordinator:
                 owner_ref=owner_ref,
             )
 
-    async def _abort_orphaned_activity(self, agent_id: str, target_mode: str) -> None:
-        """Abort the agent's current activity if a mode change orphaned it (§4.5).
+    async def _abort_orphaned_activity(
+        self, agent_id: str, target_mode: str, *, conn: Any = None
+    ) -> RuntimeActivity | None:
+        """Abort the agent's current activity if a mode change orphaned it (§4.5/D25).
 
         An activity belongs to a mode; once the agent leaves that mode the activity
         can't continue, so it's aborted. An activity already in the target mode
         (e.g. a handler started it for the mode we're entering) is left alone.
-        Wholly best-effort: any failure is logged, never propagated — observability
-        must not break an applied transition. `update_state`'s active-only guard
-        makes this race-safe against the owning handler terminalizing first.
+        Runs on the caller's unit-of-work `conn`, so the abort commits atomically
+        with the mode write and rolls back if a later step fails. `update_state`'s
+        active-only guard keeps it race-safe against the owning handler
+        terminalizing first (matches no row → returns None).
 
-        NOTE (§4.5/D25): in v1.1 this path is effectively unexercised — scheduler
-        ambient↔duty transitions have no live activity, and cycle activities are
-        owned/terminated by their handler (§4.4). Recruitment #233 now drives
-        ambient↔cycle through the coordinator but acquires/releases only the lease
-        (no live activity to orphan), so the abort path stays unexercised. The
-        §4.5 single-Postgres-transaction wrapping of lease+activity+mode (D25)
-        remains a follow-up in #244 (unblocked now that #233 has landed); v1.1
-        keeps the best-effort post-write abort here.
+        Returns the aborted activity (so the caller can emit `runtime_activity.*`
+        post-commit), or `None` when nothing was orphaned / the guard matched
+        nothing. Unlike the Phase-4 thin seam this no longer swallows errors: the
+        abort is now part of the atomic unit (D25), so a failure aborts the
+        transition. In v1.1 this path is effectively unexercised — scheduler
+        `ambient↔duty` has no live activity, cycle activities are owned by their
+        handler (§4.4), and recruitment (#233) moves only the lease — so the
+        best-effort→transactional change is observable only under a future
+        live-activity preemption (cycle→duty mid-task).
         """
         assert self._activity is not None  # guarded by the caller
-        try:
-            current = await self._activity.get_current_activity(agent_id)
-            if current is None or current.mode == target_mode:
-                return
-            aborted = await self._activity.abort_activity(
-                current.runtime_activity_id, reasons.ACTIVITY_PREEMPTED_BY_MODE_CHANGE
-            )
-            if aborted is not None and self._events is not None:
-                self._events.emit(
-                    events.RUNTIME_ACTIVITY_ABORTED,
-                    agent_id=agent_id,
-                    reason_code=reasons.ACTIVITY_PREEMPTED_BY_MODE_CHANGE,
-                    payload={
-                        "runtime_activity_id": current.runtime_activity_id,
-                        "from_mode": current.mode,
-                        "to_mode": target_mode,
-                    },
-                )
-        except Exception:
-            logger.warning(
-                "best-effort abort of orphaned activity failed for agent %s",
-                agent_id,
-                exc_info=True,
-            )
+        current = await self._activity.get_current_activity(agent_id, conn=conn)
+        if current is None or current.mode == target_mode:
+            return None
+        return await self._activity.abort_activity(
+            current.runtime_activity_id, reasons.ACTIVITY_PREEMPTED_BY_MODE_CHANGE, conn=conn
+        )
 
 
 def _idem_key(

--- a/tests/integration/runtime/test_coordinator_transaction_integration.py
+++ b/tests/integration/runtime/test_coordinator_transaction_integration.py
@@ -1,0 +1,159 @@
+"""Integration tests for SIP-0089 §4.5/D25 — coordinator RuntimeTransaction rollback.
+
+Requires a running Postgres (docker-compose up -d postgres). Proves the real
+atomicity an in-memory fake can't model: a failure at the mode write (step 6)
+rolls back BOTH the FocusLease acquired in step 4 and the RuntimeActivity abort in
+step 5 — no stranded lease, no orphaned activity state. Plus a positive control
+that the committed path writes the lease and mode together.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from squadops.runtime import reasons
+from squadops.runtime.coordinator import RuntimeCoordinator
+
+pytestmark = [pytest.mark.docker, pytest.mark.domain_runtime]
+
+POSTGRES_URL = os.getenv(
+    "POSTGRES_URL", "postgresql://squadops:squadops-dev@localhost:5432/squadops"
+)
+
+try:
+    import asyncpg  # noqa: F401
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+
+def _pg_available() -> bool:
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(2)
+        s.connect(("localhost", 5432))
+        s.close()
+        return True
+    except OSError:
+        return False
+
+
+if not _pg_available():
+    pytest.skip(
+        "Postgres not reachable on localhost:5432 — start with docker-compose up -d postgres",
+        allow_module_level=True,
+    )
+
+
+@pytest_asyncio.fixture
+async def pool():
+    from squadops.api.runtime.migrations import apply_migrations
+
+    p = await asyncpg.create_pool(POSTGRES_URL, min_size=1, max_size=5)
+    await apply_migrations(p, Path(__file__).parents[3] / "infra" / "migrations")
+    yield p
+    await p.close()
+
+
+async def _cleanup(p, agent_id: str) -> None:
+    async with p.acquire() as conn:
+        await conn.execute("DELETE FROM focus_leases WHERE agent_id = $1", agent_id)
+        await conn.execute("DELETE FROM runtime_activities WHERE agent_id = $1", agent_id)
+        await conn.execute("DELETE FROM agent_runtime_state WHERE agent_id = $1", agent_id)
+
+
+def _ports(p):
+    from adapters.persistence.runtime import (
+        PostgresFocusLease,
+        PostgresRuntimeActivity,
+        PostgresRuntimeState,
+        PostgresRuntimeTransaction,
+    )
+
+    return (
+        PostgresRuntimeState(p),
+        PostgresFocusLease(p),
+        PostgresRuntimeActivity(p),
+        PostgresRuntimeTransaction(p),
+    )
+
+
+async def test_mode_write_failure_rolls_back_lease_and_activity(pool):
+    from adapters.persistence.runtime import PostgresRuntimeState
+
+    agent = f"itest-{uuid.uuid4().hex[:8]}"
+    state, fl, act, txn = _ports(pool)
+    await _cleanup(pool, agent)
+    try:
+        # Seed: agent ambient, holding an orphaned `duty` activity (running).
+        await state.ensure_state(agent)
+        orphan = await act.start_activity(
+            agent,
+            mode="duty",
+            activity_type="x",
+            goal="g",
+            source_kind="cycle_task",
+            source_ref="r",
+        )
+
+        # A coordinator whose mode write always fails — after the lease is acquired
+        # and the activity aborted on the same transaction connection.
+        class _FailingState(PostgresRuntimeState):
+            async def upsert_state(self, s, *, conn=None):
+                raise RuntimeError("simulated mode-write failure")
+
+        coord = RuntimeCoordinator(
+            _FailingState(pool), focus_lease=fl, activity=act, transaction=txn
+        )
+
+        with pytest.raises(RuntimeError, match="mode-write failure"):
+            await coord.request_transition(
+                agent,
+                "cycle",
+                reasons.CYCLE_RECRUITED,
+                requester_kind="external",
+                owner_ref="run-1",
+            )
+
+        # D25: the FocusLease acquired in step 4 rolled back — no active lease.
+        assert await fl.get_current_lease(agent) is None
+        # The activity abort in step 5 rolled back — the orphan is still running.
+        current = await act.get_current_activity(agent)
+        assert current is not None
+        assert current.runtime_activity_id == orphan.runtime_activity_id
+        assert current.state == "running"
+        # And the mode was never written.
+        st = await state.get_state(agent)
+        assert st is not None and st.mode == "ambient"
+    finally:
+        await _cleanup(pool, agent)
+
+
+async def test_committed_transition_writes_lease_and_mode_together(pool):
+    agent = f"itest-{uuid.uuid4().hex[:8]}"
+    state, fl, act, txn = _ports(pool)
+    await _cleanup(pool, agent)
+    try:
+        await state.ensure_state(agent)  # ambient
+        coord = RuntimeCoordinator(state, focus_lease=fl, activity=act, transaction=txn)
+
+        outcome = await coord.request_transition(
+            agent,
+            "cycle",
+            reasons.CYCLE_RECRUITED,
+            requester_kind="external",
+            owner_ref="run-1",
+        )
+
+        assert outcome.applied is True
+        lease = await fl.get_current_lease(agent)
+        assert lease is not None and lease.owner_type == "cycle"
+        st = await state.get_state(agent)
+        assert st is not None and st.mode == "cycle"
+    finally:
+        await _cleanup(pool, agent)

--- a/tests/unit/api/test_scheduler_bootstrap.py
+++ b/tests/unit/api/test_scheduler_bootstrap.py
@@ -91,15 +91,20 @@ def test_create_runtime_coordinator_without_pool_returns_none():
     assert create_runtime_coordinator(None) is None
 
 
-def test_create_runtime_coordinator_wires_focus_lease_and_activity():
+def test_create_runtime_coordinator_wires_focus_lease_activity_and_transaction():
     """The shared coordinator (used by the executor for recruitment) must carry
-    the same §3.4/§4.5 wiring as the scheduler's — a bare coordinator would skip
-    lease arbitration on recruitment."""
+    the §3.4/§4.5 wiring — focus lease, activity, AND the RuntimeTransaction UoW
+    (#244/D25). A bare coordinator would skip lease arbitration on recruitment, and
+    a missing transaction would silently fall back to best-effort compensation
+    instead of an atomic rollback."""
+    from adapters.persistence.runtime import PostgresRuntimeTransaction
+
     coordinator = create_runtime_coordinator(MagicMock())
 
     assert isinstance(coordinator, RuntimeCoordinator)
     assert coordinator._focus_lease is not None
     assert coordinator._activity is not None
+    assert isinstance(coordinator._transaction, PostgresRuntimeTransaction)
 
 
 def test_injected_coordinator_is_shared_not_rebuilt():

--- a/tests/unit/cycles/test_executor_activity_instrumentation.py
+++ b/tests/unit/cycles/test_executor_activity_instrumentation.py
@@ -73,7 +73,7 @@ class _FakeActivityPort(RuntimeActivityPort):
         self.started.append({"agent_id": agent_id, **kwargs})
         return _activity()
 
-    async def update_state(self, activity_id, state):
+    async def update_state(self, activity_id, state, *, conn=None):
         raise NotImplementedError
 
     async def complete_activity(self, activity_id, *, evidence_ref=None):
@@ -84,10 +84,10 @@ class _FakeActivityPort(RuntimeActivityPort):
         self.failed.append((activity_id, reason_code))
         return None
 
-    async def abort_activity(self, activity_id, reason_code):
+    async def abort_activity(self, activity_id, reason_code, *, conn=None):
         raise NotImplementedError
 
-    async def get_current_activity(self, agent_id):
+    async def get_current_activity(self, agent_id, *, conn=None):
         raise NotImplementedError
 
 

--- a/tests/unit/runtime/test_coordinator.py
+++ b/tests/unit/runtime/test_coordinator.py
@@ -55,7 +55,7 @@ class _FakeStatePort(RuntimeStatePort):
     async def get_state(self, agent_id):
         return self._rows.get(agent_id)
 
-    async def upsert_state(self, state):
+    async def upsert_state(self, state, *, conn=None):
         self._rows[state.agent_id] = state
         self.upserts.append(state)
         return state

--- a/tests/unit/runtime/test_coordinator_transaction.py
+++ b/tests/unit/runtime/test_coordinator_transaction.py
@@ -1,0 +1,148 @@
+"""Unit tests for SIP-0089 §4.5/D25 — coordinator RuntimeTransaction (UoW) wiring.
+
+Proves the coordinator opens ONE unit of work and threads its connection from
+`RuntimeTransactionPort.begin()` through the lease + activity + mode writes, in
+§4.5 order (activity abort *before* the mode write); and that the default NoOp
+transaction threads `conn=None` (the backward-compatible path). The genuine
+rollback-on-failure guarantee is proved against live Postgres in the integration
+test (slice 3) — an in-memory fake can't model a real abort.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from datetime import UTC, datetime
+
+import pytest
+
+from squadops.ports.runtime.transaction import RuntimeTransactionPort
+from squadops.runtime import reasons
+from squadops.runtime.coordinator import RuntimeCoordinator
+from squadops.runtime.models import AgentRuntimeState, LeaseGranted, RuntimeActivity
+
+pytestmark = [pytest.mark.domain_runtime]
+
+NOW = datetime(2026, 6, 28, 1, 0, tzinfo=UTC)
+_SENTINEL = "uow-conn"
+
+
+def _state(mode="ambient") -> AgentRuntimeState:
+    return AgentRuntimeState("max", mode, "online", "", None, "high", NOW, None)
+
+
+def _activity(mode="duty") -> RuntimeActivity:
+    return RuntimeActivity(
+        runtime_activity_id="act-1",
+        agent_id="max",
+        mode=mode,
+        activity_type="x",
+        goal="g",
+        priority=0,
+        state="running",
+        source_kind="cycle_task",
+        source_ref="r",
+        cycle_id=None,
+        workload_id=None,
+        task_id=None,
+        can_pause=False,
+        can_resume=False,
+        can_abort=True,
+    )
+
+
+class _RecordingUoW(RuntimeTransactionPort):
+    """Yields a sentinel connection and counts how many units of work were opened."""
+
+    def __init__(self) -> None:
+        self.begins = 0
+
+    @asynccontextmanager
+    async def begin(self):
+        self.begins += 1
+        yield _SENTINEL
+
+
+class _StateFake:
+    def __init__(self, rec: list, initial: AgentRuntimeState) -> None:
+        self._rec = rec
+        self._state = initial
+
+    async def get_state(self, agent_id):
+        return self._state
+
+    async def ensure_state(self, agent_id):
+        return self._state
+
+    async def upsert_state(self, state, *, conn=None):
+        self._rec.append(("upsert_state", conn))
+        self._state = state
+        return state
+
+
+class _LeaseFake:
+    def __init__(self, rec: list) -> None:
+        self._rec = rec
+        self._n = 0
+
+    async def get_current_lease(self, agent_id, *, conn=None):
+        self._rec.append(("get_current_lease", conn))
+        return None
+
+    async def request_lease(self, agent_id, owner_type, owner_ref, idem, *, conn=None, **kw):
+        self._rec.append(("request_lease", conn))
+        self._n += 1
+        return LeaseGranted(f"L{self._n}", None, reasons.FOCUS_LEASE_GRANTED)
+
+    async def release_lease(self, lease_id, reason_code, *, conn=None):
+        self._rec.append(("release_lease", conn))
+
+    async def revoke_lease(self, lease_id, reason_code, *, conn=None):
+        self._rec.append(("revoke_lease", conn))
+
+
+class _ActivityFake:
+    def __init__(self, rec: list, current: RuntimeActivity) -> None:
+        self._rec = rec
+        self._current = current
+
+    async def get_current_activity(self, agent_id, *, conn=None):
+        self._rec.append(("get_current_activity", conn))
+        return self._current
+
+    async def abort_activity(self, activity_id, reason_code, *, conn=None):
+        self._rec.append(("abort_activity", conn))
+        return replace(self._current, state="aborted")
+
+
+async def test_uow_conn_threaded_through_all_writes_in_4_5_order():
+    rec: list = []
+    uow = _RecordingUoW()
+    state = _StateFake(rec, _state("ambient"))
+    lease = _LeaseFake(rec)
+    activity = _ActivityFake(rec, _activity(mode="duty"))  # orphaned by ambient→cycle
+    coord = RuntimeCoordinator(state, focus_lease=lease, activity=activity, transaction=uow)
+
+    outcome = await coord.request_transition(
+        "max", "cycle", reasons.CYCLE_RECRUITED, requester_kind="external", owner_ref="run-1"
+    )
+
+    assert outcome.applied is True
+    assert uow.begins == 1  # exactly one unit of work
+    assert {conn for _, conn in rec} == {_SENTINEL}  # every write ran on the UoW conn
+    ops = [op for op, _ in rec]
+    assert ops.index("abort_activity") < ops.index("upsert_state")  # §4.5: activity before mode
+    assert ops.index("request_lease") < ops.index("abort_activity")  # lease first
+
+
+async def test_default_null_transaction_threads_conn_none():
+    rec: list = []
+    state = _StateFake(rec, _state("ambient"))
+    lease = _LeaseFake(rec)
+    coord = RuntimeCoordinator(state, focus_lease=lease)  # no transaction port → NoOp UoW
+
+    await coord.request_transition(
+        "max", "cycle", reasons.CYCLE_RECRUITED, requester_kind="external", owner_ref="run-1"
+    )
+
+    assert {conn for _, conn in rec} == {None}  # NoOp yields None → adapters acquire their own

--- a/tests/unit/runtime/test_coordinator_with_activity.py
+++ b/tests/unit/runtime/test_coordinator_with_activity.py
@@ -1,15 +1,15 @@
-"""Unit tests for SIP-0089 §4.5 (thin v1.1 seam) — coordinator RuntimeActivity action.
+"""Unit tests for SIP-0089 §4.5 — coordinator RuntimeActivity action.
 
 A mode change orphans any activity bound to the *previous* mode; the coordinator
-aborts it best-effort, post-write. Bug classes guarded:
+aborts it as part of the transition's unit of work, in §4.5 order (before the mode
+write; #244/D25). Bug classes guarded:
 - an activity left running after its mode ended (stale "current work");
 - aborting an activity that belongs to the mode being ENTERED (false abort);
-- the activity action breaking an otherwise-applied transition (it must be
-  best-effort — observability never fails a mode change);
+- an abort failure aborting the whole transition (atomicity — no "mode changed but
+  stale activity still running" state; supersedes the Phase-4 best-effort seam);
 - emitting/aborting when there is no current activity.
 
-The full §4.5 transition order + D25 single transaction are deferred to #244; these
-tests pin the v1.1 seam behavior.
+Events are emitted post-commit, so an aborted transition emits none.
 """
 
 from __future__ import annotations
@@ -63,7 +63,7 @@ class _FakeStatePort(RuntimeStatePort):
     async def get_state(self, agent_id):
         return self._rows.get(agent_id)
 
-    async def upsert_state(self, state):
+    async def upsert_state(self, state, *, conn=None):
         self._rows[state.agent_id] = state
         self.upserts.append(state)
         return state
@@ -89,7 +89,7 @@ class _FakeActivityPort(RuntimeActivityPort):
     async def start_activity(self, agent_id, **kwargs):  # unused here
         raise NotImplementedError
 
-    async def update_state(self, activity_id, state):  # unused here
+    async def update_state(self, activity_id, state, *, conn=None):  # unused here
         raise NotImplementedError
 
     async def complete_activity(self, activity_id, *, evidence_ref=None):  # unused here
@@ -98,7 +98,7 @@ class _FakeActivityPort(RuntimeActivityPort):
     async def fail_activity(self, activity_id, reason_code):  # unused here
         raise NotImplementedError
 
-    async def abort_activity(self, activity_id, reason_code):
+    async def abort_activity(self, activity_id, reason_code, *, conn=None):
         if self.abort_raises:
             raise RuntimeError("boom")
         self.aborted.append((activity_id, reason_code))
@@ -106,7 +106,7 @@ class _FakeActivityPort(RuntimeActivityPort):
         self._current = None
         return replace(cur, state="aborted") if cur is not None else None
 
-    async def get_current_activity(self, agent_id):
+    async def get_current_activity(self, agent_id, *, conn=None):
         return self._current
 
 
@@ -172,21 +172,30 @@ async def test_no_current_activity_is_a_noop():
     assert events.RUNTIME_ACTIVITY_ABORTED not in pub.names()
 
 
-async def test_activity_abort_failure_does_not_break_transition():
-    """Bug class (best-effort): the activity action is observability — a failure
-    aborting the activity must NOT fail an already-applied mode transition. The
-    mode is written, the transition reports applied, no abort event is emitted."""
+async def test_activity_abort_failure_aborts_the_transition():
+    """Bug class (§4.5/D25): the activity action is now part of the atomic unit and
+    runs BEFORE the mode write, so a failure aborting the orphaned activity aborts
+    the whole transition — the mode is NOT written and nothing is emitted. This
+    supersedes the Phase-4 best-effort seam (the coordinator can't make the abort
+    best-effort inside a unit of work without a savepoint, which would leak the
+    driver into the domain) — and it is strictly *safer*: there is no "mode changed
+    but stale activity still running" state, because either both happen or neither."""
     state = _FakeStatePort(_state(mode="cycle"))
     pub = _RecordingPublisher()
     act = _FakeActivityPort(_activity(mode="cycle"), abort_raises=True)
     coord = RuntimeCoordinator(state, events_publisher=pub, activity=act)
 
-    outcome = await coord.request_transition(
-        "max", "ambient", reasons.CYCLE_COMPLETED, requester_kind="coordinator", owner_ref="cyc-1"
-    )
+    with pytest.raises(RuntimeError, match="boom"):
+        await coord.request_transition(
+            "max",
+            "ambient",
+            reasons.CYCLE_COMPLETED,
+            requester_kind="coordinator",
+            owner_ref="cyc-1",
+        )
 
-    assert outcome.applied is True and state.upserts[-1].mode == "ambient"
-    assert events.RUNTIME_ACTIVITY_ABORTED not in pub.names()  # abort failed → no event
+    assert state.upserts == []  # mode never written — the abort precedes it (§4.5)
+    assert pub.names() == []  # nothing committed → no events
 
 
 async def test_no_activity_port_keeps_prior_behavior():

--- a/tests/unit/runtime/test_coordinator_with_lease.py
+++ b/tests/unit/runtime/test_coordinator_with_lease.py
@@ -61,7 +61,7 @@ class _FakeStatePort(RuntimeStatePort):
     async def get_state(self, agent_id):
         return self._rows.get(agent_id)
 
-    async def upsert_state(self, state):
+    async def upsert_state(self, state, *, conn=None):
         if self.fail_upsert:
             raise RuntimeError("simulated mode-write failure")
         self._rows[state.agent_id] = state
@@ -118,6 +118,7 @@ class _FakeFocusLease(FocusLeasePort):
         recall_policy="graceful",
         preemption_grace=timedelta(),
         wait=False,
+        conn=None,
     ):
         cur = self._active.get(agent_id)
         if cur is not None:
@@ -150,15 +151,15 @@ class _FakeFocusLease(FocusLeasePort):
     async def renew_lease(self, lease_id, *, expires_at=None):
         return True
 
-    async def release_lease(self, lease_id, reason_code):
+    async def release_lease(self, lease_id, reason_code, *, conn=None):
         self.released.append(lease_id)
         self._drop(lease_id)
 
-    async def revoke_lease(self, lease_id, reason_code):
+    async def revoke_lease(self, lease_id, reason_code, *, conn=None):
         self.revoked.append(lease_id)
         self._drop(lease_id)
 
-    async def get_current_lease(self, agent_id):
+    async def get_current_lease(self, agent_id, *, conn=None):
         return self._active.get(agent_id)
 
     def _drop(self, lease_id):

--- a/tests/unit/runtime/test_scheduler.py
+++ b/tests/unit/runtime/test_scheduler.py
@@ -104,7 +104,7 @@ class _FakeStatePort(RuntimeStatePort):
     async def get_state(self, agent_id):
         return self._row
 
-    async def upsert_state(self, state):
+    async def upsert_state(self, state, *, conn=None):
         self._row = state
         self.upserts.append(state)
         return state


### PR DESCRIPTION
Completes the SIP-0089 runtime arc: the coordinator's transition now applies **lease → activity → mode as one Postgres transaction** (§4.5 order, D25), so a partial failure aborts rather than relying on best-effort compensation. Unblocked by #233 (which routed recruitment through the coordinator).

Closes #244.

## Design (4 slices)

1. **UoW port + adapter + conn threading** — new `RuntimeTransactionPort` (`begin()` yields an opaque, transaction-bound connection; driver-agnostic so the port stays adapter-free, D26) + `PostgresRuntimeTransaction`. Threaded an optional `conn=` through the 7 methods the coordinator uses (`upsert_state`; lease `get_current`/`request`/`revoke`/`release`; activity `get_current`/`update_state`/`abort`) via a shared `acquire(pool, conn)` helper. **Additive — `conn=None` = today's behavior.**
2. **Coordinator wrapping + §4.5 reorder** — `_apply_transition` wraps arbitration + activity abort + mode write in `transaction.begin()`, reordered so the **activity abort precedes the mode write**. Events emit **only after commit**. Optional `transaction` param defaults to a `_NullTransaction` (yields `conn=None`) → the no-transaction path is a strict no-op. Compensation is now belt-and-suspenders (always release the acquired lease on failure — harmless no-op when a real UoW already rolled it back).
3. **Composition root (D16)** — `create_runtime_coordinator` builds one `PostgresRuntimeTransaction` and injects it, so the single shared mode-writer the executor + scheduler both drive is transactional.
4. **Docs** — coordinator docstring: D25 realized.

## ⚠️ Behavioral change (intended, documented)

The orphaned-activity abort was a Phase-4 *best-effort post-write* seam. Now that it's part of the atomic unit and runs **before** the mode write, an abort **failure aborts the transition** instead of being swallowed. This is strictly *safer* — there's no "mode changed but stale activity still running" state — and the coordinator can't make it best-effort inside a UoW without a savepoint (which would leak the driver into the domain). The v1.1 activity path is effectively unexercised, so this is practically inert today. Captured in the updated `test_activity_abort_failure_aborts_the_transition` + docstrings.

## Acceptance (per the issue)

- ✅ §4.5 order holds: a failure at step 6 (mode write) rolls back the lease acquired in step 4 **and** the activity transition in step 5 — proven against **live Postgres** in `tests/integration/runtime/test_coordinator_transaction_integration.py::test_mode_write_failure_rolls_back_lease_and_activity`.
- ✅ No regression on the common `activity=None` / no-current-activity paths (full unit suite green).

## Tests

- **Unit:** `test_coordinator_transaction.py` — conn threads through all writes in §4.5 order; the NoOp default threads `conn=None`. Updated the activity-abort test to the new semantics. All 7 port fakes thread `conn`.
- **Integration (live Postgres):** mode-write failure rolls back lease **and** activity; positive control commits lease + mode together. Both pass.
- Full regression: **4490 passed / 1 skipped**.

## Also in this branch
- A drive-by from #173: `dispatched_flow_executor.py` comment `spark-squad-with-builder` → `full` (the Spark lane flagged it for the Mac lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)