### PR TITLE
fix(#389): accept behaviorally-verified patches — stop re-rolling repaired tasks

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from hashlib import sha256
 from typing import TYPE_CHECKING, Any
@@ -43,6 +44,20 @@ if TYPE_CHECKING:
     from squadops.tasks.models import TaskResult
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CorrectionProtocolResult:
+    """Outcome of one correction-protocol run.
+
+    ``repair_artifacts`` carries the repair steps' emitted files (handler
+    ``artifacts`` dicts, validate step excluded) so the executor can verify
+    the patch behaviorally against them (#389) instead of re-dispatching
+    the generative task and re-rolling its output.
+    """
+
+    correction_path: str
+    repair_artifacts: list[dict[str, Any]] = field(default_factory=list)
 
 
 class CorrectionRunner:
@@ -241,10 +256,11 @@ class CorrectionRunner:
         plan_delta_refs: list[str],
         profile: Any = None,
         flow_run_id: str | None = None,
-    ) -> str:
+    ) -> CorrectionProtocolResult:
         """Run the correction protocol: analyze → decide → act.
 
-        Returns the correction_path chosen by the governance handler.
+        Returns the correction_path chosen by the governance handler plus,
+        on the patch path, the repair steps' emitted artifacts (#389).
         Side effects: dispatches correction/repair tasks, stores plan delta,
         emits correction events.
         """
@@ -399,6 +415,7 @@ class CorrectionRunner:
         # field, which is free-text and previously caused builder failures
         # (`affected_task_types: ["QA Handoff"]`) to silently route to the
         # dev repair handler.
+        repair_artifacts: list[dict[str, Any]] = []
         if correction_path == "patch":
             for step_idx, (task_type, role) in enumerate(repair_steps_for(envelope.task_type)):
                 repair_task_id = f"repair-{run_id[:12]}-{correction_attempts:02d}-{task_type}"
@@ -470,6 +487,14 @@ class CorrectionRunner:
                 role_key = repair_envelope.metadata.get("role", "unknown")
                 prior_outputs[role_key] = dict(repair_result.outputs or {})
 
+                # #389: surface the repair's emitted files to the executor for
+                # behavioral patch verification. The validate step's output is
+                # an LLM judgment document, not product content — excluded so
+                # it can't shadow a product file in the overlay.
+                if task_type != "qa.validate_repair":
+                    step_artifacts = (repair_result.outputs or {}).get("artifacts") or []
+                    repair_artifacts.extend(a for a in step_artifacts if isinstance(a, dict))
+
         # 8. Emit CORRECTION_COMPLETED
         self._event_bus.emit(
             EventType.CORRECTION_COMPLETED,
@@ -479,4 +504,6 @@ class CorrectionRunner:
             payload={"correction_path": correction_path},
         )
 
-        return correction_path
+        return CorrectionProtocolResult(
+            correction_path=correction_path, repair_artifacts=repair_artifacts
+        )

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -38,6 +38,11 @@ from squadops.cycles.build_completeness import compute_missing_required_files
 from squadops.cycles.checkpoint import RunCheckpoint
 from squadops.cycles.models import ArtifactRef, Cycle, GateDecisionValue, Run, RunStatus
 from squadops.cycles.naming import flow_run_name
+from squadops.cycles.patch_verification import (
+    PATCH_PASSED,
+    overlay_artifacts,
+    verify_patched_artifacts,
+)
 from squadops.cycles.run_ledger import RunLedger
 from squadops.cycles.task_outcome import TaskOutcome
 from squadops.cycles.task_plan import generate_task_plan
@@ -46,7 +51,7 @@ from squadops.events.types import EventType
 from squadops.ports.cycles.flow_execution import FlowExecutionPort
 from squadops.runtime.admission import admit_participants, release_participants
 from squadops.runtime.recruitment import reserve_buffer_decision
-from squadops.tasks.models import TaskEnvelope, TaskResult
+from squadops.tasks.models import TaskEnvelope, TaskResult, TaskResultStatus
 from squadops.telemetry.context import use_correlation_context
 from squadops.telemetry.models import CorrelationContext
 
@@ -961,11 +966,12 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     plan_delta_refs=plan_delta_refs,
                     profile=profile,
                     flow_run_id=flow_run_id,
+                    patched_result_holder=_holder,
                 )
-                if action == "continue":
-                    # #379: this attempt failed and is about to be re-dispatched — a
-                    # correction patch re-verifying behaviorally (#374), or a plain
-                    # retry. Record its evidence now so the ledger honestly holds the
+                if action in ("continue", "accept_patch"):
+                    # #379: this attempt failed — re-dispatched ("continue") or
+                    # superseded by a verified patch ("accept_patch", #389). Record
+                    # its evidence now so the ledger honestly holds the
                     # failed→passed history; aggregation supersedes it to the final
                     # state per (check_id, subject). Self-filtering: a transport retry
                     # carries no validation_result/test_result → nothing is recorded.
@@ -1006,6 +1012,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 # is additive and never alters the abort's control flow.
                 _record_task_evidence(_last_failed_result.get("result"))
                 raise
+
+            # #389: a verified patch supersedes the failed result — swap before
+            # recording/collection so the ledger and artifact store see the
+            # corrected outputs (repaired artifacts + executed-passed checks).
+            patched = _last_failed_result.pop("patched_result", None)
+            if patched is not None:
+                result = patched
 
             # Every non-abort completion — success AND corrected-failure
             # (break_correction) — records its final result here; the abort path
@@ -1307,6 +1320,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         plan_delta_refs: list[str],
         profile: Any = None,
         flow_run_id: str | None = None,
+        patched_result_holder: dict[str, Any] | None = None,
     ) -> str:
         """Route a failed task outcome. Returns an action string.
 
@@ -1314,6 +1328,11 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             "continue" — re-dispatch the same task (caller's while loop retries it):
                 a retryable failure, OR (#374) a ``patch`` correction whose repair is
                 verified behaviorally by re-running the failed check itself.
+            "accept_patch" — (#389) a ``patch`` correction whose repaired artifacts
+                behaviorally pass the failed task's typed acceptance criteria; the
+                corrected result is placed in ``patched_result_holder`` and the task
+                advances without re-dispatch (re-dispatching a generative task
+                re-rolls its artifacts and clobbers the repair).
             "break_correction" — correction handled without re-run (governance
                 "continue": advance without repair), advance to next task.
 
@@ -1364,7 +1383,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         attempt = correction_counter["n"]
         correction_counter["n"] = attempt + 1
 
-        correction_path = await self._correction_runner.run_correction_protocol(
+        protocol = await self._correction_runner.run_correction_protocol(
             run_id=run_id,
             cycle=cycle,
             envelope=envelope,
@@ -1378,6 +1397,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             profile=profile,
             flow_run_id=flow_run_id,
         )
+        correction_path = protocol.correction_path
 
         if correction_path == "abort":
             raise _ExecutionError(
@@ -1386,18 +1406,84 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         elif correction_path == "rewind":
             raise _ExecutionError(f"Rewinding to checkpoint after {envelope.task_type} failure")
         elif correction_path == "patch":
-            # #374 (pure-behavioral): re-run the ORIGINAL failed check against the
-            # patched artifacts — the re-run's pass/fail IS the verdict, not the LLM
-            # validate_repair judgment. "continue" re-dispatches the same task; a pass
-            # advances with real executed-passed evidence (recording seam), a fail
-            # re-enters correction until max_correction_attempts exhausts (guard above)
-            # → _ExecutionError → the run fails honestly instead of false-completing.
-            return "continue"
+            # #374/#389 (pure-behavioral): the verdict is the re-executed check,
+            # never the LLM validate_repair judgment. First re-run the failed
+            # task's typed acceptance criteria against the REPAIRED artifacts
+            # (#389) — a pass accepts the patch outright, because re-dispatching
+            # a generative task re-rolls its artifacts and discards the repair
+            # (the cyc_6841d75f167c oscillation). Anything short of a verified
+            # pass falls back to "continue": re-dispatch, re-enter correction
+            # until max_correction_attempts exhausts (guard above) →
+            # _ExecutionError → the run fails honestly instead of false-completing.
+            action = await self._try_accept_patch(
+                envelope, result, protocol.repair_artifacts, patched_result_holder
+            )
+            return action
         elif correction_path == "continue":
             # Governance chose to advance without repair (accept-and-move-on).
             return "break_correction"
         else:
             raise _ExecutionError(f"Unknown correction path: {correction_path}")
+
+    async def _try_accept_patch(
+        self,
+        envelope: TaskEnvelope,
+        result: TaskResult,
+        repair_artifacts: list[dict[str, Any]],
+        patched_result_holder: dict[str, Any] | None,
+    ) -> str:
+        """Behaviorally verify a patch (#389); return "accept_patch" or "continue".
+
+        Verification itself is the pure ``patch_verification`` module; this
+        method only assembles its inputs from the failed task and renders the
+        corrected result. Any non-pass (failed, unverifiable, no repair
+        artifacts, no holder) falls back to the pre-#389 re-dispatch path —
+        conservative by construction, never a false accept.
+        """
+        if not repair_artifacts or patched_result_holder is None:
+            return "continue"
+
+        resolved_config = (envelope.inputs or {}).get("resolved_config") or {}
+        criteria = (envelope.inputs or {}).get("acceptance_criteria") or []
+        patched_artifacts = overlay_artifacts(
+            (result.outputs or {}).get("artifacts") or [], repair_artifacts
+        )
+        verification = await verify_patched_artifacts(
+            criteria,
+            patched_artifacts,
+            stack=resolved_config.get("stack"),
+            typed_acceptance_enabled=resolved_config.get("typed_acceptance", True),
+            command_acceptance_enabled=resolved_config.get("command_acceptance_checks", True),
+        )
+        logger.info(
+            "patch_verification task=%s task_type=%s status=%s reason=%s checks=%d",
+            envelope.task_id,
+            envelope.task_type,
+            verification.status,
+            verification.reason or "",
+            len(verification.checks),
+        )
+        if verification.status != PATCH_PASSED:
+            return "continue"
+
+        corrected_outputs = dict(result.outputs or {})
+        corrected_outputs["artifacts"] = patched_artifacts
+        prior_validation = corrected_outputs.get("validation_result")
+        corrected_outputs["validation_result"] = {
+            **(prior_validation if isinstance(prior_validation, dict) else {}),
+            "passed": True,
+            "patch_verified": True,
+            "checks": [r.to_check_row() for r in verification.checks],
+        }
+        corrected_outputs.pop("outcome_class", None)
+        patched_result_holder["patched_result"] = dataclasses.replace(
+            result,
+            status=TaskResultStatus.SUCCEEDED,
+            outputs=corrected_outputs,
+            error=None,
+            outcome_class=None,
+        )
+        return "accept_patch"
 
     async def _collect_artifacts_and_checkpoint(
         self,

--- a/adapters/cycles/task_dispatcher.py
+++ b/adapters/cycles/task_dispatcher.py
@@ -338,6 +338,8 @@ class TaskDispatcher:
         closure over its orchestration state (§6.1: classification/routing
         stays with the orchestration loop). This method only acts on the
         returned action token: "continue" retries the same task,
+        "accept_patch" returns success without re-dispatch (#389 — the caller
+        substitutes the behaviorally-verified corrected result),
         "break_correction" returns to advance past a corrected failure.
         """
         while True:
@@ -380,6 +382,11 @@ class TaskDispatcher:
 
                 if action == "continue":
                     continue  # retry same task
+                elif action == "accept_patch":
+                    # #389: repaired artifacts behaviorally passed the failed
+                    # task's acceptance criteria — re-dispatching would re-roll
+                    # the generative output and clobber the repair.
+                    return True, result
                 elif action == "break_correction":
                     return False, result
 

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -18,6 +18,7 @@ from squadops.capabilities.handlers.base import (
 from squadops.capabilities.handlers.prompt_guard import _guard_prompt_size
 from squadops.cycles.acceptance_checks import CheckOutcome, get_check
 from squadops.cycles.implementation_plan import TypedCheck
+from squadops.cycles.patch_verification import materialize_artifacts
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
 
@@ -283,33 +284,9 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
                     typed_error_counts[fp] = prior + 1
                 # status in {passed, skipped} never blocks.
 
-    @staticmethod
-    def _materialize_artifacts(artifacts: list[dict], workspace_root: Path) -> None:
-        """Write in-memory artifacts to disk under ``workspace_root``.
-
-        Skips entries whose ``name`` is missing or escapes the workspace —
-        the typed-check evaluators apply their own ``_safe_resolve`` chroot
-        on top of this, but it is cheaper to refuse here than to
-        materialize a malformed file just to fail evaluation.
-        """
-        root_resolved = workspace_root.resolve()
-        for art in artifacts:
-            name = art.get("name")
-            content = art.get("content", "")
-            if not isinstance(name, str) or not name:
-                continue
-            if Path(name).is_absolute():
-                continue
-            target = (workspace_root / name).resolve()
-            try:
-                target.relative_to(root_resolved)
-            except ValueError:
-                continue
-            target.parent.mkdir(parents=True, exist_ok=True)
-            if isinstance(content, bytes):
-                target.write_bytes(content)
-            else:
-                target.write_text(str(content), encoding="utf-8")
+    # Shared with the executor-side patch verification (#389) — one
+    # materializer, one safety policy.
+    _materialize_artifacts = staticmethod(materialize_artifacts)
 
     @staticmethod
     async def _evaluate_typed_check(

--- a/src/squadops/cycles/patch_verification.py
+++ b/src/squadops/cycles/patch_verification.py
@@ -142,13 +142,31 @@ def _coerce_typed_criteria(criteria: list[Any]) -> list[TypedCheck] | None:
             try:
                 parsed = _parse_acceptance_criteria([dict(item)], task_index=-1)
             except ValueError:
-                logger.warning(
-                    "patch_verification: unparseable criterion %r — unverifiable", item
-                )
+                logger.warning("patch_verification: unparseable criterion %r — unverifiable", item)
                 return None
             typed.extend(c for c in parsed if isinstance(c, TypedCheck))
         # str → prose, informational only
     return typed
+
+
+async def _evaluate_criterion(
+    criterion: TypedCheck,
+    workspace_root: Path,
+    *,
+    stack: str | None,
+    typed_acceptance_enabled: bool,
+    command_acceptance_enabled: bool,
+) -> CheckOutcome:
+    """Evaluate one criterion, honoring the same config gates the handler side does."""
+    if not typed_acceptance_enabled:
+        return CheckOutcome.skipped(reason="typed_acceptance_disabled")
+    if criterion.check == "command_exit_zero" and not command_acceptance_enabled:
+        return CheckOutcome.skipped(reason="command_acceptance_checks_disabled")
+    try:
+        evaluator = get_check(criterion.check)
+    except KeyError:
+        return CheckOutcome.error(reason="no_evaluator_registered")
+    return await evaluator.evaluate(criterion.params, workspace_root, stack=stack)
 
 
 async def verify_patched_artifacts(
@@ -180,19 +198,13 @@ async def verify_patched_artifacts(
         materialize_artifacts(artifacts, workspace_root)
 
         for criterion in typed:
-            if not typed_acceptance_enabled:
-                outcome = CheckOutcome.skipped(reason="typed_acceptance_disabled")
-            elif criterion.check == "command_exit_zero" and not command_acceptance_enabled:
-                outcome = CheckOutcome.skipped(reason="command_acceptance_checks_disabled")
-            else:
-                try:
-                    evaluator = get_check(criterion.check)
-                except KeyError:
-                    outcome = CheckOutcome.error(reason="no_evaluator_registered")
-                else:
-                    outcome = await evaluator.evaluate(
-                        criterion.params, workspace_root, stack=stack
-                    )
+            outcome = await _evaluate_criterion(
+                criterion,
+                workspace_root,
+                stack=stack,
+                typed_acceptance_enabled=typed_acceptance_enabled,
+                command_acceptance_enabled=command_acceptance_enabled,
+            )
 
             records.append(
                 PatchCheckRecord(

--- a/src/squadops/cycles/patch_verification.py
+++ b/src/squadops/cycles/patch_verification.py
@@ -1,0 +1,234 @@
+"""Behavioral verification of correction-loop patches (#389).
+
+After a ``patch`` correction, the executor used to re-dispatch the failed
+task to "re-run the check" (#374). For generative tasks that re-dispatch
+does not re-run the *check* — it re-runs the *generator*, which re-rolls
+the artifacts from scratch and discards the repair. Field evidence
+(cyc_6841d75f167c, #389): every repair passed validation, every re-roll
+reintroduced the defect, and the correction budget starved on one task.
+
+This module keeps #374's principle — the verdict is the re-executed check,
+never an LLM judgment — but re-runs the failed task's typed acceptance
+criteria directly against the repaired artifacts. Pure evaluation
+(criteria + artifacts → verdict); no dispatch, no I/O beyond a temp
+workspace for the check evaluators.
+
+The executor treats the three verdicts as:
+    PASSED       — accept the patched artifacts as the task's outputs.
+    FAILED       — repair didn't satisfy the contract; re-enter correction.
+    UNVERIFIABLE — checks can't run here (no typed criteria, evaluator
+                   error, malformed criterion); fall back to the pre-#389
+                   re-dispatch path. Conservative: worst case is the old
+                   behavior, never a false accept.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from squadops.cycles.acceptance_checks import CheckOutcome, get_check
+from squadops.cycles.implementation_plan import TypedCheck, _parse_acceptance_criteria
+
+logger = logging.getLogger(__name__)
+
+# Verdict vocabulary (module constants, not an enum — matches the
+# correction_path string convention of the surrounding loop).
+PATCH_PASSED = "passed"
+PATCH_FAILED = "failed"
+PATCH_UNVERIFIABLE = "unverifiable"
+
+
+@dataclass(frozen=True)
+class PatchCheckRecord:
+    """One typed criterion's outcome against the patched workspace."""
+
+    check: str
+    severity: str
+    status: str  # CheckOutcome status: passed | failed | error | skipped
+    description: str = ""
+    reason: str | None = None
+    actual: str | None = None
+
+    def to_check_row(self) -> dict[str, Any]:
+        """Render in the handler-emitted ``checks`` row shape.
+
+        The ``acceptance:`` prefix and ``status`` key are what
+        ``normalize_task_checks`` (§6.1) keys on, so a patch-verified task
+        records the same executed evidence a first-try pass would.
+        """
+        return {
+            "check": f"acceptance:{self.check}",
+            "severity": self.severity,
+            "description": self.description,
+            "status": self.status,
+            "reason": self.reason,
+            "actual": self.actual,
+            "passed": not (self.severity == "error" and self.status in {"failed", "error"}),
+            "patch_verified": True,
+        }
+
+
+@dataclass(frozen=True)
+class PatchVerification:
+    """Aggregate verdict over all typed criteria."""
+
+    status: str  # PATCH_PASSED | PATCH_FAILED | PATCH_UNVERIFIABLE
+    checks: tuple[PatchCheckRecord, ...] = ()
+    reason: str | None = None
+
+
+def overlay_artifacts(
+    base: list[dict[str, Any]] | None, patches: list[dict[str, Any]] | None
+) -> list[dict[str, Any]]:
+    """Merge artifact dicts by ``name``; a patch supersedes the base entry.
+
+    Order: base order preserved, net-new patch files appended in patch order.
+    Entries without a usable ``name`` are dropped (they can't land in a
+    workspace anyway).
+    """
+    merged: dict[str, dict[str, Any]] = {}
+    for art in list(base or []) + list(patches or []):
+        name = art.get("name")
+        if isinstance(name, str) and name:
+            merged[name] = art
+    return list(merged.values())
+
+
+def materialize_artifacts(artifacts: list[dict], workspace_root: Path) -> None:
+    """Write in-memory artifact dicts to disk under ``workspace_root``.
+
+    Skips entries whose ``name`` is missing, absolute, or escapes the
+    workspace — the typed-check evaluators apply their own ``_safe_resolve``
+    chroot on top, but it is cheaper to refuse here than to materialize a
+    malformed file just to fail evaluation.
+    """
+    root_resolved = workspace_root.resolve()
+    for art in artifacts:
+        name = art.get("name")
+        content = art.get("content", "")
+        if not isinstance(name, str) or not name:
+            continue
+        if Path(name).is_absolute():
+            continue
+        target = (workspace_root / name).resolve()
+        try:
+            target.relative_to(root_resolved)
+        except ValueError:
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            target.write_bytes(content)
+        else:
+            target.write_text(str(content), encoding="utf-8")
+
+
+def _coerce_typed_criteria(criteria: list[Any]) -> list[TypedCheck] | None:
+    """Extract TypedCheck entries, re-parsing dict rows (deserialized envelopes).
+
+    Prose strings are informational and never block — dropped. Returns None
+    when any dict row fails to parse: an unintelligible contract must fall
+    back to re-dispatch, not silently verify against a subset of itself.
+    """
+    typed: list[TypedCheck] = []
+    for item in criteria:
+        if isinstance(item, TypedCheck):
+            typed.append(item)
+        elif isinstance(item, Mapping):
+            try:
+                parsed = _parse_acceptance_criteria([dict(item)], task_index=-1)
+            except ValueError:
+                logger.warning(
+                    "patch_verification: unparseable criterion %r — unverifiable", item
+                )
+                return None
+            typed.extend(c for c in parsed if isinstance(c, TypedCheck))
+        # str → prose, informational only
+    return typed
+
+
+async def verify_patched_artifacts(
+    criteria: list[Any],
+    artifacts: list[dict[str, Any]],
+    *,
+    stack: str | None = None,
+    typed_acceptance_enabled: bool = True,
+    command_acceptance_enabled: bool = True,
+) -> PatchVerification:
+    """Re-run the failed task's typed acceptance criteria against *artifacts*.
+
+    Mirrors the handler-side RC-9 blocking matrix: only ``severity=error``
+    criteria can block; ``skipped`` never blocks. Any evaluator ``error`` on
+    a blocking criterion makes the whole patch UNVERIFIABLE (the executor
+    environment may lack tooling the agent container has — never guess).
+    """
+    typed = _coerce_typed_criteria(criteria)
+    if typed is None:
+        return PatchVerification(status=PATCH_UNVERIFIABLE, reason="unparseable_criteria")
+    if not typed:
+        return PatchVerification(status=PATCH_UNVERIFIABLE, reason="no_typed_criteria")
+
+    records: list[PatchCheckRecord] = []
+    blocking_failure = False
+    blocking_passed = 0
+    with tempfile.TemporaryDirectory(prefix="squadops-patch-verify-") as tmpdir:
+        workspace_root = Path(tmpdir)
+        materialize_artifacts(artifacts, workspace_root)
+
+        for criterion in typed:
+            if not typed_acceptance_enabled:
+                outcome = CheckOutcome.skipped(reason="typed_acceptance_disabled")
+            elif criterion.check == "command_exit_zero" and not command_acceptance_enabled:
+                outcome = CheckOutcome.skipped(reason="command_acceptance_checks_disabled")
+            else:
+                try:
+                    evaluator = get_check(criterion.check)
+                except KeyError:
+                    outcome = CheckOutcome.error(reason="no_evaluator_registered")
+                else:
+                    outcome = await evaluator.evaluate(
+                        criterion.params, workspace_root, stack=stack
+                    )
+
+            records.append(
+                PatchCheckRecord(
+                    check=criterion.check,
+                    severity=criterion.severity,
+                    status=outcome.status,
+                    description=criterion.description or "",
+                    reason=outcome.reason,
+                    actual=outcome.actual,
+                )
+            )
+
+            if criterion.severity != "error":
+                continue
+            if outcome.status == "error":
+                # Evaluator couldn't run in this environment — the whole
+                # verification is untrustworthy, not just this row.
+                return PatchVerification(
+                    status=PATCH_UNVERIFIABLE,
+                    checks=tuple(records),
+                    reason=f"evaluator_error:{criterion.check}",
+                )
+            if outcome.status == "failed":
+                blocking_failure = True
+            elif outcome.status == "passed":
+                blocking_passed += 1
+
+    if blocking_failure:
+        return PatchVerification(status=PATCH_FAILED, checks=tuple(records))
+    if blocking_passed == 0:
+        # Every blocking criterion was skipped (disabled config, unset stack).
+        # Accepting a patch requires positive executed evidence — "nothing
+        # failed because nothing ran" is the false-green shape (§6.2).
+        return PatchVerification(
+            status=PATCH_UNVERIFIABLE,
+            checks=tuple(records),
+            reason="no_executed_blocking_checks",
+        )
+    return PatchVerification(status=PATCH_PASSED, checks=tuple(records))

--- a/src/squadops/tasks/models.py
+++ b/src/squadops/tasks/models.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Any
 
 
@@ -84,6 +85,22 @@ class TaskEnvelope:
         return cls(**{k: v for k, v in data.items() if k in known})
 
 
+class TaskResultStatus(StrEnum):
+    """``TaskResult.status`` vocabulary (ACI §7.2) — the A2A wire values.
+
+    UPPERCASE, and deliberately distinct from the lowercase capability-layer
+    ``TaskStatus`` enum; the two must never be compared across (#381). This is
+    the dedicated-enum option from #381's proposal: a ``str`` subclass whose
+    members compare equal to the existing wire literals, so producers and the
+    11 comparison sites can migrate incrementally. Do not add new bare
+    status literals — use these members.
+    """
+
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    CANCELED = "CANCELED"
+
+
 @dataclass(frozen=True)
 class TaskResult:
     """ACI Task Result - Terminal result from agent container execution.
@@ -95,7 +112,7 @@ class TaskResult:
     """
 
     task_id: str
-    status: str  # SUCCEEDED, FAILED, or CANCELED
+    status: str  # TaskResultStatus member (wire values SUCCEEDED/FAILED/CANCELED, #381)
     outputs: dict[str, Any] | None = None
     error: str | None = None
     execution_evidence: dict[str, Any] | None = None  # SIP-0.8.8

--- a/tests/unit/architecture/test_no_enum_shadow_comparisons.py
+++ b/tests/unit/architecture/test_no_enum_shadow_comparisons.py
@@ -43,6 +43,10 @@ _ALLOWLIST: set[tuple[str, str]] = {
     # RunStatus/TaskStatus but are a different concept.
     ("src/squadops/capabilities/handlers/cycle/develop.py", "failed"),
     ("src/squadops/capabilities/handlers/cycle/develop.py", "error"),
+    # Same CheckOutcome.status vocabulary, evaluated executor-side for patch
+    # verification (#389).
+    ("src/squadops/cycles/patch_verification.py", "failed"),
+    ("src/squadops/cycles/patch_verification.py", "error"),
     # External Ollama model-pull job status — a vendor vocabulary, not a domain enum.
     ("src/squadops/cli/commands/models.py", "failed"),
     # window_state() returns a duty-window lifecycle token ("active"/

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -1533,7 +1533,7 @@ class TestCorrectionRunnerStandalone:
         runner, _registry, vault, _bus = self._make_runner(responder)
         plan_delta_refs: list[str] = []
 
-        path = await runner.run_correction_protocol(
+        protocol_result = await runner.run_correction_protocol(
             run_id="run_001",
             cycle=cycle,
             envelope=self._failed_envelope(),
@@ -1546,7 +1546,7 @@ class TestCorrectionRunnerStandalone:
             plan_delta_refs=plan_delta_refs,
         )
 
-        assert path == "continue"
+        assert protocol_result.correction_path == "continue"
         assert len(plan_delta_refs) == 1
         delta_calls = [
             c for c in vault.store.call_args_list if c.args[0].artifact_type == "plan_delta"
@@ -1567,7 +1567,7 @@ class TestCorrectionRunnerStandalone:
 
         runner, _registry, _vault, bus = self._make_runner(responder)
 
-        path = await runner.run_correction_protocol(
+        protocol_result = await runner.run_correction_protocol(
             run_id="run_001",
             cycle=cycle,
             envelope=self._failed_envelope(),
@@ -1580,7 +1580,7 @@ class TestCorrectionRunnerStandalone:
             plan_delta_refs=[],
         )
 
-        assert path == "abort"
+        assert protocol_result.correction_path == "abort"
         emitted = [c.args[0] for c in bus.emit.call_args_list]
         assert EventType.CORRECTION_INITIATED in emitted
         assert EventType.CORRECTION_DECIDED in emitted
@@ -1630,3 +1630,93 @@ class TestCorrectionRunnerStandalone:
         assert any("governance.correction_decision" in t for t in completed)
         # One checkpoint saved (decision step only).
         assert registry.save_checkpoint.await_count == 1
+
+    async def test_patch_path_returns_repair_artifacts_excluding_validate_step(self, cycle):
+        """#389 regression: the executor verifies patches against the repair
+        steps' emitted files — if the protocol doesn't surface them (or lets
+        the validate step's judgment doc shadow a product file), patch
+        verification silently never engages and every repair is re-rolled."""
+        import dataclasses as _dc
+
+        repaired = {"name": "qa_handoff.md", "content": "## How to Test\n", "type": "document"}
+
+        def responder(envelope):
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "patch",
+                        "decision_rationale": "repairable",
+                        "affected_task_types": ["builder.assemble"],
+                    },
+                )
+            if envelope.task_type == "builder.assemble_repair":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={"artifacts": [repaired], "summary": "repaired"},
+                )
+            if envelope.task_type == "qa.validate_repair":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "artifacts": [{"name": "repair_validation.md", "content": "PASS"}],
+                        "verdict": "PASS",
+                    },
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, _vault, _bus = self._make_runner(responder)
+        failed_envelope = _dc.replace(
+            self._failed_envelope(), task_type="builder.assemble", metadata={"role": "builder"}
+        )
+
+        protocol_result = await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=failed_envelope,
+            result=TaskResult(task_id="task_failed", status="FAILED", error="missing sections"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+        assert protocol_result.correction_path == "patch"
+        assert protocol_result.repair_artifacts == [repaired]
+
+    async def test_non_patch_path_returns_no_repair_artifacts(self, cycle):
+        """#389: a 'continue' decision dispatches no repair steps — surfacing
+        stale/empty artifacts here would make the executor 'verify' nothing
+        and could accept an unrepaired task."""
+
+        def responder(envelope):
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={"correction_path": "continue"},
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, _vault, _bus = self._make_runner(responder)
+
+        protocol_result = await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=self._failed_envelope(),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="bad"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+        assert protocol_result.correction_path == "continue"
+        assert protocol_result.repair_artifacts == []

--- a/tests/unit/cycles/test_outcome_routing.py
+++ b/tests/unit/cycles/test_outcome_routing.py
@@ -435,3 +435,117 @@ class TestNeedsRepairOutcome:
         status_calls = mock_registry.update_run_status.call_args_list
         terminal_statuses = [c.args[1] for c in status_calls]
         assert RunStatus.FAILED in terminal_statuses
+
+
+class TestAcceptPatch:
+    """#389: a behaviorally-verified patch is accepted without re-dispatching
+    the generative task (re-dispatch re-rolls artifacts and clobbers repairs)."""
+
+    def _failed_builder_result(self):
+        return TaskResult(
+            task_id="task_5",
+            status="FAILED",
+            outputs={
+                "artifacts": [
+                    {"name": "qa_handoff.md", "content": "# QA Handoff\n## How to Run\n"}
+                ],
+                "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
+            },
+            error="acceptance failed",
+        )
+
+    def _builder_envelope(self):
+        from squadops.cycles.implementation_plan import TypedCheck
+        from squadops.tasks.models import TaskEnvelope
+
+        return TaskEnvelope(
+            task_id="task_5",
+            agent_id="bob",
+            cycle_id="cyc_001",
+            pulse_id="p",
+            project_id="hello_squad",
+            task_type="builder.assemble",
+            correlation_id="corr",
+            causation_id=None,
+            trace_id="t",
+            span_id="s",
+            inputs={
+                "resolved_config": {},
+                "acceptance_criteria": [
+                    TypedCheck(
+                        check="regex_match",
+                        params={"file": "qa_handoff.md", "pattern": "## How to Test"},
+                        severity="error",
+                        description="Contains How to Test section",
+                    )
+                ],
+            },
+            metadata={"role": "builder"},
+        )
+
+    async def test_verified_patch_accepted_with_corrected_result(self, executor):
+        """Bug caught: verified repairs re-dispatched into a re-roll — the
+        cyc_6841d75f167c oscillation that starved the correction budget."""
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            self._builder_envelope(),
+            self._failed_builder_result(),
+            [{"name": "qa_handoff.md", "content": "# QA Handoff\n## How to Test\nok\n"}],
+            holder,
+        )
+
+        assert action == "accept_patch"
+        corrected = holder["patched_result"]
+        assert corrected.status == "SUCCEEDED"
+        assert corrected.error is None
+        assert corrected.outcome_class is None
+        assert "outcome_class" not in corrected.outputs
+        # The repaired artifact supersedes the broken generation.
+        by_name = {a["name"]: a["content"] for a in corrected.outputs["artifacts"]}
+        assert "## How to Test" in by_name["qa_handoff.md"]
+        # Executed-passed evidence in the shape normalize_task_checks reads.
+        checks = corrected.outputs["validation_result"]["checks"]
+        assert checks and all(c["status"] == "passed" for c in checks)
+        assert corrected.outputs["validation_result"]["patch_verified"] is True
+
+    async def test_failed_verification_falls_back_to_continue(self, executor):
+        """Bug caught: accepting a repair that still violates the contract —
+        a false green at the task level."""
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            self._builder_envelope(),
+            self._failed_builder_result(),
+            [{"name": "qa_handoff.md", "content": "# QA Handoff\nstill missing sections\n"}],
+            holder,
+        )
+        assert action == "continue"
+        assert "patched_result" not in holder
+
+    async def test_no_repair_artifacts_falls_back_to_continue(self, executor):
+        """Bug caught: 'verifying' an empty patch against the broken original
+        (which would fail) or worse, against nothing (which could pass)."""
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            self._builder_envelope(), self._failed_builder_result(), [], holder
+        )
+        assert action == "continue"
+        assert holder == {}
+
+    async def test_unverifiable_contract_falls_back_to_continue(self, executor):
+        """Bug caught: accepting a patch with no typed criteria — zero
+        executed evidence (the §6.2 false-green shape)."""
+        import dataclasses as _dc
+
+        envelope = self._builder_envelope()
+        envelope = _dc.replace(
+            envelope, inputs={"resolved_config": {}, "acceptance_criteria": ["prose only"]}
+        )
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            envelope,
+            self._failed_builder_result(),
+            [{"name": "qa_handoff.md", "content": "# QA Handoff\n## How to Test\n"}],
+            holder,
+        )
+        assert action == "continue"
+        assert holder == {}

--- a/tests/unit/cycles/test_patch_verification.py
+++ b/tests/unit/cycles/test_patch_verification.py
@@ -1,0 +1,158 @@
+"""Unit tests for executor-side patch verification (#389).
+
+Each test names the bug it catches: the correction loop re-dispatching a
+generative task after a good repair (re-roll clobbers the patch), or the
+verifier accepting a patch without positive executed evidence.
+"""
+
+from squadops.cycles.implementation_plan import TypedCheck
+from squadops.cycles.patch_verification import (
+    PATCH_FAILED,
+    PATCH_PASSED,
+    PATCH_UNVERIFIABLE,
+    overlay_artifacts,
+    verify_patched_artifacts,
+)
+
+# The field-evidence contract from cyc_6841d75f167c: qa_handoff.md must
+# contain five headings; the broken generation misses two, the repair
+# restores them.
+BROKEN_DOC = "# QA Handoff\n## How to Run\n## Expected Behavior\n"
+REPAIRED_DOC = (
+    "# QA Handoff\n## How to Run\n## How to Test\n## Expected Behavior\n"
+    "## Implemented Scope\n## Known Limitations\n"
+)
+
+
+def _heading_criteria() -> list[TypedCheck]:
+    return [
+        TypedCheck(
+            check="regex_match",
+            params={"file": "qa_handoff.md", "pattern": f"## {section}"},
+            severity="error",
+            description=f"Contains {section} section",
+        )
+        for section in ("How to Run", "How to Test", "Implemented Scope")
+    ]
+
+
+class TestVerifyPatchedArtifacts:
+    async def test_passed_when_repair_satisfies_blocking_criteria(self):
+        """Bug caught: a good repair re-dispatched into a re-roll (the #389
+        oscillation) because no path existed to verify it behaviorally."""
+        artifacts = overlay_artifacts(
+            [{"name": "qa_handoff.md", "content": BROKEN_DOC}],
+            [{"name": "qa_handoff.md", "content": REPAIRED_DOC}],
+        )
+        result = await verify_patched_artifacts(_heading_criteria(), artifacts)
+        assert result.status == PATCH_PASSED
+        assert all(r.status == "passed" for r in result.checks)
+
+    async def test_failed_when_repair_still_misses_required_section(self):
+        """Bug caught: false-accepting an incomplete repair (broken doc kept)."""
+        result = await verify_patched_artifacts(
+            _heading_criteria(),
+            [{"name": "qa_handoff.md", "content": BROKEN_DOC}],
+        )
+        assert result.status == PATCH_FAILED
+        failed = [r for r in result.checks if r.status == "failed"]
+        assert {r.description for r in failed} == {
+            "Contains How to Test section",
+            "Contains Implemented Scope section",
+        }
+
+    async def test_overlay_patch_supersedes_base_artifact(self):
+        """Bug caught: overlay precedence inverted — verification would run
+        against the broken original and every good repair would read FAILED."""
+        merged = overlay_artifacts(
+            [{"name": "qa_handoff.md", "content": BROKEN_DOC}, {"name": "a.txt", "content": "x"}],
+            [{"name": "qa_handoff.md", "content": REPAIRED_DOC}, {"name": "b.txt", "content": "y"}],
+        )
+        by_name = {a["name"]: a["content"] for a in merged}
+        assert by_name["qa_handoff.md"] == REPAIRED_DOC
+        assert set(by_name) == {"qa_handoff.md", "a.txt", "b.txt"}
+
+    async def test_unverifiable_when_no_typed_criteria(self):
+        """Bug caught: a prose-only contract silently 'passing' with zero
+        behavioral evidence — patch acceptance requires executed checks."""
+        result = await verify_patched_artifacts(
+            ["backend responds correctly"],
+            [{"name": "qa_handoff.md", "content": REPAIRED_DOC}],
+        )
+        assert result.status == PATCH_UNVERIFIABLE
+        assert result.reason == "no_typed_criteria"
+
+    async def test_unverifiable_when_all_blocking_checks_skipped(self):
+        """Bug caught: typed acceptance disabled → every row skipped → the
+        old logic would have accepted the patch with nothing executed."""
+        result = await verify_patched_artifacts(
+            _heading_criteria(),
+            [{"name": "qa_handoff.md", "content": REPAIRED_DOC}],
+            typed_acceptance_enabled=False,
+        )
+        assert result.status == PATCH_UNVERIFIABLE
+        assert result.reason == "no_executed_blocking_checks"
+
+    async def test_unverifiable_on_unparseable_dict_criterion(self):
+        """Bug caught: verifying against only the intelligible subset of a
+        contract — an unknown check name must force fallback, not be skipped."""
+        result = await verify_patched_artifacts(
+            [{"check": "not_a_real_check", "file": "qa_handoff.md"}],
+            [{"name": "qa_handoff.md", "content": REPAIRED_DOC}],
+        )
+        assert result.status == PATCH_UNVERIFIABLE
+        assert result.reason == "unparseable_criteria"
+
+    async def test_dict_form_criteria_are_parsed_and_evaluated(self):
+        """Bug caught: criteria arriving as dicts (deserialized envelope)
+        being ignored — the fix would silently never engage."""
+        result = await verify_patched_artifacts(
+            [
+                {
+                    "check": "regex_match",
+                    "file": "qa_handoff.md",
+                    "pattern": "## Known Limitations",
+                    "description": "Contains Known Limitations section",
+                }
+            ],
+            [{"name": "qa_handoff.md", "content": REPAIRED_DOC}],
+        )
+        assert result.status == PATCH_PASSED
+
+    async def test_warning_severity_failure_does_not_block(self):
+        """Bug caught: RC-9 regression — a warning-severity miss blocking
+        patch acceptance that error-severity evidence already justified."""
+        criteria = [
+            TypedCheck(
+                check="regex_match",
+                params={"file": "qa_handoff.md", "pattern": "## How to Test"},
+                severity="error",
+                description="required section",
+            ),
+            TypedCheck(
+                check="regex_match",
+                params={"file": "qa_handoff.md", "pattern": "## Nonexistent Nicety"},
+                severity="warning",
+                description="optional section",
+            ),
+        ]
+        result = await verify_patched_artifacts(
+            criteria, [{"name": "qa_handoff.md", "content": REPAIRED_DOC}]
+        )
+        assert result.status == PATCH_PASSED
+        warning_row = next(r for r in result.checks if r.severity == "warning")
+        assert warning_row.status == "failed"
+
+    async def test_check_rows_render_for_ledger_normalization(self):
+        """Bug caught: patch-verified evidence emitted in a shape
+        normalize_task_checks can't read → the ledger would show the task
+        as never re-verified (§6.1 keys on 'check' + 'status')."""
+        result = await verify_patched_artifacts(
+            _heading_criteria()[:1],
+            [{"name": "qa_handoff.md", "content": REPAIRED_DOC}],
+        )
+        row = result.checks[0].to_check_row()
+        assert row["check"] == "acceptance:regex_match"
+        assert row["status"] == "passed"
+        assert row["passed"] is True
+        assert row["patch_verified"] is True

--- a/tests/unit/cycles/test_task_dispatcher.py
+++ b/tests/unit/cycles/test_task_dispatcher.py
@@ -530,3 +530,72 @@ class TestPublishAndAwaitInvariants:
 
         assert r1.outputs["r"] == "a"
         assert r2.outputs["r"] == "b"
+
+
+class TestAcceptPatchToken:
+    """#389: the "accept_patch" routing token returns success WITHOUT
+    re-dispatching the task."""
+
+    def _envelope(self):
+        return TaskEnvelope(
+            task_id="task_patch",
+            agent_id="bob",
+            cycle_id="cyc_001",
+            pulse_id="p1",
+            project_id="proj_001",
+            task_type="builder.assemble",
+            correlation_id="corr",
+            causation_id="cause",
+            trace_id="trace",
+            span_id="span",
+            metadata={"role": "builder"},
+        )
+
+    def _cycle(self):
+        from squadops.cycles.models import Cycle, TaskFlowPolicy
+
+        return Cycle(
+            cycle_id="cyc_001",
+            project_id="proj_001",
+            created_at=NOW,
+            created_by="system",
+            prd_ref="prd",
+            squad_profile_id="full",
+            squad_profile_snapshot_ref="sha256:abc",
+            task_flow_policy=TaskFlowPolicy(mode="sequential"),
+            build_strategy="fresh",
+        )
+
+    async def test_accept_patch_returns_success_without_redispatch(
+        self, mock_queue, reply_router
+    ) -> None:
+        """Bug caught: an unhandled token falls through the retry loop and
+        re-dispatches — the generative re-roll that clobbers the repair."""
+        dispatcher = TaskDispatcher(
+            queue=mock_queue,
+            reply_router=reply_router,
+            task_timeout=5.0,
+            event_bus=MagicMock(),
+        )
+        envelope = self._envelope()
+        reply_router.responder = lambda env: TaskResult(
+            task_id=env["task_id"], status="FAILED", error="acceptance failed"
+        )
+
+        async def handle_outcome(result):
+            return "accept_patch"
+
+        with patch("adapters.cycles.task_dispatcher.asyncio.sleep", new_callable=AsyncMock):
+            task_succeeded, result = await dispatcher.dispatch_with_retry(
+                envelope,
+                envelope,
+                self._cycle(),
+                "run_001",
+                handle_task_outcome=handle_outcome,
+            )
+
+        assert task_succeeded is True
+        # The dispatcher hands back the raw failed result; the executor
+        # substitutes the corrected one from its holder (#389).
+        assert result.status == "FAILED"
+        assert mock_queue.publish.await_count == 1


### PR DESCRIPTION
## What
The SIP-0086 patch path re-dispatched the failed task to "re-run the check" (#374). For **generative** tasks, re-dispatch re-runs the *generator*, not the *check*: artifacts re-roll from scratch and the repair is silently discarded.

**Field evidence** (cyc_6841d75f167c, 2026-07-13, the PR #408 validation run): three repair rounds each produced a correct `qa_handoff.md`, each validated PASS, each clobbered by the next full re-assemble — ~70 min of the 118-min run burned on one task's oscillation, the run-level correction budget starved, and qa.test's real failures (`frontend_build`, `tests_pass`) got zero repair attempts (full table in the #389 comment).

## Change
- **`squadops/cycles/patch_verification.py`** (new, pure): re-runs the failed task's typed acceptance criteria against the repair artifacts overlaid on the failed generation. Keeps #374's principle — the verdict is the executed check, never the LLM `validate_repair` judgment. Verdicts: `passed` / `failed` / `unverifiable`. Acceptance requires ≥1 executed-passed blocking check; all-skipped is `unverifiable`, not `passed` (§6.2 — no zero-evidence accepts).
- **`CorrectionRunner`** returns `CorrectionProtocolResult` (path + repair artifacts; validate-step judgment doc excluded from the overlay).
- **Executor**: on `patch`, verify behaviorally. Verified pass → synthesize the corrected result (repaired artifacts + executed-passed check rows, recorded per `(check_id, subject)` on the ledger per #379) and advance via the new `accept_patch` dispatch token — no re-dispatch. `failed`/`unverifiable` → the pre-existing `continue` re-dispatch path, budget-bounded as before. Conservative by construction: worst case is exactly the old behavior.
- **`TaskResultStatus` StrEnum seed** (`tasks/models.py`): the corrected result needed a status value and there was no typed primitive — this seeds #381's dedicated-A2A-enum option (members equal the wire literals, zero-impact on the 31 existing sites; the migration remains #381's scope).

## Validation
- 16 new tests: verifier semantics (overlay precedence, still-broken repair rejected, all-skipped/no-typed-criteria/unparseable → fallback, RC-9 warning-severity non-blocking, ledger row shape), protocol artifact surfacing (validate-step exclusion, non-patch paths empty), executor accept/fallback routing, dispatcher `accept_patch` token (no re-dispatch, single publish).
- Full regression: **4784 passed**, enum-shadow guardrail green (patch_verification allowlisted for the CheckOutcome vocabulary, same justification as develop.py).

## Expected field effect
A correct repair now consumes exactly one correction attempt. On a rerun of the cyc_6841d75f167c shape: round 1 repairs qa_handoff.md → verified → accepted, budget preserved for qa.test's real failures — and the #408 positive-path validation (green fullstack → `accepted`) becomes reachable.

Closes #389 (the single-pool budget allocation design is extracted to #414, gated on post-merge field evidence)
Refs #381 (enum seed only; site migration not attempted here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
