### PR TITLE
fix(#484): strategy proposer supplies guidance_id (unblocks multi-role framing)

### DIFF
--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -1072,6 +1072,23 @@ class StrategyProposePlanGuidanceHandler(_ProposeBaseHandler):
     _success_artifact_type = "plan_guidance"
     _proposer_role = "strategy"
 
+    def _build_render_variables(
+        self,
+        prd: str,
+        prior_outputs: dict[str, Any] | None,
+        inputs: dict[str, Any],
+    ) -> dict[str, str]:
+        # #484: strategy emits PlanGuidance (guidance_id), not a ProposedRoleTasks
+        # (proposal_id), so its request template requires a `guidance_id` the shared
+        # proposer base never provides — the strategy proposer crashed with
+        # TemplateMissingVariableError on every multi-role cycle. Supply one, mirroring
+        # the base's proposal_id generation.
+        import uuid
+
+        variables = super()._build_render_variables(prd, prior_outputs, inputs)
+        variables["guidance_id"] = str(inputs.get("guidance_id") or f"guid-{uuid.uuid4().hex[:8]}")
+        return variables
+
     def _parse_and_validate(
         self,
         yaml_content: str | None,

--- a/tests/unit/capabilities/test_propose_plan_tasks.py
+++ b/tests/unit/capabilities/test_propose_plan_tasks.py
@@ -475,3 +475,39 @@ class TestPromptRegistryIntegration:
         failure = ProposalFailure.from_yaml(artifact["content"])
         assert failure.failure_reason == "llm_error"
         assert "request_renderer" in failure.details
+
+
+@pytest.mark.parametrize(
+    ("handler_cls", "template_id"),
+    [
+        (DevelopmentProposePlanTasksHandler, "request.development_propose_plan_tasks"),
+        (QaProposePlanTasksHandler, "request.qa_propose_plan_tasks"),
+        (StrategyProposePlanGuidanceHandler, "request.strategy_propose_plan_guidance"),
+    ],
+)
+def test_proposer_provides_every_required_template_variable(handler_cls, template_id):
+    # #484: the strategy template requires `guidance_id`, which the handler never provided
+    # -> TemplateMissingVariableError crashed every multi-role cycle before the merge.
+    # Guard the whole proposer family: each handler must supply every variable its template
+    # declares required, or the renderer raises at render time.
+    import re
+    from pathlib import Path
+
+    import yaml
+
+    template_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "squadops"
+        / "prompts"
+        / "request_templates"
+        / f"{template_id}.md"
+    )
+    frontmatter = re.match(
+        r"^---\s*\n(.*?)\n---", template_path.read_text(encoding="utf-8"), re.DOTALL
+    )
+    required = set((yaml.safe_load(frontmatter.group(1)) or {}).get("required_variables", []))
+
+    provided = set(handler_cls()._build_render_variables("PRD", None, {}))
+    missing = required - provided
+    assert not missing, f"{handler_cls.__name__} misses required template vars: {sorted(missing)}"


### PR DESCRIPTION
Fixes the strategy-proposer crash that blocks **all** multi-role plan authoring — found live during SIP-0099 99.2 Slice-E validation.

## Bug
`StrategyProposePlanGuidanceHandler` renders `request.strategy_propose_plan_guidance`, which declares `guidance_id` as a **required** variable — but the shared `_ProposeBaseHandler._build_render_variables` only ever provides `proposal_id`. So the strategy proposer raised `TemplateMissingVariableError: Required variable 'guidance_id' missing` on every cycle that activates it, and crashed *hard* (not a graceful `ProposalFailure`), failing the framing workload before the merger could run degraded on dev+qa.

Latent until now: `validation-multirole` is the first profile that puts `strategy` in `plan_authoring_contributors`. Observed live in `run_3163f018aa62`.

## Fix
`StrategyProposePlanGuidanceHandler` overrides `_build_render_variables` to supply `guidance_id`, mirroring the base's `proposal_id` generation (strategy legitimately emits a `PlanGuidance` with its own `guidance_id`).

## Guard
A parametrized test asserts **every** proposer (dev / qa / strategy) supplies every variable its template declares required — would have caught this and prevents the class recurring.

Full regression 5001 passed.

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4Zq5Tw5FSJbdpadbxck2v