### PR TITLE
fix(#370,#371): provision the agent secret on deploy and fail honestly

### DIFF
--- a/scripts/bootstrap/lib/docker_setup.sh
+++ b/scripts/bootstrap/lib/docker_setup.sh
@@ -2,6 +2,10 @@
 # Docker setup functions for bootstrap (SIP-0081).
 # Sourced by bootstrap.sh — not executed directly.
 
+# Shared secret-provisioning helpers (agent client secret, #326/#371) —
+# single-sourced with the rebuild/deploy path so the two cannot drift.
+source "$(dirname "${BASH_SOURCE[0]}")/../../dev/ops/secrets.sh"
+
 # Ensure .env and .env.console exist for Docker Compose.
 # Copies .env from .env.example (which contains static dev passwords).
 # Generates .env.console from console lock file if missing.
@@ -78,10 +82,14 @@ ensure_env_file() {
             echo -n "postgresql://keycloak:keycloak@postgres:5432/keycloak" > secrets/keycloak_db_dsn.txt
             success "Created secrets/keycloak_db_dsn.txt"
         fi
-        if [[ ! -f "secrets/agent_client_secret.txt" ]]; then
-            # squadops-agent client secret (#326) — matches the realm export
-            echo -n "squadops-agent-secret" > secrets/agent_client_secret.txt
-            success "Created secrets/agent_client_secret.txt"
+        # Agent client secret (#326) — provisioning single-sourced in
+        # scripts/dev/lib/secrets.sh so bootstrap and rebuild/deploy can't drift (#371).
+        if [[ ! -f "$AGENT_CLIENT_SECRET_FILE" ]]; then
+            if ensure_agent_client_secret; then
+                success "Created $AGENT_CLIENT_SECRET_FILE"
+            else
+                warn "Failed to create $AGENT_CLIENT_SECRET_FILE"
+            fi
         fi
     fi
 

--- a/scripts/dev/ops/rebuild_and_deploy.sh
+++ b/scripts/dev/ops/rebuild_and_deploy.sh
@@ -29,6 +29,9 @@ cd "$REPO_ROOT"
 SOURCE_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 export SOURCE_HASH
 
+# Shared secret-provisioning helpers (agent client secret, #326/#371).
+source "$REPO_ROOT/scripts/dev/ops/secrets.sh"
+
 # Parse command-line arguments
 REBUILD_CONSOLE=false
 REBUILD_AGENTS=false
@@ -235,9 +238,12 @@ fi
 echo ""
 echo -e "${BLUE}🔨 Step 3: Rebuilding containers with updated code...${NC}"
 
-# Track build failures for non-blocking services
+# Track build/restart failures for non-blocking services so the completion
+# banner and exit code stay honest (#370).
 RUNTIME_API_FAILED=0
 CONSOLE_FAILED=0
+AGENTS_RESTART_FAILED=0
+FAILED_AGENTS=""
 
 # Rebuild Runtime API if requested
 if [ "$REBUILD_RUNTIME_API" = true ] || [ "$REBUILD_ALL" = true ]; then
@@ -383,13 +389,30 @@ if [ "$REBUILD_AGENTS" = true ] || [ "$REBUILD_ALL" = true ]; then
         fi
     done
 
+    # Ensure the #326 agent client secret exists before (re)starting agents.
+    # Only bootstrap used to create it, so a pull+rebuild on an already-
+    # bootstrapped box left agents unable to start — the mounted secret file
+    # was simply absent (#371).
+    if [ ! -f "$AGENT_CLIENT_SECRET_FILE" ]; then
+        if ensure_agent_client_secret; then
+            echo -e "${GREEN}✅ Provisioned ${AGENT_CLIENT_SECRET_FILE} (agent auth secret)${NC}"
+        else
+            echo -e "${RED}  ❌ Could not create ${AGENT_CLIENT_SECRET_FILE} — agents will fail to start${NC}"
+            exit 1
+        fi
+    fi
+
     # Step 4: Restart all agent containers
     echo ""
     echo -e "${BLUE}🔄 Step 4: Restarting agent containers...${NC}"
     for agent in $AGENTS; do
         if docker compose config --services | grep -q "^${agent}$"; then
             echo -e "  🔄 Restarting ${agent}..."
-            docker compose up -d $agent || echo -e "${RED}  ⚠️  Restart failed for ${agent}${NC}"
+            if ! docker compose up -d $agent; then
+                echo -e "${RED}  ⚠️  Restart failed for ${agent}${NC}"
+                AGENTS_RESTART_FAILED=1
+                FAILED_AGENTS="${FAILED_AGENTS} ${agent}"
+            fi
         fi
     done
 
@@ -447,7 +470,17 @@ echo -e "${BLUE}✅ Step 6: Verifying deployment...${NC}"
 docker compose ps
 
 echo ""
-echo -e "${GREEN}🎉 Rebuild and deploy complete!${NC}"
+# Honest completion banner + exit code (#370): a swallowed agent restart
+# failure used to print the success banner and exit 0, leaving stale agents.
+DEPLOY_FAILED=0
+[ "${RUNTIME_API_FAILED:-0}" = "1" ] && DEPLOY_FAILED=1
+[ "${CONSOLE_FAILED:-0}" = "1" ] && DEPLOY_FAILED=1
+[ "${AGENTS_RESTART_FAILED:-0}" = "1" ] && DEPLOY_FAILED=1
+if [ "$DEPLOY_FAILED" = "1" ]; then
+    echo -e "${RED}⚠️  Rebuild and deploy completed WITH FAILURES (details below).${NC}"
+else
+    echo -e "${GREEN}🎉 Rebuild and deploy complete!${NC}"
+fi
 echo ""
 echo -e "${BLUE}Next steps:${NC}"
 if [ "$REBUILD_AGENTS" = true ] || [ "$REBUILD_ALL" = true ]; then
@@ -464,20 +497,25 @@ if [ "$REBUILD_AGENTS" = true ] || [ "$REBUILD_ALL" = true ]; then
     echo -e "  5. Run smoke tests: ${YELLOW}python3 -m pytest tests/smoke/ -v${NC}"
 fi
 
-# Report any build failures that were deferred
-BUILD_FAILURES=0
+# Report any failures that were deferred so the run could continue. DEPLOY_FAILED
+# (computed with the banner above) drives the non-zero exit so callers and CI can
+# trust the result instead of a blanket exit 0 (#370).
 if [ "${RUNTIME_API_FAILED:-0}" = "1" ]; then
     echo ""
     echo -e "${RED}❌ runtime-api build failed. Fix the error and rebuild:${NC}"
     echo -e "${YELLOW}   ./scripts/dev/ops/rebuild_and_deploy.sh runtime-api${NC}"
-    BUILD_FAILURES=1
 fi
 if [ "${CONSOLE_FAILED:-0}" = "1" ]; then
     echo ""
     echo -e "${RED}❌ Console build failed. Fix the Svelte error and rebuild:${NC}"
     echo -e "${YELLOW}   ./scripts/dev/ops/rebuild_and_deploy.sh console${NC}"
-    BUILD_FAILURES=1
 fi
-if [ "$BUILD_FAILURES" = "1" ]; then
+if [ "${AGENTS_RESTART_FAILED:-0}" = "1" ]; then
+    echo ""
+    echo -e "${RED}❌ Agent restart failed for:${FAILED_AGENTS}${NC}"
+    echo -e "${RED}   These agents keep running their previous image (stale code).${NC}"
+    echo -e "${YELLOW}   Retry: ./scripts/dev/ops/rebuild_and_deploy.sh agents${FAILED_AGENTS}${NC}"
+fi
+if [ "$DEPLOY_FAILED" = "1" ]; then
     exit 1
 fi

--- a/scripts/dev/ops/secrets.sh
+++ b/scripts/dev/ops/secrets.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Shared secret-provisioning helpers.
+#
+# Sourced (never executed) by both the bootstrap path
+# (scripts/bootstrap/lib/docker_setup.sh) and the rebuild/deploy path
+# (scripts/dev/ops/rebuild_and_deploy.sh). Before #371 only bootstrap created
+# the agent client secret, so "git pull && rebuild_and_deploy.sh" on an
+# already-bootstrapped box left agents unable to start. Single-sourcing the
+# filename and default value here keeps the two paths from drifting.
+
+# squadops-agent Keycloak client secret (#326). docker-compose mounts this file
+# into every agent container (SQUADOPS__AUTH__AGENT_CLIENT__CLIENT_SECRET=
+# secret://agent_client_secret). The value MUST match the client secret in the
+# Keycloak realm export, or agents fail client-credentials auth at startup.
+AGENT_CLIENT_SECRET_FILE="secrets/agent_client_secret.txt"
+AGENT_CLIENT_SECRET_DEFAULT="squadops-agent-secret"
+
+# Idempotently create the agent client secret file if it is absent.
+#   - returns 0 (no output) when the file already exists
+#   - returns 0 when it creates the file — the caller prints its own message,
+#     so it can match its surrounding logging style (success() vs colored echo)
+#   - returns non-zero if the directory or file cannot be created
+ensure_agent_client_secret() {
+    [[ -f "$AGENT_CLIENT_SECRET_FILE" ]] && return 0
+    mkdir -p "$(dirname "$AGENT_CLIENT_SECRET_FILE")" || return 1
+    printf '%s' "$AGENT_CLIENT_SECRET_DEFAULT" > "$AGENT_CLIENT_SECRET_FILE"
+}


### PR DESCRIPTION
Two deploy-path hardening fixes (the "deploy pair"), both `track:spark`.

## #371 — agents dead after pull+rebuild on an existing box
The #326 agent-heartbeat auth added a required Docker secret,
`secrets/agent_client_secret.txt`, mounted into every agent container. Only
**bootstrap** created it — `rebuild_and_deploy.sh` did not. So the normal
"pull latest + rebuild" refresh on an already-bootstrapped box left agents
unable to start (the compose-mounted secret file was simply absent).

**Fix:** single-source the provisioning in `scripts/dev/ops/secrets.sh`
(`ensure_agent_client_secret` + the filename/default value) and call it from
**both** bootstrap (`docker_setup.sh`) and the deploy path. The bug existed
*because* provisioning wasn't shared — so the fix is to stop duplicating it,
not to add a second copy.

## #370 — rebuild lies about agent restart failures
The restart loop swallowed failures (`docker compose up -d $agent || echo …`),
then printed `🎉 Rebuild and deploy complete!` and exited 0. Stale agents kept
running their previous image silently — the classic stale-agent trap.
runtime-api/console builds already track failure (`RUNTIME_API_FAILED` /
`CONSOLE_FAILED`); agents had no equivalent.

**Fix:** track restart failures (`AGENTS_RESTART_FAILED` + which agents), make
the completion banner reflect reality, and exit non-zero so callers/CI can
trust the result.

## Why this shape
- `secrets.sh` lives beside the existing sourced helper `derive_binding.sh` in
  `scripts/dev/ops/`. A `scripts/dev/lib/` home is swallowed by `.gitignore`'s
  bare `lib/` rule — which would have silently un-committed the file and broken
  **both** paths on a fresh clone (caught during verification).
- Single-sourcing kills the drift class that caused #371 in the first place.

## Verified (in isolation)
- Secret content byte-exact: `squadops-agent-secret`, 21 bytes, **no** trailing
  newline (must match the Keycloak realm export).
- Idempotent: won't overwrite an existing/custom secret.
- `docker_setup.sh` resolves the helper via a `BASH_SOURCE`-relative path from
  any CWD (bootstrap-safety).
- `bash -n` clean on all three files.
- Exit truth table: agent-restart-fail → `exit 1`; all-clear → `exit 0`.

Full deploy path confirms on the next real `rebuild_and_deploy.sh` run on the box.

## Lane / version
`track:spark` hardening. No framework-version bump (ops tooling); effective on
next pull+rebuild, rides into 1.4.0's hardening-along notes. No file overlap
with the in-flight SIP-0096 slices (pure shell under `scripts/`).

Closes #370
Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)
