### PR TITLE
feat(#279): validated-fullstack request-profile (instrumentation + builder + stack)

### DIFF
--- a/src/squadops/contracts/cycle_request_profiles/profiles/validated-fullstack.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/validated-fullstack.yaml
@@ -1,0 +1,47 @@
+name: validated-fullstack
+description: >
+  Instrumented fullstack build for quality apps (#279). Composes the two levers
+  that two group_run validations isolated: `validation`'s depth instrumentation
+  (output validation, typed + command acceptance, self-eval + correction budget,
+  and a 2-run framing→implementation sequence for clean gate/checkpoint boundaries
+  and resumability) PLUS the builder path with stack-aware development
+  (`fullstack_fastapi_react`). `build_tasks: true` routes through `builder.assemble`
+  automatically when the squad has a builder (SIP-0071), so this needs a
+  builder-carrying squad to exercise assembly. Pairs with #276 (build/boot +
+  required_files) as the runnable-app backstop.
+defaults:
+  build_strategy: fresh
+  dev_capability: fullstack_fastapi_react
+  build_profile: fullstack_fastapi_react
+  task_flow_policy:
+    mode: sequential
+    gates:
+      - name: progress_plan_review
+        description: Review planning artifacts and build manifest before implementation begins.
+        after_task_types:
+          - governance.review
+  expected_artifact_types:
+    - document
+    - source
+    - test
+    - config
+  workload_sequence:
+    - type: framing
+      gate: progress_plan_review
+    - type: implementation
+      gate: null
+  build_tasks: true
+  implementation_plan: true
+  output_validation: true
+  # Implementation-profile depth: typed checks exercise meaningfully and
+  # correction has budget to surface + fix structural issues.
+  max_self_eval_passes: 2
+  max_correction_attempts: 3
+  max_build_subtasks: 15
+  # SIP-0092 M1 instrumentation (typed + command acceptance).
+  typed_acceptance: true
+  command_acceptance_checks: true
+  # Long-cycle budget for a full instrumented fullstack build.
+  time_budget_seconds: 7200
+  experiment_context: {}
+  notes: "#279 — instrumented validation + builder + fullstack_fastapi_react (best-of-both)"

--- a/tests/unit/contracts/test_validated_fullstack_profile.py
+++ b/tests/unit/contracts/test_validated_fullstack_profile.py
@@ -1,0 +1,53 @@
+"""Unit tests for the validated-fullstack cycle request profile (#279).
+
+Bug this guards: the profile must COMPOSE both quality levers — `validation`'s
+instrumentation AND the stack-aware builder path. If either silently drops (a
+missing `dev_capability`, instrumentation flags defaulting off, or the 2-run
+sequence collapsing to single-run), the profile degrades to a lean build and the
+#279 quality gain — a runnable app with a correction/typed-check trail — is lost.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.contracts.cycle_request_profiles import list_profiles, load_profile
+from squadops.contracts.cycle_request_profiles.schema import CycleRequestProfile
+
+pytestmark = [pytest.mark.domain_contracts]
+
+
+def test_profile_loads_and_is_listed():
+    profile = load_profile("validated-fullstack")
+    assert isinstance(profile, CycleRequestProfile)
+    assert profile.name == "validated-fullstack"
+    assert "validated-fullstack" in list_profiles()
+
+
+def test_composes_stack_aware_builder_path():
+    """Builder + stack lever: fullstack dev capability + builder-routed build."""
+    defaults = load_profile("validated-fullstack").defaults
+    assert defaults["dev_capability"] == "fullstack_fastapi_react"
+    assert defaults["build_profile"] == "fullstack_fastapi_react"
+    # build_tasks: true routes through builder.assemble when the squad has a builder
+    assert defaults["build_tasks"] is True
+
+
+def test_composes_validation_instrumentation():
+    """Instrumentation lever: the flags `validation` carries — not schema defaults-off."""
+    defaults = load_profile("validated-fullstack").defaults
+    assert defaults["output_validation"] is True
+    assert defaults["typed_acceptance"] is True
+    assert defaults["command_acceptance_checks"] is True
+    assert defaults["implementation_plan"] is True
+    assert defaults["max_self_eval_passes"] == 2
+    assert defaults["max_correction_attempts"] == 3
+
+
+def test_two_run_framing_then_implementation_sequence():
+    """2-run sequence with the gate on framing (clean checkpoint + resumability)."""
+    defaults = load_profile("validated-fullstack").defaults
+    sequence = defaults["workload_sequence"]
+    assert [step["type"] for step in sequence] == ["framing", "implementation"]
+    assert sequence[0]["gate"] == "progress_plan_review"
+    assert sequence[1]["gate"] is None


### PR DESCRIPTION
Refs #279 (close-criterion below). Config composition — a new CRP that combines the two quality levers two `group_run` validations isolated.

## Why
| | `validation` (instrumented, no builder) | `fullstack-fastapi-react` (lean, + builder) |
|---|---|---|
| Manual fixes to runnable | 3 | **0** |
| Correction / typed-check trail | rich | minimal |

The builder + `fullstack_fastapi_react` is the quality lever; the instrumentation is the diagnosis. No existing profile had **both**.

## What `validated-fullstack` composes
- **Instrumentation (from `validation`):** `output_validation`, `typed_acceptance`, `command_acceptance_checks`, `implementation_plan`, `max_self_eval_passes: 2`, `max_correction_attempts: 3`, and the **2-run** `framing→implementation` `workload_sequence` (clean gate/checkpoint boundaries + resumability).
- **Builder path:** `build_tasks: true` → routes through `builder.assemble` when the squad has a builder (SIP-0071). **Requires a builder squad (`lite`/`full`).**
- **Stack-aware dev:** `dev_capability` + `build_profile` = `fullstack_fastapi_react`.

## Notes
- Profiles **auto-discover** (`list_profiles()` globs `*.yaml`) — no registry change.
- Loads clean under the CRP schema (known keys + `progress_plan_review` is a valid `workload_sequence` gate prefix).
- **4 tests** assert the composition holds — both levers + the 2-run sequence — so a silently-degraded profile (dropped `dev_capability`, instrumentation defaulting off, or a collapsed single-run) fails CI. **203 contracts tests green**; ruff + quality lint clean.

## Close criterion
Config is unit-verified. Full close = a **live end-to-end run** on `group_run` with a builder squad producing a runnable app (0 manual fixes) **and** the correction/typed-check trail (#279 acceptance). Pairs with #276 (build/boot backstop); note the frontend-build teeth still depend on #306 (Node in the agent image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)