### PR TITLE
fix(#466): inter-workload gate stops the sequence on returned_for_revision

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -532,6 +532,37 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 if decision.decision == GateDecisionValue.REJECTED:
                     break  # Run stays COMPLETED; rejection in gate_decisions
 
+                if decision.decision == GateDecisionValue.RETURNED_FOR_REVISION:
+                    # #466: revision is NOT an approval — do not advance the
+                    # sequence with the un-revised plan (the 3.10 false-approve).
+                    # Parity with the mid-run gate path: revision requires
+                    # manual retry-run creation; the decision + notes stay in
+                    # gate_decisions for whoever creates it.
+                    logger.info(
+                        "Gate %r returned_for_revision on run %s: stopping the "
+                        "workload sequence; revision requires manual retry-run "
+                        "creation (automatic retry-in-same-phase is not "
+                        "implemented in this version)",
+                        gate_name,
+                        current_run_id,
+                    )
+                    break
+
+                if decision.decision not in (
+                    GateDecisionValue.APPROVED,
+                    GateDecisionValue.APPROVED_WITH_REFINEMENTS,
+                ):
+                    # #466: exhaustive dispatch — an unknown/future decision
+                    # value must never silently act as an approval.
+                    logger.warning(
+                        "Gate %r on run %s carries unrecognized decision %r: "
+                        "stopping the workload sequence",
+                        gate_name,
+                        current_run_id,
+                        decision.decision,
+                    )
+                    break
+
                 # Write refinement notes as artifact (D10)
                 if (
                     decision.decision == GateDecisionValue.APPROVED_WITH_REFINEMENTS

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -447,6 +447,81 @@ class TestInterWorkloadGates:
         executor.execute_run.assert_awaited_once()
         mock_registry.create_run.assert_not_called()
 
+    async def test_returned_for_revision_stops_orchestration(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        """#466, the 3.10 false-approve: returned_for_revision advanced the
+        sequence and spawned implementation with the un-revised plan. Revision
+        is not an approval — no next workload Run may be created."""
+        cycle = _make_cycle(
+            workload_sequence=[
+                {"type": "framing", "gate": "progress_plan_review"},
+                {"type": "implementation"},
+            ]
+        )
+        mock_registry.get_cycle.return_value = cycle
+
+        run1 = _make_run("run_001", 1, "completed", "framing")
+        run1_with_revision = _make_run(
+            "run_001",
+            1,
+            "completed",
+            "framing",
+            gate_decisions=(
+                _gate_decision(
+                    "progress_plan_review",
+                    GateDecisionValue.RETURNED_FOR_REVISION,
+                    notes="remove three style regexes",
+                ),
+            ),
+        )
+
+        mock_registry.get_run.side_effect = [
+            run1,  # status check after execute_run
+            run1,  # _is_cancelled in _poll (not cancelled)
+            run1_with_revision,  # _poll finds the revision decision
+        ]
+
+        with patch.object(asyncio, "sleep", new_callable=AsyncMock):
+            await executor.execute_cycle("cyc_001", "run_001")
+
+        executor.execute_run.assert_awaited_once()
+        mock_registry.create_run.assert_not_called()
+
+    async def test_unrecognized_decision_never_advances(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        """#466 exhaustive-dispatch guard: a decision value outside the known
+        approval set must stop the sequence, not silently act as an approval."""
+        cycle = _make_cycle(
+            workload_sequence=[
+                {"type": "framing", "gate": "progress_plan_review"},
+                {"type": "implementation"},
+            ]
+        )
+        mock_registry.get_cycle.return_value = cycle
+
+        run1 = _make_run("run_001", 1, "completed", "framing")
+        run1_with_unknown = _make_run(
+            "run_001",
+            1,
+            "completed",
+            "framing",
+            gate_decisions=(_gate_decision("progress_plan_review", "deferred"),),
+        )
+
+        mock_registry.get_run.side_effect = [
+            run1,
+            run1,
+            run1_with_unknown,
+        ]
+
+        with patch.object(asyncio, "sleep", new_callable=AsyncMock):
+            await executor.execute_cycle("cyc_001", "run_001")
+
+        executor.execute_run.assert_awaited_once()
+        mock_registry.create_run.assert_not_called()
+
     async def test_no_gate_skips_polling(self, executor, mock_registry, mock_event_bus):
         """No gate on workload entry → advances without polling."""
         cycle = _make_cycle(


### PR DESCRIPTION
## What

Attempt 3.10: `progress_plan_review` was decided `--return-for-revision` (three unwinnable criteria, notes attached) and the orchestrator **spawned the implementation run with the un-revised plan** — the inter-workload gate handler only broke on `REJECTED`, so revision fell through the approval path. The mid-run gate path already refuses the same decision with an explicit "manual retry-run creation required" error; the two surfaces disagreed and the silent one false-approved.

## How

- `RETURNED_FOR_REVISION` stops the workload sequence exactly like rejection: run stays COMPLETED, decision + notes preserved in `gate_decisions`, log line matching the mid-run path's semantics.
- Exhaustive dispatch: any decision value outside the two approval values stops the sequence with a warning — a future enum member can never silently approve.

## Tests

- 3.10 reproduction: revision decision → `execute_run` once, no next-workload run created
- Exhaustive-dispatch guard: unrecognized decision value → sequence stops
- Full `test_execute_cycle.py`: 42 passed

## Non-goal

True in-cycle revision (a framing retry that consumes the gate notes) remains unimplemented by design here — SIP-candidate follow-up.

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm