### PR TITLE
feat(sip-0098): contract schema, loader, and linter (phase 98.1)

### DIFF
--- a/src/squadops/cycles/verification_contract.py
+++ b/src/squadops/cycles/verification_contract.py
@@ -1,0 +1,617 @@
+"""Verification contract schema, loader, and linter (SIP-0098 phase 98.1).
+
+A *verification contract* is a first-class, roll-invariant artifact authored once
+by the expander alongside the skeleton (SIP-0099) and **bound — not authored — by
+framing**. It states, purely declaratively, what must be true of a filled
+skeleton: the frozen surface that fills may not rewire, the per-file interface and
+implementation criteria, and the behavioral checks/probes that are the last word on
+the deliverable. See ``sips/accepted/SIP-0098-Verification-Contracts-Contract-Owned-Acceptance.md``.
+
+This module owns three things and nothing else (phase 98.1 is deliberately pure —
+no orchestration, no I/O beyond parsing a YAML string):
+
+- **Schema** — frozen dataclasses mirroring ``verification_contract.yaml`` (§6.1).
+- **Loader** — ``VerificationContract.from_yaml`` / ``from_dict`` (tolerant: builds a
+  best-effort structure from partial data so ``lint`` can report *all* defects;
+  raises only on gross structural malformation, i.e. YAML that isn't a contract).
+- **Linter** — ``lint()`` returns ``list[str]``, one message per defect, catching
+  every §2 defect class expressible at schema level. It is the emission-time "verify
+  the verifier" gate's first job (§6.2 job 1); the bare-skeleton and reference-fill
+  runs (jobs 2–3) are empirical and land in phase 98.2.
+
+Single-sourcing: the typed-check vocabulary, command safelist, and the #464
+document-only rule for ``regex_match`` all come from ``acceptance_check_spec``; the
+behavioral framework-check identities and the ``node`` tooling id come from
+``check_registry``. This module reuses those primitives and never restates them —
+the same discipline ``implementation_plan.validate_criteria_scope`` follows.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+import yaml
+
+from squadops.cycles.acceptance_check_spec import (
+    CHECK_SPECS,
+    argv_matches_safelist,
+    command_safelist_names,
+    regex_target_is_document,
+)
+from squadops.cycles.check_registry import TOOL_NODE, framework_check_ids
+
+# --------------------------------------------------------------------------- #
+# Vocabulary
+# --------------------------------------------------------------------------- #
+
+CONTRACT_VERSION = 1
+
+# A *capability* is a toolchain the contract's executable checks REQUIRE (§6.1). It
+# is a fact about the check, not about infrastructure — where a capability runs is
+# the execution profile's concern (§6.5, phase 98.4). ``node`` is the one
+# provisionable tool already registered (``check_registry.TOOL_NODE``, #306);
+# ``python`` is the always-present base runtime (``py_compile``, pytest). This owns
+# only the vocabulary the contract may declare and the linter validates ``requires``
+# against — not the capability→environment mapping.
+CAP_PYTHON = "python"
+KNOWN_CAPABILITIES: frozenset[str] = frozenset({CAP_PYTHON, TOOL_NODE})
+
+# Which typed checks may appear in each criterion class (§6.1 "criteria are classed").
+# INTERFACE checks are style-free structural presence checks that pass on the frozen
+# skeleton (the frozen decorators make ``endpoint_defined`` true pre-fill).
+# IMPLEMENTATION checks measure the fill. ``regex_match`` is in NEITHER: it is
+# document-only (#464) and fill files are source, so textual criteria against fill
+# files are rejected by construction rather than by a runtime guard.
+INTERFACE_CHECK_NAMES: frozenset[str] = frozenset(
+    {"endpoint_defined", "import_present", "field_present"}
+)
+IMPLEMENTATION_CHECK_NAMES: frozenset[str] = frozenset({"command_exit_zero"})
+
+# Keys owned by the criterion wrapper; everything else on a criterion mapping is a
+# check param. (Contract criteria carry ``id``/``requires``; plan criteria carry
+# ``severity``/``description`` — a distinct vocabulary, hence a distinct reserved set.)
+_CRITERION_RESERVED: frozenset[str] = frozenset({"check", "id", "requires"})
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _is_sha256(value: object) -> bool:
+    return isinstance(value, str) and bool(_SHA256_RE.match(value))
+
+
+def _path_is_safe_relative(value: object) -> bool:
+    """True when ``value`` is a relative workspace path with no ``..`` traversal."""
+    if not isinstance(value, str) or not value:
+        return False
+    if value.startswith("/"):
+        return False
+    parts = value.replace("\\", "/").split("/")
+    return ".." not in parts
+
+
+# --------------------------------------------------------------------------- #
+# Schema (frozen dataclasses mirroring verification_contract.yaml)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Criterion:
+    """A single typed criterion: a ``check`` name, a stable ``id``, its params, and
+    an optional capability ``requires``. The target file, when the check needs one,
+    is the parent ``fill_files`` key — not an inline param (unlike a plan TypedCheck)."""
+
+    check: str
+    id: str
+    params: dict[str, Any] = field(default_factory=dict)
+    requires: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> Criterion:
+        if not isinstance(raw, dict):
+            raise ValueError(f"criterion must be a mapping, got {type(raw).__name__}")
+        requires = raw.get("requires")
+        return cls(
+            check=str(raw.get("check", "")),
+            id=str(raw.get("id", "")),
+            params={k: v for k, v in raw.items() if k not in _CRITERION_RESERVED},
+            requires=str(requires) if requires is not None else None,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"check": self.check, "id": self.id, **self.params}
+        if self.requires is not None:
+            out["requires"] = self.requires
+        return out
+
+
+@dataclass(frozen=True)
+class Probe:
+    """A behavioral probe: boot the ``subject``, issue ``request``, assert ``expect``
+    (§6.4). Declarative request/expect only — boot/retry/timeout are the execution
+    profile's concern, so the same probe drives the qa container today and the
+    sandbox later (§6.5)."""
+
+    id: str
+    subject: str
+    request: dict[str, Any]
+    expect: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> Probe:
+        if not isinstance(raw, dict):
+            raise ValueError(f"probe must be a mapping, got {type(raw).__name__}")
+        request = raw.get("request", {})
+        expect = raw.get("expect", {})
+        return cls(
+            id=str(raw.get("id", "")),
+            subject=str(raw.get("subject", "")),
+            request=dict(request) if isinstance(request, dict) else {},
+            expect=dict(expect) if isinstance(expect, dict) else {},
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "subject": self.subject,
+            "request": self.request,
+            "expect": self.expect,
+        }
+
+
+@dataclass(frozen=True)
+class FrozenFile:
+    """A non-fill skeleton file pinned by content hash (§6.1 ``frozen``, P7)."""
+
+    path: str
+    sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"path": self.path, "sha256": self.sha256}
+
+
+@dataclass(frozen=True)
+class FillFile:
+    """A fill slot with its interface and implementation criteria (§6.1)."""
+
+    path: str
+    interface: tuple[Criterion, ...] = ()
+    implementation: tuple[Criterion, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "interface": [c.to_dict() for c in self.interface],
+            "implementation": [c.to_dict() for c in self.implementation],
+        }
+
+
+@dataclass(frozen=True)
+class Suite:
+    """The test contract (§6.1 ``behavioral.suite``): behavioral checks plus the
+    coverage expectations consumed by qa.test prompting (P6).
+
+    Canonicalization note: SIP §6.1 sketches the ``tests_pass`` check and
+    ``coverage_expectations`` adjacently under ``suite:``; that is not valid YAML (a
+    sequence cannot carry a sibling mapping key). Phase 98.1 settles the schema:
+    ``suite`` is a mapping ``{checks: [...], coverage_expectations: [...]}``."""
+
+    checks: tuple[Criterion, ...] = ()
+    coverage_expectations: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "checks": [c.to_dict() for c in self.checks],
+            "coverage_expectations": list(self.coverage_expectations),
+        }
+
+
+@dataclass(frozen=True)
+class Behavioral:
+    """Behavioral section: build checks, the suite, and probes (§6.1)."""
+
+    build: tuple[Criterion, ...] = ()
+    suite: Suite = field(default_factory=Suite)
+    probes: tuple[Probe, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "build": [c.to_dict() for c in self.build],
+            "suite": self.suite.to_dict(),
+            "probes": [p.to_dict() for p in self.probes],
+        }
+
+
+@dataclass(frozen=True)
+class Skeleton:
+    """Binds the contract to the exact skeleton it was authored against (§6.1)."""
+
+    expander: str
+    interface_manifest_hash: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "expander": self.expander,
+            "interface_manifest_hash": self.interface_manifest_hash,
+        }
+
+
+@dataclass(frozen=True)
+class VerificationContract:
+    contract_version: int
+    skeleton: Skeleton
+    capabilities: tuple[str, ...]
+    frozen_files: tuple[FrozenFile, ...]
+    fill_files: tuple[FillFile, ...]
+    behavioral: Behavioral
+
+    # --- loading ---------------------------------------------------------- #
+
+    @classmethod
+    def from_yaml(cls, content: str) -> VerificationContract:
+        """Parse a ``verification_contract.yaml`` string. Raises ``ValueError`` on
+        YAML-syntax errors or a non-mapping root (the "malformed" class); semantic
+        defects are reported by ``lint()``, never raised."""
+        try:
+            data = yaml.safe_load(content)
+        except yaml.YAMLError as exc:  # noqa: BLE001 — normalize to a single loader-error type
+            raise ValueError(f"verification contract is not valid YAML: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ValueError("verification contract must be a mapping at the top level")
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> VerificationContract:
+        if not isinstance(data, dict):
+            raise ValueError(f"verification contract must be a mapping, got {type(data).__name__}")
+
+        version = data.get("contract_version", 0)
+
+        skel_raw = data.get("skeleton", {})
+        if not isinstance(skel_raw, dict):
+            raise ValueError("'skeleton' must be a mapping")
+        skeleton = Skeleton(
+            expander=str(skel_raw.get("expander", "")),
+            interface_manifest_hash=str(skel_raw.get("interface_manifest_hash", "")),
+        )
+
+        caps_raw = data.get("capabilities", [])
+        if not isinstance(caps_raw, list):
+            raise ValueError("'capabilities' must be a list")
+        capabilities = tuple(str(c) for c in caps_raw)
+
+        frozen_raw = data.get("frozen", [])
+        if not isinstance(frozen_raw, list):
+            raise ValueError("'frozen' must be a list")
+        frozen_files = tuple(_frozen_file_from(entry) for entry in frozen_raw)
+
+        fill_raw = data.get("fill_files", {})
+        if not isinstance(fill_raw, dict):
+            raise ValueError("'fill_files' must be a mapping of path -> criteria")
+        fill_files = tuple(_fill_file_from(path, spec) for path, spec in fill_raw.items())
+
+        behavioral = _behavioral_from(data.get("behavioral", {}))
+
+        return cls(
+            contract_version=version if isinstance(version, int) else 0,
+            skeleton=skeleton,
+            capabilities=capabilities,
+            frozen_files=frozen_files,
+            fill_files=fill_files,
+            behavioral=behavioral,
+        )
+
+    # --- serialization / identity ---------------------------------------- #
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "skeleton": self.skeleton.to_dict(),
+            "capabilities": list(self.capabilities),
+            "frozen": [f.to_dict() for f in self.frozen_files],
+            "fill_files": {ff.path: ff.to_dict() for ff in self.fill_files},
+            "behavioral": self.behavioral.to_dict(),
+        }
+
+    def content_hash(self) -> str:
+        """Stable sha256 over the canonical contract content. Recorded in each
+        consuming run's resolved config (provenance, P3) and frozen for the yield
+        baseline (§6.3). Independent of source key order and whitespace."""
+        canonical = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    # --- iteration -------------------------------------------------------- #
+
+    def all_criteria(self) -> tuple[Criterion, ...]:
+        """Every typed criterion across all sections (not probes)."""
+        out: list[Criterion] = []
+        for ff in self.fill_files:
+            out.extend(ff.interface)
+            out.extend(ff.implementation)
+        out.extend(self.behavioral.build)
+        out.extend(self.behavioral.suite.checks)
+        return tuple(out)
+
+    def criterion_ids(self) -> tuple[str, ...]:
+        """Every stable id in the contract — criteria and probes — in document
+        order. Downstream (98.3) resolves ``criteria_refs`` against this."""
+        ids = [c.id for c in self.all_criteria()]
+        ids.extend(p.id for p in self.behavioral.probes)
+        return tuple(ids)
+
+    # --- linting ---------------------------------------------------------- #
+
+    def lint(self) -> list[str]:
+        """Return every schema-level defect (§6.2 job 1). Empty list ⇒ the contract
+        is well-formed enough to bind; empirical winnability (bare-skeleton +
+        reference-fill runs) is phase 98.2's separate, empirical gate."""
+        errors: list[str] = []
+        self._lint_top_level(errors)
+        self._lint_ids(errors)
+        self._lint_capabilities(errors)
+        self._lint_frozen(errors)
+        self._lint_fill_files(errors)
+        self._lint_behavioral(errors)
+        self._lint_probes(errors)
+        return errors
+
+    def _lint_top_level(self, errors: list[str]) -> None:
+        if self.contract_version != CONTRACT_VERSION:
+            errors.append(
+                f"contract_version must be {CONTRACT_VERSION}, got {self.contract_version!r}"
+            )
+        if not self.skeleton.expander:
+            errors.append("skeleton.expander is required")
+        # P3/§6.1: the contract must bind to the exact skeleton it verifies.
+        if not self.skeleton.interface_manifest_hash:
+            errors.append("skeleton.interface_manifest_hash is required (binds the contract)")
+        elif not _is_sha256(self.skeleton.interface_manifest_hash):
+            errors.append(
+                "skeleton.interface_manifest_hash must be a 64-char sha256 hex digest "
+                f"(got {self.skeleton.interface_manifest_hash!r})"
+            )
+        if not self.fill_files:
+            errors.append("fill_files is empty — a contract must cover at least one fill file")
+
+    def _lint_ids(self, errors: list[str]) -> None:
+        seen: set[str] = set()
+        dupes: set[str] = set()
+        empty = 0
+        for cid in self.criterion_ids():
+            if not cid:
+                empty += 1
+                continue
+            if cid in seen:
+                dupes.add(cid)
+            seen.add(cid)
+        if empty:
+            errors.append(f"{empty} criterion/probe(s) missing a stable id")
+        for cid in sorted(dupes):
+            errors.append(
+                f"duplicate criterion id {cid!r} — ids must be unique across the contract"
+            )
+
+    def _lint_capabilities(self, errors: list[str]) -> None:
+        for cap in self.capabilities:
+            if cap not in KNOWN_CAPABILITIES:
+                errors.append(
+                    f"capabilities declares unknown capability {cap!r} "
+                    f"(known: {', '.join(sorted(KNOWN_CAPABILITIES))})"
+                )
+        declared = set(self.capabilities)
+        for label, crit in self._labelled_criteria():
+            if crit.requires is None:
+                continue
+            if crit.requires not in KNOWN_CAPABILITIES:
+                errors.append(
+                    f"{label}: requires unknown capability {crit.requires!r} "
+                    f"(known: {', '.join(sorted(KNOWN_CAPABILITIES))})"
+                )
+            elif crit.requires not in declared:
+                errors.append(
+                    f"{label}: requires {crit.requires!r} but it is not declared in "
+                    f"the top-level capabilities list"
+                )
+
+    def _lint_frozen(self, errors: list[str]) -> None:
+        for f in self.frozen_files:
+            if not _path_is_safe_relative(f.path):
+                errors.append(f"frozen: {f.path!r} must be a relative path with no '..' traversal")
+            if not _is_sha256(f.sha256):
+                errors.append(f"frozen[{f.path}]: sha256 must be a 64-char hex digest")
+
+    def _lint_fill_files(self, errors: list[str]) -> None:
+        for ff in self.fill_files:
+            if not _path_is_safe_relative(ff.path):
+                errors.append(
+                    f"fill_files: {ff.path!r} must be a relative path with no '..' traversal"
+                )
+            for crit in ff.interface:
+                self._lint_typed_criterion(
+                    errors,
+                    f"fill_files[{ff.path}].interface[{crit.id or '?'}]",
+                    crit,
+                    INTERFACE_CHECK_NAMES,
+                    "interface",
+                    implied_file=ff.path,
+                )
+            for crit in ff.implementation:
+                self._lint_typed_criterion(
+                    errors,
+                    f"fill_files[{ff.path}].implementation[{crit.id or '?'}]",
+                    crit,
+                    IMPLEMENTATION_CHECK_NAMES,
+                    "implementation",
+                    implied_file=ff.path,
+                )
+
+    def _lint_typed_criterion(
+        self,
+        errors: list[str],
+        label: str,
+        crit: Criterion,
+        allowed_for_class: frozenset[str],
+        class_name: str,
+        *,
+        implied_file: str,
+    ) -> None:
+        if not crit.check:
+            errors.append(f"{label}: missing 'check'")
+            return
+        if crit.check not in CHECK_SPECS:
+            errors.append(
+                f"{label}: unknown check {crit.check!r} (known: {', '.join(sorted(CHECK_SPECS))})"
+            )
+            return
+        if crit.check not in allowed_for_class:
+            errors.append(
+                f"{label}: check {crit.check!r} is not allowed in the {class_name} class "
+                f"(allowed: {', '.join(sorted(allowed_for_class))})"
+            )
+            # keep validating params — the message above is the actionable one
+
+        spec = CHECK_SPECS[crit.check]
+        # The target file, when the check needs one, is the fill_files key.
+        effective = dict(crit.params)
+        if "file" in spec.required_params or "file" in spec.path_params:
+            effective.setdefault("file", implied_file)
+
+        missing = spec.required_params - set(effective)
+        if missing:
+            errors.append(f"{label}: missing required param(s): {', '.join(sorted(missing))}")
+        allowed_params = spec.required_params | spec.optional_params
+        unknown = set(effective) - allowed_params
+        if unknown:
+            errors.append(
+                f"{label}: unknown param(s): {', '.join(sorted(unknown))} "
+                f"(allowed: {', '.join(sorted(allowed_params))})"
+            )
+
+        for key, value in effective.items():
+            expected = spec.param_types.get(key)
+            if expected is not None and not isinstance(value, expected):
+                names = (
+                    expected.__name__
+                    if isinstance(expected, type)
+                    else " | ".join(t.__name__ for t in expected)
+                )
+                errors.append(f"{label}: param {key!r} must be {names}, got {type(value).__name__}")
+
+        self._lint_regex_and_command(errors, label, crit)
+
+    def _lint_regex_and_command(self, errors: list[str], label: str, crit: Criterion) -> None:
+        # regexes must compile, and regex_match may only target documents (#464).
+        if "pattern" in crit.params:
+            pattern = crit.params["pattern"]
+            if isinstance(pattern, str):
+                try:
+                    re.compile(pattern)
+                except re.error as exc:
+                    errors.append(f"{label}: pattern does not compile: {exc}")
+        if crit.check == "regex_match":
+            target = crit.params.get("file", "")
+            if not regex_target_is_document(target):
+                errors.append(
+                    f"{label}: regex_match may only target document artifacts "
+                    f"(.md/.txt/.rst), not source file {target!r} (#464)"
+                )
+        # command_exit_zero argv must be safelisted string argv (#422/RC-10a).
+        if crit.check == "command_exit_zero":
+            argv = crit.params.get("argv")
+            if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
+                errors.append(f"{label}: command_exit_zero argv must be a list of strings")
+            elif not argv_matches_safelist(argv):
+                errors.append(
+                    f"{label}: command {argv!r} is not in the execution safelist and can "
+                    f"never run. Use one of: {'; '.join(command_safelist_names())}"
+                )
+
+    def _lint_behavioral(self, errors: list[str]) -> None:
+        known = framework_check_ids()
+        for crit in (*self.behavioral.build, *self.behavioral.suite.checks):
+            if not crit.check:
+                errors.append(f"behavioral[{crit.id or '?'}]: missing 'check'")
+            elif crit.check not in known:
+                errors.append(
+                    f"behavioral[{crit.id or '?'}]: unknown framework check {crit.check!r} "
+                    f"(known: {', '.join(sorted(known))})"
+                )
+
+    def _lint_probes(self, errors: list[str]) -> None:
+        for probe in self.behavioral.probes:
+            label = f"probe[{probe.id or '?'}]"
+            if not probe.subject:
+                errors.append(f"{label}: missing 'subject'")
+            if "method" not in probe.request or "path" not in probe.request:
+                errors.append(f"{label}: request must declare 'method' and 'path'")
+            if "status" not in probe.expect:
+                errors.append(f"{label}: expect must declare a 'status'")
+
+    def _labelled_criteria(self) -> list[tuple[str, Criterion]]:
+        out: list[tuple[str, Criterion]] = []
+        for ff in self.fill_files:
+            for crit in ff.interface:
+                out.append((f"fill_files[{ff.path}].interface[{crit.id or '?'}]", crit))
+            for crit in ff.implementation:
+                out.append((f"fill_files[{ff.path}].implementation[{crit.id or '?'}]", crit))
+        for crit in self.behavioral.build:
+            out.append((f"behavioral.build[{crit.id or '?'}]", crit))
+        for crit in self.behavioral.suite.checks:
+            out.append((f"behavioral.suite[{crit.id or '?'}]", crit))
+        return out
+
+
+# --------------------------------------------------------------------------- #
+# Section parsers (module-private; keep from_dict readable)
+# --------------------------------------------------------------------------- #
+
+
+def _frozen_file_from(entry: Any) -> FrozenFile:
+    if not isinstance(entry, dict):
+        raise ValueError(f"each 'frozen' entry must be a mapping, got {type(entry).__name__}")
+    return FrozenFile(path=str(entry.get("path", "")), sha256=str(entry.get("sha256", "")))
+
+
+def _fill_file_from(path: Any, spec: Any) -> FillFile:
+    if not isinstance(spec, dict):
+        raise ValueError(f"fill_files[{path!r}] must be a mapping of class -> criteria")
+    interface_raw = spec.get("interface", [])
+    implementation_raw = spec.get("implementation", [])
+    if not isinstance(interface_raw, list) or not isinstance(implementation_raw, list):
+        raise ValueError(f"fill_files[{path!r}]: interface/implementation must be lists")
+    return FillFile(
+        path=str(path),
+        interface=tuple(Criterion.from_dict(c) for c in interface_raw),
+        implementation=tuple(Criterion.from_dict(c) for c in implementation_raw),
+    )
+
+
+def _behavioral_from(raw: Any) -> Behavioral:
+    if not isinstance(raw, dict):
+        raise ValueError("'behavioral' must be a mapping")
+    build_raw = raw.get("build", [])
+    if not isinstance(build_raw, list):
+        raise ValueError("behavioral.build must be a list")
+
+    suite_raw = raw.get("suite", {})
+    if not isinstance(suite_raw, dict):
+        raise ValueError("behavioral.suite must be a mapping (checks + coverage_expectations)")
+    checks_raw = suite_raw.get("checks", [])
+    coverage_raw = suite_raw.get("coverage_expectations", [])
+    if not isinstance(checks_raw, list) or not isinstance(coverage_raw, list):
+        raise ValueError("behavioral.suite.checks and coverage_expectations must be lists")
+
+    probes_raw = raw.get("probes", [])
+    if not isinstance(probes_raw, list):
+        raise ValueError("behavioral.probes must be a list")
+
+    return Behavioral(
+        build=tuple(Criterion.from_dict(c) for c in build_raw),
+        suite=Suite(
+            checks=tuple(Criterion.from_dict(c) for c in checks_raw),
+            coverage_expectations=tuple(str(x) for x in coverage_raw),
+        ),
+        probes=tuple(Probe.from_dict(p) for p in probes_raw),
+    )

--- a/tests/unit/cycles/test_verification_contract.py
+++ b/tests/unit/cycles/test_verification_contract.py
@@ -1,0 +1,423 @@
+"""Tests for the verification-contract schema, loader, and linter (SIP-0098 phase 98.1).
+
+The linter is the emission-time "verify the verifier" gate (§6.2 job 1): a contract
+that lints clean cannot carry the schema-level defect classes from §2's criteria
+lottery — env mismatches, uncompilable/style regexes on source, off-safelist
+commands, class-confused checks, colliding ids, an unbound skeleton. Each rejection
+test names the exact §2 bug it would have caught. Loader tests pin the parsed shape
+and hash stability (the frozen hash the yield baseline measures against).
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from squadops.cycles.verification_contract import (
+    KNOWN_CAPABILITIES,
+    VerificationContract,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_HASH_A = "a" * 64
+_HASH_B = "b" * 64
+_HASH_C = "c" * 64
+
+
+def _valid_contract_dict() -> dict:
+    """A well-formed group_run contract — mirrors the group_run skeleton (§6.1).
+
+    Kept as a builder so each rejection test can deep-copy and inject exactly one
+    defect, proving the linter rejects that defect *and* that the base is clean."""
+    return {
+        "contract_version": 1,
+        "skeleton": {
+            "expander": "fullstack_fastapi_react",
+            "interface_manifest_hash": _HASH_A,
+        },
+        "capabilities": ["python", "node"],
+        "frozen": [
+            {"path": "backend/errors.py", "sha256": _HASH_B},
+            {"path": "frontend/src/api.js", "sha256": _HASH_C},
+        ],
+        "fill_files": {
+            "backend/routes.py": {
+                "interface": [
+                    {
+                        "check": "endpoint_defined",
+                        "id": "vc-routes-endpoints",
+                        "methods_paths": [
+                            "GET /runs",
+                            "POST /runs",
+                            "GET /runs/{id}",
+                            "POST /runs/{id}/join",
+                            "POST /runs/{id}/leave",
+                        ],
+                    },
+                    {
+                        "check": "import_present",
+                        "id": "vc-routes-apierror",
+                        "module": ".errors",
+                        "symbol": "ApiError",
+                    },
+                ],
+                "implementation": [
+                    {
+                        "check": "command_exit_zero",
+                        "id": "vc-routes-compiles",
+                        "argv": ["python", "-m", "py_compile", "backend/routes.py"],
+                        "requires": "python",
+                    },
+                ],
+            },
+            "frontend/src/views/RunDetailView.jsx": {
+                "interface": [
+                    {
+                        "check": "import_present",
+                        "id": "vc-detail-apifetch",
+                        "module": "../api",
+                        "symbol": "apiFetch",
+                    },
+                ],
+                "implementation": [
+                    {
+                        "check": "command_exit_zero",
+                        "id": "vc-detail-parses",
+                        "argv": ["node", "--check", "frontend/src/views/RunDetailView.jsx"],
+                        "requires": "node",
+                    },
+                ],
+            },
+        },
+        "behavioral": {
+            "build": [
+                {"check": "frontend_build", "id": "vc-frontend-builds", "requires": "node"},
+            ],
+            "suite": {
+                "checks": [
+                    {"check": "tests_pass", "id": "vc-suite-passes", "requires": "python"},
+                ],
+                "coverage_expectations": [
+                    "create/list/get/join/leave happy paths",
+                    "duplicate join -> 409, unknown run/participant -> 404",
+                ],
+            },
+            "probes": [
+                {
+                    "id": "vc-probe-create",
+                    "subject": "backend",
+                    "request": {
+                        "method": "POST",
+                        "path": "/runs",
+                        "json": {"title": "T", "datetime": "D", "location": "L"},
+                    },
+                    "expect": {"status": 200, "json_has": ["id", "participants"]},
+                },
+                {
+                    "id": "vc-probe-dup-join",
+                    "subject": "backend",
+                    "request": {"method": "POST", "path": "/runs/x/join", "json": {"name": "A"}},
+                    "expect": {"status": 409, "error_code": "duplicate_participant"},
+                },
+            ],
+        },
+    }
+
+
+def _lint(mutate=None) -> list[str]:
+    data = _valid_contract_dict()
+    if mutate is not None:
+        mutate(data)
+    return VerificationContract.from_dict(data).lint()
+
+
+# --------------------------------------------------------------------------- #
+# Loader + identity
+# --------------------------------------------------------------------------- #
+
+
+def test_from_yaml_parses_structure_and_binds_skeleton():
+    contract = VerificationContract.from_yaml(yaml.safe_dump(_valid_contract_dict()))
+
+    assert contract.contract_version == 1
+    assert contract.skeleton.expander == "fullstack_fastapi_react"
+    assert contract.skeleton.interface_manifest_hash == _HASH_A
+    assert contract.capabilities == ("python", "node")
+    assert [f.path for f in contract.frozen_files] == ["backend/errors.py", "frontend/src/api.js"]
+    assert [ff.path for ff in contract.fill_files] == [
+        "backend/routes.py",
+        "frontend/src/views/RunDetailView.jsx",
+    ]
+
+    routes = next(ff for ff in contract.fill_files if ff.path == "backend/routes.py")
+    endpoints = routes.interface[0]
+    assert endpoints.check == "endpoint_defined"
+    # the file target is the fill_files key, NOT an inline param (contract vs plan check)
+    assert "file" not in endpoints.params
+    assert endpoints.params["methods_paths"][0] == "GET /runs"
+    assert routes.implementation[0].requires == "python"
+
+    assert [c.id for c in contract.behavioral.build] == ["vc-frontend-builds"]
+    assert contract.behavioral.suite.checks[0].check == "tests_pass"
+    assert contract.behavioral.suite.coverage_expectations[0].startswith("create/list")
+    assert [p.id for p in contract.behavioral.probes] == ["vc-probe-create", "vc-probe-dup-join"]
+    assert contract.behavioral.probes[1].expect["error_code"] == "duplicate_participant"
+
+
+def test_content_hash_stable_and_order_independent():
+    data = _valid_contract_dict()
+    reordered = {k: data[k] for k in reversed(list(data))}  # same content, keys reversed
+    h1 = VerificationContract.from_dict(data).content_hash()
+    h2 = VerificationContract.from_dict(reordered).content_hash()
+    assert h1 == h2  # hash follows content, not source key order (the frozen-hash guarantee)
+    assert len(h1) == 64
+
+    # a real content change moves the hash (so drift is detectable, not masked)
+    changed = _valid_contract_dict()
+    changed["skeleton"]["interface_manifest_hash"] = _HASH_B
+    assert VerificationContract.from_dict(changed).content_hash() != h1
+
+
+def test_criterion_ids_span_every_section():
+    contract = VerificationContract.from_dict(_valid_contract_dict())
+    assert set(contract.criterion_ids()) == {
+        "vc-routes-endpoints",
+        "vc-routes-apierror",
+        "vc-routes-compiles",
+        "vc-detail-apifetch",
+        "vc-detail-parses",
+        "vc-frontend-builds",
+        "vc-suite-passes",
+        "vc-probe-create",
+        "vc-probe-dup-join",
+    }
+
+
+def test_from_yaml_rejects_malformed_yaml():
+    with pytest.raises(ValueError, match="not valid YAML"):
+        VerificationContract.from_yaml("contract_version: 1\n  bad: : indent")
+
+
+def test_from_yaml_rejects_non_mapping_root():
+    with pytest.raises(ValueError, match="must be a mapping"):
+        VerificationContract.from_yaml("- just\n- a\n- list")
+
+
+def test_from_dict_rejects_structurally_wrong_sections():
+    for bad in ({"fill_files": []}, {"capabilities": "python,node"}, {"frozen": {}}):
+        data = _valid_contract_dict()
+        data.update(bad)
+        with pytest.raises(ValueError):
+            VerificationContract.from_dict(data)
+
+
+# --------------------------------------------------------------------------- #
+# The clean base lints clean — otherwise every rejection test is vacuous
+# --------------------------------------------------------------------------- #
+
+
+def test_valid_contract_lints_clean():
+    assert VerificationContract.from_dict(_valid_contract_dict()).lint() == []
+
+
+# --------------------------------------------------------------------------- #
+# One rejection test per lint rule (each names the §2 bug it catches)
+# --------------------------------------------------------------------------- #
+
+
+def test_lint_rejects_wrong_contract_version():
+    errors = _lint(lambda d: d.__setitem__("contract_version", 2))
+    assert any("contract_version" in e for e in errors)
+
+
+def test_lint_rejects_missing_interface_manifest_hash():
+    # P3/drift: an unbound contract could verify a different skeleton than it describes.
+    errors = _lint(lambda d: d["skeleton"].__setitem__("interface_manifest_hash", ""))
+    assert any("interface_manifest_hash is required" in e for e in errors)
+
+
+def test_lint_rejects_non_sha256_manifest_hash():
+    errors = _lint(lambda d: d["skeleton"].__setitem__("interface_manifest_hash", "deadbeef"))
+    assert any("64-char sha256" in e for e in errors)
+
+
+def test_lint_rejects_duplicate_ids():
+    # 3.x: "same check failed in two rolls" is only knowable if ids are unique.
+    def dupe(d):
+        d["fill_files"]["backend/routes.py"]["interface"][1]["id"] = "vc-routes-endpoints"
+
+    errors = _lint(dupe)
+    assert any("duplicate criterion id 'vc-routes-endpoints'" in e for e in errors)
+
+
+def test_lint_rejects_missing_id():
+    def drop_id(d):
+        del d["fill_files"]["backend/routes.py"]["interface"][0]["id"]
+
+    errors = _lint(drop_id)
+    assert any("missing a stable id" in e for e in errors)
+
+
+def test_lint_rejects_unknown_declared_capability():
+    errors = _lint(lambda d: d["capabilities"].append("rust"))
+    assert any("unknown capability 'rust'" in e for e in errors)
+
+
+def test_lint_rejects_requires_not_in_known_capabilities():
+    # #462: Node-on-dev style env mismatch — a check requiring a tool that isn't a
+    # known capability is exactly the 3.9 failure, caught before dispatch.
+    def bad_requires(d):
+        d["fill_files"]["backend/routes.py"]["implementation"][0]["requires"] = "deno"
+
+    errors = _lint(bad_requires)
+    assert any("requires unknown capability 'deno'" in e for e in errors)
+
+
+def test_lint_rejects_requires_not_declared_in_capabilities():
+    errors = _lint(lambda d: d["capabilities"].remove("node"))
+    assert any("not declared in the top-level capabilities" in e for e in errors)
+
+
+def test_lint_rejects_frozen_traversal_path_and_bad_hash():
+    def bad_frozen(d):
+        d["frozen"][0]["path"] = "../etc/passwd"
+        d["frozen"][1]["sha256"] = "nothex"
+
+    errors = _lint(bad_frozen)
+    assert any("traversal" in e for e in errors)
+    assert any("frozen[frontend/src/api.js]: sha256" in e for e in errors)
+
+
+def test_lint_rejects_unknown_check_name():
+    def unknown(d):
+        d["fill_files"]["backend/routes.py"]["interface"][0]["check"] = "vibes_present"
+
+    errors = _lint(unknown)
+    assert any("unknown check 'vibes_present'" in e for e in errors)
+
+
+def test_lint_rejects_check_in_wrong_class():
+    # command_exit_zero measures the fill — it is an implementation check, never
+    # an interface one; placing it in interface confuses the bare-skeleton gate.
+    def misclass(d):
+        d["fill_files"]["backend/routes.py"]["interface"].append(
+            {
+                "check": "command_exit_zero",
+                "id": "vc-x",
+                "argv": ["python", "-m", "py_compile", "backend/routes.py"],
+                "requires": "python",
+            }
+        )
+
+    errors = _lint(misclass)
+    assert any("not allowed in the interface class" in e for e in errors)
+
+
+def test_lint_rejects_missing_required_param():
+    def drop_param(d):
+        del d["fill_files"]["backend/routes.py"]["interface"][0]["methods_paths"]
+
+    errors = _lint(drop_param)
+    assert any("missing required param(s): methods_paths" in e for e in errors)
+
+
+def test_lint_rejects_unknown_param():
+    def extra(d):
+        d["fill_files"]["backend/routes.py"]["interface"][1]["nonsense"] = "x"
+
+    errors = _lint(extra)
+    assert any("unknown param(s): nonsense" in e for e in errors)
+
+
+def test_lint_rejects_wrong_param_type():
+    def wrong_type(d):
+        d["fill_files"]["backend/routes.py"]["interface"][0]["methods_paths"] = "GET /runs"
+
+    errors = _lint(wrong_type)
+    assert any("must be list" in e for e in errors)
+
+
+def test_lint_rejects_off_safelist_command():
+    # 3.9 class: a command that can never execute (pytest is not on the safelist).
+    def bad_cmd(d):
+        d["fill_files"]["backend/routes.py"]["implementation"][0]["argv"] = ["pytest", "-q"]
+
+    errors = _lint(bad_cmd)
+    assert any("not in the execution safelist" in e for e in errors)
+
+
+def test_lint_rejects_regex_match_against_source_file():
+    # 3.10/3.14 class: source-file regexes prescribe another roll's style. #464 as
+    # a schema rule — regex_match is document-only, and fill files are source.
+    def source_regex(d):
+        d["fill_files"]["backend/routes.py"]["implementation"].append(
+            {
+                "check": "regex_match",
+                "id": "vc-style",
+                "file": "backend/routes.py",
+                "pattern": r"runs_store\s*=\s*\[",
+            }
+        )
+
+    errors = _lint(source_regex)
+    assert any("regex_match may only target document" in e for e in errors) or any(
+        "not allowed in the implementation class" in e for e in errors
+    )
+
+
+def test_lint_rejects_uncompilable_regex():
+    # 3.14 class: a pattern syntactically incapable of matching anything.
+    def bad_regex(d):
+        d["fill_files"]["backend/routes.py"]["implementation"].append(
+            {
+                "check": "regex_match",
+                "id": "vc-broken",
+                "file": "qa_handoff.md",
+                "pattern": r"(unclosed[",
+            }
+        )
+
+    errors = _lint(bad_regex)
+    assert any("does not compile" in e for e in errors)
+
+
+def test_lint_rejects_unknown_behavioral_check():
+    def bad_behavioral(d):
+        d["behavioral"]["build"][0]["check"] = "vibe_check"
+
+    errors = _lint(bad_behavioral)
+    assert any("unknown framework check 'vibe_check'" in e for e in errors)
+
+
+def test_lint_rejects_incomplete_probe():
+    def bad_probe(d):
+        d["behavioral"]["probes"][0]["subject"] = ""
+        del d["behavioral"]["probes"][0]["expect"]["status"]
+
+    errors = _lint(bad_probe)
+    assert any("probe[vc-probe-create]: missing 'subject'" in e for e in errors)
+    assert any("expect must declare a 'status'" in e for e in errors)
+
+
+def test_lint_rejects_empty_fill_files():
+    errors = _lint(lambda d: d.__setitem__("fill_files", {}))
+    assert any("fill_files is empty" in e for e in errors)
+
+
+def test_known_capabilities_are_python_and_node():
+    # Guards the vocabulary the whole contract binds against; python is the always-
+    # present base, node the one provisionable tool (check_registry.TOOL_NODE, #306).
+    assert KNOWN_CAPABILITIES == {"python", "node"}
+
+
+def test_lint_accumulates_multiple_defects():
+    # collect-all, not raise-first: the whole contract is validated in one pass so
+    # authors see every defect at once (unlike the plan parser's first-error raise).
+    def many(d):
+        d["skeleton"]["interface_manifest_hash"] = ""
+        d["capabilities"].append("rust")
+        d["fill_files"]["backend/routes.py"]["implementation"][0]["argv"] = ["make"]
+
+    errors = _lint(many)
+    assert len(errors) >= 3


### PR DESCRIPTION
**Phase 98.1 of SIP-0098 (Verification Contracts)** — `sips/accepted/SIP-0098-Verification-Contracts-Contract-Owned-Acceptance.md`, plan `docs/plans/SIP-0098-verification-contracts-plan.md`. The first slice of the Lane-M golden-path contract surface: pure, standalone, unblocks the 98.2 emission gates (which pair with SIP-0099's skeleton CI gate).

## What

- **`src/squadops/cycles/verification_contract.py`** — frozen dataclasses mirroring `verification_contract.yaml` (§6.1: `skeleton` / `capabilities` / `frozen` / `fill_files` {interface, implementation} / `behavioral` {build, suite, probes}), a tolerant `from_yaml`/`from_dict` loader, `content_hash()` (the frozen hash the yield baseline measures against, §6.3), and `lint()`.
- **`tests/unit/cycles/test_verification_contract.py`** — 29 unit tests.

## The linter — §6.2 job 1, "verify the verifier"

`lint()` returns `list[str]`, collecting **every** defect in one pass (the plan parser raises on the first — authors of a contract want the whole picture). Each rule maps to a real §2 criteria-lottery bug, so this isn't a tautological suite:

| Rule | §2 bug it catches |
|---|---|
| `requires:` ∈ known capabilities & declared | 3.9 — Node-on-dev env mismatch (#306/#462), before dispatch |
| `command_exit_zero` argv on the safelist | commands that can never execute (`pytest`, `make`, …) |
| `regex_match` document-only + patterns compile | 3.10/3.14 — source-file style regexes & unmatchable patterns |
| criterion class rules (interface vs implementation) | a fill-measuring check mis-placed where the bare-skeleton gate expects a pass |
| unique/present stable ids | 3.x — "same check failed in two rolls" only knowable with stable ids |
| `interface_manifest_hash` present + sha256-shaped | drift — an unbound contract could verify a different skeleton |
| frozen path traversal + sha256 shape; param presence/types | malformed authoring caught at emission, not at the gate |

## Single-sourcing (ownership-before-extension)

Reuses `acceptance_check_spec` (`CHECK_SPECS`, `argv_matches_safelist`, `regex_target_is_document`, `command_safelist_names`) and `check_registry` (`framework_check_ids`, `TOOL_NODE`) — never restates the vocabulary, safelist, or #464 rule. Same discipline `implementation_plan.validate_criteria_scope` already follows. `_parse_acceptance_criteria` was **not** reused directly: it's raise-first, emits `TypedCheck`, and expects `file` inline, whereas the contract linter collects-all and derives `file` from the fill-files key.

## Schema decisions I settled (noted in code for 98.2 to inherit)

1. **`suite` canonicalized** to a mapping `{checks, coverage_expectations}`. SIP §6.1 sketches the `tests_pass` check and `coverage_expectations` adjacently under `suite:`, which is not valid YAML (a sequence can't carry a sibling mapping key). The 98.2 reference contract must match this shape.
2. **Capability vocabulary** = `{python, node}`, reusing `check_registry.TOOL_NODE` rather than coining a second `"node"` literal; `python` is the always-present base runtime. The capability→environment *mapping* stays deferred to the execution profile (98.4), per §6.5.
3. **Collect-all lint** (asserted by a test), not raise-first.

## Verification

- 29/29 new tests pass · **1690** cycles-domain tests pass (no regressions) · `ruff check` + `ruff format` clean.
- Import-pure at source level: direct imports are stdlib + `yaml` + two pure sibling data modules. (The 12 orchestration modules pulled transitively are the `squadops.cycles` package `__init__` — importing the field-proven-pure `acceptance_check_spec` loads the identical set; pre-existing, unrelated to this file.)

## Not in this PR (later phases)

- Contract **emission** by the expander + the bare-skeleton/reference-fill CI gates → **98.2** (after SIP-0099's 99.1 skeleton gate lands).
- Orchestration **binding** — seeding (`contract_ref`), proposer fragments, plan-validation extensions, dispatch `criteria_refs` resolution, evidence ids → **98.3**.

No `Closes` — this is a SIP implementation phase; SIP-0098 and its plan are the tracking artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4Zq5Tw5FSJbdpadbxck2v
