### PR TITLE
fix(#328): broker-hygiene doctor check + sweep orphaned pre-SIP-0094 queues

### DIFF
--- a/src/squadops/bootstrap/setup/checks.py
+++ b/src/squadops/bootstrap/setup/checks.py
@@ -7,6 +7,7 @@ and returns a CheckResult with pass/fail, fix guidance, and heuristic flag.
 from __future__ import annotations
 
 import asyncio
+import json
 import platform
 import shutil
 import socket
@@ -28,7 +29,9 @@ from squadops.bootstrap.setup.profile import (
 # Result model
 # ---------------------------------------------------------------------------
 
-VALID_CATEGORIES = frozenset({"python", "platform", "tools", "docker", "models", "gpu", "auth"})
+VALID_CATEGORIES = frozenset(
+    {"python", "platform", "tools", "docker", "models", "squad", "gpu", "auth", "broker"}
+)
 
 
 @dataclass(frozen=True)
@@ -653,6 +656,150 @@ def check_auth_token() -> CheckResult:
 
 
 # ---------------------------------------------------------------------------
+# Broker hygiene checks (#328)
+# ---------------------------------------------------------------------------
+
+# Queue-name prefixes retired by SIP-0094 (per-run cycle_results_{run_id} reply
+# queues, replaced by durable per-agent {agent_id}_replies). Any surviving queue
+# with one of these prefixes is orphaned residue, not a live path.
+_RETIRED_QUEUE_PREFIXES = ("cycle_results",)
+
+
+def _query_broker_queues(service: str = "rabbitmq") -> list[dict] | None:
+    """Per-queue ``{name, messages, consumers}`` via ``rabbitmqctl list_queues``
+    run inside the broker container.
+
+    The container is resolved from the compose *service* name (``docker compose
+    ps -q``) rather than a hardcoded container name, and rabbitmqctl runs as the
+    broker admin so no credentials are needed — the same host-side access path
+    ``rebuild_and_deploy.sh`` uses. Returns ``None`` when the broker can't be
+    queried (docker absent, container down, rabbitmqctl error); callers warn
+    heuristically rather than hard-fail on an unqueryable broker.
+    """
+    try:
+        cid_proc = subprocess.run(
+            ["docker", "compose", "ps", "-q", service],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        container_id = cid_proc.stdout.strip()
+        if cid_proc.returncode != 0 or not container_id:
+            return None
+        proc = subprocess.run(
+            [
+                "docker",
+                "exec",
+                container_id,
+                "rabbitmqctl",
+                "list_queues",
+                "name",
+                "messages",
+                "consumers",
+                "--formatter",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if proc.returncode != 0:
+            return None
+        data = json.loads(proc.stdout)
+        return [
+            {
+                "name": q.get("name", ""),
+                "messages": int(q.get("messages", 0) or 0),
+                "consumers": int(q.get("consumers", 0) or 0),
+            }
+            for q in data
+        ]
+    except (subprocess.TimeoutExpired, OSError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def check_broker_hygiene(service: str = "rabbitmq") -> list[CheckResult]:
+    """Flag broker cruft: queues on a retired naming scheme, and any queue
+    holding messages with no consumer (undrained backlog). Both are the residue
+    the SIP-0094 migration left and the #323 consumer churn would have shown
+    (#328). An unqueryable broker warns (~) rather than failing.
+    """
+    queues = _query_broker_queues(service)
+    if queues is None:
+        return [
+            CheckResult(
+                name="broker:queues",
+                category="broker",
+                passed=False,
+                heuristic=True,
+                message="Broker not queryable — skipped queue hygiene",
+                detail=(
+                    "Could not run `rabbitmqctl list_queues` in the broker container "
+                    "(docker unavailable or broker not running)."
+                ),
+            )
+        ]
+
+    results: list[CheckResult] = []
+
+    retired = sorted(
+        q["name"] for q in queues if any(q["name"].startswith(p) for p in _RETIRED_QUEUE_PREFIXES)
+    )
+    if retired:
+        preview = ", ".join(retired[:5]) + (" …" if len(retired) > 5 else "")
+        results.append(
+            CheckResult(
+                name="broker:retired-queues",
+                category="broker",
+                passed=False,
+                message=(
+                    f"{len(retired)} queue(s) use a retired naming scheme "
+                    "(pre-SIP-0094 cycle_results_*)"
+                ),
+                detail=f"Orphaned by the SIP-0094 per-agent reply-queue migration: {preview}",
+                fix_command=(
+                    "Delete after confirming the backlog is dead history, e.g. "
+                    "`docker compose exec rabbitmq rabbitmqctl delete_queue <name>`"
+                ),
+            )
+        )
+
+    undrained = sorted(
+        (q for q in queues if q["messages"] > 0 and q["consumers"] == 0),
+        key=lambda q: -q["messages"],
+    )
+    if undrained:
+        preview = ", ".join(f"{q['name']} ({q['messages']} msg)" for q in undrained[:5])
+        results.append(
+            CheckResult(
+                name="broker:undrained-queues",
+                category="broker",
+                passed=False,
+                message=f"{len(undrained)} queue(s) hold messages with no consumer",
+                detail=f"Undrained backlog — results produced but nothing draining: {preview}",
+                fix_command=(
+                    "Investigate the missing consumer; drain or delete the queue "
+                    "once the backlog is confirmed dead."
+                ),
+            )
+        )
+
+    if not results:
+        results.append(
+            CheckResult(
+                name="broker:queues",
+                category="broker",
+                passed=True,
+                message=(
+                    f"{len(queues)} broker queue(s) healthy — no retired schemes, "
+                    "no undrained backlogs"
+                ),
+            )
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Orchestrator
 # ---------------------------------------------------------------------------
 
@@ -751,6 +898,15 @@ def _collect_auth_checks(profile: BootstrapProfile) -> list[CheckResult]:
     return [check_auth_token()]
 
 
+def _collect_broker_checks(profile: BootstrapProfile) -> list[CheckResult]:
+    """Broker hygiene, only when the profile declares the rabbitmq service —
+    mirrors how the GPU checks gate on an nvidia dependency."""
+    broker_svc = next((svc for svc in profile.docker_services if svc.name == "rabbitmq"), None)
+    if broker_svc is None:
+        return []
+    return check_broker_hygiene(broker_svc.name)
+
+
 _CHECK_REGISTRY: list[tuple[str, object]] = [
     ("python", _collect_python_checks),
     ("platform", _collect_platform_checks),
@@ -760,6 +916,7 @@ _CHECK_REGISTRY: list[tuple[str, object]] = [
     ("squad", _collect_squad_checks),
     ("gpu", _collect_gpu_checks),
     ("auth", _collect_auth_checks),
+    ("broker", _collect_broker_checks),
 ]
 
 

--- a/tests/unit/bootstrap/setup/test_checks.py
+++ b/tests/unit/bootstrap/setup/test_checks.py
@@ -618,3 +618,106 @@ class TestSquadModelChecks:
         (r,) = results
         assert r.passed is False
         assert "not defined" in r.message
+
+
+class TestBrokerHygiene:
+    """#328: doctor flags retired-scheme queues and undrained backlogs.
+
+    Each test patches _query_broker_queues (the docker/rabbitmqctl boundary) so
+    the hygiene logic is exercised without a live broker.
+    """
+
+    _Q = "squadops.bootstrap.setup.checks._query_broker_queues"
+
+    def test_retired_scheme_queues_hard_fail(self):
+        with patch(
+            self._Q,
+            return_value=[
+                {"name": "max_replies", "messages": 0, "consumers": 1},
+                {"name": "cycle_results_run_abc", "messages": 0, "consumers": 0},
+                {"name": "cycle_results_run_def", "messages": 0, "consumers": 0},
+            ],
+        ):
+            results = checks_mod.check_broker_hygiene()
+        retired = [r for r in results if r.name == "broker:retired-queues"]
+        assert len(retired) == 1
+        r = retired[0]
+        assert r.passed is False and r.heuristic is False
+        assert "2 queue(s)" in r.message
+        assert r.fix_command is not None
+
+    def test_undrained_backlog_hard_fail(self):
+        """A queue with messages and no consumer is flagged even if its name is
+        the current SIP-0094 scheme — the general hygiene signal, not just cruft."""
+        with patch(
+            self._Q,
+            return_value=[
+                {"name": "eve_replies", "messages": 7, "consumers": 0},
+                {"name": "max_replies", "messages": 0, "consumers": 1},
+            ],
+        ):
+            results = checks_mod.check_broker_hygiene()
+        undrained = [r for r in results if r.name == "broker:undrained-queues"]
+        assert len(undrained) == 1
+        assert undrained[0].passed is False and undrained[0].heuristic is False
+        assert "eve_replies (7 msg)" in undrained[0].detail
+
+    def test_a_consumed_queue_with_messages_is_not_flagged(self):
+        """messages>0 WITH a consumer is normal in-flight work, not a backlog."""
+        with patch(
+            self._Q,
+            return_value=[{"name": "max_comms", "messages": 3, "consumers": 1}],
+        ):
+            results = checks_mod.check_broker_hygiene()
+        assert [r.name for r in results] == ["broker:queues"]
+        assert results[0].passed is True
+
+    def test_retired_and_undrained_both_reported(self):
+        with patch(
+            self._Q,
+            return_value=[
+                {"name": "cycle_results_run_abc", "messages": 48, "consumers": 0},
+            ],
+        ):
+            results = checks_mod.check_broker_hygiene()
+        names = {r.name for r in results}
+        # The one retired queue is both wrong-scheme AND an undrained backlog.
+        assert names == {"broker:retired-queues", "broker:undrained-queues"}
+        assert all(r.passed is False for r in results)
+
+    def test_clean_broker_passes(self):
+        with patch(
+            self._Q,
+            return_value=[
+                {"name": "max_replies", "messages": 0, "consumers": 1},
+                {"name": "eve_replies", "messages": 0, "consumers": 1},
+            ],
+        ):
+            results = checks_mod.check_broker_hygiene()
+        assert len(results) == 1
+        assert results[0].passed is True
+        assert "2 broker queue(s) healthy" in results[0].message
+
+    def test_unqueryable_broker_warns_not_fails(self):
+        """docker down / broker unreachable → heuristic warn (~), never a hard
+        fail — doctor must not go red just because the broker isn't up."""
+        with patch(self._Q, return_value=None):
+            results = checks_mod.check_broker_hygiene()
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert results[0].heuristic is True
+
+    def test_collect_gates_on_rabbitmq_service_present(self):
+        """Broker checks run only when the profile declares the rabbitmq service
+        (mirrors GPU gating on an nvidia dep)."""
+        with_broker = _profile(
+            docker_services=[DockerService(name="rabbitmq", healthcheck="tcp", port=5672)]
+        )
+        without_broker = _profile(
+            docker_services=[DockerService(name="postgres", healthcheck="tcp", port=5432)]
+        )
+        with patch(self._Q, return_value=[]) as mock_q:
+            assert checks_mod._collect_broker_checks(without_broker) == []
+            mock_q.assert_not_called()
+            checks_mod._collect_broker_checks(with_broker)
+            mock_q.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #328.

`rabbitmqctl list_queues` on the deployed broker showed ~19 legacy per-run reply queues still present — SIP-0094 (v1.0.6) replaced the per-run `cycle_results_{run_id}` scheme with durable per-agent `{agent_id}_replies` queues precisely because the old scheme leaked one orphan per run, but the existing corpses were never swept. Two held undrained backlogs (48 and 2 messages) with **0 consumers**.

This does the three things the issue asks:

### 1. Audit — confirmed dead residue, not a live bug
The only `cycle_results` references anywhere in the codebase are **comments** in `task_dispatcher.py` and `reply_router.py` describing what SIP-0094 *replaced*. Nothing publishes to the old scheme. So the queues are orphaned history, safe to sweep.

### 2. Durable doctor check (the code in this PR)
New `broker` doctor category flagging two classes of cruft:
- **Retired naming scheme** — queues matching the pre-SIP-0094 `cycle_results_*` prefix.
- **Undrained backlog** — any queue with `messages > 0` and `consumers == 0` (results produced but nothing draining — the same signal the #323 consumer churn would have surfaced).

Both are hard failures with actionable fix guidance. An **unqueryable broker warns heuristically** (`~`) rather than failing, so doctor never goes red just because the stack is down. The check runs only when the profile declares the `rabbitmq` service (mirrors GPU gating on an nvidia dep).

Queues are read via `rabbitmqctl list_queues` **inside** the broker container, with the container resolved from the compose *service* name (`docker compose ps -q rabbitmq`) rather than a hardcoded container name — no credentials, the same host-side access path `rebuild_and_deploy.sh` already uses.

### 3. One-time sweep (operational, done)
The 16 orphaned `cycle_results_*` queues were deleted after confirming (audit above) the backlog is dead history.

## Tests

`TestBrokerHygiene` (7 tests) patches the docker/rabbitmqctl boundary and asserts: retired scheme → hard fail with count; undrained backlog → hard fail (including a *current*-scheme queue with a stuck backlog, not just cruft); a consumed queue with in-flight messages is **not** flagged; both classes reported together; clean broker passes; unqueryable → heuristic warn (never a hard fail); and the check gates on the `rabbitmq` service being in the profile.

Full regression: **4726 passed, 1 skipped**, exit 0. Ruff clean.

## Live validation (deployed stack)

| | retired queues | undrained backlogs | doctor exit |
|---|---|---|---|
| **before sweep** | 16 flagged | 2 flagged (48 msg, 2 msg) | **1** |
| **after sweep** | 0 | 0 | **0** (`14 broker queue(s) healthy`) |

The SIP-0094 `{agent_id}_replies` queues (max/neo/nat/bob/eve/data/comms-agent) are all intact after the sweep — only the retired scheme was removed.

Targeted for the 1.3.1 hardening patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ
