### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to SquadOps are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [1.2.0] — 2026-07-04
+
+First **feature release** on the even/odd minor cadence (#281): even minors carry
+features, gated by headline feature SIPs. 1.2.0 is led by three — the SIP-0089
+runtime-arc completion, the SIP-0090 Agent Embodiment Substrate (Phase 1), and the
+SIP-0095 Cycle Create Preflight — riding a hardening base (#158, #231). Two lanes
+fed it: features from the Macbook lane, hardening + supporting decisions from Spark.
+
+### Added
+- **SIP-0090 Agent Embodiment Substrate — Phase 1 (core model).** The internal
+  substrate for embodied agents: an `Embodiment` lifecycle state machine
+  (`unattached→attaching→attached→desynced→reconnecting→detached`) with an explicit
+  transition allow-list and a single-active-embodiment-per-agent invariant (enforced
+  both in code and by a Postgres partial unique index); resource budget primitives
+  (attention/compute/action consumables + a concurrency capacity gauge, with
+  non-silent exhaustion made type-unrepresentable); an `EmbodimentStatePort` with a
+  Postgres adapter; and an `EmbodimentCoordinator` that validates transitions and
+  emits canonical events. No adapter yet — Discord/browser embodiments are later
+  phases (#312, #317).
+- **SIP-0095 Cycle Create Preflight.** A create-time fail-fast gate: a cycle is
+  rejected (HTTP 422 `PREFLIGHT_REJECTED`) when the squad can't satisfy the requested
+  workloads' required roles, or names a model definitively not pulled (exact
+  canonical-tag match, no family inference). An unreachable LLM backend
+  warns-and-allows rather than blocking on missing evidence; warnings surface on the
+  create response and in the CLI. `squadops doctor` gained model-availability parity
+  via the same shared decision (#298, #309, #311, #315, #321).
+- **SIP-0089 runtime-arc completion.** Cycle recruitment now routes through the
+  RuntimeCoordinator with FocusLease arbitration (a lease conflict is a deferral, not
+  a failure) (#233), and coordinator transitions commit lease + activity + mode in a
+  single `RuntimeTransaction` unit of work with live-validated rollback (#244).
+- **Validated-fullstack request-profile** — instrumentation + builder + stack for
+  end-to-end framework validation (#279).
+
+### Changed
+- **Health signal consolidated to a single source of truth (#231).** `runtime_status`
+  is now the canonical health signal across every read surface (API single + list
+  routes, CLI, both console plugins); it is always-populated (the heartbeat ensures
+  the runtime row and reconciliation backfills legacy agents), and the
+  `runtime_status || network_status` fallback is gone. `network_status` is demoted to
+  a deprecated back-compat field (column drop tracked separately) (#302).
+- **Squad profiles consolidated to `smoke` / `lite` / `full`** (#173).
+
+### Fixed
+- **CLI now renders cycle-route error messages (#319).** They were nested under
+  FastAPI's `detail` and silently dropped — the operator saw `validation failed —`
+  with no reason (e.g. the preflight's actionable "pull model X"). Found via live
+  cycle validation (#320).
+- **Operational hardening (#158)** — configurable adapter timeouts + a DDL↔model
+  drift guard; the `_schema_migrations` applier remains idempotent.
+- Local-spark bootstrap models reconciled with the squad profiles (#285); QA-harness
+  robustness + portable-frontend build fixes (#303, #296, #280).
+
+### Deferred / follow-ups
+- SIP-0095's materialized-plan capability check at the plan-review gate (#295) —
+  deferred to land with the #186 executor decomposition; the dispatch-time check
+  remains the net.
+- SIP-0090 Phase 1 budget persistence + composition-root wiring — no live consumer
+  until Phase 2 (Discord).
+
 ## [1.1.1] — 2026-06-29
 
 Hardening patch on the 1.1.0 runtime line. The runtime lane (SIP-0089) was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 SquadOps is a multi-agent orchestration framework for software development. It uses a hexagonal architecture (ports & adapters) with dependency injection for testability.
 
-**Framework Version**: 1.1.1 (single-sourced via `importlib.metadata.version("squadops")`)
+**Framework Version**: 1.2.0 (single-sourced via `importlib.metadata.version("squadops")`)
 **Python Requirement**: 3.11+ (production runs 3.11); develop and test on **Python 3.12** to match CI
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 **SquadOps** is an AI agent collaboration framework for software development. The system implements a role-based agent architecture where specialized agents handle different aspects of development tasks, from requirements analysis to application deployment.
 
-**Current Status**: v1.1.1 — Production-ready framework with hexagonal architecture, the Agent Runtime State platform (SIP-0089: runtime modes ambient/cycle/duty, single-writer coordinator, duty scheduler, FocusLease arbitration, RuntimeActivity observability), distributed cycle execution pipeline, multi-run cycle orchestration, workload protocols (planning, implementation, wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, build convergence loop with dynamic task decomposition (SIP-0086), Prefect task-scoped log streaming (SIP-0087), Postgres-backed persistence, LangFuse observability, Keycloak authentication, CLI tooling, test quality enforcement, and 4,470+ passing tests.
+**Current Status**: v1.2.0 — Production-ready framework with hexagonal architecture, the Agent Embodiment Substrate (SIP-0090 Phase 1: embodiment lifecycle, single-active invariant, resource budgets), the Cycle Create Preflight (SIP-0095: create-time fail-fast on unsatisfiable roles / unpulled models), the completed Agent Runtime State platform (SIP-0089: runtime modes ambient/cycle/duty, single-writer coordinator, FocusLease arbitration, single-transaction UoW, RuntimeActivity observability), distributed cycle execution pipeline, multi-run cycle orchestration, workload protocols (planning, implementation, wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, build convergence loop (SIP-0086), Prefect task-scoped log streaming (SIP-0087), Postgres-backed persistence, LangFuse observability, Keycloak authentication, CLI tooling, test quality enforcement, and 4,650+ passing tests.
 
 ---
 
@@ -173,12 +173,12 @@ See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for full setup instructio
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for the full release timeline.
 
-**Current**: v1.1.1 — Agent Runtime State (SIP-0089) on a hardened 1.0.x foundation; distributed cycle execution, multi-run orchestration, correction protocol, build convergence loop (SIP-0086), and Prefect task-scoped log streaming (SIP-0087) shipped
+**Current**: v1.2.0 — first even/odd feature release: SIP-0090 Agent Embodiment Substrate (Phase 1), SIP-0095 Cycle Create Preflight (create-time fail-fast), and the SIP-0089 runtime-arc completion (recruitment→coordinator FocusLease, single-transaction UoW), on a #158/#231 hardening base
 
 ---
 
 ## Current Status
-**Framework Version**: 1.1.1
+**Framework Version**: 1.2.0
 **Development Status**: Post-1.1 stable multi-agent orchestration with the Agent Runtime State platform (SIP-0089: runtime modes, duty scheduler, FocusLease, RuntimeActivity), console UI, distributed cycle execution, multi-run cycle orchestration, workload protocols (planning → implementation → wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, Prefect task-scoped log streaming, durable persistence, authentication, CLI tooling, profile-driven bootstrap, test quality enforcement, and full observability stack.
 
 ### Project Statistics

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,7 +8,15 @@ Semver with an **even/odd minor** overlay (parity gates *features*, not hardenin
 
 ## Release Timeline
 
-### v1.1.1 (2026-06-28) — Current — Runtime Lane Hardening
+### v1.2.0 (2026-07-04) — Current — First Feature Release (even/odd cadence)
+First **even-minor feature release** (#281). Three feature SIPs, on a hardening base:
+- **SIP-0090 Agent Embodiment Substrate — Phase 1:** the internal embodiment model — lifecycle state machine (single-active-per-agent, enforced in code + a Postgres partial unique index), resource budget primitives (non-silent exhaustion), `EmbodimentStatePort` + Postgres persistence, `EmbodimentCoordinator`. No adapter yet (#312, #317).
+- **SIP-0095 Cycle Create Preflight:** create-time fail-fast (422 `PREFLIGHT_REJECTED`) on unsatisfiable roles / unpulled models; unreachable backend warns-and-allows; doctor parity; warnings on response + CLI (#298, #309, #311, #315, #321).
+- **SIP-0089 runtime-arc completion:** recruitment via coordinator + FocusLease (#233); single-transaction coordinator UoW (#244).
+- **#231** health signal → single source of truth (`runtime_status` always-populated); **#173** profiles → smoke/lite/full; **#158** operational hardening; **#319/#320** CLI error-message fix.
+- **Deferred:** #295 (materialized-plan gate check → rides #186); SIP-0090 budget persistence/wiring (→ Phase 2).
+
+### v1.1.1 (2026-06-28) — Runtime Lane Hardening
 - **Live-validated the runtime lane (SIP-0089) end-to-end** after 1.1.0, which surfaced two regressions the unit suites couldn't catch:
   - **#270** cycle API routes 403'd every authenticated user — #150's `cycles:*` scope checks didn't account for the role-centric Keycloak realm (issues roles, not scopes); fixed with a role→scope bridge in `resolve_identity`.
   - **#272** duty windows never auto-opened under the default `missed_window_policy="skip"` — poll-cadence lag was misread as a missed window; fixed with an on-time grace of one poll interval.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["squadops*", "adapters*"]  # Include both packages
 
 [project]
 name = "squadops"
-version = "1.1.1"
+version = "1.2.0"
 description = "SquadOps: a production-grade multi-agent orchestration framework."
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
Cuts **v1.2.0** — the first feature release on the even/odd minor cadence (#281).

## Version
`1.1.1 → 1.2.0` (pyproject, single-sourced); markers synced in `CLAUDE.md`, `README.md`, `docs/ROADMAP.md`.

## Headline (three feature SIPs)
- **SIP-0090 Agent Embodiment Substrate — Phase 1** (#312, #317) — embodiment lifecycle + single-active invariant + budgets + `EmbodimentStatePort`/Postgres + coordinator. Internal substrate, no adapter yet.
- **SIP-0095 Cycle Create Preflight** (#298, #309, #311, #315, #321) — create-time fail-fast (422) on unsatisfiable roles / unpulled models; unreachable backend warns-and-allows; doctor parity; warnings on response + CLI.
- **SIP-0089 runtime-arc completion** — recruitment→coordinator FocusLease (#233), single-transaction UoW (#244).

Plus: #231 health single-source-of-truth, #173 profile consolidation, #158 hardening, #320 CLI error-message fix. Full notes in `CHANGELOG.md`.

## Validation
- **4656 unit regression green.**
- **E2E smoke validated** — `smoke` cycles ran to completion on the deployed stack (rebuilt with the preflight); the `full`-block and `smoke`-pass preflight paths were live-validated.

## Deferred (documented)
#295 (materialized-plan gate check → rides #186); SIP-0090 budget persistence/wiring (→ Phase 2).

---
**After merge:** I'll cut the annotated **`v1.2.0`** tag + GitHub Release from the CHANGELOG (per the restarted tagging discipline).