### PR TITLE
SIP proposal: Verification Evidence Integrity + evidence-arc reconciliation

### DIFF
--- a/docs/plans/1-4-evidence-arc-plan.md
+++ b/docs/plans/1-4-evidence-arc-plan.md
@@ -1,0 +1,123 @@
+# 1.4 Evidence Arc — Execution Plan (1.3 riders → 1.4 → 1.6 gates)
+
+**Established:** 2026-07-06 · companion to `1-3-x-two-lane-plan.md` (which governs the
+current release and is **not disturbed** by this plan) and `2-0-roadmap-reconciliation.md`
+(whose Finding-5 feature-lane line this supersedes: 1.4 is now **duty durability +
+verification evidence integrity**, not duty durability alone).
+
+## The thesis (one sentence per release)
+
+- **1.3 (current)** stabilizes the *structure* (god-object decomposition, port de-leak, comms push consumer).
+- **1.4** makes the *evidence* trustworthy (Verification Evidence Integrity SIP + SIP-0091 duty durability).
+- **1.6** automates decisions *over* trusted evidence (Campaign Orchestration).
+- **2.0** compounds on top (Capability-Backed Agents, Self-Improvement, Test Bay, Scorecard).
+
+The ordering is load-bearing: Campaign's continuation policy reads the `CycleOutcome`
+roll-up the evidence SIP defines, and its recruitment safety depends on lease hardening
+(#288). Every gate below exists to keep "automate over evidence" strictly behind
+"evidence is honest."
+
+## SIP map
+
+| SIP | Status | Release | Role in the arc |
+|---|---|---|---|
+| Verification Evidence Integrity | proposed (`sips/proposed/`) | **1.4 headline** | integrity invariant, provenance, inert-check detection, `CycleOutcome` contract |
+| SIP-0091 Duty Durability via Temporal | accepted (fix stale `Targets: v1.3` → 1.4, #335) | **1.4 headline** | durable responsibility |
+| SIP-0090 Embodiment Phase 2 (Discord) | accepted (phased) | 1.4 **or** 1.6 — open decision | first live embodiment consumer |
+| Campaign Orchestration | proposed (revised 2026-07-06 per #334) | **1.6 headline** | objective envelope + continuation policy |
+| Self-Improvement + Test Bay; Capability-Backed Agents; Cycle Evaluation Scorecard | proposed (vision/backlog) | 2.0 / post-1.6 | consumers of the trusted-evidence substrate |
+
+## Phase-by-release execution
+
+### Now / patch lane (no release gate — ship when ready)
+
+| Item | Lane | Notes |
+|---|---|---|
+| #276 stub-fallback fix | S | bug; also unblocks #152 (the 1.3 collision rule) |
+| #306 Node.js in agent image / #296 source_filter | S | bugs; make frontend checks *able* to run |
+| #329 aio_pika log demotion | S | restores fleet observability this week |
+| #326 `/health` write-lane fix | S | untracked security hole → 1.3-hardening-shaped |
+| #335 docs hygiene (ROADMAP stats, SIP-0091 tag, untracked refs) | M | direct-push OK (simple docs) |
+
+The three bug fixes ship as ordinary patches; the evidence SIP later locks the *class*
+(its Phase 2 converts each fix into a permanent honest-reporting conformance case).
+
+### During 1.3 (riders — additive to the two-lane plan, not amendments)
+
+| Item | Lane | Why it rides here |
+|---|---|---|
+| **Evidence SIP Phase 0** — vocabulary reconciliation audit (read accepted SIP-0092/0070/0079 against §6–§7; field-level mapping; no third vocabulary) | M | docs-only, feature-free, keeps 1.4 unblocked |
+| **#288 lease-arbitration fix** | M | lease-semantics *hardening* (1.3-legal); runtime surface is Lane-M-owned; hard gate for 1.6 Phase 2 — do not let it slip past 1.5 |
+| Evidence SIP proposal PR → design review → **accept** | M (maintainer) | acceptance is a design commitment on main; the 1.4 feature branch starts from it |
+| #336 docs-drift lint | S | CI/test-infra is Lane-S-owned |
+
+Note: #295 stays exactly where the 1.3 plan put it (rides #186). The evidence SIP's
+choke point attaches to the **post-#186 completion boundary**, so #186 landing in 1.3
+is itself an arc prerequisite — a reason to protect the 1.3 batch, not change it.
+
+### 1.4 (feature minor — the evidence release)
+
+- **Evidence SIP Phase 1** — aggregation function + `blocked_unverified` verdict +
+  provenance fields + `required_checks` profile schema. (Lane M: cycles/executor seam.)
+- **Evidence SIP Phase 2** — retrofit the proof cases (#276/#306/#296 honest reporting,
+  #291 required-files check, SIP-0095 preflight tooling-parity). Each lands with a live
+  `lite` cycle per the live-validation rule. (Split M/S along the usual file ownership:
+  executor/handlers = M; test-runner/build-check/agent-image conformance = S.)
+- **Evidence SIP Phase 3** — inert-check detection, doctor report, console badging,
+  `verification.check_inert` event, `CycleOutcome` roll-up consumed by wrap-up.
+  #114 (typed-check evaluation surfacing) rides this phase.
+- **SIP-0091 duty durability** per its own spec (Lane M).
+- **Open decision (make at 1.4 planning, not now):** does SIP-0090 Phase 2 (Discord)
+  ride 1.4 or wait for 1.6? Leaning 1.4 if capacity allows — it is the first *live*
+  embodiment test and independent of the evidence work.
+- **Cut gate:** standard checklist (bump → CHANGELOG/markers → regression → tag +
+  Release → rebuild+deploy+verify → E2E smoke → SIP promotion sweep). Promotion sweep
+  expects: Verification Evidence Integrity → implemented (all phases), SIP-0091 →
+  implemented; SIP-0090 stays accepted unless Phase 2 shipped *and* its arc is complete.
+
+### 1.5 (stabilization — feature-free by rule)
+
+Home for: #288 if it slipped 1.3; evidence-arc hardening spillover (provenance-storage
+tuning, roll-up persistence cleanup); the next god-module batch (#331 planning_tasks.py
+if it didn't ride #152's arc); accumulated debt (#154 residue, #301, #234 follow-through).
+
+### 1.6 (feature minor — Campaign)
+
+Campaign Orchestration accepts and implements **only when its named gates are green**:
+
+| Gate | Where it lands |
+|---|---|
+| Verification Evidence Integrity implemented (the `CycleOutcome` contract §7.2 reads) | 1.4 |
+| #288 lease arbitration fixed | 1.3 (target) / 1.5 (backstop) |
+| #316 request-profile naming taxonomy (for policy-derived `next_request_profile`) | 1.3–1.5, Lane S (`SIP-Cycle-Request-Profile-Naming-Taxonomy.md` exists in proposed) |
+| Campaign SIP open questions 1 (fork) and 5 (defer mechanism) resolved | pre-acceptance |
+
+## Issue → arc map (everything filed 2026-07-04/05)
+
+| Issue | Arc slot |
+|---|---|
+| #326 /health write lane | patch/1.3 hardening (S) |
+| #327 prompt manifest | patch (S); Phase-2-adjacent (deploy-time verification = same honesty principle) |
+| #328 broker hygiene + doctor queue check | patch/1.3 (S) |
+| #329 log demotion | patch now (S) |
+| #330 Prefect loop starvation | investigate before any long Spark cycle; no release gate |
+| #331 planning_tasks.py | 1.3 if #152's layout extends cheaply, else 1.5 (M) |
+| #332 hoist copy-pasted helpers | 1.3, step 0 of #152 (M) |
+| #333 entrypoint fallbacks/env drift | 1.3–1.5 hardening (M) |
+| #334 Campaign SIP fixes | **done 2026-07-06** (SIP revised; close via the proposal PR) |
+| #335 docs hygiene | now (M, direct-push) |
+| #336 docs-drift lint | 1.3 rider (S) |
+
+## What must be true before each "go"
+
+1. **Evidence SIP acceptance** ← Phase 0 audit complete (no vocabulary collision with 0092/0070/0079).
+2. **1.4 cut** ← evidence Phases 1–3 live-validated (one `lite` cycle blocking honestly on a required unrunnable check; one completing with disclosure); SIP-0091 arc complete.
+3. **Campaign SIP acceptance** ← the four 1.6 gates above.
+4. **Any 2.0 measurement work (scorecard, self-improvement)** ← consumes `CycleOutcome` only; never raw check results.
+
+## Ratification note
+
+This plan does not edit `docs/ROADMAP.md`. When ROADMAP is next touched (#335), apply:
+the Finding-4 remap from `2-0-roadmap-reconciliation.md`, the stats-block fix, **and**
+the 1.4 line from this plan (duty durability + verification evidence integrity as the
+even-minor headliners, embodiment Phase 2 as the open rider).

--- a/docs/plans/1-4-evidence-arc-plan.md
+++ b/docs/plans/1-4-evidence-arc-plan.md
@@ -33,20 +33,21 @@ roll-up the evidence SIP defines, and its recruitment safety depends on lease ha
 
 | Item | Lane | Notes |
 |---|---|---|
-| #276 stub-fallback fix | S | bug; also unblocks #152 (the 1.3 collision rule) |
-| #306 Node.js in agent image / #296 source_filter | S | bugs; make frontend checks *able* to run |
-| #329 aio_pika log demotion | S | restores fleet observability this week |
-| #326 `/health` write-lane fix | S | untracked security hole → 1.3-hardening-shaped |
+| ~~#276 stub-fallback + frontend-build checks~~ | S | **already shipped** (PRs #289/#290); #296 **closed** (`5cb22ce`). What remains of #276 is #291 (executor `required_files`, Lane M → rides the 1.4 evidence arc). **#152's #276-gate is therefore satisfied.** |
+| #306 Node.js in agent image | S (Mac-doable) | bug; makes the shipped #290 frontend check actually executable |
+| #329 aio_pika log demotion | S (Mac-doable) | restores fleet observability this week |
+| #326 `/health` write-lane fix | S (Mac-doable) | untracked security hole → 1.3-hardening-shaped |
 | #335 docs hygiene (ROADMAP stats, SIP-0091 tag, untracked refs) | M | direct-push OK (simple docs) |
 
-The three bug fixes ship as ordinary patches; the evidence SIP later locks the *class*
-(its Phase 2 converts each fix into a permanent honest-reporting conformance case).
+The remaining bug fixes ship as ordinary patches; the evidence SIP locks the *class*
+(its Phase 2 covers the shipped #289/#290 checks with classification + provenance
+conformance, no behavior change).
 
 ### During 1.3 (riders — additive to the two-lane plan, not amendments)
 
 | Item | Lane | Why it rides here |
 |---|---|---|
-| **Evidence SIP Phase 0** — vocabulary reconciliation audit (read accepted SIP-0092/0070/0079 against §6–§7; field-level mapping; no third vocabulary) | M | docs-only, feature-free, keeps 1.4 unblocked |
+| **Evidence SIP Phase 0** — verification audit (confirm the SIP's §6.1 classification mapping + §8 conformance table against code and the accepted SIP-0092/0070 texts; semantics are decided in the SIP, not here) | M | docs-only, feature-free, keeps 1.4 unblocked |
 | **#288 lease-arbitration fix** | M | lease-semantics *hardening* (1.3-legal); runtime surface is Lane-M-owned; hard gate for 1.6 Phase 2 — do not let it slip past 1.5 |
 | Evidence SIP proposal PR → design review → **accept** | M (maintainer) | acceptance is a design commitment on main; the 1.4 feature branch starts from it |
 | #336 docs-drift lint | S | CI/test-infra is Lane-S-owned |
@@ -59,12 +60,15 @@ is itself an arc prerequisite — a reason to protect the 1.3 batch, not change 
 
 - **Evidence SIP Phase 1** — aggregation function + `blocked_unverified` verdict +
   provenance fields + `required_checks` profile schema. (Lane M: cycles/executor seam.)
-- **Evidence SIP Phase 2** — retrofit the proof cases (#276/#306/#296 honest reporting,
-  #291 required-files check, SIP-0095 preflight tooling-parity). Each lands with a live
-  `lite` cycle per the live-validation rule. (Split M/S along the usual file ownership:
-  executor/handlers = M; test-runner/build-check/agent-image conformance = S.)
-- **Evidence SIP Phase 3** — inert-check detection, doctor report, console badging,
-  `verification.check_inert` event, `CycleOutcome` roll-up consumed by wrap-up.
+- **Evidence SIP Phase 2** — conformance of the real gaps (rev-2 §8): the two named
+  SIP-0070 amendments (SKIP-only→PASS pulse fix; D13 required-frontend blocking),
+  #306 image fix + preflight tooling-parity, #291 required-files as a checked contract,
+  and classification/provenance retrofit of the shipped #289/#290 checks. Each lands
+  with a live `lite` cycle per the live-validation rule. (Split M/S along the usual
+  file ownership: executor/handlers = M; test-runner/build-check/agent-image = S.)
+- **Evidence SIP Phase 3** — `CycleOutcome` roll-up persisted + consumed by wrap-up,
+  gate waiver flow, doctor verification category (non-executable + inert reporting;
+  console badging and a dedicated event are deferred until demand).
   #114 (typed-check evaluation surfacing) rides this phase.
 - **SIP-0091 duty durability** per its own spec (Lane M).
 - **Open decision (make at 1.4 planning, not now):** does SIP-0090 Phase 2 (Discord)

--- a/docs/plans/2-0-roadmap-reconciliation.md
+++ b/docs/plans/2-0-roadmap-reconciliation.md
@@ -102,7 +102,7 @@ capability-backed agents*) and its concept-boundary table (§11) are sound and w
 
 ## Next moves
 
-1. ~~Draft the carved-out **Campaign Orchestration SIP (1.6)**~~ — **done**: `sips/proposed/SIP-Campaign-Orchestration.md`. The near-term acceptable unit: objective envelope + continuation policy, reusing recruitment unchanged, with the Loop-Policy decision vocab folded in. Not yet accepted (proposed).
+1. ~~Draft the carved-out **Campaign Orchestration SIP (1.6)**~~ — **done**: `sips/proposed/SIP-Campaign-Orchestration.md`. The near-term acceptable unit: objective envelope + continuation policy, reusing recruitment unchanged, with the Loop-Policy decision vocab folded in. Not yet accepted (proposed). **Update 2026-07-06:** revised per #334 (evidence contract, #288 prerequisite, AC#4 hardening); the Finding-5 feature-lane line is superseded by `docs/plans/1-4-evidence-arc-plan.md` — 1.4 = duty durability **+ Verification Evidence Integrity** (`sips/proposed/SIP-Verification-Evidence-Integrity.md`), which gates Campaign Phase 2.
 2. Reconcile the umbrella boundary (Campaign vs Capability-Backed-Agents vs Continuum-Runtime-Console).
 3. When `docs/ROADMAP.md` is next touched, apply the Finding-4 remap and the Finding-2 pillar map.
 4. Fix SIP-0091's stale `Targets: v1.3` → 1.4.

--- a/sips/proposed/SIP-Campaign-Orchestration.md
+++ b/sips/proposed/SIP-Campaign-Orchestration.md
@@ -13,6 +13,7 @@ Proposed
 **Carved from:** `SIP-Campaign-Self-Improvement-and-Test-Bay-Requirements.md` (the 2.0 vision anchor). This SIP is the **near-term, implementable mechanic** — the objective envelope + continuation policy — with no dependency on capability packs, Test Bay, or new agent roles. See `docs/plans/2-0-roadmap-reconciliation.md`.
 **Supersedes:** the "Loop Policy" naming in `docs/ideas/SquadOps-Roadmap-Runtime-Loop-Capability-Backed-Agents.md`. The idea's continuance-decision vocabulary is adopted here as the Campaign continuation decision.
 **Builds on:** SIP-0064 (Cycle/Run/TaskFlowPolicy + gates), SIP-0067 (Postgres cycle registry pattern), SIP-0070 (pulse checks / verification evidence), SIP-0083 (multi-run cycle orchestration), SIP-0089 (runtime state / cycle recruitment via the coordinator + FocusLease), SIP-0069 (Continuum console).
+**Depends on (must land before Phase 2):** the **Verification Evidence Integrity SIP** (`sips/proposed/SIP-Verification-Evidence-Integrity.md`, targets 1.4) — defines the `CycleOutcome` roll-up the continuation decision reads (§7.2); it ships one even-minor ahead so the evidence contract is live-validated before Campaign automates over it. And **#288** (coordinator same-mode lease free-ride) — see §8; automated back-to-back launches and `fork` make that window systematic.
 
 ---
 
@@ -126,7 +127,11 @@ campaign_continuation_decision(
 
 ### 7.2 Decision inputs
 
-The objective's **measurement method**, the latest Cycle's **verification/acceptance evidence** (SIP-0070 pulse checks + gate outcomes), accumulated evidence, and **policy limits** (max cycles, budget, time, required-evidence thresholds). No agent narrative alone may drive `stop_success` — it must point to verification evidence or an operator gate.
+The objective's **measurement method**, the latest Cycle's **`CycleOutcome` evidence roll-up** (Verification Evidence Integrity SIP: the `verified` / `failed` / `unverified` / `inert` sets + `verdict`, built on SIP-0070 pulse checks and gate outcomes), accumulated evidence, and **policy limits** (max cycles, budget, time, required-evidence thresholds).
+
+Integrity rules the decision inherits, not re-implements:
+- No agent narrative alone may drive `stop_success` — it requires a roll-up with `verdict = accepted` (executed-and-passed evidence) or an operator gate.
+- A `blocked_unverified` verdict (required checks never executed) may only yield `repair` or `escalate` — never `continue`, `retry`, `fork`, or `stop_success`. An unverified Cycle proves nothing to continue from; treating its silence as signal is exactly the failure class the evidence-integrity invariant exists to kill.
 
 ### 7.3 Decision output
 
@@ -139,6 +144,11 @@ The objective's **measurement method**, the latest Cycle's **verification/accept
 > **A Campaign launches Cycles; it never holds agents between them.**
 
 Each Cycle recruits its squad exactly as today: the SIP-0089 coordinator grants a per-run `ambient→cycle` transition (`owner_ref = run_id`, `duty(2) > cycle(1) > ambient(0)` precedence, reserve-buffer guard), released when the run ends. Campaign sits entirely *above* recruitment — it decides *whether* and *with what request profile* to launch the next Cycle, then calls the ordinary path. There is no Campaign-scoped FocusLease, no cross-Cycle attention hold, no change to `runtime` lease semantics. This keeps the highest-risk part of the runtime untouched and is the reason Campaign is a bounded, low-risk feature.
+
+Two ordering constraints make the invariant real rather than aspirational:
+
+1. **#288 is a named prerequisite.** The coordinator's same-mode `idempotent_skip` returns before lease arbitration, so a second same-agent Cycle free-rides the first's lease and loses the agent mid-run when the first releases. Today that is a rare concurrent edge; Campaign's automated back-to-back launches — and `fork`, which creates concurrent sibling Cycles *by design* — make it a routine path. #288 lands before Phase 2.
+2. **The continuation choke point runs only after the terminated Cycle's participant release completes** (the executor returns participants `cycle→ambient` in its `finally`; the decision must sequence after that), *or* recruitment must arbitrate on `owner_ref` mismatch even for same-mode requests. Otherwise the next Cycle recruits agents still holding the prior run's lease — the #288 window, manufactured sequentially.
 
 ---
 
@@ -170,14 +180,14 @@ Frozen dataclasses in the SIP-0064 style, alongside `Cycle`/`Run`:
 
 ## 12. Continuum Surface (SIP-0069)
 
-Continuum shows active/paused/blocked/completed Campaigns; a Campaign detail view exposes objective, current Cycle, accumulated evidence summary, the **continuation-decision history** (each with its rationale + evidence refs), and disposition. Operator actions map to existing gate decisions where a continuation `escalate` is pending. No new HTTP prefix — Campaign resources follow the `/api/v1/<resource>` lane (per the API conventions rule); read surfaces reuse the cycle read patterns.
+Continuum shows active/paused/blocked/completed Campaigns; a Campaign detail view exposes objective, current Cycle, accumulated evidence summary, the **continuation-decision history** (each with its rationale + evidence refs), and disposition. Operator actions map to existing gate decisions where a continuation `escalate` is pending. No new HTTP prefix — Campaign resources follow the `/api/v1/<resource>` lane (per the API conventions rule); read surfaces reuse the cycle read patterns. Continuation decisions are also emitted as SIP-0077 cycle events (e.g. `campaign.continuation_decided`, with the taxonomy-parity tests updated) and reach LangFuse/Prefect/metrics through the existing bridges — no new observability channel.
 
 ---
 
 ## 13. Phasing (within the 1.6 arc)
 
 - **Phase 1 — Model + registry + manual coordination.** `Campaign`/`CampaignObjective`/`CampaignPolicy` models, `CampaignRegistryPort` + adapters, the additive `Cycle.campaign_id`, create/attach via API+CLI, derived status. An operator can group Cycles under an objective and see the aggregate. *No auto-continuation yet.* (Migration-light, CI-able — mirrors how SIP-0090 Phase 1 proved the model before wiring.)
-- **Phase 2 — Continuation policy.** `campaign_continuation_decision` pure function + the choke point that runs it when a Campaign's Cycle terminates, records the decision, and launches the next Cycle through the existing create path. This is the headline capability.
+- **Phase 2 — Continuation policy.** `campaign_continuation_decision` pure function + the choke point that runs it when a Campaign's Cycle terminates, records the decision, and launches the next Cycle through the existing create path. This is the headline capability. **Sequenced behind:** #288 (lease arbitration, §8), the Verification Evidence Integrity SIP (the `CycleOutcome` contract §7.2 reads), and the request-profile naming taxonomy (#316) — a *policy-derived* `next_request_profile` needs a coherent profile namespace to derive from.
 - **Phase 3 — Continuum surface.** The Campaign views + continuation-decision history + operator gate integration.
 
 Acceptance of the SIP is **all three phases**, consistent with the SIP-0089/0090 precedent that a phase ≠ the whole SIP.
@@ -189,8 +199,8 @@ Acceptance of the SIP is **all three phases**, consistent with the SIP-0089/0090
 1. A Campaign can be created against a Project with a declared objective and policy, and persists across restart (Postgres adapter).
 2. A Cycle can be created **with** a `campaign_id` and **without** one; the Campaign-less path is byte-for-byte unchanged in behavior.
 3. After a Campaign's Cycle terminates, a `ContinuationDecision` is computed, **recorded with its rationale and evidence refs**, and — when the outcome launches a Cycle — the next Cycle is created through the ordinary cycle-create path with the policy-derived request profile.
-4. **Recruitment invariant holds:** no Campaign-scoped lease exists; each launched Cycle recruits per-run through the SIP-0089 coordinator exactly as a standalone Cycle does (verified by asserting lease `owner_ref` is a `run_id`, never a `campaign_id`).
-5. `stop_success` is never emitted on agent narrative alone — it requires verification evidence or an operator gate.
+4. **Recruitment invariant holds — asserted positively:** every Campaign-launched Cycle acquires its **own** `cycle` FocusLease per recruited agent (`owner_ref` = that Cycle's `run_id`), held for the duration of its run. The negative form ("no lease has `owner_ref = campaign_id`") is necessary but insufficient — the #288 failure mode is a Cycle holding *no* lease at all, which a negative assertion cannot catch.
+5. `stop_success` is never emitted on agent narrative alone — it requires a `CycleOutcome` roll-up with `verdict = accepted` or an operator gate; a `blocked_unverified` verdict yields only `repair` or `escalate` (§7.2).
 6. Policy limits are enforced: a Campaign cannot exceed `max_cycles` or its budget; exhaustion yields `stop_failure`/`exhausted`, not silent looping.
 7. The continuation decision is **pure** — an architecture test asserts the decision function performs no persistence/dispatch (side effects live only at the choke point).
 8. Continuum shows a Campaign's objective, current Cycle, decision history, and disposition.
@@ -204,6 +214,7 @@ Acceptance of the SIP is **all three phases**, consistent with the SIP-0089/0090
 - **Scope creep into the 2.0 apparatus.** Self-Improvement/Test-Bay/capability pressure will want in. *Mitigation:* §5 non-goals are load-bearing; `target_type` is the single neutral extension hook, unused here.
 - **Recruitment-semantics drift.** A "keep the squad warm across Cycles" optimization would breach §8. *Mitigation:* AC#4 architecture assertion; the invariant is stated as the SIP's central constraint.
 - **Continuation-map vs verification drift.** The decision reads SIP-0070/gate evidence; if that evidence shape changes, the decision inputs must track it. *Mitigation:* consume verification through its existing contract, not a private copy.
+- **Acting on untrustworthy evidence.** The decision is only as good as the roll-up it reads; inert or stubbed checks (the #276/#306 class) would let `continue`/`stop_success` fire on fabricated green. *Mitigation:* the Verification Evidence Integrity SIP is a named Phase-2 dependency, and `blocked_unverified` maps only to `repair`/`escalate` (§7.2) — the decision refuses to treat silence as signal.
 - **Overlap with SIP-0083.** Multi-run-within-a-cycle already exists; a poorly-drawn boundary could duplicate it. *Mitigation:* §6 layering — Campaign only acts *after a Cycle terminates*, never on runs within a Cycle.
 
 ---
@@ -212,7 +223,7 @@ Acceptance of the SIP is **all three phases**, consistent with the SIP-0089/0090
 
 - **Carved from** the Campaign/Self-Improvement/Test-Bay vision anchor; **enables** the 2.0 Self-Improvement SIP (a Self-Improvement Campaign is a specialized Campaign type).
 - **Sibling** to `TaskFlowPolicy` (SIP-0064); **above** SIP-0086/0079/0083.
-- **Consumes** SIP-0070 verification, SIP-0064 gates, SIP-0089 recruitment, SIP-0069 Continuum — all unchanged.
+- **Consumes** SIP-0070 verification (via the Verification Evidence Integrity `CycleOutcome` contract), SIP-0064 gates, SIP-0089 recruitment, SIP-0069 Continuum — all unchanged.
 - **Precedent** for the pure-decision-at-a-choke-point shape: SIP-0089 §2.5 reserve-buffer guard, SIP-0095 cycle-create preflight.
 
 ---
@@ -229,10 +240,11 @@ Acceptance of the SIP is **all three phases**, consistent with the SIP-0089/0090
 
 ## 18. Open Questions
 
-1. Should `fork` create a sibling Campaign or a branched Cycle path within the same Campaign? (Leaning: branched Cycle path; a separate objective is a separate Campaign.)
+1. Should `fork` create a sibling Campaign or a branched Cycle path within the same Campaign? (Leaning: branched Cycle path; a separate objective is a separate Campaign.) **Must resolve before acceptance:** `fork` implies concurrent sibling Cycles, which manufactures the #288 window and changes the recruitment-safety story (§8) — if fork ships in Phase 2, #288 is a hard blocker; if fork defers to a later phase, say so explicitly.
 2. Minimum `CampaignPolicy` for Phase 2 — is `max_cycles` + budget + a verification threshold enough, or is a small stop-condition DSL needed?
 3. Does scheduled/nightly Campaign creation belong here (thin scheduler reuse of SIP-0089's poll) or in the 2.0 Self-Improvement SIP? (Leaning: the *scheduling mechanic* here if cheap; *nightly-improvement policy* in 2.0.)
 4. How much evidence does the continuation decision need inline vs by reference to stay pure and cheap?
+5. What does `defer` concretely wait on? §7.1 says "Reuses SIP-0089 duty windows," but duty windows are *agent-scoped* posture and Campaign defer is *orchestration-scoped* pausing — a vocabulary borrow, not a mechanism. Candidates: an operator-declared condition, a scheduled resume time (thin reuse of the SIP-0089 scheduler poll), or an external signal. Needs a concrete answer before Phase 2.
 
 ---
 

--- a/sips/proposed/SIP-Campaign-Self-Improvement-and-Test-Bay-Requirements.md
+++ b/sips/proposed/SIP-Campaign-Self-Improvement-and-Test-Bay-Requirements.md
@@ -1328,7 +1328,7 @@ The following capabilities should be considered late 1.x enablers:
 
 - Durable Run records.
 - Better artifact linking.
-- Improved Cycle evidence model.
+- Improved Cycle evidence model — concretely: the **Verification Evidence Integrity SIP** (`sips/proposed/SIP-Verification-Evidence-Integrity.md`, targets 1.4). Promotion gates, scorecards, and self-improvement measurement all presume acceptance signals cannot be fabricated by a stub, a skip, or an inert check; that SIP's integrity invariant + `CycleOutcome` roll-up is the enabler this line item means.
 - Basic Campaign model.
 - Test Bay source-control integration.
 - Disposable workspace cleanup.

--- a/sips/proposed/SIP-Capability-Backed-Agents.md
+++ b/sips/proposed/SIP-Capability-Backed-Agents.md
@@ -254,6 +254,7 @@ Umbrella phases; each becomes its own bounded implementation SIP. Per the roadma
 - **SIP-0089 / SIP-0090 / SIP-0091** — preserves identity ≠ capability ≠ embodiment ≠ mode; capability activation is not a mode; duty may activate a capability but is not the capability.
 - **SIP-0095** — capability preflight extends the cycle-create preflight gate.
 - **SIP-0070 / SIP-042** — evidence/acceptance and memory build on pulse verification and LanceDB.
+- **Verification Evidence Integrity (proposed, targets 1.4)** — the Evidence Ledger's "evidence is not acceptance" boundary (§12) presumes acceptance signals are themselves integrity-checked; skill evidence adopts the same executed vs not-executed honesty (a skill that could not run is recorded as not-executed with a reason, never silently omitted).
 - **SIP-0064 (`TaskFlowPolicy`) / Campaign** — capability activation respects run-level flow policy; cross-cycle capability-driven squad augmentation is the 2.0 Campaign story.
 - **SIP-0069 + Continuum Runtime Console** — future console visibility into bindings, active capabilities, working sets, evidence, and design workflows.
 

--- a/sips/proposed/SIP-Cycle-Evaluation-Scorecard.md
+++ b/sips/proposed/SIP-Cycle-Evaluation-Scorecard.md
@@ -4,6 +4,7 @@
 **Authors:** SquadOps Architecture
 **Created:** 2026-02-28
 **Revision:** 1
+**Sequences after:** the Verification Evidence Integrity SIP (`sips/proposed/SIP-Verification-Evidence-Integrity.md`, targets 1.4) — every scorecard dimension presumes the underlying acceptance/verification signals cannot be fabricated by stubbed, skipped, or inert checks; scoring un-integrity-checked evidence would institutionalize exactly the wrong lessons §2 warns about.
 
 ## 1. Abstract
 

--- a/sips/proposed/SIP-Verification-Evidence-Integrity.md
+++ b/sips/proposed/SIP-Verification-Evidence-Integrity.md
@@ -1,0 +1,223 @@
+---
+title: Verification Evidence Integrity
+status: proposed
+author: jladd
+created_at: '2026-07-05T00:00:00Z'
+---
+# SIP: Verification Evidence Integrity
+
+## Status
+Proposed
+
+**Targets:** v1.4 (feature minor — headline feature SIP candidate, alongside SIP-0091)
+**Motivated by:** the 2026-07-04 health assessment finding that orchestration maturity is outrunning evidence quality: the framework cannot yet distinguish "this check passed" from "this check never ran." The 2.0 self-improvement arc (Campaign → Test Bay → capability promotion) automates decisions over cycle evidence; this SIP is what makes that evidence worth deciding on.
+**Builds on:** SIP-0070 (pulse checks / verification framework, `PulseVerificationRecord`), SIP-0092 (typed acceptance — the check *types*; this SIP owns the trust semantics of their *results*), SIP-0079 (outcome classes, failure classification), SIP-0086 (output validation / build convergence), SIP-0095 (deterministic-gate + doctor-parity precedent), SIP-0077 (cycle event system), SIP-0064 (Cycle/Run/Gate).
+**Proof cases (existing bugs this SIP prevents as a class):** #276 (generated tests stub-fallback on ImportError → acceptance passes on an app that never ran), #306 (agent image lacks Node.js → frontend build + vitest checks are permanently inert), #296 (`source_filter` excludes package.json/configs → buildable frontend never materializes, checks skip), #291 (`build_profile.required_files` declared but unenforced at run completion).
+
+---
+
+## 1. Summary
+
+Introduce a single, framework-wide **integrity invariant** for every acceptance and verification signal:
+
+> Every check result is exactly one of **executed-and-passed**, **executed-and-failed**, or **not-executed** (with a machine-readable reason) — and **a not-executed result never aggregates as a pass**. A run whose *required* checks include any not-executed result cannot report acceptance.
+
+SquadOps already has most of the vocabulary: `CheckOutcome.status ∈ {passed, failed, skipped, error}` with documented RC-9a/RC-12 semantics (`src/squadops/cycles/acceptance_checks.py:40`), a `tests_not_executed` detail in the QA path, and `not_executed` handling in the test runner's timeout path. What it does not have is the **enforcement**: skipped/error/inert results flow into acceptance aggregation without blocking it, and nothing detects a check that has *never* executed across many cycles. Every proof-case bug above is the same defect — a verification signal silently degraded to "no signal" and the framework counted the silence as success.
+
+This SIP adds exactly three things: (1) the **aggregation rule** enforced at a single choke point, (2) **execution provenance** on every check result, and (3) **inert-check detection** across cycles. It defines the `CycleOutcome` evidence contract that the Campaign continuation policy (1.6) will consume — certifying the ground truth before the framework automates decisions over it.
+
+---
+
+## 2. Motivation / Problem
+
+The 1.x arc built substantial verification *machinery*: typed acceptance checks (SIP-0092), pulse checks and verification records (SIP-0070), output validation (SIP-0086), correction protocols keyed on failure classes (SIP-0079). But the machinery has a systemic soft spot: **when a check cannot run, the failure mode is silence, and silence reads as green.**
+
+Concretely, today:
+
+- A generated test suite that fails to import falls back to a stub — and *passes* (#276). This is worse than a skip: it is a fabricated positive.
+- The frontend build check and vitest have never executed on the deployed agent image (no Node.js) — every cycle since has "passed" them by permanent skip (#306), and the source filter guarantees there is never a frontend to check anyway (#296).
+- `required_files` is a declared contract with no enforcement point (#291).
+
+Each was filed as an individual bug, but the class keeps reappearing (#187 called its instance "the 3rd whack-a-mole failure") because no rule makes the class impossible. Meanwhile the roadmap is about to raise the stakes: the Campaign SIP's continuation decision (§7.2) and the entire self-improvement direction *act automatically* on this evidence. `stop_success` "must point to verification evidence" — which is only a safeguard if verification evidence cannot be a stub, a skip, or an inert check. Scorecards, Test Bay promotion gates, and nightly improvement Campaigns all inherit the same dependency.
+
+This is the codebase's existing hard rule — *no fallbacks that mask a missing data source* — applied to verification itself.
+
+---
+
+## 3. Decision
+
+1. Adopt the **integrity invariant** (§6) as a framework-wide rule over all acceptance/verification surfaces (§8), enforced at a single aggregation choke point per run — following the established pure-decision-at-a-choke-point pattern (SIP-0089 reserve-buffer guard, SIP-0095 preflight, Campaign continuation).
+2. Extend the existing result vocabulary, not replace it: `CheckOutcome`'s four states remain; the invariant formalizes `skipped`/`error` (and runner-level `not_executed`) as the **not-executed family**, adds required **execution provenance** (§7), and defines how the family aggregates (never as pass; blocking when the check is required).
+3. Add **inert-check detection**: a required or declared check that reports not-executed for N consecutive cycles is surfaced via doctor, the console, and a cycle event — because a permanently skipping check is indistinguishable from no check at all.
+4. Define the **run/cycle evidence roll-up** (`CycleOutcome` contract, §10) — the durable, honest summary of what was verified, what failed, and what was never checked — as the input contract for wrap-up (SIP-0080), gates, and later the Campaign continuation decision.
+
+---
+
+## 4. Scope
+
+- **In:** the integrity invariant and its aggregation choke point; execution-provenance fields on check results; conformance of the five existing verification surfaces (§8); the required-vs-optional check distinction in profiles; inert-check detection + doctor/console surfacing; the `CycleOutcome` evidence roll-up; SIP-0077 events for not-executed and inert findings; retrofit of the four proof-case paths as conformance proof.
+- **In (reuse, not rebuild):** `CheckOutcome` and the typed-check registry (SIP-0092), `PulseVerificationRecord` persistence (SIP-0070), outcome classes (SIP-0079), gate/HITL mechanics (SIP-0064).
+- **Applies to:** typed acceptance checks, generated-test execution, build-profile checks, required-files enforcement, and pulse-check verification — anything whose result can gate acceptance or feed a continuation/wrap-up decision.
+
+---
+
+## 5. Non-Goals
+
+- **No new check types.** Check semantics belong to SIP-0092; this SIP governs the trust semantics of results, whatever the check.
+- **No scorecard.** The Cycle Evaluation Scorecard (proposed) *measures* quality; it sequences after this SIP so its inputs cannot be fabricated. Nothing here scores anything.
+- **No Test Bay / capability promotion.** 2.0 consumers of trustworthy evidence, not part of producing it.
+- **No Campaign mechanics.** This SIP defines the evidence contract Campaign reads; the continuation policy stays in the Campaign SIP.
+- **No third evidence vocabulary.** The implementation must extend `CheckOutcome` + `PulseVerificationRecord` + SIP-0079 outcome classes after a reconciliation audit (Phase 0), never introduce a parallel model. (The 2.0 umbrella SIPs' overlapping-vocabulary problem is the cautionary tale.)
+- **No blanket "everything is required."** Profiles legitimately run degraded on small local models (`smoke`/`lite`); the invariant forces *honesty* about what didn't run, not maximal strictness. Which checks are required is profile policy (§6.3).
+
+---
+
+## 6. The Integrity Invariant
+
+### 6.1 Result states
+
+Every verification signal resolves to exactly one of:
+
+| Family | States (existing vocabulary) | Meaning |
+|---|---|---|
+| **executed-and-passed** | `passed` | The check ran against the real subject and met its criterion. |
+| **executed-and-failed** | `failed` | The check ran and the criterion was not met (RC-9a: app gap). |
+| **not-executed** | `skipped`, `error`, `not_executed` | The check did not evaluate the real subject — intentional skip, evaluator failure (RC-12), missing tooling, missing subject, timeout, or stub substitution. Carries a machine-readable `reason`. |
+
+**Hard rule:** substituting a stand-in subject (a stub module, a placeholder file, an empty suite) and reporting `passed` is an integrity violation, not a fallback. The #276 stub path must report `not_executed(reason="import_error")`, never pass.
+
+### 6.2 Aggregation rule (the choke point)
+
+A pure function, evaluated once per run at the acceptance boundary:
+
+```
+aggregate_verification(results, required_check_ids) -> RunVerificationSummary
+```
+
+- not-executed **never** counts toward pass totals, thresholds, or "all checks green."
+- If any **required** check is in the not-executed family → the run's acceptance verdict is `blocked_unverified` (a distinct verdict — neither passed nor failed; the correction protocol and gates can route on it).
+- **Optional** checks in the not-executed family never block, but are always disclosed in the roll-up (§10) — silence is still forbidden; it is just non-blocking.
+- No side effects in the function; enforcement only at the boundary that acts on the summary. An architecture test asserts purity (Campaign-SIP AC#7 precedent).
+
+### 6.3 Required vs optional is declared, not inferred
+
+Cycle request profiles / build profiles declare which checks are required (extending the existing profile schema in the SIP-0092 style). Defaults are conservative per profile tier: `smoke` may mark most checks optional (honest disclosure, no blocking); `full` marks the build/test spine required. Preflight (SIP-0095) gains a parity check: if a *required* check's tooling is knowably absent at create time (e.g. no Node.js for a required frontend build — #306), that is a create-time warn or 422, not a mid-run surprise.
+
+---
+
+## 7. Execution Provenance
+
+Every check result carries evidence that it actually ran (extending `CheckOutcome.actual` / `PulseVerificationRecord`, exact fields reconciled in Phase 0):
+
+`executed_at`, `duration_ms`, `subject_ref` (what was checked — file set hash, artifact ID, endpoint), `executor_ref` (where — container/image), and for command-backed checks `exit_code` + a bounded output digest. For the not-executed family, `reason` is mandatory and machine-readable (`missing_tooling:node`, `import_error`, `timeout`, `subject_missing`, `filtered_out`).
+
+Provenance is what makes an audit ("did this ever run?") answerable from records instead of log archaeology — and it is the raw material for #114's typed-check evaluation surfacing.
+
+---
+
+## 8. Surfaces That Must Conform
+
+| Surface | Today | Conformance change |
+|---|---|---|
+| Typed acceptance checks (`cycles/acceptance_checks.py`, SIP-0092) | 4-state `CheckOutcome`, semantics documented, aggregation permissive | provenance fields; results flow through §6.2 |
+| Generated-test runner (`capabilities/handlers/test_runner.py`) | timeout path already yields not-executed; **ImportError path stubs and passes (#276)** | stub fallback removed → `not_executed(import_error)`; provenance (exit code, duration) |
+| Build checks (frontend build, vitest — #306/#296) | permanently skip; skip does not block | report `not_executed(missing_tooling / subject_missing)`; required-in-profile ⇒ blocking; preflight parity |
+| `required_files` (#291) | declared, unenforced | becomes a required typed check evaluated at run completion through the same choke point |
+| Pulse checks (SIP-0070, `PulseVerificationRecord`) | records persist; executed-vs-skipped distinction not enforced in roll-ups | records carry the state family + provenance; wrap-up consumes the honest roll-up |
+
+---
+
+## 9. Inert-Check Detection
+
+A check (by stable check ID) that reports not-executed for **N consecutive cycles** in the same project/profile (default N=3) is an **inert check** — operationally equivalent to no check, and historically how #306 stayed invisible.
+
+- `squadops doctor` gains an inert-check report (deployed-image parity: which declared checks *cannot* execute here — the #306 class detectable before any cycle runs).
+- The console cycle/run views badge not-executed and inert results distinctly from passes (never folded into a green count).
+- A cycle event (`verification.check_inert`, taxonomy addition per SIP-0077's drift-parity tests) fires on detection.
+
+---
+
+## 10. The `CycleOutcome` Evidence Roll-Up
+
+The durable per-cycle summary — the contract downstream consumers read:
+
+`verified` (executed-and-passed, with provenance refs) / `failed` (executed-and-failed) / `unverified` (not-executed, with reasons) / `inert` (chronic) / `verdict` (`accepted | rejected | blocked_unverified`) — all as references into the SIP-0070/0092 records, not copies.
+
+Consumers, in order of arrival: **wrap-up** (SIP-0080 confidence classification gets an honest basis — "partial completion with honest confidence" becomes computable), **operator gates** (a gate presented with `blocked_unverified` sees *why*), and — the strategic one — the **Campaign continuation decision** (1.6), whose §7.2 "no `stop_success` on agent narrative alone" is only as strong as this contract. This SIP deliberately ships one even-minor ahead of Campaign so the contract exists, live-validated, before anything automates over it.
+
+---
+
+## 11. Phasing (within the 1.4 arc)
+
+- **Phase 0 — Reconciliation audit (docs-only, can run during 1.3).** Read the accepted SIP-0092 spec + SIP-0070/0079 models against §6–§7; produce the field-level mapping (what extends `CheckOutcome`, what extends `PulseVerificationRecord`, where SIP-0079 outcome classes meet the not-executed family). Gate: no third vocabulary.
+- **Phase 1 — Invariant + provenance.** The pure aggregation function + `blocked_unverified` verdict + provenance fields + required/optional profile schema. Choke point wired at the run acceptance boundary. (Behavior change only where a required check already reports skip/error — knowingly none in default profiles until Phase 2 retrofits.)
+- **Phase 2 — Retrofit the proof cases.** #276 stub removal, #306/#296 honest reporting + preflight parity, #291 required-files check. Each lands with a live `lite` cycle demonstrating the honest result (per the live-validation rule). **This phase will turn silently-green paths honestly red — that is the point; profile required-lists are the throttle.**
+- **Phase 3 — Detection + surfaces.** Inert-check detection, doctor report, console badging, `verification.check_inert` event, `CycleOutcome` roll-up consumed by wrap-up.
+
+Acceptance of the SIP is all phases (SIP-0089/0090 precedent). The proof-case *bugs* remain independently fixable as patches at any time; this SIP is the rule that keeps them fixed.
+
+---
+
+## 12. Acceptance Criteria
+
+1. A check result in the not-executed family can never contribute to a pass count, threshold, or acceptance verdict — property-tested at the aggregation function.
+2. A run with any required check not-executed yields `blocked_unverified`, never `accepted`; the verdict is distinct from `rejected` and routable by gates/correction.
+3. The #276 path: an ImportError in generated tests produces `not_executed(import_error)` and (where tests are required) `blocked_unverified` — demonstrated by the previously-stubbed fixture.
+4. The #306/#296 paths: on an image without Node.js, frontend checks report `not_executed(missing_tooling:node)`; doctor reports them as inert-capable before any cycle; a profile marking them required fails preflight (SIP-0095 parity).
+5. `required_files` (#291) is enforced at run completion through the same choke point.
+6. Every executed check result carries provenance (§7); every not-executed result carries a machine-readable reason. No verification surface can emit a bare pass.
+7. A check not-executed for N consecutive cycles surfaces via doctor + console + `verification.check_inert` (event-taxonomy parity tests updated).
+8. The `CycleOutcome` roll-up is persisted per cycle and consumed by wrap-up; its `unverified`/`inert` sets are never empty-by-construction (i.e., the roll-up cannot be produced by a path that discards not-executed results).
+9. Vocabulary reconciliation: no new persisted status vocabulary beyond the documented extension of `CheckOutcome`/`PulseVerificationRecord`; an architecture test pins the aggregation function's purity.
+10. Existing default-profile cycles still complete (the invariant changes verdicts only where a *required* check was silently degrading — each such flip is an intended, documented Phase 2 change).
+
+---
+
+## 13. Risks
+
+- **Honest red is disruptive.** Paths that "worked" for months will start blocking (that is the SIP working). *Mitigation:* required-lists are per-profile policy (§6.3) — the throttle is explicit declaration, never a report-only mode (a report-only mode would recreate the masking this SIP exists to kill); Phase 2 lands per-path with live cycles.
+- **Small-model ergonomics.** `smoke`/`lite` cycles on the Mac legitimately can't run everything; if defaults are too strict the invariant gets worked around. *Mitigation:* conservative per-tier required-lists; disclosure (not blocking) is the floor everywhere.
+- **Vocabulary collision with SIP-0092/0070.** *Top design risk; Phase 0 exists to kill it before code.*
+- **Choke-point placement inside the #186 decomposition.** The acceptance boundary lives in executor territory being restructured in 1.3. *Mitigation:* targeting 1.4 sequences this after the decomposition lands; the choke point attaches to the post-#186 completion boundary (same seam the Campaign SIP plans to use).
+- **Provenance bloat.** Digests and refs, not payloads; caps follow the existing acceptance-check safety caps pattern.
+
+---
+
+## 14. Relationships
+
+- **SIP-0092** — owns check types and typed-criteria authoring; this SIP owns result trust + aggregation. #114 (typed-check evaluation surfacing) is the observability sibling and can ride Phase 3.
+- **SIP-0070 / SIP-0080** — verification records gain the state family + provenance; wrap-up's confidence classification consumes the roll-up.
+- **SIP-0095** — preflight gains required-check tooling parity (the create-time half of #306's lesson).
+- **Campaign Orchestration (1.6)** — consumes `CycleOutcome` (§10); this SIP is its evidence prerequisite (see #334).
+- **Cycle Evaluation Scorecard (proposed)** — sequences after; scores presume un-fabricated inputs.
+- **Issues:** closes the *class* behind #276, #306, #296, #291; enables #114; feeds #334.
+
+---
+
+## 15. Testing
+
+- **Aggregation (unit, property-style):** every combination of {passed, failed, skipped, error, not_executed} × {required, optional} → asserted verdict; not-executed can never flip a verdict to accepted; purity architecture test.
+- **Proof-case regression fixtures:** the exact #276 stub scenario, a no-Node image simulation (#306), a filtered-out frontend (#296), a missing required file (#291) — each asserting the honest state + reason, not just "doesn't pass."
+- **Inert detection:** N-cycle sequences in the registry fixtures → detection fires at exactly N, resets on execution.
+- **Doctor parity:** doctor's inert-capability report agrees with runtime behavior on the same profile (SIP-0095 parity precedent).
+- **E2E (live, per the live-validation rule):** one `lite` cycle with a deliberately unrunnable required check → `blocked_unverified` + gate shows the reason; one with it optional → completes with disclosure in the roll-up.
+
+---
+
+## 16. Open Questions
+
+1. Exact verdict name (`blocked_unverified` vs extending SIP-0079's outcome classes) — Phase 0 decides with the reconciliation mapping.
+2. Does `blocked_unverified` route to the correction protocol (repair the *harness*, not the app) or straight to a gate? Leaning: gate first; harness-repair correction is a later refinement.
+3. N for inert detection — fixed default (3) vs profile-tunable.
+4. Where the roll-up persists — new columns on the run/cycle records vs a `verification_summary` artifact. Leaning: registry columns for the verdict + an artifact for the full roll-up.
+5. Should provenance `subject_ref` hashing reuse the artifact-vault identity scheme (Campaign §22.1 traceability enablers) so run→artifact traceability composes for free?
+
+---
+
+## Appendix A — Implementation Seams (non-normative)
+
+- **Aggregation:** a pure module `cycles/verification_integrity.py` (mirrors `cycles/preflight.py`), importable by executor, wrap-up, and tests without boundary violations.
+- **Choke point:** the run-completion acceptance boundary — post-#186, the decomposed executor's completion collaborator (the same seam Appendix A of the Campaign SIP targets for continuation).
+- **Provenance:** extend `CheckOutcome.actual` conventions + `PulseVerificationRecord` fields; migration in whichever lane owns the touched registry tables at implementation time.
+- **Doctor:** a new check category alongside the SIP-0095 model-availability checks (`squadops doctor <profile> --check verification`).
+- **Profiles:** `required_checks` key in the cycle-request-profile schema, validated at load like `time_budget_seconds` (SIP-0082 precedent). Coordinate naming with the #316 taxonomy work.

--- a/sips/proposed/SIP-Verification-Evidence-Integrity.md
+++ b/sips/proposed/SIP-Verification-Evidence-Integrity.md
@@ -7,38 +7,38 @@ created_at: '2026-07-05T00:00:00Z'
 # SIP: Verification Evidence Integrity
 
 ## Status
-Proposed
+Proposed — **revision 2** (2026-07-06: incorporates maintainer design review + independent adversarial review; rev 1's account of current behavior contained errors, corrected in §2/§8; load-bearing semantics previously deferred to Phase 0 are now decided in-text)
 
 **Targets:** v1.4 (feature minor — headline feature SIP candidate, alongside SIP-0091)
-**Motivated by:** the 2026-07-04 health assessment finding that orchestration maturity is outrunning evidence quality: the framework cannot yet distinguish "this check passed" from "this check never ran." The 2.0 self-improvement arc (Campaign → Test Bay → capability promotion) automates decisions over cycle evidence; this SIP is what makes that evidence worth deciding on.
-**Builds on:** SIP-0070 (pulse checks / verification framework, `PulseVerificationRecord`), SIP-0092 (typed acceptance — the check *types*; this SIP owns the trust semantics of their *results*), SIP-0079 (outcome classes, failure classification), SIP-0086 (output validation / build convergence), SIP-0095 (deterministic-gate + doctor-parity precedent), SIP-0077 (cycle event system), SIP-0064 (Cycle/Run/Gate).
-**Proof cases (existing bugs this SIP prevents as a class):** #276 (generated tests stub-fallback on ImportError → acceptance passes on an app that never ran), #306 (agent image lacks Node.js → frontend build + vitest checks are permanently inert), #296 (`source_filter` excludes package.json/configs → buildable frontend never materializes, checks skip), #291 (`build_profile.required_files` declared but unenforced at run completion).
+**Motivated by:** the 2026-07-04 health assessment finding that orchestration maturity is outrunning evidence quality. The 2.0 arc (Campaign → Test Bay → capability promotion) automates decisions over cycle evidence; this SIP must land before Campaign continuation automation because Campaign decisions must not consume unclassified or non-creditable verification evidence.
+**Builds on:** SIP-0070 (pulse checks / verification framework, `PulseVerificationRecord`, decisions D13/D18), SIP-0092 (typed acceptance — the check *types* and severity model; **this SIP does not amend SIP-0092 §6.1.4** — see §6.1), SIP-0079 (outcome classes), SIP-0086 (output validation), SIP-0095 (deterministic-gate + doctor-parity precedent), SIP-0077 (cycle event system), SIP-0064 (Cycle/Run/Gate).
+**Proof cases:** #291 (`required_files` declared but unenforced), #306 (agent image lacks Node.js → frontend checks cannot execute and their results merge non-blocking), the SIP-0070 `determine_boundary_decision` SKIP-only→PASS rule, and — as *predecessors whose class this SIP locks* — #276 (stub-fallback, detection shipped in PR #289), #290 (frontend build check, shipped), #296 (source-filter, **closed** `5cb22ce`).
 
 ---
 
 ## 1. Summary
 
-Introduce a single, framework-wide **integrity invariant** for every acceptance and verification signal:
+Introduce a single, framework-wide **integrity invariant** over acceptance and verification evidence:
 
-> Every check result is exactly one of **executed-and-passed**, **executed-and-failed**, or **not-executed** (with a machine-readable reason) — and **a not-executed result never aggregates as a pass**. A run whose *required* checks include any not-executed result cannot report acceptance.
+> **For aggregation purposes, every verification result resolves to exactly one evidence family: executed-and-passed, executed-and-failed, or not-executed. Only executed-and-passed credits as success. Not-executed results are non-creditable: they never improve a pass count, threshold, or all-green rule, and — when the check is required — they block acceptance as `blocked_unverified` rather than disappearing.**
 
-SquadOps already has most of the vocabulary: `CheckOutcome.status ∈ {passed, failed, skipped, error}` with documented RC-9a/RC-12 semantics (`src/squadops/cycles/acceptance_checks.py:40`), a `tests_not_executed` detail in the QA path, and `not_executed` handling in the test runner's timeout path. What it does not have is the **enforcement**: skipped/error/inert results flow into acceptance aggregation without blocking it, and nothing detects a check that has *never* executed across many cycles. Every proof-case bug above is the same defect — a verification signal silently degraded to "no signal" and the framework counted the silence as success.
+SquadOps enforces pieces of this already (SIP-0092 evaluator errors block per severity; SIP-0070 D18 fails a suite on timeout-skips; the QA path blocks on `executed=False`; PR #289 detects stub-fallback tests). What it lacks is the *rule* — so the remaining leaks each read silence as green in a different way: pulse boundary decisions treat SKIP-only records as PASS, fullstack frontend results merge non-blocking even when the toolchain is absent (#306), typed-check `skipped` never blocks anything, `required_files` is a contract nothing enforces (#291), and no run-level evidence roll-up exists at all.
 
-This SIP adds exactly three things: (1) the **aggregation rule** enforced at a single choke point, (2) **execution provenance** on every check result, and (3) **inert-check detection** across cycles. It defines the `CycleOutcome` evidence contract that the Campaign continuation policy (1.6) will consume — certifying the ground truth before the framework automates decisions over it.
+This SIP adds: (1) the **classification and aggregation rule** enforced at a single choke point, (2) **execution provenance** on every result, (3) **non-executable/inert check detection** (doctor-first), and (4) the **`CycleOutcome` roll-up** — the honest per-cycle evidence contract consumed by wrap-up, gates, and later the Campaign continuation decision.
 
 ---
 
 ## 2. Motivation / Problem
 
-The 1.x arc built substantial verification *machinery*: typed acceptance checks (SIP-0092), pulse checks and verification records (SIP-0070), output validation (SIP-0086), correction protocols keyed on failure classes (SIP-0079). But the machinery has a systemic soft spot: **when a check cannot run, the failure mode is silence, and silence reads as green.**
+The 1.x arc built substantial verification machinery, and parts of it already refuse to credit silence. But the enforcement is per-surface and inconsistent, so the same defect class keeps reappearing wherever a surface lacks it:
 
-Concretely, today:
+- **Pulse boundary decisions credit silence:** `determine_boundary_decision` treats SKIP-only records as PASS ("no guardrail evidence to block") — the purest shipped instance of not-executed aggregating as success. Meanwhile the *same subsystem's* D18 correctly fails a suite when timeout skips checks. Two rules, one framework.
+- **Frontend verification is invisible when it cannot run:** the fullstack path merges frontend build/test results non-blocking (SIP-0070 D13), and the deployed agent image lacks Node.js (#306) — so every fullstack cycle has "passed" frontend verification that never executed.
+- **Typed-check `skipped` never blocks**, whatever the reason — a designed graceful bound (RC-12a `unsupported_stack`) and a missing subject look identical in aggregation.
+- **Declared contracts go unenforced:** `build_profile.required_files` (#291) — a run shipped without the Dockerfile its own profile required, green.
+- **No run-level roll-up exists:** runs terminate in `RunStatus` and gates record `GateDecision`s, but nothing durable answers "what was verified, what failed, what never ran."
 
-- A generated test suite that fails to import falls back to a stub — and *passes* (#276). This is worse than a skip: it is a fabricated positive.
-- The frontend build check and vitest have never executed on the deployed agent image (no Node.js) — every cycle since has "passed" them by permanent skip (#306), and the source filter guarantees there is never a frontend to check anyway (#296).
-- `required_files` is a declared contract with no enforcement point (#291).
-
-Each was filed as an individual bug, but the class keeps reappearing (#187 called its instance "the 3rd whack-a-mole failure") because no rule makes the class impossible. Meanwhile the roadmap is about to raise the stakes: the Campaign SIP's continuation decision (§7.2) and the entire self-improvement direction *act automatically* on this evidence. `stop_success` "must point to verification evidence" — which is only a safeguard if verification evidence cannot be a stub, a skip, or an inert check. Scorecards, Test Bay promotion gates, and nightly improvement Campaigns all inherit the same dependency.
+The class has already produced the #276 incident (a `completed`, qa-green run whose backend could not import and whose frontend could not build). The individual fixes that followed (#289, #290, #296) were whack-a-mole wins; this SIP is the rule that makes the class unrepresentable. The stakes rise at 1.6: Campaign's continuation policy acts automatically on this evidence, and `stop_success` on fabricated green is the failure mode the whole 2.0 direction cannot afford.
 
 This is the codebase's existing hard rule — *no fallbacks that mask a missing data source* — applied to verification itself.
 
@@ -46,94 +46,135 @@ This is the codebase's existing hard rule — *no fallbacks that mask a missing 
 
 ## 3. Decision
 
-1. Adopt the **integrity invariant** (§6) as a framework-wide rule over all acceptance/verification surfaces (§8), enforced at a single aggregation choke point per run — following the established pure-decision-at-a-choke-point pattern (SIP-0089 reserve-buffer guard, SIP-0095 preflight, Campaign continuation).
-2. Extend the existing result vocabulary, not replace it: `CheckOutcome`'s four states remain; the invariant formalizes `skipped`/`error` (and runner-level `not_executed`) as the **not-executed family**, adds required **execution provenance** (§7), and defines how the family aggregates (never as pass; blocking when the check is required).
-3. Add **inert-check detection**: a required or declared check that reports not-executed for N consecutive cycles is surfaced via doctor, the console, and a cycle event — because a permanently skipping check is indistinguishable from no check at all.
-4. Define the **run/cycle evidence roll-up** (`CycleOutcome` contract, §10) — the durable, honest summary of what was verified, what failed, and what was never checked — as the input contract for wrap-up (SIP-0080), gates, and later the Campaign continuation decision.
+1. Adopt the **integrity invariant** (§6) as a framework-wide rule, enforced at a single pure aggregation choke point per run (§6.4) — the established pure-decision-at-a-choke-point pattern (SIP-0089 reserve-buffer guard, SIP-0095 preflight).
+2. **Classify, don't re-vocabulary:** producers keep their existing persisted statuses; every result is *classified* into an evidence family for aggregation (§6.1). No new persisted status vocabulary.
+3. Add **execution provenance** (§7) and **non-executable/inert detection** (§9, doctor-first).
+4. Define the **`CycleOutcome` roll-up** (§10) as the durable evidence contract for wrap-up, gates, and the Campaign continuation decision.
+5. Decide the previously-open semantics **in this text**: `error` classification (§6.1), `blocked_unverified` routing, lifecycle mapping and operator waiver (§6.5), the check-identity model (§6.3), and the severity × required interaction (§6.3).
 
 ---
 
 ## 4. Scope
 
-- **In:** the integrity invariant and its aggregation choke point; execution-provenance fields on check results; conformance of the five existing verification surfaces (§8); the required-vs-optional check distinction in profiles; inert-check detection + doctor/console surfacing; the `CycleOutcome` evidence roll-up; SIP-0077 events for not-executed and inert findings; retrofit of the four proof-case paths as conformance proof.
-- **In (reuse, not rebuild):** `CheckOutcome` and the typed-check registry (SIP-0092), `PulseVerificationRecord` persistence (SIP-0070), outcome classes (SIP-0079), gate/HITL mechanics (SIP-0064).
-- **Applies to:** typed acceptance checks, generated-test execution, build-profile checks, required-files enforcement, and pulse-check verification — anything whose result can gate acceptance or feed a continuation/wrap-up decision.
+- **In:** the classification + aggregation rule and its choke point; provenance; the required-check declaration model; the conformance changes in §8; non-executable/inert detection (doctor); the `CycleOutcome` roll-up; the SIP-0095 preflight parity extension.
+- **In (reuse, not rebuild):** `CheckOutcome` and typed-check severity (SIP-0092), `PulseVerificationRecord` + D13/D18 (SIP-0070, with the two amendments named in §8), outcome classes (SIP-0079), gate/HITL mechanics (SIP-0064).
+- **Applies to:** typed acceptance checks, generated-test execution, build-profile checks, `required_files`, and pulse-check verification.
 
 ---
 
 ## 5. Non-Goals
 
-- **No new check types.** Check semantics belong to SIP-0092; this SIP governs the trust semantics of results, whatever the check.
-- **No scorecard.** The Cycle Evaluation Scorecard (proposed) *measures* quality; it sequences after this SIP so its inputs cannot be fabricated. Nothing here scores anything.
-- **No Test Bay / capability promotion.** 2.0 consumers of trustworthy evidence, not part of producing it.
-- **No Campaign mechanics.** This SIP defines the evidence contract Campaign reads; the continuation policy stays in the Campaign SIP.
-- **No third evidence vocabulary.** The implementation must extend `CheckOutcome` + `PulseVerificationRecord` + SIP-0079 outcome classes after a reconciliation audit (Phase 0), never introduce a parallel model. (The 2.0 umbrella SIPs' overlapping-vocabulary problem is the cautionary tale.)
-- **No blanket "everything is required."** Profiles legitimately run degraded on small local models (`smoke`/`lite`); the invariant forces *honesty* about what didn't run, not maximal strictness. Which checks are required is profile policy (§6.3).
+- **No new check types** (SIP-0092's lane) and **no new persisted status vocabulary** — classification is derived (§6.1).
+- **No amendment to SIP-0092 §6.1.4**: evaluator `error` remains an executed, severity-governed failure. This SIP names its two SIP-0070 amendments explicitly (§8) rather than overriding silently.
+- **No scorecard, no Test Bay, no Campaign mechanics** — downstream consumers of trustworthy evidence.
+- **No global report-only mode.** A framework-wide soft switch would recreate the masking this SIP exists to kill. The throttle is per-check declaration (§6.3) — optional checks are, by design, per-check disclosure-without-blocking.
+- **No blanket "everything is required."** `smoke`/`lite` legitimately run degraded; the invariant forces honesty about what didn't run, not maximal strictness.
+- **No automated harness repair** beyond what already ships (#289's correction path). Expanding agent authority to rewrite verification harnesses is explicitly deferred until the system can distinguish harness defects from product defects with high confidence.
 
 ---
 
 ## 6. The Integrity Invariant
 
-### 6.1 Result states
+### 6.1 Three layers, deliberately separate
 
-Every verification signal resolves to exactly one of:
-
-| Family | States (existing vocabulary) | Meaning |
+| Layer | Vocabulary | Status |
 |---|---|---|
-| **executed-and-passed** | `passed` | The check ran against the real subject and met its criterion. |
-| **executed-and-failed** | `failed` | The check ran and the criterion was not met (RC-9a: app gap). |
-| **not-executed** | `skipped`, `error`, `not_executed` | The check did not evaluate the real subject — intentional skip, evaluator failure (RC-12), missing tooling, missing subject, timeout, or stub substitution. Carries a machine-readable `reason`. |
+| **Persisted result status** | `CheckOutcome.status` (`passed/failed/skipped/error`), runner `executed`/`not_executed`, `PulseVerificationRecord` outcomes | **unchanged** — producers emit what they emit today |
+| **Evidence family** (aggregation-time classification) | `executed-and-passed` · `executed-and-failed` · `not-executed` | **new, derived** — from persisted status + reason + provenance; not persisted per-producer |
+| **Run verdict** | `accepted` · `rejected` · `blocked_unverified` | **new** — computed once per run by the choke point, recorded on the roll-up (§10); **not** a `RunStatus` (§6.5) |
 
-**Hard rule:** substituting a stand-in subject (a stub module, a placeholder file, an empty suite) and reporting `passed` is an integrity violation, not a fallback. The #276 stub path must report `not_executed(reason="import_error")`, never pass.
+This SIP does not require any producer to emit a new status. It requires every result to be *classifiable*:
 
-### 6.2 Aggregation rule (the choke point)
+- `passed` → **executed-and-passed** (only when provenance shows the real subject was evaluated — see the stub rule, §6.6).
+- `failed` → **executed-and-failed**.
+- `error` → **executed-and-failed** — preserving SIP-0092 §6.1.4 (evaluator errors block per severity and route to correction). An evaluator that crashed *attempting* the real subject is executed context, not silence. Its `reason` distinguishes it for diagnostics; its aggregation family does not credit it and does not soften it.
+- `skipped` / `not_executed` → **not-executed**, with a mandatory machine-readable reason (§7). This family includes designed skips (`config_disabled`, `unsupported_stack` per RC-12a), environment gaps (`missing_tooling`), subject gaps (`subject_missing`, `import_error`, `filtered_out`), and `timeout_before_execution`. These are semantically different diagnoses; the invariant is not that they are identical — it is that **none of them can aggregate as success**.
 
-A pure function, evaluated once per run at the acceptance boundary:
+### 6.2 Aggregation rule
 
-```
-aggregate_verification(results, required_check_ids) -> RunVerificationSummary
-```
+A single **pure aggregation decision** evaluates all of a run's recorded check results against the declared required-check set and produces the run verification summary. (Signature and module placement are implementation detail — Appendix A.)
 
-- not-executed **never** counts toward pass totals, thresholds, or "all checks green."
-- If any **required** check is in the not-executed family → the run's acceptance verdict is `blocked_unverified` (a distinct verdict — neither passed nor failed; the correction protocol and gates can route on it).
-- **Optional** checks in the not-executed family never block, but are always disclosed in the roll-up (§10) — silence is still forbidden; it is just non-blocking.
-- No side effects in the function; enforcement only at the boundary that acts on the summary. An architecture test asserts purity (Campaign-SIP AC#7 precedent).
+- **Not-executed results are excluded from both the numerator and all success-credit calculations, and their presence is separately disclosed.** They may not improve a percentage, satisfy an all-green rule, or be treated as neutral success evidence. "0 failed out of 0 executed" is not 100%; it is zero evidence.
+- Any **required** check classified not-executed → verdict `blocked_unverified`.
+- **Executed-and-failed** results keep their existing blocking/correction semantics (SIP-0092 severity for typed checks; existing QA/build blocking elsewhere). This SIP changes nothing about how genuine failures route.
+- **Optional** checks are non-blocking but **never invisible**: their failed and not-executed outcomes are recorded and surfaced in the roll-up. Optional means non-blocking, never irrelevant.
+- The decision is **pure** — no persistence or dispatch inside; side effects only at the boundary that acts on it (architecture-tested, per the SIP-0095/Campaign precedent).
 
-### 6.3 Required vs optional is declared, not inferred
+### 6.3 Required vs optional: declared, scoped to stable checks
 
-Cycle request profiles / build profiles declare which checks are required (extending the existing profile schema in the SIP-0092 style). Defaults are conservative per profile tier: `smoke` may mark most checks optional (honest disclosure, no blocking); `full` marks the build/test spine required. Preflight (SIP-0095) gains a parity check: if a *required* check's tooling is knowably absent at create time (e.g. no Node.js for a required frontend build — #306), that is a create-time warn or 422, not a mid-run surprise.
+Required-vs-optional classification is resolved **only from explicit profile/build-profile declarations** — never inferred from check names, check types, historical behavior, or agent narrative.
+
+**Check identity model (which checks are even addressable):**
+
+- **Framework and profile-declared checks have stable identity** and are the domain of `required_checks`: the test-execution check, stub detection, the frontend build check, `required_files`, and pulse suites (by `suite_id`). These are the checks a profile can require and the only checks §9 tracks across cycles.
+- **Plan-authored typed checks (SIP-0092) have per-cycle identity only** (they are LLM-authored inside each cycle's plan). They are classified into evidence families and disclosed in the roll-up, but they are **not** profile-addressable as required and are excluded from cross-cycle inert detection. Their blocking behavior remains governed by SIP-0092 **severity**, unchanged.
+
+This also resolves the severity × required interaction: **severity governs plan-authored checks; required/optional governs framework/profile checks. The domains are disjoint by construction.**
+
+Defaults are conservative per profile tier: `smoke`/`lite` mark most framework checks optional (honest disclosure, no blocking); `full` marks the build/test spine required. **Ordering constraint:** a profile may not mark a check required whose tooling is knowably absent from the deployment it targets — concretely, `full` cannot require frontend checks before #306's image fix ships. SIP-0095 preflight gains the parity check: a *required* check whose tooling is absent at create time is a create-time warn/422, never a mid-run surprise.
+
+### 6.4 Choke point placement (and the #186 relationship)
+
+The aggregation decision runs once per run at completion. Because the executor is being decomposed in 1.3, the placement is stated as a **requirement on #186's design, not a dependency on its outcome**: the decomposition must produce a completion collaborator that computes the run verification summary — this SIP's aggregation function is that collaborator's first client. **Fallback if #186 lands differently or slips:** the aggregation call attaches to the current executor's run-finalization path; the pure module is seam-independent either way.
+
+### 6.5 `blocked_unverified`: routing, lifecycle, and waiver
+
+**`blocked_unverified` is a harness/evidence-integrity verdict, not an application-quality verdict.** `failed` means the product did not satisfy a criterion and routes to product correction. `blocked_unverified` means the framework cannot honestly claim verification — the repair target is the harness, environment, profile, or source set. Console and wrap-up copy must preserve this distinction (§13).
+
+- **Lifecycle:** the verdict is recorded on the roll-up (§10); it introduces **no new `RunStatus`**. The run terminates per existing lifecycle semantics; acceptance surfaces (gates, wrap-up, Campaign) read the verdict, not the lifecycle.
+- **Routing, by reason class:**
+  - *Harness-diagnosable during the run* (stub substitution, generated-test import failure): the existing correction path keeps working exactly as PR #289 wired it — detection → validation failure → correction regenerates the harness. This SIP does not convert that self-healing loop into an operator interrupt; the verdict reflects the *final* state after correction has had its bounded attempts.
+  - *Create-time-knowable* (`missing_tooling` for a required check): SIP-0095 preflight 422 — never reaches a run.
+  - *Residual at run end* (required check still not-executed after the above): the verdict is `blocked_unverified` and routes to the **gate**.
+- **Operator waiver:** a gate presented with `blocked_unverified` may explicitly **accept-with-waiver**, recording the waived checks and reason on the gate decision and the roll-up. This is consistent with SIP-0092 §6.3.2's prohibition on `loosen_acceptance`: the check results stand unaltered and un-loosened; the waiver is an operator decision recorded *above* the evidence, never a mutation of it. A waiver is never implicit.
+
+### 6.6 Evidence integrity violations (named class)
+
+The following are **evidence integrity violations** — the phrase is normative so QA and architecture tests can assert against it:
+
+1. **Stub substitution reporting pass:** no verification producer may substitute a stub, placeholder, empty suite, mock subject, or generated fallback artifact and report `passed`, unless that substitution is explicitly the subject under test and disclosed in provenance.
+2. **A missing required check yielding `accepted`.**
+3. **Dropping not-executed results from the roll-up** (silent disclosure failure).
+4. **Narrative override:** agent narrative, self-report, generated summaries, or wrap-up prose cannot override the structured verification verdict.
 
 ---
 
 ## 7. Execution Provenance
 
-Every check result carries evidence that it actually ran (extending `CheckOutcome.actual` / `PulseVerificationRecord`, exact fields reconciled in Phase 0):
+Every check result carries evidence that it ran — or a machine-readable reason it did not (extending `CheckOutcome.actual` conventions / `PulseVerificationRecord` fields; exact field names are implementation detail):
 
-`executed_at`, `duration_ms`, `subject_ref` (what was checked — file set hash, artifact ID, endpoint), `executor_ref` (where — container/image), and for command-backed checks `exit_code` + a bounded output digest. For the not-executed family, `reason` is mandatory and machine-readable (`missing_tooling:node`, `import_error`, `timeout`, `subject_missing`, `filtered_out`).
+`executed_at`, `duration_ms`, `subject_ref` (what was checked — file-set hash, artifact ID, endpoint), `executor_ref` (where), and for command-backed checks exit metadata + a bounded output digest. For not-executed results the `reason` is mandatory and machine-readable; the taxonomy must include SIP-0092's designed skips (`config_disabled`, `unsupported_stack`) alongside `missing_tooling`, `import_error`, `subject_missing`, `filtered_out`, `timeout_before_execution`.
 
-Provenance is what makes an audit ("did this ever run?") answerable from records instead of log archaeology — and it is the raw material for #114's typed-check evaluation surfacing.
+**Provenance captures bounded identifiers, hashes, exit metadata, and digests; it must not persist unbounded logs or payload copies** (the existing acceptance-check caps pattern applies).
 
 ---
 
-## 8. Surfaces That Must Conform
+## 8. Surfaces That Must Conform (corrected against actual current behavior)
 
-| Surface | Today | Conformance change |
+| Surface | Today (verified) | Conformance change |
 |---|---|---|
-| Typed acceptance checks (`cycles/acceptance_checks.py`, SIP-0092) | 4-state `CheckOutcome`, semantics documented, aggregation permissive | provenance fields; results flow through §6.2 |
-| Generated-test runner (`capabilities/handlers/test_runner.py`) | timeout path already yields not-executed; **ImportError path stubs and passes (#276)** | stub fallback removed → `not_executed(import_error)`; provenance (exit code, duration) |
-| Build checks (frontend build, vitest — #306/#296) | permanently skip; skip does not block | report `not_executed(missing_tooling / subject_missing)`; required-in-profile ⇒ blocking; preflight parity |
-| `required_files` (#291) | declared, unenforced | becomes a required typed check evaluated at run completion through the same choke point |
-| Pulse checks (SIP-0070, `PulseVerificationRecord`) | records persist; executed-vs-skipped distinction not enforced in roll-ups | records carry the state family + provenance; wrap-up consumes the honest roll-up |
+| Pulse boundary decision (SIP-0070) | **D18 already fails** a suite on timeout-skips; but `determine_boundary_decision` treats **SKIP-only records as PASS** | **Named amendment to SIP-0070:** SKIP-only is zero evidence, not PASS — classify per §6.1, aggregate per §6.2 |
+| Fullstack frontend results (SIP-0070 D13) | Frontend build/vitest results **merge non-blocking**; toolchain absent on deployed image (#306) so they never execute, invisibly | **Named amendment to SIP-0070 D13:** when frontend checks are profile-required, not-executed blocks per §6.2; #306 image fix makes them executable; preflight parity covers the required-but-absent case |
+| Typed acceptance checks (SIP-0092) | `error` **already blocks** per severity; `skipped` **never blocks**, whatever the reason | No semantics change to severity routing; results gain reasons + provenance and are classified/disclosed in the roll-up. Designed skips stay non-blocking (plan-authored checks are not required-addressable, §6.3) |
+| Generated-test execution | QA path **already blocks** on `executed=False`; stub detection **shipped** (PR #289) and self-heals via correction | Keep both. Conformance = classification + provenance (stub detections recorded as integrity events, §6.6), not behavior change |
+| `required_files` (#291) | Declared in build profiles, **enforced nowhere** | Remains a build/profile **contract**; its enforcement **emits a normal check result** aggregated through the same choke point — not a parallel mechanism |
+
+(Rev-1 errata, for the record: rev 1 claimed `error` flowed through aggregation without blocking and listed #296 as open — both wrong; #296 closed via `5cb22ce` before rev 1 was drafted, and PRs #289/#290 had already landed the stub-detection and frontend-build checks.)
 
 ---
 
-## 9. Inert-Check Detection
+## 9. Non-Executable and Inert Checks
 
-A check (by stable check ID) that reports not-executed for **N consecutive cycles** in the same project/profile (default N=3) is an **inert check** — operationally equivalent to no check, and historically how #306 stayed invisible.
+Two related conditions, deliberately distinct:
 
-- `squadops doctor` gains an inert-check report (deployed-image parity: which declared checks *cannot* execute here — the #306 class detectable before any cycle runs).
-- The console cycle/run views badge not-executed and inert results distinctly from passes (never folded into a green count).
-- A cycle event (`verification.check_inert`, taxonomy addition per SIP-0077's drift-parity tests) fires on detection.
+- **Non-executable** — knowable before or during a run: this check cannot execute in the current environment/profile (missing tooling, absent subject class). Surfaced by **doctor** (`squadops doctor` gains a verification category reporting, per profile, which declared checks are non-executable in the target environment) and by SIP-0095 preflight when the check is required.
+- **Inert** — historical: a check with stable identity has reported not-executed for **N consecutive cycles** (default N=3) in the same project/profile. A permanently skipping check is indistinguishable from no check.
+
+Rules:
+
+- Detection keys on **stable logical check identity** (§6.3's stable subset only) — not transient runner names, generated file paths, or display labels — and must survive refactors and profile reloads.
+- The inert counter **resets only when the check evaluates the real subject** — not when the check disappears, is renamed, or is reclassified optional. Disappearance of a previously-required check is itself surfaced.
+- **v1.4 ships doctor-only.** The console badging and a dedicated SIP-0077 event are deferred until demand — preflight parity + required-check blocking already cover the acute cases; the detector's residual v1 value is optional-check hygiene, which doctor serves.
 
 ---
 
@@ -141,83 +182,92 @@ A check (by stable check ID) that reports not-executed for **N consecutive cycle
 
 The durable per-cycle summary — the contract downstream consumers read:
 
-`verified` (executed-and-passed, with provenance refs) / `failed` (executed-and-failed) / `unverified` (not-executed, with reasons) / `inert` (chronic) / `verdict` (`accepted | rejected | blocked_unverified`) — all as references into the SIP-0070/0092 records, not copies.
+`verified` (executed-and-passed, provenance refs) / `failed` (executed-and-failed) / `unverified` (not-executed, with reasons) / `inert` (chronic) / `waived` (operator gate waivers, §6.5) / `verdict` (`accepted | rejected | blocked_unverified`) — all as references into the SIP-0070/0092 records, not copies.
 
-Consumers, in order of arrival: **wrap-up** (SIP-0080 confidence classification gets an honest basis — "partial completion with honest confidence" becomes computable), **operator gates** (a gate presented with `blocked_unverified` sees *why*), and — the strategic one — the **Campaign continuation decision** (1.6), whose §7.2 "no `stop_success` on agent narrative alone" is only as strong as this contract. This SIP deliberately ships one even-minor ahead of Campaign so the contract exists, live-validated, before anything automates over it.
+Consumers, in order of arrival: **wrap-up** (SIP-0080 confidence classification gets an honest basis), **operator gates** (a `blocked_unverified` gate sees the harness-vs-product distinction and the waiver option), and — the strategic one — the **Campaign continuation decision** (1.6), whose rule that `stop_success` requires accepted evidence, and that `blocked_unverified` yields only `repair`/`escalate`, is only as strong as this contract. This SIP ships one even-minor ahead of Campaign so the contract exists, live-validated, before anything automates over it.
 
 ---
 
 ## 11. Phasing (within the 1.4 arc)
 
-- **Phase 0 — Reconciliation audit (docs-only, can run during 1.3).** Read the accepted SIP-0092 spec + SIP-0070/0079 models against §6–§7; produce the field-level mapping (what extends `CheckOutcome`, what extends `PulseVerificationRecord`, where SIP-0079 outcome classes meet the not-executed family). Gate: no third vocabulary.
-- **Phase 1 — Invariant + provenance.** The pure aggregation function + `blocked_unverified` verdict + provenance fields + required/optional profile schema. Choke point wired at the run acceptance boundary. (Behavior change only where a required check already reports skip/error — knowingly none in default profiles until Phase 2 retrofits.)
-- **Phase 2 — Retrofit the proof cases.** #276 stub removal, #306/#296 honest reporting + preflight parity, #291 required-files check. Each lands with a live `lite` cycle demonstrating the honest result (per the live-validation rule). **This phase will turn silently-green paths honestly red — that is the point; profile required-lists are the throttle.**
-- **Phase 3 — Detection + surfaces.** Inert-check detection, doctor report, console badging, `verification.check_inert` event, `CycleOutcome` roll-up consumed by wrap-up.
+- **Phase 0 — Verification audit (docs-only, can run during 1.3).** *Confirm* the §6.1 classification mapping and §8 conformance table against the code and the accepted SIP-0092/0070 texts — including the known 0092 spec-vs-code divergence (out-of-safelist commands: spec says `skipped`, code returns `error`). Phase 0 verifies the mapping this SIP specifies; it does **not** decide semantics — those are decided above. Gate: any discovered conflict returns to this SIP as a revision, not a silent reinterpretation.
+- **Phase 1 — Classification + aggregation + provenance.** The pure aggregation module, evidence-family classification, `blocked_unverified` verdict on the roll-up, provenance fields, `required_checks` declaration schema, choke-point wiring per §6.4 (fallback seam if #186 hasn't landed). Inert by construction in default profiles (no required lists shipped yet).
+- **Phase 2 — Conformance of the real gaps.** (a) The two named SIP-0070 amendments: SKIP-only→PASS fix and D13 required-frontend blocking; (b) #306 image fix (makes frontend checks executable) + preflight parity; (c) #291 `required_files` as a checked contract; (d) provenance/classification retrofit of the already-shipped #289/#290 checks (no behavior change). Each lands with a live `lite` cycle demonstrating the honest result. **This phase turns silently-green paths honestly red where a profile requires them — that is the point; the per-profile required lists are the throttle.**
+- **Phase 3 — Surfaces.** `CycleOutcome` roll-up persisted + consumed by wrap-up; gate waiver flow; doctor verification category. #114 (typed-check evaluation surfacing) rides here.
 
-Acceptance of the SIP is all phases (SIP-0089/0090 precedent). The proof-case *bugs* remain independently fixable as patches at any time; this SIP is the rule that keeps them fixed.
+Acceptance of the SIP is all phases (SIP-0089/0090 precedent).
 
 ---
 
 ## 12. Acceptance Criteria
 
-1. A check result in the not-executed family can never contribute to a pass count, threshold, or acceptance verdict — property-tested at the aggregation function.
-2. A run with any required check not-executed yields `blocked_unverified`, never `accepted`; the verdict is distinct from `rejected` and routable by gates/correction.
-3. The #276 path: an ImportError in generated tests produces `not_executed(import_error)` and (where tests are required) `blocked_unverified` — demonstrated by the previously-stubbed fixture.
-4. The #306/#296 paths: on an image without Node.js, frontend checks report `not_executed(missing_tooling:node)`; doctor reports them as inert-capable before any cycle; a profile marking them required fails preflight (SIP-0095 parity).
-5. `required_files` (#291) is enforced at run completion through the same choke point.
-6. Every executed check result carries provenance (§7); every not-executed result carries a machine-readable reason. No verification surface can emit a bare pass.
-7. A check not-executed for N consecutive cycles surfaces via doctor + console + `verification.check_inert` (event-taxonomy parity tests updated).
-8. The `CycleOutcome` roll-up is persisted per cycle and consumed by wrap-up; its `unverified`/`inert` sets are never empty-by-construction (i.e., the roll-up cannot be produced by a path that discards not-executed results).
-9. Vocabulary reconciliation: no new persisted status vocabulary beyond the documented extension of `CheckOutcome`/`PulseVerificationRecord`; an architecture test pins the aggregation function's purity.
-10. Existing default-profile cycles still complete (the invariant changes verdicts only where a *required* check was silently degrading — each such flip is an intended, documented Phase 2 change).
+1. **Aggregation property (tested property-style):** across all combinations of persisted status × required/optional, only executed-and-passed credits toward any pass count, threshold, percentage, or all-green rule; not-executed results are excluded from numerator and success credit and always disclosed; "0 failed of 0 executed" yields zero evidence, never 100%.
+2. A run with any required check not-executed yields verdict `blocked_unverified` — distinct from `rejected`, carried on the roll-up (no new `RunStatus`), routed per §6.5, and presented by gates as a harness/evidence problem, not a product failure.
+3. **Anti-stub (integrity violation #1):** no verification producer may substitute a stub, placeholder, empty suite, mock subject, or fallback artifact and report `passed` unless the substitution is explicitly the subject under test and disclosed in provenance — regression-tested with the #276 stub fixture; #289's detection path records an integrity event in provenance.
+4. **No narrative override (integrity violation #4):** agent narrative, self-report, or wrap-up prose cannot alter the structured verdict — tested by injecting a contradicting narrative and asserting the verdict stands.
+5. **Declared, not inferred:** required-vs-optional resolves only from explicit profile/build-profile declarations; a test asserts no code path infers requiredness from names, types, or history. Plan-authored typed checks are not required-addressable and remain severity-governed (SIP-0092 unchanged).
+6. **Pulse amendment:** SKIP-only pulse records no longer produce PASS; the boundary decision reflects zero evidence per §6.2 (the D18 timeout rule is unchanged).
+7. **Frontend amendment (#306):** on the fixed image, frontend checks execute; where a profile requires them, absence of tooling is a create-time preflight warn/422 and a run-time not-executed never merges silently (D13 amended for the required case).
+8. **`required_files` (#291):** enforced at run completion as a check result through the same choke point; a missing declared file on a profile that requires it yields a blocking verdict per its Open-Q6 classification, never silent completion.
+9. **Provenance:** every executed result carries provenance; every not-executed result carries a machine-readable reason from the taxonomy (including `config_disabled`/`unsupported_stack` designed skips); provenance is bounded (no raw logs/payloads).
+10. **Inert/non-executable:** doctor reports non-executable checks per profile/environment before any cycle; a stable-identity check not-executed for N consecutive cycles is reported inert; the counter keys on logical identity, survives renames, and resets only on real-subject evaluation.
+11. **Roll-up integrity (violation #3):** the roll-up is constructible only via the aggregation decision, which receives every recorded check result — architecture-tested so no construction path can discard not-executed results.
+12. **Waiver:** an operator can accept a `blocked_unverified` run only through an explicit gate decision that records the waived checks and reason on the roll-up; no implicit waiver path exists; check results are never mutated by a waiver.
+13. **Purity + no third vocabulary:** the aggregation decision is side-effect-free (architecture test); producers emit no new persisted status vocabulary — the evidence family is derived at aggregation time from the §6.1 mapping as written in this SIP.
+14. **Compatibility, honestly stated:** existing default-profile cycles continue to complete **except** where they currently rely on a required check silently degrading; Phase 2 enumerates the exact default-profile verdict flips in advance (expected: none until profiles opt into required lists), and no verdicts outside that enumeration change.
 
 ---
 
 ## 13. Risks
 
-- **Honest red is disruptive.** Paths that "worked" for months will start blocking (that is the SIP working). *Mitigation:* required-lists are per-profile policy (§6.3) — the throttle is explicit declaration, never a report-only mode (a report-only mode would recreate the masking this SIP exists to kill); Phase 2 lands per-path with live cycles.
-- **Small-model ergonomics.** `smoke`/`lite` cycles on the Mac legitimately can't run everything; if defaults are too strict the invariant gets worked around. *Mitigation:* conservative per-tier required-lists; disclosure (not blocking) is the floor everywhere.
-- **Vocabulary collision with SIP-0092/0070.** *Top design risk; Phase 0 exists to kill it before code.*
-- **Choke-point placement inside the #186 decomposition.** The acceptance boundary lives in executor territory being restructured in 1.3. *Mitigation:* targeting 1.4 sequences this after the decomposition lands; the choke point attaches to the post-#186 completion boundary (same seam the Campaign SIP plans to use).
-- **Provenance bloat.** Digests and refs, not payloads; caps follow the existing acceptance-check safety caps pattern.
+- **Honest red is disruptive.** Paths that "worked" start blocking where profiles require them — that is the SIP working. *Mitigation:* per-profile required lists are the only throttle (no global report-only mode, §5); Phase 2 lands per-path with live cycles; preflight converts create-time-knowable cases into 422s before any run spends compute.
+- **Run-time-only reasons bite mid-run.** `import_error`/`subject_missing` cannot be caught at create time; on `smoke`/`lite` most checks are optional so blocking behavior is under-exercised until `full` (Spark) runs. *Mitigation:* the §6.5 routing keeps #289's correction self-healing for harness-diagnosable reasons (no new operator interrupts there); the E2E tests (§15) exercise a required blocking case on `lite` deliberately before any long Spark cycle depends on it.
+- **Operator confusion between `failed` and `blocked_unverified`.** *Mitigation:* §6.5's framing is normative — console and wrap-up copy must distinguish failed verification from unverified evidence and show the repair-target category; the gate waiver flow makes the operator path explicit.
+- **Vocabulary collision with SIP-0092/0070.** Mitigated structurally: the three-layer model (§6.1) leaves persisted vocabularies untouched, `error` semantics are preserved, and the two SIP-0070 amendments are named rather than implicit. Phase 0 verifies rather than decides.
+- **#186 lands differently or slips.** *Mitigation:* §6.4 states the completion boundary as a requirement on #186's design with a pre-#186 fallback seam; the pure module is placement-independent.
+- **Provenance bloat.** Digests and refs only, bounded per §7.
 
 ---
 
 ## 14. Relationships
 
-- **SIP-0092** — owns check types and typed-criteria authoring; this SIP owns result trust + aggregation. #114 (typed-check evaluation surfacing) is the observability sibling and can ride Phase 3.
-- **SIP-0070 / SIP-0080** — verification records gain the state family + provenance; wrap-up's confidence classification consumes the roll-up.
-- **SIP-0095** — preflight gains required-check tooling parity (the create-time half of #306's lesson).
-- **Campaign Orchestration (1.6)** — consumes `CycleOutcome` (§10); this SIP is its evidence prerequisite (see #334).
-- **Cycle Evaluation Scorecard (proposed)** — sequences after; scores presume un-fabricated inputs.
-- **Issues:** closes the *class* behind #276, #306, #296, #291; enables #114; feeds #334.
+- **SIP-0092** — unchanged: check types, plan-authored typed checks, severity routing, `error`-blocks semantics, and the `loosen_acceptance` prohibition (the §6.5 waiver records above evidence; it never loosens a check). #114 rides Phase 3.
+- **SIP-0070** — two named amendments (§8): SKIP-only→PASS and D13's non-blocking frontend merge for the required case. D18 unchanged. `PulseVerificationRecord` gains reasons/provenance.
+- **SIP-0079/0080** — outcome classes and wrap-up consume the roll-up; wrap-up's confidence classification gets an honest basis.
+- **SIP-0095** — preflight gains required-check tooling parity.
+- **Campaign Orchestration (1.6)** — consumes `CycleOutcome` (§10); this SIP is its named evidence prerequisite.
+- **Cycle Evaluation Scorecard (proposed)** — sequences after.
+- **Issues:** closes the class behind #276 (predecessors #289/#290/#296 already shipped), #306, #291; enables #114; feeds #334.
 
 ---
 
 ## 15. Testing
 
-- **Aggregation (unit, property-style):** every combination of {passed, failed, skipped, error, not_executed} × {required, optional} → asserted verdict; not-executed can never flip a verdict to accepted; purity architecture test.
-- **Proof-case regression fixtures:** the exact #276 stub scenario, a no-Node image simulation (#306), a filtered-out frontend (#296), a missing required file (#291) — each asserting the honest state + reason, not just "doesn't pass."
-- **Inert detection:** N-cycle sequences in the registry fixtures → detection fires at exactly N, resets on execution.
-- **Doctor parity:** doctor's inert-capability report agrees with runtime behavior on the same profile (SIP-0095 parity precedent).
-- **E2E (live, per the live-validation rule):** one `lite` cycle with a deliberately unrunnable required check → `blocked_unverified` + gate shows the reason; one with it optional → completes with disclosure in the roll-up.
+- **Aggregation (unit, property-style):** the full status × required/optional matrix per AC#1; purity architecture test; the "0 of 0 executed" case explicitly.
+- **Integrity-violation fixtures:** the #276 stub scenario (detection → integrity event in provenance), a narrative-override attempt, a roll-up construction path that tries to drop not-executed results (must be impossible), an implicit-waiver attempt.
+- **Amendment regressions:** SKIP-only pulse records (was PASS, now zero evidence), required-frontend on a no-Node image (preflight 422; run-time not-executed blocks), `required_files` missing file.
+- **Identity/inert:** N-cycle sequences with a rename mid-sequence (counter must not reset), a disappearing required check (surfaced), reset on real execution.
+- **Doctor parity:** doctor's non-executable report agrees with runtime behavior for the same profile (SIP-0095 precedent).
+- **E2E (live, per the live-validation rule):** one `lite` cycle with a deliberately unrunnable **required** check → `blocked_unverified`, gate shows harness framing, waiver path exercised and recorded; one with the check optional → completes with disclosure in the roll-up.
 
 ---
 
 ## 16. Open Questions
 
-1. Exact verdict name (`blocked_unverified` vs extending SIP-0079's outcome classes) — Phase 0 decides with the reconciliation mapping.
-2. Does `blocked_unverified` route to the correction protocol (repair the *harness*, not the app) or straight to a gate? Leaning: gate first; harness-repair correction is a later refinement.
+1. Verdict naming only (`blocked_unverified` vs an SIP-0079-style spelling) — cosmetic; the semantics, routing, lifecycle mapping, and waiver are decided in §6.5.
+2. ~~Gate vs correction routing~~ — **decided in §6.5** (by reason class; #289's correction path preserved; gate for residuals; waiver explicit). Automated harness repair beyond #289 is explicitly deferred (§5) until the system can distinguish harness defects from product defects with high confidence.
 3. N for inert detection — fixed default (3) vs profile-tunable.
-4. Where the roll-up persists — new columns on the run/cycle records vs a `verification_summary` artifact. Leaning: registry columns for the verdict + an artifact for the full roll-up.
-5. Should provenance `subject_ref` hashing reuse the artifact-vault identity scheme (Campaign §22.1 traceability enablers) so run→artifact traceability composes for free?
+4. Roll-up persistence — registry columns for the verdict + an artifact for the full roll-up (leaning), vs columns only.
+5. Should provenance `subject_ref` hashing reuse the artifact-vault identity scheme so run→artifact traceability (Campaign §22.1 enabler) composes for free?
+6. `required_files` family classification: is a missing declared file "not-executed" (subject missing) or "executed-and-failed" (contract checked, violated)? Leaning executed-and-failed (the check *can* run; the file is absent) — Phase 0 confirms against the #291 implementation seam.
 
 ---
 
-## Appendix A — Implementation Seams (non-normative)
+## Appendix A — Candidate Implementation Seams (non-normative)
 
-- **Aggregation:** a pure module `cycles/verification_integrity.py` (mirrors `cycles/preflight.py`), importable by executor, wrap-up, and tests without boundary violations.
-- **Choke point:** the run-completion acceptance boundary — post-#186, the decomposed executor's completion collaborator (the same seam Appendix A of the Campaign SIP targets for continuation).
+- **Aggregation:** a pure module (e.g. `cycles/verification_integrity.py`, mirroring `cycles/preflight.py`), importable by executor, wrap-up, and tests without boundary violations; plausible shape `aggregate_verification(results, required_check_ids) -> RunVerificationSummary`.
+- **Choke point:** post-#186, the decomposed executor's completion collaborator (this function as its first client); pre-#186 fallback at the current executor's run-finalization path.
 - **Provenance:** extend `CheckOutcome.actual` conventions + `PulseVerificationRecord` fields; migration in whichever lane owns the touched registry tables at implementation time.
-- **Doctor:** a new check category alongside the SIP-0095 model-availability checks (`squadops doctor <profile> --check verification`).
-- **Profiles:** `required_checks` key in the cycle-request-profile schema, validated at load like `time_budget_seconds` (SIP-0082 precedent). Coordinate naming with the #316 taxonomy work.
+- **Doctor:** a verification category alongside the SIP-0095 model-availability checks.
+- **Profiles:** a `required_checks` key in the cycle-request-profile / build-profile schema, validated at load (SIP-0082 precedent); naming coordinated with the #316 taxonomy work.
+- **Waiver:** a field on the existing `GateDecision` record + roll-up reference — no new gate type.


### PR DESCRIPTION
## What this is

**Step 1 (Propose) of the SIP workflow** for the Verification Evidence Integrity SIP, bundled with the reconciliation edits that make the acceptance-toward-goal chain read cleanly across the existing proposed SIPs, and the execution plan for the arc. Design review here approves the *design*, not code.

## Why

The 2026-07-04 health assessment's central strategic finding: orchestration maturity is outrunning evidence quality. The framework cannot currently distinguish "this check passed" from "this check never ran" — #276 (stub-fallback passes on an app that never ran), #306 (frontend checks permanently inert), #296 (frontend never materializes), #291 (`required_files` unenforced) are one defect class, not four bugs. The 1.6/2.0 arc (Campaign continuation, Test Bay, capability promotion, scorecards) automates decisions over exactly this evidence.

## Contents

**New: `sips/proposed/SIP-Verification-Evidence-Integrity.md`** (targets 1.4, headline candidate)
- Core invariant: every check result is `executed-passed | executed-failed | not-executed`; not-executed **never** aggregates as a pass; a required not-executed check ⇒ `blocked_unverified` (a distinct, routable verdict).
- Extends the existing vocabulary (`CheckOutcome`'s 4 states, `PulseVerificationRecord`, SIP-0079 outcome classes) — Phase 0 is a reconciliation audit; no third vocabulary.
- Execution provenance on every result; inert-check detection (N consecutive not-executed cycles → doctor/console/event); the `CycleOutcome` roll-up contract consumed by wrap-up, gates, and later the Campaign continuation decision.
- Proof cases #276/#306/#296/#291 are both Phase-2 retrofits and named acceptance criteria. No report-only mode (it would recreate the masking); per-profile `required_checks` lists are the throttle so `smoke`/`lite` stay runnable.

**Revised: `sips/proposed/SIP-Campaign-Orchestration.md`** — applies #334 in full:
- §7.2 consumes the `CycleOutcome` roll-up; `stop_success` requires `verdict = accepted` or a gate; `blocked_unverified` → `repair`/`escalate` only.
- §8 names #288 as a Phase-2 prerequisite and pins choke-point-after-release ordering.
- AC#4 rewritten as a **positive** lease assertion (the #288 failure mode is a cycle holding *no* lease — the old negative form couldn't catch it).
- Phase 2 sequenced behind #288, the evidence SIP, and #316; continuation decisions emit as SIP-0077 events; fork marked resolve-before-acceptance; new open question on what `defer` concretely waits on.

**Cross-references (one edit each):** vision anchor §22.1 ("Improved Cycle evidence model" now names this SIP as the enabler); Capability-Backed-Agents §22 (skill evidence adopts the same honesty); Cycle-Evaluation-Scorecard ("sequences after" — scoring fabricated evidence institutionalizes the wrong lessons its own §2 warns about).

**New: `docs/plans/1-4-evidence-arc-plan.md`** — the execution roadmap: patch lane (bugs ship anytime) → 1.3 riders (Phase 0 audit, #288, #336 — all feature-free, 1.3's rule holds) → 1.4 headliners (this SIP + SIP-0091) → the four named 1.6 gates for Campaign. Plus a pointer update in `2-0-roadmap-reconciliation.md` superseding its Finding-5 feature-lane line.

## Review focus

1. The invariant itself (§6) — especially `blocked_unverified` as a third verdict vs extending SIP-0079 outcome classes (Open Q1).
2. The no-report-only-mode hard line (§13) — intentional; push back if you want a softer rollout.
3. The Campaign SIP's hardened AC#4 and Phase-2 gates — this is the recruitment-safety story for 1.6.
4. 1.4 headline framing (evidence SIP + SIP-0091, embodiment Phase 2 as open rider).

Closes #334
Refs #276 #306 #296 #291 #114 #288 #316 #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wp5b6VzqNynR8X6ACJ5bh