### PR TITLE
fix(#422): command-safelist lint at the plan-authoring boundary + manifest retry runway

### DIFF
--- a/src/squadops/capabilities/handlers/_plan_authoring_service.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring_service.py
@@ -378,7 +378,7 @@ def _validate_manifest_candidate(
         )
 
     try:
-        manifest = ImplementationPlan.from_yaml(yaml_content)
+        manifest = ImplementationPlan.from_yaml(yaml_content, enforce_command_safelist=True)
     except ValueError as exc:
         return None, (
             f"The previous plan YAML failed validation: {exc}. "

--- a/src/squadops/capabilities/handlers/cycle/governance.py
+++ b/src/squadops/capabilities/handlers/cycle/governance.py
@@ -264,7 +264,11 @@ class GovernanceReviewHandler(_CycleTaskHandler):
             handler_name=self._handler_name,
         )
 
-        # Structural validation
+        # Structural validation. enforce_command_safelist stays OFF here (#422):
+        # this path has no corrective-retry loop, so a safelist rejection would
+        # silently downgrade to static task steps (#424) instead of feeding the
+        # error back — strictly worse than letting the check fail closed at
+        # evaluation time. Revisit with #424's fail-fast design.
         try:
             manifest = ImplementationPlan.from_yaml(yaml_content)
         except ValueError as exc:

--- a/src/squadops/contracts/cycle_request_profiles/profiles/validated-fullstack.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/validated-fullstack.yaml
@@ -41,6 +41,12 @@ defaults:
   # SIP-0092 M1 instrumentation (typed + command acceptance).
   typed_acceptance: true
   command_acceptance_checks: true
+  # Plan-authoring retry runway. The default (2) is too tight for a merger
+  # converging through validation feedback — cyc_7d2f505e5e8f exhausted both
+  # attempts and silently fell back to static (untyped) task steps, voiding
+  # this profile's instrumentation promise (#424). The #422 safelist lint adds
+  # one more constraint to converge on, so give the loop room.
+  manifest_max_attempts: 4
   # SIP-0096 §6.3 throttle: the fullstack build/test spine this profile REQUIRES.
   # A run that doesn't execute one — e.g. frontend_build skipped because Node is
   # absent (#306) — is blocked_unverified instead of reading green (the D13

--- a/src/squadops/contracts/cycle_request_profiles/schema.py
+++ b/src/squadops/contracts/cycle_request_profiles/schema.py
@@ -35,6 +35,9 @@ _APPLIED_DEFAULTS_EXTRA_KEYS = {
     "implementation_plan",
     "max_build_subtasks",
     "min_build_subtasks",
+    # Plan-authoring retry runway for the merge/manifest loop (#424); read by
+    # _plan_authoring_service via resolved_config (default 2).
+    "manifest_max_attempts",
     "output_validation",
     "max_self_eval_passes",
     "min_artifact_count",

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -25,6 +25,7 @@ PlanTask, etc.).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 
@@ -63,6 +64,9 @@ class CheckSpec:
             proposer vocabulary so models see the exact flat-YAML shape. Kept in
             sync with the spec by test (must include every required param and
             only allowed params, with correct types).
+        notes: Free-text constraint rendered into the proposer vocabulary as a
+            ``- Note:`` line. For constraints the param schema alone can't
+            express (e.g. the command safelist).
     """
 
     name: str
@@ -73,10 +77,83 @@ class CheckSpec:
     requires_stack_context: bool = False
     path_params: frozenset[str] = frozenset()
     example: dict[str, object] = field(default_factory=dict)
+    notes: str = ""
 
 
 # Allowed severity values. Anything else → ValueError at parse time.
 ALLOWED_SEVERITIES: frozenset[str] = frozenset({"error", "warning", "info"})
+
+
+# ---------------------------------------------------------------------------
+# Command safelist (RC-10a) — single source for the ``command_exit_zero``
+# argv contract. Consumed by the runtime evaluator (``acceptance_checks.py``),
+# the authoring-time lint (``implementation_plan.py``, #422), and the proposer
+# vocabulary below, so the three surfaces cannot drift.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CommandPattern:
+    name: str
+    matcher: Callable[[list[str]], bool]
+
+
+def _exact(*expected: str) -> Callable[[list[str]], bool]:
+    expected_list = list(expected)
+
+    def matcher(argv: list[str]) -> bool:
+        return list(argv) == expected_list
+
+    return matcher
+
+
+def _exact_then_one_path(*prefix: str) -> Callable[[list[str]], bool]:
+    prefix_list = list(prefix)
+
+    def matcher(argv: list[str]) -> bool:
+        return len(argv) == len(prefix_list) + 1 and list(argv[: len(prefix_list)]) == prefix_list
+
+    return matcher
+
+
+def _prefix_with_args(*prefix: str) -> Callable[[list[str]], bool]:
+    prefix_list = list(prefix)
+
+    def matcher(argv: list[str]) -> bool:
+        return len(argv) > len(prefix_list) and list(argv[: len(prefix_list)]) == prefix_list
+
+    return matcher
+
+
+def _argv0_with_args(name: str) -> Callable[[list[str]], bool]:
+    def matcher(argv: list[str]) -> bool:
+        return len(argv) >= 1 and argv[0] == name
+
+    return matcher
+
+
+# Order matters only for human readability; the matcher is `any(...)`.
+COMMAND_SAFELIST: tuple[CommandPattern, ...] = (
+    CommandPattern(
+        "python -m py_compile <file>", _exact_then_one_path("python", "-m", "py_compile")
+    ),
+    CommandPattern("python -m mypy <args...>", _prefix_with_args("python", "-m", "mypy")),
+    CommandPattern("node --check <file>", _exact_then_one_path("node", "--check")),
+    CommandPattern("ruff check <args...>", _prefix_with_args("ruff", "check")),
+    CommandPattern("tsc --noEmit", _exact("tsc", "--noEmit")),
+    CommandPattern("eslint <args...>", _argv0_with_args("eslint")),
+    CommandPattern("pyflakes <file>", _exact_then_one_path("pyflakes")),
+)
+
+
+def argv_matches_safelist(argv: list[str]) -> bool:
+    """True when argv matches one of the safelisted command forms."""
+    return any(pat.matcher(argv) for pat in COMMAND_SAFELIST)
+
+
+def command_safelist_names() -> tuple[str, ...]:
+    """Human-readable safelisted command forms, for error messages and prompts."""
+    return tuple(pat.name for pat in COMMAND_SAFELIST)
 
 
 # Rev 1 vocabulary. Each entry's evaluator implementation lands in M1.2;
@@ -141,11 +218,16 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         param_types={"argv": list, "cwd": str, "timeout_s": int},
         supported_stacks=frozenset(),
         requires_stack_context=False,
-        # argv elements are not single paths; the M1.2 safelist (RC-10a)
+        # argv elements are not single paths; the RC-10a safelist above
         # validates argv shapes pattern-by-pattern. cwd is path-checked at
         # evaluation time, not here.
         path_params=frozenset(),
         example={"argv": ["python", "-m", "py_compile", "app/main.py"]},
+        notes=(
+            "argv MUST match one of these safelisted forms (anything else — "
+            "pytest, npm, make, pip, setup.py, ... — cannot execute and fails "
+            "plan validation): " + "; ".join(f"`{p.name}`" for p in COMMAND_SAFELIST)
+        ),
     ),
 }
 
@@ -226,6 +308,8 @@ def render_typed_acceptance_vocabulary() -> str:
                 f"`{p}` ({_type_label(spec, p)})" for p in sorted(spec.optional_params)
             )
             out.append(f"- Optional: {optional}")
+        if spec.notes:
+            out.append(f"- Note: {spec.notes}")
         out.append("- Example:")
         out.append("  ```yaml")
         out.append(f"  - check: {name}")

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -26,7 +26,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from squadops.cycles.acceptance_check_spec import CHECK_SPECS, CheckSpec
+from squadops.cycles.acceptance_check_spec import (
+    CHECK_SPECS,
+    CheckSpec,
+    argv_matches_safelist,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -139,69 +143,6 @@ def _restricted_env() -> dict[str, str]:
 
     keep = {"PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TZ"}
     return {k: v for k, v in os.environ.items() if k in keep}
-
-
-# ---------------------------------------------------------------------------
-# Command safelist (RC-10a)
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class _CommandPattern:
-    name: str
-    matcher: Callable[[list[str]], bool]
-
-
-def _exact(*expected: str) -> Callable[[list[str]], bool]:
-    expected_list = list(expected)
-
-    def matcher(argv: list[str]) -> bool:
-        return list(argv) == expected_list
-
-    return matcher
-
-
-def _exact_then_one_path(*prefix: str) -> Callable[[list[str]], bool]:
-    prefix_list = list(prefix)
-
-    def matcher(argv: list[str]) -> bool:
-        return len(argv) == len(prefix_list) + 1 and list(argv[: len(prefix_list)]) == prefix_list
-
-    return matcher
-
-
-def _prefix_with_args(*prefix: str) -> Callable[[list[str]], bool]:
-    prefix_list = list(prefix)
-
-    def matcher(argv: list[str]) -> bool:
-        return len(argv) > len(prefix_list) and list(argv[: len(prefix_list)]) == prefix_list
-
-    return matcher
-
-
-def _argv0_with_args(name: str) -> Callable[[list[str]], bool]:
-    def matcher(argv: list[str]) -> bool:
-        return len(argv) >= 1 and argv[0] == name
-
-    return matcher
-
-
-# Order matters only for human readability; the matcher is `any(...)`.
-_COMMAND_SAFELIST: tuple[_CommandPattern, ...] = (
-    _CommandPattern(
-        "python -m py_compile <file>", _exact_then_one_path("python", "-m", "py_compile")
-    ),
-    _CommandPattern("python -m mypy <args...>", _prefix_with_args("python", "-m", "mypy")),
-    _CommandPattern("node --check <file>", _exact_then_one_path("node", "--check")),
-    _CommandPattern("ruff check <args...>", _prefix_with_args("ruff", "check")),
-    _CommandPattern("tsc --noEmit", _exact("tsc", "--noEmit")),
-    _CommandPattern("eslint <args...>", _argv0_with_args("eslint")),
-    _CommandPattern("pyflakes <file>", _exact_then_one_path("pyflakes")),
-)
-
-
-def _argv_matches_safelist(argv: list[str]) -> bool:
-    return any(pat.matcher(argv) for pat in _COMMAND_SAFELIST)
 
 
 # ---------------------------------------------------------------------------
@@ -624,7 +565,7 @@ class CommandExitZeroCheck(BaseCheck):
             return CheckOutcome.error(reason="command_must_be_argv")
         if not argv:
             return CheckOutcome.error(reason="command_must_be_argv")
-        if not _argv_matches_safelist(argv):
+        if not argv_matches_safelist(argv):
             return CheckOutcome.error(reason="command_not_in_safelist", argv=argv)
 
         timeout_s = int(params.get("timeout_s", DEFAULT_COMMAND_TIMEOUT_S))

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -25,6 +25,8 @@ import yaml
 from squadops.cycles.acceptance_check_spec import (
     ALLOWED_SEVERITIES,
     CHECK_SPECS,
+    argv_matches_safelist,
+    command_safelist_names,
     reserved_keys_for,
 )
 
@@ -140,7 +142,9 @@ class ImplementationPlan:
     summary: PlanSummary
 
     @classmethod
-    def from_yaml(cls, content: str) -> ImplementationPlan:
+    def from_yaml(
+        cls, content: str, *, enforce_command_safelist: bool = False
+    ) -> ImplementationPlan:
         """Parse and validate a plan from YAML string.
 
         Performs structural validation: required fields, known task types,
@@ -148,6 +152,15 @@ class ImplementationPlan:
 
         Policy validation (min/max subtask counts) is NOT performed here —
         that belongs in the handler/executor using resolved config.
+
+        Args:
+            content: The plan YAML document.
+            enforce_command_safelist: When true, reject ``command_exit_zero``
+                criteria whose argv is outside the RC-10a execution safelist
+                (#422). Authoring-boundary only — leave false when re-parsing
+                already-approved plans, so pre-lint plans stay loadable and
+                out-of-safelist commands keep failing closed at evaluation
+                time instead of being demoted to unparseable.
 
         Raises:
             ValueError: If the YAML is malformed or structurally invalid.
@@ -199,7 +212,11 @@ class ImplementationPlan:
             raw_criteria = td.get("acceptance_criteria", [])
             if not isinstance(raw_criteria, list):
                 raise ValueError(f"Task {task_index}: acceptance_criteria must be a list")
-            criteria = _parse_acceptance_criteria(raw_criteria, task_index)
+            criteria = _parse_acceptance_criteria(
+                raw_criteria,
+                task_index,
+                enforce_command_safelist=enforce_command_safelist,
+            )
 
             tasks.append(
                 PlanTask(
@@ -324,7 +341,12 @@ def _serialize_acceptance_criterion(c: str | TypedCheck) -> str | dict:
     return flat
 
 
-def _parse_acceptance_criteria(raw: list, task_index: int) -> list[str | TypedCheck]:
+def _parse_acceptance_criteria(
+    raw: list,
+    task_index: int,
+    *,
+    enforce_command_safelist: bool = False,
+) -> list[str | TypedCheck]:
     """Parse a mixed acceptance_criteria list per SIP-0092 M1.
 
     Accepts:
@@ -341,6 +363,11 @@ def _parse_acceptance_criteria(raw: list, task_index: int) -> list[str | TypedCh
         - Path-typed param value containing absolute path or '..' traversal
           (cheap pre-eval rejection; full chrooting still applies at
           evaluation time per RC-10).
+        - When ``enforce_command_safelist`` is set (authoring boundary only,
+          #422): ``command_exit_zero`` argv outside the RC-10a execution
+          safelist, or with non-string items. Such a command can never
+          execute, so accepting it authors a run that is guaranteed to die
+          at evaluation.
 
     Returns:
         Mixed list of str and TypedCheck instances, preserving authored order.
@@ -439,6 +466,22 @@ def _parse_acceptance_criteria(raw: list, task_index: int) -> list[str | TypedCh
         for path_key in spec.path_params:
             if path_key in params:
                 _reject_unsafe_path(params[path_key], path_key, task_index, j, check_name)
+
+        # Authoring-time command-safelist lint (#422)
+        if enforce_command_safelist and check_name == "command_exit_zero":
+            argv = params["argv"]
+            if not all(isinstance(a, str) for a in argv):
+                raise ValueError(
+                    f"Task {task_index}.acceptance_criteria[{j}] "
+                    f"(command_exit_zero): every argv item must be a string"
+                )
+            if not argv_matches_safelist(argv):
+                raise ValueError(
+                    f"Task {task_index}.acceptance_criteria[{j}] "
+                    f"(command_exit_zero): command {argv!r} is not in the "
+                    f"execution safelist and can never run. Use one of: "
+                    f"{'; '.join(command_safelist_names())}"
+                )
 
         parsed.append(
             TypedCheck(

--- a/tests/unit/capabilities/test_plan_authoring_service.py
+++ b/tests/unit/capabilities/test_plan_authoring_service.py
@@ -484,3 +484,58 @@ async def test_produce_plan_filters_builder_assemble_by_squad_capability():
     )
     builder_render = str(ctx_builder.ports.request_renderer.render.call_args)
     assert "builder.assemble" in builder_render
+
+
+# ---------------------------------------------------------------------------
+# Command-safelist enforcement at the authoring boundary (#422)
+# ---------------------------------------------------------------------------
+
+_SAFELIST_PLAN_TEMPLATE = """\
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+tasks:
+  - task_index: 0
+    task_type: development.develop
+    role: dev
+    focus: "Backend"
+    description: "Build the backend"
+    expected_artifacts:
+      - "backend/main.py"
+    acceptance_criteria:
+      - check: command_exit_zero
+        description: "command check"
+        argv: {argv}
+    depends_on: []
+summary:
+  total_tasks: 1
+"""
+
+
+def test_validate_manifest_candidate_feeds_safelist_error_back():
+    """A merger-authored plan with an unrunnable command must produce
+    corrective error_msg (retry feedback), not a valid manifest — the live
+    failure was cyc_bc325a67417d dying at evaluation on `npm test`."""
+    from squadops.capabilities.handlers._plan_authoring_service import (
+        _validate_manifest_candidate,
+    )
+
+    yaml_content = _SAFELIST_PLAN_TEMPLATE.format(argv='["npm", "test"]')
+    manifest, error_msg = _validate_manifest_candidate(yaml_content, 1, 15, ["dev"])
+    assert manifest is None
+    assert "safelist" in error_msg
+    assert "py_compile" in error_msg  # feedback must teach an allowed form
+
+
+def test_validate_manifest_candidate_accepts_safelisted_command():
+    from squadops.capabilities.handlers._plan_authoring_service import (
+        _validate_manifest_candidate,
+    )
+
+    yaml_content = _SAFELIST_PLAN_TEMPLATE.format(
+        argv='["python", "-m", "py_compile", "backend/main.py"]'
+    )
+    manifest, error_msg = _validate_manifest_candidate(yaml_content, 1, 15, ["dev"])
+    assert error_msg is None
+    assert manifest is not None

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -14,10 +14,9 @@ from pathlib import Path
 
 import pytest
 
-from squadops.cycles.acceptance_check_spec import CHECK_SPECS
+from squadops.cycles.acceptance_check_spec import CHECK_SPECS, argv_matches_safelist
 from squadops.cycles.acceptance_checks import (
     _CHECK_IMPLS,
-    _argv_matches_safelist,
     _safe_resolve,
     assert_registry_complete,
     get_check,
@@ -563,7 +562,7 @@ class TestCommandExitZero:
     ],
 )
 def test_argv_matches_safelist(argv, expected):
-    assert _argv_matches_safelist(argv) is expected
+    assert argv_matches_safelist(argv) is expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cycles/test_acceptance_evaluation.py
+++ b/tests/unit/cycles/test_acceptance_evaluation.py
@@ -175,3 +175,20 @@ class TestEvaluateCriterionGates:
         )
         assert outcome.status == "failed"
         assert outcome.reason == "file_not_found"
+
+
+def test_split_keeps_non_safelisted_command_rows_typed():
+    """The #422 authoring lint must NOT leak into wire coercion: a dispatched
+    plan may legally carry an out-of-safelist command (pre-lint plan, static
+    fallback). Demoting it to unparseable here would fail OPEN — the row must
+    stay typed so evaluation fails CLOSED with command_not_in_safelist."""
+    wire_row = {
+        "check": "command_exit_zero",
+        "severity": "error",
+        "description": "runs tests",
+        "params": {"argv": ["npm", "test"]},
+    }
+    result = split_acceptance_criteria([wire_row])
+    assert len(result.typed) == 1
+    assert result.typed[0].params["argv"] == ["npm", "test"]
+    assert not result.unparseable

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -570,3 +570,104 @@ class TestPlannerBuildTaskTypes:
         result.add("bogus.capability")
         assert "bogus.capability" not in planner_build_task_types(has_builder=True)
         assert "bogus.capability" not in planner_build_task_types(has_builder=False)
+
+
+# ---------------------------------------------------------------------------
+# Command-safelist authoring lint (#422)
+# ---------------------------------------------------------------------------
+
+
+def _plan_yaml_with_command(argv_yaml: str) -> str:
+    return f"""\
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+tasks:
+  - task_index: 0
+    task_type: development.develop
+    role: dev
+    focus: "Backend"
+    description: "Build the backend"
+    expected_artifacts:
+      - "backend/main.py"
+    acceptance_criteria:
+      - check: command_exit_zero
+        description: "command check"
+        argv: {argv_yaml}
+    depends_on: []
+summary:
+  total_tasks: 1
+"""
+
+
+class TestCommandSafelistLint:
+    """Authoring-boundary rejection of commands the evaluator can never run.
+
+    Live failure this pins: cycle cyc_bc325a67417d authored `npm test` /
+    `pytest --cov` / `make build` acceptance commands that passed plan
+    validation, then deterministically died at evaluation with
+    command_not_in_safelist after the correction budget was spent.
+    """
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            '["npm", "test"]',
+            '["pytest", "--cov=backend"]',
+            '["make", "build"]',
+            '["python", "setup.py", "install"]',
+            '["python", "-m", "pytest", "tests/"]',
+        ],
+    )
+    def test_authoring_rejects_non_safelisted_command(self, argv):
+        with pytest.raises(ValueError, match=r"Task 0\.acceptance_criteria\[0\].*safelist"):
+            ImplementationPlan.from_yaml(
+                _plan_yaml_with_command(argv), enforce_command_safelist=True
+            )
+
+    def test_rejection_message_teaches_allowed_forms(self):
+        """The ValueError text becomes the merger's corrective feedback —
+        it must name concrete allowed forms, not just say 'no'."""
+        with pytest.raises(ValueError, match=r"python -m py_compile <file>"):
+            ImplementationPlan.from_yaml(
+                _plan_yaml_with_command('["npm", "test"]'), enforce_command_safelist=True
+            )
+
+    @pytest.mark.parametrize(
+        "argv,parsed_argv",
+        [
+            (
+                '["python", "-m", "py_compile", "backend/main.py"]',
+                ["python", "-m", "py_compile", "backend/main.py"],
+            ),
+            ('["python", "-m", "mypy", "src/"]', ["python", "-m", "mypy", "src/"]),
+            ('["node", "--check", "app.js"]', ["node", "--check", "app.js"]),
+            ('["ruff", "check", "."]', ["ruff", "check", "."]),
+            ('["tsc", "--noEmit"]', ["tsc", "--noEmit"]),
+            ('["eslint", "src/"]', ["eslint", "src/"]),
+            ('["pyflakes", "main.py"]', ["pyflakes", "main.py"]),
+        ],
+    )
+    def test_authoring_accepts_every_safelisted_form(self, argv, parsed_argv):
+        plan = ImplementationPlan.from_yaml(
+            _plan_yaml_with_command(argv), enforce_command_safelist=True
+        )
+        criterion = plan.tasks[0].acceptance_criteria[0]
+        assert isinstance(criterion, TypedCheck)
+        assert criterion.params["argv"] == parsed_argv
+
+    def test_default_parse_accepts_non_safelisted_command(self):
+        """Dispatch-time re-parse must stay permissive: flipping the default
+        would break loading pre-lint plans and demote out-of-safelist commands
+        from blocking evaluation errors to unparseable (fail-open)."""
+        plan = ImplementationPlan.from_yaml(_plan_yaml_with_command('["npm", "test"]'))
+        criterion = plan.tasks[0].acceptance_criteria[0]
+        assert isinstance(criterion, TypedCheck)
+        assert criterion.params["argv"] == ["npm", "test"]
+
+    def test_authoring_rejects_non_string_argv_items(self):
+        with pytest.raises(ValueError, match="every argv item must be a string"):
+            ImplementationPlan.from_yaml(
+                _plan_yaml_with_command('["python", 1]'), enforce_command_safelist=True
+            )


### PR DESCRIPTION
## What

Three slices:

1. **Single-source the RC-10a command safelist** in `acceptance_check_spec.py`. The runtime evaluator (`acceptance_checks.py`), the new authoring lint, and the proposer vocabulary all consume one definition. The vocabulary renderer gains a per-check `Note:` line, and `command_exit_zero`'s note now spells out the safelisted argv forms — proposers/mergers are told the allowed commands instead of guessing (#422 direction 2).
2. **Authoring-boundary lint**: `ImplementationPlan.from_yaml(..., enforce_command_safelist=True)` rejects `command_exit_zero` criteria whose argv can never execute, with a ValueError naming the allowed forms — which `_validate_manifest_candidate` feeds straight back to the merger as corrective retry feedback.
3. **Manifest retry runway**: `validated-fullstack` sets `manifest_max_attempts: 4` via the existing `resolved_config` seam (key registered in the CRP schema registry). Two attempts were too tight to converge through validation feedback (#424 direction 3), and the lint adds one more constraint to satisfy.

## Why

Live #419 validation evidence (2026-07-14): `cyc_bc325a67417d` authored `npm test` / `pytest --cov` / `make build` acceptance commands that passed plan validation, then deterministically died at evaluation (`command_not_in_safelist`) at task 10/13 with the correction budget already spent — `builder.assemble` never ran. `cyc_dafd6b5fe58c` repeated the pattern despite operator notes. `cyc_7d2f505e5e8f` exhausted its 2 manifest attempts on other validation errors and silently fell back to untyped static steps (#424).

## Deliberate non-enforcement (both regression-tested)

- **`governance.py` inline manifest path**: no corrective-retry loop there — a safelist rejection would silently downgrade to static task steps (the #424 shape), strictly worse than failing closed at evaluation. Commented at the call site; revisit with #424's fail-fast design.
- **`split_acceptance_criteria` wire coercion**: pre-lint plans and static fallbacks may legally carry out-of-safelist commands; demoting them to `unparseable` would fail open. They stay typed and keep failing closed at evaluation.

## Out of scope

#424's fail-fast/surfacing design (fallback still silent), #423 (skip-as-pass), and the dead `command_check_safelist` CRP key discovered during this work (declared in the schema registry, consumed nowhere).

Closes #422
Addresses #424 (direction 3 only — attempt budget; fail-fast + surfacing remain open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)