### PR TITLE
feat(#224): model-availability preflight decision (Spark half of SIP-0095)

### DIFF
--- a/src/squadops/cycles/preflight.py
+++ b/src/squadops/cycles/preflight.py
@@ -12,11 +12,11 @@ Pure by design (mirrors ``runtime.recruitment.reserve_buffer_decision``): caller
 fetch the I/O (the profile snapshot, the backend's pulled-model list) and pass it
 in, so the decisions stay unit-testable and this module imports no adapters (D26).
 
-This module holds the **capability** half (:func:`required_roles_decision`,
-Macbook lane). The **model-availability** half — ``model_availability_decision``,
-pure over ``(profile, pulled_models)`` — is added here by the Spark lane (SIP §12,
-plan Phase 2); it belongs in this module so both halves share ``combine`` and the
-``Finding``/``PreflightDecision`` shapes.
+This module holds both halves so they share ``combine`` and the
+``Finding``/``PreflightDecision`` shapes: the **capability** half
+(:func:`required_roles_decision`, Macbook lane) and the **model-availability**
+half (:func:`model_availability_decision`, pure over ``(profile, pulled_models)``,
+Spark lane — SIP §12).
 
 Scope (SIP-0095, option A): the capability check is **static workload→role
 satisfiability only**. The materialized-plan / ``builder.assemble`` mismatch
@@ -27,7 +27,7 @@ satisfiability only**. The materialized-plan / ``builder.assemble`` mismatch
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -129,3 +129,71 @@ def _required_roles_by_workload(applied_defaults: Mapping[str, Any]) -> dict[str
     if applied_defaults.get("plan_tasks", True):
         return {"plan_tasks": REQUIRED_PLAN_ROLES}
     return {}
+
+
+def _canonical_model(name: str) -> str:
+    """Ollama canonical model tag: a tagless reference defaults to ``:latest``.
+
+    So ``llama3.2`` and ``llama3.2:latest`` compare equal — but NO prefix/family
+    inference: ``qwen3:7b`` never matches ``qwen3:27b`` (SIP §137, decided).
+    """
+    return name if ":" in name else f"{name}:latest"
+
+
+def model_availability_decision(
+    profile: SquadProfile, pulled_models: Iterable[str] | None
+) -> PreflightDecision:
+    """Block when a profile's enabled agents name a model definitively not pulled.
+
+    ``pulled_models`` is the backend's set of available model *names* — the caller
+    fetches it (e.g. from ``OllamaAdapter.list_pulled_models``) and passes names
+    in, keeping this decision pure and adapter-free (D26).
+
+    Per SIP §6.2/§6.3:
+    - ``pulled_models is None`` ⇒ the backend couldn't be queried: availability is
+      *unverifiable*, so **warn and allow** — never block on missing evidence.
+    - A reachable-but-empty list is *verifiable* and blocks every required model.
+    - Matching is exact on the canonical tag (tagless ⇒ ``:latest``); no
+      prefix/family inference (§137). Only enabled agents' models are checked.
+    """
+    required = sorted({a.model for a in profile.agents if a.enabled and a.model})
+    if not required:
+        return PreflightDecision()
+
+    if pulled_models is None:
+        listed = ", ".join(f"`{m}`" for m in required)
+        return PreflightDecision(
+            warnings=(
+                Finding(
+                    code="model_unverifiable",
+                    severity="warning",
+                    message=(
+                        f"could not verify model availability for squad profile "
+                        f"`{profile.profile_id}` (LLM backend unreachable) — required "
+                        f"models {listed} were not checked and may fail fast at "
+                        f"runtime. Verify the backend has them pulled."
+                    ),
+                ),
+            )
+        )
+
+    pulled = sorted(pulled_models)
+    pulled_canonical = {_canonical_model(m) for m in pulled}
+    have = ", ".join(f"`{m}`" for m in pulled[:10]) or "(none)"
+    if len(pulled) > 10:
+        have += f" (+{len(pulled) - 10} more)"
+
+    findings = [
+        Finding(
+            code="model_unavailable",
+            severity="block",
+            message=(
+                f"squad profile `{profile.profile_id}` requires model `{model}`, but "
+                f"the LLM backend has {have}. Pull `{model}` on the backend or choose "
+                f"a profile whose models are available."
+            ),
+        )
+        for model in required
+        if _canonical_model(model) not in pulled_canonical
+    ]
+    return PreflightDecision(blocking=tuple(findings))

--- a/tests/unit/cycles/test_preflight.py
+++ b/tests/unit/cycles/test_preflight.py
@@ -1,12 +1,18 @@
 """
-Unit tests for the cycle-create preflight capability check — SIP-0095 (#172), Phase 1.
+Unit tests for the cycle-create preflight — SIP-0095 capability check (#172) +
+model-availability check (#224, Spark half).
 
-Bug classes guarded: false-positive blocks on a satisfiable squad; the wrong
-required-role set per workload; unhelpful error text; **incorrectly blocking a
-builder-less build cycle** (the option-A scope: build/implementation impose no
-static role requirement); disabled agents counting toward roles; multi-workload
-non-aggregation; and the combine/decision semantics (any block rejects; warnings
-ride alongside).
+Capability bug classes guarded: false-positive blocks on a satisfiable squad; the
+wrong required-role set per workload; unhelpful error text; **incorrectly blocking
+a builder-less build cycle** (option-A scope); disabled agents counting toward
+roles; multi-workload non-aggregation; combine/decision semantics.
+
+Model-availability bug classes guarded (SIP §6.2/§6.3/§137): blocking on
+unverifiable evidence (backend unreachable MUST warn-and-allow, not block);
+conflating a reachable-empty list with an unreachable backend; false blocks from
+tag normalization (`llama3.2` vs `llama3.2:latest`); false *passes* from
+family inference (`qwen3:7b` satisfying `qwen3:27b`); disabled agents' models
+being checked; non-actionable error text.
 """
 
 from __future__ import annotations
@@ -20,6 +26,7 @@ from squadops.cycles.preflight import (
     Finding,
     PreflightDecision,
     combine,
+    model_availability_decision,
     required_roles_decision,
 )
 
@@ -148,3 +155,98 @@ def test_empty_decision_is_not_rejected():
     d = PreflightDecision()
     assert d.rejected is False
     assert d.summary() == ""
+
+
+# --- model_availability_decision (SIP §6.2/§6.3, #224 — Spark half) ------------
+
+
+def _model_profile(models, *, profile_id="test-squad", disabled_idx=()):
+    """Profile whose enabled agents carry the given model names."""
+    agents = tuple(
+        AgentProfileEntry(
+            agent_id=f"agent-{i}", role=f"r{i}", model=m, enabled=(i not in disabled_idx)
+        )
+        for i, m in enumerate(models)
+    )
+    return SquadProfile(
+        profile_id=profile_id, name="Test", description="", version=1, agents=agents, created_at=NOW
+    )
+
+
+def test_all_required_models_pulled_allows():
+    profile = _model_profile(["qwen3:27b", "nomic-embed-text"])
+    decision = model_availability_decision(profile, ["qwen3:27b", "nomic-embed-text", "extra:1b"])
+    assert decision.rejected is False
+    assert decision.blocking == ()
+    assert decision.warnings == ()
+
+
+def test_missing_model_blocks_with_actionable_message():
+    profile = _model_profile(["qwen3:27b"], profile_id="full")
+    decision = model_availability_decision(profile, ["qwen3:7b", "llama3.2:latest"])
+
+    assert decision.rejected is True
+    (finding,) = decision.blocking
+    assert finding.code == "model_unavailable"
+    assert finding.severity == "block"
+    assert "`qwen3:27b`" in finding.message  # the required-but-missing model
+    assert "squad profile `full`" in finding.message
+    assert "qwen3:7b" in finding.message  # shows what the backend actually has
+
+
+def test_unreachable_backend_warns_and_allows():
+    """None pulled list = unverifiable → warn, never block (SIP §6.3, AC#5)."""
+    profile = _model_profile(["qwen3:27b"])
+    decision = model_availability_decision(profile, None)
+
+    assert decision.rejected is False  # allowed, not blocked on missing evidence
+    (warning,) = decision.warnings
+    assert warning.code == "model_unverifiable"
+    assert warning.severity == "warning"
+    assert "`qwen3:27b`" in warning.message
+
+
+def test_empty_pulled_list_is_verifiable_and_blocks():
+    """Reachable-but-empty (a list, not None) is verifiable → blocks, unlike unreachable."""
+    profile = _model_profile(["qwen3:27b"])
+    decision = model_availability_decision(profile, [])
+    assert decision.rejected is True
+    assert decision.blocking[0].code == "model_unavailable"
+
+
+def test_tagless_model_matches_latest_no_false_block():
+    """`llama3.2` ⇔ `llama3.2:latest` (canonical tag) — no false block (SIP §137)."""
+    profile = _model_profile(["llama3.2"])
+    decision = model_availability_decision(profile, ["llama3.2:latest"])
+    assert decision.rejected is False
+
+
+def test_different_tag_blocks_no_family_inference():
+    """`qwen3:7b` must NOT satisfy a required `qwen3:27b` — no family inference (§137)."""
+    profile = _model_profile(["qwen3:27b"])
+    decision = model_availability_decision(profile, ["qwen3:7b"])
+    assert decision.rejected is True
+
+
+def test_disabled_agent_model_not_checked():
+    """A missing model belonging to a disabled agent must not block."""
+    profile = _model_profile(["present:1b", "missing:27b"], disabled_idx={1})
+    decision = model_availability_decision(profile, ["present:1b"])
+    assert decision.rejected is False
+
+
+def test_multiple_missing_models_each_block():
+    profile = _model_profile(["a:1b", "b:2b", "c:3b"])
+    decision = model_availability_decision(profile, ["a:1b"])
+
+    assert len(decision.blocking) == 2
+    missing = {m for f in decision.blocking for m in ("b:2b", "c:3b") if f"`{m}`" in f.message}
+    assert missing == {"b:2b", "c:3b"}
+
+
+def test_no_enabled_models_is_empty_decision():
+    """No enabled agents with models → nothing to check, even with no backend."""
+    profile = _model_profile(["x:1b"], disabled_idx={0})
+    decision = model_availability_decision(profile, None)
+    assert decision.rejected is False
+    assert decision.blocking == () and decision.warnings == ()


### PR DESCRIPTION
Refs #224 (partial — the Spark half of the option-A split). The cross-lane handoff was announced on #224.

## What this adds
The **model-availability** half of the SIP-0095 cycle-create preflight, into the shared `cycles/preflight.py` (which #298 scaffolded with `Finding`/`PreflightDecision`/`combine`/`required_roles_decision`):

```python
def model_availability_decision(profile, pulled_models) -> PreflightDecision
```

Pure, mirroring `required_roles_decision` — the caller fetches the pulled model **names** and passes them in; no adapter import.

## Semantics (SIP §6.2/§6.3/§137)
- **Verifiable + required model definitively missing → `block`** (`model_unavailable`), one finding per missing model.
- **`pulled_models is None` (backend unreachable) → `warning`** (`model_unverifiable`) — **warn-and-allow**, never block on missing evidence.
- **Reachable-but-empty list is verifiable → blocks** (the crucial None-vs-`[]` distinction).
- **Exact canonical-tag matching** (tagless ⇒ `:latest`, so `llama3.2` == `llama3.2:latest`) with **no prefix/family inference** (`qwen3:7b` never satisfies `qwen3:27b`) — the §137 decision, avoiding both false blocks and false passes. Enabled agents only.

## Tests (9 new, 21 total in the file)
allow / block-with-actionable-message / warn-and-allow-on-None / reachable-empty-blocks / canonical-`:latest`-match / no-family-inference / disabled-agent-skipped / multi-missing / empty. ruff + quality lint clean; **1379 cycles tests green**.

## Remaining on #224 (this PR does NOT close it)
- **Mac lane (SIP-0095 Phase 3):** wire `combine(required_roles_decision(...), model_availability_decision(...))` into the create route; supply `pulled_models` from the LLM adapter (`None` on query failure); surface the warning on the response + CLI.
- **Spark follow-on:** `doctor` parity — call the same decision with `ollama list` as the pulled-list source (§8).

Parallel-safe with SIP-0090 (#308) — disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)