### PR TITLE
fix(#333): never fabricate agent identity (id + role); document intentional defaults

### DIFF
--- a/adapters/observability/healthcheck_http.py
+++ b/adapters/observability/healthcheck_http.py
@@ -37,6 +37,10 @@ class HealthCheckHttpReporter(AgentHeartbeatReporter):
         fail_silently: bool = True,
         token_provider: Callable[[], Awaitable[str]] | None = None,
     ) -> None:
+        # The final default is the runtime-api's in-network compose address — a
+        # service-discovery default, not the config-masking class #333 targets:
+        # an explicit SQUADOPS_RUNTIME_API_URL still wins, and a wrong endpoint
+        # fails visibly (connection error), it doesn't fabricate required data.
         self._base_url = (
             base_url or os.getenv("SQUADOPS_RUNTIME_API_URL") or "http://runtime-api:8001"
         ).rstrip("/")

--- a/src/squadops/agents/entrypoint.py
+++ b/src/squadops/agents/entrypoint.py
@@ -89,10 +89,25 @@ class AgentRunner:
 
         Args:
             role: Agent role (lead, dev, qa, strat, data)
-            agent_id: Optional agent identifier (defaults to role-based)
+            agent_id: Agent identifier. When omitted it is read from the required
+                ``SQUADOPS__AGENT__ID`` env var — never fabricated (identity is not
+                defaulted).
+
+        Raises:
+            ValueError: if no agent id is provided or set in the environment.
         """
         self.role = role
-        self.agent_id = agent_id or os.getenv("SQUADOPS__AGENT__ID", f"{role}-001")
+        # Identity is required, never fabricated. Defaulting the id (the former
+        # f"{role}-001") masks a missing SQUADOPS__AGENT__ID and misdirects
+        # diagnosis to the instance-config load below — which fails with a
+        # confusing "no instance configuration for 'lead-001'" instead of naming
+        # the real cause (#333, the _get_default_instances() masking class).
+        self.agent_id = agent_id or os.getenv("SQUADOPS__AGENT__ID")
+        if not self.agent_id:
+            raise ValueError(
+                "Agent ID is not configured — set SQUADOPS__AGENT__ID. "
+                "Agent identity is never defaulted."
+            )
         self.system: SquadOpsSystem | None = None
         self._shutdown_event = asyncio.Event()
         self._heartbeat_task: asyncio.Task | None = None

--- a/src/squadops/agents/entrypoint.py
+++ b/src/squadops/agents/entrypoint.py
@@ -25,7 +25,14 @@ import signal
 import sys
 from typing import TYPE_CHECKING
 
-# Configure logging early
+# Configure logging early.
+# LOG_LEVEL (and MEMORY_DB_PATH / HEARTBEAT_INTERVAL below) are bare-env
+# *operational* knobs with sensible defaults — deliberately distinct from the
+# SQUADOPS__* nested-config convention and NOT the config-masking class #333
+# targets: they are optional tuning values, not required data, and a wrong value
+# fails visibly rather than fabricating something that looks correct. Required
+# identity (agent id / role) is the opposite — never defaulted (see AgentRunner
+# and _resolve_role).
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -363,6 +370,8 @@ class AgentRunner:
         # Create memory adapter
         memory = create_memory_provider(
             provider_type="lancedb",
+            # Operational default (see the LOG_LEVEL note) — intentional, not
+            # masked required config (#333).
             db_path=os.getenv("MEMORY_DB_PATH", "/app/data/memory_db"),
         )
 
@@ -816,6 +825,8 @@ class AgentRunner:
 
         Reports agent status to the health dashboard.
         """
+        # Operational default (see the LOG_LEVEL note) — intentional tuning knob,
+        # not masked required config (#333).
         heartbeat_interval = int(os.getenv("HEARTBEAT_INTERVAL", "30"))
 
         while not self._shutdown_event.is_set():
@@ -865,27 +876,35 @@ def setup_signal_handlers(runner: AgentRunner) -> None:
         loop.add_signal_handler(sig, lambda s=sig: handle_signal(s))
 
 
+def _resolve_role() -> str | None:
+    """Resolve the agent role for bootstrap.
+
+    Role selection happens before the config loader runs, so it is read from the
+    env (``SQUADOPS_AGENT_ROLE`` — a bootstrap selector, deliberately *not* the
+    ``SQUADOPS__*`` nested-config convention). When unset it is resolved from the
+    authoritative roster (``instances.yaml``) by agent id — **never fabricated**
+    from the id string. The former hardcoded ``{id: role}`` map duplicated the
+    roster, and its ``id.split("-")[0]`` fallback could mislabel an agent: the same
+    identity-masking class as the fabricated-id default (#333).
+    """
+    role = os.getenv("SQUADOPS_AGENT_ROLE")
+    if role:
+        return role
+    agent_id = os.getenv("SQUADOPS__AGENT__ID")
+    instance = load_instance_config(agent_id) if agent_id else None
+    return instance.get("role") if instance else None
+
+
 async def main() -> int:
     """Main entry point."""
-    # Get role from environment
-    role = os.getenv("SQUADOPS_AGENT_ROLE")
+    role = _resolve_role()
     if not role:
-        # Try to infer from SQUADOPS__AGENT__ID
-        agent_id = os.getenv("SQUADOPS__AGENT__ID", "")
-        if agent_id:
-            # Map agent IDs to roles (max -> lead, neo -> dev, etc.)
-            agent_role_map = {
-                "max": "lead",
-                "neo": "dev",
-                "bob": "builder",
-                "eve": "qa",
-                "nat": "strat",
-                "data": "data",
-            }
-            role = agent_role_map.get(agent_id.lower(), agent_id.split("-")[0])
-        else:
-            logger.error("SQUADOPS_AGENT_ROLE or SQUADOPS__AGENT__ID must be set")
-            return 1
+        logger.error(
+            "Agent role is not configured — set SQUADOPS_AGENT_ROLE, or ensure the "
+            "agent's instances.yaml entry declares a role. Identity is never "
+            "fabricated from the id string (#333)."
+        )
+        return 1
 
     logger.info(f"Starting agent with role: {role}")
 

--- a/tests/unit/agents/test_entrypoint_agent_id.py
+++ b/tests/unit/agents/test_entrypoint_agent_id.py
@@ -64,3 +64,45 @@ def test_empty_string_agent_id_is_rejected(monkeypatch):
 
     with pytest.raises(ValueError, match="SQUADOPS__AGENT__ID"):
         AgentRunner(role="qa")
+
+
+# --- role resolution (#333): authoritative roster, never fabricated ------------
+
+
+def test_role_from_env_wins(monkeypatch):
+    """An explicit SQUADOPS_AGENT_ROLE is authoritative (the bootstrap selector)."""
+    from squadops.agents import entrypoint
+
+    monkeypatch.setenv("SQUADOPS_AGENT_ROLE", "lead")
+    assert entrypoint._resolve_role() == "lead"
+
+
+def test_role_derived_from_instances_when_env_unset(monkeypatch):
+    """No role env → resolve from the authoritative roster (instances.yaml) by id."""
+    from squadops.agents import entrypoint
+
+    monkeypatch.delenv("SQUADOPS_AGENT_ROLE", raising=False)
+    monkeypatch.setenv("SQUADOPS__AGENT__ID", "neo")
+    monkeypatch.setattr(entrypoint, "load_instance_config", lambda aid: {"role": "dev"})
+    assert entrypoint._resolve_role() == "dev"
+
+
+def test_role_never_fabricated_from_id(monkeypatch):
+    """The bug this catches: the former ``id.split("-")[0]`` fabricated a role for an
+    id absent from the roster (e.g. 'quark-1' -> 'quark'), silently mislabeling the
+    agent. An unknown id now yields None (→ main() fails loudly), never a guess."""
+    from squadops.agents import entrypoint
+
+    monkeypatch.delenv("SQUADOPS_AGENT_ROLE", raising=False)
+    monkeypatch.setenv("SQUADOPS__AGENT__ID", "quark-1")
+    monkeypatch.setattr(entrypoint, "load_instance_config", lambda aid: None)  # not in roster
+    assert entrypoint._resolve_role() is None
+
+
+def test_role_none_when_nothing_configured(monkeypatch):
+    """Neither role env nor id → None (main() logs the error and exits non-zero)."""
+    from squadops.agents import entrypoint
+
+    monkeypatch.delenv("SQUADOPS_AGENT_ROLE", raising=False)
+    monkeypatch.delenv("SQUADOPS__AGENT__ID", raising=False)
+    assert entrypoint._resolve_role() is None

--- a/tests/unit/agents/test_entrypoint_agent_id.py
+++ b/tests/unit/agents/test_entrypoint_agent_id.py
@@ -1,0 +1,66 @@
+"""AgentRunner identity resolution — no fabricated agent id (#333).
+
+Identity is required config, never defaulted. The former ``f"{role}-001"`` fallback
+masked a missing ``SQUADOPS__AGENT__ID`` and misdirected diagnosis to the
+instance-config load. These tests pin that a missing id now fails loudly at the
+right place, and that a configured id (env or explicit) still resolves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.domain_agents]
+
+
+def test_missing_agent_id_raises_at_the_right_place_not_fabricated(monkeypatch):
+    """No ``SQUADOPS__AGENT__ID`` and no explicit id → a clear error naming the
+    missing var, raised BEFORE the instance-config load. The bug this catches: the
+    old ``f"{role}-001"`` default fabricated 'lead-001', which then failed the
+    instance-config load with a misdirecting 'no instance configuration' message."""
+    from squadops.agents.entrypoint import AgentRunner
+
+    monkeypatch.delenv("SQUADOPS__AGENT__ID", raising=False)
+
+    with pytest.raises(ValueError) as exc_info:
+        AgentRunner(role="lead")
+
+    msg = str(exc_info.value)
+    assert "SQUADOPS__AGENT__ID" in msg
+    # Fails naming the real cause, NOT the downstream instance-config misdirection.
+    assert "instance configuration" not in msg
+
+
+def test_env_agent_id_used_when_no_param(monkeypatch):
+    """A configured ``SQUADOPS__AGENT__ID`` resolves as the identity (no param)."""
+    from squadops.agents import entrypoint
+
+    monkeypatch.setenv("SQUADOPS__AGENT__ID", "neo")
+    monkeypatch.setattr(
+        entrypoint, "load_instance_config", lambda aid: {"model": "m", "display_name": aid}
+    )
+
+    runner = entrypoint.AgentRunner(role="dev")
+    assert runner.agent_id == "neo"
+
+
+def test_explicit_agent_id_overrides_env(monkeypatch):
+    """An explicit id wins over the env var — the param is authoritative."""
+    from squadops.agents import entrypoint
+
+    monkeypatch.setenv("SQUADOPS__AGENT__ID", "neo")
+    monkeypatch.setattr(entrypoint, "load_instance_config", lambda aid: {"model": "m"})
+
+    runner = entrypoint.AgentRunner(role="lead", agent_id="max")
+    assert runner.agent_id == "max"
+
+
+def test_empty_string_agent_id_is_rejected(monkeypatch):
+    """An empty ``SQUADOPS__AGENT__ID`` is not a valid identity — it must not slip
+    through as a falsy-but-present value; it fails the same as unset."""
+    from squadops.agents.entrypoint import AgentRunner
+
+    monkeypatch.setenv("SQUADOPS__AGENT__ID", "")
+
+    with pytest.raises(ValueError, match="SQUADOPS__AGENT__ID"):
+        AgentRunner(role="qa")


### PR DESCRIPTION
## Summary

Closes #333 by fixing the **real value** (both identity-fabrication holes) and **documenting the rest as intentional-not-drift** — the config-masking hard rule ("never fabricate/mask required config") is now upheld for agent identity, and the non-violations are commented so they aren't re-flagged.

## Fixed (the substance)
1. **Agent id** (`AgentRunner.__init__`) — was defaulting to `f"{role}-001"`, masking a missing `SQUADOPS__AGENT__ID` and misdirecting diagnosis to the instance-config load. Now a missing id raises a clear error naming the var, before that load.
2. **Agent role** (`main()`) — inference used a hardcoded `{id: role}` map (a duplicate of `instances.yaml`) plus an `id.split("-")[0]` fallback that could **mislabel an agent** whose id wasn't in the map — the same masking class. Extracted `_resolve_role()`: env-first (bootstrap selector), else the **authoritative roster** (`instances.yaml`) by id, **never fabricated**.

Both are safe: docker-compose sets `SQUADOPS__AGENT__ID` + `SQUADOPS_AGENT_ROLE` for every agent, so the removed fallbacks were dead code that only fired on misconfig.

## Commented as intentional (not fixed — not violations)
- **`LOG_LEVEL` / `MEMORY_DB_PATH` / `HEARTBEAT_INTERVAL`** — operational tuning defaults: optional, fail visibly if wrong, never fabricate required data. Deliberately distinct from the `SQUADOPS__*` nested-config convention.
- **`healthcheck_http.py` runtime-api URL** — a service-discovery default to the in-network compose address; explicit `SQUADOPS_RUNTIME_API_URL` still wins, a wrong endpoint fails visibly.
- **`LLM_MODEL`** — already correct (priority chain that *raises* if unresolved).

## Documented won't-do
- **`SQUADOPS_AGENT_ROLE` single→double underscore rename** — it's a *bootstrap selector* read before the config loader runs, not nested config, so single-underscore isn't drift. Renaming would need a lockstep docker-compose change (rebuild + revalidate) purely for aesthetics — not a correctness fix. Left as-is by design, and now commented so it isn't re-flagged.

## Tests
8 unit tests: id (missing→clear error at the right place, env used, explicit overrides, empty rejected) + role (env wins, derived-from-roster, **never-fabricated-from-id**, none-when-unconfigured). Regression **4831**, ruff clean.

## Live validation
The id-path was validated on the Mac stack (all agents boot with compose ids, smoke `cyc_7cd1b6ac81db` completed). Re-validating after the `main()` role-path change — will post the result before merge.

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ
