### PR TITLE
fix(#434): rebuild forwarding overrides from durable state on mid-sequence entry

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -481,6 +481,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # into each run invocation, not executor state. Built at the end of
         # workload i, consumed by workload i+1's execute_run.
         forwarding_overrides: dict | None = None
+        if start_index > 0:
+            # #434: a mid-sequence entry (post-crash retry, #257 resume) has no
+            # threaded value — rebuild it from durable state so the resumed
+            # path forwards exactly what the uninterrupted loop would have.
+            forwarding_overrides = await self._rebuild_forwarding_overrides_on_entry(
+                cycle, cycle_id, start_index
+            )
         for i in range(start_index, len(workload_sequence)):
             workload_entry = workload_sequence[i]
             await self.execute_run(
@@ -710,6 +717,51 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 if decision.gate_name == gate_name:
                     return decision
             await asyncio.sleep(poll_interval)
+
+    async def _rebuild_forwarding_overrides_on_entry(
+        self,
+        cycle: Cycle,
+        cycle_id: str,
+        start_index: int,
+    ) -> dict | None:
+        """Reconstruct forwarding for a mid-sequence entry (#434).
+
+        Forwarding overrides live only in the memory of the running loop
+        (SIP-0097 §6.6), so they died with the orchestrating process — a
+        post-crash retry or #257 mid-sequence resume started workload N
+        without workload N-1's promoted outputs (including the gate-approved
+        implementation plan) and silently fell back to static task steps
+        (RC-4). Every input is durable (vault promotions, run records), and
+        the live transition builds fresh from them at each hop — there is no
+        cross-workload accumulation — so rebuilding from the completed run at
+        ``start_index - 1`` yields exactly the value the uninterrupted loop
+        would have threaded. A missing or non-completed prior run degrades to
+        no forwarding (logged), matching pre-#434 behavior.
+        """
+        all_runs = await self._cycle_registry.list_runs(cycle_id)
+        non_cancelled = sorted(
+            (r for r in all_runs if r.status != RunStatus.CANCELLED.value),
+            key=lambda r: r.run_number,
+        )
+        prior_position = start_index - 1
+        if prior_position >= len(non_cancelled):
+            logger.warning(
+                "Cannot rebuild forwarding for cycle %s: no run at workload position %d",
+                cycle_id,
+                prior_position,
+            )
+            return None
+        prior_run = non_cancelled[prior_position]
+        if prior_run.status != RunStatus.COMPLETED.value:
+            logger.warning(
+                "Cannot rebuild forwarding for cycle %s: prior workload run %s is %r,"
+                " not completed",
+                cycle_id,
+                prior_run.run_id,
+                prior_run.status,
+            )
+            return None
+        return await self._build_forwarding_overrides(cycle, prior_run)
 
     async def _build_forwarding_overrides(
         self,

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -328,6 +328,106 @@ class TestResumeMidSequence:
         assert completed_types == ["implementation", "wrapup"]
 
 
+class TestForwardingRebuildOnEntry:
+    """#434: a mid-sequence entry rebuilds forwarding from durable state.
+
+    Forwarding overrides used to exist only in the memory of the running
+    execute_cycle loop — a post-crash retry started workload N with
+    forwarding_overrides=None, so the implementation run never received the
+    framing run's promoted artifacts (including the gate-approved plan) and
+    silently fell back to static task steps.
+    """
+
+    def _artifact(self, artifact_id: str, artifact_type: str, minute: int) -> ArtifactRef:
+        return ArtifactRef(
+            artifact_id=artifact_id,
+            project_id="proj_001",
+            artifact_type=artifact_type,
+            filename=f"{artifact_id}.txt",
+            content_hash="h",
+            size_bytes=10,
+            media_type="text/plain",
+            created_at=datetime(2026, 1, 15, 12, minute, 0, tzinfo=UTC),
+            promotion_status="promoted",
+        )
+
+    async def test_post_crash_retry_forwards_prior_workload_artifacts(
+        self, executor, mock_registry
+    ):
+        # The incident shape (cyc_9d775e1aebeb): framing completed + promoted,
+        # process died, bad retry cancelled, fresh retry at position 1.
+        cycle = _make_cycle(workload_sequence=[{"type": "framing"}, {"type": "implementation"}])
+        mock_registry.get_cycle.return_value = cycle
+
+        run1 = _make_run("run_001", 1, "completed", "framing")
+        run2 = _make_run("run_002", 2, "cancelled", None)
+        run3 = _make_run("run_003", 3, "completed", "implementation")
+        executor._starting_workload_index = AsyncMock(return_value=1)
+        mock_registry.list_runs.return_value = [run1, run2, run3]
+        mock_registry.get_run.return_value = run3
+
+        plan_artifact = self._artifact("art_plan", "control_implementation_plan", minute=0)
+        code_artifact = self._artifact("art_code", "code", minute=1)
+        executor._artifact_vault.list_artifacts.return_value = [plan_artifact, code_artifact]
+
+        await executor.execute_cycle("cyc_001", "run_003")
+
+        executor._artifact_vault.list_artifacts.assert_awaited_once_with(
+            run_id="run_001", promotion_status="promoted"
+        )
+        forwarded = executor.execute_run.call_args_list[0][1]["forwarding_overrides"]
+        assert forwarded["prior_workload_artifact_refs"] == ["art_plan", "art_code"]
+        # framing → plan refs carry only document/plan types, not code
+        assert forwarded["plan_artifact_refs"] == ["art_plan"]
+
+    async def test_fresh_start_does_not_rebuild(self, executor, mock_registry):
+        # Rebuild must never fire at position 0 — a fresh cycle has no prior
+        # workload, and forwarding starts empty exactly as before #434.
+        cycle = _make_cycle(workload_sequence=[{"type": "framing"}, {"type": "implementation"}])
+        mock_registry.get_cycle.return_value = cycle
+        run1 = _make_run("run_001", 1, "failed", "framing")
+        mock_registry.get_run.return_value = run1
+        mock_registry.list_runs.return_value = [run1]
+
+        await executor.execute_cycle("cyc_001", "run_001")
+
+        assert executor.execute_run.call_args_list[0][1]["forwarding_overrides"] is None
+        executor._artifact_vault.list_artifacts.assert_not_awaited()
+
+    async def test_prior_run_not_completed_degrades_to_no_forwarding(self, executor, mock_registry):
+        # A failed prior workload has nothing trustworthy to forward — the
+        # resumed run executes without overrides instead of crashing or
+        # forwarding a failed run's leftovers.
+        cycle = _make_cycle(workload_sequence=[{"type": "framing"}, {"type": "implementation"}])
+        mock_registry.get_cycle.return_value = cycle
+        run1 = _make_run("run_001", 1, "failed", "framing")
+        run2 = _make_run("run_002", 2, "completed", "implementation")
+        executor._starting_workload_index = AsyncMock(return_value=1)
+        mock_registry.list_runs.return_value = [run1, run2]
+        mock_registry.get_run.return_value = run2
+
+        await executor.execute_cycle("cyc_001", "run_002")
+
+        assert executor.execute_run.call_args_list[0][1]["forwarding_overrides"] is None
+        executor._artifact_vault.list_artifacts.assert_not_awaited()
+
+    async def test_missing_prior_run_degrades_to_no_forwarding(self, executor, mock_registry):
+        # Defensive: an index pointing past the known runs (registry drift)
+        # must degrade, not IndexError inside the orchestration loop.
+        cycle = _make_cycle(workload_sequence=[{"type": "framing"}, {"type": "implementation"}])
+        mock_registry.get_cycle.return_value = cycle
+        run2 = _make_run("run_002", 2, "completed", "implementation")
+        executor._starting_workload_index = AsyncMock(return_value=2)
+        mock_registry.list_runs.return_value = [run2]
+        mock_registry.get_run.return_value = run2
+
+        await executor.execute_cycle("cyc_001", "run_002")
+
+        # start_index 2 on a 2-entry sequence: loop body never runs, but the
+        # rebuild guard must not blow up resolving position 1 of a 1-run list.
+        executor._artifact_vault.list_artifacts.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Failed/cancelled run stops orchestration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Inter-workload forwarding overrides existed only in the memory of the `execute_cycle` background task. If the runtime-api process died between workloads, every supported resume path (`runs retry`, `runs resume`, #257 mid-sequence start) re-entered the loop with `forwarding_overrides=None` — workload N started without workload N-1's promoted outputs, **including the reviewed, gate-approved implementation plan**, and RC-4's graceful fallback silently substituted static task steps.

Observed live in the attempt-2 crash recovery (`cyc_9d775e1aebeb`): recovery required reproducing `_build_forwarding_overrides`' merge by hand and writing it into `execution_overrides` via psql.

## Fix

Rebuild on entry (the issue's preferred shape, no schema change): when `execute_cycle` starts at `start_index > 0` , it locates the completed run at `start_index - 1` (non-cancelled, by `run_number` — the same D14 positional rule as `_starting_workload_index`) and calls the existing `_build_forwarding_overrides` on it.

This is **semantically exact, not an approximation**: the live transition builds fresh from durable inputs at each hop (`cycle.execution_overrides` + the immediately-prior run's vault promotions — there is no cross-workload in-memory accumulation), so the rebuilt value is byte-for-byte what the uninterrupted loop would have threaded. Operator-supplied overrides keep precedence, and the merge is dedup-idempotent against manually repaired cycles.

Degradation is explicit: a missing or non-completed prior run logs a warning and proceeds with no forwarding (pre-#434 behavior), never crashes the orchestration loop.

## Tests

`TestForwardingRebuildOnEntry` through real `execute_cycle`: the incident shape (completed framing + cancelled bad retry + fresh retry at position 1 → `plan_artifact_refs`/`prior_workload_artifact_refs` forwarded, plan-type filter honored), fresh starts never rebuilding (vault untouched), failed prior run degrading to `None`, and out-of-range positions not raising. Full cycles+events domains green (1854 passed).

## Notes

Second of the two 98.5-readiness fixes from the #433/#434 triage (first: #479). With both landed, post-crash recovery of a multi-workload cycle works through supported interfaces end-to-end. The issue's startup-reconciliation-sweep suggestion (auto-detect stranded active cycles on boot) is deliberately not bundled — I'll file it as a follow-up hardening issue.

Fixes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm
