### PR TITLE
feat(SIP-0096 Phase 2 slice 1): normalize task-result verification into the ledger (+ #376 honest-red guards)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -926,12 +926,22 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # only acts on the returned action token.
             # Loop-scoped values bind as defaults: fixed at definition time,
             # exactly like the old per-call parameter passing (and B023-safe).
+            # SIP-0096 §6.4 (Phase 2): holds the latest failed result so the abort
+            # path — where the correction protocol raises from *inside*
+            # dispatch_with_retry before it can return — can still record the
+            # failing task's verification evidence. The #276-class evidence (a
+            # failed/not-executed qa.test that triggers the abort) is exactly what
+            # must survive, or a failed run reads as "0 verified" instead of red.
+            _last_failed_result: dict[str, Any] = {}
+
             async def _route_outcome(
                 result,
                 _envelope=envelope,
                 _consecutive_failures=consecutive_failures,
                 _correction_attempts=correction_attempts,
+                _holder=_last_failed_result,
             ):
+                _holder["result"] = result
                 return await self._handle_task_outcome(
                     result=result,
                     envelope=_envelope,
@@ -949,27 +959,40 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     flow_run_id=flow_run_id,
                 )
 
-            task_succeeded, result = await self._task_dispatcher.dispatch_with_retry(
-                enriched,
-                envelope,
-                cycle,
-                run_id,
-                flow_run_id=flow_run_id,
-                task_run_id=task_run_id,
-                handle_task_outcome=_route_outcome,
-            )
-
-            # SIP-0096 §6.4 (Phase 2): record this task's verification evidence into
-            # the run ledger for the end-of-run aggregation choke point. Runs for
-            # every completed task — success AND corrected-failure — so failed/stub
-            # evidence is never dropped. Best-effort: a normalizer defect must never
-            # break task execution (the report path has the same guard).
-            if result is not None and result.outputs:
+            def _record_task_evidence(task_result) -> None:
+                # Normalize this task's verification outputs into the run ledger for
+                # the end-of-run aggregation choke point. Best-effort: a normalizer
+                # defect must never break task execution (the report path is guarded
+                # the same way).
+                if task_result is None or not getattr(task_result, "outputs", None):
+                    return
                 try:
-                    for check_result in normalize_task_checks(result.outputs):
+                    for check_result in normalize_task_checks(task_result.outputs):
                         ledger.record_check_result(check_result)
                 except Exception:
                     logger.warning("Verification-evidence recording failed", exc_info=True)
+
+            try:
+                task_succeeded, result = await self._task_dispatcher.dispatch_with_retry(
+                    enriched,
+                    envelope,
+                    cycle,
+                    run_id,
+                    flow_run_id=flow_run_id,
+                    task_run_id=task_run_id,
+                    handle_task_outcome=_route_outcome,
+                )
+            except Exception:
+                # Correction aborted (raised inside dispatch_with_retry). Record the
+                # final failed result before the run unwinds, then re-raise — recording
+                # is additive and never alters the abort's control flow.
+                _record_task_evidence(_last_failed_result.get("result"))
+                raise
+
+            # Every non-abort completion — success AND corrected-failure
+            # (break_correction) — records its final result here; the abort path
+            # above is the only other producer, so no task is double-recorded.
+            _record_task_evidence(result)
 
             if not task_succeeded:
                 # SIP-0079: correction completed with continue/patch outcome.

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -40,6 +40,7 @@ from squadops.cycles.naming import flow_run_name
 from squadops.cycles.run_ledger import RunLedger
 from squadops.cycles.task_outcome import TaskOutcome
 from squadops.cycles.task_plan import generate_task_plan
+from squadops.cycles.verification_normalize import normalize_task_checks
 from squadops.events.types import EventType
 from squadops.ports.cycles.flow_execution import FlowExecutionPort
 from squadops.runtime.admission import admit_participants, release_participants
@@ -958,6 +959,18 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 handle_task_outcome=_route_outcome,
             )
 
+            # SIP-0096 §6.4 (Phase 2): record this task's verification evidence into
+            # the run ledger for the end-of-run aggregation choke point. Runs for
+            # every completed task — success AND corrected-failure — so failed/stub
+            # evidence is never dropped. Best-effort: a normalizer defect must never
+            # break task execution (the report path has the same guard).
+            if result is not None and result.outputs:
+                try:
+                    for check_result in normalize_task_checks(result.outputs):
+                        ledger.record_check_result(check_result)
+                except Exception:
+                    logger.warning("Verification-evidence recording failed", exc_info=True)
+
             if not task_succeeded:
                 # SIP-0079: correction completed with continue/patch outcome.
                 # Original flow: consecutive_failures was incremented before
@@ -1515,6 +1528,12 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
+        # SIP-0096 Phase 2 slice-1 gap: this fan-out path does NOT yet record
+        # verification evidence to the run ledger (the sequential path does, at the
+        # dispatch-with-retry seam). Harmless while the throttle is off (no shipped
+        # profile declares required_checks) — a FAN_OUT_FAN_IN cycle simply records
+        # zero evidence, same as pre-Phase-2. MUST be wired before slice 4 turns the
+        # throttle on, or a required check would falsely block here. Tracked in #375.
         all_artifact_refs: list[str] = []
         for i, result in enumerate(results):
             task_context = {

--- a/src/squadops/cycles/run_report_builder.py
+++ b/src/squadops/cycles/run_report_builder.py
@@ -10,9 +10,20 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from squadops.cycles.models import RunStatus
+from squadops.cycles.verification_integrity import RunVerdict
+
 if TYPE_CHECKING:
     from squadops.cycles.verification_integrity import RunVerificationSummary
     from squadops.tasks.models import TaskEnvelope
+
+# terminal_status flows through the report pipeline as an UPPERCASE bare string
+# (an untyped shadow of RunStatus — see #377 to unify). Source the compared values
+# from the RunStatus enum so this stays the single source of truth, and compare
+# case-insensitively so a lowercase RunStatus value can't silently miss.
+_COMPLETED = RunStatus.COMPLETED.value.upper()
+_FAILED = RunStatus.FAILED.value.upper()
+_CANCELLED = RunStatus.CANCELLED.value.upper()
 
 
 def _build_report_metadata_lines(
@@ -43,14 +54,35 @@ def _build_report_metadata_lines(
     return lines
 
 
-def _build_report_quality_lines(terminal_status: str) -> list[str]:
-    """Build the quality notes section for the run report."""
+def _build_report_quality_lines(
+    terminal_status: str, verification_summary: RunVerificationSummary | None = None
+) -> list[str]:
+    """Build the quality notes section for the run report.
+
+    SIP-0096 §6.6(4), narrative-override prohibition: the narrative must not
+    claim success when the structured verification verdict is ``rejected`` or
+    ``blocked_unverified``. A run can reach COMPLETED with failed/unverified
+    evidence — the verdict is deliberately not a ``RunStatus`` (§6.5) — so when
+    it does, this note reflects the verdict instead of asserting all-clear.
+    """
     lines = ["", "## Quality Notes"]
-    if terminal_status == "COMPLETED":
+    status = (terminal_status or "").upper()
+    verdict = verification_summary.verdict if verification_summary else None
+    if status == _COMPLETED and verdict == RunVerdict.REJECTED:
+        lines.append(
+            "Tasks completed, but verification **REJECTED** — one or more executed "
+            "checks failed. See Verification Integrity."
+        )
+    elif status == _COMPLETED and verdict == RunVerdict.BLOCKED_UNVERIFIED:
+        lines.append(
+            "Tasks completed, but verification **BLOCKED_UNVERIFIED** — a required "
+            "check did not execute. See Verification Integrity."
+        )
+    elif status == _COMPLETED:
         lines.append("All tasks completed successfully.")
-    elif terminal_status == "FAILED":
+    elif status == _FAILED:
         lines.append("One or more tasks failed. Check task artifacts for details.")
-    elif terminal_status == "CANCELLED":
+    elif status == _CANCELLED:
         lines.append("Run was cancelled before completion.")
     else:
         lines.append(f"Terminal status: {terminal_status}")
@@ -165,6 +197,6 @@ def build_run_report(
         lines.extend(_build_verification_lines(verification_summary))
 
     # Quality notes
-    lines.extend(_build_report_quality_lines(terminal_status))
+    lines.extend(_build_report_quality_lines(terminal_status, verification_summary))
 
     return "\n".join(lines)

--- a/src/squadops/cycles/verification_normalize.py
+++ b/src/squadops/cycles/verification_normalize.py
@@ -1,0 +1,140 @@
+"""Normalize task-result verification evidence into ``CheckResult`` (SIP-0096 Phase 2).
+
+The Phase-1 pure core (`verification_integrity`) is deliberately producer-agnostic:
+it classifies a normalized ``CheckResult`` and never knows the shape of any
+producer. This module is the **producer adapter** the Phase-1 design deferred —
+it maps a completed task's ``outputs`` (the qa/dev handlers' ``validation_result``
+checks + ``test_result``) into ``CheckResult`` objects the executor records on the
+``RunLedger``. Pure (dict → list[CheckResult]); no I/O.
+
+Two producer shapes are folded here (both land in ``outputs`` and flow back to the
+executor at the dispatch seam):
+
+- **SIP-0092 typed-acceptance rows** (`check` = ``acceptance:<name>``) — emitted for
+  *every* criterion, carrying a ``CheckOutcome`` ``status`` (passed/failed/skipped/
+  error) directly. Per-cycle identity (§6.3): disclosed, not required-addressable.
+- **Framework test-spine checks** — ``tests_pass`` and ``no_stub_fallback_tests`` are
+  appended to ``checks`` **only on failure**, so a passing run records no row. Relying
+  on the row alone would make a green run look like "no result" and — once the check
+  is required (Phase 2 slice 4) — falsely block it. So ``tests_pass`` is synthesized
+  from the always-present ``test_result`` dict, and the §6.6.1 stub signal
+  (``no_stub_fallback_tests`` failing) marks that synthesized pass as a stub so it
+  cannot credit.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from squadops.cycles.verification_integrity import (
+    CheckProvenance,
+    CheckResult,
+    NotExecutedReason,
+    ResultStatus,
+)
+
+# Framework test-spine check identities (stable, §6.3 required-addressable).
+CHECK_TESTS_PASS = "tests_pass"
+CHECK_NO_STUB = "no_stub_fallback_tests"
+
+
+def normalize_task_checks(outputs: Mapping[str, Any]) -> list[CheckResult]:
+    """Map one completed task's ``outputs`` into recordable ``CheckResult``s (§6.1).
+
+    Robust by construction — a malformed row is skipped, never raised, because this
+    runs in the executor's per-task path and must never break task execution.
+    Returns an empty list for tasks that carry no verification evidence.
+    """
+    results: list[CheckResult] = []
+    validation = outputs.get("validation_result")
+    checks = validation.get("checks") if isinstance(validation, Mapping) else None
+    test_result = outputs.get("test_result")
+
+    stub_detected = False
+    for row in checks or ():
+        if not isinstance(row, Mapping):
+            continue
+        cid = row.get("check")
+        if not cid or not isinstance(cid, str):
+            continue
+        if cid == CHECK_TESTS_PASS:
+            # Failure-only row; the real signal is synthesized from test_result
+            # below (richer + present on a passing run). Skip to avoid double-record.
+            continue
+        if cid == CHECK_NO_STUB:
+            # Present only when stubs were found → the stub check executed-and-failed,
+            # and its presence flags the synthesized tests_pass as a stub (§6.6.1).
+            stub_detected = True
+            results.append(CheckResult(check_id=cid, status=ResultStatus.FAILED))
+            continue
+        if "status" in row:
+            # Typed-acceptance row: carries a CheckOutcome status verbatim.
+            results.append(
+                CheckResult(
+                    check_id=cid,
+                    status=str(row.get("status") or ""),
+                    reason=_str_or_none(row.get("reason")),
+                )
+            )
+        else:
+            # Generic boolean-passed row (e.g. non_stub_files): executed unless it
+            # explicitly says otherwise.
+            results.append(_from_passed_row(cid, row))
+
+    if isinstance(test_result, Mapping):
+        results.append(_tests_pass_from_result(test_result, is_stub=stub_detected))
+
+    return results
+
+
+def _from_passed_row(cid: str, row: Mapping[str, Any]) -> CheckResult:
+    """Normalize a check row that carries a boolean ``passed`` (no ``status``)."""
+    if row.get("executed") is False:
+        return CheckResult(
+            check_id=cid, status=ResultStatus.SKIPPED, reason=NotExecutedReason.SUBJECT_MISSING
+        )
+    status = ResultStatus.PASSED if row.get("passed") else ResultStatus.FAILED
+    return CheckResult(check_id=cid, status=status)
+
+
+def _tests_pass_from_result(tr: Mapping[str, Any], *, is_stub: bool) -> CheckResult:
+    """Synthesize the ``tests_pass`` check from the always-present ``test_result``.
+
+    ``executed=False`` → not-executed (reason mapped from the runner error);
+    ``executed`` + exit 0 → passed; ``executed`` + non-zero → failed. ``is_stub``
+    carries the §6.6.1 signal so a stub-backed pass is classified not-executed.
+    """
+    if not tr.get("executed", False):
+        return CheckResult(
+            check_id=CHECK_TESTS_PASS,
+            status=ResultStatus.SKIPPED,
+            reason=_not_executed_reason(tr),
+        )
+    tests_passed = tr.get("tests_passed")
+    if tests_passed is None:
+        tests_passed = tr.get("exit_code", 1) == 0
+    return CheckResult(
+        check_id=CHECK_TESTS_PASS,
+        status=ResultStatus.PASSED if tests_passed else ResultStatus.FAILED,
+        is_stub=is_stub,
+        provenance=CheckProvenance(exit_code=_int_or_none(tr.get("exit_code"))),
+    )
+
+
+def _not_executed_reason(tr: Mapping[str, Any]) -> str:
+    """Map a runner error string to a §7 not-executed reason (best-effort)."""
+    err = str(tr.get("error") or "").lower()
+    if "import" in err:
+        return NotExecutedReason.IMPORT_ERROR
+    if "not found" in err or "no module" in err or "command" in err:
+        return NotExecutedReason.MISSING_TOOLING
+    return NotExecutedReason.SUBJECT_MISSING
+
+
+def _str_or_none(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _int_or_none(value: Any) -> int | None:
+    return value if isinstance(value, int) else None

--- a/tests/unit/cycles/test_executor_checkpoint.py
+++ b/tests/unit/cycles/test_executor_checkpoint.py
@@ -601,3 +601,80 @@ class TestResumeOfAlreadyRunningRun:
         assert state["status"] == "completed"
         first_transition = mock_registry.update_run_status.call_args_list[0].args[1]
         assert first_transition == RunStatus.RUNNING
+
+
+# ---------------------------------------------------------------------------
+# SIP-0096 Phase 2 slice 1: verification-evidence recording to the ledger
+# ---------------------------------------------------------------------------
+
+
+class TestVerificationEvidenceRecording:
+    """Each completed task's verification outputs are normalized into the run
+    ledger at the dispatch seam and surface in the run_report integrity roll-up —
+    the wiring that makes the Phase-1 aggregation non-inert."""
+
+    def _run_report(self, mock_vault) -> str:
+        for call in mock_vault.store.call_args_list:
+            ref, content = call.args[0], call.args[1]
+            if getattr(ref, "filename", "") == "run_report.md":
+                return content.decode()
+        raise AssertionError("run_report.md was not stored")
+
+    async def test_passing_test_result_recorded_and_disclosed(
+        self, executor, mock_registry, mock_queue, mock_vault
+    ) -> None:
+        """A passing test_result on each task makes the roll-up show real executed
+        evidence — not the inert 'Executed: 0'."""
+
+        def responder(env):
+            return TaskResult(
+                task_id=env["task_id"],
+                status="SUCCEEDED",
+                outputs={
+                    "summary": "ok",
+                    "artifacts": [],
+                    "test_result": {"executed": True, "exit_code": 0, "tests_passed": True},
+                },
+            )
+
+        mock_queue.reply_router.responder = responder
+
+        with patch(
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
+        ):
+            await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
+
+        report = self._run_report(mock_vault)
+        assert "## Verification Integrity" in report
+        assert "Verdict: **accepted**" in report
+        # 3 implementation tasks each carry a passing test_result → 3 tests_pass recorded.
+        assert "Executed: 3 " in report
+
+    async def test_not_executed_test_result_is_disclosed_not_dropped(
+        self, executor, mock_registry, mock_queue, mock_vault
+    ) -> None:
+        """A not-executed test_result surfaces under 'Unverified (not executed)' —
+        silence is disclosed through the choke point, never dropped (§6.6.3)."""
+
+        def responder(env):
+            return TaskResult(
+                task_id=env["task_id"],
+                status="SUCCEEDED",
+                outputs={
+                    "summary": "ok",
+                    "artifacts": [],
+                    "test_result": {"executed": False, "error": "ImportError: app"},
+                },
+            )
+
+        mock_queue.reply_router.responder = responder
+
+        with patch(
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
+        ):
+            await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
+
+        report = self._run_report(mock_vault)
+        assert "### Unverified (not executed)" in report
+        assert "tests_pass" in report
+        assert "Executed: 0 " in report  # not-executed excluded from the executed count

--- a/tests/unit/cycles/test_executor_checkpoint.py
+++ b/tests/unit/cycles/test_executor_checkpoint.py
@@ -710,3 +710,35 @@ class TestVerificationEvidenceRecording:
         assert "## Verification Integrity" in report
         assert "Failed: tests_pass" in report
         assert "Executed: 1 " in report
+
+    async def test_break_correction_records_failure_and_blocks_false_green(
+        self, executor, mock_registry, mock_queue, mock_vault
+    ) -> None:
+        """The #376 leak: after a `patch` correction the executor advances
+        (break_correction) with the ORIGINAL failed result. That failed evidence
+        must still be recorded, and a COMPLETED run whose verdict is rejected must
+        NOT print 'All tasks completed successfully' (§6.6.4 narrative override)."""
+        failed = TaskResult(
+            task_id="t",
+            status="FAILED",
+            error="build failed",
+            outputs={"test_result": {"executed": True, "exit_code": 1, "tests_passed": False}},
+        )
+        with (
+            patch.object(
+                executor._task_dispatcher,
+                "dispatch_with_retry",
+                new_callable=AsyncMock,
+                return_value=(False, failed),
+            ),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
+
+        # Every task advanced on break_correction → run COMPLETED...
+        assert mock_registry.update_run_status.call_args_list[-1].args[1] == RunStatus.COMPLETED
+        report = self._run_report(mock_vault)
+        # ...but the failed evidence was recorded and the narrative is honest.
+        assert "Failed: tests_pass" in report
+        assert "REJECTED" in report
+        assert "All tasks completed successfully." not in report

--- a/tests/unit/cycles/test_executor_checkpoint.py
+++ b/tests/unit/cycles/test_executor_checkpoint.py
@@ -678,3 +678,35 @@ class TestVerificationEvidenceRecording:
         assert "### Unverified (not executed)" in report
         assert "tests_pass" in report
         assert "Executed: 0 " in report  # not-executed excluded from the executed count
+
+    async def test_aborted_task_evidence_survives_the_abort(
+        self, executor, mock_registry, mock_queue, mock_vault
+    ) -> None:
+        """A task that fails and aborts the run must still record its verification
+        evidence. The abort path raises from inside dispatch_with_retry (before the
+        normal recording line), so this is the #276-class failing evidence that
+        would otherwise vanish — a failed run must read as honest red, not '0
+        verified'."""
+
+        def responder(env):
+            return TaskResult(
+                task_id=env["task_id"],
+                status="FAILED",
+                error="tests broke",
+                outputs={"test_result": {"executed": True, "exit_code": 1, "tests_passed": False}},
+            )
+
+        mock_queue.reply_router.responder = responder
+
+        with patch(
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock
+        ):
+            await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
+
+        # Run failed, but the failing task's evidence reached the roll-up.
+        status_calls = mock_registry.update_run_status.call_args_list
+        assert status_calls[-1].args[1] == RunStatus.FAILED
+        report = self._run_report(mock_vault)
+        assert "## Verification Integrity" in report
+        assert "Failed: tests_pass" in report
+        assert "Executed: 1 " in report

--- a/tests/unit/cycles/test_run_report_builder.py
+++ b/tests/unit/cycles/test_run_report_builder.py
@@ -1,0 +1,71 @@
+"""Tests for the run-report quality-notes narrative-override guard (SIP-0096 §6.6.4).
+
+Bug caught: a run that reaches terminal COMPLETED while its verification verdict
+is rejected/blocked_unverified must NOT render "All tasks completed
+successfully" — the narrative cannot override the structured verdict (the
+false-green shown live in #376).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.run_report_builder import _build_report_quality_lines
+from squadops.cycles.verification_integrity import (
+    CheckResult,
+    ResultStatus,
+    aggregate_verification,
+)
+
+
+def _notes(terminal_status, results=(), required=()):
+    summary = aggregate_verification(list(results), required) if results or required else None
+    return "\n".join(_build_report_quality_lines(terminal_status, summary))
+
+
+def test_completed_and_accepted_still_says_success():
+    text = _notes("COMPLETED", [CheckResult(check_id="a", status=ResultStatus.PASSED)])
+    assert "All tasks completed successfully." in text
+
+
+def test_completed_but_rejected_does_not_claim_success():
+    text = _notes("COMPLETED", [CheckResult(check_id="a", status=ResultStatus.FAILED)])
+    assert "All tasks completed successfully." not in text
+    assert "REJECTED" in text
+
+
+def test_completed_but_blocked_unverified_does_not_claim_success():
+    text = _notes(
+        "COMPLETED",
+        [CheckResult(check_id="a", status=ResultStatus.SKIPPED, reason="missing_tooling")],
+        required=["a"],
+    )
+    assert "All tasks completed successfully." not in text
+    assert "BLOCKED_UNVERIFIED" in text
+
+
+def test_completed_with_no_summary_uses_default_narrative():
+    """Back-compat: without a verification summary (pre-wire callers), the old
+    narrative stands."""
+    assert "All tasks completed successfully." in _notes("COMPLETED")
+
+
+def test_status_compare_is_case_robust():
+    """The status compare is sourced from RunStatus and normalized, so a lowercase
+    RunStatus value ('completed') can't silently miss the branch (#377 footgun)."""
+    text = _notes("completed", [CheckResult(check_id="a", status=ResultStatus.FAILED)])
+    assert "REJECTED" in text
+    assert "All tasks completed successfully." not in text
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("FAILED", "One or more tasks failed"),
+        ("CANCELLED", "Run was cancelled"),
+    ],
+)
+def test_non_completed_statuses_unchanged(status, expected):
+    # a rejected verdict must not mask the real terminal reason on non-COMPLETED runs
+    text = _notes(status, [CheckResult(check_id="a", status=ResultStatus.FAILED)])
+    assert expected in text

--- a/tests/unit/cycles/test_verification_normalize.py
+++ b/tests/unit/cycles/test_verification_normalize.py
@@ -1,0 +1,226 @@
+"""Tests for the SIP-0096 Phase 2 task-result → CheckResult normalizer.
+
+The load-bearing correctness points: tests_pass is synthesized from the
+always-present test_result (the checks[] row is failure-only), the §6.6.1 stub
+signal flows onto that synthesized pass, typed-acceptance status passes through
+verbatim, and a malformed row is skipped rather than raised. Each test names the
+bug it catches.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.verification_integrity import (
+    EvidenceFamily,
+    NotExecutedReason,
+    ResultStatus,
+    RunVerdict,
+    aggregate_verification,
+    classify,
+)
+from squadops.cycles.verification_normalize import (
+    CHECK_NO_STUB,
+    CHECK_TESTS_PASS,
+    normalize_task_checks,
+)
+
+
+def _by_id(results):
+    return {r.check_id: r for r in results}
+
+
+# --------------------------------------------------------------------------- #
+# tests_pass synthesis from test_result (the failure-only-row trap)
+# --------------------------------------------------------------------------- #
+
+
+def test_passing_run_synthesizes_tests_pass_even_with_no_checks_row():
+    """A green run appends no tests_pass row; synthesis from test_result is the
+    only thing that keeps the passing evidence from vanishing (and later falsely
+    blocking once tests_pass is required)."""
+    out = {"test_result": {"executed": True, "exit_code": 0, "tests_passed": True}}
+    r = _by_id(normalize_task_checks(out))
+    assert CHECK_TESTS_PASS in r
+    assert r[CHECK_TESTS_PASS].status == ResultStatus.PASSED
+    assert classify(r[CHECK_TESTS_PASS]) is EvidenceFamily.EXECUTED_PASSED
+
+
+def test_failed_tests_synthesized_as_failed():
+    out = {"test_result": {"executed": True, "exit_code": 1, "tests_passed": False}}
+    r = _by_id(normalize_task_checks(out))
+    assert r[CHECK_TESTS_PASS].status == ResultStatus.FAILED
+    assert r[CHECK_TESTS_PASS].provenance.exit_code == 1
+
+
+def test_not_executed_tests_are_not_executed_with_mapped_reason():
+    out = {"test_result": {"executed": False, "error": "ImportError: no module named app"}}
+    r = _by_id(normalize_task_checks(out))
+    assert r[CHECK_TESTS_PASS].status == ResultStatus.SKIPPED
+    assert r[CHECK_TESTS_PASS].reason == NotExecutedReason.IMPORT_ERROR
+    assert classify(r[CHECK_TESTS_PASS]) is EvidenceFamily.NOT_EXECUTED
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        ("ImportError somewhere", NotExecutedReason.IMPORT_ERROR),
+        ("bash: pytest: command not found", NotExecutedReason.MISSING_TOOLING),
+        ("no module named x", NotExecutedReason.MISSING_TOOLING),
+        ("weird runner blowup", NotExecutedReason.SUBJECT_MISSING),
+        ("", NotExecutedReason.SUBJECT_MISSING),
+    ],
+)
+def test_not_executed_reason_mapping(error, expected):
+    out = {"test_result": {"executed": False, "error": error}}
+    assert _by_id(normalize_task_checks(out))[CHECK_TESTS_PASS].reason == expected
+
+
+def test_tests_passed_falls_back_to_exit_code_when_flag_absent():
+    out = {"test_result": {"executed": True, "exit_code": 0}}  # no tests_passed key
+    assert _by_id(normalize_task_checks(out))[CHECK_TESTS_PASS].status == ResultStatus.PASSED
+
+
+# --------------------------------------------------------------------------- #
+# Stub cross-signal (§6.6.1)
+# --------------------------------------------------------------------------- #
+
+
+def test_stub_offenders_mark_tests_pass_as_stub_and_record_stub_check():
+    """no_stub_fallback_tests failing must (a) record itself as executed-failed and
+    (b) flag the synthesized tests_pass as a stub so its green cannot credit."""
+    out = {
+        "test_result": {"executed": True, "exit_code": 0, "tests_passed": True},
+        "validation_result": {
+            "checks": [{"check": CHECK_NO_STUB, "offenders": ["test_app.py"], "passed": False}]
+        },
+    }
+    r = _by_id(normalize_task_checks(out))
+    assert r[CHECK_NO_STUB].status == ResultStatus.FAILED
+    assert r[CHECK_TESTS_PASS].is_stub is True
+    # the stub-backed pass is non-creditable
+    assert classify(r[CHECK_TESTS_PASS]) is EvidenceFamily.NOT_EXECUTED
+
+
+def test_no_stub_row_means_tests_pass_credits_normally():
+    out = {"test_result": {"executed": True, "exit_code": 0, "tests_passed": True}}
+    assert _by_id(normalize_task_checks(out))[CHECK_TESTS_PASS].is_stub is False
+
+
+def test_failure_only_tests_pass_row_is_not_double_recorded():
+    """The handler's failure-only tests_pass row must not produce a second
+    CheckResult alongside the synthesized one."""
+    out = {
+        "test_result": {"executed": True, "exit_code": 1, "tests_passed": False},
+        "validation_result": {
+            "checks": [
+                {"check": CHECK_TESTS_PASS, "executed": True, "exit_code": 1, "passed": False}
+            ]
+        },
+    }
+    tests_pass_results = [r for r in normalize_task_checks(out) if r.check_id == CHECK_TESTS_PASS]
+    assert len(tests_pass_results) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Typed-acceptance rows (status passthrough)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("status", ["passed", "failed", "skipped", "error"])
+def test_typed_acceptance_status_passes_through(status):
+    out = {
+        "validation_result": {
+            "checks": [
+                {"check": "acceptance:file_exists", "status": status, "reason": "r", "passed": True}
+            ]
+        }
+    }
+    r = _by_id(normalize_task_checks(out))
+    assert r["acceptance:file_exists"].status == status
+
+
+def test_typed_skipped_carries_reason_for_disclosure():
+    out = {
+        "validation_result": {
+            "checks": [
+                {"check": "acceptance:x", "status": "skipped", "reason": "unsupported_stack"}
+            ]
+        }
+    }
+    r = _by_id(normalize_task_checks(out))
+    assert r["acceptance:x"].reason == "unsupported_stack"
+    assert classify(r["acceptance:x"]) is EvidenceFamily.NOT_EXECUTED
+
+
+def test_generic_passed_row_without_status():
+    out = {"validation_result": {"checks": [{"check": "non_stub_files", "passed": True}]}}
+    assert _by_id(normalize_task_checks(out))["non_stub_files"].status == ResultStatus.PASSED
+
+
+def test_generic_row_executed_false_is_not_executed():
+    out = {
+        "validation_result": {"checks": [{"check": "custom", "executed": False, "passed": False}]}
+    }
+    assert _by_id(normalize_task_checks(out))["custom"].status == ResultStatus.SKIPPED
+
+
+# --------------------------------------------------------------------------- #
+# Robustness — must never raise in the executor hot path
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "out",
+    [
+        {},
+        {"test_result": None, "validation_result": None},
+        {"validation_result": {"checks": None}},
+        {"validation_result": {"checks": ["not-a-dict", 42, {}]}},  # bad rows skipped
+        {"validation_result": {"checks": [{"no_check_key": 1}]}},
+        {"validation_result": "not-a-mapping"},
+    ],
+)
+def test_malformed_outputs_never_raise(out):
+    assert normalize_task_checks(out) == [] or isinstance(normalize_task_checks(out), list)
+
+
+def test_non_verification_task_yields_nothing():
+    """A strategy/governance task with no test_result or validation_result records
+    no evidence (empty), so aggregation is unaffected by it."""
+    assert normalize_task_checks({"artifacts": [{"filename": "prd.md"}]}) == []
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: normalize → aggregate (the point of the wiring)
+# --------------------------------------------------------------------------- #
+
+
+def test_stub_pass_on_required_tests_blocks_end_to_end():
+    """The whole reason for the stub signal: a green-but-stubbed qa run, with
+    tests_pass required, must aggregate to blocked_unverified — not accepted."""
+    out = {
+        "test_result": {"executed": True, "exit_code": 0, "tests_passed": True},
+        "validation_result": {
+            "checks": [{"check": CHECK_NO_STUB, "offenders": ["t.py"], "passed": False}]
+        },
+    }
+    summary = aggregate_verification(
+        normalize_task_checks(out), required_check_ids=[CHECK_TESTS_PASS]
+    )
+    assert summary.verdict is RunVerdict.BLOCKED_UNVERIFIED
+    assert CHECK_TESTS_PASS in summary.required_unmet
+
+
+def test_clean_pass_aggregates_accepted():
+    out = {
+        "test_result": {"executed": True, "exit_code": 0, "tests_passed": True},
+        "validation_result": {
+            "checks": [{"check": "acceptance:file_exists", "status": "passed", "passed": True}]
+        },
+    }
+    summary = aggregate_verification(
+        normalize_task_checks(out), required_check_ids=[CHECK_TESTS_PASS]
+    )
+    assert summary.verdict is RunVerdict.ACCEPTED
+    assert CHECK_TESTS_PASS in summary.verified


### PR DESCRIPTION
## SIP-0096 Phase 2 slice 1 — normalize task-result verification into the ledger

Makes the Phase-1 aggregation choke point **non-inert**: the real verification producers now record their results into the `RunLedger`, so `RunCompletion.finalize` aggregates genuine evidence. **Disclosure-only** — no profile ships `required_checks` yet, so **no verdicts flip**; the run_report integrity roll-up starts showing real `Executed: N` evidence, and — critically — a failed/unverified run now reads as honest red instead of a false green.

Part of #375 (Phase 2). Addresses #376 points 1 & 4 (field evidence from the Spark's 1.3.1 regression). Phase 1 = #368 (merged `d62ce0d`).

### What's in this slice
- **Pure producer adapter** `verification_normalize.py` — `normalize_task_checks(outputs) -> list[CheckResult]`. One normalizer folds both producer shapes in `outputs["validation_result"]["checks"]`: SIP-0092 typed-acceptance rows (status passthrough) and the framework test spine. `tests_pass` is **synthesized from the always-present `test_result`** (the `checks[]` row is failure-only — relying on it would make a passing run look like "no result" and falsely block once required). The §6.6.1 stub signal marks a stub-backed green so it can't credit. Defensive — never raises on malformed rows.
- **Executor recording** at the `_execute_sequential` dispatch seam, for **every** completed task on **all three paths**:
  - success + `break_correction` (patch-advance) → the returned result (`61ba91b`);
  - **abort** (correction raises from inside `dispatch_with_retry`) → the final failed result, captured via the outcome callback and recorded before re-raise (`43b3736`).
  - This is #376 pt1: the failing `qa.test`/build evidence (the #276 class) survives correction and abort — a failed run aggregates to `rejected`, not silent green.
- **Narrative-override guard** (`5022b99`, #376 pt4 / §6.6.4): a COMPLETED run whose verdict is `rejected`/`blocked_unverified` no longer prints "All tasks completed successfully"; the Quality Notes reflect the verdict.
- **Drive-by cleanup (Jason flagged in review):** `_build_report_quality_lines` compared bare uppercase `"COMPLETED"`/`"FAILED"`/`"CANCELLED"` literals — an untyped shadow of the lowercase `RunStatus` enum. Now sourced from `RunStatus.*.value.upper()` and compared case-insensitively. Full unification across the ~6 producers filed as **#377**.

### Convergence with the Spark lane (1.3.x)
Design point this slice clarifies: the SIP makes failure **honest** (verdict + narrative), but the **run status stays COMPLETED** by design — the verdict is not a `RunStatus` (§6.5). Making the run itself *fail* on an unsatisfied repair is **#374** (Spark). Shared seam: `run_correction_protocol` surfacing the `qa.validate_repair` verdict — Spark exposes+enforces it, my **next slice** (#376 pt2) consumes it as evidence. Sequenced Spark-first.

### Not in this slice
Fan-out (`FAN_OUT_FAN_IN`) recording (in-code marker + #375 note; harmless while the throttle is off, must land before slice 4); #376 pt2 (repair-verdict aggregation, after #374); #376 pt3 (required behavioral frontend check — slice 4 + D13); the throttle itself (slice 4).

### Testing
- **38 new tests** across the slice: 28 normalizer; 4 executor recording (passing→`Executed:3`; not-executed→disclosed `Executed:0`; **abort→`Failed: tests_pass`**; **break_correction→recorded + narrative honest**); 6 narrative-override + case-robustness.
- **Full regression: 4812 passed, 1 skipped.**

### Live validation
- **Seam validated live** — two cycles (`cyc_f7e86def85b2` framing, `cyc_9313bebfdbc0` implementation) ran on the rebuilt runtime-api without the seam disturbing execution.
- **A real bug was caught by live validation** — the implementation cycle FAILED at `builder.assemble` and reported `Executed: 0`, which exposed the abort-path evidence drop (now fixed + tested).
- **Positive-path (real `Executed: N` from a completed build→qa.test) not yet shown on Mac** — lite 7b cycles abort at `builder.assemble` before `qa.test` runs. The Spark's **full-squad (27b)** cycles complete that chain, so a re-run against a slice-1 stack there is the natural positive-path validation (coordinated in #376). **I don't recommend merge until that positive-path validation lands.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ
