### PR TITLE
fix(#451): anchored hash replacement in regen_fragment_manifest.py

### DIFF
--- a/scripts/dev/regen_fragment_manifest.py
+++ b/scripts/dev/regen_fragment_manifest.py
@@ -115,12 +115,23 @@ def write() -> int:
             print(f"ERROR: fragment file missing for {fid} ({path})", file=sys.stderr)
         return 1
     if drift:
-        # Minimal edit: replace only the changed (globally unique) hash strings
-        # so the diff is exactly the stale lines and all other formatting is
-        # preserved.
+        # Minimal edit, ANCHORED to the sha256 line (#451): a bare global
+        # replace of the stored value corrupts the whole file when the stale
+        # hash is degenerate (a placeholder like '0' matched every zero in
+        # every other hash, the version, and the timestamp). Replace exactly
+        # one `sha256: <stored>` occurrence per drift entry; tolerate quoted
+        # placeholder forms.
         raw = MANIFEST_PATH.read_text(encoding="utf-8")
         for fid, path, stored, computed in drift:
-            raw = raw.replace(stored, computed)
+            replaced = False
+            for old_line in (f"sha256: {stored}", f"sha256: '{stored}'", f'sha256: "{stored}"'):
+                if old_line in raw:
+                    raw = raw.replace(old_line, f"sha256: {computed}", 1)
+                    replaced = True
+                    break
+            if not replaced:
+                print(f"ERROR: could not locate sha256 line for {fid} ({path})", file=sys.stderr)
+                return 1
             print(f"updated {fid} ({path})")
         MANIFEST_PATH.write_text(raw, encoding="utf-8")
         print(f"wrote {len(drift)} fragment hash(es) to {MANIFEST_PATH}")
@@ -128,8 +139,9 @@ def write() -> int:
     if hash_drift:
         stored, computed = hash_drift
         raw = MANIFEST_PATH.read_text(encoding="utf-8")
-        if stored and stored in raw:
-            raw = raw.replace(stored, computed)
+        if stored and f"manifest_hash: {stored}" in raw:
+            # Anchored for the same reason as the fragment hashes (#451).
+            raw = raw.replace(f"manifest_hash: {stored}", f"manifest_hash: {computed}", 1)
         else:
             print(
                 "ERROR: could not locate stored manifest_hash for in-place update", file=sys.stderr

--- a/tests/unit/prompts/test_regen_manifest_script.py
+++ b/tests/unit/prompts/test_regen_manifest_script.py
@@ -1,0 +1,94 @@
+"""Tests for regen_fragment_manifest.py's anchored write path (#451).
+
+The bug this catches: the write path replaced the stored hash value with a
+bare global ``str.replace`` across the whole manifest. A degenerate stored
+value (a placeholder like ``'0'``) matched every zero character in the file —
+version, timestamp, and every other fragment's hash were destroyed (observed
+live 2026-07-15 while registering ``task_type.qa.test``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "dev" / "regen_fragment_manifest.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("regen_fragment_manifest", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["regen_fragment_manifest"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    """A two-fragment sandbox: one current entry, one placeholder-hash entry."""
+    frag_dir = tmp_path / "fragments"
+    (frag_dir / "shared" / "task_type").mkdir(parents=True)
+
+    good = frag_dir / "shared" / "task_type" / "task_type.good.md"
+    good.write_text("---\nfragment_id: task_type.good\n---\nGood content here.\n")
+    new = frag_dir / "shared" / "task_type" / "task_type.new.md"
+    new.write_text("---\nfragment_id: task_type.new\n---\nNew content here.\n")
+
+    mod = _load_script()
+    from adapters.prompts.filesystem import FileSystemPromptRepository
+
+    good_hash = FileSystemPromptRepository.hash_fragment_file(good)
+
+    manifest = frag_dir / "manifest.yaml"
+    manifest.write_text(
+        "version: 0.9.99\n"
+        "updated_at: '2026-07-15T00:00:00.000000Z'\n"
+        "fragments:\n"
+        "- fragment_id: task_type.good\n"
+        "  path: shared/task_type/task_type.good.md\n"
+        "  layer: task_type\n"
+        "  roles:\n"
+        "  - qa\n"
+        f"  sha256: {good_hash}\n"
+        "- fragment_id: task_type.new\n"
+        "  path: shared/task_type/task_type.new.md\n"
+        "  layer: task_type\n"
+        "  roles:\n"
+        "  - qa\n"
+        "  sha256: '0'\n"  # the degenerate placeholder that triggered #451
+        "manifest_hash: placeholder\n"
+    )
+
+    monkeypatch.setattr(mod, "FRAGMENTS_DIR", frag_dir)
+    monkeypatch.setattr(mod, "MANIFEST_PATH", manifest)
+    return mod, manifest, good_hash
+
+
+class TestAnchoredWrite:
+    def test_placeholder_hash_does_not_corrupt_other_entries(self, sandbox):
+        mod, manifest, good_hash = sandbox
+        rc = mod.write()
+        assert rc == 0
+        raw = manifest.read_text()
+        # The pre-#451 bug: every '0' in the file became the new 64-char hash.
+        assert "version: 0.9.99" in raw  # version intact
+        assert "'2026-07-15T00:00:00.000000Z'" in raw  # timestamp intact
+        assert f"sha256: {good_hash}" in raw  # sibling hash intact
+        assert "sha256: '0'" not in raw  # placeholder actually updated
+
+    def test_write_is_idempotent(self, sandbox):
+        mod, manifest, _ = sandbox
+        assert mod.write() == 0
+        first = manifest.read_text()
+        assert mod.write() == 0
+        assert manifest.read_text() == first
+
+    def test_check_passes_after_write(self, sandbox):
+        mod, _, _ = sandbox
+        assert mod.write() == 0
+        assert mod.check() == 0


### PR DESCRIPTION
Anchors both the per-fragment and manifest_hash replacements to their labeled lines (one occurrence, quoted placeholders tolerated, hard error when missing). Regression test reproduces the live corruption: a placeholder `sha256: '0'` no longer rewrites every zero in the file. Details in #451.

Closes #451. Related: #448/PR #450 (where it detonated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm