### PR TITLE
fix(#276): verify the delivered backend imports, not just the tests

### DIFF
--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -453,6 +453,147 @@ async def run_frontend_build(
         shutil.rmtree(workspace, ignore_errors=True)
 
 
+# Subprocess driver for run_backend_import_check (#276). Byte-compiling is not
+# enough — the canonical bug (``backend/main.py`` using ``BaseModel`` without
+# importing it) is a NameError that only surfaces when the module *body runs* —
+# so this executes each delivered module via ``exec_module`` and writes, to the
+# path in argv[1], a JSON verdict of which modules failed. A ModuleNotFoundError
+# whose missing top-level module is not itself a delivered module is recorded as
+# a dependency gap (the runner lacks the dep), not a deliverable failure, so a
+# missing third-party never produces a false red. Output goes to a file, not
+# stdout, so a module that prints on import can't corrupt the verdict.
+_BACKEND_IMPORT_DRIVER = r"""
+import importlib.util as _u, json as _json, pathlib as _pl, sys as _sys
+
+_out = _sys.argv[1]
+_root = _pl.Path(".").resolve()
+_delivered = {}
+for _p in _root.rglob("*.py"):
+    if "__pycache__" in _p.parts:
+        continue
+    _name = _p.name
+    if _name.startswith("test_") or _name.endswith("_test.py") or _name == "conftest.py":
+        continue
+    _delivered[str(_p.relative_to(_root))] = _p
+_stems = {_p.stem for _p in _delivered.values()}
+
+_failures, _assessed, _skipped = [], 0, []
+for _rel, _path in sorted(_delivered.items()):
+    _spec = _u.spec_from_file_location("_qa_imp_" + _rel.replace("/", "_")[:-3], str(_path))
+    if _spec is None or _spec.loader is None:
+        continue
+    _mod = _u.module_from_spec(_spec)
+    try:
+        _spec.loader.exec_module(_mod)
+        _assessed += 1
+    except ModuleNotFoundError as _e:
+        _missing = (getattr(_e, "name", "") or "").split(".")[0]
+        if _missing and _missing in _stems:
+            _failures.append({"module": _rel, "error": "ModuleNotFoundError: " + str(_e)})
+        else:
+            _skipped.append(_missing or _rel)
+    except Exception as _e:
+        _failures.append({"module": _rel, "error": type(_e).__name__ + ": " + str(_e)})
+
+with open(_out, "w", encoding="utf-8") as _fh:
+    _json.dump({"failures": _failures, "assessed": _assessed, "skipped_deps": sorted(set(_skipped))}, _fh)
+"""
+
+
+async def run_backend_import_check(
+    source_files: list[dict[str, str]],
+    timeout_seconds: int = 60,
+) -> BuildCheckResult:
+    """Verify the delivered backend actually imports (#276).
+
+    Executes each delivered backend Python module (everything not under
+    ``frontend/``) in a subprocess, using the same ``PYTHONPATH`` model as the
+    generated tests so sibling imports resolve. The canonical bug — a
+    ``backend/main.py`` that references ``BaseModel`` without importing it —
+    passes the (stubbed) generated suite but raises ``NameError`` here, exactly
+    the ``cyc_2f415e43f9cf`` false-green. Complements ``compute_missing_required_files``
+    (#291), which checks a required file is *present*; this checks it *runs*.
+
+    A *skip* (``ran=False``) never fails: no backend Python source, a runner
+    crash or timeout, or import failures that are only missing third-party
+    dependencies not installed in the runner (not the deliverable's fault). A
+    module that raises anything else — ``NameError``, ``SyntaxError``,
+    ``ImportError`` of a delivered sibling — is a BLOCKING failure: a backend
+    that can't import is broken, not absent. Never raises.
+    """
+    backend_py = [
+        rec
+        for rec in source_files
+        if rec["path"].endswith(".py") and not rec["path"].startswith("frontend/")
+    ]
+    if not backend_py:
+        return BuildCheckResult(ran=False, error="no backend Python source")
+
+    workspace = tempfile.mkdtemp(prefix="qa_import_")
+    try:
+        _materialize_files(workspace, backend_py)
+        outfile = os.path.join(workspace, "__qa_import_result.json")
+        env = {**os.environ, "PYTHONPATH": _source_dir_pythonpath(workspace, backend_py)}
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-c",
+                _BACKEND_IMPORT_DRIVER,
+                outfile,
+                cwd=workspace,
+                env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError:
+            return BuildCheckResult(ran=False, error="python interpreter not found")
+
+        try:
+            _, raw_err = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return BuildCheckResult(
+                ran=False, error=f"backend import check timed out after {timeout_seconds}s"
+            )
+
+        import json
+
+        try:
+            with open(outfile, encoding="utf-8") as fh:
+                report = json.load(fh)
+        except (OSError, ValueError):
+            # Driver never wrote a verdict (hard crash / segfault / sys.exit on
+            # import): can't assess, so skip rather than fabricate a failure.
+            logger.warning(
+                "backend import check produced no result; stderr: %s",
+                raw_err.decode(errors="replace")[:500],
+            )
+            return BuildCheckResult(ran=False, error="backend import check produced no result")
+
+        failures = report.get("failures", [])
+        if failures:
+            first = failures[0]
+            return BuildCheckResult(
+                ran=True,
+                ok=False,
+                exit_code=1,
+                error=f"backend module {first['module']} failed to import: {first['error']}",
+                stderr="\n".join(f"{f['module']}: {f['error']}" for f in failures)[:_STDOUT_LIMIT],
+            )
+        if not report.get("assessed"):
+            skipped = ", ".join(report.get("skipped_deps", [])) or "unknown"
+            return BuildCheckResult(
+                ran=False, error=f"backend deps unavailable — cannot assess ({skipped})"
+            )
+        return BuildCheckResult(ran=True, ok=True, exit_code=0)
+    except Exception as exc:  # never raise — a runner error is a skip, not a failure
+        logger.warning("Backend import check error: %s", exc, exc_info=True)
+        return BuildCheckResult(ran=False, error=str(exc))
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
 async def run_fullstack_tests(
     source_files: list[dict[str, str]],
     test_files: list[dict[str, str]],
@@ -537,15 +678,17 @@ async def run_build_validation(
     test_files: list[dict[str, str]],
     timeout_seconds: int = 60,
 ) -> RunTestsResult:
-    """Run the framework-appropriate test suite plus a build check, as one result.
+    """Run the framework-appropriate test suite plus build/boot checks, as one result.
 
     Single entry point that owns all test-framework dispatch (pytest / vitest /
-    both) and the #276 frontend build check, so callers stay framework-agnostic.
+    both) and the #276 deliverable checks — the frontend *build* check and the
+    backend *import* check — so callers stay framework-agnostic.
 
-    A frontend *build* failure is BLOCKING (a non-building app is broken) even
-    where frontend unit tests are non-blocking (D13). A build *skip* — no
-    frontend, no ``package.json``, or no Node — never fails. Returns a
-    ``RunTestsResult`` — never raises.
+    A build/boot *failure* is BLOCKING (a non-building frontend or a non-importing
+    backend is broken) even where unit tests passed and are otherwise non-blocking
+    (D13). A *skip* — no frontend/backend source, no ``package.json``, no Node, or
+    a missing third-party dep the runner lacks — never turns a passing suite red.
+    Returns a ``RunTestsResult`` — never raises.
     """
     from squadops.capabilities.dev_capabilities import (
         TEST_FRAMEWORK_BOTH,
@@ -554,24 +697,40 @@ async def run_build_validation(
 
     if test_framework == TEST_FRAMEWORK_VITEST:
         result = await run_node_tests(source_files, test_files, timeout_seconds=timeout_seconds)
-        build_target: str | None = None
+        frontend_target: str | None = None
+        run_frontend, run_backend = True, False
     elif test_framework == TEST_FRAMEWORK_BOTH:
         result = await run_fullstack_tests(
             source_files, test_files, timeout_seconds=timeout_seconds
         )
-        build_target = "frontend"
+        frontend_target = "frontend"
+        run_frontend, run_backend = True, True
     else:
-        # pytest / backend-only: nothing to build
-        return await run_generated_tests(source_files, test_files, timeout_seconds=timeout_seconds)
+        # pytest / backend-only: no frontend to build, but the backend must import
+        result = await run_generated_tests(
+            source_files, test_files, timeout_seconds=timeout_seconds
+        )
+        frontend_target = None
+        run_frontend, run_backend = False, True
 
-    build = await run_frontend_build(
-        source_files, target_dir=build_target, timeout_seconds=timeout_seconds
-    )
-    if build.failed:
-        merged_error = "; ".join(part for part in (result.error, build.error) if part)
+    checks: list[BuildCheckResult] = []
+    if run_frontend:
+        checks.append(
+            await run_frontend_build(
+                source_files, target_dir=frontend_target, timeout_seconds=timeout_seconds
+            )
+        )
+    if run_backend:
+        checks.append(await run_backend_import_check(source_files, timeout_seconds=timeout_seconds))
+
+    failed = [check for check in checks if check.failed]
+    if failed:
+        merged_error = "; ".join(
+            part for part in (result.error, *(check.error for check in failed)) if part
+        )
         result = replace(
             result,
-            exit_code=result.exit_code or build.exit_code or 1,
+            exit_code=result.exit_code or failed[0].exit_code or 1,
             error=merged_error,
         )
     return result

--- a/tests/unit/capabilities/test_backend_import_check.py
+++ b/tests/unit/capabilities/test_backend_import_check.py
@@ -1,0 +1,146 @@
+"""Tests for the backend import-acceptance check (#276).
+
+Bug this guards: a backend can pass its generated pytest suite yet fail to
+import. The generated ``test_api.py`` wraps ``from backend.main import app`` in
+a ``try/except ImportError`` that silently substitutes an inline stub app, so a
+``backend/main.py`` that raises ``NameError`` on import (``BaseModel`` used
+without ``from pydantic import BaseModel``) shipped green in a ``completed`` run
+(cyc_2f415e43f9cf). ``run_backend_import_check`` must FAIL when a delivered
+module can't import, and must SKIP (not fail) when it genuinely can't assess:
+no backend source, or a missing third-party dependency the runner lacks.
+
+These run real subprocesses (they must actually *execute* module bodies to catch
+a NameError — byte-compiling wouldn't), but need only the Python interpreter, so
+they are hermetic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import squadops.capabilities.handlers.test_runner as tr
+from squadops.capabilities.dev_capabilities import TEST_FRAMEWORK_PYTEST
+from squadops.capabilities.handlers.test_runner import (
+    RunTestsResult,
+    run_backend_import_check,
+    run_build_validation,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+def _rec(path: str, content: str) -> dict[str, str]:
+    return {"path": path, "content": content}
+
+
+# --- run_backend_import_check: real import execution --------------------------
+
+
+async def test_nameerror_module_is_a_failure():
+    """The canonical #276 case: BaseModel referenced without importing it. The
+    module byte-compiles fine but NameErrors when its body runs."""
+    result = await run_backend_import_check(
+        [_rec("backend/main.py", "class RunCreateRequest(BaseModel):\n    pass\n")]
+    )
+    assert result.ran is True
+    assert result.ok is False
+    assert result.failed is True
+    assert "main.py" in result.error
+    assert "NameError" in result.error
+
+
+async def test_clean_backend_imports_ok():
+    result = await run_backend_import_check(
+        [_rec("backend/main.py", "VALUE = 1\n\n\ndef add(a, b):\n    return a + b\n")]
+    )
+    assert result.ran is True
+    assert result.ok is True
+    assert result.failed is False
+
+
+async def test_no_backend_python_source_skips():
+    """A frontend-only deliverable has no backend to import — skip, not fail."""
+    result = await run_backend_import_check([_rec("frontend/src/App.jsx", "export default 1")])
+    assert result.ran is False
+    assert result.failed is False
+
+
+async def test_missing_third_party_dep_is_skip_not_failure():
+    """A module importing a package the runner doesn't have can't be assessed —
+    a SKIP, not a deliverable failure (don't punish the app for our env). The
+    guard against false reds."""
+    result = await run_backend_import_check(
+        [_rec("backend/main.py", "import totally_absent_pkg_xyz_9000\n")]
+    )
+    assert result.ran is False
+    assert result.failed is False
+
+
+async def test_syntax_error_is_a_failure():
+    result = await run_backend_import_check([_rec("backend/main.py", "def broken(:\n    pass\n")])
+    assert result.ran is True
+    assert result.failed is True
+
+
+async def test_only_backend_is_checked_not_frontend_py():
+    """A stray broken .py under frontend/ is excluded (the frontend build check
+    owns frontend); a clean backend passes despite it."""
+    result = await run_backend_import_check(
+        [
+            _rec("frontend/tooling.py", "class X(NotDefinedAnywhere):\n    pass\n"),
+            _rec("backend/main.py", "OK = True\n"),
+        ]
+    )
+    assert result.ran is True
+    assert result.ok is True
+
+
+async def test_broken_delivered_sibling_fails_via_entrypoint():
+    """The entrypoint imports a delivered sibling that NameErrors — importing the
+    entrypoint surfaces it (not a missing-dep skip), so the real defect blocks."""
+    result = await run_backend_import_check(
+        [
+            _rec("backend/main.py", "from schemas import Thing\n\napp = Thing\n"),
+            _rec("backend/schemas.py", "class Thing(BaseModel):\n    pass\n"),
+        ]
+    )
+    assert result.ran is True
+    assert result.failed is True
+    assert "NameError" in result.error
+
+
+# --- run_build_validation: pytest branch folds the backend import failure ------
+
+
+async def test_pytest_build_validation_folds_backend_import_failure(monkeypatch):
+    """#276 end-to-end: generated tests pass (against a stub) yet the real
+    backend won't import → the run is red, not green."""
+
+    async def _generated(*_a, **_k):
+        return RunTestsResult(executed=True, exit_code=0)  # tests green against the stub
+
+    monkeypatch.setattr(tr, "run_generated_tests", _generated)
+    result = await run_build_validation(
+        TEST_FRAMEWORK_PYTEST,
+        [_rec("backend/main.py", "class Req(BaseModel):\n    pass\n")],
+        [_rec("backend/tests/test_api.py", "def test_ok():\n    assert True\n")],
+    )
+    assert result.tests_passed is False
+    assert result.exit_code != 0
+    assert "import" in result.error
+
+
+async def test_pytest_build_validation_clean_backend_stays_green(monkeypatch):
+    """A clean backend must not turn a passing suite red (no false positive)."""
+
+    async def _generated(*_a, **_k):
+        return RunTestsResult(executed=True, exit_code=0)
+
+    monkeypatch.setattr(tr, "run_generated_tests", _generated)
+    result = await run_build_validation(
+        TEST_FRAMEWORK_PYTEST,
+        [_rec("backend/main.py", "app = object()\n")],
+        [_rec("backend/tests/test_api.py", "def test_ok():\n    assert True\n")],
+    )
+    assert result.tests_passed is True
+    assert result.exit_code == 0


### PR DESCRIPTION
Closes the last open symptom of **#276** — build acceptance passing on a
non-running app.

## The bug
A `validation`-profile cycle completed **green** while the delivered
`backend/main.py` used `BaseModel` without `from pydantic import BaseModel` —
`python -c "import backend.main"` → `NameError`. It shipped because the generated
`test_api.py` wrapped its import in a fallback:

```python
try:
    from backend.main import app
except ImportError:
    from fastapi import FastAPI          # ~70-line inline re-implementation
    app = FastAPI()
```

So `qa.test` validated an **inline stub app**, not the deliverable. `command_acceptance_checks`
and `typed_acceptance` were both on, yet nothing checked that the primary module
even imports.

## The fix
Add `run_backend_import_check` — a build/boot check **symmetric to the existing
frontend `run_frontend_build`** (#276/#303, same cycle in its docstring):

- Executes each delivered backend module *body* in a subprocess (byte-compiling
  wouldn't catch a NameError — only running the body does), with the same
  `PYTHONPATH` model the generated tests use, so sibling imports resolve.
- **Failure** (BLOCKING) on `NameError` / `SyntaxError` / `ImportError` of a
  delivered sibling — a backend that can't import is broken, not absent.
- **Skip** (never a failure) on no backend source, timeout, or a missing
  third-party dependency the runner lacks — no false reds.

Wired into `run_build_validation` for the **pytest** and **both** frameworks
(vitest has no Python), folding a failure into the exit code exactly like the
frontend build already does. So it flows through the **same acceptance gate**,
and — post-#374 — drives a real correction instead of shipping green.

Complements Mac's #291 `compute_missing_required_files` (slice 3): that checks a
required file is *present*; this checks it *runs*. Present-vs-runs, no overlap.

## Tests
9 new, all real-subprocess and hermetic (need only the interpreter):
canonical NameError, clean import, no-backend skip, **missing-dep skip
(false-red guard)**, syntax error, frontend-`.py` exclusion,
broken-sibling-via-entrypoint, and the end-to-end `run_build_validation` fold
(generated tests green + backend won't import → run is red). Full capabilities
suite green (1116), ruff clean.

## Lane / version
`track:spark` build-reliability hardening (Lane S owns test-runner/build-check
per the 1.4 plan). Rides into 1.4.0 hardening-along. No file overlap with the
in-flight SIP-0096 slices.

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)
