### PR TITLE
fix(#306): install Node.js in the qa agent image so the frontend build check runs

### DIFF
--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -71,6 +71,21 @@ RUN --mount=type=cache,target=/root/.cache/pip \
       pip install -r "agents/instances/${AGENT_ROLE}/requirements.txt"; \
     fi
 
+# Install per-role system (apt) extras — the system-level analog of the pip
+# step above. A role declares its native packages in
+# agents/instances/<role>/system-packages.txt (comments and blank lines ignored);
+# the role name is NOT hardcoded here, so a new build-capable role (or a renamed
+# one) is a data change, not a Dockerfile edit (#306). Today only the qa role
+# declares any — Node.js/npm for the frontend build check + vitest.
+RUN sys_pkgs="agents/instances/${AGENT_ROLE}/system-packages.txt"; \
+    if [ -f "$sys_pkgs" ]; then \
+      pkgs="$(grep -vE '^\s*#|^\s*$' "$sys_pkgs")"; \
+      if [ -n "$pkgs" ]; then \
+        apt-get update && apt-get install -y --no-install-recommends $pkgs \
+        && rm -rf /var/lib/apt/lists/*; \
+      fi; \
+    fi
+
 # Cache-bust: when SOURCE_HASH changes, Docker invalidates this layer and below
 ARG SOURCE_HASH=unknown
 

--- a/agents/instances/qa/system-packages.txt
+++ b/agents/instances/qa/system-packages.txt
@@ -1,0 +1,10 @@
+# QA agent role — system (apt) packages, the system-level analog of
+# requirements.txt. Installed at image build time for this role only.
+#
+# Node.js + npm: the qa.test capability runs the frontend build check (#290)
+# and vitest (run_build_validation → run_node_tests / run_frontend_build),
+# which shell out to npm/npx. Any role that runs npm/npx or other native
+# tooling declares its packages here — no role name is hardcoded in the
+# Dockerfile (#306).
+nodejs
+npm


### PR DESCRIPTION
## Summary

Closes #306.

The frontend build check (#290) and vitest (`run_node_tests` / `run_frontend_build`) shell out to `npm`/`npx` from the `qa.test` capability, which runs in the QA agent's own container. The agent base image (`python:3.11-slim`) had no Node, so those checks hit `FileNotFoundError` and skipped — **a non-building frontend shipped green.**

## Fix — config-driven, not role-name-hardcoded

`qa.test` (role `qa`, handler `cycle/qa_test.py`) is the **sole** Node consumer in the squad — the only handler reaching `run_build_validation`. So Node ships in the qa image alone, not bloating all six agent images.

The trigger is **declarative**, mirroring the existing per-role pip extras (`agents/instances/<role>/requirements.txt`): a role declares native packages in `agents/instances/<role>/system-packages.txt` and the Dockerfile installs whatever is declared. The role name is **not** hardcoded in the Dockerfile — a new build-capable role (or a rename) is a data change, not a Dockerfile edit. Today only `qa` declares any: `nodejs` + `npm`.

(First cut branched on `if [ "$AGENT_ROLE" = "qa" ]`; revised to the file-driven form so it doesn't rot the moment another role needs a toolchain.)

Debian's packaged nodejs is 20.x on this base — satisfies Vite's Node ≥18.

## Live validation (rebuilt qa image, fullstack cycle on the deployed stack)

- **Targeting:** `docker exec squadops-eve node --version` → `v20.19.2` / npm `9.2.0`; `squadops-max` → `node: not found` (Node is in the qa image only, other five untouched).
- **The check now runs** — fullstack cycle `cyc_652f7440d0c3` (`lite` squad, `fullstack-fastapi-react` profile, plan-review gate approved) produced a React/Vite frontend and its qa.test `test_report` artifact shows the frontend toolchain **executing**, where before it skipped on "npm not found":

  ```
  === Frontend (vitest) ===
   RUN  v4.1.10  /tmp/qa_node_dlwgfmhl/frontend
  npm WARN exec The following package was not found and will be installed: vitest@4.1.10
  ```

  `npm` ran (fetched vitest), `npx vitest run` ran, and the vite build check ran (exit 0, so it didn't block). Frontend problems now **surface in the report** instead of being invisible.

## Scope notes (not this PR)

- The generated app's vitest suite failed on a missing `@testing-library/react` dep — a 7b generation-quality gap (incomplete `package.json`), not a framework issue.
- Frontend vitest is **non-blocking** by the documented D13 merge policy (backend pytest controls pass/fail); the vite *build* is blocking. That split is intentional and is what SIP-0096 already flags for a future evidence-integrity amendment — out of scope here.
- The principled longer-term home (externalize build execution to a sandbox so no agent image carries a toolchain) is filed as a proposed SIP draft in #360; this PR is the correct interim and that SIP is its exit.

Refs #290, #296, #303. Targeted for the 1.3.1 hardening patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ
