### PR TITLE
fix(#288): arbitrate FocusLease on same-mode request from a different owner

### DIFF
--- a/src/squadops/runtime/admission.py
+++ b/src/squadops/runtime/admission.py
@@ -74,11 +74,14 @@ async def admit_participants(
     the same blocking agent across retries. Per agent:
 
       * ``applied`` → recruited (release it on finalize);
-      * ``idempotent_skip`` → already in ``cycle`` (replay or another owner) —
-        admitted, but **not** recorded as recruited-by-us, so finalize won't
-        release a lease we didn't take;
+      * ``idempotent_skip`` → this run already holds the agent's cycle lease (a
+        recruitment replay) — admitted, but **not** recorded as recruited-by-us,
+        so finalize won't release a lease we didn't take this call;
       * rejected → defer: roll back everyone recruited so far, then return the
-        coordinator's typed reason (a ``focus_lease_*`` code).
+        coordinator's typed reason (a ``focus_lease_*`` code). A concurrent run
+        holding the agent's lease reaches *here*, not ``idempotent_skip`` — the
+        coordinator rejects a same-mode request from a different lease owner
+        (#288), so a second cycle never free-rides the first's lease.
 
     ``owner_ref`` identifies the lease owner (the run/cycle id); the coordinator
     derives a stable lease idem key from it, so retrying the same run replays the

--- a/src/squadops/runtime/coordinator.py
+++ b/src/squadops/runtime/coordinator.py
@@ -225,8 +225,20 @@ class RuntimeCoordinator:
             state = await self._state.ensure_state(agent_id)
         current = state.mode
 
-        # target == current: nothing to do.
+        # target == current: normally a no-op — but a same-mode request never
+        # reaches lease arbitration, so a focus-bearing mode whose lease is held
+        # by a DIFFERENT owner must be rejected here, not skipped (#288). Without
+        # this, a second cycle recruiting an already-recruited agent free-rides
+        # the incumbent's lease (admission treats the skip as "admitted"), then
+        # loses the agent mid-run when the incumbent finalizes and releases. A
+        # same-owner replay still skips (genuinely idempotent).
         if current == target_mode:
+            if self._focus_lease is not None and _owner_type_for_mode(target_mode) is not None:
+                held = await self._focus_lease.get_current_lease(agent_id)
+                if held is not None and held.owner_ref != owner_ref:
+                    return self._reject(
+                        agent_id, current, target_mode, reason_code, reasons.FOCUS_LEASE_CONFLICT
+                    )
             if idem_key is not None:
                 self._applied_keys.add(idem_key)
             return TransitionOutcome(

--- a/tests/unit/runtime/test_coordinator_with_lease.py
+++ b/tests/unit/runtime/test_coordinator_with_lease.py
@@ -324,3 +324,82 @@ async def test_no_lease_port_preserves_phase2_behavior():
 
     assert outcome.applied is True and state.upserts[-1].mode == "cycle"
     assert pub.names() == [events.MODE_TRANSITION]  # no focus_lease.* events
+
+
+# ---------------------------------------------------------------------------
+# #288 — a same-mode request from a DIFFERENT lease owner must arbitrate,
+# not free-ride the incumbent's lease.
+# ---------------------------------------------------------------------------
+
+
+async def test_same_mode_different_owner_rejects_not_skips():
+    """Bug class (#288): agent already in `cycle` for run A; run B requests
+    `cycle` for the same agent. The same-mode path must reject with a lease
+    conflict — NOT return idempotent_skip — so B never free-rides A's lease and
+    loses the agent when A finalizes. A's lease is left untouched."""
+    state = _FakeStatePort(_state(mode="cycle"))
+    pub = _RecordingPublisher()
+    fl = _FakeFocusLease()
+    incumbent = fl.seed("max", "cycle", "cyc-A")  # A holds the lease
+    coord = RuntimeCoordinator(state, events_publisher=pub, focus_lease=fl)
+
+    outcome = await coord.request_transition(
+        "max", "cycle", reasons.CYCLE_RECRUITED, requester_kind="external", owner_ref="cyc-B"
+    )
+
+    assert outcome.applied is False
+    assert outcome.idempotent_skip is False  # the bug was: this was True
+    assert outcome.rejected_reason == reasons.FOCUS_LEASE_CONFLICT
+    # A's lease is untouched — B neither stole nor released it.
+    still = await fl.get_current_lease("max")
+    assert still is not None and still.lease_id == incumbent.lease_id
+    assert still.owner_ref == "cyc-A"
+    assert fl.released == [] and fl.revoked == []
+    # Mode unchanged; no transition/lease events for a rejected request.
+    assert (await state.get_state("max")).mode == "cycle"
+    assert pub.names() == []
+
+
+async def test_same_mode_same_owner_still_idempotent_skips():
+    """A recruitment replay by the SAME owner is genuinely idempotent — it must
+    still skip (not reject), so #288's fix doesn't break lease-replay retries."""
+    state = _FakeStatePort(_state(mode="cycle"))
+    pub = _RecordingPublisher()
+    fl = _FakeFocusLease()
+    fl.seed("max", "cycle", "cyc-A")
+    coord = RuntimeCoordinator(state, events_publisher=pub, focus_lease=fl)
+
+    outcome = await coord.request_transition(
+        "max", "cycle", reasons.CYCLE_RECRUITED, requester_kind="external", owner_ref="cyc-A"
+    )
+
+    assert outcome.applied is False
+    assert outcome.idempotent_skip is True
+    assert outcome.rejected_reason is None
+    assert fl.released == [] and fl.revoked == []
+
+
+async def test_concurrent_recruit_of_same_agent_defers_second_run():
+    """End-to-end through admit_participants with a real coordinator: run A
+    recruits `max`, then run B recruits the same `max`. B must DEFER on a lease
+    conflict (admitted=False), not be silently admitted while free-riding A's
+    lease (#288). A's lease survives B's attempt."""
+    from squadops.runtime.admission import admit_participants
+
+    state = _FakeStatePort(_state(mode="ambient"))
+    fl = _FakeFocusLease()
+    coord = RuntimeCoordinator(state, events_publisher=_RecordingPublisher(), focus_lease=fl)
+
+    a = await admit_participants(coord, ["max"], owner_ref="cyc-A")
+    assert a.admitted is True and a.recruited_agent_ids == ("max",)
+    a_lease = await fl.get_current_lease("max")
+    assert a_lease is not None and a_lease.owner_ref == "cyc-A"
+
+    b = await admit_participants(coord, ["max"], owner_ref="cyc-B")
+    assert b.admitted is False
+    assert b.blocking_agent_id == "max"
+    assert b.reason == reasons.FOCUS_LEASE_CONFLICT
+    assert b.recruited_agent_ids == ()
+    # A still owns max; B neither took nor dropped the lease.
+    still = await fl.get_current_lease("max")
+    assert still is not None and still.owner_ref == "cyc-A"


### PR DESCRIPTION
## Summary

Closes #288.

`RuntimeCoordinator.request_transition` short-circuited **every** same-mode request (`current == target`) to `idempotent_skip` *before* reaching FocusLease arbitration:

```python
if current == target_mode:      # returned here, before _arbitrate_lease
    return TransitionOutcome(..., idempotent_skip=True)
```

`admission.admit_participants` treats `idempotent_skip` as *admitted*. So two cycles recruiting the **same agent concurrently** broke the FocusLease's core guarantee:

1. Cycle **A** recruits agent X → X enters `cycle`, A holds `cycle:runA:X`.
2. Cycle **B** recruits X → `request_transition(X, "cycle", owner_ref=runB)` sees `current == target == cycle` → `idempotent_skip`. **B never requests its own lease** but admission admits it — B free-rides A's lease.
3. A finalizes → releases `cycle:runA:X` → X flips to `ambient` **while B is still dispatching tasks to it.**

The FocusLease is the hard gate for an agent's primary attention (D16); this silently bypassed it for the concurrent-same-agent case.

## Fix

In the same-mode branch, when the mode is focus-bearing (`cycle`/`duty`) and a current lease is held by a **different** `owner_ref`, reject with `focus_lease_conflict` instead of skipping. That's the same outcome arbitration would reach anyway (an equal owner type = conflict), and `admission` already handles a rejected outcome by **deferring** the run (rolling back any prior recruits). A **same-owner replay still skips** (genuinely idempotent), so lease-replay retries are unaffected.

This is direction 1 + 2 from the issue, implemented at the coordinator so the single lease-arbiter stays the single source of truth. Note: it does *not* route the same-mode case through `_arbitrate_lease`, because that method's `holds_leaving_lease` branch keys on owner *type*, not *ref* — routing a different-owner same-mode request through it would incorrectly release the incumbent's lease. A direct reject is both correct and safe. (That owner_ref blind spot in `_arbitrate_lease` is not reachable by recruitment today — recruitment only ever requests `cycle`, and the only way two `cycle` owners collide is the same-mode path this PR fixes — but it's worth a follow-up look for the duty-preempt paths.)

## Tests

`test_coordinator_with_lease.py`:
- **same-mode / different owner → rejects** with `focus_lease_conflict` (`idempotent_skip=False`), incumbent's lease untouched (not released/revoked), mode unchanged, no events.
- **same-mode / same owner → still `idempotent_skip`** (replay safety preserved).
- **end-to-end through `admit_participants`** with a real coordinator: run A recruits `max`; run B recruits the same `max` → B defers (`admitted=False`, `blocking_agent_id=max`, `reason=focus_lease_conflict`, `recruited_agent_ids=()`), and A's lease survives.

Full regression: **4729 passed, 1 skipped**, exit 0. Ruff clean.

## Live validation (runtime-api rebuilt from this branch; FocusLease is wired live via `create_runtime_coordinator`)

Two overlapping `lite` cycles created back-to-back (same 6 agents):

| run | status | active focus leases held |
|---|---|---|
| **A** (`run_73365a098a7d`) | `running` | all recruited agents (`owner_ref=runA`) |
| **B** (`run_a599a5ad081e`) | `paused` | **none** |

B **deferred** instead of being admitted — it holds zero leases while A owns them all. Before the fix, B would have been admitted (free-riding). Both cycles cancelled after; all leases released (0 active).

Targeted for the 1.3.1 hardening patch — this was the last item in the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ
