### PR TITLE
fix(#319): render cycle-route error messages in the CLI

### DIFF
--- a/src/squadops/cli/client.py
+++ b/src/squadops/cli/client.py
@@ -157,8 +157,19 @@ class APIClient:
 
         try:
             body = response.json()
-            error_msg = body.get("error", {}).get("message", "") if isinstance(body, dict) else ""
-            detail = body.get("error", {}).get("details") if isinstance(body, dict) else None
+            # Cycle routes nest the {"error": {...}} envelope under FastAPI's `detail`
+            # ({"detail": {"error": {...}}}); health/auth return {"detail": "<string>"}.
+            # Unwrap `detail` first, then read the error envelope — falling back to the
+            # top level for an un-wrapped body (#319).
+            inner = body.get("detail", body) if isinstance(body, dict) else body
+            error_obj = inner.get("error") if isinstance(inner, dict) else None
+            if isinstance(error_obj, dict):
+                error_msg = error_obj.get("message", "")
+                detail = error_obj.get("details")
+            elif isinstance(inner, str):
+                error_msg, detail = inner, None
+            else:
+                error_msg, detail = (str(inner)[:200] if inner else ""), None
         except Exception:
             error_msg = response.text[:200]
             detail = None

--- a/tests/unit/cli/test_client.py
+++ b/tests/unit/cli/test_client.py
@@ -129,6 +129,35 @@ class TestErrorMapping:
         assert exc_info.value.exit_code == exit_codes.VALIDATION_ERROR
         assert "validation failed" in str(exc_info.value)
 
+    def test_422_wrapped_detail_envelope_renders_the_message(self):
+        """#319: cycle routes nest {"error": {...}} under FastAPI's `detail`. The
+        actionable message (e.g. the SIP-0095 preflight's 'pull model X') must reach
+        the operator, not get swallowed into an empty 'validation failed —'."""
+        api = _make_api_client_with_response(
+            422,
+            {
+                "detail": {
+                    "error": {
+                        "code": "PREFLIGHT_REJECTED",
+                        "message": "requires model `qwen3.6:27b`",
+                        "details": None,
+                    }
+                }
+            },
+        )
+        with pytest.raises(CLIError) as exc_info:
+            api.post("/test")
+        assert exc_info.value.exit_code == exit_codes.VALIDATION_ERROR
+        assert "requires model `qwen3.6:27b`" in str(exc_info.value)
+
+    def test_plain_string_detail_still_renders(self):
+        """#319: health/auth return {"detail": "<string>"} — that message must survive
+        the unwrap unchanged, not regress to empty."""
+        api = _make_api_client_with_response(404, {"detail": "resource missing"})
+        with pytest.raises(CLIError) as exc_info:
+            api.get("/test")
+        assert "resource missing" in str(exc_info.value)
+
     def test_413_maps_to_validation_error(self):
         api = _make_api_client_with_response(413)
         with pytest.raises(CLIError) as exc_info:


### PR DESCRIPTION
## What
Cycle-route errors were showing as `Error: validation failed —` with **no reason**. Root cause: `_handle_error_status` read `body["error"]["message"]`, but cycle routes nest the envelope under FastAPI's `detail` (`{"detail": {"error": {...}}}` via `handle_cycle_error`). So `error_msg` was always empty.

**Pre-existing** — affects every cycle-route 404/409/422 — but the **SIP-0095 preflight** made it painful: the API returns a perfect *"requires model `qwen3.6:27b`, pull it or choose another profile"* that the operator never saw.

## Fix
Unwrap `detail` before reading the `error` envelope; still handle plain-string `detail` (health/auth) and un-wrapped bodies.

## How it was found
Live validation of the SIP-0095 preflight on the deployed stack (rebuilt runtime-api, ran a `full` cycle → 422). The API returned the right message; the CLI dropped it. The existing CLI tests only covered the *un-wrapped* `{"error": {...}}` shape — which is exactly why the bug slipped through.

## Tests
- New: the wrapped `{"detail": {"error": {...}}}` envelope renders the message; plain-string `detail` still renders.
- **Live-validated**: a blocked `full` create now prints the full model message (verified after the fix).

Closes #319