### PR TITLE
fix(#388): a non-succeeded run never reads `accepted` on zero evidence

### DIFF
--- a/adapters/cycles/run_completion.py
+++ b/adapters/cycles/run_completion.py
@@ -190,7 +190,7 @@ class RunCompletion:
         # and no shipped profile declares required_checks — so this computes
         # `accepted` with zero recorded evidence and discloses it in the report.
         # Phase 2 wires the producers and per-profile required lists (the throttle).
-        summary = self._aggregate_verification(cycle, ledger)
+        summary = self._aggregate_verification(cycle, ledger, terminal_status)
 
         # Run report: best-effort (D10)
         try:
@@ -209,14 +209,22 @@ class RunCompletion:
 
     @staticmethod
     def _aggregate_verification(
-        cycle: Cycle | None, ledger: RunLedger | None
+        cycle: Cycle | None, ledger: RunLedger | None, terminal_status: str
     ) -> RunVerificationSummary:
         """Run the SIP-0096 aggregation over the ledger against the cycle's required set.
 
         Requiredness comes only from the cycle's ``applied_defaults['required_checks']``
         (an explicit profile declaration, §6.3 / AC#5) — never inferred. Both the
         results and the required list default to empty, so a pre-SIP-0096 cycle or
-        a Phase-1 (throttle-off) cycle aggregates to an honest `accepted`.
+        a Phase-1 (throttle-off) cycle that *completes* aggregates to an honest
+        `accepted`.
+
+        ``terminal_status`` supplies the run-level context the pure verdict cannot
+        see: only a ``COMPLETED`` run is eligible for `accepted` (#388). A run that
+        FAILED/cancelled/paused with no failed check would otherwise fall through to
+        `accepted` on zero evidence — the `Status: FAILED` / `Verdict: accepted`
+        contradiction — so we pass ``run_succeeded`` and let the choke point resolve
+        it to `blocked_unverified`.
         """
         required_check_ids: tuple[str, ...] = ()
         if cycle is not None:
@@ -224,7 +232,8 @@ class RunCompletion:
             if declared:
                 required_check_ids = tuple(declared)
         results = ledger.check_results if ledger else ()
-        summary = aggregate_verification(results, required_check_ids)
+        run_succeeded = (terminal_status or "").upper() == RunStatus.COMPLETED.value.upper()
+        summary = aggregate_verification(results, required_check_ids, run_succeeded=run_succeeded)
         logger.info(
             "Verification integrity: verdict=%s executed=%d passed=%d unverified=%d required_unmet=%d",
             summary.verdict.value,

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -282,6 +282,8 @@ def _resolve_final_state(results: Sequence[CheckResult]) -> list[CheckResult]:
 def aggregate_verification(
     results: Sequence[CheckResult],
     required_check_ids: Collection[str] = (),
+    *,
+    run_succeeded: bool = True,
 ) -> RunVerificationSummary:
     """Pure aggregation choke point (SIP-0096 §6.2, §6.4).
 
@@ -293,12 +295,25 @@ def aggregate_verification(
     ``required_check_ids`` is supplied by the caller from explicit profile
     declarations only (§6.3, AC#5).
 
+    ``run_succeeded`` is the one piece of run-level context the verdict needs but
+    cannot see in the check ledger: whether the run reached a successful terminal
+    state. The verdict is deliberately not a ``RunStatus`` (§6.5), but it must stay
+    *consistent* with one — a run that FAILED/cancelled/aborted must never read
+    ``accepted`` (#388). The caller derives this from the terminal status; it
+    defaults ``True`` so a pure roll-up over a completed run is unchanged.
+
     Verdict rule (§6.2):
       - any **required** check not-executed (including a required check that
         produced *no* result at all — e.g. ``required_files`` #291) →
         ``blocked_unverified`` (AC#2), taking precedence over a plain failure so
         the incomplete-evidence signal is never hidden behind a product failure;
       - else any executed-and-failed → ``rejected``;
+      - else if the run did **not** reach a successful terminal state →
+        ``blocked_unverified`` (#388): zero-of-zero is zero evidence for the
+        verdict exactly as it is for ``pass_rate`` (AC#1), so an aborted run with
+        no failed check — or only passing checks recorded before it died — cannot
+        be endorsed as ``accepted``; the framework simply never finished
+        verifying it;
       - else ``accepted``.
 
     Not-executed results are excluded from ``executed_count``/``passed_count`` and
@@ -348,6 +363,15 @@ def aggregate_verification(
         verdict = RunVerdict.BLOCKED_UNVERIFIED
     elif failed:
         verdict = RunVerdict.REJECTED
+    elif not run_succeeded:
+        # The run did not reach a successful terminal state, yet no check failed and
+        # nothing required is unmet — so it would fall through to `accepted` on the
+        # strength of zero (or only-passed) evidence. That is the #388 contradiction:
+        # `Status: FAILED` next to `Verdict: accepted`. The run aborted before
+        # verification could complete, so the framework cannot honestly claim the
+        # deliverable is verified (§6.5) — disclose it as blocked_unverified, never
+        # an endorsement.
+        verdict = RunVerdict.BLOCKED_UNVERIFIED
     else:
         verdict = RunVerdict.ACCEPTED
 

--- a/tests/unit/cycles/test_run_completion.py
+++ b/tests/unit/cycles/test_run_completion.py
@@ -513,6 +513,24 @@ class TestVerificationIntegrityWiring:
         assert "required_files" in content
         assert "harness/evidence problem" in content  # framed as harness, not product failure
 
+    async def test_finalize_failed_run_zero_evidence_blocks_not_accepts(self):
+        """#388: a FAILED terminal status threads run_succeeded=False through the real
+        finalize→aggregate→report path, so an empty ledger rolls up to
+        blocked_unverified — the report never shows `accepted` next to a FAILED run.
+        Catches the wiring bug of aggregating without the run's terminal disposition."""
+        from squadops.cycles.run_ledger import RunLedger
+
+        completion, vault = self._completion()
+
+        await completion.finalize(
+            "cyc_001", "run_001", "FAILED", None, None, cycle=_make_cycle(), ledger=RunLedger()
+        )
+        content = vault.store.call_args[0][1].decode()
+        assert "Verdict: **blocked_unverified**" in content
+        assert "Verdict: **accepted**" not in content
+        # Zero-evidence block, not a required-check block: no required warning line.
+        assert "required check(s) unverified" not in content
+
     async def test_finalize_reflects_recorded_failure(self):
         """A recorded executed-failed result reaches the verdict (rejected) end-to-end,
         proving the ledger→aggregation→report wiring carries real evidence (Phase 2 shape)."""

--- a/tests/unit/cycles/test_verification_integrity.py
+++ b/tests/unit/cycles/test_verification_integrity.py
@@ -148,6 +148,47 @@ def test_zero_of_zero_executed_is_zero_evidence_not_100_percent():
     assert s.verdict is RunVerdict.ACCEPTED  # inert: no required checks, nothing failed
 
 
+# --------------------------------------------------------------------------- #
+# #388 — a run that did not succeed must never read `accepted` on zero evidence
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("run_succeeded", "expected"),
+    [
+        (True, RunVerdict.ACCEPTED),  # completed run: inert Phase-1 behavior preserved
+        (False, RunVerdict.BLOCKED_UNVERIFIED),  # #388: FAILED + zero evidence ≠ accepted
+    ],
+)
+def test_zero_evidence_verdict_tracks_run_success(run_succeeded, expected):
+    """Zero-of-zero is zero evidence for the *verdict*, not an endorsement (#388).
+
+    Catches the field bug (cyc_60eb5a481b5b): a run that FAILED inside the builder
+    correction loop before any check ran displayed `Verdict: accepted` next to
+    `Status: FAILED`.
+    """
+    s = aggregate_verification([], run_succeeded=run_succeeded)
+    assert s.executed_count == 0
+    assert s.verdict is expected
+
+
+def test_failed_run_with_only_passed_checks_is_not_accepted():
+    """A run that died for a non-check reason after some checks passed still cannot
+    read `accepted` — verification never completed (#388)."""
+    s = aggregate_verification([_passed("a"), _passed("b")], run_succeeded=False)
+    assert s.passed_count == 2
+    assert s.verdict is RunVerdict.BLOCKED_UNVERIFIED
+
+
+def test_failed_run_with_a_failed_check_is_rejected_not_blocked():
+    """A genuine executed-failure on a failed run is a product `rejected`, not a
+    harness `blocked_unverified`: the failed-check branch keeps precedence over the
+    run-success gate (#388) — reordering the two would regress this."""
+    s = aggregate_verification([_failed("a")], run_succeeded=False)
+    assert s.verdict is RunVerdict.REJECTED
+    assert s.failed == ("a",)
+
+
 def test_not_executed_excluded_from_denominator():
     """A skipped check cannot inflate pass_rate: 1 passed + 1 skipped is 1/1, not 1/2."""
     s = aggregate_verification([_passed("a"), _skipped("b")])


### PR DESCRIPTION
## Summary

A run that ended `Status: FAILED` displayed `Verification Integrity → Verdict: **accepted**` — the roll-up self-contradiction surfaced in the #374/#379 field validation (`cyc_60eb5a481b5b / run_a6d3654c9265`). The run aborted **inside the `builder.assemble` correction loop before any check executed**, so the ledger was empty and `aggregate_verification([])` returned the inert `ACCEPTED`. `pass_rate` correctly read 0%, but the **verdict** did not carry the zero-evidence signal.

## Fix

Extend the AC#1 spirit — *"0-of-0 is zero evidence, never 100%"* — from `pass_rate` to the **verdict** itself, without disturbing the deliberate Phase-1 inert behavior for *completed* runs.

- `aggregate_verification` gains a keyword-only **`run_succeeded: bool = True`**. The default preserves every existing pure-core roll-up (a completed run with no required checks + no failures still reads `accepted`).
- New verdict branch, **after** `required_unmet` (blocked) and `failed` (rejected): when the run did **not** reach a successful terminal state and nothing failed / nothing required is unmet, the would-be `accepted` resolves to **`blocked_unverified`** — the framework never finished verifying, so it cannot endorse the deliverable (§6.5). A genuine executed-failure keeps precedence as `rejected`.
- The `RunCompletion` seam derives `run_succeeded` from the terminal status (**`COMPLETED` only**) using the enum-sourced, case-insensitive compare already used in `run_report_builder` (no new bare-string shadow — the enum-shadow architecture test passes), and threads it into the choke point.

### Verdict table (verdict is **not** a `RunStatus`, but must stay consistent with one)

| terminal status | ledger | before | after |
|---|---|---|---|
| COMPLETED | empty | accepted | **accepted** (unchanged, inert) |
| FAILED | empty | ❌ accepted | ✅ **blocked_unverified** |
| FAILED | only passed checks | ❌ accepted | ✅ **blocked_unverified** |
| FAILED | a failed check | rejected | **rejected** (unchanged, precedence) |
| any | required-unmet | blocked_unverified | **blocked_unverified** (unchanged) |

## Distinct from #376

#376 point 4 is *narrative overriding a correctly-rejected/blocked verdict*. Here the **verdict itself was wrong** (`accepted` on zero evidence). Same roll-up, different defect.

## Tests
- **Pure core** (`test_verification_integrity.py`): parametrized zero-evidence verdict (succeeded → accepted vs not → blocked); only-passed-on-a-failed-run → blocked; failed-check keeps `rejected` precedence (reordering the two branches would regress this).
- **Seam, end-to-end** (`test_run_completion.py`): a `FAILED` terminal status through the real `finalize → aggregate → build_run_report` path renders `Verdict: **blocked_unverified**` and never `accepted` — catches the wiring bug of aggregating without the run's terminal disposition.
- Regression: **4760 passed**.

## Live validation
Deterministic non-success path validated on the deployed stack via a cancelled `lite` cycle — see comment below.

Closes #388