### PR TITLE
feat(sip-0098): expander emission + emission-time contract gates (phase 98.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,12 +87,6 @@ jobs:
             examples/03_group_run/interface_manifest.yaml \
             "$RUNNER_TEMP/skeleton"
 
-      - name: Frontend builds (vite)
-        working-directory: ${{ runner.temp }}/skeleton/frontend
-        run: |
-          npm install
-          npm run build
-
       - name: Backend imports and boots
         working-directory: ${{ runner.temp }}/skeleton
         run: |
@@ -108,3 +102,16 @@ jobs:
             curl -sf http://127.0.0.1:8099/health && break || sleep 0.5
           done
           curl -sf http://127.0.0.1:8099/health
+
+      # --- SIP-0098 §6.2 contract gates: "author once, validate twice" ---
+      # These prove no criterion false-greens on stubs or is unwinnable by correct code.
+      # Each expands the skeleton fresh (and, for reference-fill, overlays the checked-in
+      # fill), so a skeleton, contract-emitter, or fill edit re-proves all three.
+      - name: Contract lints clean
+        run: python scripts/dev/contract_gate.py lint
+
+      - name: Bare-skeleton contract gate
+        run: python scripts/dev/contract_gate.py bare-skeleton
+
+      - name: Reference-fill contract gate
+        run: python scripts/dev/contract_gate.py reference-fill

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,11 @@ extend-exclude = [
     "docs",
     "htmlcov",
     "scripts/dev/migrations",
+    # Reference fills are checked-in sample *application* code (skeleton + fill), not
+    # squad-ops source: their `backend` package is first-party to the generated app, so
+    # squad-ops's isort/lint config does not apply. The contract gate materializes and
+    # runs them; that is their gate, not ruff (SIP-0098 phase 98.2).
+    "tests/fixtures/reference_fills",
 ]
 
 [tool.ruff.lint]

--- a/scripts/dev/contract_gate.py
+++ b/scripts/dev/contract_gate.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Contract emission-time gate — "verify the verifier" (SIP-0098 §6.2).
+
+Three modes, run in CI on the SIP-0099 skeleton gate. Together they guarantee no
+criterion can enter the contract that either false-greens on stubs or is unwinnable by
+correct code — the structural fix for the criteria lottery.
+
+  lint            The emitted contract lints clean (the 98.1 linter).
+  bare-skeleton   Every structural (interface/compile) criterion and the frontend_build
+                  guard PASS on the freshly expanded skeleton; the fill-behavior
+                  measure (tests_pass) does NOT (no suite exists until the fill). Proves
+                  the behavior measures actually measure the fill.
+  reference-fill  The FULL contract passes against skeleton + the checked-in reference
+                  fill. The winnability proof.
+
+Refinement of SIP §6.2 (approved 2026-07-17, noted on the PR): a walking skeleton
+compiles/builds/boots by design, so compile/build checks are regression guards that
+PASS on the bare skeleton; only behavior-exercising checks (tests_pass; probes, from
+98.4) fail on it. Probes are not executed here — the probe runner lands in 98.4.
+
+Usage:
+    python scripts/dev/contract_gate.py <lint|bare-skeleton|reference-fill> \
+        [--manifest PATH] [--reference-fill DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from squadops.capabilities.scaffold import InterfaceManifest, expand
+from squadops.capabilities.scaffold_contract import emit_contract_dict
+from squadops.cycles.verification_contract import VerificationContract
+from squadops.cycles.verification_contract_runner import (
+    FILL_BEHAVIOR_MEASURES,
+    evaluate_structural,
+    structural_criteria,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_MANIFEST = _REPO_ROOT / "examples" / "03_group_run" / "interface_manifest.yaml"
+_DEFAULT_REFERENCE_FILL = (
+    _REPO_ROOT / "tests" / "fixtures" / "reference_fills" / "fullstack_fastapi_react" / "group_run"
+)
+
+
+class _Result:
+    def __init__(self) -> None:
+        self.rows: list[tuple[str, str, str, bool]] = []  # (id, got, expected, ok)
+
+    def record(self, criterion_id: str, got: str, expected: str) -> None:
+        self.rows.append((criterion_id, got, expected, got == expected))
+
+    def ok(self) -> bool:
+        return all(row[3] for row in self.rows)
+
+    def report(self, mode: str) -> None:
+        for cid, got, expected, ok in self.rows:
+            mark = "ok  " if ok else "FAIL"
+            print(f"  [{mark}] {cid:28} got={got:9} expected={expected}")
+        verdict = "GREEN" if self.ok() else "RED"
+        print(f"{mode}: {verdict} ({sum(r[3] for r in self.rows)}/{len(self.rows)} criteria)")
+
+
+def _materialize(manifest_path: Path, dest: Path) -> InterfaceManifest:
+    manifest = InterfaceManifest.from_yaml(manifest_path.read_text(encoding="utf-8"))
+    for f in expand(manifest):
+        out = dest / f["name"]
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(f["content"], encoding="utf-8")
+    return manifest
+
+
+def _overlay(ref_dir: Path, dest: Path) -> None:
+    for src in ref_dir.rglob("*"):
+        if src.is_file():
+            out = dest / src.relative_to(ref_dir)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, out)
+
+
+def _run(argv: list[str], cwd: Path) -> bool:
+    """True iff the command exits 0. Output streamed so CI logs show failures."""
+    print(f"    $ {' '.join(argv)}  (cwd={cwd})")
+    return subprocess.run(argv, cwd=cwd).returncode == 0  # noqa: S603 — fixed argv, CI gate
+
+
+def _tests_pass(workspace: Path) -> bool:
+    if not (workspace / "backend" / "tests").is_dir():
+        return False  # no suite on the bare skeleton -> tests_pass cannot pass
+    return _run([sys.executable, "-m", "pytest", "backend/tests", "-q"], workspace)
+
+
+def _frontend_build(workspace: Path) -> bool:
+    frontend = workspace / "frontend"
+    return _run(["npm", "install", "--no-audit", "--no-fund"], frontend) and _run(
+        ["npm", "run", "build"], frontend
+    )
+
+
+def _evaluate(contract: VerificationContract, workspace: Path, result: _Result) -> None:
+    """Fill structural + frontend_build outcomes (shared by both run modes)."""
+    for criterion, fill_file in structural_criteria(contract):
+        outcome = evaluate_structural(criterion, workspace, fill_file=fill_file)
+        # structural checks pass on both the bare skeleton and the reference fill
+        result.record(criterion["id"], outcome.status, "passed")
+    build = contract.behavioral.build
+    if build:
+        got = "passed" if _frontend_build(workspace) else "failed"
+        result.record(build[0].id, got, "passed")
+
+
+def _mode_lint(manifest_path: Path) -> int:
+    manifest = InterfaceManifest.from_yaml(manifest_path.read_text(encoding="utf-8"))
+    errors = VerificationContract.from_dict(emit_contract_dict(manifest)).lint()
+    if errors:
+        print("lint: RED")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print("lint: GREEN (emitted contract lints clean)")
+    return 0
+
+
+def _mode_bare(manifest_path: Path) -> int:
+    result = _Result()
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        manifest = _materialize(manifest_path, workspace)
+        contract = VerificationContract.from_dict(emit_contract_dict(manifest))
+        _evaluate(contract, workspace, result)
+        # fill-behavior measures must NOT pass on the bare skeleton
+        for crit in contract.behavioral.suite.checks:
+            if crit.check in FILL_BEHAVIOR_MEASURES:
+                got = "passed" if _tests_pass(workspace) else "not_passed"
+                result.record(crit.id, got, "not_passed")
+    result.report("bare-skeleton")
+    return 0 if result.ok() else 1
+
+
+def _mode_reference_fill(manifest_path: Path, ref_dir: Path) -> int:
+    result = _Result()
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        manifest = _materialize(manifest_path, workspace)
+        _overlay(ref_dir, workspace)
+        contract = VerificationContract.from_dict(emit_contract_dict(manifest))
+        _evaluate(contract, workspace, result)
+        # with the reference fill in place, every behavior measure must pass
+        for crit in contract.behavioral.suite.checks:
+            if crit.check in FILL_BEHAVIOR_MEASURES:
+                got = "passed" if _tests_pass(workspace) else "failed"
+                result.record(crit.id, got, "passed")
+    result.report("reference-fill")
+    return 0 if result.ok() else 1
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="SIP-0098 contract emission-time gate")
+    parser.add_argument("mode", choices=["lint", "bare-skeleton", "reference-fill"])
+    parser.add_argument("--manifest", type=Path, default=_DEFAULT_MANIFEST)
+    parser.add_argument("--reference-fill", type=Path, default=_DEFAULT_REFERENCE_FILL)
+    args = parser.parse_args(argv)
+
+    if args.mode == "lint":
+        return _mode_lint(args.manifest)
+    if args.mode == "bare-skeleton":
+        return _mode_bare(args.manifest)
+    return _mode_reference_fill(args.manifest, args.reference_fill)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -333,6 +333,23 @@ def expand(manifest: InterfaceManifest) -> list[dict[str, str]]:
     return expander(manifest)
 
 
+def fill_slot_paths(manifest: InterfaceManifest) -> tuple[str, ...]:
+    """Workspace-relative paths of the *fill slots* — the files the dev agent fills
+    bodies into. Everything else ``expand`` emits is frozen (scaffold-owned): the
+    SIP-0098 verification contract pins those by hash and hangs per-file criteria only
+    on these slots. Same stack dispatch as ``expand``; raises for an unknown stack.
+
+    (fullstack_fastapi_react: the route bodies + one component per declared route. As
+    more stacks land in 99.4 they carry their own slot map alongside their expander.)
+    """
+    if manifest.stack not in _EXPANDERS:
+        raise ValueError(
+            f"no scaffold expander for stack {manifest.stack!r}; available: {sorted(_EXPANDERS)}"
+        )
+    views = tuple(f"frontend/src/views/{r.view}.jsx" for r in manifest.frontend.routes)
+    return ("backend/routes.py", *dict.fromkeys(views))
+
+
 # ------------------------------------------------- fullstack_fastapi_react templates
 
 _PY_PRIMITIVES = {"string": "str", "integer": "int", "number": "float", "boolean": "bool"}
@@ -420,6 +437,16 @@ def _routes_source(manifest: InterfaceManifest) -> str:
             if base in known_models:
                 referenced.add(base)
     import_line = f"from .models import {', '.join(sorted(referenced))}" if referenced else ""
+    # The fill raises ApiError for the declared error codes, so the seam import is wired
+    # into the frozen stub — that makes import_present(ApiError) a valid *interface*
+    # criterion (it must pass on the bare skeleton, SIP-0098 §6.2), and the fill dev just
+    # calls the already-imported symbol.
+    errors_import = "from .errors import ApiError" if manifest.api.error_contract else ""
+    import_block = "\n".join(
+        ln
+        for ln in ("from fastapi import APIRouter, HTTPException", import_line, errors_import)
+        if ln
+    )
     error_codes = [
         c.code for c in (manifest.api.error_contract.codes if manifest.api.error_contract else ())
     ]
@@ -438,9 +465,7 @@ def _routes_source(manifest: InterfaceManifest) -> str:
         codes_hint,
         '"""',
         "",
-        "from fastapi import APIRouter, HTTPException",
-        "",
-        import_line,
+        import_block,
         "",
         "router = APIRouter()",
         "",

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -667,7 +667,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
 """
 
 _API_JS = """// Scaffold-owned API client — the /api base path and error-envelope unwrapping
-// are interface wiring, fixed here. Views call apiFetch('/runs'); the /api prefix
+// are interface wiring, fixed here. Views call apiFetch('/path'); the /api prefix
 // routes through the Vite dev proxy to the backend. A response carrying the pinned
 // {"error": {code, message}} envelope is thrown as ApiError.
 export class ApiError extends Error {

--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -1,0 +1,208 @@
+"""Verification-contract emission (SIP-0098 phase 98.2).
+
+Authors the ``verification_contract.yaml`` the expander emits **alongside** the
+skeleton and interface manifest (SIP-0098 §6.1). This is the "author once" half of
+*author once, validate twice*: the criteria are derived deterministically from the
+same interface manifest the skeleton is expanded from, so verification is a fixed
+property of the scaffold rather than a per-roll LLM lottery.
+
+Placement: this lives on the **expander surface** (capabilities), not the cycles
+domain — emission is the scaffold's job; the cycles-domain
+``verification_contract`` module *consumes* (loads/lints) what this produces. So this
+module imports only ``scaffold`` and emits a plain dict/YAML artifact; a test proves
+the artifact lints clean against the cycles-domain schema (the 98.1 ↔ 98.2 interlock).
+
+Fill vs frozen: every file ``expand`` emits that is not a fill slot
+(``scaffold.fill_slot_paths``) is frozen and pinned by content hash; criteria hang
+only on the slots. The behavioral section (build/suite/probes) is the last word on
+the deliverable. Probes are emitted here but not *executed* until phase 98.4 lands the
+probe runner (§6.1/§6.4).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+import yaml
+
+from squadops.capabilities.scaffold import InterfaceManifest, expand, fill_slot_paths
+
+CONTRACT_VERSION = 1
+CAP_PYTHON = "python"
+CAP_NODE = "node"
+
+_ROUTES_PATH = "backend/routes.py"
+
+
+def emit_contract_dict(manifest: InterfaceManifest) -> dict[str, Any]:
+    """Derive the verification contract for ``manifest`` (SIP-0098 §6.1).
+
+    Deterministic: the same manifest always yields the same contract (and therefore
+    the same ``content_hash``), so the frozen hash the yield baseline measures against
+    is reproducible.
+    """
+    files = {f["name"]: f["content"] for f in expand(manifest)}
+    fill = fill_slot_paths(manifest)
+    fill_set = set(fill)
+
+    frozen = [
+        {"path": name, "sha256": _sha256(files[name])}
+        for name in sorted(files)
+        if name not in fill_set
+    ]
+
+    fill_files: dict[str, Any] = {}
+    for path in fill:
+        fill_files[path] = (
+            _routes_criteria(manifest) if path == _ROUTES_PATH else _view_criteria(path)
+        )
+
+    behavioral = _behavioral(manifest)
+
+    contract = {
+        "contract_version": CONTRACT_VERSION,
+        "skeleton": {
+            "expander": manifest.stack,
+            "interface_manifest_hash": manifest.content_hash(),
+        },
+        # Declared from what the criteria actually require, so the two can't drift.
+        "capabilities": _required_capabilities(fill_files, behavioral),
+        "frozen": frozen,
+        "fill_files": fill_files,
+        "behavioral": behavioral,
+    }
+    return contract
+
+
+def emit_contract_yaml(manifest: InterfaceManifest) -> str:
+    """The emitted ``verification_contract.yaml`` artifact text."""
+    header = (
+        "# Verification contract — emitted by the scaffold expander (SIP-0098).\n"
+        "# Roll-invariant: framing BINDS these criteria by id; it never authors them.\n"
+        "# Regenerate with the expander; do not hand-edit.\n"
+    )
+    body = yaml.safe_dump(emit_contract_dict(manifest), sort_keys=False, default_flow_style=False)
+    return header + body
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _slug(name: str) -> str:
+    """CamelCase / path-ish name -> kebab id fragment (stable, unique per manifest)."""
+    kebab = re.sub(r"(?<!^)(?=[A-Z])", "-", name)
+    return re.sub(r"[^a-z0-9]+", "-", kebab.lower()).strip("-")
+
+
+def _routes_criteria(manifest: InterfaceManifest) -> dict[str, Any]:
+    interface: list[dict[str, Any]] = [
+        {
+            "check": "endpoint_defined",
+            "id": "vc-routes-endpoints",
+            "methods_paths": [f"{ep.method} {ep.path}" for ep in manifest.api.endpoints],
+        }
+    ]
+    # The ApiError seam exists only when the manifest declares an error contract.
+    if manifest.api.error_contract:
+        interface.append(
+            {
+                "check": "import_present",
+                "id": "vc-routes-apierror",
+                "module": ".errors",
+                "symbol": "ApiError",
+            }
+        )
+    implementation = [
+        {
+            "check": "command_exit_zero",
+            "id": "vc-routes-compiles",
+            "argv": ["python", "-m", "py_compile", _ROUTES_PATH],
+            "requires": CAP_PYTHON,
+        }
+    ]
+    return {"interface": interface, "implementation": implementation}
+
+
+def _view_criteria(_path: str) -> dict[str, Any]:
+    # Views (.jsx) carry NO per-file criteria in v1:
+    #   - `node --check` cannot parse JSX (fails on correct code), so no per-view
+    #     implementation criterion is winnable; and
+    #   - the SIP-0092 `import_present` evaluator skips .js/.jsx ("frontend acceptance
+    #     checks disabled" — out of scope for M1.2), so a view interface criterion could
+    #     only ever *skip*, never verify anything.
+    # View compilation is verified by the behavioral `frontend_build` (vite is the
+    # JSX-aware compiler). Per-view frontend structural criteria arrive when the
+    # frontend-acceptance-checks follow-up lands; the slot is recorded here regardless so
+    # the fill/frozen partition stays complete.
+    return {"interface": [], "implementation": []}
+
+
+def _behavioral(manifest: InterfaceManifest) -> dict[str, Any]:
+    return {
+        "build": [
+            {"check": "frontend_build", "id": "vc-frontend-builds", "requires": CAP_NODE},
+        ],
+        "suite": {
+            "checks": [
+                {"check": "tests_pass", "id": "vc-suite-passes", "requires": CAP_PYTHON},
+            ],
+            "coverage_expectations": _coverage_expectations(manifest),
+        },
+        "probes": _probes(manifest),
+    }
+
+
+def _coverage_expectations(manifest: InterfaceManifest) -> list[str]:
+    out: list[str] = []
+    eps = ", ".join(f"{ep.method} {ep.path}" for ep in manifest.api.endpoints)
+    if eps:
+        out.append(f"happy path for each endpoint: {eps}")
+    if manifest.api.error_contract:
+        out.extend(f"{code.code} -> HTTP {code.http}" for code in manifest.api.error_contract.codes)
+    out.append("tests are order-independent; module-level state reset per test")
+    return out
+
+
+def _probes(manifest: InterfaceManifest) -> list[dict[str, Any]]:
+    """Self-contained probes only (POST endpoints with no path params). Sequenced
+    probes (join/leave requiring a prior create) and richer response assertions land
+    with the probe runner in 98.4; these are emitted now so the contract is complete."""
+    shapes = {s.name: s for s in manifest.api.request_shapes}
+    probes: list[dict[str, Any]] = []
+    for ep in manifest.api.endpoints:
+        if ep.method != "POST" or "{" in ep.path:
+            continue
+        shape = shapes.get(ep.request or "")
+        json_body = {field: "x" for field in (shape.required if shape else ())}
+        probes.append(
+            {
+                "id": f"vc-probe-{_slug(ep.path) or 'root'}",
+                "subject": "backend",
+                "request": {"method": ep.method, "path": ep.path, "json": json_body},
+                "expect": {"status": 200},
+            }
+        )
+    return probes
+
+
+def _required_capabilities(fill_files: dict[str, Any], behavioral: dict[str, Any]) -> list[str]:
+    found: set[str] = set()
+    for spec in fill_files.values():
+        for cls in ("interface", "implementation"):
+            for crit in spec.get(cls, []):
+                if crit.get("requires"):
+                    found.add(crit["requires"])
+    for crit in behavioral.get("build", []):
+        if crit.get("requires"):
+            found.add(crit["requires"])
+    for crit in behavioral.get("suite", {}).get("checks", []):
+        if crit.get("requires"):
+            found.add(crit["requires"])
+    # Stable order: python before node.
+    return [c for c in (CAP_PYTHON, CAP_NODE) if c in found]

--- a/src/squadops/cycles/verification_contract_runner.py
+++ b/src/squadops/cycles/verification_contract_runner.py
@@ -1,0 +1,82 @@
+"""Evaluate a verification contract's structural criteria (SIP-0098 §6.2).
+
+Bridges the contract's interface/implementation criteria to the SIP-0092 typed-check
+evaluators (``acceptance_checks``): those are structural (AST / safelisted command) and
+evaluated here. The behavioral checks (``tests_pass``, ``frontend_build``) exercise
+runtime behavior and are run by the gate as subprocesses (pytest / vite), not here.
+
+This module also owns the bare-skeleton classification so the gate and its tests share
+one source of truth. Bare-skeleton semantics (SIP §6.2, refined 2026-07-17): a walking
+skeleton compiles, builds, and boots by construction, so interface checks *and*
+compile/build guards PASS on the bare skeleton. Only checks that exercise BEHAVIOR need
+the fill and must NOT pass on the bare skeleton — today just ``tests_pass`` (probes join
+in 98.4). Every structural check therefore passes on the bare skeleton; none is a
+fill-behavior measure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from squadops.cycles.acceptance_check_spec import CHECK_SPECS
+from squadops.cycles.acceptance_checks import CheckOutcome, get_check
+
+if TYPE_CHECKING:
+    from squadops.cycles.verification_contract import VerificationContract
+
+# endpoint_defined gates on ``stack == "fastapi"``; the fullstack backend's structural
+# checks evaluate in that context.
+FASTAPI_STACK = "fastapi"
+
+# Behavioral checks that exercise runtime behavior — they need the fill and must NOT
+# pass on the bare skeleton. Structural checks and the frontend_build guard pass on the
+# walking skeleton by design, so they are not listed here.
+FILL_BEHAVIOR_MEASURES = frozenset({"tests_pass"})
+
+_RESERVED = frozenset({"check", "id", "requires"})
+
+
+def is_structural(check_name: str) -> bool:
+    """True when a check is evaluated by a SIP-0092 typed-check evaluator (vs a
+    behavioral check the gate runs as a subprocess)."""
+    return check_name in CHECK_SPECS
+
+
+def evaluate_structural(
+    criterion: dict[str, Any], workspace_root: Path, *, fill_file: str | None = None
+) -> CheckOutcome:
+    """Evaluate one structural criterion via its registered evaluator.
+
+    Contract criteria omit ``file`` (it is the ``fill_files`` key), so inject it for the
+    checks whose spec needs a file target. Drives the async evaluator to completion.
+    """
+    check_name = criterion["check"]
+    if not is_structural(check_name):
+        raise ValueError(f"{check_name!r} is not a structural check")
+    params = {k: v for k, v in criterion.items() if k not in _RESERVED}
+    spec = CHECK_SPECS[check_name]
+    if fill_file is not None and ("file" in spec.required_params or "file" in spec.path_params):
+        params.setdefault("file", fill_file)
+    return asyncio.run(get_check(check_name).evaluate(params, workspace_root, stack=FASTAPI_STACK))
+
+
+def structural_criteria(
+    contract: VerificationContract,
+) -> list[tuple[dict[str, Any], str | None]]:
+    """``(criterion_dict, fill_file)`` for every structural criterion in the contract,
+    in document order. ``fill_file`` is the fill-slot path for ``fill_files`` criteria,
+    else ``None`` (behavioral-section structural criteria, of which there are none today).
+    """
+    out: list[tuple[dict[str, Any], str | None]] = []
+    for ff in contract.fill_files:
+        for crit in (*ff.interface, *ff.implementation):
+            raw = crit.to_dict()
+            if is_structural(raw["check"]):
+                out.append((raw, ff.path))
+    for crit in (*contract.behavioral.build, *contract.behavioral.suite.checks):
+        raw = crit.to_dict()
+        if is_structural(raw["check"]):
+            out.append((raw, None))
+    return out

--- a/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/backend/routes.py
+++ b/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/backend/routes.py
@@ -1,0 +1,71 @@
+"""API routes — group_run reference fill (SIP-0098 §6.2 winnability oracle).
+
+A known-good implementation of the scaffold-owned route signatures: an in-memory
+store plus the join/leave logic the PRD's behaviors require. This is the "reference
+fill" the contract's reference-fill CI gate runs against — no criterion may enter the
+contract that this correct fill does not already satisfy. Fill-only: the scaffold owns
+the imports, ``router``, and every decorator/signature below; only the bodies are ours.
+"""
+
+import uuid
+
+from fastapi import APIRouter
+
+from .errors import ApiError
+from .models import Participant, ParticipantName, RunEvent, RunEventCreate
+
+router = APIRouter()
+
+# In-memory store: run id -> RunEvent (persistence: in_memory).
+_RUNS: dict[str, RunEvent] = {}
+
+
+def _get_run(run_id: str) -> RunEvent:
+    run = _RUNS.get(run_id)
+    if run is None:
+        raise ApiError("run_not_found", f"run {run_id!r} does not exist")
+    return run
+
+
+@router.get("/runs", response_model=list[RunEvent])
+def get_runs():
+    """list runs."""
+    return list(_RUNS.values())
+
+
+@router.post("/runs", response_model=RunEvent)
+def post_runs(payload: RunEventCreate):
+    """create run."""
+    run = RunEvent(id=uuid.uuid4().hex, participants=[], **payload.model_dump())
+    _RUNS[run.id] = run
+    return run
+
+
+@router.get("/runs/{id}", response_model=RunEvent)
+def get_runs_id(id: str):
+    """run details."""
+    return _get_run(id)
+
+
+@router.post("/runs/{id}/join", response_model=RunEvent)
+def post_runs_id_join(id: str, payload: ParticipantName):
+    """join run by participant name."""
+    run = _get_run(id)
+    # Case-insensitive uniqueness; the stored name is NOT normalized (manifest decisions).
+    if any(p.name.casefold() == payload.name.casefold() for p in run.participants):
+        raise ApiError("duplicate_participant", f"{payload.name!r} has already joined")
+    run.participants.append(Participant(id=uuid.uuid4().hex, name=payload.name))
+    return run
+
+
+@router.post("/runs/{id}/leave", response_model=RunEvent)
+def post_runs_id_leave(id: str, payload: ParticipantName):
+    """leave run by participant name."""
+    run = _get_run(id)
+    match = next(
+        (p for p in run.participants if p.name.casefold() == payload.name.casefold()), None
+    )
+    if match is None:
+        raise ApiError("participant_not_found", f"{payload.name!r} is not in this run")
+    run.participants.remove(match)
+    return run

--- a/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/backend/tests/test_routes.py
+++ b/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/backend/tests/test_routes.py
@@ -1,0 +1,75 @@
+"""Generated suite for the group_run reference fill — the ``tests_pass`` behavioral.
+
+Order-independent (module-level store reset per test) and covers the contract's
+coverage_expectations: create/list/get/join/leave happy paths plus the error codes
+(duplicate join -> 409, unknown run/participant -> 404).
+"""
+
+from fastapi.testclient import TestClient
+
+from backend import routes
+from backend.main import app
+
+client = TestClient(app)
+
+
+def setup_function():
+    routes._RUNS.clear()  # module-level state reset per test (order-independence)
+
+
+def _create(title="Saturday Long Run"):
+    resp = client.post(
+        "/runs", json={"title": title, "datetime": "2026-08-01T08:00", "location": "Park Gate"}
+    )
+    assert resp.status_code == 200
+    return resp.json()
+
+
+def test_create_then_list_then_get():
+    run = _create()
+    assert run["id"] and run["participants"] == []
+
+    assert [r["id"] for r in client.get("/runs").json()] == [run["id"]]
+
+    got = client.get(f"/runs/{run['id']}").json()
+    assert got["id"] == run["id"]
+    assert got["title"] == "Saturday Long Run"
+
+
+def test_get_unknown_run_is_404():
+    resp = client.get("/runs/does-not-exist")
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "run_not_found"
+
+
+def test_join_returns_full_run_and_rejects_case_insensitive_duplicate():
+    run = _create()
+
+    joined = client.post(f"/runs/{run['id']}/join", json={"name": "Alice"})
+    assert joined.status_code == 200
+    # mutation returns the FULL updated RunEvent, not just the participant
+    assert joined.json()["id"] == run["id"]
+    assert [p["name"] for p in joined.json()["participants"]] == ["Alice"]
+
+    dup = client.post(f"/runs/{run['id']}/join", json={"name": "alice"})
+    assert dup.status_code == 409
+    assert dup.json()["error"]["code"] == "duplicate_participant"
+
+
+def test_leave_removes_participant_and_unknown_is_404():
+    run = _create()
+    client.post(f"/runs/{run['id']}/join", json={"name": "Bob"})
+
+    left = client.post(f"/runs/{run['id']}/leave", json={"name": "bob"})  # case-insensitive
+    assert left.status_code == 200
+    assert left.json()["participants"] == []
+
+    unknown = client.post(f"/runs/{run['id']}/leave", json={"name": "ghost"})
+    assert unknown.status_code == 404
+    assert unknown.json()["error"]["code"] == "participant_not_found"
+
+
+def test_create_requires_title_datetime_location():
+    resp = client.post("/runs", json={"title": "missing the rest"})
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "validation_error"

--- a/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/frontend/src/views/CreateRunView.jsx
+++ b/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/frontend/src/views/CreateRunView.jsx
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { apiFetch } from '../api.js'
+
+export default function CreateRunView() {
+  const navigate = useNavigate()
+  const [form, setForm] = useState({ title: '', datetime: '', location: '' })
+  const [error, setError] = useState(null)
+
+  const update = (field) => (e) => setForm({ ...form, [field]: e.target.value })
+
+  const submit = async (e) => {
+    e.preventDefault()
+    setError(null)
+    try {
+      const run = await apiFetch('/runs', { method: 'POST', body: JSON.stringify(form) })
+      navigate(`/runs/${run.id}`)
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <form onSubmit={submit}>
+      <h1>Create a run</h1>
+      {error && <p role="alert">{error}</p>}
+      <input placeholder="Title" value={form.title} onChange={update('title')} />
+      <input placeholder="Date and time" value={form.datetime} onChange={update('datetime')} />
+      <input placeholder="Location" value={form.location} onChange={update('location')} />
+      <button type="submit">Create</button>
+    </form>
+  )
+}

--- a/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/frontend/src/views/RunDetailView.jsx
+++ b/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/frontend/src/views/RunDetailView.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { apiFetch } from '../api.js'
+
+export default function RunDetailView() {
+  const { id } = useParams()
+  const [run, setRun] = useState(null)
+  const [name, setName] = useState('')
+  const [error, setError] = useState(null)
+
+  const load = () =>
+    apiFetch(`/runs/${id}`)
+      .then(setRun)
+      .catch((e) => setError(e.message))
+
+  useEffect(() => {
+    load()
+  }, [id])
+
+  const mutate = (action) => async (e) => {
+    e.preventDefault()
+    setError(null)
+    try {
+      const updated = await apiFetch(`/runs/${id}/${action}`, {
+        method: 'POST',
+        body: JSON.stringify({ name }),
+      })
+      setRun(updated)
+      setName('')
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  if (error && !run) return <p role="alert">{error}</p>
+  if (!run) return <p>Loading…</p>
+
+  return (
+    <div>
+      <h1>{run.title}</h1>
+      <p>
+        {run.location} · {run.datetime}
+      </p>
+      {error && <p role="alert">{error}</p>}
+      <ul>
+        {run.participants.map((p) => (
+          <li key={p.id}>{p.name}</li>
+        ))}
+      </ul>
+      <form>
+        <input placeholder="Your name" value={name} onChange={(e) => setName(e.target.value)} />
+        <button onClick={mutate('join')}>Join</button>
+        <button onClick={mutate('leave')}>Leave</button>
+      </form>
+    </div>
+  )
+}

--- a/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/frontend/src/views/RunsListView.jsx
+++ b/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/frontend/src/views/RunsListView.jsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { apiFetch } from '../api.js'
+
+export default function RunsListView() {
+  const [runs, setRuns] = useState([])
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    apiFetch('/runs')
+      .then(setRuns)
+      .catch((e) => setError(e.message))
+  }, [])
+
+  return (
+    <div>
+      <h1>Group Runs</h1>
+      <Link to="/create">Create a run</Link>
+      {error && <p role="alert">{error}</p>}
+      <ul>
+        {runs.map((run) => (
+          <li key={run.id}>
+            <Link to={`/runs/${run.id}`}>{run.title}</Link> — {run.participants.length} joined
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -171,8 +171,11 @@ def test_expand_renders_pinned_error_contract():
     assert "from .errors import register_error_handlers" in main
     assert "register_error_handlers(app)" in main
 
-    # route stubs steer the fill dev at ApiError with the real codes
-    assert "raise ApiError(code, message) from .errors" in files["backend/routes.py"]
+    # route stubs steer the fill dev at ApiError with the real codes, and the seam
+    # import is wired into the frozen stub so import_present(ApiError) is valid interface
+    routes = files["backend/routes.py"]
+    assert "from .errors import ApiError" in routes
+    assert "raise ApiError(code, message) from .errors" in routes
 
 
 def test_expand_emits_api_client_prefixing_api():

--- a/tests/unit/capabilities/test_scaffold_contract.py
+++ b/tests/unit/capabilities/test_scaffold_contract.py
@@ -1,0 +1,159 @@
+"""Tests for verification-contract emission (SIP-0098 phase 98.2).
+
+The load-bearing test is the 98.1 ↔ 98.2 interlock: the contract the expander emits
+must lint clean against the cycles-domain schema/linter — an emitter that produced a
+malformed or class-confused contract would be caught here, not in a cycle. The rest
+pin the derivation (frozen covers every non-fill file by real hash; each slot carries
+its interface + implementation criteria; the skeleton is bound by manifest hash) and
+determinism (same manifest → same contract → same frozen hash).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from squadops.capabilities.scaffold import InterfaceManifest, expand, fill_slot_paths
+from squadops.capabilities.scaffold_contract import emit_contract_dict, emit_contract_yaml
+from squadops.cycles.verification_contract import VerificationContract
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+
+
+def _manifest() -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _raw() -> dict:
+    return yaml.safe_load(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+# --------------------------------------------------------------------------- #
+# The interlock: emitted contract must lint clean (98.1's linter)
+# --------------------------------------------------------------------------- #
+
+
+def test_emitted_group_run_contract_lints_clean():
+    contract = VerificationContract.from_dict(emit_contract_dict(_manifest()))
+    assert contract.lint() == []
+
+
+def test_emitted_yaml_roundtrips_and_lints_clean():
+    # the actual artifact path: YAML text -> loader -> lint
+    text = emit_contract_yaml(_manifest())
+    assert text.startswith("# Verification contract")
+    contract = VerificationContract.from_yaml(text)
+    assert contract.lint() == []
+
+
+def test_contract_without_error_contract_omits_apierror_and_lints_clean():
+    # the ApiError seam is emitted only when the manifest declares an error contract
+    def apierror_ids(contract: dict) -> list[str]:
+        return [
+            c["id"]
+            for c in contract["fill_files"]["backend/routes.py"]["interface"]
+            if c["id"] == "vc-routes-apierror"
+        ]
+
+    assert apierror_ids(emit_contract_dict(_manifest())) == ["vc-routes-apierror"]
+
+    raw = _raw()
+    raw["api"].pop("error_contract", None)
+    without_ec = emit_contract_dict(InterfaceManifest.from_dict(raw))
+    assert apierror_ids(without_ec) == []
+    assert VerificationContract.from_dict(without_ec).lint() == []
+
+
+# --------------------------------------------------------------------------- #
+# Derivation
+# --------------------------------------------------------------------------- #
+
+
+def test_skeleton_bound_by_interface_manifest_hash():
+    manifest = _manifest()
+    contract = emit_contract_dict(manifest)
+    assert contract["skeleton"]["expander"] == manifest.stack
+    assert contract["skeleton"]["interface_manifest_hash"] == manifest.content_hash()
+
+
+def test_frozen_covers_every_non_fill_file_by_real_hash():
+    manifest = _manifest()
+    files = {f["name"]: f["content"] for f in expand(manifest)}
+    fill = set(fill_slot_paths(manifest))
+
+    contract = emit_contract_dict(manifest)
+    frozen = {entry["path"]: entry["sha256"] for entry in contract["frozen"]}
+
+    assert set(frozen) == set(files) - fill  # every non-fill file, nothing else
+    assert "backend/routes.py" not in frozen  # a fill slot is never frozen
+    # hashes are of the actual expanded content (drift in a frozen file is detectable)
+    for path, digest in frozen.items():
+        assert digest == _sha256(files[path])
+
+
+def test_fill_slots_carry_interface_and_implementation_criteria():
+    contract = emit_contract_dict(_manifest())
+    routes = contract["fill_files"]["backend/routes.py"]
+
+    endpoints = next(c for c in routes["interface"] if c["check"] == "endpoint_defined")
+    assert endpoints["methods_paths"] == [
+        "GET /runs",
+        "POST /runs",
+        "GET /runs/{id}",
+        "POST /runs/{id}/join",
+        "POST /runs/{id}/leave",
+    ]
+    assert any(c["id"] == "vc-routes-apierror" for c in routes["interface"])
+    compiles = next(c for c in routes["implementation"] if c["check"] == "command_exit_zero")
+    assert compiles["argv"] == ["python", "-m", "py_compile", "backend/routes.py"]
+    assert compiles["requires"] == "python"
+
+    # views carry NO per-file criteria in v1: node --check can't parse JSX and the
+    # import_present evaluator skips .jsx — view compilation is verified by frontend_build
+    detail = contract["fill_files"]["frontend/src/views/RunDetailView.jsx"]
+    assert detail["interface"] == []
+    assert detail["implementation"] == []
+
+
+def test_behavioral_has_build_suite_and_self_contained_probe():
+    contract = emit_contract_dict(_manifest())
+    behavioral = contract["behavioral"]
+
+    assert behavioral["build"][0]["check"] == "frontend_build"
+    assert behavioral["suite"]["checks"][0]["check"] == "tests_pass"
+    assert any("happy path" in exp for exp in behavioral["suite"]["coverage_expectations"])
+
+    # one self-contained probe (POST /runs); path-param endpoints defer to 98.4
+    probe_paths = {p["request"]["path"] for p in behavioral["probes"]}
+    assert probe_paths == {"/runs"}
+    create = behavioral["probes"][0]
+    assert create["request"]["method"] == "POST"
+    assert set(create["request"]["json"]) == {"title", "datetime", "location"}
+    assert create["expect"]["status"] == 200
+
+
+def test_capabilities_derived_from_what_criteria_require():
+    contract = emit_contract_dict(_manifest())
+    assert contract["capabilities"] == ["python", "node"]
+
+
+def test_emission_is_deterministic():
+    a = emit_contract_dict(_manifest())
+    b = emit_contract_dict(_manifest())
+    assert a == b
+    # and the frozen hash the yield baseline measures against is stable
+    assert (
+        VerificationContract.from_dict(a).content_hash()
+        == VerificationContract.from_dict(b).content_hash()
+    )

--- a/tests/unit/cycles/test_verification_contract_runner.py
+++ b/tests/unit/cycles/test_verification_contract_runner.py
@@ -1,0 +1,111 @@
+"""Tests for the contract runner (SIP-0098 §6.2 structural evaluation bridge).
+
+The gate's three CI jobs are the end-to-end proof; these guard the reusable pieces the
+gate and its tests share: which criteria are structural (evaluator-backed) vs behavioral
+(subprocess), that every structural criterion PASSES on the bare skeleton (the refined
+§6.2 model — a walking skeleton compiles/builds, so only tests_pass/probes fail on it),
+and that the file target is injected from the fill-slot key.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from squadops.capabilities.scaffold import InterfaceManifest, expand
+from squadops.capabilities.scaffold_contract import emit_contract_dict
+from squadops.cycles.verification_contract import VerificationContract
+from squadops.cycles.verification_contract_runner import (
+    FILL_BEHAVIOR_MEASURES,
+    evaluate_structural,
+    is_structural,
+    structural_criteria,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+_REFERENCE_FILL = (
+    Path(__file__).resolve().parents[3]
+    / "tests"
+    / "fixtures"
+    / "reference_fills"
+    / "fullstack_fastapi_react"
+    / "group_run"
+)
+
+
+def _materialize(dest: Path) -> InterfaceManifest:
+    manifest = InterfaceManifest.from_yaml(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    for f in expand(manifest):
+        out = dest / f["name"]
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(f["content"], encoding="utf-8")
+    return manifest
+
+
+def _contract() -> VerificationContract:
+    manifest = InterfaceManifest.from_yaml(_MANIFEST_PATH.read_text(encoding="utf-8"))
+    return VerificationContract.from_dict(emit_contract_dict(manifest))
+
+
+def test_structural_criteria_selects_only_evaluator_backed_checks():
+    checks = {c["check"] for c, _ in structural_criteria(_contract())}
+    assert checks == {"endpoint_defined", "import_present", "command_exit_zero"}
+    # behavioral checks are the gate's subprocess job, never structural
+    assert "tests_pass" not in checks
+    assert "frontend_build" not in checks
+
+
+def test_fill_behavior_measures_is_tests_pass_only():
+    # only behavior-exercising checks fail on the bare skeleton; frontend_build is a
+    # regression guard that PASSES on the walking skeleton, so it is NOT listed
+    assert FILL_BEHAVIOR_MEASURES == {"tests_pass"}
+    assert not is_structural("tests_pass")
+    assert not is_structural("frontend_build")
+
+
+def test_every_structural_criterion_passes_on_bare_skeleton(tmp_path):
+    # the §6.2 refinement: interface (endpoint_defined, import_present ApiError) AND the
+    # compile guard (py_compile) all pass on the freshly expanded stub skeleton
+    _materialize(tmp_path)
+    contract = _contract()
+    for criterion, fill_file in structural_criteria(contract):
+        outcome = evaluate_structural(criterion, tmp_path, fill_file=fill_file)
+        assert outcome.status == "passed", (
+            f"{criterion['id']} -> {outcome.status} ({outcome.reason})"
+        )
+
+
+def test_structural_criteria_still_pass_with_reference_fill(tmp_path):
+    _materialize(tmp_path)
+    for src in _REFERENCE_FILL.rglob("*"):
+        if src.is_file():
+            out = tmp_path / src.relative_to(_REFERENCE_FILL)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, out)
+    for criterion, fill_file in structural_criteria(_contract()):
+        outcome = evaluate_structural(criterion, tmp_path, fill_file=fill_file)
+        assert outcome.status == "passed"
+
+
+def test_endpoint_defined_fails_when_routes_file_missing(tmp_path):
+    # edge: no skeleton materialized -> the interface check FAILS (not error), so a fill
+    # that deleted the routes file would be caught
+    criterion = {
+        "check": "endpoint_defined",
+        "id": "vc-routes-endpoints",
+        "methods_paths": ["GET /runs", "POST /runs"],
+    }
+    outcome = evaluate_structural(criterion, tmp_path, fill_file="backend/routes.py")
+    assert outcome.status == "failed"
+    assert outcome.reason == "file_not_found"
+
+
+def test_evaluate_structural_rejects_behavioral_check(tmp_path):
+    with pytest.raises(ValueError, match="not a structural check"):
+        evaluate_structural({"check": "tests_pass", "id": "vc-suite-passes"}, tmp_path)


### PR DESCRIPTION
**Phase 98.2 of SIP-0098 (Verification Contracts)** — expander emission + the emission-time "verify the verifier" gates. This is the **"author once, validate twice"** heart of the surface. Builds on 98.1 (schema/linter, merged) and 99.1 (skeleton gate, merged).

## What ships (three parts)

1. **Emitter** (`scaffold_contract.py`) — derives `verification_contract.yaml` deterministically from the interface manifest: endpoints→`endpoint_defined`, the ApiError seam→`import_present`, `py_compile`, `frontend_build`+`tests_pass`+coverage, self-contained probes. Capabilities derived from what criteria require; skeleton bound by `content_hash`. `scaffold.fill_slot_paths()` owns the fill/frozen partition.
2. **Reference fill** — a manually-validated known-good group_run implementation (`tests/fixtures/reference_fills/…/group_run/`: routes body + 3 views + generated suite). Fill files only; the skeleton is expanded fresh in CI so drift is caught, not frozen in.
3. **Runner + 3 CI gates** — `verification_contract_runner` bridges structural criteria to the SIP-0092 evaluators; `scripts/dev/contract_gate.py` runs **lint / bare-skeleton / reference-fill** as steps on the skeleton gate.

## ⚠️ Refinement of SIP §6.2 / §8 (approved 2026-07-17)

Building the bare-skeleton gate surfaced three things where the SIP's §6.2 sketch met reality. All three are the "verify the verifier" process working *before* anything shipped:

1. **`node --check` cannot parse JSX** (`ERR_UNKNOWN_FILE_EXTENSION`) — the per-view `node --check` implementation criterion in the §6.1 sketch is unwinnable by correct code. **Dropped**; view compilation is verified by the behavioral `frontend_build` (vite is the JSX-aware compiler).
2. **The SIP-0092 `import_present` evaluator skips `.js`/`.jsx`** ("frontend acceptance checks disabled — out of scope for M1.2"), so a view `import_present(apiFetch)` criterion could only ever *skip*. **Views carry no per-file criteria in v1** (recorded as fill slots; covered by `frontend_build`). Per-view frontend criteria return when frontend acceptance checks land.
3. **The big one — a walking skeleton compiles, builds, and boots *by design*** (99.1's whole point), so `py_compile` and `frontend_build` **PASS on the bare skeleton**. SIP §6.2/§8 says *"every implementation/behavioral criterion fails-or-skips on the bare skeleton"* — that over-reached. The honest partition: **interface + compile/build guards → pass on bare; only behavior measures (`tests_pass`; probes, from 98.4) → fail on bare.** The bare-skeleton gate asserts exactly that; the reference-fill gate remains the real winnability proof.

One scaffold co-evolution followed from #2's counterpart on the backend: `routes.py`'s stub now wires `from .errors import ApiError`, making `import_present(ApiError)` a genuine interface criterion (passes on bare, `.py` is evaluable). This effectively refines §6.2/§8 language; a light SIP amendment can follow.

## Verification (all local, deterministic)

- **Reference fill, boot-probed live**: backend suite 5/5, `py_compile` OK, `vite build` OK; create/list/get 200, unknown 404, join 200, **dup case-insensitive 409**, leave-unknown 404, **missing-fields 422**.
- **Gate, all 3 modes GREEN**:
  - `lint` → emitted contract lints clean
  - `bare-skeleton` **5/5** → `vc-routes-endpoints`/`vc-routes-apierror`/`vc-routes-compiles`/`vc-frontend-builds` **passed**, `vc-suite-passes` **not_passed** (needs the fill — exactly right)
  - `reference-fill` **5/5** → `vc-suite-passes` flips to **passed**
- **9 emitter tests** (incl. the 98.1↔98.2 lint interlock) + **6 runner tests**; **full regression 4998 passed**; ruff clean.

The 3 gate steps run on this PR's `skeleton-gate` job — their own proof in CI.

## Scope

- **In:** emission + reference fill + the three emission-time gates (SIP §8 bullet 1).
- **Not here:** orchestration binding — seeding/proposer fragments/plan validation/dispatch (98.3); the **probe runner** (98.4 — probes are emitted but not executed yet); PRD v0.4 + yield baseline (98.5, Spark).

No `Closes` — SIP implementation phase; SIP-0098 + its plan are the tracking artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4Zq5Tw5FSJbdpadbxck2v
