### PR TITLE
release: 1.3.1 — hardening patch (#326, #288, #306, #328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to SquadOps are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [1.3.1] — 2026-07-08
+
+Hardening patch on the 1.3.0 stabilization line — the post-1.3.0 batch surfaced by
+the 2026-07-04 independent health assessment, reassigned to the Macbook lane while
+Spark was offline. All fixes; no feature SIPs (patches land on either lane anytime,
+independent of the even/odd feature parity — #281). Every runtime-affecting change
+was live-validated on the deployed stack before merge.
+
+### Security
+- **Agent-status writes moved off the unauthenticated `/health` lane (#326).**
+  `POST/PUT /health/agents/status` were writable by any anonymous network client
+  (the auth middleware allowlists the whole `/health` prefix). They now live at
+  `POST/PUT /api/v1/agents/status` behind the `agents:write` scope; `/health/*`
+  keeps only GET probes. The middleware allowlist is now **method-scoped**
+  (GET/HEAD), so a future write route under `/health` fails closed instead of
+  riding the no-auth lane. Agents authenticate their heartbeats via a new
+  `squadops-agent` service identity (client credentials, `agent` realm role ⇒
+  `agents:write` only); a half-configured identity raises at startup rather than
+  silently sending anonymous heartbeats.
+
+### Fixed
+- **Concurrent same-agent cycles no longer bypass FocusLease arbitration (#288).**
+  `RuntimeCoordinator.request_transition` short-circuited every same-mode request
+  to `idempotent_skip` before arbitration, so a second cycle recruiting an
+  already-recruited agent free-rode the first run's lease and lost the agent when
+  the first finalized. A same-mode request from a *different* lease owner now
+  rejects with `focus_lease_conflict` (admission defers the run); a same-owner
+  replay still skips.
+- **QA agent image now has Node.js so the frontend build check runs (#306).** The
+  `qa.test` frontend build check (#290) and vitest shelled out to `npm`/`npx` in an
+  image with no Node — every frontend check silently skipped, so a non-building
+  frontend shipped green. Node ships in the qa image only (the sole Node consumer),
+  declared via a config-driven per-role `system-packages.txt` (the apt analog of the
+  existing per-role `requirements.txt` — no role name hardcoded in the Dockerfile).
+
+### Added
+- **Broker-hygiene check in `squadops doctor` (#328).** A new `broker` category
+  flags queues on the retired pre-SIP-0094 `cycle_results_*` naming scheme and any
+  queue holding messages with no consumer (an undrained backlog). Reads queue stats
+  via `rabbitmqctl` inside the container (resolved from the compose service name, no
+  credentials); an unqueryable broker warns rather than fails. The orphaned
+  `cycle_results_*` queues left by the SIP-0094 migration (one with 48 undrained
+  messages) were swept.
+
+### Docs & SIP lifecycle
+- Filed the **Externalized Build Sandbox** proposal (`sips/proposed/`) — the
+  principled long-term home for build/test execution (a `BuildSandboxPort` so agents
+  carry no toolchain), with #306 as its interim. Stays `proposed`.
+
 ## [1.3.0] — 2026-07-08
 
 First **stabilization release** on the even/odd minor cadence (#281): odd minors are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 SquadOps is a multi-agent orchestration framework for software development. It uses a hexagonal architecture (ports & adapters) with dependency injection for testability.
 
-**Framework Version**: 1.3.0 (single-sourced via `importlib.metadata.version("squadops")`)
+**Framework Version**: 1.3.1 (single-sourced via `importlib.metadata.version("squadops")`)
 **Python Requirement**: 3.11+ (production runs 3.11); develop and test on **Python 3.12** to match CI
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Overview
 **SquadOps** is an AI agent collaboration framework for software development. The system implements a role-based agent architecture where specialized agents handle different aspects of development tasks, from requirements analysis to application deployment.
 
-**Current Status**: v1.3.0 — Production-ready framework with hexagonal architecture, freshly stabilized in the first even/odd stabilization release (SIP-0097 executor decomposition, cycle-task handler package split, push-based agent comms, vendor-type-free ports), plus the Agent Embodiment Substrate (SIP-0090 Phase 1), the Cycle Create Preflight (SIP-0095), the completed Agent Runtime State platform (SIP-0089: runtime modes ambient/cycle/duty, single-writer coordinator, FocusLease arbitration, single-transaction UoW, RuntimeActivity observability), distributed cycle execution pipeline, multi-run cycle orchestration, workload protocols (planning, implementation, wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, build convergence loop (SIP-0086), Prefect task-scoped log streaming (SIP-0087), Postgres-backed persistence, LangFuse observability, Keycloak authentication, CLI tooling, test quality enforcement, and 4,700+ passing tests.
+**Current Status**: v1.3.1 — Production-ready framework with hexagonal architecture, freshly stabilized in the first even/odd stabilization release (SIP-0097 executor decomposition, cycle-task handler package split, push-based agent comms, vendor-type-free ports) and hardened in the 1.3.1 patch (authed agent-status lane #326, FocusLease concurrency fix #288, QA-image Node #306, broker-hygiene doctor check #328), plus the Agent Embodiment Substrate (SIP-0090 Phase 1), the Cycle Create Preflight (SIP-0095), the completed Agent Runtime State platform (SIP-0089: runtime modes ambient/cycle/duty, single-writer coordinator, FocusLease arbitration, single-transaction UoW, RuntimeActivity observability), distributed cycle execution pipeline, multi-run cycle orchestration, workload protocols (planning, implementation, wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, build convergence loop (SIP-0086), Prefect task-scoped log streaming (SIP-0087), Postgres-backed persistence, LangFuse observability, Keycloak authentication, CLI tooling, test quality enforcement, and 4,700+ passing tests.
 
 ---
 
@@ -173,16 +173,16 @@ See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for full setup instructio
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for the full release timeline.
 
-**Current**: v1.3.0 — first stabilization release (feature-free by rule): SIP-0097 executor decomposition (#186, 3,358→1,805 lines, zero per-run mutable state), `cycle_tasks` package split (#152), agent comms poll→push consumer (#323), dead `DbRuntime` backend removed (#234), plus the prompt-registry deploy re-sync (#327) and resume fix (#342)
+**Current**: v1.3.1 — hardening patch on the 1.3.0 stabilization line: agent-status writes moved off the unauthenticated `/health` lane onto the authed `/api/v1` lane with a service identity (#326), concurrent same-agent cycles no longer bypass FocusLease arbitration (#288), the QA image now has Node so the frontend build check actually runs (#306), and a broker-hygiene `doctor` check + sweep of orphaned pre-SIP-0094 queues (#328). Built on v1.3.0 — the first stabilization release (SIP-0097 executor decomposition #186 3,358→1,805 lines, `cycle_tasks` package split #152, agent comms poll→push #323, dead `DbRuntime` removed #234)
 
 ---
 
 ## Current Status
-**Framework Version**: 1.3.0
+**Framework Version**: 1.3.1
 **Development Status**: Stabilized multi-agent orchestration (post-SIP-0097 decomposition) with the Agent Runtime State platform (SIP-0089: runtime modes, duty scheduler, FocusLease, RuntimeActivity), console UI, distributed cycle execution, multi-run cycle orchestration, workload protocols (planning → implementation → wrapup), cycle event system, correction protocol with checkpoint/resume, agent build capabilities, Prefect task-scoped log streaming, durable persistence, authentication, CLI tooling, profile-driven bootstrap, test quality enforcement, and full observability stack.
 
 ### Project Statistics
-*As of 2026-07-08 (v1.3.0):*
+*As of 2026-07-08 (v1.3.1):*
 - **~61,000 lines** of Python source code (src + adapters)
 - **~83,000 lines** of test code
 - **~110,000 lines** of documentation

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,7 +17,15 @@ Version labels per the even/odd remap in `docs/plans/2-0-roadmap-reconciliation.
 
 ## Release Timeline
 
-### v1.3.0 (2026-07-08) — Current — First Stabilization Release (feature-free)
+### v1.3.1 (2026-07-08) — Current — Hardening Patch
+Post-1.3.0 batch from the 2026-07-04 independent health assessment (Macbook lane while Spark offline). All fixes, no feature SIPs — patches ride either lane anytime, independent of even/odd feature parity (#281). Every runtime-affecting change live-validated before merge.
+- **#326 (security):** agent-status writes moved off the unauthenticated `/health` lane (any client could write) to `POST/PUT /api/v1/agents/status` behind `agents:write`; `/health/*` is GET-only and the middleware allowlist is method-scoped so a future `/health` write fails closed. Agents authenticate heartbeats via a new `squadops-agent` service identity (client credentials, `agent` role ⇒ `agents:write`).
+- **#288 (concurrency):** concurrent same-agent cycles no longer bypass FocusLease arbitration — a same-mode recruit from a *different* lease owner now rejects with `focus_lease_conflict` (the run defers) instead of free-riding the incumbent's lease and losing the agent mid-run.
+- **#306 (inert check):** the QA image now has Node.js, so the frontend build check (#290) + vitest actually run instead of silently skipping on "npm not found". Node ships in the qa image only, via a config-driven per-role `system-packages.txt` (no role name hardcoded).
+- **#328 (broker hygiene):** new `broker` category in `squadops doctor` flags retired-scheme (`cycle_results_*`) queues + undrained backlogs (messages, no consumer); the orphaned pre-SIP-0094 queues (one with 48 undrained messages) were swept.
+- **Docs/SIP:** filed the Externalized Build Sandbox proposal (the principled exit to toolchain-bundling that #306 works around near-term); stays `proposed`.
+
+### v1.3.0 (2026-07-08) — First Stabilization Release (feature-free)
 First **odd-minor stabilization release** (#281): the big structural refactors quarantined out of feature releases, plus debt paydown. Entire core scope landed from the Macbook lane (Spark offline); every structural change live-validated before merge.
 - **SIP-0097 executor decomposition (#186, #295):** `DispatchedFlowExecutor` 3,358→1,805 lines across 6 sliced PRs; five injected collaborators (pure hoists, `RunLedger`+`RunCompletion` — zero per-run mutable state, the SIP-0096 §6.4 seam — `CorrectionRunner`, `PulseBoundaryRunner`, `TaskDispatcher`); slice 6 = the #295 plan-review gate check. SIP-0097 promoted → implemented.
 - **#152:** `cycle_tasks.py` (3,276 lines) → `capabilities/handlers/cycle/` package behind a compat shim (after the #332 helper hoist).
@@ -25,7 +33,7 @@ First **odd-minor stabilization release** (#281): the big structural refactors q
 - **#234:** dead sqlalchemy `DbRuntime` backend removed — `ports/` is vendor-type-free; asyncpg everywhere.
 - **Fixed:** #327 prompt-registry drift (deploy re-sync + manifest hard-fail), #342 resume insta-fail (live pause→resume→complete verified, closed #258), #345 color-env test flakiness.
 - **Docs/CI:** #335 hygiene pass (this file's stats/tables un-froze) + #336 docs-drift guards in the regression gate (version markers, SIP target parity, doc-ref existence).
-- **Deferred:** #288 (Campaign 1.6 gate → pulled into the 1.4 window), #331/#333 (→ 1.5).
+- **Deferred:** #331/#333 (→ 1.5). (#288, originally eyed for the 1.4 window, shipped in the 1.3.1 hardening patch above.)
 
 ### v1.2.0 (2026-07-04) — First Feature Release (even/odd cadence)
 First **even-minor feature release** (#281). Three feature SIPs, on a hardening base:
@@ -446,10 +454,10 @@ The following areas are identified for future work but do not block 1.0 readines
 
 ## Stats
 
-*As of 2026-07-08 (v1.3.0):*
+*As of 2026-07-08 (v1.3.1):*
 
-- **Framework version**: 1.3.0
-- **SIPs**: 60 implemented, 6 accepted (SIP-0088, 0090–0093, 0096), 20 deprecated (registry); 14 files in `sips/proposed/` (7 registry-tracked legacy + 7 unnumbered drafts)
+- **Framework version**: 1.3.1
+- **SIPs**: 60 implemented, 6 accepted (SIP-0088, 0090–0093, 0096), 20 deprecated (registry); 23 files in `sips/proposed/` (7 registry-tracked legacy + 15 unnumbered SIP drafts + 1 idea doc)
 - **Tests**: 4,700+ passing in the regression suite
 - **Python source**: ~61,000 lines (src + adapters; ~83,000 test lines, ~110,000 doc lines)
 - **~6 months** from initial repo (2025-09-20) to 1.0.0 release (2026-03-10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ include = ["squadops*", "adapters*"]  # Include both packages
 
 [project]
 name = "squadops"
-version = "1.3.0"
+version = "1.3.1"
 description = "SquadOps: a production-grade multi-agent orchestration framework."
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
## Release 1.3.1 — hardening patch on the 1.3.0 stabilization line

The post-1.3.0 batch surfaced by the 2026-07-04 independent health assessment, landed from the Macbook lane while Spark was offline. All fixes, no feature SIPs — patches ride either lane anytime, independent of the even/odd feature parity (#281). Every runtime-affecting change was live-validated on the deployed stack before merge.

### What shipped
| Issue | Class | Summary |
|---|---|---|
| **#326** | security | Agent-status writes moved off the unauthenticated `/health` lane to `POST/PUT /api/v1/agents/status` behind `agents:write`; `/health/*` is GET-only and the middleware allowlist is method-scoped. Agents authenticate heartbeats via a new `squadops-agent` service identity. |
| **#288** | concurrency | A same-mode recruit from a *different* FocusLease owner now rejects with `focus_lease_conflict` (the run defers) instead of free-riding the incumbent's lease and losing the agent mid-run. |
| **#306** | inert check | The QA image now has Node.js, so the frontend build check (#290) + vitest actually run. Node ships in the qa image only, via a config-driven per-role `system-packages.txt`. |
| **#328** | broker hygiene | New `broker` category in `squadops doctor` flags retired-scheme + undrained queues; the orphaned pre-SIP-0094 queues (one with 48 undrained messages) were swept. |

Plus: filed the Externalized Build Sandbox proposal (`sips/proposed/`, stays `proposed`) — the principled exit to toolchain-bundling that #306 works around near-term.

### Release mechanics
- Version bumped 1.3.0 → 1.3.1 (`version_cli.py`).
- CHANGELOG `[1.3.1]` section added.
- All **six** version markers synced (CLAUDE.md, README ×3, ROADMAP ×2) — **CI-enforced** by the #336 docs-drift guards.
- ROADMAP stats reconciled: `sips/proposed/` count corrected 14 → 23 (pre-existing drift caught).
- Regression: **4,729 passed, 1 skipped**, exit 0. Ruff clean.

Tag `v1.3.1` + GitHub Release (Latest) and stack rebuild/verify + E2E smoke follow the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ
