### PR TITLE
feat(#415): persist per-run RunVerificationSummary (SIP-0096 Phase 3 slice 2a)

### DIFF
--- a/adapters/cycles/memory_cycle_registry.py
+++ b/adapters/cycles/memory_cycle_registry.py
@@ -28,6 +28,7 @@ from squadops.cycles.models import (
     ValidationError,
 )
 from squadops.cycles.pulse_models import PulseVerificationRecord
+from squadops.cycles.verification_integrity import RunVerificationSummary
 from squadops.ports.cycles.cycle_registry import CycleRegistryPort
 
 
@@ -40,6 +41,7 @@ class MemoryCycleRegistry(CycleRegistryPort):
         self._runs: dict[str, dict] = {}
         self._cancelled_cycles: set[str] = set()
         self._pulse_verifications: dict[str, list[dict]] = {}
+        self._verification_summaries: dict[str, RunVerificationSummary] = {}
         self._checkpoints: dict[str, list[RunCheckpoint]] = {}
 
     # --- Cycle CRUD ---
@@ -212,6 +214,19 @@ class MemoryCycleRegistry(CycleRegistryPort):
         }
         self._pulse_verifications.setdefault(run_id, []).append(rec)
         return self._to_run(data)
+
+    # --- Verification Summary (SIP-0096 Phase 3) ---
+
+    async def record_run_verification_summary(
+        self, run_id: str, summary: RunVerificationSummary
+    ) -> None:
+        """Store a run's verification roll-up (upsert; terminal-OK, unlike pulse).
+
+        The summary is frozen, so the object is kept as-is; a re-finalize overwrites.
+        """
+        if run_id not in self._runs:
+            raise RunNotFoundError(f"Run not found: {run_id}")
+        self._verification_summaries[run_id] = summary
 
     # --- Internal helpers ---
 

--- a/adapters/cycles/postgres_cycle_registry.py
+++ b/adapters/cycles/postgres_cycle_registry.py
@@ -36,6 +36,7 @@ from squadops.cycles.models import (
     ValidationError,
 )
 from squadops.cycles.pulse_models import PulseVerificationRecord
+from squadops.cycles.verification_integrity import RunVerificationSummary
 from squadops.ports.cycles.cycle_registry import CycleRegistryPort
 
 logger = logging.getLogger(__name__)
@@ -384,6 +385,28 @@ class PostgresCycleRegistry(CycleRegistryPort):
             )
         return await self.get_run(run_id)
 
+    # --- Verification Summary (SIP-0096 Phase 3) ---
+
+    async def record_run_verification_summary(
+        self, run_id: str, summary: RunVerificationSummary
+    ) -> None:
+        """Persist a run's verification roll-up to Postgres (upsert, terminal-OK)."""
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT 1 FROM cycle_runs WHERE run_id = $1", run_id)
+            if row is None:
+                raise RunNotFoundError(f"Run not found: {run_id}")
+            # Written at finalization (run is terminal), so no terminal guard. Upsert
+            # so a re-finalize supersedes rather than colliding on the PK.
+            await conn.execute(
+                "INSERT INTO run_verification_summaries (run_id, verdict, summary) "
+                "VALUES ($1, $2, $3) "
+                "ON CONFLICT (run_id) DO UPDATE SET "
+                "verdict = EXCLUDED.verdict, summary = EXCLUDED.summary, recorded_at = now()",
+                run_id,
+                summary.verdict.value,
+                json.dumps(_verification_summary_to_dict(summary)),
+            )
+
     # --- Checkpoint (SIP-0079) ---
 
     async def save_checkpoint(self, checkpoint: RunCheckpoint, max_keep: int = 5) -> None:
@@ -541,4 +564,25 @@ def _policy_to_dict(policy: TaskFlowPolicy) -> dict:
             }
             for g in policy.gates
         ],
+    }
+
+
+def _verification_summary_to_dict(summary: RunVerificationSummary) -> dict:
+    """Serialize a RunVerificationSummary to a JSON-compatible dict (SIP-0096 §10).
+
+    Explicit (not ``dataclasses.asdict``) so the stored shape is a stable contract
+    the CycleOutcome roll-up (slice 2b) reconstructs from. ``unverified`` carries
+    each not-executed check's reason so disclosure survives the round-trip (§6.6.3).
+    """
+    return {
+        "verdict": summary.verdict.value,
+        "verified": list(summary.verified),
+        "failed": list(summary.failed),
+        "unverified": [
+            {"check_id": u.check_id, "reason": u.reason, "required": u.required}
+            for u in summary.unverified
+        ],
+        "required_unmet": list(summary.required_unmet),
+        "executed_count": summary.executed_count,
+        "passed_count": summary.passed_count,
     }

--- a/adapters/cycles/run_completion.py
+++ b/adapters/cycles/run_completion.py
@@ -192,6 +192,17 @@ class RunCompletion:
         # Phase 2 wires the producers and per-profile required lists (the throttle).
         summary = self._aggregate_verification(cycle, ledger, terminal_status)
 
+        # SIP-0096 Phase 3 (§10): persist the run's verdict as durable structured
+        # evidence so the CycleOutcome roll-up can read it back — until now the
+        # summary was only rendered into run_report.md and discarded. Best-effort:
+        # a persistence failure is logged, never affects the run's terminal status
+        # (same contract as the run report below).
+        if run_id:
+            try:
+                await self._cycle_registry.record_run_verification_summary(run_id, summary)
+            except Exception:
+                logger.warning("Verification summary persistence failed", exc_info=True)
+
         # Run report: best-effort (D10)
         try:
             if cycle_id and run_id:

--- a/infra/migrations/1400_run_verification_summaries.sql
+++ b/infra/migrations/1400_run_verification_summaries.sql
@@ -1,0 +1,14 @@
+-- 1400_run_verification_summaries.sql
+-- SIP-0096 Phase 3 (§10): durable per-run verification verdict/summary.
+-- One row per run, written at run finalization (upsert on re-finalize). Feeds
+-- the CycleOutcome roll-up (aggregate_cycle_outcome). verdict is the SIP-0096
+-- run verdict, NOT a RunStatus (§6.5); the CHECK matches the RunVerdict StrEnum.
+
+CREATE TABLE IF NOT EXISTS run_verification_summaries (
+    run_id       TEXT PRIMARY KEY REFERENCES cycle_runs(run_id),
+    verdict      TEXT NOT NULL CHECK (verdict IN ('accepted', 'rejected', 'blocked_unverified')),
+    summary      JSONB NOT NULL,
+    recorded_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rvs_verdict ON run_verification_summaries(verdict);

--- a/infra/migrations/README.md
+++ b/infra/migrations/README.md
@@ -15,6 +15,7 @@ Numeric ranges are reserved to keep parallel work streams from colliding. SIP-00
 | `1100–1199` | SIP-0089 Agent Runtime State (v1.1) | In use — see `1100_agent_runtime_state.sql` |
 | `1200–1299` | SIP-0090 Agent Embodiment Substrate (v1.2) | Reserved (tentative) |
 | `1300–1399` | SIP-0091 Duty Durability via Temporal (v1.3) | Reserved (tentative) |
+| `1400–1499` | SIP-0096 Verification Evidence Integrity (v1.4) | In use — see `1400_run_verification_summaries.sql` |
 
 If your work doesn't fit a reserved range, pick the next free hundred and add a row here in the same PR.
 

--- a/src/squadops/ports/cycles/cycle_registry.py
+++ b/src/squadops/ports/cycles/cycle_registry.py
@@ -15,6 +15,7 @@ from squadops.cycles.models import (
     RunStatus,
 )
 from squadops.cycles.pulse_models import PulseVerificationRecord
+from squadops.cycles.verification_integrity import RunVerificationSummary
 
 
 class CycleRegistryPort(ABC):
@@ -137,6 +138,23 @@ class CycleRegistryPort(ABC):
         Raises:
             RunNotFoundError: If the run_id is not found.
             RunTerminalError: If the run is in a terminal state.
+        """
+
+    # --- Verification Summary (SIP-0096 Phase 3) ---
+
+    @abstractmethod
+    async def record_run_verification_summary(
+        self, run_id: str, summary: RunVerificationSummary
+    ) -> None:
+        """Persist a run's SIP-0096 verification roll-up (§10), one row per run.
+
+        Written at run finalization, when the run is already terminal — so, unlike
+        ``record_pulse_verification``, this does **not** reject a terminal run. It
+        upserts: a re-finalize overwrites the prior summary rather than erroring.
+        ``summary.verdict`` is the SIP-0096 run verdict, not a ``RunStatus`` (§6.5).
+
+        Raises:
+            RunNotFoundError: If the run_id is not found.
         """
 
     # --- Checkpoint (SIP-0079) ---

--- a/tests/unit/cycles/test_cycle_registry_contract.py
+++ b/tests/unit/cycles/test_cycle_registry_contract.py
@@ -333,3 +333,46 @@ class TestRecordPulseVerification:
         assert run.run_id == "run_001"
         stored = registry._pulse_verifications["run_001"][-1]
         assert stored["repair_task_refs"] == ["task_repair_001", "task_repair_002"]
+
+
+class TestRecordRunVerificationSummary:
+    """Contract tests for record_run_verification_summary (SIP-0096 Phase 3 §10)."""
+
+    async def _setup_terminal_run(self, registry):
+        await registry.create_cycle(_make_cycle())
+        await registry.create_run(_make_run())
+        await registry.update_run_status("run_001", RunStatus.RUNNING)
+        await registry.update_run_status("run_001", RunStatus.COMPLETED)
+
+    async def test_records_summary_on_terminal_run(self, registry):
+        """Written at finalize, so — unlike pulse — a TERMINAL run must be accepted,
+        not rejected. The stored verdict is the SIP-0096 run verdict."""
+        from squadops.cycles.verification_integrity import RunVerdict, aggregate_verification
+
+        await self._setup_terminal_run(registry)
+        await registry.record_run_verification_summary("run_001", aggregate_verification([]))
+        assert registry._verification_summaries["run_001"].verdict is RunVerdict.ACCEPTED
+
+    async def test_unknown_run_raises(self, registry):
+        from squadops.cycles.verification_integrity import aggregate_verification
+
+        with pytest.raises(RunNotFoundError):
+            await registry.record_run_verification_summary("nope", aggregate_verification([]))
+
+    async def test_refinalize_upserts_not_appends(self, registry):
+        """A re-finalize supersedes the prior summary rather than erroring/appending —
+        the final state wins (§6.5), not the union of attempts."""
+        from squadops.cycles.verification_integrity import (
+            CheckResult,
+            RunVerdict,
+            aggregate_verification,
+        )
+
+        await self._setup_terminal_run(registry)
+        await registry.record_run_verification_summary("run_001", aggregate_verification([]))
+        rejected = aggregate_verification([CheckResult(check_id="frontend_build", status="failed")])
+        await registry.record_run_verification_summary("run_001", rejected)
+
+        stored = registry._verification_summaries["run_001"]
+        assert stored.verdict is RunVerdict.REJECTED
+        assert stored.failed == ("frontend_build",)

--- a/tests/unit/cycles/test_postgres_cycle_registry.py
+++ b/tests/unit/cycles/test_postgres_cycle_registry.py
@@ -665,3 +665,68 @@ class TestPostgresCycleRegistry:
         assert len(runs[0].gate_decisions) == 1
         assert runs[0].gate_decisions[0].gate_name == "qa_gate"
         assert len(runs[1].gate_decisions) == 0
+
+
+class TestRecordRunVerificationSummary:
+    """Unit tests for record_run_verification_summary (SIP-0096 Phase 3) — SQL + serialization."""
+
+    @pytest.fixture
+    def conn(self):
+        return _make_conn()
+
+    @pytest.fixture
+    def registry(self, conn):
+        from adapters.cycles.postgres_cycle_registry import PostgresCycleRegistry
+
+        return PostgresCycleRegistry(_make_pool(conn))
+
+    async def test_upserts_verdict_and_serialized_summary(self, registry, conn):
+        from squadops.cycles.verification_integrity import CheckResult, aggregate_verification
+
+        conn.fetchrow.return_value = {"?column?": 1}  # run exists
+        conn.execute.return_value = None
+        # a run with a failure + a required-not-executed → rejected/blocked disclosure
+        summary = aggregate_verification(
+            [CheckResult(check_id="frontend_build", status="failed")],
+            required_check_ids=["required_files"],
+        )
+
+        await registry.record_run_verification_summary("run_001", summary)
+
+        sql, run_id, verdict, payload = conn.execute.call_args[0]
+        assert "INSERT INTO run_verification_summaries" in sql
+        assert "ON CONFLICT (run_id) DO UPDATE" in sql  # upsert, not a plain insert
+        assert run_id == "run_001"
+        assert verdict == "blocked_unverified"  # required_files unmet drives the verdict
+        stored = json.loads(payload)
+        assert stored["verdict"] == "blocked_unverified"
+        assert stored["failed"] == ["frontend_build"]
+        assert stored["required_unmet"] == ["required_files"]
+        # not-executed disclosure survives the round-trip with its reason (§6.6.3)
+        assert {
+            "check_id": "required_files",
+            "reason": "subject_missing",
+            "required": True,
+        } in stored["unverified"]
+
+    async def test_unknown_run_raises_and_writes_nothing(self, registry, conn):
+        from squadops.cycles.models import RunNotFoundError
+        from squadops.cycles.verification_integrity import aggregate_verification
+
+        conn.fetchrow.return_value = None  # run absent
+
+        with pytest.raises(RunNotFoundError):
+            await registry.record_run_verification_summary("nope", aggregate_verification([]))
+        conn.execute.assert_not_awaited()
+
+    def test_serializer_shape_is_json_safe(self):
+        """_verification_summary_to_dict yields only JSON primitives (no enums/tuples)."""
+        from adapters.cycles.postgres_cycle_registry import _verification_summary_to_dict
+        from squadops.cycles.verification_integrity import CheckResult, aggregate_verification
+
+        summary = aggregate_verification([CheckResult(check_id="a", status="passed")])
+        d = _verification_summary_to_dict(summary)
+        # round-trips through json without a custom encoder
+        assert json.loads(json.dumps(d))["verdict"] == "accepted"
+        assert d["verified"] == ["a"]
+        assert isinstance(d["unverified"], list)

--- a/tests/unit/cycles/test_run_completion.py
+++ b/tests/unit/cycles/test_run_completion.py
@@ -547,3 +547,52 @@ class TestVerificationIntegrityWiring:
         content = vault.store.call_args[0][1].decode()
         assert "rejected" in content
         assert "tests_pass" in content
+
+    @pytest.mark.parametrize(
+        ("terminal_status", "expected_verdict"),
+        [
+            ("COMPLETED", "accepted"),
+            ("FAILED", "blocked_unverified"),  # #388 verdict carried into the persisted row
+        ],
+    )
+    async def test_finalize_persists_run_verification_summary(
+        self, terminal_status, expected_verdict
+    ):
+        """#415: finalize persists the computed summary as durable structured evidence
+        (not just the markdown report) — the CycleOutcome roll-up substrate. Catches the
+        summary being discarded, and that the persisted verdict tracks the terminal status."""
+        from squadops.cycles.run_ledger import RunLedger
+
+        completion, _vault = self._completion()
+
+        await completion.finalize(
+            "cyc_001",
+            "run_001",
+            terminal_status,
+            None,
+            None,
+            cycle=_make_cycle(),
+            ledger=RunLedger(),
+        )
+
+        record = completion._cycle_registry.record_run_verification_summary
+        record.assert_awaited_once()
+        run_id, summary = record.call_args[0]
+        assert run_id == "run_001"
+        assert summary.verdict.value == expected_verdict
+
+    async def test_finalize_survives_summary_persistence_failure(self):
+        """Persistence is best-effort: a registry error must not break finalize or the
+        run report (same contract as the report write)."""
+        from squadops.cycles.run_ledger import RunLedger
+
+        completion, vault = self._completion()
+        completion._cycle_registry.record_run_verification_summary = AsyncMock(
+            side_effect=RuntimeError("db down")
+        )
+
+        await completion.finalize(
+            "cyc_001", "run_001", "COMPLETED", None, None, cycle=_make_cycle(), ledger=RunLedger()
+        )
+        # report still generated despite the persistence failure
+        assert vault.store.call_args is not None


### PR DESCRIPTION
## Summary

Phase 3 slice 2a — the durable foundation under the `CycleOutcome` roll-up (#412 shipped the pure `aggregate_cycle_outcome` core). Until now `RunCompletion.finalize` computed each run's `RunVerificationSummary` at the §6.4 choke point and **discarded it** — it was only rendered into `run_report.md` markdown, and `RunLedger` is in-memory. So there was no durable, structured per-run verdict to roll up (or query). This slice persists it.

Follows the `pulse_verification_records` precedent exactly (child table + narrow port method + `json.dumps`/`parse_jsonb`, both adapters).

## What's here
- **Migration `1400_run_verification_summaries.sql`** — one row per run (`run_id` PK/FK → `verdict TEXT` with a `CHECK` matching the `RunVerdict` StrEnum, `summary JSONB`, `recorded_at`). Reserves the **`1400–1499`** range for SIP-0096 in the migrations README.
- **`record_run_verification_summary(run_id, summary)`** on `CycleRegistryPort` — a narrow writer (no generic `update_run`). Two deliberate departures from `record_pulse_verification`: it's written **at finalize when the run is already terminal**, so it does **not** reject terminal runs; and it **upserts** (`ON CONFLICT`) so a re-finalize supersedes rather than colliding.
- Implemented in **both** `PostgresCycleRegistry` (with a `_verification_summary_to_dict` serializer mirroring `_policy_to_dict` — explicit shape, not `asdict`, so slice 2b reconstructs from a stable contract; `unverified` reasons survive the round-trip) and `MemoryCycleRegistry` (stores the frozen object directly).
- Wired into `RunCompletion.finalize`, **best-effort**: a persistence failure is logged and never affects the run's terminal status (same contract as the run report).

## Out of scope (later slices)
Reading the summaries back + `aggregate_cycle_outcome` roll-up (**2b**); wrap-up consumption; gate waiver flow; #114.

## Tests
Memory contract (records on a terminal run; unknown-run raises; re-finalize upserts, not appends), Postgres unit (upsert SQL + serialized verdict/disclosure; unknown-run raises and writes nothing; serializer is JSON-safe), finalize wiring (persists the computed summary; verdict tracks terminal status incl. **#388** FAILED→`blocked_unverified`; survives a persistence failure). **Regression: 4787.**

## Live validation (deployed stack, runtime-api rebuilt)
Migration auto-applied at startup (table + `_schema_migrations` row present). Then:
- COMPLETED run `run_0fcb3147fd1a` → row `verdict=accepted`
- Cancelled run `run_22e2e0fce003` → row `verdict=blocked_unverified` (the #388 verdict, now durable)

JSONB summary round-trips cleanly in both cases.

Closes #415