### PR TITLE
refactor(#186): SIP-0097 slice 3 — CorrectionRunner extraction

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -1,0 +1,496 @@
+"""Correction-protocol collaborator (SIP-0097 §6.3).
+
+Owns the four-step correction protocol — analyze → decide → (patch) → done —
+moved verbatim from ``DispatchedFlowExecutor._run_correction_protocol`` plus
+its two helpers (``_store_correction_task_artifacts``,
+``_checkpoint_correction_task``). Outcome *routing* (what the run does with
+the returned correction path) stays with the executor's orchestration loop.
+
+**Interim state (slice 3 < slice 5):** task transport does not exist as a
+collaborator yet, so this runner receives three narrow executor-supplied
+callables — ``dispatch_task`` and ``create_task_run`` (both owned by
+``TaskDispatcher`` from slice 5, which replaces these callables per §6.3/AC#9)
+and ``store_artifact`` (executor-resident artifact plumbing per §6.7,
+residual-but-watched).
+
+Cancellation: the protocol performs no cancellation checks of its own (it
+never did); it relies on the dispatch path's checks at dispatch/await
+boundaries per the §6 cancellation ownership rule.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from hashlib import sha256
+from typing import TYPE_CHECKING, Any
+
+from squadops.cycles.agent_config import resolve_agent_config
+from squadops.cycles.checkpoint import RunCheckpoint
+from squadops.cycles.failure_evidence import build_failure_evidence, compose_failure_trigger
+from squadops.cycles.models import ArtifactRef
+from squadops.cycles.plan_delta import PlanDelta
+from squadops.events.types import EventType
+from squadops.tasks.models import TaskEnvelope
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from squadops.cycles.models import Cycle
+    from squadops.ports.cycles.artifact_vault import ArtifactVaultPort
+    from squadops.ports.cycles.cycle_registry import CycleRegistryPort
+    from squadops.ports.events.cycle_event_bus import CycleEventBusPort
+    from squadops.tasks.models import TaskResult
+
+logger = logging.getLogger(__name__)
+
+
+class CorrectionRunner:
+    """Runs the correction protocol for a failed task (SIP-0079 semantics).
+
+    Plain injected collaborator (not a port); the executor composes a
+    default from its own deps. Independently unit-testable without a
+    ``DispatchedFlowExecutor`` instance.
+    """
+
+    def __init__(
+        self,
+        cycle_registry: CycleRegistryPort,
+        artifact_vault: ArtifactVaultPort,
+        event_bus: CycleEventBusPort,
+        *,
+        dispatch_task: Callable[..., Awaitable[TaskResult]],
+        create_task_run: Callable[[str | None, TaskEnvelope], Awaitable[str | None]],
+        store_artifact: Callable[..., Awaitable[ArtifactRef]],
+    ) -> None:
+        self._cycle_registry = cycle_registry
+        self._artifact_vault = artifact_vault
+        self._event_bus = event_bus
+        self._dispatch_task = dispatch_task
+        self._create_task_run = create_task_run
+        self._store_artifact = store_artifact
+
+    async def _store_correction_task_artifacts(
+        self,
+        result: TaskResult,
+        envelope: TaskEnvelope,
+        cycle: Cycle,
+        run_id: str,
+        all_artifact_refs: list[str],
+        stored_artifacts: list[tuple[str, ArtifactRef]],
+    ) -> None:
+        """Persist a correction-task or repair-task's output artifacts.
+
+        Mirrors the artifact-storage loop in the executor's
+        ``_collect_artifacts_and_checkpoint`` but is split out so the
+        correction/repair success branches can call it before
+        ``_checkpoint_correction_task`` — which only snapshots existing
+        ``all_artifact_refs`` into a checkpoint and does not itself
+        persist new artifacts. Without this call, repaired deliverables
+        (e.g. the ``qa_handoff.md`` produced by ``builder.assemble_repair``
+        or the ``correction_decision.md`` from the correction protocol)
+        never reach the artifact registry, even though the cycle marks
+        completed and the run_report counts them as repaired. This was
+        observed across cycles 4b, 6, and prior gate-batch runs as the
+        recurring "silent artifact-drop" pattern.
+        """
+        new_refs: list[str] = []
+        for art in (result.outputs or {}).get("artifacts", []):
+            ref = await self._store_artifact(
+                art,
+                cycle,
+                run_id,
+                envelope,
+                producing_task_type=envelope.task_type,
+            )
+            new_refs.append(ref.artifact_id)
+            all_artifact_refs.append(ref.artifact_id)
+            stored_artifacts.append((ref.artifact_id, ref))
+
+        if new_refs:
+            await self._cycle_registry.append_artifact_refs(run_id, tuple(new_refs))
+
+    async def _checkpoint_correction_task(
+        self,
+        task_id: str,
+        run_id: str,
+        cycle: Cycle,
+        completed_task_ids: list[str],
+        prior_outputs: dict[str, Any],
+        all_artifact_refs: list[str],
+        plan_delta_refs: list[str],
+    ) -> None:
+        """Checkpoint a correction or repair task after successful dispatch."""
+        completed_task_ids.append(task_id)
+        checkpoint_index = len(completed_task_ids)
+        new_checkpoint = RunCheckpoint(
+            run_id=run_id,
+            checkpoint_index=checkpoint_index,
+            completed_task_ids=tuple(completed_task_ids),
+            prior_outputs=dict(prior_outputs),
+            artifact_refs=tuple(all_artifact_refs),
+            plan_delta_refs=tuple(plan_delta_refs),
+            created_at=datetime.now(UTC),
+        )
+        await self._cycle_registry.save_checkpoint(new_checkpoint)
+        self._event_bus.emit(
+            EventType.CHECKPOINT_CREATED,
+            entity_type="run",
+            entity_id=run_id,
+            context={"cycle_id": cycle.cycle_id, "run_id": run_id},
+            payload={
+                "checkpoint_index": checkpoint_index,
+                "completed_task_id": task_id,
+            },
+        )
+
+    async def run_correction_protocol(
+        self,
+        run_id: str,
+        cycle: Cycle,
+        envelope: TaskEnvelope,
+        result: TaskResult,
+        correction_attempts: int,
+        prior_outputs: dict[str, Any],
+        all_artifact_refs: list[str],
+        stored_artifacts: list[tuple[str, ArtifactRef]],
+        completed_task_ids: list[str],
+        plan_delta_refs: list[str],
+        profile: Any = None,
+        flow_run_id: str | None = None,
+    ) -> str:
+        """Run the correction protocol: analyze → decide → act.
+
+        Returns the correction_path chosen by the governance handler.
+        Side effects: dispatches correction/repair tasks, stores plan delta,
+        emits correction events.
+        """
+        from uuid import uuid4
+
+        from squadops.cycles.task_plan import CORRECTION_TASK_STEPS, repair_steps_for
+
+        # 1. Emit CORRECTION_INITIATED
+        self._event_bus.emit(
+            EventType.CORRECTION_INITIATED,
+            entity_type="run",
+            entity_id=run_id,
+            context={"cycle_id": cycle.cycle_id, "run_id": run_id},
+            payload={
+                "failed_task_id": envelope.task_id,
+                "failed_task_type": envelope.task_type,
+                "correction_attempt": correction_attempts + 1,
+            },
+        )
+
+        # 2. Build correction task envelopes (deterministic IDs)
+        failure_evidence = build_failure_evidence(
+            envelope, result, prior_plan_deltas_count=len(plan_delta_refs)
+        )
+
+        # Issue #95: capture each correction step's outputs in its own variable
+        # so the analyzer's classification/analysis_summary survive past the
+        # subsequent governance.correction_decision step (which doesn't carry
+        # those fields forward). Reusing a single variable used to mask the
+        # analyzer's diagnosis with defaults at PlanDelta time.
+        analysis_outputs: dict[str, Any] = {}
+        decision_outputs: dict[str, Any] = {}
+        corr_correlation_id = uuid4().hex
+
+        for step_idx, (task_type, role) in enumerate(CORRECTION_TASK_STEPS):
+            corr_task_id = f"corr-{run_id[:12]}-{correction_attempts:02d}-{task_type}"
+            resolved = resolve_agent_config(role, profile)
+            agent_id = resolved.agent_id
+            agent_model = resolved.model
+            agent_overrides = resolved.config_overrides
+
+            # Issue #110: propagate squad-profile model + overrides so
+            # correction-loop reasoning runs on the cycle's specified model
+            # (e.g. the `full` profile pins data/lead to qwen3.6:27b)
+            # rather than the agent container's instance default.
+            corr_inputs: dict[str, Any] = {
+                "prd": cycle.prd_ref,
+                "failure_evidence": failure_evidence,
+                "prior_outputs": prior_outputs,
+                "artifact_refs": list(all_artifact_refs),
+                "agent_model": agent_model,
+                "agent_config_overrides": agent_overrides,
+            }
+            if analysis_outputs:
+                corr_inputs["failure_analysis"] = analysis_outputs
+
+            corr_envelope = TaskEnvelope(
+                task_id=corr_task_id,
+                agent_id=agent_id,
+                cycle_id=cycle.cycle_id,
+                pulse_id=uuid4().hex,
+                project_id=cycle.project_id,
+                task_type=task_type,
+                correlation_id=corr_correlation_id,
+                causation_id=envelope.task_id,
+                trace_id=uuid4().hex,
+                span_id=uuid4().hex,
+                inputs=corr_inputs,
+                metadata={"role": role, "step_index": step_idx},
+            )
+
+            # 3. Dispatch correction task. SIP-0087 B2: create task_run before
+            # dispatch so the agent's PrefectLogHandler can scope correction-
+            # task logs to a dedicated UI pane and the bridge can transition
+            # terminal state without owning the ID.
+            corr_task_run_id = await self._create_task_run(flow_run_id, corr_envelope)
+            corr_task_context = {
+                "cycle_id": cycle.cycle_id,
+                "run_id": run_id,
+                "flow_run_id": flow_run_id or "",
+                "task_run_id": corr_task_run_id or "",
+            }
+            self._event_bus.emit(
+                EventType.TASK_DISPATCHED,
+                entity_type="task",
+                entity_id=corr_task_id,
+                context=corr_task_context,
+                payload={"task_type": task_type},
+            )
+
+            corr_result = await self._dispatch_task(
+                corr_envelope,
+                run_id,
+                flow_run_id=flow_run_id,
+                task_run_id=corr_task_run_id,
+            )
+
+            if corr_result.status == "SUCCEEDED":
+                self._event_bus.emit(
+                    EventType.TASK_SUCCEEDED,
+                    entity_type="task",
+                    entity_id=corr_task_id,
+                    context=corr_task_context,
+                    payload={"task_type": task_type},
+                )
+                # Persist the correction task's output artifacts BEFORE
+                # checkpointing — _checkpoint_correction_task only snapshots
+                # existing refs and would otherwise drop these silently.
+                await self._store_correction_task_artifacts(
+                    corr_result,
+                    corr_envelope,
+                    cycle,
+                    run_id,
+                    all_artifact_refs,
+                    stored_artifacts,
+                )
+                await self._checkpoint_correction_task(
+                    corr_task_id,
+                    run_id,
+                    cycle,
+                    completed_task_ids,
+                    prior_outputs,
+                    all_artifact_refs,
+                    plan_delta_refs,
+                )
+            else:
+                self._event_bus.emit(
+                    EventType.TASK_FAILED,
+                    entity_type="task",
+                    entity_id=corr_task_id,
+                    context=corr_task_context,
+                    payload={"task_type": task_type, "error": corr_result.error or ""},
+                )
+
+            # Collect correction task outputs into the right named bucket so
+            # downstream PlanDelta construction reads each field from the
+            # handler that owns it (issue #95).
+            step_outputs = {
+                k: v for k, v in (corr_result.outputs or {}).items() if k != "artifacts"
+            }
+            if task_type == "data.analyze_failure":
+                analysis_outputs = step_outputs
+            elif task_type == "governance.correction_decision":
+                decision_outputs = step_outputs
+
+        # 4. Read correction_path
+        correction_path = decision_outputs.get("correction_path", "abort")
+
+        # 5. Emit CORRECTION_DECIDED
+        self._event_bus.emit(
+            EventType.CORRECTION_DECIDED,
+            entity_type="run",
+            entity_id=run_id,
+            context={"cycle_id": cycle.cycle_id, "run_id": run_id},
+            payload={
+                "correction_path": correction_path,
+                "decision_rationale": decision_outputs.get("decision_rationale", ""),
+            },
+        )
+
+        # 6. Store plan delta as artifact
+        delta = PlanDelta(
+            delta_id=uuid4().hex,
+            run_id=run_id,
+            correction_path=correction_path,
+            trigger=compose_failure_trigger(envelope, failure_evidence),
+            failure_classification=analysis_outputs.get("classification", "unknown"),
+            analysis_summary=analysis_outputs.get("analysis_summary", "N/A"),
+            decision_rationale=decision_outputs.get("decision_rationale", "N/A"),
+            changes=tuple(decision_outputs.get("affected_task_types", [])),
+            affected_task_types=tuple(decision_outputs.get("affected_task_types", [])),
+            created_at=datetime.now(UTC),
+            # SIP-0092 M2 → M3 gate diagnostic.
+            structural_plan_change_candidate=str(
+                decision_outputs.get("structural_plan_change_candidate", "none")
+            ),
+            structural_plan_change_rationale=str(
+                decision_outputs.get("structural_plan_change_rationale", "")
+            ),
+        )
+        delta_content = json.dumps(delta.to_dict(), default=str).encode()
+        delta_ref = ArtifactRef(
+            artifact_id=f"delta_{delta.delta_id[:12]}",
+            project_id=cycle.project_id,
+            artifact_type="plan_delta",
+            filename=f"plan_delta_{correction_attempts}.json",
+            content_hash=sha256(delta_content).hexdigest(),
+            size_bytes=len(delta_content),
+            media_type="application/json",
+            created_at=datetime.now(UTC),
+            cycle_id=cycle.cycle_id,
+            run_id=run_id,
+        )
+        await self._artifact_vault.store(delta_ref, delta_content)
+        all_artifact_refs.append(delta_ref.artifact_id)
+        plan_delta_refs.append(delta_ref.artifact_id)
+
+        # 7. Handle patch path: dispatch repair tasks
+        # Repair-step selection is keyed on the failed task's task_type
+        # (authoritative) rather than the LLM-emitted `affected_task_types`
+        # field, which is free-text and previously caused builder failures
+        # (`affected_task_types: ["QA Handoff"]`) to silently route to the
+        # dev repair handler.
+        if correction_path == "patch":
+            for step_idx, (task_type, role) in enumerate(repair_steps_for(envelope.task_type)):
+                repair_task_id = f"repair-{run_id[:12]}-{correction_attempts:02d}-{task_type}"
+                resolved = resolve_agent_config(role, profile)
+                agent_id = resolved.agent_id
+                agent_model = resolved.model
+                agent_overrides = resolved.config_overrides
+
+                # Plumb the failed task's contract through to the repair
+                # envelope. Without this the repair handler only sees the
+                # PRD + failure evidence and produces a generic "repair_output.md"
+                # rather than re-emitting the named artifact (e.g. qa_handoff.md)
+                # that originally failed acceptance.
+                failed_inputs = envelope.inputs or {}
+                repair_inputs: dict[str, Any] = {
+                    "prd": cycle.prd_ref,
+                    "failed_task_type": envelope.task_type,
+                    "failure_evidence": failure_evidence,
+                    "failure_analysis": analysis_outputs,
+                    "correction_decision": decision_outputs,
+                    "prior_outputs": prior_outputs,
+                    "artifact_refs": list(all_artifact_refs),
+                    "agent_model": agent_model,
+                    "agent_config_overrides": agent_overrides,
+                    "subtask_focus": failed_inputs.get("subtask_focus"),
+                    "subtask_description": failed_inputs.get("subtask_description"),
+                    "expected_artifacts": failed_inputs.get("expected_artifacts", []),
+                    "acceptance_criteria": failed_inputs.get("acceptance_criteria", []),
+                }
+
+                repair_envelope = TaskEnvelope(
+                    task_id=repair_task_id,
+                    agent_id=agent_id,
+                    cycle_id=cycle.cycle_id,
+                    pulse_id=uuid4().hex,
+                    project_id=cycle.project_id,
+                    task_type=task_type,
+                    correlation_id=corr_correlation_id,
+                    causation_id=envelope.task_id,
+                    trace_id=uuid4().hex,
+                    span_id=uuid4().hex,
+                    inputs=repair_inputs,
+                    metadata={"role": role, "step_index": step_idx},
+                )
+
+                # SIP-0087 B2: create repair task_run + propagate IDs through
+                # dispatch and terminal events so correction-driven repairs
+                # appear in the Prefect UI.
+                repair_task_run_id = await self._create_task_run(flow_run_id, repair_envelope)
+                repair_task_context = {
+                    "cycle_id": cycle.cycle_id,
+                    "run_id": run_id,
+                    "flow_run_id": flow_run_id or "",
+                    "task_run_id": repair_task_run_id or "",
+                }
+                self._event_bus.emit(
+                    EventType.TASK_DISPATCHED,
+                    entity_type="task",
+                    entity_id=repair_task_id,
+                    context=repair_task_context,
+                    payload={"task_type": task_type},
+                )
+
+                repair_result = await self._dispatch_task(
+                    repair_envelope,
+                    run_id,
+                    flow_run_id=flow_run_id,
+                    task_run_id=repair_task_run_id,
+                )
+
+                if repair_result.status == "SUCCEEDED":
+                    self._event_bus.emit(
+                        EventType.TASK_SUCCEEDED,
+                        entity_type="task",
+                        entity_id=repair_task_id,
+                        context=repair_task_context,
+                        payload={"task_type": task_type},
+                    )
+                    # Persist the repair task's output artifacts (e.g.
+                    # the regenerated qa_handoff.md from
+                    # builder.assemble_repair) before checkpointing.
+                    await self._store_correction_task_artifacts(
+                        repair_result,
+                        repair_envelope,
+                        cycle,
+                        run_id,
+                        all_artifact_refs,
+                        stored_artifacts,
+                    )
+                    await self._checkpoint_correction_task(
+                        repair_task_id,
+                        run_id,
+                        cycle,
+                        completed_task_ids,
+                        prior_outputs,
+                        all_artifact_refs,
+                        plan_delta_refs,
+                    )
+                else:
+                    self._event_bus.emit(
+                        EventType.TASK_FAILED,
+                        entity_type="task",
+                        entity_id=repair_task_id,
+                        context=repair_task_context,
+                        payload={"task_type": task_type, "error": repair_result.error or ""},
+                    )
+
+                # Collect repair outputs. Unlike the regular fan-in path
+                # (executor fan-in), keep `artifacts` so the next step in this
+                # sequence — `qa.validate_repair` — can see the actual
+                # repaired files rather than only the role-keyed one-line
+                # summary. Without this the qa role renders Verdict: FAIL
+                # on repairs whose artifacts are already in the registry,
+                # because the validate-repair prompt has no visibility
+                # into what the upstream repair handler produced.
+                role_key = repair_envelope.metadata.get("role", "unknown")
+                prior_outputs[role_key] = dict(repair_result.outputs or {})
+
+        # 8. Emit CORRECTION_COMPLETED
+        self._event_bus.emit(
+            EventType.CORRECTION_COMPLETED,
+            entity_type="run",
+            entity_id=run_id,
+            context={"cycle_id": cycle.cycle_id, "run_id": run_id},
+            payload={"correction_path": correction_path},
+        )
+
+        return correction_path

--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -145,6 +145,89 @@ class CorrectionRunner:
             },
         )
 
+    async def _dispatch_protocol_step(
+        self,
+        step_envelope: TaskEnvelope,
+        run_id: str,
+        cycle: Cycle,
+        flow_run_id: str | None,
+        *,
+        prior_outputs: dict[str, Any],
+        all_artifact_refs: list[str],
+        stored_artifacts: list[tuple[str, ArtifactRef]],
+        completed_task_ids: list[str],
+        plan_delta_refs: list[str],
+    ) -> TaskResult:
+        """Dispatch one correction/repair step and handle its outcome.
+
+        The shared per-step sequence both protocol loops used verbatim:
+        create the Prefect task_run (SIP-0087 B2), emit TASK_DISPATCHED,
+        dispatch, then on success emit TASK_SUCCEEDED + persist the step's
+        output artifacts BEFORE checkpointing (the silent-artifact-drop
+        guard), or on failure emit TASK_FAILED. Returns the step's result;
+        output collection stays with the caller (the two loops bucket
+        outputs differently — issue #95 vs. repair prior_outputs).
+        """
+        task_run_id = await self._create_task_run(flow_run_id, step_envelope)
+        task_context = {
+            "cycle_id": cycle.cycle_id,
+            "run_id": run_id,
+            "flow_run_id": flow_run_id or "",
+            "task_run_id": task_run_id or "",
+        }
+        self._event_bus.emit(
+            EventType.TASK_DISPATCHED,
+            entity_type="task",
+            entity_id=step_envelope.task_id,
+            context=task_context,
+            payload={"task_type": step_envelope.task_type},
+        )
+
+        result = await self._dispatch_task(
+            step_envelope,
+            run_id,
+            flow_run_id=flow_run_id,
+            task_run_id=task_run_id,
+        )
+
+        if result.status == "SUCCEEDED":
+            self._event_bus.emit(
+                EventType.TASK_SUCCEEDED,
+                entity_type="task",
+                entity_id=step_envelope.task_id,
+                context=task_context,
+                payload={"task_type": step_envelope.task_type},
+            )
+            # Persist the step's output artifacts BEFORE checkpointing —
+            # _checkpoint_correction_task only snapshots existing refs and
+            # would otherwise drop these silently.
+            await self._store_correction_task_artifacts(
+                result,
+                step_envelope,
+                cycle,
+                run_id,
+                all_artifact_refs,
+                stored_artifacts,
+            )
+            await self._checkpoint_correction_task(
+                step_envelope.task_id,
+                run_id,
+                cycle,
+                completed_task_ids,
+                prior_outputs,
+                all_artifact_refs,
+                plan_delta_refs,
+            )
+        else:
+            self._event_bus.emit(
+                EventType.TASK_FAILED,
+                entity_type="task",
+                entity_id=step_envelope.task_id,
+                context=task_context,
+                payload={"task_type": step_envelope.task_type, "error": result.error or ""},
+            )
+        return result
+
     async def run_correction_protocol(
         self,
         run_id: str,
@@ -234,68 +317,19 @@ class CorrectionRunner:
                 metadata={"role": role, "step_index": step_idx},
             )
 
-            # 3. Dispatch correction task. SIP-0087 B2: create task_run before
-            # dispatch so the agent's PrefectLogHandler can scope correction-
-            # task logs to a dedicated UI pane and the bridge can transition
-            # terminal state without owning the ID.
-            corr_task_run_id = await self._create_task_run(flow_run_id, corr_envelope)
-            corr_task_context = {
-                "cycle_id": cycle.cycle_id,
-                "run_id": run_id,
-                "flow_run_id": flow_run_id or "",
-                "task_run_id": corr_task_run_id or "",
-            }
-            self._event_bus.emit(
-                EventType.TASK_DISPATCHED,
-                entity_type="task",
-                entity_id=corr_task_id,
-                context=corr_task_context,
-                payload={"task_type": task_type},
-            )
-
-            corr_result = await self._dispatch_task(
+            # 3. Dispatch correction task (task_run creation + task events
+            # live in _dispatch_protocol_step, SIP-0087 B2).
+            corr_result = await self._dispatch_protocol_step(
                 corr_envelope,
                 run_id,
-                flow_run_id=flow_run_id,
-                task_run_id=corr_task_run_id,
+                cycle,
+                flow_run_id,
+                prior_outputs=prior_outputs,
+                all_artifact_refs=all_artifact_refs,
+                stored_artifacts=stored_artifacts,
+                completed_task_ids=completed_task_ids,
+                plan_delta_refs=plan_delta_refs,
             )
-
-            if corr_result.status == "SUCCEEDED":
-                self._event_bus.emit(
-                    EventType.TASK_SUCCEEDED,
-                    entity_type="task",
-                    entity_id=corr_task_id,
-                    context=corr_task_context,
-                    payload={"task_type": task_type},
-                )
-                # Persist the correction task's output artifacts BEFORE
-                # checkpointing — _checkpoint_correction_task only snapshots
-                # existing refs and would otherwise drop these silently.
-                await self._store_correction_task_artifacts(
-                    corr_result,
-                    corr_envelope,
-                    cycle,
-                    run_id,
-                    all_artifact_refs,
-                    stored_artifacts,
-                )
-                await self._checkpoint_correction_task(
-                    corr_task_id,
-                    run_id,
-                    cycle,
-                    completed_task_ids,
-                    prior_outputs,
-                    all_artifact_refs,
-                    plan_delta_refs,
-                )
-            else:
-                self._event_bus.emit(
-                    EventType.TASK_FAILED,
-                    entity_type="task",
-                    entity_id=corr_task_id,
-                    context=corr_task_context,
-                    payload={"task_type": task_type, "error": corr_result.error or ""},
-                )
 
             # Collect correction task outputs into the right named bucket so
             # downstream PlanDelta construction reads each field from the
@@ -411,67 +445,20 @@ class CorrectionRunner:
                     metadata={"role": role, "step_index": step_idx},
                 )
 
-                # SIP-0087 B2: create repair task_run + propagate IDs through
-                # dispatch and terminal events so correction-driven repairs
-                # appear in the Prefect UI.
-                repair_task_run_id = await self._create_task_run(flow_run_id, repair_envelope)
-                repair_task_context = {
-                    "cycle_id": cycle.cycle_id,
-                    "run_id": run_id,
-                    "flow_run_id": flow_run_id or "",
-                    "task_run_id": repair_task_run_id or "",
-                }
-                self._event_bus.emit(
-                    EventType.TASK_DISPATCHED,
-                    entity_type="task",
-                    entity_id=repair_task_id,
-                    context=repair_task_context,
-                    payload={"task_type": task_type},
-                )
-
-                repair_result = await self._dispatch_task(
+                # Dispatch the repair step (task_run creation + task events
+                # live in _dispatch_protocol_step, SIP-0087 B2 — so
+                # correction-driven repairs appear in the Prefect UI).
+                repair_result = await self._dispatch_protocol_step(
                     repair_envelope,
                     run_id,
-                    flow_run_id=flow_run_id,
-                    task_run_id=repair_task_run_id,
+                    cycle,
+                    flow_run_id,
+                    prior_outputs=prior_outputs,
+                    all_artifact_refs=all_artifact_refs,
+                    stored_artifacts=stored_artifacts,
+                    completed_task_ids=completed_task_ids,
+                    plan_delta_refs=plan_delta_refs,
                 )
-
-                if repair_result.status == "SUCCEEDED":
-                    self._event_bus.emit(
-                        EventType.TASK_SUCCEEDED,
-                        entity_type="task",
-                        entity_id=repair_task_id,
-                        context=repair_task_context,
-                        payload={"task_type": task_type},
-                    )
-                    # Persist the repair task's output artifacts (e.g.
-                    # the regenerated qa_handoff.md from
-                    # builder.assemble_repair) before checkpointing.
-                    await self._store_correction_task_artifacts(
-                        repair_result,
-                        repair_envelope,
-                        cycle,
-                        run_id,
-                        all_artifact_refs,
-                        stored_artifacts,
-                    )
-                    await self._checkpoint_correction_task(
-                        repair_task_id,
-                        run_id,
-                        cycle,
-                        completed_task_ids,
-                        prior_outputs,
-                        all_artifact_refs,
-                        plan_delta_refs,
-                    )
-                else:
-                    self._event_bus.emit(
-                        EventType.TASK_FAILED,
-                        entity_type="task",
-                        entity_id=repair_task_id,
-                        context=repair_task_context,
-                        payload={"task_type": task_type, "error": repair_result.error or ""},
-                    )
 
                 # Collect repair outputs. Unlike the regular fan-in path
                 # (executor fan-in), keep `artifacts` so the next step in this

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -23,6 +23,7 @@ from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from adapters.cycles.correction_runner import CorrectionRunner
 from adapters.cycles.execution_errors import (
     _CancellationError,
     _ExecutionError,
@@ -31,12 +32,10 @@ from adapters.cycles.execution_errors import (
 )
 from adapters.cycles.run_completion import RunCompletion, resolve_terminal_outcome
 from adapters.cycles.task_naming import build_task_name
-from squadops.cycles.agent_config import build_agent_resolver, resolve_agent_config
+from squadops.cycles.agent_config import build_agent_resolver
 from squadops.cycles.checkpoint import RunCheckpoint
-from squadops.cycles.failure_evidence import build_failure_evidence, compose_failure_trigger
 from squadops.cycles.models import ArtifactRef, Cycle, GateDecisionValue, Run, RunStatus
 from squadops.cycles.naming import flow_run_name
-from squadops.cycles.plan_delta import PlanDelta
 from squadops.cycles.pulse_models import (
     CADENCE_BOUNDARY_ID,
     CadencePolicy,
@@ -110,6 +109,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         activity_port: RuntimeActivityPort | None = None,
         coordinator: RuntimeCoordinator | None = None,
         run_completion: RunCompletion | None = None,
+        correction_runner: CorrectionRunner | None = None,
     ) -> None:
         self._cycle_registry = cycle_registry
         self._artifact_vault = artifact_vault
@@ -153,6 +153,27 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
             event_bus = NoOpCycleEventBus()
         self._cycle_event_bus = event_bus
+        # SIP-0097 §6.3: correction-protocol collaborator. Plain injected
+        # collaborator with a default composed from this executor's own deps.
+        # The three callables are the sanctioned interim seam (slice 3 <
+        # slice 5): dispatch_task/create_task_run are re-pointed to
+        # TaskDispatcher in slice 5 (AC#9); store_artifact stays
+        # executor-supplied (artifact plumbing is §6.7 residual). Late-bound
+        # lambdas (not captured bound methods) so the runner always sees the
+        # executor's *current* dispatch — tests stub `_dispatch_task` on the
+        # instance.
+        self._correction_runner = correction_runner or CorrectionRunner(
+            cycle_registry=cycle_registry,
+            artifact_vault=artifact_vault,
+            event_bus=event_bus,
+            dispatch_task=lambda envelope, run_id, **kw: self._dispatch_task(
+                envelope, run_id, **kw
+            ),
+            create_task_run=lambda flow_run_id, envelope: self._create_task_run_if_enabled(
+                flow_run_id, envelope
+            ),
+            store_artifact=lambda *args, **kw: self._store_artifact(*args, **kw),
+        )
         # SIP-0097 §6.6: per-run pulse summaries live on the RunLedger created
         # in execute_run() and passed explicitly; multi-workload forwarding
         # overrides are threaded execute_cycle() → execute_run() as a
@@ -1626,7 +1647,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         if correction_attempts >= max_corrections:
             raise _ExecutionError(f"Max correction attempts ({max_corrections}) exhausted")
 
-        correction_path = await self._run_correction_protocol(
+        correction_path = await self._correction_runner.run_correction_protocol(
             run_id=run_id,
             cycle=cycle,
             envelope=envelope,
@@ -1904,440 +1925,6 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 logger.warning("Prefect flow run creation failed", exc_info=True)
 
         return obs_ctx, flow_run_id
-
-    # ------------------------------------------------------------------
-    # Extracted helpers for _run_correction_protocol
-    # ------------------------------------------------------------------
-
-    async def _store_correction_task_artifacts(
-        self,
-        result: TaskResult,
-        envelope: TaskEnvelope,
-        cycle: Cycle,
-        run_id: str,
-        all_artifact_refs: list[str],
-        stored_artifacts: list[tuple[str, ArtifactRef]],
-    ) -> None:
-        """Persist a correction-task or repair-task's output artifacts.
-
-        Mirrors the artifact-storage loop in
-        ``_collect_artifacts_and_checkpoint`` but is split out so the
-        correction/repair success branches can call it before
-        ``_checkpoint_correction_task`` — which only snapshots existing
-        ``all_artifact_refs`` into a checkpoint and does not itself
-        persist new artifacts. Without this call, repaired deliverables
-        (e.g. the ``qa_handoff.md`` produced by ``builder.assemble_repair``
-        or the ``correction_decision.md`` from the correction protocol)
-        never reach the artifact registry, even though the cycle marks
-        completed and the run_report counts them as repaired. This was
-        observed across cycles 4b, 6, and prior gate-batch runs as the
-        recurring "silent artifact-drop" pattern.
-        """
-        new_refs: list[str] = []
-        for art in (result.outputs or {}).get("artifacts", []):
-            ref = await self._store_artifact(
-                art,
-                cycle,
-                run_id,
-                envelope,
-                producing_task_type=envelope.task_type,
-            )
-            new_refs.append(ref.artifact_id)
-            all_artifact_refs.append(ref.artifact_id)
-            stored_artifacts.append((ref.artifact_id, ref))
-
-        if new_refs:
-            await self._cycle_registry.append_artifact_refs(run_id, tuple(new_refs))
-
-    async def _checkpoint_correction_task(
-        self,
-        task_id: str,
-        run_id: str,
-        cycle: Cycle,
-        completed_task_ids: list[str],
-        prior_outputs: dict[str, Any],
-        all_artifact_refs: list[str],
-        plan_delta_refs: list[str],
-    ) -> None:
-        """Checkpoint a correction or repair task after successful dispatch."""
-        completed_task_ids.append(task_id)
-        checkpoint_index = len(completed_task_ids)
-        new_checkpoint = RunCheckpoint(
-            run_id=run_id,
-            checkpoint_index=checkpoint_index,
-            completed_task_ids=tuple(completed_task_ids),
-            prior_outputs=dict(prior_outputs),
-            artifact_refs=tuple(all_artifact_refs),
-            plan_delta_refs=tuple(plan_delta_refs),
-            created_at=datetime.now(UTC),
-        )
-        await self._cycle_registry.save_checkpoint(new_checkpoint)
-        self._cycle_event_bus.emit(
-            EventType.CHECKPOINT_CREATED,
-            entity_type="run",
-            entity_id=run_id,
-            context={"cycle_id": cycle.cycle_id, "run_id": run_id},
-            payload={
-                "checkpoint_index": checkpoint_index,
-                "completed_task_id": task_id,
-            },
-        )
-
-    # ------------------------------------------------------------------
-    # Correction protocol
-    # ------------------------------------------------------------------
-
-    async def _run_correction_protocol(
-        self,
-        run_id: str,
-        cycle: Cycle,
-        envelope: TaskEnvelope,
-        result: TaskResult,
-        correction_attempts: int,
-        prior_outputs: dict[str, Any],
-        all_artifact_refs: list[str],
-        stored_artifacts: list[tuple[str, ArtifactRef]],
-        completed_task_ids: list[str],
-        plan_delta_refs: list[str],
-        profile: Any = None,
-        flow_run_id: str | None = None,
-    ) -> str:
-        """Run the correction protocol: analyze → decide → act.
-
-        Returns the correction_path chosen by the governance handler.
-        Side effects: dispatches correction/repair tasks, stores plan delta,
-        emits correction events.
-        """
-        from uuid import uuid4
-
-        from squadops.cycles.task_plan import CORRECTION_TASK_STEPS, repair_steps_for
-
-        # 1. Emit CORRECTION_INITIATED
-        self._cycle_event_bus.emit(
-            EventType.CORRECTION_INITIATED,
-            entity_type="run",
-            entity_id=run_id,
-            context={"cycle_id": cycle.cycle_id, "run_id": run_id},
-            payload={
-                "failed_task_id": envelope.task_id,
-                "failed_task_type": envelope.task_type,
-                "correction_attempt": correction_attempts + 1,
-            },
-        )
-
-        # 2. Build correction task envelopes (deterministic IDs)
-        failure_evidence = build_failure_evidence(
-            envelope, result, prior_plan_deltas_count=len(plan_delta_refs)
-        )
-
-        # Issue #95: capture each correction step's outputs in its own variable
-        # so the analyzer's classification/analysis_summary survive past the
-        # subsequent governance.correction_decision step (which doesn't carry
-        # those fields forward). Reusing a single variable used to mask the
-        # analyzer's diagnosis with defaults at PlanDelta time.
-        analysis_outputs: dict[str, Any] = {}
-        decision_outputs: dict[str, Any] = {}
-        corr_correlation_id = uuid4().hex
-
-        for step_idx, (task_type, role) in enumerate(CORRECTION_TASK_STEPS):
-            corr_task_id = f"corr-{run_id[:12]}-{correction_attempts:02d}-{task_type}"
-            resolved = resolve_agent_config(role, profile)
-            agent_id = resolved.agent_id
-            agent_model = resolved.model
-            agent_overrides = resolved.config_overrides
-
-            # Issue #110: propagate squad-profile model + overrides so
-            # correction-loop reasoning runs on the cycle's specified model
-            # (e.g. the `full` profile pins data/lead to qwen3.6:27b)
-            # rather than the agent container's instance default.
-            corr_inputs: dict[str, Any] = {
-                "prd": cycle.prd_ref,
-                "failure_evidence": failure_evidence,
-                "prior_outputs": prior_outputs,
-                "artifact_refs": list(all_artifact_refs),
-                "agent_model": agent_model,
-                "agent_config_overrides": agent_overrides,
-            }
-            if analysis_outputs:
-                corr_inputs["failure_analysis"] = analysis_outputs
-
-            corr_envelope = TaskEnvelope(
-                task_id=corr_task_id,
-                agent_id=agent_id,
-                cycle_id=cycle.cycle_id,
-                pulse_id=uuid4().hex,
-                project_id=cycle.project_id,
-                task_type=task_type,
-                correlation_id=corr_correlation_id,
-                causation_id=envelope.task_id,
-                trace_id=uuid4().hex,
-                span_id=uuid4().hex,
-                inputs=corr_inputs,
-                metadata={"role": role, "step_index": step_idx},
-            )
-
-            # 3. Dispatch correction task. SIP-0087 B2: create task_run before
-            # dispatch so the agent's PrefectLogHandler can scope correction-
-            # task logs to a dedicated UI pane and the bridge can transition
-            # terminal state without owning the ID.
-            corr_task_run_id = await self._create_task_run_if_enabled(flow_run_id, corr_envelope)
-            corr_task_context = {
-                "cycle_id": cycle.cycle_id,
-                "run_id": run_id,
-                "flow_run_id": flow_run_id or "",
-                "task_run_id": corr_task_run_id or "",
-            }
-            self._cycle_event_bus.emit(
-                EventType.TASK_DISPATCHED,
-                entity_type="task",
-                entity_id=corr_task_id,
-                context=corr_task_context,
-                payload={"task_type": task_type},
-            )
-
-            corr_result = await self._dispatch_task(
-                corr_envelope,
-                run_id,
-                flow_run_id=flow_run_id,
-                task_run_id=corr_task_run_id,
-            )
-
-            if corr_result.status == "SUCCEEDED":
-                self._cycle_event_bus.emit(
-                    EventType.TASK_SUCCEEDED,
-                    entity_type="task",
-                    entity_id=corr_task_id,
-                    context=corr_task_context,
-                    payload={"task_type": task_type},
-                )
-                # Persist the correction task's output artifacts BEFORE
-                # checkpointing — _checkpoint_correction_task only snapshots
-                # existing refs and would otherwise drop these silently.
-                await self._store_correction_task_artifacts(
-                    corr_result,
-                    corr_envelope,
-                    cycle,
-                    run_id,
-                    all_artifact_refs,
-                    stored_artifacts,
-                )
-                await self._checkpoint_correction_task(
-                    corr_task_id,
-                    run_id,
-                    cycle,
-                    completed_task_ids,
-                    prior_outputs,
-                    all_artifact_refs,
-                    plan_delta_refs,
-                )
-            else:
-                self._cycle_event_bus.emit(
-                    EventType.TASK_FAILED,
-                    entity_type="task",
-                    entity_id=corr_task_id,
-                    context=corr_task_context,
-                    payload={"task_type": task_type, "error": corr_result.error or ""},
-                )
-
-            # Collect correction task outputs into the right named bucket so
-            # downstream PlanDelta construction reads each field from the
-            # handler that owns it (issue #95).
-            step_outputs = {
-                k: v for k, v in (corr_result.outputs or {}).items() if k != "artifacts"
-            }
-            if task_type == "data.analyze_failure":
-                analysis_outputs = step_outputs
-            elif task_type == "governance.correction_decision":
-                decision_outputs = step_outputs
-
-        # 4. Read correction_path
-        correction_path = decision_outputs.get("correction_path", "abort")
-
-        # 5. Emit CORRECTION_DECIDED
-        self._cycle_event_bus.emit(
-            EventType.CORRECTION_DECIDED,
-            entity_type="run",
-            entity_id=run_id,
-            context={"cycle_id": cycle.cycle_id, "run_id": run_id},
-            payload={
-                "correction_path": correction_path,
-                "decision_rationale": decision_outputs.get("decision_rationale", ""),
-            },
-        )
-
-        # 6. Store plan delta as artifact
-        delta = PlanDelta(
-            delta_id=uuid4().hex,
-            run_id=run_id,
-            correction_path=correction_path,
-            trigger=compose_failure_trigger(envelope, failure_evidence),
-            failure_classification=analysis_outputs.get("classification", "unknown"),
-            analysis_summary=analysis_outputs.get("analysis_summary", "N/A"),
-            decision_rationale=decision_outputs.get("decision_rationale", "N/A"),
-            changes=tuple(decision_outputs.get("affected_task_types", [])),
-            affected_task_types=tuple(decision_outputs.get("affected_task_types", [])),
-            created_at=datetime.now(UTC),
-            # SIP-0092 M2 → M3 gate diagnostic.
-            structural_plan_change_candidate=str(
-                decision_outputs.get("structural_plan_change_candidate", "none")
-            ),
-            structural_plan_change_rationale=str(
-                decision_outputs.get("structural_plan_change_rationale", "")
-            ),
-        )
-        delta_content = json.dumps(delta.to_dict(), default=str).encode()
-        delta_ref = ArtifactRef(
-            artifact_id=f"delta_{delta.delta_id[:12]}",
-            project_id=cycle.project_id,
-            artifact_type="plan_delta",
-            filename=f"plan_delta_{correction_attempts}.json",
-            content_hash=sha256(delta_content).hexdigest(),
-            size_bytes=len(delta_content),
-            media_type="application/json",
-            created_at=datetime.now(UTC),
-            cycle_id=cycle.cycle_id,
-            run_id=run_id,
-        )
-        await self._artifact_vault.store(delta_ref, delta_content)
-        all_artifact_refs.append(delta_ref.artifact_id)
-        plan_delta_refs.append(delta_ref.artifact_id)
-
-        # 7. Handle patch path: dispatch repair tasks
-        # Repair-step selection is keyed on the failed task's task_type
-        # (authoritative) rather than the LLM-emitted `affected_task_types`
-        # field, which is free-text and previously caused builder failures
-        # (`affected_task_types: ["QA Handoff"]`) to silently route to the
-        # dev repair handler.
-        if correction_path == "patch":
-            for step_idx, (task_type, role) in enumerate(repair_steps_for(envelope.task_type)):
-                repair_task_id = f"repair-{run_id[:12]}-{correction_attempts:02d}-{task_type}"
-                resolved = resolve_agent_config(role, profile)
-                agent_id = resolved.agent_id
-                agent_model = resolved.model
-                agent_overrides = resolved.config_overrides
-
-                # Plumb the failed task's contract through to the repair
-                # envelope. Without this the repair handler only sees the
-                # PRD + failure evidence and produces a generic "repair_output.md"
-                # rather than re-emitting the named artifact (e.g. qa_handoff.md)
-                # that originally failed acceptance.
-                failed_inputs = envelope.inputs or {}
-                repair_inputs: dict[str, Any] = {
-                    "prd": cycle.prd_ref,
-                    "failed_task_type": envelope.task_type,
-                    "failure_evidence": failure_evidence,
-                    "failure_analysis": analysis_outputs,
-                    "correction_decision": decision_outputs,
-                    "prior_outputs": prior_outputs,
-                    "artifact_refs": list(all_artifact_refs),
-                    "agent_model": agent_model,
-                    "agent_config_overrides": agent_overrides,
-                    "subtask_focus": failed_inputs.get("subtask_focus"),
-                    "subtask_description": failed_inputs.get("subtask_description"),
-                    "expected_artifacts": failed_inputs.get("expected_artifacts", []),
-                    "acceptance_criteria": failed_inputs.get("acceptance_criteria", []),
-                }
-
-                repair_envelope = TaskEnvelope(
-                    task_id=repair_task_id,
-                    agent_id=agent_id,
-                    cycle_id=cycle.cycle_id,
-                    pulse_id=uuid4().hex,
-                    project_id=cycle.project_id,
-                    task_type=task_type,
-                    correlation_id=corr_correlation_id,
-                    causation_id=envelope.task_id,
-                    trace_id=uuid4().hex,
-                    span_id=uuid4().hex,
-                    inputs=repair_inputs,
-                    metadata={"role": role, "step_index": step_idx},
-                )
-
-                # SIP-0087 B2: create repair task_run + propagate IDs through
-                # dispatch and terminal events so correction-driven repairs
-                # appear in the Prefect UI.
-                repair_task_run_id = await self._create_task_run_if_enabled(
-                    flow_run_id, repair_envelope
-                )
-                repair_task_context = {
-                    "cycle_id": cycle.cycle_id,
-                    "run_id": run_id,
-                    "flow_run_id": flow_run_id or "",
-                    "task_run_id": repair_task_run_id or "",
-                }
-                self._cycle_event_bus.emit(
-                    EventType.TASK_DISPATCHED,
-                    entity_type="task",
-                    entity_id=repair_task_id,
-                    context=repair_task_context,
-                    payload={"task_type": task_type},
-                )
-
-                repair_result = await self._dispatch_task(
-                    repair_envelope,
-                    run_id,
-                    flow_run_id=flow_run_id,
-                    task_run_id=repair_task_run_id,
-                )
-
-                if repair_result.status == "SUCCEEDED":
-                    self._cycle_event_bus.emit(
-                        EventType.TASK_SUCCEEDED,
-                        entity_type="task",
-                        entity_id=repair_task_id,
-                        context=repair_task_context,
-                        payload={"task_type": task_type},
-                    )
-                    # Persist the repair task's output artifacts (e.g.
-                    # the regenerated qa_handoff.md from
-                    # builder.assemble_repair) before checkpointing.
-                    await self._store_correction_task_artifacts(
-                        repair_result,
-                        repair_envelope,
-                        cycle,
-                        run_id,
-                        all_artifact_refs,
-                        stored_artifacts,
-                    )
-                    await self._checkpoint_correction_task(
-                        repair_task_id,
-                        run_id,
-                        cycle,
-                        completed_task_ids,
-                        prior_outputs,
-                        all_artifact_refs,
-                        plan_delta_refs,
-                    )
-                else:
-                    self._cycle_event_bus.emit(
-                        EventType.TASK_FAILED,
-                        entity_type="task",
-                        entity_id=repair_task_id,
-                        context=repair_task_context,
-                        payload={"task_type": task_type, "error": repair_result.error or ""},
-                    )
-
-                # Collect repair outputs. Unlike the regular fan-in path
-                # (line ~1525), keep `artifacts` so the next step in this
-                # sequence — `qa.validate_repair` — can see the actual
-                # repaired files rather than only the role-keyed one-line
-                # summary. Without this the qa role renders Verdict: FAIL
-                # on repairs whose artifacts are already in the registry,
-                # because the validate-repair prompt has no visibility
-                # into what the upstream repair handler produced.
-                role_key = repair_envelope.metadata.get("role", "unknown")
-                prior_outputs[role_key] = dict(repair_result.outputs or {})
-
-        # 8. Emit CORRECTION_COMPLETED
-        self._cycle_event_bus.emit(
-            EventType.CORRECTION_COMPLETED,
-            entity_type="run",
-            entity_id=run_id,
-            context={"cycle_id": cycle.cycle_id, "run_id": run_id},
-            payload={"correction_path": correction_path},
-        )
-
-        return correction_path
 
     async def _execute_fan_out(
         self,

--- a/tests/unit/cycles/test_correction_protocol.py
+++ b/tests/unit/cycles/test_correction_protocol.py
@@ -154,6 +154,9 @@ def executor(
 
     mock_registry.get_cycle.return_value = cycle
     mock_registry.get_run.return_value = run
+    # SIP-0097 slice 3: the event bus must be passed at construction — the
+    # default CorrectionRunner captures it in __init__, so a post-hoc
+    # `ex._cycle_event_bus = ...` assignment would not reach correction events.
     ex = DispatchedFlowExecutor(
         cycle_registry=mock_registry,
         artifact_vault=mock_vault,
@@ -161,8 +164,8 @@ def executor(
         squad_profile=mock_squad_profile,
         task_timeout=5.0,
         reply_router=mock_queue.reply_router,
+        event_bus=mock_event_bus,
     )
-    ex._cycle_event_bus = mock_event_bus
     return ex
 
 
@@ -388,7 +391,7 @@ class TestCorrectionTaskArtifactStorage:
 
         all_refs: list[str] = []
         stored: list = []
-        await executor._store_correction_task_artifacts(
+        await executor._correction_runner._store_correction_task_artifacts(
             result, envelope, cycle, "run_x", all_refs, stored
         )
 
@@ -445,7 +448,7 @@ class TestCorrectionTaskArtifactStorage:
 
         all_refs: list[str] = []
         stored: list = []
-        await executor._store_correction_task_artifacts(
+        await executor._correction_runner._store_correction_task_artifacts(
             result, envelope, cycle, "run_x", all_refs, stored
         )
 

--- a/tests/unit/cycles/test_correction_repair_prefect_propagation.py
+++ b/tests/unit/cycles/test_correction_repair_prefect_propagation.py
@@ -7,8 +7,9 @@ have no Prefect task pane and the bridge can't transition terminal state —
 acceptance criterion §7.5 ("manifest retry events appear in
 governance.review_plan task pane") is unreachable.
 
-These tests drive ``_run_correction_protocol`` and ``_verify_with_repair``
-directly and pin the contract by inspecting the spied call args of
+These tests drive ``CorrectionRunner.run_correction_protocol`` (via the
+executor's composed default) and ``_verify_with_repair`` directly and pin
+the contract by inspecting the spied call args of
 ``_create_task_run_if_enabled`` / ``_dispatch_task`` / event emissions.
 """
 
@@ -89,6 +90,9 @@ def _make_executor(mock_prefect_workflow_tracker, reply_router):
     vault.store.side_effect = lambda ref, _content: ref
     queue = AsyncMock()
     squad = AsyncMock()
+    # SIP-0097 slice 3: the event bus must be passed at construction — the
+    # default CorrectionRunner captures it in __init__, so a post-hoc
+    # `ex._cycle_event_bus = ...` assignment would not reach correction events.
     ex = DispatchedFlowExecutor(
         cycle_registry=registry,
         artifact_vault=vault,
@@ -97,8 +101,8 @@ def _make_executor(mock_prefect_workflow_tracker, reply_router):
         task_timeout=5.0,
         workflow_tracker=mock_prefect_workflow_tracker,
         reply_router=reply_router,
+        event_bus=MagicMock(),
     )
-    ex._cycle_event_bus = MagicMock()
     return ex
 
 
@@ -108,7 +112,7 @@ def _make_executor(mock_prefect_workflow_tracker, reply_router):
 
 
 class TestCorrectionTaskRunPropagation:
-    """`_run_correction_protocol` must create Prefect task_runs for each
+    """`run_correction_protocol` must create Prefect task_runs for each
     correction step and tag every emitted task event with both run IDs."""
 
     async def test_correction_steps_create_task_runs_and_emit_full_context(
@@ -150,7 +154,7 @@ class TestCorrectionTaskRunPropagation:
 
         ex._dispatch_task = fake_dispatch
 
-        await ex._run_correction_protocol(
+        await ex._correction_runner.run_correction_protocol(
             run_id="run_001",
             cycle=cycle,
             envelope=failed_envelope,
@@ -204,7 +208,7 @@ class TestCorrectionTaskRunPropagation:
 
         ex._dispatch_task = succeed
 
-        await ex._run_correction_protocol(
+        await ex._correction_runner.run_correction_protocol(
             run_id="run_001",
             cycle=cycle,
             envelope=failed_envelope,
@@ -266,7 +270,7 @@ class TestCorrectionPatchRepairTaskRunPropagation:
 
         ex._dispatch_task = fake_dispatch
 
-        await ex._run_correction_protocol(
+        await ex._correction_runner.run_correction_protocol(
             run_id="run_001",
             cycle=cycle,
             envelope=failed_envelope,

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -1,8 +1,12 @@
-"""Tests for SIP-0079 correction protocol in DispatchedFlowExecutor.
+"""Tests for the SIP-0079 correction protocol, owned by ``CorrectionRunner``
+since SIP-0097 slice 3 (renamed from test_correction_protocol.py).
 
 Covers all 4 correction paths (continue, patch, rewind, abort),
 plan delta storage, max_correction_attempts, correction task checkpointing,
-and CORRECTION_INITIATED/DECIDED/COMPLETED event emission.
+and CORRECTION_INITIATED/DECIDED/COMPLETED event emission. Most tests drive
+the protocol end-to-end through the executor (which composes the default
+runner); ``TestCorrectionRunnerStandalone`` constructs the collaborator
+directly, without a ``DispatchedFlowExecutor`` instance (SIP-0097 §9).
 """
 
 from __future__ import annotations
@@ -1349,3 +1353,203 @@ class TestCorrectionModelResolution:
         assert inputs["subtask_focus"] == "QA handoff packaging"
         assert inputs["failure_analysis"]["analysis_summary"] == "Missing '## How to Test'"
         assert inputs["correction_decision"]["correction_path"] == "patch"
+
+
+# ---------------------------------------------------------------------------
+# Standalone construction (SIP-0097 §9): the collaborator is instantiable and
+# testable without a DispatchedFlowExecutor instance
+# ---------------------------------------------------------------------------
+
+
+class TestCorrectionRunnerStandalone:
+    """Drive run_correction_protocol on a directly-constructed CorrectionRunner
+    with scripted callables — no executor anywhere."""
+
+    def _make_runner(self, responder, vault=None, registry=None, bus=None):
+        """Build a CorrectionRunner whose dispatch callable answers via
+        ``responder(envelope) -> TaskResult`` and whose store_artifact
+        callable records what would be persisted."""
+        from adapters.cycles.correction_runner import CorrectionRunner
+        from squadops.cycles.models import ArtifactRef
+
+        registry = registry or AsyncMock()
+        vault = vault or AsyncMock()
+        vault.store.side_effect = lambda ref, _content: ref
+        bus = bus or MagicMock()
+
+        async def dispatch_task(envelope, run_id, **_kwargs):
+            return responder(envelope)
+
+        async def create_task_run(_flow_run_id, _envelope):
+            return None
+
+        async def store_artifact(art, cycle, run_id, envelope, producing_task_type=None):
+            content = art.get("content", "").encode()
+            ref = ArtifactRef(
+                artifact_id=f"art_{envelope.task_id}",
+                project_id=cycle.project_id,
+                artifact_type=art.get("type", "document"),
+                filename=art["name"],
+                content_hash="h",
+                size_bytes=len(content),
+                media_type=art.get("media_type", "text/markdown"),
+                created_at=NOW,
+                cycle_id=cycle.cycle_id,
+                run_id=run_id,
+            )
+            return await vault.store(ref, content)
+
+        runner = CorrectionRunner(
+            cycle_registry=registry,
+            artifact_vault=vault,
+            event_bus=bus,
+            dispatch_task=dispatch_task,
+            create_task_run=create_task_run,
+            store_artifact=store_artifact,
+        )
+        return runner, registry, vault, bus
+
+    def _failed_envelope(self):
+        from squadops.tasks.models import TaskEnvelope
+
+        return TaskEnvelope(
+            task_id="task_failed",
+            agent_id="neo",
+            cycle_id="cyc_001",
+            pulse_id="p",
+            project_id="hello_squad",
+            task_type="development.implement",
+            correlation_id="corr",
+            causation_id=None,
+            trace_id="t",
+            span_id="s",
+            inputs={},
+            metadata={"role": "dev"},
+        )
+
+    async def test_analysis_fields_survive_to_plan_delta(self, cycle):
+        """Issue #95 regression, executor-free: the analyzer's classification
+        and analysis_summary must reach the PlanDelta even though the
+        subsequent governance.correction_decision step doesn't carry them."""
+
+        def responder(envelope):
+            if envelope.task_type == "data.analyze_failure":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "classification": "work_product",
+                        "analysis_summary": "missing acceptance section",
+                    },
+                )
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "continue",
+                        "decision_rationale": "retry remaining",
+                    },
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, vault, _bus = self._make_runner(responder)
+        plan_delta_refs: list[str] = []
+
+        path = await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=self._failed_envelope(),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="bad"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=plan_delta_refs,
+        )
+
+        assert path == "continue"
+        assert len(plan_delta_refs) == 1
+        delta_calls = [
+            c for c in vault.store.call_args_list if c.args[0].artifact_type == "plan_delta"
+        ]
+        assert len(delta_calls) == 1
+        delta = json.loads(delta_calls[0].args[1])
+        assert delta["failure_classification"] == "work_product"
+        assert delta["analysis_summary"] == "missing acceptance section"
+        assert delta["correction_path"] == "continue"
+
+    async def test_missing_decision_defaults_to_abort(self, cycle):
+        """Edge case: a decision step that returns no correction_path must
+        yield "abort" (never a silent continue) — and still emit the full
+        CORRECTION_INITIATED → DECIDED → COMPLETED lifecycle."""
+
+        def responder(envelope):
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, _vault, bus = self._make_runner(responder)
+
+        path = await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=self._failed_envelope(),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="bad"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+        assert path == "abort"
+        emitted = [c.args[0] for c in bus.emit.call_args_list]
+        assert EventType.CORRECTION_INITIATED in emitted
+        assert EventType.CORRECTION_DECIDED in emitted
+        assert EventType.CORRECTION_COMPLETED in emitted
+
+    async def test_failed_step_emits_task_failed_and_skips_checkpoint(self, cycle):
+        """Error path: a correction step that FAILs must emit TASK_FAILED and
+        must NOT be checkpointed as completed (only succeeded steps are)."""
+
+        def responder(envelope):
+            if envelope.task_type == "data.analyze_failure":
+                return TaskResult(
+                    task_id=envelope.task_id, status="FAILED", error="analyzer crashed"
+                )
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={"correction_path": "continue"},
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, registry, _vault, bus = self._make_runner(responder)
+        completed: list[str] = []
+
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=self._failed_envelope(),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="bad"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=completed,
+            plan_delta_refs=[],
+        )
+
+        failed_events = [
+            c for c in bus.emit.call_args_list if c.args and c.args[0] == EventType.TASK_FAILED
+        ]
+        assert len(failed_events) == 1
+        assert failed_events[0].kwargs["payload"]["error"] == "analyzer crashed"
+        # The failed analyzer step is not in completed_task_ids; the
+        # succeeding decision step is.
+        assert not any("data.analyze_failure" in t for t in completed)
+        assert any("governance.correction_decision" in t for t in completed)
+        # One checkpoint saved (decision step only).
+        assert registry.save_checkpoint.await_count == 1

--- a/tests/unit/events/test_event_emission.py
+++ b/tests/unit/events/test_event_emission.py
@@ -51,9 +51,11 @@ def _find_event_type_refs_in_file(filepath: Path) -> set[str]:
 # Source files that contain emit() calls (or decide the event type an emit
 # call uses — SIP-0097 slice 2 moved the run-terminal mapping, and its
 # EventType references, to the RunCompletion module; the executor's single
-# collapsed handler emits what the mapping decides)
+# collapsed handler emits what the mapping decides. Slice 3 moved the
+# correction protocol, and its emit sites, to the CorrectionRunner module.)
 _EXECUTOR_PATH = Path("adapters/cycles/dispatched_flow_executor.py")
 _RUN_COMPLETION_PATH = Path("adapters/cycles/run_completion.py")
+_CORRECTION_RUNNER_PATH = Path("adapters/cycles/correction_runner.py")
 _CYCLES_ROUTE = Path("src/squadops/api/routes/cycles/cycles.py")
 _RUNS_ROUTE = Path("src/squadops/api/routes/cycles/runs.py")
 _ARTIFACTS_ROUTE = Path("src/squadops/api/routes/cycles/artifacts.py")
@@ -61,6 +63,7 @@ _ARTIFACTS_ROUTE = Path("src/squadops/api/routes/cycles/artifacts.py")
 _ALL_EMISSION_FILES = [
     _EXECUTOR_PATH,
     _RUN_COMPLETION_PATH,
+    _CORRECTION_RUNNER_PATH,
     _CYCLES_ROUTE,
     _RUNS_ROUTE,
     _ARTIFACTS_ROUTE,
@@ -122,9 +125,6 @@ class TestExecutorEmissionPoints:
             "PULSE_REPAIR_EXHAUSTED",
             "CHECKPOINT_CREATED",
             "CHECKPOINT_RESTORED",
-            "CORRECTION_INITIATED",
-            "CORRECTION_DECIDED",
-            "CORRECTION_COMPLETED",
             "WORKLOAD_COMPLETED",
             "WORKLOAD_GATE_AWAITING",
             "WORKLOAD_ADVANCED",
@@ -133,12 +133,15 @@ class TestExecutorEmissionPoints:
     def test_executor_emits(self, attr: str, executor_refs: set[str]) -> None:
         assert attr in executor_refs
 
-    def test_executor_has_20_types(self, executor_refs: set[str]) -> None:
-        """20 = the former 22 minus RUN_FAILED/RUN_CANCELLED, whose static
-        references moved to the run-completion terminal mapping (SIP-0097
-        slice 2c). RUN_PAUSED stays: the duty-deferral path still references
-        it directly in the executor."""
-        assert len(executor_refs) == 20
+    def test_executor_has_17_types(self, executor_refs: set[str]) -> None:
+        """17 = the former 20 minus CORRECTION_INITIATED/DECIDED/COMPLETED,
+        which moved to the CorrectionRunner with the correction protocol
+        (SIP-0097 slice 3). CHECKPOINT_CREATED and TASK_DISPATCHED/
+        SUCCEEDED/FAILED stay: the sequential loop and
+        _collect_artifacts_and_checkpoint still emit them for regular tasks.
+        RUN_PAUSED stays: the duty-deferral path still references it directly
+        in the executor."""
+        assert len(executor_refs) == 17
 
 
 class TestRunCompletionEmissionPoints:
@@ -152,6 +155,32 @@ class TestRunCompletionEmissionPoints:
     @pytest.mark.parametrize("attr", ["RUN_CANCELLED", "RUN_PAUSED", "RUN_FAILED"])
     def test_terminal_mapping_covers(self, attr: str, run_completion_refs: set[str]) -> None:
         assert attr in run_completion_refs
+
+
+class TestCorrectionRunnerEmissionPoints:
+    """The correction protocol's events are emitted by the CorrectionRunner
+    (SIP-0097 §6.3): the CORRECTION_* lifecycle, per-step TASK_* events for
+    correction/repair dispatches, and CHECKPOINT_CREATED for each successful
+    step."""
+
+    @pytest.fixture(scope="class")
+    def correction_runner_refs(self) -> set[str]:
+        return _find_event_type_refs_in_file(_CORRECTION_RUNNER_PATH)
+
+    @pytest.mark.parametrize(
+        "attr",
+        [
+            "CORRECTION_INITIATED",
+            "CORRECTION_DECIDED",
+            "CORRECTION_COMPLETED",
+            "TASK_DISPATCHED",
+            "TASK_SUCCEEDED",
+            "TASK_FAILED",
+            "CHECKPOINT_CREATED",
+        ],
+    )
+    def test_correction_runner_emits(self, attr: str, correction_runner_refs: set[str]) -> None:
+        assert attr in correction_runner_refs
 
 
 class TestRouteEmissionPoints:
@@ -246,13 +275,15 @@ class TestEmitCallSitePayloadFields:
         assert with_payload >= 38
 
     def test_total_emit_call_count(self) -> None:
-        """Sanity check: 37 executor + 7 route = 44 total emit calls.
+        """Sanity check: 27 executor + 10 correction-runner + 7 route = 44
+        total emit calls.
 
         SIP-0097 slice 2c collapsed execute_run's five per-exception-class
-        terminal emits (cancelled / recruitment-deferral paused / paused /
-        execution-failed / unexpected-failed) into one emit driven by the
-        RunCompletion terminal mapping — same events at runtime, 4 fewer
-        static call sites (was 41 executor + 7 route = 48)."""
+        terminal emits into one emit driven by the RunCompletion terminal
+        mapping (48 → 44). Slice 3 moved the correction protocol's 10 emit
+        sites (CORRECTION_INITIATED/DECIDED/COMPLETED, 2× TASK_DISPATCHED/
+        SUCCEEDED/FAILED, CHECKPOINT_CREATED) from the executor to the
+        CorrectionRunner — same events at runtime, same total."""
         total = 0
         for path in _ALL_EMISSION_FILES:
             total += len(self._extract_emit_calls(path))

--- a/tests/unit/events/test_event_emission.py
+++ b/tests/unit/events/test_event_emission.py
@@ -271,20 +271,22 @@ class TestEmitCallSitePayloadFields:
                 total_calls += 1
                 if any(kw.arg == "payload" for kw in call.keywords):
                     with_payload += 1
-        # At least 38 of 44 calls have payload (a few lifecycle events omit it)
-        assert with_payload >= 38
+        # At least 35 of 41 calls have payload (a few lifecycle events omit it)
+        assert with_payload >= 35
 
     def test_total_emit_call_count(self) -> None:
-        """Sanity check: 27 executor + 10 correction-runner + 7 route = 44
+        """Sanity check: 27 executor + 7 correction-runner + 7 route = 41
         total emit calls.
 
         SIP-0097 slice 2c collapsed execute_run's five per-exception-class
         terminal emits into one emit driven by the RunCompletion terminal
-        mapping (48 → 44). Slice 3 moved the correction protocol's 10 emit
-        sites (CORRECTION_INITIATED/DECIDED/COMPLETED, 2× TASK_DISPATCHED/
-        SUCCEEDED/FAILED, CHECKPOINT_CREATED) from the executor to the
-        CorrectionRunner — same events at runtime, same total."""
+        mapping (48 → 44). Slice 3 moved the correction protocol's emit
+        sites from the executor to the CorrectionRunner and collapsed the
+        correction/repair loops' duplicated per-step emits
+        (TASK_DISPATCHED/SUCCEEDED/FAILED ×2 each) into the shared
+        _dispatch_protocol_step helper — same events at runtime, 3 fewer
+        static call sites (44 → 41)."""
         total = 0
         for path in _ALL_EMISSION_FILES:
             total += len(self._extract_emit_calls(path))
-        assert total == 44
+        assert total == 41


### PR DESCRIPTION
## SIP-0097 slice 3 of 6 — `CorrectionRunner` (§6.3)

Extracts the four-step correction protocol out of `DispatchedFlowExecutor` into `adapters/cycles/correction_runner.py`: `run_correction_protocol` (the former single biggest method in the class) plus `_store_correction_task_artifacts` and `_checkpoint_correction_task`. Outcome *routing* (`_handle_task_outcome`) stays with the executor's orchestration loop per §6.3. Three staged commits per §7.1 (move → test split → tidy).

**Executor: 3,038 → 2,632 lines.** The collaborator is a plain injected class (not a port), constructor-injected with a default composed from the executor's own deps — the slice-2 `RunCompletion` pattern.

### The sanctioned interim seam (§6.3 / AC#9)
Slice 3 lands before `TaskDispatcher` (slice 5), so the runner receives three narrow executor-supplied callables:
- `dispatch_task` + `create_task_run` — **re-pointed to `TaskDispatcher` in slice 5**, removing the interim state per AC#9.
- `store_artifact` — stays executor-supplied: artifact plumbing is §6.7 residual (residual-but-watched; re-pointed only if the post-arc 7th-collaborator decision moves it).

The callables are **late-bound lambdas**, not captured bound methods, so tests that stub `_dispatch_task` on the executor instance keep working and the runner always sees the executor's current dispatch.

**Cancellation:** no probe parameter. The protocol never performed cancellation checks of its own; per the §6 cancellation ownership rule it relies on the dispatch path's checks at dispatch/await boundaries. Adding a probe would be a behavior change.

### Tidy commit (§6.3 "moved-then-tidied")
The correction loop and repair loop duplicated an identical per-step block (create Prefect task_run per SIP-0087 B2 → `TASK_DISPATCHED` → dispatch → on success `TASK_SUCCEEDED` + store-artifacts-BEFORE-checkpoint / on failure `TASK_FAILED`). Collapsed into a shared `_dispatch_protocol_step` helper; output collection stays with each loop (they bucket outputs differently — issue #95 analysis capture vs. repair `prior_outputs` with artifacts retained).

### Verification
- **Regression:** `source .venv/bin/activate && ./scripts/dev/run_regression_tests.sh` → **4,680 passed, 1 skipped, exit 0** (captured exit code, not piped).
- **Live smoke (§7.3, agents rebuilt from this branch via `rebuild_and_deploy.sh all`):** `cyc_d58ea8cb9717` / `run_bde62dbbe574` → **completed in ~68s**, 6 artifacts including `run_report.md` — all expected role artifacts present.
- **C901 (§7.6):** `run_correction_protocol` passes the C901=12 gate at its new home — **no new per-file-ignore; `pyproject.toml` untouched** this slice.

### Parity note (§7.4 — every touched surface)
| Surface | Before → After |
|---|---|
| Task envelopes | **Unchanged** — correction/repair envelope construction moved verbatim (deterministic `corr-`/`repair-` IDs, issue-#110 model propagation, issue-#95 output bucketing, repair contract plumb-through all intact) |
| Emitted events | **Unchanged at runtime** — same types, payloads, contexts, ordering. Static call sites 44 → 41 (tidy collapsed the loops' duplicated per-step emits into the shared helper); emission guardrails re-anchored: executor 20 → 17 `EventType` refs, `CorrectionRunner` owns 7 (CORRECTION_* lifecycle, per-step TASK_*, CHECKPOINT_CREATED) |
| Registry writes | **Unchanged** — `append_artifact_refs` / `save_checkpoint` same calls, same ordering (store-before-checkpoint guard preserved) |
| Artifact names/formats | **Unchanged** — `plan_delta_{n}.json`, correction/repair task artifacts identical |
| Prefect / LangFuse | **Unchanged** — SIP-0087 B2 task_run creation + ID propagation preserved through the interim `create_task_run` callable; no observability scopes opened/closed by the runner (ownership rule §6) |
| `FlowExecutionPort` | **Untouched** |

### Test split (§9, disclosed per §7.7)
- `test_correction_protocol.py` → **`test_correction_runner.py`** (git mv, history preserved); assertions unmodified except mechanical updates: the two correction fixtures now pass `event_bus` at construction (the composed default runner captures it in `__init__`, so the old post-hoc `ex._cycle_event_bus = ...` assignment would not reach correction events), and direct protocol/helper call sites re-pointed to the collaborator.
- New `TestCorrectionRunnerStandalone` — the §9 construction-level proof the collaborator works **without a `DispatchedFlowExecutor` instance**: issue-#95 analysis-fields-to-PlanDelta regression executor-free, missing-decision→`abort` default, failed-step→`TASK_FAILED`/no-checkpoint error path.

Part of the SIP-0097 arc (#186 closes via the final slices per AC#10). Next: slice 4 (`PulseBoundaryRunner`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wp5b6VzqNynR8X6ACJ5bh