### PR TITLE
fix(#342): resumed runs fail instantly — executor re-issues an illegal RUNNING→RUNNING transition

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -173,8 +173,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             run = await self._cycle_registry.get_run(run_id)
             profile, _ = await self._squad_profile.resolve_snapshot(profile_id)
 
-            # queued/failed/paused -> running
-            await self._cycle_registry.update_run_status(run_id, RunStatus.RUNNING)
+            # queued/failed/paused -> running. Skipped when already RUNNING:
+            # the resume/retry routes flip the run to RUNNING before enqueuing
+            # execution (#222/#256), and RUNNING -> RUNNING is an illegal
+            # transition — the unconditional call instantly failed every
+            # resumed run on a lifecycle-enforcing registry (#342).
+            if run.status != RunStatus.RUNNING.value:
+                await self._cycle_registry.update_run_status(run_id, RunStatus.RUNNING)
 
             # SIP-0079: Check if resuming from checkpoint
             existing_checkpoint = await self._cycle_registry.get_latest_checkpoint(run_id)

--- a/tests/unit/cycles/test_executor_checkpoint.py
+++ b/tests/unit/cycles/test_executor_checkpoint.py
@@ -532,3 +532,72 @@ class TestPausedHandler:
 
         event_types = [c.args[0] for c in mock_event_bus.emit.call_args_list]
         assert EventType.RUN_PAUSED in event_types
+
+
+# ---------------------------------------------------------------------------
+# Resume of an already-RUNNING run (#342)
+# ---------------------------------------------------------------------------
+
+
+class TestResumeOfAlreadyRunningRun:
+    """#342: the resume/retry routes flip the run to RUNNING before enqueuing
+    execution (#222/#256). execute_run must therefore skip its own RUNNING
+    transition when the run already is — RUNNING → RUNNING is an illegal
+    self-loop on every lifecycle-enforcing registry (postgres AND memory),
+    so the unconditional call instantly failed every resumed run live."""
+
+    def _wire_lifecycle_enforcement(self, mock_registry, initial_status: str) -> dict:
+        """Make the mock registry enforce transitions exactly like the real ones."""
+        from squadops.cycles.lifecycle import validate_run_transition
+
+        state = {"status": initial_status}
+
+        def _run(run_id: str = "run_impl") -> Run:
+            return Run(
+                run_id="run_impl",
+                cycle_id="cyc_impl",
+                run_number=1,
+                status=state["status"],
+                initiated_by="api",
+                resolved_config_hash="hash",
+                workload_type=WorkloadType.IMPLEMENTATION,
+            )
+
+        async def _update(run_id: str, status: RunStatus) -> Run:
+            validate_run_transition(RunStatus(state["status"]), status)
+            state["status"] = status.value
+            return _run()
+
+        mock_registry.get_run = AsyncMock(side_effect=_run)
+        mock_registry.update_run_status = AsyncMock(side_effect=_update)
+        mock_registry.append_artifact_refs.side_effect = lambda run_id, refs: _run()
+        return state
+
+    async def test_resumed_running_run_executes_and_completes(
+        self, executor, mock_registry, mock_queue, mock_event_bus
+    ) -> None:
+        """A run the resume route already flipped to RUNNING must execute to
+        COMPLETED — not instantly FAIL on the RUNNING→RUNNING self-loop."""
+        state = self._wire_lifecycle_enforcement(mock_registry, "running")
+
+        with patch.object(executor, "_execute_sequential", new_callable=AsyncMock):
+            await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
+
+        assert state["status"] == "completed"
+        event_types = [c.args[0] for c in mock_event_bus.emit.call_args_list]
+        assert EventType.RUN_COMPLETED in event_types
+        assert EventType.RUN_FAILED not in event_types
+
+    async def test_queued_run_still_transitions_to_running_first(
+        self, executor, mock_registry, mock_queue, mock_event_bus
+    ) -> None:
+        """The create path is unchanged: a QUEUED run still gets the executor's
+        QUEUED→RUNNING transition before completing."""
+        state = self._wire_lifecycle_enforcement(mock_registry, "queued")
+
+        with patch.object(executor, "_execute_sequential", new_callable=AsyncMock):
+            await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
+
+        assert state["status"] == "completed"
+        first_transition = mock_registry.update_run_status.call_args_list[0].args[1]
+        assert first_transition == RunStatus.RUNNING


### PR DESCRIPTION
## What

Every `squadops runs resume` since the #222/#256 wiring (`3a89cb3`, 2026-06-28) has failed instantly on a real registry: the resume route flips the run PAUSED→RUNNING before enqueuing execution, then `execute_run` unconditionally issues its own `update_run_status(RUNNING)` — and `RUNNING→RUNNING` has no self-loop in the lifecycle state machine, so `IllegalStateTransitionError` lands in the terminal handler and the run goes FAILED before any task dispatches.

**Fix (2 lines):** `execute_run` transitions only when the run isn't already RUNNING. The create path is unchanged (QUEUED→RUNNING still issued by the executor). Chosen over adding a RUNNING→RUNNING self-loop to the state machine, which would weaken transition auditing globally.

## How it was found

SIP-0097 slice 2's mandatory **paused-and-resumed live validation** (its terminal-status-mapping stage touches the PAUSED paths): duty-deferred run `run_878de3ad5d0e` paused correctly, then failed ~instantly on resume with no agent activity and no Task Plan in the failure report. This is exactly the deferred **#258** scenario, exercised end-to-end for the first time — the #222-era tests used bare `AsyncMock` registries, so the illegal transition was invisible (both real registries enforce `validate_run_transition`; so does the memory one).

**Pre-existing, not a slice-2 regression:** the failing line is byte-identical on main; this PR is cut from main independently of the slice-2 branch per SIP-0097 §5 ("a bug found mid-slice is filed and fixed in its own PR, never silently in a move").

## Verification

- New `TestResumeOfAlreadyRunningRun` wires the mock registry with the real `validate_run_transition` — the already-RUNNING (resumed) run now completes with `RUN_COMPLETED` and no `RUN_FAILED`; the QUEUED (created) run still gets the executor's RUNNING transition first. Without the fix, the first test fails exactly as production did.
- Regression: **4,662 passed, exit 0**.
- Live re-validation of the full pause→resume→complete path happens as part of SIP-0097 slice 2's validation once this merges (will be reported on that PR and should close out #258's scenario).

Fixes #342
Refs #222, #256, #258, SIP-0097 §5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wp5b6VzqNynR8X6ACJ5bh