### PR TITLE
fix(#430): fenced_parser tracks nested fences instead of clipping at the first bare close

### DIFF
--- a/src/squadops/capabilities/handlers/fenced_parser.py
+++ b/src/squadops/capabilities/handlers/fenced_parser.py
@@ -20,6 +20,14 @@ Models naturally drift between these formats; the parser tolerates all of
 them so a one-character format slip doesn't drop the whole task on the floor.
 The strict format is still the recommended one and round-trips losslessly.
 
+Nested fences (#430): a block's body may itself contain fenced examples —
+any markdown deliverable with an embedded ``` ```bash``` ``` snippet, or a
+docstring quoting fenced code. A ``` ```<token>``` ``` line inside a block
+opens a nested level and a bare ``` ``` ``` ``` closes the innermost one; the
+block ends only when the depth returns to zero. Trade-off: a body containing
+an *unmatched* tokened opener leaves the block unclosed and it is abandoned
+whole — rarer and louder than the silent mid-document clip it replaces.
+
 Part of SIP-Enhanced-Agent-Build-Capabilities, Phase 1.
 """
 
@@ -32,16 +40,13 @@ from squadops.capabilities.handlers.impl._json_extraction import _strip_think_bl
 # Strict format header: ```<lang>:<path>
 _STRICT_HEADER_RE = re.compile(r"^```(\w+):(\S+)\s*$", re.MULTILINE)
 
-# Permissive open fence: ```<token> where <token> may be empty. Models
-# sometimes emit a bare ``` immediately after a filename heading
-# (``## Dockerfile`` then ``` ```\n...```\n`` `), so we cannot require
-# a non-empty language slot. The ambiguity with a close fence is resolved
-# by sequential scanning: after parsing a fence we advance past its
-# close, so a stray unmatched ``` only causes a wasted lookahead.
+# Any fence line: ```<token> where <token> may be empty. Models sometimes
+# emit a bare ``` immediately after a filename heading (``## Dockerfile``
+# then ``` ```\n...```\n`` `), so we cannot require a non-empty language
+# slot. The open/close ambiguity of a bare ``` is resolved by depth
+# tracking in _find_block_close: a tokened fence opens a nested level, a
+# bare fence closes the innermost one.
 _OPEN_FENCE_RE = re.compile(r"^```(\S*)\s*$", re.MULTILINE)
-
-# Closing fence: ``` on its own line (possibly trailing whitespace)
-_FENCE_CLOSE_RE = re.compile(r"^```\s*$", re.MULTILINE)
 
 # Markdown heading whose text is a path-like token. Accepts headings of the
 # form "## models.py", "### `backend/main.py`", "# Dockerfile". Requires
@@ -112,6 +117,28 @@ def _resolve_filename_from_heading(
     return None, last_used_heading_pos
 
 
+def _find_block_close(response: str, body_start: int) -> re.Match[str] | None:
+    """Find the close fence for a block whose body starts at ``body_start``,
+    honoring nesting (#430): a ``` ```<token>``` ``` line inside the body opens
+    a nested level, a bare ``` ``` ``` ``` closes the innermost one, and the
+    block closes when depth returns to zero. Returns the close-fence match, or
+    ``None`` if the block never closes (e.g. an unmatched nested opener).
+    """
+    depth = 1
+    pos = body_start
+    while True:
+        fence = _OPEN_FENCE_RE.search(response, pos)
+        if fence is None:
+            return None
+        if fence.group(1):
+            depth += 1
+        else:
+            depth -= 1
+            if depth == 0:
+                return fence
+        pos = fence.end()
+
+
 def _resolve_filename_from_first_comment(body: str) -> tuple[str | None, str]:
     """If the first line of ``body`` is a comment containing a filename,
     return ``(filename, body_with_first_line_stripped)``. Otherwise
@@ -161,7 +188,7 @@ def extract_fenced_files(response: str) -> list[dict]:
             break
 
         body_start = open_match.end() + 1  # skip newline after header
-        close_match = _FENCE_CLOSE_RE.search(response, body_start)
+        close_match = _find_block_close(response, body_start)
         if not close_match:
             # No closing fence — abandon this opener and resume past it
             pos = body_start

--- a/tests/unit/capabilities/test_fenced_parser.py
+++ b/tests/unit/capabilities/test_fenced_parser.py
@@ -463,3 +463,89 @@ class TestRealWorldFailurePatterns:
         assert "qa_handoff.md" in filenames
         qa_handoff = next(r for r in result if r["filename"] == "qa_handoff.md")
         assert "## How to Run" in qa_handoff["content"]
+
+
+class TestNestedFences:
+    """#430: a block body may legitimately contain fenced examples; the parser
+    must close the block at its own fence, not the first nested close."""
+
+    def test_nested_example_content_retained(self):
+        """Regression pin for #430: cyc_8830cfc78a1e clipped qa_handoff.md at
+        the close of its first embedded bash example, discarding every later
+        section, on all three assemble attempts."""
+        response = (
+            "```markdown:qa_handoff.md\n"
+            "# QA Handoff\n"
+            "## How to Test\n"
+            "```bash\n"
+            "cd backend\n"
+            "pytest\n"
+            "```\n"
+            "## Expected Behavior\n"
+            "All endpoints return JSON.\n"
+            "## Known Limitations\n"
+            "In-memory store only.\n"
+            "```\n"
+        )
+        [record] = extract_fenced_files(response)
+        assert record["filename"] == "qa_handoff.md"
+        assert "```bash\ncd backend\npytest\n```" in record["content"]
+        assert "## Expected Behavior" in record["content"]
+        assert record["content"].endswith("In-memory store only.")
+
+    def test_multiple_nested_examples_in_one_block(self):
+        response = (
+            "```markdown:docs/guide.md\n"
+            "## Backend\n"
+            "```bash\n"
+            "uvicorn main:app\n"
+            "```\n"
+            "## Frontend\n"
+            "```bash\n"
+            "npm run dev\n"
+            "```\n"
+            "Done.\n"
+            "```\n"
+        )
+        [record] = extract_fenced_files(response)
+        assert record["content"].count("```bash") == 2
+        assert record["content"].endswith("Done.")
+
+    def test_scan_resumes_correctly_after_nested_block(self):
+        """A file following a nested-fence block must still be extracted with
+        its own content — the scanner must advance past the OUTER close."""
+        response = (
+            "```markdown:docs/guide.md\n"
+            "Example:\n"
+            "```bash\n"
+            "make test\n"
+            "```\n"
+            "End of guide.\n"
+            "```\n"
+            "\n"
+            "```python:app.py\n"
+            "print('hello')\n"
+            "```\n"
+        )
+        records = extract_fenced_files(response)
+        assert [r["filename"] for r in records] == ["docs/guide.md", "app.py"]
+        assert records[0]["content"].endswith("End of guide.")
+        assert records[1]["content"] == "print('hello')"
+
+    def test_unmatched_nested_opener_abandons_block_but_recovers_later_files(self):
+        """An inner tokened fence that never closes leaves the outer block
+        unclosed: the block is dropped whole (documented #430 trade-off), and
+        the scanner still recovers subsequent well-formed files."""
+        response = (
+            "```markdown:docs/broken.md\n"
+            "Example that never closes:\n"
+            "```python\n"
+            "x = 1\n"
+            "\n"
+            "```json:config.json\n"
+            '{"ok": true}\n'
+            "```\n"
+        )
+        records = extract_fenced_files(response)
+        assert [r["filename"] for r in records] == ["config.json"]
+        assert records[0]["content"] == '{"ok": true}'


### PR DESCRIPTION
## What

`extract_fenced_files` closed a tagged block at the **first** bare ```` ``` ```` line after the opener — no concept of nesting. Any markdown deliverable whose body legitimately contains a fenced example was silently truncated at the inner block's close, discarding everything after it.

The close scan now tracks depth (`_find_block_close`): a ```` ```<token> ```` line inside a block opens a nested level, a bare ```` ``` ```` closes the innermost, and the block ends only when depth returns to zero.

## Production evidence

cyc_8830cfc78a1e (Phase-0.5 fill cycle): `builder.assemble` generated a complete `qa_handoff.md` three times (4–7k tokens/attempt); the parser clipped each to ~800 bytes at the identical spot — mid-way through the first ```` ```bash ```` example — so the section-presence checks failed identically every attempt, repair regenerated into the same parser, the correction budget exhausted, and the run failed after the code deliverable was already complete and passing (see #430 and the correction-side blindness this exposed, #431).

## Trade-off (documented in the module docstring)

A body containing an *unmatched* tokened opener now leaves the block unclosed and it is abandoned whole — rarer and louder than a silent mid-document clip. The scanner still recovers later well-formed blocks (test-pinned).

## Tests

4 new tests in `TestNestedFences`: the exact #430 production shape (embedded example retained, later sections present), multiple nested examples in one block, scanner resume after a nested block, and unmatched-opener abandonment with recovery of subsequent files. Full parser suite (45) and capabilities domain (1147) pass; `run_affected_tests.sh --branch` green; ruff clean.

## Deployment note

The parser runs in agent containers — agents need an image rebuild to pick this up (doing that from this branch on the Spark box for fill-cycle attempt 2, per the standing rebuild-during-review flow).

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)
