### PR TITLE
feat(SIP-0090 Phase 1): core embodiment model — slice 1a (model + budgets + port + coordinator)

### DIFF
--- a/src/squadops/ports/runtime/embodiment.py
+++ b/src/squadops/ports/runtime/embodiment.py
@@ -1,0 +1,72 @@
+"""
+EmbodimentStatePort — abstract interface for Embodiment record + lifecycle-state
+persistence (SIP-0090 §5).
+
+Phase 1 surface (plan §4.3). A **record/lifecycle store, not an action surface**:
+it has no method that decides intent/mode/priority or executes an embodied action.
+Attaching, detaching, sending, and listening are the Phase-2 ``EmbodimentSurfacePort``'s
+job — and even there only for *already-authorized* requests (§6 authority boundary).
+Keeping the two ports separate is deliberate; they never merge.
+
+Named to mirror SIP-0089's ``RuntimeStatePort``. Mutating methods accept an optional
+``conn`` for the §-D25 unit-of-work seam (as ``RuntimeStatePort.upsert_state`` does),
+so a Phase-3 coordinator can commit a transition atomically with its other writes.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from squadops.runtime.embodiment import AttachmentState, Embodiment, Health
+
+
+class EmbodimentStatePort(ABC):
+    """Port for `Embodiment` record CRUD and lifecycle-state writes (SIP-0090 §5)."""
+
+    @abstractmethod
+    async def create_embodiment(self, embodiment: Embodiment, *, conn: Any = None) -> Embodiment:
+        """Persist a new `Embodiment` record and return it."""
+
+    @abstractmethod
+    async def get_embodiment(self, embodiment_id: str) -> Embodiment | None:
+        """Return the `Embodiment` for `embodiment_id`, or `None` if no row exists."""
+
+    @abstractmethod
+    async def get_active_embodiment(self, agent_id: str) -> Embodiment | None:
+        """Return the agent's single active embodiment (§5.5), or `None`.
+
+        "Active" = attachment_state in {attached, desynced, reconnecting}. At most
+        one such row exists per agent — the single-active invariant (the DB partial
+        unique index in 1b is the hard backstop).
+        """
+
+    @abstractmethod
+    async def list_for_agent(self, agent_id: str) -> tuple[Embodiment, ...]:
+        """Return all `Embodiment` records for `agent_id` (any attachment state)."""
+
+    @abstractmethod
+    async def transition_state(
+        self, embodiment_id: str, target_state: AttachmentState, *, conn: Any = None
+    ) -> Embodiment:
+        """Persist an attachment-state transition and return the updated record.
+
+        The transition is validated **upstream** by the `EmbodimentCoordinator`
+        (allow-list + single-active rule); this method only writes the result.
+        """
+
+    @abstractmethod
+    async def update_health(
+        self, embodiment_id: str, health: Health, *, conn: Any = None
+    ) -> Embodiment:
+        """Persist a health change for the embodiment and return the updated record."""
+
+    @abstractmethod
+    async def update_location(
+        self, embodiment_id: str, location_ref: str | None, *, conn: Any = None
+    ) -> Embodiment:
+        """Persist an opaque `location_ref` (§5.4) and return the updated record.
+
+        `location_ref` is stored and compared verbatim; this port never parses it.
+        """

--- a/src/squadops/runtime/budgets.py
+++ b/src/squadops/runtime/budgets.py
@@ -28,6 +28,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal
 
+from squadops.runtime.reasons import BUDGET_EXHAUSTED
+
 BudgetDimension = Literal["attention", "compute", "action", "concurrency"]
 CONSUMABLE_DIMENSIONS: frozenset[BudgetDimension] = frozenset({"attention", "compute", "action"})
 
@@ -39,7 +41,9 @@ ExhaustionOutcome = Literal[
     "require_operator_override",
 ]
 
-BUDGET_EXHAUSTED_REASON = "budget_exhausted"
+# `budget_exhausted` is the single canonical reason code — sourced from
+# `runtime.reasons` (not redefined here) so there is one source of truth.
+BUDGET_EXHAUSTED_REASON = BUDGET_EXHAUSTED
 
 # Default enforcement policy: which outcome each dimension forces on exhaustion
 # (§7.2). Conservative by design — the safe default for an over-budget agent is to

--- a/src/squadops/runtime/budgets.py
+++ b/src/squadops/runtime/budgets.py
@@ -1,0 +1,189 @@
+"""
+Resource budget primitives for SIP-0090 (Agent Embodiment Substrate), Phase 1 §7.
+
+Budgets attach to the **agent** (§7.1), not the embodiment, so cross-embodiment
+usage sums. Phase 1 models decrement/acquire, release, exhaustion detection, and
+the enforcement decision — **not** reset/replenishment (plan §4.2, explicitly
+deferred so scheduling policy stays out of the substrate).
+
+Two shapes (SIP §7.1 splits three cumulative counters from one "simultaneously-
+open" gauge):
+
+- **Consumable** (``{limit, consumed}``) — attention / compute / action. Remaining
+  is derived; storing the limit (not remaining-only) keeps a future reset and
+  observability possible without rework.
+- **Capacity** (``{allowance, in_use}``) — concurrency. A gauge with symmetric
+  ``acquire`` / ``release``; ``release`` is first-class so "acquire without release"
+  is a visible bug, not a silent leak.
+
+Exhaustion is never silent (§7.2): :func:`budget_decision` always returns one of
+five :data:`ExhaustionOutcome`\\ s plus the ``budget_exhausted`` reason when a
+request would exceed a cap. Pure (mirrors ``recruitment.reserve_buffer_decision``)
+— no I/O, no adapters (D26).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal
+
+BudgetDimension = Literal["attention", "compute", "action", "concurrency"]
+CONSUMABLE_DIMENSIONS: frozenset[BudgetDimension] = frozenset({"attention", "compute", "action"})
+
+ExhaustionOutcome = Literal[
+    "reject_new_activity",
+    "pause_current_activity",
+    "detach_embodiment",
+    "transition_to_ambient",
+    "require_operator_override",
+]
+
+BUDGET_EXHAUSTED_REASON = "budget_exhausted"
+
+# Default enforcement policy: which outcome each dimension forces on exhaustion
+# (§7.2). Conservative by design — the safe default for an over-budget agent is to
+# stop taking on new work, not to detach or force an operator override. Overridable
+# per call so a specific caller can escalate.
+_DEFAULT_EXHAUSTION_POLICY: Mapping[BudgetDimension, ExhaustionOutcome] = {
+    "attention": "reject_new_activity",
+    "compute": "reject_new_activity",
+    "action": "reject_new_activity",
+    "concurrency": "reject_new_activity",
+}
+
+
+@dataclass(frozen=True)
+class ConsumableBudget:
+    """A cumulative budget: ``{limit, consumed}``. Exhausted when ``consumed >= limit``."""
+
+    limit: int
+    consumed: int = 0
+
+    @property
+    def remaining(self) -> int:
+        return max(0, self.limit - self.consumed)
+
+    @property
+    def is_exhausted(self) -> bool:
+        return self.consumed >= self.limit
+
+    def spend(self, amount: int) -> ConsumableBudget:
+        """Return a new budget with ``amount`` consumed (pure; never mutates)."""
+        if amount < 0:
+            raise ValueError("spend amount must be non-negative")
+        return ConsumableBudget(limit=self.limit, consumed=self.consumed + amount)
+
+
+@dataclass(frozen=True)
+class CapacityBudget:
+    """A capacity gauge: ``{allowance, in_use}``. Exhausted when ``in_use >= allowance``.
+
+    ``acquire`` / ``release`` are symmetric. ``release`` below zero is a caller bug
+    (acquire/release imbalance) surfaced as ``ValueError``, never silently floored —
+    a leaked slot must be observable.
+    """
+
+    allowance: int
+    in_use: int = 0
+
+    @property
+    def available(self) -> int:
+        return max(0, self.allowance - self.in_use)
+
+    @property
+    def is_exhausted(self) -> bool:
+        return self.in_use >= self.allowance
+
+    def acquire(self) -> CapacityBudget:
+        return CapacityBudget(allowance=self.allowance, in_use=self.in_use + 1)
+
+    def release(self) -> CapacityBudget:
+        if self.in_use <= 0:
+            raise ValueError("release without a matching acquire (concurrency underflow)")
+        return CapacityBudget(allowance=self.allowance, in_use=self.in_use - 1)
+
+
+@dataclass(frozen=True)
+class AgentBudget:
+    """The four §7.1 budget dimensions, attached to the agent."""
+
+    attention: ConsumableBudget
+    compute: ConsumableBudget
+    action: ConsumableBudget
+    concurrency: CapacityBudget
+
+
+@dataclass(frozen=True)
+class BudgetDecision:
+    """Verdict for a requested spend/acquire (§7.2). Pure — no event emission here.
+
+    ``allowed`` — whether the request may proceed. ``exhausted`` — whether it would
+    exceed the cap. On exhaustion ``outcome`` is one of the five forced
+    :data:`ExhaustionOutcome`\\ s and ``reason_code`` is ``budget_exhausted``; both
+    are ``None`` otherwise. Silent degradation is unrepresentable: ``exhausted`` is
+    true iff ``outcome`` is set (see :meth:`__post_init__`).
+    """
+
+    dimension: BudgetDimension
+    allowed: bool
+    exhausted: bool
+    outcome: ExhaustionOutcome | None = None
+    reason_code: str | None = None
+
+    def __post_init__(self) -> None:
+        # The type-level guard that exhaustion is never silent: an exhausted verdict
+        # must carry a forced outcome + reason, and a non-exhausted one must not.
+        if self.exhausted != (self.outcome is not None):
+            raise ValueError(
+                "an exhausted decision must carry an ExhaustionOutcome, and vice versa"
+            )
+        if self.exhausted and self.reason_code != BUDGET_EXHAUSTED_REASON:
+            raise ValueError("an exhausted decision must carry the budget_exhausted reason code")
+
+
+def _dimension_budget(
+    budget: AgentBudget, dimension: BudgetDimension
+) -> ConsumableBudget | CapacityBudget:
+    return {
+        "attention": budget.attention,
+        "compute": budget.compute,
+        "action": budget.action,
+        "concurrency": budget.concurrency,
+    }[dimension]
+
+
+def budget_decision(
+    budget: AgentBudget,
+    dimension: BudgetDimension,
+    amount: int = 1,
+    policy: Mapping[BudgetDimension, ExhaustionOutcome] | None = None,
+) -> BudgetDecision:
+    """Decide whether a spend (consumable) or acquire (capacity) may proceed (§7.2).
+
+    A hard pre-spend gate: the request is **rejected** when it would push the
+    dimension past its cap — ``consumed + amount > limit`` for a consumable,
+    ``in_use + amount > allowance`` for concurrency (``amount`` defaults to one
+    slot). Rejection is never silent: it carries a forced :data:`ExhaustionOutcome`
+    (from ``policy``, else the conservative default) and the ``budget_exhausted``
+    reason. Pure — it does not mutate ``budget``; the caller applies the
+    spend/acquire only when ``allowed``.
+    """
+    if amount < 0:
+        raise ValueError("amount must be non-negative")
+    dim = _dimension_budget(budget, dimension)
+    if isinstance(dim, CapacityBudget):
+        would_exhaust = dim.in_use + amount > dim.allowance
+    else:
+        would_exhaust = dim.consumed + amount > dim.limit
+
+    if would_exhaust:
+        outcome = (policy or _DEFAULT_EXHAUSTION_POLICY)[dimension]
+        return BudgetDecision(
+            dimension=dimension,
+            allowed=False,
+            exhausted=True,
+            outcome=outcome,
+            reason_code=BUDGET_EXHAUSTED_REASON,
+        )
+    return BudgetDecision(dimension=dimension, allowed=True, exhausted=False)

--- a/src/squadops/runtime/embodiment.py
+++ b/src/squadops/runtime/embodiment.py
@@ -1,0 +1,129 @@
+"""
+Embodiment domain model + lifecycle for SIP-0090 (Agent Embodiment Substrate).
+
+Phase 1 (§13, slice 1a): the core embodiment record, its attachment lifecycle
+state machine, and the opaque ``Location``. No adapter — this is pure,
+migration-free substrate (plan: ``docs/plans/SIP-0090-phase-1-plan.md``).
+
+Mirrors the SIP-0089 ``runtime/models.py`` conventions: frozen dataclasses mutated
+via ``dataclasses.replace()``, module-level ``Literal`` types that mirror the DB
+``CHECK`` constraints landed in 1b (D3), and an explicit transition allow-list
+(like the coordinator's ``_ALLOWED_TRANSITIONS``) so a malformed transition is
+rejected, not applied. Budgets live in ``runtime/budgets.py``; the state port and
+``EmbodimentCoordinator`` are separate modules (plan §4.3 / §4.5).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+# §5.2 attachment lifecycle; §5.3 health + embodiment_type. Literals mirror the DB
+# CHECK constraints landed in 1b (D3).
+AttachmentState = Literal[
+    "unattached", "attaching", "attached", "desynced", "reconnecting", "detached"
+]
+Health = Literal["healthy", "degraded", "failed"]
+EmbodimentType = Literal["discord", "browser", "minecraft", "cli", "other"]
+
+_CREDENTIALS_REF_SCHEME = "secret://"
+
+# §5.2 lifecycle state machine, spelled out per plan §4.1 as an explicit allow-list
+# of (from, to) pairs. This COMPLETES the SIP §5.2 ASCII (which draws only the happy
+# path plus attached ↘ detached) by making the failure-termination edges explicit:
+# a failed attach, an abandoned desync, and a failed reconnect all terminate at
+# `detached`. `detached` is terminal in Phase 1 (no outgoing). Kept explicit so an
+# illegal shortcut (e.g. unattached→attached, attached→reconnecting) is rejected,
+# not applied.
+_ALLOWED_ATTACHMENT_TRANSITIONS: frozenset[tuple[AttachmentState, AttachmentState]] = frozenset(
+    {
+        ("unattached", "attaching"),
+        ("attaching", "attached"),
+        ("attaching", "detached"),
+        ("attached", "desynced"),
+        ("attached", "detached"),
+        ("desynced", "reconnecting"),
+        ("desynced", "detached"),
+        ("reconnecting", "attached"),
+        ("reconnecting", "detached"),
+    }
+)
+
+# The attachment states in which an embodiment counts as "live" for the single-
+# active-embodiment rule (§5.5): at most one of these may exist per agent.
+_ACTIVE_ATTACHMENT_STATES: frozenset[AttachmentState] = frozenset(
+    {"attached", "desynced", "reconnecting"}
+)
+
+
+def is_allowed_attachment_transition(current: AttachmentState, target: AttachmentState) -> bool:
+    """True iff ``current → target`` is a legal §5.2 attachment transition (plan §4.1)."""
+    return (current, target) in _ALLOWED_ATTACHMENT_TRANSITIONS
+
+
+def is_active_attachment(state: AttachmentState) -> bool:
+    """True iff ``state`` counts as a live embodiment for the single-active rule (§5.5)."""
+    return state in _ACTIVE_ATTACHMENT_STATES
+
+
+def is_valid_credentials_ref(credentials_ref: str | None) -> bool:
+    """True iff ``credentials_ref`` is absent or a ``secret://`` reference (§9).
+
+    A raw credential must never land in an Embodiment record — only an indirection
+    the SecretManager resolves at attach (1b / Phase 2). ``None`` means "no
+    credentials" and is allowed.
+    """
+    return credentials_ref is None or credentials_ref.startswith(_CREDENTIALS_REF_SCHEME)
+
+
+@dataclass(frozen=True)
+class Location:
+    """An **opaque** handle to where an embodiment is attached (§5.4).
+
+    Core stores and compares ``ref`` (by equality) and routes it back to the owning
+    adapter, but MUST NOT parse or branch on its contents. ``location_type`` is a
+    coarse routing tag for choosing the adapter; it is *not* parsed for meaning by
+    core code (no ``location_type == "discord_channel"`` branching — plan §7). This
+    dataclass deliberately exposes no parsed sub-fields.
+    """
+
+    location_type: str
+    ref: str
+
+
+@dataclass(frozen=True)
+class Embodiment:
+    """A single agent↔surface attachment record (SIP-0090 §5.3).
+
+    Frozen; mutate via ``dataclasses.replace()``. ``attachment_state`` moves only
+    along the §5.2 allow-list (:func:`is_allowed_attachment_transition`); the
+    :class:`EmbodimentCoordinator` (plan §4.5) owns transitions and the single-active
+    rule (§5.5). ``location_ref`` is opaque (§5.4). ``credentials_ref`` is a
+    ``secret://`` indirection, never a raw secret (§9) — enforced at construction so
+    a raw credential can never land in a record.
+    """
+
+    embodiment_id: str
+    agent_id: str
+    embodiment_type: EmbodimentType
+    platform: str
+    attachment_state: AttachmentState
+    health: Health
+    capability_set: tuple[str, ...] = ()
+    location_ref: str | None = None
+    last_health_check_at: datetime | None = None
+    credentials_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        # Security invariant (§9 / hard rule "credentials via secret:// refs"): a raw
+        # credential must never be storable in a record.
+        if not is_valid_credentials_ref(self.credentials_ref):
+            raise ValueError(
+                "credentials_ref must be a `secret://` reference, never a raw credential"
+            )
+
+    @property
+    def is_active(self) -> bool:
+        """Whether this embodiment currently counts as live for the single-active rule (§5.5)."""
+        return is_active_attachment(self.attachment_state)

--- a/src/squadops/runtime/embodiment_coordinator.py
+++ b/src/squadops/runtime/embodiment_coordinator.py
@@ -1,0 +1,136 @@
+"""
+EmbodimentCoordinator — validates and applies Embodiment lifecycle transitions,
+emitting reason-coded events (SIP-0090 Phase 1 §5.2 / §5.5).
+
+Mirrors the SIP-0089 ``RuntimeCoordinator``: a pure orchestrator over an injected
+:class:`EmbodimentStatePort` (+ optional :class:`RuntimeEventPublisher`). It validates
+each transition against the §4.1 allow-list, enforces the single-active-embodiment
+rule (§5.5), persists the result, and emits the matching ``embodiment.*`` event. It
+decides nothing about intent or action — that authority stays outside the substrate
+(§6 authority boundary).
+
+Adapter-free (D26): imports only runtime models, ports, events/reasons, and typing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from squadops.ports.runtime.embodiment import EmbodimentStatePort
+from squadops.ports.runtime.event_publisher import RuntimeEventPublisher
+from squadops.runtime import events, reasons
+from squadops.runtime.embodiment import (
+    AttachmentState,
+    Embodiment,
+    is_active_attachment,
+    is_allowed_attachment_transition,
+)
+
+# Which `embodiment.*` event each attachment *target* state emits (§5.2). `unattached`
+# is only an initial state, never a transition target, so it carries no event.
+_STATE_EVENT: dict[AttachmentState, str] = {
+    "attaching": events.EMBODIMENT_ATTACHING,
+    "attached": events.EMBODIMENT_ATTACHED,
+    "desynced": events.EMBODIMENT_DESYNCED,
+    "reconnecting": events.EMBODIMENT_RECONNECTING,
+    "detached": events.EMBODIMENT_DETACHED,
+}
+
+
+@dataclass(frozen=True)
+class EmbodimentTransitionOutcome:
+    """Result of a :meth:`EmbodimentCoordinator.request_transition` call.
+
+    Exactly one of two shapes: applied (``applied=True``, ``event_name`` set) or
+    rejected (``applied=False``, ``rejected_reason`` set). ``reason_code`` echoes the
+    requested reason in both cases.
+    """
+
+    applied: bool
+    embodiment_id: str
+    agent_id: str
+    from_state: AttachmentState
+    to_state: AttachmentState
+    reason_code: str
+    event_name: str | None = None
+    rejected_reason: str | None = None
+
+
+class EmbodimentCoordinator:
+    """Validates and applies Embodiment attachment transitions; emits reason-coded events."""
+
+    def __init__(
+        self,
+        state: EmbodimentStatePort,
+        *,
+        events_publisher: RuntimeEventPublisher | None = None,
+    ) -> None:
+        self._state = state
+        self._events = events_publisher
+
+    async def request_transition(
+        self,
+        embodiment: Embodiment,
+        target_state: AttachmentState,
+        reason_code: str,
+        *,
+        conn: Any = None,
+    ) -> EmbodimentTransitionOutcome:
+        """Validate and apply ``embodiment.attachment_state → target_state``.
+
+        Rejections write nothing and emit nothing: a missing reason code
+        (``missing_reason_code``), an illegal transition
+        (``invalid_attachment_transition``), or a single-active violation
+        (``embodiment_already_active`` — a second live embodiment for the agent,
+        §5.5). On success the transition is persisted and the matching
+        ``embodiment.*`` event is emitted best-effort.
+        """
+        from_state = embodiment.attachment_state
+
+        def _reject(rejected_reason: str) -> EmbodimentTransitionOutcome:
+            return EmbodimentTransitionOutcome(
+                applied=False,
+                embodiment_id=embodiment.embodiment_id,
+                agent_id=embodiment.agent_id,
+                from_state=from_state,
+                to_state=target_state,
+                reason_code=reason_code,
+                rejected_reason=rejected_reason,
+            )
+
+        # (1) a reason code is mandatory (mirrors SIP-0089 §11.2).
+        if not reason_code:
+            return _reject(reasons.MISSING_REASON_CODE)
+
+        # (2 §5.2) the transition must be on the allow-list.
+        if not is_allowed_attachment_transition(from_state, target_state):
+            return _reject(reasons.INVALID_ATTACHMENT_TRANSITION)
+
+        # (3 §5.5) single-active: entering a live state must not create a second
+        # active embodiment for the agent. Only attaching→attached crosses
+        # non-active → active, so that is the one moment this guard fires.
+        if is_active_attachment(target_state) and not is_active_attachment(from_state):
+            active = await self._state.get_active_embodiment(embodiment.agent_id)
+            if active is not None and active.embodiment_id != embodiment.embodiment_id:
+                return _reject(reasons.EMBODIMENT_ALREADY_ACTIVE)
+
+        # (4) persist, then emit the target-state event (best-effort — never fatal).
+        await self._state.transition_state(embodiment.embodiment_id, target_state, conn=conn)
+        event_name = _STATE_EVENT[target_state]
+        if self._events is not None:
+            self._events.emit(
+                event_name,
+                agent_id=embodiment.agent_id,
+                reason_code=reason_code,
+                payload={"embodiment_id": embodiment.embodiment_id},
+            )
+        return EmbodimentTransitionOutcome(
+            applied=True,
+            embodiment_id=embodiment.embodiment_id,
+            agent_id=embodiment.agent_id,
+            from_state=from_state,
+            to_state=target_state,
+            reason_code=reason_code,
+            event_name=event_name,
+        )

--- a/src/squadops/runtime/events.py
+++ b/src/squadops/runtime/events.py
@@ -38,3 +38,18 @@ RUNTIME_ACTIVITY_STARTED: Final[str] = "runtime_activity.started"
 RUNTIME_ACTIVITY_COMPLETED: Final[str] = "runtime_activity.completed"
 RUNTIME_ACTIVITY_FAILED: Final[str] = "runtime_activity.failed"
 RUNTIME_ACTIVITY_ABORTED: Final[str] = "runtime_activity.aborted"
+
+# Embodiment lifecycle (SIP-0090 Phase 1 §5.2 — EmbodimentCoordinator-emitted). Each
+# attachment transition emits the `embodiment.*` event named for its target state;
+# `EMBODIMENT_HEALTH_CHANGED` covers a health change with no attachment move. Distinct
+# from the reason codes in `reasons.py` (D18).
+EMBODIMENT_ATTACHING: Final[str] = "embodiment.attaching"
+EMBODIMENT_ATTACHED: Final[str] = "embodiment.attached"
+EMBODIMENT_DESYNCED: Final[str] = "embodiment.desynced"
+EMBODIMENT_RECONNECTING: Final[str] = "embodiment.reconnecting"
+EMBODIMENT_DETACHED: Final[str] = "embodiment.detached"
+EMBODIMENT_HEALTH_CHANGED: Final[str] = "embodiment.health_changed"
+
+# Resource-budget enforcement (SIP-0090 Phase 1 §7.2). Emitted whenever a budget
+# request is rejected on exhaustion — degradation is never silent.
+BUDGET_EXHAUSTED: Final[str] = "budget.exhausted"

--- a/src/squadops/runtime/reasons.py
+++ b/src/squadops/runtime/reasons.py
@@ -55,3 +55,24 @@ ACTIVITY_PREEMPTED_BY_MODE_CHANGE: Final[str] = "activity_preempted_by_mode_chan
 
 # Ambient irreversibility policy (Phase 4 §4.6 — v1.2 embodiment seam, no v1.1 callers)
 AMBIENT_IRREVERSIBLE_ACTION_FORBIDDEN: Final[str] = "ambient_irreversible_action_forbidden"
+
+# Embodiment lifecycle reasons (SIP-0090 Phase 1 §5.2 — the "why" behind each
+# attachment transition, supplied to the EmbodimentCoordinator and echoed on the
+# emitted `embodiment.*` event). Distinct from the event names in `events.py` (D18).
+EMBODIMENT_ATTACH_REQUESTED: Final[str] = "embodiment_attach_requested"
+EMBODIMENT_ATTACH_SUCCEEDED: Final[str] = "embodiment_attach_succeeded"
+EMBODIMENT_ATTACH_FAILED: Final[str] = "embodiment_attach_failed"
+EMBODIMENT_DESYNC_DETECTED: Final[str] = "embodiment_desync_detected"
+EMBODIMENT_RECONNECT_STARTED: Final[str] = "embodiment_reconnect_started"
+EMBODIMENT_RECONNECT_FAILED: Final[str] = "embodiment_reconnect_failed"
+EMBODIMENT_RELEASED: Final[str] = "embodiment_released"
+EMBODIMENT_HEALTH_CHANGED: Final[str] = "embodiment_health_changed"
+
+# Transition-rejection reasons (SIP-0090 §5.2 — EmbodimentCoordinator, mirrors the
+# SIP-0089 INVALID_MODE_TRANSITION / MISSING_REASON_CODE precedent).
+INVALID_ATTACHMENT_TRANSITION: Final[str] = "invalid_attachment_transition"
+EMBODIMENT_ALREADY_ACTIVE: Final[str] = "embodiment_already_active"
+
+# Resource-budget enforcement (SIP-0090 Phase 1 §7.2). The single canonical reason a
+# budget-exhaustion decision carries; `runtime.budgets` imports it (single source).
+BUDGET_EXHAUSTED: Final[str] = "budget_exhausted"

--- a/tests/unit/runtime/test_budgets.py
+++ b/tests/unit/runtime/test_budgets.py
@@ -1,0 +1,164 @@
+"""Unit tests for SIP-0090 Phase 1 budget primitives (slice 1a, §7).
+
+Each test answers: what bug would it catch?
+
+Bug classes guarded:
+- a concurrency slot leaked (acquire without release) going undetected (§7.1);
+- silent budget degradation — an exhausted decision with no forced outcome (§7.2);
+- the off-by-one at the cap boundary (spending *exactly* to the limit wrongly blocked
+  or the next spend wrongly allowed);
+- a policy override being ignored so every dimension collapses to the default outcome.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.runtime.budgets import (
+    BUDGET_EXHAUSTED_REASON,
+    AgentBudget,
+    BudgetDecision,
+    CapacityBudget,
+    ConsumableBudget,
+    budget_decision,
+)
+
+
+def _budget(*, attention=100, compute=100, action=100, concurrency=3, in_use=0):
+    return AgentBudget(
+        attention=ConsumableBudget(limit=attention),
+        compute=ConsumableBudget(limit=compute),
+        action=ConsumableBudget(limit=action),
+        concurrency=CapacityBudget(allowance=concurrency, in_use=in_use),
+    )
+
+
+# ── ConsumableBudget ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("limit", "consumed", "remaining", "exhausted"),
+    [
+        (10, 3, 7, False),
+        (10, 10, 0, True),  # at the cap
+        (10, 12, 0, True),  # over the cap → remaining floors at 0
+        (10, 0, 10, False),
+    ],
+)
+def test_consumable_remaining_and_exhaustion(limit, consumed, remaining, exhausted):
+    b = ConsumableBudget(limit=limit, consumed=consumed)
+    assert b.remaining == remaining
+    assert b.is_exhausted is exhausted
+
+
+def test_consumable_spend_is_pure_and_accumulates():
+    b = ConsumableBudget(limit=10, consumed=2)
+    after = b.spend(5)
+    assert (after.consumed, after.remaining) == (7, 3)
+    assert b.consumed == 2  # original untouched (pure)
+
+
+def test_consumable_spend_rejects_negative():
+    with pytest.raises(ValueError, match="non-negative"):
+        ConsumableBudget(limit=10).spend(-1)
+
+
+# ── CapacityBudget ───────────────────────────────────────────────────────────
+
+
+def test_capacity_available_and_exhaustion():
+    b = CapacityBudget(allowance=3, in_use=1)
+    assert (b.available, b.is_exhausted) == (2, False)
+    full = CapacityBudget(allowance=3, in_use=3)
+    assert (full.available, full.is_exhausted) == (0, True)
+
+
+def test_capacity_acquire_then_release_round_trips():
+    b = CapacityBudget(allowance=3, in_use=1)
+    assert b.acquire().in_use == 2
+    assert b.acquire().release().in_use == 1  # symmetric
+
+
+def test_capacity_release_underflow_raises_not_floors():
+    """A release with nothing acquired is an imbalance bug — it must surface, not
+    silently floor at 0 (that would hide a leaked-slot accounting error)."""
+    with pytest.raises(ValueError, match="underflow"):
+        CapacityBudget(allowance=3, in_use=0).release()
+
+
+# ── budget_decision (§7.2) ───────────────────────────────────────────────────
+
+
+def test_consumable_with_room_is_allowed_and_not_exhausted():
+    d = budget_decision(_budget(compute=100), "compute", amount=10)
+    assert (d.allowed, d.exhausted) == (True, False)
+    assert d.outcome is None and d.reason_code is None
+
+
+def test_spend_exactly_to_the_cap_is_allowed_but_over_is_blocked():
+    """Boundary: consumed+amount == limit is fine; the amount that crosses it blocks."""
+    budget = _budget(action=10)
+    assert budget_decision(budget, "action", amount=10).allowed is True  # exactly to cap
+    over = budget_decision(budget, "action", amount=11)
+    assert over.allowed is False and over.exhausted is True
+
+
+def test_consumable_exhaustion_carries_default_outcome_and_reason():
+    already = AgentBudget(
+        attention=ConsumableBudget(limit=10, consumed=10),
+        compute=ConsumableBudget(limit=100),
+        action=ConsumableBudget(limit=100),
+        concurrency=CapacityBudget(allowance=3),
+    )
+    d = budget_decision(already, "attention", amount=1)
+    assert (d.allowed, d.exhausted) == (False, True)
+    assert d.outcome == "reject_new_activity"
+    assert d.reason_code == BUDGET_EXHAUSTED_REASON
+
+
+def test_concurrency_free_slot_allowed_full_blocked():
+    assert budget_decision(_budget(concurrency=3, in_use=2), "concurrency").allowed is True
+    full = budget_decision(_budget(concurrency=3, in_use=3), "concurrency")
+    assert (full.allowed, full.exhausted, full.outcome) == (False, True, "reject_new_activity")
+
+
+def test_policy_override_selects_a_different_outcome():
+    full = _budget(concurrency=1, in_use=1)
+    d = budget_decision(full, "concurrency", policy={"concurrency": "detach_embodiment"})
+    assert d.exhausted is True and d.outcome == "detach_embodiment"
+
+
+def test_budget_decision_rejects_negative_amount():
+    with pytest.raises(ValueError, match="non-negative"):
+        budget_decision(_budget(), "compute", amount=-5)
+
+
+# ── Non-silent-exhaustion invariant (§7.2) ───────────────────────────────────
+
+
+def test_exhausted_decision_must_carry_outcome():
+    """The type itself forbids a silent exhaustion (exhausted with no outcome)."""
+    with pytest.raises(ValueError, match="ExhaustionOutcome"):
+        BudgetDecision(dimension="compute", allowed=False, exhausted=True, outcome=None)
+
+
+def test_non_exhausted_decision_must_not_carry_outcome():
+    with pytest.raises(ValueError, match="ExhaustionOutcome"):
+        BudgetDecision(
+            dimension="compute",
+            allowed=True,
+            exhausted=False,
+            outcome="reject_new_activity",
+            reason_code=BUDGET_EXHAUSTED_REASON,
+        )
+
+
+def test_exhausted_decision_requires_the_budget_exhausted_reason():
+    with pytest.raises(ValueError, match="budget_exhausted"):
+        BudgetDecision(
+            dimension="compute",
+            allowed=False,
+            exhausted=True,
+            outcome="reject_new_activity",
+            reason_code="something_else",
+        )

--- a/tests/unit/runtime/test_embodiment.py
+++ b/tests/unit/runtime/test_embodiment.py
@@ -1,0 +1,163 @@
+"""Unit tests for SIP-0090 Phase 1 embodiment model + lifecycle (slice 1a).
+
+Each test answers: what bug would it catch?
+
+Bug classes guarded:
+- an illegal attachment shortcut (e.g. unattached→attached, attached→reconnecting,
+  or any edge out of terminal `detached`) being silently permitted;
+- the single-active-embodiment set (§5.5) drifting from attached/desynced/reconnecting;
+- a raw credential landing in an Embodiment record (§9 security invariant);
+- the failure-termination edges the plan §4.1 matrix adds to SIP §5.2 going missing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, replace
+
+import pytest
+
+from squadops.runtime.embodiment import (
+    _ALLOWED_ATTACHMENT_TRANSITIONS,
+    Embodiment,
+    Location,
+    is_active_attachment,
+    is_allowed_attachment_transition,
+    is_valid_credentials_ref,
+)
+
+ALL_STATES = ("unattached", "attaching", "attached", "desynced", "reconnecting", "detached")
+
+
+def _embodiment(**overrides):
+    base = dict(
+        embodiment_id="emb-1",
+        agent_id="max",
+        embodiment_type="discord",
+        platform="discord.com",
+        attachment_state="unattached",
+        health="healthy",
+    )
+    base.update(overrides)
+    return Embodiment(**base)
+
+
+# ── Lifecycle transitions (plan §4.1) ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("current", "target"),
+    [
+        ("unattached", "attaching"),
+        ("attaching", "attached"),
+        ("attaching", "detached"),  # failed attach terminates
+        ("attached", "desynced"),
+        ("attached", "detached"),
+        ("desynced", "reconnecting"),
+        ("desynced", "detached"),  # abandoned desync terminates
+        ("reconnecting", "attached"),
+        ("reconnecting", "detached"),  # failed reconnect terminates
+    ],
+)
+def test_allowed_transitions_are_permitted(current, target):
+    assert is_allowed_attachment_transition(current, target) is True
+
+
+@pytest.mark.parametrize(
+    ("current", "target"),
+    [
+        ("unattached", "attached"),  # never skip `attaching`
+        ("attached", "reconnecting"),  # recovery only via `desynced`
+        ("attached", "attaching"),  # no going backward
+        ("desynced", "attached"),  # must reconnect first
+        ("attaching", "desynced"),  # not live yet
+        ("detached", "attaching"),  # `detached` is terminal
+        ("detached", "attached"),
+        ("unattached", "detached"),  # can't detach before attaching
+    ],
+)
+def test_illegal_transitions_are_rejected(current, target):
+    assert is_allowed_attachment_transition(current, target) is False
+
+
+def test_detached_is_terminal():
+    """No transition may leave `detached` — the embodiment record is done (Phase 1)."""
+    assert not any(frm == "detached" for (frm, _to) in _ALLOWED_ATTACHMENT_TRANSITIONS)
+
+
+def test_every_non_terminal_state_has_an_exit():
+    """No non-terminal state is a dead end — otherwise an embodiment could get stuck."""
+    with_exit = {frm for (frm, _to) in _ALLOWED_ATTACHMENT_TRANSITIONS}
+    non_terminal = set(ALL_STATES) - {"detached"}
+    assert non_terminal <= with_exit
+
+
+# ── Single-active rule (§5.5) ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ("attached", True),
+        ("desynced", True),
+        ("reconnecting", True),
+        ("unattached", False),
+        ("attaching", False),  # connecting, not yet live — must not block a re-attach
+        ("detached", False),
+    ],
+)
+def test_is_active_attachment(state, expected):
+    assert is_active_attachment(state) is expected
+
+
+def test_embodiment_is_active_property_tracks_state():
+    assert _embodiment(attachment_state="attached").is_active is True
+    assert _embodiment(attachment_state="unattached").is_active is False
+    # frozen — a lifecycle move goes through replace(), and is_active follows
+    detached = replace(_embodiment(attachment_state="attached"), attachment_state="detached")
+    assert detached.is_active is False
+
+
+# ── Credentials security invariant (§9) ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("ref", "expected"),
+    [
+        (None, True),  # no credentials
+        ("secret://discord/bot-token", True),
+        ("raw-bot-token", False),  # a raw secret must be rejected
+        ("", False),
+        ("secret:/typo", False),  # malformed scheme
+    ],
+)
+def test_is_valid_credentials_ref(ref, expected):
+    assert is_valid_credentials_ref(ref) is expected
+
+
+def test_embodiment_rejects_raw_credential_at_construction():
+    """A raw credential must never be storable — the record cannot be constructed."""
+    with pytest.raises(ValueError, match="secret://"):
+        _embodiment(credentials_ref="raw-bot-token")
+
+
+def test_embodiment_accepts_secret_ref_and_none():
+    assert _embodiment(credentials_ref="secret://x").credentials_ref == "secret://x"
+    assert _embodiment(credentials_ref=None).credentials_ref is None
+
+
+# ── Model invariants ─────────────────────────────────────────────────────────
+
+
+def test_embodiment_is_frozen():
+    """Frozen: mutation must go through dataclasses.replace(), not attribute set."""
+    emb = _embodiment()
+    with pytest.raises(FrozenInstanceError):
+        emb.attachment_state = "attached"  # type: ignore[misc]
+
+
+def test_location_exposes_only_opaque_fields():
+    """Opacity (§5.4): Location carries a routing tag + an opaque ref, nothing parsed."""
+    loc = Location(location_type="discord_channel", ref="guild/123/chan/456")
+    assert (loc.location_type, loc.ref) == ("discord_channel", "guild/123/chan/456")
+    # no parsed sub-fields leaked onto the model
+    assert set(vars(loc)) == {"location_type", "ref"}

--- a/tests/unit/runtime/test_embodiment_coordinator.py
+++ b/tests/unit/runtime/test_embodiment_coordinator.py
@@ -1,0 +1,229 @@
+"""Unit tests for SIP-0090 Phase 1 EmbodimentCoordinator (slice 4).
+
+This is the model-level "transitions cleanly" acceptance (§13). Each test answers:
+what bug would it catch?
+
+Bug classes guarded:
+- an illegal transition being persisted / evented instead of rejected (§5.2);
+- a rejection still writing to the store or emitting an event (partial application);
+- a second live embodiment for one agent slipping past the single-active rule (§5.5);
+- the single-active guard false-positiving on an active→active move (e.g. attached→
+  desynced) and blocking a legitimate transition;
+- the coordinator coupling to a concrete adapter early (D26).
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+import squadops.runtime.embodiment_coordinator as coordinator_module
+from squadops.ports.runtime.embodiment import EmbodimentStatePort
+from squadops.ports.runtime.event_publisher import RuntimeEventPublisher
+from squadops.runtime import events, reasons
+from squadops.runtime.embodiment import Embodiment
+from squadops.runtime.embodiment_coordinator import EmbodimentCoordinator
+
+pytestmark = pytest.mark.asyncio
+
+
+def _embodiment(
+    embodiment_id="emb-1", agent_id="max", attachment_state="unattached", health="healthy"
+):
+    return Embodiment(
+        embodiment_id=embodiment_id,
+        agent_id=agent_id,
+        embodiment_type="discord",
+        platform="discord.com",
+        attachment_state=attachment_state,
+        health=health,
+    )
+
+
+class _FakeStatePort(EmbodimentStatePort):
+    """Records transition writes; returns a configurable active embodiment."""
+
+    def __init__(self, active: Embodiment | None = None) -> None:
+        self._active = active
+        self.transitions: list[tuple[str, str]] = []
+        self.get_active_calls = 0
+
+    async def create_embodiment(self, embodiment, *, conn=None):
+        return embodiment
+
+    async def get_embodiment(self, embodiment_id):
+        return None
+
+    async def get_active_embodiment(self, agent_id):
+        self.get_active_calls += 1
+        return self._active
+
+    async def list_for_agent(self, agent_id):
+        return ()
+
+    async def transition_state(self, embodiment_id, target_state, *, conn=None):
+        self.transitions.append((embodiment_id, target_state))
+        return _embodiment(embodiment_id=embodiment_id, attachment_state=target_state)
+
+    async def update_health(self, embodiment_id, health, *, conn=None):  # pragma: no cover
+        raise NotImplementedError
+
+    async def update_location(self, embodiment_id, location_ref, *, conn=None):  # pragma: no cover
+        raise NotImplementedError
+
+
+class _FakePublisher(RuntimeEventPublisher):
+    def __init__(self) -> None:
+        self.emitted: list[tuple[str, str, str, dict | None]] = []
+
+    def emit(self, event_name, *, agent_id, reason_code, payload=None):
+        self.emitted.append((event_name, agent_id, reason_code, payload))
+
+
+# ── Applied transitions ──────────────────────────────────────────────────────
+
+
+async def test_valid_transition_persists_and_emits_target_event():
+    port, pub = _FakeStatePort(), _FakePublisher()
+    coord = EmbodimentCoordinator(port, events_publisher=pub)
+
+    outcome = await coord.request_transition(
+        _embodiment(attachment_state="unattached"),
+        "attaching",
+        reasons.EMBODIMENT_ATTACH_REQUESTED,
+    )
+
+    assert outcome.applied is True
+    assert outcome.event_name == events.EMBODIMENT_ATTACHING
+    assert port.transitions == [("emb-1", "attaching")]
+    assert pub.emitted == [
+        (
+            events.EMBODIMENT_ATTACHING,
+            "max",
+            reasons.EMBODIMENT_ATTACH_REQUESTED,
+            {"embodiment_id": "emb-1"},
+        )
+    ]
+
+
+async def test_attach_completes_when_no_other_active_embodiment():
+    port = _FakeStatePort(active=None)
+    coord = EmbodimentCoordinator(port)
+
+    outcome = await coord.request_transition(
+        _embodiment(attachment_state="attaching"), "attached", reasons.EMBODIMENT_ATTACH_SUCCEEDED
+    )
+
+    assert outcome.applied is True
+    assert outcome.event_name == events.EMBODIMENT_ATTACHED
+    assert port.get_active_calls == 1  # the single-active guard ran
+
+
+async def test_applies_without_an_events_publisher():
+    """Emission is best-effort: no publisher wired must not break the transition."""
+    port = _FakeStatePort()
+    outcome = await EmbodimentCoordinator(port).request_transition(
+        _embodiment(attachment_state="attached"), "desynced", reasons.EMBODIMENT_DESYNC_DETECTED
+    )
+    assert outcome.applied is True and port.transitions == [("emb-1", "desynced")]
+
+
+# ── Rejections write nothing and emit nothing ────────────────────────────────
+
+
+async def test_illegal_transition_is_rejected_without_write_or_event():
+    port, pub = _FakeStatePort(), _FakePublisher()
+    coord = EmbodimentCoordinator(port, events_publisher=pub)
+
+    outcome = await coord.request_transition(
+        _embodiment(attachment_state="unattached"),  # unattached→attached skips `attaching`
+        "attached",
+        reasons.EMBODIMENT_ATTACH_SUCCEEDED,
+    )
+
+    assert outcome.applied is False
+    assert outcome.rejected_reason == reasons.INVALID_ATTACHMENT_TRANSITION
+    assert port.transitions == [] and pub.emitted == []
+
+
+async def test_missing_reason_code_is_rejected():
+    port = _FakeStatePort()
+    outcome = await EmbodimentCoordinator(port).request_transition(
+        _embodiment(attachment_state="unattached"), "attaching", ""
+    )
+    assert outcome.applied is False
+    assert outcome.rejected_reason == reasons.MISSING_REASON_CODE
+    assert port.transitions == []
+
+
+# ── Single-active rule (§5.5) ────────────────────────────────────────────────
+
+
+async def test_second_live_embodiment_is_rejected():
+    other_active = _embodiment(embodiment_id="emb-2", agent_id="max", attachment_state="attached")
+    port, pub = _FakeStatePort(active=other_active), _FakePublisher()
+    coord = EmbodimentCoordinator(port, events_publisher=pub)
+
+    outcome = await coord.request_transition(
+        _embodiment(embodiment_id="emb-1", attachment_state="attaching"),
+        "attached",
+        reasons.EMBODIMENT_ATTACH_SUCCEEDED,
+    )
+
+    assert outcome.applied is False
+    assert outcome.rejected_reason == reasons.EMBODIMENT_ALREADY_ACTIVE
+    assert port.transitions == [] and pub.emitted == []
+
+
+async def test_same_embodiment_already_active_does_not_block_itself():
+    """The agent's active embodiment being *this* one must not reject its own move."""
+    self_active = _embodiment(embodiment_id="emb-1", agent_id="max", attachment_state="attached")
+    port = _FakeStatePort(active=self_active)
+    outcome = await EmbodimentCoordinator(port).request_transition(
+        _embodiment(embodiment_id="emb-1", attachment_state="attaching"),
+        "attached",
+        reasons.EMBODIMENT_ATTACH_SUCCEEDED,
+    )
+    assert outcome.applied is True
+
+
+async def test_active_to_active_move_skips_the_single_active_check():
+    """attached→desynced keeps the *same* live embodiment — it must not consult (nor
+    be blocked by) another agent embodiment's active status."""
+    other_active = _embodiment(embodiment_id="emb-2", agent_id="max", attachment_state="attached")
+    port = _FakeStatePort(active=other_active)
+    outcome = await EmbodimentCoordinator(port).request_transition(
+        _embodiment(embodiment_id="emb-1", attachment_state="attached"),
+        "desynced",
+        reasons.EMBODIMENT_DESYNC_DETECTED,
+    )
+    assert outcome.applied is True
+    assert port.get_active_calls == 0  # guard skipped: from-state is already active
+
+
+# ── D26: substrate stays adapter-free (plan §4.5 named acceptance check) ──────
+
+
+def test_coordinator_imports_no_concrete_adapter():
+    src = pathlib.Path(coordinator_module.__file__).read_text()
+    imported: list[str] = []
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.ImportFrom):
+            imported.append(node.module or "")
+        elif isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+
+    banned = ("adapters", "discord", "browser", "playwright", "minecraft")
+    assert not any(any(b in m for b in banned) for m in imported), imported
+    # only runtime models/ports/events/reasons + stdlib
+    allowed_prefixes = (
+        "squadops.runtime",
+        "squadops.ports.runtime",
+        "dataclasses",
+        "typing",
+        "__future__",
+    )
+    for m in imported:
+        assert m == "" or m.startswith(allowed_prefixes), f"unexpected import: {m}"

--- a/tests/unit/runtime/test_embodiment_port.py
+++ b/tests/unit/runtime/test_embodiment_port.py
@@ -1,0 +1,53 @@
+"""Unit tests for SIP-0090 Phase 1 EmbodimentStatePort surface + vocabulary (slice 3).
+
+Each test answers: what bug would it catch?
+
+Bug classes guarded:
+- the state port silently growing an action/intent method (`attach`, `send`,
+  `execute_*`, `decide_*`) — the §6 authority-boundary erosion the naming split
+  exists to prevent;
+- the `budget_exhausted` reason code getting re-hardcoded in `budgets.py` instead
+  of single-sourced from `reasons.py` (the constant-duplication drift).
+"""
+
+from __future__ import annotations
+
+from squadops.ports.runtime.embodiment import EmbodimentStatePort
+from squadops.runtime import budgets, reasons
+
+# The intended record/lifecycle surface (plan §4.3). Adding to this set must be a
+# conscious edit here — that is the review gate against scope creep on the port.
+_EXPECTED_SURFACE = {
+    "create_embodiment",
+    "get_embodiment",
+    "get_active_embodiment",
+    "list_for_agent",
+    "transition_state",
+    "update_health",
+    "update_location",
+}
+
+# Verbs that would make this a mini action-surface / brain instead of a record store.
+_ACTION_VERBS = ("execute", "send", "listen", "decide", "intent", "attach", "detach", "act_")
+
+
+def test_state_port_surface_is_record_and_lifecycle_only():
+    """Authority boundary (§6 / §14.3): the state port persists records + lifecycle
+    state — it must not expose an action or intent-deciding method (that is the
+    Phase-2 EmbodimentSurfacePort's job)."""
+    assert EmbodimentStatePort.__abstractmethods__ == frozenset(_EXPECTED_SURFACE)
+
+
+def test_state_port_has_no_action_or_intent_method():
+    for name in EmbodimentStatePort.__abstractmethods__:
+        assert not any(verb in name for verb in _ACTION_VERBS), (
+            f"`{name}` reads like an action/intent verb — it belongs on the "
+            f"Phase-2 EmbodimentSurfacePort, not the record store"
+        )
+
+
+def test_budget_exhausted_reason_is_single_sourced_from_reasons():
+    """No constant duplication: budgets re-exports the canonical reason, it does not
+    redefine the literal (a re-hardcode would drift the two apart)."""
+    assert budgets.BUDGET_EXHAUSTED_REASON is reasons.BUDGET_EXHAUSTED
+    assert reasons.BUDGET_EXHAUSTED == "budget_exhausted"


### PR DESCRIPTION
Implements **SIP-0090 §13 Phase 1, slice 1a** — the migration-free core embodiment substrate (plan: `docs/plans/SIP-0090-phase-1-plan.md`). Mirrors the SIP-0089 shape: pure model + port + coordinator first; persistence (1b) follows.

## What's here (4 incremental slices)
| Slice | Module | Tests |
|---|---|---|
| 1 | `runtime/embodiment.py` — `Embodiment` model, explicit §4.1 transition matrix, opaque `Location`, credentials invariant | 35 |
| 2 | `runtime/budgets.py` — consumable `{limit,consumed}` + capacity `{allowance,in_use}`, non-silent exhaustion | 18 |
| 3 | `ports/runtime/embodiment.py` `EmbodimentStatePort` + `embodiment.*`/`budget.exhausted` events & reasons | 3 |
| 4 | `runtime/embodiment_coordinator.py` — transitions + single-active enforcement + event emission | 9 |

Full regression: **4633 passed, 1 skipped**. Adapter-free (D26).

## Review-feedback decisions baked in (from the plan PR #308)
- **Explicit transition matrix** (`_ALLOWED_ATTACHMENT_TRANSITIONS`) — completes SIP §5.2's happy-path ASCII with the failure-termination edges; `detached` terminal; illegal shortcuts (`unattached→attached`, `attached→reconnecting`) rejected.
- **`EmbodimentStatePort`** (not a bare `EmbodimentPort`) — a record/lifecycle store with **no action/intent method**; the Phase-2 driver stays a separate `EmbodimentSurfacePort`. Guarded by a structural authority-boundary test.
- **Budgets**: consumable vs capacity split; `concurrency` is a gauge with `acquire`/`release` (release-underflow raises — a leaked slot is observable); **non-silent exhaustion is type-unrepresentable** (`BudgetDecision.__post_init__`); reset/replenishment deferred.
- **Credentials**: `credentials_ref` validated at construction — a raw secret can never land in a record (§9).
- **`budget_exhausted`** single-sourced from `reasons.py` (no duplicated literal).
- **Named D26 guard**: `test_coordinator_imports_no_concrete_adapter`.

## Acceptance boundary (per plan §2)
1a satisfies the **model-level** acceptance — lifecycle correctness, budget enforcement, event emission — proven by unit tests. **This is NOT full SIP-0090 Phase 1** until **1b** lands persistence + live records (embodiments/agent_budgets migrations + Postgres adapters + the single-active DB index). 1b is unblocked now (#158 closed) and follows in a separate PR.

Does not close an issue (no SIP-0090 tracking issue; 1a is partial Phase 1).