### PR TITLE
docs(#335) + test(#336): fix doc drift and add the CI ratchet — last pre-1.3.0 item

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,6 +6,15 @@ Living document tracking the implementation progression from initial prototype t
 
 Semver with an **even/odd minor** overlay (parity gates *features*, not hardening — #281): **even minors (1.2, 1.4, …) are feature releases** (led by a headline feature SIP; hardening rides along), **odd minors (1.3, 1.5, …) are feature-free stabilization releases** (the big risky refactors + debt paydown), and **patches ship urgent fixes any time, either lane.** Hardening lands wherever it's ready. See `docs/plans/1-2-0-release-plan.md` and CLAUDE.md.
 
+## Forward Cadence (planned)
+
+Version labels per the even/odd remap in `docs/plans/2-0-roadmap-reconciliation.md` (Findings 2 + 4):
+
+- **v1.3 (in progress)** — first stabilization minor, feature-free by rule: executor decomposition (SIP-0097 / #186), `cycle_tasks` package split (#152), comms poll→push consumer (#323), dead `DbRuntime` backend removal (#234).
+- **v1.4** — duty durability (SIP-0091) + verification evidence integrity (SIP-0096), the headline pair; possibly embodiment Phase 2 (SIP-0090, first live adapter). Plan: `docs/plans/1-4-evidence-arc-plan.md`.
+- **v1.6** — Campaign mechanic (objective envelope + continuation policy; `sips/proposed/SIP-Campaign-Orchestration.md`), gated on SIP-0096 implemented + #288 + #316.
+- **v1.8/v2.0** — the three 2.0 pillars: Capability-Backed Agents (what an agent *is*), Campaign capability-augmentation, Self-Improvement + Test Bay (the capstone).
+
 ## Release Timeline
 
 ### v1.2.0 (2026-07-04) — Current — First Feature Release (even/odd cadence)
@@ -383,13 +392,14 @@ The following areas are identified for future work but do not block 1.0 readines
 
 ## Accepted (Next Up)
 
-| SIP | Title |
-|-----|-------|
-| **SIP-0088** | Agent Runtime Modes (umbrella; v1.2 pieces future) |
-| **SIP-0090** | Agent Embodiment Substrate |
-| **SIP-0091** | Duty Durability via Temporal |
-| **SIP-0092** | Implementation Plan Improvement — Typed Acceptance, Separated Authoring, and Plan Changes |
-| **SIP-0093** | Multi-Role Plan Authoring |
+| SIP | Title | Target |
+|-----|-------|--------|
+| **SIP-0088** | Agent Runtime Modes (umbrella; runtime arc shipped 1.1–1.2, remaining pieces future) | — |
+| **SIP-0090** | Agent Embodiment Substrate (Phase 1 shipped 1.2.0) | Phases 2+ → v1.4+ |
+| **SIP-0091** | Duty Durability via Temporal | v1.4 |
+| **SIP-0092** | Implementation Plan Improvement — Typed Acceptance, Separated Authoring, and Plan Changes | — |
+| **SIP-0093** | Multi-Role Plan Authoring | — |
+| **SIP-0096** | Verification Evidence Integrity | v1.4 |
 
 ## Proposals (Backlog)
 
@@ -400,7 +410,17 @@ The following areas are identified for future work but do not block 1.0 readines
 | (unnumbered) | API Contract Hardening |
 | (unnumbered) | Cycle Evaluation Scorecard |
 
-### Other Proposals
+### Unnumbered Drafts (filed, awaiting design review)
+
+| SIP | Title |
+|-----|-------|
+| (unnumbered) | Campaign Orchestration (v1.6 candidate) |
+| (unnumbered) | Campaign Self-Improvement and Test Bay Requirements (2.0 vision anchor) |
+| (unnumbered) | Agent Comms Delivery Guarantees (Campaign 1.6 gate) |
+| (unnumbered) | Edge Deployment Profile |
+| (unnumbered) | Experiment Queue and Cycle Assessment |
+
+### Legacy Proposals
 
 | SIP | Title |
 |-----|-------|
@@ -411,16 +431,15 @@ The following areas are identified for future work but do not block 1.0 readines
 | SIP-0018-v2 | Squad Context Protocol |
 | SIP-0023 | Domain Expert Architecture for Product Strategy |
 | SIP-0028 | Hybrid Deployment Model (Multi-Environment) |
-| (unnumbered) | Edge Deployment Profile |
-| (unnumbered) | Experiment Queue and Cycle Assessment |
-| (unnumbered) | Intelligent Delegation Protocols |
 
 ---
 
 ## Stats
 
-- **Framework version**: 1.0.6
-- **SIPs**: 57 implemented, 6 accepted (SIP-0088–0093), 8 proposed, 20 deprecated (~91 total)
-- **Tests**: 3,030+ passing in the regression suite
-- **Python source**: ~39,000 lines (~51,000 test lines, ~84,000 doc lines)
+*As of 2026-07-08 (v1.2.0, pre-1.3.0 cut):*
+
+- **Framework version**: 1.2.0
+- **SIPs**: 60 implemented, 6 accepted (SIP-0088, 0090–0093, 0096), 20 deprecated (registry); 14 files in `sips/proposed/` (7 registry-tracked legacy + 7 unnumbered drafts)
+- **Tests**: 4,700+ passing in the regression suite
+- **Python source**: ~61,000 lines (src + adapters; ~83,000 test lines, ~110,000 doc lines)
 - **~6 months** from initial repo (2025-09-20) to 1.0.0 release (2026-03-10)

--- a/docs/ideas/SquadOps-Roadmap-Runtime-Loop-Capability-Backed-Agents.md
+++ b/docs/ideas/SquadOps-Roadmap-Runtime-Loop-Capability-Backed-Agents.md
@@ -1,0 +1,664 @@
+# Roadmap Idea: SquadOps Runtime Maturity → Loop Policy → Capability-Backed Agents
+
+**Status:** Idea / Roadmap Note  
+**Date:** 2026-07-01  
+**Owner:** Backspring Labs / SquadOps  
+**Related:** Runtime Modes, Duty Assignment, Cycle Loop Policy, Capability Pack Plugins, Skill-Mediated Tool Use, Iris/Glyph Design Capability Reference Pack
+
+---
+
+## 1. Executive Summary
+
+This roadmap captures the proposed sequencing for SquadOps after the current 1.1 hardening work.
+
+The central idea:
+
+> **SquadOps 1.x should mature the execution/runtime substrate before SquadOps 2.0 introduces capability-backed, memory-aware, tool-governed specialist agents.**
+
+The Capability Pack Plugin SIP and Skill-Mediated Tool Use amendment feel like a true **2.0 target**. They change the meaning of what a SquadOps agent is: from primarily a prompt-defined role with handlers into a capability-backed specialist operating from resources, memory, tools/skills, working sets, and evidence.
+
+Before that 2.0 shift, SquadOps should first finish:
+
+1. **1.1 hardening** — make the existing cycle/runtime/artifact foundation reliable.
+2. **1.2 runtime/presence maturity** — complete richer runtime posture and/or embodiment substrate work.
+3. **1.3 duty durability / duty roster assignment** — make persistent operational responsibility visible, schedulable, recallable, and durable.
+4. **Late 1.x loop policy** — add verification-guided continuance across runs/cycles.
+5. **2.0 capability-backed agents** — introduce capability pack plugins, working sets, scoped memory, artifact workspaces, and skill-mediated tool use.
+
+This sequencing keeps each conceptual layer clean:
+
+| Layer | Question answered |
+|---|---|
+| Runtime hardening | Can SquadOps reliably execute and observe bounded work? |
+| Duty/runtime assignment | Can agents hold operational responsibilities without blurring modes? |
+| Loop policy | Can SquadOps continue improving toward a goal using evidence and verification? |
+| Capability-backed agents | Can agents become reusable, memory-aware, tool-governed specialists? |
+
+---
+
+## 2. Roadmap Thesis
+
+The roadmap should preserve this distinction:
+
+> **1.x is about execution maturity. 2.0 is about agent expertise maturity.**
+
+### 1.x execution maturity
+
+1.x should focus on making SquadOps reliable, observable, schedulable, and capable of bounded iterative improvement.
+
+This includes:
+
+- reliable cycle execution,
+- clearer runtime modes,
+- duty assignments,
+- runtime state visibility,
+- focus and activity tracking,
+- duty durability,
+- artifact quality,
+- verification,
+- loop/continuance policy.
+
+### 2.0 agent expertise maturity
+
+2.0 should focus on making agents truly capability-backed specialists.
+
+This includes:
+
+- Capability Pack Plugins,
+- Capability Binding Contracts,
+- Skill-Mediated Tool Use,
+- Working Set Assembly,
+- Squad Artifact Workspaces,
+- scoped memory,
+- evidence ledgers,
+- reusable design/architecture/QA/security/domain capability packs,
+- Iris/Glyph as the first design reference capability binding.
+
+---
+
+## 3. Proposed Release Sequence
+
+```text
+1.1 — Runtime and cycle hardening
+1.2 — Embodiment substrate / richer runtime presence
+1.3 — Duty durability, duty roster assignment, runtime console maturity
+1.x — Loop Policy for iterative cycle/run continuance
+2.0 — Capability Pack Plugins, working sets, scoped memory, skill-mediated tool use
+```
+
+This keeps the 2.0 SIP from landing before the runtime substrate is mature enough to support it.
+
+---
+
+## 4. Phase 1: SquadOps 1.1 — Runtime and Cycle Hardening
+
+### 4.1 Intent
+
+1.1 should make the current platform dependable.
+
+The goal is not to add large new abstractions. The goal is to stabilize the foundation that later runtime, loop, and capability systems depend on.
+
+### 4.2 Focus areas
+
+1. Cycle execution reliability
+2. Task/run status correctness
+3. Artifact persistence and lineage
+4. Telemetry and evidence quality
+5. Acceptance checks and validation
+6. Agent status/runtime-state consistency
+7. Existing handler behavior
+8. Regression coverage
+9. CLI/API/operator visibility
+10. Hardening around failure states
+
+### 4.3 What 1.1 should avoid
+
+1.1 should avoid pulling in:
+
+- Capability Pack Plugins,
+- Iris/Glyph design capability runtime,
+- full skill-mediated tool governance,
+- scoped memory promotion flows,
+- long-running autonomous loops,
+- broad new tool surfaces.
+
+### 4.4 Guiding sentence
+
+> **1.1 should make the existing machine trustworthy before adding more intelligence to it.**
+
+---
+
+## 5. Phase 2: SquadOps 1.2 — Embodiment Substrate / Richer Runtime Presence
+
+### 5.1 Intent
+
+1.2 should mature the idea that agents can have runtime presence in external surfaces without confusing that presence with agent identity or agent intent.
+
+This may include embodiment substrate work, Discord presence, richer runtime surface attachments, and clearer observability of where/how an agent is available.
+
+### 5.2 Key boundary
+
+The runtime should preserve the distinction between:
+
+| Concept | Meaning |
+|---|---|
+| Agent identity | Durable agent identity and role |
+| RuntimeMode | Current posture: duty, cycle, ambient |
+| Embodiment | External surface attachment |
+| Capability | Work the agent can perform |
+| Assignment | Commitment or responsibility |
+| RuntimeActivity | Observable current unit of work |
+
+### 5.3 Why this comes before loop policy
+
+Loop policy will be cleaner if runtime state and embodiment boundaries are already settled.
+
+Without this, loops may accidentally become:
+
+- hidden ambient autonomy,
+- duty substitutes,
+- background execution hacks,
+- surface-specific agents.
+
+### 5.4 Guiding sentence
+
+> **1.2 should make agent presence observable without letting presence become intent.**
+
+---
+
+## 6. Phase 3: SquadOps 1.3 — Duty Durability, Duty Roster Assignment, and Runtime Console Maturity
+
+### 6.1 Intent
+
+1.3 should complete the operational responsibility layer.
+
+Duty should become a first-class, visible, schedulable, recallable, durable responsibility model — not a vague prompt instruction and not a hidden loop.
+
+### 6.2 Focus areas
+
+1. Duty assignment records
+2. Duty windows
+3. Duty roster binding
+4. Recall policy
+5. Reserve windows
+6. FocusLease integration
+7. RuntimeActivity visibility for duty work
+8. Duty continuity and handoff
+9. Durable wake/recall mechanics
+10. Continuum console surfaces for runtime/duty visibility
+
+### 6.3 Duty is not loop policy
+
+Duty answers:
+
+> What operational responsibility does this agent hold, and when may it claim attention?
+
+Loop policy answers:
+
+> Given verification/evidence, should work continue, repair, retry, fork, escalate, or stop?
+
+Those must remain separate.
+
+### 6.4 Duty is not capability binding
+
+Duty may activate an agent/capability binding later, but duty itself is not the capability.
+
+Example:
+
+- Joi may hold a Spanish coaching duty assignment.
+- The actual teaching/review capability may be activated during that duty window.
+- The duty assignment is the commitment.
+- The capability is the type of work.
+- The skill/tool surface is what the capability may use.
+
+### 6.5 Guiding sentence
+
+> **1.3 should make persistent responsibility explicit, durable, and observable without turning Duty into a generic background loop.**
+
+---
+
+## 7. Phase 4: Late 1.x — Loop Policy for Iterative Cycle/Run Continuance
+
+### 7.1 Intent
+
+After 1.2/1.3 and hardening, SquadOps should add a late 1.x enhancement SIP for **Loop Policy**.
+
+This should come before the 2.0 capability-pack architecture because loop policy is still part of execution maturity.
+
+The loop answers:
+
+> How does SquadOps continue improving toward a goal across runs and/or cycles using verification, acceptance evidence, and continuance policy?
+
+### 7.2 Proposed SIP title ideas
+
+Possible titles:
+
+- **SIP: Loop Policy for Iterative Cycle Continuance**
+- **SIP: Cycle Loop Policy and Verification-Guided Continuance**
+- **SIP: Verification-Guided Loop Policy for Runs and Cycles**
+- **SIP: Loop Policy for Goal-Oriented Cycle Improvement**
+
+The important word is **Policy**.
+
+The loop should not sound like a new top-level runtime mode.
+
+### 7.3 Core invariant
+
+> **Loop is a continuance policy around bounded work. It does not replace Cycle, Duty, Run, Task, FocusLease, or RuntimeActivity.**
+
+### 7.4 Conceptual model
+
+```text
+Goal / Request
+  ↓
+Cycle
+  ↓
+Run(s)
+  ↓
+Verification / Acceptance Evidence
+  ↓
+Loop Policy Decision
+  ↓
+continue | repair | retry | fork | escalate | stop | summarize
+```
+
+### 7.5 What a loop owns
+
+A Loop Policy may own:
+
+- continuance rules,
+- stop conditions,
+- retry limits,
+- repair activation criteria,
+- verification thresholds,
+- escalation rules,
+- run/cycle summary logic,
+- evidence review rules,
+- improvement target tracking,
+- decision history.
+
+### 7.6 What a loop does not own
+
+A Loop Policy must not own:
+
+- agent identity,
+- agent runtime mode,
+- duty assignment,
+- embodiment,
+- FocusLease authority,
+- task execution semantics,
+- handler behavior,
+- memory promotion,
+- external tool authority,
+- product scope.
+
+### 7.7 Loop decision outcomes
+
+Initial decision outcomes could include:
+
+| Outcome | Meaning |
+|---|---|
+| `continue` | Proceed with another run/cycle using current strategy |
+| `repair` | Activate correction path based on failed verification |
+| `retry` | Repeat a failed or incomplete step with bounded changes |
+| `fork` | Create an alternate path/approach |
+| `escalate` | Ask operator/lead/higher-capability agent for decision |
+| `stop_success` | Goal satisfied |
+| `stop_failure` | Goal cannot be met under current constraints |
+| `summarize` | Produce final state and recommendations |
+| `defer` | Pause until external condition, input, or duty window |
+
+### 7.8 Loop inputs
+
+Loop policy should evaluate:
+
+- goal/request,
+- run outputs,
+- artifact evidence,
+- verification results,
+- acceptance checks,
+- QA findings,
+- build/test status,
+- operator gates,
+- failure reasons,
+- budget usage,
+- time limits,
+- prior loop decisions,
+- open questions/blockers.
+
+### 7.9 Loop outputs
+
+Loop policy should produce:
+
+- loop decision,
+- rationale,
+- evidence considered,
+- next requested action,
+- modified request/run profile if needed,
+- repair instructions,
+- stop summary,
+- candidate lessons,
+- artifact lineage references.
+
+### 7.10 Loop and runs
+
+The earlier conceptual direction still holds:
+
+- A **run** is execution.
+- A **task run** can execute a deterministic flow.
+- A **cycle run** can coordinate squad work.
+- A **loop policy** decides whether to continue improving toward a goal.
+- Design, research, build, QA, and repair runs may have different bounded contexts and deliverable types.
+- Verification and continuance logic should use those deliverable types.
+
+### 7.11 Why loop belongs before 2.0
+
+Loop policy should land before capability-backed agents because it creates the execution evidence that 2.0 agents will later use.
+
+Loop policy can generate:
+
+- run outcome classifications,
+- verification summaries,
+- failure reasons,
+- repair decisions,
+- artifact lineage,
+- acceptance traces,
+- candidate lessons,
+- evidence ledgers.
+
+Then 2.0 can give agents richer expertise and memory to improve how they participate in loops.
+
+### 7.12 What loop should avoid
+
+The loop SIP should avoid:
+
+- becoming a hidden autonomous agent life loop,
+- competing with Duty,
+- competing with Cycle,
+- becoming a scheduler,
+- becoming a background task runner,
+- creating unbounded autonomy,
+- replacing acceptance criteria,
+- making memory automatically durable,
+- giving agents new tool authority by implication.
+
+### 7.13 Guiding sentence
+
+> **Loop Policy lets SquadOps improve bounded work across runs using evidence, without turning Cycle into Duty or Duty into autonomy.**
+
+---
+
+## 8. Phase 5: SquadOps 2.0 — Capability-Backed Specialist Agents
+
+### 8.1 Intent
+
+SquadOps 2.0 should introduce the major architectural advancement captured in the Capability Pack Plugin SIP and Skill-Mediated Tool Use amendment.
+
+2.0 answers:
+
+> How do SquadOps agents become reusable, memory-aware, tool-governed specialists with real subject matter expertise?
+
+### 8.2 Core 2.0 platform primitives
+
+2.0 should introduce or complete:
+
+1. Capability Pack Plugins
+2. Capability Binding Contracts
+3. Agent Capability Bindings
+4. Capability-Skill Contracts
+5. Skill-Mediated Tool Use
+6. Working Set Assembly
+7. Squad Artifact Workspaces
+8. Scoped Memory
+9. Memory Promotion
+10. Evidence Ledgers
+11. Resource Modules
+12. Design Capability Reference Pack
+13. Optional Iris/Glyph roster bindings
+14. Hybrid adoption for hardwired agents such as Neo
+
+### 8.3 Core principle
+
+> **Agents are identities. Plugins publish capabilities and binding contracts. Rosters bind agents to capabilities. Assignments activate those bindings. Working sets supply context. Capabilities activate skills. Skills operate tools through ports/adapters and produce evidence.**
+
+### 8.4 Why this is a 2.0-level change
+
+This changes the meaning of an agent.
+
+Before:
+
+> role prompt + model + handler
+
+After:
+
+> agent identity + role charter + bound capabilities + scoped memory + tool permissions + working set + artifact responsibilities + evaluation rubric
+
+That is not just another feature. It is the next architecture tier.
+
+### 8.5 Design reference pack
+
+The first reference plugin should be the Design Capability Pack.
+
+It should demonstrate:
+
+- reusable capability pack plugin structure,
+- capability binding contracts,
+- modular resource modules,
+- design-system application,
+- design-system stewardship,
+- working set assembly,
+- workspace artifacts,
+- evidence,
+- memory candidates,
+- Iris/Glyph reference roster bindings.
+
+### 8.6 Iris and Glyph split
+
+Reference roster expression:
+
+| Agent | Responsibility |
+|---|---|
+| Iris | Applies relevant design systems to requirements; produces UX/design plans, critiques, acceptance criteria, and gap reports |
+| Glyph | Stewards and evolves design systems; evaluates gap reports and proposes reusable design-system additions/changes |
+
+Important boundary:
+
+> The Design Capability Plugin does not own Iris or Glyph. It publishes design capabilities. The roster binds Iris and Glyph to those capabilities.
+
+### 8.7 Skill-mediated tool use
+
+2.0 should also clarify the hierarchy:
+
+| Layer | Meaning |
+|---|---|
+| Tool | Underlying instrument/service/API/app/adapter |
+| Skill | Defined, governed use of a specific tool |
+| Capability | Domain-level ability that composes skills, resources, memory, templates, rubrics, and judgment |
+| Assignment | Runtime activation of agent/capability in context |
+| Agent | Durable identity/actor bound to capabilities |
+
+Core rule:
+
+> **Capabilities do not use raw tools directly. Capabilities activate approved skills. Skills operate tools through ports/adapters and produce evidence.**
+
+### 8.8 Why loop policy should already exist by 2.0
+
+Capability-backed agents will be more valuable if there is already a loop policy substrate they can participate in.
+
+Examples:
+
+- Iris improves UX plans across loop iterations.
+- Glyph evolves design-system guidance based on repeated gaps.
+- Neo uses architecture memory and ADR resources to improve repair decisions.
+- Eve feeds verification results into loop policy.
+- Max coordinates continuance/escalation decisions.
+- Bob executes build/repair skills under capability-specific tool permissions.
+
+Without loop policy, 2.0 agents may become smarter but still lack a mature execution continuance model.
+
+### 8.9 Guiding sentence
+
+> **2.0 should make SquadOps a runtime for composing capable agents from reusable, governed capability packs.**
+
+---
+
+## 9. Roadmap Dependency Map
+
+```text
+1.1 Hardening
+  ↓
+Reliable cycle/run/task/artifact substrate
+  ↓
+1.2 Runtime presence / embodiment substrate
+  ↓
+Clear separation of identity, runtime mode, surface presence
+  ↓
+1.3 Duty durability and roster assignment
+  ↓
+Persistent responsibility becomes schedulable, recallable, visible
+  ↓
+Late 1.x Loop Policy
+  ↓
+Evidence-guided continuance across runs/cycles
+  ↓
+2.0 Capability-Backed Agents
+  ↓
+Reusable capability packs, working sets, scoped memory, skill-mediated tools
+```
+
+---
+
+## 10. Suggested SIP Packaging
+
+### 10.1 Keep the 2.0 SIP as an umbrella / architecture target
+
+The Capability Pack Plugin SIP is broad. It should probably remain a 2.0 architecture target or umbrella SIP.
+
+It may later split into implementation SIPs:
+
+1. Capability Pack Plugin Substrate
+2. Capability Binding Contracts
+3. Working Set Assembly
+4. Evidence Ledger
+5. Squad Artifact Workspace
+6. Scoped Memory Promotion
+7. Skill-Mediated Tool Use
+8. Design Capability Reference Pack
+9. Iris/Glyph Optional Roster Bindings
+10. Neo Hybrid Capability Adoption
+
+### 10.2 Add a late 1.x Loop Policy SIP before 2.0
+
+The Loop Policy SIP should be more bounded.
+
+It should define:
+
+- loop policy,
+- loop state,
+- continuance decisions,
+- verification inputs,
+- stop/repair/retry/fork/escalate outcomes,
+- run/cycle relationship,
+- evidence output,
+- constraints against autonomy,
+- relationship to Duty/Cycle/RuntimeActivity/FocusLease.
+
+### 10.3 Keep duty work separate
+
+Duty durability and roster assignment should remain separate from loop policy.
+
+Duty is operational responsibility.
+
+Loop is continuance policy.
+
+Capability pack 2.0 is agent expertise and tool/memory/resource governance.
+
+---
+
+## 11. Concept Boundary Table
+
+| Concept | Release area | Owns | Does not own |
+|---|---|---|---|
+| RuntimeMode | 1.1/1.2 | Current posture: duty/cycle/ambient | Future assignment, capability, loop policy |
+| Assignment | 1.1/1.3 | Commitment/responsibility | Current focus or capability definition |
+| Duty | 1.3 | Persistent service responsibility | Iterative continuance policy |
+| Cycle | 1.x | Bounded formal work | Long-running duty/autonomy |
+| Run | 1.x | Execution attempt | Goal continuance policy |
+| Loop Policy | late 1.x | Continue/repair/retry/fork/escalate/stop decisions | Runtime mode, duty assignment, agent identity |
+| Capability | 2.0 | Domain-level ability | Agent identity, raw tool authority |
+| Skill | 2.0 | Governed use of a tool | Domain-level outcome |
+| Tool | 2.0 | Instrument/API/service/adapter | Intent or policy |
+| Working Set | 2.0 | Prepared execution context | Durable memory authority |
+| Memory | 2.0 | Scoped learned context | Canonical resource authority |
+| Artifact Workspace | 2.0 | Shared work state | RuntimeActivity replacement |
+
+---
+
+## 12. Strategic Narrative
+
+The roadmap story is clean:
+
+### 1.1
+
+> Make the machine reliable.
+
+### 1.2
+
+> Make agent presence observable.
+
+### 1.3
+
+> Make operational responsibility durable and schedulable.
+
+### Late 1.x
+
+> Make improvement across runs evidence-guided.
+
+### 2.0
+
+> Make agents capability-backed specialists.
+
+This is a strong architecture progression because each stage creates a platform layer the next stage can rely on.
+
+---
+
+## 13. Recommended Next Moves
+
+### Immediate
+
+Finish 1.1 hardening without pulling in the 2.0 concepts.
+
+### Next
+
+Complete runtime/duty roster assignment and Continuum visibility.
+
+### Then
+
+Draft the late 1.x Loop Policy SIP.
+
+Suggested title:
+
+> **SIP: Loop Policy for Verification-Guided Cycle Continuance**
+
+Core invariant:
+
+> **Loop is a continuance policy around bounded work. It does not replace Cycle, Duty, Run, Task, FocusLease, or RuntimeActivity.**
+
+### Later
+
+Keep the Capability Pack Plugin SIP and Skill-Mediated Tool Use amendment as the 2.0 architecture target.
+
+---
+
+## 14. Final Roadmap Principle
+
+> **Do not give agents more autonomy before the runtime can observe, schedule, verify, and govern them.**
+
+The right order is:
+
+1. harden execution,
+2. mature runtime and duty,
+3. add loop continuance,
+4. then make agents capability-backed, memory-aware, and tool-governed.
+
+This preserves SquadOps' architectural discipline while giving it a clear path toward much more capable specialist agents.

--- a/sips/accepted/SIP-0090-Agent-Embodiment-Substrate.md
+++ b/sips/accepted/SIP-0090-Agent-Embodiment-Substrate.md
@@ -12,7 +12,7 @@ updated_at: '2026-04-25T17:57:13.839284Z'
 **Authors:** Jason Ladd
 **Created:** 2026-04-25
 **Revision:** 2 (incorporated review feedback on 2026-04-25)
-**Targets:** v1.2
+**Targets:** v1.2 (Phase 1 — shipped in 1.2.0; Phases 2+ target v1.4+, first live adapter = Discord)
 **Depends on:** `sips/accepted/SIP-0089-Agent-Runtime-State.md` (v1.1) — must land first
 **Parent vision:** `sips/accepted/SIP-0088-Agent-Runtime-Modes.md` (umbrella index)
 **Sibling:** `sips/accepted/SIP-0091-Duty-Durability-via-Temporal.md` (v1.3)

--- a/sips/accepted/SIP-0091-Duty-Durability-via-Temporal.md
+++ b/sips/accepted/SIP-0091-Duty-Durability-via-Temporal.md
@@ -12,7 +12,7 @@ updated_at: '2026-04-25T17:57:14.005001Z'
 **Authors:** Jason Ladd
 **Created:** 2026-04-25
 **Revision:** 2 (incorporated review feedback on 2026-04-25)
-**Targets:** v1.3
+**Targets:** v1.4 (feature minor — headline alongside SIP-0096; remapped from the stale v1.3 self-tag, which predated the even/odd convention #281 under which 1.3 is feature-free stabilization — see `docs/plans/2-0-roadmap-reconciliation.md` Finding 4, #335)
 **Depends on:** `sips/accepted/SIP-0089-Agent-Runtime-State.md` (v1.1) — must land first
 **Parent vision:** `sips/accepted/SIP-0088-Agent-Runtime-Modes.md` (umbrella index)
 **Sibling:** `sips/accepted/SIP-0090-Agent-Embodiment-Substrate.md` (v1.2)

--- a/sips/proposed/SIP-Edge-Deployment-Profile.md
+++ b/sips/proposed/SIP-Edge-Deployment-Profile.md
@@ -1,0 +1,412 @@
+---
+title: Edge Deployment Profile for Lightweight SquadOps Nodes
+status: proposed
+author: jladd
+created_at: '2026-03-16T00:00:00Z'
+---
+# SIP: Edge Deployment Profile for Lightweight SquadOps Nodes
+
+## Status
+Proposed
+
+## Summary
+
+Introduce an `edge-nano` deployment profile for SquadOps that allows hardware-constrained nodes (initially a Jetson Nano) to participate as managed capability nodes. An edge node bootstraps from the main repo, deploys only targeted agents, connects to the Spark-hosted RabbitMQ broker as a remote AMQP client, and registers with the primary control plane for discovery and routing.
+
+The first reference agent is an OpenClaw wrapper that translates SquadOps task envelopes into local OpenClaw HTTP API calls and returns structured results.
+
+## SIP Relationships
+- **Extends SIP-0081** (Profile-Driven Bootstrap): Adds `edge-nano` as a new bootstrap profile with reduced dependencies.
+- **Extends SIP-0077** (Cycle Event System): Edge nodes emit registration/heartbeat events via the existing event bus.
+- **Uses SIP-0062** (Auth Boundary): Edge nodes authenticate via Keycloak service account (client credentials grant).
+
+## Problem
+
+SquadOps assumes a rich runtime (Docker Compose with 17+ services, local Postgres, Redis, etc.). A Jetson Nano cannot run the full platform but should be able to host a specialized local runtime (OpenClaw) and expose it as a governed, discoverable SquadOps capability. No deployment profile exists for this use case.
+
+## Goals
+
+1. Add `edge-nano` as a bootstrap profile with minimal dependencies (Python, Docker, AMQP client — no local Postgres/Redis/Keycloak).
+2. Implement an `EdgeNodeRegistryPort` so the primary control plane tracks edge node identity, capabilities, and health.
+3. Deploy an OpenClaw wrapper agent on the Nano that consumes tasks via RabbitMQ and returns structured results.
+4. Authenticate edge nodes via Keycloak service account — no interactive login.
+5. Keep the edge runtime to a single agent container plus the local OpenClaw process.
+
+## Non-Goals
+
+1. Running any control-plane services (Postgres, Redis, runtime-api, Keycloak) on the edge node.
+2. Multi-agent group chat or A2A messaging on edge nodes.
+3. Agent-to-agent messaging without human intermediary.
+4. Dynamic migration of arbitrary agents to edge — only explicitly configured agents deploy.
+5. Local LLM inference on the Nano — the wrapper agent calls OpenClaw's local API, not an LLM.
+
+---
+
+## Design
+
+### 1. Architecture
+
+```text
+[Primary Spark]
+  Orchestration, RabbitMQ, Postgres, Redis,
+  Keycloak, runtime-api, all squad agents
+        |
+        | TLS AMQP (5671) + HTTPS (Keycloak token endpoint)
+        v
+[Edge Nano]
+  openclaw-wrapper agent container
+  OpenClaw runtime (local process or container)
+  edge-node-client (registration + heartbeat)
+```
+
+The edge node connects to the Spark-hosted RabbitMQ as a remote native AMQP client. It does not run its own broker. Registration and heartbeat go through the runtime-api over HTTPS.
+
+### 2. EdgeNodeRegistryPort
+
+A new port on the primary side tracks edge nodes. This is a primary-side port — edge nodes call it via runtime-api HTTP endpoints, not directly.
+
+```python
+class EdgeNodeRegistryPort(ABC):
+    """Registry for edge node identity, capabilities, and health."""
+
+    @abstractmethod
+    async def register_node(self, registration: EdgeNodeRegistration) -> None:
+        """Register or re-register an edge node. Idempotent by node_id."""
+
+    @abstractmethod
+    async def heartbeat(self, node_id: str, status: EdgeNodeStatus) -> None:
+        """Update node health. Sets last_heartbeat_at and current status."""
+
+    @abstractmethod
+    async def deregister_node(self, node_id: str) -> None:
+        """Mark node unavailable. Does not delete — preserves audit trail."""
+
+    @abstractmethod
+    async def get_node(self, node_id: str) -> EdgeNodeRegistration | None:
+        """Return node registration or None if unknown."""
+
+    @abstractmethod
+    async def list_available_nodes(self) -> list[EdgeNodeRegistration]:
+        """Return nodes with status READY and heartbeat within TTL."""
+```
+
+```python
+@dataclass(frozen=True)
+class EdgeNodeRegistration:
+    node_id: str                          # e.g. "nano-01"
+    hostname: str                         # e.g. "jetson-nano-01.local"
+    deployment_profile: str               # "edge-nano"
+    hardware_class: str                   # "jetson-nano", "jetson-orin", etc.
+    agent_ids: list[str]                  # ["openclaw-wrapper"]
+    capabilities: list[str]              # ["edge.openclaw.command", "edge.openclaw.chat"]
+    concurrency_limit: int                # max simultaneous tasks
+    status: str                           # STARTING | READY | DEGRADED | OFFLINE
+    registered_at: datetime
+    last_heartbeat_at: datetime | None
+    metadata: dict[str, str]              # free-form (firmware version, IP, etc.)
+```
+
+### 3. OpenClaw Wrapper Agent
+
+The wrapper is a standard `BaseAgent` subclass with a reduced `PortsBundle` (no memory, no prompt_service, no llm). It translates TaskEnvelopes into OpenClaw HTTP API calls:
+
+```python
+class OpenClawWrapperAgent(BaseAgent):
+    """Edge agent wrapping a local OpenClaw runtime via HTTP."""
+
+    def __init__(self, *, queue: QueuePort, metrics: MetricsPort,
+                 events: EventPort, openclaw_url: str, **kwargs):
+        super().__init__(
+            llm=None, memory=None, prompt_service=None,
+            queue=queue, metrics=metrics, events=events,
+            filesystem=None, **kwargs,
+        )
+        self._openclaw_url = openclaw_url  # e.g. "http://localhost:8000"
+
+    async def handle_task(self, envelope: TaskEnvelope) -> TaskResult:
+        """Route task to OpenClaw and normalize response."""
+        # Map task_type to OpenClaw endpoint
+        endpoint = _TASK_TYPE_TO_ENDPOINT[envelope.task_type]
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{self._openclaw_url}{endpoint}",
+                json={"input": envelope.payload},
+                timeout=envelope.resolved_config.get("timeout_seconds", 120),
+            )
+            resp.raise_for_status()
+        return TaskResult(
+            task_id=envelope.task_id,
+            status="completed",
+            output=resp.json(),
+        )
+```
+
+OpenClaw exposes an HTTP API (assumed at `http://localhost:8000`). The wrapper does not call an LLM — it translates between SquadOps task format and OpenClaw's REST interface. If OpenClaw's API shape differs, only `_TASK_TYPE_TO_ENDPOINT` and the request/response mapping change.
+
+### 4. Bootstrap Profile
+
+```yaml
+# config/profiles/bootstrap/edge-nano.yaml
+schema_version: 1
+name: edge-nano
+description: "Jetson Nano edge node — OpenClaw wrapper agent"
+
+platform:
+  os: linux
+  distro: ubuntu
+  distro_min_version: "20.04"
+
+python:
+  version: "3.11"
+  manager: system        # Nano ships with system Python; no pyenv
+  extras: []
+  test_deps: null        # No test runner on edge
+
+system_deps:
+  - name: docker
+    check: "docker --version"
+    install: apt
+    package: docker.io
+    required: true
+    confirm: false
+
+docker_services: []      # No local services — connects to Spark's
+
+ollama_models: []        # No local LLM
+
+deployment_profile: edge
+squad_profile: null      # No squad — single agent only
+```
+
+The bootstrap shell script for `edge-nano` installs Python 3.11, Docker, and pip dependencies from `requirements/edge.txt` (a minimal subset: `pika`, `httpx`, `pydantic`). It does NOT start Postgres, Redis, Keycloak, or any squad agents.
+
+### 5. RabbitMQ Connectivity and Credentials
+
+Edge nodes connect to the Spark-hosted RabbitMQ over TLS (port 5671). Credential provisioning:
+
+1. **Primary-side setup** (one-time, maintainer): Create a scoped RabbitMQ user and vhost for edge nodes via `rabbitmqctl` or management API. The user has `configure` + `read` + `write` permissions scoped to `edge.*` queue/exchange patterns only.
+2. **Edge-side config**: The bootstrap writes a `.env` file with `SQUADOPS__COMMS__RABBITMQ__URL=amqps://edge-nano-01:secret@spark.local:5671/edge`. The password is provisioned out-of-band (copied manually or via `scp` during bootstrap — no credential service on the Nano).
+3. **TLS**: RabbitMQ on Spark exposes port 5671 with TLS. The edge node's `.env` includes `SQUADOPS__COMMS__RABBITMQ__CA_CERT=/etc/squadops/ca.pem`. Self-signed CA is acceptable for local network.
+
+Queue declarations follow the existing idempotent pattern — the wrapper agent declares its queue (`edge.openclaw.tasks`) and binding on every startup.
+
+### 6. Authentication
+
+Edge nodes authenticate to the runtime-api (for registration/heartbeat) using a Keycloak **service account** (client credentials grant). No interactive login.
+
+1. Maintainer creates a Keycloak client `edge-nano-01` with `Service Account Roles` enabled in the `squadops-dev` realm.
+2. Client ID and secret are written to the edge node's `.env` during bootstrap.
+3. The edge-node-client fetches a token from `https://spark.local:8180/realms/squadops-dev/protocol/openid-connect/token` on startup and refreshes it on expiry.
+4. Registration and heartbeat calls include the bearer token. The runtime-api validates it via the existing auth middleware (SIP-0062).
+
+### 7. Registration and Heartbeat
+
+The `edge-node-client` is a lightweight Python process (or thread within the wrapper agent) that:
+
+1. On startup: `POST /api/edge/nodes` with `EdgeNodeRegistration` payload. Idempotent by `node_id`.
+2. Every 30s: `PUT /api/edge/nodes/{node_id}/heartbeat` with current status and task counts.
+3. On shutdown (SIGTERM): `DELETE /api/edge/nodes/{node_id}` to mark offline.
+
+The primary-side registry marks a node `OFFLINE` if no heartbeat is received within 90s (3x interval). The orchestrator skips offline nodes when routing tasks.
+
+### 8. Readiness Model
+
+Two-tier readiness, both required before routing:
+
+| Layer | Condition | Checked by |
+|-------|-----------|------------|
+| **Messaging** | AMQP connected, queue declared, consumer active | Wrapper agent (local) |
+| **Platform** | Registered, heartbeat current, status READY | Primary registry (TTL-based) |
+
+The wrapper agent does not set status to READY until both its RabbitMQ consumer is active AND the local OpenClaw health endpoint (`GET /health`) responds 200.
+
+### 9. Chat Persistence (DDL)
+
+```sql
+-- infra/migrations/007_edge_node_registry.sql
+-- SIP-EDGE-NANO: Edge node registration and health tracking
+
+CREATE TABLE edge_nodes (
+    node_id         TEXT PRIMARY KEY,
+    hostname        TEXT NOT NULL,
+    deployment_profile TEXT NOT NULL DEFAULT 'edge-nano',
+    hardware_class  TEXT NOT NULL,
+    agent_ids       JSONB NOT NULL DEFAULT '[]',
+    capabilities    JSONB NOT NULL DEFAULT '[]',
+    concurrency_limit INT NOT NULL DEFAULT 1,
+    status          TEXT NOT NULL DEFAULT 'STARTING'
+                    CHECK (status IN ('STARTING', 'READY', 'DEGRADED', 'OFFLINE')),
+    registered_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_heartbeat_at TIMESTAMPTZ,
+    metadata        JSONB DEFAULT '{}'
+);
+
+CREATE INDEX idx_edge_nodes_status ON edge_nodes(status);
+```
+
+### 10. Docker Compose (Edge-Side)
+
+The edge node uses a separate `docker-compose.edge.yaml` (not the primary `docker-compose.yml`):
+
+```yaml
+# docker-compose.edge.yaml — runs on the Jetson Nano
+services:
+  openclaw-wrapper:
+    build:
+      context: .
+      dockerfile: agents/edge/Dockerfile
+      args:
+        AGENT_ROLE: openclaw_wrapper
+    container_name: squadops-openclaw-wrapper
+    restart: unless-stopped
+    environment:
+      SQUADOPS__AGENT__ID: openclaw-wrapper
+      SQUADOPS_AGENT_ROLE: openclaw_wrapper
+      SQUADOPS__COMMS__RABBITMQ__URL: "${SQUADOPS__COMMS__RABBITMQ__URL}"
+      SQUADOPS__EDGE__OPENCLAW_URL: "http://host.docker.internal:8000"
+      SQUADOPS__EDGE__NODE_ID: "${SQUADOPS__EDGE__NODE_ID}"
+      SQUADOPS__EDGE__RUNTIME_API_URL: "${SQUADOPS__EDGE__RUNTIME_API_URL}"
+      SQUADOPS__AUTH__CLIENT_ID: "${SQUADOPS__AUTH__CLIENT_ID}"
+      SQUADOPS__AUTH__CLIENT_SECRET: "${SQUADOPS__AUTH__CLIENT_SECRET}"
+      SQUADOPS__AUTH__TOKEN_URL: "${SQUADOPS__AUTH__TOKEN_URL}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    network_mode: host  # Simplifies Nano networking — no docker network needed
+```
+
+OpenClaw itself runs as a host process (not in Docker) since it may need direct hardware access. The wrapper container reaches it via `host.docker.internal` or `localhost` (with `network_mode: host`).
+
+---
+
+## Key Design Decisions
+
+### D1: Edge as Managed Capability Node, Not Peer
+Edge nodes are not reduced control planes. They do not run Postgres, Redis, Keycloak, or runtime-api. They connect to existing infrastructure on the Spark. This keeps the edge footprint minimal and avoids split-brain scenarios.
+
+### D2: Native Remote AMQP, Not Bridge
+Edge agents connect directly to the Spark's RabbitMQ over TLS as remote AMQP clients. No message bridge, no local broker. This reuses the existing RabbitMQ adapter (`adapters/comms/rabbitmq.py`) with only a connection URL change.
+
+### D3: Keycloak Service Account for Auth
+Edge nodes use OAuth2 client credentials (not interactive login). The maintainer provisions a Keycloak client per edge node. Credentials are injected via `.env` during bootstrap — no credential service runs on the Nano.
+
+### D4: Scoped RabbitMQ Permissions
+Edge users have permissions scoped to `edge.*` patterns. An edge node cannot declare or consume queues belonging to primary agents. This is enforced at the broker level, not application level.
+
+### D5: Primary-Side Registry in Postgres
+Edge node registration lives in the primary Postgres (table `edge_nodes`). The runtime-api exposes CRUD + heartbeat endpoints. No new service — these are routes on the existing API.
+
+### D6: Heartbeat-Based Liveness
+30s heartbeat interval, 90s TTL. Missed heartbeats mark the node OFFLINE. The orchestrator filters out offline nodes before routing. No complex consensus — simple TTL expiry.
+
+### D7: Wrapper Agent Uses BaseAgent, Not LLM
+The OpenClaw wrapper extends `BaseAgent` but passes `llm=None`. It is a protocol translator (TaskEnvelope → HTTP → TaskResult), not a generative agent. This keeps the edge dependency set minimal.
+
+### D8: Separate docker-compose.edge.yaml
+Edge nodes do not use the primary `docker-compose.yml`. A dedicated `docker-compose.edge.yaml` defines only the wrapper container. This avoids accidental startup of primary services on constrained hardware.
+
+### D9: One Wrapper Agent per Edge Profile (v1)
+v1 supports one agent per edge node. Multi-agent edge nodes are future work — the `agent_ids` list in the registry supports it, but the bootstrap and compose file wire exactly one agent.
+
+### D10: OpenClaw HTTP API Assumption
+The wrapper assumes OpenClaw exposes a local HTTP API. If OpenClaw is CLI-only, the wrapper shells out via `subprocess` instead. The adapter boundary is in the wrapper agent, not in a port — OpenClaw is a local detail, not a SquadOps abstraction.
+
+---
+
+## File-Level Design
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/squadops/ports/edge/node_registry.py` | `EdgeNodeRegistryPort` abstract interface |
+| `src/squadops/edge/models.py` | `EdgeNodeRegistration`, `EdgeNodeStatus` frozen dataclasses |
+| `adapters/edge/postgres_node_registry.py` | Postgres adapter for `EdgeNodeRegistryPort` |
+| `src/squadops/agents/edge/openclaw_wrapper.py` | `OpenClawWrapperAgent(BaseAgent)` — task-to-HTTP translator |
+| `src/squadops/agents/edge/node_client.py` | Registration + heartbeat client (calls runtime-api) |
+| `src/squadops/api/routes/edge/routes.py` | Edge node API routes (register, heartbeat, list, deregister) |
+| `src/squadops/api/routes/edge/dtos.py` | Edge DTOs: `EdgeNodeRegistrationRequest`, `EdgeNodeDTO` |
+| `infra/migrations/007_edge_node_registry.sql` | DDL for `edge_nodes` table |
+| `config/profiles/bootstrap/edge-nano.yaml` | Bootstrap profile for Jetson Nano |
+| `scripts/bootstrap/profiles/edge-nano.sh` | Bootstrap shell script for edge profile |
+| `agents/edge/Dockerfile` | Minimal Dockerfile for edge wrapper agent |
+| `docker-compose.edge.yaml` | Edge-side compose file (wrapper container only) |
+| `requirements/edge.txt` | Minimal pip deps: pika, httpx, pydantic |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/squadops/api/main.py` | Mount edge routes (`/api/edge/`) |
+| `agents/instances/instances.yaml` | Add `openclaw-wrapper` instance (role: `edge_wrapper`, enabled: false by default) |
+| `src/squadops/agents/base.py` | Allow `llm=None` in BaseAgent constructor (guard existing property) |
+| `src/squadops/bootstrap/setup/profile.py` | No changes needed — schema already supports the edge-nano.yaml shape |
+| `scripts/bootstrap/bootstrap.sh` | Add `edge-nano` to recognized profile list |
+
+### Files NOT Modified
+
+| File | Reason |
+|------|--------|
+| `docker-compose.yml` | Edge nodes use separate `docker-compose.edge.yaml` (D8) |
+| `adapters/comms/rabbitmq.py` | Reused as-is — only the connection URL differs |
+| `src/squadops/cycles/` | No cycle model changes — edge tasks use existing TaskEnvelope |
+| `src/squadops/capabilities/handlers/` | No handler changes — wrapper agent handles its own task routing |
+
+---
+
+## Implementation Phases
+
+### Phase 1: Foundation — Profile, Port, DDL
+- Add `edge-nano.yaml` bootstrap profile and shell script
+- Implement `EdgeNodeRegistryPort` and `EdgeNodeRegistration` model
+- Implement Postgres adapter (`edge_nodes` table, DDL migration 007)
+- Add `requirements/edge.txt`
+- Tests: profile validation, port contract, registry adapter CRUD, heartbeat TTL
+
+### Phase 2: Wrapper Agent and Edge Entrypoint
+- Implement `OpenClawWrapperAgent(BaseAgent)` with HTTP-based task handling
+- Implement `edge-node-client` (registration + heartbeat against runtime-api)
+- Create `agents/edge/Dockerfile` and `docker-compose.edge.yaml`
+- Wire Keycloak service account token fetch
+- Tests: wrapper unit tests with mock OpenClaw HTTP, node client registration/heartbeat, auth token refresh
+
+### Phase 3: Runtime-API Routes and Routing
+- Add edge node API routes (register, heartbeat, list available, deregister)
+- Add DTOs and mapping
+- Wire orchestrator to filter out offline edge nodes when routing tasks
+- Tests: route tests, availability filtering, heartbeat expiry
+
+### Phase 4: E2E Validation
+- Bootstrap a Jetson Nano with `edge-nano` profile
+- Deploy OpenClaw wrapper, connect to Spark RabbitMQ
+- Send a task from primary, verify round-trip through OpenClaw
+- Validate registration, heartbeat, and offline detection
+- Version bump, SIP promotion
+
+---
+
+## Acceptance Criteria
+
+1. `squadops bootstrap edge-nano` installs minimal deps and does NOT start Postgres/Redis/Keycloak.
+2. `squadops doctor edge-nano` validates Python, Docker, AMQP connectivity, and OpenClaw health.
+3. Edge wrapper agent starts, declares `edge.openclaw.tasks` queue on Spark's RabbitMQ, and consumes tasks.
+4. `POST /api/edge/nodes` registers the edge node; `GET /api/edge/nodes` returns it with status READY.
+5. Missed heartbeats (>90s) cause the node status to transition to OFFLINE.
+6. A task routed to the edge agent returns a structured `TaskResult` with OpenClaw output.
+7. Edge RabbitMQ user cannot access non-`edge.*` queues (broker-level enforcement).
+8. Keycloak service account token authenticates edge API calls through existing auth middleware.
+
+---
+
+## Risks
+
+### A1: OpenClaw API Instability
+OpenClaw's HTTP API may change. **Mitigation**: The wrapper's `_TASK_TYPE_TO_ENDPOINT` mapping isolates SquadOps from OpenClaw's API shape. Changes are confined to the wrapper agent.
+
+### A2: Network Reliability (Nano ↔ Spark)
+WiFi or LAN flakiness may cause AMQP disconnects. **Mitigation**: `pika`'s built-in connection recovery handles reconnects. Heartbeat TTL (90s) tolerates brief outages without marking the node offline.
+
+### A3: Nano Resource Constraints
+Docker + Python + OpenClaw on a 4GB Nano is tight. **Mitigation**: The wrapper agent is minimal (no LLM, no memory, no prompt service). `docker-compose.edge.yaml` runs a single container. Monitor memory during Phase 4 E2E and adjust concurrency_limit accordingly.
+
+### A4: Credential Provisioning is Manual
+v1 requires manually copying RabbitMQ and Keycloak credentials to the Nano. **Mitigation**: Acceptable for a single-device lab setup. A future SIP can add a credential enrollment flow if edge nodes scale beyond 2-3 devices.

--- a/sips/proposed/SIP-Experiment-Queue-and-Cycle-Assessment.md
+++ b/sips/proposed/SIP-Experiment-Queue-and-Cycle-Assessment.md
@@ -1,0 +1,435 @@
+---
+title: Experiment Queue and Cycle Assessment Framework
+status: proposed
+authors: SquadOps Architecture
+created_at: '2026-03-29'
+---
+# SIP: Experiment Queue and Cycle Assessment Framework
+
+**Status:** Proposed
+**Authors:** SquadOps Architecture
+**Created:** 2026-03-29
+
+## 1. Abstract
+
+Introduce a governed experiment queue and cycle assessment framework for SquadOps. This SIP adds the ability to define hypotheses with measurable targets, queue experiments containing one or more cycle configurations, execute them sequentially through the existing cycle pipeline, score each cycle with a structured assessment, and evaluate results against the hypothesis.
+
+The framework extends the existing multi-workload orchestration (SIP-0083) by one level: an experiment is a governed sequence of cycles, the same way a cycle is a governed sequence of workloads. No new agent roles are introduced. The existing squad produces assessment artifacts through new handlers in the wrap-up workload.
+
+This is the foundation for Plutarch — the master experimenter capability for SquadOps. v1.1 establishes the harness; v1.2 can plug in an autonomous experimenter that designs and queues experiments via the same API.
+
+## 2. Problem Statement
+
+SquadOps can execute cycles and produce artifacts, but it has no structured way to:
+
+1. **Measure cycle effectiveness** — there is no standardized scorecard that captures outcome quality, efficiency, retry burden, or artifact completeness in a comparable format across cycles.
+2. **Test hypotheses** — there is no mechanism to define what "better" means for a given change (new memory rules, different model, changed routing) and measure whether the change actually improved outcomes.
+3. **Run multiple experiments unattended** — operators must manually create cycles one at a time and visually inspect results. There is no queue, no batch execution, and no automated comparison.
+4. **Accumulate operational knowledge** — without structured assessment, lessons from each cycle remain trapped in raw telemetry and human memory rather than feeding into a measurable improvement loop.
+
+Without this, SquadOps cannot answer its central question: **can coordinated squads outperform a single strong model on sustained software-building work, and what changes improve that performance?**
+
+## 3. Goals
+
+1. Define a `CycleAssessment` artifact produced after every cycle, scoring outcome, quality, efficiency, and stability in a structured, comparable format.
+2. Define an `ExperimentDefinition` model that captures a hypothesis, target metrics with thresholds, a list of cycle configurations to run, and budget/stop controls.
+3. Implement an experiment queue (Postgres-backed) with CLI and API operations: queue, list, show, cancel.
+4. Implement an experiment runner that processes queued experiments: execute each cycle, collect assessments, evaluate against hypothesis thresholds, produce an `ExperimentAssessment`.
+5. Add a `CycleAssessmentHandler` to the wrap-up workload (Data role) that consumes run telemetry and produces the scorecard artifact.
+6. Expose experiment results as structured artifacts in the vault for downstream consumption (future diagnosis, MemoryRule extraction, trend analysis).
+
+## 4. Non-Goals
+
+1. Autonomous experiment design — v1.1 is human-queued, system-executed.
+2. External benchmark integration (SWE-bench, BFCL, etc.) — deferred to v1.2.
+3. MemoryRule extraction or registry — separate SIP, consumes this framework's output.
+4. Failure diagnosis automation — v1.1 produces scorecards; structured diagnosis is a follow-on.
+5. Squad health or agent impact assessments — deferred to v1.2.
+6. Model lane policies or automatic model swapping.
+7. New agent roles — experiments use the existing squad.
+
+## 5. SIP Relationships
+
+- **Extends SIP-0083** (Multi-Run Cycle Orchestration): Adds `execute_experiment` as a higher-order loop over `execute_cycle`.
+- **Extends SIP-0080** (Wrap-Up Workload Protocol): Adds a `CycleAssessmentHandler` to the wrap-up task steps.
+- **Uses SIP-0077** (Cycle Event System): Emits experiment lifecycle events.
+- **Uses SIP-0076** (Workload-Gate Canon): Experiments use auto-gates for unattended execution.
+- **Prepares for** Collaborative Memory Distillation: Assessment artifacts are the input for future MemoryRule extraction.
+- **Prepares for** Plutarch v1.2: The experiment API becomes the surface an autonomous experimenter calls.
+
+## 6. Design
+
+### 6.1 CycleAssessment Artifact
+
+Produced by the Data role during wrap-up. Consumes telemetry from the completed cycle.
+
+```yaml
+kind: CycleAssessment
+uid: assessment-cyc_a6161205cf1e
+cycle_id: cyc_a6161205cf1e
+run_id: run_43022c7d61c6
+project_id: play_game
+squad_profile_id: full-squad
+request_profile: selftest
+model: qwen2.5:7b
+
+scores:
+  outcome: 1.0          # 1.0 = completed, 0.5 = partial, 0.0 = failed
+  quality: 0.85         # test pass ratio, artifact completeness
+  efficiency: 0.72      # inverse of retry/rewind/escalation burden
+  stability: 0.90       # no downstream regressions, correction loops bounded
+
+telemetry:
+  total_tasks: 5
+  completed_tasks: 5
+  failed_tasks: 0
+  retries: 1
+  corrections: 0
+  rewinds: 0
+  wall_clock_seconds: 127
+  token_cost_usd: 0.42
+
+artifact_summary:
+  total_artifacts: 5
+  artifact_types:
+    document: 3
+    source: 1
+    test: 1
+
+tags: {}
+```
+
+#### Scoring Rules
+
+| Dimension | Inputs | Formula (v1) |
+|-----------|--------|-------------|
+| outcome | terminal status | COMPLETED=1.0, FAILED=0.0, CANCELLED=0.0 |
+| quality | test_pass_ratio, artifact_count vs expected | weighted average |
+| efficiency | retries, corrections, rewinds, wall_clock vs budget | 1.0 - (penalty_sum / max_penalty) clamped to [0,1] |
+| stability | correction_attempts, downstream failures | 1.0 - (instability_signals / max_signals) |
+
+Exact weights are configurable via `applied_defaults` on the cycle request profile. v1 uses simple defaults; refinement is expected through experimentation.
+
+### 6.2 ExperimentDefinition Model
+
+```python
+@dataclass(frozen=True)
+class ExperimentDefinition:
+    experiment_id: str
+    hypothesis: str
+    target_metrics: tuple[TargetMetric, ...]
+    cycle_configs: tuple[ExperimentCycleConfig, ...]
+    budget_cap_usd: float | None = None
+    time_cap_seconds: int | None = None
+    stop_on_first_failure: bool = False
+    status: str = "queued"  # queued | running | completed | failed | cancelled
+    created_at: datetime
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    tags: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TargetMetric:
+    metric: str          # e.g. "retries", "quality", "outcome", "wall_clock_seconds"
+    operator: str        # lte, gte, eq, lt, gt
+    threshold: float
+
+
+@dataclass(frozen=True)
+class ExperimentCycleConfig:
+    project_id: str
+    request_profile: str
+    squad_profile: str
+    execution_overrides: dict[str, Any] = field(default_factory=dict)
+    tags: dict[str, str] = field(default_factory=dict)  # e.g. {"role": "baseline"}
+```
+
+### 6.3 ExperimentAssessment Artifact
+
+Produced after all cycles in an experiment complete.
+
+```yaml
+kind: ExperimentAssessment
+uid: exp-assessment-exp_001
+experiment_id: exp_001
+hypothesis: "MemoryRules reduce retry count below 2"
+verdict: passed  # passed | failed | inconclusive
+target_metrics:
+  - metric: retries
+    operator: lte
+    threshold: 2.0
+    observed_values: [1, 3]
+    passed: false
+  - metric: quality
+    operator: gte
+    threshold: 0.8
+    observed_values: [0.85, 0.78]
+    passed: false
+cycle_assessments:
+  - assessment_id: assessment-cyc_001
+    tags: { role: baseline }
+  - assessment_id: assessment-cyc_002
+    tags: { role: challenger }
+summary: "1 of 2 target metrics met. Retry count exceeded threshold in challenger cycle."
+```
+
+### 6.4 Experiment Queue (DDL)
+
+```sql
+CREATE TABLE experiments (
+    experiment_id   TEXT PRIMARY KEY,
+    hypothesis      TEXT NOT NULL,
+    target_metrics  JSONB NOT NULL DEFAULT '[]',
+    cycle_configs   JSONB NOT NULL DEFAULT '[]',
+    budget_cap_usd  NUMERIC,
+    time_cap_seconds INT,
+    stop_on_first_failure BOOLEAN NOT NULL DEFAULT false,
+    status          TEXT NOT NULL DEFAULT 'queued'
+                    CHECK (status IN ('queued', 'running', 'completed', 'failed', 'cancelled')),
+    queue_position  SERIAL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    started_at      TIMESTAMPTZ,
+    finished_at     TIMESTAMPTZ,
+    cycle_ids       JSONB DEFAULT '[]',
+    assessment_refs JSONB DEFAULT '[]',
+    tags            JSONB DEFAULT '{}',
+    error           TEXT
+);
+
+CREATE INDEX idx_experiments_status ON experiments(status);
+CREATE INDEX idx_experiments_queue ON experiments(queue_position) WHERE status = 'queued';
+```
+
+### 6.5 ExperimentRegistryPort
+
+```python
+class ExperimentRegistryPort(ABC):
+    """Registry for experiment definitions and queue management."""
+
+    @abstractmethod
+    async def enqueue(self, definition: ExperimentDefinition) -> None:
+        """Add an experiment to the queue. Idempotent by experiment_id."""
+
+    @abstractmethod
+    async def dequeue_next(self) -> ExperimentDefinition | None:
+        """Return the next queued experiment (by queue_position), or None."""
+
+    @abstractmethod
+    async def update_status(
+        self, experiment_id: str, status: str, **kwargs
+    ) -> None:
+        """Update experiment status and optional fields (started_at, finished_at, error)."""
+
+    @abstractmethod
+    async def append_cycle_id(self, experiment_id: str, cycle_id: str) -> None:
+        """Record a cycle_id created as part of this experiment."""
+
+    @abstractmethod
+    async def append_assessment_ref(
+        self, experiment_id: str, assessment_id: str
+    ) -> None:
+        """Record an assessment artifact produced for this experiment."""
+
+    @abstractmethod
+    async def get(self, experiment_id: str) -> ExperimentDefinition | None:
+        """Retrieve an experiment by ID."""
+
+    @abstractmethod
+    async def list_experiments(
+        self, status: str | None = None
+    ) -> list[ExperimentDefinition]:
+        """List experiments, optionally filtered by status."""
+```
+
+### 6.6 Experiment Execution Flow
+
+```
+execute_experiment(experiment_id)
+  │
+  ├─ for each cycle_config in experiment.cycle_configs:
+  │    ├─ create_cycle(project, profile, squad_profile, overrides)
+  │    ├─ execute_cycle(cycle_id)  # existing SIP-0083 flow
+  │    │    └─ includes wrap-up workload with CycleAssessmentHandler
+  │    ├─ collect CycleAssessment artifact from vault
+  │    ├─ check budget/time caps → break if exceeded
+  │    └─ check stop_on_first_failure → break if cycle failed
+  │
+  ├─ build ExperimentAssessment
+  │    ├─ compare each cycle's scorecard against target_metrics
+  │    ├─ determine verdict (passed/failed/inconclusive)
+  │    └─ store as artifact
+  │
+  └─ update experiment status → completed/failed
+```
+
+The experiment runner is a simple loop — no new orchestration paradigm. It calls `execute_cycle` (SIP-0083) for each cycle config and collects the results.
+
+### 6.7 CycleAssessmentHandler
+
+A new handler registered for the `data.assess_cycle` task type, added to the wrap-up workload task steps.
+
+```python
+class CycleAssessmentHandler(_CycleTaskHandler):
+    _handler_name = "cycle_assessment_handler"
+    _capability_id = "data.assess_cycle"
+    _role = "data"
+    _artifact_name = "cycle_assessment"
+```
+
+The handler:
+1. Receives run telemetry via `inputs` (task counts, retry counts, timing, artifact refs)
+2. Computes scores using the scoring rules
+3. Produces a `CycleAssessment` YAML artifact
+4. Stores it in the vault as artifact type `assessment`
+
+This does NOT require an LLM call. It's a deterministic computation from telemetry — the Data agent produces it as a structured artifact, not a generated document.
+
+### 6.8 CLI Commands
+
+```bash
+# Queue an experiment
+squadops experiments queue <project_id> \
+  --profile <profile>[,<profile2>] \
+  --squad-profile <squad_profile> \
+  --hypothesis "description" \
+  --metric "retries:lte:3" \
+  [--metric "quality:gte:0.8"] \
+  [--budget-cap-usd 25] \
+  [--tag role=baseline,role=challenger]
+
+# List experiments
+squadops experiments list [--status queued|running|completed]
+
+# Show experiment details + assessment
+squadops experiments show <experiment_id>
+
+# Cancel a queued experiment
+squadops experiments cancel <experiment_id>
+
+# Run the queue (processes experiments sequentially)
+squadops experiments run-queue [--max-experiments N] [--budget-cap-usd N]
+```
+
+### 6.9 API Routes
+
+```
+POST   /api/v1/experiments                    # enqueue
+GET    /api/v1/experiments                    # list (filter by status)
+GET    /api/v1/experiments/{experiment_id}    # show
+DELETE /api/v1/experiments/{experiment_id}    # cancel
+POST   /api/v1/experiments/run-queue          # start queue runner
+```
+
+### 6.10 Event Types
+
+New event types added to the existing taxonomy:
+
+```python
+EXPERIMENT_QUEUED = "experiment.queued"
+EXPERIMENT_STARTED = "experiment.started"
+EXPERIMENT_CYCLE_STARTED = "experiment.cycle_started"
+EXPERIMENT_CYCLE_COMPLETED = "experiment.cycle_completed"
+EXPERIMENT_ASSESSED = "experiment.assessed"
+EXPERIMENT_COMPLETED = "experiment.completed"
+EXPERIMENT_FAILED = "experiment.failed"
+EXPERIMENT_CANCELLED = "experiment.cancelled"
+```
+
+## 7. Key Design Decisions
+
+### D1: Experiments are N cycles, not forced pairs
+An experiment contains a list of cycle configs. Could be 1 (smoke test), 2 (A/B comparison), or 10 (repeatability study). The hypothesis + target metrics define success, not the structure.
+
+### D2: CycleAssessment is independent of experiments
+Every cycle can produce an assessment during wrap-up, regardless of whether it's part of an experiment. This makes assessments useful for standalone cycle monitoring too.
+
+### D3: Assessment scoring is deterministic, not LLM-generated
+The CycleAssessmentHandler computes scores from telemetry, not from LLM judgment. This ensures assessments are comparable and reproducible. LLM-assisted analysis belongs in a future diagnosis layer.
+
+### D4: No new agent roles
+Experiments use the existing squad. The Data agent produces assessments. Max leads cycles. No Plutarch agent.
+
+### D5: Experiment runner is framework-level
+The runner sits on `FlowExecutionPort`, same as `execute_cycle`. It is not an agent, not a workload — it's an outer loop that calls `execute_cycle` for each config.
+
+### D6: Auto-gates for unattended execution
+Experiment cycles should use `"auto"` gates (SIP-0083) so they can run without human intervention. The experiment definition inherits this from the cycle request profiles used.
+
+### D7: Queue runner is human-initiated in v1.1
+`run-queue` is a CLI/API command that processes experiments. It is not a persistent daemon. v1.2 can add scheduled or autonomous queue population.
+
+### D8: Budget enforcement at experiment level
+Budget caps and time caps are checked after each cycle completes. If exceeded, remaining cycles are skipped and the experiment status is set to `completed` with a note.
+
+### D9: Tags for flexible grouping
+Cycle configs have a `tags` dict (e.g., `{"role": "baseline"}`) that flows into the assessment. This allows flexible grouping without baking in baseline/challenger semantics.
+
+## 8. Implementation Phases
+
+### Phase 1: CycleAssessment Foundation
+- Define `CycleAssessment` frozen dataclass and YAML artifact schema
+- Implement `CycleAssessmentHandler` (deterministic scoring from telemetry)
+- Add `data.assess_cycle` to `WRAPUP_TASK_STEPS`
+- Register handler in capability dispatch
+- Tests: handler unit tests, scoring rule tests, artifact format tests
+
+### Phase 2: Experiment Models and Registry
+- Define `ExperimentDefinition`, `TargetMetric`, `ExperimentCycleConfig` frozen dataclasses
+- Define `ExperimentAssessment` artifact schema
+- Implement `ExperimentRegistryPort` and Postgres adapter
+- DDL migration for `experiments` table
+- Add `experiment_id` keys to `_APPLIED_DEFAULTS_EXTRA_KEYS` if needed
+- Tests: model tests, registry adapter CRUD, queue ordering
+
+### Phase 3: Experiment Execution
+- Implement `execute_experiment` on `FlowExecutionPort`
+- Implement experiment runner loop (cycle execution, assessment collection, budget checks)
+- Implement `ExperimentAssessment` generation (compare scorecards vs target metrics)
+- Wire experiment lifecycle events
+- Tests: executor unit tests, budget/stop condition tests, assessment comparison tests
+
+### Phase 4: CLI and API
+- Implement `experiments` CLI commands (queue, list, show, cancel, run-queue)
+- Implement experiment API routes
+- Wire DTOs and mapping
+- Tests: CLI tests, route tests
+
+### Phase 5: Integration and Validation
+- End-to-end: queue experiment via CLI, run queue, verify scorecards and assessment produced
+- Version bump
+- SIP promotion
+
+## 9. Acceptance Criteria
+
+1. Every cycle with a wrap-up workload produces a `CycleAssessment` artifact with outcome, quality, efficiency, and stability scores.
+2. `squadops experiments queue` creates an experiment with hypothesis, target metrics, and cycle configs.
+3. `squadops experiments run-queue` processes queued experiments, executing each cycle and collecting assessments.
+4. Each completed experiment produces an `ExperimentAssessment` with per-metric pass/fail against thresholds.
+5. Budget caps halt experiment execution when exceeded.
+6. Experiment status transitions are tracked (queued → running → completed/failed/cancelled).
+7. All experiment and assessment artifacts are stored in the vault and queryable.
+8. Experiments work with auto-gates for unattended execution.
+
+## 10. Risks
+
+### A1: Scoring formula produces misleading results early
+Mitigation: Start with simple formulas, make weights configurable, iterate based on experiment evidence. v1 scoring does not need to be perfect — it needs to be consistent and comparable.
+
+### A2: Queue runner hangs on a stuck cycle
+Mitigation: Time cap per experiment. The existing cycle-level time budget (SIP-0079) handles per-cycle timeouts. The experiment-level cap handles the aggregate.
+
+### A3: Assessment handler adds overhead to every cycle
+Mitigation: Assessment is a deterministic computation from telemetry — no LLM call, negligible latency. It's a structured artifact write, not a generation task.
+
+### A4: Experiment queue grows without bound
+Mitigation: Queue position ordering ensures FIFO. `--max-experiments` flag on `run-queue` bounds each invocation. Stale experiments can be cancelled.
+
+## 11. Future Extensions (v1.2+)
+
+- **Autonomous experiment design**: An external system (OpenClaw, scheduled job) reads prior assessments and queues new experiments via the API.
+- **MemoryRule extraction**: A diagnosis step consumes experiment assessments and proposes candidate MemoryRules from recurring failure patterns.
+- **External benchmarks**: Benchmark registry entries that reference SWE-bench, BFCL, etc., with experiment configs that run them.
+- **Trend analysis**: Historical assessment queries that detect regression or improvement over time.
+- **Squad health assessments**: Aggregate assessments across cycles to evaluate squad-level bottlenecks and handoff quality.
+- **Experiment scheduling**: Cron-based experiment queue population for continuous regression detection.

--- a/sips/registry.yaml
+++ b/sips/registry.yaml
@@ -1,14 +1,5 @@
 last_assigned: 97
 sips:
-- sip_uid: null
-  sip_number: null
-  title: Intelligent Delegation Protocols for SquadOps
-  path: sips/proposed/SIP-intelligent-delegation-protocols.md
-  status: proposed
-  author: SquadOps Core Team
-  approver: null
-  created_at: '2026-02-16T00:00:00Z'
-  updated_at: '2026-02-16T00:00:00Z'
 - sip_number: 3
   sip_uid: '17642554775787694'
   title: -SIP-003-Paperclip-Protocol-Squad-Arbitrage-Portfolio-Protocol

--- a/tests/unit/architecture/test_docs_version_sync.py
+++ b/tests/unit/architecture/test_docs_version_sync.py
@@ -1,0 +1,211 @@
+"""Docs-drift guards (#336).
+
+Version/doc drift shipped three separate times despite the sync rule in
+CLAUDE.md: CLAUDE.md + README stuck at 1.0.5 through the 1.1.x releases,
+the ROADMAP stats block stuck at 1.0.6 through 1.2.0 (#335), and accepted
+SIP-0091 self-targeting the feature-free stabilization minor. The pattern:
+what a test enforces stays true; what discipline enforces drifts. These
+guards put the ratchet in the regression gate.
+
+Three rules:
+1. Every version marker (CLAUDE.md / README.md / docs/ROADMAP.md) equals
+   the pyproject.toml version — a release bump physically cannot ship with
+   a stale marker.
+2. Every ``**Targets:** vX.Y`` line in an accepted SIP names an even minor
+   (feature SIPs ⇒ feature releases, per the even/odd convention #281),
+   unless the line itself says "stabilization" — the escape hatch for
+   structural SIPs like SIP-0097 that legitimately land on odd minors.
+3. Repo paths referenced from the living planning docs (ROADMAP + the
+   docs/plans/ set) exist in the tree — committed docs must not cite files
+   that live only in someone's working copy.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Line-anchored so SIP body prose like "Targets observed ..." (SIP-0092's
+# acceptance-check tables) can never false-positive.
+TARGETS_RE = re.compile(r"^\*\*Targets:\*\* *v(\d+)\.(\d+)(.*)$", re.MULTILINE)
+
+# Backtick-quoted repo-relative doc paths, e.g. `docs/plans/foo.md`.
+DOC_REF_RE = re.compile(r"`((?:docs|sips)/[A-Za-z0-9._/\-]+\.md)`")
+
+
+def _read(rel_path: str) -> str:
+    return (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def _pyproject_version() -> str:
+    match = re.search(r'^version = "(\d+\.\d+\.\d+)"', _read("pyproject.toml"), re.MULTILINE)
+    assert match, "pyproject.toml has no version field"
+    return match.group(1)
+
+
+def _odd_target_offenders(sip_text: str) -> list[str]:
+    """Return the ``**Targets:**`` lines that violate even/odd parity.
+
+    A line offends when it targets an odd minor and does not declare itself
+    stabilization work.
+    """
+    offenders = []
+    for match in TARGETS_RE.finditer(sip_text):
+        minor = int(match.group(2))
+        line = match.group(0)
+        if minor % 2 == 1 and "stabilization" not in line.lower():
+            offenders.append(line.strip())
+    return offenders
+
+
+class TestVersionMarkersInSync:
+    """Rule 1: the four documents' version markers equal pyproject.toml."""
+
+    @pytest.mark.parametrize(
+        ("rel_path", "pattern"),
+        [
+            ("CLAUDE.md", r"\*\*Framework Version\*\*: (\d+\.\d+\.\d+)"),
+            ("README.md", r"\*\*Current Status\*\*: v(\d+\.\d+\.\d+)"),
+            ("README.md", r"\*\*Framework Version\*\*: (\d+\.\d+\.\d+)"),
+            ("README.md", r"\*\*Current\*\*: v(\d+\.\d+\.\d+)"),
+            ("docs/ROADMAP.md", r"### v(\d+\.\d+\.\d+) \([0-9-]+\) — Current"),
+            ("docs/ROADMAP.md", r"\*\*Framework version\*\*: (\d+\.\d+\.\d+)"),
+        ],
+        ids=[
+            "claude-md",
+            "readme-current-status",
+            "readme-framework-version",
+            "readme-version-history-current",
+            "roadmap-current-header",
+            "roadmap-stats-version",
+        ],
+    )
+    def test_marker_matches_pyproject(self, rel_path: str, pattern: str) -> None:
+        """Bug caught: a release bump that edits pyproject but misses one of
+        the doc markers (the 1.0.5-through-1.1.x and 1.0.6-through-1.2.0
+        incidents) — the marker must exist AND carry the current version."""
+        expected = _pyproject_version()
+        found = re.findall(pattern, _read(rel_path))
+        assert found, f"{rel_path}: version marker /{pattern}/ not found — was it reworded?"
+        stale = [version for version in found if version != expected]
+        assert not stale, (
+            f"{rel_path}: marker /{pattern}/ says {stale} but pyproject.toml says {expected} — "
+            "sync the doc (see CLAUDE.md 'Versioning & Release Cadence')"
+        )
+
+
+class TestAcceptedSipTargetsParity:
+    """Rule 2: accepted SIPs target even minors unless declared stabilization."""
+
+    def test_no_accepted_sip_targets_an_odd_minor(self) -> None:
+        """Bug caught: the SIP-0091 incident — an accepted feature SIP whose
+        Targets line names a stabilization (odd) release the parity rule
+        forbids it from shipping in."""
+        offenders = {
+            sip.name: lines
+            for sip in sorted((REPO_ROOT / "sips" / "accepted").glob("*.md"))
+            if (lines := _odd_target_offenders(sip.read_text(encoding="utf-8")))
+        }
+        assert not offenders, (
+            f"accepted SIPs target odd (feature-free) minors: {offenders} — "
+            "remap to the next even minor (#281), or mark the line 'stabilization' "
+            "if it is genuinely structural work"
+        )
+
+    def test_odd_target_detected_in_synthetic_sip(self) -> None:
+        """Guards the guard: the exact SIP-0091 header shape must be flagged."""
+        text = "**Revision:** 2\n**Targets:** v1.3\n**Depends on:** x\n"
+        assert _odd_target_offenders(text) == ["**Targets:** v1.3"]
+
+    @pytest.mark.parametrize(
+        ("text", "reason"),
+        [
+            ("**Targets:** v1.4 (feature minor)\n", "even minor is allowed"),
+            ("**Targets:** v1.5 (stabilization — structural refactor)\n", "declared stabilization"),
+            ("| x | Targets observed v1.3 failures |\n", "prose mention, not a Targets header"),
+        ],
+        ids=["even-minor", "stabilization-escape", "body-prose"],
+    )
+    def test_non_offending_shapes_pass(self, text: str, reason: str) -> None:
+        """Bug caught: an over-eager regex flagging SIP-0092-style body prose
+        or the legitimate stabilization escape hatch."""
+        assert _odd_target_offenders(text) == [], reason
+
+
+SIP_NUMBER_RE = re.compile(r"SIP-(\d{4})")
+
+# Historical plan docs reference SIP drafts by their pre-numbering names, and
+# a couple reference companion docs that were never committed. Frozen as-is
+# 2026-07-08 (#336): these are dated execution records, not living docs — we
+# don't rewrite them, but nothing new may join this list.
+LEGACY_DANGLING_REFS = frozenset(
+    {
+        "docs/plans/SIP-0.8.8-implementation-plan.md -> sips/proposed/SIP-Agent-Migration-0-8-8.md",
+        "docs/plans/SIP-0073-llm-budget-timeout-controls-plan.md -> sips/proposed/SIP-LLM-Budget-and-Timeout-Controls.md",
+        "docs/plans/SIP-0089-agent-runtime-state-plan.md -> sips/proposed/SIP-Agent-Runtime-Modes.md",
+        "docs/plans/SIP-0089-agent-runtime-state-plan.md -> docs/plans/SIP-0067-postgres-cycle-registry-plan.md",
+        "docs/plans/SIP-0092-implementation-plan-improvement-plan.md -> docs/plans/SIP-0092-gate-M2-evaluation.md",
+        "docs/plans/SIP-Console-Cycle-Operations-UX-plan.md -> sips/proposed/SIP-Console-Cycle-Operations-UX.md",
+        "docs/plans/SIP-build-capabilities-plan.md -> sips/proposed/SIP-Enhanced-Agent-Build-Capabilities.md",
+        "docs/plans/SIP-console-control-plane-plan.md -> sips/proposed/SIP-SquadOps-Console-Control-Plane-UI.md",
+        "docs/plans/SIP-postgres-cycle-registry-plan.md -> sips/proposed/SIP-Postgres-Cycle-Registry.md",
+        "docs/plans/SIP-time-budget-awareness-planning-prompts-plan.md -> sips/proposed/SIP-Time-Budget-Awareness-Planning-Prompts.md",
+    }
+)
+
+
+def _ref_resolves(ref: str, sip_files: dict[str, set[str]]) -> bool:
+    """True if a referenced repo path exists, treating `sips/` references as
+    lifecycle-aware: a SIP moves proposed → accepted → implemented (renamed
+    with its number on acceptance), so a numbered reference resolves if that
+    SIP number exists at ANY stage, and an unnumbered draft reference
+    resolves if its basename exists anywhere under sips/."""
+    if (REPO_ROOT / ref).exists():
+        return True
+    if not ref.startswith("sips/"):
+        return False
+    basename = ref.rsplit("/", 1)[-1]
+    number_match = SIP_NUMBER_RE.search(basename)
+    if number_match:
+        return number_match.group(1) in sip_files["numbers"]
+    return basename in sip_files["basenames"]
+
+
+class TestReferencedDocPathsExist:
+    """Rule 3: living planning docs only reference files that exist."""
+
+    def test_roadmap_and_plans_reference_existing_files(self) -> None:
+        """Bug caught: the #335 item-3 incident — ROADMAP's proposal table and
+        the reconciliation doc citing drafts that existed only in a local
+        working tree, so every fresh clone got dangling links."""
+        scope = ["docs/ROADMAP.md"] + sorted(
+            str(p.relative_to(REPO_ROOT)) for p in (REPO_ROOT / "docs" / "plans").glob("*.md")
+        )
+        all_sips = list((REPO_ROOT / "sips").rglob("SIP-*.md"))
+        sip_files = {
+            "numbers": {m.group(1) for p in all_sips if (m := SIP_NUMBER_RE.search(p.name))},
+            "basenames": {p.name for p in all_sips},
+        }
+        dangling = []
+        for rel_path in scope:
+            for ref in DOC_REF_RE.findall(_read(rel_path)):
+                entry = f"{rel_path} -> {ref}"
+                if not _ref_resolves(ref, sip_files) and entry not in LEGACY_DANGLING_REFS:
+                    dangling.append(entry)
+        assert not dangling, (
+            "committed docs reference paths missing from the tree "
+            f"(commit the file or update the reference): {dangling}"
+        )
+
+    def test_dangling_ref_detected(self) -> None:
+        """Guards the guard: a path that exists at no lifecycle stage must not
+        resolve, while a stage-moved SIP reference must."""
+        sip_files = {"numbers": {"0094"}, "basenames": {"SIP-Draft-Thing.md"}}
+        assert not _ref_resolves("docs/plans/never-written.md", sip_files)
+        assert not _ref_resolves("sips/proposed/SIP-Never-Filed.md", sip_files)
+        assert _ref_resolves("sips/accepted/SIP-0094-Old-Name.md", sip_files)
+        assert _ref_resolves("sips/proposed/SIP-Draft-Thing.md", sip_files)


### PR DESCRIPTION
## Summary

The pre-cut docs pass: fixes the three verified drift items (#335) and lands the lint that prevents the fourth incident (#336). One PR because each half proves the other — the guards land green only because the content was just fixed.

## #335 — the content fixes

1. **ROADMAP**: stats block un-froze from 1.0.6 / 3,030 tests / 57 SIPs → 1.2.0 / 4,700+ / 60 implemented + 6 accepted, with an as-of stamp. Added the missing SIP-0096 row to the accepted table (now with a Target column per the remap), applied the reconciliation doc's **Finding-4 remap + Finding-2 pillar map** as a new *Forward Cadence* section (1.3 stabilization → 1.4 duty+evidence → 1.6 Campaign → 1.8/2.0 pillars), and rebuilt the proposals tables to match `sips/proposed/` reality (the Campaign ×2 and comms-delivery drafts were unlisted; the "Intelligent Delegation Protocols" row pointed at a file that never existed anywhere).
2. **SIP-0091** `Targets: v1.3` → **v1.4** with the remap rationale inline (its self-tag predated the even/odd convention; 1.3 is feature-free by rule). SIP-0090's target line now records *Phase 1 shipped in 1.2.0; Phases 2+ → v1.4+*.
3. **Dangling refs**: committed the three files that committed docs cite but which existed only locally — the runtime-loop idea doc (cited by the Campaign SIP + reconciliation doc) and the **Edge Deployment Profile** + **Experiment Queue** proposals (listed in ROADMAP's table). Both SIPs enter as *filed unnumbered drafts*, nothing more. Also removed the `registry.yaml` entry for `SIP-intelligent-delegation-protocols.md` — the canonical index itself referenced a path never committed (same #335 item-3 disease, one level up).

## #336 — the ratchet

`tests/unit/architecture/test_docs_version_sync.py` (dir already in REGRESSION_DIRS — no shared-file edit):

- **Rule 1**: CLAUDE.md / README (×3 markers) / ROADMAP (Current header + stats) version markers must equal pyproject.toml. Parametrized per marker; a *reworded* marker fails too. **This makes the 1.3.0 cut self-verifying** — the bump PR cannot pass CI with a stale marker.
- **Rule 2**: accepted-SIP `**Targets:**` lines must name even minors (#281), with a documented `stabilization` escape hatch for structural SIPs (the SIP-0097 class). Line-anchored so SIP-0092-style body prose ("Targets observed …") can't false-positive.
- **Rule 3**: backtick doc paths in ROADMAP + docs/plans must exist — lifecycle-aware for `sips/` (a numbered SIP resolves at any stage, since acceptance renames and moves files). Ten pre-numbering references in dated historical plan docs are frozen in an explicit allowlist; new dangling refs fail.
- Each rule has a guards-the-guard synthetic case (the exact SIP-0091 header shape must flag; the escape hatch and prose shapes must not).

## Validation

Regression **4,713 passed, exit 0** (4,700 + the 13 new guards); ruff clean. Docs + a text lint only — no runtime surface, so no live cycle.

## After merge

1.3.0 core scope + pre-cut hygiene are both complete → next step is the release cut (bump, CHANGELOG, release PR, tag + GitHub Release, rebuild+deploy+verify, E2E smoke, SIP sweep), with rule 1 now enforcing the marker sync.

Closes #335
Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ