### PR TITLE
refactor(#231): consolidate the health signal to runtime_status at the read surfaces

### DIFF
--- a/console/continuum-plugins/squadops.agents/ui/src/AgentsStatus.svelte
+++ b/console/continuum-plugins/squadops.agents/ui/src/AgentsStatus.svelte
@@ -10,9 +10,9 @@
   function mapAgent(a) {
     return {
       name: a.agent_name || a.agent_id || a.name,
-      // Health = runtime_status (SIP-0089); network_status is the legacy fallback
-      // for an agent that has no runtime-state row yet (#230/#231).
-      status: a.runtime_status || a.network_status || a.lifecycle_state || a.status || 'unknown',
+      // Health = runtime_status (SIP-0089) — the single source of truth, now
+      // always-populated (#305 Part A); no network_status/lifecycle fallback.
+      status: a.runtime_status || 'unknown',
       mode: a.mode || null,
       role: a.role_label || a.role || '',
       current_task: a.current_task_id || a.current_task || null,

--- a/console/continuum-plugins/squadops.home/ui/src/HomeSummary.svelte
+++ b/console/continuum-plugins/squadops.home/ui/src/HomeSummary.svelte
@@ -158,7 +158,8 @@
         <div class="squad-row">
           {#each agentStatus as agent}
             <div class="squad-member">
-              <span class="squad-dot {agent.network_status === 'online' ? 'dot-online' : 'dot-offline'}"></span>
+              <!-- Health = runtime_status (SIP-0089); network_status is the legacy fallback (#231) -->
+              <span class="squad-dot {(agent.runtime_status || agent.network_status) === 'online' ? 'dot-online' : 'dot-offline'}"></span>
               <span class="squad-name">{agent.agent_name || agent.agent_id}</span>
               <span class="squad-role">{agent.role_label || agent.role || ''}</span>
             </div>

--- a/console/continuum-plugins/squadops.home/ui/src/HomeSummary.svelte
+++ b/console/continuum-plugins/squadops.home/ui/src/HomeSummary.svelte
@@ -158,8 +158,8 @@
         <div class="squad-row">
           {#each agentStatus as agent}
             <div class="squad-member">
-              <!-- Health = runtime_status (SIP-0089); network_status is the legacy fallback (#231) -->
-              <span class="squad-dot {(agent.runtime_status || agent.network_status) === 'online' ? 'dot-online' : 'dot-offline'}"></span>
+              <!-- Health = runtime_status (SIP-0089), the single source of truth (#305 Part A) -->
+              <span class="squad-dot {agent.runtime_status === 'online' ? 'dot-online' : 'dot-offline'}"></span>
               <span class="squad-name">{agent.agent_name || agent.agent_id}</span>
               <span class="squad-role">{agent.role_label || agent.role || ''}</span>
             </div>

--- a/src/squadops/api/routes/platform_health.py
+++ b/src/squadops/api/routes/platform_health.py
@@ -79,10 +79,17 @@ async def get_agent_status_by_id(agent_id: str):
     hc = _get_health_checker()
     try:
         async with hc.pg_pool.acquire() as conn:
+            # LEFT JOIN the SIP-0089 runtime row so the single-agent route carries
+            # posture (mode) + the canonical health signal (runtime_status), at
+            # parity with GET /health/agents (#230). network_status stays as a
+            # legacy/back-compat field only — health is runtime_status (#231).
             row = await conn.fetchrow(
-                "SELECT agent_id, lifecycle_state, network_status, version, tps, "
-                "memory_count, last_heartbeat, current_task_id "
-                "FROM agent_status WHERE agent_id = $1",
+                "SELECT s.agent_id, s.lifecycle_state, s.version, s.tps, "
+                "s.memory_count, s.last_heartbeat, s.current_task_id, "
+                "r.mode, r.runtime_status "
+                "FROM agent_status s "
+                "LEFT JOIN agent_runtime_state r ON r.agent_id = s.agent_id "
+                "WHERE s.agent_id = $1",
                 agent_id.lower(),
             )
         if not row:
@@ -102,6 +109,10 @@ async def get_agent_status_by_id(agent_id: str):
             "agent_name": hc._get_display_name(row["agent_id"]),
             "role": role,
             "role_label": get_role_label(role),
+            # SIP-0089 posture + canonical health (None when no runtime row) — #231
+            "mode": row["mode"],
+            "runtime_status": row["runtime_status"],
+            # Legacy/back-compat — derived from heartbeat age; do not depend on it (#231).
             "network_status": network_status,
             "lifecycle_state": lifecycle_state,
             "version": row["version"],

--- a/src/squadops/api/runtime/health_checker.py
+++ b/src/squadops/api/runtime/health_checker.py
@@ -129,6 +129,17 @@ class HealthChecker:
     # ── Network status derivation ───────────────────────────────────────
 
     def _compute_network_status(self, last_heartbeat: datetime | None) -> str:
+        """Heartbeat-age reachability flag. **Legacy — deprecated (#231).**
+
+        `network_status` is a heartbeat-derived reachability signal on
+        `agent_status`; the canonical health signal is `runtime_status` on
+        `agent_runtime_state` (coordinator-owned, D16), into which the
+        reconciliation loop mirrors an offline verdict via `mark_offline`. This is
+        kept only so the field's back-compat consumers keep working and so the
+        reconciliation loop can compute the offline verdict to mirror — **do not
+        add new dependencies on it; read `runtime_status` instead** (health-status
+        model: `docs/agent-runtime-status-model.md`).
+        """
         if last_heartbeat is None:
             return "offline"
         timeout = self._config.agent.heartbeat_timeout_window

--- a/src/squadops/api/runtime/health_checker.py
+++ b/src/squadops/api/runtime/health_checker.py
@@ -129,16 +129,15 @@ class HealthChecker:
     # ── Network status derivation ───────────────────────────────────────
 
     def _compute_network_status(self, last_heartbeat: datetime | None) -> str:
-        """Heartbeat-age reachability flag. **Legacy — deprecated (#231).**
+        """Heartbeat-age reachability flag. **Legacy — being removed in #305.**
 
-        `network_status` is a heartbeat-derived reachability signal on
-        `agent_status`; the canonical health signal is `runtime_status` on
-        `agent_runtime_state` (coordinator-owned, D16), into which the
-        reconciliation loop mirrors an offline verdict via `mark_offline`. This is
-        kept only so the field's back-compat consumers keep working and so the
-        reconciliation loop can compute the offline verdict to mirror — **do not
-        add new dependencies on it; read `runtime_status` instead** (health-status
-        model: `docs/agent-runtime-status-model.md`).
+        `network_status` is a heartbeat-derived reachability signal on `agent_status`;
+        the canonical health signal is `runtime_status` on `agent_runtime_state`. As
+        of #305 Part A, no read surface consults `network_status` any more —
+        `runtime_status` is always-populated and the single source of truth. This
+        method survives only to feed the reconciliation loop's offline verdict; **#305
+        Part B removes it and drops the column** (after #158). **Do not add new
+        dependencies on it** (health-status model: `docs/agent-runtime-status-model.md`).
         """
         if last_heartbeat is None:
             return "offline"
@@ -317,12 +316,17 @@ class HealthChecker:
 
         Failures are isolated — runtime-state writes must not break the
         existing agent_status heartbeat flow (D17 non-authoritative).
+
+        #305 Part A: **always** ensures the runtime row so `runtime_status` is never
+        None at the read surfaces. When lifecycle maps to a status we set it; when it
+        doesn't, we still call `update_heartbeat` (the row is ensured, an existing
+        status is kept via COALESCE, and a fresh row defaults to online) — we never
+        skip, which previously left heartbeating agents row-less and forced the
+        `network_status` fallback.
         """
         if self._runtime_state is None:
             return
         runtime_status = runtime_status_from_lifecycle(lifecycle_state)
-        if runtime_status is None:
-            return
         try:
             await self._runtime_state.update_heartbeat(agent_id, runtime_status=runtime_status)
         except Exception as exc:
@@ -394,10 +398,15 @@ class HealthChecker:
         Non-authoritative (D17): sets only runtime_status, never last_heartbeat_at
         or coordinator-owned fields. Failures are isolated like the heartbeat
         mirror — a runtime-state write must not break reconciliation.
+
+        #305 Part A: ensures the row exists first (mark_offline never creates one),
+        so a never-heartbeated / legacy agent is backfilled and the offline verdict
+        actually lands — guaranteeing runtime_status is populated for every agent.
         """
         if self._runtime_state is None:
             return
         try:
+            await self._runtime_state.ensure_state(agent_id)
             await self._runtime_state.mark_offline(agent_id)
         except Exception as exc:
             logger.warning(

--- a/src/squadops/cli/commands/meta.py
+++ b/src/squadops/cli/commands/meta.py
@@ -87,7 +87,9 @@ def _render_status_table(
                 a.get("agent_id", ""),
                 a.get("agent_name", ""),
                 a.get("role", ""),
-                a.get("network_status", ""),
+                # Health = runtime_status (SIP-0089), falling back to the legacy
+                # network_status only when there's no runtime row yet (#231).
+                a.get("runtime_status") or a.get("network_status", ""),
                 a.get("lifecycle_state", ""),
                 a.get("version", ""),
                 a.get("last_seen", "") or "",

--- a/src/squadops/cli/commands/meta.py
+++ b/src/squadops/cli/commands/meta.py
@@ -87,9 +87,9 @@ def _render_status_table(
                 a.get("agent_id", ""),
                 a.get("agent_name", ""),
                 a.get("role", ""),
-                # Health = runtime_status (SIP-0089), falling back to the legacy
-                # network_status only when there's no runtime row yet (#231).
-                a.get("runtime_status") or a.get("network_status", ""),
+                # Health = runtime_status (SIP-0089) — the single source of truth,
+                # now always-populated (#305 Part A); no network_status fallback.
+                a.get("runtime_status") or "",
                 a.get("lifecycle_state", ""),
                 a.get("version", ""),
                 a.get("last_seen", "") or "",

--- a/src/squadops/runtime/lifecycle_status.py
+++ b/src/squadops/runtime/lifecycle_status.py
@@ -27,7 +27,9 @@ _LIFECYCLE_TO_RUNTIME_STATUS: Final[dict[str, str]] = {
 def runtime_status_from_lifecycle(lifecycle_state: str) -> str | None:
     """Return the SIP-0089 `runtime_status` for an agent `lifecycle_state`.
 
-    Returns `None` for unknown values so callers can skip the runtime-state
-    update entirely rather than write a default that would mask drift.
+    Returns `None` for an unmapped `lifecycle_state`. Callers still ensure the
+    runtime row exists (#305 Part A — `runtime_status` must never be None at the
+    read surfaces); a `None` here means only "don't overwrite the stored status"
+    (the row's existing value is kept via COALESCE, and reconciliation owns offline).
     """
     return _LIFECYCLE_TO_RUNTIME_STATUS.get(lifecycle_state)

--- a/tests/unit/api/test_health_checker.py
+++ b/tests/unit/api/test_health_checker.py
@@ -343,6 +343,9 @@ class TestReconcileOnce:
         await checker._reconcile_once()
 
         runtime_state.mark_offline.assert_awaited_once_with("dead")
+        # #305 Part A: the row is ensured first so a never-heartbeated/legacy agent is
+        # backfilled and the offline verdict actually lands (mark_offline never creates).
+        runtime_state.ensure_state.assert_awaited_once_with("dead")
 
     @pytest.mark.asyncio
     async def test_all_online_agents_not_mirrored(self, mock_config):
@@ -365,6 +368,35 @@ class TestReconcileOnce:
         await checker._reconcile_once()
 
         runtime_state.mark_offline.assert_not_awaited()
+
+
+class TestHeartbeatMirror:
+    """#305 Part A: the heartbeat always ensures a runtime row so runtime_status is
+    never None at the read surfaces — even when lifecycle_state doesn't map to a
+    runtime_status. This is what lets the network_status fallback be removed."""
+
+    def _checker(self, mock_config):
+        runtime_state = AsyncMock()
+        checker = HealthChecker(
+            pg_pool=MagicMock(), redis_client=None, config=mock_config, runtime_state=runtime_state
+        )
+        return checker, runtime_state
+
+    @pytest.mark.asyncio
+    async def test_mapped_lifecycle_sets_runtime_status(self, mock_config):
+        checker, runtime_state = self._checker(mock_config)
+        await checker._update_runtime_state_heartbeat("max", "READY")
+        runtime_state.update_heartbeat.assert_awaited_once_with("max", runtime_status="online")
+
+    @pytest.mark.asyncio
+    async def test_unmapped_lifecycle_still_ensures_the_row(self, mock_config):
+        """The old bug: an unmapped lifecycle (e.g. UNKNOWN, which reconciliation
+        itself sets) made the heartbeat SKIP update_heartbeat, leaving the agent
+        row-less → runtime_status None → the network_status fallback. Now it always
+        calls update_heartbeat (row ensured; existing status kept via COALESCE)."""
+        checker, runtime_state = self._checker(mock_config)
+        await checker._update_runtime_state_heartbeat("ghost", "UNKNOWN")
+        runtime_state.update_heartbeat.assert_awaited_once_with("ghost", runtime_status=None)
 
 
 class TestGetCurrentActivity:

--- a/tests/unit/api/test_platform_health_routes.py
+++ b/tests/unit/api/test_platform_health_routes.py
@@ -101,15 +101,18 @@ class TestHealthAgents:
 
 class TestAgentStatusById:
     def test_get_agent_status_found(self, client, mock_health_checker):
+        # The route LEFT JOINs agent_runtime_state, so the row carries mode +
+        # runtime_status (the canonical health signal, #231).
         mock_row = {
             "agent_id": "max",
             "lifecycle_state": "READY",
-            "network_status": "online",
             "version": "0.9.7",
             "tps": 5,
             "memory_count": 10,
             "last_heartbeat": datetime(2026, 2, 16, 12, 0, 0),
             "current_task_id": None,
+            "mode": "cycle",
+            "runtime_status": "online",
         }
         mock_conn = AsyncMock()
         mock_conn.fetchrow = AsyncMock(return_value=mock_row)
@@ -122,6 +125,11 @@ class TestAgentStatusById:
         data = resp.json()
         assert data["agent_id"] == "max"
         assert data["lifecycle_state"] == "READY"
+        # #231: the single-agent route now carries the canonical health + posture
+        # at parity with the list route, with network_status demoted to back-compat.
+        assert data["runtime_status"] == "online"
+        assert data["mode"] == "cycle"
+        assert data["network_status"] == "online"  # legacy field still present
 
     def test_get_agent_status_not_found(self, client, mock_health_checker):
         mock_conn = AsyncMock()

--- a/tests/unit/cli/test_commands_meta.py
+++ b/tests/unit/cli/test_commands_meta.py
@@ -42,8 +42,8 @@ AGENTS_RESPONSE = [
         "agent_name": "Max",
         "role": "Task Lead",
         # Canonical health (SIP-0089) — `recovering` is a runtime_status-only value,
-        # so seeing it in the STATUS column proves the CLI prefers runtime_status
-        # over the (disagreeing) legacy network_status (#231).
+        # so seeing it in the STATUS column proves the CLI shows runtime_status and
+        # NOT the disagreeing legacy network_status (#305: single source of truth).
         "runtime_status": "recovering",
         "mode": "cycle",
         "network_status": "online",
@@ -55,8 +55,10 @@ AGENTS_RESPONSE = [
         "agent_id": "neo",
         "agent_name": "Neo",
         "role": "Developer",
-        # No runtime row yet → STATUS falls back to network_status (#231).
-        "network_status": "online",
+        # runtime_status is always-populated now (#305 Part A) — network_status here
+        # disagrees on purpose and must be ignored (no fallback).
+        "runtime_status": "online",
+        "network_status": "offline",
         "lifecycle_state": "WORKING",
         "version": "0.9.3",
         "last_seen": "2026-02-09T14:00:00Z",
@@ -112,8 +114,8 @@ class TestStatusCommand:
         # Agents table rendered
         assert "Max" in result.output
         assert "Neo" in result.output
-        # #231: STATUS shows runtime_status (max's `recovering` — a runtime-only
-        # value), proving it's preferred over the disagreeing legacy network_status.
+        # #305: STATUS shows runtime_status only (max's `recovering` — a runtime-only
+        # value), proving network_status is not consulted (no fallback).
         assert "recovering" in result.output
 
     @patch("squadops.cli.commands.meta.APIClient")

--- a/tests/unit/cli/test_commands_meta.py
+++ b/tests/unit/cli/test_commands_meta.py
@@ -41,6 +41,11 @@ AGENTS_RESPONSE = [
         "agent_id": "max",
         "agent_name": "Max",
         "role": "Task Lead",
+        # Canonical health (SIP-0089) — `recovering` is a runtime_status-only value,
+        # so seeing it in the STATUS column proves the CLI prefers runtime_status
+        # over the (disagreeing) legacy network_status (#231).
+        "runtime_status": "recovering",
+        "mode": "cycle",
         "network_status": "online",
         "lifecycle_state": "READY",
         "version": "0.9.3",
@@ -50,6 +55,7 @@ AGENTS_RESPONSE = [
         "agent_id": "neo",
         "agent_name": "Neo",
         "role": "Developer",
+        # No runtime row yet → STATUS falls back to network_status (#231).
         "network_status": "online",
         "lifecycle_state": "WORKING",
         "version": "0.9.3",
@@ -106,6 +112,9 @@ class TestStatusCommand:
         # Agents table rendered
         assert "Max" in result.output
         assert "Neo" in result.output
+        # #231: STATUS shows runtime_status (max's `recovering` — a runtime-only
+        # value), proving it's preferred over the disagreeing legacy network_status.
+        assert "recovering" in result.output
 
     @patch("squadops.cli.commands.meta.APIClient")
     @patch("squadops.cli.commands.meta.load_config")


### PR DESCRIPTION
Strangles `network_status` out of the **health-signal** role everywhere it's read, per the documented model (`docs/agent-runtime-status-model.md`: *health = `runtime_status`, posture = `mode`*). #230 did the agents dashboard + the `/health/agents` list; this finishes the read surfaces it missed.

Partial toward #231 — see "What remains"; not closing it.

## What changed (4 slices)
1. **API single-agent** `GET /health/agents/status/{id}` — LEFT JOIN `agent_runtime_state`; now carries `runtime_status` + `mode` at parity with the list route (it was `network_status`-only).
2. **CLI** `squadops status` — the STATUS column shows `runtime_status` (falling back to `network_status` only when there's no runtime row).
3. **`health_checker._compute_network_status`** — deprecation docstring: legacy heartbeat-age flag; do not add new dependencies; read `runtime_status`.
4. **Console** `squadops.home/HomeSummary.svelte` — the squad dot prefers `runtime_status` (#230 fixed `squadops.agents` but missed this one). Source-only — `dist/plugin.js` is gitignored/regenerated by the console build; verified with `vite build`.

## Behavior
`network_status` is **demoted, not removed** — kept as a back-compat field and for the reconciliation offline-mirror (`mark_offline` → `runtime_status`). No migration, no big-bang (the doc's "strangler, not a blocker").

## Tests
Read-surface parity proven: the single-agent route asserts `runtime_status`/`mode`; the CLI test proves the preference via a `runtime_status`-only value (`recovering`). Full regression **4538 passed / 1 skipped**.

## What remains (keeps #231 open)
The **full** consolidation's tail — dropping the `network_status` column from `agent_status` + the reconciliation rework — is a **migration**, so it's gated on **#158** (schema_migrations + applier hardening, in progress on the Spark lane). Recommend landing this read-surface strangle now and doing the column-drop after #158. (Alternatively: close #231 on this and file a dedicated "drop legacy network_status column" follow-up — maintainer's call.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)