### PR TITLE
feat(SIP-0095 Phase 4): surface create-time preflight warnings (response + CLI)

### DIFF
--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -9,7 +9,11 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, BackgroundTasks, Depends
 
 from squadops.api.middleware.auth import require_scopes
-from squadops.api.routes.cycles.dtos import CycleCreateRequest, CycleCreateResponse
+from squadops.api.routes.cycles.dtos import (
+    CycleCreateRequest,
+    CycleCreateResponse,
+    PreflightWarningDTO,
+)
 from squadops.api.routes.cycles.errors import handle_cycle_error
 from squadops.api.routes.cycles.mapping import cycle_to_response
 from squadops.auth.models import Scope
@@ -25,6 +29,7 @@ from squadops.cycles.models import (
     TaskFlowPolicy,
 )
 from squadops.cycles.preflight import (
+    Finding,
     combine,
     model_availability_decision,
     required_roles_decision,
@@ -57,23 +62,27 @@ async def _pulled_model_names() -> list[str] | None:
     return [name for m in raw if (name := m.get("name"))]
 
 
-async def _run_create_preflight(profile: SquadProfile, applied_defaults: dict) -> None:
+async def _run_create_preflight(
+    profile: SquadProfile, applied_defaults: dict
+) -> tuple[Finding, ...]:
     """SIP-0095 create-time preflight: fail fast BEFORE persist/dispatch.
 
     Blocks (HTTP 422) when the squad can't satisfy the requested workloads' required
     roles or names a model definitively not pulled; an unreachable backend warns and
-    allows. Warnings are logged here — the response/CLI surface is Phase 4.
+    allows. Returns the non-blocking warnings so the route can surface them on the
+    response (Phase 4); raises on a blocking finding.
     """
     decision = combine(
         required_roles_decision(profile, applied_defaults),
         model_availability_decision(profile, await _pulled_model_names()),
     )
+    if decision.rejected:
+        raise PreflightRejectedError(decision.summary())
     for w in decision.warnings:
         logger.warning(
             "cycle_create_preflight_warning", extra={"code": w.code, "detail": w.message}
         )
-    if decision.rejected:
-        raise PreflightRejectedError(decision.summary())
+    return decision.warnings
 
 
 @router.post("", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
@@ -119,7 +128,7 @@ async def create_cycle(
         applied_defaults = body.applied_defaults
 
         # SIP-0095: create-time preflight — fail fast (422) before persist/dispatch.
-        await _run_create_preflight(profile, applied_defaults)
+        preflight_warnings = await _run_create_preflight(profile, applied_defaults)
 
         config_hash = compute_config_hash(applied_defaults, body.execution_overrides)
 
@@ -196,6 +205,9 @@ async def create_cycle(
             squad_profile_snapshot_ref=snapshot_hash,
             task_flow_policy=body.task_flow_policy,
             resolved_config_hash=config_hash,
+            warnings=[
+                PreflightWarningDTO(code=w.code, message=w.message) for w in preflight_warnings
+            ],
         )
     except CycleError as e:
         raise handle_cycle_error(e) from e

--- a/src/squadops/api/routes/cycles/dtos.py
+++ b/src/squadops/api/routes/cycles/dtos.py
@@ -178,6 +178,17 @@ class CycleResponse(BaseModel):
     workload_progress: list[WorkloadProgressEntry] = Field(default_factory=list)
 
 
+class PreflightWarningDTO(BaseModel):
+    """A non-blocking create-time preflight warning (SIP-0095 §7).
+
+    `code` is a stable machine label (e.g. `model_unverifiable`); `message` is the
+    actionable operator text. The cycle was created despite the warning (warn-and-allow).
+    """
+
+    code: str
+    message: str
+
+
 class CycleCreateResponse(BaseModel):
     """Response for cycle creation — includes first run_id."""
 
@@ -191,6 +202,8 @@ class CycleCreateResponse(BaseModel):
     squad_profile_snapshot_ref: str
     task_flow_policy: TaskFlowPolicyDTO
     resolved_config_hash: str
+    # SIP-0095 Phase 4: non-blocking preflight warnings surfaced to the operator.
+    warnings: list[PreflightWarningDTO] = Field(default_factory=list)
 
 
 class AgentProfileEntryResponse(BaseModel):

--- a/src/squadops/cli/commands/cycles.py
+++ b/src/squadops/cli/commands/cycles.py
@@ -167,6 +167,9 @@ def create_cycle(
                 "hash": data.get("resolved_config_hash", ""),
             }
         )
+        # SIP-0095 Phase 4: surface non-blocking preflight warnings (warn-and-allow).
+        for w in data.get("warnings", []):
+            print_error(f"Warning: preflight [{w['code']}] — {w['message']}")
 
 
 @app.command("list")

--- a/tests/unit/cycles/test_api_cycles.py
+++ b/tests/unit/cycles/test_api_cycles.py
@@ -410,3 +410,22 @@ class TestCreateCyclePreflight:
         ):
             resp = client.post("/api/v1/projects/hello_squad/cycles", json=self._REQUEST)
         assert resp.status_code == 200
+
+    def test_warn_and_allow_surfaces_the_warning_on_the_response(self, client):
+        """Phase 4: an unreachable backend (None) → created, but the response carries a
+        `model_unverifiable` warning so the operator isn't left in the dark."""
+        # no LLM port is wired in this test → _pulled_model_names() returns None
+        resp = client.post("/api/v1/projects/hello_squad/cycles", json=self._REQUEST)
+        assert resp.status_code == 200
+        warnings = resp.json()["warnings"]
+        assert [w["code"] for w in warnings] == ["model_unverifiable"]
+        assert "unreachable" in warnings[0]["message"]  # actionable operator text
+
+    def test_no_warnings_when_models_are_verified(self, client):
+        with patch(
+            "squadops.api.routes.cycles.cycles._pulled_model_names",
+            new=AsyncMock(return_value=["gpt-4:latest"]),
+        ):
+            resp = client.post("/api/v1/projects/hello_squad/cycles", json=self._REQUEST)
+        assert resp.status_code == 200
+        assert resp.json()["warnings"] == []


### PR DESCRIPTION
Completes the SIP-0095 arc — the preflight's **warn-and-allow** findings now reach the operator instead of only hitting the server log.

## What changed
- `CycleCreateResponse` gains **`warnings: [{code, message}]`** (`PreflightWarningDTO`).
- `_run_create_preflight` now **returns** the non-blocking warnings (still raises 422 on a block); the route attaches them to the response.
- `squadops cycles create` **echoes** each warning (`Warning: preflight [code] — message`); `--format json` carries them inline.

This complements #320 (which fixed the *error*-message rendering); Phase 4 is the *warning* surface.

## The one warning source today
`model_unverifiable` — the LLM backend was unreachable at create time, so models couldn't be verified (warn-and-allow, never block on missing evidence).

## Tests + validation
- Unit: warn-and-allow surfaces `model_unverifiable` on the response; a verified squad has `warnings: []`. **4656 regression green.**
- **Live-validated** (rebuilt runtime-api): a `smoke` create returns the `warnings` field as `[]` (Ollama reachable → models verified, no false positive) and the cycle creates. The warn *display* path is unit-proven — triggering it live needs an unreachable backend, which I did not induce on the running stack (it would disrupt agents).

## Deferred (defer-infra-completeness)
Persisting warnings on the cycle record for `cycles show` — a migration + `Cycle`-model change for a narrow (backend-unreachable) edge. The response + CLI echo already deliver the create-time operator feedback; persistence can follow if durability is wanted.

References SIP-0095 (no tracking issue; #172/#224 already closed).