### PR TITLE
feat(#397): required-check tooling parity (preflight) + doctor verification category

### DIFF
--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -17,6 +17,7 @@ from squadops.api.routes.cycles.dtos import (
 from squadops.api.routes.cycles.errors import handle_cycle_error
 from squadops.api.routes.cycles.mapping import cycle_to_response
 from squadops.auth.models import Scope
+from squadops.cycles.check_tooling import resolve_provisioned_tooling
 from squadops.cycles.lifecycle import compute_config_hash
 from squadops.cycles.models import (
     Cycle,
@@ -32,6 +33,7 @@ from squadops.cycles.preflight import (
     Finding,
     combine,
     model_availability_decision,
+    required_check_tooling_decision,
     required_roles_decision,
 )
 
@@ -75,6 +77,12 @@ async def _run_create_preflight(
     decision = combine(
         required_roles_decision(profile, applied_defaults),
         model_availability_decision(profile, await _pulled_model_names()),
+        # SIP-0096 §6.5: a required check whose tooling is knowably absent is a
+        # create-time reject, never a mid-run blocked_unverified surprise.
+        required_check_tooling_decision(
+            applied_defaults.get("required_checks") or (),
+            resolve_provisioned_tooling(),
+        ),
     )
     if decision.rejected:
         raise PreflightRejectedError(decision.summary())

--- a/src/squadops/bootstrap/setup/checks.py
+++ b/src/squadops/bootstrap/setup/checks.py
@@ -30,7 +30,18 @@ from squadops.bootstrap.setup.profile import (
 # ---------------------------------------------------------------------------
 
 VALID_CATEGORIES = frozenset(
-    {"python", "platform", "tools", "docker", "models", "squad", "gpu", "auth", "broker"}
+    {
+        "python",
+        "platform",
+        "tools",
+        "docker",
+        "models",
+        "squad",
+        "gpu",
+        "auth",
+        "broker",
+        "verification",
+    }
 )
 
 
@@ -907,6 +918,63 @@ def _collect_broker_checks(profile: BootstrapProfile) -> list[CheckResult]:
     return check_broker_hygiene(broker_svc.name)
 
 
+def _collect_verification_checks(profile: BootstrapProfile) -> list[CheckResult]:
+    """SIP-0096 §8: report which tooling-backed framework checks can execute here.
+
+    Deployment-scoped (not per cycle-request profile): for each framework check
+    that needs external tooling, is that tooling provisioned in this deployment
+    (``agents/instances/*/system-packages.txt``)? This is the same resolution the
+    create-time preflight parity uses, so doctor's report agrees with the runtime
+    reject (§8 parity). Checks with no external tooling are always executable and
+    reported only implicitly (nothing to verify). Unresolvable provisioning →
+    heuristic pass (never red when it cannot verify — the broker pattern)."""
+    from squadops.cycles.check_registry import FRAMEWORK_CHECKS
+    from squadops.cycles.check_tooling import resolve_provisioned_tooling
+
+    provisioned = resolve_provisioned_tooling()
+    results: list[CheckResult] = []
+    for check in FRAMEWORK_CHECKS.values():
+        if not check.required_tooling:
+            continue
+        needs = ", ".join(check.required_tooling)
+        if provisioned is None:
+            results.append(
+                CheckResult(
+                    name=f"check_tooling:{check.check_id}",
+                    category="verification",
+                    passed=True,
+                    heuristic=True,
+                    message=f"{check.check_id} needs {needs} — provisioning could not be resolved",
+                )
+            )
+            continue
+        missing = [t for t in check.required_tooling if t not in provisioned]
+        if missing:
+            results.append(
+                CheckResult(
+                    name=f"check_tooling:{check.check_id}",
+                    category="verification",
+                    passed=False,
+                    message=(
+                        f"{check.check_id} requires {', '.join(missing)}, not provisioned — "
+                        f"a profile requiring it is rejected at create-time preflight"
+                    ),
+                    detail="Provisioned via agents/instances/<role>/system-packages.txt",
+                    fix_command="Declare the package in the role's system-packages.txt and rebuild",
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    name=f"check_tooling:{check.check_id}",
+                    category="verification",
+                    passed=True,
+                    message=f"{check.check_id} tooling provisioned ({needs})",
+                )
+            )
+    return results
+
+
 _CHECK_REGISTRY: list[tuple[str, object]] = [
     ("python", _collect_python_checks),
     ("platform", _collect_platform_checks),
@@ -917,6 +985,7 @@ _CHECK_REGISTRY: list[tuple[str, object]] = [
     ("gpu", _collect_gpu_checks),
     ("auth", _collect_auth_checks),
     ("broker", _collect_broker_checks),
+    ("verification", _collect_verification_checks),
 ]
 
 

--- a/src/squadops/cycles/check_tooling.py
+++ b/src/squadops/cycles/check_tooling.py
@@ -1,0 +1,85 @@
+"""Resolve which framework-check tooling a deployment provisions (SIP-0096 §6.3/§8).
+
+The frontend build check needs Node, which #306 provisions in the **qa agent
+image** via ``agents/instances/qa/system-packages.txt`` — not in runtime-api or
+on the host. So availability cannot be probed with ``shutil.which``; the only
+create-time-knowable signal is that provisioning **declaration**.
+
+This resolver reads it. The same ``agents/instances/`` tree is COPY'd into the
+runtime-api image *and* present on the host checkout, so create-time preflight
+and ``squadops doctor`` resolve the same answer — the §8 parity requirement
+("doctor's non-executable report agrees with runtime behavior"). When the
+declarations can't be found, the resolver returns ``None`` so the pure decision
+*warns rather than blocks* — never block on missing evidence.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from squadops.cycles.check_registry import TOOL_NODE
+
+logger = logging.getLogger(__name__)
+
+# apt package (as declared in a role's system-packages.txt) → the framework tool
+# identifier used in the check registry's ``required_tooling``.
+_PACKAGE_TO_TOOL: dict[str, str] = {
+    "nodejs": TOOL_NODE,
+    "npm": TOOL_NODE,
+}
+
+
+def _find_instances_dir() -> Path | None:
+    """First existing ``agents/instances`` dir — container, local, or base-path.
+
+    Mirrors ``entrypoint``'s instances.yaml lookup so the resolver agrees with
+    where the roster actually lives in each runtime.
+    """
+    candidates = (
+        Path("/app/agents/instances"),
+        Path("agents/instances"),
+        Path(os.getenv("SQUADOPS_BASE_PATH", ".")) / "agents/instances",
+    )
+    for path in candidates:
+        if path.is_dir():
+            return path
+    return None
+
+
+def resolve_provisioned_tooling(instances_dir: Path | None = None) -> frozenset[str] | None:
+    """Framework tools provisioned across the deployment's agent roles.
+
+    Unions ``system-packages.txt`` declarations across roles and maps them to
+    tool identifiers. Returns:
+
+    - a (possibly empty) set when the declarations were read — an empty/partial
+      set is *verifiable absence* and blocks a required check that needs the tool;
+    - ``None`` when the ``agents/instances`` tree can't be located — *unverifiable*,
+      so the decision warns and allows.
+
+    Union-across-roles answers "is this tool provisioned anywhere in the
+    deployment"; today only the qa role declares Node and only qa runs the
+    frontend check, so the union is exact. If a check ever needs role-precise
+    tooling, the registry can carry the owning role.
+    """
+    root = instances_dir or _find_instances_dir()
+    if root is None or not root.is_dir():
+        logger.info("check_tooling_unresolved: agents/instances not found")
+        return None
+
+    tools: set[str] = set()
+    for pkg_file in sorted(root.glob("*/system-packages.txt")):
+        try:
+            lines = pkg_file.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for raw in lines:
+            pkg = raw.strip()
+            if not pkg or pkg.startswith("#"):
+                continue
+            tool = _PACKAGE_TO_TOOL.get(pkg)
+            if tool:
+                tools.add(tool)
+    return frozenset(tools)

--- a/src/squadops/cycles/preflight.py
+++ b/src/squadops/cycles/preflight.py
@@ -31,6 +31,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from squadops.cycles.check_registry import get_framework_check
 from squadops.cycles.models import REQUIRED_PLAN_ROLES, WORKLOAD_REQUIRED_ROLES
 
 if TYPE_CHECKING:
@@ -195,5 +196,70 @@ def model_availability_decision(
         )
         for model in required
         if _canonical_model(model) not in pulled_canonical
+    ]
+    return PreflightDecision(blocking=tuple(findings))
+
+
+def required_check_tooling_decision(
+    required_check_ids: Iterable[str],
+    available_tooling: Iterable[str] | None,
+) -> PreflightDecision:
+    """Block when a profile requires a framework check whose tooling is knowably absent.
+
+    SIP-0096 §6.5 *create-time-knowable* routing: a required check that cannot
+    execute in the target deployment (e.g. the frontend build check on a squad
+    whose image lacks Node) must be caught here — a create-time reject — never a
+    mid-run ``not-executed → blocked_unverified`` surprise.
+
+    Mirrors :func:`model_availability_decision` on evidence:
+    - ``available_tooling is None`` ⇒ provisioning couldn't be resolved:
+      *unverifiable*, so **warn and allow** — never block on missing evidence.
+    - a resolved set blocks any required check whose ``required_tooling`` isn't a
+      subset. Checks with no external tooling (the test spine, pure-Python diffs)
+      never block.
+
+    ``required_check_ids`` come from ``applied_defaults['required_checks']``; every
+    id is a registered framework check (unknown ids are rejected at CRP load, #395),
+    so an unregistered id here simply contributes no tooling requirement.
+    """
+    needing: list[tuple[str, tuple[str, ...]]] = []
+    for cid in required_check_ids:
+        check = get_framework_check(cid)
+        if check and check.required_tooling:
+            needing.append((cid, check.required_tooling))
+    if not needing:
+        return PreflightDecision()
+
+    if available_tooling is None:
+        return PreflightDecision(
+            warnings=tuple(
+                Finding(
+                    code="check_tooling_unverifiable",
+                    severity="warning",
+                    message=(
+                        f"could not verify tooling for required check `{cid}` "
+                        f"(needs {', '.join(f'`{t}`' for t in tools)}) — the deployment's "
+                        f"provisioning could not be resolved; it may fail to execute at "
+                        f"runtime. Verify the tooling is provisioned."
+                    ),
+                )
+                for cid, tools in needing
+            )
+        )
+
+    have = frozenset(available_tooling)
+    findings = [
+        Finding(
+            code="check_tooling_unavailable",
+            severity="block",
+            message=(
+                f"required check `{cid}` needs {', '.join(f'`{t}`' for t in missing)}, "
+                f"which the target deployment does not provision. Add the package to the "
+                f"role's `system-packages.txt` and rebuild, or drop `{cid}` from "
+                f"`required_checks`."
+            ),
+        )
+        for cid, tools in needing
+        if (missing := [t for t in tools if t not in have])
     ]
     return PreflightDecision(blocking=tuple(findings))

--- a/tests/unit/bootstrap/setup/test_checks.py
+++ b/tests/unit/bootstrap/setup/test_checks.py
@@ -721,3 +721,39 @@ class TestBrokerHygiene:
             mock_q.assert_not_called()
             checks_mod._collect_broker_checks(with_broker)
             mock_q.assert_called_once()
+
+
+class TestVerificationChecks:
+    """SIP-0096 §8 doctor verification category: does the deployment provision the
+    tooling each tooling-backed framework check needs? (create-time-preflight parity)."""
+
+    _R = "squadops.cycles.check_tooling.resolve_provisioned_tooling"
+
+    def test_provisioned_tooling_passes(self):
+        with patch(self._R, return_value=frozenset({"node"})):
+            results = checks_mod._collect_verification_checks(_profile())
+        frontend = next(r for r in results if r.name == "check_tooling:frontend_build")
+        assert frontend.passed is True and frontend.category == "verification"
+
+    def test_absent_tooling_fails_with_fix(self):
+        """No Node provisioned → the frontend check is non-executable; doctor flags
+        it (and preflight would reject a profile requiring it) with a fix."""
+        with patch(self._R, return_value=frozenset()):
+            results = checks_mod._collect_verification_checks(_profile())
+        frontend = next(r for r in results if r.name == "check_tooling:frontend_build")
+        assert frontend.passed is False
+        assert frontend.fix_command and "system-packages.txt" in frontend.fix_command
+
+    def test_unresolved_provisioning_is_heuristic_pass_not_red(self):
+        """Can't resolve provisioning → heuristic pass, never a false red (the
+        broker pattern) — doctor must not fail when it cannot verify."""
+        with patch(self._R, return_value=None):
+            results = checks_mod._collect_verification_checks(_profile())
+        frontend = next(r for r in results if r.name == "check_tooling:frontend_build")
+        assert frontend.passed is True and frontend.heuristic is True
+
+    def test_verification_category_is_runnable_and_registered(self):
+        with patch(self._R, return_value=frozenset({"node"})):
+            results = run_checks(_profile(), category="verification")
+        assert results and all(r.category == "verification" for r in results)
+        assert "verification" in checks_mod.VALID_CATEGORIES

--- a/tests/unit/cycles/test_check_tooling.py
+++ b/tests/unit/cycles/test_check_tooling.py
@@ -1,0 +1,58 @@
+"""Provisioned-tooling resolver (SIP-0096 §6.3/§8).
+
+The resolver turns the per-role ``system-packages.txt`` declarations into the
+set of framework tools a deployment provides. The distinction that matters for
+the parity guard: a *read but empty* set is verifiable absence (→ block a
+required check), while an *unfindable* tree is unverifiable (→ ``None`` → warn).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.check_registry import TOOL_NODE
+from squadops.cycles.check_tooling import resolve_provisioned_tooling
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+
+def _write_role_packages(root, role: str, contents: str) -> None:
+    role_dir = root / role
+    role_dir.mkdir(parents=True)
+    (role_dir / "system-packages.txt").write_text(contents, encoding="utf-8")
+
+
+def test_node_packages_resolve_to_the_node_tool(tmp_path):
+    """nodejs/npm in the qa role → the deployment provisions `node` — the exact
+    provisioning the frontend-build check's tooling requirement is matched against."""
+    _write_role_packages(tmp_path, "qa", "nodejs\nnpm\n")
+    assert resolve_provisioned_tooling(tmp_path) == frozenset({TOOL_NODE})
+
+
+def test_comments_blanks_and_unknown_packages_are_ignored(tmp_path):
+    """Only recognized packages count; a stray comment/blank/unmapped apt package
+    must not be miscounted as a framework tool."""
+    _write_role_packages(tmp_path, "qa", "# QA packages\n\nnodejs\ncurl\n  \n")
+    assert resolve_provisioned_tooling(tmp_path) == frozenset({TOOL_NODE})
+
+
+def test_tooling_is_unioned_across_roles(tmp_path):
+    """A role declaring node and another declaring nothing relevant → node still
+    provisioned deployment-wide."""
+    _write_role_packages(tmp_path, "qa", "npm\n")
+    _write_role_packages(tmp_path, "dev", "build-essential\n")
+    assert resolve_provisioned_tooling(tmp_path) == frozenset({TOOL_NODE})
+
+
+def test_present_but_no_node_is_verifiable_absence_not_none(tmp_path):
+    """A readable tree with no node declaration is *verifiable* absence — an empty
+    set (which blocks a required node check), NOT None (which would only warn).
+    Conflating the two is exactly the false-green this guard prevents."""
+    _write_role_packages(tmp_path, "dev", "build-essential\n")
+    assert resolve_provisioned_tooling(tmp_path) == frozenset()
+
+
+def test_missing_tree_is_unverifiable_none(tmp_path):
+    """An absent agents/instances tree can't be verified → None → the decision
+    warns and allows rather than blocking on missing evidence."""
+    assert resolve_provisioned_tooling(tmp_path / "does_not_exist") is None

--- a/tests/unit/cycles/test_preflight.py
+++ b/tests/unit/cycles/test_preflight.py
@@ -27,6 +27,7 @@ from squadops.cycles.preflight import (
     PreflightDecision,
     combine,
     model_availability_decision,
+    required_check_tooling_decision,
     required_roles_decision,
 )
 
@@ -249,4 +250,47 @@ def test_no_enabled_models_is_empty_decision():
     profile = _model_profile(["x:1b"], disabled_idx={0})
     decision = model_availability_decision(profile, None)
     assert decision.rejected is False
+    assert decision.blocking == () and decision.warnings == ()
+
+
+# --- required-check tooling parity (SIP-0096 §6.5, slice-4a-2) -----------------
+# frontend_build needs `node`; tests_pass/required_files need no external tooling.
+
+
+def test_required_tooling_backed_check_blocks_when_tooling_absent():
+    """The point of the guard: a profile requiring the frontend build on a
+    deployment that provisions no Node is rejected at create-time — not left to
+    surface mid-run as blocked_unverified."""
+    decision = required_check_tooling_decision(["frontend_build"], available_tooling=frozenset())
+    assert decision.rejected is True
+    assert decision.blocking[0].code == "check_tooling_unavailable"
+    assert "frontend_build" in decision.blocking[0].message
+
+
+def test_required_tooling_backed_check_passes_when_provisioned():
+    decision = required_check_tooling_decision(["frontend_build"], available_tooling={"node"})
+    assert decision.rejected is False
+    assert decision.warnings == ()
+
+
+def test_unresolved_provisioning_warns_never_blocks():
+    """None ⇒ provisioning unverifiable ⇒ warn-and-allow, mirroring the model
+    check — never block on missing evidence."""
+    decision = required_check_tooling_decision(["frontend_build"], available_tooling=None)
+    assert decision.rejected is False
+    assert decision.warnings[0].code == "check_tooling_unverifiable"
+
+
+def test_tooling_free_required_checks_never_block():
+    """tests_pass / required_files declare no external tooling, so requiring them
+    is never a tooling-parity concern even when nothing is provisioned."""
+    decision = required_check_tooling_decision(
+        ["tests_pass", "required_files"], available_tooling=frozenset()
+    )
+    assert decision.rejected is False
+    assert decision.warnings == ()
+
+
+def test_empty_required_checks_is_empty_decision():
+    decision = required_check_tooling_decision([], available_tooling=None)
     assert decision.blocking == () and decision.warnings == ()


### PR DESCRIPTION
## What
SIP-0096 Phase 2 **slice-4a-2** — the create-time **guard** the §6.3 ordering constraint requires *before* any profile marks a tooling-backed check required (slice-4b): "a profile may not mark a check required whose tooling is knowably absent — SIP-0095 preflight gains the parity check."

## Change
- **`required_check_tooling_decision`** (pure, `cycles/preflight.py`) — mirrors `model_availability_decision`: a required check whose tooling is knowably absent → **block (422)**; unresolved provisioning → **warn** (never block on missing evidence); tooling-free checks (test spine, `required_files`) never block. §6.5 routes this create-time-knowable case to preflight, never a mid-run `blocked_unverified` surprise.
- **`cycles/check_tooling.py`** resolves provisioned tooling from `agents/instances/*/system-packages.txt` (`nodejs`/`npm` → `node`). Those files are COPY'd into the runtime-api image **and** on the host, so preflight and doctor agree (§8 parity). Unfindable → `None` → warn. *Verifiable-absence (empty set → block) vs unverifiable (`None` → warn)* is the key distinction, unit-pinned.
- **Route** wires it into `_run_create_preflight`'s `combine(...)`.
- **`squadops doctor` `verification` category** (deployment-scoped): for each tooling-backed framework check, is its tooling provisioned here? Unresolvable → heuristic pass, never a false red (the broker pattern). Per §6.4/§8 "v1.4 ships doctor-only" for the non-executable detector.

## Posture
Inert until a profile declares a tooling-backed required check (slice-4b) — **no live cycle flips**. Doctor gives the accurate deployment report today.

## Live validation
`squadops doctor dev-mac --check verification` (host, real `agents/instances`):
```
[verification]
  ✓ frontend_build tooling provisioned (node)
1/1 checks passed
```
The §8 parity detector works and correctly resolves Node from the qa role's provisioning. The preflight route change is inert on all current profiles (none declare `required_checks`) — unit-covered; exercised live in 4b when a profile declares one and the stack is rebuilt.

## Tests
Resolver (verifiable-absence vs unverifiable-`None`, comment/union handling), pure decision (block/warn/tooling-free/empty), doctor category (provisioned/absent/unresolved-heuristic). Regression **4875 passed**.

## Next (4b, Spark-coordinated)
Declare `required_checks` in `full`/`validated-fullstack` + SIP-0070 D13 required-frontend blocking + emit frontend/`required_files` as recorded CheckResults — the red-flipping runtime change, validated on a 27b full-squad cycle.

Closes #397
Refs #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ