### PR TITLE
fix(#399): apply the live-validated required_files builder-task seam (PR #402 merged the wrong cut)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -34,7 +34,7 @@ from adapters.cycles.run_completion import RunCompletion, resolve_terminal_outco
 from adapters.cycles.task_dispatcher import TaskDispatcher
 from adapters.cycles.task_naming import build_task_name
 from squadops.cycles.agent_config import build_agent_resolver
-from squadops.cycles.build_completeness import evaluate_required_files
+from squadops.cycles.build_completeness import compute_missing_required_files
 from squadops.cycles.checkpoint import RunCheckpoint
 from squadops.cycles.models import ArtifactRef, Cycle, GateDecisionValue, Run, RunStatus
 from squadops.cycles.naming import flow_run_name
@@ -1093,23 +1093,19 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # is never checked, so a run can ship green without the Dockerfile its
         # own profile mandates (#276). The loop is done, so stored_artifacts now
         # holds the complete emitted set — the only point where the deliverable
-        # is fully known.
-        #
-        # #399: record the result on the ledger as a required_files CheckResult
-        # BEFORE deciding to raise, so a missing-files run's verification verdict
-        # is honestly `rejected` (executed-failed evidence) instead of reading
-        # `accepted` on zero evidence — then fail the run (FAILED, via
-        # _ExecutionError → resolve_terminal_outcome) with the missing list.
+        # is fully known. Missing → fail the run (FAILED, via _ExecutionError →
+        # resolve_terminal_outcome). The per-task required_files *evidence* the
+        # roll-up reads is emitted at the builder task itself (#399), so an
+        # in-loop builder failure is disclosed even though this gate is only
+        # reached when every task succeeded.
         resolved_config = {**cycle.applied_defaults, **cycle.execution_overrides}
-        required_files = evaluate_required_files(plan, stored_artifacts, resolved_config)
-        if required_files is not None:
-            ledger.record_check_result(required_files.check_result)
-            if required_files.missing:
-                raise _ExecutionError(
-                    f"Build deliverable incomplete: build profile "
-                    f"{required_files.profile_name!r} requires files the run never emitted. "
-                    f"Missing required files: {list(required_files.missing)}."
-                )
+        deficiency = compute_missing_required_files(plan, stored_artifacts, resolved_config)
+        if deficiency is not None:
+            profile_name, missing = deficiency
+            raise _ExecutionError(
+                f"Build deliverable incomplete: build profile {profile_name!r} requires files "
+                f"the run never emitted. Missing required files: {missing}."
+            )
 
     # ------------------------------------------------------------------
     # SIP-0086: Manifest loading for implementation workloads

--- a/src/squadops/capabilities/handlers/cycle/builder.py
+++ b/src/squadops/capabilities/handlers/cycle/builder.py
@@ -281,6 +281,7 @@ class BuilderAssembleHandler(_CycleTaskHandler):
             get_profile,
         )
         from squadops.capabilities.handlers.fenced_parser import extract_fenced_files
+        from squadops.cycles.check_registry import CHECK_REQUIRED_FILES
 
         start_time = time.perf_counter()
 
@@ -405,6 +406,18 @@ class BuilderAssembleHandler(_CycleTaskHandler):
             QA_HANDOFF_REQUIRED_SECTIONS,
             task_required_files=task_required_files or None,
         )
+
+        # #399: emit a required_files check row so the SIP-0096 roll-up sees this
+        # builder task's deliverable evidence. Recorded on BOTH paths — so the
+        # common in-loop failure (a builder that can't emit its required files,
+        # then exhausts correction) is disclosed as executed-failed instead of
+        # leaving the run with zero evidence and a vacuous `accepted` verdict.
+        # Independent of the section check: this row tracks *files* only.
+        effective_required = task_required_files or profile.required_files
+        extracted_basenames = {_os.path.basename(f["filename"]) for f in extracted}
+        rf_missing = [rf for rf in effective_required if rf not in extracted_basenames]
+        required_files_row = {"check": CHECK_REQUIRED_FILES, "passed": not rf_missing}
+
         if validation_error is not None:
             from squadops.cycles.task_outcome import FailureClassification, TaskOutcome
 
@@ -412,6 +425,7 @@ class BuilderAssembleHandler(_CycleTaskHandler):
                 start_time,
                 inputs,
                 validation_error,
+                outputs={"validation_result": {"checks": [required_files_row]}},
                 outcome_class=TaskOutcome.SEMANTIC_FAILURE,
                 failure_classification=FailureClassification.WORK_PRODUCT,
             )
@@ -435,6 +449,9 @@ class BuilderAssembleHandler(_CycleTaskHandler):
             "summary": f"[builder] Assembled {len(artifacts)} deployment artifact(s)",
             "role": self._role,
             "artifacts": artifacts,
+            # #399: per-task required_files evidence for the SIP-0096 roll-up
+            # (passed here — validation succeeded, so every required file present).
+            "validation_result": {"checks": [required_files_row]},
             "diagnostics": {
                 "resolved_handler": self._handler_name,
                 "build_profile": profile_name,

--- a/src/squadops/cycles/build_completeness.py
+++ b/src/squadops/cycles/build_completeness.py
@@ -16,24 +16,21 @@ Scope: builder deliverable runs only (``plan_has_builder_task``). The generic
 ``development.develop`` / ``qa.test`` build steps have no build profile and are
 intentionally out of scope — see ``_BUILD_TASK_TYPES`` vs
 ``BUILDER_TASK_TYPE_PREFIX`` in ``task_plan``.
+
+This gate *enforces* (fail-fast on a missing cross-task file); the per-task
+``required_files`` **evidence** the roll-up reads is emitted by the builder
+handler itself (a check row normalized onto the ledger, #399) so an in-loop
+builder failure is disclosed even when this post-loop gate is never reached.
 """
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from squadops.capabilities.handlers.build_profiles import get_profile
-from squadops.cycles.check_registry import CHECK_REQUIRED_FILES
 from squadops.cycles.task_plan import plan_has_builder_task
-from squadops.cycles.verification_integrity import (
-    CheckProvenance,
-    CheckResult,
-    ResultStatus,
-)
 
 if TYPE_CHECKING:
     from squadops.cycles.models import ArtifactRef
@@ -41,42 +38,33 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Bound the missing-file digest carried in provenance (§7: bounded, never a
-# payload copy). Basenames are short; this caps a pathological deliverable.
-_MISSING_DIGEST_MAX = 200
 
-
-@dataclass(frozen=True)
-class RequiredFilesOutcome:
-    """Result of evaluating a builder run's ``required_files`` (#291/#399).
-
-    ``missing`` empty ⇒ every required file was emitted. ``check_result`` is the
-    SIP-0096 evidence record (§6.1) the executor appends to the ``RunLedger`` so
-    a missing-files run's verdict is honestly ``rejected`` rather than reading
-    ``accepted`` on zero evidence.
-    """
-
-    profile_name: str
-    missing: tuple[str, ...]
-    check_result: CheckResult
-
-
-def evaluate_required_files(
+def compute_missing_required_files(
     plan: list[TaskEnvelope],
     stored_artifacts: list[tuple[str, ArtifactRef]],
     resolved_config: dict[str, Any],
-) -> RequiredFilesOutcome | None:
-    """Evaluate ``build_profile.required_files`` against the emitted artifact set.
+) -> tuple[str, list[str]] | None:
+    """Profile-level required-files check for a completed builder run.
 
-    Returns ``None`` when the run isn't a builder deliverable run (or its profile
-    can't be resolved — deferred, see below); otherwise the profile, the missing
-    basenames (empty ⇒ complete), and a normalized ``required_files``
-    ``CheckResult`` (passed when complete, failed otherwise, with bounded §7
-    provenance: a digest of the emitted set and, on failure, the missing list).
+    Args:
+        plan: the run's full task plan (used only to detect a builder run).
+        stored_artifacts: ``(artifact_id, ArtifactRef)`` for every artifact the
+            run emitted — the complete deliverable set at run completion.
+        resolved_config: ``{**applied_defaults, **execution_overrides}`` — the
+            same merged config the builder handler reads ``build_profile`` from.
+            ``build_profile`` is required for builder runs (#392); a builder run
+            reaching here without one was already rejected at plan generation.
+
+    Returns:
+        ``(profile_name, missing_files)`` when the run built a deliverable and
+        one or more of the build profile's ``required_files`` is absent from the
+        complete emitted set; ``None`` when the run isn't a builder run or every
+        required file is present.
 
     Filenames are compared by basename on both sides — matching the builder
     handler's ``os.path.basename`` normalization — so a required ``Dockerfile``
-    is satisfied whether emitted at the root or under a subdirectory.
+    is satisfied whether it was emitted at the root or under a subdirectory, and
+    a path mismatch never fails a complete deliverable.
     """
     if not plan_has_builder_task(plan):
         return None
@@ -89,7 +77,7 @@ def evaluate_required_files(
         # fabricate a profile to check against — but log, since reaching here
         # means the plan-generation guard was bypassed.
         logger.warning(
-            "required_files check skipped: builder run has no build_profile "
+            "required_files completeness check skipped: builder run has no build_profile "
             "(should have been rejected at plan generation)"
         )
         return None
@@ -98,43 +86,15 @@ def evaluate_required_files(
     except ValueError:
         # An unknown profile would already have failed the builder task in the
         # handler (get_profile raises there too), so a fail-fast run never
-        # reaches completion with one. Defer rather than crash on a config error
-        # already surfaced upstream.
-        logger.warning("required_files check skipped: unknown build profile %r", profile_name)
+        # reaches completion with one. Defer rather than crash the completeness
+        # net on a config error already surfaced upstream.
+        logger.warning(
+            "required_files completeness check skipped: unknown build profile %r", profile_name
+        )
         return None
 
     emitted = {os.path.basename(ref.filename) for _, ref in stored_artifacts if ref.filename}
-    missing = tuple(
-        name for name in profile.required_files if os.path.basename(name) not in emitted
-    )
-    subject_ref = (
-        "fileset:" + hashlib.sha256(",".join(sorted(emitted)).encode("utf-8")).hexdigest()[:16]
-    )
-    check_result = CheckResult(
-        check_id=CHECK_REQUIRED_FILES,
-        status=ResultStatus.FAILED if missing else ResultStatus.PASSED,
-        provenance=CheckProvenance(
-            subject_ref=subject_ref,
-            output_digest=(",".join(missing)[:_MISSING_DIGEST_MAX] if missing else None),
-        ),
-    )
-    return RequiredFilesOutcome(
-        profile_name=profile_name, missing=missing, check_result=check_result
-    )
-
-
-def compute_missing_required_files(
-    plan: list[TaskEnvelope],
-    stored_artifacts: list[tuple[str, ArtifactRef]],
-    resolved_config: dict[str, Any],
-) -> tuple[str, list[str]] | None:
-    """The #291 deliverable-completeness verdict: ``(profile, missing)`` or ``None``.
-
-    Thin wrapper over :func:`evaluate_required_files` preserving #291's shape —
-    ``None`` when the run isn't a builder run **or** every required file is
-    present; the profile + missing list only when the deliverable is incomplete.
-    """
-    outcome = evaluate_required_files(plan, stored_artifacts, resolved_config)
-    if outcome is None or not outcome.missing:
-        return None
-    return outcome.profile_name, list(outcome.missing)
+    missing = [name for name in profile.required_files if os.path.basename(name) not in emitted]
+    if missing:
+        return profile_name, missing
+    return None

--- a/tests/unit/capabilities/test_builder_assemble_handler.py
+++ b/tests/unit/capabilities/test_builder_assemble_handler.py
@@ -226,6 +226,17 @@ class TestBuilderAssembleSuccess:
         assert diag["qa_validation_errors"] == []
         assert diag["missing_required_files"] == []
 
+    async def test_success_emits_passed_required_files_evidence(self, mock_context, builder_inputs):
+        """#399: a complete build also records the required_files check (passed),
+        so the check is present in the evidence family on every builder task, not
+        only on failure — the roll-up sees a real result either way."""
+        handler = BuilderAssembleHandler()
+        result = await handler.handle(mock_context, builder_inputs)
+
+        checks = result.outputs["validation_result"]["checks"]
+        rf = next(c for c in checks if c["check"] == "required_files")
+        assert rf["passed"] is True
+
     async def test_source_files_in_prompt(self, mock_context, builder_inputs):
         """Source artifacts from dev role appear in the LLM prompt."""
         handler = BuilderAssembleHandler()
@@ -354,6 +365,26 @@ class TestRequiredFileValidation:
         assert result.success is False
         # Dockerfile is missing
         assert "Dockerfile" in result.error
+
+    async def test_missing_required_file_emits_failed_required_files_evidence(
+        self, mock_context, builder_inputs
+    ):
+        """#399: the builder-task failure must carry a required_files check row so
+        the SIP-0096 roll-up records executed-FAILED evidence — otherwise an
+        in-loop builder failure leaves the run with zero evidence and a vacuous
+        `accepted` verdict (the false-green a live lite cycle exposed)."""
+        mock_context.ports.llm.chat = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=LLM_MISSING_REQUIRED_FILE),
+        )
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=LLM_MISSING_REQUIRED_FILE),
+        )
+        handler = BuilderAssembleHandler()
+        result = await handler.handle(mock_context, builder_inputs)
+
+        checks = result.outputs["validation_result"]["checks"]
+        rf = next(c for c in checks if c["check"] == "required_files")
+        assert rf["passed"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cycles/test_build_completeness.py
+++ b/tests/unit/cycles/test_build_completeness.py
@@ -13,13 +13,8 @@ from datetime import UTC, datetime
 
 import pytest
 
-from squadops.cycles.build_completeness import (
-    compute_missing_required_files,
-    evaluate_required_files,
-)
-from squadops.cycles.check_registry import CHECK_REQUIRED_FILES
+from squadops.cycles.build_completeness import compute_missing_required_files
 from squadops.cycles.models import ArtifactRef
-from squadops.cycles.verification_integrity import EvidenceFamily, ResultStatus, classify
 from squadops.tasks.models import TaskEnvelope
 
 pytestmark = [pytest.mark.domain_orchestration]
@@ -152,56 +147,3 @@ def test_only_missing_subset_reported_not_present_ones():
         {"build_profile": "python_cli_builder"},
     )
     assert result == ("python_cli_builder", ["requirements.txt"])
-
-
-# --- evaluate_required_files → CheckResult evidence (#399) ---------------------
-
-
-def test_complete_deliverable_records_a_passed_required_files_check():
-    """A builder run with every required file emits an executed-passed
-    required_files CheckResult — so the evidence family reflects it, not silence."""
-    outcome = evaluate_required_files(
-        _BUILDER_PLAN,
-        [_ref("Dockerfile"), _ref("qa_handoff.md")],
-        {"build_profile": "fullstack_fastapi_react"},
-    )
-    assert outcome is not None
-    assert outcome.missing == ()
-    assert outcome.check_result.check_id == CHECK_REQUIRED_FILES
-    assert outcome.check_result.status == ResultStatus.PASSED
-    assert classify(outcome.check_result) is EvidenceFamily.EXECUTED_PASSED
-
-
-def test_missing_file_records_a_failed_required_files_check_with_the_missing_list():
-    """The #399 fix: a missing-file run records an executed-FAILED required_files
-    check (→ verdict rejected, not accepted-on-zero-evidence), and the missing
-    file rides in bounded provenance so the report can name it."""
-    outcome = evaluate_required_files(
-        _BUILDER_PLAN,
-        [_ref("qa_handoff.md")],  # no Dockerfile
-        {"build_profile": "fullstack_fastapi_react"},
-    )
-    assert outcome is not None
-    assert outcome.missing == ("Dockerfile",)
-    assert outcome.check_result.status == ResultStatus.FAILED
-    assert classify(outcome.check_result) is EvidenceFamily.EXECUTED_FAILED
-    assert "Dockerfile" in outcome.check_result.provenance.output_digest
-
-
-def test_non_builder_run_yields_no_evidence():
-    """A non-builder run has no build profile — no required_files check is
-    fabricated (the gate stays scoped to builder deliverables)."""
-    plan = [_envelope("development.develop"), _envelope("qa.test")]
-    assert evaluate_required_files(plan, [_ref("src/main.py")], {}) is None
-
-
-def test_passed_check_provenance_digests_the_emitted_set_not_raw_content():
-    """§7: provenance carries a bounded subject_ref (a fileset digest), never a
-    payload copy — and no output_digest on the passing path."""
-    outcome = evaluate_required_files(
-        _BUILDER_PLAN,
-        [_ref("Dockerfile"), _ref("qa_handoff.md")],
-        {"build_profile": "fullstack_fastapi_react"},
-    )
-    assert outcome.check_result.provenance.subject_ref.startswith("fileset:")
-    assert outcome.check_result.provenance.output_digest is None

--- a/tests/unit/cycles/test_executor_build_wiring.py
+++ b/tests/unit/cycles/test_executor_build_wiring.py
@@ -651,67 +651,6 @@ class TestBuilderDeliverableCompleteness:
         assert ("run_001", RunStatus.COMPLETED) in calls
         assert ("run_001", RunStatus.FAILED) not in calls
 
-    async def test_builder_run_records_required_files_evidence_on_the_ledger(self, reply_router):
-        """#399: the executor must append a required_files CheckResult to the
-        RunLedger so the verdict reflects the deliverable-completeness evidence
-        (not silence). A complete run records it as PASSED."""
-        from unittest.mock import patch
-
-        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
-        from squadops.cycles.check_registry import CHECK_REQUIRED_FILES
-        from squadops.cycles.run_ledger import RunLedger
-        from squadops.cycles.verification_integrity import ResultStatus
-        from squadops.tasks.models import TaskResult
-
-        cycle = self._builder_cycle()
-        run = Run(
-            run_id="run_001",
-            cycle_id="cyc_001",
-            run_number=1,
-            status="queued",
-            initiated_by="api",
-            resolved_config_hash="hash",
-        )
-        registry = self._registry(cycle, run)
-        vault = self._vault()
-
-        reply_router.responder = lambda env: TaskResult(
-            task_id=env["task_id"],
-            status="SUCCEEDED",
-            outputs={
-                "summary": "done",
-                "role": env["metadata"].get("role"),
-                "artifacts": [
-                    {"name": "Dockerfile", "content": "FROM python:3.12\n", "type": "source"},
-                    {
-                        "name": "qa_handoff.md",
-                        "content": "## How to Run\n## How to Test\n## Expected Behavior\n",
-                        "type": "document",
-                    },
-                ],
-            },
-        )
-        ex = DispatchedFlowExecutor(
-            cycle_registry=registry,
-            artifact_vault=vault,
-            queue=reply_router.bind(AsyncMock()),
-            squad_profile=self._builder_squad(),
-            reply_router=reply_router,
-        )
-
-        recorded = []
-        with patch.object(
-            RunLedger,
-            "record_check_result",
-            autospec=True,
-            side_effect=lambda _self, r: recorded.append(r),
-        ):
-            await ex.execute_run("cyc_001", "run_001")
-
-        req = [r for r in recorded if r.check_id == CHECK_REQUIRED_FILES]
-        assert len(req) == 1
-        assert req[0].status == ResultStatus.PASSED
-
 
 class TestPlanOnlyCyclesUnaffected:
     """Regression: plan-only cycles still work as before."""

--- a/tests/unit/cycles/test_verification_normalize.py
+++ b/tests/unit/cycles/test_verification_normalize.py
@@ -265,3 +265,27 @@ def test_task_re_run_supersedes_earlier_failure_via_subject():
     summary = aggregate_verification(ledger, required_check_ids=[CHECK_TESTS_PASS])
     assert summary.verdict is RunVerdict.ACCEPTED
     assert summary.failed == ()
+
+
+# --------------------------------------------------------------------------- #
+# required_files evidence from the builder task (#399)
+# --------------------------------------------------------------------------- #
+
+
+def test_builder_required_files_row_normalizes_to_a_check_with_subject():
+    """The #399 seam: the builder emits a `required_files` check row on its own
+    outputs; normalize must record it as an executed check stamped with the
+    builder task's subject — so an in-loop builder failure lands honest
+    executed-failed evidence on the ledger (verdict rejected, not accepted/0)."""
+    out = {"validation_result": {"checks": [{"check": "required_files", "passed": False}]}}
+    r = _by_id(normalize_task_checks(out, subject="task-build-7"))["required_files"]
+    assert r.status == ResultStatus.FAILED
+    assert classify(r) is EvidenceFamily.EXECUTED_FAILED
+    assert r.subject == "task-build-7"
+
+
+def test_builder_required_files_row_passed_is_executed_passed():
+    out = {"validation_result": {"checks": [{"check": "required_files", "passed": True}]}}
+    r = _by_id(normalize_task_checks(out))["required_files"]
+    assert r.status == ResultStatus.PASSED
+    assert classify(r) is EvidenceFamily.EXECUTED_PASSED


### PR DESCRIPTION
## Why this exists
PR #402 merged the **first cut** of #399 (`d2f9322`, post-loop gate). Live validation had already shown that approach **doesn't fix the false-green** — a builder run that fails *in-loop* at `builder.assemble` never reaches the post-loop gate, so it still reports `Verdict: accepted / Executed: 0`. The **builder-task seam rework** (`125d1ca`) that fixes it was pushed *after* the merge and never landed. So `main` currently has the broken version.

This PR applies that rework (cherry-picked cleanly onto current main).

## What it does (the correct version)
- `builder.assemble` emits a `required_files` check row (passed/failed vs its effective required files) on **both** the success and validation-failure paths.
- The existing slice-1 `normalize_task_checks` records it onto the ledger with the builder task's subject — **no executor change**. An in-loop builder failure now lands executed-failed evidence → verdict honestly `rejected`.
- Reverts the post-loop `CheckResult` recording; #291's fail-fast stays as the cross-task deliverable net.

## Already live-validated
This is byte-identical to `125d1ca`, which I validated on the rebuilt stack (`cyc_bbd91c578713`): a lite builder cycle failing in-loop produced:
```
Verdict: rejected
Executed: 1 (passed 0, pass-rate 0%)
Failed: required_files
```
(vs `accepted / 0` on the post-loop version now on main). The deployed Mac stack already runs this code, so no redeploy is needed after merge. Regression **4755**.

Closes #399
Refs #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ