### PR TITLE
fix(#447): correction policy guard — continue cannot discard executed-failed required checks

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -357,19 +357,43 @@ class CorrectionRunner:
             elif task_type == "governance.correction_decision":
                 decision_outputs = step_outputs
 
-        # 4. Read correction_path
-        correction_path = decision_outputs.get("correction_path", "abort")
+        # 4. Read correction_path — bounded by the deterministic policy guard
+        # (#447): `continue` may not discard a required check that executed
+        # and failed while this chain's repair slot is unspent. The model's
+        # original rationale stays intact in the decision artifact; the
+        # override is disclosed in the event payload below.
+        from squadops.cycles.correction_policy import resolve_correction_path
+
+        resolution = resolve_correction_path(
+            decision_outputs.get("correction_path", "abort"),
+            failure_evidence,
+            cycle.applied_defaults,
+        )
+        correction_path = resolution.path
+        if resolution.overridden_from:
+            logger.warning(
+                "correction_policy_override: %s -> patch (executed-failed required checks: %s)",
+                resolution.overridden_from,
+                ", ".join(resolution.failed_required_checks),
+            )
 
         # 5. Emit CORRECTION_DECIDED
+        decided_payload: dict[str, Any] = {
+            "correction_path": correction_path,
+            "decision_rationale": decision_outputs.get("decision_rationale", ""),
+        }
+        if resolution.overridden_from:
+            decided_payload["policy_override"] = {
+                "from": resolution.overridden_from,
+                "reason": "executed_failed_required_checks",
+                "checks": list(resolution.failed_required_checks),
+            }
         self._event_bus.emit(
             EventType.CORRECTION_DECIDED,
             entity_type="run",
             entity_id=run_id,
             context={"cycle_id": cycle.cycle_id, "run_id": run_id},
-            payload={
-                "correction_path": correction_path,
-                "decision_rationale": decision_outputs.get("decision_rationale", ""),
-            },
+            payload=decided_payload,
         )
 
         # 6. Store plan delta as artifact

--- a/src/squadops/cycles/correction_policy.py
+++ b/src/squadops/cycles/correction_policy.py
@@ -1,0 +1,96 @@
+"""Deterministic correction-path policy (#447).
+
+The correction *decision* is LLM judgment; this layer bounds it with evidence
+the model cannot overrule. First anchor (#447): a ``continue`` that would
+discard a REQUIRED check which **executed and failed** is escalated to
+``patch`` — an executed failure names the work product by definition, and a
+narrative rationale cannot outvote it while the current chain's repair slot
+is unspent. Environment failures (``executed: false`` — subject_missing,
+runner errors) are exempt: repairing correct code against harness config
+burns budget for nothing (the attempt-3.5 case, where ``continue`` was
+right). ``abort`` is never overridden — it is a deliberate hard stop.
+
+This module is the intended home for the #435 convergence policy
+(signature strikes, progress requirement, artifact-delta guard).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+#: Correction paths the guard may escalate. ``abort`` is deliberately absent.
+_ESCALATABLE_PATHS = frozenset({"continue"})
+
+
+@dataclass(frozen=True)
+class CorrectionPathResolution:
+    """The policy's final word on a correction path.
+
+    ``overridden_from`` is set when the guard escalated the decision;
+    ``failed_required_checks`` carries the evidence that justified it.
+    """
+
+    path: str
+    overridden_from: str | None = None
+    failed_required_checks: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _executed_failed_required(
+    failure_evidence: dict[str, Any],
+    required_check_ids: frozenset[str],
+) -> tuple[str, ...]:
+    """Required checks that executed and failed, from the evidence payload.
+
+    A check entry counts iff its ``check`` id is required, ``passed`` is
+    explicitly False, and ``executed`` is not False (absent means the check
+    ran — the executed path omits the key; env-skips set ``executed: False``).
+    """
+    checks = (failure_evidence.get("validation_result") or {}).get("checks") or []
+    hits: list[str] = []
+    for entry in checks:
+        if not isinstance(entry, dict):
+            continue
+        check_id = entry.get("check")
+        if (
+            isinstance(check_id, str)
+            and check_id in required_check_ids
+            and entry.get("passed") is False
+            and entry.get("executed") is not False
+        ):
+            hits.append(check_id)
+    return tuple(sorted(set(hits)))
+
+
+def resolve_correction_path(
+    decision_path: str,
+    failure_evidence: dict[str, Any],
+    applied_defaults: dict[str, Any],
+) -> CorrectionPathResolution:
+    """Apply the deterministic guard to the LLM-chosen correction path.
+
+    Args:
+        decision_path: ``correction_path`` from the governance decision handler.
+        failure_evidence: the payload handed to ``data.analyze_failure``
+            (``build_failure_evidence`` shape).
+        applied_defaults: the cycle's resolved defaults (``required_checks``).
+
+    Returns:
+        The path to act on, with override provenance when the guard fired.
+    """
+    if decision_path not in _ESCALATABLE_PATHS:
+        return CorrectionPathResolution(path=decision_path)
+
+    required = frozenset(applied_defaults.get("required_checks") or [])
+    if not required:
+        return CorrectionPathResolution(path=decision_path)
+
+    failed_required = _executed_failed_required(failure_evidence, required)
+    if not failed_required:
+        return CorrectionPathResolution(path=decision_path)
+
+    return CorrectionPathResolution(
+        path="patch",
+        overridden_from=decision_path,
+        failed_required_checks=failed_required,
+    )

--- a/tests/unit/cycles/test_correction_policy.py
+++ b/tests/unit/cycles/test_correction_policy.py
@@ -1,0 +1,82 @@
+"""Tests for the deterministic correction-path policy guard (#447)."""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.correction_policy import resolve_correction_path
+
+pytestmark = [pytest.mark.domain_contracts]
+
+DEFAULTS = {"required_checks": ["frontend_build", "tests_pass", "required_files"]}
+
+
+def _evidence(checks):
+    return {"validation_result": {"checks": checks}}
+
+
+class TestResolveCorrectionPath:
+    def test_continue_with_executed_failed_required_escalates_to_patch(self):
+        """The attempt-3.6 case: frontend_build ran and failed on a real JSX
+        syntax error, yet the lead chose continue with budget unspent."""
+        ev = _evidence(
+            [
+                {"check": "frontend_build", "passed": False},  # ran path omits `executed`
+                {"check": "non_stub_files", "passed": True},
+            ]
+        )
+        res = resolve_correction_path("continue", ev, DEFAULTS)
+        assert res.path == "patch"
+        assert res.overridden_from == "continue"
+        assert res.failed_required_checks == ("frontend_build",)
+
+    def test_continue_with_env_skip_failures_stands(self):
+        """The attempt-3.5 case: checks failed as environment problems
+        (executed: False) — repair can't fix harness config; continue is right."""
+        ev = _evidence(
+            [
+                {"check": "frontend_build", "executed": False, "reason": "no_package_json"},
+                {"check": "tests_pass", "executed": False, "passed": False},
+            ]
+        )
+        res = resolve_correction_path("continue", ev, DEFAULTS)
+        assert res.path == "continue"
+        assert res.overridden_from is None
+
+    def test_continue_with_only_optional_failures_stands(self):
+        ev = _evidence([{"check": "no_stub_fallback_tests", "passed": False}])
+        res = resolve_correction_path("continue", ev, DEFAULTS)
+        assert res.path == "continue"
+
+    def test_patch_passes_through_untouched(self):
+        ev = _evidence([{"check": "frontend_build", "passed": False}])
+        res = resolve_correction_path("patch", ev, DEFAULTS)
+        assert res.path == "patch"
+        assert res.overridden_from is None
+
+    def test_abort_is_never_overridden(self):
+        ev = _evidence([{"check": "frontend_build", "passed": False}])
+        res = resolve_correction_path("abort", ev, DEFAULTS)
+        assert res.path == "abort"
+        assert res.overridden_from is None
+
+    def test_no_required_checks_configured_stands(self):
+        ev = _evidence([{"check": "frontend_build", "passed": False}])
+        res = resolve_correction_path("continue", ev, {"required_checks": []})
+        assert res.path == "continue"
+
+    def test_malformed_evidence_stands(self):
+        for ev in ({}, {"validation_result": None}, _evidence([None, "junk", {}])):
+            res = resolve_correction_path("continue", ev, DEFAULTS)
+            assert res.path == "continue", ev
+
+    def test_mixed_executed_and_skipped_failures_reports_only_executed(self):
+        ev = _evidence(
+            [
+                {"check": "tests_pass", "executed": True, "passed": False, "exit_code": 1},
+                {"check": "frontend_build", "executed": False, "reason": "npm_missing"},
+            ]
+        )
+        res = resolve_correction_path("continue", ev, DEFAULTS)
+        assert res.path == "patch"
+        assert res.failed_required_checks == ("tests_pass",)


### PR DESCRIPTION
Deterministic guard in a new `correction_policy` module (seeds the #435 home): evidence distinguishes executed failures from env-skips via the `executed` field, so 3.6's wrong continue gets escalated while 3.5's correct continue would stand. 8 tests including both live cases. Full evidence in #447.

Closes #447. Related: #435, #448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm