### PR TITLE
feat(#295): SIP-0097 slice 6 — reject unsatisfiable plans at the plan-review gate

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1026,7 +1026,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
             # Post-task gate check (runs after verification)
             if self._is_gate_boundary(cycle, envelope.task_type):
-                await self._handle_gate(run_id, cycle, envelope.task_type)
+                await self._handle_gate(
+                    run_id,
+                    cycle,
+                    envelope.task_type,
+                    stored_artifacts=stored_artifacts,
+                    profile=profile,
+                )
 
     # ------------------------------------------------------------------
     # SIP-0086: Manifest loading for implementation workloads
@@ -1561,11 +1567,31 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 return True
         return False
 
-    async def _handle_gate(self, run_id: str, cycle: Cycle, task_type: str) -> None:
-        """Pause, poll for decision, resume or reject."""
+    async def _handle_gate(
+        self,
+        run_id: str,
+        cycle: Cycle,
+        task_type: str,
+        *,
+        stored_artifacts: list[tuple[str, ArtifactRef]] | None = None,
+        profile: Any = None,
+    ) -> None:
+        """Pause, poll for decision, resume or reject.
+
+        #295 (SIP-0097 slice 6): before pausing for review, a materialized
+        implementation plan naming a role the squad can't satisfy is rejected
+        here — the operator is never asked to approve an unsatisfiable plan,
+        and the failure lands at the gate instead of mid-implementation
+        dispatch. The dispatch-time check in generate_task_plan remains the
+        final net.
+        """
         gate_names = [
             g.name for g in cycle.task_flow_policy.gates if task_type in g.after_task_types
         ]
+        if stored_artifacts and profile is not None:
+            await self._reject_unsatisfiable_plan_at_gate(
+                stored_artifacts, profile, gate_names, cycle
+            )
         logger.info("Run %s paused at gate(s): %s", run_id, gate_names)
         await self._cycle_registry.update_run_status(run_id, RunStatus.PAUSED)
         self._cycle_event_bus.emit(
@@ -1615,6 +1641,58 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                             )
 
             await asyncio.sleep(poll_interval)
+
+    async def _reject_unsatisfiable_plan_at_gate(
+        self,
+        stored_artifacts: list[tuple[str, ArtifactRef]],
+        profile: Any,
+        gate_names: list[str],
+        cycle: Cycle,
+    ) -> None:
+        """#295: fail fast when the materialized plan can't be satisfied.
+
+        Looks for the run's authored ``implementation_plan.yaml`` /
+        ``control_implementation_plan`` artifact (same detection as
+        ``_load_plan_for_run``) and validates its roles against the squad
+        profile. Keyed on plan presence, not the gate's name, so it holds
+        across the ``progress_plan_review`` / ``plan-review`` naming variants.
+        An absent or unreadable plan defers to the dispatch-time net —
+        this check only ever *adds* an earlier rejection, never a pass.
+        """
+        if not cycle.applied_defaults.get("implementation_plan", False):
+            return
+
+        from squadops.cycles.implementation_plan import ImplementationPlan
+
+        plan = None
+        for artifact_id, ref in stored_artifacts:
+            if ref.filename == "implementation_plan.yaml" or (
+                hasattr(ref, "artifact_type") and ref.artifact_type == "control_implementation_plan"
+            ):
+                try:
+                    _, content_bytes = await self._artifact_vault.retrieve(artifact_id)
+                    plan = ImplementationPlan.from_yaml(content_bytes.decode(errors="replace"))
+                except Exception:
+                    logger.warning(
+                        "Plan artifact %s unreadable at gate(s) %s — deferring to the "
+                        "dispatch-time validation net",
+                        artifact_id,
+                        gate_names,
+                        exc_info=True,
+                    )
+                    return
+                break
+        if plan is None:
+            return
+
+        errors = plan.validate_against_profile(profile)
+        if errors:
+            raise _ExecutionError(
+                f"Plan rejected at gate(s) {gate_names}: the materialized implementation "
+                f"plan cannot be satisfied by squad profile {profile.profile_id!r} — "
+                + "; ".join(errors)
+                + ". Fix the plan or run with a squad profile that has the missing role(s)."
+            )
 
     # ------------------------------------------------------------------
     # Helpers

--- a/tests/unit/cycles/test_handle_gate_decisions.py
+++ b/tests/unit/cycles/test_handle_gate_decisions.py
@@ -198,3 +198,195 @@ class TestHandleGateDecisions:
         assert mock_registry.get_run.call_count == 2
         status_calls = mock_registry.update_run_status.call_args_list
         assert status_calls[-1] == ((("run_001", RunStatus.RUNNING),))
+
+
+# ---------------------------------------------------------------------------
+# #295 (SIP-0097 slice 6): plan↔squad mismatch rejected at the plan-review gate
+# ---------------------------------------------------------------------------
+
+_PLAN_YAML_WITH_BUILDER_ROLE = """\
+version: 1
+project_id: proj_001
+cycle_id: cyc_001
+prd_hash: abc123
+summary:
+  total_dev_tasks: 0
+  total_qa_tasks: 0
+  total_tasks: 1
+tasks:
+  - task_index: 1
+    task_type: builder.assemble
+    role: builder
+    focus: packaging
+    description: Assemble the app for handoff
+"""
+
+_PLAN_YAML_DEV_ONLY = _PLAN_YAML_WITH_BUILDER_ROLE.replace(
+    "task_type: builder.assemble", "task_type: development.develop"
+).replace("role: builder", "role: dev")
+
+
+def _profile_without_builder():
+    """A 2-role squad profile (no builder) for mismatch tests."""
+    from squadops.cycles.models import AgentProfileEntry, SquadProfile
+
+    return SquadProfile(
+        profile_id="smoke",
+        name="Smoke",
+        description="No builder",
+        version=1,
+        agents=(
+            AgentProfileEntry(agent_id="neo", role="dev", model="m", enabled=True),
+            AgentProfileEntry(agent_id="eve", role="qa", model="m", enabled=True),
+        ),
+        created_at=NOW,
+    )
+
+
+def _plan_cycle(cycle):
+    """The gate-fixture cycle with the implementation-plan path enabled."""
+    import dataclasses
+
+    return dataclasses.replace(cycle, applied_defaults={"implementation_plan": True})
+
+
+def _plan_artifact(vault, artifact_id: str, yaml_text: str, *, filename="implementation_plan.yaml"):
+    """Register a plan artifact on the mock vault; returns (artifact_id, ref)."""
+    ref = MagicMock()
+    ref.filename = filename
+    ref.artifact_type = "control_implementation_plan"
+    vault.retrieve = AsyncMock(return_value=(ref, yaml_text.encode()))
+    return (artifact_id, ref)
+
+
+class TestPlanReviewGateCheck:
+    """#295: _handle_gate rejects an unsatisfiable materialized plan BEFORE
+    pausing for operator review; satisfiable/absent/unreadable plans leave
+    gate behavior exactly as it was (dispatch-time net retained)."""
+
+    async def test_unsatisfiable_plan_rejected_before_pause(
+        self, executor, mock_registry, mock_event_bus, cycle
+    ):
+        """Bug class: a plan naming a role the squad lacks used to sail through
+        the gate and abort ~9 min later at implementation dispatch (#172). It
+        must now fail AT the gate, with the role, profile, and gate named —
+        and the run must never pause (the operator is not asked to review a
+        doomed plan)."""
+        from adapters.cycles.execution_errors import _ExecutionError
+
+        stored = [
+            _plan_artifact(executor._artifact_vault, "art_plan", _PLAN_YAML_WITH_BUILDER_ROLE)
+        ]
+
+        with pytest.raises(_ExecutionError) as exc_info:
+            await executor._handle_gate(
+                "run_001",
+                _plan_cycle(cycle),
+                "plan_tasks",
+                stored_artifacts=stored,
+                profile=_profile_without_builder(),
+            )
+
+        msg = str(exc_info.value)
+        assert "'builder' not in profile" in msg
+        assert "'smoke'" in msg
+        assert "progress_plan_review" in msg
+        # Never paused: no status write, no RUN_PAUSED.
+        mock_registry.update_run_status.assert_not_awaited()
+        emit_types = [c[0][0] for c in mock_event_bus.emit.call_args_list]
+        assert EventType.RUN_PAUSED not in emit_types
+
+    async def test_satisfiable_plan_gates_normally(
+        self, executor, mock_registry, mock_event_bus, cycle
+    ):
+        """A plan the squad CAN satisfy must not trip the check — the gate
+        pauses and an approved decision resumes the run, exactly as before."""
+        mock_registry.get_run.return_value = _run_with_gate_decision(GateDecisionValue.APPROVED)
+        stored = [_plan_artifact(executor._artifact_vault, "art_plan", _PLAN_YAML_DEV_ONLY)]
+
+        await executor._handle_gate(
+            "run_001",
+            _plan_cycle(cycle),
+            "plan_tasks",
+            stored_artifacts=stored,
+            profile=_profile_without_builder(),
+        )
+
+        status_calls = mock_registry.update_run_status.call_args_list
+        assert status_calls[-1] == ((("run_001", RunStatus.RUNNING),))
+
+    async def test_no_plan_artifact_skips_check(
+        self, executor, mock_registry, mock_event_bus, cycle
+    ):
+        """No materialized plan among the run's artifacts → the check is inert
+        (vault never read past the scan) and the gate pauses as before."""
+        mock_registry.get_run.return_value = _run_with_gate_decision(GateDecisionValue.APPROVED)
+        other_ref = MagicMock()
+        other_ref.filename = "strategy_analysis.md"
+        other_ref.artifact_type = "document"
+
+        await executor._handle_gate(
+            "run_001",
+            _plan_cycle(cycle),
+            "plan_tasks",
+            stored_artifacts=[("art_doc", other_ref)],
+            profile=_profile_without_builder(),
+        )
+
+        executor._artifact_vault.retrieve.assert_not_awaited()
+        status_calls = mock_registry.update_run_status.call_args_list
+        assert status_calls[-1] == ((("run_001", RunStatus.RUNNING),))
+
+    async def test_implementation_plan_disabled_skips_check(
+        self, executor, mock_registry, mock_event_bus, cycle
+    ):
+        """Cycles without the implementation-plan path (e.g. smoke/selftest)
+        must be untouched — even if an artifact matches the plan filename."""
+        mock_registry.get_run.return_value = _run_with_gate_decision(GateDecisionValue.APPROVED)
+        stored = [
+            _plan_artifact(executor._artifact_vault, "art_plan", _PLAN_YAML_WITH_BUILDER_ROLE)
+        ]
+
+        await executor._handle_gate(
+            "run_001",
+            cycle,  # applied_defaults lacks implementation_plan
+            "plan_tasks",
+            stored_artifacts=stored,
+            profile=_profile_without_builder(),
+        )
+
+        executor._artifact_vault.retrieve.assert_not_awaited()
+        status_calls = mock_registry.update_run_status.call_args_list
+        assert status_calls[-1] == ((("run_001", RunStatus.RUNNING),))
+
+    async def test_unreadable_plan_defers_to_dispatch_net(
+        self, executor, mock_registry, mock_event_bus, cycle
+    ):
+        """A plan artifact that fails to parse must NOT fail the gate — the
+        check only adds earlier rejections; malformed plans stay the
+        dispatch-time net's problem (same graceful path as _load_plan_for_run)."""
+        mock_registry.get_run.return_value = _run_with_gate_decision(GateDecisionValue.APPROVED)
+        stored = [_plan_artifact(executor._artifact_vault, "art_plan", "not: [valid, plan yaml")]
+
+        await executor._handle_gate(
+            "run_001",
+            _plan_cycle(cycle),
+            "plan_tasks",
+            stored_artifacts=stored,
+            profile=_profile_without_builder(),
+        )
+
+        status_calls = mock_registry.update_run_status.call_args_list
+        assert status_calls[-1] == ((("run_001", RunStatus.RUNNING),))
+
+    async def test_gate_without_threaded_context_behaves_as_before(
+        self, executor, mock_registry, mock_event_bus, cycle
+    ):
+        """Callers that don't thread stored_artifacts/profile (defaults None)
+        get pre-#295 behavior — the check never runs."""
+        mock_registry.get_run.return_value = _run_with_gate_decision(GateDecisionValue.APPROVED)
+
+        await executor._handle_gate("run_001", _plan_cycle(cycle), "plan_tasks")
+
+        status_calls = mock_registry.update_run_status.call_args_list
+        assert status_calls[-1] == ((("run_001", RunStatus.RUNNING),))


### PR DESCRIPTION
## SIP-0097 slice 6 of 6 — the #295 rider (§8), the arc's one behavior addition

Before `_handle_gate` pauses a run for operator review, the run's materialized implementation plan (same artifact detection as `_load_plan_for_run`) is now validated against the squad profile via `ImplementationPlan.validate_against_profile`. A plan naming a role the squad can't satisfy fails **at the gate** with an actionable message naming the role, profile, and gate — instead of aborting ~9 minutes later at implementation dispatch (#172's late-failure half, which SIP-0095 deliberately left out of create-time scope because the plan doesn't exist yet at create time).

### Semantics
- **Keyed on plan presence + the `implementation_plan` flag, not the gate's name** — robust across the `progress_plan_review` / `plan-review` naming variants.
- **Fails before pausing**: the operator is never asked to review a doomed plan. The failure surfaces through the standard `_ExecutionError` → `RunCompletion` terminal path (run FAILED, honest report, events) — no new status semantics.
- **Dispatch-time net retained unchanged** (`generate_task_plan` → `CycleError`): absent or unreadable plans defer to it — the gate check only ever *adds* an earlier rejection, never a pass.
- **Backward compatible**: callers that don't thread `stored_artifacts`/`profile` get pre-#295 gate behavior; smoke/selftest cycles (no `implementation_plan`) are untouched.
- Gate handling stays executor-resident per §6.3/§6.7 — the check is a new executor method, not a collaborator.

Example failure message:
> `Plan rejected at gate(s) ['progress_plan_review']: the materialized implementation plan cannot be satisfied by squad profile 'smoke' — Task 1: role 'builder' not in profile. Fix the plan or run with a squad profile that has the missing role(s).`

### Verification
- **Regression:** `source .venv/bin/activate && ./scripts/dev/run_regression_tests.sh` → **4,694 passed, 1 skipped, exit 0** (captured exit code, not piped).
- **Tests** (`TestPlanReviewGateCheck`, in the gate-decisions file since gate handling is executor-resident): unsatisfiable plan rejected **pre-pause** with the exact message asserted and no `PAUSED` write / no `RUN_PAUSED` emit; satisfiable plan gates normally; no-plan, plan-disabled, unreadable-plan, and unthreaded-caller paths all preserve prior behavior exactly.
- **Live smoke (§7.3, agents rebuilt from this branch):** `cyc_cf0bbcd9aa36` / `run_9e46d3bd9b95` → **completed**, standard artifact set — no regression on the non-gated path.
- **Live gated cycle — attempted, blocked by pre-existing #327:** `cyc_266191c438da` (`build` × `smoke`) failed at `governance.merge_plan` with `Prompt asset not found: request.governance_review_plan_manifest` **before any plan was authored or the gate reached** — the deployed prompt-pack drift #327 describes (evidence commented there). The #295 check is inert without a materialized plan, so nothing regresses; the live positive-path validation is deferred to #327's fix. Silver lining: that failure was the **first live end-to-end exercise of the full correction protocol through the new collaborators** — `CorrectionRunner` dispatched analyze/decide via `TaskDispatcher`, stored the correction artifacts + plan delta, decided abort, and `RunCompletion` produced the honest FAILED report.

### Parity note (§7.4)
The intended deviation is exactly the #295 addition above (§7.2's sanctioned exception). Every other surface — envelopes, events, registry writes, artifacts, Prefect/LangFuse, `FlowExecutionPort` — **unchanged**; cycles without a materialized plan at a gate behave byte-identically.

### Arc status (AC#10)
This is the final slice: all six §6 extraction targets are merged code, the interim callables are gone (AC#9, slice 5), the executor carries no per-run mutable state (AC#3, slice 2), and the residual matches §6.7 — 1,805 lines (from 3,358), every remaining method in a §6.7 residual cluster (orchestration loops, gates, recruitment/lifecycle, artifact/checkpoint plumbing, workload sequencing). Remaining post-arc items ride the SIP's open questions (residual/7th-collaborator review, the `RunOrchestrator` rename + #168 sweep) and promotion follows verification per the maintainer flow.

Closes #295
Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wp5b6VzqNynR8X6ACJ5bh