### PR TITLE
feat(sip-0099): interface manifest in framing (phase 99.2)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2085,13 +2085,16 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
         from squadops.cycles.implementation_plan import ImplementationPlan
 
+        errors: list[str] = []
+        interface_content: str | None = None
         for ref_id in tuple(run.artifact_refs or ()):
             try:
                 ref, content_bytes = await self._artifact_vault.retrieve(ref_id)
             except Exception:
                 continue
+            artifact_type = getattr(ref, "artifact_type", None)
             if ref.filename == "implementation_plan.yaml" or (
-                getattr(ref, "artifact_type", None) == "control_implementation_plan"
+                artifact_type == "control_implementation_plan"
             ):
                 try:
                     plan = ImplementationPlan.from_yaml(content_bytes.decode(errors="replace"))
@@ -2103,9 +2106,33 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         gate_name,
                         exc_info=True,
                     )
-                    return []
-                return plan.validate_criteria_scope()
-        return []
+                else:
+                    errors.extend(plan.validate_criteria_scope())
+            elif ref.filename == "interface_manifest.yaml" or artifact_type == "interface_manifest":
+                interface_content = content_bytes.decode(errors="replace")
+
+        # SIP-0099 99.2: a framing-emitted interface manifest is validated here — this is
+        # its ONLY net (the dispatch-time net in cycles/task_plan.py stays scaffold-free to
+        # preserve the cycles→capabilities layering). Errors join the same returned list,
+        # so they flow into the identical system:plan_validation REJECTED recording.
+        # Absent manifest → no-op = today's behavior (byte-identical for plan-only cycles).
+        if interface_content is not None:
+            errors.extend(self._validate_interface_manifest(interface_content))
+        return errors
+
+    @staticmethod
+    def _validate_interface_manifest(content: str) -> list[str]:
+        """Parse + lint a framing-emitted interface manifest, returning errors prefixed
+        for the REJECTED gate note (SIP-0099 99.2). ``scaffold`` is imported lazily —
+        the adapter layer may depend on capabilities, and this keeps the module import
+        light and the dependency out of the cycles domain."""
+        from squadops.capabilities.scaffold import InterfaceManifest
+
+        try:
+            manifest = InterfaceManifest.from_yaml(content)
+        except Exception as exc:  # noqa: BLE001 — untrusted LLM output: any parse/shape failure is one rejection, never a crash
+            return [f"interface_manifest: unparseable ({exc})"]
+        return [f"interface_manifest: {e}" for e in manifest.lint()]
 
     async def _reject_unsatisfiable_plan_at_gate(
         self,

--- a/src/squadops/capabilities/handlers/_plan_authoring.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring.py
@@ -38,6 +38,7 @@ async def retry_yaml_call(
     parse_and_validate: Callable[[str | None], tuple[Any | None, str | None]],
     max_attempts: int,
     handler_name: str,
+    on_success_content: Callable[[str], None] | None = None,
 ) -> tuple[Any | None, str | None, str | None]:
     """Drive an LLM call with up to ``max_attempts`` retries.
 
@@ -49,6 +50,11 @@ async def retry_yaml_call(
     Returns ``(parsed_obj, last_yaml, last_error)``. ``parsed_obj`` is
     ``None`` if all attempts failed; ``last_yaml`` carries the most
     recent raw YAML for diagnostic logging.
+
+    ``on_success_content``, if given, is called with the full raw response of
+    the accepted attempt — the caller can then pull additional fenced blocks
+    the primary YAML extractor discards (SIP-0099 99.2: the interface manifest
+    a framing proposer may emit alongside ``proposed_plan_tasks.yaml``).
     """
     messages: list[ChatMessage] = [
         ChatMessage(role="system", content=system_prompt),
@@ -83,6 +89,8 @@ async def retry_yaml_call(
         parsed, err = parse_and_validate(last_yaml)
         if err is None and parsed is not None:
             logger.info("%s: produced valid output on attempt %d", handler_name, attempt)
+            if on_success_content is not None:
+                on_success_content(content)
             return parsed, last_yaml, None
 
         logger.warning(
@@ -103,6 +111,17 @@ async def retry_yaml_call(
         ]
 
     return None, last_yaml, last_error
+
+
+def extract_interface_manifest_yaml(content: str) -> str | None:
+    """Return the raw ``interface_manifest.yaml`` fenced block a framing role emitted,
+    or ``None`` if it did not (SIP-0099 phase 99.2). Data-driven: absence means the
+    cycle keeps today's non-scaffolded behavior. Selected by filename, so it is robust
+    to block ordering (unlike the first-yaml-block plan extraction)."""
+    for f in extract_fenced_files(content or ""):
+        if f["filename"] == "interface_manifest.yaml":
+            return f["content"]
+    return None
 
 
 def _first_yaml_block_or_none(content: str) -> str | None:

--- a/src/squadops/capabilities/handlers/_plan_authoring_service.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring_service.py
@@ -271,12 +271,19 @@ async def produce_plan(
                 prd_hash=hashlib.sha256(prd.encode()).hexdigest() if prd else "",
                 handler_name=handler_name,
             )
-            return {
+            result_artifact: dict[str, Any] = {
                 "name": "implementation_plan.yaml",
                 "content": yaml_content,
                 "media_type": "text/yaml",
                 "type": "control_implementation_plan",
             }
+            # SIP-0099 99.2: a sole-author governance run may emit interface_manifest.yaml
+            # alongside the plan; carry the raw block so the merger emits it as a sibling
+            # artifact (absent = no key = today's behavior, byte-identical).
+            interface_files = [f for f in extracted if f["filename"] == "interface_manifest.yaml"]
+            if interface_files:
+                result_artifact["interface_manifest_yaml"] = interface_files[0]["content"]
+            return result_artifact
 
         logger.warning(
             "%s: manifest attempt %d/%d failed (%s)",

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -807,6 +807,27 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
             "typed_acceptance_vocabulary": render_typed_acceptance_vocabulary(),
         }
 
+    async def _scaffold_section(self, renderer: Any, inputs: dict[str, Any]) -> str:
+        """The interface-manifest instruction, or "" (SIP-0099 99.2 Slice B).
+
+        Non-empty ONLY for the dev proposer on a scaffoldable stack — dev owns the
+        interface section, and a non-scaffoldable cycle must not be asked to emit a
+        manifest that plan validation would reject. The instruction text lives in a
+        managed prompt asset (``request.development_interface_manifest_appendix``), not
+        inline here (CLAUDE.md #448)."""
+        from squadops.capabilities.scaffold import is_scaffoldable_stack
+
+        if self._proposer_role != "development":
+            return ""
+        resolved_config = inputs.get("resolved_config") or {}
+        stack = str(resolved_config.get("build_profile") or "")
+        if not is_scaffoldable_stack(stack):
+            return ""
+        rendered = await renderer.render(
+            "request.development_interface_manifest_appendix", {"stack": stack}
+        )
+        return rendered.content
+
     async def handle(
         self,
         context: ExecutionContext,
@@ -839,6 +860,14 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
             )
 
         variables = self._build_render_variables(prd, prior_outputs, inputs)
+        # SIP-0099 99.2 (Slice B): on a scaffoldable stack, the dev proposer is asked to
+        # ALSO author an interface manifest. Data-driven — a non-scaffoldable cycle gets
+        # "" and stays on today's path — and the instruction lives in a managed prompt
+        # asset, not an inline literal (CLAUDE.md #448). Only set when non-empty so qa/
+        # strategy renders don't log an unknown-variable warning.
+        scaffold_section = await self._scaffold_section(renderer, inputs)
+        if scaffold_section:
+            variables["scaffold_section"] = scaffold_section
         rendered = await renderer.render(self._request_template_id, variables)
         user_prompt = rendered.content
 

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -812,7 +812,10 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
         context: ExecutionContext,
         inputs: dict[str, Any],
     ) -> HandlerResult:
-        from squadops.capabilities.handlers._plan_authoring import retry_yaml_call
+        from squadops.capabilities.handlers._plan_authoring import (
+            extract_interface_manifest_yaml,
+            retry_yaml_call,
+        )
 
         start_time = time.perf_counter()
 
@@ -854,6 +857,11 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
         def parse_and_validate(yaml_or_none: str | None) -> tuple[Any | None, str | None]:
             return self._parse_and_validate(yaml_or_none, expected_brief_id)
 
+        captured: dict[str, str] = {}
+
+        def _capture_content(content: str) -> None:
+            captured["content"] = content
+
         parsed, last_yaml, last_error = await retry_yaml_call(
             llm=context.ports.llm,
             chat_kwargs=chat_kwargs,
@@ -862,6 +870,7 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
             parse_and_validate=parse_and_validate,
             max_attempts=max_attempts,
             handler_name=self._handler_name,
+            on_success_content=_capture_content,
         )
 
         if parsed is None:
@@ -873,7 +882,13 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
                 last_error or "exhausted retry budget without parseable output",
             )
 
-        return self._build_success_result(start_time, inputs, last_yaml or "")
+        # SIP-0099 99.2: a framing proposer may emit interface_manifest.yaml alongside
+        # its proposed_plan_tasks.yaml; carry the raw block for the merger (data-driven —
+        # absent = today's behavior).
+        interface_manifest_yaml = extract_interface_manifest_yaml(captured.get("content", ""))
+        return self._build_success_result(
+            start_time, inputs, last_yaml or "", interface_manifest_yaml
+        )
 
     def _classify_failure(self, last_error: str | None, last_yaml: str | None) -> str:
         """Map the retry loop's last error to a ProposalFailure failure_reason."""
@@ -893,7 +908,22 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
         start_time: float,
         inputs: dict[str, Any],
         yaml_content: str,
+        interface_manifest_yaml: str | None = None,
     ) -> HandlerResult:
+        # The merger consumes this via prior_outputs (PR 93.3). The cycle
+        # executor strips "artifacts" from prior_outputs by design, so we
+        # surface the YAML content under a non-artifacts key the merger
+        # reads by role.
+        proposal_outcome: dict[str, Any] = {
+            "status": "success",
+            "proposing_role": self._proposer_role,
+            "yaml_content": yaml_content,
+            "artifact_name": self._success_artifact_name,
+        }
+        # SIP-0099 99.2: carry the raw interface manifest for the merger, only when the
+        # proposer emitted one (no key = no interface manifest = today's behavior).
+        if interface_manifest_yaml:
+            proposal_outcome["interface_manifest_yaml"] = interface_manifest_yaml
         outputs = {
             "summary": f"[{self._role}] proposal produced for {self._capability_id}",
             "role": self._role,
@@ -905,16 +935,7 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
                     "type": self._success_artifact_type,
                 },
             ],
-            # The merger consumes this via prior_outputs (PR 93.3). The cycle
-            # executor strips "artifacts" from prior_outputs by design, so we
-            # surface the YAML content under a non-artifacts key the merger
-            # reads by role.
-            "proposal_outcome": {
-                "status": "success",
-                "proposing_role": self._proposer_role,
-                "yaml_content": yaml_content,
-                "artifact_name": self._success_artifact_name,
-            },
+            "proposal_outcome": proposal_outcome,
         }
         duration_ms = (time.perf_counter() - start_time) * 1000
         evidence = HandlerEvidence.create(
@@ -1267,7 +1288,20 @@ class GovernanceMergePlanHandler(_CycleTaskHandler):
             plan_yaml=emit_plan_yaml(plan),
             decisions_yaml=emit_merge_decisions_yaml(decisions),
             authoring_mode=decisions.authoring_mode,
+            interface_manifest_yaml=self._read_interface_manifest(prior_outputs),
         )
+
+    @staticmethod
+    def _read_interface_manifest(prior_outputs: dict[str, Any]) -> str | None:
+        """Raw ``interface_manifest.yaml`` a framing proposer emitted (dev preferred, qa
+        fallback), or ``None`` (SIP-0099 99.2). Data-driven: absence = today's behavior,
+        no flag."""
+        for role_key in ("dev", "qa"):
+            outcome = (prior_outputs.get(role_key) or {}).get("proposal_outcome") or {}
+            raw = outcome.get("interface_manifest_yaml")
+            if raw:
+                return raw
+        return None
 
     def _parse_proposal_outcome(
         self,
@@ -1392,6 +1426,9 @@ class GovernanceMergePlanHandler(_CycleTaskHandler):
             plan_yaml=emit_plan_yaml(plan),
             decisions_yaml=emit_merge_decisions_yaml(decisions),
             authoring_mode="sole_author",
+            # sole-author path: the interface manifest, if any, rides produce_plan's
+            # return (SIP-0099 99.2).
+            interface_manifest_yaml=manifest.get("interface_manifest_yaml"),
         )
 
     def _build_planning_content_from_framing(
@@ -1422,24 +1459,41 @@ class GovernanceMergePlanHandler(_CycleTaskHandler):
         plan_yaml: str,
         decisions_yaml: str,
         authoring_mode: str,
+        interface_manifest_yaml: str | None = None,
     ) -> HandlerResult:
+        artifacts: list[dict[str, Any]] = [
+            {
+                "name": "implementation_plan.yaml",
+                "content": plan_yaml,
+                "media_type": "text/yaml",
+                "type": "control_implementation_plan",
+            },
+            {
+                "name": "merge_decisions.yaml",
+                "content": decisions_yaml,
+                "media_type": "text/yaml",
+                "type": "merge_decisions",
+            },
+        ]
+        # SIP-0099 99.2: the framing-authored interface manifest rides alongside the plan
+        # as a sibling artifact — surfaced in the gate package for operator review and
+        # loaded by the executor (99.3). Emitted only when a proposer/sole-author authored
+        # one; absent → the artifact set is byte-identical to today. The merger does NOT
+        # validate it — that is net-b's job (dispatched_flow_executor), keeping emission
+        # and validation cleanly separated.
+        if interface_manifest_yaml:
+            artifacts.append(
+                {
+                    "name": "interface_manifest.yaml",
+                    "content": interface_manifest_yaml,
+                    "media_type": "text/yaml",
+                    "type": "interface_manifest",
+                }
+            )
         outputs = {
             "summary": f"[{self._role}] merged plan produced ({authoring_mode})",
             "role": self._role,
-            "artifacts": [
-                {
-                    "name": "implementation_plan.yaml",
-                    "content": plan_yaml,
-                    "media_type": "text/yaml",
-                    "type": "control_implementation_plan",
-                },
-                {
-                    "name": "merge_decisions.yaml",
-                    "content": decisions_yaml,
-                    "media_type": "text/yaml",
-                    "type": "merge_decisions",
-                },
-            ],
+            "artifacts": artifacts,
             # Surfaced for review_plan's sign-off and the gate package.
             "merge_outcome": {
                 "authoring_mode": authoring_mode,

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -391,6 +391,14 @@ def fill_slot_paths(manifest: InterfaceManifest) -> tuple[str, ...]:
     return ("backend/routes.py", *dict.fromkeys(views))
 
 
+def is_scaffoldable_stack(stack: str) -> bool:
+    """True when ``stack`` has a registered walking-skeleton expander — i.e. a cycle on
+    this stack can be scaffolded. The data-driven gate for the framing instruction
+    (SIP-0099 99.2): only scaffoldable cycles are asked to author an interface manifest,
+    so a non-scaffoldable stack never emits one that plan validation would then reject."""
+    return bool(stack) and stack in _EXPANDERS
+
+
 # ------------------------------------------------- fullstack_fastapi_react templates
 
 _PY_PRIMITIVES = {"string": "str", "integer": "int", "number": "float", "boolean": "bool"}

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -245,6 +245,47 @@ class InterfaceManifest:
         canonical = json.dumps(self._canonical(), sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
+    def lint(self) -> list[str]:
+        """Return the consistency defects that make this manifest unusable for
+        scaffolding — the "malformed/incomplete" net a framing LLM emission is checked
+        against (SIP-0099 phase 99.2). Gross malformation (bad version/kind, missing
+        required keys) is already raised by ``from_dict``; this catches the manifests
+        that *parse* but cannot be expanded (no endpoints, an endpoint referencing an
+        undeclared request shape, a route with no view). Empty list ⇒ usable.
+        """
+        errors: list[str] = []
+        if not self.project_id:
+            errors.append("project_id is required")
+        if self.stack not in _EXPANDERS:
+            errors.append(
+                f"stack {self.stack!r} has no scaffold expander (known: {sorted(_EXPANDERS)})"
+            )
+        if not self.api.endpoints:
+            errors.append("api.endpoints is empty — declare at least one endpoint to scaffold")
+
+        entity_names = {e.name for e in self.entities}
+        shape_names = {s.name for s in self.api.request_shapes}
+        for ep in self.api.endpoints:
+            label = f"endpoint {ep.method} {ep.path}".rstrip()
+            if not ep.method or not ep.path:
+                errors.append(f"{label}: method and path are required")
+            if ep.request and ep.request not in shape_names and ep.request not in entity_names:
+                errors.append(
+                    f"{label}: request {ep.request!r} is not a declared request_shape or entity"
+                )
+            if ep.response:
+                base = _base_type_name(ep.response)
+                # a capitalized response type names an entity; a lowercase one is a
+                # primitive (str/int/…) the expander passes through.
+                if base and base[0].isupper() and base not in entity_names:
+                    errors.append(f"{label}: response references undeclared entity {base!r}")
+
+        for route in self.frontend.routes:
+            if not route.view:
+                errors.append(f"frontend route {route.path!r}: view is required")
+
+        return errors
+
 
 def _parse_entity(raw: dict[str, Any]) -> Entity:
     fields = []

--- a/src/squadops/prompts/request_templates/request.development_interface_manifest_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_interface_manifest_appendix.md
@@ -1,0 +1,84 @@
+---
+template_id: request.development_interface_manifest_appendix
+version: "1"
+required_variables:
+  - stack
+optional_variables: []
+---
+## Interface manifest (this build is scaffolded)
+
+This build uses **contract-first scaffolding**: a deterministic tool generates the wired,
+buildable application skeleton — entry files, config, data models, route stubs, error
+handling, and frontend routing — from a typed **interface manifest**, and the developer
+then fills only the endpoint and component *bodies*. Your job is to author that interface
+manifest: a precise description of the application's **interface**, never its
+implementation.
+
+**Emit it as a SECOND fenced block, AFTER your `proposed_plan_tasks.yaml` block above** —
+same output, one extra file. Order matters: the plan block must come first, the manifest
+second. Use this exact schema and filename:
+
+```yaml:interface_manifest.yaml
+version: 1
+kind: interface_manifest
+project_id: <short-slug-for-this-app>
+stack: fullstack_fastapi_react
+entities:                          # the data types the app stores and returns
+  - name: Item
+    fields:
+      - name: id
+        type: string
+        generated: true            # server-assigned identifier
+      - name: title
+        type: string
+      - name: done
+        type: boolean
+        required: false
+        default: false
+api:
+  base_path: /api
+  request_shapes:                  # request BODIES — a projection of entity fields
+    ItemCreate:
+      required: [title]
+      optional: [done]
+  endpoints:                       # every HTTP endpoint the app exposes
+    - method: GET
+      path: /items
+      response: list[Item]         # a list response — write list[Entity], no quotes
+    - method: POST
+      path: /items
+      request: ItemCreate
+      response: Item
+      errors: [validation_error]
+    - method: GET
+      path: /items/{id}
+      response: Item
+      errors: [item_not_found]
+  error_contract:
+    shape: '{"error": {"code": "...", "message": "..."}}'
+    codes:
+      validation_error:
+        http: 422
+      item_not_found:
+        http: 404
+frontend:
+  framework: react_vite
+  routes:                          # one view component per route
+    - path: /
+      view: ItemsListView
+      purpose: list items and a create form
+    - path: /items/:id
+      view: ItemDetailView
+      purpose: one item's details
+persistence: in_memory
+```
+
+Rules:
+- Describe the **interface only** — entities, request shapes, endpoints, routes. Do NOT
+  write endpoint logic or component code here; the scaffold wires the skeleton and the
+  developer fills the bodies.
+- Every `response` that names an entity, and every `request` that names a request shape,
+  must be declared in `entities` / `request_shapes`.
+- Keep `kind: interface_manifest` exactly, and set `stack: {{stack}}` (this build's stack).
+- The example above is illustrative — replace it with THIS build's real entities,
+  endpoints, and routes, drawn from the brief and PRD.

--- a/src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md
+++ b/src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md
@@ -11,6 +11,7 @@ optional_variables:
   - roles_section
   - builder_section
   - typed_acceptance_vocabulary
+  - scaffold_section
 ---
 You are proposing development-domain plan tasks for the upcoming build.
 
@@ -67,3 +68,5 @@ risks: []
 gaps_not_covered: []
 confidence: ""  # low | medium | high
 ```
+
+{{scaffold_section}}

--- a/tests/unit/capabilities/test_interface_manifest_framing.py
+++ b/tests/unit/capabilities/test_interface_manifest_framing.py
@@ -1,0 +1,141 @@
+"""Interface-manifest-in-framing deterministic core (SIP-0099 phase 99.2).
+
+Covers the two seams that carry a framing-authored interface manifest without a live
+LLM: the proposer-output extraction helper (``extract_interface_manifest_yaml``) and
+the executor's plan-gate validation net (``_reject_invalid_plan_before_workload_gate``
++ ``_validate_interface_manifest``), which is the ONLY net that validates the manifest
+and feeds the existing ``system:plan_validation`` REJECTED recording. Merger emission is
+covered in ``test_merge_plan_handler.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+from squadops.capabilities.handlers._plan_authoring import extract_interface_manifest_yaml
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+
+
+def _clean_manifest_yaml() -> str:
+    return _MANIFEST_PATH.read_text(encoding="utf-8")
+
+
+def _malformed_manifest_yaml() -> str:
+    raw = yaml.safe_load(_clean_manifest_yaml())
+    raw["api"]["endpoints"] = []  # parses, but nothing to scaffold — a lint defect
+    return yaml.safe_dump(raw)
+
+
+# --------------------------------------------------------------------------- #
+# extract_interface_manifest_yaml — capture the block from proposer output
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_returns_the_interface_block_by_filename_regardless_of_order():
+    # interface_manifest.yaml is emitted SECOND here, after the plan block; the helper
+    # selects by filename, so ordering can't hide it (unlike first-yaml-block extraction)
+    content = (
+        "Plan first:\n"
+        "```yaml:proposed_plan_tasks.yaml\nversion: 1\ntasks: []\n```\n"
+        "Then the interface:\n"
+        "```yaml:interface_manifest.yaml\nversion: 1\nkind: interface_manifest\n```\n"
+    )
+    extracted = extract_interface_manifest_yaml(content)
+    assert extracted is not None
+    assert "kind: interface_manifest" in extracted
+
+
+def test_extract_returns_none_when_no_interface_block():
+    # data-driven: no interface_manifest.yaml block => None => today's behavior downstream
+    content = "```yaml:proposed_plan_tasks.yaml\nversion: 1\ntasks: []\n```\n"
+    assert extract_interface_manifest_yaml(content) is None
+    assert extract_interface_manifest_yaml("") is None
+
+
+# --------------------------------------------------------------------------- #
+# _validate_interface_manifest — parse + lint + prefix (the rejection payload)
+# --------------------------------------------------------------------------- #
+
+
+def test_validate_clean_manifest_yields_no_errors():
+    assert DispatchedFlowExecutor._validate_interface_manifest(_clean_manifest_yaml()) == []
+
+
+def test_validate_malformed_manifest_yields_prefixed_lint_errors():
+    errors = DispatchedFlowExecutor._validate_interface_manifest(_malformed_manifest_yaml())
+    assert errors
+    assert all(e.startswith("interface_manifest:") for e in errors)
+    assert any("endpoint" in e for e in errors)
+
+
+def test_validate_unparseable_manifest_is_a_single_error():
+    errors = DispatchedFlowExecutor._validate_interface_manifest("::: not valid yaml :::")
+    assert len(errors) == 1
+    assert "interface_manifest: unparseable" in errors[0]
+
+
+# --------------------------------------------------------------------------- #
+# net-b: _reject_invalid_plan_before_workload_gate surfaces interface errors
+# --------------------------------------------------------------------------- #
+
+
+def _executor_for(manifest_yaml: str | None) -> tuple[DispatchedFlowExecutor, Any, Any]:
+    stored: dict[str, tuple[Any, bytes]] = {}
+    refs: list[str] = []
+    if manifest_yaml is not None:
+        ref = MagicMock()
+        ref.filename = "interface_manifest.yaml"
+        ref.artifact_type = "interface_manifest"
+        stored["ref-iface"] = (ref, manifest_yaml.encode("utf-8"))
+        refs.append("ref-iface")
+
+    vault = AsyncMock()
+
+    async def _retrieve(ref_id: str):
+        return stored[ref_id]
+
+    vault.retrieve.side_effect = _retrieve
+
+    executor = DispatchedFlowExecutor(artifact_vault=vault)
+    run = MagicMock()
+    run.artifact_refs = refs
+    cycle = MagicMock()
+    cycle.applied_defaults = {"implementation_plan": True}
+    return executor, run, cycle
+
+
+async def test_net_b_rejects_a_malformed_interface_manifest():
+    executor, run, cycle = _executor_for(_malformed_manifest_yaml())
+    errors = await executor._reject_invalid_plan_before_workload_gate(
+        run, cycle, "progress_plan_review"
+    )
+    # these errors are what the caller records as the system:plan_validation REJECTED note
+    assert any(e.startswith("interface_manifest:") and "endpoint" in e for e in errors)
+
+
+async def test_net_b_passes_a_clean_interface_manifest():
+    executor, run, cycle = _executor_for(_clean_manifest_yaml())
+    errors = await executor._reject_invalid_plan_before_workload_gate(
+        run, cycle, "progress_plan_review"
+    )
+    assert errors == []
+
+
+async def test_net_b_no_manifest_is_todays_behavior():
+    # absent interface manifest => no new rejection (byte-identical for plan-only cycles)
+    executor, run, cycle = _executor_for(None)
+    errors = await executor._reject_invalid_plan_before_workload_gate(
+        run, cycle, "progress_plan_review"
+    )
+    assert errors == []

--- a/tests/unit/capabilities/test_interface_manifest_framing.py
+++ b/tests/unit/capabilities/test_interface_manifest_framing.py
@@ -19,11 +19,23 @@ import yaml
 
 from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
 from squadops.capabilities.handlers._plan_authoring import extract_interface_manifest_yaml
+from squadops.capabilities.handlers.planning_tasks import (
+    DevelopmentProposePlanTasksHandler,
+    QaProposePlanTasksHandler,
+)
+from squadops.capabilities.scaffold import InterfaceManifest, is_scaffoldable_stack
 
 pytestmark = [pytest.mark.domain_capabilities]
 
-_MANIFEST_PATH = (
-    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MANIFEST_PATH = _REPO_ROOT / "examples" / "03_group_run" / "interface_manifest.yaml"
+_APPENDIX_PATH = (
+    _REPO_ROOT
+    / "src"
+    / "squadops"
+    / "prompts"
+    / "request_templates"
+    / "request.development_interface_manifest_appendix.md"
 )
 
 
@@ -139,3 +151,54 @@ async def test_net_b_no_manifest_is_todays_behavior():
         run, cycle, "progress_plan_review"
     )
     assert errors == []
+
+
+# --------------------------------------------------------------------------- #
+# Slice B: the conditional scaffold_section injection (dev-only, scaffoldable-only)
+# --------------------------------------------------------------------------- #
+
+
+async def test_scaffold_section_rendered_for_dev_on_scaffoldable_stack():
+    handler = DevelopmentProposePlanTasksHandler()
+    renderer = AsyncMock()
+    renderer.render.return_value = MagicMock(content="INTERFACE MANIFEST INSTRUCTION")
+
+    out = await handler._scaffold_section(
+        renderer, {"resolved_config": {"build_profile": "fullstack_fastapi_react"}}
+    )
+
+    assert out == "INTERFACE MANIFEST INSTRUCTION"
+    renderer.render.assert_awaited_once_with(
+        "request.development_interface_manifest_appendix", {"stack": "fullstack_fastapi_react"}
+    )
+
+
+async def test_scaffold_section_empty_and_unrendered_for_non_scaffoldable_stack():
+    handler = DevelopmentProposePlanTasksHandler()
+    renderer = AsyncMock()
+    out = await handler._scaffold_section(
+        renderer, {"resolved_config": {"build_profile": "django_htmx"}}
+    )
+    assert out == ""
+    renderer.render.assert_not_awaited()  # never told to author a manifest it can't scaffold
+
+
+async def test_scaffold_section_empty_for_non_dev_proposer():
+    # qa proposes tests, not the interface — only dev owns the interface section
+    handler = QaProposePlanTasksHandler()
+    renderer = AsyncMock()
+    out = await handler._scaffold_section(
+        renderer, {"resolved_config": {"build_profile": "fullstack_fastapi_react"}}
+    )
+    assert out == ""
+    renderer.render.assert_not_awaited()
+
+
+def test_appendix_example_manifest_is_itself_valid_and_scaffoldable():
+    # the schema example we teach the LLM must itself parse, lint clean, and be
+    # scaffoldable — otherwise a squad copying it faithfully still gets rejected
+    example = extract_interface_manifest_yaml(_APPENDIX_PATH.read_text(encoding="utf-8"))
+    assert example is not None
+    manifest = InterfaceManifest.from_yaml(example)
+    assert manifest.lint() == []
+    assert is_scaffoldable_stack(manifest.stack)

--- a/tests/unit/capabilities/test_merge_plan_handler.py
+++ b/tests/unit/capabilities/test_merge_plan_handler.py
@@ -707,6 +707,52 @@ async def test_handler_emits_both_artifacts_on_multi_role_merge():
     assert decisions.authoring_mode == "multi_role"
 
 
+async def test_handler_emits_interface_manifest_when_a_proposer_supplies_it():
+    # SIP-0099 99.2: a proposer's outcome carrying interface_manifest_yaml makes the
+    # merger emit a THIRD sibling artifact, verbatim — the merger does not validate it.
+    ctx = _make_merger_context()
+    handler = GovernanceMergePlanHandler()
+    interface_yaml = (
+        "version: 1\nkind: interface_manifest\nproject_id: group_run\n"
+        "stack: fullstack_fastapi_react\n"
+    )
+
+    inputs = {
+        "prd": "PRD",
+        "resolved_config": {"plan_authoring_contributors": ["development", "qa"]},
+        "prior_outputs": {
+            "lead": {"brief_outcome": {"status": "success", "yaml_content": _BRIEF_YAML}},
+            "dev": {
+                "proposal_outcome": {
+                    "status": "success",
+                    "proposing_role": "development",
+                    "yaml_content": _DEV_PROPOSAL_YAML,
+                    "interface_manifest_yaml": interface_yaml,
+                },
+            },
+            "qa": {
+                "proposal_outcome": {
+                    "status": "success",
+                    "proposing_role": "qa",
+                    "yaml_content": _QA_PROPOSAL_YAML,
+                },
+            },
+        },
+    }
+
+    result = await handler.handle(ctx, inputs)
+    assert result.success is True
+    artifacts = {a["name"]: a for a in result.outputs["artifacts"]}
+    assert set(artifacts) == {
+        "implementation_plan.yaml",
+        "merge_decisions.yaml",
+        "interface_manifest.yaml",
+    }
+    iface = artifacts["interface_manifest.yaml"]
+    assert iface["type"] == "interface_manifest"
+    assert iface["content"] == interface_yaml  # carried verbatim
+
+
 async def test_handler_fails_loudly_when_brief_missing():
     """The brief is mandatory upstream context. Missing brief = wiring
     bug, not a recoverable runtime condition. Surface explicitly."""

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -276,3 +276,49 @@ def test_materialize_refuses_path_traversal(tmp_path, monkeypatch):
     with pytest.raises(ValueError, match="refusing to write outside"):
         mod.materialize(_MANIFEST_PATH, tmp_path)
     assert not (tmp_path.parent / "escape.txt").exists()
+
+
+# --------------------------------------------------------------------------- #
+# 99.2: InterfaceManifest.lint — the malformed/incomplete net for framing emissions
+# --------------------------------------------------------------------------- #
+
+
+def test_lint_accepts_the_group_run_manifest():
+    assert _group_run_manifest().lint() == []
+
+
+def test_lint_rejects_manifest_with_no_endpoints():
+    raw = _raw_manifest()
+    raw["api"]["endpoints"] = []
+    assert any("at least one endpoint" in e for e in InterfaceManifest.from_dict(raw).lint())
+
+
+def test_lint_rejects_endpoint_with_undeclared_request_shape():
+    raw = _raw_manifest()
+    raw["api"]["endpoints"][1]["request"] = "NopeShape"  # POST /runs
+    errors = InterfaceManifest.from_dict(raw).lint()
+    assert any("request 'NopeShape' is not a declared request_shape" in e for e in errors)
+
+
+def test_lint_rejects_response_naming_an_undeclared_entity():
+    raw = _raw_manifest()
+    raw["api"]["endpoints"][1]["response"] = "RunEvnt"  # typo of RunEvent
+    errors = InterfaceManifest.from_dict(raw).lint()
+    assert any("response references undeclared entity 'RunEvnt'" in e for e in errors)
+
+
+def test_lint_rejects_route_without_view():
+    raw = _raw_manifest()
+    raw["frontend"]["routes"][0]["view"] = ""
+    assert any("view is required" in e for e in InterfaceManifest.from_dict(raw).lint())
+
+
+def test_lint_rejects_unscaffoldable_stack_and_empty_manifest():
+    # a bare manifest with an unknown stack: flagged for both the missing expander and
+    # the absent endpoints (framing produced something unusable)
+    m = InterfaceManifest.from_dict(
+        {"version": 1, "kind": "interface_manifest", "project_id": "x", "stack": "cobol_cics"}
+    )
+    errors = m.lint()
+    assert any("no scaffold expander" in e for e in errors)
+    assert any("at least one endpoint" in e for e in errors)


### PR DESCRIPTION
**Phase 99.2 of SIP-0099 (Contract-First Build Scaffolding)** — framing now **emits + validates + surfaces** a typed interface manifest, single-sourcing 99.1's `InterfaceManifest`. Rebased on the #484 strategy fix (PR #485). Executor loading/materialization is 99.3.

## Slices

- **A — `InterfaceManifest.lint()`** — the malformed/incomplete net: no endpoints, an endpoint referencing an undeclared request-shape/entity, a route with no view, an unscaffoldable stack.
- **C — merger emits** — a framing proposer (dev preferred, qa fallback) or sole-author run may emit `interface_manifest.yaml` alongside the plan; the proposer captures it via a new `on_success_content` callback + filename-robust `extract_interface_manifest_yaml`; the merger threads it into `_success_result`, which appends a third sibling artifact (`type: interface_manifest`). The merger does **not** validate it.
- **D — net-b validates** — `_reject_invalid_plan_before_workload_gate` loads + lints the manifest (lazy `scaffold` import; untrusted LLM output → any parse failure is one prefixed error, never a gate crash); errors flow into the existing `system:plan_validation` REJECTED recording. Net-a (`cycles/task_plan.py`) untouched — cycles→capabilities layering preserved.
- **B — dev proposes, conditionally** — on a scaffoldable stack the dev proposer is asked to author the manifest; the instruction is a rendered `scaffold_section` appended **after** the plan block (the plan extraction grabs the first YAML block). **Resilient by construction**: data-driven on `is_scaffoldable_stack(build_profile)` and dev-only, so a non-scaffoldable/non-dev cycle is never asked to emit a manifest that validation would reject. Instruction lives in a managed prompt asset (`request.development_interface_manifest_appendix`, required `stack` var), not an inline handler literal (#448).

**Data-driven, no flag** everywhere — absent manifest ⇒ byte-identical to today.

## Slice E — validated live (rebuilt-from-branch stack, lite/7b, group_run)

The multi-role framing ran through the merge, and the **7b dev proposer, given the appendix instruction, emitted a schema-valid interface manifest** (retrieved from `run_checkpoints.prior_outputs`):

```
parses: True   lint() errors: []   scaffoldable: True   expands to 14 skeleton files
```

Block-style, correct schema (`RunEvent`/`User` entities, `RunEventCreate` shape, GET/POST `/runs` + `list[RunEvent]` response, `error_contract` 422/404, frontend routes). Captured into the dev's `proposal_outcome` (`interface_manifest_yaml` present) and carried to the merger, which succeeded. This is the core 99.2 proof: instruction injected → 7b followed it → valid manifest → captured → merged.

Caveat: the lite run itself terminated at the plan-review gate on an **unrelated 7b plan/review quality issue** (merge + review both succeeded; no net-b rejection; the interface manifest is valid) — the known Mac small-model framing wall, which the arc defers to the Spark/27b yield baseline (98.5). The interface-manifest path is proven.

## Tests

`InterfaceManifest.lint` (6) · emitter/extraction/net-b through real entry points · Slice-B injection + **a test that the appendix example itself parses, lints clean, and is scaffoldable** (caught a real YAML flow-mapping bug before it could mislead a squad). Full regression **5022 passed**.

No `Closes` — SIP implementation phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4Zq5Tw5FSJbdpadbxck2v
