### PR TITLE
re-land fix(#473) + fix(#472): stranded by stacked-base merge (#474)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -36,7 +36,14 @@ from adapters.cycles.task_naming import build_task_name
 from squadops.cycles.agent_config import build_agent_resolver
 from squadops.cycles.build_completeness import compute_missing_required_files
 from squadops.cycles.checkpoint import RunCheckpoint
-from squadops.cycles.models import ArtifactRef, Cycle, GateDecisionValue, Run, RunStatus
+from squadops.cycles.models import (
+    ArtifactRef,
+    Cycle,
+    GateDecision,
+    GateDecisionValue,
+    Run,
+    RunStatus,
+)
 from squadops.cycles.naming import flow_run_name
 from squadops.cycles.patch_verification import (
     PATCH_PASSED,
@@ -57,7 +64,7 @@ from squadops.telemetry.models import CorrelationContext
 
 if TYPE_CHECKING:
     from adapters.cycles.reply_router import ReplyRouter
-    from squadops.cycles.models import GateDecision, SquadProfile
+    from squadops.cycles.models import SquadProfile
     from squadops.ports.comms.queue import QueuePort
     from squadops.ports.cycles.artifact_vault import ArtifactVaultPort
     from squadops.ports.cycles.cycle_registry import CycleRegistryPort
@@ -521,7 +528,43 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 # fires for task_flow_policy gates) — validate the authored
                 # plan BEFORE asking the operator to review it. A doomed plan
                 # gets a rejection, not a review request.
-                await self._reject_invalid_plan_before_workload_gate(run, cycle, gate_name)
+                #
+                # #473: mechanical rejection is congruent with a human
+                # --reject: a REJECTED gate decision is recorded (visible in
+                # `runs show` / gate_decisions), GATE_DECIDED is emitted, and
+                # the sequence stops cleanly — never a silent orchestrator
+                # death the operator can only diagnose by re-reviewing the
+                # manifest by hand (the 3.13 stall).
+                plan_errors = await self._reject_invalid_plan_before_workload_gate(
+                    run, cycle, gate_name
+                )
+                if plan_errors:
+                    rejection = GateDecision(
+                        gate_name=gate_name,
+                        decision=GateDecisionValue.REJECTED.value,
+                        decided_by="system:plan_validation",
+                        decided_at=datetime.now(UTC),
+                        notes="; ".join(plan_errors),
+                    )
+                    await self._cycle_registry.record_gate_decision(current_run_id, rejection)
+                    self._cycle_event_bus.emit(
+                        EventType.GATE_DECIDED,
+                        entity_type="run",
+                        entity_id=current_run_id,
+                        context={"cycle_id": cycle_id, "run_id": current_run_id},
+                        payload={
+                            "gate_name": gate_name,
+                            "decision": GateDecisionValue.REJECTED.value,
+                            "decided_by": "system:plan_validation",
+                        },
+                    )
+                    logger.error(
+                        "Plan auto-rejected at gate %r on run %s: %s",
+                        gate_name,
+                        current_run_id,
+                        "; ".join(plan_errors),
+                    )
+                    break
                 self._cycle_event_bus.emit(
                     EventType.WORKLOAD_GATE_AWAITING,
                     entity_type="workload",
@@ -1971,21 +2014,22 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         run: Any,
         cycle: Cycle,
         gate_name: str,
-    ) -> None:
+    ) -> list[str]:
         """#464: criteria-scope validation at the inter-workload plan gate.
 
         This is the gate path multi-workload cycles actually traverse (the
         framing run COMPLETES, then the sequence gates) — the mid-run
         ``_reject_unsatisfiable_plan_at_gate`` never fires here. Searches the
-        completed run's artifacts for the authored plan and rejects the
-        sequence before the operator is asked to review a mechanically doomed
-        plan. Role validation is not duplicated at this seam: it keeps its
-        dispatch-time net in ``generate_task_plan``, which fails the next
-        workload within seconds. Absent or unreadable plans defer to that same
-        net — this check only ever adds an earlier rejection, never a pass.
+        completed run's artifacts for the authored plan; validation errors
+        are RETURNED (#473) so the caller records a system REJECTED gate
+        decision instead of the orchestrator dying silently (the 3.13
+        stall). Role validation is not duplicated at this seam: it keeps its
+        dispatch-time net in ``generate_task_plan``. Absent or unreadable
+        plans defer to that same net — this check only ever adds an earlier
+        rejection, never a pass.
         """
         if not cycle.applied_defaults.get("implementation_plan", False):
-            return
+            return []
 
         from squadops.cycles.implementation_plan import ImplementationPlan
 
@@ -2007,13 +2051,9 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         gate_name,
                         exc_info=True,
                     )
-                    return
-                errors = plan.validate_criteria_scope()
-                if errors:
-                    raise _ExecutionError(
-                        f"Plan rejected before gate {gate_name!r}: " + "; ".join(errors)
-                    )
-                return
+                    return []
+                return plan.validate_criteria_scope()
+        return []
 
     async def _reject_unsatisfiable_plan_at_gate(
         self,

--- a/src/squadops/prompts/fragments/manifest.yaml
+++ b/src/squadops/prompts/fragments/manifest.yaml
@@ -102,7 +102,7 @@ fragments:
   layer: task_type
   roles:
   - qa
-  sha256: 92ec4bcc853a83ed22b6885e6798fc82d3b7d80bf8727abfd977969700160f5d
+  sha256: 564c58fb8f7882f4af9c48e275a34bafa6ae863ae7bfbc89935525bc761366bc
 - fragment_id: task_type.strategy.propose_plan_guidance
   path: shared/task_type/task_type.strategy.propose_plan_guidance.md
   layer: task_type
@@ -187,4 +187,4 @@ fragments:
   roles:
   - data
   sha256: fd44a28f65e449c6320b5ee5f1d8121013a03c7baa757965334c4e19c7904779
-manifest_hash: 1f365c0d1d5d35fe6ad8c62a2a7e3aa63ca0769e9de1bb59d1f4f41a92dcca9b
+manifest_hash: f2c4d643cf5d9d36f2628767c386f113a4e9262fa6426fedb4c051be94d30848

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.qa.propose_plan_tasks.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.qa.propose_plan_tasks.md
@@ -68,11 +68,11 @@ Each task you propose must:
 
 Prefer **typed checks** for qa assertions:
 
-- `regex_match` for test-function presence (e.g.,
-  `pattern: "def test_", count_min: N`) — DOCUMENT artifacts
-  (`.md`/`.txt`/`.rst`) only; a regex against a source file prescribes
-  stylistic choices and is REJECTED by plan validation. Test-file
-  behavior is verified by executing the suite, not by pattern-matching it.
+- `regex_match` for DOCUMENT artifacts only (`.md`/`.txt`/`.rst` — e.g.
+  `file: qa_handoff.md`, `pattern: "## How to Test"`). NEVER against a
+  source or test file — that prescribes stylistic choices and is REJECTED
+  by plan validation, failing the whole plan. Test-file behavior is
+  verified by executing the suite, not by pattern-matching it.
 - `count_at_least` for test-file/spec-file counts via glob
 - `command_exit_zero` for invoking a test runner (argv-only safelist:
   `python -m py_compile`, `ruff check`, `tsc --noEmit`, etc.). The command

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -1246,12 +1246,14 @@ class TestInterWorkloadGatePlanValidation:
         )
         return ref, yaml_text.encode()
 
-    async def test_source_regex_plan_rejected_before_gate_awaiting(
+    async def test_source_regex_plan_rejected_as_recorded_gate_decision(
         self, executor, mock_registry, mock_event_bus
     ):
-        """The 3.10 shape through the REAL path: framing completes carrying a
-        source-regex plan → the sequence must fail before the operator is
-        asked to review, and no implementation run may be created."""
+        """The 3.10 shape through the REAL path, with #473 semantics: framing
+        completes carrying a source-regex plan → a system REJECTED gate
+        decision is recorded (visible state, not a silent orchestrator death
+        — the 3.13 stall), the operator is never asked to review, no
+        implementation run is created, and execute_cycle returns cleanly."""
         cycle = self._cycle_with_gate()
         mock_registry.get_cycle.return_value = cycle
 
@@ -1260,14 +1262,18 @@ class TestInterWorkloadGatePlanValidation:
         mock_registry.get_run.return_value = run1
         executor._artifact_vault.retrieve.return_value = self._plan_ref(_PLAN_YAML_SOURCE_REGEX_WL)
 
-        with pytest.raises(Exception) as exc_info:
-            await executor.execute_cycle("cyc_001", "run_001")
+        await executor.execute_cycle("cyc_001", "run_001")  # must NOT raise
 
-        assert "RunDetailView.jsx" in str(exc_info.value)
-        assert "#464" in str(exc_info.value)
+        mock_registry.record_gate_decision.assert_awaited_once()
+        _, decision = mock_registry.record_gate_decision.await_args.args
+        assert decision.decision == GateDecisionValue.REJECTED.value
+        assert decision.decided_by == "system:plan_validation"
+        assert "RunDetailView.jsx" in (decision.notes or "")
+        assert "#464" in (decision.notes or "")
         mock_registry.create_run.assert_not_called()
         emit_types = _emit_types(mock_event_bus)
         assert EventType.WORKLOAD_GATE_AWAITING not in emit_types
+        assert EventType.GATE_DECIDED in emit_types
 
     async def test_document_regex_plan_gates_normally(
         self, executor, mock_registry, mock_event_bus

--- a/tests/unit/events/test_event_emission.py
+++ b/tests/unit/events/test_event_emission.py
@@ -129,13 +129,19 @@ class TestExecutorEmissionPoints:
             "WORKLOAD_COMPLETED",
             "WORKLOAD_GATE_AWAITING",
             "WORKLOAD_ADVANCED",
+            "GATE_DECIDED",
         ],
     )
     def test_executor_emits(self, attr: str, executor_refs: set[str]) -> None:
         assert attr in executor_refs
 
-    def test_executor_has_12_types(self, executor_refs: set[str]) -> None:
-        """12 = the former 17 minus the five PULSE_* types, which moved to
+    def test_executor_has_13_types(self, executor_refs: set[str]) -> None:
+        """13 = the post-slice-5 twelve plus GATE_DECIDED (#473): the
+        inter-workload pre-gate validation records a system REJECTED gate
+        decision and emits GATE_DECIDED, so a mechanically rejected plan is
+        visible state instead of a silent orchestrator death.
+
+        The twelve: the former 17 minus the five PULSE_* types, which moved to
         the PulseBoundaryRunner with the pulse path (SIP-0097 slice 4; slice
         3 had moved CORRECTION_INITIATED/DECIDED/COMPLETED to the
         CorrectionRunner). CHECKPOINT_CREATED and TASK_DISPATCHED/
@@ -146,7 +152,7 @@ class TestExecutorEmissionPoints:
         FAILED emits to TaskDispatcher, but the fan-out path still
         references all three TASK_* types here, so the count is unchanged.)
         """
-        assert len(executor_refs) == 12
+        assert len(executor_refs) == 13
 
 
 class TestRunCompletionEmissionPoints:
@@ -320,9 +326,9 @@ class TestEmitCallSitePayloadFields:
         assert with_payload >= 35
 
     def test_total_emit_call_count(self) -> None:
-        """Sanity check: 17 executor + 7 correction-runner +
-        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 41 total
-        emit calls.
+        """Sanity check: 18 executor + 7 correction-runner +
+        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 42 total
+        emit calls (#473 added the pre-gate rejection's GATE_DECIDED emit).
 
         SIP-0097 slice 2c collapsed execute_run's five per-exception-class
         terminal emits into one emit driven by the RunCompletion terminal
@@ -335,4 +341,4 @@ class TestEmitCallSitePayloadFields:
         total = 0
         for path in _ALL_EMISSION_FILES:
             total += len(self._extract_emit_calls(path))
-        assert total == 41
+        assert total == 42


### PR DESCRIPTION
## Why this PR exists

PR #474 was stacked on `fix/464-regex-criteria-source-files` and never retargeted to main — a stacked PR only retargets when its base *branch* is deleted, not when the base PR merges. #468 (this branch → main) merged at 2026-07-16 23:35; #474 then merged at 2026-07-17 01:01 **into this already-consumed branch**, so its commits never reached main. The `fix(#472)` commit also landed on this branch after the #468 merge. GitHub shows #474 as "Merged" (it did merge — into the wrong place) and neither issue auto-closed (non-default-branch merge).

Caught by the tree-parity diff (main vs `integration/attempt-3-14`, the field-validated deploy tree).

## What re-lands

- **fix(#473)** — pre-gate plan rejection records a system `REJECTED` gate decision (`decided_by: system:plan_validation`), emits `GATE_DECIDED`, and stops the sequence cleanly, instead of the orchestrator dying via `_ExecutionError` with no record (the 3.13 invisible stall). Field-proven end-to-end in attempt 3.14 (recorded `rejected | system:plan_validation`).
- **fix(#472)** — qa proposer fragment's `regex_match` teaching example targets a document (`qa_handoff.md` / `## How to Test`) instead of contradicting the document-only rule it sits next to.
- Event-census test update (+`GATE_DECIDED`: 13 executor event types, 42 emit sites).

Merges clean into current main (dry-run: zero conflicts).

Fixes #472
Fixes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm
