### PR TITLE
refactor(#323): migrate agent comms from queue polling to a persistent push consumer

### DIFF
--- a/adapters/comms/rabbitmq.py
+++ b/adapters/comms/rabbitmq.py
@@ -56,6 +56,7 @@ class RabbitMQAdapter(QueuePort):
         url: str,
         namespace: str | None = None,
         consume_poll_timeout_seconds: float = _DEFAULT_CONSUME_POLL_TIMEOUT,
+        prefetch_count: int | None = None,
     ):
         """
         Initialize RabbitMQ adapter.
@@ -64,10 +65,15 @@ class RabbitMQAdapter(QueuePort):
             url: RabbitMQ connection URL (e.g., 'amqp://user:pass@host:port/vhost')
             namespace: Optional namespace to prepend to queue names (e.g., 'comms.namespace')
             consume_poll_timeout_seconds: Bounded wait per consume() poll cycle (#158).
+            prefetch_count: Per-consumer QoS prefetch applied to the channel
+                (#323). Bounds how many unacked messages the broker pushes to
+                a long-lived consumer; None keeps the broker default
+                (unbounded).
         """
         self.url = url
         self.namespace = namespace
         self._consume_poll_timeout = consume_poll_timeout_seconds
+        self._prefetch_count = prefetch_count
         self._connection: Connection | None = None
         self._channel: aio_pika.Channel | None = None
         self._queues: dict[str, Queue] = {}
@@ -84,6 +90,11 @@ class RabbitMQAdapter(QueuePort):
 
         if self._channel is None or self._channel.is_closed:
             self._channel = await self._connection.channel()
+            if self._prefetch_count is not None:
+                # #323: bound unacked deliveries so a persistent subscribe()
+                # consumer is handed one message at a time instead of the
+                # broker flushing the whole queue into its client-side buffer.
+                await self._channel.set_qos(prefetch_count=self._prefetch_count)
             logger.debug("RabbitMQ channel created")
 
     def _apply_namespace(self, queue_name: str) -> str:

--- a/docs/plans/1-3-x-two-lane-plan.md
+++ b/docs/plans/1-3-x-two-lane-plan.md
@@ -17,11 +17,11 @@ collision matrix matters more than usual.
 
 | # | Lane | Surface | Notes |
 |---|------|---------|-------|
-| **#186** decompose `DispatchedFlowExecutor` | **M** | `adapters/cycles/dispatched_flow_executor.py` (3,358 lines / 53 methods) | 100% Mac-internal — no Spark contention. **Boundary SIP ACCEPTED 2026-07-06: SIP-0097** (PR #340); now slicing (6 slices, #295 rides as slice 6). |
+| ~~**#186** decompose `DispatchedFlowExecutor`~~ | **M** | `adapters/cycles/dispatched_flow_executor.py` | **DONE 2026-07-08** — SIP-0097 arc complete (6 slice PRs #341/#344/#347/#348/#349/#350; executor 3,358→1,805, #295 rode as slice 6); SIP-0097 promoted → implemented. |
 | ~~**#152** split `cycle_tasks.py`~~ | **M** | `capabilities/handlers/cycle/` package | **DONE 2026-07-06** — #332 hoist (PR #338) then package split + compat shim (PR #339, merge `b59f4ef`); live-validated. #276 gate was satisfied by PRs #289/#290. |
 | **#295** hoist `validate_against_profile` | **M** | plan-review gate | Rides #186 (finishes SIP-0095's materialized-plan half / #172). |
 | **#234** de-leak `DbRuntime` port | **S → M** (2026-07-07) | `ports/` + postgres adapter | Port leaks sqlalchemy vendor types / shaped to legacy backend. **Reassigned to Mac lane** (Spark offline, no in-flight contention; see issue comment). Filler item — no sequencing dependency; audit-first, keep-or-kill decision ratified before any deletion. |
-| **#323** comms poll→push consumer | **S → M** (2026-07-07) | `adapters/comms/*` | Replace 1s open/close `consume()` with the persistent `subscribe()` push consumer; removes churn + up-to-1s latency + the `aio_pika` "closing" INFO flood. **Reassigned to Mac lane** (see issue comment); picks up after SIP-0097 slice 2, own branch + live validation. |
+| ~~**#323** comms poll→push consumer~~ | **S → M** (2026-07-07) | `adapters/comms/*` | **DONE 2026-07-07** — agent entrypoint consumes via the persistent `subscribe()` push consumer + `prefetch_count=1` QoS (branch `refactor/323-comms-push-consumer`); removes churn + up-to-1s latency + the `aio_pika` "closing" INFO flood, obsoleting the #329 interim. Live-validated per issue AC. |
 
 ## Coordination rules (carried over from 1.1.x — still in force)
 
@@ -59,8 +59,9 @@ collision matrix matters more than usual.
   ~~#152 waits on #276~~ **#152 done (2026-07-06)**; #295 rides the #186 decomposition.
 - **Lane S:** ~~#234 and #323~~ **both reassigned to Lane M 2026-07-07** (Spark offline; issues
   commented + relabeled `track:macbook`). The entire 1.3.0 core scope is now Mac-lane; Spark's
-  return blocks nothing for the cut. Mac sequencing: SIP-0097 slices → #323 → #234 (filler,
-  independent). ~~#276 unblocks #152~~ (both resolved).
+  return blocks nothing for the cut. Mac sequencing: ~~SIP-0097 slices~~ (done 2026-07-08) →
+  ~~#323~~ (done 2026-07-07) → #234 (filler, independent — the remaining core item).
+  ~~#276 unblocks #152~~ (both resolved).
 
 ## Out of scope for 1.3 (feature-free rule)
 

--- a/src/squadops/agents/entrypoint.py
+++ b/src/squadops/agents/entrypoint.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from squadops.bootstrap.system import SquadOpsSystem
+    from squadops.comms.queue_message import QueueMessage
     from squadops.ports.observability import LogForwarderPort
 
 
@@ -346,9 +347,11 @@ class AgentRunner:
         # Create filesystem adapter
         filesystem = LocalFileSystemAdapter()
 
-        # Create RabbitMQ queue adapter
+        # Create RabbitMQ queue adapter. prefetch_count=1 (#323): the broker
+        # hands this agent one unacked comms message at a time, matching the
+        # old poll loop's one-at-a-time pickup.
         rabbitmq_url = config.comms.rabbitmq.url
-        queue = RabbitMQAdapter(url=rabbitmq_url)
+        queue = RabbitMQAdapter(url=rabbitmq_url, prefetch_count=1)
         self._queue = queue  # Store for use in _consume_tasks
 
         # Conditionally wire A2A messaging (SIP-0085 P2-RC6)
@@ -428,12 +431,13 @@ class AgentRunner:
         }
 
     async def _consume_tasks(self) -> None:
-        """Consume tasks from the queue.
+        """Consume comms messages via a persistent push consumer (#323).
 
-        Connects to RabbitMQ and processes incoming tasks through the orchestrator.
+        Registers a single long-lived ``subscribe()`` consumer on the agent's
+        comms queue — the broker delivers each message the moment it arrives,
+        with no per-poll ``basic.consume``/``basic.cancel`` churn — then parks
+        until shutdown is requested.
         """
-        import json
-
         # Queue name for this agent's communications
         comms_queue = f"{self.agent_id}_comms"
         replies_queue = f"{self.agent_id}_replies"
@@ -449,63 +453,66 @@ class AgentRunner:
         # queue won't create it. Idempotent — safe to call on every boot.
         await self._queue.ensure_queue(replies_queue)
 
-        while not self._shutdown_event.is_set():
-            try:
-                # Consume messages from the comms queue
-                messages = await self._queue.consume(comms_queue, max_messages=1)
+        # The subscription layer owns the ack: each delivery is acked after
+        # _process_comms_message returns — success or failure — preserving the
+        # old poll loop's ack-always policy. subscribe() re-establishes the
+        # consumer itself if the channel drops.
+        subscription = await self._queue.subscribe(
+            comms_queue, on_message=self._process_comms_message
+        )
 
-                for message in messages:
-                    try:
-                        # Parse the message payload
-                        payload = json.loads(message.payload)
-                        action = payload.get("action", "")
-                        metadata = payload.get("metadata", {})
+        try:
+            await self._shutdown_event.wait()
+        finally:
+            # Cancel the consumer before closing the connection, so the
+            # subscription's resubscribe loop can't race the teardown.
+            await subscription.cancel()
+            if self._queue:
+                await self._queue.close()
 
-                        logger.info(
-                            "Received message",
-                            extra={
-                                "agent_id": self.agent_id,
-                                "action": action,
-                                "message_id": message.message_id,
-                            },
-                        )
+        logger.info("Task consumer stopped")
 
-                        # Handle different action types
-                        if action == "comms.chat":
-                            await self._handle_chat_message(payload, metadata)
-                        elif action == "comms.task":
-                            await self._handle_task_envelope(payload, metadata)
-                        else:
-                            logger.warning(
-                                f"Unknown action: {action}",
-                                extra={"agent_id": self.agent_id},
-                            )
+    async def _process_comms_message(self, message: QueueMessage) -> None:
+        """Route one comms delivery to its action handler.
 
-                        # Acknowledge the message
-                        await self._queue.ack(message)
+        Callback for the persistent ``subscribe()`` consumer (#323). Never
+        raises: failures are logged with agent context and swallowed, so the
+        subscription acks the message and keeps consuming — the same outcome
+        the old poll loop's ack-on-error path produced. It must not ack
+        either; the subscription layer acks every delivery after this returns.
+        """
+        import json
 
-                    except Exception as e:
-                        logger.error(
-                            f"Failed to process message: {e}",
-                            extra={"agent_id": self.agent_id, "message_id": message.message_id},
-                        )
-                        # Acknowledge anyway to avoid infinite retries
-                        await self._queue.ack(message)
+        try:
+            payload = json.loads(message.payload)
+            action = payload.get("action", "")
+            metadata = payload.get("metadata", {})
 
-            except Exception as e:
-                logger.error(
-                    f"Queue consumption error: {e}",
+            logger.info(
+                "Received message",
+                extra={
+                    "agent_id": self.agent_id,
+                    "action": action,
+                    "message_id": message.message_id,
+                },
+            )
+
+            # Handle different action types
+            if action == "comms.chat":
+                await self._handle_chat_message(payload, metadata)
+            elif action == "comms.task":
+                await self._handle_task_envelope(payload, metadata)
+            else:
+                logger.warning(
+                    f"Unknown action: {action}",
                     extra={"agent_id": self.agent_id},
                 )
 
-            # Small delay between consumption cycles
-            await asyncio.sleep(0.5)
-
-        # Close queue connection on shutdown
-        if self._queue:
-            await self._queue.close()
-
-        logger.info("Task consumer stopped")
+        except Exception as e:
+            logger.error(
+                f"Failed to process message: {e}",
+                extra={"agent_id": self.agent_id, "message_id": message.message_id},
+            )
 
     def _build_system_prompt(self) -> str:
         """Build system prompt using PromptService for role-specific identity.

--- a/tests/unit/agents/test_entrypoint_task.py
+++ b/tests/unit/agents/test_entrypoint_task.py
@@ -1,17 +1,20 @@
-"""Tests for AgentRunner._handle_task_envelope().
+"""Tests for the AgentRunner comms path.
 
-Verifies that the agent correctly deserializes incoming TaskEnvelopes,
-submits them to the local orchestrator, and publishes results to the
-reply queue.
+Verifies that the agent consumes its comms queue push-style (#323), routes
+deliveries to the right action handler, correctly deserializes incoming
+TaskEnvelopes, submits them to the local orchestrator, and publishes results
+to the reply queue.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from squadops.comms.queue_message import QueueMessage
 from squadops.tasks.models import TaskEnvelope, TaskResult
 
 pytestmark = [pytest.mark.domain_agents]
@@ -151,10 +154,10 @@ class TestHandleTaskEnvelope:
         assert published["metadata"]["correlation_id"] == "corr_001"
 
 
-class TestConsumeTasksEnsuresReplyQueue:
-    """`_consume_tasks` must declare the agent's `{agent_id}_replies` reply
-    queue at startup (SIP-0094 D9) so the orchestrator never publishes a reply
-    to a queue the agent never created."""
+class TestConsumeTasksPushConsumer:
+    """`_consume_tasks` registers ONE persistent subscribe() consumer (#323),
+    declares the reply queue first (SIP-0094 D9), and tears the consumer down
+    on shutdown."""
 
     def _runner(self):
         from squadops.agents.entrypoint import AgentRunner
@@ -164,19 +167,136 @@ class TestConsumeTasksEnsuresReplyQueue:
             r.agent_id = "neo"
             r.role = "dev"
             r._queue = AsyncMock()
-            r._shutdown_event = MagicMock()
+            r._shutdown_event = asyncio.Event()
             return r
 
-    async def test_declares_replies_queue_before_consuming(self) -> None:
-        """ensure_queue("{agent_id}_replies") is awaited exactly once, ahead of
-        the consume loop. With the loop short-circuited, a call count of one
-        proves the declaration sits *before* the loop, not inside it (which
-        would yield zero calls here and N calls in steady state)."""
+    async def test_declares_replies_queue_before_subscribing(self) -> None:
+        """ensure_queue("{agent_id}_replies") must be awaited before the comms
+        subscription registers (SIP-0094 D9) — a consumer that comes up first
+        can receive a task whose reply queue doesn't exist yet."""
         r = self._runner()
-        r._shutdown_event.is_set.return_value = True  # exit loop immediately
+        r._shutdown_event.set()  # tear down right after the subscription is up
 
         await r._consume_tasks()
 
         r._queue.ensure_queue.assert_awaited_once_with("neo_replies")
-        # The loop body never ran, so nothing was consumed this pass.
+        names = [call[0] for call in r._queue.mock_calls]
+        assert names.index("ensure_queue") < names.index("subscribe")
+
+    async def test_subscribes_push_style_not_poll(self) -> None:
+        """One subscribe() on the comms queue, routed to the runner's message
+        processor; the poll-based consume() path must be gone — its per-poll
+        open/close churn is the bug #323 removes."""
+        r = self._runner()
+        r._shutdown_event.set()
+
+        await r._consume_tasks()
+
+        r._queue.subscribe.assert_awaited_once()
+        args, kwargs = r._queue.subscribe.await_args
+        assert args[0] == "neo_comms"
+        assert kwargs["on_message"] == r._process_comms_message
         r._queue.consume.assert_not_awaited()
+
+    async def test_consumer_survives_until_shutdown_then_cancels_before_close(self) -> None:
+        """The subscription must stay up until the shutdown event fires, then
+        be cancelled BEFORE the connection closes — close-then-cancel would
+        strand the resubscribe loop against a dead connection."""
+        r = self._runner()
+        teardown_order: list[str] = []
+        handle = AsyncMock()
+        handle.cancel.side_effect = lambda: teardown_order.append("cancel")
+        r._queue.subscribe.return_value = handle
+        r._queue.close.side_effect = lambda: teardown_order.append("close")
+
+        task = asyncio.create_task(r._consume_tasks())
+        for _ in range(5):
+            await asyncio.sleep(0)  # let the task reach the shutdown wait
+
+        assert not task.done()
+        handle.cancel.assert_not_awaited()
+
+        r._shutdown_event.set()
+        await asyncio.wait_for(task, timeout=1)
+
+        handle.cancel.assert_awaited_once()
+        assert teardown_order == ["cancel", "close"]
+
+
+class TestProcessCommsMessage:
+    """`_process_comms_message` — the subscribe() callback — routes actions,
+    never raises, and never acks (the subscription layer owns the ack)."""
+
+    def _runner(self):
+        from squadops.agents.entrypoint import AgentRunner
+
+        with patch.object(AgentRunner, "__init__", lambda self, *a, **kw: None):
+            r = AgentRunner.__new__(AgentRunner)
+            r.agent_id = "neo"
+            r.role = "dev"
+            r._queue = AsyncMock()
+            r._handle_chat_message = AsyncMock()
+            r._handle_task_envelope = AsyncMock()
+            return r
+
+    @staticmethod
+    def _message(body: dict | str) -> QueueMessage:
+        return QueueMessage(
+            message_id="42",
+            queue_name="neo_comms",
+            payload=body if isinstance(body, str) else json.dumps(body),
+            receipt_handle="42",
+            attributes={},
+        )
+
+    async def test_routes_task_action_with_parsed_payload(self) -> None:
+        r = self._runner()
+        payload = {"action": "comms.task", "metadata": {"reply_queue": "q"}, "payload": {}}
+
+        await r._process_comms_message(self._message(payload))
+
+        r._handle_task_envelope.assert_awaited_once_with(payload, {"reply_queue": "q"})
+        r._handle_chat_message.assert_not_awaited()
+        # The subscription acks every delivery itself; a second ack here would
+        # raise on the same delivery tag.
+        r._queue.ack.assert_not_awaited()
+
+    async def test_routes_chat_action(self) -> None:
+        r = self._runner()
+        payload = {"action": "comms.chat", "metadata": {"correlation_id": "c1"}, "payload": {}}
+
+        await r._process_comms_message(self._message(payload))
+
+        r._handle_chat_message.assert_awaited_once_with(payload, {"correlation_id": "c1"})
+        r._handle_task_envelope.assert_not_awaited()
+
+    async def test_unknown_action_is_dropped_without_dispatch(self) -> None:
+        r = self._runner()
+
+        await r._process_comms_message(self._message({"action": "comms.bogus"}))
+
+        r._handle_chat_message.assert_not_awaited()
+        r._handle_task_envelope.assert_not_awaited()
+
+    async def test_malformed_json_never_raises(self) -> None:
+        """An unparseable delivery must be swallowed: if the callback raised,
+        the message would still be acked upstream, but the agent-context error
+        log (agent_id + message_id) would be lost to a generic transport log."""
+        r = self._runner()
+
+        await r._process_comms_message(self._message("{not json"))
+
+        r._handle_task_envelope.assert_not_awaited()
+        r._handle_chat_message.assert_not_awaited()
+
+    async def test_handler_failure_is_swallowed_and_never_acked_here(self) -> None:
+        """A raising handler must not propagate (the consumer keeps running)
+        and must not trigger an ack from the callback — matching the old poll
+        loop's log-and-ack-anyway policy, with the ack owned upstream."""
+        r = self._runner()
+        r._handle_task_envelope.side_effect = RuntimeError("handler blew up")
+        payload = {"action": "comms.task", "metadata": {}}
+
+        await r._process_comms_message(self._message(payload))
+
+        r._queue.ack.assert_not_awaited()

--- a/tests/unit/comms/test_rabbitmq_adapter.py
+++ b/tests/unit/comms/test_rabbitmq_adapter.py
@@ -168,6 +168,47 @@ class TestEnsureQueue:
         ch2.declare_queue.assert_awaited_once_with("neo_replies", **REPLY_QUEUE_DECLARE_ARGS)
 
 
+class TestPrefetchQos:
+    """#323: an adapter constructed with ``prefetch_count`` must apply it as
+    channel QoS so a persistent push consumer is handed one unacked message
+    at a time."""
+
+    @staticmethod
+    def _connect(adapter: RabbitMQAdapter) -> MagicMock:
+        """Wire a live mock connection that yields a fresh mock channel."""
+        ch = MagicMock()
+        ch.is_closed = False
+        ch.set_qos = AsyncMock()
+        conn = MagicMock()
+        conn.is_closed = False
+        conn.channel = AsyncMock(return_value=ch)
+        adapter._connection = conn
+        return ch
+
+    async def test_prefetch_applied_on_channel_creation(self) -> None:
+        """Bug caught: dropping the set_qos call silently reverts to unbounded
+        prefetch — the broker flushes the whole queue into the consumer's
+        client-side buffer, and an agent dying mid-task takes every buffered
+        message with it."""
+        adapter = RabbitMQAdapter(url="amqp://test", prefetch_count=1)
+        ch = self._connect(adapter)
+
+        await adapter._ensure_connection()
+
+        ch.set_qos.assert_awaited_once_with(prefetch_count=1)
+
+    async def test_no_prefetch_leaves_qos_untouched(self) -> None:
+        """Default construction must not impose QoS on the shared channel —
+        existing publish-only and reply-subscriber users keep broker-default
+        delivery."""
+        adapter = RabbitMQAdapter(url="amqp://test")
+        ch = self._connect(adapter)
+
+        await adapter._ensure_connection()
+
+        ch.set_qos.assert_not_awaited()
+
+
 class TestConsumeBlockingErrorWrapping:
     """``consume_blocking`` must wrap broker errors in QueueError so callers
     can recover (invalidate cache, retry) instead of crashing on raw


### PR DESCRIPTION
## Summary

The agent entrypoint loop polled its comms queue: `consume(comms_queue, max_messages=1)` opened a fresh `basic.consume`, waited up to 1s, and cancelled it — every cycle, per agent. That cost consumer churn (counts flapping 0↔1 with recurring consumer-less windows), up to a full second of pickup latency, and the `aio_pika` "RobustQueueIterator closing" INFO line once per second per agent — 99.7% of retained agent logs, evicting all real signal within ~1.5h.

`_consume_tasks` now registers **one persistent `subscribe()` consumer** (the SIP-0094 push primitive, which already handles resubscribe-on-channel-drop and callback isolation) and parks on the shutdown event. The new `_process_comms_message` callback carries the old loop's routing unchanged and never raises; the subscription layer acks after every delivery — success or failure — which is exactly the old loop's ack-always policy. On shutdown the consumer is cancelled before the connection closes.

`RabbitMQAdapter` gains an opt-in `prefetch_count` (channel QoS); the agent passes 1 so the broker hands it one unacked message at a time, preserving the poll loop's one-at-a-time pickup. Other adapter users are untouched (default None = broker default).

Also brings the two-lane plan up to date: #323 + #186 rows marked done; #234 is the remaining 1.3.0 core item.

## Live validation (deployed stack rebuilt from this branch)

- **Consumer churn gone:** `rabbitmqctl list_queues name consumers` sampled 5× at 3s intervals — every `*_comms` queue steady at 1 (before: flapping 0↔1 between every sample).
- **Log flood gone:** 0 "closing with timeout" lines across all 7 agents since restart (before: 397/397 lines of max's last 10 minutes were the flood). The line now appears exactly once, on genuine shutdown — where you'd want it.
- **Lite cycle end-to-end:** `cyc_3833c109e6f2` / `run_9bd678b82e42` on `play_game` created → completed (~2 min); agents picked up and processed task envelopes delivery-time, replies published, run completed.
- **Graceful shutdown + reconnect:** `docker compose stop neo` → clean teardown ("Stopping agent" → single iterator close → "RabbitMQ connection closed" → "Task consumer stopped"); on start, the consumer re-registers (neo_comms=1) with no flood.
- Regression suite: 4,718 passed, exit 0. `ruff format` + `ruff check` clean.

## Why this also closes #329

#329 was the interim mitigation (demote `aio_pika` INFO logs) so observability was restored *before* this structural fix landed. It was never implemented, and this PR removes the flood at its cause — the demotion would now only mask the one log line we want to see (genuine reconnect/shutdown). Obsolete, not fixed.

Closes #323
Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ