### PR TITLE
feat(cycles): SIP-0095 Cycle Create Preflight — Phase 1 (scaffold + capability check)

### DIFF
--- a/docs/plans/SIP-0095-cycle-create-preflight-plan.md
+++ b/docs/plans/SIP-0095-cycle-create-preflight-plan.md
@@ -4,7 +4,7 @@
 **Implements:** `sips/accepted/SIP-0095-Cycle-Create-Preflight.md` (accepted 2026-07-01)
 **Lanes:** Macbook (capability half + route wiring) · Spark (model-availability half + doctor parity)
 
-This plan resolves SIP-0095's two open questions and reconciles the SIP against the actual code, then lays out the build. **Read §1–§3 first — they contain one material scope correction to the accepted SIP that needs a nod before implementation.**
+This plan resolves SIP-0095's two open questions and reconciles the SIP against the actual code, then lays out the build. **§2.1 carried a material scope correction (the builder case is not create-time-checkable); option A is confirmed (2026-07-01) and SIP §6.1 + §9 AC#4 have been amended to match. The materialized-plan/gate half is tracked separately as #295.**
 
 ---
 
@@ -47,7 +47,7 @@ Therefore **SIP-0095 §9 acceptance criterion #4 ("a build-enabled cycle on a bu
 - The **create-time** capability check covers **static workload→role satisfiability** only (the table above). It catches "you requested a `WRAPUP` workload but your squad has no `data` role," etc.
 - The **materialized-plan** capability mismatch (the builder case) stays with `validate_against_profile`. It already runs at dispatch; **optionally** hoisting it earlier — to the `progress_plan_review` gate, right after framing authors the plan and before implementation dispatch — is the real "catch #172 sooner" win, but it is a **distinct seam from create-time** and arguably its own small follow-up (not this SIP's create-time scope).
 
-**Decision for you:** (A) ship SIP-0095 as create-time-only (static role + model) and file the gate-time hoist of `validate_against_profile` as a separate follow-up to fully close #172; or (B) include the gate-time hoist as Phase 5 of this plan. I recommend **(A)** — it keeps SIP-0095 cohesively "create-time," and the gate hoist is a clean, separately-reviewable change. This plan is written for (A) with (B) sketched as an optional appendix phase.
+**Decision: option (A), confirmed 2026-07-01.** SIP-0095 ships **create-time-only** (static role + model). The gate-time hoist of `validate_against_profile` — the materialized-plan/builder half of #172 — is tracked as a **separate follow-up, [#295](https://github.com/backspring-labs/squad-ops/issues/295)**, and is **out of this plan's scope**. SIP §6.1 and §9 AC#4 have been amended to match.
 
 ---
 
@@ -135,7 +135,7 @@ Annotate the `cycles.py` seam with a one-line comment marking the Mac wiring vs 
 2. **Model decision + doctor (Spark)** — `model_availability_decision`; doctor check; unit tests.
 3. **Route wiring (Mac)** — call both in `create_cycle`; 422 mapping; block path.
 4. **Warning surface (Mac)** — response DTO `warnings` + persist on cycle metadata + CLI echo on success.
-5. *(Optional, pending §2.1 decision (B))* — hoist `validate_against_profile` to the `progress_plan_review` gate to catch the materialized-plan/builder mismatch earlier than dispatch.
+*(Out of scope — tracked as #295: hoist `validate_against_profile` to the `progress_plan_review` gate to catch the materialized-plan/builder mismatch earlier than dispatch. Not part of SIP-0095 per option A.)*
 
 ---
 
@@ -155,7 +155,7 @@ Annotate the `cycles.py` seam with a one-line comment marking the Mac wiring vs 
 - **422 mapping:** if `handle_cycle_error` currently maps `CycleError` → 400, either add a `PreflightRejected` subclass → 422 or adjust the mapping; verify no other `CycleError` caller depends on the current status.
 - **Warning-surface persistence:** confirm the cycle record has a metadata field (or `applied_defaults`-adjacent slot) to carry `preflight_warnings` without a schema migration; if not, a small additive migration (Mac lane, migration range 11xx).
 - **Model-name exactness:** exact tag matching (SIP §6.2) means `config/squad-profiles.yaml` model tags must match Ollama's reported tags exactly; a mismatch is a *clear config error* by design, but worth a one-time audit of the current profiles against a pulled list.
-- **Scope creep into the gate:** §2.1 decision (B) would pull the plan-review gate into scope — keep it out unless you choose (B).
+- **Scope creep into the gate:** the plan-review-gate hoist (#295) is deliberately out of scope — keep it out of this plan; it's a separately-reviewable follow-up.
 
 ---
 
@@ -163,6 +163,6 @@ Annotate the `cycles.py` seam with a one-line comment marking the Mac wiring vs 
 
 1. **OQ1:** warnings surface on create response + CLI echo + persisted cycle metadata; defer event/Continuum.
 2. **OQ2:** static workload→role map as tabled; **`build_tasks`/`IMPLEMENTATION` require no static role** (builder-optional).
-3. **Scope correction:** SIP §9 AC#4 revised — the builder/materialized-plan case is a dispatch/gate concern (`validate_against_profile`), not create-time. **Recommend option (A):** SIP-0095 ships create-time-only; the gate-time hoist is a separate follow-up.
+3. **Scope correction (option A, confirmed):** SIP §6.1 + §9 AC#4 amended — the builder/materialized-plan case is a dispatch/gate concern (`validate_against_profile`), not create-time. SIP-0095 ships create-time-only; the gate-time hoist is tracked as **#295**.
 
-Awaiting your review before implementation begins.
+Plan finalized for option A. Ready to implement Phase 1 on approval.

--- a/docs/plans/SIP-0095-cycle-create-preflight-plan.md
+++ b/docs/plans/SIP-0095-cycle-create-preflight-plan.md
@@ -1,0 +1,168 @@
+# SIP-0095 Cycle Create Preflight — Implementation Plan
+
+**Status:** draft (for review before implementation) · **Created:** 2026-07-01 · **Branch:** `feature/sip-0095-cycle-create-preflight`
+**Implements:** `sips/accepted/SIP-0095-Cycle-Create-Preflight.md` (accepted 2026-07-01)
+**Lanes:** Macbook (capability half + route wiring) · Spark (model-availability half + doctor parity)
+
+This plan resolves SIP-0095's two open questions and reconciles the SIP against the actual code, then lays out the build. **Read §1–§3 first — they contain one material scope correction to the accepted SIP that needs a nod before implementation.**
+
+---
+
+## 1. Open Question 1 — where to surface *unverifiable* warnings
+
+**Resolved:** the operator-visible surfaces are **(a) the create API response, (b) the CLI echo after a successful create, and (c) a durable warning persisted on the cycle record** (visible in `squadops cycles show`). Runtime-event and Continuum surfaces are **explicitly deferred** (optional follow-ups), not built here.
+
+**Why this set:**
+- (a) + (b) cover the operator *at create time* — already SIP-mandated (§6.3).
+- (c) covers the *post-hoc investigator*: when a run later misbehaves, `cycles show` reveals "model availability was unverifiable at create time," turning a silent condition into a durable, queryable signal — the whole "make it legible" goal.
+- Deferring events/Continuum honors the SIP-0089 §2.5 discipline (reuse existing surfaces, don't mint a new EventType or UI plumbing for a small SIP). If a runtime-event surface is wanted later, it rides the existing event bus as a follow-up.
+
+**Implication:** the create-cycle response DTO gains an optional `warnings: list[str]` (or `list[{code,message,severity}]`) field; warnings are stored on the cycle record (a `preflight_warnings` entry in existing cycle metadata — no new table). Warning severity is **`warning`**, never `info` (§6.3).
+
+---
+
+## 2. Open Question 2 — the `applied_defaults` → required-role map
+
+**Resolved (from tracing `cycles/task_plan.py`).** The create-time capability check evaluates the **static** required-role sets implied by the requested workloads:
+
+| Requested work | Required roles (create-time-checkable) | Source |
+|---|---|---|
+| workload `FRAMING` | `{strat, dev, qa, data, lead}` (`REQUIRED_PLAN_ROLES`) | `task_plan.py:278` |
+| workload `REFINEMENT` | `{lead, qa}` (`REQUIRED_REFINEMENT_ROLES`) | `:285` |
+| workload `EVALUATION` | `{strat, dev, qa, data, lead}` | `:296` |
+| workload `WRAPUP` | `{data, qa, lead}` (`REQUIRED_WRAPUP_ROLES`) | `:299` |
+| workload `IMPLEMENTATION` | **none** (builder-optional; graceful) | `:289–294` |
+| legacy `plan_tasks` (default true) | `{strat, dev, qa, data, lead}` | `:324–325` |
+| legacy `build_tasks` | **none** (builder-optional; graceful) | `:312–322` |
+
+The check reads `run.workload_type` (per-run, forming the sequence across a multi-run cycle) or, when absent, the legacy `applied_defaults.plan_tasks` / `build_tasks` flags — the same dispatch (`generate_task_plan:363`) uses.
+
+### 2.1 Scope correction to SIP-0095 (needs your nod)
+
+Tracing the code contradicts one SIP claim: **`build_tasks` / `IMPLEMENTATION` do NOT statically require a `builder` role.** `_has_builder_role` selects the builder-vs-non-builder step path (`task_plan.py:290, 313`); a builder-less squad gracefully runs the **non-builder** build steps. That graceful fallback is *intentional*, not a bug.
+
+Therefore **SIP-0095 §9 acceptance criterion #4 ("a build-enabled cycle on a builder-less squad is blocked at create time") is not implementable as written and should be revised.** The `builder.assemble`-on-a-builder-less-squad failure (#172's live case) comes from a **materialized** implementation plan (authored *during* the framing run), and is validated by `ImplementationPlan.validate_against_profile` — which is already wired, but at **dispatch** (`task_plan.py:492`, inside `generate_task_plan`), not at create time. At create time there is no plan to check, so this class of mismatch is *structurally* not a create-time gate.
+
+**Recommended revision (baked into this plan; confirm in review):**
+- The **create-time** capability check covers **static workload→role satisfiability** only (the table above). It catches "you requested a `WRAPUP` workload but your squad has no `data` role," etc.
+- The **materialized-plan** capability mismatch (the builder case) stays with `validate_against_profile`. It already runs at dispatch; **optionally** hoisting it earlier — to the `progress_plan_review` gate, right after framing authors the plan and before implementation dispatch — is the real "catch #172 sooner" win, but it is a **distinct seam from create-time** and arguably its own small follow-up (not this SIP's create-time scope).
+
+**Decision for you:** (A) ship SIP-0095 as create-time-only (static role + model) and file the gate-time hoist of `validate_against_profile` as a separate follow-up to fully close #172; or (B) include the gate-time hoist as Phase 5 of this plan. I recommend **(A)** — it keeps SIP-0095 cohesively "create-time," and the gate hoist is a clean, separately-reviewable change. This plan is written for (A) with (B) sketched as an optional appendix phase.
+
+---
+
+## 3. What this plan delivers
+
+A create-time preflight that, before a cycle is persisted or dispatched:
+- **blocks** when the resolved squad snapshot is missing a role the requested workloads statically require (§2);
+- **blocks** when a profile-named model is definitively not pulled on the backend;
+- **warns-and-allows** when model availability is unverifiable, surfaced per §1;
+- returns **HTTP 422** with an actionable, standardized message;
+- shares the model check with `squadops doctor`.
+
+Dispatch-time validation (role check + `validate_against_profile`) is untouched and remains the deeper net (SIP §5).
+
+---
+
+## 4. Design
+
+### 4.1 New module `src/squadops/cycles/preflight.py` (pure)
+
+```python
+@dataclass(frozen=True)
+class Finding:            # one check outcome
+    code: str             # e.g. "missing_role", "model_unavailable", "model_unverifiable"
+    severity: str         # "block" | "warning"
+    message: str          # standardized, actionable (SIP §7)
+
+@dataclass(frozen=True)
+class PreflightDecision:  # the aggregate "decision summary" (SIP §6)
+    blocking: tuple[Finding, ...]
+    warnings: tuple[Finding, ...]
+    @property
+    def rejected(self) -> bool: return bool(self.blocking)
+
+def required_roles_decision(profile, workload_types) -> PreflightDecision   # pure (Mac)
+def model_availability_decision(profile, pulled_models: list[str] | None) -> PreflightDecision   # pure (Spark)
+def combine(*decisions) -> PreflightDecision   # any block ⇒ rejected; warnings ride alongside (SIP §6)
+```
+
+Pure over already-fetched inputs (mirrors `reserve_buffer_decision`). Callers do the I/O. Importable by both the API route and the CLI `doctor` with no D26 violation (`cycles/*` is domain).
+
+- `required_roles_decision`: derive `profile_roles = {a.role for a in profile.agents if a.enabled}`, map each requested workload to its `REQUIRED_*` set (§2), block on any missing role. Reuses the constants from `cycles/models.py:181`.
+- `model_availability_decision`: `pulled_models is None` → one `warning` finding (`model_unverifiable`); else each enabled agent model **exact-matched** against `pulled_models` (SIP §6.2 — no prefix/family inference), absent → `block`.
+
+### 4.2 Create-route seam (`api/routes/cycles/cycles.py::create_cycle`, Mac)
+
+Insert after `resolve_snapshot` (line 50, gives `profile.agents`) and before first persist (line ~104):
+
+```python
+decision = combine(
+    required_roles_decision(profile, _requested_workloads(body)),
+    model_availability_decision(profile, await _pulled_models_or_none()),
+)
+if decision.rejected:
+    raise CycleError(decision.summary())          # → handle_cycle_error → HTTP 422
+warnings = [f.message for f in decision.warnings]  # attached to response + persisted (§1)
+```
+
+- `_pulled_models_or_none()` calls `LLMPort.refresh_models()`, returning `None` when the port is unconfigured/unreachable (the unverifiable path).
+- 422: confirm `handle_cycle_error` maps `CycleError` (or a `PreflightRejected(CycleError)` subclass) to 422; add the mapping if it currently maps to 400.
+- `warnings` flow into the response DTO and the persisted cycle metadata (§1).
+
+### 4.3 doctor parity (`bootstrap/setup/checks.py`, Spark)
+
+Add a check that feeds the squad-profile models + the pulled list into `model_availability_decision` and renders each `Finding` as a `CheckResult`. Reconciles the current divergence (doctor uses `subprocess ollama list` + bootstrap profile) by sharing the *judgment*, not the fetch.
+
+---
+
+## 5. Cross-lane sequencing (PR order)
+
+The two lanes touch `api/routes/cycles/*` and `cycles/*`; sequence to keep merges mechanical (SIP §12, plan §5.6 of the 1.2.0 plan):
+
+1. **Mac — `cycles/preflight.py` scaffold** (the dataclasses + `combine` + `required_roles_decision`). Pure, no route change. Lands first; Spark rebases onto it.
+2. **Spark — `model_availability_decision`** added to `cycles/preflight.py` (new function, same module — no collision) + the doctor check. Independent of the route.
+3. **Mac — create-route wiring** (`cycles.py`) calling `combine(required_roles_decision, model_availability_decision)`. Depends on 1 + 2 being on main.
+4. **Mac — response/persistence** of warnings (DTO + cycle metadata) + 422 mapping.
+
+Annotate the `cycles.py` seam with a one-line comment marking the Mac wiring vs the Spark helper, per the §5.6 convention.
+
+---
+
+## 6. Phases
+
+1. **Preflight module + capability decision (Mac)** — `preflight.py`, `required_roles_decision`, `combine`; unit tests (§7). No behavior change yet (nothing calls it).
+2. **Model decision + doctor (Spark)** — `model_availability_decision`; doctor check; unit tests.
+3. **Route wiring (Mac)** — call both in `create_cycle`; 422 mapping; block path.
+4. **Warning surface (Mac)** — response DTO `warnings` + persist on cycle metadata + CLI echo on success.
+5. *(Optional, pending §2.1 decision (B))* — hoist `validate_against_profile` to the `progress_plan_review` gate to catch the materialized-plan/builder mismatch earlier than dispatch.
+
+---
+
+## 7. Testing (maps to SIP §13 + the §2.1 correction)
+
+- **Unit — capability:** each workload's `REQUIRED_*` set; missing role → `block` naming the role; satisfied → allow; **`build_tasks`/`IMPLEMENTATION` on a builder-less squad → allow** (graceful fallback — the corrected behavior, *not* a block).
+- **Unit — model:** reachable + absent → block (names the model); `None` → `warning` (unverifiable); all present → allow; **tag mismatch** (`qwen2.5:7b` vs pulled `qwen2.5:7b-instruct`) → block (exact matching, SIP §6.2).
+- **Unit — combine:** any block ⇒ rejected even with warnings present; warnings ride alongside without altering the reject reason.
+- **Integration (create route, real persistence):** missing role → 422, **no cycle row, no dispatch**; missing model → 422, no row/dispatch; **unverifiable → cycle IS created + warning on response and persisted**; happy path → 201 unchanged.
+- **Defense-in-depth:** dispatch-time `validate_against_profile` still rejects a materialized-plan mismatch the static preflight can't see (proves addition, not replacement).
+- **doctor:** flags a squad-profile model not pulled; passes when all present.
+
+---
+
+## 8. Risks / residual
+
+- **422 mapping:** if `handle_cycle_error` currently maps `CycleError` → 400, either add a `PreflightRejected` subclass → 422 or adjust the mapping; verify no other `CycleError` caller depends on the current status.
+- **Warning-surface persistence:** confirm the cycle record has a metadata field (or `applied_defaults`-adjacent slot) to carry `preflight_warnings` without a schema migration; if not, a small additive migration (Mac lane, migration range 11xx).
+- **Model-name exactness:** exact tag matching (SIP §6.2) means `config/squad-profiles.yaml` model tags must match Ollama's reported tags exactly; a mismatch is a *clear config error* by design, but worth a one-time audit of the current profiles against a pulled list.
+- **Scope creep into the gate:** §2.1 decision (B) would pull the plan-review gate into scope — keep it out unless you choose (B).
+
+---
+
+## 9. Summary of decisions baked in (for review)
+
+1. **OQ1:** warnings surface on create response + CLI echo + persisted cycle metadata; defer event/Continuum.
+2. **OQ2:** static workload→role map as tabled; **`build_tasks`/`IMPLEMENTATION` require no static role** (builder-optional).
+3. **Scope correction:** SIP §9 AC#4 revised — the builder/materialized-plan case is a dispatch/gate concern (`validate_against_profile`), not create-time. **Recommend option (A):** SIP-0095 ships create-time-only; the gate-time hoist is a separate follow-up.
+
+Awaiting your review before implementation begins.

--- a/sips/accepted/SIP-0095-Cycle-Create-Preflight.md
+++ b/sips/accepted/SIP-0095-Cycle-Create-Preflight.md
@@ -74,8 +74,8 @@ A deterministic validation gate applied before a cycle is persisted or dispatche
 
 Capability satisfiability is evaluated through the **required role sets implied by the requested workloads** — this SIP validates *static workload-role* satisfiability, not a dynamic per-task capability-registry proof. It does not attempt to prove that every eventually-materialized task capability has a handler; **dispatch-time plan validation remains the deeper defense.**
 
-- The gate maps each requested workload (and workload-expanding defaults) to its required role set and blocks when the enabled squad roster is missing any required role.
-- **Workload-expanding defaults MUST be accounted for, not just the bare workload sequence** — in particular, **build-task paths require a builder-capable squad** (the motivating `builder.assemble` case). A build-enabled cycle on a builder-less squad MUST be blocked at create time.
+- The gate maps each requested workload to its required role set and blocks when the enabled squad roster is missing any required role.
+- **The `builder` / materialized-plan case is *not* a create-time check** *(corrected during implementation planning — see `docs/plans/SIP-0095-cycle-create-preflight-plan.md` §2.1)*. `build_tasks` / `IMPLEMENTATION` impose **no** static builder requirement: a builder-less squad gracefully runs the non-builder build path, by design. The `builder.assemble`-on-a-builder-less-squad mismatch (#172's live case) comes from a *materialized* plan authored *during* the run — there is no plan at create time — and is validated by `ImplementationPlan.validate_against_profile` at dispatch; hoisting that check to the plan-review gate is tracked as **#295**. This SIP's create-time capability check is therefore **static workload-role satisfiability only**.
 
 ### 6.2 Model availability (#224)
 
@@ -123,7 +123,7 @@ If the backend cannot be queried, the result is *unverifiable* and MUST be surfa
 1. A rejected cycle-create request **creates no cycle row**.
 2. A rejected cycle-create request **creates no dispatch request** and **starts no background execution**.
 3. The operator receives a **clear, actionable error** naming the missing role or the missing model (per §7).
-4. **Build-task expansion is honored:** a build-enabled cycle on a builder-less squad is blocked at create time (§6.1).
+4. **Builder/materialized-plan mismatch is correctly out of create-time scope (§6.1):** a build-enabled cycle on a builder-less squad is **not** blocked at create time (the non-builder build path is a valid graceful fallback); the `builder.assemble`-type mismatch is caught by dispatch-time `validate_against_profile`, and hoisting it to the plan-review gate is tracked as #295.
 5. **Unverifiable ≠ blocked:** when the backend is unreachable, the cycle is still created and the operator is warned (§6.3) — creation is not blocked on missing evidence.
 6. **Unverifiable warning is visible:** when creation succeeds with unverifiable model availability, the API response includes a warning-level message **and the CLI visibly prints it** — the warning cannot be returned-but-invisible.
 7. **Doctor parity:** the same model-availability finding enforced at create time is visible through `doctor` when `doctor` has enough backend visibility to evaluate it.

--- a/src/squadops/cycles/models.py
+++ b/src/squadops/cycles/models.py
@@ -186,6 +186,20 @@ REQUIRED_REFINEMENT_ROLES = frozenset({"lead", "qa"})
 # Required roles for wrap-up workloads. Wrap-up is data + QA + lead. (SIP-0080 §7.1)
 REQUIRED_WRAPUP_ROLES = frozenset({"data", "qa", "lead"})
 
+# Static role requirement per workload type — the single source of truth shared by
+# dispatch-time step resolution (task_plan._resolve_workload_steps) and the create-time
+# preflight (cycles.preflight.required_roles_decision), so the two never drift (SIP-0095 §2,
+# R3). IMPLEMENTATION carries NO static role requirement: a builder-less squad gracefully runs
+# the non-builder build path by design — the builder/materialized-plan mismatch is a
+# dispatch/gate concern (#295), not a create-time check.
+WORKLOAD_REQUIRED_ROLES: dict[str, frozenset[str]] = {
+    WorkloadType.FRAMING: REQUIRED_PLAN_ROLES,
+    WorkloadType.REFINEMENT: REQUIRED_REFINEMENT_ROLES,
+    WorkloadType.EVALUATION: REQUIRED_PLAN_ROLES,
+    WorkloadType.WRAPUP: REQUIRED_WRAPUP_ROLES,
+    WorkloadType.IMPLEMENTATION: frozenset(),
+}
+
 
 # =============================================================================
 # Validation helpers

--- a/src/squadops/cycles/preflight.py
+++ b/src/squadops/cycles/preflight.py
@@ -1,0 +1,131 @@
+"""
+Cycle Create Preflight — pure create-time decisions (SIP-0095).
+
+A deterministic validation gate applied *before* a cycle is persisted or
+dispatched. Each check is a pure function over the resolved squad-profile snapshot
+and the requested workloads; it returns a :class:`PreflightDecision` aggregating
+``block`` and ``warning`` findings. The route calls :func:`combine` over the
+checks: **if any check blocks, the cycle is rejected — even if other checks are
+unverifiable; warnings ride alongside but do not alter the rejection** (SIP §6).
+
+Pure by design (mirrors ``runtime.recruitment.reserve_buffer_decision``): callers
+fetch the I/O (the profile snapshot, the backend's pulled-model list) and pass it
+in, so the decisions stay unit-testable and this module imports no adapters (D26).
+
+This module holds the **capability** half (:func:`required_roles_decision`,
+Macbook lane). The **model-availability** half — ``model_availability_decision``,
+pure over ``(profile, pulled_models)`` — is added here by the Spark lane (SIP §12,
+plan Phase 2); it belongs in this module so both halves share ``combine`` and the
+``Finding``/``PreflightDecision`` shapes.
+
+Scope (SIP-0095, option A): the capability check is **static workload→role
+satisfiability only**. The materialized-plan / ``builder.assemble`` mismatch
+(#172's live case) has no plan at create time and is validated at dispatch
+(``task_plan.validate_against_profile``); hoisting it to the plan-review gate is
+#295, out of scope here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from squadops.cycles.models import REQUIRED_PLAN_ROLES, WORKLOAD_REQUIRED_ROLES
+
+if TYPE_CHECKING:
+    from squadops.cycles.models import SquadProfile
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One preflight check outcome (SIP §7).
+
+    ``severity`` is ``"block"`` (rejects the request) or ``"warning"`` (surfaced
+    to the operator but does not reject). ``code`` is a stable machine label
+    (``missing_role`` / ``model_unavailable`` / ``model_unverifiable``);
+    ``message`` is the standardized, actionable operator text.
+    """
+
+    code: str
+    severity: str
+    message: str
+
+
+@dataclass(frozen=True)
+class PreflightDecision:
+    """The aggregate decision summary for a set of checks (SIP §6)."""
+
+    blocking: tuple[Finding, ...] = field(default_factory=tuple)
+    warnings: tuple[Finding, ...] = field(default_factory=tuple)
+
+    @property
+    def rejected(self) -> bool:
+        """True iff any check blocked — the cycle must not be created."""
+        return bool(self.blocking)
+
+    def summary(self) -> str:
+        """The joined blocking messages, for the error raised at the route."""
+        return " ".join(f.message for f in self.blocking)
+
+
+def combine(*decisions: PreflightDecision) -> PreflightDecision:
+    """Aggregate check decisions: any block ⇒ rejected; warnings ride alongside."""
+    return PreflightDecision(
+        blocking=tuple(f for d in decisions for f in d.blocking),
+        warnings=tuple(f for d in decisions for f in d.warnings),
+    )
+
+
+def required_roles_decision(
+    profile: SquadProfile, applied_defaults: Mapping[str, Any]
+) -> PreflightDecision:
+    """Block when the squad can't satisfy the roles the requested workloads statically require.
+
+    Reads the same inputs dispatch uses — ``applied_defaults["workload_sequence"]``
+    (a list of ``{"type": ...}`` entries) or, when absent, the legacy
+    ``plan_tasks`` / ``build_tasks`` flags — and the same
+    :data:`WORKLOAD_REQUIRED_ROLES` map, so create-time and dispatch never drift.
+    Emits one ``block`` finding per (workload, missing-role). Never warns (role
+    satisfiability is always verifiable from the profile).
+    """
+    profile_roles = frozenset(a.role for a in profile.agents if a.enabled)
+    provided = ", ".join(f"`{r}`" for r in sorted(profile_roles)) or "(none)"
+    findings: list[Finding] = []
+    for label, required in _required_roles_by_workload(applied_defaults).items():
+        for role in sorted(required - profile_roles):
+            findings.append(
+                Finding(
+                    code="missing_role",
+                    severity="block",
+                    message=(
+                        f"workload `{label}` requires role `{role}`, but squad profile "
+                        f"`{profile.profile_id}` provides {provided}. Choose a profile with a "
+                        f"`{role}` agent or adjust the requested workloads."
+                    ),
+                )
+            )
+    return PreflightDecision(blocking=tuple(findings))
+
+
+def _required_roles_by_workload(applied_defaults: Mapping[str, Any]) -> dict[str, frozenset[str]]:
+    """Map each requested workload label → its required role set (create-time static).
+
+    Workloads/toggles with no static requirement (``implementation``,
+    ``build_tasks``) contribute nothing — a builder-less squad is a valid graceful
+    fallback, not a block (SIP §6.1). Unknown workload types are ignored here (the
+    executor rejects them at dispatch).
+    """
+    sequence = applied_defaults.get("workload_sequence") or []
+    if sequence:
+        result: dict[str, frozenset[str]] = {}
+        for entry in sequence:
+            wtype = entry.get("type") if isinstance(entry, Mapping) else None
+            roles = WORKLOAD_REQUIRED_ROLES.get(wtype) if wtype else None
+            if roles:  # skip unknown + no-requirement workloads (implementation)
+                result[wtype] = roles
+        return result
+    # Legacy path: plan_tasks (default true) requires the plan roles; build_tasks requires none.
+    if applied_defaults.get("plan_tasks", True):
+        return {"plan_tasks": REQUIRED_PLAN_ROLES}
+    return {}

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -24,8 +24,7 @@ from squadops.capabilities.handlers.build_profiles import (
 from squadops.cycles.implementation_plan import ImplementationPlan
 from squadops.cycles.models import (
     REQUIRED_PLAN_ROLES,
-    REQUIRED_REFINEMENT_ROLES,
-    REQUIRED_WRAPUP_ROLES,
+    WORKLOAD_REQUIRED_ROLES,
     Cycle,
     CycleError,
     Run,
@@ -275,7 +274,9 @@ def _resolve_workload_steps(
     builder_used = False
 
     if workload_type == WorkloadType.FRAMING:
-        _check_required_roles(profile.profile_id, REQUIRED_PLAN_ROLES, profile_roles)
+        _check_required_roles(
+            profile.profile_id, WORKLOAD_REQUIRED_ROLES[workload_type], profile_roles
+        )
         # SIP-0093 PR 93.3: framing sequence is dynamic per
         # plan_authoring_contributors config. Empty/missing contributors
         # → sole-author route through the merger.
@@ -283,7 +284,7 @@ def _resolve_workload_steps(
         steps = build_planning_steps(contributors)
     elif workload_type == WorkloadType.REFINEMENT:
         _check_required_roles(
-            profile.profile_id, REQUIRED_REFINEMENT_ROLES, profile_roles, "refinement"
+            profile.profile_id, WORKLOAD_REQUIRED_ROLES[workload_type], profile_roles, "refinement"
         )
         steps = list(REFINEMENT_TASK_STEPS)
     elif workload_type == WorkloadType.IMPLEMENTATION:
@@ -293,10 +294,14 @@ def _resolve_workload_steps(
         else:
             steps = list(IMPLEMENTATION_TASK_STEPS)
     elif workload_type == WorkloadType.EVALUATION:
-        _check_required_roles(profile.profile_id, REQUIRED_PLAN_ROLES, profile_roles)
+        _check_required_roles(
+            profile.profile_id, WORKLOAD_REQUIRED_ROLES[workload_type], profile_roles
+        )
         steps = list(CYCLE_TASK_STEPS)
     elif workload_type == WorkloadType.WRAPUP:
-        _check_required_roles(profile.profile_id, REQUIRED_WRAPUP_ROLES, profile_roles, "wrap-up")
+        _check_required_roles(
+            profile.profile_id, WORKLOAD_REQUIRED_ROLES[workload_type], profile_roles, "wrap-up"
+        )
         steps = list(WRAPUP_TASK_STEPS)
     else:
         steps = []

--- a/tests/unit/cycles/test_preflight.py
+++ b/tests/unit/cycles/test_preflight.py
@@ -1,0 +1,150 @@
+"""
+Unit tests for the cycle-create preflight capability check — SIP-0095 (#172), Phase 1.
+
+Bug classes guarded: false-positive blocks on a satisfiable squad; the wrong
+required-role set per workload; unhelpful error text; **incorrectly blocking a
+builder-less build cycle** (the option-A scope: build/implementation impose no
+static role requirement); disabled agents counting toward roles; multi-workload
+non-aggregation; and the combine/decision semantics (any block rejects; warnings
+ride alongside).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from squadops.cycles.models import AgentProfileEntry, SquadProfile
+from squadops.cycles.preflight import (
+    Finding,
+    PreflightDecision,
+    combine,
+    required_roles_decision,
+)
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+NOW = datetime(2026, 1, 1, tzinfo=UTC)
+PLAN_ROLES = ("strat", "dev", "qa", "data", "lead")
+
+
+def _profile(roles, *, profile_id="test-squad", disabled=()):
+    agents = tuple(
+        AgentProfileEntry(agent_id=f"agent-{r}", role=r, model="m", enabled=(r not in disabled))
+        for r in roles
+    )
+    return SquadProfile(
+        profile_id=profile_id, name="Test", description="", version=1, agents=agents, created_at=NOW
+    )
+
+
+def _ws(*types):
+    return {"workload_sequence": [{"type": t} for t in types]}
+
+
+def test_full_plan_squad_satisfies_framing_and_evaluation():
+    profile = _profile(PLAN_ROLES)
+    for wtype in ("framing", "evaluation"):
+        decision = required_roles_decision(profile, _ws(wtype))
+        assert decision.rejected is False
+        assert decision.blocking == ()
+
+
+@pytest.mark.parametrize(
+    ("wtype", "missing_role", "squad_roles"),
+    [
+        ("wrapup", "data", ("qa", "lead")),  # wrapup needs {data, qa, lead}
+        ("refinement", "qa", ("lead", "dev")),  # refinement needs {lead, qa}
+        ("framing", "strat", ("dev", "qa", "data", "lead")),  # plan needs strat too
+    ],
+)
+def test_missing_required_role_blocks_naming_workload_and_role(wtype, missing_role, squad_roles):
+    profile = _profile(squad_roles, profile_id="lite")
+    decision = required_roles_decision(profile, _ws(wtype))
+
+    assert decision.rejected is True
+    codes = {f.code for f in decision.blocking}
+    assert codes == {"missing_role"}
+    # the finding for the missing role names the workload, the role, and stays a block
+    hit = next(f for f in decision.blocking if f"role `{missing_role}`" in f.message)
+    assert hit.severity == "block"
+    assert f"workload `{wtype}`" in hit.message
+    assert "squad profile `lite`" in hit.message
+    assert missing_role in hit.message
+
+
+def test_missing_role_message_is_actionable():
+    profile = _profile(("qa", "lead"), profile_id="lite")  # wrapup missing `data`
+    decision = required_roles_decision(profile, _ws("wrapup"))
+
+    (finding,) = decision.blocking
+    assert finding.message == (
+        "workload `wrapup` requires role `data`, but squad profile `lite` provides "
+        "`lead`, `qa`. Choose a profile with a `data` agent or adjust the requested workloads."
+    )
+
+
+def test_build_and_implementation_on_builderless_squad_do_not_block():
+    """Option A: `implementation` / `build_tasks` impose NO static builder requirement —
+    a builder-less squad is a valid graceful fallback, not a create-time block."""
+    builderless = _profile(PLAN_ROLES)  # no `builder` role
+
+    # workload-sequence form
+    assert required_roles_decision(builderless, _ws("implementation")).rejected is False
+    # legacy form: build_tasks with no plan_tasks requirement
+    legacy = {"plan_tasks": False, "build_tasks": True}
+    assert required_roles_decision(builderless, legacy).rejected is False
+
+
+def test_legacy_plan_tasks_default_true_requires_plan_roles():
+    profile = _profile(("strat", "dev", "qa", "lead"))  # missing `data`
+    # no workload_sequence → legacy path; plan_tasks defaults True
+    decision = required_roles_decision(profile, {})
+
+    assert decision.rejected is True
+    assert any("plan_tasks" in f.message and "role `data`" in f.message for f in decision.blocking)
+
+
+def test_legacy_plan_tasks_false_allows_regardless_of_roles():
+    profile = _profile(("lead",))  # almost nothing
+    decision = required_roles_decision(profile, {"plan_tasks": False, "build_tasks": True})
+    assert decision.rejected is False
+
+
+def test_disabled_agent_does_not_satisfy_a_required_role():
+    """A `data` agent that is disabled must not count — wrapup still blocks on `data`."""
+    profile = _profile(("data", "qa", "lead"), disabled=("data",))
+    decision = required_roles_decision(profile, _ws("wrapup"))
+
+    assert decision.rejected is True
+    assert any("role `data`" in f.message for f in decision.blocking)
+
+
+def test_multiple_workloads_aggregate_required_roles():
+    """A sequence checks every workload's roles, not just the first."""
+    # framing needs strat; wrapup needs data. Squad has neither.
+    profile = _profile(("dev", "qa", "lead"))
+    decision = required_roles_decision(profile, _ws("framing", "wrapup"))
+
+    blocked_roles = {
+        r for f in decision.blocking for r in ("strat", "data") if f"role `{r}`" in f.message
+    }
+    assert {"strat", "data"} <= blocked_roles
+
+
+def test_combine_any_block_rejects_and_warnings_ride_alongside():
+    block = PreflightDecision(blocking=(Finding("missing_role", "block", "boom"),))
+    warn = PreflightDecision(warnings=(Finding("model_unverifiable", "warning", "heads up"),))
+
+    merged = combine(block, warn)
+
+    assert merged.rejected is True
+    assert merged.summary() == "boom"  # only blocking messages
+    assert [f.message for f in merged.warnings] == ["heads up"]  # warning preserved, not dropped
+
+
+def test_empty_decision_is_not_rejected():
+    d = PreflightDecision()
+    assert d.rejected is False
+    assert d.summary() == ""


### PR DESCRIPTION
First implementation slice of **SIP-0095 (Cycle Create Preflight)** — the pure preflight scaffold + the capability-satisfiability half (Macbook lane). **Additive: no route change, no behavior change** (nothing calls the new module yet). Lands first so the Spark lane can build the model-availability half on the shared shapes (plan §5).

Partial toward #172 and #224 — see "What remains" below; not closing either yet.

## What's here
- **`cycles/preflight.py`** — `Finding` + `PreflightDecision` (the decision summary: *any block rejects; warnings ride alongside*) + `combine` + `required_roles_decision`. Pure (mirrors `reserve_buffer_decision`), imports no adapters (D26). The **model-availability half is left for the Spark lane** to add in this module (Phase 2).
- **Single source of truth** — new `WORKLOAD_REQUIRED_ROLES` in `models.py`; `_resolve_workload_steps` refactored to source its `REQUIRED_*` sets from it (behavior-preserving), so create-time and dispatch can't drift (plan R3).
- **Implementation plan** — `docs/plans/SIP-0095-cycle-create-preflight-plan.md` (both open questions resolved).
- **SIP correction** — §6.1 + §9 AC#4 amended to option A: `build_tasks`/`IMPLEMENTATION` impose **no** static builder requirement (graceful fallback); the `builder.assemble` case is a dispatch/gate concern (#295), not create-time.

## Tests
12 unit tests incl. the **option-A guard** (a builder-less build cycle does *not* block), disabled-agent filtering, multi-workload aggregation, the legacy path, and combine semantics. Full regression **4532 passed / 1 skipped**; the shared-map refactor is behavior-preserving (132 task_plan tests green).

## What remains (tracked, not in this PR)
- **Spark — Phase 2:** `model_availability_decision` + `doctor` parity (#224 half).
- **Mac — Phase 3:** wire `combine(required_roles_decision, model_availability_decision)` into `create_cycle` (needs Phase 2). **This is what actually closes #172's create-time half + #224.**
- **Mac — Phase 4:** warning surface (response + CLI echo + persisted on the cycle record).
- **Deferred — #295:** hoist `validate_against_profile` to the plan-review gate (the materialized-plan/builder half of #172).

🤖 Generated with [Claude Code](https://claude.com/claude-code)