### PR TITLE
feat: capture request_profile at the cycle level (SIP-0096 provenance)

### DIFF
--- a/adapters/cycles/postgres_cycle_registry.py
+++ b/adapters/cycles/postgres_cycle_registry.py
@@ -57,8 +57,8 @@ class PostgresCycleRegistry(CycleRegistryPort):
                     "(cycle_id, project_id, created_at, created_by, prd_ref, "
                     "squad_profile_id, squad_profile_snapshot_ref, task_flow_policy, "
                     "build_strategy, applied_defaults, execution_overrides, "
-                    "expected_artifact_types, experiment_context, notes) "
-                    "VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)",
+                    "expected_artifact_types, experiment_context, notes, request_profile) "
+                    "VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)",
                     cycle.cycle_id,
                     cycle.project_id,
                     cycle.created_at,
@@ -73,6 +73,7 @@ class PostgresCycleRegistry(CycleRegistryPort):
                     list(cycle.expected_artifact_types),
                     json.dumps(cycle.experiment_context),
                     cycle.notes,
+                    cycle.request_profile,
                 )
         except asyncpg.UniqueViolationError as err:
             raise ValidationError(f"Cycle already exists: {cycle.cycle_id}") from err
@@ -464,6 +465,7 @@ class PostgresCycleRegistry(CycleRegistryPort):
             execution_overrides=overrides,
             expected_artifact_types=tuple(row["expected_artifact_types"] or []),
             experiment_context=experiment,
+            request_profile=row["request_profile"],
             notes=row["notes"],
             cancelled=row["cancelled"],
         )

--- a/infra/migrations/007_cycle_request_profile.sql
+++ b/infra/migrations/007_cycle_request_profile.sql
@@ -1,0 +1,8 @@
+-- 007_cycle_request_profile.sql
+-- SIP-0096 run-config provenance: capture the cycle-request-profile name a cycle was
+-- created from. This is a cycle-level config attribute (all runs of a cycle share it),
+-- recorded so the 1.8 cycle-evaluation scorecard can attribute outcomes to config.
+-- All DDL is idempotent.
+
+ALTER TABLE cycle_registry
+    ADD COLUMN IF NOT EXISTS request_profile TEXT;

--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -146,6 +146,7 @@ async def create_cycle(
             execution_overrides=body.execution_overrides,
             expected_artifact_types=tuple(body.expected_artifact_types),
             experiment_context=body.experiment_context,
+            request_profile=body.request_profile,
             notes=body.notes,
         )
 

--- a/src/squadops/api/routes/cycles/dtos.py
+++ b/src/squadops/api/routes/cycles/dtos.py
@@ -41,6 +41,7 @@ class CycleCreateRequest(BaseModel):
     execution_overrides: dict = Field(default_factory=dict)
     expected_artifact_types: list[str] = Field(default_factory=list)
     experiment_context: dict = Field(default_factory=dict)
+    request_profile: str | None = None  # SIP-0096: cycle-level config provenance (CRP name)
     notes: str | None = None
 
     model_config = ConfigDict(extra="forbid")

--- a/src/squadops/cli/commands/cycles.py
+++ b/src/squadops/cli/commands/cycles.py
@@ -133,6 +133,7 @@ def create_cycle(
         "squad_profile_id": squad_profile_id,
         "applied_defaults": crp.defaults,
         "execution_overrides": overrides,
+        "request_profile": profile,
         "notes": notes,
     }
     if prd_ref:

--- a/src/squadops/cycles/models.py
+++ b/src/squadops/cycles/models.py
@@ -305,6 +305,11 @@ class Cycle:
     # Extensible experiment context
     experiment_context: dict = field(default_factory=dict)
 
+    # Cycle-request-profile name this cycle was created from — cycle-level config
+    # provenance (SIP-0096). All runs of the cycle share it; None for cycles created
+    # before this field existed.
+    request_profile: str | None = None
+
     notes: str | None = None
 
     # Operator cancellation flag. When True, derived status is CANCELLED

--- a/tests/unit/cycles/test_postgres_cycle_registry.py
+++ b/tests/unit/cycles/test_postgres_cycle_registry.py
@@ -8,6 +8,7 @@ Concurrency, locking, and uniqueness are validated by integration tests (Phase 3
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
@@ -125,6 +126,7 @@ def _cycle_row(**overrides):
         "execution_overrides": {},
         "expected_artifact_types": [],
         "experiment_context": {},
+        "request_profile": None,
         "notes": None,
         "cancelled": False,
     }
@@ -185,7 +187,7 @@ class TestPostgresCycleRegistry:
         conn.execute.assert_awaited_once()
         sql = conn.execute.call_args[0][0]
         assert "INSERT INTO cycle_registry" in sql
-        # Verify all 14 positional params ($1 ... $14)
+        # Verify positional params ($1 ... $15)
         args = conn.execute.call_args[0][1:]
         assert args[0] == "cyc_001"  # cycle_id
         assert args[1] == "proj_1"  # project_id
@@ -234,6 +236,25 @@ class TestPostgresCycleRegistry:
         assert isinstance(gate, Gate)
         assert gate.name == "qa_gate"
         assert gate.after_task_types == ("dev",)
+
+    async def test_create_cycle_persists_request_profile(self, registry, conn):
+        """Catches the INSERT dropping the cycle-level request-profile provenance."""
+        conn.execute.return_value = None
+
+        await registry.create_cycle(replace(_CYCLE, request_profile="selftest"))
+
+        sql = conn.execute.call_args[0][0]
+        assert "request_profile" in sql
+        args = conn.execute.call_args[0][1:]
+        assert args[14] == "selftest"  # $15
+
+    async def test_get_cycle_reads_request_profile(self, registry, conn):
+        """Catches _row_to_cycle not mapping the request_profile column back."""
+        conn.fetchrow.return_value = _cycle_row(request_profile="selftest")
+
+        cycle = await registry.get_cycle("cyc_001")
+
+        assert cycle.request_profile == "selftest"
 
     # ------------------------------------------------------------------
     # 4. create_run — cancelled cycle raises IllegalStateTransitionError


### PR DESCRIPTION
First landed increment of the SIP-0096 run-config provenance work (1.4 evidence arc). Closes #365.

## The reframe (why this is small)
The original plan proposed a run-level `RunProvenance` record. A cycle-vs-run analysis showed it duplicated config the model already carries at the correct levels:
- squad profile + roster + per-role models → pinned by the cycle's immutable `squad_profile_snapshot_ref` (cycle-level)
- `experiment_context`, `applied_defaults` → cycle-level
- per-attempt resolution → already on `Run` (`resolved_config_hash` / `resolved_config_ref`)

The **one** config dimension not recorded today is the **cycle-request-profile name** — a cycle-level attribute (all runs of a cycle share it), needed so the 1.8 cycle-evaluation scorecard can attribute an outcome to its config. `framework_version` (the only genuinely run-level provenance fact) is deferred to the SIP-0096 `CycleOutcome` roll-up as an execution stamp (Phase 3).

## What
Threads `request_profile` CLI → DTO → route → `Cycle` → `cycle_registry`:
- `Cycle.request_profile` field (cycle-level, immutable per cycle)
- migration `007` (idempotent `ADD COLUMN cycle_registry.request_profile TEXT`)
- `CycleCreateRequest` DTO field; route maps `body.request_profile` → `Cycle`
- CLI now sends the `--request-profile` name (was resolved locally then dropped)
- postgres `create_cycle` INSERT + `_row_to_cycle` read; memory registry rides `Cycle(**d)` unchanged
- DDL-model-drift guard satisfied (field has its backing column)

## Validation
- **Unit:** full regression **4731 passed**; 2 new round-trip tests (INSERT includes `request_profile`; `get_cycle` reads it back).
- **Live** (rebuilt runtime-api, migration 007 applied): created `cyc_8338409c2daa` with `--request-profile selftest` on the deployed stack → `cycle_registry.request_profile = 'selftest'` confirmed via direct DB query; cycle cancelled.

## Follow-ups (not in scope)
- `framework_version` execution stamp on the `CycleOutcome` roll-up — SIP-0096 Phase 3.
- Optional: surface `request_profile` in the get-cycle response DTO / `cycles show` (the registry port already returns it, so the scorecard can read it programmatically today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ