### PR TITLE
fix(#419/#420): typed acceptance at the builder seam + wire-shape criteria coercion

### DIFF
--- a/docs/plans/1-4-evidence-arc-plan.md
+++ b/docs/plans/1-4-evidence-arc-plan.md
@@ -108,6 +108,13 @@ is itself an arc prerequisite — a reason to protect the 1.3 batch, not change 
   and classification/provenance retrofit of the shipped #289/#290 checks. Each lands
   with a live `lite` cycle per the live-validation rule. (Split M/S along the usual
   file ownership: executor/handlers = M; test-runner/build-check/agent-image = S.)
+- **#419/#420 typed-acceptance seam integrity** (Phase-2-shaped, found via the
+  post-#413 validation cycle): builder.assemble evaluates the plan's typed contract
+  (SIP-0092 M1.3) through a seam hoisted to the cycle-handler base, and criteria now
+  survive distributed dispatch — `asdict()` was flattening `TypedCheck` to dicts the
+  handlers misfiled as prose, so M1.3 was silently inert in the field (#420). With
+  #413 in, a builder path-contract violation becomes a one-round self-heal instead
+  of an unfixable qa.test stall.
 - **Evidence SIP Phase 3** — `CycleOutcome` roll-up persisted + consumed by wrap-up,
   gate waiver flow, doctor verification category (non-executable + inert reporting;
   console badging and a dedicated event are deferred until demand).

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -5,7 +5,9 @@ Split from cycle_tasks.py (#152).
 from __future__ import annotations
 
 import logging
+import tempfile
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from squadops.capabilities.handlers.base import (
@@ -13,6 +15,13 @@ from squadops.capabilities.handlers.base import (
     HandlerEvidence,
     HandlerResult,
 )
+from squadops.cycles.acceptance_checks import CheckOutcome
+from squadops.cycles.acceptance_evaluation import (
+    evaluate_criterion,
+    split_acceptance_criteria,
+)
+from squadops.cycles.implementation_plan import TypedCheck
+from squadops.cycles.patch_verification import materialize_artifacts
 from squadops.llm.exceptions import LLMError
 from squadops.llm.model_registry import get_model_spec
 from squadops.llm.models import ChatMessage
@@ -255,6 +264,155 @@ class _CycleTaskHandler(CapabilityHandler):
         async so subclasses can await without restructuring.
         """
         return ValidationResult(passed=True, summary="No validation configured")
+
+    # ---- SIP-0092 M1.3 typed acceptance (shared seam, #419/#420) ----------
+    #
+    # Hoisted from DevelopmentDevelopHandler so every cycle handler whose
+    # plan task carries typed acceptance criteria enforces them identically
+    # (#419: the builder seam silently ignored its contract). Criteria arrive
+    # as wire-shape dicts after distributed dispatch; coercion happens in
+    # split_acceptance_criteria (#420), never via isinstance filtering here.
+
+    async def _evaluate_typed_acceptance(
+        self,
+        inputs: dict[str, Any],
+        artifacts: list[dict],
+        checks: list[dict],
+        missing: list[str],
+        typed_error_counts: dict[str, int],
+    ) -> None:
+        """Evaluate typed acceptance criteria, mutating ``checks`` and ``missing`` in place.
+
+        Implements RC-9 (severity × status blocking matrix), RC-9a (error-vs-
+        failed wording distinction), RC-9b (per-criterion error count with
+        2-strikes escalation), RC-12a (skipped-not-error for unset stack).
+        """
+        split = split_acceptance_criteria(inputs.get("acceptance_criteria", []))
+
+        # Prose strings stay informational, evidence-only — same as Rev 1's
+        # included_in_evidence behavior. They never block.
+        if split.prose:
+            checks.append(
+                {
+                    "check": "acceptance_criteria_prose",
+                    "criteria": list(split.prose),
+                    "evaluation": "included_in_evidence",
+                    "passed": True,
+                }
+            )
+
+        # #420: disclosed, non-blocking. The parser enforces vocabulary at
+        # plan-authoring time, so a row landing here is a transport-shape
+        # bug — surface it in evidence rather than misfiling it as prose.
+        if split.unparseable:
+            checks.append(
+                {
+                    "check": "acceptance_criteria_unparseable",
+                    "criteria": [repr(c) for c in split.unparseable],
+                    "evaluation": "unparseable_not_evaluated",
+                    "passed": True,
+                }
+            )
+
+        typed_criteria = list(split.typed)
+        if not typed_criteria:
+            return
+
+        resolved_config = inputs.get("resolved_config", {})
+        typed_acceptance_enabled = resolved_config.get("typed_acceptance", True)
+        command_acceptance_enabled = resolved_config.get("command_acceptance_checks", True)
+        stack = resolved_config.get("stack")
+
+        with tempfile.TemporaryDirectory(prefix="squadops-typed-acc-") as tmpdir_str:
+            workspace_root = Path(tmpdir_str)
+            self._materialize_artifacts(artifacts, workspace_root)
+
+            for check_index, criterion in enumerate(typed_criteria):
+                outcome = await evaluate_criterion(
+                    criterion,
+                    workspace_root,
+                    stack=stack,
+                    typed_acceptance_enabled=typed_acceptance_enabled,
+                    command_acceptance_enabled=command_acceptance_enabled,
+                )
+                check_record = {
+                    "check": f"acceptance:{criterion.check}",
+                    "severity": criterion.severity,
+                    "params": criterion.params,
+                    "description": criterion.description,
+                    "status": outcome.status,
+                    "actual": outcome.actual,
+                    "reason": outcome.reason,
+                    # `passed` flag for compatibility with the legacy
+                    # all-checks-pass aggregator: only severity=error AND
+                    # blocking status counts as not-passed.
+                    "passed": not (
+                        criterion.severity == "error" and outcome.status in {"failed", "error"}
+                    ),
+                    # Issue #114: identity fields for downstream trigger
+                    # composition and per-cycle evaluation persistence.
+                    # task_index is None for tasks not driven by an
+                    # implementation_plan (legacy monolithic flow).
+                    "task_index": inputs.get("subtask_index"),
+                    "check_index": check_index,
+                }
+                checks.append(check_record)
+
+                # Issue #83: per-check observability. Without these the M1.3
+                # path is invisible to operators — see issue body for context.
+                blocking = criterion.severity == "error" and outcome.status in {"failed", "error"}
+                log_fn = logger.info if blocking else logger.debug
+                log_fn(
+                    "typed_acceptance_check subtask=%s check=%s severity=%s status=%s blocking=%s reason=%s",
+                    inputs.get("subtask_index"),
+                    criterion.check,
+                    criterion.severity,
+                    outcome.status,
+                    blocking,
+                    outcome.reason or "",
+                )
+
+                # RC-9: severity AND status are independent. Only error+blocking missions.
+                if criterion.severity != "error":
+                    continue
+                if outcome.status == "failed":
+                    # RC-9a: app-incompleteness wording.
+                    label = criterion.description or criterion.check
+                    missing.append(f"acceptance:{label}")
+                elif outcome.status == "error":
+                    fp = criterion.fingerprint()
+                    prior = typed_error_counts.get(fp, 0)
+                    if prior < 2:
+                        # RC-9a: evaluator-error wording, distinct from app-incomplete.
+                        missing.append(f"evaluator-error:{criterion.check}: {outcome.reason}")
+                    else:
+                        self._escalate_persistent_evaluator_error(criterion, outcome)
+                    typed_error_counts[fp] = prior + 1
+                # status in {passed, skipped} never blocks.
+
+    # Shared with the executor-side patch verification (#389) — one
+    # materializer, one safety policy.
+    _materialize_artifacts = staticmethod(materialize_artifacts)
+
+    @staticmethod
+    def _escalate_persistent_evaluator_error(criterion: TypedCheck, outcome: CheckOutcome) -> None:
+        """RC-9b: surface a persistent evaluator error outside the self-eval feedback loop.
+
+        Logged at WARNING with structured fields; the correction protocol
+        and operator-facing surfaces consume the log. A first-class
+        escalation channel is a follow-up if/when the prompt-feedback
+        suppression proves insufficient.
+        """
+        logger.warning(
+            "typed_check_evaluator_error_escalated",
+            extra={
+                "check": criterion.check,
+                "severity": criterion.severity,
+                "fingerprint": criterion.fingerprint(),
+                "reason": outcome.reason,
+                "actual": outcome.actual,
+            },
+        )
 
     @staticmethod
     def _build_self_eval_prompt(

--- a/src/squadops/capabilities/handlers/cycle/builder.py
+++ b/src/squadops/capabilities/handlers/cycle/builder.py
@@ -399,7 +399,11 @@ class BuilderAssembleHandler(_CycleTaskHandler):
                 failure_classification=FailureClassification.WORK_PRODUCT,
             )
 
-        # Step 6-8: Validate builder output
+        # Step 6: Deduplicate and classify. Runs before validation (#419) so
+        # typed acceptance evaluates the exact artifact set that ships.
+        extracted, artifacts, qa_handoff_content = self._dedup_and_classify(extracted)
+
+        # Step 7: profile/task-scoped required-files + qa_handoff sections
         validation_error = self._validate_builder_output(
             extracted,
             profile,
@@ -418,20 +422,46 @@ class BuilderAssembleHandler(_CycleTaskHandler):
         rf_missing = [rf for rf in effective_required if rf not in extracted_basenames]
         required_files_row = {"check": CHECK_REQUIRED_FILES, "passed": not rf_missing}
 
-        if validation_error is not None:
-            from squadops.cycles.task_outcome import FailureClassification, TaskOutcome
+        # Step 8 (#419): typed acceptance criteria — the plan's contract on
+        # this builder task, evaluated identically to the dev seam (SIP-0092
+        # M1.3, RC-9 blocking matrix). The required_files seam above matches
+        # basenames (#107); typed checks address full paths in a materialized
+        # workspace, so a path-prefix violation fails HERE, at the seam that
+        # can repair it, instead of surfacing as an unfixable qa.test failure.
+        validation_checks: list[dict] = [required_files_row]
+        acceptance_missing: list[str] = []
+        await self._evaluate_typed_acceptance(
+            inputs, artifacts, validation_checks, acceptance_missing, typed_error_counts={}
+        )
 
+        # Issue #114: per-task typed-check evaluation evidence, same as the
+        # dev seam — emitted whenever typed checks ran, both outcomes.
+        tce_artifact = self._build_typed_check_evaluation_artifact(
+            validation_checks, inputs.get("subtask_index"), self._capability_id
+        )
+        if tce_artifact is not None:
+            artifacts.append(tce_artifact)
+
+        if acceptance_missing:
+            acceptance_error = "Typed acceptance criteria not met: " + "; ".join(acceptance_missing)
+            validation_error = (
+                f"{validation_error}; {acceptance_error}" if validation_error else acceptance_error
+            )
+
+        if validation_error is not None:
             return self._fail_result(
                 start_time,
                 inputs,
                 validation_error,
-                outputs={"validation_result": {"checks": [required_files_row]}},
+                # Artifacts ride the failure so the #413 patch overlay
+                # verifies repairs against the emitted set, not a vacuum.
+                outputs={
+                    "artifacts": artifacts,
+                    "validation_result": {"checks": validation_checks},
+                },
                 outcome_class=TaskOutcome.SEMANTIC_FAILURE,
                 failure_classification=FailureClassification.WORK_PRODUCT,
             )
-
-        # Step 8b: Deduplicate and classify
-        extracted, artifacts, qa_handoff_content = self._dedup_and_classify(extracted)
 
         # Step 9: Build outputs with diagnostics
         # SIP-0084 §10: build prompt provenance for artifact traceability
@@ -449,9 +479,9 @@ class BuilderAssembleHandler(_CycleTaskHandler):
             "summary": f"[builder] Assembled {len(artifacts)} deployment artifact(s)",
             "role": self._role,
             "artifacts": artifacts,
-            # #399: per-task required_files evidence for the SIP-0096 roll-up
-            # (passed here — validation succeeded, so every required file present).
-            "validation_result": {"checks": [required_files_row]},
+            # #399/#419: per-task required_files + typed-acceptance evidence
+            # for the SIP-0096 roll-up (all passed — validation succeeded).
+            "validation_result": {"checks": validation_checks},
             "diagnostics": {
                 "resolved_handler": self._handler_name,
                 "build_profile": profile_name,

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -5,9 +5,7 @@ Split from cycle_tasks.py (#152).
 from __future__ import annotations
 
 import logging
-import tempfile
 import time
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from squadops.capabilities.dev_capabilities import get_capability
@@ -16,9 +14,6 @@ from squadops.capabilities.handlers.base import (
     HandlerResult,
 )
 from squadops.capabilities.handlers.prompt_guard import _guard_prompt_size
-from squadops.cycles.acceptance_checks import CheckOutcome, get_check
-from squadops.cycles.implementation_plan import TypedCheck
-from squadops.cycles.patch_verification import materialize_artifacts
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
 
@@ -177,158 +172,9 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
             summary="; ".join(summary_parts) or "All checks passed",
         )
 
-    # ---- SIP-0092 M1.3 typed acceptance helpers --------------------------
-
-    async def _evaluate_typed_acceptance(
-        self,
-        inputs: dict[str, Any],
-        artifacts: list[dict],
-        checks: list[dict],
-        missing: list[str],
-        typed_error_counts: dict[str, int],
-    ) -> None:
-        """Evaluate typed acceptance criteria, mutating ``checks`` and ``missing`` in place.
-
-        Implements RC-9 (severity × status blocking matrix), RC-9a (error-vs-
-        failed wording distinction), RC-9b (per-criterion error count with
-        2-strikes escalation), RC-12a (skipped-not-error for unset stack).
-        """
-        criteria = inputs.get("acceptance_criteria", [])
-        typed_criteria = [c for c in criteria if isinstance(c, TypedCheck)]
-        prose_criteria = [c for c in criteria if not isinstance(c, TypedCheck)]
-
-        # Prose strings stay informational, evidence-only — same as Rev 1's
-        # included_in_evidence behavior. They never block.
-        if prose_criteria:
-            checks.append(
-                {
-                    "check": "acceptance_criteria_prose",
-                    "criteria": prose_criteria,
-                    "evaluation": "included_in_evidence",
-                    "passed": True,
-                }
-            )
-
-        if not typed_criteria:
-            return
-
-        resolved_config = inputs.get("resolved_config", {})
-        typed_acceptance_enabled = resolved_config.get("typed_acceptance", True)
-        command_acceptance_enabled = resolved_config.get("command_acceptance_checks", True)
-        stack = resolved_config.get("stack")
-
-        with tempfile.TemporaryDirectory(prefix="squadops-typed-acc-") as tmpdir_str:
-            workspace_root = Path(tmpdir_str)
-            self._materialize_artifacts(artifacts, workspace_root)
-
-            for check_index, criterion in enumerate(typed_criteria):
-                outcome = await self._evaluate_typed_check(
-                    criterion,
-                    workspace_root,
-                    stack=stack,
-                    typed_acceptance_enabled=typed_acceptance_enabled,
-                    command_acceptance_enabled=command_acceptance_enabled,
-                )
-                check_record = {
-                    "check": f"acceptance:{criterion.check}",
-                    "severity": criterion.severity,
-                    "params": criterion.params,
-                    "description": criterion.description,
-                    "status": outcome.status,
-                    "actual": outcome.actual,
-                    "reason": outcome.reason,
-                    # `passed` flag for compatibility with the legacy
-                    # all-checks-pass aggregator: only severity=error AND
-                    # blocking status counts as not-passed.
-                    "passed": not (
-                        criterion.severity == "error" and outcome.status in {"failed", "error"}
-                    ),
-                    # Issue #114: identity fields for downstream trigger
-                    # composition and per-cycle evaluation persistence.
-                    # task_index is None for tasks not driven by an
-                    # implementation_plan (legacy monolithic flow).
-                    "task_index": inputs.get("subtask_index"),
-                    "check_index": check_index,
-                }
-                checks.append(check_record)
-
-                # Issue #83: per-check observability. Without these the M1.3
-                # path is invisible to operators — see issue body for context.
-                blocking = criterion.severity == "error" and outcome.status in {"failed", "error"}
-                log_fn = logger.info if blocking else logger.debug
-                log_fn(
-                    "typed_acceptance_check subtask=%s check=%s severity=%s status=%s blocking=%s reason=%s",
-                    inputs.get("subtask_index"),
-                    criterion.check,
-                    criterion.severity,
-                    outcome.status,
-                    blocking,
-                    outcome.reason or "",
-                )
-
-                # RC-9: severity AND status are independent. Only error+blocking missions.
-                if criterion.severity != "error":
-                    continue
-                if outcome.status == "failed":
-                    # RC-9a: app-incompleteness wording.
-                    label = criterion.description or criterion.check
-                    missing.append(f"acceptance:{label}")
-                elif outcome.status == "error":
-                    fp = criterion.fingerprint()
-                    prior = typed_error_counts.get(fp, 0)
-                    if prior < 2:
-                        # RC-9a: evaluator-error wording, distinct from app-incomplete.
-                        missing.append(f"evaluator-error:{criterion.check}: {outcome.reason}")
-                    else:
-                        self._escalate_persistent_evaluator_error(criterion, outcome)
-                    typed_error_counts[fp] = prior + 1
-                # status in {passed, skipped} never blocks.
-
-    # Shared with the executor-side patch verification (#389) — one
-    # materializer, one safety policy.
-    _materialize_artifacts = staticmethod(materialize_artifacts)
-
-    @staticmethod
-    async def _evaluate_typed_check(
-        criterion: TypedCheck,
-        workspace_root: Path,
-        *,
-        stack: str | None,
-        typed_acceptance_enabled: bool,
-        command_acceptance_enabled: bool,
-    ) -> CheckOutcome:
-        """Dispatch a typed criterion to its registered evaluator, honoring config gates."""
-        if not typed_acceptance_enabled:
-            return CheckOutcome.skipped(reason="typed_acceptance_disabled")
-        if criterion.check == "command_exit_zero" and not command_acceptance_enabled:
-            return CheckOutcome.skipped(reason="command_acceptance_checks_disabled")
-        try:
-            evaluator = get_check(criterion.check)
-        except KeyError:
-            # Should not happen — parser already enforces vocabulary — but
-            # treat as evaluator-error rather than crashing the cycle.
-            return CheckOutcome.error(reason="no_evaluator_registered")
-        return await evaluator.evaluate(criterion.params, workspace_root, stack=stack)
-
-    @staticmethod
-    def _escalate_persistent_evaluator_error(criterion: TypedCheck, outcome: CheckOutcome) -> None:
-        """RC-9b: surface a persistent evaluator error outside the self-eval feedback loop.
-
-        Logged at WARNING with structured fields; the correction protocol
-        and operator-facing surfaces consume the log. A first-class
-        escalation channel is a follow-up if/when the prompt-feedback
-        suppression proves insufficient.
-        """
-        logger.warning(
-            "typed_check_evaluator_error_escalated",
-            extra={
-                "check": criterion.check,
-                "severity": criterion.severity,
-                "fingerprint": criterion.fingerprint(),
-                "reason": outcome.reason,
-                "actual": outcome.actual,
-            },
-        )
+    # SIP-0092 M1.3 typed-acceptance evaluation is inherited from
+    # _CycleTaskHandler (#419/#420) — one seam for every cycle handler
+    # whose plan task carries typed acceptance criteria.
 
     def _validate_monolithic(
         self,

--- a/src/squadops/cycles/acceptance_evaluation.py
+++ b/src/squadops/cycles/acceptance_evaluation.py
@@ -1,0 +1,114 @@
+"""Shared typed-acceptance criterion evaluation seam (SIP-0092 M1.3, #419/#420).
+
+One canonical view of a task's acceptance criteria for every consumer:
+handler-side output validation (``handlers/cycle/base.py``, used by the dev
+and builder seams) and executor-side patch verification (#389).
+
+Criteria cross the A2A wire as plain dicts — ``TaskEnvelope.to_dict()`` uses
+``dataclasses.asdict``, which recursively flattens ``TypedCheck`` — and the
+agent side never rehydrates them. Any consumer filtering on
+``isinstance(TypedCheck)`` alone therefore silently loses its typed contract
+after dispatch (#420). ``split_acceptance_criteria`` owns that coercion in
+one place so no seam can drift back into the wire-shape trap.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from squadops.cycles.acceptance_checks import CheckOutcome, get_check
+from squadops.cycles.implementation_plan import TypedCheck, _parse_acceptance_criteria
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SplitCriteria:
+    """A mixed acceptance-criteria list, partitioned by evaluability.
+
+    ``typed`` — machine-evaluable ``TypedCheck`` entries, including dict rows
+    re-parsed from a deserialized envelope (#420).
+    ``prose`` — informational strings; evidence-only, never block.
+    ``unparseable`` — rows that are neither prose nor a parseable typed
+    criterion. The parser enforces vocabulary at plan-authoring time, so an
+    entry landing here indicates a transport-shape bug, not an authored
+    contract; consumers decide their own severity (patch verification treats
+    any as UNVERIFIABLE, handler validation discloses without blocking).
+    """
+
+    typed: tuple[TypedCheck, ...] = ()
+    prose: tuple[str, ...] = ()
+    unparseable: tuple[Any, ...] = ()
+
+
+_SERIALIZED_ROW_KEYS = frozenset({"check", "params", "severity", "description"})
+
+
+def _flatten_serialized_row(item: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize a ``dataclasses.asdict``-shaped row to the flat authored shape.
+
+    ``TaskEnvelope.to_dict()`` serializes ``TypedCheck`` with ``params``
+    nested (the dataclass field), while the parser speaks the flat authored
+    YAML shape (param keys inline, minus reserved keys). No check in
+    ``CHECK_SPECS`` has a param literally named ``params`` and the key-set
+    guard is exact, so a flat authored row can never be misread as serialized.
+    """
+    if isinstance(item.get("params"), Mapping) and set(item) <= _SERIALIZED_ROW_KEYS:
+        flat = {k: v for k, v in item.items() if k != "params"}
+        flat.update(item["params"])
+        return flat
+    return dict(item)
+
+
+def split_acceptance_criteria(criteria: Iterable[Any] | None) -> SplitCriteria:
+    """Partition a mixed/wire-shape criteria list into ``SplitCriteria``."""
+    typed: list[TypedCheck] = []
+    prose: list[str] = []
+    unparseable: list[Any] = []
+    for item in criteria or ():
+        if isinstance(item, TypedCheck):
+            typed.append(item)
+        elif isinstance(item, str):
+            prose.append(item)
+        elif isinstance(item, Mapping):
+            try:
+                parsed = _parse_acceptance_criteria([_flatten_serialized_row(item)], task_index=-1)
+            except ValueError:
+                logger.warning("split_acceptance_criteria: unparseable criterion %r", item)
+                unparseable.append(item)
+                continue
+            typed.extend(c for c in parsed if isinstance(c, TypedCheck))
+        else:
+            logger.warning(
+                "split_acceptance_criteria: unsupported criterion type %s: %r",
+                type(item).__name__,
+                item,
+            )
+            unparseable.append(item)
+    return SplitCriteria(tuple(typed), tuple(prose), tuple(unparseable))
+
+
+async def evaluate_criterion(
+    criterion: TypedCheck,
+    workspace_root: Path,
+    *,
+    stack: str | None,
+    typed_acceptance_enabled: bool,
+    command_acceptance_enabled: bool,
+) -> CheckOutcome:
+    """Dispatch one typed criterion to its registered evaluator, honoring config gates."""
+    if not typed_acceptance_enabled:
+        return CheckOutcome.skipped(reason="typed_acceptance_disabled")
+    if criterion.check == "command_exit_zero" and not command_acceptance_enabled:
+        return CheckOutcome.skipped(reason="command_acceptance_checks_disabled")
+    try:
+        evaluator = get_check(criterion.check)
+    except KeyError:
+        # Should not happen — the parser already enforces vocabulary — but
+        # treat as evaluator-error rather than crashing the cycle.
+        return CheckOutcome.error(reason="no_evaluator_registered")
+    return await evaluator.evaluate(criterion.params, workspace_root, stack=stack)

--- a/src/squadops/cycles/patch_verification.py
+++ b/src/squadops/cycles/patch_verification.py
@@ -26,13 +26,15 @@ from __future__ import annotations
 
 import logging
 import tempfile
-from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from squadops.cycles.acceptance_checks import CheckOutcome, get_check
-from squadops.cycles.implementation_plan import TypedCheck, _parse_acceptance_criteria
+from squadops.cycles.acceptance_evaluation import (
+    evaluate_criterion,
+    split_acceptance_criteria,
+)
+from squadops.cycles.implementation_plan import TypedCheck
 
 logger = logging.getLogger(__name__)
 
@@ -128,45 +130,20 @@ def materialize_artifacts(artifacts: list[dict], workspace_root: Path) -> None:
 
 
 def _coerce_typed_criteria(criteria: list[Any]) -> list[TypedCheck] | None:
-    """Extract TypedCheck entries, re-parsing dict rows (deserialized envelopes).
+    """Extract TypedCheck entries via the shared seam (#420).
 
     Prose strings are informational and never block — dropped. Returns None
-    when any dict row fails to parse: an unintelligible contract must fall
+    when any row fails to parse: an unintelligible contract must fall
     back to re-dispatch, not silently verify against a subset of itself.
     """
-    typed: list[TypedCheck] = []
-    for item in criteria:
-        if isinstance(item, TypedCheck):
-            typed.append(item)
-        elif isinstance(item, Mapping):
-            try:
-                parsed = _parse_acceptance_criteria([dict(item)], task_index=-1)
-            except ValueError:
-                logger.warning("patch_verification: unparseable criterion %r — unverifiable", item)
-                return None
-            typed.extend(c for c in parsed if isinstance(c, TypedCheck))
-        # str → prose, informational only
-    return typed
-
-
-async def _evaluate_criterion(
-    criterion: TypedCheck,
-    workspace_root: Path,
-    *,
-    stack: str | None,
-    typed_acceptance_enabled: bool,
-    command_acceptance_enabled: bool,
-) -> CheckOutcome:
-    """Evaluate one criterion, honoring the same config gates the handler side does."""
-    if not typed_acceptance_enabled:
-        return CheckOutcome.skipped(reason="typed_acceptance_disabled")
-    if criterion.check == "command_exit_zero" and not command_acceptance_enabled:
-        return CheckOutcome.skipped(reason="command_acceptance_checks_disabled")
-    try:
-        evaluator = get_check(criterion.check)
-    except KeyError:
-        return CheckOutcome.error(reason="no_evaluator_registered")
-    return await evaluator.evaluate(criterion.params, workspace_root, stack=stack)
+    split = split_acceptance_criteria(criteria)
+    if split.unparseable:
+        logger.warning(
+            "patch_verification: %d unparseable criteria — unverifiable",
+            len(split.unparseable),
+        )
+        return None
+    return list(split.typed)
 
 
 async def verify_patched_artifacts(
@@ -198,7 +175,7 @@ async def verify_patched_artifacts(
         materialize_artifacts(artifacts, workspace_root)
 
         for criterion in typed:
-            outcome = await _evaluate_criterion(
+            outcome = await evaluate_criterion(
                 criterion,
                 workspace_root,
                 stack=stack,

--- a/tests/unit/architecture/test_no_enum_shadow_comparisons.py
+++ b/tests/unit/architecture/test_no_enum_shadow_comparisons.py
@@ -39,10 +39,12 @@ _ALLOWLIST: set[tuple[str, str]] = {
     ("src/squadops/capabilities/runner.py", "succeeded"),
     ("src/squadops/orchestration/orchestrator.py", "succeeded"),
     # CheckOutcome.status vocabulary (passed/failed/skipped/error) — CheckOutcome
-    # is a dataclass, not a StrEnum (SIP-0092); "failed"/"error" coincide with
-    # RunStatus/TaskStatus but are a different concept.
+    # is a dataclass, not a StrEnum (SIP-0092); "failed" coincides with
+    # RunStatus/TaskStatus but is a different concept. The evaluation loop was
+    # hoisted from develop.py to the shared cycle-handler base (#419); develop
+    # keeps its summary-line filter over the same vocabulary.
+    ("src/squadops/capabilities/handlers/cycle/base.py", "failed"),
     ("src/squadops/capabilities/handlers/cycle/develop.py", "failed"),
-    ("src/squadops/capabilities/handlers/cycle/develop.py", "error"),
     # Same CheckOutcome.status vocabulary, evaluated executor-side for patch
     # verification (#389).
     ("src/squadops/cycles/patch_verification.py", "failed"),

--- a/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
+++ b/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
@@ -474,9 +474,7 @@ class TestWireShapeCriteria:
         )
         assert result.passed is False
         assert "acceptance:frontend manifest" in result.missing_components
-        acceptance_rows = [
-            c for c in result.checks if c.get("check", "").startswith("acceptance:")
-        ]
+        acceptance_rows = [c for c in result.checks if c.get("check", "").startswith("acceptance:")]
         assert len(acceptance_rows) == 1
         assert acceptance_rows[0]["status"] == "failed"
 
@@ -490,9 +488,7 @@ class TestWireShapeCriteria:
         assert result.passed is True
         prose_rows = [c for c in result.checks if c.get("check") == "acceptance_criteria_prose"]
         assert prose_rows == []
-        acceptance_rows = [
-            c for c in result.checks if c.get("check", "").startswith("acceptance:")
-        ]
+        acceptance_rows = [c for c in result.checks if c.get("check", "").startswith("acceptance:")]
         assert len(acceptance_rows) == 1
         assert acceptance_rows[0]["status"] == "passed"
 

--- a/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
+++ b/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
@@ -377,7 +377,8 @@ class TestM13Observability:
             severity="error",
             description="users endpoint",
         )
-        with caplog.at_level("DEBUG", logger="squadops.capabilities.handlers.cycle.develop"):
+        # Per-check log emits from the shared base seam (#419 hoist).
+        with caplog.at_level("DEBUG", logger="squadops.capabilities.handlers.cycle.base"):
             await h._validate_output(
                 _inputs([criterion], config={"stack": "fastapi"}),
                 [_art("main.py", _FASTAPI_ALL)],
@@ -398,7 +399,8 @@ class TestM13Observability:
             severity="error",
             description="users CRUD",
         )
-        with caplog.at_level("INFO", logger="squadops.capabilities.handlers.cycle.develop"):
+        # Per-check log emits from the shared base seam (#419 hoist).
+        with caplog.at_level("INFO", logger="squadops.capabilities.handlers.cycle.base"):
             await h._validate_output(
                 _inputs([criterion], config={"stack": "fastapi"}),
                 [_art("main.py", _FASTAPI_MISSING)],
@@ -443,6 +445,69 @@ class TestM13Observability:
             )
         summary_logs = [r for r in caplog.records if "typed_acceptance_summary" in r.getMessage()]
         assert len(summary_logs) == 0
+
+
+# ---------------------------------------------------------------------------
+# Wire-shape criteria (#420)
+# ---------------------------------------------------------------------------
+
+
+class TestWireShapeCriteria:
+    """Criteria arrive as plain dicts after distributed dispatch —
+    ``dataclasses.asdict`` flattens TypedCheck on ``TaskEnvelope.to_dict()``
+    and nothing agent-side rehydrates. Before #420 these rows were
+    misclassified as prose and M1.3 silently never ran in the field.
+    """
+
+    async def test_dict_criteria_are_evaluated_and_block(self):
+        h = DevelopmentDevelopHandler()
+        wire_row = {
+            "check": "regex_match",
+            "severity": "error",
+            "description": "frontend manifest",
+            "file": "frontend/package.json",
+            "pattern": "vite",
+        }
+        result = await h._validate_output(
+            _inputs([wire_row]),
+            [_art("main.py"), _art("package.json", '{"scripts": {"dev": "vite"}}')],
+        )
+        assert result.passed is False
+        assert "acceptance:frontend manifest" in result.missing_components
+        acceptance_rows = [
+            c for c in result.checks if c.get("check", "").startswith("acceptance:")
+        ]
+        assert len(acceptance_rows) == 1
+        assert acceptance_rows[0]["status"] == "failed"
+
+    async def test_dict_criteria_are_not_misfiled_as_prose(self):
+        h = DevelopmentDevelopHandler()
+        wire_row = {"check": "regex_match", "file": "main.py", "pattern": "def"}
+        result = await h._validate_output(
+            _inputs([wire_row]),
+            [_art("main.py", "def main():\n    return 0\n" + "#" * 180)],
+        )
+        assert result.passed is True
+        prose_rows = [c for c in result.checks if c.get("check") == "acceptance_criteria_prose"]
+        assert prose_rows == []
+        acceptance_rows = [
+            c for c in result.checks if c.get("check", "").startswith("acceptance:")
+        ]
+        assert len(acceptance_rows) == 1
+        assert acceptance_rows[0]["status"] == "passed"
+
+    async def test_unparseable_row_is_disclosed_not_blocking(self):
+        h = DevelopmentDevelopHandler()
+        result = await h._validate_output(
+            _inputs([{"severity": "error", "note": "no check key"}]),
+            [_art("main.py")],
+        )
+        assert result.passed is True
+        disclosed = [
+            c for c in result.checks if c.get("check") == "acceptance_criteria_unparseable"
+        ]
+        assert len(disclosed) == 1
+        assert disclosed[0]["evaluation"] == "unparseable_not_evaluated"
 
 
 class TestEvaluationIdentityFields:

--- a/tests/unit/capabilities/test_builder_assemble_handler.py
+++ b/tests/unit/capabilities/test_builder_assemble_handler.py
@@ -879,3 +879,146 @@ class TestBuilderFailureOutcomeClass:
         # Transient failures must NOT set outcome_class so the executor's
         # D5 retry-before-semantic-failure path activates.
         assert "outcome_class" not in result.outputs
+
+
+# ---------------------------------------------------------------------------
+# Issue #419: typed acceptance criteria at the builder seam (SIP-0092 M1.3)
+# ---------------------------------------------------------------------------
+
+LLM_BARE_PATH_FRONTEND = (
+    # The cyc_815d769b7a3a field shape: frontend files emitted at bare paths
+    # while the task contract addresses frontend/-prefixed paths.
+    "```json:package.json\n"
+    '{"name": "app", "scripts": {"dev": "vite", "build": "vite build"}}\n'
+    "```\n\n"
+    "```python:my_app/__main__.py\n"
+    "pass\n"
+    "```\n\n"
+    "```dockerfile:Dockerfile\n"
+    "FROM python:3.11-slim\n"
+    "```\n\n"
+    "```text:requirements.txt\n"
+    "# none\n"
+    "```\n\n"
+    "```markdown:qa_handoff.md\n"
+    "## How to Run\nrun it\n\n"
+    "## How to Test\ntest it\n\n"
+    "## Expected Behavior\nworks\n"
+    "```\n"
+)
+
+# Wire-shape criterion (#420): dicts, exactly as a dispatched envelope
+# delivers them — never TypedCheck instances.
+_FRONTEND_MANIFEST_CRITERION = {
+    "check": "regex_match",
+    "severity": "error",
+    "description": "frontend package manifest",
+    "file": "frontend/package.json",
+    "pattern": "vite",
+}
+
+
+class TestTypedAcceptance:
+    """#419: builder.assemble evaluates the plan's typed contract — a
+    path-contract violation fails HERE, repairable, instead of surfacing
+    downstream as an unfixable qa.test failure."""
+
+    def _with_response(self, mock_context, content: str):
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=content),
+        )
+
+    async def test_bare_path_emission_fails_the_contract(self, mock_context, builder_inputs):
+        from squadops.cycles.task_outcome import FailureClassification, TaskOutcome
+
+        self._with_response(mock_context, LLM_BARE_PATH_FRONTEND)
+        builder_inputs["acceptance_criteria"] = [_FRONTEND_MANIFEST_CRITERION]
+        builder_inputs["subtask_index"] = 5
+
+        result = await BuilderAssembleHandler().handle(mock_context, builder_inputs)
+
+        assert result.success is False
+        assert "Typed acceptance criteria not met" in result.error
+        assert "acceptance:frontend package manifest" in result.error
+        assert result.outputs["outcome_class"] == TaskOutcome.SEMANTIC_FAILURE
+        assert result.outputs["failure_classification"] == FailureClassification.WORK_PRODUCT
+
+        checks = result.outputs["validation_result"]["checks"]
+        row = next(c for c in checks if c["check"] == "acceptance:regex_match")
+        assert row["status"] == "failed"
+        assert row["reason"] == "file_not_found"
+        assert row["task_index"] == 5
+
+    async def test_failure_outputs_carry_artifacts_for_patch_overlay(
+        self, mock_context, builder_inputs
+    ):
+        """#413: patch verification overlays repairs onto the failed task's
+        artifacts; a builder failure without them would force every repair
+        to re-emit the full set."""
+        self._with_response(mock_context, LLM_BARE_PATH_FRONTEND)
+        builder_inputs["acceptance_criteria"] = [_FRONTEND_MANIFEST_CRITERION]
+
+        result = await BuilderAssembleHandler().handle(mock_context, builder_inputs)
+
+        assert result.success is False
+        names = [a["name"] for a in result.outputs["artifacts"]]
+        assert "package.json" in names
+        assert "Dockerfile" in names
+
+    async def test_correctly_pathed_emission_passes(self, mock_context, builder_inputs):
+        fixed = LLM_BARE_PATH_FRONTEND.replace(
+            "```json:package.json\n", "```json:frontend/package.json\n"
+        )
+        self._with_response(mock_context, fixed)
+        builder_inputs["acceptance_criteria"] = [_FRONTEND_MANIFEST_CRITERION]
+        builder_inputs["subtask_index"] = 5
+
+        result = await BuilderAssembleHandler().handle(mock_context, builder_inputs)
+
+        assert result.success is True
+        checks = result.outputs["validation_result"]["checks"]
+        row = next(c for c in checks if c["check"] == "acceptance:regex_match")
+        assert row["status"] == "passed"
+        assert row["passed"] is True
+        # Issue #114: evaluation evidence artifact rides the outputs.
+        names = [a["name"] for a in result.outputs["artifacts"]]
+        assert "typed_check_evaluation_task_5.json" in names
+
+    async def test_warning_severity_failure_is_disclosed_not_blocking(
+        self, mock_context, builder_inputs
+    ):
+        self._with_response(mock_context, LLM_BARE_PATH_FRONTEND)
+        builder_inputs["acceptance_criteria"] = [
+            {**_FRONTEND_MANIFEST_CRITERION, "severity": "warning"}
+        ]
+
+        result = await BuilderAssembleHandler().handle(mock_context, builder_inputs)
+
+        assert result.success is True
+        checks = result.outputs["validation_result"]["checks"]
+        row = next(c for c in checks if c["check"] == "acceptance:regex_match")
+        assert row["status"] == "failed"  # disclosed in evidence
+        assert row["passed"] is True  # but never blocks (RC-9)
+
+    async def test_typed_acceptance_config_gate_skips(self, mock_context, builder_inputs):
+        self._with_response(mock_context, LLM_BARE_PATH_FRONTEND)
+        builder_inputs["acceptance_criteria"] = [_FRONTEND_MANIFEST_CRITERION]
+        builder_inputs["resolved_config"]["typed_acceptance"] = False
+
+        result = await BuilderAssembleHandler().handle(mock_context, builder_inputs)
+
+        assert result.success is True
+        checks = result.outputs["validation_result"]["checks"]
+        row = next(c for c in checks if c["check"] == "acceptance:regex_match")
+        assert row["status"] == "skipped"
+
+    async def test_no_criteria_keeps_legacy_behavior(self, mock_context, builder_inputs):
+        # Cycles without a plan contract: exactly one required_files row,
+        # no acceptance rows, no #114 artifact.
+        result = await BuilderAssembleHandler().handle(mock_context, builder_inputs)
+
+        assert result.success is True
+        checks = result.outputs["validation_result"]["checks"]
+        assert [c["check"] for c in checks] == ["required_files"]
+        names = [a["name"] for a in result.outputs["artifacts"]]
+        assert not any(n.startswith("typed_check_evaluation") for n in names)

--- a/tests/unit/cycles/test_acceptance_evaluation.py
+++ b/tests/unit/cycles/test_acceptance_evaluation.py
@@ -1,0 +1,177 @@
+"""Shared typed-acceptance evaluation seam (#419/#420).
+
+``split_acceptance_criteria`` owns wire-shape coercion: ``TaskEnvelope.to_dict()``
+flattens ``TypedCheck`` to plain dicts (``dataclasses.asdict``) and the agent
+side never rehydrates, so any consumer filtering on ``isinstance(TypedCheck)``
+loses its typed contract after dispatch — the #420 silent-skip defect. The
+round-trip test here is the regression pin for that bug.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from squadops.cycles.acceptance_evaluation import (
+    evaluate_criterion,
+    split_acceptance_criteria,
+)
+from squadops.cycles.implementation_plan import TypedCheck
+from squadops.tasks.models import TaskEnvelope
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+def _envelope(criteria: list) -> TaskEnvelope:
+    return TaskEnvelope(
+        task_id="t1",
+        agent_id="a1",
+        cycle_id="c1",
+        pulse_id="p1",
+        project_id="pr1",
+        task_type="builder.assemble",
+        correlation_id="x",
+        causation_id="y",
+        trace_id="z",
+        span_id="s",
+        inputs={"acceptance_criteria": criteria},
+    )
+
+
+class TestWireShapeCoercion:
+    """The #420 regression: criteria must survive the A2A JSON round-trip."""
+
+    def test_envelope_round_trip_recovers_typed_checks(self):
+        criterion = TypedCheck(
+            check="regex_match",
+            params={"file": "frontend/package.json", "pattern": "vite"},
+            severity="error",
+            description="frontend manifest",
+        )
+        wire = json.loads(json.dumps(_envelope([criterion, "prose note"]).to_dict()))
+        back = TaskEnvelope.from_dict(wire)
+
+        # The wire shape is dicts — the exact input the handlers receive.
+        raw = back.inputs["acceptance_criteria"]
+        assert [type(c).__name__ for c in raw] == ["dict", "str"]
+
+        split = split_acceptance_criteria(raw)
+        assert len(split.typed) == 1
+        recovered = split.typed[0]
+        assert recovered.check == "regex_match"
+        assert recovered.params == {"file": "frontend/package.json", "pattern": "vite"}
+        assert recovered.severity == "error"
+        assert split.prose == ("prose note",)
+        assert split.unparseable == ()
+
+    def test_round_trip_preserves_fingerprint(self):
+        # RC-9b error counters key on fingerprint; a round-tripped criterion
+        # must share the counter of its in-process original.
+        criterion = TypedCheck(
+            check="count_at_least", params={"glob": "tests/test_*.py", "min_count": 3}
+        )
+        wire = json.loads(json.dumps(_envelope([criterion]).to_dict()))
+        split = split_acceptance_criteria(
+            TaskEnvelope.from_dict(wire).inputs["acceptance_criteria"]
+        )
+        assert split.typed[0].fingerprint() == criterion.fingerprint()
+
+
+class TestSplitPartitioning:
+    def test_typed_instances_pass_through(self):
+        criterion = TypedCheck(check="regex_match", params={"file": "a.py", "pattern": "x"})
+        split = split_acceptance_criteria([criterion])
+        assert split.typed == (criterion,)
+        assert split.prose == ()
+        assert split.unparseable == ()
+
+    def test_dict_missing_check_key_is_unparseable(self):
+        row = {"severity": "error", "file": "a.py"}
+        split = split_acceptance_criteria([row])
+        assert split.typed == ()
+        assert split.unparseable == (row,)
+
+    def test_unknown_check_name_is_unparseable(self):
+        row = {"check": "no_such_check", "file": "a.py"}
+        split = split_acceptance_criteria([row])
+        assert split.typed == ()
+        assert split.unparseable == (row,)
+
+    def test_non_string_non_mapping_is_unparseable(self):
+        split = split_acceptance_criteria([42])
+        assert split.unparseable == (42,)
+
+    @pytest.mark.parametrize("criteria", [None, [], ()])
+    def test_empty_inputs_yield_empty_split(self, criteria):
+        split = split_acceptance_criteria(criteria)
+        assert split == split_acceptance_criteria([])
+        assert split.typed == () and split.prose == () and split.unparseable == ()
+
+
+class TestEvaluateCriterionGates:
+    async def test_typed_acceptance_disabled_skips(self, tmp_path):
+        criterion = TypedCheck(check="regex_match", params={"file": "a.py", "pattern": "x"})
+        outcome = await evaluate_criterion(
+            criterion,
+            tmp_path,
+            stack=None,
+            typed_acceptance_enabled=False,
+            command_acceptance_enabled=True,
+        )
+        assert outcome.status == "skipped"
+        assert outcome.reason == "typed_acceptance_disabled"
+
+    async def test_command_gate_skips_only_command_check(self, tmp_path):
+        (tmp_path / "a.py").write_text("x = 1\n")
+        command = TypedCheck(check="command_exit_zero", params={"argv": ["true"]})
+        regex = TypedCheck(check="regex_match", params={"file": "a.py", "pattern": "x"})
+
+        cmd_outcome = await evaluate_criterion(
+            command,
+            tmp_path,
+            stack=None,
+            typed_acceptance_enabled=True,
+            command_acceptance_enabled=False,
+        )
+        regex_outcome = await evaluate_criterion(
+            regex,
+            tmp_path,
+            stack=None,
+            typed_acceptance_enabled=True,
+            command_acceptance_enabled=False,
+        )
+        assert cmd_outcome.status == "skipped"
+        assert cmd_outcome.reason == "command_acceptance_checks_disabled"
+        assert regex_outcome.status == "passed"
+
+    async def test_unregistered_check_is_evaluator_error(self, tmp_path):
+        # Constructed directly, bypassing the parser's vocabulary gate —
+        # models a registry/spec drift, which must not crash the cycle.
+        bogus = TypedCheck(check="not_registered", params={})
+        outcome = await evaluate_criterion(
+            bogus,
+            tmp_path,
+            stack=None,
+            typed_acceptance_enabled=True,
+            command_acceptance_enabled=True,
+        )
+        assert outcome.status == "error"
+        assert outcome.reason == "no_evaluator_registered"
+
+    async def test_missing_file_fails_with_file_not_found(self, tmp_path):
+        # The #419 field shape: criterion addresses frontend/package.json,
+        # the workspace has only a bare-path package.json.
+        (tmp_path / "package.json").write_text('{"scripts": {"build": "vite build"}}')
+        criterion = TypedCheck(
+            check="regex_match", params={"file": "frontend/package.json", "pattern": "vite"}
+        )
+        outcome = await evaluate_criterion(
+            criterion,
+            tmp_path,
+            stack=None,
+            typed_acceptance_enabled=True,
+            command_acceptance_enabled=True,
+        )
+        assert outcome.status == "failed"
+        assert outcome.reason == "file_not_found"


### PR DESCRIPTION
## Summary

The post-#413 validation cycle (`cyc_815d769b7a3a`) shipped a green builder task whose files violated the plan's path contract — nothing evaluated the typed acceptance criteria at the builder seam, and the correction loop burned its budget chasing downstream symptoms (#419). Tracing the fix surfaced a second, wider defect: **typed acceptance was silently inert on the distributed dispatch path for every handler** — `TaskEnvelope.to_dict()` flattens `TypedCheck` to plain dicts via `dataclasses.asdict()`, nothing agent-side rehydrates them, and `develop.py`'s `isinstance(TypedCheck)` filter misfiled the wire rows as prose (#420). M1.3 only ever ran in unit tests, which pass dataclass instances in-memory.

Per review direction on #419: this is a hoist, not a copy-paste — one seam, every role handler.

## Changes

**New shared seam — `squadops/cycles/acceptance_evaluation.py`**
- `split_acceptance_criteria()` partitions mixed criteria into typed / prose / unparseable, coercing wire-shape dict rows back into `TypedCheck` — including the `asdict()` nested-`params` shape the flat-YAML parser alone rejects (#420).
- `evaluate_criterion()` consolidates the config-gated evaluator dispatch previously duplicated between `develop.py` and `patch_verification.py`.

**Hoist — `_CycleTaskHandler` base**
- `_evaluate_typed_acceptance` (RC-9 blocking matrix, RC-9a wording, RC-9b 2-strikes escalation) moves from `DevelopmentDevelopHandler` to the shared base. Any cycle handler whose plan task carries typed criteria now enforces them identically; dev behavior is unchanged except that wire-shape criteria are now actually evaluated.
- Unparseable rows are disclosed in evidence (`acceptance_criteria_unparseable`) instead of misfiled as prose; non-blocking, since the parser enforces vocabulary at authoring time.

**Builder integration — `builder.assemble`**
- Evaluates the task's typed contract against the classified artifact set. The #107 basename seam is untouched; typed checks address full paths in a materialized workspace, so the `cyc_815d769b7a3a` bare-path emission now fails at 03:21 with `frontend/package.json: file_not_found` instead of stalling qa.test hours later.
- Acceptance rows land in `validation_result.checks` (SIP-0096 roll-up), the #114 `typed_check_evaluation` artifact is emitted, and failures carry the emitted artifacts so #413 patch verification overlays repairs against the real set — completing the one-round self-heal loop for builder path-fidelity defects.

**Consolidation**
- `patch_verification.py` drops its private `_coerce_typed_criteria` internals and `_evaluate_criterion` in favor of the shared seam (its UNVERIFIABLE-on-unparseable contract is preserved), and gains asdict-shape tolerance it also lacked.

## Tests

- Wire round-trip regression pin: envelope → JSON → `split_acceptance_criteria` recovers the typed contract (params, severity, fingerprint).
- Field-scenario regression: builder emits bare-path frontend files against a `frontend/`-prefixed contract → blocks at the seam with the acceptance row, SEMANTIC_FAILURE/WORK_PRODUCT, artifacts riding the failure.
- RC-9 matrix at the builder seam: warning-severity disclosed-not-blocking, config gates, legacy no-criteria path unchanged.
- Enum-shadow allowlist entries moved with the hoisted code (stale `"error"` literals dropped).
- Full regression suite: 4833 passed, 1 skipped.

## 1.4 evidence arc

Slotted into `docs/plans/1-4-evidence-arc-plan.md` as a Phase-2-shaped conformance item. Live `lite` cycle validation (per the arc's live-validation rule) still pending — needs agent + runtime-api image rebuild first.

Closes #419
Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)
