### PR TITLE
release: 1.3.0 — first stabilization release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,87 @@ All notable changes to SquadOps are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-07-08
+
+First **stabilization release** on the even/odd minor cadence (#281): odd minors are
+feature-free by rule, and the big risky structural refactors quarantined out of the
+feature releases are the *product*. Spark was offline for this cycle, so the entire
+core scope landed from the Macbook lane. Every structural change below was
+live-validated on the deployed stack before merge.
+
+### Changed
+- **SIP-0097 Dispatched Flow Executor decomposition (#186, #295).** The 3,358-line /
+  53-method executor god-object decomposed to 1,805 lines across six sliced PRs
+  (#341, #344, #347–#350), extracting five plain injected collaborators: pure hoists,
+  **`RunLedger` + `RunCompletion`** (append-only run evidence + terminal-outcome
+  mapping — the executor now carries **zero per-run mutable state**, and
+  `RunCompletion.finalize(ledger, …)` is the seam SIP-0096 §6.4 wires into),
+  **`CorrectionRunner`**, **`PulseBoundaryRunner`**, and **`TaskDispatcher`** (the
+  interim dispatch callables were replaced by the real collaborator per AC#9). Slice
+  6 carried the arc's one behavior addition (#295): the plan-review gate validates
+  the run's materialized implementation plan against the squad profile *before*
+  pausing — completing SIP-0095's materialized-plan half. SIP-0097 accepted (PR #340)
+  and **promoted to implemented** within this release.
+- **`cycle_tasks.py` split into the `capabilities/handlers/cycle/` package (#152).**
+  The 3,276-line handler monolith is now per-handler modules behind a compat shim
+  (PR #339), preceded by hoisting its copy-pasted helpers into `_CycleTaskHandler`
+  (#332, PR #338). Shim retirement rides the importer migration filed in #339.
+- **Agent comms migrated from queue polling to a persistent push consumer (#323,
+  PR #354).** The entrypoint's 1s open/close `consume()` poll is gone; agents hold
+  one long-lived `subscribe()` consumer (delivery-time pickup, `prefetch_count=1`,
+  ack semantics unchanged). Removes the consumer-count flapping, up-to-1s dispatch
+  latency, and the `aio_pika` "closing" INFO flood that was 99.7% of retained agent
+  logs — which also closed #329 (the interim log-demotion mitigation) as obsolete.
+- **Dead sqlalchemy `DbRuntime` backend removed (#234, PR #356).** Audit found zero
+  production callers (its factory was only ever constructed by its own tests, and
+  the one production breadcrumb referenced a method that never existed).
+  `src/squadops/ports/` now contains no vendor types in any contract; the `postgres`
+  extra and sqlalchemy test pin are dropped. Every active persistence path is asyncpg.
+
+### Fixed
+- **Prompt-pack drift broke `merge_plan` fleet-wide (#327, PR #351).** Agents resolve
+  prompts from the LangFuse registry, which was seeded once and never re-synced —
+  SIP-0093's templates were missing at runtime though the files shipped in the image.
+  Deploys now re-sync prompts to LangFuse (production label) as a pipeline step; the
+  manifest loader hard-fails on hash mismatch (was warn-and-continue); the regen tool
+  maintains the whole-manifest hash; CI guards manifest integrity. Design-debt
+  follow-ups filed: #352 (registry runtime guard), #353 (build-time fingerprint).
+- **`runs resume` insta-failed since 1.1.1 (#342, PR #343).** The resume route
+  pre-flipped the run to RUNNING and the executor then re-issued an illegal
+  RUNNING→RUNNING transition — every resume died in ~2s. Found by SIP-0097 slice-2
+  live validation; pause→resume→complete now verified live end-to-end (closed #258).
+- **Test suite is color-env-proof (#345, PR #346).** Shells exporting `FORCE_COLOR`
+  broke CLI output assertions (rich token-splits digits under forced color); all
+  assertions now ANSI-strip first.
+
+### Added
+- **CI docs-drift guards (#336, PR #357).** Version markers across
+  CLAUDE.md/README/ROADMAP must equal `pyproject.toml` (this release's bump is the
+  first it enforces), accepted-SIP `Targets:` lines must respect even/odd parity,
+  and planning-doc references must resolve — lifecycle-aware, with the historical
+  residue frozen in an explicit allowlist.
+
+### Docs & SIP lifecycle
+- **SIP-0096 Verification Evidence Integrity accepted** (PR #337, rev 2) — the 1.4
+  headline alongside SIP-0091; execution plan in `docs/plans/1-4-evidence-arc-plan.md`.
+- **SIP-0095 promoted to implemented** (PR #324); SIP-0091's stale `Targets: v1.3`
+  remapped to v1.4 per the parity rule (#335).
+- **Docs hygiene pass (#335, PR #357):** ROADMAP stats/tables reconciled (they were
+  frozen at 1.0.6), Forward Cadence section added (1.3 → 1.4 → 1.6 → 2.0 pillar map),
+  referenced-but-untracked drafts committed (Edge Deployment Profile, Experiment
+  Queue), and a registry entry pointing at a never-committed file removed.
+- **Drafts filed** (proposed, not accepted): Agent Comms Delivery Guarantees
+  (PR #355 — Campaign 1.6 gate candidate), Campaign SIP revision + two-lane/evidence
+  plans (PR #325).
+
+### Deferred / follow-ups
+- **#288** (same-mode lease bypass — a named Campaign 1.6 gate) slipped this release;
+  pulled forward into the 1.4 window as hardening.
+- **#331** (`planning_tasks.py` split) and **#333** (entrypoint config-masking
+  fallbacks) → 1.5 stabilization backlog.
+- SIP-0097 post-arc open questions (residual-method review / optional seventh
+  collaborator; `RunOrchestrator` rename + #168 sweep) are standalone follow-ups.
+
 ## [1.2.0] — 2026-07-04
 
 First **feature release** on the even/odd minor cadence (#281): even minors carry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 SquadOps is a multi-agent orchestration framework for software development. It uses a hexagonal architecture (ports & adapters) with dependency injection for testability.
 
-**Framework Version**: 1.2.0 (single-sourced via `importlib.metadata.version("squadops")`)
+**Framework Version**: 1.3.0 (single-sourced via `importlib.metadata.version("squadops")`)
 **Python Requirement**: 3.11+ (production runs 3.11); develop and test on **Python 3.12** to match CI
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 **SquadOps** is an AI agent collaboration framework for software development. The system implements a role-based agent architecture where specialized agents handle different aspects of development tasks, from requirements analysis to application deployment.
 
-**Current Status**: v1.2.0 — Production-ready framework with hexagonal architecture, the Agent Embodiment Substrate (SIP-0090 Phase 1: embodiment lifecycle, single-active invariant, resource budgets), the Cycle Create Preflight (SIP-0095: create-time fail-fast on unsatisfiable roles / unpulled models), the completed Agent Runtime State platform (SIP-0089: runtime modes ambient/cycle/duty, single-writer coordinator, FocusLease arbitration, single-transaction UoW, RuntimeActivity observability), distributed cycle execution pipeline, multi-run cycle orchestration, workload protocols (planning, implementation, wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, build convergence loop (SIP-0086), Prefect task-scoped log streaming (SIP-0087), Postgres-backed persistence, LangFuse observability, Keycloak authentication, CLI tooling, test quality enforcement, and 4,650+ passing tests.
+**Current Status**: v1.3.0 — Production-ready framework with hexagonal architecture, freshly stabilized in the first even/odd stabilization release (SIP-0097 executor decomposition, cycle-task handler package split, push-based agent comms, vendor-type-free ports), plus the Agent Embodiment Substrate (SIP-0090 Phase 1), the Cycle Create Preflight (SIP-0095), the completed Agent Runtime State platform (SIP-0089: runtime modes ambient/cycle/duty, single-writer coordinator, FocusLease arbitration, single-transaction UoW, RuntimeActivity observability), distributed cycle execution pipeline, multi-run cycle orchestration, workload protocols (planning, implementation, wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, build convergence loop (SIP-0086), Prefect task-scoped log streaming (SIP-0087), Postgres-backed persistence, LangFuse observability, Keycloak authentication, CLI tooling, test quality enforcement, and 4,700+ passing tests.
 
 ---
 
@@ -173,20 +173,21 @@ See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for full setup instructio
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for the full release timeline.
 
-**Current**: v1.2.0 — first even/odd feature release: SIP-0090 Agent Embodiment Substrate (Phase 1), SIP-0095 Cycle Create Preflight (create-time fail-fast), and the SIP-0089 runtime-arc completion (recruitment→coordinator FocusLease, single-transaction UoW), on a #158/#231 hardening base
+**Current**: v1.3.0 — first stabilization release (feature-free by rule): SIP-0097 executor decomposition (#186, 3,358→1,805 lines, zero per-run mutable state), `cycle_tasks` package split (#152), agent comms poll→push consumer (#323), dead `DbRuntime` backend removed (#234), plus the prompt-registry deploy re-sync (#327) and resume fix (#342)
 
 ---
 
 ## Current Status
-**Framework Version**: 1.2.0
-**Development Status**: Post-1.1 stable multi-agent orchestration with the Agent Runtime State platform (SIP-0089: runtime modes, duty scheduler, FocusLease, RuntimeActivity), console UI, distributed cycle execution, multi-run cycle orchestration, workload protocols (planning → implementation → wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, Prefect task-scoped log streaming, durable persistence, authentication, CLI tooling, profile-driven bootstrap, test quality enforcement, and full observability stack.
+**Framework Version**: 1.3.0
+**Development Status**: Stabilized multi-agent orchestration (post-SIP-0097 decomposition) with the Agent Runtime State platform (SIP-0089: runtime modes, duty scheduler, FocusLease, RuntimeActivity), console UI, distributed cycle execution, multi-run cycle orchestration, workload protocols (planning → implementation → wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, Prefect task-scoped log streaming, durable persistence, authentication, CLI tooling, profile-driven bootstrap, test quality enforcement, and full observability stack.
 
 ### Project Statistics
-- **~39,000 lines** of Python source code
-- **~51,000 lines** of test code
-- **~84,000 lines** of documentation
-- **3,030+ tests** passing in regression suite
-- **~88 SIPs** (54 implemented, 1 accepted, 13 proposed, 20 deprecated)
+*As of 2026-07-08 (v1.3.0):*
+- **~61,000 lines** of Python source code (src + adapters)
+- **~83,000 lines** of test code
+- **~110,000 lines** of documentation
+- **4,700+ tests** passing in regression suite
+- **~94 SIPs** (60 implemented, 6 accepted, 20 deprecated; 14 proposals/drafts)
 
 ### Functional Components
 - 6 Agents: Max (Lead), Neo (Dev), Nat (Strategy), Bob (Builder), Eve (QA), Data (Analytics)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,14 +10,24 @@ Semver with an **even/odd minor** overlay (parity gates *features*, not hardenin
 
 Version labels per the even/odd remap in `docs/plans/2-0-roadmap-reconciliation.md` (Findings 2 + 4):
 
-- **v1.3 (in progress)** — first stabilization minor, feature-free by rule: executor decomposition (SIP-0097 / #186), `cycle_tasks` package split (#152), comms poll→push consumer (#323), dead `DbRuntime` backend removal (#234).
+- **v1.3 — shipped 2026-07-08** (first stabilization minor; see Release Timeline).
 - **v1.4** — duty durability (SIP-0091) + verification evidence integrity (SIP-0096), the headline pair; possibly embodiment Phase 2 (SIP-0090, first live adapter). Plan: `docs/plans/1-4-evidence-arc-plan.md`.
 - **v1.6** — Campaign mechanic (objective envelope + continuation policy; `sips/proposed/SIP-Campaign-Orchestration.md`), gated on SIP-0096 implemented + #288 + #316.
 - **v1.8/v2.0** — the three 2.0 pillars: Capability-Backed Agents (what an agent *is*), Campaign capability-augmentation, Self-Improvement + Test Bay (the capstone).
 
 ## Release Timeline
 
-### v1.2.0 (2026-07-04) — Current — First Feature Release (even/odd cadence)
+### v1.3.0 (2026-07-08) — Current — First Stabilization Release (feature-free)
+First **odd-minor stabilization release** (#281): the big structural refactors quarantined out of feature releases, plus debt paydown. Entire core scope landed from the Macbook lane (Spark offline); every structural change live-validated before merge.
+- **SIP-0097 executor decomposition (#186, #295):** `DispatchedFlowExecutor` 3,358→1,805 lines across 6 sliced PRs; five injected collaborators (pure hoists, `RunLedger`+`RunCompletion` — zero per-run mutable state, the SIP-0096 §6.4 seam — `CorrectionRunner`, `PulseBoundaryRunner`, `TaskDispatcher`); slice 6 = the #295 plan-review gate check. SIP-0097 promoted → implemented.
+- **#152:** `cycle_tasks.py` (3,276 lines) → `capabilities/handlers/cycle/` package behind a compat shim (after the #332 helper hoist).
+- **#323:** agent comms poll→push — persistent `subscribe()` consumer, prefetch 1; kills consumer churn, up-to-1s pickup latency, and the `aio_pika` log flood (obsoleted #329).
+- **#234:** dead sqlalchemy `DbRuntime` backend removed — `ports/` is vendor-type-free; asyncpg everywhere.
+- **Fixed:** #327 prompt-registry drift (deploy re-sync + manifest hard-fail), #342 resume insta-fail (live pause→resume→complete verified, closed #258), #345 color-env test flakiness.
+- **Docs/CI:** #335 hygiene pass (this file's stats/tables un-froze) + #336 docs-drift guards in the regression gate (version markers, SIP target parity, doc-ref existence).
+- **Deferred:** #288 (Campaign 1.6 gate → pulled into the 1.4 window), #331/#333 (→ 1.5).
+
+### v1.2.0 (2026-07-04) — First Feature Release (even/odd cadence)
 First **even-minor feature release** (#281). Three feature SIPs, on a hardening base:
 - **SIP-0090 Agent Embodiment Substrate — Phase 1:** the internal embodiment model — lifecycle state machine (single-active-per-agent, enforced in code + a Postgres partial unique index), resource budget primitives (non-silent exhaustion), `EmbodimentStatePort` + Postgres persistence, `EmbodimentCoordinator`. No adapter yet (#312, #317).
 - **SIP-0095 Cycle Create Preflight:** create-time fail-fast (422 `PREFLIGHT_REJECTED`) on unsatisfiable roles / unpulled models; unreachable backend warns-and-allows; doctor parity; warnings on response + CLI (#298, #309, #311, #315, #321).
@@ -436,9 +446,9 @@ The following areas are identified for future work but do not block 1.0 readines
 
 ## Stats
 
-*As of 2026-07-08 (v1.2.0, pre-1.3.0 cut):*
+*As of 2026-07-08 (v1.3.0):*
 
-- **Framework version**: 1.2.0
+- **Framework version**: 1.3.0
 - **SIPs**: 60 implemented, 6 accepted (SIP-0088, 0090–0093, 0096), 20 deprecated (registry); 14 files in `sips/proposed/` (7 registry-tracked legacy + 7 unnumbered drafts)
 - **Tests**: 4,700+ passing in the regression suite
 - **Python source**: ~61,000 lines (src + adapters; ~83,000 test lines, ~110,000 doc lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["squadops*", "adapters*"]  # Include both packages
 
 [project]
 name = "squadops"
-version = "1.2.0"
+version = "1.3.0"
 description = "SquadOps: a production-grade multi-agent orchestration framework."
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Release PR — v1.3.0

First **odd-minor stabilization release** (#281). Feature-free by rule; the product is the structural refactors:

- **SIP-0097 executor decomposition** (#186 + #295) — 3,358→1,805 lines, zero per-run mutable state, `RunCompletion`/`RunLedger` seam ready for SIP-0096; promoted → implemented
- **#152** `cycle_tasks` package split (+ #332 hoist)
- **#323** agent comms poll→push consumer (+ closed #329 as obsolete)
- **#234** dead sqlalchemy `DbRuntime` backend removed
- **Fixed:** #327 prompt-registry drift, #342 resume insta-fail (+ closed #258), #345 color-env flakiness
- **Docs/CI:** #335 hygiene + #336 docs-drift guards (enforcing this very PR's marker sync)

Full details in the CHANGELOG entry (this PR).

## Contents of this PR

`version_cli.py` bump → 1.3.0; CHANGELOG 1.3.0 entry; marker sync in CLAUDE.md, README (including a second stale stats block at the bottom, frozen since ~1.0.6 — same disease #335 fixed in ROADMAP), and ROADMAP (new Current section, v1.2.0 header demoted, Forward Cadence + stats refreshed).

## Validation

Regression **4,713 passed, exit 0**; the #336 marker guards pass — the first release cut where the sync is CI-enforced rather than discipline-enforced.

## After merge (remainder of the cut checklist)

Annotated `v1.3.0` tag + GitHub Release from the CHANGELOG (marked Latest) → `rebuild_and_deploy.sh all` + `/health` verify → E2E smoke cycle → SIP promotion sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ