### PR TITLE
fix(#296): materialize frontend config/entry files into the QA build workspace

### DIFF
--- a/src/squadops/capabilities/dev_capabilities.py
+++ b/src/squadops/capabilities/dev_capabilities.py
@@ -44,6 +44,11 @@ class DevelopmentCapability:
     test_file_patterns: tuple[str, ...]
     max_completion_tokens: int = 4000
     test_timeout_seconds: int = 60
+    # Config/entry files (by basename) needed to *build/test* the deliverable but
+    # excluded by ``source_filter`` (e.g. package.json, vite.config.js, index.html).
+    # Materialized into the QA build/test workspace so the frontend build check
+    # (#290) and vitest actually run instead of skipping on "no package.json" (#296).
+    build_support_files: tuple[str, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -201,6 +206,14 @@ DEV_CAPABILITIES: dict[str, DevelopmentCapability] = {
             "*.spec.js",
             "*.spec.jsx",
         ),
+        build_support_files=(
+            "package.json",
+            "vite.config.js",
+            "vite.config.ts",
+            "index.html",
+            "tsconfig.json",
+            "tsconfig.node.json",
+        ),
         max_completion_tokens=8000,
         test_timeout_seconds=120,
     ),
@@ -304,6 +317,14 @@ DEV_CAPABILITIES: dict[str, DevelopmentCapability] = {
             "*.test.jsx",
             "*.spec.js",
             "*.spec.jsx",
+        ),
+        build_support_files=(
+            "package.json",
+            "vite.config.js",
+            "vite.config.ts",
+            "index.html",
+            "tsconfig.json",
+            "tsconfig.node.json",
         ),
         max_completion_tokens=12000,
         test_timeout_seconds=180,

--- a/src/squadops/capabilities/handlers/cycle_tasks.py
+++ b/src/squadops/capabilities/handlers/cycle_tasks.py
@@ -2178,16 +2178,27 @@ class QATestHandler(_CycleTaskHandler):
         return None
 
     def _get_source_artifacts(self, inputs: dict[str, Any]) -> dict[str, str]:
-        """Get source artifacts filtered by capability (D4, D9)."""
+        """Get source artifacts filtered by capability (D4, D9).
+
+        Includes source files (by ``source_filter`` extension, non-test) AND the
+        capability's ``build_support_files`` (config/entry files matched by
+        basename — package.json, vite.config.js, index.html, …). Without the
+        support files the QA build/test workspace can't build the deliverable and
+        the frontend build check (#290) + vitest skip on "no package.json" (#296).
+        """
         capability = get_capability(
             inputs.get("resolved_config", {}).get("dev_capability", "python_cli")
         )
         contents = inputs.get("artifact_contents", {})
+        support = set(getattr(capability, "build_support_files", ()))
         sources = {}
         for key, value in contents.items():
-            if any(key.endswith(ext) for ext in capability.source_filter):
-                if not _is_test_file(key, capability.test_file_patterns):
-                    sources[key] = value
+            basename = key.replace("\\", "/").rsplit("/", 1)[-1]
+            is_source = any(
+                key.endswith(ext) for ext in capability.source_filter
+            ) and not _is_test_file(key, capability.test_file_patterns)
+            if is_source or basename in support:
+                sources[key] = value
         return sources
 
     @staticmethod

--- a/tests/unit/capabilities/test_source_artifact_materialization.py
+++ b/tests/unit/capabilities/test_source_artifact_materialization.py
@@ -1,0 +1,88 @@
+"""QA source-artifact materialization incl. build-support files (#296).
+
+Bug this guards: package.json / index.html / vite.config.js were excluded from
+the QA build/test workspace (``source_filter`` is only .py/.js/.jsx), so the
+frontend build check (#290) and vitest skipped on "no package.json" and a
+non-runnable frontend shipped undetected (cyc_8617e0975ed5).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.dev_capabilities import (
+    DEV_CAPABILITIES,
+    TEST_FRAMEWORK_BOTH,
+    TEST_FRAMEWORK_VITEST,
+    get_capability,
+)
+from squadops.capabilities.handlers.cycle_tasks import QATestHandler
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_CONTENTS = {
+    "backend/main.py": "app = 1",
+    "frontend/src/main.jsx": "import App from './App'",
+    "frontend/package.json": "{}",
+    "frontend/vite.config.js": "export default {}",
+    "frontend/index.html": "<div id='root'></div>",
+    "frontend/tsconfig.json": "{}",
+    "backend/tests/test_api.py": "def test_x(): pass",  # test file -> excluded
+    "frontend/src/__tests__/App.test.jsx": "test('a', () => {})",  # test file -> excluded
+    "qa_handoff.md": "# doc",  # non-source doc -> excluded
+}
+
+
+def _inputs(dev_capability: str) -> dict:
+    return {
+        "resolved_config": {"dev_capability": dev_capability},
+        "artifact_contents": dict(_CONTENTS),
+    }
+
+
+class TestSourceArtifactMaterialization:
+    def test_build_support_files_materialized(self):
+        sources = QATestHandler()._get_source_artifacts(_inputs("fullstack_fastapi_react"))
+        for f in (
+            "frontend/package.json",
+            "frontend/vite.config.js",
+            "frontend/index.html",
+            "frontend/tsconfig.json",
+        ):
+            assert f in sources, f"{f} must be materialized so the build check can run (#296)"
+
+    def test_source_files_still_included(self):
+        sources = QATestHandler()._get_source_artifacts(_inputs("fullstack_fastapi_react"))
+        assert "backend/main.py" in sources
+        assert "frontend/src/main.jsx" in sources
+
+    def test_test_and_doc_files_excluded(self):
+        sources = QATestHandler()._get_source_artifacts(_inputs("fullstack_fastapi_react"))
+        assert "backend/tests/test_api.py" not in sources
+        assert "frontend/src/__tests__/App.test.jsx" not in sources
+        assert "qa_handoff.md" not in sources
+
+    def test_backend_only_capability_has_no_frontend_support(self):
+        """A python-only capability shouldn't drag in frontend config files."""
+        sources = QATestHandler()._get_source_artifacts(_inputs("python_cli"))
+        assert "backend/main.py" in sources
+        assert "frontend/package.json" not in sources
+
+
+def test_frontend_capabilities_declare_build_support():
+    """Every frontend-bearing capability must list the files needed to build,
+    else #290/vitest silently skip on "no package.json"."""
+    frontend_caps = [
+        c
+        for c in DEV_CAPABILITIES.values()
+        if c.test_framework in (TEST_FRAMEWORK_VITEST, TEST_FRAMEWORK_BOTH)
+    ]
+    assert frontend_caps, "expected at least one vitest/both capability"
+    for cap in frontend_caps:
+        assert "package.json" in cap.build_support_files, f"{cap.name} missing package.json"
+        assert "index.html" in cap.build_support_files, f"{cap.name} missing index.html"
+
+
+def test_get_capability_default_build_support_empty():
+    """Non-frontend capabilities default to no build-support files."""
+    assert get_capability("python_cli").build_support_files == ()


### PR DESCRIPTION
Closes #296. Follow-up that makes the #290 frontend build check actually function.

## Problem (found live, cyc_8617e0975ed5)
The #290 frontend build check + the pre-existing vitest both **skip** with `No package.json found in frontend`, even though `package.json` is a generated artifact — so a **non-runnable frontend shipped** (`main.jsx` imports `./App`, but no `App.jsx`) undetected.

## Root cause
`QATestHandler._get_source_artifacts` materializes the QA workspace filtered by `capability.source_filter` (`.py`/`.js`/`.jsx`), which **excludes** `package.json`, `vite.config.js`, `index.html`, `tsconfig.json`. Without them, `npm install`/`vite build`/`vitest` bail as a skip. (The files *do* reach qa.test — its executor filter is `by_type: [source, config]`, and `.html`→source, `.json`/`package.json`/`vite.config.js`→config — so this is purely the handler's materialization filter. Spark-clean; no executor change.)

## Fix
- New `DevelopmentCapability.build_support_files` (config/entry files by basename), set on the **fullstack** and **react/vitest** capabilities: `package.json`, `vite.config.{js,ts}`, `index.html`, `tsconfig{,.node}.json`.
- `_get_source_artifacts` now includes `build_support_files` (matched by basename) alongside source files. **Did not** widen `source_filter` globally (it drives other logic).

## Tests
Build-support files materialized; source files still included; test/doc files still excluded; backend-only capability unaffected; regression guard that *every* frontend-bearing capability declares the build-support files. ruff + quality lint clean; 2450 capabilities+cycles green.

## Post-merge confirmation (not a blocker to closing)
The `source_filter` exclusion is fully fixed here. A batched live fullstack cycle (after the build-quality PRs + a rebuild) will confirm #290 end-to-end — `test_report.md` should show the frontend build **ran** (a build result, not `No package.json found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
