### PR TITLE
fix(#439): plan substitution preserves the workload-invariant tail (assemble + qa.test)

### DIFF
--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -223,6 +223,12 @@ _KNOWN_WORKLOAD_TYPES = {
 # Task types that are build steps (for routing_reason metadata)
 _BUILD_TASK_TYPES = {s[0] for s in BUILD_TASK_STEPS} | {s[0] for s in BUILDER_ASSEMBLY_TASK_STEPS}
 
+# Workload-invariant tail (#439): assembly and verification are workload-owned.
+# Plan substitution may replace dev work but must never descope these — a
+# dev-only manifest that dropped them completed green with no build subject
+# (every required check `subject_missing` → blocked_unverified).
+_WORKLOAD_INVARIANT_TASK_TYPES = frozenset({"builder.assemble", "qa.test"})
+
 # Builder-role (SIP-0071) capability namespace. A run is a *builder deliverable*
 # run — subject to the profile-level ``required_files`` completeness gate
 # (#291) — iff its plan contains a ``builder.*`` task. This is deliberately
@@ -528,5 +534,13 @@ def _replace_build_steps_with_plan(
     }
     non_build_steps = [s for s in steps if s[0] not in static_build_types]
 
-    # Append plan tasks (PlanTask objects, not tuples)
-    return non_build_steps + list(plan.tasks)
+    # Re-append the workload-invariant tail (#439): assembly/verification
+    # steps survive substitution unless the plan authored its own task of
+    # that type (which then stands in).
+    plan_task_types = {t.task_type for t in plan.tasks}
+    invariant_tail = [
+        s for s in steps if s[0] in _WORKLOAD_INVARIANT_TASK_TYPES and s[0] not in plan_task_types
+    ]
+
+    # Append plan tasks (PlanTask objects, not tuples), then the tail
+    return non_build_steps + list(plan.tasks) + invariant_tail

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -303,3 +303,167 @@ class TestGenerateTaskPlanWithManifest:
         # Only planning steps, no build steps at all
         assert len(envelopes) == 5
         assert all("subtask_focus" not in e.inputs for e in envelopes)
+
+
+# ---------------------------------------------------------------------------
+# Workload-invariant tail preservation (#439)
+# ---------------------------------------------------------------------------
+
+DEV_ONLY_MANIFEST_YAML = """\
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+tasks:
+  - task_index: 0
+    task_type: development.develop
+    role: dev
+    focus: "Backend routes"
+    description: "Fill route stubs"
+    expected_artifacts: ["backend/routes.py"]
+    depends_on: []
+  - task_index: 1
+    task_type: development.develop
+    role: dev
+    focus: "Frontend views"
+    description: "Fill view stubs"
+    expected_artifacts: ["frontend/src/views/RunsListView.jsx"]
+    depends_on: []
+summary:
+  total_dev_tasks: 2
+  total_qa_tasks: 0
+  total_tasks: 2
+  estimated_layers: [backend, frontend]
+"""
+
+BUILDER_MANIFEST_YAML = """\
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+tasks:
+  - task_index: 0
+    task_type: development.develop
+    role: dev
+    focus: "Backend routes"
+    description: "Fill route stubs"
+    expected_artifacts: ["backend/routes.py"]
+    depends_on: []
+  - task_index: 1
+    task_type: builder.assemble
+    role: builder
+    focus: "Package deliverable"
+    description: "Assemble qa_handoff.md"
+    expected_artifacts: ["qa_handoff.md"]
+    depends_on: [0]
+summary:
+  total_dev_tasks: 1
+  total_builder_tasks: 1
+  total_qa_tasks: 0
+  total_tasks: 2
+  estimated_layers: [backend]
+"""
+
+
+def _make_builder_profile() -> SquadProfile:
+    profile = _make_profile()
+    return SquadProfile(
+        profile_id="full",
+        name="Full Squad",
+        description="Test profile",
+        version=1,
+        agents=[
+            *profile.agents,
+            AgentProfileEntry(agent_id="bob", role="builder", model="test", enabled=True),
+        ],
+        created_at=NOW,
+    )
+
+
+class TestWorkloadInvariantTail:
+    """#439: a dev-only manifest must not descope assembly/verification.
+
+    Attempt 3 of the Phase-0.5 spike (cyc_62c30fcc91a3) authored a 4-dev-task
+    manifest; substitution dropped builder.assemble AND qa.test, the run
+    completed with no build subject, and every required check reported
+    subject_missing (blocked_unverified) — while the deliverable was in fact
+    functional. The tail is workload-owned, not plan-optional.
+    """
+
+    def test_implementation_workload_dev_only_plan_keeps_tail(self):
+        """The attempt-3 reproduction: implementation workload + builder squad."""
+        manifest = ImplementationPlan.from_yaml(DEV_ONLY_MANIFEST_YAML)
+        run = _make_run(workload_type="implementation")
+        cycle = _make_cycle(
+            applied_defaults={
+                "plan_tasks": True,
+                "build_tasks": True,
+                "build_profile": "fullstack_fastapi_react",
+            }
+        )
+        envelopes = generate_task_plan(cycle, run, _make_builder_profile(), plan=manifest)
+
+        types = [e.task_type for e in envelopes]
+        assert types == [
+            "governance.define_done",
+            "development.develop",
+            "development.develop",
+            "builder.assemble",
+            "qa.test",
+        ]
+
+    def test_tail_agents_resolve_to_builder_and_qa_roles(self):
+        manifest = ImplementationPlan.from_yaml(DEV_ONLY_MANIFEST_YAML)
+        run = _make_run(workload_type="implementation")
+        cycle = _make_cycle(
+            applied_defaults={
+                "plan_tasks": True,
+                "build_tasks": True,
+                "build_profile": "fullstack_fastapi_react",
+            }
+        )
+        envelopes = generate_task_plan(cycle, run, _make_builder_profile(), plan=manifest)
+
+        tail = {e.task_type: e.agent_id for e in envelopes[-2:]}
+        assert tail == {"builder.assemble": "bob", "qa.test": "eve"}
+
+    def test_plan_authored_builder_task_stands_in_no_duplicate(self):
+        """A manifest that authors its own builder.assemble replaces the static
+        one; only the missing qa.test is re-appended."""
+        manifest = ImplementationPlan.from_yaml(BUILDER_MANIFEST_YAML)
+        run = _make_run(workload_type="implementation")
+        cycle = _make_cycle(
+            applied_defaults={
+                "plan_tasks": True,
+                "build_tasks": True,
+                "build_profile": "fullstack_fastapi_react",
+            }
+        )
+        envelopes = generate_task_plan(cycle, run, _make_builder_profile(), plan=manifest)
+
+        types = [e.task_type for e in envelopes]
+        assert types.count("builder.assemble") == 1
+        assert types[-1] == "qa.test"
+        # The surviving builder task is the plan's (manifest -m namespace id)
+        builder_env = next(e for e in envelopes if e.task_type == "builder.assemble")
+        assert "-m001-" in builder_env.task_id
+
+    def test_legacy_path_non_builder_profile_keeps_qa_test(self):
+        """Legacy flags path, no builder role: dev-only plan still ends in qa.test."""
+        manifest = ImplementationPlan.from_yaml(DEV_ONLY_MANIFEST_YAML)
+        envelopes = generate_task_plan(_make_cycle(), _make_run(), _make_profile(), plan=manifest)
+
+        types = [e.task_type for e in envelopes]
+        assert types[-1] == "qa.test"
+        assert types.count("qa.test") == 1
+        assert "builder.assemble" not in types  # no builder role, no builder step
+
+    def test_plan_with_qa_task_unchanged_from_before(self):
+        """Existing behavior guard: a manifest that already carries qa.test gets
+        no extra tail (the original MANIFEST_YAML shape)."""
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
+        envelopes = generate_task_plan(_make_cycle(), _make_run(), _make_profile(), plan=manifest)
+
+        types = [e.task_type for e in envelopes]
+        assert len(envelopes) == 9
+        assert types.count("qa.test") == 1


### PR DESCRIPTION
## Summary

`_replace_build_steps_with_plan` stripped the entire static build segment and appended only the manifest's tasks, letting a dev-only manifest **silently descope assembly and verification**. The run completes green with no build subject; every cycle-level required check reports `subject_missing` → `blocked_unverified` — the #374/#376 false-green class, reintroduced through plan substitution.

Fix: `builder.assemble` and `qa.test` are **workload-invariant** — re-appended after plan tasks unless the plan authored its own task of that type (which then stands in, so attempt-2-style manifests with an explicit builder task are unchanged). The plan replaces dev work; it cannot descope verification.

## Live evidence (attempt 3, cyc_62c30fcc91a3)

Manifest declared 4 dev tasks; the implementation run executed `define_done` + 4 develops — no assemble, no qa.test, outcome `blocked_unverified`. Manual assembly + boot proved the deliverable fully functional (all 5 endpoints, correct 409/404 error paths, `vite build` green) — the cycle just never looked. With this fix, the same manifest yields `define_done` → 4 develops → `builder.assemble` → `qa.test`.

## Tests

5 new tests in `TestWorkloadInvariantTail`, including the exact attempt-3 reproduction (implementation workload + builder profile + dev-only manifest → full tail restored, correct role routing), the no-duplicate stand-in case, the legacy non-builder path, and an existing-behavior guard for manifests that already carry qa.test. All 1615 cycles-domain tests pass. The #291 `build_profile` gate now correctly fires for restored builder steps (test fixtures carry `build_profile`, as real cycles do).

## Validation

Spike attempt 3.5 (same recipe, images with this fix + #438) is the live validation — the bar is the arc's first `verified` cycle outcome.

Closes #439. Related: #435 (no-silent-caps doctrine), #438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm