### PR TITLE
fix(#454): package dirs stay off the test runner's PYTHONPATH

### DIFF
--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -100,14 +100,28 @@ def _source_dir_pythonpath(workspace: str, source_files: list[dict[str, str]]) -
     So a ``backend/``-nested app whose test does ``from main import app`` (main at
     ``backend/main.py``) imports cleanly even though pytest runs from the
     workspace root (#303).
+
+    #454: a directory that IS a package (has ``__init__.py``) never goes on the
+    path directly — putting ``backend/`` itself on PYTHONPATH makes its modules
+    importable as top-level, where ``from .errors import X`` raises "attempted
+    relative import with no known parent package" (the fill-contract scaffold's
+    35/35-passing suite failed on exactly this in run_33640d896265). Instead,
+    walk up to the first non-package ancestor (usually the workspace root,
+    already present). Flat layouts without ``__init__.py`` keep the #303
+    behavior unchanged.
     """
     dirs = {
         os.path.dirname(os.path.join(workspace, rec["path"]))
         for rec in source_files
         if rec["path"].endswith(".py")
     }
+    resolved: set[str] = set()
+    for d in dirs:
+        while os.path.exists(os.path.join(d, "__init__.py")) and len(d) > len(workspace):
+            d = os.path.dirname(d)
+        resolved.add(d)
     existing = os.environ.get("PYTHONPATH", "")
-    parts = [workspace, *sorted(dirs)]
+    parts = [workspace, *sorted(resolved)]
     if existing:
         parts.append(existing)
     return os.pathsep.join(parts)

--- a/tests/unit/capabilities/test_test_runner.py
+++ b/tests/unit/capabilities/test_test_runner.py
@@ -280,3 +280,78 @@ class TestRunBuildValidationSurfacesFrontend:
 
         result = await tr.run_build_validation(TEST_FRAMEWORK_PYTEST, [], [])
         assert result.frontend_build is None
+
+
+# ---------------------------------------------------------------------------
+# #454 — package dirs stay off PYTHONPATH (relative-import scaffolds)
+# ---------------------------------------------------------------------------
+
+
+class TestPackageRelativeImports:
+    """#454: the fill-contract scaffold is a package (backend/__init__.py) whose
+    modules use relative imports. Putting backend/ itself on PYTHONPATH made
+    those modules importable as top-level, where `from .errors import X` dies —
+    run_33640d896265's suite passed 35/35 yet exited 1 on exactly this."""
+
+    _PKG_SOURCES = [
+        {"path": "backend/__init__.py", "content": ""},
+        {"path": "backend/errors.py", "content": "class ApiError(Exception):\n    pass\n"},
+        {
+            "path": "backend/routes.py",
+            "content": "from .errors import ApiError\n\ndef ping():\n    return 'ok'\n",
+        },
+    ]
+
+    async def test_package_relative_scaffold_tests_pass(self):
+        tests = [
+            {
+                "path": "tests/test_routes.py",
+                "content": (
+                    "from backend.routes import ping\n\n"
+                    "def test_ping():\n    assert ping() == 'ok'\n"
+                ),
+            },
+        ]
+        result = await run_generated_tests(self._PKG_SOURCES, tests)
+        assert result.executed is True
+        assert result.exit_code == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+        assert result.tests_passed is True
+
+    async def test_flat_layout_303_still_works(self):
+        """The #303 case this fix must not regress: no __init__.py, test uses
+        a bare `from main import app`-style import against a nested dir."""
+        sources = [{"path": "backend/main.py", "content": "app = 'the-app'\n"}]
+        tests = [
+            {
+                "path": "test_main.py",
+                "content": "from main import app\n\ndef test_app():\n    assert app == 'the-app'\n",
+            },
+        ]
+        result = await run_generated_tests(sources, tests)
+        assert result.executed is True
+        assert result.exit_code == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+
+    def test_pythonpath_excludes_package_dirs(self, tmp_path):
+        from squadops.capabilities.handlers.test_runner import (
+            _materialize_files,
+            _source_dir_pythonpath,
+        )
+
+        ws = str(tmp_path)
+        _materialize_files(ws, self._PKG_SOURCES)
+        path = _source_dir_pythonpath(ws, self._PKG_SOURCES)
+        parts = path.split(os.pathsep)
+        assert ws in parts
+        assert str(tmp_path / "backend") not in parts  # package dir stays off
+
+    def test_pythonpath_keeps_non_package_dirs(self, tmp_path):
+        from squadops.capabilities.handlers.test_runner import (
+            _materialize_files,
+            _source_dir_pythonpath,
+        )
+
+        sources = [{"path": "backend/main.py", "content": "x = 1\n"}]
+        ws = str(tmp_path)
+        _materialize_files(ws, sources)
+        path = _source_dir_pythonpath(ws, sources)
+        assert str(tmp_path / "backend") in path.split(os.pathsep)  # #303 preserved


### PR DESCRIPTION
A directory with `__init__.py` never goes on PYTHONPATH directly — it walks up to its first non-package ancestor, so package-relative scaffolds import correctly while #303's flat layouts keep their direct entries. Real-subprocess regression tests for both. Evidence in #454: 3.7's suite passed 35/35 yet exited 1 on this collision — the arc's last failing check.

Closes #454. Related: #303, #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm