### PR TITLE
chore(SIP-0095): promote Cycle-Create Preflight → implemented

### DIFF
--- a/sips/implemented/SIP-0095-Cycle-Create-Preflight.md
+++ b/sips/implemented/SIP-0095-Cycle-Create-Preflight.md
@@ -1,15 +1,15 @@
 ---
 title: Cycle-Create Preflight
-status: accepted
+status: implemented
 author: jladd
 created_at: '2026-07-01T00:00:00Z'
 sip_number: 95
-updated_at: '2026-06-30T21:57:45.818751Z'
+updated_at: '2026-07-04T06:39:04.348281Z'
 ---
 # SIP-0095: Cycle Create Preflight
 
 ## Status
-Accepted
+Implemented (v1.2.0)
 
 **Targets:** v1.2
 **Combines:** #172 (capability/role satisfiability) + #224 (model availability)

--- a/sips/registry.yaml
+++ b/sips/registry.yaml
@@ -858,9 +858,9 @@ sips:
 - sip_uid: null
   sip_number: 95
   title: Cycle-Create Preflight
-  path: sips/accepted/SIP-0095-Cycle-Create-Preflight.md
-  status: accepted
+  path: sips/implemented/SIP-0095-Cycle-Create-Preflight.md
+  status: implemented
   author: jladd
   approver: jladd
   created_at: '2026-07-01T00:00:00Z'
-  updated_at: '2026-06-30T21:57:45.847512Z'
+  updated_at: '2026-07-04T06:39:04.349114Z'


### PR DESCRIPTION
Promotes **SIP-0095 Cycle-Create Preflight** from `accepted` → `implemented`, matching what shipped in **v1.2.0**.

## Why now
All nine acceptance criteria (§9) are met and were live-validated on the deployed stack:
- `full` → **HTTP 422** with the actionable "pull model" message (missing-model block)
- `smoke` → creates + completes (happy path unchanged)
- `squadops doctor` model-availability parity via the shared decision
- unverifiable (backend-unreachable) → warn-and-allow, surfaced on the create response **and** echoed by the CLI

## On #295 (not deferred scope)
The CHANGELOG lists the materialized-plan check at the plan-review gate (#295) under "Deferred / follow-ups," but per the SIP itself (§6.1, §5 Non-Goals, acceptance criterion #4) that check is **explicitly out of create-time scope** — the builder/materialized-plan mismatch is caught by dispatch-time `validate_against_profile`, and hoisting it to the plan-review gate is tracked separately as #295 (rides the #186 executor decomposition). The create-time preflight contract this SIP defines is complete.

## Changes
- `sips/accepted/…` → `sips/implemented/SIP-0095-Cycle-Create-Preflight.md` (via `update_sip_status.py`)
- `sips/registry.yaml`: `status: accepted → implemented`, path updated
- Body `## Status` heading updated `Accepted → Implemented (v1.2.0)` by hand (the script only rewrites a `**Status:**` line, which this SIP doesn't use)

Bookkeeping only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)