### PR TITLE
docs: track 8 idea/vision drafts under docs/ideas

### DIFF
--- a/docs/ideas/ADDENDUM-Plutarch-Artifact-Schemas-and-Event-Taxonomy-v1.1.md
+++ b/docs/ideas/ADDENDUM-Plutarch-Artifact-Schemas-and-Event-Taxonomy-v1.1.md
@@ -1,0 +1,1007 @@
+# ADDENDUM: Proposal for Plutarch Artifact Schemas and Event Taxonomy
+## Companion Addendum to: SIP-XXXX — Plutarch Experimentation and Cycle Assessment Framework
+## Target Release: v1.1
+
+### Status
+Proposed Addendum
+
+### Owner
+Strategy / Architecture / Eval
+
+### Purpose
+This addendum proposes the initial schema model and event taxonomy needed to support the Plutarch framework described in the companion SIP.
+
+The intent of this addendum is not to lock the final semantics prematurely. It is to provide a concrete, implementation-oriented design proposal that can be reviewed, tightened, and validated before coding. Claude or other design-review passes can refine the field semantics later, but SquadOps needs a strong proposed shape now in order to:
+- define observable contracts
+- persist the right artifacts
+- support diagnosis and replay
+- support baseline/challenger comparisons
+- support recommendation generation
+- preserve traceability from cycle execution to improvement decision
+
+This addendum therefore focuses on:
+1. artifact design principles
+2. proposed core artifact set
+3. proposed event taxonomy
+4. required linkage and traceability rules
+5. rollout sequencing for implementation
+
+---
+
+## 1. Design Principles
+
+### 1.1 Artifact principles
+Plutarch artifacts should be:
+- explicit
+- durable
+- linkable
+- reviewable
+- minimally ambiguous
+- useful for both machine processing and human inspection
+
+### 1.2 Event principles
+Events should be:
+- append-only
+- timestamped
+- scoped
+- structured enough for automation
+- lightweight enough to emit throughout long runs
+- expressive enough to reconstruct failure chains and experiment outcomes
+
+### 1.3 Separation of concerns
+The system should distinguish:
+- raw execution events
+- derived assessments
+- diagnoses
+- experiments
+- recommendations
+- promotion decisions
+
+Do not collapse all of these into one catch-all record type.
+
+### 1.4 Traceability requirement
+Every major Plutarch conclusion should be traceable back to:
+- one or more events
+- one or more artifacts
+- a known cycle/task/agent/model context
+- a bounded assessment or experiment window
+
+### 1.5 Reviewability requirement
+Any recommendation that could affect active policy should be reviewable through linked evidence, not only through summary text.
+
+---
+
+## 2. Proposed Artifact Set
+
+The v1.1 addendum proposes the following artifact families:
+
+1. registry artifacts
+2. execution artifacts
+3. assessment artifacts
+4. diagnosis artifacts
+5. experiment artifacts
+6. recommendation and governance artifacts
+
+---
+
+# 3. Registry Artifacts
+
+## 3.1 BenchmarkRegistryEntry
+
+### Purpose
+Defines an external or internal benchmark known to the system.
+
+### Why it exists
+Plutarch needs a stable registry of benchmark options by role and purpose so experiments are not ad hoc.
+
+### Proposed shape
+```yaml
+kind: BenchmarkRegistryEntry
+uid: benchmark-entry-dev-swebench
+status: active
+name: swe_bench_verified
+benchmark_type: external
+roles:
+  - dev
+purpose:
+  - model_selection
+  - regression_tracking
+scope:
+  task_classes:
+    - repo_issue_resolution
+  environments:
+    - sandbox
+harness_ref: evals/external/swe_bench_verified
+scoring_mode: benchmark_native
+cadence: on_demand
+cost_profile: medium
+owner: eval
+tags:
+  - coding
+  - repo
+notes:
+  - "best external fit for repo issue resolution style tasks"
+```
+
+### Minimum required fields
+- uid
+- status
+- name
+- benchmark_type
+- roles
+- purpose
+- harness_ref
+
+---
+
+## 3.2 InternalEvalPack
+
+### Purpose
+Defines a SquadOps-native evaluation pack.
+
+### Proposed shape
+```yaml
+kind: InternalEvalPack
+uid: internal-eval-pack-contract-changes-v1
+status: active
+name: internal_eval_contract_changes
+roles:
+  - dev
+  - qa
+task_classes:
+  - adapter_contract_change
+  - boundary_validation
+cases:
+  - internal-eval-case-001
+  - internal-eval-case-002
+scoring_mode: mixed
+owner: eval
+version: 1
+tags:
+  - contract
+  - regression
+```
+
+### Minimum required fields
+- uid
+- status
+- name
+- roles
+- cases
+- scoring_mode
+
+---
+
+## 3.3 InternalEvalCase
+
+### Purpose
+Defines one repeatable evaluation case within an internal pack.
+
+### Proposed shape
+```yaml
+kind: InternalEvalCase
+uid: internal-eval-case-001
+pack_uid: internal-eval-pack-contract-changes-v1
+status: active
+title: propagate_contract_change_with_fixture_updates
+role: dev
+task_class: adapter_contract_change
+setup_ref: setups/contract_case_001
+expected_outputs:
+  - updated_contract
+  - updated_fixture
+  - updated_tests
+scoring_refs:
+  - rubric-contract-propagation-v1
+  - deterministic-check-contract-case-001
+difficulty: medium
+tags:
+  - contract
+  - fixture
+```
+
+---
+
+## 3.4 ModelLanePolicy
+
+### Purpose
+Defines which models are allowed in which Plutarch lanes.
+
+### Proposed shape
+```yaml
+kind: ModelLanePolicy
+uid: model-lane-policy-v1
+status: active
+lanes:
+  planning:
+    allowed_models:
+      - claude_reasoning
+      - codex_high
+    cost_ceiling_usd: 10
+  monitoring:
+    allowed_models:
+      - qwen_local_small
+      - llama_local_small
+    cost_ceiling_usd: 2
+  evaluation:
+    allowed_models:
+      - claude_reasoning
+      - codex_high
+    cost_ceiling_usd: 10
+approval_requirements:
+  planning: none
+  monitoring: none
+  evaluation: none
+notes:
+  - "production mutation remains out of scope for v1.1"
+```
+
+---
+
+# 4. Execution Artifacts
+
+## 4.1 CycleRecord
+
+### Purpose
+A durable summary record for a cycle.
+
+### Proposed shape
+```yaml
+kind: CycleRecord
+uid: cycle-0042
+status: completed
+cycle_type: app_build
+squad_uid: squad-main
+root_task_uid: task-1284
+environment:
+  runtime_profile: local
+  repo_ref: repo-main
+  branch_ref: experiment/plutarch-0042
+started_at: 2026-03-29T09:00:00Z
+ended_at: 2026-03-29T12:20:00Z
+result: partial_success
+event_stream_ref: events/cycle-0042.jsonl
+artifacts:
+  - artifact-001
+  - artifact-002
+tags:
+  - v1_1_eval_window
+```
+
+### Why this artifact matters
+Events are append-only, but a top-level cycle object is still needed for indexing, retrieval, and linkage.
+
+---
+
+## 4.2 TaskRecord
+
+### Purpose
+Represents a task instance within a cycle.
+
+### Proposed shape
+```yaml
+kind: TaskRecord
+uid: task-1284
+cycle_uid: cycle-0042
+parent_task_uid: null
+status: failed
+task_class: adapter_contract_change
+role_expected: dev
+assigned_agent: neo
+assigned_model: qwen-coder-32b
+lane: execution
+started_at: 2026-03-29T09:05:00Z
+ended_at: 2026-03-29T09:43:00Z
+outcome: failed_validation
+dependencies: []
+memory_bundle_refs:
+  - memory-bundle-011
+prompt_template_ref: prompt-dev-v7
+artifact_refs:
+  - artifact-004
+  - artifact-005
+```
+
+---
+
+## 4.3 HandoffRecord
+
+### Purpose
+Represents a handoff between roles or agents.
+
+### Proposed shape
+```yaml
+kind: HandoffRecord
+uid: handoff-0029
+cycle_uid: cycle-0042
+from_agent: nat
+to_agent: neo
+from_role: strategy
+to_role: dev
+status: rejected
+task_uid: task-1284
+artifact_refs:
+  - artifact-003
+rejection_reason: insufficient_acceptance_criteria
+created_at: 2026-03-29T09:02:00Z
+resolved_at: 2026-03-29T09:06:00Z
+```
+
+### Why this matters
+Squad health depends heavily on handoff quality. Handoffs need first-class representation.
+
+---
+
+## 4.4 ArtifactRecord
+
+### Purpose
+Represents a generated or modified artifact.
+
+### Proposed shape
+```yaml
+kind: ArtifactRecord
+uid: artifact-005
+cycle_uid: cycle-0042
+task_uid: task-1284
+artifact_type: code_patch
+path: src/adapters/payment_adapter.py
+version: 3
+parent_version_uid: artifact-004
+status: superseded
+generator_agent: neo
+generator_model: qwen-coder-32b
+created_at: 2026-03-29T09:31:00Z
+diff_ref: diffs/artifact-005.diff
+validation_refs:
+  - validation-009
+```
+
+---
+
+## 4.5 ValidationRun
+
+### Purpose
+Represents a test or validation execution.
+
+### Proposed shape
+```yaml
+kind: ValidationRun
+uid: validation-009
+cycle_uid: cycle-0042
+task_uid: task-1284
+validation_type: unit_and_contract
+status: failed
+runner_ref: pytest_contract_suite
+started_at: 2026-03-29T09:35:00Z
+ended_at: 2026-03-29T09:37:00Z
+summary:
+  passed: 52
+  failed: 3
+failure_refs:
+  - failure-signal-001
+```
+
+---
+
+# 5. Assessment Artifacts
+
+## 5.1 CycleAssessment
+
+### Purpose
+Represents the scored assessment of a cycle or task window.
+
+### Proposed shape
+```yaml
+kind: CycleAssessment
+uid: cycle-assessment-0042
+cycle_uid: cycle-0042
+task_uid: task-1284
+scope: single_task
+role: dev
+agent: neo
+model: qwen-coder-32b
+
+scores:
+  outcome: 0.85
+  quality: 0.78
+  efficiency: 0.61
+  memory: 0.73
+  routing: 0.54
+  stability: 0.80
+  benchmark_alignment: 0.58
+
+telemetry:
+  retries: 3
+  escalations: 1
+  rewinds: 1
+  token_cost_usd: 1.84
+  wall_clock_minutes: 21
+
+linked_diagnoses:
+  - failure-diagnosis-0091
+linked_recommendations:
+  - improvement-rec-0048
+```
+
+### Design note
+Scores should be normalized, but exact formulas can remain configurable.
+
+---
+
+## 5.2 AgentImpactAssessment
+
+### Purpose
+Measures how individual-agent change relates to squad-level outcomes.
+
+### Proposed shape
+```yaml
+kind: AgentImpactAssessment
+uid: agent-impact-0017
+agent: neo
+role: dev
+window: release_v1_1_eval_window
+
+individual_delta:
+  external_benchmark_delta: 0.07
+  internal_eval_delta: 0.11
+  first_pass_quality_delta: 0.09
+
+squad_translation:
+  deliverable_quality_delta: 0.04
+  throughput_delta: 0.03
+  regression_delta: -0.02
+  handoff_acceptance_delta: 0.10
+
+derived:
+  bottleneck_index: 0.72
+  force_multiplier_score: 0.68
+  translation_efficiency: 0.44
+```
+
+### Design note
+The exact semantics of translation efficiency should be validated before implementation hardening.
+
+---
+
+## 5.3 SquadHealthAssessment
+
+### Purpose
+Represents the health of the squad over a window.
+
+### Proposed shape
+```yaml
+kind: SquadHealthAssessment
+uid: squad-health-0003
+squad_uid: squad-main
+window: release_v1_1_eval_window
+
+health:
+  topology_health: medium
+  coordination_health: low
+  handoff_health: medium
+  stability_health: medium
+
+bottlenecks:
+  - qa
+  - dev_handoff
+
+signals:
+  repeated_rework: true
+  downstream_rejection_high: true
+  escalation_pattern_inefficient: true
+```
+
+### Why this matters
+Broken squads need explicit representation, not only broken tasks.
+
+---
+
+# 6. Diagnosis Artifacts
+
+## 6.1 FailureDiagnosis
+
+### Purpose
+A structured diagnosis of a failure.
+
+### Proposed shape
+```yaml
+kind: FailureDiagnosis
+uid: failure-diagnosis-0091
+cycle_uid: cycle-0042
+scope: cycle
+first_failing_node: task-1284
+failure_class: handoff_degradation
+local_vs_systemic: systemic
+dominant_cause: insufficient_boundary_validation
+symptoms:
+  - downstream_contract_mismatch
+  - qa_rejection
+likely_contributors:
+  - memory_rule_missing
+  - escalation_late
+candidate_remediations:
+  - rerun_with_stronger_model
+  - memory_update
+confidence: medium
+```
+
+### Required fields
+- uid
+- cycle_uid
+- scope
+- failure_class
+- local_vs_systemic
+- confidence
+
+### Design note
+This artifact is central. It should be easy to produce manually first, then partially automate later.
+
+---
+
+## 6.2 FailureSignal
+
+### Purpose
+A smaller-grain signal emitted during execution or validation that may feed diagnosis.
+
+### Proposed shape
+```yaml
+kind: FailureSignal
+uid: failure-signal-001
+cycle_uid: cycle-0042
+task_uid: task-1284
+signal_type: contract_validation_failure
+source: validation_run
+severity: medium
+detected_at: 2026-03-29T09:36:00Z
+details_ref: logs/contract_failures_0042.json
+```
+
+### Why it exists
+This allows noisy or low-level evidence to be persisted without prematurely declaring a diagnosis.
+
+---
+
+# 7. Experiment Artifacts
+
+## 7.1 ExperimentRun
+
+### Purpose
+Represents a baseline/challenger experiment.
+
+### Proposed shape
+```yaml
+kind: ExperimentRun
+uid: experiment-0021
+status: completed
+hypothesis: "Routing contract-heavy changes to a stronger dev lane earlier will reduce rework."
+baseline_config_ref: routing-policy-v3
+challenger_config_ref: routing-policy-v3a
+task_pack_ref: internal_eval_contract_changes
+budget_cap_usd: 15
+time_cap_minutes: 120
+stop_conditions:
+  - cost_cap
+  - regression_detected
+runs:
+  baseline:
+    - cycle-100
+  challenger:
+    - cycle-101
+result_summary_ref: experiment-results-0021
+```
+
+---
+
+## 7.2 ExperimentResultSummary
+
+### Purpose
+Provides a compact result view for an experiment.
+
+### Proposed shape
+```yaml
+kind: ExperimentResultSummary
+uid: experiment-results-0021
+experiment_uid: experiment-0021
+winner: challenger
+confidence: medium
+metric_deltas:
+  quality: 0.08
+  efficiency: 0.03
+  regression_rate: -0.05
+recommendation_refs:
+  - improvement-rec-0048
+notes:
+  - "challenger improved contract propagation quality with acceptable cost increase"
+```
+
+---
+
+# 8. Recommendation and Governance Artifacts
+
+## 8.1 ImprovementRecommendation
+
+### Purpose
+Represents a proposed system improvement.
+
+### Proposed shape
+```yaml
+kind: ImprovementRecommendation
+uid: improvement-rec-0048
+source_artifacts:
+  - cycle-assessment-0042
+  - failure-diagnosis-0091
+type: routing_change
+priority: medium
+confidence: medium
+expected_impact: reduce_contract_rework
+action: escalate_earlier_for_multi_boundary_contract_changes
+resource_implications:
+  token_cost_change: low
+  latency_change: medium
+approval_status: pending
+```
+
+### Required fields
+- uid
+- source_artifacts
+- type
+- priority
+- confidence
+- action
+- approval_status
+
+---
+
+## 8.2 PromotionDecision
+
+### Purpose
+Represents the outcome of approving or rejecting a recommendation.
+
+### Proposed shape
+```yaml
+kind: PromotionDecision
+uid: promotion-decision-0012
+recommendation_uid: improvement-rec-0048
+decision: approved
+decided_by: lead
+decided_at: 2026-03-29T15:12:00Z
+effective_change_ref: routing-policy-v3a
+notes:
+  - "approved for sandbox promotion only"
+```
+
+---
+
+# 9. Event Taxonomy Proposal
+
+This section proposes the event stream categories needed for observability.
+
+## 9.1 Event envelope
+
+Every event should carry a common envelope:
+
+```yaml
+event_uid: event-000001
+event_type: task.started
+occurred_at: 2026-03-29T09:05:00Z
+cycle_uid: cycle-0042
+task_uid: task-1284
+agent: neo
+role: dev
+lane: execution
+correlation_uid: corr-019
+payload: {}
+```
+
+### Required common fields
+- event_uid
+- event_type
+- occurred_at
+- cycle_uid
+- payload
+
+Optional but strongly recommended:
+- task_uid
+- agent
+- role
+- lane
+- correlation_uid
+
+---
+
+## 9.2 Event categories
+
+### A. Cycle lifecycle events
+- cycle.created
+- cycle.started
+- cycle.paused
+- cycle.resumed
+- cycle.completed
+- cycle.failed
+- cycle.cancelled
+
+### B. Task lifecycle events
+- task.created
+- task.started
+- task.blocked
+- task.unblocked
+- task.completed
+- task.failed
+- task.retried
+- task.rewound
+
+### C. Handoff events
+- handoff.created
+- handoff.accepted
+- handoff.rejected
+- handoff.revised
+
+### D. Agent execution events
+- agent.step.started
+- agent.step.completed
+- agent.step.failed
+
+### E. Model lane events
+- lane.selected
+- lane.denied
+- model.selected
+- model.escalated
+- model.deescalated
+
+### F. Memory and retrieval events
+- memory.classification.completed
+- memory.bundle.retrieved
+- memory.bundle.injected
+- memory.bundle.flagged_noisy
+- memory.rule.violation.suspected
+
+### G. Tool events
+- tool.invoked
+- tool.completed
+- tool.failed
+
+### H. Artifact events
+- artifact.created
+- artifact.updated
+- artifact.superseded
+- artifact.diff.generated
+
+### I. Validation events
+- validation.started
+- validation.completed
+- validation.failed
+
+### J. Experiment events
+- experiment.created
+- experiment.started
+- experiment.baseline.completed
+- experiment.challenger.completed
+- experiment.stopped
+- experiment.completed
+
+### K. Recommendation/governance events
+- recommendation.created
+- recommendation.reviewed
+- recommendation.approved
+- recommendation.rejected
+- promotion.applied
+
+---
+
+# 10. Event Payload Suggestions
+
+The exact semantics can be refined later, but these event types should at least include the following payload hints.
+
+## 10.1 `task.failed`
+Suggested payload:
+```yaml
+failure_reason: failed_validation
+retry_count: 2
+escalation_count: 1
+artifact_refs:
+  - artifact-005
+validation_refs:
+  - validation-009
+```
+
+## 10.2 `memory.bundle.retrieved`
+Suggested payload:
+```yaml
+memory_bundle_refs:
+  - memory-bundle-011
+classification:
+  task_class: adapter_contract_change
+retrieval_reason: task_class_match
+```
+
+## 10.3 `model.escalated`
+Suggested payload:
+```yaml
+from_model: qwen-coder-32b
+to_model: claude_reasoning
+reason: repeated_contract_validation_failure
+```
+
+## 10.4 `handoff.rejected`
+Suggested payload:
+```yaml
+from_agent: nat
+to_agent: neo
+reason: insufficient_acceptance_criteria
+artifact_refs:
+  - artifact-003
+```
+
+## 10.5 `validation.failed`
+Suggested payload:
+```yaml
+validation_type: unit_and_contract
+passed: 52
+failed: 3
+failure_signal_refs:
+  - failure-signal-001
+```
+
+---
+
+# 11. Linkage and Traceability Rules
+
+The system should enforce the following design rules:
+
+### Rule 1
+Every `CycleAssessment` should link back to at least one `CycleRecord`.
+
+### Rule 2
+Every `FailureDiagnosis` should reference:
+- a cycle
+- at least one supporting event, artifact, validation, or signal
+
+### Rule 3
+Every `ImprovementRecommendation` should reference one or more source artifacts.
+
+### Rule 4
+Every `PromotionDecision` should reference exactly one recommendation.
+
+### Rule 5
+Every `ExperimentRun` should identify baseline and challenger configs explicitly.
+
+### Rule 6
+Every assessment or diagnosis tied to a specific role should preserve:
+- agent
+- role
+- model
+- lane
+where applicable.
+
+### Rule 7
+Event streams should be queryable by:
+- cycle
+- task
+- agent
+- role
+- experiment
+- model
+- lane
+- time window
+
+---
+
+# 12. Minimum Viable Implementation Set for v1.1
+
+Not everything has to ship at once. This addendum recommends the following minimal artifact subset for the first wave.
+
+## Must-have artifacts
+- BenchmarkRegistryEntry
+- InternalEvalPack
+- CycleRecord
+- TaskRecord
+- HandoffRecord
+- ArtifactRecord
+- ValidationRun
+- CycleAssessment
+- FailureDiagnosis
+- ExperimentRun
+- ImprovementRecommendation
+- PromotionDecision
+
+## Strongly recommended in first wave
+- AgentImpactAssessment
+- SquadHealthAssessment
+- FailureSignal
+- ModelLanePolicy
+
+---
+
+# 13. Suggested Storage and Processing Model
+
+This is intentionally high level, but the implementation direction should likely be:
+
+### Raw events
+- append-only event log
+- immutable
+- cheap to emit
+- used for replay and reconstruction
+
+### Durable artifacts
+- structured documents in registry/artifact store
+- mutable only by versioned supersession or explicit status changes
+- queryable by UID and references
+
+### Derived outputs
+- assessments, diagnoses, and recommendations are generated from events + artifacts
+- they should preserve source references to avoid opaque conclusions
+
+---
+
+# 14. Suggested Rollout Sequence
+
+## Phase 1 — Event envelope and core records
+Implement:
+- event envelope
+- cycle/task/handoff/artifact/validation records
+- core event taxonomy
+
+## Phase 2 — Assessment and diagnosis artifacts
+Implement:
+- CycleAssessment
+- FailureDiagnosis
+- ImprovementRecommendation
+- PromotionDecision
+
+## Phase 3 — Eval and experiment registry
+Implement:
+- BenchmarkRegistryEntry
+- InternalEvalPack
+- InternalEvalCase
+- ExperimentRun
+- ExperimentResultSummary
+
+## Phase 4 — Translation and squad health
+Implement:
+- AgentImpactAssessment
+- SquadHealthAssessment
+- supporting trend queries
+
+---
+
+# 15. Open Design Questions
+
+- Should `CycleRecord` and `TaskRecord` be persisted as independent artifacts or derived from the event log plus summary materialization?
+- Should `FailureDiagnosis` have one dominant cause only, or ranked causes?
+- Should `ImprovementRecommendation` allow multiple actions, or one action per recommendation?
+- Should `SquadHealthAssessment` be generated only on windows, or optionally per large cycle?
+- How much of `ModelLanePolicy` belongs in Plutarch versus global SquadOps policy?
+- Should `ArtifactRecord` be generic across docs/code/slides, or typed into separate schemas?
+- Should recommendation promotion always produce a new versioned policy artifact?
+
+---
+
+# 16. Recommendation
+
+Adopt this addendum as the proposed design direction for the companion SIP.
+
+It is intentionally more specific than the SIP while still leaving room for semantic refinement. That is the right balance for now.
+
+The important design claim is:
+
+**Plutarch needs both an artifact model and an event model.**
+Without both:
+- diagnosis will be weak
+- experiments will be hard to compare
+- recommendations will be hard to trust
+- promotion decisions will be hard to audit
+
+With both:
+- SquadOps gets a viable foundation for continuous testing, assessment, diagnosis, and governed improvement.
+
+---
+
+## Appendix A — Short Design Summary
+
+Plutarch should be implemented on top of:
+- registry artifacts for benchmarks, eval packs, and model lanes
+- execution artifacts for cycles, tasks, handoffs, artifacts, and validations
+- derived artifacts for assessments, diagnoses, experiments, and recommendations
+- an append-only event taxonomy that makes reconstruction and traceability possible
+
+That combination is the minimum viable substrate for a real master experimenter.

--- a/docs/ideas/IDEA-agent-intelligence-improvement-program.md
+++ b/docs/ideas/IDEA-agent-intelligence-improvement-program.md
@@ -1,0 +1,1037 @@
+---
+title: Agent Intelligence Improvement Program
+id: idea.agent_intelligence_improvement_program
+type: idea
+status: draft
+created_at: 2026-04-03
+updated_at: 2026-04-03
+owner: Jason Ladd
+tags:
+  - squad_ops
+  - agents
+  - benchmarks
+  - evaluation
+  - notebooklm
+  - chatgpt
+  - claude
+  - gemini
+---
+
+# Agent Intelligence Improvement Program
+
+## 1. Overview
+
+This idea defines a structured program for improving the intelligence of individual agents inside SquadOps while SquadOps itself continues to evolve as a coordination and autonomous execution framework.
+
+The core motivation is simple:
+
+- SquadOps needs to run autonomously for **8–10 hours**
+- that requires not only stronger coordination
+- but also **stronger individual agents**
+- and those agents need to improve in a disciplined, measurable way rather than through ad hoc prompt tweaking
+
+This program treats agent intelligence improvement as a first-class workstream.
+
+It also intentionally uses the “big 3” cloud agents the user already has access to:
+
+- ChatGPT
+- Claude
+- Gemini
+
+Those systems are not the end state. They are the external intelligence partners used to help design, critique, benchmark, and improve the agents that live inside SquadOps.
+
+The long-term goal is not dependency on the big 3. The long-term goal is to build a **durable Agent Intelligence Improvement System** that strengthens SquadOps over time.
+
+---
+
+## 2. Problem Statement
+
+SquadOps is evolving well on the orchestration side:
+
+- coordination patterns
+- cycle execution
+- failure handling
+- recovery logic
+- experiments around autonomy and runtime operation
+
+But stronger orchestration does not automatically create stronger agents.
+
+There are two related but distinct problems:
+
+### Problem A — Squad coordination quality
+How well does the squad decompose work, assign the right agent, sequence tasks, recover from failures, and sustain productive autonomous execution over long windows?
+
+### Problem B — Individual agent intelligence quality
+How well does a given agent perform its role-specific work compared with what that role should be capable of doing?
+
+These two problems interact, but they are not interchangeable.
+
+A weak agent can sometimes be partially rescued by strong orchestration.
+A strong agent can still be wasted by poor orchestration.
+If both are weak, long autonomous runs become theater.
+
+This program focuses on **Problem B** without losing sight of the connection to Problem A.
+
+---
+
+## 3. Core Thesis
+
+Individual agents improve fastest when they are treated like role-specific systems with:
+
+- explicit design definitions
+- explicit tool and memory boundaries
+- explicit benchmark suites
+- explicit promotion criteria
+- explicit learning loops from real cycle outcomes
+
+In other words:
+
+> Agent intelligence should be improved the same way a serious engineering team improves any meaningful subsystem:
+> by documenting the current design, measuring behavior against known standards, testing upgrades under controlled conditions, and promoting only what actually improves results.
+
+This implies several commitments:
+
+1. “Intelligence” must be role-specific, not generic.
+2. Improvements must be measurable, not vibe-based.
+3. Research and experimentation should be separated from canonical design docs.
+4. External frontier models should be used as accelerants, not as the permanent operating substrate.
+5. Internal evidence from actual SquadOps runs must become part of the improvement loop.
+
+---
+
+## 4. Program Goal
+
+Build a repeatable system that continuously improves the role-specific intelligence of SquadOps agents so the squad can operate autonomously for long windows with higher quality, better judgment, and lower supervision cost.
+
+### Success criteria
+The program is successful if it produces:
+
+- stronger role performance by individual agents
+- more reliable long-duration autonomous execution
+- better benchmark scores by role
+- better real-cycle outcomes
+- lower failure rates on known weak points
+- better recovery and decision quality during drift or failure
+- a reusable system for future agent improvement rather than one-off upgrades
+
+---
+
+## 5. Program Principles
+
+### 5.1 Separate coordination from intelligence
+Do not confuse “the squad got better” with “the agents got smarter.”
+Track both separately.
+
+### 5.2 Benchmark by role
+There is no single meaningful benchmark for all agents.
+Each role should be measured against what that role is supposed to do.
+
+### 5.3 Keep the crown jewels internal
+Use the big 3 for research, critique, implementation support, and comparison.
+Keep canonical designs, benchmarks, artifacts, and conclusions inside the SquadOps knowledge base and repo.
+
+### 5.4 Promote only measurable improvements
+No upgrade becomes canonical unless it improves benchmark or real-cycle performance in a way that survives review.
+
+### 5.5 Preserve institutional memory
+Lessons from failed and successful cycles should become reusable evidence, not disappear into chat history.
+
+### 5.6 Prefer structured evidence over aesthetic intuition
+Prompt changes, model changes, memory changes, and tool changes should all be evaluated using evidence.
+
+---
+
+## 6. The Big 3 Operating Model
+
+The big 3 should not be treated as interchangeable. Each should be used where it is strongest for this initiative.
+
+## 6.1 ChatGPT role
+Use ChatGPT for:
+
+- program planning
+- benchmark architecture
+- evaluation framework design
+- schema design
+- artifact structure
+- synthesis across many documents
+- experiment design
+- comparative analysis of results
+
+ChatGPT is especially useful as the planning and evaluation architect for the program.
+
+## 6.2 Claude role
+Use Claude for:
+
+- codebase reading
+- architecture critique
+- specification tightening
+- prompt design pressure-testing
+- implementation review
+- agent behavior critique
+- repo- and code-oriented improvement proposals
+
+Claude is especially useful as a code and design critic.
+
+## 6.3 Gemini role
+Use Gemini for:
+
+- broad research collection
+- source aggregation
+- NotebookLM knowledge synthesis
+- research note generation
+- corpus comparison
+- literature and framework scanning
+- agent-pattern briefing generation
+
+Gemini plus NotebookLM is especially useful as the research library and synthesis workspace.
+
+## 6.4 What the big 3 are not
+They are not the canonical source of truth.
+They are not the lasting operating substrate of SquadOps.
+They are not the replacement for internal benchmark discipline.
+
+They are accelerators.
+
+---
+
+## 7. NotebookLM Role in the Plan
+
+NotebookLM is a strong fit as a **research and synthesis workspace**, but it should not be the final canonical system of record.
+
+### Recommended use of NotebookLM
+Use NotebookLM to:
+
+- gather external research on agents and autonomous systems
+- store source packs per role
+- compare public frameworks and design approaches
+- generate briefings from source collections
+- create shared research context for future planning artifacts
+
+### Do not use NotebookLM as the canonical source of truth for
+- final SquadOps architecture
+- final role definitions
+- benchmark specs
+- experiment results
+- promotion decisions
+- canonical agent design docs
+
+### Better pattern
+Use NotebookLM as a **source workspace** and keep canonical outputs in:
+- markdown docs
+- repo artifacts
+- SIPs / IDEA docs
+- benchmark specs
+- experiment reports
+- structured evaluation records
+
+### Recommended NotebookLM notebook structure
+1. Common Agent Architecture Research
+2. Lead Agent Research
+3. Strategy Agent Research
+4. Dev Agent Research
+5. QA Agent Research
+6. Data Agent Research
+7. External Autonomous Agent Research
+8. Benchmark Design Research
+9. SquadOps Lessons Learned
+10. Agent Improvement Program Artifacts
+
+---
+
+## 8. Knowledge Capture Strategy
+
+Before improving agents, build a knowledge foundation.
+
+This foundation should have four buckets.
+
+## 8.1 Current SquadOps agent design knowledge
+Capture what exists today:
+
+- current role definitions
+- current prompts/instructions
+- tool access
+- memory access
+- task contracts
+- coordination assumptions
+- current runtime model choices
+- known limitations
+
+This becomes the baseline design pack.
+
+## 8.2 External agent system research
+Capture lessons from:
+
+- OpenHands / agentic coding systems
+- Devin-like public patterns
+- public Anthropic / OpenAI / Google guidance
+- open-source autonomous agents
+- tool-using agent frameworks
+- research papers on agent evaluation and autonomy
+- public examples of long-duration software agents
+
+### Important note
+This program should avoid relying on unauthorized or questionable leaked material as a foundational source. Public, open, and clearly usable material is a stronger and safer base.
+
+## 8.3 Internal SquadOps evidence
+Capture what SquadOps itself is already teaching:
+
+- successful cycles
+- failed cycles
+- RCA findings
+- benchmark failures
+- where agents drift
+- where prompts collapse
+- where memory helps
+- where model swaps help
+- where coordination masks individual weakness
+
+This is one of the most valuable data sources because it is directly relevant to the real runtime.
+
+## 8.4 Improvement proposals
+Capture candidate upgrades such as:
+
+- revised role prompts
+- role splits or merges
+- model-routing changes
+- memory-structure improvements
+- tool-access changes
+- planning-pattern changes
+- evaluation-pattern changes
+- recovery-behavior changes
+
+---
+
+## 9. Role Intelligence Model
+
+The program should define intelligence by role rather than as a generic property.
+
+## 9.1 Lead / Max intelligence
+Key qualities:
+
+- decomposition quality
+- assignment quality
+- sequencing judgment
+- escalation quality
+- RCA and rewind quality
+- stop/go judgment
+- ability to preserve momentum without creating chaos
+
+### Sample benchmark categories
+- task decomposition
+- ambiguous multi-step planning
+- conflict resolution between agent outputs
+- failure triage
+- recovery sequencing
+- escalation path selection
+
+## 9.2 Strategy / Nat intelligence
+Key qualities:
+
+- PRD interpretation
+- ambiguity detection
+- scope control
+- tradeoff clarity
+- story and capability decomposition
+- design intent preservation
+
+### Sample benchmark categories
+- PRD reading
+- scope extraction
+- ambiguity surfacing
+- user story generation
+- option analysis
+- architecture implication analysis
+
+## 9.3 Dev / Neo intelligence
+Key qualities:
+
+- implementation planning
+- code correctness
+- architectural adherence
+- patch quality
+- debugging ability
+- recovery after failed attempt
+- consistency with repo conventions
+
+### Sample benchmark categories
+- code patching
+- implementation design
+- refactoring
+- bug fixing
+- test-driven adjustments
+- partial failure recovery
+
+## 9.4 QA / Eve intelligence
+Key qualities:
+
+- failure detection
+- signal-to-noise quality
+- edge-case rigor
+- test coverage quality
+- validation depth
+- ability to catch semantic breakage
+
+### Sample benchmark categories
+- test design
+- failure case discovery
+- regression detection
+- edge-case identification
+- bug report quality
+- artifact validation
+
+## 9.5 Data intelligence
+Key qualities:
+
+- experiment interpretation
+- telemetry reading
+- anomaly detection
+- metric design
+- evidence summarization
+- recommendation quality
+
+### Sample benchmark categories
+- metric selection
+- anomaly interpretation
+- experiment result summary
+- false positive discrimination
+- RCA support
+- recommendation clarity
+
+---
+
+## 10. The Agent Intelligence Baseline Pack
+
+Before any major improvement work, create an **Agent Intelligence Baseline Pack** for each primary agent.
+
+Each pack should include:
+
+### 10.1 Identity and role
+- agent name
+- role
+- responsibilities
+- key interfaces with other agents
+
+### 10.2 Current design
+- prompt / instruction set
+- model(s) used
+- tool access
+- memory access
+- runtime assumptions
+- escalation assumptions
+
+### 10.3 Observed current behavior
+- strengths
+- weaknesses
+- common failure modes
+- known blind spots
+- known latency/cost issues
+
+### 10.4 Evidence
+- examples from successful cycles
+- examples from failed cycles
+- benchmark observations if any already exist
+- notable RCA findings
+
+### 10.5 Candidate improvement hypotheses
+- prompt improvements
+- memory improvements
+- model-routing changes
+- tool additions
+- role split possibilities
+- role contract refinements
+
+This baseline pack becomes the foundation for every later experiment.
+
+---
+
+## 11. Benchmark Strategy
+
+## 11.1 Why benchmarks are necessary
+Without benchmarks, “smarter” becomes subjective.
+That leads to prompt drift, excitement bias, and false confidence.
+
+Benchmarks provide:
+- a before/after baseline
+- a repeatable test harness
+- evidence for promotion
+- a way to compare model-role combinations
+- a way to compare design changes over time
+
+## 11.2 Benchmark design approach
+Each role should have a benchmark pack with:
+
+- 5 core tasks
+- 5 edge-case tasks
+- 5 failure-recovery tasks
+- optional stretch tasks
+
+This yields a realistic benchmark suite rather than a toy test.
+
+## 11.3 Benchmark sources
+Benchmark tasks can come from:
+
+- actual SquadOps failures
+- known good historical work products
+- synthetic role challenges
+- public benchmark inspiration adapted to role reality
+- hand-crafted scenarios based on your architecture
+
+## 11.4 What benchmark outputs should measure
+Possible metrics:
+
+- correctness
+- completeness
+- ambiguity detection
+- recovery quality
+- adherence to architecture
+- evidence quality
+- speed/latency
+- token/cost profile
+- repeatability / consistency
+
+## 11.5 Promotion criteria
+An upgrade should only be promoted if it improves at least one of:
+- benchmark performance
+- real-cycle usefulness
+- failure recovery
+- signal-to-noise ratio
+- autonomy durability
+
+without unacceptable regression in:
+- cost
+- latency
+- control
+- architecture alignment
+
+---
+
+## 12. Experiment Tracks
+
+To avoid blob-ifying the effort, start with three experiment tracks only.
+
+## 12.1 Track A — Role benchmark creation
+Create benchmark packs for each target role.
+This is the most important first move.
+
+### Outputs
+- role benchmark spec
+- benchmark task library
+- scoring rubrics
+- benchmark execution harness plan
+
+## 12.2 Track B — Model-role matching
+Test whether different base models are better for different roles.
+
+### Hypothesis
+Different reasoning styles and model strengths may fit different roles better than a one-model-for-all strategy.
+
+### Outputs
+- model-role comparison matrix
+- candidate default routing by role
+- cost/latency tradeoff notes
+
+## 12.3 Track C — Context and memory design
+Test whether better role context improves performance more than model changes alone.
+
+### Hypothesis
+Structured role context, memory, and artifact retrieval may deliver larger gains than blindly switching models.
+
+### Outputs
+- role context pack design
+- memory structure proposals
+- retrieval strategy options
+- before/after benchmark results
+
+---
+
+## 13. Improvement Loop
+
+The core improvement loop should be:
+
+### Step 1 — Document current role design
+Capture the actual current state, not the aspirational state.
+
+### Step 2 — Benchmark current performance
+Establish a real baseline.
+
+### Step 3 — Choose one upgrade hypothesis
+Examples:
+- change prompt contract
+- change tool access
+- change memory structure
+- change model
+- add self-critique pass
+- split role in two
+
+### Step 4 — Run controlled evaluation
+Test the specific hypothesis against the benchmark pack and, where possible, selected real cycle tasks.
+
+### Step 5 — Review cost / latency / control tradeoffs
+A better answer that destroys cost or latency may not be a real promotion candidate.
+
+### Step 6 — Promote or reject
+Only promote if the evidence is strong enough.
+
+### Step 7 — Capture lessons learned
+Every experiment should produce a structured artifact, not just a vague memory.
+
+---
+
+## 14. Suggested Phases
+
+## Phase 1 — Program foundation
+Create:
+- program charter
+- role list
+- baseline pack template
+- benchmark template
+- research corpus structure
+- NotebookLM workspace structure
+
+## Phase 2 — Baseline capture
+For each primary agent:
+- document current design
+- capture known strengths/weaknesses
+- gather examples from real cycles
+- define preliminary benchmark hypotheses
+
+## Phase 3 — Research corpus build
+Assemble:
+- public docs
+- open-source agent references
+- benchmarking literature
+- design comparisons
+- SquadOps internal lessons learned
+
+## Phase 4 — Role benchmark suite
+Create benchmark packs for:
+- Max
+- Nat
+- Neo
+- Eve
+- Data
+
+## Phase 5 — Comparative evaluation
+Compare:
+- ChatGPT-based role support
+- Claude-based role support
+- Gemini-based role support
+- local/runtime alternatives where relevant
+
+## Phase 6 — Targeted upgrades
+Implement one or two role upgrades at a time, not all at once.
+
+## Phase 7 — Promotion policy
+Define what makes an agent design canonical.
+
+---
+
+## 15. Recommended Artifact Set
+
+This initiative should produce a set of stable artifacts.
+
+### Core artifacts
+- Agent Intelligence Program Charter
+- Agent Intelligence Baseline Template
+- Role Benchmark Template
+- Research Corpus Map
+- Experiment Report Template
+- Promotion Criteria Spec
+
+### Role artifacts
+- Max Baseline Pack
+- Nat Baseline Pack
+- Neo Baseline Pack
+- Eve Baseline Pack
+- Data Baseline Pack
+
+### Evaluation artifacts
+- Model-Role Comparison Matrix
+- Role Benchmark Results
+- Improvement Hypothesis Log
+- Promotion / Rejection Decisions
+
+---
+
+## 16. Suggested Canonical Repo / Knowledge Layout
+
+```text
+docs/
+  ideas/
+    IDEA-agent-intelligence-improvement-program.md
+  agents/
+    baseline/
+      max-baseline-pack.md
+      nat-baseline-pack.md
+      neo-baseline-pack.md
+      eve-baseline-pack.md
+      data-baseline-pack.md
+    benchmarks/
+      max-benchmark-pack.md
+      nat-benchmark-pack.md
+      neo-benchmark-pack.md
+      eve-benchmark-pack.md
+      data-benchmark-pack.md
+    experiments/
+      EXP-role-model-comparison-001.md
+      EXP-role-context-design-001.md
+      EXP-neo-memory-upgrade-001.md
+    evaluations/
+      role-model-comparison-matrix.md
+      promotion-decisions.md
+  research/
+    corpus-map.md
+    external-agent-patterns.md
+    notebooklm-source-map.md
+```
+
+This keeps the canonical outputs in markdown and in-repo, while NotebookLM remains the synthesis layer.
+
+---
+
+## 17. Use of Real SquadOps Evidence
+
+One of the strongest advantages you have is that SquadOps is already producing runtime evidence.
+
+This initiative should explicitly mine:
+
+- failed cycle reports
+- RCA outputs
+- successful autonomous runs
+- prompt breakdowns
+- tool-use confusion patterns
+- model mismatch cases
+- latency/cost pain points
+- recovery success/failure examples
+
+That evidence is better than generic external benchmark material because it directly reflects your real operating environment.
+
+A useful principle:
+
+> External research should shape hypotheses.  
+> Internal runtime evidence should shape priorities.
+
+---
+
+## 18. What to Avoid
+
+### 18.1 Avoid one giant “agent intelligence” blob
+Keep separate tracks for:
+- role design
+- benchmark design
+- orchestration design
+- runtime implementation
+- research knowledge management
+
+### 18.2 Avoid assuming frontier model quality equals role fitness
+A stronger generic model may still be the wrong fit for a particular role.
+
+### 18.3 Avoid overfitting to benchmark theater
+Benchmarks matter, but real-cycle utility matters too.
+
+### 18.4 Avoid making NotebookLM the canonical truth
+Use it as a research workspace, not as the lasting system of record.
+
+### 18.5 Avoid promoting improvements without hard evidence
+Interesting is not the same thing as better.
+
+---
+
+## 19. Recommended First 30 Days
+
+### Week 1
+- finalize program charter
+- define target agent list
+- create baseline pack template
+- create benchmark pack template
+- create NotebookLM workspace map
+
+### Week 2
+- complete Max, Nat, Neo baseline packs
+- start research corpus build
+- identify 10–15 benchmark tasks for each of those roles
+
+### Week 3
+- complete Eve and Data baseline packs
+- finalize role benchmark packs
+- define scoring rubrics
+- run first baseline benchmark pass
+
+### Week 4
+- run first model-role comparison
+- identify top 1–2 upgrade hypotheses per role
+- choose one pilot upgrade role
+- produce first experiment report
+
+---
+
+## 20. Recommended Pilot
+
+The cleanest pilot is probably:
+
+### Pilot option A — Max
+Why:
+- highest leverage on overall squad behavior
+- strong link between individual judgment and squad autonomy
+- clearer connection to long-run autonomous operation
+
+### Pilot option B — Neo
+Why:
+- easier to benchmark concretely
+- strong impact on real deliverables
+- easier to compare across models
+
+### Pilot recommendation
+Start with **Max and Neo**:
+- Max as the high-leverage coordination intelligence pilot
+- Neo as the concrete implementation intelligence pilot
+
+That gives you one strategic role and one execution role.
+
+---
+
+## 21. Exit Criteria for Phase 1
+
+Phase 1 should be considered complete only when all of the following exist:
+
+- a written program charter
+- a defined role inventory
+- a baseline pack template
+- a benchmark pack template
+- a canonical research corpus map
+- NotebookLM notebook structure
+- at least 2 completed role baseline packs
+- at least 1 completed role benchmark pack
+- at least 1 comparative model evaluation plan
+
+---
+
+## 22. Recommended Next Artifacts
+
+The next documents to create after this one should be:
+
+1. **Agent Intelligence Baseline Template**
+2. **Role Benchmark Pack Template**
+3. **Model-Role Comparison Matrix Template**
+4. **Research Corpus Map**
+5. **Max Baseline Pack**
+6. **Neo Baseline Pack**
+
+---
+
+## 23. Final Framing
+
+The strongest way to describe this initiative is:
+
+> SquadOps is not only trying to coordinate agents better.  
+> It is building a durable system for continuously improving the intelligence of the individual agents that make up the squad.
+
+And the strongest strategic framing is:
+
+> Use ChatGPT, Claude, and Gemini as external research, critique, evaluation, and implementation partners — while keeping SquadOps itself as the long-term operating substrate and the owner of its own intelligence improvement system.
+
+That framing keeps the value compounding inside your system instead of inside theirs.
+
+---
+
+## 24. Benchmark Execution Strategy
+
+The benchmark design (Section 11) defines what to measure. This section defines how benchmarks actually run.
+
+The recommended approach layers four execution methods, each suited to different roles and evaluation needs.
+
+### 24.1 Option A — pytest-based Benchmark Harness
+
+Run benchmarks as a dedicated pytest suite under `tests/benchmarks/`.
+
+Each benchmark task is a test case that sends a prompt and context to a handler and scores the output. Fixtures provide the role context, capability config, and mock or real LLM backend. Scoring functions assert on structured output properties such as correctness, completeness, and adherence. Results are captured via pytest markers and a custom plugin that writes JSON reports.
+
+**Strengths:**
+- Fits existing test infrastructure (3000+ tests already run this way)
+- Repeatable, CI-friendly, version-controlled alongside the code
+- Can run against mock LLM responses (deterministic) or real LLM calls (realistic)
+- Developers already know how to run it
+
+**Limitations:**
+- Scoring LLM output with assertions is brittle — string checks or regex can miss valid alternatives
+- Does not exercise the full agent runtime (message routing, memory, tool use)
+- Fast but potentially shallow
+
+**Best for:** Handler-level intelligence testing. Example: does Neo's dev handler produce correct code given a specific input?
+
+### 24.2 Option B — Cycle-based Benchmark Runs
+
+Use the actual cycle execution pipeline with dedicated benchmark cycle request profiles.
+
+Create profiles like `benchmark-neo-impl.yaml` and `benchmark-max-decomposition.yaml`. Each profile defines a known task with known inputs (a synthetic PRD, a known bug, a planning scenario). Run via `squadops cycles create benchmark-project --request-profile benchmark-neo-impl`. Score the output artifacts against a rubric. LangFuse traces provide token counts, latency, and full prompt/response history. The event bus (SIP-0077) captures per-agent runtime data automatically.
+
+**Strengths:**
+- Exercises the real runtime — agents, message routing, memory, tool access, the full stack
+- Produces real artifacts that can be inspected and compared across runs
+- Event bus and LangFuse already capture everything needed for analysis
+- Closest to how the agent actually performs in production
+
+**Limitations:**
+- Slow — a full cycle takes minutes, not seconds
+- Requires Docker services running (Postgres, RabbitMQ, Prefect, agents)
+- Non-deterministic — LLM responses vary between runs
+- Harder to isolate agent intelligence changes from orchestration changes
+
+**Best for:** End-to-end role performance validation, model-role comparison (Track B), autonomy durability testing.
+
+### 24.3 Option C — LLM-as-Judge Evaluation
+
+Use a separate LLM to score agent outputs against a structured rubric.
+
+Capture agent outputs from Option A or Option B. Feed each output plus the original task plus a scoring rubric to a judge model. The judge returns structured scores (e.g., correctness: 4/5, completeness: 3/5, architecture adherence: 5/5). Aggregate scores across the benchmark pack.
+
+**Strengths:**
+- Can evaluate semantic quality that string assertions cannot (was this a good decomposition?)
+- Scales — can score hundreds of outputs without manual review
+- Rubrics are version-controlled and improvable
+
+**Limitations:**
+- Judge model introduces its own biases and failure modes
+- Need to validate the judge itself (does it actually discriminate good from bad?)
+- Cost multiplier — every benchmark run also costs judge tokens
+- Risk of benchmark theater if the judge is too lenient
+
+**Best for:** Scoring subjective qualities like Max's decomposition judgment or Nat's ambiguity detection.
+
+### 24.4 Option D — Golden Output Comparison
+
+Maintain a set of known-good outputs and diff against them.
+
+For each benchmark task, store a reference golden output that has been human-reviewed and approved. Run the agent, diff the output against golden. Score based on structural similarity, key content presence, and absence of known failure patterns. Similar to snapshot testing.
+
+**Strengths:**
+- Simple, deterministic scoring — no LLM judge needed
+- Easy to see exactly what changed between agent versions
+- Good regression detection
+
+**Limitations:**
+- Rigid — any valid-but-different output looks like a failure
+- Maintenance burden — golden outputs need updating as the system evolves
+- Does not work well for roles with legitimately variable output (Max's planning)
+
+**Best for:** Neo's code output (did it produce correct, runnable code?), Eve's test output (did it find the known bugs?).
+
+### 24.5 Recommended Layering Strategy
+
+Layer the four options rather than choosing one. Roll them out in this order:
+
+**Layer 1 — pytest + golden outputs (Options A and D) for Neo and Eve.**
+Their outputs are concrete and scorable. This gets benchmarks running fast with zero new infrastructure.
+
+**Layer 2 — Cycle-based benchmark profiles (Option B) for Max.**
+Decomposition and coordination judgment need the full runtime to be meaningful. The cycle request profile infrastructure from SIP-0083 already supports this.
+
+**Layer 3 — LLM-as-judge (Option C) for Nat and Max.**
+Add once there are enough outputs to validate the judge against human scoring. Use for roles where output quality is subjective.
+
+### 24.6 Benchmark Result Storage
+
+Benchmark results should land in `docs/agents/benchmarks/results/` as timestamped JSON reports. Each report should reference:
+
+- git SHA of the codebase at time of run
+- model and model version used
+- cycle request profile version (for Option B runs)
+- role and benchmark pack version
+- raw scores and aggregate scores
+- LangFuse trace IDs (for Option B runs)
+
+This keeps results version-controlled and diffable without requiring new infrastructure.
+
+### 24.7 Concrete Benchmark Pack Example — Neo (Dev Agent)
+
+To make the benchmark strategy tangible, here is a sketch of what Neo's benchmark pack would look like.
+
+#### Core tasks (5)
+1. Implement a single-file Python function from a clear spec
+2. Add a new API route to an existing FastAPI service
+3. Refactor a function to reduce cyclomatic complexity
+4. Fix a failing test by correcting the implementation (not the test)
+5. Add error handling to an existing function that currently swallows exceptions
+
+#### Edge-case tasks (5)
+1. Implement when the spec contains contradictory requirements (should surface ambiguity)
+2. Implement when the target file has an unusual structure (non-standard patterns)
+3. Fix a bug where the root cause is in a different file than the symptom
+4. Implement a feature that requires modifying frozen dataclasses correctly (using `dataclasses.replace()`)
+5. Handle a spec that requests a change violating an existing architectural constraint
+
+#### Failure-recovery tasks (5)
+1. Resume after a previous attempt produced syntactically invalid code
+2. Resume after a previous attempt broke existing tests
+3. Recover from a partial implementation (half the files written, then interrupted)
+4. Respond to QA feedback that rejects the first implementation
+5. Implement correctly after receiving a correction decision from the lead agent
+
+#### Scoring rubric (per task)
+- **Correctness** (0-5): Does the code work? Does it pass the expected tests?
+- **Completeness** (0-5): Are all requirements addressed? Any missing pieces?
+- **Architecture adherence** (0-5): Does it follow repo conventions, hexagonal patterns, existing code style?
+- **Recovery quality** (0-5, failure-recovery tasks only): Did the agent correctly identify the failure and produce a meaningfully different second attempt?
+- **Token efficiency** (measured): Total tokens consumed for the task
+
+---
+
+## 25. Review Recommendations
+
+The following recommendations were identified during initial review and should be addressed before this idea is promoted to a SIP.
+
+### 25.1 Trim the Big 3 and NotebookLM sections
+
+Sections 6 and 7 describe personal operational workflow rather than program architecture. The program principles (Section 5) already establish that external models are accelerants, not substrate. The Big 3 Operating Model and NotebookLM sections should be moved to an operational playbook appendix so they do not appear to contradict that principle by giving specific external tools first-class architectural standing.
+
+### 25.2 Connect to existing telemetry infrastructure
+
+The program should explicitly state that SIP-0077 cycle events and SIP-0061 LangFuse traces are the primary data sources for internal evidence (Section 8.3). The event bus already captures per-agent runtime data. LangFuse already captures token counts, latency, and full prompt/response chains. Mining these existing sources is cheaper and more reliable than manual cycle log review.
+
+### 25.3 Elevate cost as a first-class success criterion
+
+Section 4 (success criteria) does not mention cost. Section 11.4 lists token/cost profile as a possible metric but treats it as optional. For 8-10 hour autonomous runs, cost is load-bearing. An agent that is 10% smarter but 3x more expensive may not be a real improvement. Cost should appear in the success criteria alongside benchmark scores and cycle outcomes.
+
+### 25.4 Add cross-role regression protection
+
+When an upgrade is promoted for one role (e.g., Neo), there is no described mechanism to ensure other roles do not regress. Agent interactions mean a change to Neo's output quality can affect Eve's QA work and Max's coordination decisions. The promotion criteria (Section 11.5) should include a cross-role smoke test — at minimum, a multi-agent benchmark cycle that exercises the full squad after any single-role promotion.
+
+### 25.5 Cap the research corpus scope
+
+Section 8.2 (external research) defines what to collect but not when to stop. Research corpus builds expand indefinitely without a cap. Define a concrete scope limit — e.g., 10 source documents per role, reviewed and tagged — so research serves benchmarking rather than becoming its own workstream.
+
+### 25.6 Narrow the 30-day timeline to pilot scope
+
+The 30-day plan (Section 19) attempts baseline packs for all 5 roles, full benchmark suites, and a first model-role comparison. Given that SquadOps is still actively building coordination infrastructure (SIP-0079, SIP-0083), running a parallel agent intelligence program at this pace risks splitting focus. Scope Phase 1 to Max and Neo only (which Section 20 already recommends as pilots) and explicitly defer Eve, Nat, and Data baseline packs until the two pilots produce results.
+
+---
+
+## 26. Open Questions
+
+1. Which roles should be in scope for the first wave beyond Max and Neo?
+2. Should benchmark packs be fully deterministic or partially scenario-based?
+3. How should real-cycle evidence be normalized so it can feed benchmarks?
+4. How much of the evaluation harness should live inside SquadOps itself?
+5. When should a role split into sub-roles instead of being “improved” as one agent?
+6. Which improvements should be considered local-runtime compatible vs cloud-model dependent?
+7. How should cost discipline be incorporated into promotion criteria?
+8. What is the minimum number of benchmark runs needed to account for LLM non-determinism?
+9. How should the LLM-as-judge be validated before trusting its scores?
+10. Should benchmark results trigger automated alerts or remain a manual review process?
+
+---
+
+## 27. Recommendation
+
+Proceed with this as a dedicated initiative, not as an informal side thread.
+
+Treat the next concrete milestone as:
+
+**Build the Agent Intelligence Baseline System.**
+
+That means:
+- define the templates
+- build the baseline packs
+- build the benchmark packs
+- establish the first comparison loop
+- only then start promoting intelligence upgrades into SquadOps

--- a/docs/ideas/IDEA-agent-squad-self-play-consensus-benchmark.md
+++ b/docs/ideas/IDEA-agent-squad-self-play-consensus-benchmark.md
@@ -1,0 +1,248 @@
+# IDEA: Agent Squad Self-Play Consensus Benchmark
+
+## Status
+Draft
+
+## Summary
+Explore an experiment where two agent squads are given a structured game such as chess, a fixed overall time budget to complete play, and the freedom to devise their own internal consensus method.
+
+The goal is not simply to see which squad wins a game. The real goal is to observe whether different consensus methods emerge, how they behave under combinatorial pressure, and whether they produce coherent, repeatable play rather than random motion, accidental wins, or time-loss failures.
+
+This idea is less about chess itself and more about creating a compact benchmark harness for evaluating agent coordination quality.
+
+## Core Intent
+The experiment should avoid over-scaffolding the internal decision process.
+
+You want to see whether squads can invent workable consensus approaches on their own, while still making those approaches observable and comparable.
+
+That means the system should provide:
+- the game rules
+- the win/loss conditions
+- the total time budget
+- the evidence capture requirements
+- a minimal failsafe so the run cannot hang forever
+
+The squads should provide:
+- the consensus method
+- the authority model
+- the candidate-pruning approach
+- the escalation behavior
+- the tradeoff between move quality and decision speed
+
+## Central Question
+Can Spark squads devise distinct consensus methods that produce coherent gameplay under an overall game deadline, and can those methods be compared meaningfully?
+
+## Why Chess or a Similar Game Works
+A game like chess is useful because it has:
+- clear turns
+- deterministic rules
+- a massive decision space
+- obvious outcomes
+- replayable evidence
+- enough complexity to expose coordination weakness quickly
+
+The agents do not need to solve chess exhaustively. They only need to create a consensus process that can manage the combinatorial pressure well enough to make coherent moves before time expires.
+
+## Key Hypothesis
+A well-designed self-play experiment can surface meaningful differences in squad coordination methods, but only if the benchmark measures more than win/loss.
+
+A weak squad may:
+- make random or weak moves
+- over-deliberate and lose on time
+- fail to converge on decisions
+- produce accidental wins that do not reflect true coordination quality
+
+A stronger squad may:
+- narrow candidate moves quickly
+- coordinate authority effectively
+- balance speed and move quality
+- maintain a coherent strategy across turns
+- improve its method between rounds
+
+## Important Design Principle
+Do not prescribe the exact move-loop consensus process.
+
+If you overly define:
+- how many debate rounds are allowed
+- whether voting must occur
+- how tie-breaking must work
+- what internal decision sequence is required
+
+then you are testing your scaffolding more than their emergent coordination design.
+
+The better constraint is:
+- fixed rules
+- fixed overall game deadline
+- required observability of method and outcomes
+
+## Proposed Experiment Structure
+
+### Phase 1: Setup
+Each squad is asked to:
+- understand the game rules
+- declare its consensus method before play
+- define any internal roles it wants to use
+- define how it will prune candidate moves
+- define how it will resolve disagreement
+- define how it will prevent endless deliberation
+
+The important point is that the method is declared by the squad, not by the benchmark designer.
+
+### Phase 2: Play
+The squads play under a fixed overall completion deadline.
+
+They should be free to manage their internal timing however they choose.
+
+This means:
+- a squad may spend more time on critical moves and less on obvious ones
+- one squad may use a lead-agent model
+- another may use weighted voting or challenge-and-override
+- another may rotate authority
+- another may use a critic/champion pattern
+
+The deadline creates the incentive. Poor coordination should naturally cause time loss.
+
+### Phase 3: Evidence Capture
+The system should record enough evidence to compare methods without requiring essay-length reasoning.
+
+Examples:
+- declared consensus method
+- role assignments
+- move candidates considered
+- short rationale for final move
+- timeout or fallback events
+- override frequency
+- disagreement frequency
+- move times
+- game outcome
+- post-game reflection
+
+### Phase 4: Review
+After the game, each squad should analyze:
+- where consensus worked
+- where it stalled
+- where time was wasted
+- whether authority was too centralized or too diffuse
+- whether the method helped or hurt move quality
+- what they would change next round
+
+### Phase 5: Iteration
+Run multiple games so the benchmark evaluates repeatability rather than one noisy outcome.
+
+The real signal is whether a squad's method:
+- produces coherent play repeatedly
+- avoids collapse under pressure
+- adapts after evidence review
+- improves over time
+
+## Core Risk
+The major risk in v1 is that both squads make effectively random moves, and one squad wins by accident or simply because the other ran out of time.
+
+If that happens, win/loss alone is not meaningful.
+
+So the benchmark needs to separate:
+- coherent but imperfect play
+from
+- chaotic move emission with lucky results
+
+## What Should Be Measured
+Early versions of the benchmark should weight coordination quality more heavily than raw victory.
+
+Potential measures:
+- legal move rate
+- completion within allotted time
+- average decision time
+- stall frequency
+- fallback frequency
+- declared-plan versus actual-move alignment
+- position quality trend using a lightweight evaluator
+- blunder frequency
+- repeatability across games
+- post-game reflection quality
+
+## Success Tiers
+One way to interpret results is through maturity tiers.
+
+### Tier 1
+The squad can complete legal games within the overall deadline.
+
+### Tier 2
+The squad shows evidence of coherent strategic behavior rather than random move selection.
+
+### Tier 3
+The squad produces repeatable performance across multiple games.
+
+### Tier 4
+The squad adapts and improves its consensus method between rounds.
+
+This helps prevent accidental wins from being mistaken for meaningful success.
+
+## Enabling Capabilities vs Over-Scaffolding
+The squads may need a few enabling capabilities, but not a fully prescribed solution.
+
+Helpful capabilities:
+- candidate move generation
+- lightweight move evaluation
+- budget awareness
+- disagreement detection
+- final-decision closure
+- evidence compression
+- post-game review support
+
+Avoid baking in:
+- exact consensus flow
+- required voting rules
+- mandatory internal round structure
+- overly detailed reasoning templates
+
+The environment should make good coordination easier without dictating the answer.
+
+## Why This Matters for Spark Squads
+This is a compact proxy test for a bigger question:
+
+Can a squad turn reasoning into timely action under pressure?
+
+If a squad cannot:
+- prune options
+- assign authority
+- close deliberation
+- act before the clock expires
+
+then the same failure pattern is likely to show up in more important workloads too.
+
+That is what makes this experiment valuable. It is a smaller, safer pressure chamber for the broader coordination problem.
+
+## Benchmark Value
+This can become a repeatable harness for comparing consensus styles such as:
+- lead-agent override
+- majority vote
+- weighted vote
+- proposal plus veto
+- rotating authority
+- critic/champion
+- hierarchical narrowing
+- confidence-weighted selection
+
+The benchmark can then compare not just who won, but which method:
+- stayed coherent
+- used time well
+- avoided stalls
+- produced better positions
+- improved after review
+
+## Recommended Next Step
+Turn this into a more formal IDEA or SIP that defines:
+- experiment objective
+- minimum viable game implementation
+- evidence schema
+- benchmark metrics
+- iteration protocol
+- method declaration requirements
+- cross-run comparison model
+
+## Closing Framing
+This is not really a chess experiment.
+
+It is an experiment in whether agent squads can invent, inhabit, and improve their own coordination methods under constraint.
+
+The game is just the test chamber.

--- a/docs/ideas/IDEA-benchmark-driven-cycle-assessment-v1.1-v1.2.md
+++ b/docs/ideas/IDEA-benchmark-driven-cycle-assessment-v1.1-v1.2.md
@@ -1,0 +1,956 @@
+# IDEA: Benchmark-Driven Cycle Assessment for SquadOps
+## Target Release: v1.1 / v1.2
+
+### Status
+Draft
+
+### Owner
+Strategy / Architecture / Eval
+
+### Summary
+Introduce a benchmark-driven cycle assessment capability for SquadOps that evaluates agent roles against objective external benchmarks where available, combines that with SquadOps-native internal evals, scores cycle performance, and produces structured recommendations for memory updates, model comparison, routing changes, and tuning priorities.
+
+This idea extends the broader collaborative memory direction by adding an explicit measurement loop:
+- benchmark the role
+- observe cycle performance
+- compare actual outcomes against expected role capability
+- recommend targeted improvements
+- feed approved lessons back into MemoryRules, routing, prompts, and model policy
+
+The goal is not to turn SquadOps into a leaderboard product. The goal is to create a disciplined evaluation and feedback system that can answer:
+- which model is best for which role?
+- which agent is regressing?
+- which failures should become MemoryRules?
+- when should routing or escalation policy change?
+- when is prompt or memory tuning sufficient vs when is a model swap justified?
+
+---
+
+## Problem
+
+SquadOps will likely generate a large amount of execution evidence, but raw activity volume does not equal trustworthy performance insight.
+
+Without a benchmark and assessment layer, several things become hard to answer with confidence:
+- whether an agent is actually improving
+- whether a given model is underperforming for its assigned role
+- whether a failure is due to model capability, missing memory, weak routing, poor decomposition, or weak task setup
+- whether premium-model usage is buying real value
+- whether cycle-level quality is rising because the system is better, or because the tasks have become easier
+- whether a specific failure should lead to a memory update, a prompt update, a model change, or no change at all
+
+This can lead to:
+- subjective impressions rather than measurable evidence
+- noisy RCA without a repeatable scoring baseline
+- over-rotating on anecdotal failures
+- unnecessary model churn
+- excessive escalation to larger models
+- weak confidence in long-term system quality
+
+---
+
+## Opportunity
+
+SquadOps can treat evaluation as a first-class operating capability.
+
+The system can combine:
+1. **objective external benchmarks** for role-aligned capability measurement
+2. **internal SquadOps benchmark tasks** aligned to the actual repo, artifacts, and workflows
+3. **cycle-native telemetry** such as retries, escalations, rework, latency, cost, and quality outcomes
+4. **contrastive RCA** to determine whether failures should become new MemoryRules or trigger tuning changes
+
+The result would be a more disciplined assessment loop that supports:
+- role-to-model fit analysis
+- model comparison under the same harness
+- memory effectiveness measurement
+- targeted change recommendations
+- evidence-based release quality decisions
+
+---
+
+## Why This Fits SquadOps
+
+This idea aligns well with the current SquadOps direction:
+- you already care about RCA, rewind, and correction rather than hand-waving over failure
+- you already assume heterogeneous model routing
+- you already want premium inference used intentionally, not casually
+- you already value golden-source comparison, quality gates, and structured outputs
+- you already want a force multiplier, which requires measurable performance and not just impressive demos
+
+This idea also pairs naturally with collaborative memory:
+- benchmarks help reveal recurring failure classes
+- cycle assessment helps determine whether a failure came from missing capability or missing guidance
+- approved lessons can become MemoryRules
+- memory effectiveness can be measured by before/after score deltas and cycle efficiency changes
+
+---
+
+## Goals
+
+- Establish objective role-aligned evaluation where external benchmarks exist
+- Create SquadOps-native evals for roles that do not have good public benchmarks
+- Score cycle performance in a structured and repeatable way
+- Compare models for the same role under the same harness
+- Recommend changes in memory, routing, prompt policy, or model assignment
+- Make evaluation outputs useful to RCA, not separate from it
+- Support release gating and ongoing health monitoring
+
+---
+
+## Non-Goals
+
+- Blindly optimizing SquadOps to public benchmark leaderboards
+- Replacing human judgment for architecture or product decisions
+- Assuming that benchmark wins automatically translate to repo-specific excellence
+- Building a public benchmark submission platform in v1
+- Fully autonomous model swapping without review
+- Treating all roles as equally benchmarkable with public suites
+
+---
+
+## Core Idea
+
+Add a benchmark-driven cycle assessment subsystem made of four parts:
+
+1. **Role Benchmark Registry**
+   A mapping of SquadOps roles to external and internal benchmark suites.
+
+2. **Cycle Assessment Scorecard**
+   A normalized scorecard that measures the actual performance of a cycle.
+
+3. **Recommendation Engine**
+   A decision layer that proposes memory updates, prompt tuning, routing changes, model comparisons, or model swaps based on observed evidence.
+
+4. **Improvement Feedback Loop**
+   A mechanism that routes approved recommendations into MemoryRules, eval baselines, routing policy, or model config.
+
+---
+
+## Release Framing
+
+### v1.1 focus
+Build the minimum viable evaluation backbone:
+- role-to-benchmark map
+- benchmark registry artifact
+- cycle scorecard schema
+- manual or semi-automated assessment workflow
+- recommendation categories
+- internal eval harness for SquadOps-native tasks
+- tie-ins to RCA and MemoryRule proposals
+
+### v1.2 focus
+Expand into adaptive and more automated eval operations:
+- scheduled benchmark runs
+- per-role trend analysis
+- automatic comparison across candidate models
+- memory effectiveness analytics
+- routing policy recommendations
+- release gating from eval thresholds
+- eval dashboards and longitudinal health metrics
+
+---
+
+## External Benchmark Landscape by Role
+
+Not every role has a strong public benchmark. The fit varies.
+
+### 1. Dev / Implementation Agents
+Best objective options:
+- **SWE-bench / SWE-bench Verified**
+- **HumanEval**
+- **MBPP**
+- **Aider Polyglot**
+
+Why they matter:
+- SWE-bench evaluates real GitHub issue resolution against actual repos and tests.
+- SWE-bench Verified is the human-validated subset and is generally the more trusted view.
+- HumanEval focuses on function-level code generation with correctness checked by tests.
+- MBPP covers simpler Python programming tasks and is useful for lightweight coding checks.
+- Aider Polyglot stresses coding and editing ability across multiple languages and iterative fix loops.
+
+Best SquadOps fit:
+- Neo / Dev
+- code-fixing agents
+- implementation specialists
+- repo-modifying execution roles
+
+### 2. Tool-Use / Function-Calling Agents
+Best objective options:
+- **BFCL** (Berkeley Function Calling Leaderboard)
+- **τ-bench** for tool + policy conversation settings
+
+Why they matter:
+- BFCL measures function-calling correctness and executability across realistic tool schemas.
+- τ-bench evaluates dynamic user-agent-tool interaction with policy constraints.
+
+Best SquadOps fit:
+- executor agents
+- API / tool orchestrators
+- data-query agents
+- workflow-driving assistants
+
+### 3. Research / Browsing Agents
+Best objective options:
+- **BrowseComp**
+- **GAIA**
+
+Why they matter:
+- BrowseComp focuses on locating difficult-to-find information through browsing.
+- GAIA evaluates broader general-assistant capability, including reasoning, tool use, browsing, and multimodal problem solving.
+
+Best SquadOps fit:
+- research agents
+- market / vendor analysis roles
+- evidence-gathering agents
+- policy or standard lookup tasks
+
+### 4. Web UI / App-Operation Agents
+Best objective options:
+- **WebArena**
+- **VisualWebArena**
+- broader WebArena-x family where relevant
+
+Why they matter:
+- WebArena evaluates realistic web-task completion in controlled environments.
+- VisualWebArena adds visual and multimodal interaction stress.
+
+Best SquadOps fit:
+- UI-walker agents
+- product demo or test agents
+- browser automation roles
+- future GuideRail / app navigation test agents
+
+### 5. General Digital Worker / Cross-Functional Agents
+Best objective options:
+- **TheAgentCompany**
+- **GAIA**
+- selected τ-bench scenarios
+
+Why they matter:
+- TheAgentCompany is closer to a simulated workplace benchmark than a narrow coding or browsing suite.
+- It blends browsing, code, communication, and task execution.
+
+Best SquadOps fit:
+- generalist operators
+- future lead-assistant helpers
+- hybrid task runners
+
+### 6. Support / Policy-Constrained Workflow Agents
+Best objective options:
+- **τ-bench**
+- domain-specific internal evals
+
+Why they matter:
+- τ-bench is highly relevant for tool use under policy and user interaction constraints.
+
+Best SquadOps fit:
+- support-oriented agents
+- banking or operations workflow assistants
+- policy-sensitive customer interaction roles
+
+---
+
+## Role Coverage Reality Check
+
+The benchmark landscape is not equally mature across all SquadOps roles.
+
+### Roles with strong public benchmark alignment
+- Dev
+- tool executor
+- browsing / research
+- browser UI operator
+- support / policy workflow
+
+### Roles with weak or partial public benchmark alignment
+- Lead
+- Strategy
+- Product
+- Architecture
+- QA reviewer in the deeper judgment sense
+- decomposition / orchestration quality
+
+These roles usually need **internal SquadOps evals** rather than dependence on public leaderboards.
+
+That means the right answer for SquadOps is not one benchmark. It is a hybrid eval stack.
+
+---
+
+## Recommended Hybrid Eval Stack
+
+### Layer 1: External objective benchmarks
+Used to assess raw role capability and model comparisons under known public tasks.
+
+Purpose:
+- model selection
+- baseline capability comparisons
+- detect obvious model-role mismatch
+- monitor broader model quality changes over time
+
+### Layer 2: Internal SquadOps benchmark tasks
+Used for repo-specific and workflow-specific relevance.
+
+Examples:
+- implement a bounded change in `hello_squad`
+- repair a known seeded regression
+- produce a valid PRD section from a seeded feature brief
+- classify defects into the right capability / task class
+- regenerate a design artifact that matches a golden source
+- update a contract and propagate required fixture/test changes
+- complete a small DDD / Hex scaffold change without boundary violations
+
+Purpose:
+- assess what matters in SquadOps specifically
+- avoid overfitting to generic public tasks
+- test architecture and artifact quality expectations
+
+### Layer 3: Live cycle assessment
+Used to score real execution.
+
+Examples:
+- pass / fail
+- first-pass quality
+- retries
+- escalation count
+- rework needed
+- QA rejection rate
+- cost
+- latency
+- memory retrieval usefulness
+- downstream breakage
+- golden-source delta quality
+
+Purpose:
+- reveal how the system performs under real operating conditions
+
+---
+
+## Proposed SquadOps Role-to-Benchmark Map
+
+### Neo / Dev
+Primary external:
+- SWE-bench Verified
+- Aider Polyglot
+Secondary external:
+- HumanEval
+- MBPP
+Primary internal:
+- repo issue repair tasks
+- scaffold extension tasks
+- contract change propagation tasks
+- golden-source reproduction checks
+
+### Data / Tool Executor
+Primary external:
+- BFCL
+- τ-bench
+Primary internal:
+- tool routing tasks
+- API sequencing tasks
+- schema extraction and transformation tasks
+- evidence gathering with structured output tasks
+
+### Research / Analyst
+Primary external:
+- BrowseComp
+- GAIA
+Primary internal:
+- vendor comparison tasks
+- standards / policy evidence lookup
+- research synthesis with source-grounded output
+- architecture precedent lookup
+
+### UI Walker / Product Operator
+Primary external:
+- WebArena
+- VisualWebArena
+Primary internal:
+- product walkthrough tasks
+- guided-tour tasks
+- click-path verification
+- UI-state validation tasks
+
+### Lead / Strategy / Product / Architecture
+Primary external:
+- partial only; GAIA or TheAgentCompany may provide some signal, but not enough by themselves
+Primary internal:
+- PRD scoring
+- decomposition scoring
+- acceptance criteria completeness
+- architecture review pass rate
+- downstream rework introduced vs prevented
+- handoff quality
+- decision trace quality
+- requirement coverage and ambiguity reduction
+
+### QA
+Primary external:
+- partial overlap with coding and tool benchmarks, but no single public benchmark really captures deep QA judgment
+Primary internal:
+- seeded defect detection
+- regression identification
+- contract drift detection
+- test adequacy review
+- artifact completeness checks
+- golden-source variance review
+
+---
+
+## Proposed Cycle Assessment Scorecard
+
+Each cycle should produce a scorecard with both absolute and diagnostic measures.
+
+### Scorecard dimensions
+
+#### 1. Outcome Score
+Did the cycle accomplish the objective?
+- complete success
+- partial success
+- failure
+- blocked / invalid task setup
+
+#### 2. Quality Score
+How good was the output?
+- tests passed
+- artifact completeness
+- conformance to contract
+- architectural correctness
+- review acceptance
+- defect escape rate
+
+#### 3. Efficiency Score
+How expensive and noisy was the path?
+- number of turns
+- retries
+- rewinds
+- escalations
+- latency
+- token / dollar cost
+
+#### 4. Memory Score
+Did memory help?
+- relevant rules retrieved
+- rules followed vs ignored
+- rule usefulness correlation
+- new repeated failure class observed
+- candidate new MemoryRule detected
+
+#### 5. Routing Score
+Was the chosen model/agent path appropriate?
+- underpowered model selected
+- overpowered model selected
+- escalation justified or avoidable
+- handoff sequence appropriate or wasteful
+
+#### 6. Stability Score
+Did the result hold up downstream?
+- regression introduced
+- downstream task breakage
+- follow-on correction required
+- golden-source deviation severity
+
+#### 7. Benchmark Alignment Score
+How does live performance compare to expected role capability?
+- below expected
+- on profile
+- above expected
+
+This is especially useful when comparing a role’s live results against:
+- recent external benchmark standing
+- recent internal eval standing
+- recent cycle trend
+
+---
+
+## Example Cycle Assessment Artifact
+
+```yaml
+kind: CycleAssessment
+uid: cycle-assessment-0042
+cycle_uid: cycle-0042
+task_uid: task-1284
+role: dev
+agent: neo
+model: qwen-coder-32b
+assessment_window: single_cycle
+
+scores:
+  outcome: 0.85
+  quality: 0.78
+  efficiency: 0.61
+  memory: 0.73
+  routing: 0.54
+  stability: 0.80
+  benchmark_alignment: 0.58
+
+telemetry:
+  retries: 3
+  escalations: 1
+  rewinds: 1
+  qa_rejections: 1
+  tests_passed_ratio: 0.92
+  token_cost_usd: 1.84
+  wall_clock_minutes: 21
+
+memory_observations:
+  retrieved_rules:
+    - mem-rule-0042
+    - mem-rule-0118
+  likely_helpful:
+    - mem-rule-0042
+  ignored_or_violated:
+    - mem-rule-0118
+  candidate_new_rule: true
+
+diagnostics:
+  dominant_failure_mode: contract_drift
+  likely_cause: insufficient_boundary_validation
+  benchmark_gap_signal: moderate
+
+recommendations:
+  - type: memory_update
+    priority: high
+    action: draft_new_rule_from_contrastive_rca
+  - type: routing_change
+    priority: medium
+    action: escalate earlier for multi-boundary contract changes
+  - type: model_comparison
+    priority: medium
+    action: compare against claude-sonnet and gpt-coder on same internal task pack
+```
+
+---
+
+## Recommendation Categories
+
+The assessment layer should not just score. It should recommend.
+
+### 1. Memory Update Recommendation
+Use when:
+- a repeated failure class appears
+- a contrastive RCA reveals a reusable invariant
+- memory was absent, weak, or mis-scoped
+
+Examples:
+- create new MemoryRule
+- strengthen existing rule
+- split an over-broad rule
+- retire stale rule
+- add role or environment scope
+
+### 2. Prompt / Instruction Tuning Recommendation
+Use when:
+- failures appear procedural rather than capability-bound
+- the model is strong enough, but instructions underconstrain the behavior
+- consistent formatting or verification steps are missing
+
+Examples:
+- require explicit contract validation step
+- require artifact completeness checklist
+- add role-specific verification language
+- tighten “done means done” criteria
+
+### 3. Routing Policy Recommendation
+Use when:
+- the wrong model was chosen for task complexity
+- escalation happened late and wasted cycles
+- a specialist should have been used earlier
+- a weaker model handled the task fine and premium usage was unnecessary
+
+Examples:
+- escalate immediately for repo-wide refactors
+- keep small model for local bounded edits
+- route policy-sensitive tool tasks through a tool-strong model
+- use browser-specialized path for research tasks
+
+### 4. Model Comparison Recommendation
+Use when:
+- live cycle results are below expected profile
+- two models may be close in cost but far apart in value
+- a new model candidate should be tested
+
+Examples:
+- run same eval pack across three models
+- compare first-pass quality and correction cost
+- compare memory sensitivity by model family
+
+### 5. Tuning / Configuration Recommendation
+Use when:
+- failures are tied to context assembly, retrieval, or decoding policy
+- task classification is weak
+- memory retrieval is noisy
+- iteration limits or tool policies are poorly set
+
+Examples:
+- reduce retrieval count
+- change task classifier granularity
+- increase tool validation strictness
+- alter max-turn or rewind threshold
+- improve fixture diff presentation
+
+### 6. No Change Recommendation
+Use when:
+- failure came from invalid task setup
+- benchmark evidence and cycle history do not support intervention
+- issue appears isolated and non-recurring
+
+This is important. Not every failure should trigger system mutation.
+
+---
+
+## Decision Logic for Recommendations
+
+The recommendation layer should reason roughly like this:
+
+### Memory change likely
+When:
+- repeated failure class
+- clear contrastive lesson
+- same class improves when guidance is present
+- issue is not mainly raw model capability
+
+### Model / routing change likely
+When:
+- benchmark gap is persistent
+- internal evals show consistent underperformance
+- failures persist even with appropriate memory and prompt policy
+- escalation repeatedly rescues the same task class
+
+### Prompt / instruction change likely
+When:
+- failures are procedural
+- benchmark capability is adequate
+- the agent omits required steps rather than lacks underlying ability
+
+### Internal eval expansion likely
+When:
+- the failure matters a lot in SquadOps but is not represented in the current eval pack
+- a role has weak public benchmark coverage
+- there is a recurring repo-specific failure mode
+
+---
+
+## Internal SquadOps Eval Design
+
+Because many high-value roles are weakly benchmarked publicly, SquadOps should create its own eval packs.
+
+### Suggested internal eval classes
+
+#### Dev evals
+- bounded code fix
+- contract evolution propagation
+- DDD boundary preservation
+- Hex adapter refactor
+- seeded regression repair
+- golden-source rebuild
+
+#### QA evals
+- find seeded defect
+- detect missing tests
+- identify contract drift
+- detect architecture boundary violation
+- score artifact completeness
+
+#### Strategy / Product evals
+- transform feature brief into structured PRD section
+- generate acceptance criteria
+- identify ambiguity and missing decisions
+- decompose initiative into tasks without leakage or omission
+
+#### Architecture evals
+- evaluate design against capability contracts
+- identify wrong dependency direction
+- propose bounded-context placement
+- review change for cross-layer leakage
+
+#### Research evals
+- collect evidence for vendor / standard comparison
+- summarize findings into structured decision memo
+- verify claim grounding
+- identify missing evidence
+
+### Scoring approach
+Internal evals should be scored with a mix of:
+- deterministic checks where possible
+- golden-source comparison
+- rubric scoring
+- downstream pass/fail effects
+- review acceptance
+
+---
+
+## Benchmark-Driven Model Comparison
+
+A useful function of the system is to compare models under the same role and harness.
+
+### Suggested comparison dimensions
+- external benchmark fit for the role
+- internal eval pack score
+- live cycle quality
+- cost per successful completion
+- escalation rate
+- memory sensitivity
+- correction burden after first pass
+- stability of outputs over repeated runs
+
+### Why this matters
+A model that looks great on a public leaderboard may still be a poor fit if:
+- it ignores your structure
+- it is expensive relative to its gains
+- it performs poorly with your retrieval strategy
+- it generates unstable outputs on your repo tasks
+
+Likewise, a smaller model may be excellent if:
+- it performs well on your bounded internal tasks
+- memory closes the gap enough
+- its correction burden is low
+- cost-adjusted throughput is much better
+
+---
+
+## Memory Effectiveness Measurement
+
+This idea should explicitly connect to collaborative memory.
+
+### Questions to answer
+- Did memory improve first-pass success?
+- Did memory reduce retries or turns?
+- Did memory reduce escalations?
+- Did memory reduce repeated failure classes?
+- Which rules actually help by task class?
+- Which rules are stale or noisy?
+
+### Useful measurements
+- success delta with vs without memory on same eval class
+- cycle efficiency delta after rule introduction
+- rule retrieval frequency
+- rule helpfulness correlation
+- rule violation frequency
+- task-class-level failure reduction after rule activation
+
+### Resulting actions
+- promote rule to active
+- narrow rule scope
+- split rule by task class
+- retire rule
+- change retrieval ranking
+- improve task classification
+
+---
+
+## Proposed Architecture
+
+### 1. Benchmark Registry
+A structured registry of:
+- role
+- benchmark name
+- benchmark type
+- external/internal
+- scope notes
+- harness location
+- scoring method
+- cadence
+- owner
+
+Example:
+```yaml
+kind: BenchmarkRegistryEntry
+uid: benchmark-entry-neo-swebench
+role: dev
+benchmark: swe_bench_verified
+type: external
+purpose:
+  - model_selection
+  - regression_tracking
+harness: evals/external/swe_bench_verified
+cadence: on_demand
+owner: eval
+notes:
+  - "best external fit for repo issue resolution role"
+```
+
+### 2. Eval Harness Layer
+Runs:
+- external benchmark subsets where practical
+- internal task packs
+- comparison runs across candidate models
+
+### 3. Cycle Assessment Layer
+Consumes:
+- task telemetry
+- validation results
+- review outcomes
+- memory retrieval logs
+- routing and escalation data
+
+### 4. Recommendation Engine
+Generates:
+- memory update proposals
+- routing changes
+- prompt changes
+- model comparison jobs
+- model replacement recommendations
+- no-change outcomes
+
+### 5. Feedback Layer
+Routes approved changes into:
+- MemoryRule registry
+- prompt templates
+- routing policy
+- model config
+- eval pack expansion
+- release readiness reporting
+
+---
+
+## v1.1 Design
+
+### v1.1 components
+- `BenchmarkRegistry` schema
+- `CycleAssessment` schema
+- manual scorecard workflow
+- internal eval pack starter set
+- role-to-benchmark mapping
+- recommendation taxonomy
+- RCA integration
+- MemoryRule proposal handoff
+
+### v1.1 operating mode
+- human-reviewed
+- squad-assisted analysis
+- low automation risk
+- clear evidence trails
+- no automatic production model swapping
+
+### v1.1 initial supported roles
+Recommended first wave:
+- Dev
+- QA
+- Research
+- Tool Executor
+
+These have the clearest starting eval paths.
+
+---
+
+## v1.2 Design
+
+### v1.2 extensions
+- scheduled benchmark jobs
+- historical trend tracking
+- model tournament runs by role
+- memory effectiveness dashboards
+- routing recommendation confidence scores
+- release gating policies tied to eval thresholds
+- automatic candidate recommendation drafting
+- environment-specific eval profiles
+- per-role health dashboards
+
+### v1.2 possible advanced features
+- benchmark slices by task class
+- benchmark-conditioned model routing
+- eval-triggered warm boot recommendations
+- automated drift alerts when a role degrades
+- confidence-weighted recommendation ranking
+
+---
+
+## Repo / Package Implications
+
+Potential areas:
+- `squad_ops/evals/`
+- `squad_ops/benchmarks/`
+- `squad_ops/cycle_assessment/`
+- `squad_ops/recommendations/`
+- `squad_ops/memory/`
+- `docs/ideas/`
+- `docs/evals/`
+
+Possible modules:
+- `benchmark_registry.py`
+- `cycle_assessment_schema.py`
+- `cycle_scorer.py`
+- `recommendation_engine.py`
+- `model_comparison_runner.py`
+- `memory_effectiveness.py`
+- `internal_eval_pack.py`
+
+---
+
+## Risks
+
+- overfitting to public benchmarks
+- false confidence from synthetic evals
+- too much scoring complexity early
+- weak rubric consistency for subjective roles
+- noisy recommendations
+- benchmark costs becoming excessive
+- automation pressure leading to premature model churn
+- treating benchmark rank as more important than actual SquadOps task success
+
+---
+
+## Mitigations
+
+- use a hybrid eval stack rather than a single benchmark
+- keep internal evals tightly tied to SquadOps reality
+- require evidence-backed recommendations
+- preserve a no-change path
+- cap benchmark scope in v1.1
+- start with manual review of recommendations
+- separate experimental changes from active routing policy
+- measure live cycle performance alongside benchmark results
+
+---
+
+## Open Questions
+
+- Should benchmark results be role-level only, or tracked by agent + model + workload profile?
+- How should internal eval packs be versioned as the architecture evolves?
+- Should MemoryRule usefulness be measured at rule level, bundle level, or task-class level?
+- Should release gating use absolute thresholds or trend thresholds?
+- How should subjective artifact scoring be normalized across reviewers?
+- Should benchmark cadence be scheduled, event-driven, or both?
+- How much of model comparison should be run locally vs remotely?
+- Should the eval system be able to trigger a recommendation to expand the internal eval pack itself?
+
+---
+
+## Recommendation
+
+Target this as:
+- **v1.1**: benchmark registry, cycle scorecard, internal eval pack starter set, and evidence-based recommendation outputs
+- **v1.2**: automated benchmark operations, trend analytics, memory effectiveness measurement, and stronger routing/model recommendations
+
+This is a strong companion idea to collaborative memory distillation. Together, they form a cleaner operating loop:
+
+1. evaluate role capability  
+2. assess real cycle execution  
+3. run RCA on failures  
+4. decide whether to change memory, prompts, routing, or models  
+5. verify the change with evals and future cycle performance  
+
+That would give SquadOps a much more defensible path toward becoming a measurable force multiplier rather than a collection of interesting agent behaviors.
+
+---
+
+## Suggested Next Follow-On Artifacts
+1. SIP: Benchmark Registry and Cycle Assessment subsystem
+2. BenchmarkRegistry schema spec
+3. CycleAssessment schema spec
+4. internal eval pack design for first-wave roles
+5. recommendation engine decision matrix
+6. MemoryRule effectiveness measurement addendum
+
+---
+
+## Reference Notes on Public Benchmarks Considered
+The following benchmark families were considered for role mapping in this idea:
+- SWE-bench / SWE-bench Verified
+- HumanEval
+- MBPP
+- Aider Polyglot
+- BFCL
+- BrowseComp
+- GAIA
+- WebArena / VisualWebArena
+- TheAgentCompany
+- τ-bench

--- a/docs/ideas/IDEA-collaborative-memory-distillation-v1.1-v1.2.md
+++ b/docs/ideas/IDEA-collaborative-memory-distillation-v1.1-v1.2.md
@@ -1,0 +1,406 @@
+# IDEA: Collaborative Memory Distillation for SquadOps
+## Target Release: v1.1 / v1.2
+
+### Status
+Draft
+
+### Owner
+Strategy / Architecture
+
+### Summary
+Introduce a collaborative memory layer for SquadOps that distills reusable execution guidance from contrasted task trajectories rather than relying primarily on raw episodic history. The goal is to improve cross-agent reuse, reduce repeated failure modes, and increase cycle efficiency across heterogeneous models and roles.
+
+This idea is inspired by the principle that shared memory is most reusable when it captures task-level invariants and failure-prevention rules, not the stylistic reasoning patterns of any one agent.
+
+### Problem
+Current or likely default memory patterns in agent systems tend to over-index on raw traces:
+- full cycle transcripts
+- tool call history
+- prompt/response logs
+- per-agent local notes
+- artifact snapshots without normalized lessons
+
+Those are useful for audit, debugging, and replay, but they are noisy as a primary reasoning substrate. In a heterogeneous squad, naive reuse of one agent’s trace-derived memory can carry agent-specific bias, local heuristics, and non-transferable reasoning habits.
+
+For SquadOps, this creates several risks:
+- repeated recurrence of the same failure class across cycles
+- weak transfer of lessons between agents, roles, and model families
+- prompt bloat from over-retrieving low-signal history
+- unnecessary escalation to larger models
+- excess Dev ↔ QA churn
+- reduced value from RCA if lessons remain trapped in prose instead of normalized reusable guidance
+
+### Opportunity
+SquadOps can introduce a higher-order memory layer that transforms execution experience into compact, reusable MemoryRules. These rules would be generated through contrastive analysis of:
+- failed vs successful task executions
+- weaker-model attempt vs stronger-model correction
+- pre-fix vs post-fix code paths
+- QA-rejected vs QA-accepted outputs
+- rebuilt output vs golden-source output
+- regression-introducing change vs stabilized correction
+
+The resulting memory would not store “how one agent happened to think,” but rather:
+- when a class of situation is present
+- what must be enforced
+- what must be avoided
+- what evidence supports the rule
+- where the rule applies
+
+### Core Idea
+Add a collaborative memory distillation subsystem that produces normalized MemoryRules from contrastive RCA and routes those rules into future cycles using task-aware retrieval.
+
+In practical terms:
+
+1. SquadOps continues to preserve episodic execution history for replay and audit.
+2. RCA or validation workflows compare good and bad trajectories for the same or similar task class.
+3. A distillation step extracts reusable constraints.
+4. Those constraints are stored in a structured memory registry.
+5. Future tasks are classified before execution.
+6. Only the most relevant high-confidence rules are injected into the active cycle context.
+
+### Why This Fits SquadOps
+This idea aligns strongly with existing SquadOps direction:
+- RCA is already a key protocol
+- golden-source validation already implies contrastive comparison
+- heterogeneous model routing is a core assumption
+- Pulse / quality gates already produce evidence that can feed memory distillation
+- Capability Contracts give a natural scoping layer for memory applicability
+- force-multiplier positioning benefits from reducing rework, not just increasing raw autonomy
+
+### Goals
+- Improve cross-agent reuse of lessons learned
+- Reduce recurrence of known failure modes
+- Improve first-pass quality of work products
+- Reduce turns, retries, and escalation frequency
+- Keep memory prompts compact and high-signal
+- Make RCA outputs operationally reusable
+- Preserve separation between audit memory and reasoning memory
+
+### Non-Goals
+- Replacing episodic memory, logs, or artifact history
+- Storing private chain-of-thought style transcripts as the primary reusable memory object
+- Building a universal memory system for all domains in v1
+- Fully autonomous memory mutation without verification
+- Solving long-term knowledge management for arbitrary user content
+
+### Release Framing
+This idea is best treated as a staged capability across v1.1 and v1.2.
+
+#### v1.1 focus
+Introduce the minimum viable collaborative memory foundation:
+- MemoryRule artifact definition
+- manual or semi-automated distillation from RCA outcomes
+- task classification + filtered retrieval
+- prompt injection of top-N relevant rules
+- basic feedback logging on rule usefulness
+
+#### v1.2 focus
+Expand into adaptive memory operations:
+- automated contrastive extraction pipelines
+- confidence scoring and decay
+- rule merge / split / supersession workflows
+- stronger retrieval ranking
+- broader integration with warm boot, golden-source validation, and model routing
+- analytics on memory contribution to cycle success
+
+### Proposed Architecture
+
+#### 1. Memory Layers
+SquadOps should explicitly separate three memory layers:
+
+##### Episodic Memory
+Stores raw execution history:
+- tasks
+- cycles
+- messages
+- tool outputs
+- artifacts
+- environment snapshots
+- validation logs
+
+Purpose:
+- replay
+- audit
+- debugging
+- RCA source material
+
+##### Operational Memory
+Stores environment and system facts:
+- repo topology
+- active contracts
+- adapter mappings
+- dependency state
+- deployment profile facts
+- known runtime capabilities
+- open defects / workstream state
+
+Purpose:
+- execution grounding
+
+##### Collaborative Reasoning Memory
+Stores distilled reusable guidance:
+- invariants
+- forbidden patterns
+- trigger conditions
+- recommended enforcement steps
+- applicability metadata
+- evidence references
+
+Purpose:
+- future execution guidance
+
+This idea concerns the third layer.
+
+#### 2. New Artifact: MemoryRule
+Introduce a canonical structured artifact to represent distilled execution guidance.
+
+Suggested baseline shape:
+
+```yaml
+kind: MemoryRule
+uid: mem-rule-0001
+status: active
+domain: squad_ops
+scope:
+  capability: implementation.execution
+  task_class: adapter_contract_change
+  roles:
+    - dev
+    - qa
+  environments:
+    - local
+    - aws
+trigger: "When modifying an adapter boundary used by more than one workload"
+enforce:
+  - "update contract tests before merge"
+  - "validate downstream schema compatibility against fixtures"
+avoid:
+  - "changing payload shape without fixture regeneration"
+  - "treating integration coverage as sufficient contract validation"
+evidence:
+  source_type: contrastive_rca
+  source_refs:
+    - task-1284
+    - cycle-77
+    - qa-run-443
+confidence: high
+freshness:
+  introduced_in: v1.1
+  last_validated_at: 2026-03-29
+supersedes: []
+tags:
+  - contract-drift
+  - adapter
+  - regression-prevention
+```
+
+### Distillation Model
+
+#### Contrast Sources
+The strongest initial sources for rule extraction in SquadOps are:
+
+1. Failed attempt vs successful correction  
+2. QA-rejected output vs QA-accepted revision  
+3. Warm rebuild vs golden source  
+4. Regression-causing change vs stabilized fix  
+5. Small-model draft vs large-model recovery  
+6. Human override vs original agent path
+
+#### Distillation Output
+Each extracted rule should answer:
+- what situation triggered the lesson?
+- what invariant needed to hold?
+- what anti-pattern caused failure?
+- what evidence proves the lesson?
+- where is the lesson applicable?
+
+#### Preferred Rule Format
+A normalized natural-language format is useful for both storage and prompt injection:
+
+**When [trigger], enforce [constraint or practice]; avoid [failure pattern].**
+
+Example:
+- When updating a message schema consumed by multiple workloads, enforce fixture-backed contract validation before integration testing; avoid assuming downstream compatibility from unit coverage alone.
+
+### Retrieval Strategy
+A key part of this idea is that retrieval should be task-aware before similarity-aware.
+
+#### Retrieval Flow
+1. Classify the current task
+2. Filter candidate MemoryRules by scope:
+   - domain
+   - capability
+   - task_class
+   - role
+   - environment
+3. Rank remaining candidates by:
+   - relevance
+   - confidence
+   - recency
+   - verified usefulness
+   - rule specificity
+4. Inject only the top few rules into the cycle
+
+#### Initial Guidance Budget
+Recommended initial budget:
+- top 3 rule bundles
+- each bundle contains 1–3 rules
+- deduplicate overlapping rules
+- enforce a strict token ceiling
+
+This protects the cycle from memory overloading and low-signal prompt stuffing.
+
+### Integration Points
+
+#### RCA Protocol
+RCA becomes a primary feeder for collaborative memory.
+Every meaningful failure investigation should be eligible to produce:
+- zero new rules
+- one refined rule
+- multiple rules if distinct failure mechanisms are found
+
+#### Pulse / Quality Gates
+Pulse checks can provide evidence:
+- rule followed / violated
+- pass / fail outcome
+- whether injected rule correlated with success
+
+#### Warm Boot / Golden Source
+Golden-source comparison is an excellent contrastive input:
+- generated artifact diverges from canonical reference
+- corrected artifact reveals enforceable invariants
+
+#### Capability Contracts
+Capability Contracts provide scoping anchors for rules:
+- task class
+- interface boundary
+- enforcement obligations
+- downstream dependencies
+
+#### Model Routing
+Collaborative memory can lower unnecessary premium-model invocation by:
+- improving first-pass outputs from smaller models
+- reducing retries
+- helping route escalation only when rule-guided execution still fails
+
+### Initial v1.1 Design
+For v1.1, keep this intentionally constrained.
+
+#### v1.1 Components
+- `MemoryRule` schema
+- `memory_rules/` registry
+- manual or assisted distillation workflow
+- task classification service
+- simple filtered retrieval
+- prompt assembly integration
+- rule feedback logging
+
+#### v1.1 Authoring Model
+Likely best as:
+- human-reviewed
+- squad-assisted
+- no silent self-writing into active memory
+
+This keeps the memory layer trustworthy while the patterns mature.
+
+#### v1.1 Example Flow
+1. Dev cycle fails contract compatibility downstream
+2. QA detects regression
+3. RCA compares failing and corrected paths
+4. Squad drafts one or more MemoryRules
+5. Human or Lead approves rule
+6. Rule enters active registry
+7. Future adapter-contract tasks retrieve that rule pre-execution
+
+### v1.2 Expansion
+v1.2 can extend the subsystem toward managed evolution.
+
+#### Candidate v1.2 Features
+- automated contrastive extraction jobs
+- rule scoring based on observed impact
+- rule conflict detection
+- supersession chains
+- confidence decay for stale rules
+- split / merge recommendations
+- role-specific views of shared rules
+- metrics dashboard for memory contribution
+- selective environment-specific rule packs
+- model-family sensitivity analysis
+
+### Proposed Repo / Package Implications
+Potential areas:
+- `squad_ops/memory/`
+- `squad_ops/memory_rules/`
+- `squad_ops/rca/`
+- `squad_ops/retrieval/`
+- `squad_ops/task_classification/`
+- `docs/ideas/`
+- `docs/architecture/`
+
+Possible modules:
+- `memory_rule_schema.py`
+- `memory_distiller.py`
+- `memory_registry.py`
+- `memory_retriever.py`
+- `task_classifier.py`
+- `memory_feedback.py`
+
+### Example Rule Categories for SquadOps
+Useful early classes of MemoryRules may include:
+
+- contract drift prevention
+- fixture regeneration requirements
+- adapter boundary discipline
+- dependency inversion preservation
+- test pyramid enforcement
+- migration sequencing
+- schema evolution safety
+- environment parity checks
+- idempotency handling
+- retry / timeout guardrails
+- task decomposition guidance
+- artifact completeness checks
+- golden-source delta review
+
+### Risks
+- low-quality rules may pollute future cycles
+- overly generic rules may become platitudes
+- overly specific rules may never retrieve again
+- automated extraction may infer false lessons
+- stale rules may outlive the architecture they describe
+- too many rules may increase prompt noise rather than reduce it
+- role-specific context may be lost if scoping is weak
+
+### Mitigations
+- require evidence references for every active rule
+- start with human-reviewed rule approval
+- enforce strict schema and scope fields
+- support confidence and validation timestamps
+- cap retrieval budget
+- track rule usefulness explicitly
+- allow retirement and supersession
+- separate active rules from experimental rules
+
+### Open Questions
+- Should MemoryRules live as standalone artifacts or as a section within RCA records plus a promoted registry view?
+- Should Nat own draft rule generation while Max owns retrieval and routing?
+- Should QA have veto authority on rule activation when evidence is weak?
+- Should rules be capability-scoped, workload-scoped, or both?
+- How should rules differ between local and cloud deployment profiles?
+- Should warm boot consume special golden-source rule packs?
+- Is there a useful distinction between “invariant rules” and “heuristic rules”?
+- How should rule usefulness be measured without overfitting to single cycles?
+
+### Recommendation
+Target this as:
+- **v1.1**: foundational collaborative memory with manual / assisted MemoryRule creation and task-aware retrieval
+- **v1.2**: adaptive and measurable collaborative memory evolution
+
+This is a strong fit for SquadOps because it converts RCA from a diagnostic activity into a reusable execution advantage. It also supports the broader SquadOps thesis that a trusted squad should improve output through structured coordination and learned operational discipline, not just through bigger models or larger context windows.
+
+### Suggested Next Follow-On Artifacts
+1. SIP: Collaborative Memory Distillation subsystem
+2. MemoryRule schema spec
+3. RCA addendum for rule extraction workflow
+4. Retrieval and routing design for task-aware memory injection
+5. metrics definition for memory effectiveness

--- a/docs/ideas/IDEA_telemetry_distillation_artifacts_for_run_analysis_v2.md
+++ b/docs/ideas/IDEA_telemetry_distillation_artifacts_for_run_analysis_v2.md
@@ -1,0 +1,482 @@
+# IDEA — Telemetry Distillation Artifacts for Run Analysis
+
+**Status:** Draft  
+**Date:** 2026-03-11  
+**Owner:** SquadOps Platform  
+
+---
+
+## 1. Summary
+
+This IDEA proposes introducing a **Telemetry Distillation capability** within SquadOps so that raw observability and orchestration signals can be converted into structured analysis artifacts during cycle wrap-up.
+
+The purpose of this capability is to ensure that telemetry from systems such as **OpenTelemetry (OTEL)**, **Prometheus**, **Langfuse**, and **Prefect** becomes usable as evidence during post-run review rather than remaining an overwhelming raw data dump.
+
+The recommended initial approach is to have the **Data role** produce telemetry summary artifacts as part of the **wrap-up workload**. These artifacts would then become part of the run bundle used by RAAP and related assessment protocols.
+
+This capability creates a cleaner path from:
+
+- raw traces, metrics, and orchestration run details
+- to structured telemetry evidence
+- to artifact assessment
+- to limiting-factor identification
+- to framework and protocol improvement recommendations
+
+---
+
+## 2. Intent
+
+The intent of this IDEA is to introduce a disciplined way for SquadOps to transform telemetry and orchestration state into **analysis-ready evidence artifacts**.
+
+This is not about replacing raw observability systems. It is about producing the right level of distilled evidence for post-run analysis so that reviewers can identify whether poor outcomes were caused by:
+
+- model limitations
+- prompt limitations
+- protocol limitations
+- framework limitations
+- resource limitations
+
+The goal is to make telemetry legible and comparable across runs.
+
+---
+
+## 3. Motivation
+
+Raw telemetry is extremely valuable, but it is usually too large, too noisy, and too low-level to hand directly to an LLM reviewer or to a human reviewer during comparative artifact analysis.
+
+Without distillation, several problems arise:
+
+- reviewers are overwhelmed by volume
+- important runtime patterns are buried inside traces and metrics
+- artifact quality may be judged incorrectly without operational context
+- limiting factors may be misattributed to the model when the runtime or orchestration was actually the problem
+- telemetry becomes archived rather than operationally useful
+
+SquadOps needs a way to convert runtime telemetry and orchestration behavior into compact evidence artifacts that preserve the meaningful signals while remaining readable and comparable.
+
+---
+
+## 4. Core Problem
+
+SquadOps generates artifacts, provenance, orchestration state, and runtime telemetry during a cycle run, but these evidence streams do not naturally exist at the same level of abstraction.
+
+Artifacts are readable outputs.  
+Telemetry is machine-oriented operational exhaust.  
+Flow-run state is orchestration-layer control evidence.
+
+For post-run assessment, these need to be reconciled.
+
+The problem is not merely storing telemetry. The problem is distilling telemetry and orchestration details into evidence that can help answer questions such as:
+
+- Where did the run spend time?
+- Where did retries occur?
+- Was the system under resource pressure?
+- Did context sizes inflate over time?
+- Were tool calls stable or thrashy?
+- Did prompt resolution or model invocation behavior degrade?
+- Did the orchestration layer stall, pause, retry, or route work poorly?
+- Was the framework itself the limiting factor?
+
+---
+
+## 5. Proposed Concept
+
+Introduce a **Telemetry Distillation step** in the wrap-up workload, initially owned by the **Data role**, that generates structured telemetry companion artifacts for each cycle run.
+
+This distillation step would consume selected telemetry and orchestration sources and produce summary artifacts that are easier to use during RAAP and related analysis workflows.
+
+Conceptually, the flow becomes:
+
+- cycle run executes
+- artifacts, raw telemetry, and orchestration run details are generated
+- wrap-up workload runs
+- Data distills those signals into summary artifacts
+- run bundle includes both output artifacts and telemetry evidence artifacts
+- RAAP or other review protocols consume the bundle
+
+This avoids forcing downstream reviewers to interpret raw telemetry directly.
+
+---
+
+## 6. Architectural Positioning
+
+Telemetry distillation should sit within the **wrap-up workload** rather than inside the live execution loop.
+
+This positioning is recommended because:
+
+- it avoids adding excessive complexity to active task execution
+- it keeps the real-time runtime focused on delivery
+- it allows telemetry and flow-run state to be summarized after the run has stabilized
+- it naturally aligns with evidence packaging and review preparation
+
+The initial implementation should therefore treat telemetry distillation as a **post-run evidence preparation step**.
+
+---
+
+## 7. Recommended Role Ownership
+
+The **Data role** is the most natural initial owner for this capability.
+
+Reasons:
+
+- telemetry interpretation is fundamentally an evidence and analysis concern
+- Data is already well positioned to assemble structured run evidence
+- Data can normalize telemetry and orchestration details from multiple sources into comparable artifacts
+- wrap-up is a natural place to produce evidence packaging outputs
+
+This does not prevent other roles from using the resulting artifacts, but Data should own the initial distillation responsibility.
+
+---
+
+## 8. Evidence Sources
+
+The initial telemetry inputs may include the following categories.
+
+### OpenTelemetry (OTEL)
+
+OTEL provides trace-oriented execution evidence such as:
+
+- workload timing
+- task timing
+- span failures
+- retries
+- tool call sequences
+- long pauses or bottlenecks
+
+This is especially useful for understanding execution flow and identifying where a cycle slowed down or failed.
+
+### Prometheus
+
+Prometheus provides resource and service metrics such as:
+
+- CPU utilization
+- memory pressure
+- GPU utilization where available
+- queue depth
+- error counts
+- service latency
+- throughput
+
+This is especially useful for identifying infrastructure or runtime pressure that may have constrained the run.
+
+### Langfuse
+
+Langfuse provides LLM interaction evidence such as:
+
+- model invocation counts
+- prompt version usage
+- token counts
+- latency per generation
+- trace linkage between prompts and outputs
+- prompt-related metadata
+
+This is especially useful for understanding prompt behavior, context growth, and model interaction quality during the cycle.
+
+### Prefect
+
+Prefect provides orchestration-layer evidence such as:
+
+- flow run identifiers
+- deployment and workload context
+- task run states
+- retries and retry timing
+- pauses, resumptions, or suspensions
+- cancellations
+- dependency behavior across task runs
+- failed task chains
+- longest-running task runs
+- manual intervention points where applicable
+
+This is especially useful for understanding whether the limiting factor was in task orchestration, retry policy, state handling, dependency design, or flow-run control behavior.
+
+---
+
+## 9. Telemetry Distillation Principles
+
+### 9.1 Distill, Do Not Dump
+
+The system should produce concise summary artifacts rather than handing raw telemetry dumps directly to reviewers.
+
+### 9.2 Preserve Drill-Down Paths
+
+Summary artifacts should retain references back to raw traces, metrics, flow runs, or run identifiers so that deeper investigation remains possible.
+
+### 9.3 Focus on Analysis Value
+
+Only include telemetry that helps answer meaningful run-analysis questions.
+
+### 9.4 Standardize Across Runs
+
+The same telemetry artifact types should be produced consistently so that runs can be compared over time.
+
+### 9.5 Support Limiting-Factor Attribution
+
+The distilled evidence should help reviewers distinguish between model, protocol, framework, and resource limitations.
+
+---
+
+## 10. Candidate Telemetry Companion Artifacts
+
+The following telemetry summary artifacts are recommended for the initial design.
+
+### Execution Timeline Summary
+
+This artifact should summarize the timing and flow of the run.
+
+Suggested signals:
+
+- total cycle duration
+- duration by workload
+- longest-running tasks
+- retry counts
+- failure spans
+- pause or stall windows
+- unusually long handoff delays
+
+This artifact supports bottleneck analysis and framework timing review.
+
+### LLM Invocation Summary
+
+This artifact should summarize model behavior across the run.
+
+Suggested signals:
+
+- total invocation count
+- model distribution
+- average and peak latency
+- prompt token totals
+- completion token totals
+- largest observed context sizes
+- prompt version usage by capability or workload
+
+This artifact supports prompt and model behavior review.
+
+### Retry and Failure Summary
+
+This artifact should summarize retry loops and failure patterns.
+
+Suggested signals:
+
+- total retry events
+- retry causes
+- repeated task failures
+- largest retry loops
+- timeout patterns
+- tool failure concentrations
+
+This artifact supports RCA and protocol-quality review.
+
+### Resource Envelope Summary
+
+This artifact should summarize the runtime pressure placed on the environment.
+
+Suggested signals:
+
+- average and peak CPU utilization
+- memory peaks
+- GPU utilization peaks
+- queue depth peaks
+- latency spike windows
+- contention periods during concurrent workloads
+
+This artifact supports resource-limitation analysis.
+
+### Tool Usage Summary
+
+This artifact should summarize tool behavior during the run.
+
+Suggested signals:
+
+- tool call counts
+- tool failure counts
+- repeated tool loops
+- filesystem activity volumes
+- test execution frequency
+- tool thrash patterns
+
+This artifact supports workflow efficiency and execution-discipline review.
+
+### Flow Run Summary
+
+This artifact should summarize the orchestration behavior of the run using Prefect flow-run and task-run details.
+
+Suggested signals:
+
+- flow run id
+- deployment or workload name
+- run start and end time
+- final flow-run state
+- task-run counts by state
+- retries by task
+- pause, suspend, resume, or cancellation events
+- failed task chain
+- longest-running task runs
+- orchestration anomalies
+- manual intervention points where applicable
+
+This artifact supports framework-limitation analysis by making it easier to distinguish model-quality problems from orchestration-control problems.
+
+---
+
+## 11. Recommended Output Form
+
+Each telemetry artifact should be compact, structured, and readable by both humans and LLM-based reviewers.
+
+The output should favor:
+
+- concise summaries
+- key metrics
+- notable anomalies
+- explicit references back to raw telemetry and flow-run sources where appropriate
+
+The goal is to produce telemetry evidence that is easy to compare across runs, not to mirror the full observability system.
+
+---
+
+## 12. Relationship to RAAP
+
+Telemetry distillation should be treated as a supporting evidence layer for RAAP.
+
+RAAP should continue to assess artifact quality, differences, and downstream impact, but telemetry companion artifacts should strengthen:
+
+- constraint attribution
+- limiting-factor analysis
+- improvement recommendations
+
+This is especially important when artifact quality is affected by runtime or orchestration behavior rather than by the model alone.
+
+Telemetry evidence should therefore be considered an optional but highly valuable input to RAAP.
+
+---
+
+## 13. Limiting-Factor Attribution Support
+
+Telemetry companion artifacts should help reviewers identify whether a limiting factor is best explained by:
+
+- model limitation
+- prompt limitation
+- protocol limitation
+- framework limitation
+- resource limitation
+- mixed or uncertain causes
+
+Examples:
+
+- repeated retry storms may indicate protocol or framework weakness
+- latency spikes during fan-out may indicate resource pressure
+- context inflation may indicate prompt or task-boundary issues
+- excessive tool loops may indicate framework or role-instruction weakness
+- repeated orchestration pauses or unhealthy task-state patterns may indicate flow design or retry-policy weakness
+
+This is one of the most important reasons to introduce telemetry distillation.
+
+---
+
+## 14. Improvement Recommendation Support
+
+The distilled telemetry artifacts should directly support better improvement recommendations after a run.
+
+Examples:
+
+- framework changes to reduce handoff delays
+- protocol changes to improve repair-loop behavior
+- prompt changes to reduce context growth
+- resource changes to avoid runtime contention
+- task-boundary changes to reduce thrash or retries
+- Prefect flow or retry-policy changes to reduce orchestration instability
+
+This moves analysis beyond artifact comparison and into continuous improvement of SquadOps itself.
+
+---
+
+## 15. Run Bundle Integration
+
+The run bundle for a completed cycle should be expanded to include telemetry companion artifacts alongside output artifacts and provenance.
+
+Conceptually, a run bundle may contain:
+
+- primary output artifacts
+- artifact provenance
+- prompt provenance
+- execution timeline summary
+- LLM invocation summary
+- retry and failure summary
+- resource envelope summary
+- tool usage summary
+- flow run summary
+
+This makes the run bundle much more suitable for external review systems such as RAAP, NotebookLM, or a future Cycle Analysis MCP Server.
+
+---
+
+## 16. Phased Approach
+
+### Phase 1 — Manual or Lightweight Distillation
+
+Produce a small number of telemetry companion artifacts during wrap-up using basic summarization logic and simple thresholds.
+
+### Phase 2 — Standardized Distillation Pipeline
+
+Introduce more disciplined extraction and summary rules so that telemetry artifacts are consistent across runs.
+
+### Phase 3 — Comparative Telemetry Analysis
+
+Support cross-run comparison of telemetry companion artifacts in RAAP and related review workflows.
+
+### Phase 4 — Native Analysis Workloads
+
+Allow Max or another analysis-oriented role to consume telemetry artifacts directly as part of formal analysis workloads.
+
+---
+
+## 17. Risks
+
+### Overproduction of Metrics
+
+Too many summary metrics can recreate the same overwhelm that raw telemetry caused in the first place.
+
+### Weak Summaries
+
+If the summary artifacts are too shallow, they may hide important limiting factors.
+
+### Inconsistent Distillation
+
+If the same run shape produces different summary formats, comparisons across runs will be weak.
+
+### Premature Complexity
+
+Trying to build a full observability analytics platform too early would distract from the core purpose of producing useful run-analysis artifacts.
+
+---
+
+## 18. Benefits
+
+A telemetry distillation capability would provide several benefits:
+
+- makes telemetry and orchestration evidence usable during post-run assessment
+- strengthens RAAP and other review protocols
+- improves limiting-factor identification
+- supports better framework and protocol improvement recommendations
+- reduces the risk of misattributing runtime or orchestration problems to the model alone
+- improves cross-run comparability
+- prepares SquadOps for more disciplined long-cycle analysis
+
+---
+
+## 19. Recommendation
+
+Proceed with a **Data-owned telemetry distillation step** in the wrap-up workload.
+
+Keep the initial implementation intentionally narrow and focused on a small set of high-value telemetry companion artifacts, including a **Flow Run Summary** derived from Prefect.
+
+Do not attempt to replace raw observability or orchestration systems. Instead, produce analysis-ready artifacts that preserve the important runtime and orchestration signals while remaining compact and comparable.
+
+---
+
+## 20. Closing Thought
+
+A strong orchestration framework should not only capture telemetry. It should make telemetry meaningful.
+
+Telemetry distillation is how SquadOps turns runtime exhaust and orchestration behavior into evidence.
+
+That evidence can then be used to judge run quality, identify limiting factors, and recommend how the framework and protocols should evolve before the next cycle.

--- a/docs/ideas/Mercenary_Agent_Model_IDEA.md
+++ b/docs/ideas/Mercenary_Agent_Model_IDEA.md
@@ -1,0 +1,142 @@
+# IDEA — Mercenary Agent Model (External Specialist Integration)
+
+## Context
+
+In evaluating the integration of OpenClaw into SquadOps, it is important to distinguish between:
+
+- core disciplined agents (aligned to SquadOps operating model)
+- external specialist agents (highly capable, but not aligned with governance)
+
+This IDEA proposes a classification:
+
+> OpenClaw should be treated as a “Mercenary Agent” — a bounded, external specialist capability — not a core SquadOps agent.
+
+---
+
+## Core Insight
+
+Some systems provide value precisely because they are optimized for a narrow objective, even if they:
+
+- do not follow SquadOps protocols
+- have their own runtime assumptions
+- do not align with governance or orchestration
+
+Attempting to deeply integrate such systems introduces:
+
+- abstraction conflicts
+- authority ambiguity
+- duplicated orchestration
+- fragility
+
+Instead, they should be explicitly constrained.
+
+---
+
+## Definition — Mercenary Agent
+
+A Mercenary Agent is:
+
+> an external, capability-rich system invoked for specific missions, not part of command structure.
+
+---
+
+## Characteristics
+
+- not part of squad hierarchy
+- no orchestration authority
+- not a system of record
+- no planning/governance role
+- strict interface boundary
+- scoped task invocation
+- outputs must be normalized
+
+---
+
+## When to Use
+
+- channel integrations (Slack, Discord, etc.)
+- local assistant behavior
+- rapid capability reuse
+- experimentation
+- edge-node interactions
+
+---
+
+## When NOT to Use
+
+- orchestration
+- planning/strategy
+- governance
+- memory ownership
+- long-running control loops
+
+---
+
+## Integration Model
+
+SquadOps Workload → Routing → Wrapper Agent → OpenClaw → Normalized Output → Evidence
+
+---
+
+## Guardrails
+
+### Input Boundaries
+- sanitize inputs
+- restrict scope
+
+### Output Normalization
+- structured output
+- metadata attached
+
+### No Direct Access
+- no memory / orchestration / registry access
+
+### Observability
+- logs, traceability, evidence
+
+### Revocability
+- removable without impact
+
+---
+
+## Architectural Positioning
+
+| Capability        | SquadOps | OpenClaw |
+|------------------|---------|----------|
+| Orchestration    | Yes     | No       |
+| Governance       | Yes     | No       |
+| Memory           | Yes     | No       |
+| Planning         | Yes     | No       |
+| Execution        | Yes     | Yes      |
+| Channels         | Optional| Strong   |
+
+---
+
+## Design Principle
+
+Do not let a powerful specialist redefine your architecture.
+
+---
+
+## Implementation Guidance
+
+- thin wrapper agent
+- llm=None
+- HTTP interface
+- capability: edge.openclaw.*
+- enforce timeouts and retries
+
+---
+
+## Strategic Value
+
+- fast experimentation
+- no tight coupling
+- replaceable integration
+- preserves system discipline
+
+---
+
+## One-Line Summary
+
+OpenClaw is best used as a mercenary: highly capable, tightly scoped, and never in command.

--- a/docs/ideas/SIP-Plutarch-Experimentation-and-Cycle-Assessment-Framework-v1.1-rev2.md
+++ b/docs/ideas/SIP-Plutarch-Experimentation-and-Cycle-Assessment-Framework-v1.1-rev2.md
@@ -1,0 +1,1275 @@
+# SIP-XXXX: Plutarch Experimentation and Cycle Assessment Framework
+## Target Release: v1.1
+
+### Status
+Proposed
+
+### Authors
+Strategy / Architecture
+
+### Type
+Platform Capability
+
+### Summary
+Introduce **Plutarch** as a first-class SquadOps capability for benchmark-driven experimentation, cycle assessment, failure diagnosis, and improvement recommendation.
+
+Plutarch is the governed **master experimenter** for SquadOps. Its purpose is to determine whether coordinated squads can outperform a single strong model on meaningful long-horizon software-building work, and to measure how individual-agent improvement translates into squad-level delivery improvement.
+
+This revised SIP is intentionally more implementation-specific than the earlier version. It does not only define Plutarch’s mission and evaluation model. It also defines the **supporting capabilities SquadOps itself must implement** in order for Plutarch to function.
+
+For v1.1, the proposal is to implement:
+- explicit observability contracts for cycles, agents, tools, memory, and artifacts
+- benchmark and internal eval registries
+- cycle and squad health assessment artifacts
+- failure diagnosis workflows and diagnostic categories
+- bounded experiment orchestration primitives
+- multi-model experiment lanes before, during, and after cycle runs
+- recommendation and remediation workflows
+- governance controls and approval boundaries
+
+The guiding principle is simple:
+
+**Plutarch cannot improve what SquadOps cannot observe, isolate, compare, and govern.**
+
+---
+
+## Motivation
+
+SquadOps is aiming toward a demanding long-horizon goal: a governed squad that can build meaningful app increments autonomously over an 8–10 hour run.
+
+That requires a disciplined way to answer:
+1. **Can coordinated squads outperform a single strong model on sustained software-building work?**
+2. **How does individual-agent improvement translate into squad-level improvement?**
+3. **When a cycle fails, what actually broke?**
+4. **When a squad underperforms, where is the real bottleneck?**
+5. **What intervention should happen next: memory update, prompt change, routing change, model comparison, configuration change, topology change, or no change?**
+
+Without a formal master experimenter capability, SquadOps risks:
+- relying on intuition instead of evidence
+- diagnosing symptoms rather than causes
+- overreacting to isolated failures
+- confusing local agent gains with real squad gains
+- spending premium inference without measured return
+- producing RCA that is descriptive but not operationally reusable
+
+Plutarch exists to close that gap.
+
+---
+
+## Problem Statement
+
+The earlier framing correctly described Plutarch’s strategic value, but it left a key implementation question under-specified:
+
+**What exact capabilities must SquadOps expose and implement so that Plutarch can actually design experiments, diagnose broken cycles, assess broken squads, and recommend credible improvements?**
+
+Without explicit support in the core framework, Plutarch would be reduced to a passive analyst with partial telemetry and weak intervention fidelity.
+
+That is not sufficient.
+
+To function as a real master experimenter, Plutarch needs:
+- full-cycle observability
+- agent-level and squad-level health signals
+- explicit failure diagnosis surfaces
+- comparable experiment setup and replay primitives
+- controlled access to eval harnesses, models, memory, routing, and artifact history
+- governed remediation and recommendation pathways
+
+This SIP proposes those support requirements as part of v1.1 scope.
+
+---
+
+## Goals
+
+### Primary Goals
+- Establish **Plutarch** as the governed master experimenter for SquadOps
+- Measure whether coordinated squads outperform a single strong model on long-horizon software-building work
+- Measure how individual-agent improvement translates into squad-level delivery improvement
+- Enable Plutarch to diagnose:
+  - broken cycles
+  - broken agents
+  - broken handoffs
+  - broken routing
+  - broken memory usage
+  - broken squad topology
+- Produce evidence-backed recommendations for:
+  - memory updates
+  - prompt/instruction changes
+  - routing changes
+  - model comparisons
+  - tuning/configuration changes
+  - reruns and isolation experiments
+  - squad topology changes
+  - no-change outcomes
+
+### Secondary Goals
+- Create a repeatable improvement loop for SquadOps
+- Improve confidence in long-run autonomous execution
+- Reduce wasted time and cost from poorly-targeted changes
+- Create a clean path from telemetry -> diagnosis -> experiment -> recommendation -> governed adoption
+
+---
+
+## Non-Goals
+
+- Fully autonomous self-modification in v1.1
+- Unreviewed production model swapping
+- Silent mutation of active routing or prompt policy
+- Treating public benchmarks as sufficient for all roles
+- Building a public benchmark platform
+- Replacing human strategic judgment
+- Letting Plutarch directly bypass governance controls
+
+---
+
+## Core Charter
+
+### Definition
+**Plutarch** is the governed master experimenter for SquadOps. It designs bounded experiments, observes cycle execution, diagnoses failures, evaluates comparative performance, and generates evidence-backed recommendations for continuous improvement.
+
+### Core Questions Owned
+1. Can squads outperform a single strong model?
+2. How does individual-agent improvement translate into squad improvement?
+3. What failed in a broken cycle?
+4. What failed in a broken squad?
+5. What change is most likely to improve future performance?
+
+### Core Principle
+Plutarch is not one model. It is an **experiment orchestration role** with governed access to different model-backed lanes and framework resources across planning, monitoring, diagnosis, and evaluation.
+
+---
+
+## Why v1.1
+
+This belongs in v1.1 because it improves the entire operating model of SquadOps without requiring unsafe autonomous mutation first.
+
+v1.1 should create the foundation:
+- observability contracts
+- artifact schemas
+- eval registries
+- diagnosis surfaces
+- experiment orchestration primitives
+- recommendation workflows
+- governance boundaries
+
+Later releases can add:
+- more automation
+- adaptive tuning
+- scheduled experiment cadences
+- stronger release gating
+- challenger lanes and tournament flows
+
+---
+
+# 1. Required Capabilities SquadOps Must Implement to Support Plutarch
+
+This section is the most important addition in this revision.
+
+Plutarch is only viable if SquadOps implements the following capability categories.
+
+## 1.1 Observability Capabilities
+
+Plutarch must have a complete and structured view of how a cycle executed.
+
+### Required implementation in SquadOps
+
+#### A. Cycle Graph Visibility
+SquadOps must expose:
+- cycle UID
+- task graph
+- dependency graph
+- execution order
+- task parent/child relationships
+- blocked/unblocked transitions
+- completion status transitions
+
+#### B. Event Timeline Visibility
+SquadOps must emit structured events for:
+- task started
+- task completed
+- task failed
+- handoff created
+- handoff accepted
+- handoff rejected
+- escalation triggered
+- rewind triggered
+- tool invoked
+- tool failed
+- model lane selected
+- memory bundle retrieved
+- validation started/completed
+- artifact generated/updated
+- approval requested/granted/denied
+
+#### C. Agent Execution Visibility
+For each agent step, SquadOps must preserve:
+- agent identity
+- role
+- model used
+- lane used
+- task context package ID
+- prompt/instruction template version
+- memory bundle IDs injected
+- tool calls made
+- outputs generated
+- validation outcomes
+- duration
+- token/cost telemetry
+
+#### D. Memory Retrieval Visibility
+SquadOps must record:
+- which MemoryRules or memory bundles were retrieved
+- why they were retrieved
+- task classification used
+- whether they were likely followed, ignored, or violated
+- whether the retrieval looked relevant or noisy
+
+#### E. Artifact and Diff Visibility
+SquadOps must preserve:
+- artifact versions
+- artifact diffs across attempts
+- generated code diffs
+- generated document diffs
+- test result deltas
+- golden-source comparison results where applicable
+
+#### F. Environment and Runtime Visibility
+SquadOps must record:
+- runtime profile used
+- environment (local/cloud)
+- repo/branch/worktree
+- dependency/environment version snapshot
+- failure in infra/tooling vs failure in reasoning/execution
+
+### Why this matters
+Without this, Plutarch cannot distinguish root cause from downstream symptom.
+
+---
+
+## 1.2 Diagnostic Capabilities
+
+Plutarch must be able to diagnose both a **broken cycle** and a **broken squad**.
+
+### Required implementation in SquadOps
+
+#### A. Failure Classification Framework
+SquadOps must support structured failure classification at minimum across:
+- task setup failure
+- dependency or prerequisite failure
+- prompt/instruction failure
+- memory miss
+- memory misuse
+- routing failure
+- model capability gap
+- tool failure
+- validation failure
+- handoff degradation
+- artifact incompleteness
+- architecture boundary violation
+- environment/config drift
+- budget exhaustion
+- coordination failure
+- topology failure
+
+#### B. First Failure vs Symptom Detection
+SquadOps must support identifying:
+- first failing node
+- first invalid handoff
+- first incorrect routing decision
+- first bad memory retrieval
+- first tool failure
+- first invalid artifact generation
+- downstream cascade effects
+
+#### C. Local vs Systemic Failure Analysis
+SquadOps must support distinguishing:
+- single-task failure
+- single-agent failure
+- repeated role-level failure
+- role interaction failure
+- squad-wide instability
+
+#### D. Broken Cycle Diagnosis
+Plutarch must be able to answer:
+- why this cycle failed
+- where the cycle first diverged
+- whether the failure was recoverable
+- whether retries were wasted
+- whether escalation timing was correct
+- whether memory or routing would likely have changed the outcome
+
+#### E. Broken Squad Diagnosis
+Plutarch must be able to answer:
+- which role is bottlenecking the squad
+- whether handoffs are degrading output quality
+- whether coordination overhead is too high
+- whether role boundaries are wrong
+- whether one agent’s improvement is being lost downstream
+- whether squad topology should change
+
+### Why this matters
+A broken cycle and a broken squad are not the same problem. v1.1 must make both diagnosable.
+
+---
+
+## 1.3 Experiment Orchestration Capabilities
+
+Plutarch must be able to run bounded, comparable experiments.
+
+### Required implementation in SquadOps
+
+#### A. Experiment Definition Primitive
+SquadOps must support an experiment object that includes:
+- experiment UID
+- hypothesis
+- target metric(s)
+- baseline config
+- challenger config
+- dataset/task pack
+- stop conditions
+- budget cap
+- time cap
+- governance level
+- result artifact links
+
+#### B. Supported Experiment Types
+v1.1 should explicitly support:
+- single strong model vs squad comparison
+- model A vs model B comparison for same role
+- memory on/off experiment
+- memory bundle A vs B experiment
+- routing policy A vs B experiment
+- prompt/instruction variant comparison
+- retry/escalation threshold comparison
+- single-agent substitution test
+- seeded failure replay
+- golden-source rebuild comparison
+- benchmark slice comparison
+
+#### C. Isolated Execution Surface
+SquadOps must support:
+- sandbox branch/worktree runs
+- isolated eval runs
+- non-production experiment lanes
+- replay of prior tasks or task packs
+- reproducible baseline/challenger comparison conditions
+
+#### D. Stop Conditions and Guardrails
+SquadOps must support:
+- max tokens
+- max cost
+- max wall-clock duration
+- max retries
+- max rewinds
+- allowed tools list
+- allowed mutation scope
+- required approval gates
+
+### Why this matters
+Plutarch should not run vague experiments. It should run bounded, comparable ones.
+
+---
+
+## 1.4 Resource Access Contracts
+
+Plutarch must have explicit governed access to the resources required to design and assess experiments.
+
+### Required implementation in SquadOps
+
+#### A. Benchmark Registry Access
+Plutarch must be able to:
+- read benchmark definitions
+- read benchmark scope notes
+- read harness locations
+- request benchmark execution
+- read benchmark result history
+
+#### B. Internal Eval Pack Access
+Plutarch must be able to:
+- read available eval packs
+- select eval packs by role/task class
+- request eval execution
+- compare results across runs
+
+#### C. Model Registry Access
+Plutarch must be able to:
+- read available models
+- read model tags/capabilities
+- read cost and lane restrictions
+- select from allowed models for experiments
+
+#### D. Routing Policy Access
+Plutarch must be able to:
+- read active routing policies
+- compare current vs candidate routing config
+- propose changes
+- run experiments under alternate routing policies
+
+#### E. Prompt/Instruction Registry Access
+Plutarch must be able to:
+- read active role prompts/instruction templates
+- compare versions
+- run bounded experiments with candidate variants
+- propose revisions
+
+#### F. Memory Registry Access
+Plutarch must be able to:
+- read MemoryRules and bundle definitions
+- inspect retrieval history
+- propose new rules or scope changes
+- run memory-related experiments
+
+#### G. RCA and Historical Assessment Access
+Plutarch must be able to:
+- read prior RCA artifacts
+- read prior CycleAssessments
+- read prior AgentImpactAssessments
+- detect recurring patterns over time
+
+#### H. Test and Validation Access
+Plutarch must be able to:
+- request tests
+- request validations
+- read results
+- compare pass/fail deltas between configurations
+
+### Why this matters
+Without resource contracts, Plutarch becomes an advisory concept instead of an executable system capability.
+
+---
+
+## 1.5 Recommendation and Remediation Capabilities
+
+Plutarch must not stop at diagnosis. It must be able to propose credible next actions.
+
+### Required implementation in SquadOps
+
+#### A. Recommendation Taxonomy
+SquadOps must support recommendation categories at minimum:
+- memory_update
+- prompt_update
+- routing_change
+- model_comparison
+- model_assignment_change
+- tuning_or_config_change
+- rerun_same_config
+- rerun_with_isolation
+- rerun_with_stronger_model
+- topology_review
+- no_change
+
+#### B. Recommendation Artifact
+SquadOps must support a recommendation artifact containing:
+- recommendation UID
+- source assessment(s)
+- hypothesis
+- expected impact
+- priority
+- confidence
+- resource implications
+- approval status
+- follow-on experiment link if needed
+
+#### C. Remediation Planning
+Plutarch must be able to propose:
+- rerun with same settings
+- rerun with isolated role change
+- rerun with memory patch
+- rerun with changed routing
+- rerun with stronger model
+- remove one suspect agent from the flow
+- add a validation gate
+- request new eval coverage for an uncovered failure mode
+
+### Why this matters
+The improvement loop is incomplete if Plutarch can only score and complain.
+
+---
+
+## 1.6 Governance Capabilities
+
+v1.1 must keep Plutarch governed.
+
+### Required implementation in SquadOps
+
+SquadOps must support:
+- experiment approval levels
+- recommendation approval workflow
+- distinction between experimental and active policies
+- audit trail for experiment execution
+- audit trail for recommendation promotion or rejection
+- budget ceilings per experiment
+- model lane restrictions
+- tool restrictions
+- mutation scope restrictions
+
+### Why this matters
+Plutarch in v1.1 must be recommendation-producing, not self-authorizing.
+
+---
+
+# 2. Architecture Overview
+
+Plutarch v1.1 consists of seven parts:
+
+1. Benchmark Registry
+2. Internal Eval Pack Framework
+3. Cycle Assessment Framework
+4. Squad Health and Agent Impact Assessment
+5. Failure Diagnosis Layer
+6. Experiment Orchestration Layer
+7. Recommendation and Governance Layer
+
+---
+
+## 2.1 Benchmark Registry
+
+A structured registry of role-aligned external and internal benchmarks.
+
+Purpose:
+- map roles to relevant evals
+- define benchmark intent and scope
+- record harness locations and execution policy
+- support consistent model and role comparison
+
+### Required artifacts
+- `BenchmarkRegistryEntry`
+- benchmark result history records
+
+---
+
+## 2.2 Internal Eval Pack Framework
+
+A registry and harness for SquadOps-native evaluation packs.
+
+Purpose:
+- cover roles with weak public benchmark coverage
+- evaluate repo-specific and architecture-specific work
+- provide reusable comparison packs for experiments
+
+### Required artifacts
+- `InternalEvalPack`
+- `InternalEvalCase`
+- `EvalRunResult`
+
+---
+
+## 2.3 Cycle Assessment Framework
+
+A scorecard for real production or sandbox cycles.
+
+Purpose:
+- assess whether an actual cycle succeeded
+- measure quality, efficiency, stability, memory usefulness, and routing fit
+- provide a normalized artifact for RCA and recommendations
+
+### Required artifact
+- `CycleAssessment`
+
+---
+
+## 2.4 Squad Health and Agent Impact Assessment
+
+A layer specifically focused on the relationship between local agent gains and squad-level gains.
+
+Purpose:
+- measure bottlenecks
+- measure handoff quality
+- measure force-multiplier roles
+- measure translation efficiency from individual improvement to squad improvement
+
+### Required artifacts
+- `AgentImpactAssessment`
+- `SquadHealthAssessment`
+
+---
+
+## 2.5 Failure Diagnosis Layer
+
+A structured diagnosis layer that operates over observability data.
+
+Purpose:
+- classify failure types
+- identify first failing node
+- detect local vs systemic issues
+- diagnose broken cycles
+- diagnose broken squads
+
+### Required artifact
+- `FailureDiagnosis`
+
+---
+
+## 2.6 Experiment Orchestration Layer
+
+A governed mechanism for baseline/challenger experiments.
+
+Purpose:
+- define experiments
+- run isolated comparisons
+- support ablations and substitutions
+- support stop conditions and budget controls
+
+### Required artifact
+- `ExperimentRun`
+
+---
+
+## 2.7 Recommendation and Governance Layer
+
+A layer that turns observations and diagnoses into governed next-step proposals.
+
+Purpose:
+- produce recommendation artifacts
+- rank interventions
+- support approval workflow
+- support adoption into active policy
+
+### Required artifacts
+- `ImprovementRecommendation`
+- `PromotionDecision`
+
+---
+
+# 3. Key Questions the Framework Must Support
+
+## 3.1 Can squads outperform one strong model?
+
+The baseline must not be weak.
+
+Plutarch should support comparison against:
+- single strong model
+- single strong model + tools
+- single strong model + memory
+- single strong model + orchestrated retries
+
+### Required comparison dimensions
+- completion rate
+- first-pass acceptance
+- accepted deliverables
+- defect rate
+- regression rate
+- cost per accepted task
+- throughput over an 8–10 hour window
+- architectural conformance
+- recovery behavior
+- long-run stability
+
+A squad is only “better” if it wins on meaningful weighted delivery outcomes, not because it generated more intermediate activity.
+
+---
+
+## 3.2 How does individual improvement translate into squad improvement?
+
+Plutarch must explicitly separate:
+
+### Local Improvement
+The agent itself improved on role-aligned work.
+
+### Systemic Improvement
+The squad produced better results because of that improvement.
+
+### Required measures
+- role benchmark delta
+- internal eval delta
+- first-pass quality delta
+- handoff acceptance delta
+- downstream correction burden delta
+- throughput delta
+- regression delta
+- completion delta
+
+### Required derived metrics
+- bottleneck index
+- handoff quality score
+- force multiplier score
+- translation efficiency
+
+This is the mechanism for deciding where limited tuning bandwidth should be spent.
+
+---
+
+# 4. Multi-Model Operating Pattern
+
+Plutarch should support different model-backed lanes at different phases.
+
+## 4.1 Before the Cycle
+Use stronger planning/evaluator lanes for:
+- experiment design
+- benchmark selection
+- hypothesis generation
+- risk framing
+- selecting baseline/challenger setups
+
+## 4.2 During the Cycle
+Use lower-cost or narrower lanes for:
+- telemetry monitoring
+- anomaly detection
+- threshold checks
+- narrow live interventions
+- bounded challenger runs in isolation
+
+## 4.3 After the Cycle
+Use stronger evaluator lanes for:
+- RCA support
+- contrastive analysis
+- recommendation generation
+- model comparison interpretation
+- adoption proposals
+
+## Policy rule
+Plutarch must use **policy-bounded model lanes**, not unrestricted model access.
+
+---
+
+# 5. Role-to-Benchmark Mapping
+
+Public benchmark fit varies by role.
+
+## Roles with stronger public benchmark alignment
+- Dev / implementation
+- tool executor / function caller
+- research / browsing
+- web UI operator
+- support / policy workflow
+
+## Roles with weaker public benchmark alignment
+- Lead
+- Strategy
+- Product
+- Architecture
+- QA in deeper judgment mode
+- orchestration and decomposition quality
+
+These require internal evals.
+
+### Initial map
+
+#### Dev / Neo
+External:
+- SWE-bench / SWE-bench Verified
+- HumanEval
+- MBPP
+- Aider Polyglot
+
+Internal:
+- bounded code fix
+- contract evolution propagation
+- DDD boundary preservation
+- Hex adapter refactor
+- seeded regression repair
+- golden-source rebuild
+
+#### Tool Executor / Data
+External:
+- BFCL
+- τ-bench
+
+Internal:
+- tool routing tasks
+- API sequencing
+- schema transformation
+- structured extraction tasks
+
+#### Research / Analyst
+External:
+- BrowseComp
+- GAIA
+
+Internal:
+- vendor comparison
+- standards lookup
+- architecture precedent lookup
+- evidence-grounded synthesis
+
+#### UI Walker / Product Operator
+External:
+- WebArena
+- VisualWebArena
+
+Internal:
+- product walkthrough
+- click-path verification
+- guided-tour tasks
+- UI-state validation
+
+#### QA
+External:
+- partial only; no single benchmark is sufficient
+
+Internal:
+- seeded defect detection
+- regression identification
+- contract drift detection
+- architecture boundary violation detection
+- artifact completeness review
+
+#### Strategy / Product / Architecture
+External:
+- partial generalist signal only
+
+Internal:
+- PRD generation quality
+- acceptance criteria completeness
+- ambiguity detection
+- decomposition quality
+- architecture review pass rate
+- boundary-placement correctness
+- downstream rework introduced vs prevented
+
+---
+
+# 6. Hybrid Eval Stack
+
+Plutarch should use three layers.
+
+## Layer 1: External Objective Benchmarks
+Purpose:
+- model selection
+- baseline capability comparison
+- role-model mismatch detection
+
+## Layer 2: Internal SquadOps Eval Packs
+Purpose:
+- evaluate repo-specific and architecture-specific work
+- assess the roles public benchmarks do not cover well
+
+## Layer 3: Live Cycle Assessment
+Purpose:
+- measure actual operating performance under real work
+
+The three together create a more honest improvement system than any one layer alone.
+
+---
+
+# 7. Required Artifact Model
+
+Below are the core artifacts v1.1 should implement.
+
+## 7.1 BenchmarkRegistryEntry
+```yaml
+kind: BenchmarkRegistryEntry
+uid: benchmark-entry-dev-swebench
+role: dev
+benchmark: swe_bench_verified
+type: external
+purpose:
+  - model_selection
+  - regression_tracking
+harness: evals/external/swe_bench_verified
+cadence: on_demand
+owner: eval
+notes:
+  - "best external fit for repo issue resolution style tasks"
+```
+
+## 7.2 CycleAssessment
+```yaml
+kind: CycleAssessment
+uid: cycle-assessment-0042
+cycle_uid: cycle-0042
+task_uid: task-1284
+role: dev
+agent: neo
+model: qwen-coder-32b
+assessment_window: single_cycle
+
+scores:
+  outcome: 0.85
+  quality: 0.78
+  efficiency: 0.61
+  memory: 0.73
+  routing: 0.54
+  stability: 0.80
+  benchmark_alignment: 0.58
+
+telemetry:
+  retries: 3
+  escalations: 1
+  rewinds: 1
+  qa_rejections: 1
+  tests_passed_ratio: 0.92
+  token_cost_usd: 1.84
+  wall_clock_minutes: 21
+```
+
+## 7.3 FailureDiagnosis
+```yaml
+kind: FailureDiagnosis
+uid: failure-diagnosis-0091
+cycle_uid: cycle-0042
+scope: cycle
+first_failing_node: task-1284
+failure_class: handoff_degradation
+local_vs_systemic: systemic
+dominant_cause: insufficient_boundary_validation
+symptoms:
+  - downstream_contract_mismatch
+  - qa_rejection
+likely_contributors:
+  - memory_rule_missing
+  - escalation_late
+confidence: medium
+```
+
+## 7.4 AgentImpactAssessment
+```yaml
+kind: AgentImpactAssessment
+uid: agent-impact-0017
+agent: neo
+role: dev
+window: release_v1_1_eval_window
+
+individual_delta:
+  external_benchmark_delta: 0.07
+  internal_eval_delta: 0.11
+  first_pass_quality_delta: 0.09
+
+squad_translation:
+  deliverable_quality_delta: 0.04
+  throughput_delta: 0.03
+  regression_delta: -0.02
+  handoff_acceptance_delta: 0.10
+
+derived:
+  bottleneck_index: 0.72
+  force_multiplier_score: 0.68
+  translation_efficiency: 0.44
+```
+
+## 7.5 SquadHealthAssessment
+```yaml
+kind: SquadHealthAssessment
+uid: squad-health-0003
+squad_uid: squad-main
+window: release_v1_1_eval_window
+
+health:
+  topology_health: medium
+  coordination_health: low
+  handoff_health: medium
+  stability_health: medium
+
+bottlenecks:
+  - qa
+  - dev_handoff
+
+signals:
+  repeated_rework: true
+  downstream_rejection_high: true
+  escalation_pattern_inefficient: true
+```
+
+## 7.6 ExperimentRun
+```yaml
+kind: ExperimentRun
+uid: experiment-0021
+hypothesis: "Routing contract-heavy changes to a stronger dev lane earlier will reduce rework."
+baseline_config: routing-policy-v3
+challenger_config: routing-policy-v3a
+task_pack: internal_eval_contract_changes
+budget_cap_usd: 15
+time_cap_minutes: 120
+stop_conditions:
+  - cost_cap
+  - regression_detected
+status: completed
+result_links:
+  - cycle-assessment-100
+  - cycle-assessment-101
+```
+
+## 7.7 ImprovementRecommendation
+```yaml
+kind: ImprovementRecommendation
+uid: improvement-rec-0048
+source_artifacts:
+  - cycle-assessment-0042
+  - failure-diagnosis-0091
+type: routing_change
+priority: medium
+confidence: medium
+expected_impact: reduce_contract_rework
+action: escalate_earlier_for_multi_boundary_contract_changes
+approval_status: pending
+```
+
+---
+
+# 8. Cycle Assessment Scorecard
+
+Every meaningful cycle should produce a `CycleAssessment`.
+
+## Dimensions
+- outcome
+- quality
+- efficiency
+- memory
+- routing
+- stability
+- benchmark alignment
+
+## Additional requirement
+v1.1 should also allow scorecard linkage to:
+- related failure diagnoses
+- related recommendations
+- related experiment runs
+- related memory proposals
+
+That creates traceability from execution to improvement.
+
+---
+
+# 9. Failure Diagnosis Model
+
+v1.1 must treat diagnosis as a first-class subsystem.
+
+## Required diagnosis questions
+- What failed first?
+- What failed later as a symptom?
+- Was the issue local or systemic?
+- Was the issue likely due to memory, prompt, routing, model capability, tooling, environment, or topology?
+- Was the failure recoverable?
+- Was recovery attempted well?
+- What is the most plausible next experiment to isolate the cause?
+
+## Required outputs
+- failure class
+- first failing node
+- local vs systemic classification
+- likely contributors
+- confidence
+- candidate remediation path
+
+---
+
+# 10. Recommendation Taxonomy
+
+The system should not only score. It should propose next actions.
+
+## Categories
+- memory_update
+- prompt_update
+- routing_change
+- model_comparison
+- model_assignment_change
+- tuning_or_config_change
+- rerun_same_config
+- rerun_with_isolation
+- rerun_with_stronger_model
+- topology_review
+- no_change
+
+## Important rule
+Every recommendation should point to:
+- supporting evidence
+- expected impact
+- confidence
+- approval requirement
+
+---
+
+# 11. What Must Be Implemented in SquadOps for v1.1
+
+This is the concrete implementation checklist.
+
+## 11.1 Telemetry and Eventing
+Implement:
+- structured cycle events
+- structured agent-step events
+- structured handoff events
+- structured escalation/rewind events
+- structured memory retrieval events
+- structured validation/test events
+- structured cost/time events
+
+## 11.2 Artifact Persistence
+Implement persistence for:
+- prompts/instruction template version references
+- memory bundle references
+- artifact versions and diffs
+- cycle assessments
+- failure diagnoses
+- agent impact assessments
+- squad health assessments
+- experiment runs
+- improvement recommendations
+
+## 11.3 Eval Infrastructure
+Implement:
+- benchmark registry
+- internal eval pack registry
+- first-wave internal eval harness
+- result history storage
+- model comparison execution surface
+
+## 11.4 Diagnosis Infrastructure
+Implement:
+- failure classification taxonomy
+- first-failing-node detection support
+- local vs systemic analysis support
+- broken cycle diagnostic workflow
+- broken squad diagnostic workflow
+
+## 11.5 Experiment Infrastructure
+Implement:
+- experiment definition object
+- baseline/challenger config support
+- isolated execution support
+- cost/time/stop controls
+- replay and seeded-failure execution support
+
+## 11.6 Model Lane Policy
+Implement:
+- planning lane definition
+- monitoring lane definition
+- evaluation lane definition
+- allowed models per lane
+- cost ceilings per lane
+- approval requirements per lane
+
+## 11.7 Recommendation Workflow
+Implement:
+- recommendation schema
+- recommendation review workflow
+- approval status tracking
+- promotion decision logging
+- linkage to MemoryRule proposal flow where applicable
+
+## 11.8 Historical Analysis Support
+Implement:
+- ability to query past assessments
+- ability to detect repeated failure classes
+- ability to detect trend regressions
+- ability to compare pre/post change outcomes
+
+---
+
+# 12. Rollout Plan
+
+## Phase 1 — Schema and Contracts
+- define all core artifact schemas
+- define observability contracts
+- define event taxonomy
+- define failure taxonomy
+
+## Phase 2 — First-Wave Infrastructure
+- benchmark registry
+- internal eval pack registry
+- telemetry persistence
+- cycle assessment generation
+
+## Phase 3 — Diagnosis and Experimentation
+- failure diagnosis workflow
+- experiment definition and execution support
+- isolated baseline/challenger runs
+
+## Phase 4 — Recommendation Layer
+- recommendation generation
+- recommendation review workflow
+- MemoryRule proposal handoff
+
+## Phase 5 — Agent and Squad Impact
+- agent impact assessment
+- squad health assessment
+- translation efficiency reporting
+
+---
+
+# 13. Success Criteria for v1.1
+
+Plutarch v1.1 is successful if it can:
+
+1. observe and reconstruct a full cycle execution with structured evidence
+2. diagnose at least the basic cause of a broken cycle
+3. produce a first-pass squad health assessment
+4. compare at least one squad configuration against at least one strong single-model baseline
+5. compare at least one role across at least two models under the same eval pack
+6. generate evidence-backed recommendations in the defined taxonomy
+7. identify at least one case where individual improvement did or did not translate into squad improvement
+8. do all of the above without autonomous mutation of active production policy
+
+---
+
+# 14. Risks
+
+- overbuilding the experiment system before the app-building loop is stable
+- generating too much telemetry with too little signal
+- false confidence from synthetic evals
+- noisy recommendations
+- overfitting to benchmark behavior
+- misclassifying local failures as systemic
+- high implementation overhead in v1.1
+
+---
+
+# 15. Mitigations
+
+- focus first on Dev, QA, Research, and Tool Executor roles
+- keep v1.1 recommendation-producing, not self-authorizing
+- start with a narrow first-wave artifact set
+- keep telemetry structured and purpose-driven
+- preserve a no-change path
+- use benchmark + internal eval + live cycle assessment together
+- build diagnosis around first-failing-node and repeated-failure logic
+
+---
+
+# 16. Alternatives Considered
+
+## 16.1 Keep the earlier higher-level SIP only
+Rejected because it does not specify the operational support Plutarch needs.
+
+## 16.2 Build Plutarch as a pure external sidecar analyst
+Rejected because it would lack sufficient access to internal state, experiments, and replay surfaces.
+
+## 16.3 Make Plutarch fully autonomous in v1.1
+Rejected because governance and trust risk is too high before the scoring and diagnosis system is proven.
+
+---
+
+# 17. Open Questions
+
+- Should `FailureDiagnosis` be generated automatically first, or drafted and then reviewed?
+- Which internal eval packs should be in the very first wave after Dev?
+- Should squad topology changes be recommendation-only in v1.1, or require a separate design review?
+- How should weighted scorecards be calibrated initially?
+- How much historical retention is needed for useful trend analysis without overcomplicating storage?
+- Should challenger lanes such as NemoClaw be explicitly deferred to v1.2, even if the extension points exist in v1.1?
+
+---
+
+# 18. Recommendation
+
+Accept this SIP for v1.1 with the explicit understanding that **Plutarch is not only an experiment idea but a supported system capability**.
+
+That means SquadOps must implement:
+- observability contracts
+- diagnostic artifacts
+- experiment primitives
+- registry access surfaces
+- recommendation workflows
+- governance boundaries
+
+Without those, Plutarch cannot reliably execute cycles, diagnose failures, or perform credible experiments.
+
+With those, Plutarch becomes a concrete path toward disciplined continuous improvement and toward the broader goal of sustained autonomous app building over long-horizon runs.
+
+---
+
+## Appendix A — Plutarch Identity
+
+**Name:** Plutarch  
+**Role:** Master Experimenter  
+**Mission:** Design bounded experiments, observe execution, diagnose failures, compare baselines, and recommend evidence-backed improvements to memory, prompts, routing, model assignment, and squad structure.
+
+**Primary Questions Owned:**
+1. Can squads outperform a single strong model?
+2. How does individual-agent improvement translate into squad improvement?
+3. What broke in this cycle or squad?
+4. What change is most likely to improve the next run?
+
+---
+
+## Appendix B — Short Charter
+
+**Plutarch measures whether coordinated specialization, memory, and governance allow SquadOps to outperform a single strong model in long-horizon autonomous app building, diagnoses what breaks when cycles or squads fail, and determines which changes produce the highest squad-level return.**


### PR DESCRIPTION
Tracks 8 idea/vision drafts that were living only in a local working copy under `docs/ideas/` — the recurring untracked-docs drift (same class the #335 pass swept for `sips/proposed`).

## What
Brings under version control:
- `ADDENDUM-Plutarch-Artifact-Schemas-and-Event-Taxonomy-v1.1.md`
- `IDEA-agent-intelligence-improvement-program.md`
- `IDEA-agent-squad-self-play-consensus-benchmark.md`
- `IDEA-benchmark-driven-cycle-assessment-v1.1-v1.2.md`
- `IDEA-collaborative-memory-distillation-v1.1-v1.2.md`
- `IDEA_telemetry_distillation_artifacts_for_run_analysis_v2.md`
- `Mercenary_Agent_Model_IDEA.md`
- `SIP-Plutarch-Experimentation-and-Cycle-Assessment-Framework-v1.1-rev2.md`

## Notes
- `docs/ideas/` is read-only reference material (per CLAUDE.md) — this is the vision corpus the 1.8 grading arc draws on, not active specs. No code, no `Closes`.
- "Plutarch" stays a **vision codename** here; the roadmap and evidence-arc plan name the capability functionally (cycle-evaluation scorecard).
- Screenshots (`docs/screenshots/*.png`) left untracked — binaries, not idea docs. Say the word if you want them tracked too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ