### PR TITLE
feat(sip-0099): executor materialization + fill-only develop (phase 99.3)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -323,6 +323,17 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 if plan_refs:
                     seed_artifact_refs = list(plan_refs)
 
+            # SIP-0099 99.3: if framing forwarded an interface manifest, expand it into a
+            # walking skeleton and seed those files so develop fills the fixed slots.
+            # Data-driven: no manifest -> seed_artifact_refs unchanged = byte-identical to
+            # today (the manifest itself is already among plan_artifact_refs; this ADDS the
+            # expanded skeleton). Logic lives in helpers (#290 god-file rule).
+            interface_manifest = await self._load_interface_manifest_for_run(cycle, run)
+            if interface_manifest is not None:
+                seed_artifact_refs.extend(
+                    await self._seed_skeleton_artifacts(interface_manifest, cycle, run_id)
+                )
+
             # LangFuse + Prefect observability setup
             obs_ctx, flow_run_id = await self._init_run_observability(
                 cycle_id,
@@ -1313,6 +1324,103 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 return None
 
         return None
+
+    async def _load_interface_manifest_for_run(
+        self,
+        cycle: Any,
+        run: Any,
+    ) -> Any:
+        """Load the framing-emitted interface manifest for a run (SIP-0099 99.3).
+
+        Mirrors ``_load_plan_for_run``: searches the forwarded ``plan_artifact_refs``
+        for the ``interface_manifest.yaml`` a scaffolded framing run emitted (99.2) and
+        parses it. Returns ``InterfaceManifest`` or ``None`` — a missing or unparseable
+        manifest leaves the run on today's non-scaffolded path (graceful, data-driven).
+        """
+        from squadops.capabilities.scaffold import InterfaceManifest
+
+        plan_refs = cycle.execution_overrides.get("plan_artifact_refs", [])
+        if not plan_refs:
+            return None
+
+        for ref_id in plan_refs:
+            try:
+                ref, content_bytes = await self._artifact_vault.retrieve(ref_id)
+                if ref.filename == "interface_manifest.yaml" or (
+                    getattr(ref, "artifact_type", None) == "interface_manifest"
+                ):
+                    manifest = InterfaceManifest.from_yaml(content_bytes.decode(errors="replace"))
+                    logger.info(
+                        "Loaded interface manifest (stack=%s, %d entities) for run %s",
+                        manifest.stack,
+                        len(manifest.entities),
+                        run.run_id,
+                    )
+                    return manifest
+            except Exception:
+                logger.warning(
+                    "Failed to load interface manifest from artifact %s; skipping scaffold",
+                    ref_id,
+                    exc_info=True,
+                )
+                return None
+
+        return None
+
+    async def _seed_skeleton_artifacts(
+        self,
+        manifest: Any,
+        cycle: Cycle,
+        run_id: str,
+    ) -> list[str]:
+        """Expand the interface manifest into a walking skeleton and store each file in
+        the vault, returning the stored artifact ids to seed into the run (SIP-0099 99.3).
+
+        Reuses the 99.1 profile seam (``BuildProfile.expand`` -> the pure ``scaffold``
+        module). Never crashes the run: an unscaffoldable stack or an expander failure
+        yields ``[]`` and the run proceeds on today's non-scaffolded path.
+        """
+        from squadops.capabilities.handlers.build_profiles import get_profile
+        from squadops.capabilities.scaffold import is_scaffoldable_stack
+
+        if not is_scaffoldable_stack(manifest.stack):
+            return []
+        try:
+            files = get_profile(manifest.stack).expand(manifest)
+        except Exception:
+            logger.warning(
+                "Failed to expand interface manifest (stack=%s); skipping scaffold seed",
+                manifest.stack,
+                exc_info=True,
+            )
+            return []
+
+        seeded_ids: list[str] = []
+        for f in files:
+            content = f["content"].encode("utf-8")
+            ref = ArtifactRef(
+                artifact_id=f"art_{uuid4().hex[:12]}",
+                project_id=cycle.project_id,
+                cycle_id=cycle.cycle_id,
+                run_id=run_id,
+                artifact_type="source",
+                filename=f["name"],
+                content_hash=sha256(content).hexdigest(),
+                size_bytes=len(content),
+                media_type="text/plain",
+                created_at=datetime.now(UTC),
+                metadata={"producing_task_type": "scaffold.expand", "scaffold_seeded": True},
+            )
+            await self._artifact_vault.store(ref, content)
+            seeded_ids.append(ref.artifact_id)
+
+        logger.info(
+            "Seeded %d walking-skeleton files (stack=%s) for run %s",
+            len(seeded_ids),
+            manifest.stack,
+            run_id,
+        )
+        return seeded_ids
 
     # ------------------------------------------------------------------
     # Extracted helpers for _execute_sequential

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -621,6 +621,12 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
             if strategy:
                 variables["strategy"] = f"\n\n## Strategy Analysis\n\n{strategy}"
             variables["prior_outputs"] = self._format_prior_outputs(prior_outputs)
+            # SIP-0099 99.3 (part 2): on a scaffoldable stack a walking skeleton was
+            # seeded into the workspace (part 1), so instruct the dev to FILL the fixed
+            # slots rather than rewire. Data-driven — "" for a non-scaffolded cycle.
+            fill_only = await self._fill_only_section(renderer)
+            if fill_only:
+                variables["fill_only_section"] = fill_only
             rendered = await renderer.render(
                 "request.development_develop.code_generate",
                 variables,
@@ -634,3 +640,21 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
             strategy=strategy,
         )
         return None, user_prompt
+
+    async def _fill_only_section(self, renderer: Any) -> str:
+        """The fill-only instruction, or "" (SIP-0099 99.3 part 2).
+
+        Non-empty only on a scaffoldable stack — a walking skeleton has been seeded into
+        the workspace (part 1), so the dev fills fixed slots instead of rewiring. The
+        instruction lives in a managed prompt asset, not an inline literal (CLAUDE.md
+        #448). Frozen-surface *enforcement* is SIP-0098's `frozen:` contract, not here.
+        """
+        from squadops.capabilities.scaffold import is_scaffoldable_stack
+
+        stack = str(self._resolved_config.get("build_profile") or "")
+        if not is_scaffoldable_stack(stack):
+            return ""
+        rendered = await renderer.render(
+            "request.development_develop_fill_only_appendix", {"stack": stack}
+        )
+        return rendered.content

--- a/src/squadops/prompts/request_templates/request.development_develop.code_generate.md
+++ b/src/squadops/prompts/request_templates/request.development_develop.code_generate.md
@@ -9,10 +9,12 @@ optional_variables:
   - impl_plan
   - strategy
   - prior_outputs
+  - fill_only_section
 ---
 ## Product Requirements Document
 
 {{prd}}
+{{fill_only_section}}
 {{impl_plan}}
 {{strategy}}
 {{file_structure_guidance}}

--- a/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix.md
@@ -1,0 +1,35 @@
+---
+template_id: request.development_develop_fill_only_appendix
+version: "1"
+required_variables:
+  - stack
+optional_variables: []
+---
+## Fill-only: a walking skeleton is already in your workspace
+
+This build was scaffolded (`{{stack}}`). A deterministic tool has **already generated a
+wired, buildable, bootable application skeleton** into your workspace — entry files,
+config, data models, error handling, the API client, cross-file routing, and route/
+component **stubs**. It already builds and boots. Your job is to **fill the bodies of
+the fixed slots** — never to rebuild, rewire, or regenerate the scaffold.
+
+**FILL — edit only the stubbed bodies:**
+- Backend route functions in `backend/routes.py` — implement the logic inside each
+  existing function. The in-memory store, the request/response models, and `ApiError`
+  are already imported and wired; use them.
+- Frontend view components (`frontend/src/views/*.jsx`) — implement each component's
+  body. `apiFetch` is the wired data-access seam; call it (it prefixes `/api` and
+  unwraps the error envelope).
+
+**DO NOT touch the scaffold-owned surface — it is frozen and verified:**
+- Do NOT change route **paths, methods, decorators, or signatures** in `backend/routes.py`.
+- Do NOT edit entry / config / wiring files: `backend/main.py`, `backend/models.py`,
+  `backend/errors.py`, `frontend/src/main.jsx`, `frontend/src/App.jsx`,
+  `frontend/src/api.js`, `vite.config.js`, `package.json`, `index.html`, or the
+  requirements/manifest files.
+- Do NOT rewire `App.jsx`'s import/route graph, rename or move views, or add/remove files.
+
+Filling the fixed slots — rather than regenerating the app — is the whole point: the
+skeleton already builds and boots, so a fill that preserves it stays green, while one
+that rewrites scaffold-owned files is rejected by the verification contract. When in
+doubt, change less: implement the body, keep everything around it exactly as scaffolded.

--- a/tests/unit/capabilities/test_develop_fill_only.py
+++ b/tests/unit/capabilities/test_develop_fill_only.py
@@ -1,0 +1,70 @@
+"""Fill-only develop instruction wiring (SIP-0099 phase 99.3 part 2).
+
+On a scaffoldable stack the executor seeds a walking skeleton into develop's workspace
+(part 1), so the dev is told to FILL the fixed slots rather than rewire. Data-driven,
+dev-only, content in a managed asset — mirrors 99.2's scaffold_section.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities.handlers.cycle.develop import DevelopmentDevelopHandler
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_APPENDIX = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "squadops"
+    / "prompts"
+    / "request_templates"
+    / "request.development_develop_fill_only_appendix.md"
+)
+
+
+def _handler(build_profile: str) -> DevelopmentDevelopHandler:
+    handler = DevelopmentDevelopHandler()
+    handler._resolved_config = {"build_profile": build_profile}
+    return handler
+
+
+async def test_fill_only_section_rendered_on_scaffoldable_stack():
+    handler = _handler("fullstack_fastapi_react")
+    renderer = AsyncMock()
+    renderer.render.return_value = MagicMock(content="FILL ONLY INSTRUCTION")
+
+    out = await handler._fill_only_section(renderer)
+
+    assert out == "FILL ONLY INSTRUCTION"
+    renderer.render.assert_awaited_once_with(
+        "request.development_develop_fill_only_appendix", {"stack": "fullstack_fastapi_react"}
+    )
+
+
+async def test_fill_only_section_empty_on_non_scaffoldable_stack():
+    # a non-scaffolded build (no seeded skeleton) must never get fill-only guidance
+    handler = _handler("python_cli_builder")
+    renderer = AsyncMock()
+    out = await handler._fill_only_section(renderer)
+    assert out == ""
+    renderer.render.assert_not_awaited()
+
+
+async def test_fill_only_section_empty_when_no_build_profile():
+    handler = _handler("")
+    renderer = AsyncMock()
+    assert await handler._fill_only_section(renderer) == ""
+    renderer.render.assert_not_awaited()
+
+
+def test_fill_only_appendix_asset_is_well_formed():
+    text = _APPENDIX.read_text(encoding="utf-8")
+    assert "template_id: request.development_develop_fill_only_appendix" in text
+    assert "- stack" in text  # required var (template-contract test enforces >=1)
+    assert "backend/routes.py" in text  # the fill slot
+    assert "Do NOT" in text  # the frozen-surface discipline
+    assert "{{stack}}" in text

--- a/tests/unit/cycles/test_executor_interface_manifest.py
+++ b/tests/unit/cycles/test_executor_interface_manifest.py
@@ -1,0 +1,134 @@
+"""Tests for executor interface-manifest materialization (SIP-0099 phase 99.3).
+
+The executor loads the framing-emitted interface manifest, expands it into a walking
+skeleton, and seeds those files so ``develop`` fills fixed slots. Mirrors the
+``_load_plan_for_run`` test pattern in ``test_executor_plan_loading.py``. Data-driven:
+no manifest artifact -> nothing seeded -> byte-identical to today.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+_GROUP_RUN_MANIFEST = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+).read_text(encoding="utf-8")
+
+
+@dataclass
+class _FakeManifestRef:
+    artifact_id: str = "art_iface"
+    filename: str = "interface_manifest.yaml"
+    artifact_type: str = "interface_manifest"
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class _FakePlanRef:
+    artifact_id: str = "art_plan"
+    filename: str = "implementation_plan.yaml"
+    artifact_type: str = "control_implementation_plan"
+    metadata: dict = field(default_factory=dict)
+
+
+def _make_executor() -> DispatchedFlowExecutor:
+    executor = DispatchedFlowExecutor.__new__(DispatchedFlowExecutor)
+    executor._artifact_vault = MagicMock()
+    executor._artifact_vault.retrieve = AsyncMock()
+    executor._artifact_vault.store = AsyncMock()
+    return executor
+
+
+def _make_cycle(**overrides) -> MagicMock:
+    cycle = MagicMock()
+    cycle.execution_overrides = {}
+    cycle.project_id = "group_run"
+    cycle.cycle_id = "cyc_test"
+    for k, v in overrides.items():
+        setattr(cycle, k, v)
+    return cycle
+
+
+def _make_run() -> MagicMock:
+    run = MagicMock()
+    run.run_id = "run_abcdef123456"
+    return run
+
+
+class TestLoadInterfaceManifestForRun:
+    async def test_manifest_found_in_plan_refs(self):
+        executor = _make_executor()
+        executor._artifact_vault.retrieve.return_value = (
+            _FakeManifestRef(),
+            _GROUP_RUN_MANIFEST.encode(),
+        )
+        cycle = _make_cycle(execution_overrides={"plan_artifact_refs": ["art_iface"]})
+
+        manifest = await executor._load_interface_manifest_for_run(cycle, _make_run())
+
+        assert manifest is not None
+        assert manifest.stack == "fullstack_fastapi_react"
+        assert {e.name for e in manifest.entities} == {"Participant", "RunEvent"}
+
+    async def test_no_plan_refs_returns_none(self):
+        executor = _make_executor()
+        cycle = _make_cycle(execution_overrides={})
+        assert await executor._load_interface_manifest_for_run(cycle, _make_run()) is None
+
+    async def test_non_manifest_ref_skipped_returns_none(self):
+        # the plan artifact is present but not the interface manifest -> None (data-driven)
+        executor = _make_executor()
+        executor._artifact_vault.retrieve.return_value = (_FakePlanRef(), b"version: 1\ntasks: []")
+        cycle = _make_cycle(execution_overrides={"plan_artifact_refs": ["art_plan"]})
+        assert await executor._load_interface_manifest_for_run(cycle, _make_run()) is None
+
+    async def test_malformed_manifest_returns_none(self):
+        # graceful: an unparseable manifest leaves the run on today's non-scaffolded path
+        executor = _make_executor()
+        executor._artifact_vault.retrieve.return_value = (
+            _FakeManifestRef(),
+            b"::: not yaml :::\nkind: nope",
+        )
+        cycle = _make_cycle(execution_overrides={"plan_artifact_refs": ["art_iface"]})
+        assert await executor._load_interface_manifest_for_run(cycle, _make_run()) is None
+
+
+class TestSeedSkeletonArtifacts:
+    async def test_seeds_full_skeleton_set_as_source_artifacts(self):
+        from squadops.capabilities.handlers.build_profiles import get_profile
+        from squadops.capabilities.scaffold import InterfaceManifest
+
+        manifest = InterfaceManifest.from_yaml(_GROUP_RUN_MANIFEST)
+        expected_files = get_profile("fullstack_fastapi_react").expand(manifest)
+
+        executor = _make_executor()
+        ids = await executor._seed_skeleton_artifacts(manifest, _make_cycle(), "run_x")
+
+        # one seeded artifact per expanded skeleton file, and the returned ids are exactly
+        # the artifact_ids of the refs handed to the vault (so _seed_prior_artifacts can
+        # retrieve them into the workspace)
+        assert len(ids) == len(expected_files)
+        assert executor._artifact_vault.store.await_count == len(expected_files)
+        stored_refs = [call.args[0] for call in executor._artifact_vault.store.await_args_list]
+        assert [r.artifact_id for r in stored_refs] == ids
+        # every skeleton file is a source artifact with a workspace-relative name
+        assert {r.artifact_type for r in stored_refs} == {"source"}
+        assert {r.filename for r in stored_refs} == {f["name"] for f in expected_files}
+        assert all(not Path(r.filename).is_absolute() for r in stored_refs)
+
+    async def test_unscaffoldable_stack_seeds_nothing(self):
+        from squadops.capabilities.scaffold import InterfaceManifest
+
+        manifest = InterfaceManifest.from_dict(
+            {"version": 1, "kind": "interface_manifest", "project_id": "x", "stack": "django_htmx"}
+        )
+        executor = _make_executor()
+
+        ids = await executor._seed_skeleton_artifacts(manifest, _make_cycle(), "run_x")
+
+        assert ids == []
+        executor._artifact_vault.store.assert_not_awaited()


### PR DESCRIPTION
**Phase 99.3 of SIP-0099 (Contract-First Build Scaffolding)** — the executor now **consumes** the interface manifest 99.2 emits: it loads it, expands the walking skeleton, and seeds it into `develop`'s workspace before dispatch. This is where the two halves of the golden path meet in a live cycle.

## Part 1 — executor materialization

At the run-setup seam, if framing forwarded an `interface_manifest.yaml`, the executor expands it and seeds the skeleton. Two helpers keep the god-file's execute path to thin delegating lines (#290):

- **`_load_interface_manifest_for_run`** — mirrors `_load_plan_for_run` exactly: finds the manifest in `plan_artifact_refs`, parses it via `InterfaceManifest.from_yaml`; any retrieve/parse failure → `None` (graceful).
- **`_seed_skeleton_artifacts`** — `get_profile(stack).expand(manifest)` (the 99.1 seam) → stores each `{name,content}` file as a `source` `ArtifactRef` in the vault → returns the ids appended to `seed_artifact_refs`, which `_seed_prior_artifacts` materializes into the workspace. Guarded: unscaffoldable stack or an expander failure → `[]` (never crashes the run).

**Data-driven, no flag:** no manifest forwarded → `seed_artifact_refs` unchanged = byte-identical to today. (The manifest itself is already seeded via `plan_artifact_refs`; this ADDS the expanded skeleton.)

## Part 2 — fill-only `develop` instruction

On a scaffoldable stack (skeleton seeded), a conditional `fill_only_section` — rendered only when `is_scaffoldable_stack(build_profile)`, mirroring 99.2's `scaffold_section` — is injected into `request.development_develop.code_generate`. It tells the dev to **fill the fixed slots** (route bodies, view component bodies), never rewire/regenerate the scaffold-owned surface (paths, signatures, entry/config/wiring files, the `App.jsx` route graph). Content in a managed prompt asset (#448).

**Soft guidance by design:** mechanical frozen-surface *enforcement* is SIP-0098's `frozen:` contract, not duplicated here — so the gate is a simple, consistent nudge (its precision has no correctness impact; 98 verifies regardless).

## Tests

- Executor: 6 tests through the real methods — manifest found / absent / non-manifest-ref / malformed → correct `None`; seed stores the full skeleton set as `source` artifacts with workspace-relative names + returns matching ids; unscaffoldable stack → `[]`, stores nothing.
- Develop: 4 tests — `fill_only_section` rendered on a scaffoldable stack, `""` + unrendered otherwise, asset well-formed.
- Full regression **5040 passed**; ruff clean.

## Not here

- The lite end-to-end validation (a scaffolded fill run on the deployed 7b) — the Mac framing is flaky (see the 99.2 Slice-E notes); the definitive fill run is Spark/27b territory (98.5). The materialization + fill-only path is fully unit-covered.

No `Closes` — SIP implementation phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4Zq5Tw5FSJbdpadbxck2v
