### PR TITLE
fix: plan-authoring guidance forbids style-dependent regex criteria

### DIFF
--- a/src/squadops/capabilities/handlers/_plan_authoring_service.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring_service.py
@@ -170,6 +170,16 @@ async def produce_plan(
         "Anything else (notably `python -c`, `python -m pip`, shell strings) errors at evaluation time — "
         "treat the safelist as the universe.\n"
         "- Per-command timeout is bounded; do not author long-running builds as acceptance checks.\n\n"
+        "**Check-selection hierarchy — behavioral > structural > textual:**\n"
+        "- Prefer checks that execute or parse code (`command_exit_zero`, `endpoint_defined`, "
+        "`import_present`, `field_present`) over `regex_match`. Executing verifies what the "
+        "code DOES; a regex only verifies how it is written.\n"
+        "- `regex_match` patterns MUST NOT depend on stylistic choices the developer is free "
+        "to vary: quote style, whitespace, attribute order, import aliasing. Example: "
+        "`pattern: to='/runs/` fails correct JSX that uses double quotes — write a "
+        "quote-agnostic class (`to=[\"']/runs/`) or assert the outcome behaviorally instead.\n"
+        "- A regex that asserts how code is written rather than what it must do should be "
+        "`severity: info` or prose, never a blocking `error`.\n\n"
         '**When in doubt, prefer typed checks over prose.** Prose like "User model exists" '
         "is a good candidate to typed-encode as `field_present` against the actual class.\n"
     )


### PR DESCRIPTION
## Summary

Attempt-2 framing (cyc_9d775e1aebeb) authored three blocking `regex_match` criteria that pin JSX quote style (`pattern: to='/runs/`). A correct deliverable using double quotes would fail acceptance and burn correction attempts on a style mismatch — the same checker-false-negative class as #436, but originating at authoring time instead of evaluation time.

This adds a **check-selection hierarchy** to the typed-acceptance authoring guidance in `_plan_authoring_service.py`:

- behavioral > structural > textual — prefer executing/parsing checks (`command_exit_zero`, `endpoint_defined`, `import_present`, `field_present`) over `regex_match`
- regex patterns must not depend on stylistic choices (quote style, whitespace, attribute order, aliasing); quote-agnostic classes shown as the fallback
- how-it-is-written assertions get `severity: info` or prose, never blocking `error`

Prompt-guidance only — no evaluator behavior changes. All 1147 capabilities tests pass.

## Validation

Spike attempt 3 (group_run, fresh framing on images rebuilt from this branch) is the live validation: its authored manifest should contain no style-dependent blocking regexes. Will report the authored criteria on the PR once framing completes.

## Follow-up candidate

A deterministic manifest lint (flag blocking regexes containing quote literals) would enforce this doctrine mechanically rather than by prompt — fits the #435 policy work.

Related: #435, #436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm