### PR TITLE
test(#380): enum-shadow architecture guardrail — fail CI on status string-literal comparisons

### DIFF
--- a/src/squadops/api/routes/cycles/artifacts.py
+++ b/src/squadops/api/routes/cycles/artifacts.py
@@ -16,6 +16,7 @@ from squadops.auth.models import Scope
 from squadops.cycles.models import (
     ArtifactRef,
     BaselineNotAllowedError,
+    BuildStrategy,
     CycleError,
     PromotionStatus,
     ValidationError,
@@ -264,7 +265,7 @@ async def promote_baseline(project_id: str, artifact_type: str, body: BaselinePr
         if ref.cycle_id:
             registry = get_cycle_registry()
             cycle = await registry.get_cycle(ref.cycle_id)
-            if cycle.build_strategy == "fresh":
+            if cycle.build_strategy == BuildStrategy.FRESH.value:
                 raise BaselineNotAllowedError(
                     "Cannot promote baseline for a fresh build strategy cycle"
                 )

--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -22,6 +22,7 @@ from squadops.cycles.models import (
     CycleError,
     CycleStatus,
     GateDecision,
+    GateDecisionValue,
     Run,
     RunStatus,
     RunTerminalError,
@@ -179,7 +180,7 @@ async def gate_decision(
         # flow to the next workload via plan_artifact_refs /
         # prior_workload_artifact_refs. Without this the manifest stays
         # at "working" status and the impl workload gets no inputs.
-        if body.decision == "approved":
+        if body.decision == GateDecisionValue.APPROVED.value:
             await _promote_run_artifacts(run_id)
 
         # SIP-0077: gate.decided

--- a/src/squadops/cycles/run_report_builder.py
+++ b/src/squadops/cycles/run_report_builder.py
@@ -10,9 +10,20 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from squadops.cycles.models import RunStatus
+from squadops.cycles.pulse_models import PulseDecision
+
 if TYPE_CHECKING:
     from squadops.cycles.verification_integrity import RunVerificationSummary
     from squadops.tasks.models import TaskEnvelope
+
+# terminal_status flows through the report pipeline as an UPPERCASE bare string
+# (an untyped shadow of RunStatus — full unification tracked in #377). Source the
+# compared values from the enum so it stays the single source of truth, and
+# compare case-insensitively so a lowercase RunStatus value can't silently miss.
+_COMPLETED = RunStatus.COMPLETED.value.upper()
+_FAILED = RunStatus.FAILED.value.upper()
+_CANCELLED = RunStatus.CANCELLED.value.upper()
 
 
 def _build_report_metadata_lines(
@@ -46,11 +57,12 @@ def _build_report_metadata_lines(
 def _build_report_quality_lines(terminal_status: str) -> list[str]:
     """Build the quality notes section for the run report."""
     lines = ["", "## Quality Notes"]
-    if terminal_status == "COMPLETED":
+    status = (terminal_status or "").upper()
+    if status == _COMPLETED:
         lines.append("All tasks completed successfully.")
-    elif terminal_status == "FAILED":
+    elif status == _FAILED:
         lines.append("One or more tasks failed. Check task artifacts for details.")
-    elif terminal_status == "CANCELLED":
+    elif status == _CANCELLED:
         lines.append("Run was cancelled before completion.")
     else:
         lines.append(f"Terminal status: {terminal_status}")
@@ -63,9 +75,11 @@ def _build_pulse_report_lines(pulse_report_entries: list[dict[str, Any]]) -> lis
     lines: list[str] = []
     lines.append("")
     lines.append("## Pulse Verification")
-    pass_count = sum(1 for e in pulse_report_entries if e["decision"] == "pass")
-    fail_count = sum(1 for e in pulse_report_entries if e["decision"] == "fail")
-    exhausted_count = sum(1 for e in pulse_report_entries if e["decision"] == "exhausted")
+    pass_count = sum(1 for e in pulse_report_entries if e["decision"] == PulseDecision.PASS.value)
+    fail_count = sum(1 for e in pulse_report_entries if e["decision"] == PulseDecision.FAIL.value)
+    exhausted_count = sum(
+        1 for e in pulse_report_entries if e["decision"] == PulseDecision.EXHAUSTED.value
+    )
     total = len(pulse_report_entries)
     lines.append(
         f"Total boundary checks: {total} "

--- a/tests/unit/architecture/test_no_enum_shadow_comparisons.py
+++ b/tests/unit/architecture/test_no_enum_shadow_comparisons.py
@@ -1,0 +1,139 @@
+"""Architecture test: no enum-shadow string-literal comparisons (#380).
+
+A comparison against a bare string literal that matches an existing ``StrEnum``
+value is latent drift — an untyped shadow of a type that already exists (the
+``terminal_status == "COMPLETED"`` class that propagated across three SIPs
+before review caught it). It never fails at runtime because the two vocabularies
+don't collide, so tests stay green and only human review — the least reliable
+gate — can catch it. This test makes it fail CI instead.
+
+Off-the-shelf ruff ``PLR2004`` (magic-value-comparison) is numeric-only and does
+not flag string literals, hence this custom AST rule (same vehicle as
+``test_forbidden_imports.py``).
+
+The rule: in ``src/squadops`` domain code, a variable must not be compared
+against a raw string literal that equals a domain enum's value (case-insensitive,
+to catch upper/lower shadows). Compare against the enum member (or ``.value``),
+or — at an adapter boundary translating an external vocabulary — add a justified
+allowlist entry.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC = REPO_ROOT / "src" / "squadops"
+
+# Reviewed, justified exceptions: {(repo_relative_path, literal_lower)}.
+# Each entry MUST carry a comment explaining why the raw literal is correct here
+# (a genuine boundary-translation point, or a word that coincidentally matches an
+# enum value but is not that concept). A shared status WORD ("failed", "active")
+# is defined by several enums AND by non-enum vocabularies, so value-matching
+# flags coincidences — those are triaged here, not silently swept.
+_ALLOWLIST: set[tuple[str, str]] = {
+    # TaskResult.status is an UPPERCASE bare-str vocabulary ("SUCCEEDED"/...), NOT
+    # the lowercase TaskStatus enum — case-mismatched, so the naive enum fix would
+    # break it. Reconciliation tracked in #381 (twin of #377).
+    ("src/squadops/capabilities/runner.py", "succeeded"),
+    ("src/squadops/orchestration/orchestrator.py", "succeeded"),
+    # CheckOutcome.status vocabulary (passed/failed/skipped/error) — CheckOutcome
+    # is a dataclass, not a StrEnum (SIP-0092); "failed"/"error" coincide with
+    # RunStatus/TaskStatus but are a different concept.
+    ("src/squadops/capabilities/handlers/cycle/develop.py", "failed"),
+    ("src/squadops/capabilities/handlers/cycle/develop.py", "error"),
+    # Generated-test result-row status dict ({"status": "passed"|"failed"}); a
+    # per-result vocabulary with no enum.
+    ("src/squadops/agents/skills/qa/test_execution.py", "failed"),
+    # External Ollama model-pull job status — a vendor vocabulary, not a domain enum.
+    ("src/squadops/cli/commands/models.py", "failed"),
+    # window_state() returns a duty-window lifecycle token ("active"/
+    # "in_reserve_before"/...), not a CycleStatus/FlowState.
+    ("src/squadops/runtime/recruitment.py", "active"),
+    ("src/squadops/runtime/scheduler.py", "active"),
+    # RuntimeMode is a Literal["duty","cycle","ambient"] (models.py:24), not an
+    # enum; "cycle"/"duty" are its own values, coincidental with LifecycleScope.
+    ("src/squadops/runtime/coordinator.py", "cycle"),
+    # workload_statuses is a DTO-derived progress-token Sequence[str] that mixes
+    # gate states ("gate_awaiting"/"rejected") with WorkloadStatus values; a
+    # broader ad-hoc vocabulary, not a single enum (enum-ifying it is a follow-up).
+    ("src/squadops/cycles/lifecycle.py", "rejected"),
+    ("src/squadops/cycles/lifecycle.py", "pending"),
+}
+
+# Enum values this short/common that they produce coincidental matches are not
+# worth guarding — matching them would flag unrelated string handling. (None today;
+# kept as the escape hatch if a future enum defines e.g. "r"/"a".)
+_IGNORED_VALUES: set[str] = set()
+
+
+def _enum_base_names(node: ast.ClassDef) -> set[str]:
+    names: set[str] = set()
+    for base in node.bases:
+        if isinstance(base, ast.Name):
+            names.add(base.id)
+        elif isinstance(base, ast.Attribute):
+            names.add(base.attr)
+    return names
+
+
+def _discover_enum_values(root: Path) -> dict[str, set[str]]:
+    """Map each StrEnum/Enum string value (lowercased) -> the enum class(es) that own it."""
+    values: dict[str, set[str]] = {}
+    for py in root.rglob("*.py"):
+        tree = ast.parse(py.read_text(), filename=str(py))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            if not ({"StrEnum", "Enum"} & _enum_base_names(node)):
+                continue
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.Assign)
+                    and isinstance(stmt.value, ast.Constant)
+                    and isinstance(stmt.value.value, str)
+                    and stmt.value.value
+                ):
+                    values.setdefault(stmt.value.value.lower(), set()).add(node.name)
+    return values
+
+
+def _string_literals_in_comparator(node: ast.expr):
+    """Yield str-literal values directly in a comparator (incl. tuple/list/set members)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        yield node.value
+    elif isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        for elt in node.elts:
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                yield elt.value
+
+
+def _find_violations(root: Path, enum_values: dict[str, set[str]]) -> list[str]:
+    violations: list[str] = []
+    for py in root.rglob("*.py"):
+        rel = str(py.relative_to(REPO_ROOT))
+        tree = ast.parse(py.read_text(), filename=str(py))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Compare):
+                continue
+            for comparator in [node.left, *node.comparators]:
+                for literal in _string_literals_in_comparator(comparator):
+                    key = literal.lower()
+                    if key in _IGNORED_VALUES or key not in enum_values:
+                        continue
+                    if (rel, key) in _ALLOWLIST:
+                        continue
+                    owners = ", ".join(sorted(enum_values[key]))
+                    violations.append(f'  {rel}:{node.lineno}  == "{literal}"  shadows {owners}')
+    return violations
+
+
+def test_no_enum_shadow_string_comparisons() -> None:
+    enum_values = _discover_enum_values(SRC)
+    assert enum_values, "no StrEnum vocabularies discovered — discovery is broken"
+    violations = _find_violations(SRC, enum_values)
+    assert not violations, (
+        f"{len(violations)} enum-shadow string comparison(s) — compare against the enum "
+        f"member (or .value), not a raw literal (#380):\n" + "\n".join(violations)
+    )


### PR DESCRIPTION
## Why

`terminal_status == "COMPLETED"` — an untyped uppercase shadow of the lowercase `RunStatus` enum — slipped in and **propagated across three SIPs** because it's *latent* drift: the two vocabularies never collide at runtime, so tests stay green and only human review can catch it (and "looks like existing code → approve" is the propagation mechanism). Discipline doesn't stop this; an executable guardrail does. Ruff `PLR2004` (magic-value-comparison) is **numeric-only** and doesn't flag strings, so this is a custom AST rule — same vehicle as `test_forbidden_imports.py`, runs in the regression suite.

Closes #380.

## The guardrail
`tests/unit/architecture/test_no_enum_shadow_comparisons.py` auto-discovers every `StrEnum` vocabulary in the domain (67 values today; future enums covered for free) and **fails CI** when domain code compares a variable against a raw string literal that matches an enum value (case-insensitive, to catch the upper/lower shadow that started this).

Off main it found **22**. This PR resolves each as either a mechanical fix or a justified allowlist entry — no silent sweeps.

## Fixed (mechanical — value+case exact, right enum)
- `run_report_builder`: `terminal_status` → `RunStatus.*.value.upper()` (case-robust); pulse decisions → `PulseDecision.*.value`
- `artifacts`: `build_strategy` → `BuildStrategy.FRESH.value`
- `runs`: gate decision → `GateDecisionValue.APPROVED.value`

## Allowlisted (11, each justified in-file)
A shared status **word** (`"failed"`, `"active"`) is defined by several enums *and* by non-enum vocabularies, so value-matching flags coincidences — triaged, not swept:
- **`result.status == "SUCCEEDED"`** (`runner`, `orchestrator`) — `TaskResult.status` is an UPPERCASE bare-str vocabulary, **not** the lowercase `TaskStatus` enum; the naive enum fix would *break* it (case). Reconciliation tracked in **#381** (a loaded footgun, twin of #377).
- `CheckOutcome.status` (`develop`) — a dataclass, not a StrEnum (SIP-0092).
- generated-test result rows (`test_execution`), Ollama pull status (`models`), `window_state()` tokens (`recruitment`/`scheduler`), `RuntimeMode` Literal (`coordinator`), DTO workload-progress tokens (`lifecycle`) — each a distinct vocabulary.

## Honest limits (documented, not hidden)
- The rule flags string-literal comparisons; it would **not** catch the *firing* form of #381 (`== TaskStatus.X`) — it finds the root (untyped vocabulary) and forces reconciliation, it's the smoke detector not the extinguisher.
- ~311 other string-literal comparisons with **no** backing enum are out of scope (a blanket rule = 324 sites = noise); a softer "same literal in ≥3 places = missing enum" signal is a possible follow-up.

## Overlap note
`run_report_builder._build_report_quality_lines` is also touched by the SIP-0096 slice-1 PR #378 (which adds the narrative-override *feature* on top of the same enum-referenced compares). On merge, take #378's superset of that function; the guardrail passes against either.

Relates to #377, #381. Regression **4774**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ