### PR TITLE
feat(#417): derive-on-read CycleOutcome + cycle-detail surface (SIP-0096 Phase 3 slice 2b)

### DIFF
--- a/adapters/cycles/memory_cycle_registry.py
+++ b/adapters/cycles/memory_cycle_registry.py
@@ -228,6 +228,18 @@ class MemoryCycleRegistry(CycleRegistryPort):
             raise RunNotFoundError(f"Run not found: {run_id}")
         self._verification_summaries[run_id] = summary
 
+    async def list_run_verification_summaries(self, cycle_id: str) -> list[RunVerificationSummary]:
+        """Return a cycle's persisted per-run verification summaries, by run_number."""
+        runs = sorted(
+            (r for r in self._runs.values() if r["cycle_id"] == cycle_id),
+            key=lambda r: r["run_number"],
+        )
+        return [
+            self._verification_summaries[r["run_id"]]
+            for r in runs
+            if r["run_id"] in self._verification_summaries
+        ]
+
     # --- Internal helpers ---
 
     def _to_cycle(self, data: dict) -> Cycle:

--- a/adapters/cycles/postgres_cycle_registry.py
+++ b/adapters/cycles/postgres_cycle_registry.py
@@ -36,7 +36,11 @@ from squadops.cycles.models import (
     ValidationError,
 )
 from squadops.cycles.pulse_models import PulseVerificationRecord
-from squadops.cycles.verification_integrity import RunVerificationSummary
+from squadops.cycles.verification_integrity import (
+    RunVerdict,
+    RunVerificationSummary,
+    UnverifiedCheck,
+)
 from squadops.ports.cycles.cycle_registry import CycleRegistryPort
 
 logger = logging.getLogger(__name__)
@@ -407,6 +411,17 @@ class PostgresCycleRegistry(CycleRegistryPort):
                 json.dumps(_verification_summary_to_dict(summary)),
             )
 
+    async def list_run_verification_summaries(self, cycle_id: str) -> list[RunVerificationSummary]:
+        """Return a cycle's persisted per-run verification summaries (SIP-0096 §10)."""
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT rvs.summary FROM run_verification_summaries rvs "
+                "JOIN cycle_runs r ON r.run_id = rvs.run_id "
+                "WHERE r.cycle_id = $1 ORDER BY r.run_number",
+                cycle_id,
+            )
+        return [_verification_summary_from_dict(parse_jsonb(row["summary"])) for row in rows]
+
     # --- Checkpoint (SIP-0079) ---
 
     async def save_checkpoint(self, checkpoint: RunCheckpoint, max_keep: int = 5) -> None:
@@ -586,3 +601,24 @@ def _verification_summary_to_dict(summary: RunVerificationSummary) -> dict:
         "executed_count": summary.executed_count,
         "passed_count": summary.passed_count,
     }
+
+
+def _verification_summary_from_dict(d: dict) -> RunVerificationSummary:
+    """Reconstruct a RunVerificationSummary from its stored dict (inverse of _..to_dict).
+
+    The read side of the slice-2a contract, feeding the derive-on-read cycle roll-up.
+    """
+    return RunVerificationSummary(
+        verdict=RunVerdict(d["verdict"]),
+        verified=tuple(d.get("verified", [])),
+        failed=tuple(d.get("failed", [])),
+        unverified=tuple(
+            UnverifiedCheck(
+                check_id=u["check_id"], reason=u["reason"], required=bool(u["required"])
+            )
+            for u in d.get("unverified", [])
+        ),
+        required_unmet=tuple(d.get("required_unmet", [])),
+        executed_count=int(d.get("executed_count", 0)),
+        passed_count=int(d.get("passed_count", 0)),
+    )

--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -18,6 +18,7 @@ from squadops.api.routes.cycles.errors import handle_cycle_error
 from squadops.api.routes.cycles.mapping import cycle_to_response
 from squadops.auth.models import Scope
 from squadops.cycles.check_tooling import resolve_provisioned_tooling
+from squadops.cycles.cycle_outcome import resolve_cycle_outcome
 from squadops.cycles.lifecycle import compute_config_hash
 from squadops.cycles.models import (
     Cycle,
@@ -246,7 +247,11 @@ async def get_cycle(project_id: str, cycle_id: str):
         registry = get_cycle_registry()
         cycle = await registry.get_cycle(cycle_id)
         runs = await registry.list_runs(cycle_id)
-        return cycle_to_response(cycle, runs)
+        # SIP-0096 §10: derive the verification roll-up on read (detail GET only —
+        # kept out of the list path to avoid a per-cycle query), the same
+        # derive-on-read pattern as the cycle status above.
+        outcome = await resolve_cycle_outcome(registry, cycle_id)
+        return cycle_to_response(cycle, runs, cycle_outcome=outcome)
     except CycleError as e:
         raise handle_cycle_error(e) from e
 

--- a/src/squadops/api/routes/cycles/dtos.py
+++ b/src/squadops/api/routes/cycles/dtos.py
@@ -159,6 +159,30 @@ class WorkloadProgressEntry(BaseModel):
     status: str  # "pending" | "running" | "completed" | "failed" | "gate_awaiting" | "rejected"
 
 
+class UnverifiedCheckDTO(BaseModel):
+    """A not-executed check disclosed in the cycle roll-up (SIP-0096 §6.6.3)."""
+
+    check_id: str
+    reason: str
+    required: bool
+
+
+class CycleOutcomeDTO(BaseModel):
+    """SIP-0096 §10 per-cycle verification roll-up, derived on read.
+
+    `verdict` is the worst-of-runs verification verdict — **not** a cycle status
+    (§6.5). `blocked_unverified` is a harness/evidence problem, not a product
+    failure. Not-executed checks are always disclosed in `unverified`.
+    """
+
+    verdict: str  # accepted | rejected | blocked_unverified
+    verified: list[str] = Field(default_factory=list)
+    failed: list[str] = Field(default_factory=list)
+    unverified: list[UnverifiedCheckDTO] = Field(default_factory=list)
+    required_unmet: list[str] = Field(default_factory=list)
+    run_count: int = 0
+
+
 class CycleResponse(BaseModel):
     cycle_id: str
     project_id: str
@@ -177,6 +201,7 @@ class CycleResponse(BaseModel):
     status: str  # Derived CycleStatus
     runs: list[RunResponse] = Field(default_factory=list)
     workload_progress: list[WorkloadProgressEntry] = Field(default_factory=list)
+    cycle_outcome: CycleOutcomeDTO | None = None  # SIP-0096 §10, derived on the detail GET
 
 
 class PreflightWarningDTO(BaseModel):

--- a/src/squadops/api/routes/cycles/mapping.py
+++ b/src/squadops/api/routes/cycles/mapping.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from squadops.api.routes.cycles.dtos import (
     AgentProfileEntryResponse,
     ArtifactRefResponse,
+    CycleOutcomeDTO,
     CycleResponse,
     GateDecisionResponse,
     GateDTO,
@@ -14,6 +15,7 @@ from squadops.api.routes.cycles.dtos import (
     RunResponse,
     SquadProfileResponse,
     TaskFlowPolicyDTO,
+    UnverifiedCheckDTO,
     WorkloadProgressEntry,
 )
 from squadops.api.runtime.agent_labels import get_role_label
@@ -27,6 +29,7 @@ from squadops.cycles.models import (
     RunStatus,
     SquadProfile,
 )
+from squadops.cycles.verification_integrity import CycleOutcome
 
 
 def project_to_response(project: Project) -> ProjectResponse:
@@ -138,7 +141,23 @@ def compute_workload_progress(
     return entries
 
 
-def cycle_to_response(cycle: Cycle, runs: list[Run]) -> CycleResponse:
+def _cycle_outcome_to_dto(outcome: CycleOutcome) -> CycleOutcomeDTO:
+    return CycleOutcomeDTO(
+        verdict=outcome.verdict.value,
+        verified=list(outcome.verified),
+        failed=list(outcome.failed),
+        unverified=[
+            UnverifiedCheckDTO(check_id=u.check_id, reason=u.reason, required=u.required)
+            for u in outcome.unverified
+        ],
+        required_unmet=list(outcome.required_unmet),
+        run_count=outcome.run_count,
+    )
+
+
+def cycle_to_response(
+    cycle: Cycle, runs: list[Run], cycle_outcome: CycleOutcome | None = None
+) -> CycleResponse:
     ws = cycle.applied_defaults.get("workload_sequence", [])
     progress = compute_workload_progress(ws, runs)
     workload_statuses = [e.status for e in progress] if progress else None
@@ -163,6 +182,7 @@ def cycle_to_response(cycle: Cycle, runs: list[Run]) -> CycleResponse:
         status=status.value,
         runs=[run_to_response(r) for r in runs],
         workload_progress=progress,
+        cycle_outcome=_cycle_outcome_to_dto(cycle_outcome) if cycle_outcome else None,
     )
 
 

--- a/src/squadops/cycles/cycle_outcome.py
+++ b/src/squadops/cycles/cycle_outcome.py
@@ -1,0 +1,31 @@
+"""Derive-on-read of the per-cycle ``CycleOutcome`` roll-up (SIP-0096 §10, Phase 3).
+
+The cycle-level analogue of ``lifecycle.derive_cycle_status``: rather than persist a
+roll-up at a cycle-completion seam (there is none — a cycle's terminal state is itself
+derived on read), we compute the ``CycleOutcome`` on demand from the durable per-run
+``RunVerificationSummary`` rows (slice 2a) via the pure ``aggregate_cycle_outcome``.
+
+Thin I/O orchestration only — one registry read, then the pure choke point. Reusable
+by every consumer (cycle-detail API here; wrap-up, gates, and the 1.6 Campaign
+continuation decision later).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from squadops.cycles.verification_integrity import CycleOutcome, aggregate_cycle_outcome
+
+if TYPE_CHECKING:
+    from squadops.ports.cycles.cycle_registry import CycleRegistryPort
+
+
+async def resolve_cycle_outcome(registry: CycleRegistryPort, cycle_id: str) -> CycleOutcome:
+    """Derive a cycle's ``CycleOutcome`` from its persisted per-run summaries (§10).
+
+    ``waived`` (operator gate waivers, §6.5) and ``inert`` (chronic not-executed, §9)
+    stay empty until their Phase-3 slices wire them — the roll-up shape carries them,
+    but there is no source yet, so we pass nothing rather than fabricate.
+    """
+    summaries = await registry.list_run_verification_summaries(cycle_id)
+    return aggregate_cycle_outcome(summaries)

--- a/src/squadops/ports/cycles/cycle_registry.py
+++ b/src/squadops/ports/cycles/cycle_registry.py
@@ -157,6 +157,16 @@ class CycleRegistryPort(ABC):
             RunNotFoundError: If the run_id is not found.
         """
 
+    @abstractmethod
+    async def list_run_verification_summaries(self, cycle_id: str) -> list[RunVerificationSummary]:
+        """Return the persisted verification summaries for a cycle's runs (SIP-0096 §10).
+
+        One entry per run that recorded a summary (runs without one — e.g. still
+        running — are omitted). Feeds the derive-on-read ``CycleOutcome`` roll-up
+        (``aggregate_cycle_outcome``). Order is by run_number; the roll-up is
+        order-independent. Returns an empty list for an unknown or run-less cycle.
+        """
+
     # --- Checkpoint (SIP-0079) ---
 
     @abstractmethod

--- a/tests/unit/api/test_cycle_dto_mapping.py
+++ b/tests/unit/api/test_cycle_dto_mapping.py
@@ -213,3 +213,36 @@ class TestCycleToResponseStatus:
         resp = cycle_to_response(cycle, runs=[])
 
         assert resp.status == "cancelled"
+
+
+class TestCycleOutcomeInResponse:
+    """SIP-0096 §10: the derived verification roll-up is surfaced on the detail response."""
+
+    def test_outcome_omitted_when_not_provided(self):
+        """List/legacy callers pass no outcome → the field is None, not fabricated."""
+        resp = cycle_to_response(_make_cycle(), runs=[])
+        assert resp.cycle_outcome is None
+
+    def test_outcome_mapped_when_provided(self):
+        from squadops.cycles.verification_integrity import (
+            CycleOutcome,
+            RunVerdict,
+            UnverifiedCheck,
+        )
+
+        outcome = CycleOutcome(
+            verdict=RunVerdict.BLOCKED_UNVERIFIED,
+            verified=("tests_pass",),
+            failed=(),
+            unverified=(UnverifiedCheck("required_files", "subject_missing", required=True),),
+            run_count=2,
+        )
+
+        resp = cycle_to_response(_make_cycle(), runs=[], cycle_outcome=outcome)
+
+        assert resp.cycle_outcome is not None
+        assert resp.cycle_outcome.verdict == "blocked_unverified"
+        assert resp.cycle_outcome.verified == ["tests_pass"]
+        assert resp.cycle_outcome.required_unmet == ["required_files"]  # derived from unverified
+        assert resp.cycle_outcome.unverified[0].check_id == "required_files"
+        assert resp.cycle_outcome.unverified[0].required is True

--- a/tests/unit/cycles/test_cycle_outcome.py
+++ b/tests/unit/cycles/test_cycle_outcome.py
@@ -1,0 +1,57 @@
+"""Tests for resolve_cycle_outcome — derive-on-read CycleOutcome (SIP-0096 Phase 3 slice 2b).
+
+The resolver is thin orchestration (one registry read → the pure aggregate_cycle_outcome,
+which is tested in test_verification_integrity.py). These tests verify the wiring: it reads
+the cycle's persisted per-run summaries and rolls them up, worst-verdict-wins.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from squadops.cycles.cycle_outcome import resolve_cycle_outcome
+from squadops.cycles.verification_integrity import RunVerdict, RunVerificationSummary
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+
+def _run_summary(verdict, *, verified=(), failed=()) -> RunVerificationSummary:
+    return RunVerificationSummary(
+        verdict=verdict,
+        verified=tuple(verified),
+        failed=tuple(failed),
+        unverified=(),
+        required_unmet=(),
+        executed_count=len(verified) + len(failed),
+        passed_count=len(verified),
+    )
+
+
+async def test_rolls_up_persisted_summaries_worst_verdict_wins():
+    registry = AsyncMock()
+    registry.list_run_verification_summaries = AsyncMock(
+        return_value=[
+            _run_summary(RunVerdict.ACCEPTED, verified=["tests_pass"]),
+            _run_summary(RunVerdict.REJECTED, failed=["frontend_build"]),
+        ]
+    )
+
+    outcome = await resolve_cycle_outcome(registry, "cyc_x")
+
+    registry.list_run_verification_summaries.assert_awaited_once_with("cyc_x")
+    assert outcome.verdict is RunVerdict.REJECTED  # a rejected run drags the cycle down
+    assert outcome.run_count == 2
+    assert "frontend_build" in outcome.failed
+    assert "tests_pass" in outcome.verified
+
+
+async def test_empty_cycle_rolls_up_to_accepted():
+    registry = AsyncMock()
+    registry.list_run_verification_summaries = AsyncMock(return_value=[])
+
+    outcome = await resolve_cycle_outcome(registry, "cyc_x")
+
+    assert outcome.verdict is RunVerdict.ACCEPTED  # zero runs = zero adverse evidence
+    assert outcome.run_count == 0

--- a/tests/unit/cycles/test_cycle_registry_contract.py
+++ b/tests/unit/cycles/test_cycle_registry_contract.py
@@ -376,3 +376,33 @@ class TestRecordRunVerificationSummary:
         stored = registry._verification_summaries["run_001"]
         assert stored.verdict is RunVerdict.REJECTED
         assert stored.failed == ("frontend_build",)
+
+
+class TestListRunVerificationSummaries:
+    """Contract tests for list_run_verification_summaries (SIP-0096 Phase 3 §10)."""
+
+    async def test_returns_summaries_by_run_number_skipping_runless(self, registry):
+        """One entry per run that recorded a summary, ordered by run_number; a run
+        without one (e.g. still running) is omitted — not a None/gap."""
+        from squadops.cycles.verification_integrity import (
+            CheckResult,
+            RunVerdict,
+            aggregate_verification,
+        )
+
+        await registry.create_cycle(_make_cycle())
+        for n in (1, 2, 3):
+            await registry.create_run(_make_run(run_id=f"run_00{n}", run_number=n))
+            await registry.update_run_status(f"run_00{n}", RunStatus.RUNNING)
+            await registry.update_run_status(f"run_00{n}", RunStatus.COMPLETED)
+        # run_002 deliberately records NO summary — it must be skipped, not surfaced.
+        await registry.record_run_verification_summary("run_001", aggregate_verification([]))
+        await registry.record_run_verification_summary(
+            "run_003", aggregate_verification([CheckResult(check_id="x", status="failed")])
+        )
+
+        summaries = await registry.list_run_verification_summaries("cyc_001")
+        assert [s.verdict for s in summaries] == [RunVerdict.ACCEPTED, RunVerdict.REJECTED]
+
+    async def test_unknown_cycle_returns_empty(self, registry):
+        assert await registry.list_run_verification_summaries("nope") == []

--- a/tests/unit/cycles/test_postgres_cycle_registry.py
+++ b/tests/unit/cycles/test_postgres_cycle_registry.py
@@ -730,3 +730,56 @@ class TestRecordRunVerificationSummary:
         assert json.loads(json.dumps(d))["verdict"] == "accepted"
         assert d["verified"] == ["a"]
         assert isinstance(d["unverified"], list)
+
+
+class TestListRunVerificationSummaries:
+    """Unit tests for list_run_verification_summaries + serializer round-trip (SIP-0096 §10)."""
+
+    @pytest.fixture
+    def conn(self):
+        return _make_conn()
+
+    @pytest.fixture
+    def registry(self, conn):
+        from adapters.cycles.postgres_cycle_registry import PostgresCycleRegistry
+
+        return PostgresCycleRegistry(_make_pool(conn))
+
+    async def test_reconstructs_summaries_from_jsonb_in_order(self, registry, conn):
+        from adapters.cycles.postgres_cycle_registry import _verification_summary_to_dict
+        from squadops.cycles.verification_integrity import (
+            CheckResult,
+            RunVerdict,
+            aggregate_verification,
+        )
+
+        s1 = aggregate_verification([CheckResult(check_id="a", status="passed")])
+        s2 = aggregate_verification([CheckResult(check_id="b", status="failed")])
+        # asyncpg hands JSONB back as a JSON string → parse_jsonb decodes it
+        conn.fetch.return_value = [
+            {"summary": json.dumps(_verification_summary_to_dict(s1))},
+            {"summary": json.dumps(_verification_summary_to_dict(s2))},
+        ]
+
+        result = await registry.list_run_verification_summaries("cyc_001")
+
+        assert [r.verdict for r in result] == [RunVerdict.ACCEPTED, RunVerdict.REJECTED]
+        assert result[1].failed == ("b",)
+        sql = conn.fetch.call_args[0][0]
+        assert "run_verification_summaries" in sql
+        assert "r.cycle_id = $1" in sql and "ORDER BY r.run_number" in sql
+
+    def test_summary_dict_round_trip_is_lossless(self):
+        from adapters.cycles.postgres_cycle_registry import (
+            _verification_summary_from_dict,
+            _verification_summary_to_dict,
+        )
+        from squadops.cycles.verification_integrity import CheckResult, aggregate_verification
+
+        # a blocked verdict with a disclosed not-executed reason exercises every field
+        original = aggregate_verification(
+            [CheckResult(check_id="a", status="passed")],
+            required_check_ids=["required_files"],
+        )
+        restored = _verification_summary_from_dict(_verification_summary_to_dict(original))
+        assert restored == original  # frozen dataclass equality — lossless


### PR DESCRIPTION
## Summary

Realizes the §10 `CycleOutcome` roll-up via **derive-on-read** — the pattern the codebase already uses for cycle status (`derive_cycle_status`). The scout confirmed there's no cycle-completion seam (a cycle's terminal state is itself derived on read), so rather than invent one + a second table, the roll-up is computed on demand from the durable per-run summaries persisted in **slice 2a (#416)** via the pure `aggregate_cycle_outcome` (**#412**).

## What's here
- **Read-back**: `list_run_verification_summaries(cycle_id)` on `CycleRegistryPort` + both adapters. Postgres reconstructs from JSONB via `_verification_summary_from_dict` — the inverse of 2a's serializer, pinned by a **lossless round-trip test**; Memory returns the stored frozen objects. One entry per run that recorded a summary, by `run_number`; runless runs omitted.
- **`resolve_cycle_outcome(registry, cycle_id)`** in `cycles/cycle_outcome.py` — thin I/O orchestration (one read → the pure aggregate). `waived` (§6.5) and `inert` (§9) stay **empty passthroughs** until their slices — no source yet, so nothing is fabricated.
- **Surface**: an optional `cycle_outcome` on `CycleResponse`, threaded through `cycle_to_response`, computed **only on the cycle-detail GET** (`GET /api/v1/projects/{p}/cycles/{id}`) — **kept out of the list path to avoid a per-cycle query**. Additive optional DTO field, not a new route/convention. CLI `cycles show` renders it via the generic detail printer.

## Verdict
Worst-of-runs (from the pure core): any run `blocked_unverified` → cycle `blocked_unverified`; else any `rejected` → `rejected`; else `accepted` (empty cycle → `accepted`).

## Out of scope (later slices)
Wrap-up consumption (SIP-0080); gate **waiver** flow (populates `waived`); inert detection (populates `inert`); #114.

## Tests
Memory contract (read-back by run_number, runless run skipped, unknown cycle empty), resolver (rolls up persisted summaries worst-verdict-wins; empty → accepted), Postgres (JSONB reconstruction + SQL shape; **lossless dict round-trip**), DTO mapping (mapped when provided, `None` when omitted). **Regression: 4811.**

## Live validation (deployed stack, runtime-api rebuilt)
- Detail GET on completed smoke cycle `cyc_3994f439f8e5` → `cycle_outcome: {verdict: accepted, run_count: 1}` — derived from the persisted per-run summary.
- List endpoint → `cycle_outcome: null` on every entry (no N+1).

Closes #417