### PR TITLE
fix(#433): runs retry resolves workload_type positionally instead of defaulting to None

### DIFF
--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -19,6 +19,7 @@ from squadops.api.routes.cycles.mapping import compute_workload_progress, run_to
 from squadops.auth.models import Scope
 from squadops.cycles.lifecycle import compute_config_hash, resolve_cycle_status
 from squadops.cycles.models import (
+    Cycle,
     CycleError,
     CycleStatus,
     GateDecision,
@@ -33,6 +34,34 @@ from squadops.cycles.models import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/projects/{project_id}/cycles/{cycle_id}/runs", tags=["runs"])
+
+
+def _resolve_retry_workload_type(cycle: Cycle, existing_runs: list[Run]) -> str | None:
+    """Positional workload resolution for retry-created runs (#433).
+
+    Mirrors the executor's ``_starting_workload_index`` semantics (D14: runs
+    map positionally to workloads): the new run's index among the cycle's
+    non-cancelled runs selects its ``workload_sequence`` entry — the same
+    resolution ``cycles create`` applies at position 0 (#26). Legacy cycles
+    (no sequence) keep ``None``. An out-of-bounds position is rejected rather
+    than falling back to a ``None``-typed run, which on a multi-workload
+    cycle silently produces the legacy plan shape with no artifact seeding.
+    To re-attempt a failed workload at the same position, cancel the failed
+    run first (or pass ``workload_type`` explicitly).
+    """
+    workload_sequence = cycle.applied_defaults.get("workload_sequence", [])
+    if not workload_sequence:
+        return None
+    non_cancelled = [r for r in existing_runs if r.status != RunStatus.CANCELLED.value]
+    position = len(non_cancelled)
+    if position >= len(workload_sequence):
+        raise ValidationError(
+            f"Cannot resolve workload_type for retry: the new run would occupy "
+            f"position {position} but workload_sequence has {len(workload_sequence)} "
+            f"entries. Cancel the run being retried first, or pass workload_type "
+            f"explicitly."
+        )
+    return workload_sequence[position]["type"]
 
 
 @router.post("", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
@@ -55,6 +84,9 @@ async def create_run(
         cycle = await registry.get_cycle(cycle_id)
         existing_runs = await registry.list_runs(cycle_id)
         run_number = len(existing_runs) + 1
+
+        if validated_wt is None:
+            validated_wt = _resolve_retry_workload_type(cycle, existing_runs)
 
         config_hash = compute_config_hash(cycle.applied_defaults, cycle.execution_overrides)
 

--- a/src/squadops/cli/commands/runs.py
+++ b/src/squadops/cli/commands/runs.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import quote
 
 import typer
 
@@ -135,6 +136,14 @@ def retry_run(
     ctx: typer.Context,
     project_id: str = typer.Argument(...),
     cycle_id: str = typer.Argument(...),
+    workload_type: str | None = typer.Option(
+        None,
+        "--workload-type",
+        help=(
+            "Explicit workload for the new run; by default the server resolves "
+            "it positionally from the cycle's workload_sequence (#433)"
+        ),
+    ),
 ):
     """Create a new run (retry) for a cycle and enqueue it for execution.
 
@@ -145,7 +154,10 @@ def retry_run(
 
     try:
         client = _get_client(ctx)
-        data = client.post(f"/api/v1/projects/{project_id}/cycles/{cycle_id}/runs")
+        path = f"/api/v1/projects/{project_id}/cycles/{cycle_id}/runs"
+        if workload_type:
+            path += f"?workload_type={quote(workload_type)}"
+        data = client.post(path)
         client.close()
     except CLIError as e:
         print_error(str(e))

--- a/tests/unit/api/test_workload_canon_api.py
+++ b/tests/unit/api/test_workload_canon_api.py
@@ -5,6 +5,7 @@ Covers ACs 5, 8, 9, 10, 14, 21.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
@@ -192,3 +193,100 @@ class TestCreateRunWorkloadType:
         assert resp.status_code == 200
         body = resp.json()
         assert body["workload_type"] == "framing"
+
+
+_MULTI_WORKLOAD_CYCLE = replace(
+    _CYCLE,
+    applied_defaults={
+        "workload_sequence": [
+            {"type": "framing", "workload_ref": "planning_workload"},
+            {"type": "implementation", "workload_ref": "implementation_workload"},
+        ]
+    },
+)
+
+
+def _existing_run(run_number: int, status: str, workload_type: str | None = None) -> Run:
+    return Run(
+        run_id=f"run_{run_number:03d}",
+        cycle_id="cyc_001",
+        run_number=run_number,
+        status=status,
+        initiated_by="api",
+        resolved_config_hash="h",
+        workload_type=workload_type,
+    )
+
+
+class TestCreateRunPositionalResolution:
+    """#433: an unspecified workload_type resolves positionally (D14), never
+    silently to None on a multi-workload cycle."""
+
+    def test_retry_resolves_next_workload_positionally(self, client, mock_cycle_registry):
+        # The incident shape: framing completed, retry meant for implementation.
+        mock_cycle_registry.get_cycle.return_value = _MULTI_WORKLOAD_CYCLE
+        mock_cycle_registry.list_runs.return_value = [
+            _existing_run(1, "completed", "framing"),
+        ]
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs")
+        assert resp.status_code == 200
+        assert resp.json()["workload_type"] == "implementation"
+
+    def test_cancelled_runs_do_not_advance_position(self, client, mock_cycle_registry):
+        mock_cycle_registry.get_cycle.return_value = _MULTI_WORKLOAD_CYCLE
+        mock_cycle_registry.list_runs.return_value = [
+            _existing_run(1, "completed", "framing"),
+            _existing_run(2, "cancelled", "implementation"),
+        ]
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs")
+        assert resp.status_code == 200
+        assert resp.json()["workload_type"] == "implementation"
+
+    def test_all_prior_runs_cancelled_resolves_position_zero(self, client, mock_cycle_registry):
+        mock_cycle_registry.get_cycle.return_value = _MULTI_WORKLOAD_CYCLE
+        mock_cycle_registry.list_runs.return_value = [
+            _existing_run(1, "cancelled", "framing"),
+            _existing_run(2, "cancelled", None),
+        ]
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs")
+        assert resp.status_code == 200
+        assert resp.json()["workload_type"] == "framing"
+
+    def test_out_of_bounds_position_rejected(self, client, mock_cycle_registry):
+        # Sequence exhausted: rejecting beats a silent None-typed run (the
+        # legacy plan shape + no artifact seeding).
+        mock_cycle_registry.get_cycle.return_value = _MULTI_WORKLOAD_CYCLE
+        mock_cycle_registry.list_runs.return_value = [
+            _existing_run(1, "completed", "framing"),
+            _existing_run(2, "failed", "implementation"),
+        ]
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs")
+        assert resp.status_code == 422
+        error = resp.json()["detail"]["error"]
+        assert error["code"] == "VALIDATION_ERROR"
+        assert "Cancel the run being retried" in error["message"]
+
+    def test_explicit_workload_type_bypasses_resolution(self, client, mock_cycle_registry):
+        # Same exhausted-sequence state as above: an explicit param must win.
+        mock_cycle_registry.get_cycle.return_value = _MULTI_WORKLOAD_CYCLE
+        mock_cycle_registry.list_runs.return_value = [
+            _existing_run(1, "completed", "framing"),
+            _existing_run(2, "failed", "implementation"),
+        ]
+        resp = client.post(
+            "/api/v1/projects/hello_squad/cycles/cyc_001/runs?workload_type=implementation"
+        )
+        assert resp.status_code == 200
+        assert resp.json()["workload_type"] == "implementation"
+
+    def test_legacy_cycle_with_runs_stays_none(self, client, mock_cycle_registry):
+        # No workload_sequence: legacy cycles must keep the None type that
+        # selects their legacy plan path, regardless of run count.
+        mock_cycle_registry.list_runs.return_value = [
+            _existing_run(1, "completed"),
+            _existing_run(2, "failed"),
+            _existing_run(3, "completed"),
+        ]
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs")
+        assert resp.status_code == 200
+        assert resp.json()["workload_type"] is None


### PR DESCRIPTION
## Problem

`runs retry` (and the underlying `POST .../runs` route) created the new run with `workload_type=None` unless the caller passed the query param — and the CLI never did. On a multi-workload cycle a `None`-typed run silently:

1. selects the legacy plan shape (`generate_task_plan` → `_resolve_legacy_steps`), re-running planning tasks instead of the intended workload's steps;
2. skips artifact seeding (`execute_run` seeds `plan_artifact_refs` only when `workload_type is not None`) — for a fill-only cycle, no skeleton;
3. still *displays* the right workload in progress (positional mapping), masking the mismatch.

Observed live during the attempt-2 post-crash recovery (`cyc_9d775e1aebeb` / `run_ddb4e76c0434`); recovery required a raw API call.

## Fix

- `create_run` now resolves an unspecified `workload_type` positionally, mirroring the executor's `_starting_workload_index` semantics (D14) and `cycles create`'s position-0 resolution (#26): the new run's index among **non-cancelled** runs selects its `workload_sequence` entry.
- An exhausted sequence (position out of bounds) is **rejected with 422** and a message pointing at the cancel-first retry convention — rejecting beats another silent `None`-typed run.
- Legacy cycles (no `workload_sequence`) keep `None` — their legacy plan path is the correct one.
- An explicit `?workload_type=` still wins; `squadops runs retry` gains `--workload-type` as the escape hatch.

## Tests

`TestCreateRunPositionalResolution` (route-level, through the FastAPI client): the incident shape (framing completed → retry resolves `implementation`), cancelled runs not advancing position, all-cancelled resolving position 0, out-of-bounds → 422 `VALIDATION_ERROR`, explicit param bypassing resolution on an exhausted sequence, and legacy cycles staying `None` regardless of run count. CLI + API domains green (394 passed).

## Notes

First of the two 98.5-readiness fixes from the #433/#434 triage; #434 (forwarding overrides don't survive orchestrator death) follows as a separate PR — the two compounded in the incident.

Fixes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm
