### PR TITLE
feat(#411): CycleOutcome roll-up — pure aggregation core (SIP-0096 Phase 3 slice 1)

### DIFF
--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 from collections.abc import Collection, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import Any
 
 
 class ResultStatus:
@@ -202,6 +203,60 @@ class RunVerificationSummary:
         denominator, so they can never inflate this toward success.
         """
         return self.passed_count / self.executed_count if self.executed_count else 0.0
+
+
+@dataclass(frozen=True)
+class WaivedCheck:
+    """An operator gate waiver, recorded *above* the evidence (SIP-0096 §6.5).
+
+    A waiver is an operator decision recorded on the roll-up — never a mutation of
+    the underlying check result (SIP-0092 §6.3.2: results stand un-loosened). Empty
+    until the Phase-3 gate-waiver slice wires it; part of the contract shape now so
+    downstream consumers can depend on it.
+    """
+
+    check_id: str
+    reason: str
+    waived_by: str | None = None
+
+
+@dataclass(frozen=True)
+class CycleOutcome:
+    """The durable per-cycle verification-evidence roll-up (SIP-0096 §10).
+
+    The contract downstream consumers read, in order of arrival: **wrap-up**
+    (SIP-0080 confidence classification gets an honest basis), **operator gates**
+    (a ``blocked_unverified`` gate sees the harness-vs-product distinction + the
+    waiver option), and — the strategic one — the **Campaign continuation
+    decision** (1.6). References only (``check_id``s / disclosure records), never
+    copies of the underlying SIP-0070/0092 records (§10).
+
+    This is also the substrate the later cycle-evaluation scorecard derives its
+    outcome/quality/efficiency/stability dimensions from — those are *projections*
+    over this honest evidence, not new raw fields here.
+
+    ``verdict`` is the cycle-level roll-up of the per-run verdicts (worst wins, so
+    the incomplete-evidence signal is never hidden); it is **not** a cycle status,
+    and it is the **un-waived** evidence verdict — a waiver sits beside it in
+    ``waived`` and never alters it (§6.5).
+    """
+
+    verdict: RunVerdict
+    verified: tuple[str, ...]  # executed-and-passed across the cycle's runs
+    failed: tuple[str, ...]  # executed-and-failed
+    unverified: tuple[UnverifiedCheck, ...]  # not-executed, with reasons — always disclosed
+    run_count: int
+    inert: tuple[str, ...] = ()  # §9 chronic not-executed — populated by the inert-detection slice
+    waived: tuple[WaivedCheck, ...] = ()  # §6.5 operator waivers — populated by the waiver slice
+
+    @property
+    def required_unmet(self) -> tuple[str, ...]:
+        """Required check_ids not-executed in any run (what drove ``blocked_unverified``).
+
+        Derived from ``unverified`` rather than stored, so the required set and its
+        disclosure can never drift apart.
+        """
+        return tuple(u.check_id for u in self.unverified if u.required)
 
 
 def classify(result: CheckResult) -> EvidenceFamily:
@@ -383,4 +438,86 @@ def aggregate_verification(
         required_unmet=required_unmet,
         executed_count=executed_count,
         passed_count=passed_count,
+    )
+
+
+def _dedupe(items: Collection[Any]) -> tuple[Any, ...]:
+    """Order-preserving dedupe for the roll-up's reference lists.
+
+    A ``check_id`` (or ``UnverifiedCheck``) can legitimately recur across a cycle's
+    runs; the roll-up discloses each distinct value once, in first-seen order.
+    """
+    seen: set[Any] = set()
+    out: list[Any] = []
+    for it in items:
+        if it not in seen:
+            seen.add(it)
+            out.append(it)
+    return tuple(out)
+
+
+def aggregate_cycle_outcome(
+    run_summaries: Sequence[RunVerificationSummary],
+    *,
+    waived: Collection[WaivedCheck] = (),
+    inert: Collection[str] = (),
+) -> CycleOutcome:
+    """Pure cycle-level roll-up over per-run summaries (SIP-0096 §10).
+
+    Rolls each run's ``RunVerificationSummary`` into the durable per-cycle contract.
+    Side-effect free — the ``CycleOutcome`` is constructible **only** here (AC#11),
+    so no path can silently discard not-executed results.
+
+    **Verdict precedence** mirrors the run-level rule (§6.2) so the
+    incomplete-evidence signal is never hidden behind a product failure:
+
+      - any run ``blocked_unverified`` → cycle ``blocked_unverified``;
+      - else any run ``rejected`` → cycle ``rejected``;
+      - else ``accepted``.
+
+    The cycle verdict is the worst of the per-run verdicts — each run verdict
+    already folded in its own required-unmet/failure state, so requiredness is not
+    re-derived here. An empty cycle (no runs) rolls up to ``accepted`` (zero runs =
+    zero adverse evidence — the inert default, matching the run-level empty case).
+
+    **Evidence lists union** across the cycle's runs: framing and implementation
+    runs are distinct evidence contexts, so everything executed / failed /
+    not-executed is disclosed (a check that failed in one run and passed in another
+    is honestly in *both* lists — runs are not collapsed), deduped to first-seen.
+
+    ``waived`` (§6.5 operator) and ``inert`` (§9 chronic) are recorded **above** the
+    evidence and passed through unchanged — a waiver never mutates a result and
+    never alters the verdict. Both default empty until their Phase-3 slices wire
+    them.
+    """
+    verified: list[str] = []
+    failed: list[str] = []
+    unverified: list[UnverifiedCheck] = []
+    any_blocked = False
+    any_rejected = False
+
+    for s in run_summaries:
+        verified.extend(s.verified)
+        failed.extend(s.failed)
+        unverified.extend(s.unverified)
+        if s.verdict is RunVerdict.BLOCKED_UNVERIFIED:
+            any_blocked = True
+        elif s.verdict is RunVerdict.REJECTED:
+            any_rejected = True
+
+    if any_blocked:
+        verdict = RunVerdict.BLOCKED_UNVERIFIED
+    elif any_rejected:
+        verdict = RunVerdict.REJECTED
+    else:
+        verdict = RunVerdict.ACCEPTED
+
+    return CycleOutcome(
+        verdict=verdict,
+        verified=_dedupe(verified),
+        failed=_dedupe(failed),
+        unverified=_dedupe(unverified),
+        run_count=len(run_summaries),
+        inert=_dedupe(inert),
+        waived=tuple(waived),
     )

--- a/tests/unit/cycles/test_verification_integrity.py
+++ b/tests/unit/cycles/test_verification_integrity.py
@@ -16,10 +16,15 @@ import pytest
 from squadops.cycles import verification_integrity as vi
 from squadops.cycles.verification_integrity import (
     CheckResult,
+    CycleOutcome,
     EvidenceFamily,
     NotExecutedReason,
     ResultStatus,
     RunVerdict,
+    RunVerificationSummary,
+    UnverifiedCheck,
+    WaivedCheck,
+    aggregate_cycle_outcome,
     aggregate_verification,
     classify,
 )
@@ -374,3 +379,108 @@ def test_summary_is_frozen():
     s = aggregate_verification([_passed("a")])
     with pytest.raises(Exception):
         s.verdict = RunVerdict.REJECTED  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# Phase 3 slice 1 — aggregate_cycle_outcome (the durable per-cycle roll-up, §10)
+# --------------------------------------------------------------------------- #
+
+
+def _run_summary(
+    verdict, *, verified=(), failed=(), unverified=(), required_unmet=()
+) -> RunVerificationSummary:
+    return RunVerificationSummary(
+        verdict=verdict,
+        verified=tuple(verified),
+        failed=tuple(failed),
+        unverified=tuple(unverified),
+        required_unmet=tuple(required_unmet),
+        executed_count=len(verified) + len(failed),
+        passed_count=len(verified),
+    )
+
+
+@pytest.mark.parametrize(
+    ("run_verdicts", "expected"),
+    [
+        ([RunVerdict.ACCEPTED, RunVerdict.ACCEPTED], RunVerdict.ACCEPTED),
+        ([RunVerdict.ACCEPTED, RunVerdict.REJECTED], RunVerdict.REJECTED),
+        # blocked wins over rejected — the incomplete-evidence signal is never
+        # hidden behind a product failure (§6.2 precedence, at cycle scope).
+        ([RunVerdict.REJECTED, RunVerdict.BLOCKED_UNVERIFIED], RunVerdict.BLOCKED_UNVERIFIED),
+        ([RunVerdict.ACCEPTED, RunVerdict.BLOCKED_UNVERIFIED], RunVerdict.BLOCKED_UNVERIFIED),
+    ],
+)
+def test_cycle_verdict_is_worst_of_runs(run_verdicts, expected):
+    """Cycle verdict = worst per-run verdict; reordering precedence would regress this."""
+    outcome = aggregate_cycle_outcome([_run_summary(v) for v in run_verdicts])
+    assert outcome.verdict is expected
+    assert outcome.run_count == len(run_verdicts)
+
+
+def test_empty_cycle_rolls_up_to_accepted():
+    """Zero runs = zero adverse evidence → accepted, run_count 0 (inert default)."""
+    outcome = aggregate_cycle_outcome([])
+    assert outcome.verdict is RunVerdict.ACCEPTED
+    assert outcome.run_count == 0
+    assert outcome.verified == () and outcome.failed == () and outcome.unverified == ()
+
+
+def test_evidence_unions_across_runs_deduped():
+    """Every run's verified/failed/unverified is disclosed at cycle scope, deduped."""
+    r1 = _run_summary(RunVerdict.ACCEPTED, verified=["tests_pass", "shared"])
+    r2 = _run_summary(RunVerdict.REJECTED, verified=["shared"], failed=["frontend_build"])
+    outcome = aggregate_cycle_outcome([r1, r2])
+    assert outcome.verified == ("tests_pass", "shared")  # 'shared' collapsed to one
+    assert outcome.failed == ("frontend_build",)
+    assert outcome.verdict is RunVerdict.REJECTED
+
+
+def test_check_failed_in_one_run_passed_in_another_disclosed_in_both():
+    """Runs are distinct evidence contexts — a check that failed once and passed once
+    is honestly in BOTH lists; the roll-up must not collapse cross-run outcomes."""
+    r1 = _run_summary(RunVerdict.REJECTED, failed=["tests_pass"])
+    r2 = _run_summary(RunVerdict.ACCEPTED, verified=["tests_pass"])
+    outcome = aggregate_cycle_outcome([r1, r2])
+    assert "tests_pass" in outcome.failed
+    assert "tests_pass" in outcome.verified
+
+
+def test_required_unmet_derived_from_unverified_disclosure():
+    """cycle.required_unmet is derived from the unverified records, so the required
+    set and its disclosure can never drift apart (roll-up integrity, violation #3)."""
+    unmet = UnverifiedCheck(
+        check_id="required_files", reason=NotExecutedReason.SUBJECT_MISSING, required=True
+    )
+    optional = UnverifiedCheck(
+        check_id="opt", reason=NotExecutedReason.CONFIG_DISABLED, required=False
+    )
+    outcome = aggregate_cycle_outcome(
+        [_run_summary(RunVerdict.BLOCKED_UNVERIFIED, unverified=[unmet, optional])]
+    )
+    assert outcome.required_unmet == ("required_files",)  # only the required one
+    assert {u.check_id for u in outcome.unverified} == {"required_files", "opt"}  # both disclosed
+
+
+def test_waiver_recorded_but_never_alters_verdict():
+    """A waiver sits beside the evidence and does not flip a blocked verdict (§6.5):
+    the result stands un-loosened; the operator decision is recorded above it."""
+    waiver = WaivedCheck(
+        check_id="required_files", reason="known-good manual build", waived_by="op"
+    )
+    unmet = UnverifiedCheck(
+        check_id="required_files", reason=NotExecutedReason.SUBJECT_MISSING, required=True
+    )
+    outcome = aggregate_cycle_outcome(
+        [_run_summary(RunVerdict.BLOCKED_UNVERIFIED, unverified=[unmet])], waived=[waiver]
+    )
+    assert outcome.verdict is RunVerdict.BLOCKED_UNVERIFIED  # unaltered by the waiver
+    assert outcome.waived == (waiver,)
+
+
+def test_cycle_outcome_is_frozen():
+    """The roll-up is an immutable value object — no post-hoc mutation of the verdict."""
+    outcome = aggregate_cycle_outcome([_run_summary(RunVerdict.ACCEPTED)])
+    assert isinstance(outcome, CycleOutcome)
+    with pytest.raises(Exception):
+        outcome.verdict = RunVerdict.REJECTED  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Kicks off **SIP-0096 Phase 3 (Surfaces)**. Phase 2 landed the honest per-**run** verdict (`aggregate_verification` → `RunVerificationSummary`, live-validated at 27b in #408). Phase 3 rolls that up into the durable per-**cycle** evidence contract (§10) — the thing wrap-up, operator gates, and (1.6) the Campaign continuation decision read.

Sliced by risk. **This slice = the pure roll-up core, inert by construction** (mirrors how Phase 1 shipped `aggregate_verification`): nothing persists or consumes it yet, so **no verdict changes** and there is nothing runtime to validate — the persistence/consumer slices follow.

## What's here (all in the pure `cycles/verification_integrity.py` choke-point module)

- **`CycleOutcome`** (frozen) — §10's contract: `verdict` / `verified` / `failed` / `unverified` (with reasons) / `inert` / `waived`, all as **references** (`check_id`s / disclosure records), never copies. `required_unmet` is a **derived property** over `unverified`, so the required set and its disclosure can't drift. Its docstring records that it's the substrate the later cycle-evaluation scorecard's outcome/quality/efficiency/stability dimensions *project over* — deliberately **not** speculative raw fields here.
- **`WaivedCheck`** (frozen) — a §6.5 operator waiver recorded **above** the evidence, never a mutation (SIP-0092 §6.3.2). Empty until the waiver slice.
- **`aggregate_cycle_outcome(run_summaries, *, waived=(), inert=())`** — pure roll-up. **Verdict precedence mirrors the run rule** so the incomplete-evidence signal is never hidden: any run `blocked_unverified` → cycle `blocked_unverified`; else any `rejected` → `rejected`; else `accepted` (empty cycle → `accepted`). Evidence **unions** across the cycle's runs (framing + implementation are distinct evidence contexts — a check that failed in one run and passed in another is honestly in *both* lists), deduped first-seen. `waived`/`inert` pass through and **never alter the verdict**.

## Deferred to later Phase-3 slices (not here)
- Persist `CycleOutcome` at cycle completion + the cycle-completion seam (needs the per-run summary persisted structurally first).
- Wrap-up consumption (SIP-0080 confidence gets an honest basis).
- Gate **waiver** flow (accept-with-waiver on `blocked_unverified`, on `GateDecision` + roll-up).
- **#114** (typed-check evaluation surfacing) rides Phase 3.

## Tests
Worst-verdict precedence (parametrized), empty-cycle, cross-run union + dedupe, failed-in-one/passed-in-another dual disclosure, `required_unmet` derived from disclosure, waiver-never-alters-verdict, frozen. The module's existing purity (AC#13) + frozen architecture tests already cover the new function. **Regression: 4778 passed.**

Closes #411