### PR TITLE
fix(#457): test-isolation doctrine in the qa.test fragment

### DIFF
--- a/src/squadops/prompts/fragments/manifest.yaml
+++ b/src/squadops/prompts/fragments/manifest.yaml
@@ -90,7 +90,7 @@ fragments:
   layer: task_type
   roles:
   - qa
-  sha256: 240228b68551f4baf235578054da96aee7e63d908787abca9934296e354d4dfc
+  sha256: 93b862c5e1482750e3f6ee8e31b59ffd862b7b9ebac07c774de2da89ceb74262
 - fragment_id: task_type.development.propose_plan_tasks
   path: shared/task_type/task_type.development.propose_plan_tasks.md
   layer: task_type
@@ -187,4 +187,4 @@ fragments:
   roles:
   - data
   sha256: fd44a28f65e449c6320b5ee5f1d8121013a03c7baa757965334c4e19c7904779
-manifest_hash: af51cc899560284c882f8a703bd210940765698ee08a690661b1e4d9f5c74cc4
+manifest_hash: 11c462144148f3c57a5a61a89fba827f599e1dba579d610010cab26b87afd850

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.qa.test.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.qa.test.md
@@ -20,6 +20,15 @@ that fails to import fails the whole `tests_pass` check. If a test would need
 an unavailable library, cover that behavior from the other side of the stack
 (e.g. backend API tests) or omit it.
 
+## Test Isolation (hard rule)
+
+- Every test must be order-independent: never rely on state created,
+  mutated, or left behind by another test.
+- Application state that lives at module level (in-memory stores, caches,
+  registries) persists across all tests in a session. Reset it in a fixture
+  that runs before each test (e.g. an autouse fixture clearing the store) —
+  a test asserting "empty" must establish empty, not hope to run first.
+
 ## Scope Discipline
 
 - Test the deliverable that exists, against the interfaces it actually


### PR DESCRIPTION
## What

Adds a **Test Isolation (hard rule)** section to the `task_type.qa.test` prompt fragment: tests must be order-independent, and module-level application state (in-memory stores, caches) must be reset in a per-test fixture. Regenerates the fragment `sha256` and `manifest_hash`.

## Why

Attempt 3.8 (`run_8c14a430ad1c`): eve's generated suite ran 13/14 — the one failure was `test_list_runs_empty`, which asserted `[]` from a module-level store that earlier creation tests had polluted. No reset fixture existed; the test only passes if it runs first. Cost a full correction chain.

Data-side companion to #456 (harness-side repair re-run): this reduces how often qa.test repairs happen; #456 makes the harness honest when they do.

## Notes

- **Stacked on #450** (`fix/448-test-generation-dependency-constraint`) — the fragment file only exists there. Retarget/merge after #450 lands.
- Hashes recomputed by hand via `FileSystemPromptRepository.hash_fragment_file` + `PromptManifest.compute_manifest_hash` with anchored line replacement — the regen script on this branch predates the #451 fix (PR #453).
- All 359 `tests/unit/prompts/` tests green (includes manifest integrity verification).

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm