### PR TITLE
feat(SIP-0095 Phase 3): wire create-time preflight into the cycle-create route

### DIFF
--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -2,6 +2,7 @@
 Cycle API routes (SIP-0064 §9.3).
 """
 
+import logging
 import uuid
 from datetime import UTC, datetime
 
@@ -18,11 +19,61 @@ from squadops.cycles.models import (
     CycleError,
     CycleStatus,
     Gate,
+    PreflightRejectedError,
     Run,
+    SquadProfile,
     TaskFlowPolicy,
 )
+from squadops.cycles.preflight import (
+    combine,
+    model_availability_decision,
+    required_roles_decision,
+)
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/projects/{project_id}/cycles", tags=["cycles"])
+
+
+async def _pulled_model_names() -> list[str] | None:
+    """Best-effort list of the LLM backend's pulled-model names, or ``None``.
+
+    ``None`` (backend not configured / not an Ollama adapter / unreachable) makes the
+    model-availability preflight *warn and allow* rather than block — never block on
+    missing evidence (SIP-0095 §6.2). Only a reachable backend yields a verifiable list.
+    """
+    from squadops.api.runtime.deps import get_llm_port
+
+    try:
+        from adapters.llm.ollama import OllamaAdapter
+
+        port = get_llm_port()
+        if not isinstance(port, OllamaAdapter):
+            return None
+        raw = await port.list_pulled_models()
+    except Exception as exc:  # not configured, wrong adapter, or backend unreachable
+        logger.info("preflight_model_list_unverifiable", extra={"error": str(exc)})
+        return None
+    return [name for m in raw if (name := m.get("name"))]
+
+
+async def _run_create_preflight(profile: SquadProfile, applied_defaults: dict) -> None:
+    """SIP-0095 create-time preflight: fail fast BEFORE persist/dispatch.
+
+    Blocks (HTTP 422) when the squad can't satisfy the requested workloads' required
+    roles or names a model definitively not pulled; an unreachable backend warns and
+    allows. Warnings are logged here — the response/CLI surface is Phase 4.
+    """
+    decision = combine(
+        required_roles_decision(profile, applied_defaults),
+        model_availability_decision(profile, await _pulled_model_names()),
+    )
+    for w in decision.warnings:
+        logger.warning(
+            "cycle_create_preflight_warning", extra={"code": w.code, "detail": w.message}
+        )
+    if decision.rejected:
+        raise PreflightRejectedError(decision.summary())
 
 
 @router.post("", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
@@ -66,6 +117,10 @@ async def create_cycle(
 
         # SIP-0065 D2: use client-supplied applied_defaults (CRP defaults from CLI)
         applied_defaults = body.applied_defaults
+
+        # SIP-0095: create-time preflight — fail fast (422) before persist/dispatch.
+        await _run_create_preflight(profile, applied_defaults)
+
         config_hash = compute_config_hash(applied_defaults, body.execution_overrides)
 
         cycle = Cycle(

--- a/src/squadops/api/routes/cycles/errors.py
+++ b/src/squadops/api/routes/cycles/errors.py
@@ -16,6 +16,7 @@ from squadops.cycles.models import (
     CycleNotFoundError,
     GateAlreadyDecidedError,
     IllegalStateTransitionError,
+    PreflightRejectedError,
     ProfileNotFoundError,
     ProfileValidationError,
     ProjectNotFoundError,
@@ -36,6 +37,7 @@ _ERROR_MAP: list[tuple[type, int, str]] = [
     (BaselineNotAllowedError, 409, "BASELINE_NOT_ALLOWED"),
     (ActiveProfileDeletionError, 409, "ACTIVE_PROFILE_DELETION"),
     (ProfileValidationError, 422, "PROFILE_VALIDATION_ERROR"),
+    (PreflightRejectedError, 422, "PREFLIGHT_REJECTED"),
     (ValidationError, 422, "VALIDATION_ERROR"),
 ]
 

--- a/src/squadops/cycles/models.py
+++ b/src/squadops/cycles/models.py
@@ -166,6 +166,15 @@ class ProfileValidationError(CycleError):
     """Raised for squad profile validation failures (bad ID, unknown override keys)."""
 
 
+class PreflightRejectedError(CycleError):
+    """Raised when the create-time preflight blocks a cycle (SIP-0095).
+
+    Carries the joined blocking-finding messages: the requested workloads' roles the
+    squad can't satisfy and/or models definitively not pulled. Maps to HTTP 422 —
+    fail fast before the cycle is persisted or dispatched.
+    """
+
+
 # Allowed keys in AgentProfileEntry.config_overrides (SIP-0075 §5.5.1).
 # Unknown keys are rejected with 422, not silently ignored.
 ALLOWED_CONFIG_OVERRIDE_KEYS = frozenset(

--- a/tests/unit/cycles/test_api_cycles.py
+++ b/tests/unit/cycles/test_api_cycles.py
@@ -3,7 +3,7 @@ Tests for SIP-0064 cycle API routes.
 """
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -48,18 +48,28 @@ def mock_cycle_registry():
     return mock
 
 
-@pytest.fixture
-def mock_squad_profile():
-    mock = AsyncMock()
-    profile = SquadProfile(
+def _full_plan_profile():
+    """A squad carrying every role the default (plan) workload requires (SIP-0095),
+    so the create-time preflight passes. Models are unverifiable in these tests (no
+    LLM port wired → warn-and-allow), so only roles gate here."""
+    roles = [("max", "lead"), ("nat", "strat"), ("neo", "dev"), ("eve", "qa"), ("data", "data")]
+    return SquadProfile(
         profile_id="full",
         name="Full Squad",
         description="All agents",
         version=1,
-        agents=(AgentProfileEntry(agent_id="max", role="lead", model="gpt-4", enabled=True),),
+        agents=tuple(
+            AgentProfileEntry(agent_id=aid, role=role, model="gpt-4", enabled=True)
+            for aid, role in roles
+        ),
         created_at=NOW,
     )
-    mock.resolve_snapshot.return_value = (profile, "sha256:abc123")
+
+
+@pytest.fixture
+def mock_squad_profile():
+    mock = AsyncMock()
+    mock.resolve_snapshot.return_value = (_full_plan_profile(), "sha256:abc123")
     return mock
 
 
@@ -344,3 +354,59 @@ class TestCycleRouteScopeEnforcement:
             client = TestClient(app)
             resp = client.get("/api/v1/projects/hello_squad/cycles", headers={})
         assert resp.status_code == 401
+
+
+class TestCreateCyclePreflight:
+    """SIP-0095 Phase 3: the create-time preflight fails fast (422) before persist."""
+
+    _REQUEST = {"squad_profile_id": "full", "task_flow_policy": {"mode": "sequential"}}
+
+    def test_full_squad_with_unverifiable_models_is_allowed(self, client):
+        """Roles satisfied + LLM backend unreachable (None) → warn-and-allow → 200."""
+        resp = client.post("/api/v1/projects/hello_squad/cycles", json=self._REQUEST)
+        assert resp.status_code == 200
+
+    def test_blocks_when_squad_cannot_satisfy_required_roles(
+        self, client, mock_squad_profile, mock_cycle_registry
+    ):
+        lean = SquadProfile(
+            profile_id="lite",
+            name="Lean",
+            description="",
+            version=1,
+            agents=(AgentProfileEntry(agent_id="max", role="lead", model="gpt-4", enabled=True),),
+            created_at=NOW,
+        )
+        mock_squad_profile.resolve_snapshot.return_value = (lean, "sha256:x")
+
+        resp = client.post("/api/v1/projects/hello_squad/cycles", json=self._REQUEST)
+
+        assert resp.status_code == 422
+        err = resp.json()["detail"]["error"]
+        assert err["code"] == "PREFLIGHT_REJECTED"
+        assert "role" in err["message"]  # names the missing role
+        mock_cycle_registry.create_cycle.assert_not_called()  # fail-fast: nothing persisted
+        mock_cycle_registry.create_run.assert_not_called()
+
+    def test_blocks_when_a_required_model_is_not_pulled(self, client, mock_cycle_registry):
+        # backend reachable but empty → the profile's `gpt-4` is definitively absent
+        with patch(
+            "squadops.api.routes.cycles.cycles._pulled_model_names",
+            new=AsyncMock(return_value=[]),
+        ):
+            resp = client.post("/api/v1/projects/hello_squad/cycles", json=self._REQUEST)
+
+        assert resp.status_code == 422
+        err = resp.json()["detail"]["error"]
+        assert err["code"] == "PREFLIGHT_REJECTED"
+        assert "gpt-4" in err["message"]
+        mock_cycle_registry.create_cycle.assert_not_called()
+
+    def test_allows_when_required_model_is_pulled(self, client):
+        # tagless `gpt-4` matches the canonical `gpt-4:latest` (no family inference)
+        with patch(
+            "squadops.api.routes.cycles.cycles._pulled_model_names",
+            new=AsyncMock(return_value=["gpt-4:latest"]),
+        ):
+            resp = client.post("/api/v1/projects/hello_squad/cycles", json=self._REQUEST)
+        assert resp.status_code == 200


### PR DESCRIPTION
Implements **SIP-0095 Phase 3** — wires the create-time preflight (Phase 1 capability decision + Phase 2 model-availability decision) into the cycle-create route so it **fails fast before persist/dispatch**.

## What changed
- `create_cycle` now runs `combine(required_roles_decision, model_availability_decision)` right after the profile resolves and **before** anything is persisted.
- **Blocks** with `422 PREFLIGHT_REJECTED` when the squad can't satisfy the requested workloads' required roles, or names a model **definitively** not pulled.
- **Warn-and-allow** when the LLM backend is unreachable/unconfigured (`_pulled_model_names()` → `None`) — never block on missing evidence (§6.2). Warnings are logged; the **response/CLI warning surface is Phase 4**.
- `PreflightRejectedError(CycleError)` → 422 through the existing `handle_cycle_error` (`{"error": {...}}` envelope) — conforms to the cycle-route error convention, no new shape.

## Decisions honored (locked in the plan)
Fail-fast before persist · HTTP **422** · **exact canonical-tag** model match (`gpt-4` ⇒ `gpt-4:latest`, no family inference) · unreachable ⇒ warn-and-allow · static workload→role only (builder/materialized-plan stays a dispatch check → #295).

## Tests
Route-level: role-block (no persist), model-block (reachable-but-empty backend), model-allow (canonical match), warn-and-allow (unverifiable). Updated the shared create fixture to a valid full-plan squad — a 1-agent squad now *correctly* fails preflight. **4572 regression green.**

## Scope
`Closes #224` — the model-availability preflight is now wired into **cycle-create** (the doctor + decision half landed in Phase 2 / #309). Completes the create-time capability preflight wiring (#172, already closed). **Not** in scope: the Phase-4 warning **display** surface (return warnings in the response + CLI echo + persist on the cycle record), and the materialized-plan/builder hoist (#295).

Closes #224