### PR TITLE
feat(#407): fullstack frontend_build as SIP-0096 evidence + declare required_checks (throttle ON)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -14,6 +14,8 @@ from squadops.capabilities.handlers.base import (
     HandlerResult,
 )
 from squadops.capabilities.handlers.prompt_guard import _guard_prompt_size
+from squadops.cycles.check_registry import CHECK_FRONTEND_BUILD
+from squadops.cycles.verification_integrity import NotExecutedReason
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
 
@@ -30,6 +32,20 @@ from squadops.capabilities.handlers.cycle.validation import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _frontend_skip_reason(error: str) -> str:
+    """Map a frontend-build skip error to a §7 not-executed reason (#407).
+
+    ``run_frontend_build`` skips (``ran=False``) with the cause in ``error``: an
+    absent Node toolchain (``npm/npx not found``) is ``missing_tooling`` — the
+    #306 case a required frontend_build must block on; anything else (no frontend
+    source) is ``subject_missing``.
+    """
+    e = (error or "").lower()
+    if "not found" in e or "not installed" in e:
+        return NotExecutedReason.MISSING_TOOLING
+    return NotExecutedReason.SUBJECT_MISSING
 
 
 class QATestHandler(_CycleTaskHandler):
@@ -602,6 +618,27 @@ class QATestHandler(_CycleTaskHandler):
             outputs["outcome_class"] = TaskOutcome.SEMANTIC_FAILURE
             outputs["failure_classification"] = FailureClassification.WORK_PRODUCT
             outputs["validation_result"] = evidence_extra.get("validation_result", {})
+
+        # #407: record the fullstack frontend build as a first-class SIP-0096
+        # check on BOTH the pass and fail paths. run_build_validation folds a
+        # frontend skip/failure into the combined result, so without this a
+        # required frontend_build that never executed (Node absent, #306) would
+        # read green — the SIP-0070 D13 false-green. A *passing* fullstack run
+        # must record frontend_build=passed too, or requiring it would false-block.
+        # Runs after the classification above so it isn't overwritten by the
+        # failure-path validation_result assignment.
+        fb = test_result.frontend_build
+        if fb is not None:
+            if fb.ran:
+                fb_row: dict[str, Any] = {"check": CHECK_FRONTEND_BUILD, "passed": fb.ok}
+            else:
+                fb_row = {
+                    "check": CHECK_FRONTEND_BUILD,
+                    "executed": False,
+                    "reason": _frontend_skip_reason(fb.error),
+                }
+            vr = outputs.setdefault("validation_result", {})
+            vr.setdefault("checks", []).append(fb_row)
 
         duration_ms = (time.perf_counter() - start_time) * 1000
         evidence = HandlerEvidence.create(

--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -35,6 +35,12 @@ class RunTestsResult:
     error: str = ""
     test_file_count: int = 0
     source_file_count: int = 0
+    # #407: the fullstack frontend build outcome, surfaced distinctly so qa.test
+    # can emit a frontend_build SIP-0096 CheckResult. None when no frontend was in
+    # scope (non-fullstack run). A skip (``ran=False``) is otherwise folded away by
+    # run_build_validation — exactly the #306 not-executed case that must not read
+    # green once frontend_build is a required check.
+    frontend_build: BuildCheckResult | None = None
 
     @property
     def tests_passed(self) -> bool:
@@ -714,12 +720,12 @@ async def run_build_validation(
         run_frontend, run_backend = False, True
 
     checks: list[BuildCheckResult] = []
+    frontend_check: BuildCheckResult | None = None
     if run_frontend:
-        checks.append(
-            await run_frontend_build(
-                source_files, target_dir=frontend_target, timeout_seconds=timeout_seconds
-            )
+        frontend_check = await run_frontend_build(
+            source_files, target_dir=frontend_target, timeout_seconds=timeout_seconds
         )
+        checks.append(frontend_check)
     if run_backend:
         checks.append(await run_backend_import_check(source_files, timeout_seconds=timeout_seconds))
 
@@ -733,4 +739,8 @@ async def run_build_validation(
             exit_code=result.exit_code or failed[0].exit_code or 1,
             error=merged_error,
         )
+    # #407: attach the frontend build outcome distinctly (a skip is dropped by the
+    # `failed` merge above, so qa.test can't otherwise see it). None ⇒ no frontend.
+    if frontend_check is not None:
+        result = replace(result, frontend_build=frontend_check)
     return result

--- a/src/squadops/contracts/cycle_request_profiles/profiles/validated-fullstack.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/validated-fullstack.yaml
@@ -41,6 +41,18 @@ defaults:
   # SIP-0092 M1 instrumentation (typed + command acceptance).
   typed_acceptance: true
   command_acceptance_checks: true
+  # SIP-0096 §6.3 throttle: the fullstack build/test spine this profile REQUIRES.
+  # A run that doesn't execute one — e.g. frontend_build skipped because Node is
+  # absent (#306) — is blocked_unverified instead of reading green (the D13
+  # false-green). Each is emitted on the happy path (tests_pass synthesized from
+  # test_result; frontend_build by qa.test #407; required_files by builder.assemble
+  # #399), so requiring them never false-blocks a clean run. no_stub_fallback_tests
+  # is intentionally omitted — it's a failure-only row, so requiring it would block
+  # a stub-free run.
+  required_checks:
+    - tests_pass
+    - frontend_build
+    - required_files
   # Long-cycle budget for a full instrumented fullstack build.
   time_budget_seconds: 7200
   experiment_context: {}

--- a/src/squadops/cycles/verification_normalize.py
+++ b/src/squadops/cycles/verification_normalize.py
@@ -110,8 +110,13 @@ def normalize_task_checks(
 def _from_passed_row(cid: str, row: Mapping[str, Any]) -> CheckResult:
     """Normalize a check row that carries a boolean ``passed`` (no ``status``)."""
     if row.get("executed") is False:
+        # Honor an explicit §7 not-executed reason when the producer supplies one
+        # (e.g. frontend_build skipped for missing_tooling, #407); default to
+        # subject_missing for producers that only signal executed=False.
         return CheckResult(
-            check_id=cid, status=ResultStatus.SKIPPED, reason=NotExecutedReason.SUBJECT_MISSING
+            check_id=cid,
+            status=ResultStatus.SKIPPED,
+            reason=_str_or_none(row.get("reason")) or NotExecutedReason.SUBJECT_MISSING,
         )
     status = ResultStatus.PASSED if row.get("passed") else ResultStatus.FAILED
     return CheckResult(check_id=cid, status=status)

--- a/tests/unit/capabilities/handlers/test_output_validation.py
+++ b/tests/unit/capabilities/handlers/test_output_validation.py
@@ -702,6 +702,79 @@ class TestQATestExecutionFoldsIntoOutcome:
         assert any("tests_failed:exit_1" in m for m in val["missing_components"])
         assert "Tests failed" in val["summary"]
 
+    def _frontend_check(self, **kw):
+        from squadops.capabilities.handlers.test_runner import BuildCheckResult
+
+        return BuildCheckResult(**kw)
+
+    async def test_frontend_build_passed_recorded_on_a_green_run(self) -> None:
+        """#407: a passing fullstack run must record frontend_build=passed — else
+        declaring it a required check (validated-fullstack) would false-block a
+        clean build. This is the success-path emission the builder-only #399 lacked."""
+        handler = QATestHandler()
+        ctx = self._make_context()
+        self._mock_llm_test_output(ctx)
+        self._patched_test_suite(
+            handler,
+            {
+                "executed": True,
+                "exit_code": 0,
+                "test_file_count": 1,
+                "source_file_count": 1,
+                "frontend_build": self._frontend_check(ran=True, ok=True),
+            },
+        )
+
+        result = await handler.handle(ctx, self._qa_inputs())
+
+        assert result.success is True
+        checks = result.outputs["validation_result"]["checks"]
+        fb = next(c for c in checks if c["check"] == "frontend_build")
+        assert fb["passed"] is True
+
+    async def test_frontend_build_skip_recorded_as_not_executed_missing_tooling(self) -> None:
+        """The #306 false-green: tests pass but the frontend never built (Node
+        absent). It must record as not-executed/missing_tooling — so a required
+        frontend_build blocks instead of the run reading green."""
+        handler = QATestHandler()
+        ctx = self._make_context()
+        self._mock_llm_test_output(ctx)
+        self._patched_test_suite(
+            handler,
+            {
+                "executed": True,
+                "exit_code": 0,
+                "test_file_count": 1,
+                "source_file_count": 1,
+                "frontend_build": self._frontend_check(
+                    ran=False, error="npm not found — Node.js not installed"
+                ),
+            },
+        )
+
+        result = await handler.handle(ctx, self._qa_inputs())
+
+        checks = result.outputs["validation_result"]["checks"]
+        fb = next(c for c in checks if c["check"] == "frontend_build")
+        assert fb["executed"] is False
+        assert fb["reason"] == "missing_tooling"
+
+    async def test_non_fullstack_run_emits_no_frontend_build_row(self) -> None:
+        """A python_cli run has no frontend in scope (frontend_build is None) — it
+        must not fabricate a frontend_build check that would then be 'missing'."""
+        handler = QATestHandler()
+        ctx = self._make_context()
+        self._mock_llm_test_output(ctx)
+        self._patched_test_suite(
+            handler,
+            {"executed": True, "exit_code": 0, "test_file_count": 1, "source_file_count": 1},
+        )
+
+        result = await handler.handle(ctx, self._qa_inputs())
+
+        checks = result.outputs.get("validation_result", {}).get("checks", [])
+        assert not any(c["check"] == "frontend_build" for c in checks)
+
     async def test_tests_not_collected_yields_semantic_failure(self) -> None:
         """Exit 5 (no tests collected — e.g., import errors) must fail the QA task.
 

--- a/tests/unit/capabilities/test_test_runner.py
+++ b/tests/unit/capabilities/test_test_runner.py
@@ -238,3 +238,45 @@ class TestRunGeneratedTestsCleanup:
 
         assert created, "run_generated_tests did not create a workspace"
         assert all(not os.path.exists(p) for p in created)
+
+
+class TestRunBuildValidationSurfacesFrontend:
+    """#407: run_build_validation must attach the frontend BuildCheckResult to its
+    RunTestsResult; the folded-away skip is exactly the #306 case qa.test needs."""
+
+    async def test_fullstack_surfaces_frontend_skip(self, monkeypatch):
+        from squadops.capabilities.dev_capabilities import TEST_FRAMEWORK_BOTH
+        from squadops.capabilities.handlers import test_runner as tr
+
+        async def _fullstack(*a, **k):
+            return tr.RunTestsResult(executed=True, exit_code=0)
+
+        async def _frontend(*a, **k):
+            return tr.BuildCheckResult(ran=False, error="npm not found — Node.js not installed")
+
+        async def _backend(*a, **k):
+            return tr.BuildCheckResult(ran=True, ok=True)
+
+        monkeypatch.setattr(tr, "run_fullstack_tests", _fullstack)
+        monkeypatch.setattr(tr, "run_frontend_build", _frontend)
+        monkeypatch.setattr(tr, "run_backend_import_check", _backend)
+
+        result = await tr.run_build_validation(TEST_FRAMEWORK_BOTH, [], [])
+        assert result.frontend_build is not None
+        assert result.frontend_build.ran is False  # the skip is surfaced, not dropped
+
+    async def test_pytest_run_has_no_frontend_build(self, monkeypatch):
+        from squadops.capabilities.dev_capabilities import TEST_FRAMEWORK_PYTEST
+        from squadops.capabilities.handlers import test_runner as tr
+
+        async def _gen(*a, **k):
+            return tr.RunTestsResult(executed=True, exit_code=0)
+
+        async def _backend(*a, **k):
+            return tr.BuildCheckResult(ran=True, ok=True)
+
+        monkeypatch.setattr(tr, "run_generated_tests", _gen)
+        monkeypatch.setattr(tr, "run_backend_import_check", _backend)
+
+        result = await tr.run_build_validation(TEST_FRAMEWORK_PYTEST, [], [])
+        assert result.frontend_build is None

--- a/tests/unit/contracts/test_validated_fullstack_profile.py
+++ b/tests/unit/contracts/test_validated_fullstack_profile.py
@@ -51,3 +51,11 @@ def test_two_run_framing_then_implementation_sequence():
     assert [step["type"] for step in sequence] == ["framing", "implementation"]
     assert sequence[0]["gate"] == "progress_plan_review"
     assert sequence[1]["gate"] is None
+
+
+def test_declares_the_sip_0096_required_check_spine():
+    """#407: the throttle. A typo or accidental removal here silently reverts the
+    profile to inert (no required checks) — so pin the spine explicitly. Omits
+    no_stub_fallback_tests deliberately (failure-only row → would false-block)."""
+    required = load_profile("validated-fullstack").defaults["required_checks"]
+    assert set(required) == {"tests_pass", "frontend_build", "required_files"}

--- a/tests/unit/cycles/test_verification_normalize.py
+++ b/tests/unit/cycles/test_verification_normalize.py
@@ -289,3 +289,30 @@ def test_builder_required_files_row_passed_is_executed_passed():
     r = _by_id(normalize_task_checks(out))["required_files"]
     assert r.status == ResultStatus.PASSED
     assert classify(r) is EvidenceFamily.EXECUTED_PASSED
+
+
+# --------------------------------------------------------------------------- #
+# explicit not-executed reason on a generic row (#407 frontend_build skip)
+# --------------------------------------------------------------------------- #
+
+
+def test_generic_skip_row_honors_explicit_reason():
+    """#407: a producer that knows *why* a check didn't run (frontend_build
+    skipped because Node is absent) supplies an explicit reason; normalize must
+    keep it (missing_tooling) rather than defaulting to subject_missing — the
+    §7 reason is what discloses the #306 not-executed case honestly."""
+    out = {
+        "validation_result": {
+            "checks": [{"check": "frontend_build", "executed": False, "reason": "missing_tooling"}]
+        }
+    }
+    r = _by_id(normalize_task_checks(out))["frontend_build"]
+    assert r.status == ResultStatus.SKIPPED
+    assert r.reason == NotExecutedReason.MISSING_TOOLING
+    assert classify(r) is EvidenceFamily.NOT_EXECUTED
+
+
+def test_generic_skip_row_without_reason_defaults_to_subject_missing():
+    out = {"validation_result": {"checks": [{"check": "frontend_build", "executed": False}]}}
+    r = _by_id(normalize_task_checks(out))["frontend_build"]
+    assert r.reason == NotExecutedReason.SUBJECT_MISSING


### PR DESCRIPTION
## What
SIP-0096 Phase 2 **slice-4b-2** — the throttle-ON red-flip for the fullstack path. Closes the SIP-0070 D13 false-green: a fullstack run whose frontend check never executed (Node absent, #306) merged non-blocking and read green.

## Change
- **Surface it:** `RunTestsResult` gains a `frontend_build` field; `run_build_validation` attaches the frontend `BuildCheckResult` distinctly (its skip was otherwise dropped by the failed-merge — the exact not-executed case that vanished).
- **Emit it:** qa.test emits a `frontend_build` check row (the #399 builder pattern) on **both** the pass and fail paths when a frontend is in scope — passed/failed, or not-executed with a §7 reason (`missing_tooling` when Node absent). *Passing runs record it too*, so a required-but-passing frontend build never false-blocks.
- **Reason:** normalize `_from_passed_row` honors an explicit not-executed `reason`.
- **Declare it:** `validated-fullstack` gets `required_checks: [tests_pass, frontend_build, required_files]` — the build/test spine. D13 blocking is realized by the aggregation core (required not-executed → `blocked_unverified`, §6.2/§8), no separate blocking change. `no_stub_fallback_tests` omitted deliberately (failure-only row → would false-block a clean run).

## Validation (Mac builds, Spark confirms)
- **Mac (this PR):** unit-tested — success-path emission (the critical no-false-block case), skip→`missing_tooling`, `run_build_validation` surfacing, non-fullstack unaffected; local rebuild + smoke cycle (result below). Regression **4763**.
- **Spark (27b, before merge):** the positive path only a completing fullstack build exercises — frontend executes → `accepted` when green; a frontend that didn't run → `blocked_unverified`. Handoff issue to follow.

Refs #375
Refs #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rVtixi7UjxrzFsHt9znZZ