### PR TITLE
feat(SIP-0096 Phase 2 slice 2): final-state resolution for re-verified checks (#379)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -942,7 +942,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 _holder=_last_failed_result,
             ):
                 _holder["result"] = result
-                return await self._handle_task_outcome(
+                action = await self._handle_task_outcome(
                     result=result,
                     envelope=_envelope,
                     cycle=cycle,
@@ -958,16 +958,30 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     profile=profile,
                     flow_run_id=flow_run_id,
                 )
+                if action == "continue":
+                    # #379: this attempt failed and is about to be re-dispatched — a
+                    # correction patch re-verifying behaviorally (#374), or a plain
+                    # retry. Record its evidence now so the ledger honestly holds the
+                    # failed→passed history; aggregation supersedes it to the final
+                    # state per (check_id, subject). Self-filtering: a transport retry
+                    # carries no validation_result/test_result → nothing is recorded.
+                    _record_task_evidence(result)
+                return action
 
-            def _record_task_evidence(task_result) -> None:
+            def _record_task_evidence(task_result, _envelope=envelope) -> None:
                 # Normalize this task's verification outputs into the run ledger for
-                # the end-of-run aggregation choke point. Best-effort: a normalizer
-                # defect must never break task execution (the report path is guarded
-                # the same way).
+                # the end-of-run aggregation choke point. Every result is stamped with
+                # the producing task id (#379) so a repaired-and-re-run check resolves
+                # to its final state at aggregation. ``_envelope`` is bound as a default
+                # (B023) so it captures THIS iteration's task, matching _route_outcome.
+                # Best-effort: a normalizer defect must never break task execution (the
+                # report path is guarded the same).
                 if task_result is None or not getattr(task_result, "outputs", None):
                     return
                 try:
-                    for check_result in normalize_task_checks(task_result.outputs):
+                    for check_result in normalize_task_checks(
+                        task_result.outputs, subject=_envelope.task_id
+                    ):
                         ledger.record_check_result(check_result)
                 except Exception:
                     logger.warning("Verification-evidence recording failed", exc_info=True)

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -155,6 +155,16 @@ class CheckResult:
     is_stub: bool = False
     stub_disclosed: bool = False
     provenance: CheckProvenance | None = None
+    subject: str | None = None
+    # The producing subject's identity (§6.3) — the plan-task id that emitted this
+    # result. DISTINCT from ``provenance.subject_ref`` (the *thing* under test — a
+    # file-set hash/artifact/endpoint, which legitimately *differs* between a failed
+    # check and its re-run against patched artifacts, so it is the wrong grouping
+    # key). ``subject`` is stable across a task's re-verification, so aggregation can
+    # supersede a repaired-and-re-run check to its final state (§6.5) without
+    # collapsing distinct producers that share a ``check_id`` (e.g. ``tests_pass``
+    # emitted once per develop task). ``None`` = no producer identity → never
+    # collapsed (each such result is its own evidence).
 
 
 @dataclass(frozen=True)
@@ -235,6 +245,40 @@ def _not_executed_reason(result: CheckResult) -> str:
     return result.reason or UNSPECIFIED_REASON
 
 
+def _resolve_final_state(results: Sequence[CheckResult]) -> list[CheckResult]:
+    """Collapse each identified producer's re-verified check to its final state (§6.5).
+
+    A check that failed, was repaired, and re-ran lands on the append-only ledger
+    twice (a FAILED then a PASSED ``CheckResult`` with the same ``(check_id,
+    subject)``). The verdict must reflect the **final** state after correction's
+    bounded attempts — not the union of all attempts (#379), which would pin a
+    recovered run to ``rejected`` forever (the "stuck-red" mirror of the false-green
+    this SIP kills). So the LAST-appended result per identity supersedes.
+
+    The ledger is append-only, so append order *is* attempt order — resolution keys
+    off position, never a timestamp, keeping this module clock-free.
+
+    Results with ``subject is None`` carry no producer identity and are **never**
+    collapsed: each is independent evidence (the correct default — e.g. distinct
+    develop tasks emitting ``tests_pass`` must accumulate, "any subject failed →
+    rejected"; only the *same* subject re-verified supersedes).
+    """
+    resolved: list[CheckResult] = []
+    final_pos_by_identity: dict[tuple[str, str], int] = {}
+    for r in results:
+        if r.subject is None:
+            resolved.append(r)
+            continue
+        identity = (r.check_id, r.subject)
+        prior = final_pos_by_identity.get(identity)
+        if prior is None:
+            final_pos_by_identity[identity] = len(resolved)
+            resolved.append(r)
+        else:
+            resolved[prior] = r  # supersede the earlier attempt with the final one
+    return resolved
+
+
 def aggregate_verification(
     results: Sequence[CheckResult],
     required_check_ids: Collection[str] = (),
@@ -259,6 +303,10 @@ def aggregate_verification(
 
     Not-executed results are excluded from ``executed_count``/``passed_count`` and
     from all success credit, and are always disclosed in ``unverified`` (§6.6.3).
+
+    A check that was repaired and re-verified is first resolved to its final state
+    per ``(check_id, subject)`` (§6.5, #379) — the verdict reflects the outcome
+    after correction, not the union of every attempt. See ``_resolve_final_state``.
     """
     required = frozenset(required_check_ids)
     verified: list[str] = []
@@ -266,7 +314,9 @@ def aggregate_verification(
     unverified: list[UnverifiedCheck] = []
     seen_ids: set[str] = set()
 
-    for r in results:
+    # Resolve each producer's re-verified check to its final state first (§6.5, #379)
+    # so a repaired-and-passed check no longer counts its superseded FAILED attempt.
+    for r in _resolve_final_state(results):
         seen_ids.add(r.check_id)
         family = classify(r)
         if family is EvidenceFamily.EXECUTED_PASSED:

--- a/src/squadops/cycles/verification_normalize.py
+++ b/src/squadops/cycles/verification_normalize.py
@@ -24,6 +24,7 @@ executor at the dispatch seam):
 
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Mapping
 from typing import Any
 
@@ -39,8 +40,17 @@ CHECK_TESTS_PASS = "tests_pass"
 CHECK_NO_STUB = "no_stub_fallback_tests"
 
 
-def normalize_task_checks(outputs: Mapping[str, Any]) -> list[CheckResult]:
+def normalize_task_checks(
+    outputs: Mapping[str, Any], *, subject: str | None = None
+) -> list[CheckResult]:
     """Map one completed task's ``outputs`` into recordable ``CheckResult``s (§6.1).
+
+    ``subject`` is the producing plan-task id (``envelope.task_id``); it is stamped
+    on every result so aggregation can supersede a repaired-and-re-run check to its
+    final state per ``(check_id, subject)`` (§6.5, #379) — the same task re-verified
+    collapses to its final outcome, while distinct tasks emitting the same
+    ``check_id`` (e.g. ``tests_pass``) stay independent. ``None`` leaves the results
+    un-identified (each counts on its own).
 
     Robust by construction — a malformed row is skipped, never raised, because this
     runs in the executor's per-task path and must never break task execution.
@@ -85,6 +95,8 @@ def normalize_task_checks(outputs: Mapping[str, Any]) -> list[CheckResult]:
     if isinstance(test_result, Mapping):
         results.append(_tests_pass_from_result(test_result, is_stub=stub_detected))
 
+    if subject is not None:
+        results = [dataclasses.replace(r, subject=subject) for r in results]
     return results
 
 

--- a/tests/unit/cycles/test_executor_checkpoint.py
+++ b/tests/unit/cycles/test_executor_checkpoint.py
@@ -29,6 +29,7 @@ from squadops.cycles.models import (
     TaskFlowPolicy,
     WorkloadType,
 )
+from squadops.cycles.run_ledger import RunLedger
 from squadops.events.types import EventType
 from squadops.tasks.models import TaskResult
 
@@ -742,3 +743,70 @@ class TestVerificationEvidenceRecording:
         assert "Failed: tests_pass" in report
         assert "REJECTED" in report
         assert "All tasks completed successfully." not in report
+
+    async def test_rerun_records_failed_attempt_then_supersedes_to_accepted(
+        self, executor, mock_registry, mock_queue, mock_vault
+    ) -> None:
+        """#379 end-to-end at the recording seam: a task whose check FAILS then PASSES
+        on re-dispatch (the ``continue`` path — a retry here, a #374 repair re-run in
+        production) records BOTH attempts, stamped with the producing task id, and the
+        verdict resolves to the FINAL state (accepted). Without recording the failed
+        attempt the honest-history is lost; without subject-keyed supersession the run
+        would be stuck ``rejected`` (the exact coupling #374 depends on).
+        """
+        dispatch_count = 0
+
+        def fail_then_pass(env):
+            nonlocal dispatch_count
+            dispatch_count += 1
+            # First dispatch of the first task fails its tests; the retry (2nd
+            # dispatch) and every later task pass. env["task_id"] is stable across the
+            # re-dispatch, so both records share the producing subject.
+            failed = dispatch_count == 1
+            return TaskResult(
+                task_id=env["task_id"],
+                status="FAILED" if failed else "SUCCEEDED",
+                error="tests failed" if failed else None,
+                outputs={
+                    "summary": "x",
+                    "artifacts": [],
+                    "test_result": {
+                        "executed": True,
+                        "exit_code": 1 if failed else 0,
+                        "tests_passed": not failed,
+                    },
+                },
+            )
+
+        mock_queue.reply_router.responder = fail_then_pass
+
+        recorded: list = []
+        real_record = RunLedger.record_check_result
+
+        def _spy(self, result):
+            recorded.append(result)
+            real_record(self, result)
+
+        with (
+            patch.object(RunLedger, "record_check_result", _spy),
+            patch("adapters.cycles.dispatched_flow_executor.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
+
+        # The failed attempt WAS recorded (my _route_outcome change fires on continue),
+        # and it carries a producing subject so it can be superseded.
+        tp = [r for r in recorded if r.check_id == "tests_pass"]
+        failed_records = [r for r in tp if r.status == "failed"]
+        passed_records = [r for r in tp if r.status == "passed"]
+        assert failed_records, "the failed re-run attempt must be recorded, not dropped"
+        assert all(r.subject for r in tp), "every recorded check must carry its subject"
+        # The failed attempt and its passing re-run share one subject (same task).
+        failed_subj = failed_records[0].subject
+        assert any(r.subject == failed_subj for r in passed_records)
+
+        # Final verdict reflects the recovered state — the superseded failure does not
+        # pin it rejected.
+        report = self._run_report(mock_vault)
+        assert mock_registry.update_run_status.call_args_list[-1].args[1] == RunStatus.COMPLETED
+        assert "Verdict: **accepted**" in report
+        assert "Failed: tests_pass" not in report

--- a/tests/unit/cycles/test_verification_integrity.py
+++ b/tests/unit/cycles/test_verification_integrity.py
@@ -207,6 +207,87 @@ def test_only_declared_ids_block():
 
 
 # --------------------------------------------------------------------------- #
+# Final-state resolution — the repaired-and-re-run check (§6.5, #379)
+# --------------------------------------------------------------------------- #
+
+
+def test_same_subject_failed_then_passed_supersedes_to_accepted():
+    """The #379 core bug: a check that FAILED then re-ran and PASSED (same producing
+    task) must resolve to its FINAL state — verdict ``accepted``, not the union that
+    would pin ``rejected`` forever. This is the coupled half of #374's re-run-to-green.
+    """
+    s = aggregate_verification(
+        [_failed("tests_pass", subject="task-A"), _passed("tests_pass", subject="task-A")]
+    )
+    assert s.verdict is RunVerdict.ACCEPTED
+    assert s.failed == ()
+    assert s.verified == ("tests_pass",)
+    assert (s.executed_count, s.passed_count) == (1, 1)
+
+
+def test_same_subject_passed_then_failed_stays_rejected():
+    """Supersession is order-sensitive, not fail-masking: a check that passed then
+    regressed (final = FAILED) must stay ``rejected`` — the fix must not swallow a
+    real later failure."""
+    s = aggregate_verification(
+        [_passed("tests_pass", subject="task-A"), _failed("tests_pass", subject="task-A")]
+    )
+    assert s.verdict is RunVerdict.REJECTED
+    assert s.failed == ("tests_pass",)
+    assert s.verified == ()
+
+
+def test_different_subjects_same_check_id_accumulate():
+    """Distinct producing tasks emitting the same check_id (``tests_pass`` once per
+    develop task) are NOT collapsed: one failing → ``rejected``. Naive last-write-wins
+    by bare check_id would wrongly drop the earlier task's real failure."""
+    s = aggregate_verification(
+        [_failed("tests_pass", subject="task-A"), _passed("tests_pass", subject="task-B")]
+    )
+    assert s.verdict is RunVerdict.REJECTED
+    assert set(s.failed) == {"tests_pass"}
+    assert set(s.verified) == {"tests_pass"}
+    assert s.executed_count == 2  # both subjects counted, not deduped to one
+
+
+def test_subjectless_results_are_never_collapsed():
+    """``subject=None`` carries no producer identity — each result stays independent
+    (the pre-#379 accumulate default), so two un-identified rows for one check_id
+    still both count. Guards against silently collapsing legacy/un-subjected producers.
+    """
+    s = aggregate_verification([_failed("c"), _passed("c")])  # no subject on either
+    assert s.verdict is RunVerdict.REJECTED
+    assert s.executed_count == 2
+
+
+def test_required_check_recovers_to_accepted_after_repair():
+    """The re-run-to-green case #374 needs: a REQUIRED check that failed then passed
+    on re-verification must reach ``accepted`` — the superseded FAILED attempt must
+    not leave it stuck ``rejected`` (nor ``blocked_unverified``, since the final state
+    IS executed-and-passed)."""
+    s = aggregate_verification(
+        [_failed("tests_pass", subject="task-A"), _passed("tests_pass", subject="task-A")],
+        required_check_ids=["tests_pass"],
+    )
+    assert s.verdict is RunVerdict.ACCEPTED
+    assert s.required_unmet == ()
+
+
+def test_multiple_failed_attempts_then_pass_all_supersede():
+    """Two failed attempts then a pass (same subject) all collapse to the final PASSED
+    — bounded correction may retry more than once before converging."""
+    s = aggregate_verification(
+        [
+            _failed("tests_pass", subject="task-A"),
+            _failed("tests_pass", subject="task-A"),
+            _passed("tests_pass", subject="task-A"),
+        ]
+    )
+    assert s.verdict is RunVerdict.ACCEPTED
+    assert (s.executed_count, s.passed_count) == (1, 1)
+
+
+# --------------------------------------------------------------------------- #
 # Drift + purity guards (AC#13)
 # --------------------------------------------------------------------------- #
 

--- a/tests/unit/cycles/test_verification_normalize.py
+++ b/tests/unit/cycles/test_verification_normalize.py
@@ -224,3 +224,44 @@ def test_clean_pass_aggregates_accepted():
     )
     assert summary.verdict is RunVerdict.ACCEPTED
     assert CHECK_TESTS_PASS in summary.verified
+
+
+# --------------------------------------------------------------------------- #
+# Producing-subject stamping — the #379 identity qualifier
+# --------------------------------------------------------------------------- #
+
+
+def test_subject_stamped_on_every_result():
+    """The producing task id is stamped on every normalized result so aggregation can
+    resolve a re-run to final state (§6.5). Without it, subject is None and the same
+    task's repaired re-run can't supersede its earlier failure."""
+    out = {
+        "test_result": {"executed": True, "exit_code": 0, "tests_passed": True},
+        "validation_result": {
+            "checks": [{"check": "acceptance:file_exists", "status": "passed", "passed": True}]
+        },
+    }
+    results = normalize_task_checks(out, subject="task-A")
+    assert results  # non-empty
+    assert {r.subject for r in results} == {"task-A"}
+
+
+def test_subject_defaults_to_none_when_unset():
+    """Backward-compatible default: no subject → un-identified results (each counts on
+    its own at aggregation), so an un-migrated call site keeps the pre-#379 behavior."""
+    out = {"test_result": {"executed": True, "exit_code": 0, "tests_passed": True}}
+    assert normalize_task_checks(out)[0].subject is None
+
+
+def test_task_re_run_supersedes_earlier_failure_via_subject():
+    """The coupled #374 path end-to-end at the normalize+aggregate level: the SAME task
+    re-recorded (failed build → repaired → passing re-run) resolves to accepted when
+    both records carry its subject; the failed attempt is superseded, not unioned."""
+    failing = {"test_result": {"executed": True, "exit_code": 1, "tests_passed": False}}
+    passing = {"test_result": {"executed": True, "exit_code": 0, "tests_passed": True}}
+    ledger = normalize_task_checks(failing, subject="task-A") + normalize_task_checks(
+        passing, subject="task-A"
+    )
+    summary = aggregate_verification(ledger, required_check_ids=[CHECK_TESTS_PASS])
+    assert summary.verdict is RunVerdict.ACCEPTED
+    assert summary.failed == ()


### PR DESCRIPTION
## Summary

The Mac half of the #374/#379 coupled pair — **final-state resolution** so a repaired-and-re-run check resolves to its final outcome, not the union of every attempt.

The Phase-1 aggregation core unioned every recorded result, so a check that FAILED, was repaired, and re-ran PASSED landed in *both* `failed` and `verified` → the verdict was pinned `rejected` permanently. That contradicts SIP-0096 **§6.5** (*"the verdict reflects the final state after correction's bounded attempts"*) and blocks #374's re-run-to-green: a genuinely-fixed check stays **stuck-red** — the exact mirror of the false-green this SIP kills.

## The fix is an identity qualifier, not a naive dedup

Framework-spine `tests_pass` is legitimately recorded **once per develop task** (3 tasks → 3 rows, "any fail → rejected" is correct). Bare last-write-wins by `check_id` would collapse distinct producers and silently drop a real mid-run failure. So:

- **`CheckResult.subject`** — the producing plan-task id (§6.3). Deliberately **distinct from `provenance.subject_ref`** (the *thing under test* — a file-set hash/artifact/endpoint, which legitimately **differs** between a failed check and its re-run against *patched* artifacts, making it the wrong grouping key).
- **`aggregate_verification`** resolves `(check_id, subject)` to its **last-appended** result before applying the invariant. The ledger is append-only, so append order *is* attempt order — resolution keys off position, keeping the module clock-free (no timestamp sort). `subject=None` rows are **never** collapsed (each is independent evidence — the pre-#379 accumulate default; distinct subjects still "any fail → rejected").
- **`normalize_task_checks`** stamps `subject=envelope.task_id` on every result.
- The **executor records the intermediate FAILED attempt** on the re-dispatch (`"continue"`) path, so the ledger honestly holds the failed→passed history; aggregation then supersedes it. Self-filtering: a transport retry carries no verification outputs → nothing recorded.

## ⚠️ Draft — must land **with #374 (PR #385)**

One half of a coupled pair. A finding worth flagging: I traced the recording seam and **with #374 as written, a converged repair currently records only the *final* PASSED result** (`_record_task_evidence` fires at the final-settle + abort seams only — the intermediate failure is captured in `_last_failed_result` but only *recorded* on abort). So #385's premise — "the append-only aggregation doesn't supersede the earlier FAILED CheckResult" — assumed a FAILED row that wasn't actually landing.

This PR makes it land (the executor change above) **and** supersedes it, so #379 is genuinely load-bearing exactly as #385 designed (without it → `rejected`; with it → `accepted`) **and** the roll-up honestly discloses the recovery rather than silently showing green.

**Merge-order note:** both this PR and #385 edit `_route_outcome` in `dispatched_flow_executor.py` (#385 swaps `correction_attempts` → `correction_counter`; this adds the `if action == "continue": _record_task_evidence(result)` tail). Whoever merges second resolves a small conflict there — union both.

## Tests

- **6 pure-core supersession cases**: fail→pass → `accepted`; pass→fail stays `rejected` (no fail-masking); distinct subjects accumulate; `subject=None` never collapses; required check recovers to `accepted`; multi-attempt-then-pass all supersede.
- **3 normalizer cases**: subject stamped on every result; defaults to `None`; end-to-end same-task supersession.
- **1 executor end-to-end**: a task whose check fails then passes on re-dispatch records **both** attempts (subject-stamped) and resolves to `accepted` — proving the intermediate failure is recorded (not dropped) *and* superseded.
- Full regression **4823 passed, 1 skipped**, ruff + enum-shadow guardrail clean.

## Joint acceptance (Spark full-squad, after both land)

- repair re-runs → green → verdict `accepted`, roll-up discloses the recovered failure
- repair never converges → run **FAILED** (#385's guarantee)

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ
