### PR TITLE
refactor(#186): SIP-0097 slice 2 — RunLedger + RunCompletion (the SIP-0096 §6.4 seam)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -29,7 +29,7 @@ from adapters.cycles.execution_errors import (
     _PausedError,
     _RecruitmentRejectedError,
 )
-from adapters.cycles.run_completion import RunCompletion
+from adapters.cycles.run_completion import RunCompletion, resolve_terminal_outcome
 from adapters.cycles.task_naming import build_task_name
 from squadops.cycles.agent_config import build_agent_resolver, resolve_agent_config
 from squadops.cycles.checkpoint import RunCheckpoint
@@ -364,72 +364,27 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 )
                 logger.info("Run %s completed successfully", run_id)
 
-        except _CancellationError:
-            terminal_status = "CANCELLED"
-            await self._safe_transition(run_id, RunStatus.CANCELLED)
-            self._cycle_event_bus.emit(
-                EventType.RUN_CANCELLED,
-                entity_type="run",
-                entity_id=run_id,
-                context={"cycle_id": cycle_id, "run_id": run_id},
-            )
-            logger.info("Run %s cancelled", run_id)
-
-        except _RecruitmentRejectedError as exc:
-            # SIP-0089 §2.5: deferral, not failure. PAUSED has a first-class
-            # resume affordance (squadops runs resume → RUN_RESUMED); the reason
-            # rides in the payload so operators can distinguish a duty deferral
-            # from a BLOCKED-outcome pause.
-            terminal_status = "PAUSED"
-            await self._safe_transition(run_id, RunStatus.PAUSED)
-            self._cycle_event_bus.emit(
-                EventType.RUN_PAUSED,
-                entity_type="run",
-                entity_id=run_id,
-                context={"cycle_id": cycle_id, "run_id": run_id},
-                payload={"reason": exc.reason, "deferred_for_agent": exc.agent_id},
-            )
-            logger.info(
-                "Run %s paused — recruitment deferred (agent=%s, reason=%s)",
-                run_id,
-                exc.agent_id,
-                exc.reason,
-            )
-
-        except _PausedError:
-            terminal_status = "PAUSED"
-            await self._safe_transition(run_id, RunStatus.PAUSED)
-            self._cycle_event_bus.emit(
-                EventType.RUN_PAUSED,
-                entity_type="run",
-                entity_id=run_id,
-                context={"cycle_id": cycle_id, "run_id": run_id},
-            )
-            logger.info("Run %s paused", run_id)
-
-        except _ExecutionError as exc:
-            terminal_status = "FAILED"
-            await self._safe_transition(run_id, RunStatus.FAILED)
-            self._cycle_event_bus.emit(
-                EventType.RUN_FAILED,
-                entity_type="run",
-                entity_id=run_id,
-                context={"cycle_id": cycle_id, "run_id": run_id},
-                payload={"error": str(exc)},
-            )
-            logger.error("Run %s failed: %s", run_id, exc)
-
         except Exception as exc:
-            terminal_status = "FAILED"
-            await self._safe_transition(run_id, RunStatus.FAILED)
+            # SIP-0097 §6.4: the exception→status mapping is owned by the
+            # run-completion module; this block persists, emits, and logs
+            # what the mapping decides (behavior-preserving collapse of the
+            # former per-class handlers).
+            outcome = resolve_terminal_outcome(exc, run_id)
+            terminal_status = outcome.terminal_status
+            await self._safe_transition(run_id, outcome.run_status)
             self._cycle_event_bus.emit(
-                EventType.RUN_FAILED,
+                outcome.event_type,
                 entity_type="run",
                 entity_id=run_id,
                 context={"cycle_id": cycle_id, "run_id": run_id},
-                payload={"error": str(exc)},
+                payload=outcome.event_payload,
             )
-            logger.exception("Run %s failed with unexpected error: %s", run_id, exc)
+            if outcome.log_kind == "exception":
+                logger.exception(outcome.log_message)
+            elif outcome.log_kind == "error":
+                logger.error(outcome.log_message)
+            else:
+                logger.info(outcome.log_message)
 
         finally:
             # SIP-0089 §3.5 (#233): release the cycle leases this run acquired,

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -50,6 +50,7 @@ from squadops.cycles.pulse_verification import (
     resolve_milestone_bindings,
     run_pulse_verification,
 )
+from squadops.cycles.run_ledger import RunLedger
 from squadops.cycles.run_report_builder import build_run_report
 from squadops.cycles.task_outcome import TaskOutcome
 from squadops.cycles.task_plan import generate_task_plan
@@ -142,24 +143,35 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
             event_bus = NoOpCycleEventBus()
         self._cycle_event_bus = event_bus
-        # Accumulated per-run pulse verification summaries for run report.
-        # Reset at the start of each execute_run().
-        self._pulse_report_entries: list[dict[str, Any]] = []
-        # SIP-0083: forwarding overrides set by execute_cycle() before
-        # calling execute_run() for subsequent workloads. Merged into
-        # cycle.execution_overrides via dataclasses.replace().
-        self._forwarding_overrides: dict = {}
+        # SIP-0097 §6.6: per-run pulse summaries live on the RunLedger created
+        # in execute_run() and passed explicitly; multi-workload forwarding
+        # overrides are threaded execute_cycle() → execute_run() as a
+        # parameter. The executor carries no per-run/per-cycle mutable
+        # instance state (self._cancelled is the one cross-run exception).
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
-    async def execute_run(self, cycle_id: str, run_id: str, profile_id: str | None = None) -> None:
-        """Execute a run by dispatching tasks to agent containers via RabbitMQ."""
+    async def execute_run(
+        self,
+        cycle_id: str,
+        run_id: str,
+        profile_id: str | None = None,
+        *,
+        forwarding_overrides: dict | None = None,
+    ) -> None:
+        """Execute a run by dispatching tasks to agent containers via RabbitMQ.
+
+        ``forwarding_overrides`` is an adapter-internal keyword extension
+        (SIP-0083 multi-workload forwarding, threaded from execute_cycle();
+        SIP-0097 §6.6 — an immutable cycle-scoped value, never stored on the
+        executor). Port callers use the positional FlowExecutionPort signature.
+        """
         obs_ctx = None
         flow_run_id = None
         terminal_status = "COMPLETED"
-        self._pulse_report_entries = []
+        ledger = RunLedger()
         cycle = None
         plan = None
         # SIP-0089 §3.5 (#233): agents this run transitioned ambient→cycle, to be
@@ -169,7 +181,9 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         recruited_agent_ids: tuple[str, ...] = ()
 
         try:
-            cycle, run_root = await self._prepare_cycle_for_run(cycle_id, run_id)
+            cycle, run_root = await self._prepare_cycle_for_run(
+                cycle_id, run_id, forwarding_overrides=forwarding_overrides
+            )
             run = await self._cycle_registry.get_run(run_id)
             profile, _ = await self._squad_profile.resolve_snapshot(profile_id)
 
@@ -298,6 +312,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         obs_ctx=obs_ctx,
                         profile=profile,
                         run_root=run_root,
+                        ledger=ledger,
                     )
                 elif mode == "fan_out_fan_in":
                     await self._execute_fan_out(plan, run_id, cycle, flow_run_id)
@@ -311,6 +326,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         obs_ctx=obs_ctx,
                         profile=profile,
                         run_root=run_root,
+                        ledger=ledger,
                     )
                 else:
                     await self._execute_sequential(
@@ -321,6 +337,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         seed_artifact_refs,
                         obs_ctx=obs_ctx,
                         run_root=run_root,
+                        ledger=ledger,
                     )
 
                 # Success -> completed
@@ -420,6 +437,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 flow_run_id,
                 cycle=cycle,
                 plan=plan,
+                ledger=ledger,
             )
 
     async def cancel_run(self, run_id: str) -> None:
@@ -458,9 +476,18 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # Cycle-create passes the first run, which resolves to index 0.
         start_index = await self._starting_workload_index(cycle_id, first_run_id)
         current_run_id = first_run_id
+        # SIP-0097 §6.6: forwarding overrides are a cycle-scoped value threaded
+        # into each run invocation, not executor state. Built at the end of
+        # workload i, consumed by workload i+1's execute_run.
+        forwarding_overrides: dict | None = None
         for i in range(start_index, len(workload_sequence)):
             workload_entry = workload_sequence[i]
-            await self.execute_run(cycle_id, current_run_id, profile_id)
+            await self.execute_run(
+                cycle_id,
+                current_run_id,
+                profile_id,
+                forwarding_overrides=forwarding_overrides,
+            )
 
             # Check terminal status (compare persisted string values)
             run = await self._cycle_registry.get_run(current_run_id)
@@ -547,7 +574,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             )
 
             # Build forwarding overrides for the next workload's execute_run()
-            self._forwarding_overrides = await self._build_forwarding_overrides(
+            forwarding_overrides = await self._build_forwarding_overrides(
                 cycle,
                 run,
             )
@@ -1040,6 +1067,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         obs_ctx: Any = None,
         profile: SquadProfile | None = None,
         run_root: str = "",
+        *,
+        ledger: RunLedger,
     ) -> None:
         """Sequential: dispatch one task at a time, fail-fast.
 
@@ -1220,6 +1249,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     flow_run_id=flow_run_id,
                     agent_resolver=agent_resolver,
                     run_root=run_root,
+                    ledger=ledger,
                 )
 
                 if cadence_closed:
@@ -1745,6 +1775,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         flow_run_id: str | None,
         agent_resolver: dict[str, str],
         run_root: str,
+        *,
+        ledger: RunLedger,
     ) -> None:
         """Run milestone and cadence pulse evaluations at the current boundary."""
         from squadops.capabilities.models import AcceptanceContext
@@ -1781,6 +1813,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     max_repair_attempts=max_repair_attempts,
                     flow_run_id=flow_run_id,
                     agent_resolver=agent_resolver,
+                    ledger=ledger,
                 )
 
         # --- Cadence close check ---
@@ -1801,13 +1834,19 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 max_repair_attempts=max_repair_attempts,
                 flow_run_id=flow_run_id,
                 agent_resolver=agent_resolver,
+                ledger=ledger,
             )
 
     # ------------------------------------------------------------------
     # Extracted helpers for execute_run
     # ------------------------------------------------------------------
 
-    async def _prepare_cycle_for_run(self, cycle_id: str, run_id: str) -> tuple[Cycle, str]:
+    async def _prepare_cycle_for_run(
+        self,
+        cycle_id: str,
+        run_id: str,
+        forwarding_overrides: dict | None = None,
+    ) -> tuple[Cycle, str]:
         """Load cycle, merge forwarding overrides, resolve PRD, materialize run root.
 
         Returns (cycle, run_root).
@@ -1816,15 +1855,15 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
         cycle = await self._cycle_registry.get_cycle(cycle_id)
         # SIP-0083: merge forwarding overrides from multi-workload orchestration
-        if self._forwarding_overrides:
+        # (threaded per-run from execute_cycle, SIP-0097 §6.6 — not executor state)
+        if forwarding_overrides:
             cycle = _dc.replace(
                 cycle,
                 execution_overrides={
                     **cycle.execution_overrides,
-                    **self._forwarding_overrides,
+                    **forwarding_overrides,
                 },
             )
-            self._forwarding_overrides = {}
 
         # Resolve PRD content — if prd_ref is an artifact ID, fetch the
         # actual content so handlers receive the PRD text, not just the ID.
@@ -1905,6 +1944,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         flow_run_id: str | None,
         cycle: Cycle | None = None,
         plan: list[TaskEnvelope] | None = None,
+        ledger: RunLedger | None = None,
     ) -> None:
         """Close observability traces and generate run report."""
         # LangFuse: close cycle trace
@@ -1939,6 +1979,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     terminal_status,
                     cycle=cycle,
                     plan=plan,
+                    ledger=ledger,
                 )
         except Exception:
             logger.warning("Run report generation failed", exc_info=True)
@@ -2578,6 +2619,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         engine: AcceptanceCheckEngine,
         context: AcceptanceContext,
         repair_attempt_number: int = 0,
+        *,
+        ledger: RunLedger,
     ) -> tuple[PulseDecision, list[PulseVerificationRecord]]:
         """Run all suites at a boundary, persist records, return decision + records.
 
@@ -2668,8 +2711,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
         decision = determine_boundary_decision(records)
 
-        # Accumulate for run report
-        self._pulse_report_entries.append(
+        # Accumulate for run report (SIP-0097 §6.6: on the RunLedger)
+        ledger.record_pulse_boundary(
             {
                 "boundary_id": boundary_id,
                 "cadence_interval_id": cadence_interval_id,
@@ -2729,6 +2772,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         max_repair_attempts: int = 2,
         flow_run_id: str | None = None,
         agent_resolver: dict[str, str] | None = None,
+        *,
+        ledger: RunLedger,
     ) -> None:
         """Verify boundary, repair on failure, exhaust on repeated failure.
 
@@ -2747,6 +2792,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             obs_ctx=obs_ctx,
             engine=engine,
             context=context,
+            ledger=ledger,
         )
 
         if decision == PulseDecision.PASS:
@@ -2952,6 +2998,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 engine=engine,
                 context=context,
                 repair_attempt_number=repair_attempt,
+                ledger=ledger,
             )
 
             if decision == PulseDecision.PASS:
@@ -3081,6 +3128,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         terminal_status: str,
         cycle: Cycle | None = None,
         plan: list[TaskEnvelope] | None = None,
+        ledger: RunLedger | None = None,
     ) -> None:
         """Generate run_report.md and store as a documentation artifact (D10).
 
@@ -3097,7 +3145,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             terminal_status,
             cycle=cycle,
             plan=plan,
-            pulse_report_entries=self._pulse_report_entries,
+            pulse_report_entries=list(ledger.pulse_entries) if ledger else None,
         )
         content_bytes = content.encode("utf-8")
 

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -29,6 +29,7 @@ from adapters.cycles.execution_errors import (
     _PausedError,
     _RecruitmentRejectedError,
 )
+from adapters.cycles.run_completion import RunCompletion
 from adapters.cycles.task_naming import build_task_name
 from squadops.cycles.agent_config import build_agent_resolver, resolve_agent_config
 from squadops.cycles.checkpoint import RunCheckpoint
@@ -51,7 +52,6 @@ from squadops.cycles.pulse_verification import (
     run_pulse_verification,
 )
 from squadops.cycles.run_ledger import RunLedger
-from squadops.cycles.run_report_builder import build_run_report
 from squadops.cycles.task_outcome import TaskOutcome
 from squadops.cycles.task_plan import generate_task_plan
 from squadops.events.types import EventType
@@ -109,6 +109,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         assignment_port: AssignmentPort | None = None,
         activity_port: RuntimeActivityPort | None = None,
         coordinator: RuntimeCoordinator | None = None,
+        run_completion: RunCompletion | None = None,
     ) -> None:
         self._cycle_registry = cycle_registry
         self._artifact_vault = artifact_vault
@@ -136,6 +137,15 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # infra.
         self._coordinator = coordinator
         self._cancelled: set[str] = set()
+        # SIP-0097 §6.4: run-completion collaborator (terminal path). Plain
+        # injected collaborator with a default composed from this executor's
+        # own deps — not a port.
+        self._run_completion = run_completion or RunCompletion(
+            cycle_registry=cycle_registry,
+            artifact_vault=artifact_vault,
+            llm_observability=llm_observability,
+            workflow_tracker=workflow_tracker,
+        )
 
         # SIP-0077: Cycle event bus (defaults to NoOp if not provided)
         if event_bus is None:
@@ -429,7 +439,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # raise. Empty (and skipped) when the run recruited no one.
             if self._coordinator is not None and recruited_agent_ids:
                 await release_participants(self._coordinator, recruited_agent_ids, owner_ref=run_id)
-            await self._finalize_run(
+            await self._run_completion.finalize(
                 cycle_id,
                 run_id,
                 terminal_status,
@@ -1935,55 +1945,6 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
         return obs_ctx, flow_run_id
 
-    async def _finalize_run(
-        self,
-        cycle_id: str,
-        run_id: str,
-        terminal_status: str,
-        obs_ctx: Any,
-        flow_run_id: str | None,
-        cycle: Cycle | None = None,
-        plan: list[TaskEnvelope] | None = None,
-        ledger: RunLedger | None = None,
-    ) -> None:
-        """Close observability traces and generate run report."""
-        # LangFuse: close cycle trace
-        if self._llm_observability and obs_ctx:
-            from squadops.telemetry.models import StructuredEvent
-
-            self._llm_observability.record_event(
-                obs_ctx,
-                StructuredEvent(
-                    name="cycle.completed",
-                    message=f"Cycle {cycle_id} reached {terminal_status}",
-                ),
-            )
-            self._llm_observability.end_cycle_trace(obs_ctx)
-            self._llm_observability.flush()
-
-        # Prefect: set terminal state
-        if self._workflow_tracker and flow_run_id:
-            try:
-                await self._workflow_tracker.set_flow_run_state(
-                    flow_run_id, terminal_status, terminal_status.title()
-                )
-            except Exception:
-                logger.warning("Prefect terminal state update failed", exc_info=True)
-
-        # Run report: best-effort (D10)
-        try:
-            if cycle_id and run_id:
-                await self._generate_run_report(
-                    cycle_id,
-                    run_id,
-                    terminal_status,
-                    cycle=cycle,
-                    plan=plan,
-                    ledger=ledger,
-                )
-        except Exception:
-            logger.warning("Run report generation failed", exc_info=True)
-
     # ------------------------------------------------------------------
     # Extracted helpers for _run_correction_protocol
     # ------------------------------------------------------------------
@@ -3120,51 +3081,3 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 status.value,
                 exc_info=True,
             )
-
-    async def _generate_run_report(
-        self,
-        cycle_id: str,
-        run_id: str,
-        terminal_status: str,
-        cycle: Cycle | None = None,
-        plan: list[TaskEnvelope] | None = None,
-        ledger: RunLedger | None = None,
-    ) -> None:
-        """Generate run_report.md and store as a documentation artifact (D10).
-
-        Best-effort: called in finally block, failures are logged but
-        never affect the run's terminal status.
-        """
-        # Fetch latest run state for gate decisions and artifact refs
-        run = await self._cycle_registry.get_run(run_id)
-
-        content = build_run_report(
-            cycle_id,
-            run_id,
-            run,
-            terminal_status,
-            cycle=cycle,
-            plan=plan,
-            pulse_report_entries=list(ledger.pulse_entries) if ledger else None,
-        )
-        content_bytes = content.encode("utf-8")
-
-        # Note: uses direct vault.store() instead of _store_artifact() because
-        # the report is generated outside of any task context (no TaskEnvelope).
-        ref = ArtifactRef(
-            artifact_id=f"art_{uuid4().hex[:12]}",
-            project_id=cycle.project_id if cycle else "unknown",
-            artifact_type="document",
-            filename="run_report.md",
-            content_hash=sha256(content_bytes).hexdigest(),
-            size_bytes=len(content_bytes),
-            media_type="text/markdown",
-            created_at=datetime.now(UTC),
-            cycle_id=cycle_id,
-            run_id=run_id,
-            metadata={"report_type": "run_report"},
-        )
-
-        await self._artifact_vault.store(ref, content_bytes)
-        await self._cycle_registry.append_artifact_refs(run_id, (ref.artifact_id,))
-        logger.info("Run report generated for %s", run_id)

--- a/adapters/cycles/run_completion.py
+++ b/adapters/cycles/run_completion.py
@@ -20,13 +20,21 @@ collaborator's first client.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from hashlib import sha256
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
-from squadops.cycles.models import ArtifactRef
+from adapters.cycles.execution_errors import (
+    _CancellationError,
+    _ExecutionError,
+    _PausedError,
+    _RecruitmentRejectedError,
+)
+from squadops.cycles.models import ArtifactRef, RunStatus
 from squadops.cycles.run_report_builder import build_run_report
+from squadops.events.types import EventType
 
 if TYPE_CHECKING:
     from squadops.cycles.models import Cycle
@@ -38,6 +46,83 @@ if TYPE_CHECKING:
     from squadops.tasks.models import TaskEnvelope
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TerminalOutcome:
+    """The run-end consequence of an exception (SIP-0097 §6.4).
+
+    Pure data: the executor's single except-block persists the status,
+    emits the event, and logs — this mapping decides what.
+    """
+
+    terminal_status: str
+    run_status: RunStatus
+    event_type: str
+    event_payload: dict[str, Any] | None
+    log_kind: Literal["info", "error", "exception"]
+    log_message: str
+
+
+def resolve_terminal_outcome(exc: BaseException, run_id: str) -> TerminalOutcome:
+    """Map an execute_run exception to its terminal outcome.
+
+    Moved from execute_run's per-class exception handlers; the mapping —
+    including event payload shapes and log wording — is behavior-preserving:
+    cancellation → CANCELLED, recruitment deferral / BLOCKED pause → PAUSED,
+    execution error / unexpected → FAILED.
+    """
+    if isinstance(exc, _CancellationError):
+        return TerminalOutcome(
+            terminal_status="CANCELLED",
+            run_status=RunStatus.CANCELLED,
+            event_type=EventType.RUN_CANCELLED,
+            event_payload=None,
+            log_kind="info",
+            log_message=f"Run {run_id} cancelled",
+        )
+    if isinstance(exc, _RecruitmentRejectedError):
+        # SIP-0089 §2.5: deferral, not failure. PAUSED has a first-class
+        # resume affordance (squadops runs resume → RUN_RESUMED); the reason
+        # rides in the payload so operators can distinguish a duty deferral
+        # from a BLOCKED-outcome pause.
+        return TerminalOutcome(
+            terminal_status="PAUSED",
+            run_status=RunStatus.PAUSED,
+            event_type=EventType.RUN_PAUSED,
+            event_payload={"reason": exc.reason, "deferred_for_agent": exc.agent_id},
+            log_kind="info",
+            log_message=(
+                f"Run {run_id} paused — recruitment deferred "
+                f"(agent={exc.agent_id}, reason={exc.reason})"
+            ),
+        )
+    if isinstance(exc, _PausedError):
+        return TerminalOutcome(
+            terminal_status="PAUSED",
+            run_status=RunStatus.PAUSED,
+            event_type=EventType.RUN_PAUSED,
+            event_payload=None,
+            log_kind="info",
+            log_message=f"Run {run_id} paused",
+        )
+    if isinstance(exc, _ExecutionError):
+        return TerminalOutcome(
+            terminal_status="FAILED",
+            run_status=RunStatus.FAILED,
+            event_type=EventType.RUN_FAILED,
+            event_payload={"error": str(exc)},
+            log_kind="error",
+            log_message=f"Run {run_id} failed: {exc}",
+        )
+    return TerminalOutcome(
+        terminal_status="FAILED",
+        run_status=RunStatus.FAILED,
+        event_type=EventType.RUN_FAILED,
+        event_payload={"error": str(exc)},
+        log_kind="exception",
+        log_message=f"Run {run_id} failed with unexpected error: {exc}",
+    )
 
 
 class RunCompletion:

--- a/adapters/cycles/run_completion.py
+++ b/adapters/cycles/run_completion.py
@@ -1,0 +1,157 @@
+"""Run-completion collaborator (SIP-0097 §6.4).
+
+Owns everything that happens once, at the end of a run: the terminal-status
+mapping (exception → ``RunStatus``/event/log), observability closeout
+(LangFuse trace close + Prefect terminal state), and run-report generation
+(formatting lives in the domain ``run_report_builder``; this collaborator
+owns the vault write).
+
+Per the SIP-0097 observability ownership rule: per-run observability starts
+in the executor (``_init_run_observability``) and closes here; per-task
+observability belongs to the dispatch path.
+
+**The 1.4 socket (SIP-0096 §6.4):** ``finalize`` is the single call site
+that sees the run's ``RunLedger`` at run end. In v1.3 it computes the
+existing completion/report surface — no new semantics. In v1.4, SIP-0096
+wires its pure ``aggregate_verification`` function here as this
+collaborator's first client.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from hashlib import sha256
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from squadops.cycles.models import ArtifactRef
+from squadops.cycles.run_report_builder import build_run_report
+
+if TYPE_CHECKING:
+    from squadops.cycles.models import Cycle
+    from squadops.cycles.run_ledger import RunLedger
+    from squadops.ports.cycles.artifact_vault import ArtifactVaultPort
+    from squadops.ports.cycles.cycle_registry import CycleRegistryPort
+    from squadops.ports.cycles.workflow_tracker import WorkflowTrackerPort
+    from squadops.ports.telemetry.llm_observability import LLMObservabilityPort
+    from squadops.tasks.models import TaskEnvelope
+
+logger = logging.getLogger(__name__)
+
+
+class RunCompletion:
+    """Composes the executor's run-end path (SIP-0097 §6.4).
+
+    Plain injected collaborator, not a port — a decomposition seam inside
+    the existing adapter, not an alternate runtime strategy.
+    """
+
+    def __init__(
+        self,
+        cycle_registry: CycleRegistryPort | None = None,
+        artifact_vault: ArtifactVaultPort | None = None,
+        llm_observability: LLMObservabilityPort | None = None,
+        workflow_tracker: WorkflowTrackerPort | None = None,
+    ) -> None:
+        self._cycle_registry = cycle_registry
+        self._artifact_vault = artifact_vault
+        self._llm_observability = llm_observability
+        self._workflow_tracker = workflow_tracker
+
+    async def finalize(
+        self,
+        cycle_id: str,
+        run_id: str,
+        terminal_status: str,
+        obs_ctx: Any,
+        flow_run_id: str | None,
+        cycle: Cycle | None = None,
+        plan: list[TaskEnvelope] | None = None,
+        ledger: RunLedger | None = None,
+    ) -> None:
+        """Close observability traces and generate run report."""
+        # LangFuse: close cycle trace
+        if self._llm_observability and obs_ctx:
+            from squadops.telemetry.models import StructuredEvent
+
+            self._llm_observability.record_event(
+                obs_ctx,
+                StructuredEvent(
+                    name="cycle.completed",
+                    message=f"Cycle {cycle_id} reached {terminal_status}",
+                ),
+            )
+            self._llm_observability.end_cycle_trace(obs_ctx)
+            self._llm_observability.flush()
+
+        # Prefect: set terminal state
+        if self._workflow_tracker and flow_run_id:
+            try:
+                await self._workflow_tracker.set_flow_run_state(
+                    flow_run_id, terminal_status, terminal_status.title()
+                )
+            except Exception:
+                logger.warning("Prefect terminal state update failed", exc_info=True)
+
+        # Run report: best-effort (D10)
+        try:
+            if cycle_id and run_id:
+                await self.generate_run_report(
+                    cycle_id,
+                    run_id,
+                    terminal_status,
+                    cycle=cycle,
+                    plan=plan,
+                    ledger=ledger,
+                )
+        except Exception:
+            logger.warning("Run report generation failed", exc_info=True)
+
+    async def generate_run_report(
+        self,
+        cycle_id: str,
+        run_id: str,
+        terminal_status: str,
+        cycle: Cycle | None = None,
+        plan: list[TaskEnvelope] | None = None,
+        ledger: RunLedger | None = None,
+    ) -> None:
+        """Generate run_report.md and store as a documentation artifact (D10).
+
+        Best-effort: called from finalize's try/except, failures are logged
+        but never affect the run's terminal status.
+        """
+        # Fetch latest run state for gate decisions and artifact refs
+        run = await self._cycle_registry.get_run(run_id)
+
+        content = build_run_report(
+            cycle_id,
+            run_id,
+            run,
+            terminal_status,
+            cycle=cycle,
+            plan=plan,
+            pulse_report_entries=list(ledger.pulse_entries) if ledger else None,
+        )
+        content_bytes = content.encode("utf-8")
+
+        # Note: uses direct vault.store() because the report is generated
+        # outside of any task context (no TaskEnvelope).
+        ref = ArtifactRef(
+            artifact_id=f"art_{uuid4().hex[:12]}",
+            project_id=cycle.project_id if cycle else "unknown",
+            artifact_type="document",
+            filename="run_report.md",
+            content_hash=sha256(content_bytes).hexdigest(),
+            size_bytes=len(content_bytes),
+            media_type="text/markdown",
+            created_at=datetime.now(UTC),
+            cycle_id=cycle_id,
+            run_id=run_id,
+            metadata={"report_type": "run_report"},
+        )
+
+        await self._artifact_vault.store(ref, content_bytes)
+        await self._cycle_registry.append_artifact_refs(run_id, (ref.artifact_id,))
+        logger.info("Run report generated for %s", run_id)

--- a/src/squadops/cycles/run_ledger.py
+++ b/src/squadops/cycles/run_ledger.py
@@ -1,0 +1,38 @@
+"""Per-run verification-evidence accumulator (SIP-0097 §6.6).
+
+Created once at the top of ``execute_run`` and passed explicitly to the
+collaborators that need it — never stored on the executor or any long-lived
+collaborator, and never retained past finalization (the run report is the
+last reader). Append-only writes, immutable read accessors.
+
+Contents are versioned by SIP-0097 §6.6: in v1.3 the ledger carries the
+pulse boundary verification summaries (the former executor
+``_pulse_report_entries`` instance state); in v1.4, SIP-0096 extends it to
+every recorded check result and wires its aggregation function to consume
+it at the ``RunCompletion`` seam.
+
+This is an in-memory accumulator, not a persistence abstraction —
+persistence stays with the existing registry/report paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class RunLedger:
+    """Append-only per-run evidence ledger with immutable read accessors."""
+
+    __slots__ = ("_pulse_entries",)
+
+    def __init__(self) -> None:
+        self._pulse_entries: list[dict[str, Any]] = []
+
+    def record_pulse_boundary(self, entry: dict[str, Any]) -> None:
+        """Record one pulse boundary-decision summary (append-only)."""
+        self._pulse_entries.append(entry)
+
+    @property
+    def pulse_entries(self) -> tuple[dict[str, Any], ...]:
+        """Immutable view of the accumulated pulse boundary summaries."""
+        return tuple(self._pulse_entries)

--- a/tests/unit/cycles/test_correction_repair_prefect_propagation.py
+++ b/tests/unit/cycles/test_correction_repair_prefect_propagation.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from squadops.cycles.models import Cycle, TaskFlowPolicy
+from squadops.cycles.run_ledger import RunLedger
 from squadops.events.types import EventType
 from squadops.tasks.models import TaskEnvelope, TaskResult
 
@@ -356,6 +357,7 @@ class TestPulseRepairTaskRunPropagation:
             max_repair_attempts=2,
             flow_run_id="fr_main",
             agent_resolver={"strat": "nat", "dev": "neo", "qa": "eve", "lead": "max"},
+            ledger=RunLedger(),
         )
 
         # Repair task_runs were created and IDs threaded through dispatch.

--- a/tests/unit/cycles/test_run_completion.py
+++ b/tests/unit/cycles/test_run_completion.py
@@ -1,9 +1,9 @@
-"""Tests for run report generation (SIP-Enhanced-Agent-Build-Capabilities).
+"""Tests for the RunCompletion collaborator (SIP-0097 §6.4, slice 2).
 
-Validates that _generate_run_report() produces a structured markdown report
+Validates that generate_run_report() produces a structured markdown report
 stored as a documentation artifact, and that failures don't affect run status.
-
-Part of Phase 3.
+Moved from test_run_report.py — assertions unmodified; the fixture now
+constructs RunCompletion directly, without a DispatchedFlowExecutor instance.
 """
 
 from __future__ import annotations
@@ -89,35 +89,31 @@ def _make_plan(count: int = 3) -> list[TaskEnvelope]:
 
 
 @pytest.fixture
-def executor(reply_router):
-    """Create a DispatchedFlowExecutor with mocked ports."""
-    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+def completion():
+    """Create a RunCompletion with mocked ports — no executor needed."""
+    from adapters.cycles.run_completion import RunCompletion
 
     vault = AsyncMock()
     vault.store = AsyncMock(side_effect=lambda ref, content: ref)
     registry = AsyncMock()
 
-    ex = DispatchedFlowExecutor(
+    return RunCompletion(
         cycle_registry=registry,
         artifact_vault=vault,
-        queue=AsyncMock(),
-        squad_profile=AsyncMock(),
-        reply_router=reply_router,
     )
-    return ex
 
 
 class TestReportContainsMetadata:
-    async def test_report_contains_metadata(self, executor):
+    async def test_report_contains_metadata(self, completion):
         """Run report includes cycle/run metadata."""
         cycle = _make_cycle()
         run = _make_run(
             started_at=NOW,
             artifact_refs=("art_001", "art_002"),
         )
-        executor._cycle_registry.get_run = AsyncMock(return_value=run)
+        completion._cycle_registry.get_run = AsyncMock(return_value=run)
 
-        await executor._generate_run_report(
+        await completion.generate_run_report(
             "cyc_001",
             "run_001",
             "COMPLETED",
@@ -126,7 +122,7 @@ class TestReportContainsMetadata:
         )
 
         # Verify vault.store was called with the report content
-        call_args = executor._artifact_vault.store.call_args
+        call_args = completion._artifact_vault.store.call_args
         ref = call_args[0][0]
         content_bytes = call_args[0][1]
         content = content_bytes.decode()
@@ -139,13 +135,13 @@ class TestReportContainsMetadata:
         assert "play_game" in content
         assert "fresh" in content
 
-    async def test_report_includes_quality_notes(self, executor):
+    async def test_report_includes_quality_notes(self, completion):
         """Run report includes quality notes section."""
         cycle = _make_cycle()
         run = _make_run()
-        executor._cycle_registry.get_run = AsyncMock(return_value=run)
+        completion._cycle_registry.get_run = AsyncMock(return_value=run)
 
-        await executor._generate_run_report(
+        await completion.generate_run_report(
             "cyc_001",
             "run_001",
             "COMPLETED",
@@ -153,17 +149,17 @@ class TestReportContainsMetadata:
             plan=None,
         )
 
-        content = executor._artifact_vault.store.call_args[0][1].decode()
+        content = completion._artifact_vault.store.call_args[0][1].decode()
         assert "Quality Notes" in content
         assert "All tasks completed successfully" in content
 
-    async def test_report_quality_notes_failed(self, executor):
+    async def test_report_quality_notes_failed(self, completion):
         """Run report quality notes reflect FAILED status."""
         cycle = _make_cycle()
         run = _make_run()
-        executor._cycle_registry.get_run = AsyncMock(return_value=run)
+        completion._cycle_registry.get_run = AsyncMock(return_value=run)
 
-        await executor._generate_run_report(
+        await completion.generate_run_report(
             "cyc_001",
             "run_001",
             "FAILED",
@@ -171,18 +167,18 @@ class TestReportContainsMetadata:
             plan=None,
         )
 
-        content = executor._artifact_vault.store.call_args[0][1].decode()
+        content = completion._artifact_vault.store.call_args[0][1].decode()
         assert "Quality Notes" in content
         assert "failed" in content.lower()
 
-    async def test_report_includes_task_plan(self, executor):
+    async def test_report_includes_task_plan(self, completion):
         """Run report includes task plan breakdown."""
         cycle = _make_cycle()
         run = _make_run()
-        executor._cycle_registry.get_run = AsyncMock(return_value=run)
+        completion._cycle_registry.get_run = AsyncMock(return_value=run)
         plan = _make_plan(3)
 
-        await executor._generate_run_report(
+        await completion.generate_run_report(
             "cyc_001",
             "run_001",
             "COMPLETED",
@@ -190,14 +186,14 @@ class TestReportContainsMetadata:
             plan=plan,
         )
 
-        content = executor._artifact_vault.store.call_args[0][1].decode()
+        content = completion._artifact_vault.store.call_args[0][1].decode()
         assert "Task Plan" in content
         assert "strategy.analyze_prd" in content
         assert "development.design" in content
         assert "qa.validate" in content
         assert "Total tasks: 3" in content
 
-    async def test_report_includes_gate_decisions(self, executor):
+    async def test_report_includes_gate_decisions(self, completion):
         """Run report includes gate decisions when present."""
         cycle = _make_cycle()
         run = _make_run(
@@ -211,9 +207,9 @@ class TestReportContainsMetadata:
                 ),
             ),
         )
-        executor._cycle_registry.get_run = AsyncMock(return_value=run)
+        completion._cycle_registry.get_run = AsyncMock(return_value=run)
 
-        await executor._generate_run_report(
+        await completion.generate_run_report(
             "cyc_001",
             "run_001",
             "COMPLETED",
@@ -221,19 +217,19 @@ class TestReportContainsMetadata:
             plan=None,
         )
 
-        content = executor._artifact_vault.store.call_args[0][1].decode()
+        content = completion._artifact_vault.store.call_args[0][1].decode()
         assert "Gate Decisions" in content
         assert "plan-review" in content
         assert "approved" in content
         assert "LGTM" in content
 
-    async def test_report_includes_artifact_count(self, executor):
+    async def test_report_includes_artifact_count(self, completion):
         """Run report includes artifact inventory count."""
         cycle = _make_cycle()
         run = _make_run(artifact_refs=("a1", "a2", "a3"))
-        executor._cycle_registry.get_run = AsyncMock(return_value=run)
+        completion._cycle_registry.get_run = AsyncMock(return_value=run)
 
-        await executor._generate_run_report(
+        await completion.generate_run_report(
             "cyc_001",
             "run_001",
             "COMPLETED",
@@ -241,36 +237,36 @@ class TestReportContainsMetadata:
             plan=None,
         )
 
-        content = executor._artifact_vault.store.call_args[0][1].decode()
+        content = completion._artifact_vault.store.call_args[0][1].decode()
         assert "Total artifacts: 3" in content
 
 
 class TestReportFailureNoStatusChange:
-    async def test_report_failure_no_status_change(self, executor):
+    async def test_report_failure_no_status_change(self, completion):
         """Report generation failure doesn't affect run status."""
-        executor._cycle_registry.get_run = AsyncMock(
+        completion._cycle_registry.get_run = AsyncMock(
             side_effect=Exception("registry down"),
         )
 
         # Should not raise — caller wraps in try/except
         with pytest.raises(Exception, match="registry down"):
-            await executor._generate_run_report(
+            await completion.generate_run_report(
                 "cyc_001",
                 "run_001",
                 "COMPLETED",
             )
 
         # The run status was NOT updated (no update_run_status calls)
-        executor._cycle_registry.update_run_status.assert_not_called()
+        completion._cycle_registry.update_run_status.assert_not_called()
 
 
 class TestReportWithoutCycleOrPlan:
-    async def test_report_without_cycle_or_plan(self, executor):
+    async def test_report_without_cycle_or_plan(self, completion):
         """Report works with minimal data (no cycle, no plan)."""
         run = _make_run()
-        executor._cycle_registry.get_run = AsyncMock(return_value=run)
+        completion._cycle_registry.get_run = AsyncMock(return_value=run)
 
-        await executor._generate_run_report(
+        await completion.generate_run_report(
             "cyc_001",
             "run_001",
             "FAILED",
@@ -278,7 +274,7 @@ class TestReportWithoutCycleOrPlan:
             plan=None,
         )
 
-        call_args = executor._artifact_vault.store.call_args
+        call_args = completion._artifact_vault.store.call_args
         ref = call_args[0][0]
         content = call_args[0][1].decode()
 

--- a/tests/unit/cycles/test_run_completion.py
+++ b/tests/unit/cycles/test_run_completion.py
@@ -281,3 +281,163 @@ class TestReportWithoutCycleOrPlan:
         assert ref.project_id == "unknown"
         assert "FAILED" in content
         assert "cyc_001" in content
+
+
+# ---------------------------------------------------------------------------
+# Terminal-status mapping (SIP-0097 slice 2c) — one case per exception class,
+# asserting the exact status/event/payload/log consequence execute_run acts on.
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTerminalOutcome:
+    def test_cancellation_maps_to_cancelled(self):
+        from adapters.cycles.execution_errors import _CancellationError
+        from adapters.cycles.run_completion import resolve_terminal_outcome
+        from squadops.cycles.models import RunStatus
+        from squadops.events.types import EventType
+
+        outcome = resolve_terminal_outcome(_CancellationError("run_1"), "run_1")
+        assert outcome.terminal_status == "CANCELLED"
+        assert outcome.run_status == RunStatus.CANCELLED
+        assert outcome.event_type == EventType.RUN_CANCELLED
+        assert outcome.event_payload is None
+        assert outcome.log_kind == "info"
+        assert outcome.log_message == "Run run_1 cancelled"
+
+    def test_recruitment_rejection_maps_to_paused_with_reason_payload(self):
+        """A duty deferral must stay distinguishable from a BLOCKED pause —
+        losing the reason/agent payload would break the operator's resume
+        triage (SIP-0089 §2.5)."""
+        from adapters.cycles.execution_errors import _RecruitmentRejectedError
+        from adapters.cycles.run_completion import resolve_terminal_outcome
+        from squadops.cycles.models import RunStatus
+        from squadops.events.types import EventType
+
+        exc = _RecruitmentRejectedError("max", "hard_duty_window")
+        outcome = resolve_terminal_outcome(exc, "run_1")
+        assert outcome.terminal_status == "PAUSED"
+        assert outcome.run_status == RunStatus.PAUSED
+        assert outcome.event_type == EventType.RUN_PAUSED
+        assert outcome.event_payload == {
+            "reason": "hard_duty_window",
+            "deferred_for_agent": "max",
+        }
+        assert outcome.log_kind == "info"
+        assert "recruitment deferred" in outcome.log_message
+
+    def test_paused_error_maps_to_paused_without_payload(self):
+        from adapters.cycles.execution_errors import _PausedError
+        from adapters.cycles.run_completion import resolve_terminal_outcome
+        from squadops.cycles.models import RunStatus
+        from squadops.events.types import EventType
+
+        outcome = resolve_terminal_outcome(_PausedError("blocked"), "run_1")
+        assert outcome.terminal_status == "PAUSED"
+        assert outcome.run_status == RunStatus.PAUSED
+        assert outcome.event_type == EventType.RUN_PAUSED
+        assert outcome.event_payload is None
+        assert outcome.log_message == "Run run_1 paused"
+
+    def test_execution_error_maps_to_failed_with_error_payload(self):
+        from adapters.cycles.execution_errors import _ExecutionError
+        from adapters.cycles.run_completion import resolve_terminal_outcome
+        from squadops.cycles.models import RunStatus
+        from squadops.events.types import EventType
+
+        outcome = resolve_terminal_outcome(_ExecutionError("task t-1 failed"), "run_1")
+        assert outcome.terminal_status == "FAILED"
+        assert outcome.run_status == RunStatus.FAILED
+        assert outcome.event_type == EventType.RUN_FAILED
+        assert outcome.event_payload == {"error": "task t-1 failed"}
+        assert outcome.log_kind == "error"
+
+    def test_unexpected_exception_maps_to_failed_with_traceback_logging(self):
+        """An unclassified crash must keep log_kind='exception' — downgrading
+        it to 'error' silently drops the traceback from the logs."""
+        from adapters.cycles.run_completion import resolve_terminal_outcome
+        from squadops.cycles.models import RunStatus
+        from squadops.events.types import EventType
+
+        outcome = resolve_terminal_outcome(ValueError("boom"), "run_1")
+        assert outcome.terminal_status == "FAILED"
+        assert outcome.run_status == RunStatus.FAILED
+        assert outcome.event_type == EventType.RUN_FAILED
+        assert outcome.event_payload == {"error": "boom"}
+        assert outcome.log_kind == "exception"
+        assert "unexpected error" in outcome.log_message
+
+    def test_recruitment_rejection_checked_before_generic_paused(self):
+        """_RecruitmentRejectedError must not fall through to the payload-less
+        PAUSED branch — the reason payload is the resume affordance."""
+        from adapters.cycles.execution_errors import _RecruitmentRejectedError
+        from adapters.cycles.run_completion import resolve_terminal_outcome
+
+        outcome = resolve_terminal_outcome(_RecruitmentRejectedError(None, None), "run_1")
+        assert outcome.event_payload == {"reason": None, "deferred_for_agent": None}
+
+
+# ---------------------------------------------------------------------------
+# RunLedger (SIP-0097 §6.6)
+# ---------------------------------------------------------------------------
+
+
+class TestRunLedger:
+    def test_read_before_any_write_is_empty(self):
+        """finalize on a run with no pulse boundaries must see zero entries,
+        not crash — the report's pulse section is skipped entirely."""
+        from squadops.cycles.run_ledger import RunLedger
+
+        ledger = RunLedger()
+        assert ledger.pulse_entries == ()
+
+    def test_entries_accumulate_in_order(self):
+        from squadops.cycles.run_ledger import RunLedger
+
+        ledger = RunLedger()
+        ledger.record_pulse_boundary({"boundary_id": "b1", "decision": "pass"})
+        ledger.record_pulse_boundary({"boundary_id": "b2", "decision": "fail"})
+        assert [e["boundary_id"] for e in ledger.pulse_entries] == ["b1", "b2"]
+
+    def test_read_accessor_is_immutable_view(self):
+        """A consumer mutating its view must not corrupt the ledger —
+        the accumulated evidence is append-only by contract."""
+        from squadops.cycles.run_ledger import RunLedger
+
+        ledger = RunLedger()
+        ledger.record_pulse_boundary({"boundary_id": "b1", "decision": "pass"})
+        view = ledger.pulse_entries
+        with pytest.raises((TypeError, AttributeError)):
+            view.append({"boundary_id": "rogue"})  # type: ignore[attr-defined]
+        assert len(ledger.pulse_entries) == 1
+
+    async def test_report_renders_ledger_entries(self):
+        """End-to-end through generate_run_report: ledger entries reach the
+        pulse section — the seam SIP-0096 will aggregate over."""
+        from adapters.cycles.run_completion import RunCompletion
+        from squadops.cycles.run_ledger import RunLedger
+
+        vault = AsyncMock()
+        vault.store = AsyncMock(side_effect=lambda ref, content: ref)
+        registry = AsyncMock()
+        registry.get_run = AsyncMock(return_value=_make_run())
+        completion = RunCompletion(cycle_registry=registry, artifact_vault=vault)
+
+        ledger = RunLedger()
+        ledger.record_pulse_boundary(
+            {
+                "boundary_id": "post_qa",
+                "cadence_interval_id": 0,
+                "decision": "pass",
+                "repair_attempt": 0,
+                "suites": [{"suite_id": "smoke_suite", "outcome": "pass"}],
+            }
+        )
+
+        await completion.generate_run_report(
+            "cyc_001", "run_001", "COMPLETED", cycle=_make_cycle(), ledger=ledger
+        )
+
+        content = vault.store.call_args[0][1].decode()
+        assert "Pulse Verification" in content
+        assert "post_qa" in content
+        assert "smoke_suite=pass" in content

--- a/tests/unit/events/test_event_emission.py
+++ b/tests/unit/events/test_event_emission.py
@@ -48,13 +48,23 @@ def _find_event_type_refs_in_file(filepath: Path) -> set[str]:
     return refs
 
 
-# Source files that contain emit() calls
+# Source files that contain emit() calls (or decide the event type an emit
+# call uses — SIP-0097 slice 2 moved the run-terminal mapping, and its
+# EventType references, to the RunCompletion module; the executor's single
+# collapsed handler emits what the mapping decides)
 _EXECUTOR_PATH = Path("adapters/cycles/dispatched_flow_executor.py")
+_RUN_COMPLETION_PATH = Path("adapters/cycles/run_completion.py")
 _CYCLES_ROUTE = Path("src/squadops/api/routes/cycles/cycles.py")
 _RUNS_ROUTE = Path("src/squadops/api/routes/cycles/runs.py")
 _ARTIFACTS_ROUTE = Path("src/squadops/api/routes/cycles/artifacts.py")
 
-_ALL_EMISSION_FILES = [_EXECUTOR_PATH, _CYCLES_ROUTE, _RUNS_ROUTE, _ARTIFACTS_ROUTE]
+_ALL_EMISSION_FILES = [
+    _EXECUTOR_PATH,
+    _RUN_COMPLETION_PATH,
+    _CYCLES_ROUTE,
+    _RUNS_ROUTE,
+    _ARTIFACTS_ROUTE,
+]
 
 
 @pytest.fixture(scope="module")
@@ -100,8 +110,6 @@ class TestExecutorEmissionPoints:
         [
             "RUN_STARTED",
             "RUN_COMPLETED",
-            "RUN_FAILED",
-            "RUN_CANCELLED",
             "RUN_PAUSED",
             "RUN_RESUMED",
             "TASK_DISPATCHED",
@@ -125,8 +133,25 @@ class TestExecutorEmissionPoints:
     def test_executor_emits(self, attr: str, executor_refs: set[str]) -> None:
         assert attr in executor_refs
 
-    def test_executor_has_22_types(self, executor_refs: set[str]) -> None:
-        assert len(executor_refs) == 22
+    def test_executor_has_20_types(self, executor_refs: set[str]) -> None:
+        """20 = the former 22 minus RUN_FAILED/RUN_CANCELLED, whose static
+        references moved to the run-completion terminal mapping (SIP-0097
+        slice 2c). RUN_PAUSED stays: the duty-deferral path still references
+        it directly in the executor."""
+        assert len(executor_refs) == 20
+
+
+class TestRunCompletionEmissionPoints:
+    """The run-terminal event types are decided by the RunCompletion mapping
+    (SIP-0097 §6.4); the executor's collapsed handler emits what it decides."""
+
+    @pytest.fixture(scope="class")
+    def run_completion_refs(self) -> set[str]:
+        return _find_event_type_refs_in_file(_RUN_COMPLETION_PATH)
+
+    @pytest.mark.parametrize("attr", ["RUN_CANCELLED", "RUN_PAUSED", "RUN_FAILED"])
+    def test_terminal_mapping_covers(self, attr: str, run_completion_refs: set[str]) -> None:
+        assert attr in run_completion_refs
 
 
 class TestRouteEmissionPoints:
@@ -217,18 +242,18 @@ class TestEmitCallSitePayloadFields:
                 total_calls += 1
                 if any(kw.arg == "payload" for kw in call.keywords):
                     with_payload += 1
-        # At least 38 of 48 calls have payload (a few lifecycle events omit it)
+        # At least 38 of 44 calls have payload (a few lifecycle events omit it)
         assert with_payload >= 38
 
     def test_total_emit_call_count(self) -> None:
-        """Sanity check: 41 executor + 7 route = 48 total emit calls.
+        """Sanity check: 37 executor + 7 route = 44 total emit calls.
 
-        The 41st executor emit is the SIP-0089 §2.5 reserve-buffer deferral —
-        `EventType.RUN_PAUSED` with payload reason `upcoming_hard_duty_window`,
-        raised from the `_RecruitmentRejectedError` handler. Reusing RUN_PAUSED
-        (rather than minting a new EventType) keeps the locked cycle taxonomy
-        intact, so this count — not the taxonomy size — is what moves."""
+        SIP-0097 slice 2c collapsed execute_run's five per-exception-class
+        terminal emits (cancelled / recruitment-deferral paused / paused /
+        execution-failed / unexpected-failed) into one emit driven by the
+        RunCompletion terminal mapping — same events at runtime, 4 fewer
+        static call sites (was 41 executor + 7 route = 48)."""
         total = 0
         for path in _ALL_EMISSION_FILES:
             total += len(self._extract_emit_calls(path))
-        assert total == 48
+        assert total == 44


### PR DESCRIPTION
## What (SIP-0097 §6.4 / §6.6 / §8 slice 2 of 6)

Internally staged exactly as the SIP mandates — one commit per stage:

| Stage | Commit | Contents |
|---|---|---|
| (a) ledger + state threading | `60a0dc7` | `src/squadops/cycles/run_ledger.py` (per-run append-only accumulator, immutable read accessors, created at the top of `execute_run`, passed explicitly through the pulse chain and into finalization). **`_pulse_report_entries` and `_forwarding_overrides` instance attributes deleted** — forwarding overrides thread `execute_cycle` → `execute_run` as an adapter-internal keyword param (`FlowExecutionPort` signature unchanged) |
| (b) `RunCompletion` | `cef4319` | `adapters/cycles/run_completion.py`: `finalize()` (LangFuse close + Prefect terminal state + best-effort report) and `generate_run_report()` (reads the ledger, owns the vault write). Constructor-injected into the executor with a default composed from its own deps |
| (c) terminal-status mapping **last** | `85e27e0` | `resolve_terminal_outcome()` pure mapping + `TerminalOutcome`; `execute_run`'s five per-exception-class handlers collapse into one block that persists/emits/logs what the mapping decides — payload shapes and log wording preserved verbatim |

Executor: **3,122 → 3,038 lines**, and after this slice the executor carries **no per-run/per-cycle mutable instance state** — `_cancelled` is the only surviving mutable attribute, per the SIP's state rule.

**The 1.4 socket is now real:** `RunCompletion.finalize(ledger, …)` is the single call site that sees all ledger-recorded verification results at run end; SIP-0096 Phase 1 wires `aggregate_verification` here with no fallback seam.

## 🔴 Live validation found a real pre-existing bug → #342 / PR #343

The SIP-mandated **paused-and-resumed** validation failed on first run: every `runs resume` since the #222/#256 wiring fails instantly (route pre-flips RUNNING; executor re-issues the illegal RUNNING→RUNNING transition). Filed as **#342**, fixed in **PR #343** (cut from main per SIP-0097 §5 — a bug found mid-slice gets its own PR, never a silent fix in a move). Verified byte-identical on main = pre-existing, not a slice regression; it's the deferred **#258** scenario, exercised end-to-end for the first time. **Recommend merging #343 before or with this PR.**

## Live validation (stack rebuilt via `rebuild_and_deploy.sh all`)

- **Happy path (slice-2 branch alone):** cycle `cyc_4fcdde65195c` → **completed**; report generated through `RunCompletion` + ledger.
- **Paused-and-resumed (slice-2 + #343, throwaway local merge — never pushed):** cycle `cyc_5134f354acca` / run `run_748a4aa88329`: hard-duty assignment on `nat` → run **paused** via reserve-buffer deferral (PAUSED-finalize report generated, with task plan) → assignment deactivated → `runs resume` → **completed in ~70s**, all 5 handler artifacts + COMPLETED-finalize report. The §11 risk case (terminal-status mapping × pause/resume) passes.

## Parity note (SIP-0097 §7.4)

- **Events:** same event types, payload shapes, and ordering at runtime. Static structure changed: 5 terminal emit call sites collapsed into 1 mapping-driven emit (48 → 44 total; AST ground-truth counts). The `test_event_emission.py` guardrails were re-anchored: `run_completion.py` added to the scanned emission files, executor static refs 22→20 (RUN_FAILED/RUN_CANCELLED now decided in the mapping), new `TestRunCompletionEmissionPoints`.
- **Registry writes:** unchanged (same transitions via `_safe_transition`, same report artifact append).
- **Artifacts:** unchanged — live reports section-identical to pre-slice format (PAUSED and COMPLETED variants both verified).
- **Observability:** unchanged surfaces; closeout moved to `RunCompletion` per the SIP's ownership rule (per-run opens in executor, closes in completion).
- **`pyproject.toml` per-file-ignores delta:** none.

## Verification

- **Regression:** slice-2 branch **4,671 passed, exit 0**; combined with #343 **4,673 passed, exit 0** (captured directly). (Note: `FORCE_COLOR` in the shell env makes 2 pre-existing `test_assemble_command.py` assertions fail on any branch incl. main — environmental, reproduced on clean main, not related.)
- **New tests:** `TestResolveTerminalOutcome` (every exception class → exact status/event/payload/log), `TestRunLedger` (empty read, ordering, immutable view, ledger→report rendering). `test_run_report.py` → `test_run_completion.py` with the fixture constructing `RunCompletion` **without an executor instance** (the §9 construction-level requirement); assertions unmodified.
- **Test moves disclosed (§7.7):** one direct `_verify_with_repair` test call gains `ledger=RunLedger()`.

## Slice ledger

Slice 2 of 6 — #186 stays open (closes via final slices, AC#10). Next: slice 3 (`CorrectionRunner`, interim dispatch callable per §6.3).

Refs #186, #342, SIP-0096 §6.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wp5b6VzqNynR8X6ACJ5bh