### PR TITLE
feat(SIP-0090 Phase 1): embodiment persistence — slice 1b (completes Phase 1)

### DIFF
--- a/adapters/persistence/runtime/embodiment_postgres.py
+++ b/adapters/persistence/runtime/embodiment_postgres.py
@@ -1,0 +1,135 @@
+"""Postgres-backed embodiment-state adapter (SIP-0090 Phase 1 §5, slice 1b).
+
+Implements `EmbodimentStatePort` via the shared asyncpg pool. All writes hit
+`embodiments` (migration `1140_embodiments.sql`). The single-active-embodiment
+invariant (§5.5) is enforced in the DB by the partial unique index
+`uq_embodiments_one_active_per_agent` — the hard backstop behind the
+EmbodimentCoordinator's logic-level guard.
+
+`capability_set` is a JSONB array (`json.dumps` on write, decode on read — the cycle
+registry convention). Mutating methods carry the §4.5/D25 `conn` seam so a Phase-3
+coordinator can commit an embodiment transition atomically with other writes.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import asyncpg
+
+from adapters.persistence.runtime._conn import acquire
+from squadops.ports.runtime.embodiment import EmbodimentStatePort
+from squadops.runtime.embodiment import AttachmentState, Embodiment, Health
+
+_ACTIVE_STATES = ["attached", "desynced", "reconnecting"]
+
+_COLS = (
+    "embodiment_id, agent_id, embodiment_type, platform, attachment_state, health, "
+    "capability_set, location_ref, last_health_check_at, credentials_ref"
+)
+
+
+class PostgresEmbodimentState(EmbodimentStatePort):
+    """Postgres-backed `EmbodimentStatePort` implementation."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def create_embodiment(self, embodiment: Embodiment, *, conn: Any = None) -> Embodiment:
+        async with acquire(self._pool, conn) as c:
+            await c.execute(
+                f"INSERT INTO embodiments ({_COLS}) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)",
+                embodiment.embodiment_id,
+                embodiment.agent_id,
+                embodiment.embodiment_type,
+                embodiment.platform,
+                embodiment.attachment_state,
+                embodiment.health,
+                json.dumps(list(embodiment.capability_set)),
+                embodiment.location_ref,
+                embodiment.last_health_check_at,
+                embodiment.credentials_ref,
+            )
+        return embodiment
+
+    async def get_embodiment(self, embodiment_id: str) -> Embodiment | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"SELECT {_COLS} FROM embodiments WHERE embodiment_id = $1", embodiment_id
+            )
+        return _row_to_embodiment(row) if row else None
+
+    async def get_active_embodiment(self, agent_id: str) -> Embodiment | None:
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"SELECT {_COLS} FROM embodiments "
+                "WHERE agent_id = $1 AND attachment_state = ANY($2::text[])",
+                agent_id,
+                _ACTIVE_STATES,
+            )
+        return _row_to_embodiment(row) if row else None
+
+    async def list_for_agent(self, agent_id: str) -> tuple[Embodiment, ...]:
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                f"SELECT {_COLS} FROM embodiments WHERE agent_id = $1 ORDER BY created_at",
+                agent_id,
+            )
+        return tuple(_row_to_embodiment(r) for r in rows)
+
+    async def transition_state(
+        self, embodiment_id: str, target_state: AttachmentState, *, conn: Any = None
+    ) -> Embodiment:
+        return await self._update_returning(
+            "attachment_state", embodiment_id, target_state, conn=conn
+        )
+
+    async def update_health(
+        self, embodiment_id: str, health: Health, *, conn: Any = None
+    ) -> Embodiment:
+        return await self._update_returning("health", embodiment_id, health, conn=conn)
+
+    async def update_location(
+        self, embodiment_id: str, location_ref: str | None, *, conn: Any = None
+    ) -> Embodiment:
+        return await self._update_returning("location_ref", embodiment_id, location_ref, conn=conn)
+
+    async def _update_returning(
+        self, column: str, embodiment_id: str, value: Any, *, conn: Any
+    ) -> Embodiment:
+        # `column` is always an internal literal (never caller input) — no injection.
+        async with acquire(self._pool, conn) as c:
+            row = await c.fetchrow(
+                f"UPDATE embodiments SET {column} = $2, updated_at = now() "
+                f"WHERE embodiment_id = $1 RETURNING {_COLS}",
+                embodiment_id,
+                value,
+            )
+        if row is None:
+            raise KeyError(f"embodiment not found: {embodiment_id}")
+        return _row_to_embodiment(row)
+
+
+def _loads_jsonb(value: Any) -> list:
+    """Decode a JSONB column value (asyncpg returns str by default)."""
+    if value is None:
+        return []
+    if isinstance(value, list | tuple):
+        return list(value)
+    return json.loads(value)
+
+
+def _row_to_embodiment(row: asyncpg.Record) -> Embodiment:
+    return Embodiment(
+        embodiment_id=row["embodiment_id"],
+        agent_id=row["agent_id"],
+        embodiment_type=row["embodiment_type"],
+        platform=row["platform"],
+        attachment_state=row["attachment_state"],
+        health=row["health"],
+        capability_set=tuple(_loads_jsonb(row["capability_set"])),
+        location_ref=row["location_ref"],
+        last_health_check_at=row["last_health_check_at"],
+        credentials_ref=row["credentials_ref"],
+    )

--- a/infra/migrations/1140_embodiments.sql
+++ b/infra/migrations/1140_embodiments.sql
@@ -1,0 +1,47 @@
+-- 1140_embodiments.sql
+-- SIP-0090 Phase 1 §5.3: embodiments table.
+-- All DDL is idempotent (CREATE ... IF NOT EXISTS).
+--
+-- Field semantics mirror src/squadops/runtime/embodiment.py::Embodiment. Enum-shaped
+-- columns carry CHECK constraints matching the Literal types in code (D3).
+-- `capability_set` is a JSONB array of capability strings (§5.7). `location_ref` is
+-- opaque (§5.4) — stored/compared verbatim, never parsed by the platform.
+-- `credentials_ref` is a `secret://` reference only, never a raw secret (§9); the
+-- domain model enforces that invariant at construction.
+--
+-- agent_id is the owning agent. It is indexed (the port queries by agent) but
+-- intentionally NOT a hard FK to agent_runtime_state: that row is created lazily by
+-- heartbeat (Phase 1 ensure_state), so an embodiment may be written before the agent
+-- has heartbeated (mirrors 1110/1120).
+
+CREATE TABLE IF NOT EXISTS embodiments (
+    embodiment_id         TEXT PRIMARY KEY,
+    agent_id              TEXT NOT NULL,
+    embodiment_type       TEXT NOT NULL
+        CHECK (embodiment_type IN ('discord', 'browser', 'minecraft', 'cli', 'other')),
+    platform              TEXT NOT NULL,
+    attachment_state      TEXT NOT NULL
+        CHECK (attachment_state IN
+            ('unattached', 'attaching', 'attached', 'desynced', 'reconnecting', 'detached')),
+    health                TEXT NOT NULL
+        CHECK (health IN ('healthy', 'degraded', 'failed')),
+    capability_set        JSONB NOT NULL DEFAULT '[]'::jsonb,
+    location_ref          TEXT,
+    last_health_check_at  TIMESTAMPTZ,
+    credentials_ref       TEXT,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Single active-embodiment invariant (§5.5): at most one *live* embodiment per agent.
+-- A partial unique index over the active attachment states lets historical
+-- (unattached / detached) rows accumulate freely while guaranteeing the agent has at
+-- most one embodiment that is attached, desynced, or reconnecting at any time. This
+-- is the hard backstop behind the EmbodimentCoordinator's logic-level guard.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_embodiments_one_active_per_agent
+    ON embodiments (agent_id)
+    WHERE attachment_state IN ('attached', 'desynced', 'reconnecting');
+
+-- get_active_embodiment(agent_id) / list_for_agent(agent_id).
+CREATE INDEX IF NOT EXISTS idx_embodiments_agent_id
+    ON embodiments (agent_id);

--- a/tests/integration/runtime/test_embodiment_postgres_integration.py
+++ b/tests/integration/runtime/test_embodiment_postgres_integration.py
@@ -1,0 +1,137 @@
+"""Integration tests for SIP-0090 §5 — PostgresEmbodimentState against live Postgres.
+
+Requires a running Postgres (docker-compose up -d postgres). Proves what an
+in-memory fake can't: the `embodiments` migration applies, records round-trip with
+fields intact (the §13 "records exist" acceptance), and the partial unique index
+`uq_embodiments_one_active_per_agent` is the **hard backstop** for the single-active
+rule (§5.5) — a second *live* embodiment for one agent is rejected at the DB, while
+detached history and a second agent's active embodiment are fine.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from squadops.runtime.embodiment import Embodiment
+
+pytestmark = [pytest.mark.docker, pytest.mark.domain_runtime]
+
+POSTGRES_URL = os.getenv(
+    "POSTGRES_URL", "postgresql://squadops:squadops-dev@localhost:5432/squadops"
+)
+
+try:
+    import asyncpg
+except ImportError:
+    pytest.skip("asyncpg not installed", allow_module_level=True)
+
+
+def _pg_available() -> bool:
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(2)
+        s.connect(("localhost", 5432))
+        s.close()
+        return True
+    except OSError:
+        return False
+
+
+if not _pg_available():
+    pytest.skip(
+        "Postgres not reachable on localhost:5432 — start with docker-compose up -d postgres",
+        allow_module_level=True,
+    )
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    from adapters.persistence.runtime.embodiment_postgres import PostgresEmbodimentState
+    from squadops.api.runtime.migrations import apply_migrations
+
+    pool = await asyncpg.create_pool(POSTGRES_URL, min_size=1, max_size=5)
+    await apply_migrations(pool, Path(__file__).parents[3] / "infra" / "migrations")
+    yield PostgresEmbodimentState(pool)
+    await pool.close()
+
+
+def _emb(agent_id: str, state: str, **overrides) -> Embodiment:
+    base = dict(
+        embodiment_id=f"emb_{uuid.uuid4().hex[:10]}",
+        agent_id=agent_id,
+        embodiment_type="discord",
+        platform="discord.com",
+        attachment_state=state,
+        health="healthy",
+    )
+    base.update(overrides)
+    return Embodiment(**base)
+
+
+async def _cleanup(adapter, agent_id: str) -> None:
+    async with adapter._pool.acquire() as conn:
+        await conn.execute("DELETE FROM embodiments WHERE agent_id = $1", agent_id)
+
+
+async def test_record_round_trips_with_fields_intact(adapter):
+    agent = f"agent_{uuid.uuid4().hex[:8]}"
+    emb = _emb(
+        agent,
+        "attaching",
+        capability_set=("send_message", "read_channel"),
+        location_ref="guild/1/chan/2",
+        credentials_ref="secret://discord/token",
+    )
+    try:
+        await adapter.create_embodiment(emb)
+        got = await adapter.get_embodiment(emb.embodiment_id)
+        assert got == emb  # frozen-dataclass equality: every field, incl. the tuple capability_set
+    finally:
+        await _cleanup(adapter, agent)
+
+
+async def test_second_active_embodiment_for_agent_is_rejected_by_the_index(adapter):
+    agent = f"agent_{uuid.uuid4().hex[:8]}"
+    try:
+        await adapter.create_embodiment(_emb(agent, "attached"))
+        with pytest.raises(asyncpg.UniqueViolationError):
+            await adapter.create_embodiment(_emb(agent, "desynced"))  # 2nd live → rejected
+    finally:
+        await _cleanup(adapter, agent)
+
+
+async def test_detached_history_and_other_agents_do_not_block_a_new_active(adapter):
+    agent = f"agent_{uuid.uuid4().hex[:8]}"
+    other = f"agent_{uuid.uuid4().hex[:8]}"
+    try:
+        await adapter.create_embodiment(_emb(agent, "detached"))
+        await adapter.create_embodiment(_emb(agent, "detached"))  # history accumulates freely
+        await adapter.create_embodiment(_emb(other, "attached"))  # different agent is fine
+        await adapter.create_embodiment(_emb(agent, "attached"))  # one active for `agent` — ok
+
+        active = await adapter.get_active_embodiment(agent)
+        assert active is not None and active.attachment_state == "attached"
+        assert len(await adapter.list_for_agent(agent)) == 3
+    finally:
+        await _cleanup(adapter, agent)
+        await _cleanup(adapter, other)
+
+
+async def test_transition_moves_state_and_active_query_reflects_it(adapter):
+    agent = f"agent_{uuid.uuid4().hex[:8]}"
+    emb = _emb(agent, "attaching")
+    try:
+        await adapter.create_embodiment(emb)
+        assert await adapter.get_active_embodiment(agent) is None  # attaching is not live
+
+        await adapter.transition_state(emb.embodiment_id, "attached")
+        active = await adapter.get_active_embodiment(agent)
+        assert active is not None and active.embodiment_id == emb.embodiment_id
+    finally:
+        await _cleanup(adapter, agent)

--- a/tests/unit/runtime/test_embodiment_postgres.py
+++ b/tests/unit/runtime/test_embodiment_postgres.py
@@ -1,0 +1,154 @@
+"""Unit tests for SIP-0090 §5 — PostgresEmbodimentState adapter (slice 1b).
+
+Each test answers: what bug would it catch?
+
+Bug classes guarded:
+- Row→dataclass mapping drift: the JSONB `capability_set` must decode to a **tuple**
+  (a list would silently break the frozen dataclass's equality/hashing), and the
+  enum columns must round-trip;
+- write-side JSONB drift: `capability_set` must be `json.dumps`'d, not passed as a
+  Python list;
+- the `get_active_embodiment` query filtering on the wrong states (§5.5 semantics);
+- a missing-row update returning None instead of surfacing (KeyError).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from adapters.persistence.runtime.embodiment_postgres import (
+    PostgresEmbodimentState,
+    _loads_jsonb,
+)
+from squadops.runtime.embodiment import Embodiment
+
+pytestmark = [pytest.mark.domain_runtime]
+
+
+class _AcquireCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *_):
+        return False
+
+
+def _make_pool(conn):
+    pool = MagicMock()
+    pool.acquire.return_value = _AcquireCtx(conn)
+    return pool
+
+
+def _embodiment(**overrides):
+    base = dict(
+        embodiment_id="emb-1",
+        agent_id="max",
+        embodiment_type="discord",
+        platform="discord.com",
+        attachment_state="unattached",
+        health="healthy",
+    )
+    base.update(overrides)
+    return Embodiment(**base)
+
+
+def _row(**overrides):
+    base = {
+        "embodiment_id": "emb-1",
+        "agent_id": "max",
+        "embodiment_type": "discord",
+        "platform": "discord.com",
+        "attachment_state": "attached",
+        "health": "healthy",
+        "capability_set": '["send_message", "read_channel"]',
+        "location_ref": "guild/1/chan/2",
+        "last_health_check_at": None,
+        "credentials_ref": "secret://discord/token",
+    }
+    base.update(overrides)
+    return base
+
+
+async def test_create_serializes_capability_set_as_json():
+    conn = AsyncMock()
+    adapter = PostgresEmbodimentState(_make_pool(conn))
+
+    await adapter.create_embodiment(_embodiment(capability_set=("send_message", "read_channel")))
+
+    params = conn.execute.call_args.args
+    # params[0] is the SQL; the capability_set arg must be a JSON string, not a list
+    cap_arg = next(p for p in params[1:] if isinstance(p, str) and p.startswith("["))
+    assert json.loads(cap_arg) == ["send_message", "read_channel"]
+
+
+async def test_get_embodiment_maps_row_and_decodes_capability_set_to_tuple():
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _row(attachment_state="attached")
+    adapter = PostgresEmbodimentState(_make_pool(conn))
+
+    emb = await adapter.get_embodiment("emb-1")
+
+    assert emb is not None
+    assert emb.capability_set == ("send_message", "read_channel")  # JSONB → tuple, frozen-safe
+    assert isinstance(emb.capability_set, tuple)
+    assert emb.attachment_state == "attached"
+    assert emb.is_active is True  # mapped state drives the §5.5 helper
+
+
+async def test_get_embodiment_returns_none_when_absent():
+    conn = AsyncMock()
+    conn.fetchrow.return_value = None
+    adapter = PostgresEmbodimentState(_make_pool(conn))
+    assert await adapter.get_embodiment("nope") is None
+
+
+async def test_get_active_embodiment_filters_on_the_live_states():
+    conn = AsyncMock()
+    conn.fetchrow.return_value = None
+    adapter = PostgresEmbodimentState(_make_pool(conn))
+
+    await adapter.get_active_embodiment("max")
+
+    sql, agent_id, states = conn.fetchrow.call_args.args
+    assert agent_id == "max"
+    assert states == ["attached", "desynced", "reconnecting"]  # §5.5 active set only
+    assert "attachment_state = ANY" in sql
+
+
+async def test_transition_state_raises_when_row_absent():
+    conn = AsyncMock()
+    conn.fetchrow.return_value = None
+    adapter = PostgresEmbodimentState(_make_pool(conn))
+    with pytest.raises(KeyError, match="nope"):
+        await adapter.transition_state("nope", "attaching")
+
+
+async def test_transition_state_updates_the_attachment_state_column():
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _row(attachment_state="attaching")
+    adapter = PostgresEmbodimentState(_make_pool(conn))
+
+    result = await adapter.transition_state("emb-1", "attaching")
+
+    sql, embodiment_id, value = conn.fetchrow.call_args.args
+    assert "SET attachment_state = $2" in sql
+    assert (embodiment_id, value) == ("emb-1", "attaching")
+    assert result.attachment_state == "attaching"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, []),  # NULL column
+        ('["a", "b"]', ["a", "b"]),  # asyncpg default: JSONB as str
+        (["a"], ["a"]),  # a driver that already decoded it
+    ],
+)
+def test_loads_jsonb_is_robust_to_str_null_and_list(value, expected):
+    assert _loads_jsonb(value) == expected


### PR DESCRIPTION
Implements **SIP-0090 §13 Phase 1, slice 1b** — embodiment persistence. With 1a (merged, #312) this **completes Phase 1**: the §13 acceptance is *"Embodiment records exist and transition states cleanly."* 1a proved "transition cleanly" at the model level; 1b makes the records **exist**.

## What's here
- **`infra/migrations/1140_embodiments.sql`** — the `embodiments` table (§5.3 fields, D3 CHECK constraints mirroring the code Literals) + the **partial unique index** `uq_embodiments_one_active_per_agent` enforcing the single-active rule (§5.5) in the DB — the hard backstop behind the coordinator's logic-level guard. Idempotent DDL, mirrors `1120_focus_leases.sql`.
- **`adapters/persistence/runtime/embodiment_postgres.py`** — `PostgresEmbodimentState` implementing `EmbodimentStatePort`. JSONB `capability_set` (dumps on write, decode → tuple on read), the §4.5/D25 `conn` unit-of-work seam on mutators.

## Tests
- **9 unit tests** (mock-conn, in the regression suite): row→dataclass mapping, JSONB round-trip to a **tuple** (a list would break frozen-dataclass equality), the `get_active` active-state filter, not-found → KeyError.
- **4 integration tests, live-validated against the running stack DB** ✅: record round-trips with every field intact; **the single-active index rejects a 2nd live embodiment** (`UniqueViolationError`); detached history + other agents don't block; transition moves state + `get_active` reflects it.

**4652 unit regression green**; integration validated on real Postgres.

## Deferred (per the defer-infra-completeness principle)
- **Budget persistence** (`1141_agent_budgets.sql` + adapter) — needs a `BudgetPort` that isn't in 1a, and is **not** part of the §13 acceptance (budgets become persistence-relevant when Phase 3 activities consume them). The budget *primitives* (1a slice 2) are complete and enforce non-silent exhaustion.
- **Composition-root wiring** — no live consumer drives the `EmbodimentCoordinator` until Phase 2 (Discord adapter); wiring it now would be a factory ahead of its use.

Does not close an issue (no SIP-0090 tracking issue). Completes Phase 1 alongside #312.