### PR TITLE
feat(sip-0099): expander canonicalization + skeleton CI gate (phase 99.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,57 @@ jobs:
       # format sweep landed in #196, so the format check is now gated here.
       - name: Regression suite (ruff check + format + test-quality lint + pytest)
         run: bash scripts/dev/run_regression_tests.sh
+
+  skeleton-gate:
+    # SIP-0099 acceptance surface: the deterministic expander must materialize a
+    # walking skeleton that BUILDS and BOOTS with zero manual intervention, on plain
+    # runners (x86_64 here vs aarch64 dev — acceptable; plain toolchains, no GPU/
+    # agents). SIP-0098 phase 98.2 hangs its lint / bare-skeleton / reference-fill
+    # contract jobs off this same gate, so a skeleton or template edit re-proves both.
+    name: scaffold skeleton gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install squadops (expander import only)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Expand the group_run skeleton from its interface manifest
+        run: |
+          python scripts/dev/materialize_skeleton.py \
+            examples/03_group_run/interface_manifest.yaml \
+            "$RUNNER_TEMP/skeleton"
+
+      - name: Frontend builds (vite)
+        working-directory: ${{ runner.temp }}/skeleton/frontend
+        run: |
+          npm install
+          npm run build
+
+      - name: Backend imports and boots
+        working-directory: ${{ runner.temp }}/skeleton
+        run: |
+          pip install -r backend/requirements.txt
+          # imports clean and the wired /health route is present
+          python -c "from backend.main import app; \
+            assert any(getattr(r, 'path', None) == '/health' for r in app.routes), 'no /health route'"
+          # actually boots: start uvicorn, probe /health, stop
+          python -m uvicorn backend.main:app --host 127.0.0.1 --port 8099 &
+          UVPID=$!
+          trap 'kill $UVPID 2>/dev/null || true' EXIT
+          for _ in $(seq 1 40); do
+            curl -sf http://127.0.0.1:8099/health && break || sleep 0.5
+          done
+          curl -sf http://127.0.0.1:8099/health

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,14 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Install squadops (expander import only)
+      - name: Install squadops
         run: |
           python -m pip install --upgrade pip
           pip install -e .
+          # Importing the expander triggers the squadops package __init__ chain
+          # (pydantic et al.); SquadOps pins its runtime deps here, not in pyproject,
+          # so mirror the test job's install rather than `pip install -e .` alone.
+          pip install -r tests/requirements.txt -c ci-constraints.txt
 
       - name: Expand the group_run skeleton from its interface manifest
         run: |

--- a/scripts/dev/materialize_skeleton.py
+++ b/scripts/dev/materialize_skeleton.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Materialize a walking skeleton from an interface manifest (SIP-0099 skeleton gate).
+
+Loads an interface manifest, expands it via the scaffold expander, and writes every
+``{name, content}`` file under ``out_dir``. The skeleton-gate CI job runs this and then
+proves the expanded skeleton builds (``vite build``) and boots (``uvicorn``) on plain
+runners — SIP-0099's own acceptance surface, and the gate SIP-0098 phase 98.2 emits its
+contract checks into. Kept deliberately thin: expansion + chroot-safe writes only, no
+build/boot logic (that is the CI job's shell steps, and later the sandbox's).
+
+Usage:
+    python scripts/dev/materialize_skeleton.py <manifest.yaml> <out_dir>
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from squadops.capabilities.scaffold import InterfaceManifest, expand
+
+
+def materialize(manifest_path: Path, out_dir: Path) -> int:
+    manifest = InterfaceManifest.from_yaml(manifest_path.read_text(encoding="utf-8"))
+    files = expand(manifest)
+    out_root = out_dir.resolve()
+    for f in files:
+        dest = (out_dir / f["name"]).resolve()
+        # chroot safety: an expander must never write outside the target root.
+        if out_root != dest and out_root not in dest.parents:
+            raise ValueError(f"refusing to write outside {out_root}: {f['name']!r}")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(f["content"], encoding="utf-8")
+    print(
+        f"materialized {len(files)} files from {manifest_path} "
+        f"(manifest_hash={manifest.content_hash()[:12]}) -> {out_root}"
+    )
+    return len(files)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    materialize(Path(argv[1]), Path(argv[2]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/squadops/capabilities/handlers/build_profiles.py
+++ b/src/squadops/capabilities/handlers/build_profiles.py
@@ -155,6 +155,19 @@ class BuildProfile:
             f"{qa_block}"
         )
 
+    def expand(self, manifest: object) -> list[dict[str, str]]:
+        """Materialize the walking skeleton for ``manifest`` (SIP-0099 §4).
+
+        Thin dispatch: the profile is the seam the executor calls (phase 99.3), while
+        all template logic stays in the pure ``scaffold`` module so it keeps no port /
+        NoOp / factory. ``scaffold.expand`` owns the stack→expander registry and raises
+        if ``manifest.stack`` has no expander, so profiles without a scaffold need no
+        special-casing here. Lazily imported to keep ``scaffold`` a leaf sibling.
+        """
+        from squadops.capabilities.scaffold import expand as _expand
+
+        return _expand(manifest)
+
 
 # ---------------------------------------------------------------------------
 # V1 profile registry

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -23,10 +23,19 @@ components exist, wire together, build, and boot, but their bodies are stubs.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
 import yaml
+
+# Schema v1 is frozen (SIP-0099 phase 99.1): the shape below is the canonical
+# interface-manifest contract the fullstack_fastapi_react expander was proven against
+# in the Phase-0.5 spike. A manifest declaring any other version/kind is rejected at
+# parse time rather than silently mis-expanded — a future v2 gets its own expander.
+INTERFACE_MANIFEST_VERSION = 1
+INTERFACE_MANIFEST_KIND = "interface_manifest"
 
 # --------------------------------------------------------------------------- schema
 
@@ -132,12 +141,24 @@ class InterfaceManifest:
         if missing:
             raise ValueError(f"interface manifest missing required keys: {missing}")
 
+        version = int(data["version"])
+        if version != INTERFACE_MANIFEST_VERSION:
+            raise ValueError(
+                f"unsupported interface manifest version {version}; "
+                f"this expander is schema v{INTERFACE_MANIFEST_VERSION}"
+            )
+        kind = str(data["kind"])
+        if kind != INTERFACE_MANIFEST_KIND:
+            raise ValueError(
+                f"interface manifest kind must be {INTERFACE_MANIFEST_KIND!r}, got {kind!r}"
+            )
+
         entities = tuple(_parse_entity(e) for e in data.get("entities", []))
         api = _parse_api(data.get("api", {}) or {})
         frontend = _parse_frontend(data.get("frontend", {}) or {})
         return cls(
-            version=int(data["version"]),
-            kind=str(data["kind"]),
+            version=version,
+            kind=kind,
             project_id=str(data["project_id"]),
             stack=str(data["stack"]),
             source_prd=str(data.get("source_prd", "")),
@@ -147,6 +168,82 @@ class InterfaceManifest:
             frontend=frontend,
             persistence=str(data.get("persistence", "in_memory")),
         )
+
+    def _canonical(self) -> dict[str, Any]:
+        """Deterministic structural projection for hashing — every field the expander
+        reads to produce the skeleton, and nothing else. Provenance (``source_prd``,
+        ``scope``) is excluded: the expander ignores it, so a provenance-only edit must
+        not spuriously move the hash and invalidate the verification contract bound to
+        it (SIP-0098 §10 drift). ``project_id`` IS included — it is substituted into the
+        emitted package name and app title, so it changes the skeleton."""
+        return {
+            "version": self.version,
+            "kind": self.kind,
+            "project_id": self.project_id,
+            "stack": self.stack,
+            "persistence": self.persistence,
+            "entities": [
+                {
+                    "name": e.name,
+                    "fields": [
+                        {
+                            "name": f.name,
+                            "type": f.type,
+                            "required": f.required,
+                            "generated": f.generated,
+                            "default": f.default,
+                            "has_default": f.has_default,
+                        }
+                        for f in e.fields
+                    ],
+                }
+                for e in self.entities
+            ],
+            "api": {
+                "base_path": self.api.base_path,
+                "request_shapes": [
+                    {"name": s.name, "required": list(s.required), "optional": list(s.optional)}
+                    for s in self.api.request_shapes
+                ],
+                "endpoints": [
+                    {
+                        "method": ep.method,
+                        "path": ep.path,
+                        "summary": ep.summary,
+                        "request": ep.request,
+                        "response": ep.response,
+                        "errors": list(ep.errors),
+                    }
+                    for ep in self.api.endpoints
+                ],
+                "error_contract": (
+                    {
+                        "shape": self.api.error_contract.shape,
+                        "codes": [
+                            {"code": c.code, "http": c.http} for c in self.api.error_contract.codes
+                        ],
+                    }
+                    if self.api.error_contract
+                    else None
+                ),
+            },
+            "frontend": {
+                "framework": self.frontend.framework,
+                "language": self.frontend.language,
+                "api_client": self.frontend.api_client,
+                "routes": [
+                    {"path": r.path, "view": r.view, "purpose": r.purpose}
+                    for r in self.frontend.routes
+                ],
+            },
+        }
+
+    def content_hash(self) -> str:
+        """Stable sha256 identifying the skeleton this manifest expands to. SIP-0098's
+        verification contract binds ``skeleton.interface_manifest_hash`` to this value,
+        so drift between a contract and the skeleton it verifies becomes detectable."""
+        canonical = json.dumps(self._canonical(), sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 def _parse_entity(raw: dict[str, Any]) -> Entity:

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -9,21 +9,36 @@ CI/local gate; these guard the expander logic itself.
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 
 import pytest
+import yaml
 
+from squadops.capabilities.handlers.build_profiles import get_profile
 from squadops.capabilities.scaffold import InterfaceManifest, expand
 
 pytestmark = [pytest.mark.domain_capabilities]
 
-_MANIFEST_PATH = (
-    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
-)
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MANIFEST_PATH = _REPO_ROOT / "examples" / "03_group_run" / "interface_manifest.yaml"
 
 
 def _group_run_manifest() -> InterfaceManifest:
     return InterfaceManifest.from_yaml(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _raw_manifest() -> dict:
+    return yaml.safe_load(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _load_materialize_module():
+    """Import scripts/dev/materialize_skeleton.py by path (scripts/ is not a package)."""
+    path = _REPO_ROOT / "scripts" / "dev" / "materialize_skeleton.py"
+    spec = importlib.util.spec_from_file_location("materialize_skeleton", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 def _by_name(files: list[dict[str, str]]) -> dict[str, str]:
@@ -170,3 +185,91 @@ def test_expand_emits_api_client_prefixing_api():
     assert "body.error" in api  # unwraps the pinned envelope
     assert "class ApiError extends Error" in api
     assert "apiFetch from '../api.js'" in files["frontend/src/views/RunsListView.jsx"]
+
+
+# --------------------------------------------------------------------------- #
+# 99.1 canonicalization: schema v1 freeze, content hash, profile seam
+# --------------------------------------------------------------------------- #
+
+
+def test_content_hash_is_sha256_hex():
+    # SIP-0098's contract linter requires interface_manifest_hash to be a 64-char
+    # sha256 hex digest; this proves the hash 99.1 produces satisfies that shape,
+    # so the two phases interlock at 98.2's binding.
+    h = _group_run_manifest().content_hash()
+    assert len(h) == 64
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_content_hash_is_order_independent_for_mapping_keys():
+    raw = _raw_manifest()
+    reordered = {k: raw[k] for k in reversed(list(raw))}  # same content, keys reversed
+    assert (
+        InterfaceManifest.from_dict(reordered).content_hash()
+        == InterfaceManifest.from_dict(raw).content_hash()
+    )
+
+
+def test_content_hash_ignores_provenance_but_tracks_interface():
+    h = _group_run_manifest().content_hash()
+
+    # provenance-only edits must NOT move the hash — else a re-pointed PRD would
+    # spuriously invalidate the verification contract bound to it (SIP-0098 §10).
+    prov = dict(_raw_manifest(), source_prd="totally/different.md", scope="rewritten")
+    assert InterfaceManifest.from_dict(prov).content_hash() == h
+
+    # an interface change DOES move it, so real drift is detectable, not masked.
+    changed = _raw_manifest()
+    changed["api"]["endpoints"].append({"method": "DELETE", "path": "/runs/{id}"})
+    assert InterfaceManifest.from_dict(changed).content_hash() != h
+
+
+def test_from_dict_rejects_unsupported_version():
+    raw = dict(_raw_manifest(), version=2)
+    with pytest.raises(ValueError, match="unsupported interface manifest version"):
+        InterfaceManifest.from_dict(raw)
+
+
+def test_from_dict_rejects_wrong_kind():
+    raw = dict(_raw_manifest(), kind="pcr_manifest")
+    with pytest.raises(ValueError, match="kind must be"):
+        InterfaceManifest.from_dict(raw)
+
+
+def test_build_profile_expand_delegates_to_scaffold():
+    # The profile is the executor's seam (99.3); it must add no transformation of
+    # its own — a byte-for-byte match with the pure expander.
+    m = _group_run_manifest()
+    via_profile = get_profile("fullstack_fastapi_react").expand(m)
+    assert via_profile == expand(m)
+    assert {f["name"] for f in via_profile} >= {"backend/main.py", "frontend/src/App.jsx"}
+
+
+def test_build_profile_expand_surfaces_unknown_stack():
+    bad = InterfaceManifest.from_dict(
+        {"version": 1, "kind": "interface_manifest", "project_id": "x", "stack": "cobol_cics"}
+    )
+    with pytest.raises(ValueError, match="no scaffold expander"):
+        get_profile("fullstack_fastapi_react").expand(bad)
+
+
+def test_materialize_writes_every_expanded_file(tmp_path):
+    mod = _load_materialize_module()
+    count = mod.materialize(_MANIFEST_PATH, tmp_path)
+
+    expected = {f["name"] for f in expand(_group_run_manifest())}
+    written = {str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*") if p.is_file()}
+    assert written == expected
+    assert count == len(expected)
+    # content lands verbatim (spot-check the wired entrypoint)
+    assert "app.include_router(router)" in (tmp_path / "backend" / "main.py").read_text()
+
+
+def test_materialize_refuses_path_traversal(tmp_path, monkeypatch):
+    # Defense-in-depth: even if a future expander emitted an escaping name, the
+    # materializer must refuse to write outside the target root.
+    mod = _load_materialize_module()
+    monkeypatch.setattr(mod, "expand", lambda _m: [{"name": "../escape.txt", "content": "x"}])
+    with pytest.raises(ValueError, match="refusing to write outside"):
+        mod.materialize(_MANIFEST_PATH, tmp_path)
+    assert not (tmp_path.parent / "escape.txt").exists()


### PR DESCRIPTION
**Phase 99.1 of SIP-0099 (Contract-First Build Scaffolding)** — `sips/accepted/SIP-0099-Contract-First-Build-Scaffolding.md`, plan `docs/plans/SIP-0099-contract-first-build-scaffolding-plan.md`. Canonicalizes the Phase-0.5 spike expander and stands up the skeleton CI gate that **SIP-0098 phase 98.2 hangs its lint / bare-skeleton / reference-fill contract jobs off** — so this unblocks 98.2.

## What

- **`scaffold.py`**
  - **Schema v1 frozen** — `from_dict` rejects any `version`/`kind` other than `1`/`interface_manifest` at parse time (a future v2 gets its own expander; no silent mis-expansion).
  - **`InterfaceManifest.content_hash()`** — stable sha256 over the *skeleton-determining* fields. This is the value SIP-0098's contract binds `skeleton.interface_manifest_hash` to, and it satisfies the 64-hex shape phase 98.1's linter requires — the two phases **interlock at 98.2** (a unit test asserts the shape).
- **`build_profiles.py`** — **`BuildProfile.expand()`**, the profile seam the executor (99.3) invokes. Thin delegation to the pure `scaffold` module so template logic never leaves `scaffold.py` (it keeps no port/NoOp/factory). A test asserts the seam is byte-for-byte identical to calling the expander directly.
- **`scripts/dev/materialize_skeleton.py`** — chroot-safe `expand → write` helper (permanent util).
- **`ci.yml`** — new **`skeleton-gate`** job on plain python+node runners: expand the group_run manifest → `vite build` passes → backend imports and **boots** (uvicorn + `/health` probe). SIP-0099's own acceptance surface.

## Design decision I settled (flagging — it feeds 98.3's drift semantics)

`content_hash` covers the fields the expander actually reads to produce the skeleton (`version, kind, project_id, stack, persistence, entities, api, frontend`) and **excludes provenance** (`source_prd`, `scope`). Rationale: the expander ignores provenance, so a re-pointed PRD must not spuriously move the hash and invalidate the bound contract (the SIP-0098 §10 drift-vs-warn question). `project_id` **is** included — it's substituted into the emitted package name and app title, so it genuinely changes the skeleton. Tests pin both directions (provenance edit → same hash; interface edit → different hash).

## Verification

Proven end-to-end **locally**, zero manual intervention, on node 25 + the CI's exact steps:
- `materialize_skeleton.py` → **15 files** written (`manifest_hash=2eab74bd7070`)
- backend boots: `GET /health` → `{"status":"ok"}`; all 5 declared endpoints + `/health` registered
- frontend: `npm install` + `npm run build` → **✓ 36 modules transformed**, `dist/` produced
- **9 new unit tests** (18 in the file); **full regression 4983 passed**; ruff check + format clean; `ci.yml` parses.

The **skeleton-gate job runs on this PR** and is its own proof in CI. Suggest marking it a Required check alongside `test` once green.

## Scope (per the plan)

- **In:** expander canonicalization + hash + profile seam + the deterministic skeleton gate.
- **Not here:** interface manifest **in framing** (99.2); executor **materialization + fill-only develop** (99.3); the follow-on `python_cli_builder`/`static_web_builder` template sets (99.4, non-gating).

No `Closes` — SIP implementation phase; SIP-0099 + its plan are the tracking artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4Zq5Tw5FSJbdpadbxck2v
