### PR TITLE
fix(#285): reconcile local-spark bootstrap models with squad-profiles

### DIFF
--- a/config/profiles/bootstrap/local-spark.yaml
+++ b/config/profiles/bootstrap/local-spark.yaml
@@ -92,15 +92,14 @@ docker_services:
     timeout_seconds: 90
 
 ollama_models:
-  - name: "qwen2.5:72b"
-    required: true
-  - name: "llama3:70b"
+  # Must cover every squad profile this box runs (config/squad-profiles.yaml):
+  # smoke → qwen2.5:3b-instruct, lite → qwen2.5:7b, full → qwen3.6:27b. Keep in
+  # sync with squad-profiles.yaml so a fresh bootstrap provisions a runnable squad (#285).
+  - name: "qwen2.5:3b-instruct"
     required: true
   - name: "qwen2.5:7b"
     required: true
-  - name: "llama3.1:8b"
-    required: true
-  - name: "qwen2.5:3b-instruct"
+  - name: "qwen3.6:27b"
     required: true
 
 deployment_profile: local

--- a/tests/unit/bootstrap/setup/test_profile.py
+++ b/tests/unit/bootstrap/setup/test_profile.py
@@ -450,8 +450,12 @@ class TestRealProfiles:
         assert len(gpu_deps) == 2
         assert all(d.install == "none" for d in gpu_deps)
 
-        # Spark has large models
-        assert len(profile.ollama_models) >= 4
+        # Spark runs the `full` squad, so it must pull `full`'s 27b model — plus
+        # `lite` (7b) and `smoke` (3b) so any validation profile is runnable (#285).
+        model_names = {m.name for m in profile.ollama_models}
+        assert "qwen3.6:27b" in model_names  # `full` — the #285 gap this guards
+        assert "qwen2.5:7b" in model_names  # `lite`
+        assert "qwen2.5:3b-instruct" in model_names  # `smoke`
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #285 (Spark-owned substantive fix; residuals noted below).

## Problem
A fresh `squadops bootstrap local-spark` provisioned a **non-runnable `full` squad** — the box's `ollama_models` didn't include `qwen3.6:27b` (what `full` needs per `config/squad-profiles.yaml`); `full` only ran because 27b was pulled outside bootstrap. The list also carried stale/dead entries.

## Change (local-spark only)
Reconcile `config/profiles/bootstrap/local-spark.yaml` to exactly the models its squad profiles need:

| | model | why |
|---|---|---|
| **+** | `qwen3.6:27b` | `full` — the missing one (the #285 fix) |
| keep | `qwen2.5:7b` | `lite` |
| keep | `qwen2.5:3b-instruct` | `smoke` |
| **−** | `qwen2.5:72b` | stale (replaced in the 72b→27b switch) |
| **−** | `llama3:70b` | no squad profile references it |
| **−** | `llama3.1:8b` | dead pull — referenced nowhere but the pull-lists (verified across `config/`+`src/`) |

Added a comment tying the list to `squad-profiles.yaml` to resist re-drift. Cross-checked: local-spark now covers smoke/lite/full (all ✅).

## Test
Replaced the brittle `len(ollama_models) >= 4` assertion (it encoded the stale 5-model list) with a meaningful one — the profile pulls `full`'s 27b + lite/smoke, so a regression that drops the 27b again fails CI. **86 bootstrap tests green**; ruff + quality lint clean.

## Scope / residuals (this PR does NOT close #285)
- **dev-mac / dev-pc** carry the same dead `llama3.1:8b`, but they're **Mac-lane environments** — flagged for Mac on #285, not touched here (don't-touch-other-profiles).
- Optional follow-on: a bootstrap-time check that `squad_profile` models ⊆ `ollama_models` so this can't silently drift again (ties to #224/doctor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)