### PR TITLE
fix(#441): dotless import_present spec matches relative imports

### DIFF
--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -370,7 +370,15 @@ class ImportPresentCheck(BaseCheck):
                 # `from .errors import X` → ImportFrom(module='errors', level=1).
                 prefix = "." * node.level
                 effective_module = prefix + (node.module or "")
-                if effective_module == target_module:
+                # #441: a dotless spec follows author intent — `module: errors`
+                # accepts `from .errors import X` at any level. A dotted spec
+                # stays exact (`.errors` still rejects `backend.errors`).
+                dotless_match = (
+                    not target_module.startswith(".")
+                    and node.level > 0
+                    and (node.module or "") == target_module
+                )
+                if effective_module == target_module or dotless_match:
                     module_imported = True
                     if target_symbol is None:
                         symbol_imported = True

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -704,3 +704,59 @@ async def test_absolute_path_all_path_checks_error(check_name, params, tmp_path)
     result = await get_check(check_name).evaluate(params, tmp_path, stack=stack)
     assert result.status == "error"
     assert result.reason == "path_escapes_workspace"
+
+
+class TestImportPresentDotlessLeniency:
+    """#441: a dotless module spec matches a relative import of the same name.
+
+    Attempt 3.5's framing authored `module: errors` for code using
+    `from .errors import ApiError` — exact-form matching made the check
+    unwinnable against correct code (the #436 class, from the spec side).
+    """
+
+    @pytest.fixture
+    def relative_ws(self, tmp_path):
+        (tmp_path / "routes.py").write_text("from .errors import ApiError\n")
+        return tmp_path
+
+    async def test_dotless_spec_matches_relative_import(self, relative_ws):
+        result = await get_check("import_present").evaluate(
+            {"file": "routes.py", "module": "errors", "symbol": "ApiError"},
+            relative_ws,
+        )
+        assert result.status == "passed"
+
+    async def test_dotless_spec_still_matches_absolute_import(self, tmp_path):
+        (tmp_path / "app.py").write_text("from errors import ApiError\n")
+        result = await get_check("import_present").evaluate(
+            {"file": "app.py", "module": "errors", "symbol": "ApiError"},
+            tmp_path,
+        )
+        assert result.status == "passed"
+
+    async def test_dotted_spec_stays_exact_rejects_absolute(self, tmp_path):
+        (tmp_path / "app.py").write_text("from backend.errors import ApiError\n")
+        result = await get_check("import_present").evaluate(
+            {"file": "app.py", "module": ".errors", "symbol": "ApiError"},
+            tmp_path,
+        )
+        assert result.status == "failed"
+        assert result.reason == "module_not_imported"
+
+    async def test_dotless_spec_rejects_different_name(self, relative_ws):
+        result = await get_check("import_present").evaluate(
+            {"file": "routes.py", "module": "exceptions", "symbol": "ApiError"},
+            relative_ws,
+        )
+        assert result.status == "failed"
+        assert result.reason == "module_not_imported"
+
+    async def test_dotless_spec_does_not_match_plain_import_of_submodule(self, tmp_path):
+        # `import backend.errors` is alias 'backend.errors', not 'errors' —
+        # dotless leniency applies only to relative ImportFrom nodes.
+        (tmp_path / "app.py").write_text("import backend.errors\n")
+        result = await get_check("import_present").evaluate(
+            {"file": "app.py", "module": "errors"},
+            tmp_path,
+        )
+        assert result.status == "failed"


### PR DESCRIPTION
## Summary

#437 chose exact-form matching; attempt 3.5's live framing immediately produced the inverse false-negative: the manifest specs `module: errors` (dotless) while the task description and scaffold use `from .errors import ApiError`. Exact-form makes that check unwinnable against correct code — and the correction loop could go checker-green by inserting a dead `import errors` that `py_compile` won't catch.

A dotless spec now accepts a relative import of the same name at any level (author's evident intent); a dotted spec stays exact (`.errors` still rejects `backend.errors`). This deliberately amends #437's documented exact-form rule in one direction only — flagging that explicitly for review.

5 new tests; all 1615 cycles-domain tests pass. Gate for attempt 3.5 (cyc_17bdc66c1669) is being held until images carry this; its manifest is the live validation.

Closes #441. Related: #436, #437, #438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm