### PR TITLE
fix(#374): re-run the failed check on a patch (pure-behavioral repair verification)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -833,7 +833,11 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
         # SIP-0079 Phase 3: Outcome routing state
         consecutive_failures: int = 0
-        correction_attempts: int = 0
+        # #374: run-level correction count as a mutable holder. A `patch` re-runs the
+        # failed check via dispatch_with_retry's "continue", so the count must bump on
+        # each inner-loop correction (not just once per outer iteration) to bound it
+        # (max_correction_attempts) and keep corr-/plan_delta- ids unique across re-runs.
+        correction_counter: dict[str, int] = {"n": 0}
         task_attempt_counts: dict[str, int] = {}
 
         # SIP-0079: Time budget enforcement (RC-8)
@@ -938,7 +942,6 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 result,
                 _envelope=envelope,
                 _consecutive_failures=consecutive_failures,
-                _correction_attempts=correction_attempts,
                 _holder=_last_failed_result,
             ):
                 _holder["result"] = result
@@ -949,7 +952,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     run_id=run_id,
                     task_attempt_counts=task_attempt_counts,
                     consecutive_failures=_consecutive_failures,
-                    correction_attempts=_correction_attempts,
+                    correction_counter=correction_counter,
                     prior_outputs=prior_outputs,
                     all_artifact_refs=all_artifact_refs,
                     stored_artifacts=stored_artifacts,
@@ -1009,13 +1012,12 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             _record_task_evidence(result)
 
             if not task_succeeded:
-                # SIP-0079: correction completed with continue/patch outcome.
-                # Original flow: consecutive_failures was incremented before
-                # correction, then reset to 0 on continue/patch. The increment
-                # only survives on abort/rewind paths which raise inside
-                # _handle_task_outcome before reaching here. Net effect: reset.
+                # #374: reaching here means the correction returned break_correction —
+                # i.e. governance chose "continue" (advance without repair). A `patch`
+                # now returns "continue", re-running the failed check inside
+                # dispatch_with_retry, so it never lands here. The correction count is
+                # bumped on the shared holder inside _handle_task_outcome, not here.
                 consecutive_failures = 0
-                correction_attempts += 1
 
             if not task_succeeded:
                 # Correction "continue"/"patch" handled — skip to next task
@@ -1276,7 +1278,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         run_id: str,
         task_attempt_counts: dict[str, int],
         consecutive_failures: int,
-        correction_attempts: int,
+        correction_counter: dict[str, int],
         prior_outputs: dict[str, Any],
         all_artifact_refs: list[str],
         stored_artifacts: list[tuple[str, ArtifactRef]],
@@ -1288,12 +1290,16 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         """Route a failed task outcome. Returns an action string.
 
         Returns:
-            "continue" — retry the same task (caller continues while loop)
-            "break_correction" — correction handled, advance to next task
+            "continue" — re-dispatch the same task (caller's while loop retries it):
+                a retryable failure, OR (#374) a ``patch`` correction whose repair is
+                verified behaviorally by re-running the failed check itself.
+            "break_correction" — correction handled without re-run (governance
+                "continue": advance without repair), advance to next task.
 
         Raises:
             _PausedError — task is blocked
-            _ExecutionError — unrecoverable failure
+            _ExecutionError — unrecoverable failure (incl. max_correction_attempts
+                exhausted, so a repair that never converges fails the run)
         """
         outcome = (result.outputs or {}).get("outcome_class") if result.outputs else None
 
@@ -1328,15 +1334,21 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # Trigger correction protocol
         max_corrections = cycle.applied_defaults.get("max_correction_attempts", 2)
 
-        if correction_attempts >= max_corrections:
+        if correction_counter["n"] >= max_corrections:
             raise _ExecutionError(f"Max correction attempts ({max_corrections}) exhausted")
+
+        # #374: bump the shared run-level count on THIS correction (before dispatch) so a
+        # patch that re-runs the check (below) is bounded, and each re-run gets a fresh
+        # corr-/plan_delta- id. The pre-increment value keys those deterministic ids.
+        attempt = correction_counter["n"]
+        correction_counter["n"] = attempt + 1
 
         correction_path = await self._correction_runner.run_correction_protocol(
             run_id=run_id,
             cycle=cycle,
             envelope=envelope,
             result=result,
-            correction_attempts=correction_attempts,
+            correction_attempts=attempt,
             prior_outputs=prior_outputs,
             all_artifact_refs=all_artifact_refs,
             stored_artifacts=stored_artifacts,
@@ -1352,7 +1364,16 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             )
         elif correction_path == "rewind":
             raise _ExecutionError(f"Rewinding to checkpoint after {envelope.task_type} failure")
-        elif correction_path in ("continue", "patch"):
+        elif correction_path == "patch":
+            # #374 (pure-behavioral): re-run the ORIGINAL failed check against the
+            # patched artifacts — the re-run's pass/fail IS the verdict, not the LLM
+            # validate_repair judgment. "continue" re-dispatches the same task; a pass
+            # advances with real executed-passed evidence (recording seam), a fail
+            # re-enters correction until max_correction_attempts exhausts (guard above)
+            # → _ExecutionError → the run fails honestly instead of false-completing.
+            return "continue"
+        elif correction_path == "continue":
+            # Governance chose to advance without repair (accept-and-move-on).
             return "break_correction"
         else:
             raise _ExecutionError(f"Unknown correction path: {correction_path}")

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -305,6 +305,8 @@ class TestCorrectionPatch:
             ("SUCCEEDED", {"summary": "repaired", "role": "dev"}, None),
             # Repair: qa.validate_repair
             ("SUCCEEDED", {"summary": "validated", "role": "qa"}, None),
+            # #374: a patch re-runs the ORIGINAL failed check (Task 1) — now passes
+            ("SUCCEEDED", {"summary": "task1 re-run ok", "role": "dev"}, None),
             # Tasks 2-5: succeed
             ("SUCCEEDED", {"summary": "ok", "role": "dev"}, None),
             ("SUCCEEDED", {"summary": "ok", "role": "dev"}, None),
@@ -319,12 +321,83 @@ class TestCorrectionPatch:
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
 
-        # 1 (failed) + 2 (correction) + 2 (repair) + 4 (remaining) = 9
-        assert mock_queue.publish.call_count == 9
+        # 1 (failed) + 2 (correction) + 2 (repair) + 1 (#374 re-run of Task 1) + 4 (remaining) = 10
+        assert mock_queue.publish.call_count == 10
 
         status_calls = mock_registry.update_run_status.call_args_list
         terminal_statuses = [c.args[1] for c in status_calls]
         assert RunStatus.COMPLETED in terminal_statuses
+
+    async def test_patch_rerun_never_converges_fails_run(self, executor, mock_queue, mock_registry):
+        """#374: a patch whose re-run never passes must FAIL the run, not false-complete.
+
+        Catches the pre-#374 false-green (#276 class): a ``patch`` advanced
+        unconditionally, so a task whose repair never actually fixed the check still
+        reached COMPLETED. Now a ``patch`` re-runs the original check; a persistent
+        failure re-enters correction until ``max_correction_attempts`` exhausts,
+        raising ``_ExecutionError`` → the run is FAILED, never COMPLETED.
+        """
+        import dataclasses
+
+        cycle_2 = dataclasses.replace(
+            mock_registry.get_cycle.return_value,
+            applied_defaults={"max_correction_attempts": 2},
+        )
+        mock_registry.get_cycle.return_value = cycle_2
+
+        patch_decision = {
+            "summary": "patch",
+            "role": "lead",
+            "correction_path": "patch",
+            "decision_rationale": "Fix is localized",
+            "affected_task_types": ["development.develop"],
+            "classification": "work_product",
+            "analysis_summary": "Output quality issue",
+        }
+
+        def responder(env):
+            tid = env["task_id"]
+            if "correction_decision" in tid:
+                return TaskResult(
+                    task_id=tid, status="SUCCEEDED", outputs=patch_decision, error=None
+                )
+            if tid.startswith("corr-") or tid.startswith("repair-"):
+                # analyze_failure / repair / validate_repair all succeed
+                return TaskResult(
+                    task_id=tid,
+                    status="SUCCEEDED",
+                    outputs={
+                        "summary": "ok",
+                        "role": "data",
+                        "classification": "work_product",
+                        "analysis_summary": "quality",
+                    },
+                    error=None,
+                )
+            # An original plan task: its check keeps failing on every re-run.
+            return TaskResult(
+                task_id=tid,
+                status="FAILED",
+                outputs={"outcome_class": TaskOutcome.SEMANTIC_FAILURE, "role": "dev"},
+                error="check still failing",
+            )
+
+        mock_queue.reply_router.responder = responder
+
+        with patch(
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        terminal_statuses = [c.args[1] for c in mock_registry.update_run_status.call_args_list]
+        # The #374 guarantee: a non-converging repair fails honestly, never false-green.
+        assert RunStatus.FAILED in terminal_statuses
+        assert RunStatus.COMPLETED not in terminal_statuses
+        # Proof the check was actually re-run (not advanced-on-first-patch): the old
+        # behavior was exactly 5 publishes (1 fail + 2 correction + 2 repair) then a
+        # false-advance; re-running past the first patch exceeds that.
+        assert mock_queue.publish.call_count > 5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the enforcement half of #374 — the SIP-0086 convergence loop no longer advances blindly on a `patch`.

**Pure-behavioral repair verification:** a `patch` correction now re-runs the **original failed check** against the patched artifacts (it returns `"continue"`, so the executor re-dispatches the task via `dispatch_with_retry`'s existing retry loop). The re-run's pass/fail **is** the verdict — not the LLM `validate_repair` judgment.

- re-run **passes** → advances, with real executed-passed evidence through the SIP-0096 recording seam
- re-run **keeps failing** → re-enters correction until `max_correction_attempts` exhausts → `_ExecutionError` → **the run FAILS** honestly instead of false-completing (the #276-class false-green, eliminated)

**Threading gotcha handled:** the run-level correction count is now a shared mutable holder (`correction_counter`) incremented inside `_handle_task_outcome`. Without that, the inner `"continue"` loop would never hit the `max_correction_attempts` bound *and* would collide the deterministic `corr-`/`plan_delta-` ids across re-runs.

## ⚠️ Draft — must land **with #379**

This is one half of a coupled pair. Without #379, a *recovered* run (repair converges) completes but its SIP-0096 roll-up shows a **stale `rejected`** — the append-only aggregation doesn't supersede the earlier FAILED `CheckResult` with the re-run's PASSED one. #379 (Macbook lane) resolves `(check_id, subject_ref)` to final-state and populates `subject_ref` (today `None`). **Hold merge until #379 is ready and land them together.**

## Tests

- Updated `test_patch_dispatches_repair_tasks` — the re-run adds one dispatch (9→10) and the run still completes.
- New `test_patch_rerun_never_converges_fails_run` — a repair that never fixes the check **fails the run** (never COMPLETED). Catches the pre-#374 false-green directly.
- Full cycles suite: **1486 passed**, ruff clean.

## Joint acceptance (Spark full-squad, after #379)

- repair re-runs → green → verdict `accepted`
- repair never converges → run **FAILED**

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
