### PR TITLE
feat(#399): record required_files as SIP-0096 evidence at the builder-task seam

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -34,7 +34,7 @@ from adapters.cycles.run_completion import RunCompletion, resolve_terminal_outco
 from adapters.cycles.task_dispatcher import TaskDispatcher
 from adapters.cycles.task_naming import build_task_name
 from squadops.cycles.agent_config import build_agent_resolver
-from squadops.cycles.build_completeness import compute_missing_required_files
+from squadops.cycles.build_completeness import evaluate_required_files
 from squadops.cycles.checkpoint import RunCheckpoint
 from squadops.cycles.models import ArtifactRef, Cycle, GateDecisionValue, Run, RunStatus
 from squadops.cycles.naming import flow_run_name
@@ -1093,16 +1093,23 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # is never checked, so a run can ship green without the Dockerfile its
         # own profile mandates (#276). The loop is done, so stored_artifacts now
         # holds the complete emitted set — the only point where the deliverable
-        # is fully known. Missing → fail the run (FAILED, via _ExecutionError →
-        # resolve_terminal_outcome) with the missing list.
+        # is fully known.
+        #
+        # #399: record the result on the ledger as a required_files CheckResult
+        # BEFORE deciding to raise, so a missing-files run's verification verdict
+        # is honestly `rejected` (executed-failed evidence) instead of reading
+        # `accepted` on zero evidence — then fail the run (FAILED, via
+        # _ExecutionError → resolve_terminal_outcome) with the missing list.
         resolved_config = {**cycle.applied_defaults, **cycle.execution_overrides}
-        deficiency = compute_missing_required_files(plan, stored_artifacts, resolved_config)
-        if deficiency is not None:
-            profile_name, missing = deficiency
-            raise _ExecutionError(
-                f"Build deliverable incomplete: build profile {profile_name!r} requires files "
-                f"the run never emitted. Missing required files: {missing}."
-            )
+        required_files = evaluate_required_files(plan, stored_artifacts, resolved_config)
+        if required_files is not None:
+            ledger.record_check_result(required_files.check_result)
+            if required_files.missing:
+                raise _ExecutionError(
+                    f"Build deliverable incomplete: build profile "
+                    f"{required_files.profile_name!r} requires files the run never emitted. "
+                    f"Missing required files: {list(required_files.missing)}."
+                )
 
     # ------------------------------------------------------------------
     # SIP-0086: Manifest loading for implementation workloads

--- a/src/squadops/cycles/build_completeness.py
+++ b/src/squadops/cycles/build_completeness.py
@@ -20,12 +20,20 @@ intentionally out of scope — see ``_BUILD_TASK_TYPES`` vs
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from squadops.capabilities.handlers.build_profiles import get_profile
+from squadops.cycles.check_registry import CHECK_REQUIRED_FILES
 from squadops.cycles.task_plan import plan_has_builder_task
+from squadops.cycles.verification_integrity import (
+    CheckProvenance,
+    CheckResult,
+    ResultStatus,
+)
 
 if TYPE_CHECKING:
     from squadops.cycles.models import ArtifactRef
@@ -33,33 +41,42 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Bound the missing-file digest carried in provenance (§7: bounded, never a
+# payload copy). Basenames are short; this caps a pathological deliverable.
+_MISSING_DIGEST_MAX = 200
 
-def compute_missing_required_files(
+
+@dataclass(frozen=True)
+class RequiredFilesOutcome:
+    """Result of evaluating a builder run's ``required_files`` (#291/#399).
+
+    ``missing`` empty ⇒ every required file was emitted. ``check_result`` is the
+    SIP-0096 evidence record (§6.1) the executor appends to the ``RunLedger`` so
+    a missing-files run's verdict is honestly ``rejected`` rather than reading
+    ``accepted`` on zero evidence.
+    """
+
+    profile_name: str
+    missing: tuple[str, ...]
+    check_result: CheckResult
+
+
+def evaluate_required_files(
     plan: list[TaskEnvelope],
     stored_artifacts: list[tuple[str, ArtifactRef]],
     resolved_config: dict[str, Any],
-) -> tuple[str, list[str]] | None:
-    """Profile-level required-files check for a completed builder run.
+) -> RequiredFilesOutcome | None:
+    """Evaluate ``build_profile.required_files`` against the emitted artifact set.
 
-    Args:
-        plan: the run's full task plan (used only to detect a builder run).
-        stored_artifacts: ``(artifact_id, ArtifactRef)`` for every artifact the
-            run emitted — the complete deliverable set at run completion.
-        resolved_config: ``{**applied_defaults, **execution_overrides}`` — the
-            same merged config the builder handler reads ``build_profile`` from.
-            ``build_profile`` is required for builder runs (#392); a builder run
-            reaching here without one was already rejected at plan generation.
-
-    Returns:
-        ``(profile_name, missing_files)`` when the run built a deliverable and
-        one or more of the build profile's ``required_files`` is absent from the
-        complete emitted set; ``None`` when the run isn't a builder run or every
-        required file is present.
+    Returns ``None`` when the run isn't a builder deliverable run (or its profile
+    can't be resolved — deferred, see below); otherwise the profile, the missing
+    basenames (empty ⇒ complete), and a normalized ``required_files``
+    ``CheckResult`` (passed when complete, failed otherwise, with bounded §7
+    provenance: a digest of the emitted set and, on failure, the missing list).
 
     Filenames are compared by basename on both sides — matching the builder
     handler's ``os.path.basename`` normalization — so a required ``Dockerfile``
-    is satisfied whether it was emitted at the root or under a subdirectory, and
-    a path mismatch never fails a complete deliverable.
+    is satisfied whether emitted at the root or under a subdirectory.
     """
     if not plan_has_builder_task(plan):
         return None
@@ -72,7 +89,7 @@ def compute_missing_required_files(
         # fabricate a profile to check against — but log, since reaching here
         # means the plan-generation guard was bypassed.
         logger.warning(
-            "required_files completeness check skipped: builder run has no build_profile "
+            "required_files check skipped: builder run has no build_profile "
             "(should have been rejected at plan generation)"
         )
         return None
@@ -81,15 +98,43 @@ def compute_missing_required_files(
     except ValueError:
         # An unknown profile would already have failed the builder task in the
         # handler (get_profile raises there too), so a fail-fast run never
-        # reaches completion with one. Defer rather than crash the completeness
-        # net on a config error already surfaced upstream.
-        logger.warning(
-            "required_files completeness check skipped: unknown build profile %r", profile_name
-        )
+        # reaches completion with one. Defer rather than crash on a config error
+        # already surfaced upstream.
+        logger.warning("required_files check skipped: unknown build profile %r", profile_name)
         return None
 
     emitted = {os.path.basename(ref.filename) for _, ref in stored_artifacts if ref.filename}
-    missing = [name for name in profile.required_files if os.path.basename(name) not in emitted]
-    if missing:
-        return profile_name, missing
-    return None
+    missing = tuple(
+        name for name in profile.required_files if os.path.basename(name) not in emitted
+    )
+    subject_ref = (
+        "fileset:" + hashlib.sha256(",".join(sorted(emitted)).encode("utf-8")).hexdigest()[:16]
+    )
+    check_result = CheckResult(
+        check_id=CHECK_REQUIRED_FILES,
+        status=ResultStatus.FAILED if missing else ResultStatus.PASSED,
+        provenance=CheckProvenance(
+            subject_ref=subject_ref,
+            output_digest=(",".join(missing)[:_MISSING_DIGEST_MAX] if missing else None),
+        ),
+    )
+    return RequiredFilesOutcome(
+        profile_name=profile_name, missing=missing, check_result=check_result
+    )
+
+
+def compute_missing_required_files(
+    plan: list[TaskEnvelope],
+    stored_artifacts: list[tuple[str, ArtifactRef]],
+    resolved_config: dict[str, Any],
+) -> tuple[str, list[str]] | None:
+    """The #291 deliverable-completeness verdict: ``(profile, missing)`` or ``None``.
+
+    Thin wrapper over :func:`evaluate_required_files` preserving #291's shape —
+    ``None`` when the run isn't a builder run **or** every required file is
+    present; the profile + missing list only when the deliverable is incomplete.
+    """
+    outcome = evaluate_required_files(plan, stored_artifacts, resolved_config)
+    if outcome is None or not outcome.missing:
+        return None
+    return outcome.profile_name, list(outcome.missing)

--- a/tests/unit/cycles/test_build_completeness.py
+++ b/tests/unit/cycles/test_build_completeness.py
@@ -13,8 +13,13 @@ from datetime import UTC, datetime
 
 import pytest
 
-from squadops.cycles.build_completeness import compute_missing_required_files
+from squadops.cycles.build_completeness import (
+    compute_missing_required_files,
+    evaluate_required_files,
+)
+from squadops.cycles.check_registry import CHECK_REQUIRED_FILES
 from squadops.cycles.models import ArtifactRef
+from squadops.cycles.verification_integrity import EvidenceFamily, ResultStatus, classify
 from squadops.tasks.models import TaskEnvelope
 
 pytestmark = [pytest.mark.domain_orchestration]
@@ -147,3 +152,56 @@ def test_only_missing_subset_reported_not_present_ones():
         {"build_profile": "python_cli_builder"},
     )
     assert result == ("python_cli_builder", ["requirements.txt"])
+
+
+# --- evaluate_required_files → CheckResult evidence (#399) ---------------------
+
+
+def test_complete_deliverable_records_a_passed_required_files_check():
+    """A builder run with every required file emits an executed-passed
+    required_files CheckResult — so the evidence family reflects it, not silence."""
+    outcome = evaluate_required_files(
+        _BUILDER_PLAN,
+        [_ref("Dockerfile"), _ref("qa_handoff.md")],
+        {"build_profile": "fullstack_fastapi_react"},
+    )
+    assert outcome is not None
+    assert outcome.missing == ()
+    assert outcome.check_result.check_id == CHECK_REQUIRED_FILES
+    assert outcome.check_result.status == ResultStatus.PASSED
+    assert classify(outcome.check_result) is EvidenceFamily.EXECUTED_PASSED
+
+
+def test_missing_file_records_a_failed_required_files_check_with_the_missing_list():
+    """The #399 fix: a missing-file run records an executed-FAILED required_files
+    check (→ verdict rejected, not accepted-on-zero-evidence), and the missing
+    file rides in bounded provenance so the report can name it."""
+    outcome = evaluate_required_files(
+        _BUILDER_PLAN,
+        [_ref("qa_handoff.md")],  # no Dockerfile
+        {"build_profile": "fullstack_fastapi_react"},
+    )
+    assert outcome is not None
+    assert outcome.missing == ("Dockerfile",)
+    assert outcome.check_result.status == ResultStatus.FAILED
+    assert classify(outcome.check_result) is EvidenceFamily.EXECUTED_FAILED
+    assert "Dockerfile" in outcome.check_result.provenance.output_digest
+
+
+def test_non_builder_run_yields_no_evidence():
+    """A non-builder run has no build profile — no required_files check is
+    fabricated (the gate stays scoped to builder deliverables)."""
+    plan = [_envelope("development.develop"), _envelope("qa.test")]
+    assert evaluate_required_files(plan, [_ref("src/main.py")], {}) is None
+
+
+def test_passed_check_provenance_digests_the_emitted_set_not_raw_content():
+    """§7: provenance carries a bounded subject_ref (a fileset digest), never a
+    payload copy — and no output_digest on the passing path."""
+    outcome = evaluate_required_files(
+        _BUILDER_PLAN,
+        [_ref("Dockerfile"), _ref("qa_handoff.md")],
+        {"build_profile": "fullstack_fastapi_react"},
+    )
+    assert outcome.check_result.provenance.subject_ref.startswith("fileset:")
+    assert outcome.check_result.provenance.output_digest is None

--- a/tests/unit/cycles/test_executor_build_wiring.py
+++ b/tests/unit/cycles/test_executor_build_wiring.py
@@ -651,6 +651,67 @@ class TestBuilderDeliverableCompleteness:
         assert ("run_001", RunStatus.COMPLETED) in calls
         assert ("run_001", RunStatus.FAILED) not in calls
 
+    async def test_builder_run_records_required_files_evidence_on_the_ledger(self, reply_router):
+        """#399: the executor must append a required_files CheckResult to the
+        RunLedger so the verdict reflects the deliverable-completeness evidence
+        (not silence). A complete run records it as PASSED."""
+        from unittest.mock import patch
+
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+        from squadops.cycles.check_registry import CHECK_REQUIRED_FILES
+        from squadops.cycles.run_ledger import RunLedger
+        from squadops.cycles.verification_integrity import ResultStatus
+        from squadops.tasks.models import TaskResult
+
+        cycle = self._builder_cycle()
+        run = Run(
+            run_id="run_001",
+            cycle_id="cyc_001",
+            run_number=1,
+            status="queued",
+            initiated_by="api",
+            resolved_config_hash="hash",
+        )
+        registry = self._registry(cycle, run)
+        vault = self._vault()
+
+        reply_router.responder = lambda env: TaskResult(
+            task_id=env["task_id"],
+            status="SUCCEEDED",
+            outputs={
+                "summary": "done",
+                "role": env["metadata"].get("role"),
+                "artifacts": [
+                    {"name": "Dockerfile", "content": "FROM python:3.12\n", "type": "source"},
+                    {
+                        "name": "qa_handoff.md",
+                        "content": "## How to Run\n## How to Test\n## Expected Behavior\n",
+                        "type": "document",
+                    },
+                ],
+            },
+        )
+        ex = DispatchedFlowExecutor(
+            cycle_registry=registry,
+            artifact_vault=vault,
+            queue=reply_router.bind(AsyncMock()),
+            squad_profile=self._builder_squad(),
+            reply_router=reply_router,
+        )
+
+        recorded = []
+        with patch.object(
+            RunLedger,
+            "record_check_result",
+            autospec=True,
+            side_effect=lambda _self, r: recorded.append(r),
+        ):
+            await ex.execute_run("cyc_001", "run_001")
+
+        req = [r for r in recorded if r.check_id == CHECK_REQUIRED_FILES]
+        assert len(req) == 1
+        assert req[0].status == ResultStatus.PASSED
+
 
 class TestPlanOnlyCyclesUnaffected:
     """Regression: plan-only cycles still work as before."""


### PR DESCRIPTION
## What
SIP-0096 Phase 2 **slice-4b-1** — the Mac-lane, Mac-validatable piece of slice-4b: wire `required_files` into the SIP-0096 evidence family.

## Why
#291 enforces `build_profile.required_files` by raising `_ExecutionError` (run → FAILED) but records **nothing** on the `RunLedger`. So a missing-file run is FAILED yet its verification **verdict** is computed over an empty ledger — it can read `accepted` on zero evidence, the exact false-green SIP-0096 exists to kill.

## Change
- **`evaluate_required_files`** (`build_completeness`) returns the profile, the missing basenames, and a normalized `required_files` `CheckResult` — `passed` when complete, `failed` otherwise, with bounded §7 provenance (an emitted-set digest + the missing list). `compute_missing_required_files` is reimplemented over it (unchanged #291 behavior).
- The **executor** records that `CheckResult` on the ledger at the gate site *before* deciding to raise, so a missing-files run's verdict is honestly `rejected`.

## Posture
**Disclosure-only** — `required_files` is **not** declared in any profile's `required_checks` here, so **no new run flips red**: only already-FAILED runs gain honest evidence + a truthful verdict.

## Tests
Pure evidence (passed/failed/non-builder + `classify` families + bounded provenance) and an executor wiring test spying on `RunLedger.record_check_result`. Regression **4880 passed**. Live validation on the rebuilt stack (a lite builder cycle) posted below before merge.

## Next (4b-2, Spark-coordinated)
Frontend build check_id + emit-on-skip, SIP-0070 D13 required-frontend blocking, and declaring `required_checks` in the fullstack profiles — the 27b-validated red-flip that turns the throttle fully on.

Closes #399
Refs #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ