### PR TITLE
fix(#458): plan-authored invariant tasks run in canonical order (assemble before qa.test)

### DIFF
--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -227,7 +227,10 @@ _BUILD_TASK_TYPES = {s[0] for s in BUILD_TASK_STEPS} | {s[0] for s in BUILDER_AS
 # Plan substitution may replace dev work but must never descope these — a
 # dev-only manifest that dropped them completed green with no build subject
 # (every required check `subject_missing` → blocked_unverified).
-_WORKLOAD_INVARIANT_TASK_TYPES = frozenset({"builder.assemble", "qa.test"})
+# Canonical execution order of the workload-invariant tail: assembly, then
+# verification. Verification must be the last word on the deliverable (#458).
+_WORKLOAD_INVARIANT_TAIL_ORDER = ("builder.assemble", "qa.test")
+_WORKLOAD_INVARIANT_TASK_TYPES = frozenset(_WORKLOAD_INVARIANT_TAIL_ORDER)
 
 # Builder-role (SIP-0071) capability namespace. A run is a *builder deliverable*
 # run — subject to the profile-level ``required_files`` completeness gate
@@ -537,10 +540,20 @@ def _replace_build_steps_with_plan(
     # Re-append the workload-invariant tail (#439): assembly/verification
     # steps survive substitution unless the plan authored its own task of
     # that type (which then stands in).
+    #
+    # Ordering is workload-owned, not plan-owned (#458): plan-authored
+    # invariant tasks keep their titles/criteria but move to the tail in
+    # canonical order, after every mutation-producing task — otherwise an
+    # assembly (or assembly repair) can postdate all test evidence.
     plan_task_types = {t.task_type for t in plan.tasks}
-    invariant_tail = [
-        s for s in steps if s[0] in _WORKLOAD_INVARIANT_TASK_TYPES and s[0] not in plan_task_types
-    ]
+    plan_body = [t for t in plan.tasks if t.task_type not in _WORKLOAD_INVARIANT_TASK_TYPES]
+
+    invariant_tail: list = []
+    for task_type in _WORKLOAD_INVARIANT_TAIL_ORDER:
+        if task_type in plan_task_types:
+            invariant_tail.extend(t for t in plan.tasks if t.task_type == task_type)
+        else:
+            invariant_tail.extend(s for s in steps if s[0] == task_type)
 
     # Append plan tasks (PlanTask objects, not tuples), then the tail
-    return non_build_steps + list(plan.tasks) + invariant_tail
+    return non_build_steps + plan_body + invariant_tail

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -365,6 +365,42 @@ summary:
 """
 
 
+QA_BEFORE_ASSEMBLE_MANIFEST_YAML = """\
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+tasks:
+  - task_index: 0
+    task_type: development.develop
+    role: dev
+    focus: "Backend routes"
+    description: "Fill route stubs"
+    expected_artifacts: ["backend/routes.py"]
+    depends_on: []
+  - task_index: 1
+    task_type: qa.test
+    role: qa
+    focus: "Backend API Tests"
+    description: "Write tests"
+    expected_artifacts: ["tests/test_api.py"]
+    depends_on: [0]
+  - task_index: 2
+    task_type: builder.assemble
+    role: builder
+    focus: "QA Handoff and Assembly"
+    description: "Assemble qa_handoff.md"
+    expected_artifacts: ["qa_handoff.md"]
+    depends_on: [1]
+summary:
+  total_dev_tasks: 1
+  total_builder_tasks: 1
+  total_qa_tasks: 1
+  total_tasks: 3
+  estimated_layers: [backend, test]
+"""
+
+
 def _make_builder_profile() -> SquadProfile:
     profile = _make_profile()
     return SquadProfile(
@@ -467,3 +503,54 @@ class TestWorkloadInvariantTail:
         types = [e.task_type for e in envelopes]
         assert len(envelopes) == 9
         assert types.count("qa.test") == 1
+
+    def test_plan_authored_qa_before_assemble_is_reordered(self):
+        """#458, the attempt-3.8 reproduction (art_d76f0a2bf05c): the manifest
+        authored qa.test BEFORE builder.assemble, so testing preceded assembly
+        and the (repaired) assembled deliverable was never tested. Ordering is
+        workload-owned: plan tasks stand in, but the tail runs in canonical
+        order regardless of authored position."""
+        manifest = ImplementationPlan.from_yaml(QA_BEFORE_ASSEMBLE_MANIFEST_YAML)
+        run = _make_run(workload_type="implementation")
+        cycle = _make_cycle(
+            applied_defaults={
+                "plan_tasks": True,
+                "build_tasks": True,
+                "build_profile": "fullstack_fastapi_react",
+            }
+        )
+        envelopes = generate_task_plan(cycle, run, _make_builder_profile(), plan=manifest)
+
+        types = [e.task_type for e in envelopes]
+        assert types == [
+            "governance.define_done",
+            "development.develop",
+            "builder.assemble",
+            "qa.test",
+        ]
+        # The plan's own tasks stand in (manifest -m namespace), not statics
+        assert all(
+            "-m00" in e.task_id for e in envelopes if e.task_type in ("builder.assemble", "qa.test")
+        )
+
+    def test_plan_qa_only_static_assemble_precedes_it(self):
+        """Second-order #458 case: plan authors qa.test but NOT builder.assemble.
+        The re-appended static assemble must still run BEFORE the plan's qa.test
+        (pre-fix it was appended after all plan tasks, i.e. after testing)."""
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)  # 3 dev + qa.test
+        run = _make_run(workload_type="implementation")
+        cycle = _make_cycle(
+            applied_defaults={
+                "plan_tasks": True,
+                "build_tasks": True,
+                "build_profile": "fullstack_fastapi_react",
+            }
+        )
+        envelopes = generate_task_plan(cycle, run, _make_builder_profile(), plan=manifest)
+
+        types = [e.task_type for e in envelopes]
+        assert types.index("builder.assemble") < types.index("qa.test")
+        assert types[-1] == "qa.test"
+        # The surviving qa task is the plan's, not the static tuple's
+        qa_env = next(e for e in envelopes if e.task_type == "qa.test")
+        assert "-m003-" in qa_env.task_id


### PR DESCRIPTION
## What

#440 guaranteed invariant *presence* but not invariant *ordering*: a plan that authors its own `qa.test`/`builder.assemble` stood in at its **authored position**. Attempt 3.8's manifest (`art_d76f0a2bf05c`) ordered `qa.test` before `builder.assemble`, so every piece of test evidence predated assembly — and after bob's assembly failed and was repaired, the final assembled deliverable had never been tested by anything.

This PR makes ordering workload-owned: plan-authored invariant tasks keep their titles/criteria/ids but move to the tail in canonical order (`builder.assemble` → `qa.test`), after every mutation-producing task. Also fixes the second-order case: a re-appended *static* assemble used to land after the plan's own `qa.test`.

## Tests

- 3.8 reproduction: manifest authors qa-then-assemble → envelopes end `[builder.assemble, qa.test]`, both still the plan's tasks (`-m` namespace)
- Second-order case: plan authors `qa.test` only → static assemble precedes it
- All 19 task-plan tests + full `tests/unit/cycles/` (1617) green

## Notes

- **Stacked on #440** (`fix/439-plan-substitution-invariant-tail`) — base is that branch; retarget/merge after #440 lands.
- **Bridge fix**: structurally subsumed by the Sandbox SIP, where qa.test's subject becomes the booted container built *from* the assembled tree (ordering = data dependency). Kept minimal on purpose; the SIP should encode ordering as an explicit artifact dependency.

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm