### PR TITLE
fix(#469): backend import check imports package members by qualified name

### DIFF
--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -483,7 +483,7 @@ async def run_frontend_build(
 # missing third-party never produces a false red. Output goes to a file, not
 # stdout, so a module that prints on import can't corrupt the verdict.
 _BACKEND_IMPORT_DRIVER = r"""
-import importlib.util as _u, json as _json, pathlib as _pl, sys as _sys
+import importlib as _il, importlib.util as _u, json as _json, pathlib as _pl, sys as _sys
 
 _out = _sys.argv[1]
 _root = _pl.Path(".").resolve()
@@ -497,14 +497,43 @@ for _p in _root.rglob("*.py"):
     _delivered[str(_p.relative_to(_root))] = _p
 _stems = {_p.stem for _p in _delivered.values()}
 
+
+def _qualified(_path):
+    # #469: a module inside a package must be imported by its package-
+    # qualified name — executing backend/main.py under a fake top-level
+    # name breaks its relative imports ("no known parent package") and
+    # false-reds correct code (attempt 3.12: pytest passed 4/4 three
+    # times while this check failed the run). Returns
+    # (module_name, package_base) or None for top-level files.
+    if not (_path.parent / "__init__.py").exists():
+        return None
+    _parts = [] if _path.name == "__init__.py" else [_path.stem]
+    _dir = _path.parent
+    while (_dir / "__init__.py").exists() and _dir != _root:
+        _parts.insert(0, _dir.name)
+        _dir = _dir.parent
+    if not _parts:
+        return None
+    return ".".join(_parts), str(_dir)
+
+
 _failures, _assessed, _skipped = [], 0, []
 for _rel, _path in sorted(_delivered.items()):
-    _spec = _u.spec_from_file_location("_qa_imp_" + _rel.replace("/", "_")[:-3], str(_path))
-    if _spec is None or _spec.loader is None:
-        continue
-    _mod = _u.module_from_spec(_spec)
+    _qual = _qualified(_path)
     try:
-        _spec.loader.exec_module(_mod)
+        if _qual is not None:
+            _mod_name, _base = _qual
+            if _base not in _sys.path:
+                _sys.path.insert(0, _base)
+            _il.import_module(_mod_name)
+        else:
+            _spec = _u.spec_from_file_location(
+                "_qa_imp_" + _rel.replace("/", "_")[:-3], str(_path)
+            )
+            if _spec is None or _spec.loader is None:
+                continue
+            _mod = _u.module_from_spec(_spec)
+            _spec.loader.exec_module(_mod)
         _assessed += 1
     except ModuleNotFoundError as _e:
         _missing = (getattr(_e, "name", "") or "").split(".")[0]

--- a/tests/unit/capabilities/test_backend_import_check.py
+++ b/tests/unit/capabilities/test_backend_import_check.py
@@ -144,3 +144,43 @@ async def test_pytest_build_validation_clean_backend_stays_green(monkeypatch):
     )
     assert result.tests_passed is True
     assert result.exit_code == 0
+
+
+# --- #469: package-qualified imports ------------------------------------------
+
+
+async def test_package_relative_imports_ok():
+    """The 3.12 reproduction: a package whose modules use relative imports
+    BEFORE any third-party import. Loading them under fake top-level names
+    raised "no known parent package" and failed a run whose pytest suite had
+    passed 4/4 three times."""
+    result = await run_backend_import_check(
+        [
+            _rec("backend/__init__.py", ""),
+            _rec("backend/errors.py", "class ApiError(Exception):\n    pass\n"),
+            _rec(
+                "backend/routes.py",
+                "from .errors import ApiError\n\nrouter = object()\n",
+            ),
+            _rec(
+                "backend/main.py",
+                "from .routes import router\n\napp = router\n",
+            ),
+        ]
+    )
+    assert result.ran is True
+    assert result.ok is True
+
+
+async def test_package_member_nameerror_still_fails():
+    """Guard: package-qualified importing must not skip real body-execution
+    bugs — the canonical #276 NameError inside a package still blocks."""
+    result = await run_backend_import_check(
+        [
+            _rec("backend/__init__.py", ""),
+            _rec("backend/models.py", "class Run(BaseModel):\n    pass\n"),
+        ]
+    )
+    assert result.ran is True
+    assert result.ok is False
+    assert "NameError" in (result.error or "")


### PR DESCRIPTION
## What

The #276 backend import driver loaded every module under a synthetic **top-level** name, so package members using relative imports — the frozen skeleton's deliberate style — raised "attempted relative import with no known parent package" and were recorded as blocking deliverable failures.

## Why

Attempt 3.12: eve's suite **passed 4/4 three separate times** (attempt 2 + both repair retests) while this check failed `run_build_validation` every time. Three corrections burned repairing a suite that was never broken; the run failed corrections-exhausted. Data's failure analysis identified it correctly in both chains. Third member of the package-context family: #436 (checker), #454 (pytest PYTHONPATH), now the import driver. Roll-dependent masking (missing-`fastapi` skip fires first when third-party imports precede relative ones) explains why 3.8/3.11 never tripped it.

## How

Modules inside an `__init__.py` chain are imported by their package-qualified name (`importlib.import_module("backend.main")`) with the package base on `sys.path` — the same package model as #455. Top-level files keep the existing `spec_from_file_location` path. Missing-third-party skip logic unchanged.

## Tests (hermetic, real subprocesses — same style as the existing #276 suite)

- 3.12 reproduction: package with relative-imports-first modules → `ok=True`
- Guard: NameError inside a package still blocks (`ok=False`)
- Full `tests/unit/capabilities/`: green; all existing #276 cases unchanged

**Stacked on #455** (`fix/454-test-runner-package-context`) — same file. Merge #455 first.

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm