### PR TITLE
fix(#303): qa.test harness — discover package.json, block missing frontend build, fix backend pytest path

### DIFF
--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -69,6 +69,44 @@ def _materialize_files(
             fh.write(rec["content"])
 
 
+def _find_package_json_dir(files: list[dict[str, str]]) -> str | None:
+    """Return the workspace-relative dir of the shallowest ``package.json``.
+
+    Discovers where the Node project root actually is instead of assuming a fixed
+    ``frontend/`` — models sometimes place ``package.json`` at ``frontend/src/``
+    or the workspace root (#303). ``""`` means the workspace root; ``None`` means
+    no ``package.json`` was produced at all.
+    """
+    dirs = [
+        os.path.dirname(rec["path"])
+        for rec in files
+        if os.path.basename(rec["path"]) == "package.json"
+    ]
+    if not dirs:
+        return None
+    # Shallowest (fewest path segments, then shortest) is the real project root.
+    return min(dirs, key=lambda d: (d.count("/") if d else -1, len(d)))
+
+
+def _source_dir_pythonpath(workspace: str, source_files: list[dict[str, str]]) -> str:
+    """Build a ``PYTHONPATH`` covering every dir that holds a Python source file.
+
+    So a ``backend/``-nested app whose test does ``from main import app`` (main at
+    ``backend/main.py``) imports cleanly even though pytest runs from the
+    workspace root (#303).
+    """
+    dirs = {
+        os.path.dirname(os.path.join(workspace, rec["path"]))
+        for rec in source_files
+        if rec["path"].endswith(".py")
+    }
+    existing = os.environ.get("PYTHONPATH", "")
+    parts = [workspace, *sorted(dirs)]
+    if existing:
+        parts.append(existing)
+    return os.pathsep.join(parts)
+
+
 async def run_generated_tests(
     source_files: list[dict[str, str]],
     test_files: list[dict[str, str]],
@@ -93,6 +131,7 @@ async def run_generated_tests(
         all_files = source_files + test_files
         _materialize_files(workspace, all_files)
 
+        env = {**os.environ, "PYTHONPATH": _source_dir_pythonpath(workspace, source_files)}
         proc = await asyncio.create_subprocess_exec(
             sys.executable,
             "-m",
@@ -101,6 +140,7 @@ async def run_generated_tests(
             "--tb=short",
             "-q",
             cwd=workspace,
+            env=env,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -147,14 +187,12 @@ async def run_generated_tests(
 async def run_node_tests(
     source_files: list[dict[str, str]],
     test_files: list[dict[str, str]],
-    target_dir: str | None = None,
     timeout_seconds: int = 60,
 ) -> RunTestsResult:
     """Run vitest in a Node workspace (D6).
 
-    Materializes files, runs ``npm install`` then ``npx vitest run``.
-    *target_dir* is the subdirectory within the workspace where
-    ``package.json`` lives (e.g., ``"frontend"`` for fullstack projects).
+    Materializes files, discovers the ``package.json`` dir (#303 — don't assume a
+    fixed ``frontend/``), then runs ``npm install`` and ``npx vitest run`` there.
 
     Returns a ``RunTestsResult`` — never raises.
     """
@@ -171,17 +209,16 @@ async def run_node_tests(
         all_files = source_files + test_files
         _materialize_files(workspace, all_files)
 
-        # Resolve cwd: workspace/target_dir if provided, else workspace
-        cwd = os.path.join(workspace, target_dir) if target_dir else workspace
-
-        # Check for package.json
-        if not os.path.isfile(os.path.join(cwd, "package.json")):
+        # Discover where package.json actually is (#303) — don't assume a fixed dir.
+        pkg_dir = _find_package_json_dir(all_files)
+        if pkg_dir is None:
             return RunTestsResult(
                 executed=False,
-                error=f"No package.json found in {target_dir or 'workspace root'}",
+                error="No package.json found — cannot run vitest",
                 test_file_count=len(test_files),
                 source_file_count=len(source_files),
             )
+        cwd = os.path.join(workspace, pkg_dir) if pkg_dir else workspace
 
         # npm install
         try:
@@ -316,8 +353,10 @@ async def run_frontend_build(
     root ``index.html`` (observed in cyc_2f415e43f9cf: ``vite build`` failed
     immediately, yet the run shipped green).
 
-    Skips (``ran=False``) when there is no frontend source, no ``package.json``,
-    or Node is unavailable — a skip is never a failure. Never raises.
+    Skips (``ran=False``) when there is no frontend source at all, or Node is
+    unavailable — a skip is never a failure. But frontend source present with no
+    discoverable ``package.json`` is a BLOCKING failure (#303) — a frontend that
+    can't build is broken, not absent. Never raises.
     """
     frontend_source = (
         [rec for rec in source_files if rec["path"].startswith(f"{target_dir}/")]
@@ -330,11 +369,19 @@ async def run_frontend_build(
     workspace = tempfile.mkdtemp(prefix="qa_build_")
     try:
         _materialize_files(workspace, frontend_source)
-        cwd = os.path.join(workspace, target_dir) if target_dir else workspace
-
+        # Discover the package.json dir (#303) — don't assume target_dir/package.json.
+        pkg_dir = _find_package_json_dir(frontend_source)
+        if pkg_dir is None:
+            # Frontend source exists (checked above) but no package.json anywhere:
+            # the deliverable can't build — a real failure, not a benign skip (#303).
+            return BuildCheckResult(
+                ran=True,
+                ok=False,
+                exit_code=1,
+                error="frontend source present but no package.json found — cannot build",
+            )
+        cwd = os.path.join(workspace, pkg_dir) if pkg_dir else workspace
         pkg_path = os.path.join(cwd, "package.json")
-        if not os.path.isfile(pkg_path):
-            return BuildCheckResult(ran=False, error="no package.json — cannot build")
 
         # Prefer the package's own build script; fall back to vite build.
         import json
@@ -446,7 +493,6 @@ async def run_fullstack_tests(
     frontend_result = await run_node_tests(
         frontend_source,
         frontend_tests,
-        target_dir="frontend",
         timeout_seconds=timeout_seconds,
     )
 

--- a/tests/unit/capabilities/test_frontend_build.py
+++ b/tests/unit/capabilities/test_frontend_build.py
@@ -2,8 +2,10 @@
 
 Bug this guards: a Vite frontend can pass vitest unit tests yet fail to build
 (e.g. missing root ``index.html``), shipping a non-runnable deliverable green.
-``run_frontend_build`` must FAIL when the build ran and errored, and must SKIP
-(not fail) when it can't assess (no frontend, no package.json, no node).
+``run_frontend_build`` must FAIL when the build ran and errored — and also when
+frontend source is present but has no discoverable ``package.json`` (#303, a
+broken frontend, not an absent one) — and must SKIP (not fail) when it genuinely
+can't assess: no frontend at all, install failure, or no node.
 """
 
 from __future__ import annotations
@@ -73,12 +75,31 @@ async def test_skips_when_no_frontend_source():
     assert result.ran is False and result.failed is False
 
 
-async def test_skips_when_no_package_json():
+async def test_no_package_json_with_frontend_source_is_blocking():
+    """Frontend source present but no package.json anywhere → the deliverable
+    can't build → BLOCKING failure, not a benign skip (#303)."""
     result = await run_frontend_build(
         [{"path": "frontend/src/main.jsx", "content": "export default 1"}]
     )
-    assert result.ran is False
+    assert result.ran is True
+    assert result.ok is False
+    assert result.failed is True
     assert "package.json" in result.error
+
+
+async def test_discovers_package_json_in_subdir(monkeypatch):
+    """package.json at frontend/src/ (not the frontend root) is discovered and
+    built — the exact cyc_1d2e21ab0cfb case that used to skip (#303)."""
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec([0, 0]))  # install, build ok
+    result = await run_frontend_build(
+        [
+            {"path": "frontend/src/package.json", "content": _PKG_WITH_BUILD},
+            {"path": "frontend/src/main.jsx", "content": "export default 1"},
+        ]
+    )
+    assert result.ran is True
+    assert result.ok is True
+    assert result.failed is False
 
 
 # --- Build outcome (mocked subprocess) ----------------------------------------

--- a/tests/unit/capabilities/test_node_test_runner.py
+++ b/tests/unit/capabilities/test_node_test_runner.py
@@ -24,6 +24,7 @@ pytestmark = [pytest.mark.domain_capabilities]
 # ---------------------------------------------------------------------------
 
 _SOURCE_FILES = [
+    {"path": "package.json", "content": '{"scripts": {}}'},
     {"path": "src/App.jsx", "content": "export default function App() {}"},
 ]
 
@@ -61,7 +62,11 @@ class TestRunNodeTestsNoFiles:
 
 class TestRunNodeTestsNoPackageJson:
     async def test_missing_package_json(self):
-        result = await run_node_tests(_SOURCE_FILES, _TEST_FILES)
+        # No package.json anywhere in the file set → discovery finds none → skip.
+        result = await run_node_tests(
+            [{"path": "src/App.jsx", "content": "export default function App() {}"}],
+            _TEST_FILES,
+        )
         assert result.executed is False
         assert "package.json" in result.error
 
@@ -196,20 +201,33 @@ class TestRunNodeTestsTimeout:
 
 
 # ---------------------------------------------------------------------------
-# run_node_tests — target_dir
+# run_node_tests — package.json discovery (#303, replaces the old target_dir path)
 # ---------------------------------------------------------------------------
 
 
-class TestRunNodeTestsTargetDir:
-    async def test_target_dir_checked_for_package_json(self):
-        """When target_dir is set, package.json is expected in that subdir."""
-        result = await run_node_tests(
-            _SOURCE_FILES,
-            _TEST_FILES,
-            target_dir="frontend",
-        )
-        assert result.executed is False
-        assert "frontend" in result.error
+class TestRunNodeTestsDiscovery:
+    @patch("squadops.capabilities.handlers.test_runner._materialize_files")
+    @patch("tempfile.mkdtemp", return_value="/tmp/qa_node_test")
+    @patch("shutil.rmtree")
+    async def test_package_json_in_subdir_is_discovered(self, _rmtree, _mkdtemp, _mat):
+        """package.json placed at frontend/src/ (not a fixed dir) is discovered and
+        run, instead of being skipped as 'not found' (#303)."""
+        install_proc = _make_proc_mock(returncode=0)
+        vitest_proc = _make_proc_mock(returncode=0, stdout=b"1 passed")
+        call_count = 0
+
+        async def mock_exec(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            return install_proc if call_count == 1 else vitest_proc
+
+        source = [{"path": "frontend/src/package.json", "content": '{"scripts": {}}'}]
+        tests = [{"path": "frontend/src/App.test.jsx", "content": "test('a', () => {})"}]
+        with patch("asyncio.create_subprocess_exec", side_effect=mock_exec):
+            result = await run_node_tests(source, tests)
+
+        assert result.executed is True
+        assert result.exit_code == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/capabilities/test_qa_harness_robustness.py
+++ b/tests/unit/capabilities/test_qa_harness_robustness.py
@@ -1,0 +1,70 @@
+"""qa.test harness robustness helpers (#303).
+
+Guards the fixes found by cyc_1d2e21ab0cfb: package.json discovery (don't assume
+a fixed ``frontend/``) and backend ``PYTHONPATH`` so a nested app's
+``from main import app`` resolves when pytest runs from the workspace root.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from squadops.capabilities.handlers.test_runner import (
+    _find_package_json_dir,
+    _source_dir_pythonpath,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+class TestFindPackageJsonDir:
+    def test_in_frontend_subdir(self):
+        files = [
+            {"path": "frontend/src/package.json", "content": "{}"},
+            {"path": "frontend/src/App.jsx", "content": ""},
+        ]
+        assert _find_package_json_dir(files) == "frontend/src"
+
+    def test_at_frontend_root(self):
+        files = [{"path": "frontend/package.json", "content": "{}"}]
+        assert _find_package_json_dir(files) == "frontend"
+
+    def test_at_workspace_root(self):
+        assert _find_package_json_dir([{"path": "package.json", "content": "{}"}]) == ""
+
+    def test_shallowest_wins(self):
+        files = [
+            {"path": "frontend/src/package.json", "content": "{}"},
+            {"path": "frontend/package.json", "content": "{}"},
+        ]
+        assert _find_package_json_dir(files) == "frontend"
+
+    def test_none_when_absent(self):
+        assert _find_package_json_dir([{"path": "frontend/src/App.jsx", "content": ""}]) is None
+
+
+class TestSourceDirPythonpath:
+    def test_nested_backend_dir_on_path(self, monkeypatch):
+        monkeypatch.delenv("PYTHONPATH", raising=False)
+        parts = _source_dir_pythonpath("/ws", [{"path": "backend/main.py", "content": ""}]).split(
+            os.pathsep
+        )
+        assert "/ws" in parts
+        assert os.path.join("/ws", "backend") in parts  # so `from main import app` resolves
+
+    def test_only_python_source_dirs_counted(self, monkeypatch):
+        monkeypatch.delenv("PYTHONPATH", raising=False)
+        # A non-.py file contributes no import dir → just the workspace root.
+        parts = _source_dir_pythonpath(
+            "/ws", [{"path": "frontend/src/App.jsx", "content": ""}]
+        ).split(os.pathsep)
+        assert parts == ["/ws"]
+
+    def test_preserves_existing_pythonpath(self, monkeypatch):
+        monkeypatch.setenv("PYTHONPATH", "/existing")
+        parts = _source_dir_pythonpath("/ws", [{"path": "main.py", "content": ""}]).split(
+            os.pathsep
+        )
+        assert "/existing" in parts


### PR DESCRIPTION
Closes #303. Follow-up from the 1.2.0 build-quality re-validation (`cyc_1d2e21ab0cfb`, group_run/lite) — after #296 the config files reach the QA workspace, but the build check *still* didn't catch a broken fullstack app. Three robustness fixes in `test_runner.py`:

## 1. `package.json` discovery (not a fixed `frontend/`)
New `_find_package_json_dir` locates the Node project root from the materialized file list (shallowest wins). The run put `package.json` at `frontend/src/`; `run_frontend_build`/`run_node_tests` only checked `frontend/package.json` → **skipped**. Now they run from wherever it actually is. Removed the rigid `target_dir` cwd path on `run_node_tests` (discovery replaces it; `target_dir` stays on `run_frontend_build` **only** as the frontend-file filter for the fullstack split).

## 2. A missing frontend build is now **blocking**, not a skip
Frontend source present but **no** discoverable `package.json` → `BuildCheckResult(ran=True, ok=False)` → the run fails instead of shipping a non-buildable frontend green. A genuinely backend-only deliverable (no frontend source) still skips.

## 3. Backend pytest `PYTHONPATH`
New `_source_dir_pythonpath` puts every Python source dir on `PYTHONPATH`, so a `backend/`-nested app's `from main import app` resolves — instead of the spurious `ModuleNotFoundError: No module named 'main'` that masked the real test result.

## Evidence (cyc_1d2e21ab0cfb `test_report.md`)
```
E   ModuleNotFoundError: No module named 'main'          # fixed by #3
frontend (non-blocking): No package.json found in frontend  # fixed by #1 + #2
```

## Tests
Helper unit tests (discovery: subdir/root/shallowest/none; PYTHONPATH nesting); `run_frontend_build` subdir-discovery + blocking-on-missing; `run_node_tests` subdir discovery; flipped the obsolete "no package.json = skip" expectation and replaced the removed-`target_dir` test with a discovery test. ruff + quality lint clean; **1107 capabilities tests green**.

## Close criterion
Unit-verified. Full end-to-end confirmation is the next re-validation cycle (after a rebuild) showing the frontend build **runs** and the backend tests import cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)