### PR TITLE
feat(#395): canonical framework-check registry + reject unknown required_checks ids

### DIFF
--- a/src/squadops/contracts/cycle_request_profiles/schema.py
+++ b/src/squadops/contracts/cycle_request_profiles/schema.py
@@ -65,11 +65,14 @@ _VALID_GATE_PREFIXES = ("progress_", "promote_")
 
 
 def _validate_required_checks(defaults: dict) -> None:
-    """Validate the SIP-0096 ``required_checks`` declaration shape at load time.
+    """Validate the SIP-0096 ``required_checks`` declaration at load time.
 
-    Must be a list of non-empty, non-duplicate check-id strings. Fail loud on a
-    malformed declaration rather than let a mis-shaped required list silently
-    mis-aggregate at run end (the "no fallback that masks" rule).
+    Must be a list of non-empty, non-duplicate check-id strings, and every id
+    must be a **known framework check** (``check_registry``). Fail loud on a
+    malformed *or unknown* declaration rather than let it silently mis-aggregate
+    at run end: an unrecognized id (e.g. a typo ``test_pass``) matches no check,
+    so the profile would look enforced but quietly revert to inert — the exact
+    "looks-enforced-but-isn't" failure §6.3 forbids ("no fallback that masks").
     """
     checks = defaults.get("required_checks")
     if checks is None:
@@ -85,6 +88,18 @@ def _validate_required_checks(defaults: dict) -> None:
         if entry in seen:
             raise ValueError(f"required_checks contains duplicate check-id {entry!r}")
         seen.add(entry)
+
+    # Reject unknown ids only after the shape is sound (so shape errors report
+    # first). Imported locally to keep the contracts schema import-light.
+    from squadops.cycles.check_registry import framework_check_ids
+
+    known = framework_check_ids()
+    unknown = sorted(c for c in checks if c not in known)
+    if unknown:
+        raise ValueError(
+            f"required_checks contains unknown check-id(s) {unknown}; "
+            f"valid framework checks: {sorted(known)}"
+        )
 
 
 def _validate_workload_sequence_gates(defaults: dict) -> None:

--- a/src/squadops/cycles/check_registry.py
+++ b/src/squadops/cycles/check_registry.py
@@ -1,0 +1,91 @@
+"""Canonical registry of framework verification checks (SIP-0096 §6.3).
+
+The set of checks a cycle-request profile may name in ``required_checks``. §6.3:
+requiredness is resolved **only** from explicit profile declarations against
+*stable framework identities* — never inferred from names, types, or history.
+
+Before this module those identities were scattered — constants in
+``verification_normalize``, raw strings in the qa handler, ``required_files``
+only in ``build_completeness``, and the frontend build check had no id at all —
+and ``_validate_required_checks`` accepted *any* string. So a profile declaring
+``required_checks: [test_pass]`` (a typo) validated fine and then silently
+matched nothing at aggregation, reverting the profile to inert: the
+"looks-enforced-but-isn't" failure this SIP exists to kill. This module is the
+single source of truth those surfaces validate against.
+
+Out of scope by design (§6.3):
+- **Plan-authored typed checks** (SIP-0092, ``acceptance:<name>``) have per-cycle
+  identity and are disclosed but **not** required-addressable — not registered here.
+- **Pulse suites** are addressable by ``suite_id``, which is profile-defined and
+  validated against the profile's own pulse config — a separate axis, not this
+  fixed framework vocabulary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# External tooling identifiers a deployment must provision for a check to
+# execute. This is the cross-process axis the later SIP-0095 preflight parity
+# and doctor verification category consume: the frontend build runs in the qa
+# agent image (Node via #306), not in runtime-api where preflight runs, so
+# availability can't be probed locally — it is declared here and resolved per
+# deployment.
+TOOL_NODE = "node"
+
+
+@dataclass(frozen=True)
+class FrameworkCheck:
+    """A stable, ``required_checks``-addressable framework check (§6.3)."""
+
+    check_id: str
+    description: str
+    # Tooling the deployment must provision for this check to execute. Empty ⇒
+    # runs on the framework's always-present runtime (pytest, pure-Python diffs),
+    # so it can never be "knowably absent".
+    required_tooling: tuple[str, ...] = ()
+
+
+# Stable framework check-ids. Existing strings are REUSED verbatim (this
+# centralizes them; it does not coin new names — taxonomy naming coordinates
+# with #316). ``frontend_build`` is net-new so the fullstack frontend check is
+# declarable; wiring its CheckResult emission is a later slice (4b).
+CHECK_TESTS_PASS = "tests_pass"
+CHECK_NO_STUB_FALLBACK_TESTS = "no_stub_fallback_tests"
+CHECK_REQUIRED_FILES = "required_files"
+CHECK_FRONTEND_BUILD = "frontend_build"
+
+FRAMEWORK_CHECKS: dict[str, FrameworkCheck] = {
+    CHECK_TESTS_PASS: FrameworkCheck(
+        CHECK_TESTS_PASS,
+        "Generated test suite executed and passed (framework test spine).",
+    ),
+    CHECK_NO_STUB_FALLBACK_TESTS: FrameworkCheck(
+        CHECK_NO_STUB_FALLBACK_TESTS,
+        "The passing tests are not stub/placeholder fallbacks (§6.6.1).",
+    ),
+    CHECK_REQUIRED_FILES: FrameworkCheck(
+        CHECK_REQUIRED_FILES,
+        "The build profile's required_files were all emitted (#291).",
+    ),
+    CHECK_FRONTEND_BUILD: FrameworkCheck(
+        CHECK_FRONTEND_BUILD,
+        "The fullstack frontend build/test executed (SIP-0070 D13).",
+        required_tooling=(TOOL_NODE,),
+    ),
+}
+
+
+def is_framework_check(check_id: str) -> bool:
+    """True iff ``check_id`` is a stable, required-addressable framework check."""
+    return check_id in FRAMEWORK_CHECKS
+
+
+def get_framework_check(check_id: str) -> FrameworkCheck | None:
+    """Return the registered check, or ``None`` if unregistered."""
+    return FRAMEWORK_CHECKS.get(check_id)
+
+
+def framework_check_ids() -> frozenset[str]:
+    """The set of valid ``required_checks`` ids (for load-time validation)."""
+    return frozenset(FRAMEWORK_CHECKS)

--- a/src/squadops/cycles/verification_normalize.py
+++ b/src/squadops/cycles/verification_normalize.py
@@ -28,6 +28,12 @@ import dataclasses
 from collections.abc import Mapping
 from typing import Any
 
+from squadops.cycles.check_registry import (
+    CHECK_NO_STUB_FALLBACK_TESTS as CHECK_NO_STUB,
+)
+from squadops.cycles.check_registry import (
+    CHECK_TESTS_PASS,
+)
 from squadops.cycles.verification_integrity import (
     CheckProvenance,
     CheckResult,
@@ -35,9 +41,10 @@ from squadops.cycles.verification_integrity import (
     ResultStatus,
 )
 
-# Framework test-spine check identities (stable, §6.3 required-addressable).
-CHECK_TESTS_PASS = "tests_pass"
-CHECK_NO_STUB = "no_stub_fallback_tests"
+# Framework test-spine check identities (stable, §6.3 required-addressable) —
+# single-sourced from the canonical registry. ``CHECK_NO_STUB`` keeps its short
+# local name (re-exported) for the producers/tests that import it here.
+__all__ = ["CHECK_NO_STUB", "CHECK_TESTS_PASS", "normalize_task_checks"]
 
 
 def normalize_task_checks(

--- a/tests/unit/contracts/test_crp_schema_required_checks.py
+++ b/tests/unit/contracts/test_crp_schema_required_checks.py
@@ -61,3 +61,21 @@ def test_duplicate_check_ids_rejected():
     """A duplicate is a profile-authoring bug — surfaced at load, not tolerated."""
     with pytest.raises(ValidationError, match="duplicate check-id"):
         CycleRequestProfile(name="dup", defaults={"required_checks": ["a", "a"]})
+
+
+def test_unknown_check_id_rejected():
+    """The headline bug: a typo'd required id (``test_pass`` for ``tests_pass``)
+    must fail loud at load, not validate and then silently match nothing at run
+    end — the profile would look enforced but be inert (§6.3)."""
+    with pytest.raises(ValidationError, match="unknown check-id"):
+        CycleRequestProfile(name="typo", defaults={"required_checks": ["tests_pass", "test_pass"]})
+
+
+def test_every_registry_id_is_accepted():
+    """The validator and the registry must not drift: every stable framework
+    check must load as a valid required id."""
+    from squadops.cycles.check_registry import framework_check_ids
+
+    ids = sorted(framework_check_ids())
+    profile = CycleRequestProfile(name="all", defaults={"required_checks": ids})
+    assert profile.defaults["required_checks"] == ids

--- a/tests/unit/cycles/test_check_registry.py
+++ b/tests/unit/cycles/test_check_registry.py
@@ -1,0 +1,66 @@
+"""Canonical framework-check registry (SIP-0096 §6.3).
+
+The registry is the single source of truth for which check-ids a profile may
+mark ``required_checks``. Its whole reason to exist is to make an unknown id
+(a typo) detectable instead of silently inert, so these tests pin exactly that
+boundary plus the tooling axis the later preflight/doctor parity reads.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.check_registry import (
+    CHECK_FRONTEND_BUILD,
+    CHECK_NO_STUB_FALLBACK_TESTS,
+    CHECK_REQUIRED_FILES,
+    CHECK_TESTS_PASS,
+    TOOL_NODE,
+    framework_check_ids,
+    get_framework_check,
+    is_framework_check,
+)
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+_ALL_IDS = {
+    CHECK_TESTS_PASS,
+    CHECK_NO_STUB_FALLBACK_TESTS,
+    CHECK_REQUIRED_FILES,
+    CHECK_FRONTEND_BUILD,
+}
+
+
+def test_registry_holds_exactly_the_framework_checks():
+    """The vocabulary is closed. If a per-cycle id (e.g. ``acceptance:*``) or a
+    pulse suite_id ever leaks in here it would become falsely required-addressable
+    — §6.3 keeps those OUT of the fixed framework set."""
+    assert framework_check_ids() == frozenset(_ALL_IDS)
+
+
+def test_known_ids_are_recognized():
+    assert all(is_framework_check(cid) for cid in _ALL_IDS)
+
+
+@pytest.mark.parametrize("typo", ["test_pass", "tests_passed", "no_stub", "acceptance:foo", ""])
+def test_unknown_or_typoed_id_is_not_a_framework_check(typo):
+    """The exact bug the registry exists for: a mistyped required id must be
+    detectable (False), not silently accepted then matched to nothing at run end."""
+    assert is_framework_check(typo) is False
+    assert get_framework_check(typo) is None
+
+
+def test_get_framework_check_returns_the_registered_entry():
+    check = get_framework_check(CHECK_FRONTEND_BUILD)
+    assert check is not None
+    assert check.check_id == CHECK_FRONTEND_BUILD
+
+
+def test_only_tooling_backed_checks_can_be_knowably_absent():
+    """The frontend build needs Node (provisioned in the qa image, #306) — it is
+    the one check the coming preflight/doctor parity can flag as knowably absent.
+    The test-spine/pure checks declare no external tooling, so they can never be
+    'missing tooling'. Dropping Node here would silently disarm that guard."""
+    assert get_framework_check(CHECK_FRONTEND_BUILD).required_tooling == (TOOL_NODE,)
+    for cid in (CHECK_TESTS_PASS, CHECK_NO_STUB_FALLBACK_TESTS, CHECK_REQUIRED_FILES):
+        assert get_framework_check(cid).required_tooling == ()


### PR DESCRIPTION
## What
SIP-0096 Phase 2 **slice-4a** — the first, safe increment of slice-4 ("throttle ON"), split out of the red-flipping runtime change (Mac lane; **no run flips red**).

## Why
The framework check-id vocabulary was **scattered** (constants in `verification_normalize`, raw strings in the qa handler, `required_files` only in `build_completeness`, and the frontend build check had **no id at all**), and `_validate_required_checks` accepted **any** string. So a profile declaring `required_checks: [test_pass]` (a typo for `tests_pass`) validated fine and then silently matched nothing at aggregation — the profile *looks* enforced but quietly reverts to inert. That's the exact "looks-enforced-but-isn't" class SIP-0096 §6.3 exists to kill.

## Change
- **New `src/squadops/cycles/check_registry.py`** — single source of truth for the stable, `required_checks`-addressable framework checks (§6.3), each with a description and `required_tooling` (the cross-process axis the later preflight/doctor parity consumes: the frontend build needs Node in the qa image, not runtime-api). Existing id strings reused verbatim (centralized, not coined — naming coordinates with #316); `frontend_build` registered net-new so the fullstack check is **declarable** (emitting its CheckResult is slice-4b).
- `verification_normalize` single-sources its check-id constants from the registry (re-exported so importers keep working).
- `_validate_required_checks` now **rejects any id not in the registry** at CRP load — fail-loud, after the shape checks so shape errors report first.

## Scope / sequencing
Inert until a profile declares `required_checks` (slice-4b) — same "inert by construction" posture as Phase 1, so **no live cycle behavior changes** and unit tests fully cover the new load-time behavior.

Next: **4a-2** = SIP-0095 preflight required-check-tooling parity + `squadops doctor` verification category (consume this registry's tooling metadata). **4b (Spark-coordinated)** = declare `required_checks` in `full`/`validated-fullstack` + SIP-0070 D13 required-frontend blocking + emit frontend/required_files as recorded CheckResults — the red-flipping runtime change, validated on a 27b full-squad cycle.

## Tests
Registry boundary (known ids / typo detection / tooling axis) + CRP unknown-id rejection + a validator↔registry no-drift test. Regression **4856 passed**.

Closes #395
Refs #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ