### PR TITLE
fix(#456): repaired qa.test suites are re-executed before patch acceptance

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -557,6 +557,17 @@ class CorrectionRunner:
             return None
 
         failed_inputs = envelope.inputs or {}
+        if not failed_inputs.get("artifact_contents") and "artifact_vault" not in failed_inputs:
+            # No workspace to test against — the handler would reject the
+            # envelope at input validation anyway (the 3.11 instant-fail).
+            # Skip the doomed dispatch; the caller falls back to re-dispatch.
+            logger.warning(
+                "retest for %s skipped: failed envelope carries no workspace "
+                "(artifact_contents/artifact_vault) — was the enriched envelope threaded?",
+                envelope.task_id,
+            )
+            return None
+
         resolved = resolve_agent_config("qa", profile)
         retest_inputs: dict[str, Any] = {
             "prd": cycle.prd_ref,

--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -507,3 +507,92 @@ class CorrectionRunner:
         return CorrectionProtocolResult(
             correction_path=correction_path, repair_artifacts=repair_artifacts
         )
+
+    # Artifact types a qa.test task emits *about* its run, not *into* its
+    # workspace — excluded from re-execution so the repaired suite matches
+    # the original workspace composition (#456).
+    _NON_WORKSPACE_ARTIFACT_TYPES = frozenset({"test_report", "typed_check_evaluation"})
+
+    async def reexecute_repaired_suite(
+        self,
+        run_id: str,
+        cycle: Cycle,
+        envelope: TaskEnvelope,
+        patched_artifacts: list[dict[str, Any]],
+        correction_attempts: int,
+        *,
+        prior_outputs: dict[str, Any],
+        all_artifact_refs: list[str],
+        stored_artifacts: list[tuple[str, ArtifactRef]],
+        completed_task_ids: list[str],
+        plan_delta_refs: list[str],
+        profile: Any = None,
+        flow_run_id: str | None = None,
+    ) -> TaskResult | None:
+        """Re-execute a repaired qa.test suite in the QA agent's environment (#456).
+
+        Patch verification (#389) covers typed criteria only; a qa.test failure's
+        real evidence is behavioral (``tests_pass`` is synthesized from the
+        task's executed ``test_result``). A repaired suite that is never re-run
+        leaves the pre-repair failure as the check's final state — the
+        run_8c14a430ad1c false-red. This dispatches the failed task's own
+        task_type back to the QA agent in execute-only mode (``retest_files``
+        set, no generation): same workspace, same runner, honestly fresh
+        evidence for §6.5 final-state resolution to supersede with.
+
+        Returns the retest ``TaskResult`` (its Prefect task_run, events,
+        artifacts and checkpoint are handled by ``_dispatch_protocol_step``),
+        or ``None`` when no runnable suite files survive the patch overlay.
+        """
+        from uuid import uuid4
+
+        retest_files = [
+            {"filename": art["name"], "content": art.get("content", "")}
+            for art in patched_artifacts
+            if isinstance(art, dict)
+            and isinstance(art.get("name"), str)
+            and art.get("type") not in self._NON_WORKSPACE_ARTIFACT_TYPES
+        ]
+        if not retest_files:
+            return None
+
+        failed_inputs = envelope.inputs or {}
+        resolved = resolve_agent_config("qa", profile)
+        retest_inputs: dict[str, Any] = {
+            "prd": cycle.prd_ref,
+            "resolved_config": failed_inputs.get("resolved_config", {}),
+            "artifact_contents": failed_inputs.get("artifact_contents", {}),
+            "retest_files": retest_files,
+            "agent_model": resolved.model,
+            "agent_config_overrides": resolved.config_overrides,
+            "subtask_focus": failed_inputs.get("subtask_focus"),
+            "expected_artifacts": failed_inputs.get("expected_artifacts", []),
+            "acceptance_criteria": failed_inputs.get("acceptance_criteria", []),
+        }
+
+        retest_envelope = TaskEnvelope(
+            task_id=f"retest-{run_id[:12]}-{correction_attempts:02d}-{envelope.task_type}",
+            agent_id=resolved.agent_id,
+            cycle_id=cycle.cycle_id,
+            pulse_id=uuid4().hex,
+            project_id=cycle.project_id,
+            task_type=envelope.task_type,
+            correlation_id=uuid4().hex,
+            causation_id=envelope.task_id,
+            trace_id=uuid4().hex,
+            span_id=uuid4().hex,
+            inputs=retest_inputs,
+            metadata={"role": "qa", "retest": True},
+        )
+
+        return await self._dispatch_protocol_step(
+            retest_envelope,
+            run_id,
+            cycle,
+            flow_run_id,
+            prior_outputs=prior_outputs,
+            all_artifact_refs=all_artifact_refs,
+            stored_artifacts=stored_artifacts,
+            completed_task_ids=completed_task_ids,
+            plan_delta_refs=plan_delta_refs,
+        )

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1416,7 +1416,20 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # until max_correction_attempts exhausts (guard above) →
             # _ExecutionError → the run fails honestly instead of false-completing.
             action = await self._try_accept_patch(
-                envelope, result, protocol.repair_artifacts, patched_result_holder
+                envelope,
+                result,
+                protocol.repair_artifacts,
+                patched_result_holder,
+                run_id=run_id,
+                cycle=cycle,
+                correction_attempts=attempt,
+                prior_outputs=prior_outputs,
+                all_artifact_refs=all_artifact_refs,
+                stored_artifacts=stored_artifacts,
+                completed_task_ids=completed_task_ids,
+                plan_delta_refs=plan_delta_refs,
+                profile=profile,
+                flow_run_id=flow_run_id,
             )
             return action
         elif correction_path == "continue":
@@ -1431,6 +1444,17 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         result: TaskResult,
         repair_artifacts: list[dict[str, Any]],
         patched_result_holder: dict[str, Any] | None,
+        *,
+        run_id: str = "",
+        cycle: Cycle | None = None,
+        correction_attempts: int = 0,
+        prior_outputs: dict[str, Any] | None = None,
+        all_artifact_refs: list[str] | None = None,
+        stored_artifacts: list[tuple[str, ArtifactRef]] | None = None,
+        completed_task_ids: list[str] | None = None,
+        plan_delta_refs: list[str] | None = None,
+        profile: Any = None,
+        flow_run_id: str | None = None,
     ) -> str:
         """Behaviorally verify a patch (#389); return "accept_patch" or "continue".
 
@@ -1439,6 +1463,16 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         corrected result. Any non-pass (failed, unverifiable, no repair
         artifacts, no holder) falls back to the pre-#389 re-dispatch path —
         conservative by construction, never a false accept.
+
+        #456: typed criteria are necessary but not sufficient when the failed
+        task carries behavioral evidence — ``tests_pass`` is synthesized from
+        the task's executed ``test_result``, so a patched result that keeps the
+        stale pre-repair ``test_result`` records the failure as the check's
+        final state no matter what the typed rows say. When the failed outputs
+        carry a ``test_result``, the repaired suite is re-executed in the QA
+        agent's environment (via the correction runner) and the corrected
+        result takes the retest's fresh behavioral evidence. A retest that
+        fails — or can't run — falls back to "continue", same as a typed miss.
         """
         if not repair_artifacts or patched_result_holder is None:
             return "continue"
@@ -1467,13 +1501,62 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             return "continue"
 
         corrected_outputs = dict(result.outputs or {})
+
+        # #456: behavioral-evidence-backed task — re-execute the repaired
+        # suite before accepting; fresh test_result supersedes the stale one.
+        retest_rows: list[dict[str, Any]] = []
+        if isinstance(corrected_outputs.get("test_result"), dict):
+            if cycle is None:
+                logger.warning(
+                    "patch_verification task=%s carries test_result but no retest "
+                    "context — falling back to re-dispatch",
+                    envelope.task_id,
+                )
+                return "continue"
+            retest_result = await self._correction_runner.reexecute_repaired_suite(
+                run_id,
+                cycle,
+                envelope,
+                patched_artifacts,
+                correction_attempts,
+                prior_outputs=prior_outputs if prior_outputs is not None else {},
+                all_artifact_refs=all_artifact_refs if all_artifact_refs is not None else [],
+                stored_artifacts=stored_artifacts if stored_artifacts is not None else [],
+                completed_task_ids=completed_task_ids if completed_task_ids is not None else [],
+                plan_delta_refs=plan_delta_refs if plan_delta_refs is not None else [],
+                profile=profile,
+                flow_run_id=flow_run_id,
+            )
+            retest_outputs = (retest_result.outputs or {}) if retest_result else {}
+            fresh_test_result = retest_outputs.get("test_result")
+            retest_passed = (
+                retest_result is not None
+                and retest_result.status == "SUCCEEDED"
+                and isinstance(fresh_test_result, dict)
+                and fresh_test_result.get("tests_passed") is True
+            )
+            logger.info(
+                "patch_retest task=%s status=%s passed=%s",
+                envelope.task_id,
+                retest_result.status if retest_result else "not_dispatched",
+                retest_passed,
+            )
+            if not retest_passed:
+                return "continue"
+            corrected_outputs["test_result"] = fresh_test_result
+            retest_validation = retest_outputs.get("validation_result")
+            if isinstance(retest_validation, dict):
+                retest_rows = [
+                    row for row in retest_validation.get("checks", []) if isinstance(row, dict)
+                ]
+
         corrected_outputs["artifacts"] = patched_artifacts
         prior_validation = corrected_outputs.get("validation_result")
         corrected_outputs["validation_result"] = {
             **(prior_validation if isinstance(prior_validation, dict) else {}),
             "passed": True,
             "patch_verified": True,
-            "checks": [r.to_check_row() for r in verification.checks],
+            "checks": [r.to_check_row() for r in verification.checks] + retest_rows,
         }
         corrected_outputs.pop("outcome_class", None)
         patched_result_holder["patched_result"] = dataclasses.replace(

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -947,6 +947,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             async def _route_outcome(
                 result,
                 _envelope=envelope,
+                _enriched=enriched,
                 _consecutive_failures=consecutive_failures,
                 _holder=_last_failed_result,
             ):
@@ -954,6 +955,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 action = await self._handle_task_outcome(
                     result=result,
                     envelope=_envelope,
+                    enriched_envelope=_enriched,
                     cycle=cycle,
                     run_id=run_id,
                     task_attempt_counts=task_attempt_counts,
@@ -1321,8 +1323,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         profile: Any = None,
         flow_run_id: str | None = None,
         patched_result_holder: dict[str, Any] | None = None,
+        enriched_envelope: TaskEnvelope | None = None,
     ) -> str:
         """Route a failed task outcome. Returns an action string.
+
+        ``enriched_envelope`` is the dispatch-time envelope carrying the
+        materialized workspace (``artifact_contents``) — the base ``envelope``
+        never has it (#456 retest plumbing; the 3.11 instant-fail).
 
         Returns:
             "continue" — re-dispatch the same task (caller's while loop retries it):
@@ -1423,6 +1430,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 run_id=run_id,
                 cycle=cycle,
                 correction_attempts=attempt,
+                enriched_envelope=enriched_envelope,
                 prior_outputs=prior_outputs,
                 all_artifact_refs=all_artifact_refs,
                 stored_artifacts=stored_artifacts,
@@ -1455,6 +1463,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         plan_delta_refs: list[str] | None = None,
         profile: Any = None,
         flow_run_id: str | None = None,
+        enriched_envelope: TaskEnvelope | None = None,
     ) -> str:
         """Behaviorally verify a patch (#389); return "accept_patch" or "continue".
 
@@ -1513,10 +1522,14 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     envelope.task_id,
                 )
                 return "continue"
+            # The retest needs the dispatch-time workspace: artifact_contents
+            # is added by _enrich_envelope and never exists on the base
+            # envelope (3.11: the retest instant-failed input validation
+            # because it was built from the un-enriched envelope).
             retest_result = await self._correction_runner.reexecute_repaired_suite(
                 run_id,
                 cycle,
-                envelope,
+                enriched_envelope if enriched_envelope is not None else envelope,
                 patched_artifacts,
                 correction_attempts,
                 prior_outputs=prior_outputs if prior_outputs is not None else {},

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -296,6 +296,153 @@ class QATestHandler(_CycleTaskHandler):
         )
         return "".join(parts)
 
+    async def _handle_retest(
+        self,
+        context: ExecutionContext,
+        inputs: dict[str, Any],
+        capability: Any,
+        start_time: float,
+        retest_files: list[dict[str, Any]],
+    ) -> HandlerResult:
+        """Execute-only mode (#456): re-run a repaired test suite as-is.
+
+        The correction loop's patch verification covers typed criteria only;
+        ``tests_pass`` evidence is behavioral and must come from an actual
+        execution of the repaired suite in this (the QA agent's) environment.
+        No LLM is involved — the suite is provided in ``retest_files``, the
+        source workspace comes from ``artifact_contents`` exactly as the
+        original run saw it, and success is exactly "the suite passed".
+        """
+        del context  # no LLM/prompt ports in execute-only mode
+
+        extracted = []
+        for f in retest_files:
+            if not isinstance(f, dict):
+                continue
+            filename = f.get("filename") or f.get("name") or f.get("path")
+            if isinstance(filename, str) and filename:
+                extracted.append({"filename": filename, "content": f.get("content", "")})
+        if not extracted:
+            return self._fail_result(start_time, inputs, "retest_files contained no usable files")
+
+        sources = self._get_source_artifacts(inputs)
+        test_result, test_report_artifact = await self._run_test_suite(
+            capability, sources, extracted
+        )
+
+        artifacts = [
+            {
+                "name": f["filename"],
+                "content": f["content"],
+                "media_type": _classify_file(f["filename"])[1],
+                "type": "test",
+            }
+            for f in extracted
+        ]
+        artifacts.append(test_report_artifact)
+
+        checks: list[dict[str, Any]] = []
+        missing: list[str] = []
+        passed = bool(test_result.executed and test_result.tests_passed)
+        if not passed:
+            if test_result.executed:
+                detail = f"tests_failed:exit_{test_result.exit_code}"
+                summary = f"Repaired suite still fails (exit {test_result.exit_code})"
+            else:
+                reason = test_result.error or "runner_error"
+                detail = f"tests_not_executed:{reason}"
+                summary = f"Repaired suite not executed: {reason}"
+            checks.append(
+                {
+                    "check": "tests_pass",
+                    "executed": test_result.executed,
+                    "exit_code": test_result.exit_code,
+                    "tests_passed": test_result.tests_passed,
+                    "passed": False,
+                }
+            )
+            missing.append(detail)
+        else:
+            summary = "Repaired suite passed"
+
+        # #276 guard holds on the retest path too: a repair must not smuggle a
+        # stub-fallback past the correction loop.
+        from squadops.capabilities.handlers.stub_detection import detect_stub_fallback_tests
+
+        stub_offenders = detect_stub_fallback_tests(artifacts)
+        if stub_offenders:
+            passed = False
+            checks.append(
+                {
+                    "check": "no_stub_fallback_tests",
+                    "offenders": stub_offenders,
+                    "passed": False,
+                }
+            )
+            missing.append(f"stub_fallback_tests:{','.join(stub_offenders)}")
+            summary = f"{summary}; repaired test masks the entrypoint: {', '.join(stub_offenders)}"
+
+        passed_count = sum(1 for c in checks if c.get("passed"))
+        outputs: dict[str, Any] = {
+            "summary": f"[qa] Re-executed repaired suite ({len(extracted)} file(s)): {summary}",
+            "role": self._role,
+            "artifacts": artifacts,
+            "test_result": {
+                "executed": test_result.executed,
+                "exit_code": test_result.exit_code,
+                "tests_passed": test_result.tests_passed,
+                "test_file_count": test_result.test_file_count,
+                "source_file_count": test_result.source_file_count,
+                "summary": test_result.summary,
+            },
+            "validation_result": {
+                "passed": passed,
+                "checks": checks,
+                "missing_components": missing,
+                "coverage_ratio": (passed_count / len(checks)) if checks else 1.0,
+                "summary": summary,
+            },
+        }
+
+        if passed:
+            from squadops.cycles.task_outcome import TaskOutcome
+
+            outputs["outcome_class"] = TaskOutcome.SUCCESS
+        else:
+            from squadops.cycles.task_outcome import FailureClassification, TaskOutcome
+
+            outputs["outcome_class"] = TaskOutcome.SEMANTIC_FAILURE
+            outputs["failure_classification"] = FailureClassification.WORK_PRODUCT
+
+        # #407: frontend build is first-class evidence on this path too.
+        fb = test_result.frontend_build
+        if fb is not None:
+            if fb.ran:
+                fb_row: dict[str, Any] = {"check": CHECK_FRONTEND_BUILD, "passed": fb.ok}
+            else:
+                fb_row = {
+                    "check": CHECK_FRONTEND_BUILD,
+                    "executed": False,
+                    "reason": _frontend_skip_reason(fb.error),
+                }
+            outputs["validation_result"]["checks"].append(fb_row)
+
+        duration_ms = (time.perf_counter() - start_time) * 1000
+        evidence = HandlerEvidence.create(
+            handler_name=self._handler_name,
+            capability_id=self._capability_id,
+            duration_ms=duration_ms,
+            inputs_hash=self._hash_dict(inputs),
+            outputs_hash=self._hash_dict(outputs),
+            metadata={"retest": True},
+        )
+        return HandlerResult(
+            success=passed,
+            outputs=outputs,
+            _evidence=evidence,
+            error=None if passed else summary,
+        )
+
     async def handle(
         self,
         context: ExecutionContext,
@@ -315,6 +462,13 @@ class QATestHandler(_CycleTaskHandler):
             capability = get_capability(capability_name)
         except ValueError as exc:
             return self._fail_result(start_time, inputs, str(exc))
+
+        # #456 execute-only mode: the correction loop re-runs a repaired suite
+        # verbatim — no generation, no LLM. The verdict is the execution.
+        if inputs.get("retest_files"):
+            return await self._handle_retest(
+                context, inputs, capability, start_time, inputs["retest_files"]
+            )
 
         # SIP-0086 RC-6: focused prompt path for manifest-driven subtasks
         if inputs.get("subtask_focus") is not None:

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -1231,3 +1231,98 @@ class TestBuilderNoTokenBudget:
         call_kwargs = ctx.ports.llm.chat_stream_with_usage.call_args.kwargs
         assert "max_tokens" not in call_kwargs
         assert "timeout_seconds" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# QATestHandler — execute-only retest mode (#456)
+# ---------------------------------------------------------------------------
+
+
+class TestQARetestExecuteOnly:
+    """#456: ``retest_files`` puts the handler in execute-only mode — the
+    correction loop re-runs a repaired suite for fresh behavioral evidence.
+    A retest that generates (calls the LLM) would re-roll the repaired suite
+    and discard the patch; a retest that fabricates a pass without executing
+    is the false-green the whole fix exists to prevent."""
+
+    def _retest_inputs(self, qa_inputs):
+        return {
+            **qa_inputs,
+            "retest_files": [
+                {
+                    "filename": "tests/test_api.py",
+                    "content": "def test_ok():\n    assert True\n",
+                }
+            ],
+        }
+
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
+    async def test_retest_passes_without_llm(self, _mock_run, mock_context, qa_inputs):
+        handler = QATestHandler()
+        result = await handler.handle(mock_context, self._retest_inputs(qa_inputs))
+
+        assert result.success is True
+        mock_context.ports.llm.chat_stream_with_usage.assert_not_called()
+        assert result.outputs["test_result"]["tests_passed"] is True
+        assert result.outputs["validation_result"]["passed"] is True
+        # Fresh execution report accompanies the evidence.
+        names = [a["name"] for a in result.outputs["artifacts"]]
+        assert "test_report.md" in names
+
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_FAILED)
+    async def test_retest_failure_is_semantic_failure_with_evidence(
+        self, _mock_run, mock_context, qa_inputs
+    ):
+        from squadops.cycles.task_outcome import TaskOutcome
+
+        handler = QATestHandler()
+        result = await handler.handle(mock_context, self._retest_inputs(qa_inputs))
+
+        assert result.success is False
+        assert result.outputs["outcome_class"] == TaskOutcome.SEMANTIC_FAILURE
+        assert result.outputs["test_result"]["tests_passed"] is False
+        assert result.outputs["test_result"]["exit_code"] == 1
+        rows = result.outputs["validation_result"]["checks"]
+        tests_row = next(r for r in rows if r["check"] == "tests_pass")
+        assert tests_row["executed"] is True
+        assert tests_row["passed"] is False
+
+    async def test_retest_with_no_usable_files_fails(self, mock_context, qa_inputs):
+        handler = QATestHandler()
+        result = await handler.handle(
+            mock_context, {**qa_inputs, "retest_files": [{"content": "orphan"}]}
+        )
+
+        assert result.success is False
+        assert "retest_files" in (result.error or "")
+
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
+    async def test_retest_stub_fallback_blocks_even_when_suite_passes(
+        self, _mock_run, mock_context, qa_inputs
+    ):
+        """A repair that hides the entrypoint behind an ImportError stub passes
+        pytest against the stub — the #276 false-green — and must still fail."""
+        stub_suite = {
+            **qa_inputs,
+            "retest_files": [
+                {
+                    "filename": "tests/test_api.py",
+                    "content": (
+                        "try:\n"
+                        "    from src.main import app\n"
+                        "except ImportError:\n"
+                        "    from fastapi import FastAPI\n"
+                        "    app = FastAPI()\n"
+                        "def test_ok():\n    assert app\n"
+                    ),
+                }
+            ],
+        }
+        handler = QATestHandler()
+        result = await handler.handle(mock_context, stub_suite)
+
+        assert result.success is False
+        rows = result.outputs["validation_result"]["checks"]
+        stub_row = next(r for r in rows if r["check"] == "no_stub_fallback_tests")
+        assert stub_row["passed"] is False
+        assert "tests/test_api.py" in stub_row["offenders"]

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -1896,3 +1896,30 @@ class TestReexecuteRepairedSuite:
 
         assert result is None
         assert dispatcher.dispatched == []
+
+    async def test_workspaceless_envelope_never_dispatches(self):
+        """3.11 reproduction: a retest built without artifact_contents fails
+        eve's input validation in 300ms and burns a fallback re-roll — the
+        runner must refuse the doomed dispatch and return None instead."""
+        import dataclasses
+
+        runner, dispatcher = self._make_runner(
+            lambda env: TaskResult(task_id=env.task_id, status="SUCCEEDED", outputs={})
+        )
+        bare = dataclasses.replace(
+            self._failed_qa_envelope(),
+            inputs={"resolved_config": {}, "acceptance_criteria": []},
+        )
+
+        result = await runner.reexecute_repaired_suite(
+            "run_001",
+            self._cycle(),
+            bare,
+            [{"name": "tests/test_api.py", "content": "repaired", "type": "test"}],
+            0,
+            profile=self._profile(),
+            **self._state_kwargs(),
+        )
+
+        assert result is None
+        assert dispatcher.dispatched == []

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -1720,3 +1720,179 @@ class TestCorrectionRunnerStandalone:
 
         assert protocol_result.correction_path == "continue"
         assert protocol_result.repair_artifacts == []
+
+
+class TestReexecuteRepairedSuite:
+    """#456: the repaired-suite retest — the correction loop's source of fresh
+    behavioral evidence. Wrong routing, a polluted file set, or a missing
+    workspace makes the retest execute something other than 'the repaired
+    suite against the original workspace', which is worse than not retesting."""
+
+    def _make_runner(self, responder):
+        from adapters.cycles.correction_runner import CorrectionRunner
+
+        class _PassthroughDispatcher:
+            def __init__(self):
+                self.dispatched = []
+
+            async def dispatch_task(self, envelope, run_id, **_kwargs):
+                self.dispatched.append(envelope)
+                return responder(envelope)
+
+            async def create_task_run_if_enabled(self, _flow_run_id, _envelope):
+                return None
+
+        dispatcher = _PassthroughDispatcher()
+        runner = CorrectionRunner(
+            cycle_registry=AsyncMock(),
+            artifact_vault=AsyncMock(),
+            event_bus=MagicMock(),
+            task_dispatcher=dispatcher,
+            store_artifact=AsyncMock(),
+        )
+        return runner, dispatcher
+
+    def _failed_qa_envelope(self):
+        from squadops.tasks.models import TaskEnvelope
+
+        return TaskEnvelope(
+            task_id="task-run_001-m004-qa.test",
+            agent_id="eve",
+            cycle_id="cyc_001",
+            pulse_id="p",
+            project_id="hello_squad",
+            task_type="qa.test",
+            correlation_id="corr",
+            causation_id=None,
+            trace_id="t",
+            span_id="s",
+            inputs={
+                "resolved_config": {"dev_capability": "fullstack_fastapi_react"},
+                "artifact_contents": {"backend/main.py": "app = None\n"},
+                "subtask_focus": "Backend API Tests",
+                "expected_artifacts": ["tests/test_api.py"],
+                "acceptance_criteria": ["tests pass"],
+            },
+            metadata={"role": "qa"},
+        )
+
+    def _profile(self):
+        return SquadProfile(
+            profile_id="full",
+            name="Full",
+            description="d",
+            version=1,
+            agents=(AgentProfileEntry(agent_id="eve", role="qa", model="qwen", enabled=True),),
+            created_at=NOW,
+        )
+
+    def _cycle(self):
+        return Cycle(
+            cycle_id="cyc_001",
+            project_id="hello_squad",
+            created_at=NOW,
+            created_by="system",
+            prd_ref="prd_123",
+            squad_profile_id="full",
+            squad_profile_snapshot_ref="sha256:abc",
+            task_flow_policy=TaskFlowPolicy(mode="sequential"),
+            build_strategy="fresh",
+        )
+
+    def _state_kwargs(self):
+        return {
+            "prior_outputs": {},
+            "all_artifact_refs": [],
+            "stored_artifacts": [],
+            "completed_task_ids": [],
+            "plan_delta_refs": [],
+        }
+
+    async def test_retest_envelope_reruns_failed_task_in_qa_environment(self):
+        """Bug caught: retest routed to the wrong agent/task_type would produce
+        evidence from a different environment than the original run's."""
+        runner, dispatcher = self._make_runner(
+            lambda env: TaskResult(task_id=env.task_id, status="SUCCEEDED", outputs={})
+        )
+        patched = [
+            {"name": "tests/test_api.py", "content": "def test_x():\n    assert 1\n"},
+            {"name": "test_report.md", "content": "old report", "type": "test_report"},
+            {
+                "name": "typed_check_evaluation.json",
+                "content": "{}",
+                "type": "typed_check_evaluation",
+            },
+        ]
+
+        result = await runner.reexecute_repaired_suite(
+            "run_001",
+            self._cycle(),
+            self._failed_qa_envelope(),
+            patched,
+            1,
+            profile=self._profile(),
+            **self._state_kwargs(),
+        )
+
+        assert result is not None and result.status == "SUCCEEDED"
+        (env,) = dispatcher.dispatched
+        assert env.task_type == "qa.test"
+        assert env.agent_id == "eve"
+        assert env.task_id == "retest-run_001-01-qa.test"
+        assert env.causation_id == "task-run_001-m004-qa.test"
+        assert env.metadata["retest"] is True
+
+    async def test_retest_inputs_carry_suite_and_original_workspace(self):
+        """Bug caught: report/evaluation artifacts leaking into the suite, or
+        the workspace missing — the retest would run the wrong thing."""
+        runner, dispatcher = self._make_runner(
+            lambda env: TaskResult(task_id=env.task_id, status="SUCCEEDED", outputs={})
+        )
+        patched = [
+            {"name": "tests/test_api.py", "content": "repaired", "type": "test"},
+            {"name": "test_report.md", "content": "old report", "type": "test_report"},
+            {
+                "name": "typed_check_evaluation.json",
+                "content": "{}",
+                "type": "typed_check_evaluation",
+            },
+        ]
+
+        await runner.reexecute_repaired_suite(
+            "run_001",
+            self._cycle(),
+            self._failed_qa_envelope(),
+            patched,
+            0,
+            profile=self._profile(),
+            **self._state_kwargs(),
+        )
+
+        (env,) = dispatcher.dispatched
+        names = [f["filename"] for f in env.inputs["retest_files"]]
+        assert names == ["tests/test_api.py"]
+        assert env.inputs["retest_files"][0]["content"] == "repaired"
+        # Original workspace travels with the retest.
+        assert env.inputs["artifact_contents"] == {"backend/main.py": "app = None\n"}
+        assert env.inputs["resolved_config"]["dev_capability"] == "fullstack_fastapi_react"
+
+    async def test_no_usable_suite_returns_none_without_dispatch(self):
+        """Bug caught: dispatching a retest with zero files — it would 'pass'
+        vacuously (pytest collects nothing) and false-green the patch."""
+        runner, dispatcher = self._make_runner(
+            lambda env: TaskResult(task_id=env.task_id, status="SUCCEEDED", outputs={})
+        )
+        patched = [{"name": "test_report.md", "content": "r", "type": "test_report"}]
+
+        result = await runner.reexecute_repaired_suite(
+            "run_001",
+            self._cycle(),
+            self._failed_qa_envelope(),
+            patched,
+            0,
+            profile=self._profile(),
+            **self._state_kwargs(),
+        )
+
+        assert result is None
+        assert dispatcher.dispatched == []

--- a/tests/unit/cycles/test_outcome_routing.py
+++ b/tests/unit/cycles/test_outcome_routing.py
@@ -748,3 +748,84 @@ class TestAcceptPatchRetest:
         )
         assert action == "accept_patch"
         executor._correction_runner.reexecute_repaired_suite.assert_not_awaited()
+
+
+class TestAcceptPatchRetestWorkspaceThreading:
+    """3.11 instant-fail: the retest was built from the BASE envelope, but
+    artifact_contents (the workspace) exists only on the dispatch-time
+    enriched envelope — eve rejected every retest at input validation in
+    300ms and the fallback re-rolls burned the correction budget."""
+
+    async def test_retest_receives_enriched_envelope(self, executor, cycle):
+        import dataclasses
+
+        from squadops.cycles.implementation_plan import TypedCheck
+        from squadops.tasks.models import TaskEnvelope
+
+        executor._correction_runner.reexecute_repaired_suite = AsyncMock(
+            return_value=TaskResult(
+                task_id="retest",
+                status="SUCCEEDED",
+                outputs={"test_result": {"executed": True, "exit_code": 0, "tests_passed": True}},
+            )
+        )
+        base = TaskEnvelope(
+            task_id="task_9",
+            agent_id="eve",
+            cycle_id="cyc_001",
+            pulse_id="p",
+            project_id="hello_squad",
+            task_type="qa.test",
+            correlation_id="corr",
+            causation_id=None,
+            trace_id="t",
+            span_id="s",
+            inputs={
+                "resolved_config": {},
+                "acceptance_criteria": [
+                    TypedCheck(
+                        check="regex_match",
+                        params={"file": "tests/test_api.py", "pattern": "def test_"},
+                        severity="error",
+                        description="Suite defines tests",
+                    )
+                ],
+            },
+            metadata={"role": "qa"},
+        )
+        enriched = dataclasses.replace(
+            base,
+            inputs={**base.inputs, "artifact_contents": {"src/main.py": "app = 1\n"}},
+        )
+        failed = TaskResult(
+            task_id="task_9",
+            status="FAILED",
+            outputs={
+                "artifacts": [{"name": "tests/test_api.py", "content": "def test_x(): assert 0\n"}],
+                "test_result": {"executed": True, "exit_code": 1, "tests_passed": False},
+                "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
+            },
+            error="tests failed",
+        )
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            base,
+            failed,
+            [{"name": "tests/test_api.py", "content": "def test_x(): assert 1\n"}],
+            holder,
+            run_id="run_001",
+            cycle=cycle,
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+            profile=None,
+            flow_run_id=None,
+            enriched_envelope=enriched,
+        )
+
+        assert action == "accept_patch"
+        retest_envelope = executor._correction_runner.reexecute_repaired_suite.await_args.args[2]
+        assert retest_envelope.inputs["artifact_contents"] == {"src/main.py": "app = 1\n"}

--- a/tests/unit/cycles/test_outcome_routing.py
+++ b/tests/unit/cycles/test_outcome_routing.py
@@ -549,3 +549,202 @@ class TestAcceptPatch:
         )
         assert action == "continue"
         assert holder == {}
+
+
+class TestAcceptPatchRetest:
+    """#456: a qa.test-class patch (failed outputs carry ``test_result``) must
+    re-execute the repaired suite before acceptance — tests_pass is synthesized
+    from test_result, so accepting with the stale one records the pre-repair
+    failure as the check's final state (run_8c14a430ad1c false-red)."""
+
+    def _failed_qa_result(self):
+        return TaskResult(
+            task_id="task_9",
+            status="FAILED",
+            outputs={
+                "artifacts": [
+                    {
+                        "name": "tests/test_api.py",
+                        "content": "def test_x():\n    assert 0\n",
+                        "type": "test",
+                    },
+                    {"name": "test_report.md", "content": "exit 1", "type": "test_report"},
+                ],
+                "test_result": {"executed": True, "exit_code": 1, "tests_passed": False},
+                "validation_result": {"passed": False, "checks": []},
+                "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
+            },
+            error="tests failed",
+        )
+
+    def _qa_envelope(self):
+        from squadops.cycles.implementation_plan import TypedCheck
+        from squadops.tasks.models import TaskEnvelope
+
+        return TaskEnvelope(
+            task_id="task_9",
+            agent_id="eve",
+            cycle_id="cyc_001",
+            pulse_id="p",
+            project_id="hello_squad",
+            task_type="qa.test",
+            correlation_id="corr",
+            causation_id=None,
+            trace_id="t",
+            span_id="s",
+            inputs={
+                "resolved_config": {},
+                "artifact_contents": {"src/main.py": "def main():\n    pass\n"},
+                "acceptance_criteria": [
+                    TypedCheck(
+                        check="regex_match",
+                        params={"file": "tests/test_api.py", "pattern": "def test_"},
+                        severity="error",
+                        description="Suite defines tests",
+                    )
+                ],
+            },
+            metadata={"role": "qa"},
+        )
+
+    def _repair(self):
+        return [{"name": "tests/test_api.py", "content": "def test_x():\n    assert 1\n"}]
+
+    def _retest_success(self):
+        return TaskResult(
+            task_id="retest-run_001-00-qa.test",
+            status="SUCCEEDED",
+            outputs={
+                "test_result": {"executed": True, "exit_code": 0, "tests_passed": True},
+                "validation_result": {
+                    "passed": True,
+                    "checks": [{"check": "frontend_build", "passed": True}],
+                },
+            },
+        )
+
+    def _kwargs(self, cycle):
+        return {
+            "run_id": "run_001",
+            "cycle": cycle,
+            "correction_attempts": 0,
+            "prior_outputs": {},
+            "all_artifact_refs": [],
+            "stored_artifacts": [],
+            "completed_task_ids": [],
+            "plan_delta_refs": [],
+            "profile": None,
+            "flow_run_id": None,
+        }
+
+    async def test_retest_pass_accepts_with_fresh_evidence(self, executor, cycle):
+        """Bug caught (run_8c14a430ad1c): patched result keeping the stale
+        exit-1 test_result — the ledger's final tests_pass state stays failed."""
+        executor._correction_runner.reexecute_repaired_suite = AsyncMock(
+            return_value=self._retest_success()
+        )
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            self._qa_envelope(),
+            self._failed_qa_result(),
+            self._repair(),
+            holder,
+            **self._kwargs(cycle),
+        )
+
+        assert action == "accept_patch"
+        corrected = holder["patched_result"]
+        # Fresh behavioral evidence supersedes the stale failure.
+        assert corrected.outputs["test_result"]["tests_passed"] is True
+        assert corrected.outputs["test_result"]["exit_code"] == 0
+        # Retest rows (frontend_build) ride along with the typed rows.
+        checks = corrected.outputs["validation_result"]["checks"]
+        assert any(c.get("check") == "frontend_build" for c in checks)
+        # The retest received the patched (overlaid) suite, not the broken one.
+        call = executor._correction_runner.reexecute_repaired_suite.await_args
+        patched = call.args[3]
+        by_name = {a["name"]: a["content"] for a in patched}
+        assert "assert 1" in by_name["tests/test_api.py"]
+
+    async def test_retest_failure_falls_back_to_continue(self, executor, cycle):
+        """Bug caught: accepting a repair whose suite still fails when
+        re-executed — typed rows alone said yes."""
+        executor._correction_runner.reexecute_repaired_suite = AsyncMock(
+            return_value=TaskResult(
+                task_id="retest",
+                status="FAILED",
+                outputs={"test_result": {"executed": True, "exit_code": 1, "tests_passed": False}},
+                error="still failing",
+            )
+        )
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            self._qa_envelope(),
+            self._failed_qa_result(),
+            self._repair(),
+            holder,
+            **self._kwargs(cycle),
+        )
+        assert action == "continue"
+        assert "patched_result" not in holder
+
+    async def test_missing_retest_context_never_accepts_stale_evidence(self, executor):
+        """Bug caught: a legacy call shape (no cycle) silently accepting with
+        the stale test_result — conservative fallback is re-dispatch."""
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            self._qa_envelope(), self._failed_qa_result(), self._repair(), holder
+        )
+        assert action == "continue"
+        assert holder == {}
+
+    async def test_non_behavioral_patch_skips_retest(self, executor, cycle):
+        """Guard: tasks without test_result (builder) accept on typed rows
+        alone — no retest dispatch, behavior unchanged from #389."""
+        from squadops.cycles.implementation_plan import TypedCheck
+        from squadops.tasks.models import TaskEnvelope
+
+        executor._correction_runner.reexecute_repaired_suite = AsyncMock()
+        envelope = TaskEnvelope(
+            task_id="task_5",
+            agent_id="bob",
+            cycle_id="cyc_001",
+            pulse_id="p",
+            project_id="hello_squad",
+            task_type="builder.assemble",
+            correlation_id="corr",
+            causation_id=None,
+            trace_id="t",
+            span_id="s",
+            inputs={
+                "resolved_config": {},
+                "acceptance_criteria": [
+                    TypedCheck(
+                        check="regex_match",
+                        params={"file": "qa_handoff.md", "pattern": "## How to Test"},
+                        severity="error",
+                        description="Contains How to Test section",
+                    )
+                ],
+            },
+            metadata={"role": "builder"},
+        )
+        failed = TaskResult(
+            task_id="task_5",
+            status="FAILED",
+            outputs={
+                "artifacts": [{"name": "qa_handoff.md", "content": "# QA\n"}],
+                "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
+            },
+            error="acceptance failed",
+        )
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            envelope,
+            failed,
+            [{"name": "qa_handoff.md", "content": "# QA\n## How to Test\nok\n"}],
+            holder,
+            **self._kwargs(cycle),
+        )
+        assert action == "accept_patch"
+        executor._correction_runner.reexecute_repaired_suite.assert_not_awaited()


### PR DESCRIPTION
## What

Closes the correction loop's stale-evidence gap: a `patch` repair of a qa.test-class failure is now **re-executed in the QA agent's environment** before acceptance, and the corrected result carries the fresh behavioral evidence.

## Why

Attempt 3.8 (`run_8c14a430ad1c`): eve's suite failed 1/14, neo's repair fixed it, patch verification passed (checks=2, **typed criteria only**) — but `tests_pass` is synthesized from the task's executed `test_result`, and the patched result kept the stale exit-1 one. §6.5 final-state resolution supersedes per `(check_id, subject)` and was ready to accept fresh evidence; nothing produced it. Run verdict: `rejected` on a converged repair.

Third instance of the stale-evidence-after-mutation class (#433/#434, #444).

## How

- **`QATestHandler` execute-only mode** (`inputs.retest_files`): no LLM — re-runs the provided suite against the original `artifact_contents` workspace via `run_build_validation`, emitting the same evidence shapes (fresh `test_result`, `tests_pass` row on failure, `frontend_build` row, #276 stub-fallback guard). The verdict is the execution.
- **`CorrectionRunner.reexecute_repaired_suite`**: dispatches the failed task's own task_type back to the QA agent with the patched (overlaid) suite — report/evaluation artifacts filtered out — riding `_dispatch_protocol_step` for Prefect visibility, events, artifact persistence, checkpointing. Retest appears in the Prefect UI as its own task.
- **Executor `_try_accept_patch`**: whenever the failed outputs carry a `test_result`, acceptance requires a passing retest; fresh `test_result` + retest rows replace the stale evidence in the corrected result. Failing/unrunnable/context-less retest → `continue` (re-dispatch path) — conservative by construction, never a false accept. Non-behavioral tasks (builder) are unchanged from #389.

## Tests

- Handler: retest passes without any LLM call; failure emits executed-failed evidence; empty file set fails; stub-fallback repair blocked even when pytest passes (11 → 96 file total green)
- Executor: fresh evidence supersedes stale on accept; failing retest falls back; missing context never accepts stale; builder path never dispatches a retest
- CorrectionRunner: retest envelope routes to the QA agent with the failed task's type, deterministic id, causation link; suite filtered of reports; original workspace travels along; zero-file patch → no dispatch (vacuous-pass guard)
- Full `tests/unit/cycles/` + `tests/unit/capabilities/`: 2768 passed

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm