### PR TITLE
feat(#224): doctor model-availability parity via the shared preflight decision

### DIFF
--- a/src/squadops/bootstrap/setup/checks.py
+++ b/src/squadops/bootstrap/setup/checks.py
@@ -6,6 +6,7 @@ and returns a CheckResult with pass/fail, fix guidance, and heuristic flag.
 
 from __future__ import annotations
 
+import asyncio
 import platform
 import shutil
 import socket
@@ -420,8 +421,14 @@ def _check_docker_health(svc: DockerService) -> CheckResult:
 # ---------------------------------------------------------------------------
 
 
-def _get_ollama_models() -> set[str]:
-    """Get set of installed Ollama model names."""
+def _query_ollama_models() -> set[str] | None:
+    """Installed Ollama model names, or ``None`` if the backend can't be queried.
+
+    ``None`` (``ollama`` missing / non-zero exit / timeout) is deliberately
+    distinct from an empty set (reachable, nothing pulled): callers that
+    warn-and-allow on *unverifiable* availability (SIP-0095 §6.3) need that
+    distinction, or they'd wrongly block whenever the backend hiccups.
+    """
     try:
         result = subprocess.run(
             ["ollama", "list"],
@@ -429,16 +436,21 @@ def _get_ollama_models() -> set[str]:
             text=True,
             timeout=15,
         )
-        if result.returncode != 0:
-            return set()
-        models = set()
-        for line in result.stdout.splitlines()[1:]:  # skip header
-            parts = line.split()
-            if parts:
-                models.add(parts[0])
-        return models
     except (subprocess.TimeoutExpired, OSError):
-        return set()
+        return None
+    if result.returncode != 0:
+        return None
+    models = set()
+    for line in result.stdout.splitlines()[1:]:  # skip header
+        parts = line.split()
+        if parts:
+            models.add(parts[0])
+    return models
+
+
+def _get_ollama_models() -> set[str]:
+    """Installed Ollama model names, empty on failure (legacy binary pull-check)."""
+    return _query_ollama_models() or set()
 
 
 def check_ollama_model_exact(model: OllamaModelExact, installed: set[str]) -> CheckResult:
@@ -672,6 +684,64 @@ def _collect_models_checks(profile: BootstrapProfile) -> list[CheckResult]:
     return results
 
 
+def _collect_squad_checks(profile: BootstrapProfile) -> list[CheckResult]:
+    """Model-availability for the box's squad profile, via the SHARED create-time
+    decision (SIP-0095 §8, #224) — so ``doctor`` and cycle-create agree on what
+    "available" means. Blocks name a definitively-missing model; an unreachable
+    backend warns (heuristic ``~``) rather than fails, per warn-and-allow (§6.3).
+    """
+    if not profile.squad_profile:
+        return []
+
+    # Local imports: only doctor's `squad` category needs these, and this confines
+    # the adapter import to the bootstrap-wiring layer (#154).
+    from adapters.cycles.config_squad_profile import ConfigSquadProfile
+    from squadops.cycles.models import ProfileNotFoundError
+    from squadops.cycles.preflight import model_availability_decision
+
+    pid = profile.squad_profile
+    try:
+        squad = asyncio.run(ConfigSquadProfile().get_profile(pid))
+    except ProfileNotFoundError:
+        return [
+            CheckResult(
+                name=f"squad profile `{pid}`",
+                category="squad",
+                passed=False,
+                message=f"squad profile `{pid}` is not defined in config/squad-profiles.yaml",
+            )
+        ]
+
+    decision = model_availability_decision(squad, _query_ollama_models())
+    if not decision.blocking and not decision.warnings:
+        count = len({a.model for a in squad.agents if a.enabled and a.model})
+        return [
+            CheckResult(
+                name=f"squad `{pid}` models",
+                category="squad",
+                passed=True,
+                message=f"all {count} model(s) for squad `{pid}` are available",
+            )
+        ]
+
+    results = [
+        CheckResult(name=f"squad `{pid}` model", category="squad", passed=False, message=f.message)
+        for f in decision.blocking
+    ]
+    results.extend(
+        # unverifiable → warn (~), not a hard fail (warn-and-allow)
+        CheckResult(
+            name=f"squad `{pid}` model",
+            category="squad",
+            passed=False,
+            heuristic=True,
+            message=f.message,
+        )
+        for f in decision.warnings
+    )
+    return results
+
+
 def _collect_gpu_checks(profile: BootstrapProfile) -> list[CheckResult]:
     has_nvidia = any("nvidia" in dep.name for dep in profile.system_deps)
     return list(check_nvidia_gpu()) if has_nvidia else []
@@ -687,6 +757,7 @@ _CHECK_REGISTRY: list[tuple[str, object]] = [
     ("tools", _collect_tools_checks),
     ("docker", _collect_docker_checks),
     ("models", _collect_models_checks),
+    ("squad", _collect_squad_checks),
     ("gpu", _collect_gpu_checks),
     ("auth", _collect_auth_checks),
 ]

--- a/tests/unit/bootstrap/setup/test_checks.py
+++ b/tests/unit/bootstrap/setup/test_checks.py
@@ -7,8 +7,11 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import squadops.bootstrap.setup.checks as checks_mod
 from squadops.bootstrap.setup.checks import (
     CheckResult,
     check_auth_token,
@@ -31,6 +34,7 @@ from squadops.bootstrap.setup.profile import (
     PythonSpec,
     SystemDep,
 )
+from squadops.cycles.models import AgentProfileEntry, ProfileNotFoundError, SquadProfile
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -537,3 +541,80 @@ class TestRunChecks:
             result = check_system_dep(dep)
         assert result.passed is False
         assert result.fix_command is not None
+
+
+# ---------------------------------------------------------------------------
+# Squad model-availability check (#224 doctor parity — shares the create-time
+# decision so `doctor` and cycle-create can't drift on "is the model available").
+# ---------------------------------------------------------------------------
+
+
+def _squad_profile(models, *, pid="full"):
+    agents = tuple(
+        AgentProfileEntry(agent_id=f"a{i}", role=f"r{i}", model=m, enabled=True)
+        for i, m in enumerate(models)
+    )
+    return SquadProfile(
+        profile_id=pid,
+        name="X",
+        description="",
+        version=1,
+        agents=agents,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+
+class TestSquadModelChecks:
+    """`_collect_squad_checks` maps the shared model-availability decision to doctor
+    CheckResults: available→pass(✓), missing→hard fail(✗), unreachable→warn(~)."""
+
+    def _run(self, monkeypatch, *, installed, squad=None, squad_profile="full", not_found=False):
+        class _FakeCSP:
+            def __init__(self, *a, **k):
+                pass
+
+            async def get_profile(self, pid):
+                if not_found:
+                    raise ProfileNotFoundError(pid)
+                return squad
+
+        monkeypatch.setattr("adapters.cycles.config_squad_profile.ConfigSquadProfile", _FakeCSP)
+        monkeypatch.setattr(checks_mod, "_query_ollama_models", lambda: installed)
+        return checks_mod._collect_squad_checks(SimpleNamespace(squad_profile=squad_profile))
+
+    def test_all_models_available_passes(self, monkeypatch):
+        results = self._run(
+            monkeypatch, squad=_squad_profile(["qwen3.6:27b"]), installed={"qwen3.6:27b", "x:1b"}
+        )
+        assert len(results) == 1
+        assert results[0].passed is True
+        assert results[0].category == "squad"
+
+    def test_missing_model_is_hard_fail(self, monkeypatch):
+        results = self._run(
+            monkeypatch, squad=_squad_profile(["qwen3.6:27b"]), installed={"qwen2.5:7b"}
+        )
+        (r,) = results
+        assert r.passed is False and r.heuristic is False  # ✗ hard fail
+        assert "qwen3.6:27b" in r.message
+
+    def test_unreachable_backend_warns_not_fails(self, monkeypatch):
+        """installed=None (ollama unreachable) → heuristic warn (~), never a hard fail."""
+        results = self._run(monkeypatch, squad=_squad_profile(["qwen3.6:27b"]), installed=None)
+        (r,) = results
+        assert r.passed is False and r.heuristic is True  # ~ warn-and-allow
+
+    def test_empty_backend_is_hard_fail_not_warn(self, monkeypatch):
+        """Reachable-but-empty (set(), not None) is verifiable → hard fail, not warn."""
+        results = self._run(monkeypatch, squad=_squad_profile(["qwen3.6:27b"]), installed=set())
+        (r,) = results
+        assert r.passed is False and r.heuristic is False
+
+    def test_no_squad_profile_yields_no_checks(self, monkeypatch):
+        assert self._run(monkeypatch, installed=set(), squad_profile=None) == []
+
+    def test_unknown_squad_profile_is_reported(self, monkeypatch):
+        results = self._run(monkeypatch, installed=set(), not_found=True)
+        (r,) = results
+        assert r.passed is False
+        assert "not defined" in r.message


### PR DESCRIPTION
Refs #224. Completes the **Spark half** of SIP-0095's model-availability check — the doctor-parity piece (§8), building on the shared decision from #309.

## What this adds
`doctor` now checks the box's squad-profile models using the **same** `model_availability_decision` the cycle-create preflight uses — so environment diagnosis and create-time enforcement can't drift on what "available" means (SIP §8/§117).

- **New `squad` check category** (`_collect_squad_checks`): loads the box's `squad_profile` via the config provider, runs the shared decision against the pulled models, and renders each `Finding`:
  - definitively-missing model → **hard fail** (`✗`)
  - unreachable backend → **heuristic warn** (`~`), not a fail — warn-and-allow (§6.3)
  - all present → pass (`✓`)
- **Refactored the ollama fetch:** extracted `_query_ollama_models() -> set | None` (`None` on unreachable/timeout/non-zero) so the decision can tell *unverifiable* (warn) from *reachable-empty* (block). `_get_ollama_models()` stays a thin `or set()` wrapper — the existing binary pull-check is byte-for-byte unchanged.
- **Architecture:** the adapter import (`ConfigSquadProfile`) is confined to the bootstrap-wiring layer (#154's intended home); the forbidden-imports test stays green.

## Tests (6 new)
available→pass · missing→hard-fail · **unreachable→warn (the warn-and-allow guard)** · reachable-empty→hard-fail (the None-vs-`set()` distinction) · no-squad-profile→skip · unknown-profile→reported. **97 bootstrap+architecture tests green**; ruff + quality lint clean.

## #224 status after this
- ✅ **Spark half complete:** shared decision (#309) + doctor parity (this PR).
- ⏳ **Remaining (Mac, SIP-0095 Phase 3):** wire `combine(required_roles_decision, model_availability_decision)` into the create route + feed `pulled_models` from the LLM adapter + surface the warning on the response/CLI.

Try it: `squadops doctor local-spark --check squad`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)