### PR TITLE
fix(#326): move agent-status writes off the unauthenticated /health lane

### DIFF
--- a/adapters/observability/healthcheck_http.py
+++ b/adapters/observability/healthcheck_http.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
@@ -20,7 +21,13 @@ logger = logging.getLogger(__name__)
 
 
 class HealthCheckHttpReporter(AgentHeartbeatReporter):
-    """Posts agent status updates to the runtime-api health endpoints."""
+    """Posts agent status updates to the runtime-api agent-status endpoint.
+
+    Writes go to the authed /api/v1 lane (#326). When ``token_provider`` is
+    set (agent service identity via client credentials), each request carries
+    a Bearer token; without it the request is unauthenticated — valid only
+    for auth-disabled deployments.
+    """
 
     def __init__(
         self,
@@ -28,12 +35,14 @@ class HealthCheckHttpReporter(AgentHeartbeatReporter):
         base_url: str | None = None,
         timeout_seconds: int = 5,
         fail_silently: bool = True,
+        token_provider: Callable[[], Awaitable[str]] | None = None,
     ) -> None:
         self._base_url = (
             base_url or os.getenv("SQUADOPS_RUNTIME_API_URL") or "http://runtime-api:8001"
         ).rstrip("/")
         self._timeout_seconds = timeout_seconds
         self._fail_silently = fail_silently
+        self._token_provider = token_provider
 
     async def send_status(
         self,
@@ -45,7 +54,7 @@ class HealthCheckHttpReporter(AgentHeartbeatReporter):
         tps: float | None = None,
         memory_count: int | None = None,
     ) -> None:
-        url = f"{self._base_url}/health/agents/status"
+        url = f"{self._base_url}/api/v1/agents/status"
         payload: dict[str, Any] = {
             "agent_id": agent_id,
             "lifecycle_state": lifecycle_state,
@@ -56,8 +65,12 @@ class HealthCheckHttpReporter(AgentHeartbeatReporter):
         }
 
         try:
+            headers: dict[str, str] = {}
+            if self._token_provider is not None:
+                token = await self._token_provider()
+                headers["Authorization"] = f"Bearer {token}"
             async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
-                resp = await client.post(url, json=payload)
+                resp = await client.post(url, json=payload, headers=headers)
                 if resp.status_code >= 400:
                     raise RuntimeError(f"runtime-api responded {resp.status_code}: {resp.text}")
         except Exception as e:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,6 +216,7 @@ services:
     container_name: squadops-max
     restart: unless-stopped
     secrets:
+      - agent_client_secret
       - db_password
       - rabbitmq_password
       - keycloak_admin_password
@@ -236,8 +237,13 @@ services:
       SQUADOPS__LANGFUSE__SECRET_KEY: ${SQUADOPS__LANGFUSE__SECRET_KEY}
       # Prompt asset source (SIP-0084): 'filesystem' or 'langfuse'
       SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER: ${SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER:-filesystem}
-      # Auth not needed for agents (no HTTP server)
+      # Agent service identity (#326): no HTTP server, so inbound-auth middleware
+      # stays off; heartbeats to runtime-api authenticate via client credentials.
       SQUADOPS__AUTH__ENABLED: "false"
+      SQUADOPS__AUTH__OIDC__ISSUER_URL: http://squadops-keycloak:8080/realms/${SQUADOPS_REALM:-squadops-dev}
+      SQUADOPS__AUTH__OIDC__AUDIENCE: squadops-runtime
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
     volumes:
       - max_memory_data:/app/data/memory_db
@@ -263,6 +269,7 @@ services:
     container_name: squadops-nat
     restart: unless-stopped
     secrets:
+      - agent_client_secret
       - db_password
       - rabbitmq_password
       - keycloak_admin_password
@@ -283,8 +290,13 @@ services:
       SQUADOPS__LANGFUSE__SECRET_KEY: ${SQUADOPS__LANGFUSE__SECRET_KEY}
       # Prompt asset source (SIP-0084): 'filesystem' or 'langfuse'
       SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER: ${SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER:-filesystem}
-      # Auth not needed for agents (no HTTP server)
+      # Agent service identity (#326): no HTTP server, so inbound-auth middleware
+      # stays off; heartbeats to runtime-api authenticate via client credentials.
       SQUADOPS__AUTH__ENABLED: "false"
+      SQUADOPS__AUTH__OIDC__ISSUER_URL: http://squadops-keycloak:8080/realms/${SQUADOPS_REALM:-squadops-dev}
+      SQUADOPS__AUTH__OIDC__AUDIENCE: squadops-runtime
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
     depends_on:
       rabbitmq:
@@ -329,6 +341,7 @@ services:
     container_name: squadops-neo
     restart: unless-stopped
     secrets:
+      - agent_client_secret
       - db_password
       - rabbitmq_password
       - keycloak_admin_password
@@ -349,8 +362,13 @@ services:
       SQUADOPS__LANGFUSE__SECRET_KEY: ${SQUADOPS__LANGFUSE__SECRET_KEY}
       # Prompt asset source (SIP-0084): 'filesystem' or 'langfuse'
       SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER: ${SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER:-filesystem}
-      # Auth not needed for agents (no HTTP server)
+      # Agent service identity (#326): no HTTP server, so inbound-auth middleware
+      # stays off; heartbeats to runtime-api authenticate via client credentials.
       SQUADOPS__AUTH__ENABLED: "false"
+      SQUADOPS__AUTH__OIDC__ISSUER_URL: http://squadops-keycloak:8080/realms/${SQUADOPS_REALM:-squadops-dev}
+      SQUADOPS__AUTH__OIDC__AUDIENCE: squadops-runtime
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
     volumes:
       - ./docker-compose.yml:/app/docker-compose.yml
@@ -378,6 +396,7 @@ services:
     container_name: squadops-eve
     restart: unless-stopped
     secrets:
+      - agent_client_secret
       - db_password
       - rabbitmq_password
       - keycloak_admin_password
@@ -398,8 +417,13 @@ services:
       SQUADOPS__LANGFUSE__SECRET_KEY: ${SQUADOPS__LANGFUSE__SECRET_KEY}
       # Prompt asset source (SIP-0084): 'filesystem' or 'langfuse'
       SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER: ${SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER:-filesystem}
-      # Auth not needed for agents (no HTTP server)
+      # Agent service identity (#326): no HTTP server, so inbound-auth middleware
+      # stays off; heartbeats to runtime-api authenticate via client credentials.
       SQUADOPS__AUTH__ENABLED: "false"
+      SQUADOPS__AUTH__OIDC__ISSUER_URL: http://squadops-keycloak:8080/realms/${SQUADOPS_REALM:-squadops-dev}
+      SQUADOPS__AUTH__OIDC__AUDIENCE: squadops-runtime
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
     depends_on:
       rabbitmq:
@@ -423,6 +447,7 @@ services:
     container_name: squadops-data
     restart: unless-stopped
     secrets:
+      - agent_client_secret
       - db_password
       - rabbitmq_password
       - keycloak_admin_password
@@ -443,8 +468,13 @@ services:
       SQUADOPS__LANGFUSE__SECRET_KEY: ${SQUADOPS__LANGFUSE__SECRET_KEY}
       # Prompt asset source (SIP-0084): 'filesystem' or 'langfuse'
       SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER: ${SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER:-filesystem}
-      # Auth not needed for agents (no HTTP server)
+      # Agent service identity (#326): no HTTP server, so inbound-auth middleware
+      # stays off; heartbeats to runtime-api authenticate via client credentials.
       SQUADOPS__AUTH__ENABLED: "false"
+      SQUADOPS__AUTH__OIDC__ISSUER_URL: http://squadops-keycloak:8080/realms/${SQUADOPS_REALM:-squadops-dev}
+      SQUADOPS__AUTH__OIDC__AUDIENCE: squadops-runtime
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
     volumes:
       - data_memory_data:/app/data/memory_db
@@ -472,6 +502,7 @@ services:
     container_name: squadops-bob
     restart: unless-stopped
     secrets:
+      - agent_client_secret
       - db_password
       - rabbitmq_password
       - keycloak_admin_password
@@ -492,8 +523,13 @@ services:
       SQUADOPS__LANGFUSE__SECRET_KEY: ${SQUADOPS__LANGFUSE__SECRET_KEY}
       # Prompt asset source (SIP-0084): 'filesystem' or 'langfuse'
       SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER: ${SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER:-filesystem}
-      # Auth not needed for agents (no HTTP server)
+      # Agent service identity (#326): no HTTP server, so inbound-auth middleware
+      # stays off; heartbeats to runtime-api authenticate via client credentials.
       SQUADOPS__AUTH__ENABLED: "false"
+      SQUADOPS__AUTH__OIDC__ISSUER_URL: http://squadops-keycloak:8080/realms/${SQUADOPS_REALM:-squadops-dev}
+      SQUADOPS__AUTH__OIDC__AUDIENCE: squadops-runtime
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
       SQUADOPS__LLM__TIMEOUT: ${SQUADOPS__LLM__TIMEOUT:-180}
     volumes:
       - bob_memory_data:/app/data/memory_db
@@ -542,6 +578,7 @@ services:
     container_name: squadops-joi
     restart: unless-stopped
     secrets:
+      - agent_client_secret
       - db_password
       - rabbitmq_password
       - keycloak_admin_password
@@ -561,7 +598,13 @@ services:
       SQUADOPS__LANGFUSE__PUBLIC_KEY: ${SQUADOPS__LANGFUSE__PUBLIC_KEY}
       SQUADOPS__LANGFUSE__SECRET_KEY: ${SQUADOPS__LANGFUSE__SECRET_KEY}
       SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER: ${SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER:-filesystem}
+      # Agent service identity (#326): no HTTP server, so inbound-auth middleware
+      # stays off; heartbeats to runtime-api authenticate via client credentials.
       SQUADOPS__AUTH__ENABLED: "false"
+      SQUADOPS__AUTH__OIDC__ISSUER_URL: http://squadops-keycloak:8080/realms/${SQUADOPS_REALM:-squadops-dev}
+      SQUADOPS__AUTH__OIDC__AUDIENCE: squadops-runtime
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_ID: squadops-agent
+      SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET: secret://agent_client_secret
     volumes:
       - joi_memory_data:/app/data/memory_db
     depends_on:
@@ -738,6 +781,8 @@ volumes:
   data_memory_data: {}
   joi_memory_data: {}
 secrets:
+  agent_client_secret:
+    file: ./secrets/agent_client_secret.txt
   db_password:
     file: ./secrets/db_password.txt
   rabbitmq_password:

--- a/infra/auth/squadops-realm-cloud.json
+++ b/infra/auth/squadops-realm-cloud.json
@@ -55,6 +55,12 @@
             "operator"
           ]
         }
+      },
+      {
+        "name": "agent",
+        "description": "Agent service identity — status writes via /api/v1/agents/status only",
+        "composite": false,
+        "clientRole": false
       }
     ],
     "client": {
@@ -139,6 +145,37 @@
       "serviceAccountsEnabled": true,
       "protocol": "openid-connect",
       "secret": "squadops-runtime-secret",
+      "protocolMappers": [
+        {
+          "name": "runtime-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "squadops-runtime",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "openid",
+        "profile",
+        "email",
+        "roles"
+      ]
+    },
+    {
+      "clientId": "squadops-agent",
+      "name": "SquadOps Agent",
+      "description": "Confidential client for agent containers — heartbeat/status writes to runtime-api (#326)",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "protocol": "openid-connect",
+      "secret": "squadops-agent-secret",
       "protocolMappers": [
         {
           "name": "runtime-api-audience",
@@ -294,6 +331,14 @@
         "operator",
         "viewer",
         "mfa-required"
+      ]
+    },
+    {
+      "username": "service-account-squadops-agent",
+      "enabled": true,
+      "serviceAccountClientId": "squadops-agent",
+      "realmRoles": [
+        "agent"
       ]
     }
   ],

--- a/infra/auth/squadops-realm-lab.json
+++ b/infra/auth/squadops-realm-lab.json
@@ -55,6 +55,12 @@
             "operator"
           ]
         }
+      },
+      {
+        "name": "agent",
+        "description": "Agent service identity — status writes via /api/v1/agents/status only",
+        "composite": false,
+        "clientRole": false
       }
     ],
     "client": {
@@ -139,6 +145,37 @@
       "serviceAccountsEnabled": true,
       "protocol": "openid-connect",
       "secret": "squadops-runtime-secret",
+      "protocolMappers": [
+        {
+          "name": "runtime-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "squadops-runtime",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "openid",
+        "profile",
+        "email",
+        "roles"
+      ]
+    },
+    {
+      "clientId": "squadops-agent",
+      "name": "SquadOps Agent",
+      "description": "Confidential client for agent containers — heartbeat/status writes to runtime-api (#326)",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "protocol": "openid-connect",
+      "secret": "squadops-agent-secret",
       "protocolMappers": [
         {
           "name": "runtime-api-audience",
@@ -294,6 +331,14 @@
         "operator",
         "viewer",
         "mfa-required"
+      ]
+    },
+    {
+      "username": "service-account-squadops-agent",
+      "enabled": true,
+      "serviceAccountClientId": "squadops-agent",
+      "realmRoles": [
+        "agent"
       ]
     }
   ],

--- a/infra/auth/squadops-realm-local.json
+++ b/infra/auth/squadops-realm-local.json
@@ -43,6 +43,12 @@
         "description": "Read-only access to dashboards and status",
         "composite": false,
         "clientRole": false
+      },
+      {
+        "name": "agent",
+        "description": "Agent service identity — status writes via /api/v1/agents/status only",
+        "composite": false,
+        "clientRole": false
       }
     ],
     "client": {
@@ -143,6 +149,37 @@
       ]
     },
     {
+      "clientId": "squadops-agent",
+      "name": "SquadOps Agent",
+      "description": "Confidential client for agent containers — heartbeat/status writes to runtime-api (#326)",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "protocol": "openid-connect",
+      "secret": "squadops-agent-secret",
+      "protocolMappers": [
+        {
+          "name": "runtime-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "squadops-runtime",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "openid",
+        "profile",
+        "email",
+        "roles"
+      ]
+    },
+    {
       "clientId": "squadops-cli",
       "name": "SquadOps CLI",
       "description": "Public client for CLI authentication (password grant + device flow)",
@@ -195,6 +232,14 @@
         "admin",
         "operator",
         "viewer"
+      ]
+    },
+    {
+      "username": "service-account-squadops-agent",
+      "enabled": true,
+      "serviceAccountClientId": "squadops-agent",
+      "realmRoles": [
+        "agent"
       ]
     }
   ],

--- a/infra/auth/squadops-realm.json
+++ b/infra/auth/squadops-realm.json
@@ -30,6 +30,12 @@
         "description": "Read-only access to dashboards and status",
         "composite": false,
         "clientRole": false
+      },
+      {
+        "name": "agent",
+        "description": "Agent service identity — status writes via /api/v1/agents/status only",
+        "composite": false,
+        "clientRole": false
       }
     ],
     "client": {
@@ -136,6 +142,37 @@
       ]
     },
     {
+      "clientId": "squadops-agent",
+      "name": "SquadOps Agent",
+      "description": "Confidential client for agent containers — heartbeat/status writes to runtime-api (#326)",
+      "enabled": true,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "protocol": "openid-connect",
+      "secret": "squadops-agent-secret",
+      "protocolMappers": [
+        {
+          "name": "runtime-api-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "squadops-runtime",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "openid",
+        "profile",
+        "email",
+        "roles"
+      ]
+    },
+    {
       "clientId": "squadops-cli",
       "name": "SquadOps CLI",
       "description": "Public client for CLI authentication (password grant + device flow)",
@@ -188,6 +225,14 @@
         "admin",
         "operator",
         "viewer"
+      ]
+    },
+    {
+      "username": "service-account-squadops-agent",
+      "enabled": true,
+      "serviceAccountClientId": "squadops-agent",
+      "realmRoles": [
+        "agent"
       ]
     }
   ],

--- a/scripts/bootstrap/lib/docker_setup.sh
+++ b/scripts/bootstrap/lib/docker_setup.sh
@@ -57,7 +57,7 @@ ensure_env_file() {
 
     # Create Docker secret files from .env passwords
     if [[ "${DRY_RUN:-0}" == "1" ]]; then
-        info "[dry-run] create secrets/{db_password,rabbitmq_password,keycloak_admin_password}.txt"
+        info "[dry-run] create secrets/{db_password,rabbitmq_password,keycloak_admin_password,agent_client_secret}.txt"
     elif [[ -f "$env_file" ]]; then
         mkdir -p secrets
         if [[ ! -f "secrets/db_password.txt" ]]; then
@@ -77,6 +77,11 @@ ensure_env_file() {
             # Keycloak DB DSN — matches KC_DB_URL credentials in docker-compose
             echo -n "postgresql://keycloak:keycloak@postgres:5432/keycloak" > secrets/keycloak_db_dsn.txt
             success "Created secrets/keycloak_db_dsn.txt"
+        fi
+        if [[ ! -f "secrets/agent_client_secret.txt" ]]; then
+            # squadops-agent client secret (#326) — matches the realm export
+            echo -n "squadops-agent-secret" > secrets/agent_client_secret.txt
+            success "Created secrets/agent_client_secret.txt"
         fi
     fi
 

--- a/src/squadops/agents/entrypoint.py
+++ b/src/squadops/agents/entrypoint.py
@@ -97,6 +97,7 @@ class AgentRunner:
         self._shutdown_event = asyncio.Event()
         self._heartbeat_task: asyncio.Task | None = None
         self._heartbeat_reporter = None
+        self._service_token_client = None
         self._lifecycle_state = "STARTING"
         self._queue = None
         self._config = None
@@ -151,10 +152,8 @@ class AgentRunner:
             # (SIP-0087). Always-inject pattern — NoOp when disabled.
             self._log_forwarder = await self._create_log_forwarder(self._config)
 
-            # Create heartbeat reporter
-            from adapters.observability.healthcheck_http import HealthCheckHttpReporter
-
-            self._heartbeat_reporter = HealthCheckHttpReporter()
+            # Create heartbeat reporter (authed /api/v1 lane, #326)
+            self._heartbeat_reporter = self._create_heartbeat_reporter(self._config)
 
             # Bootstrap system
             self.system = await self._create_system()
@@ -200,6 +199,49 @@ class AgentRunner:
 
         return await create_log_forwarder(config.prefect)
 
+    def _create_heartbeat_reporter(self, config):
+        """Build the heartbeat reporter (#326).
+
+        Status writes live on the authed /api/v1 lane: when an agent service
+        identity is configured (auth.agent_client + auth.oidc), heartbeats
+        carry a Bearer token acquired via client credentials; otherwise they
+        go out unauthenticated — valid only for auth-disabled deployments.
+
+        Raises:
+            ValueError: agent_client is configured without the oidc section
+                needed to reach the token endpoint (misconfiguration must
+                surface, not degrade to anonymous heartbeats).
+        """
+        from adapters.observability.healthcheck_http import HealthCheckHttpReporter
+
+        auth_cfg = config.auth
+        token_provider = None
+        if auth_cfg.agent_client is not None:
+            if auth_cfg.oidc is None:
+                raise ValueError(
+                    "auth.agent_client is configured but auth.oidc is missing — "
+                    "the OIDC issuer_url is required to acquire service tokens. "
+                    "Set SQUADOPS__AUTH__OIDC__ISSUER_URL (and AUDIENCE) or unset "
+                    "SQUADOPS__AUTH__AGENT_CLIENT__*."
+                )
+            from adapters.auth.factory import create_service_token_client
+
+            self._service_token_client = create_service_token_client(
+                "agent",
+                auth_cfg.agent_client,
+                auth_cfg.oidc,
+            )
+            token_provider = self._service_token_client.get_token
+            logger.info(
+                "Agent service identity configured for heartbeats",
+                extra={
+                    "agent_id": self.agent_id,
+                    "client_id": auth_cfg.agent_client.client_id,
+                },
+            )
+
+        return HealthCheckHttpReporter(token_provider=token_provider)
+
     async def stop(self) -> None:
         """Stop the agent gracefully."""
         logger.info("Stopping agent", extra={"agent_id": self.agent_id})
@@ -227,6 +269,11 @@ class AgentRunner:
         if self._log_forwarder is not None:
             await self._log_forwarder.aclose()
             self._log_forwarder = None
+
+        # Release the service-token client's HTTP session (#326)
+        if self._service_token_client is not None:
+            await self._service_token_client.close()
+            self._service_token_client = None
 
         logger.info("Agent stopped", extra={"agent_id": self.agent_id})
 

--- a/src/squadops/api/middleware/auth.py
+++ b/src/squadops/api/middleware/auth.py
@@ -22,8 +22,11 @@ logger = logging.getLogger(__name__)
 # dropping security audit events.
 _audit_unavailable_warned = False
 
-# Always allowlisted path prefixes (no token required)
+# Always allowlisted path prefixes (no token required). Read-only lane: the
+# allowlist applies to safe methods (GET/HEAD) only, so a write route mounted
+# under /health can never ride the no-auth lane (#326).
 _ALWAYS_ALLOWLISTED_PREFIXES = ("/health",)
+_ALLOWLISTED_METHODS = ("GET", "HEAD")
 
 # Conditionally allowlisted paths (only when expose_docs=True)
 _DOCS_PATHS = {"/docs", "/openapi.json", "/redoc"}
@@ -53,7 +56,9 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
 class AuthMiddleware(BaseHTTPMiddleware):
     """JWT token validation middleware (SIP-0062).
 
-    - Always allows /health and /health/infra without a token.
+    - Always allows GET/HEAD under /health without a token (read-only probe
+      lane); any other method under /health requires a token like every
+      protected route (#326).
     - Conditionally allows /docs and /openapi.json when expose_docs=True.
     - When provider='disabled', returns 503 for protected endpoints.
     - Otherwise, validates Bearer token and injects Identity into request.state.
@@ -126,8 +131,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
         path = request.url.path.rstrip("/") or "/"
         request_id = getattr(request.state, "request_id", "unknown")
 
-        # Always-allowlisted paths (prefix match)
-        if any(path.startswith(prefix) for prefix in _ALWAYS_ALLOWLISTED_PREFIXES):
+        # Always-allowlisted paths (prefix match, safe methods only — #326)
+        if request.method in _ALLOWLISTED_METHODS and any(
+            path.startswith(prefix) for prefix in _ALWAYS_ALLOWLISTED_PREFIXES
+        ):
             return await call_next(request)
 
         # Conditionally allowlisted docs paths

--- a/src/squadops/api/routes/agent_status.py
+++ b/src/squadops/api/routes/agent_status.py
@@ -1,0 +1,138 @@
+"""
+Agent status write routes (#326).
+
+Moved off the unauthenticated /health lane: /health/* is read-only operational
+probes only (CLAUDE.md › API Conventions, #218). Writes live here on the authed
+/api/v1 lane, gated by the agents:write scope — held by the `agent` realm role
+(agent service accounts) and `admin`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from squadops.api.middleware.auth import require_scopes
+from squadops.auth.models import Scope
+
+router = APIRouter(prefix="/api/v1/agents", tags=["agents"])
+
+
+class AgentStatusCreate(BaseModel):
+    agent_id: str
+    lifecycle_state: str
+    current_task_id: str | None = None
+    version: str | None = None
+    tps: int = 0
+    memory_count: int | None = None
+    # Deprecated fields (ignored if present)
+    agent_name: str | None = None
+    status: str | None = None
+    network_status: str | None = None
+
+
+class AgentStatusUpdate(BaseModel):
+    lifecycle_state: str | None = None
+    current_task_id: str | None = None
+    version: str | None = None
+    tps: int | None = None
+    memory_count: int | None = None
+
+
+_VALID_LIFECYCLE_STATES = {"STARTING", "READY", "WORKING", "BLOCKED", "CRASHED", "STOPPING"}
+
+
+def _get_health_checker():
+    from squadops.api.runtime.deps import get_health_checker
+
+    return get_health_checker()
+
+
+@router.post("/status", dependencies=[Depends(require_scopes(Scope.AGENTS_WRITE))])
+async def create_or_update_agent_status(agent_status: AgentStatusCreate):
+    """Create or update agent status (heartbeat endpoint)."""
+    hc = _get_health_checker()
+    agent_id = agent_status.agent_id
+    if agent_status.agent_name and not agent_id:
+        agent_id = agent_status.agent_name.lower()
+
+    if agent_status.lifecycle_state not in _VALID_LIFECYCLE_STATES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid lifecycle_state: {agent_status.lifecycle_state}. "
+                f"Must be one of {sorted(_VALID_LIFECYCLE_STATES)}"
+            ),
+        )
+
+    try:
+        return await hc.update_agent_status_in_db(
+            {
+                "agent_id": agent_id,
+                "lifecycle_state": agent_status.lifecycle_state,
+                "current_task_id": agent_status.current_task_id,
+                "version": agent_status.version,
+                "tps": agent_status.tps,
+                "memory_count": agent_status.memory_count,
+            }
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to update agent status: {e}") from e
+
+
+@router.put("/status/{agent_id}", dependencies=[Depends(require_scopes(Scope.AGENTS_WRITE))])
+async def update_agent_status(agent_id: str, update: AgentStatusUpdate):
+    """Update agent status fields."""
+    hc = _get_health_checker()
+
+    updates = []
+    params: list = []
+    idx = 1
+
+    if update.lifecycle_state:
+        updates.append(f"lifecycle_state = ${idx}")
+        params.append(update.lifecycle_state)
+        idx += 1
+    if update.current_task_id is not None:
+        updates.append(f"current_task_id = ${idx}")
+        params.append(update.current_task_id)
+        idx += 1
+    if update.version:
+        updates.append(f"version = ${idx}")
+        params.append(update.version)
+        idx += 1
+    if update.tps is not None:
+        updates.append(f"tps = ${idx}")
+        params.append(update.tps)
+        idx += 1
+    if update.memory_count is not None:
+        updates.append(f"memory_count = ${idx}")
+        params.append(update.memory_count)
+        idx += 1
+
+    if not updates:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    now = datetime.utcnow()
+    updates.append(f"last_heartbeat = ${idx}")
+    params.append(now)
+    idx += 1
+    updates.append(f"updated_at = ${idx}")
+    params.append(now)
+    idx += 1
+
+    params.append(agent_id.lower())
+    query = f"UPDATE agent_status SET {', '.join(updates)} WHERE agent_id = ${idx}"
+
+    try:
+        async with hc.pg_pool.acquire() as conn:
+            result = await conn.execute(query, *params)
+            if result == "UPDATE 0":
+                raise HTTPException(status_code=404, detail=f"Agent status {agent_id} not found")
+        return {"status": "updated", "agent_id": agent_id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to update agent status: {e}") from e

--- a/src/squadops/api/routes/platform_health.py
+++ b/src/squadops/api/routes/platform_health.py
@@ -3,43 +3,21 @@ Platform health routes — infra probes + agent status.
 
 Replaces the legacy health-check service endpoints with routes
 served directly from runtime-api.
+
+Read-only lane: /health/* is unauthenticated (middleware allowlist), so only
+GET probes may live here. Agent-status writes are on the authed /api/v1 lane
+(routes/agent_status.py, #326).
 """
 
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
 
 from squadops.api.runtime.agent_labels import get_role_label
 
 router = APIRouter(prefix="/health", tags=["platform-health"])
-
-
-class AgentStatusCreate(BaseModel):
-    agent_id: str
-    lifecycle_state: str
-    current_task_id: str | None = None
-    version: str | None = None
-    tps: int = 0
-    memory_count: int | None = None
-    # Deprecated fields (ignored if present)
-    agent_name: str | None = None
-    status: str | None = None
-    network_status: str | None = None
-
-
-class AgentStatusUpdate(BaseModel):
-    lifecycle_state: str | None = None
-    current_task_id: str | None = None
-    version: str | None = None
-    tps: int | None = None
-    memory_count: int | None = None
-
-
-_VALID_LIFECYCLE_STATES = {"STARTING", "READY", "WORKING", "BLOCKED", "CRASHED", "STOPPING"}
 
 
 def _get_health_checker():
@@ -171,89 +149,6 @@ async def get_agent_current_activity(agent_id: str):
     return activity
 
 
-@router.post("/agents/status")
-async def create_or_update_agent_status(agent_status: AgentStatusCreate):
-    """Create or update agent status (heartbeat endpoint)."""
-    hc = _get_health_checker()
-    agent_id = agent_status.agent_id
-    if agent_status.agent_name and not agent_id:
-        agent_id = agent_status.agent_name.lower()
-
-    if agent_status.lifecycle_state not in _VALID_LIFECYCLE_STATES:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Invalid lifecycle_state: {agent_status.lifecycle_state}. "
-                f"Must be one of {sorted(_VALID_LIFECYCLE_STATES)}"
-            ),
-        )
-
-    try:
-        return await hc.update_agent_status_in_db(
-            {
-                "agent_id": agent_id,
-                "lifecycle_state": agent_status.lifecycle_state,
-                "current_task_id": agent_status.current_task_id,
-                "version": agent_status.version,
-                "tps": agent_status.tps,
-                "memory_count": agent_status.memory_count,
-            }
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to update agent status: {e}") from e
-
-
-@router.put("/agents/status/{agent_id}")
-async def update_agent_status(agent_id: str, update: AgentStatusUpdate):
-    """Update agent status fields."""
-    hc = _get_health_checker()
-
-    updates = []
-    params: list = []
-    idx = 1
-
-    if update.lifecycle_state:
-        updates.append(f"lifecycle_state = ${idx}")
-        params.append(update.lifecycle_state)
-        idx += 1
-    if update.current_task_id is not None:
-        updates.append(f"current_task_id = ${idx}")
-        params.append(update.current_task_id)
-        idx += 1
-    if update.version:
-        updates.append(f"version = ${idx}")
-        params.append(update.version)
-        idx += 1
-    if update.tps is not None:
-        updates.append(f"tps = ${idx}")
-        params.append(update.tps)
-        idx += 1
-    if update.memory_count is not None:
-        updates.append(f"memory_count = ${idx}")
-        params.append(update.memory_count)
-        idx += 1
-
-    if not updates:
-        raise HTTPException(status_code=400, detail="No fields to update")
-
-    now = datetime.utcnow()
-    updates.append(f"last_heartbeat = ${idx}")
-    params.append(now)
-    idx += 1
-    updates.append(f"updated_at = ${idx}")
-    params.append(now)
-    idx += 1
-
-    params.append(agent_id.lower())
-    query = f"UPDATE agent_status SET {', '.join(updates)} WHERE agent_id = ${idx}"
-
-    try:
-        async with hc.pg_pool.acquire() as conn:
-            result = await conn.execute(query, *params)
-            if result == "UPDATE 0":
-                raise HTTPException(status_code=404, detail=f"Agent status {agent_id} not found")
-        return {"status": "updated", "agent_id": agent_id}
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to update agent status: {e}") from e
+# NOTE: POST /health/agents/status and PUT /health/agents/status/{agent_id}
+# moved to /api/v1/agents/status (routes/agent_status.py) in #326 — /health is
+# the unauthenticated lane and must stay read-only.

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -127,6 +127,11 @@ from squadops.api.routes.platform_health import router as platform_health_router
 
 app.include_router(platform_health_router)
 
+# Agent status writes — authed /api/v1 lane (#326; moved off /health)
+from squadops.api.routes.agent_status import router as agent_status_router  # noqa: E402
+
+app.include_router(agent_status_router)
+
 # SIP-0085: Chat routes for console messaging
 from squadops.api.routes.chat import agents_router as chat_agents_router  # noqa: E402
 from squadops.api.routes.chat import chat_router  # noqa: E402

--- a/src/squadops/auth/models.py
+++ b/src/squadops/auth/models.py
@@ -25,6 +25,9 @@ class Role:
     ADMIN = "admin"
     OPERATOR = "operator"
     VIEWER = "viewer"
+    # Service role held by the squadops-agent service account (#326): lets agent
+    # containers report their own status via the authed lane, nothing else.
+    AGENT = "agent"
 
 
 class Scope:
@@ -72,6 +75,11 @@ ROLE_SCOPES: dict[str, frozenset[str]] = {
             Scope.CYCLES_READ,
             Scope.AGENTS_READ,
             Scope.TASKS_READ,
+        }
+    ),
+    Role.AGENT: frozenset(
+        {
+            Scope.AGENTS_WRITE,
         }
     ),
 }

--- a/src/squadops/config/schema.py
+++ b/src/squadops/config/schema.py
@@ -369,6 +369,17 @@ class AuthConfig(BaseModel):
     service_clients: dict[str, ServiceClientConfig] = Field(
         default_factory=dict, description="Named service client configurations"
     )
+    agent_client: ServiceClientConfig | None = Field(
+        default=None,
+        description=(
+            "Client credentials an agent container uses for outbound calls to "
+            "runtime-api (heartbeats via POST /api/v1/agents/status, #326). "
+            "First-class field (not a service_clients entry) so it is addressable "
+            "via SQUADOPS__AUTH__AGENT_CLIENT__* env vars; requires oidc.issuer_url "
+            "for the token endpoint. Independent of `enabled`, which governs "
+            "inbound request validation only."
+        ),
+    )
     roles_mode: str = Field(
         default="realm", description="Role extraction mode: 'realm' or 'client'"
     )

--- a/src/squadops/runtime/lifecycle_status.py
+++ b/src/squadops/runtime/lifecycle_status.py
@@ -2,8 +2,9 @@
 Map agent lifecycle_state → runtime_status for SIP-0089 heartbeat integration.
 
 `lifecycle_state` is the existing agent-status vocabulary used by
-`HealthChecker` and the `/health/agents/status` endpoint. `runtime_status`
-is the SIP-0089 §10.5 health vocabulary on `agent_runtime_state`.
+`HealthChecker` and the `/api/v1/agents/status` heartbeat endpoint (#326).
+`runtime_status` is the SIP-0089 §10.5 health vocabulary on
+`agent_runtime_state`.
 
 The mapping is locked v1.1 per §1.0 spike normalization. Server-side
 timeout detection (last_heartbeat_at older than N seconds → offline) is

--- a/tests/unit/agents/test_entrypoint_heartbeat_identity.py
+++ b/tests/unit/agents/test_entrypoint_heartbeat_identity.py
@@ -1,0 +1,90 @@
+"""
+AgentRunner heartbeat service-identity wiring (#326).
+
+Reporter behavior is covered in tests/unit/observability/test_healthcheck_http.py.
+These tests cover the runner-side wiring: agent_client + oidc config yields a
+token-carrying reporter, no agent_client yields an unauthenticated one, and a
+half-configured identity fails loudly instead of degrading to anonymous
+heartbeats against an authed endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.config.schema import OIDCConfig, ServiceClientConfig
+
+pytestmark = [pytest.mark.domain_agents]
+
+
+def _make_runner():
+    """Build a bare AgentRunner without invoking __init__ (loads instances.yaml)."""
+    from squadops.agents.entrypoint import AgentRunner
+
+    runner = AgentRunner.__new__(AgentRunner)
+    runner.agent_id = "neo"
+    runner._service_token_client = None
+    return runner
+
+
+def _config(agent_client=None, oidc=None):
+    cfg = MagicMock()
+    cfg.auth.agent_client = agent_client
+    cfg.auth.oidc = oidc
+    return cfg
+
+
+_AGENT_CLIENT = ServiceClientConfig(client_id="squadops-agent", client_secret="s3cret")
+_OIDC = OIDCConfig(
+    issuer_url="http://keycloak:8080/realms/squadops-dev",
+    audience="squadops-runtime",
+)
+
+
+class TestHeartbeatIdentityWiring:
+    def test_agent_client_configured_wires_token_provider(self):
+        runner = _make_runner()
+        reporter = runner._create_heartbeat_reporter(_config(_AGENT_CLIENT, _OIDC))
+
+        # Reporter authenticates via the runner-owned ServiceTokenClient
+        assert reporter._token_provider == runner._service_token_client.get_token
+        assert runner._service_token_client._client_id == "squadops-agent"
+        assert (
+            runner._service_token_client._token_endpoint
+            == "http://keycloak:8080/realms/squadops-dev/protocol/openid-connect/token"
+        )
+
+    def test_no_agent_client_yields_unauthenticated_reporter(self):
+        runner = _make_runner()
+        reporter = runner._create_heartbeat_reporter(_config(agent_client=None, oidc=_OIDC))
+
+        assert reporter._token_provider is None
+        assert runner._service_token_client is None
+
+    def test_agent_client_without_oidc_raises(self):
+        """Misconfiguration must surface at startup: without oidc there is no
+        token endpoint, and silently sending anonymous heartbeats would just
+        401 forever against the authed lane."""
+        runner = _make_runner()
+        with pytest.raises(ValueError, match="auth.oidc is missing"):
+            runner._create_heartbeat_reporter(_config(agent_client=_AGENT_CLIENT, oidc=None))
+        assert runner._service_token_client is None
+
+    async def test_stop_closes_token_client(self):
+        """The ServiceTokenClient owns an httpx session — stop() must release
+        it or every agent shutdown leaks a connection pool."""
+        runner = _make_runner()
+        runner._shutdown_event = asyncio.Event()
+        runner._heartbeat_task = None
+        runner.system = None
+        runner._log_forwarder = None
+        token_client = AsyncMock()
+        runner._service_token_client = token_client
+
+        await runner.stop()
+
+        token_client.close.assert_awaited_once()
+        assert runner._service_token_client is None

--- a/tests/unit/agents/test_entrypoint_log_forwarding.py
+++ b/tests/unit/agents/test_entrypoint_log_forwarding.py
@@ -33,6 +33,7 @@ def _make_runner():
     runner = AgentRunner.__new__(AgentRunner)
     runner.agent_id = "neo"
     runner._log_forwarder = None
+    runner._service_token_client = None
     return runner
 
 

--- a/tests/unit/api/test_agent_status_routes.py
+++ b/tests/unit/api/test_agent_status_routes.py
@@ -1,0 +1,183 @@
+"""
+Unit tests for agent status write routes (#326).
+
+Handler behavior (ported from the old /health lane) plus the authorization
+guard: routes are gated on agents:write, which the `agent` realm role implies
+via the #270 role→scope bridge.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from adapters.auth.keycloak.authz_adapter import KeycloakAuthzAdapter
+from squadops.api.routes.agent_status import router
+from squadops.auth.models import Identity, Role, scopes_for_roles
+
+pytestmark = pytest.mark.auth
+
+
+@pytest.fixture()
+def mock_health_checker():
+    hc = MagicMock()
+    hc.pg_pool = MagicMock()
+    hc.update_agent_status_in_db = AsyncMock(return_value={"status": "updated", "agent_id": "max"})
+    return hc
+
+
+@pytest.fixture()
+def client(mock_health_checker):
+    """Test client with no authz backend configured — guards no-op (auth-off
+    deployment behavior), so handler logic is exercised directly."""
+    app = FastAPI()
+    app.include_router(router)
+
+    with patch(
+        "squadops.api.routes.agent_status._get_health_checker",
+        return_value=mock_health_checker,
+    ):
+        yield TestClient(app)
+
+
+def _identity_for_roles(*roles: str) -> Identity:
+    """Identity as the auth middleware would build it: effective scopes are
+    the role-implied set (#270)."""
+    return Identity(
+        user_id=f"svc-{'-'.join(roles)}",
+        display_name="test",
+        roles=roles,
+        scopes=tuple(sorted(scopes_for_roles(roles))),
+    )
+
+
+def _guarded_client(mock_health_checker, identity: Identity | None):
+    """Test client with the REAL authz adapter wired and an optional identity
+    injected (as AuthMiddleware would after token validation)."""
+    app = FastAPI()
+
+    class InjectIdentity(BaseHTTPMiddleware):
+        async def dispatch(self, request: Request, call_next):
+            if identity is not None:
+                request.state.identity = identity
+            return await call_next(request)
+
+    app.add_middleware(InjectIdentity)
+    app.include_router(router)
+    return TestClient(app)
+
+
+class TestCreateOrUpdateAgentStatus:
+    def test_valid_heartbeat(self, client, mock_health_checker):
+        resp = client.post(
+            "/api/v1/agents/status",
+            json={"agent_id": "max", "lifecycle_state": "READY"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "updated"
+        mock_health_checker.update_agent_status_in_db.assert_awaited_once()
+
+    def test_invalid_lifecycle_state_returns_400(self, client, mock_health_checker):
+        resp = client.post(
+            "/api/v1/agents/status",
+            json={"agent_id": "max", "lifecycle_state": "INVALID"},
+        )
+        assert resp.status_code == 400
+        assert "Invalid lifecycle_state" in resp.json()["detail"]
+        mock_health_checker.update_agent_status_in_db.assert_not_awaited()
+
+
+class TestUpdateAgentStatus:
+    def test_update_with_no_fields_returns_400(self, client):
+        resp = client.put("/api/v1/agents/status/max", json={})
+        assert resp.status_code == 400
+        assert "No fields" in resp.json()["detail"]
+
+    def test_update_valid_fields(self, client, mock_health_checker):
+        mock_conn = AsyncMock()
+        mock_conn.execute = AsyncMock(return_value="UPDATE 1")
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_health_checker.pg_pool.acquire.return_value = mock_conn
+
+        resp = client.put(
+            "/api/v1/agents/status/max",
+            json={"lifecycle_state": "WORKING", "tps": 10},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "updated"
+
+    def test_update_not_found(self, client, mock_health_checker):
+        mock_conn = AsyncMock()
+        mock_conn.execute = AsyncMock(return_value="UPDATE 0")
+        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_conn.__aexit__ = AsyncMock(return_value=False)
+        mock_health_checker.pg_pool.acquire.return_value = mock_conn
+
+        resp = client.put(
+            "/api/v1/agents/status/ghost",
+            json={"lifecycle_state": "READY"},
+        )
+        assert resp.status_code == 404
+
+
+class TestAgentsWriteGuard:
+    """The routes enforce agents:write when an authz backend is configured.
+    Uses the real KeycloakAuthzAdapter (pure logic) + the real role→scope
+    bridge, so a ROLE_SCOPES regression (e.g. agent role losing agents:write)
+    fails here, not in production."""
+
+    HEARTBEAT = {"agent_id": "max", "lifecycle_state": "READY"}
+
+    def _post(self, identity, mock_health_checker):
+        client = _guarded_client(mock_health_checker, identity)
+        with (
+            patch(
+                "squadops.api.routes.agent_status._get_health_checker",
+                return_value=mock_health_checker,
+            ),
+            patch(
+                "squadops.api.runtime.deps.get_authz_port",
+                return_value=KeycloakAuthzAdapter(),
+            ),
+        ):
+            return client.post("/api/v1/agents/status", json=self.HEARTBEAT)
+
+    def test_anonymous_write_is_401(self, mock_health_checker):
+        resp = self._post(None, mock_health_checker)
+        assert resp.status_code == 401
+        mock_health_checker.update_agent_status_in_db.assert_not_awaited()
+
+    def test_viewer_role_is_403(self, mock_health_checker):
+        resp = self._post(_identity_for_roles(Role.VIEWER), mock_health_checker)
+        assert resp.status_code == 403
+        assert "agents:write" in resp.json()["detail"]
+        mock_health_checker.update_agent_status_in_db.assert_not_awaited()
+
+    def test_operator_role_is_403(self, mock_health_checker):
+        # Operator manages cycles/tasks but does NOT hold agents:write —
+        # status writes are the agents' own lane (plus admin).
+        resp = self._post(_identity_for_roles(Role.OPERATOR), mock_health_checker)
+        assert resp.status_code == 403
+
+    def test_agent_role_is_granted(self, mock_health_checker):
+        resp = self._post(_identity_for_roles(Role.AGENT), mock_health_checker)
+        assert resp.status_code == 200
+        mock_health_checker.update_agent_status_in_db.assert_awaited_once()
+
+    def test_admin_role_is_granted(self, mock_health_checker):
+        resp = self._post(_identity_for_roles(Role.ADMIN), mock_health_checker)
+        assert resp.status_code == 200
+
+    def test_put_is_guarded_too(self, mock_health_checker):
+        client = _guarded_client(mock_health_checker, None)
+        with patch(
+            "squadops.api.runtime.deps.get_authz_port",
+            return_value=KeycloakAuthzAdapter(),
+        ):
+            resp = client.put("/api/v1/agents/status/max", json={"lifecycle_state": "WORKING"})
+        assert resp.status_code == 401

--- a/tests/unit/api/test_platform_health_routes.py
+++ b/tests/unit/api/test_platform_health_routes.py
@@ -142,70 +142,41 @@ class TestAgentStatusById:
         assert resp.status_code == 404
 
 
-class TestCreateOrUpdateAgentStatus:
-    def test_valid_heartbeat(self, client, mock_health_checker):
+class TestHealthLaneIsReadOnly:
+    """#326: agent-status writes moved to /api/v1/agents/status. The /health
+    lane is unauthenticated, so a write route reappearing here is a security
+    regression — these paths must not resolve at all."""
+
+    def test_post_agent_status_gone_from_health_lane(self, client):
         resp = client.post(
             "/health/agents/status",
-            json={
-                "agent_id": "max",
-                "lifecycle_state": "READY",
-            },
-        )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["status"] == "updated"
-        mock_health_checker.update_agent_status_in_db.assert_awaited_once()
-
-    def test_invalid_lifecycle_state_returns_400(self, client, mock_health_checker):
-        resp = client.post(
-            "/health/agents/status",
-            json={
-                "agent_id": "max",
-                "lifecycle_state": "INVALID",
-            },
-        )
-        assert resp.status_code == 400
-        assert "Invalid lifecycle_state" in resp.json()["detail"]
-
-
-class TestUpdateAgentStatus:
-    def test_update_with_no_fields_returns_400(self, client, mock_health_checker):
-        resp = client.put("/health/agents/status/max", json={})
-        assert resp.status_code == 400
-        assert "No fields" in resp.json()["detail"]
-
-    def test_update_valid_fields(self, client, mock_health_checker):
-        mock_conn = AsyncMock()
-        mock_conn.execute = AsyncMock(return_value="UPDATE 1")
-        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
-        mock_conn.__aexit__ = AsyncMock(return_value=False)
-        mock_health_checker.pg_pool.acquire.return_value = mock_conn
-
-        resp = client.put(
-            "/health/agents/status/max",
-            json={
-                "lifecycle_state": "WORKING",
-                "tps": 10,
-            },
-        )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["status"] == "updated"
-
-    def test_update_not_found(self, client, mock_health_checker):
-        mock_conn = AsyncMock()
-        mock_conn.execute = AsyncMock(return_value="UPDATE 0")
-        mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
-        mock_conn.__aexit__ = AsyncMock(return_value=False)
-        mock_health_checker.pg_pool.acquire.return_value = mock_conn
-
-        resp = client.put(
-            "/health/agents/status/ghost",
-            json={
-                "lifecycle_state": "READY",
-            },
+            json={"agent_id": "max", "lifecycle_state": "READY"},
         )
         assert resp.status_code == 404
+
+    def test_put_agent_status_gone_from_health_lane(self, client):
+        resp = client.put(
+            "/health/agents/status/max",
+            json={"lifecycle_state": "WORKING"},
+        )
+        # 405, not 404: the path still exists for GET (single-agent status
+        # probe); only the write method must be gone.
+        assert resp.status_code == 405
+
+    def test_health_router_exposes_only_safe_methods(self):
+        """Structural ratchet for the lane rule (#218): every route on the
+        /health router must be GET-only. Catches any future write route added
+        to this router before the middleware allowlist would expose it."""
+        from squadops.api.routes.platform_health import router as health_router
+
+        for route in health_router.routes:
+            methods = getattr(route, "methods", set()) or set()
+            unsafe = methods - {"GET", "HEAD"}
+            assert not unsafe, (
+                f"Route {route.path} exposes unsafe methods {unsafe} on the "
+                "unauthenticated /health lane — writable resources belong on "
+                "/api/v1 (see routes/agent_status.py, #326)"
+            )
 
 
 class TestAgentCurrentActivity:

--- a/tests/unit/auth/test_middleware.py
+++ b/tests/unit/auth/test_middleware.py
@@ -40,6 +40,12 @@ def _make_app(
     async def health_infra():
         return {"status": "ok"}
 
+    # Deliberately-mounted write route under /health: the middleware must NOT
+    # allowlist it (#326) — the no-auth lane covers safe methods only.
+    @app.post("/health/rogue-write")
+    async def health_rogue_write():
+        return {"status": "written"}
+
     @app.get("/docs")
     async def docs():
         return {"docs": "swagger"}
@@ -86,7 +92,8 @@ def _make_auth_port(identity: Identity | None = None) -> MagicMock:
 
 
 class TestHealthEndpointAllowlist:
-    """/health and /health/infra always pass without token."""
+    """GET under /health always passes without token; the allowlist is
+    method-scoped (#326) so writes under /health still require auth."""
 
     def test_health_no_token(self):
         app = _make_app()
@@ -99,6 +106,26 @@ class TestHealthEndpointAllowlist:
         client = TestClient(app)
         resp = client.get("/health/infra")
         assert resp.status_code == 200
+
+    def test_post_under_health_requires_token(self):
+        """#326 regression: an unauthenticated client must not be able to
+        reach a write route mounted under /health — the prefix allowlist
+        applies to safe methods only."""
+        auth_port = _make_auth_port()
+        app = _make_app(auth_port=auth_port)
+        client = TestClient(app)
+        resp = client.post("/health/rogue-write")
+        assert resp.status_code == 401
+
+    def test_post_under_health_passes_with_valid_token(self):
+        """The method guard demands auth, it doesn't block the route: a
+        valid token still reaches a write route under /health."""
+        auth_port = _make_auth_port()
+        app = _make_app(auth_port=auth_port)
+        client = TestClient(app)
+        resp = client.post("/health/rogue-write", headers={"Authorization": "Bearer good-token"})
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "written"}
 
 
 class TestDocsAllowlist:

--- a/tests/unit/auth/test_realm_parity.py
+++ b/tests/unit/auth/test_realm_parity.py
@@ -1,0 +1,82 @@
+"""
+Code ↔ realm-export parity guards (#326).
+
+The #270 role→scope bridge only works if every Role constant is backed by a
+realm role in the Keycloak exports — a rename or dropped role on either side
+silently strips permissions (exactly the class of bug behind #270). These
+tests pin the two surfaces together.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from squadops.auth.models import ROLE_SCOPES, Role, Scope
+
+pytestmark = pytest.mark.auth
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_AUTH_DIR = _REPO_ROOT / "infra" / "auth"
+_REALM_FILES = [
+    "squadops-realm.json",
+    "squadops-realm-local.json",
+    "squadops-realm-cloud.json",
+    "squadops-realm-lab.json",
+]
+
+
+def _load(fname: str) -> dict:
+    return json.loads((_AUTH_DIR / fname).read_text())
+
+
+@pytest.mark.parametrize("fname", _REALM_FILES)
+class TestRealmParity:
+    def test_every_code_role_exists_in_realm(self, fname):
+        realm_roles = {r["name"] for r in _load(fname)["roles"]["realm"]}
+        missing = set(ROLE_SCOPES) - realm_roles
+        assert not missing, (
+            f"{fname} lacks realm role(s) {sorted(missing)} that ROLE_SCOPES "
+            "maps — tokens carrying them would imply no scopes"
+        )
+
+    def test_agent_client_is_confidential_service_account(self, fname):
+        """#326: the squadops-agent client must exist, be confidential, and
+        have service accounts on — otherwise agent containers cannot acquire
+        heartbeat tokens via client credentials."""
+        clients = {c["clientId"]: c for c in _load(fname)["clients"]}
+        agent = clients.get("squadops-agent")
+        assert agent is not None, f"{fname} missing squadops-agent client"
+        assert agent["publicClient"] is False
+        assert agent["serviceAccountsEnabled"] is True
+
+    def test_agent_client_token_carries_runtime_audience(self, fname):
+        """runtime-api validates aud=squadops-runtime; without the audience
+        mapper every agent token would be rejected at validation."""
+        clients = {c["clientId"]: c for c in _load(fname)["clients"]}
+        agent = clients["squadops-agent"]
+        audiences = [
+            m["config"]["included.client.audience"]
+            for m in agent.get("protocolMappers", [])
+            if m.get("protocolMapper") == "oidc-audience-mapper"
+        ]
+        assert "squadops-runtime" in audiences
+
+    def test_agent_service_account_holds_only_agent_role(self, fname):
+        """Least privilege: the agent service account gets the agent role and
+        nothing else (agents:write only — no cycle/task/admin scopes)."""
+        users = {u.get("username"): u for u in _load(fname).get("users", [])}
+        svc = users.get("service-account-squadops-agent")
+        assert svc is not None, f"{fname} missing agent service-account user"
+        assert svc.get("serviceAccountClientId") == "squadops-agent"
+        assert svc.get("realmRoles") == ["agent"]
+
+
+class TestAgentRoleScopes:
+    def test_agent_role_implies_exactly_agents_write(self):
+        """The agent role must grant agents:write (or heartbeats 403) and
+        nothing more (an agent identity must not gain cycle/task/admin
+        access if someone fattens the mapping)."""
+        assert ROLE_SCOPES[Role.AGENT] == frozenset({Scope.AGENTS_WRITE})

--- a/tests/unit/config/test_agent_client_env.py
+++ b/tests/unit/config/test_agent_client_env.py
@@ -1,0 +1,31 @@
+"""
+Env addressability of auth.agent_client (#326).
+
+agent_client exists as a first-class AuthConfig field precisely because the
+schema-authoritative env loader cannot address keys inside dict-valued fields
+(auth.service_clients). If agent_client is ever folded back into the dict,
+these resolutions break and agent containers silently lose their service
+identity — this test makes that failure loud.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.config.loader import _get_schema_path_map, _resolve_env_var_path
+
+
+@pytest.mark.parametrize(
+    "env_path,dot_path",
+    [
+        ("AUTH__AGENT_CLIENT__CLIENT_ID", "auth.agent_client.client_id"),
+        ("AUTH__AGENT_CLIENT__CLIENT_SECRET", "auth.agent_client.client_secret"),
+    ],
+)
+def test_agent_client_env_vars_resolve(env_path, dot_path):
+    info = _resolve_env_var_path(env_path, _get_schema_path_map())
+    assert info is not None, (
+        f"SQUADOPS__{env_path} does not resolve — agent containers configure "
+        "their service identity through this path (docker-compose.yml, #326)"
+    )
+    assert info.dot_path == dot_path

--- a/tests/unit/observability/test_healthcheck_http.py
+++ b/tests/unit/observability/test_healthcheck_http.py
@@ -1,0 +1,97 @@
+"""
+Unit tests for HealthCheckHttpReporter (#326).
+
+The reporter posts heartbeats to the authed /api/v1 lane and attaches a
+Bearer token when a token provider (agent service identity) is configured.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from adapters.observability.healthcheck_http import HealthCheckHttpReporter
+
+pytestmark = pytest.mark.domain_agents
+
+
+def _mock_async_client(status_code: int = 200, text: str = "ok"):
+    """Mock httpx.AsyncClient context manager capturing post() calls."""
+    response = MagicMock(status_code=status_code, text=text)
+    client = MagicMock()
+    client.post = AsyncMock(return_value=response)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx, client
+
+
+async def _send(reporter, **kwargs):
+    defaults = {"agent_id": "max", "lifecycle_state": "READY"}
+    defaults.update(kwargs)
+    await reporter.send_status(**defaults)
+
+
+class TestSendStatus:
+    async def test_posts_to_authed_lane(self):
+        """#326: heartbeats go to /api/v1/agents/status, not the removed
+        /health write route (which would 404 and drop every heartbeat)."""
+        ctx, client = _mock_async_client()
+        reporter = HealthCheckHttpReporter(base_url="http://api:8001")
+        with patch("adapters.observability.healthcheck_http.httpx.AsyncClient", return_value=ctx):
+            await _send(reporter, tps=2.7, current_task_id="t-1")
+
+        (url,), kwargs = client.post.call_args
+        assert url == "http://api:8001/api/v1/agents/status"
+        assert kwargs["json"]["agent_id"] == "max"
+        assert kwargs["json"]["lifecycle_state"] == "READY"
+        assert kwargs["json"]["tps"] == 2  # floats truncate to int
+        assert kwargs["json"]["current_task_id"] == "t-1"
+
+    async def test_bearer_token_attached_when_provider_configured(self):
+        ctx, client = _mock_async_client()
+        reporter = HealthCheckHttpReporter(
+            base_url="http://api:8001",
+            token_provider=AsyncMock(return_value="svc-token-abc"),
+        )
+        with patch("adapters.observability.healthcheck_http.httpx.AsyncClient", return_value=ctx):
+            await _send(reporter)
+
+        _, kwargs = client.post.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer svc-token-abc"
+
+    async def test_no_auth_header_without_provider(self):
+        ctx, client = _mock_async_client()
+        reporter = HealthCheckHttpReporter(base_url="http://api:8001")
+        with patch("adapters.observability.healthcheck_http.httpx.AsyncClient", return_value=ctx):
+            await _send(reporter)
+
+        _, kwargs = client.post.call_args
+        assert "Authorization" not in kwargs["headers"]
+
+    async def test_http_error_swallowed_when_fail_silently(self):
+        """An auth misconfiguration (401) must not crash the heartbeat loop."""
+        ctx, _ = _mock_async_client(status_code=401, text="Invalid or expired token")
+        reporter = HealthCheckHttpReporter(base_url="http://api:8001")
+        with patch("adapters.observability.healthcheck_http.httpx.AsyncClient", return_value=ctx):
+            await _send(reporter)  # no raise
+
+    async def test_http_error_raises_when_not_silent(self):
+        ctx, _ = _mock_async_client(status_code=401, text="Invalid or expired token")
+        reporter = HealthCheckHttpReporter(base_url="http://api:8001", fail_silently=False)
+        with patch("adapters.observability.healthcheck_http.httpx.AsyncClient", return_value=ctx):
+            with pytest.raises(RuntimeError, match="401"):
+                await _send(reporter)
+
+    async def test_token_provider_failure_swallowed_when_fail_silently(self):
+        """Keycloak being down must not crash the heartbeat loop — the send
+        fails silently and the next tick retries."""
+        ctx, client = _mock_async_client()
+        reporter = HealthCheckHttpReporter(
+            base_url="http://api:8001",
+            token_provider=AsyncMock(side_effect=ConnectionError("keycloak down")),
+        )
+        with patch("adapters.observability.healthcheck_http.httpx.AsyncClient", return_value=ctx):
+            await _send(reporter)  # no raise
+        client.post.assert_not_awaited()


### PR DESCRIPTION
## Summary

Closes #326.

`POST /health/agents/status` and `PUT /health/agents/status/{id}` were writable by **any anonymous network client** — the auth middleware allowlists the whole `/health` prefix (read-only no-auth lane), but the platform-health router mounted write routes under it. This moves those writes to the authenticated `/api/v1` lane and gives agents a service identity so their heartbeats keep flowing.

Confirmed the hole live before the fix: an anonymous `POST /health/agents/status` on the old stack returned **200** and inserted a fake `pwned-agent` row.

## What changed

**Server (the fix):**
- Agent-status writes now live at `POST/PUT /api/v1/agents/status[...]`, gated by `require_scopes(agents:write)`. `/health/*` keeps only GET probes.
- **Defense in depth:** the middleware allowlist is now method-scoped (GET/HEAD only), so any future write route mounted under `/health` fails closed instead of riding the no-auth lane. A router-level test pins `/health` to safe methods.

**Identity (so agents can still write):**
- New realm role `agent` implying **only** `agents:write` (via the #270 role→scope bridge), plus a confidential `squadops-agent` client (service accounts on, audience mapper to `squadops-runtime`) across all four realm exports. Its service account holds exactly the `agent` role — least privilege, no cycle/task/admin access.
- New first-class `auth.agent_client` config, env-addressable as `SQUADOPS__AUTH__AGENT_CLIENT__*` (a `service_clients` dict entry can't be addressed by the schema-authoritative env loader — hence a dedicated field, with a test pinning that).
- `HealthCheckHttpReporter` posts to the new path and attaches a Bearer token from the existing `ServiceTokenClient` when an identity is configured. Token-acquisition failures fail silently like any heartbeat (next tick retries); a half-configured identity (`agent_client` without `oidc`) raises at startup rather than degrading to anonymous heartbeats that would 401 forever.
- docker-compose: each agent gets the client secret via a new `agent_client_secret` docker secret; bootstrap creates the dev secret file.

## Authorization matrix (enforced by tests against the real authz adapter)

| Identity | `agents:write`? |
|---|---|
| anonymous | 401 |
| viewer / operator | 403 |
| **agent** | ✅ 200 |
| admin | ✅ 200 |

## Tests

- `test_agent_status_routes.py` — handler behavior + the guard matrix above (real `KeycloakAuthzAdapter` + role→scope bridge, so a `ROLE_SCOPES` regression fails in CI)
- `test_platform_health_routes.py` — old write paths gone (404/405); structural ratchet that every `/health` route is GET-only
- `test_middleware.py` — a deliberately-mounted write route under `/health` requires a token (401 anon, 200 with token)
- `test_realm_parity.py` — every code `Role` is backed by a realm role in all four exports; `squadops-agent` client shape + audience + least-privilege service account
- `test_healthcheck_http.py` — posts to `/api/v1/agents/status`, attaches bearer, swallows token/HTTP failures
- `test_entrypoint_heartbeat_identity.py` — runner wiring: identity → token provider, no identity → anonymous, half-config → raises, `stop()` closes the token client
- `test_agent_client_env.py` — the `SQUADOPS__AUTH__AGENT_CLIENT__*` env paths resolve

Full regression: **4726 passed, 1 skipped**, exit 0. Ruff clean.

## Live validation (rebuilt stack at 1.3.0)

- Anonymous `POST /api/v1/agents/status` → **401** (was 200); old `/health` write paths → **401**
- `POST /api/v1/agents/status` with a real `squadops-agent` token → **200**
- `GET /health`, `GET /health/agents` → **200** (probes still open)
- **All 7 deployed agents** log "service identity configured", zero heartbeat failures, fresh heartbeats landing in the DB at v1.3.0 (request logs show every internal agent IP getting 200)
- Smoke cycle `cyc_473fbf479a4a` **completed** (~84s, 6 artifacts) — squad runs end-to-end after the auth change

Targeted for the **1.3.1** hardening patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ
