### PR TITLE
feat(sip-0098): orchestration binding — bind, don't author (98.3)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -269,7 +269,19 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # before task dispatch begins.
             implementation_plan = await self._load_plan_for_run(cycle, run)
 
-            plan = generate_task_plan(cycle, run, profile, plan=implementation_plan)
+            # SIP-0098 98.3: a seeded contract_ref switches the cycle to bind mode.
+            # Loaded here (alongside the plan) so net-a inside generate_task_plan can
+            # validate the plan's criteria_refs and dispatch can resolve them into
+            # TypedChecks. Absent contract = author mode = today's behavior.
+            verification_contract = await self._load_contract_for_run(cycle, run)
+
+            plan = generate_task_plan(
+                cycle,
+                run,
+                profile,
+                plan=implementation_plan,
+                contract=verification_contract,
+            )
             participating_agent_ids = {e.agent_id for e in plan}
 
             # SIP-0089 §2.5: reserve-buffer guard. The plan now names every
@@ -1422,6 +1434,80 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         )
         return seeded_ids
 
+    @staticmethod
+    def _is_bind_mode(cycle: Any) -> bool:
+        """True when a verification contract is seeded (SIP-0098 §6.3 P9).
+
+        Bind mode is data-driven and keyed strictly on a ``contract_ref`` in
+        ``execution_overrides`` — no feature flag (house rule). Absence is
+        author mode = today's behavior exactly."""
+        return bool(cycle.execution_overrides.get("contract_ref"))
+
+    async def _load_contract_for_run(self, cycle: Any, run: Any) -> Any:
+        """Load the seeded verification contract for a run (SIP-0098 98.3).
+
+        Reads the ``contract_ref`` artifact id from ``execution_overrides`` (a bare
+        id or a single-element list) and parses it into a ``VerificationContract``.
+        Returns the contract, or ``None`` when no ref is seeded (author mode) or the
+        seeded ref is unreadable/unparseable. A seeded-but-broken ref is NOT silently
+        treated as author mode — ``_is_bind_mode`` stays true, so the plan-validation
+        net records a rejection rather than letting the run fall through unverified
+        (the stale-binding class, SIP §10)."""
+        from squadops.cycles.verification_contract import VerificationContract
+
+        ref = cycle.execution_overrides.get("contract_ref")
+        if not ref:
+            return None
+        ref_id = ref[0] if isinstance(ref, (list, tuple)) and ref else ref
+        if not isinstance(ref_id, str):
+            return None
+        try:
+            _, content_bytes = await self._artifact_vault.retrieve(ref_id)
+            contract = VerificationContract.from_yaml(content_bytes.decode(errors="replace"))
+        except Exception:
+            logger.warning(
+                "Failed to load verification contract from contract_ref %r for run %s; "
+                "bind-mode validation will reject the run",
+                ref_id,
+                run.run_id,
+                exc_info=True,
+            )
+            return None
+        logger.info(
+            "Loaded verification contract (expander=%s, %d criteria) for run %s [bind mode]",
+            contract.skeleton.expander,
+            len(contract.criterion_ids()),
+            run.run_id,
+        )
+        return contract
+
+    @staticmethod
+    def _validate_contract_binding(contract: Any, interface_content: str) -> list[str]:
+        """§10 decision — FAIL on interface-manifest hash mismatch.
+
+        A contract binds to the exact skeleton it was authored against via
+        ``skeleton.interface_manifest_hash``. If the run's manifest hashes to
+        something else, the contract measures a different skeleton's fill against
+        the wrong criteria (the stale-evidence-after-mutation class) — a hard
+        rejection, not a warning read once and ignored. The manifest's own parse
+        failures are already reported by ``_validate_interface_manifest``; here a
+        parse failure is a no-op to avoid a duplicate rejection."""
+        from squadops.capabilities.scaffold import InterfaceManifest
+
+        try:
+            manifest = InterfaceManifest.from_yaml(interface_content)
+        except Exception:  # noqa: BLE001 — parse failure already surfaced elsewhere
+            return []
+        actual = manifest.content_hash()
+        expected = contract.skeleton.interface_manifest_hash
+        if actual != expected:
+            return [
+                f"contract bound to interface_manifest_hash {expected[:12]}… but the run's "
+                f"manifest hashes to {actual[:12]}… — the contract was authored against a "
+                f"different skeleton (stale binding, rejected)"
+            ]
+        return []
+
     # ------------------------------------------------------------------
     # Extracted helpers for _execute_sequential
     # ------------------------------------------------------------------
@@ -2195,6 +2281,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
         errors: list[str] = []
         interface_content: str | None = None
+        parsed_plan: ImplementationPlan | None = None
         for ref_id in tuple(run.artifact_refs or ()):
             try:
                 ref, content_bytes = await self._artifact_vault.retrieve(ref_id)
@@ -2205,7 +2292,9 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 artifact_type == "control_implementation_plan"
             ):
                 try:
-                    plan = ImplementationPlan.from_yaml(content_bytes.decode(errors="replace"))
+                    parsed_plan = ImplementationPlan.from_yaml(
+                        content_bytes.decode(errors="replace")
+                    )
                 except Exception:
                     logger.warning(
                         "Plan artifact %s unreadable before gate %r — deferring to the "
@@ -2215,7 +2304,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         exc_info=True,
                     )
                 else:
-                    errors.extend(plan.validate_criteria_scope())
+                    errors.extend(parsed_plan.validate_criteria_scope())
             elif ref.filename == "interface_manifest.yaml" or artifact_type == "interface_manifest":
                 interface_content = content_bytes.decode(errors="replace")
 
@@ -2226,6 +2315,29 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # Absent manifest → no-op = today's behavior (byte-identical for plan-only cycles).
         if interface_content is not None:
             errors.extend(self._validate_interface_manifest(interface_content))
+
+        # SIP-0098 98.3: bind-mode contract validation. A seeded contract_ref switches the
+        # cycle to bind mode — the plan must bind the contract's covered-file criteria by
+        # id (validate_criteria_refs) rather than author them, and the contract must be
+        # bound to this run's skeleton (hash check). A seeded-but-unparseable contract is
+        # a hard rejection, never a silent fall-through to author mode (§10). Errors join
+        # the same returned list → identical system:plan_validation REJECTED recording.
+        # Contract absent (author mode) → no-op = today's behavior.
+        if self._is_bind_mode(cycle):
+            contract = await self._load_contract_for_run(cycle, run)
+            if contract is None:
+                errors.append(
+                    "verification_contract: contract_ref is seeded but the contract is "
+                    "missing or unparseable — bind mode cannot validate the plan"
+                )
+            else:
+                if interface_content is not None:
+                    errors.extend(self._validate_contract_binding(contract, interface_content))
+                if parsed_plan is not None:
+                    errors.extend(
+                        f"verification_contract: {e}"
+                        for e in parsed_plan.validate_criteria_refs(contract)
+                    )
         return errors
 
     @staticmethod

--- a/src/squadops/capabilities/handlers/_plan_merger.py
+++ b/src/squadops/capabilities/handlers/_plan_merger.py
@@ -323,6 +323,7 @@ def _build_canonical_pair(
         expected_artifacts=list(ptask.expected_artifacts),
         acceptance_criteria=list(ptask.acceptance_criteria),
         depends_on=[],  # resolved in rule-5 pass
+        criteria_refs=list(ptask.criteria_refs),  # SIP-0098 98.3: carry bind refs through
     )
     provenance = CanonicalTaskProvenance(
         task_index=0,
@@ -494,6 +495,9 @@ def _plan_task_to_dict(task: PlanTask) -> dict[str, Any]:
         "expected_artifacts": list(task.expected_artifacts),
         "acceptance_criteria": [_criterion_to_dict(c) for c in task.acceptance_criteria],
         "depends_on": list(task.depends_on),
+        # SIP-0098 98.3: emit criteria_refs only when present so contract-less merged
+        # plans stay byte-identical to today (from_yaml defaults the field to []).
+        **({"criteria_refs": list(task.criteria_refs)} if task.criteria_refs else {}),
     }
 
 

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -355,6 +355,9 @@ class _CycleTaskHandler(CapabilityHandler):
                     # implementation_plan (legacy monolithic flow).
                     "task_index": inputs.get("subtask_index"),
                     "check_index": check_index,
+                    # SIP-0098 98.3: the contract criterion id when this check was
+                    # resolved from a bind-mode criteria_ref; None for authored checks.
+                    "criterion_id": criterion.id or None,
                 }
                 checks.append(check_record)
 

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -828,6 +828,26 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
         )
         return rendered.content
 
+    async def _bind_criteria_section(self, renderer: Any, inputs: dict[str, Any]) -> str:
+        """The *bind, don't author* instruction + contract criteria index, or ""
+        (SIP-0098 98.3).
+
+        Non-empty ONLY in bind mode — a contract is seeded, so the executor injected
+        ``contract_criteria_index`` into this proposer's inputs — and only for the dev/qa
+        proposers that author build tasks (strategy proposes guidance, not tasks). The
+        instruction prose lives in a managed asset (``request.plan_bind_criteria_appendix``);
+        only the index *data* is a variable (CLAUDE.md #448). Absent contract → "" →
+        today's author-mode proposer prompt exactly."""
+        if self._proposer_role not in ("development", "qa"):
+            return ""
+        index = inputs.get("contract_criteria_index")
+        if not index:
+            return ""
+        rendered = await renderer.render(
+            "request.plan_bind_criteria_appendix", {"criteria_index": index}
+        )
+        return rendered.content
+
     async def handle(
         self,
         context: ExecutionContext,
@@ -868,6 +888,14 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
         scaffold_section = await self._scaffold_section(renderer, inputs)
         if scaffold_section:
             variables["scaffold_section"] = scaffold_section
+        # SIP-0098 98.3: in bind mode the dev/qa proposer is told to bind the contract's
+        # covered-file criteria by id (not author them). Data-driven — only set when the
+        # executor injected the criteria index (contract seeded) — and the instruction is
+        # a managed asset, not an inline literal (#448). Only set when non-empty so a
+        # non-bind render doesn't warn on an unknown variable.
+        bind_criteria_section = await self._bind_criteria_section(renderer, inputs)
+        if bind_criteria_section:
+            variables["bind_criteria_section"] = bind_criteria_section
         rendered = await renderer.render(self._request_template_id, variables)
         user_prompt = rendered.content
 

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -252,9 +252,12 @@ def reserved_keys_for(check_name: str) -> frozenset[str]:
     """Return the keys reserved for the wrapper (not part of params).
 
     Useful for the parser's flat-YAML normalization rule: params is the
-    authored dict minus these keys.
+    authored dict minus these keys. ``id`` is reserved so a ``TypedCheck``
+    resolved from a verification-contract ``criteria_ref`` (SIP-0098 98.3)
+    carries the stable contract criterion id through parse/serialize/wire
+    round-trips without the id leaking into the check's params.
     """
-    return frozenset({"check", "severity", "description"})
+    return frozenset({"check", "severity", "description", "id"})
 
 
 _PARAM_TYPE_NAMES: dict[type, str] = {

--- a/src/squadops/cycles/acceptance_evaluation.py
+++ b/src/squadops/cycles/acceptance_evaluation.py
@@ -45,7 +45,7 @@ class SplitCriteria:
     unparseable: tuple[Any, ...] = ()
 
 
-_SERIALIZED_ROW_KEYS = frozenset({"check", "params", "severity", "description"})
+_SERIALIZED_ROW_KEYS = frozenset({"check", "params", "severity", "description", "id"})
 
 
 def _flatten_serialized_row(item: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -19,6 +19,7 @@ import dataclasses
 import hashlib
 import json
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 import yaml
 
@@ -29,6 +30,9 @@ from squadops.cycles.acceptance_check_spec import (
     command_safelist_names,
     reserved_keys_for,
 )
+
+if TYPE_CHECKING:
+    from squadops.cycles.verification_contract import VerificationContract
 
 # Known task types that may appear in plan tasks.
 _KNOWN_BUILD_TASK_TYPES = {
@@ -75,12 +79,18 @@ class TypedCheck:
             Per RC-9, only severity=error AND status ∈ {failed, error}
             blocks validation.
         description: Human-readable description for evidence/UI. Optional.
+        id: Stable verification-contract criterion id when this check was
+            resolved from a plan ``criteria_ref`` in bind mode (SIP-0098 98.3);
+            empty for framing-authored checks. Carried onto evidence rows so a
+            result traces back to its contract criterion. Excluded from
+            ``fingerprint`` — it labels provenance, not check identity.
     """
 
     check: str
     params: dict
     severity: str = "error"
     description: str = ""
+    id: str = ""
 
     def fingerprint(self) -> str:
         """Stable identity for per-criterion error counting (SIP-0092 M1.3 / RC-9b).
@@ -88,8 +98,8 @@ class TypedCheck:
         Hash spans (check, severity, params) so retries against the same
         criterion share an error counter, but a tightened-acceptance plan
         change that produces a distinct param shape resets it. Description
-        is excluded — it's prose for evidence/UI, not part of the criterion's
-        identity.
+        and id are excluded — they're prose/provenance for evidence/UI, not
+        part of the criterion's identity.
         """
         canonical = json.dumps(
             {"check": self.check, "severity": self.severity, "params": self.params},
@@ -114,6 +124,12 @@ class PlanTask:
     # typed entries into TypedCheck (see ImplementationPlan.from_yaml).
     acceptance_criteria: list[str | TypedCheck] = field(default_factory=list)
     depends_on: list[int] = field(default_factory=list)
+    # SIP-0098 98.3 bind mode: stable verification-contract criterion ids this
+    # task binds for the contract-covered fill files in ``expected_artifacts``.
+    # Framing *binds* (lists refs) rather than *authors* typed criteria for
+    # covered files; dispatch resolves each ref into a TypedCheck against the
+    # seeded contract. Empty in contract-less (author) mode — the default.
+    criteria_refs: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -218,6 +234,10 @@ class ImplementationPlan:
                 enforce_command_safelist=enforce_command_safelist,
             )
 
+            raw_refs = td.get("criteria_refs", [])
+            if not isinstance(raw_refs, list) or not all(isinstance(r, str) for r in raw_refs):
+                raise ValueError(f"Task {task_index}: criteria_refs must be a list of strings")
+
             tasks.append(
                 PlanTask(
                     task_index=task_index,
@@ -228,6 +248,7 @@ class ImplementationPlan:
                     expected_artifacts=td.get("expected_artifacts", []),
                     acceptance_criteria=criteria,
                     depends_on=depends_on,
+                    criteria_refs=list(raw_refs),
                 )
             )
 
@@ -311,6 +332,73 @@ class ImplementationPlan:
                     )
         return errors
 
+    def validate_criteria_refs(self, contract: VerificationContract) -> list[str]:
+        """SIP-0098 §6.3: bind-mode plan validation against the seeded contract.
+
+        In bind mode a plan *binds* the contract's acceptance by id rather than
+        *authoring* its own typed criteria for contract-covered fill files. This
+        enforces that discipline, returning one error string per defect (empty =
+        valid). Callers surface the list at the existing #464/#473 seams alongside
+        ``validate_criteria_scope`` — net-a (dispatch) raises, net-b (gate) records
+        a system rejection. Contract-less mode never calls this (no contract to
+        bind against), so today's plans are unaffected.
+
+        Three rejection classes (§6.3, acceptance bullet 3):
+
+        1. **Unresolvable ref** — a ``criteria_ref`` naming no contract criterion id.
+        2. **Missing coverage** — a task produces a contract-covered fill file but
+           does not bind *all* its interface+implementation criteria (silent
+           descoping of verification is the #439 lesson at the criteria level).
+        3. **Authored-on-covered** — a task authors a typed criterion targeting a
+           contract-covered fill file (bind by id; do not author). Prose criteria
+           and plan-introduced document regexes remain legal.
+        """
+        errors: list[str] = []
+        index = contract.criterion_index()
+        covered = contract.covered_fill_paths()
+
+        for task in self.tasks:
+            bound = set(task.criteria_refs)
+
+            # 1. every ref must resolve.
+            for ref in task.criteria_refs:
+                if ref not in index:
+                    errors.append(
+                        f"Task {task.task_index} ({task.focus}): criteria_ref {ref!r} "
+                        f"does not resolve against the seeded verification contract"
+                    )
+
+            # 2. every contract-covered fill file this task produces must bind all
+            #    of its interface + implementation criteria (no silent descoping).
+            for artifact in task.expected_artifacts:
+                if artifact not in covered:
+                    continue
+                missing = [
+                    rid for rid in contract.required_ref_ids_for(artifact) if rid not in bound
+                ]
+                if missing:
+                    errors.append(
+                        f"Task {task.task_index} ({task.focus}): fill file {artifact!r} "
+                        f"is contract-covered but does not bind its criteria "
+                        f"{sorted(missing)} — bind every interface+implementation ref "
+                        f"(no silent descoping of verification)"
+                    )
+
+            # 3. authored typed criteria targeting a covered file are rejected.
+            for criterion in task.acceptance_criteria:
+                if not isinstance(criterion, TypedCheck):
+                    continue
+                target = criterion.params.get("file", "")
+                if target in covered:
+                    errors.append(
+                        f"Task {task.task_index} ({task.focus}): authored typed criterion "
+                        f"{criterion.check!r} targets contract-covered file {target!r} — "
+                        f"bind the contract criteria by id (criteria_refs); do not author "
+                        f"typed criteria for covered files"
+                    )
+
+        return errors
+
     def to_dict(self) -> dict:
         """Serialize to dict for YAML/JSON transport.
 
@@ -369,6 +457,8 @@ def _serialize_acceptance_criterion(c: str | TypedCheck) -> str | dict:
     flat["severity"] = c.severity
     if c.description:
         flat["description"] = c.description
+    if c.id:
+        flat["id"] = c.id
     return flat
 
 
@@ -514,12 +604,19 @@ def _parse_acceptance_criteria(
                     f"{'; '.join(command_safelist_names())}"
                 )
 
+        criterion_id = item.get("id", "")
+        if not isinstance(criterion_id, str):
+            raise ValueError(
+                f"Task {task_index}.acceptance_criteria[{j}] ({check_name}): 'id' must be a string"
+            )
+
         parsed.append(
             TypedCheck(
                 check=check_name,
                 params=params,
                 severity=severity,
                 description=description,
+                id=criterion_id,
             )
         )
 

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -417,6 +417,41 @@ class ImplementationPlan:
         return result
 
 
+def resolve_contract_refs(
+    criteria_refs: list[str], contract: VerificationContract
+) -> list[TypedCheck]:
+    """Resolve bind-mode ``criteria_refs`` into ``TypedCheck``s (SIP-0098 §6.3 dispatch).
+
+    The #420 enrichment seam for contract binding: each ref names a contract
+    criterion; this builds the executable ``TypedCheck`` for it, stamped with the
+    stable criterion ``id`` and its target file (the contract's owning ``fill_files``
+    key — contract criteria imply the file rather than inlining it). The resulting
+    checks are merged into the dispatched task's ``acceptance_criteria`` so evaluation,
+    correction, and retest operate on them unchanged.
+
+    Only ``interface``/``implementation`` criteria (the typed-acceptance vocabulary)
+    materialize here; a ref to a behavioral framework check (``frontend_build`` /
+    ``tests_pass``) is skipped — those run through the qa/build handlers, not the
+    typed-acceptance path (98.4). An unresolvable ref is skipped too: plan validation
+    already rejects it (``validate_criteria_refs``), so this stays a pure materializer.
+    """
+    index = contract.criterion_index()
+    checks: list[TypedCheck] = []
+    for ref in criteria_refs:
+        entry = index.get(ref)
+        if entry is None:
+            continue
+        criterion, owning_path = entry
+        if criterion.check not in CHECK_SPECS:
+            continue  # behavioral check bound by ref — materialized elsewhere (98.4)
+        spec = CHECK_SPECS[criterion.check]
+        params = dict(criterion.params)
+        if owning_path and ("file" in spec.required_params or "file" in spec.path_params):
+            params.setdefault("file", owning_path)
+        checks.append(TypedCheck(check=criterion.check, params=params, id=criterion.id))
+    return checks
+
+
 def _check_dependency_dag(tasks: list[PlanTask]) -> None:
     """Validate that task dependencies form a DAG (no cycles).
 

--- a/src/squadops/cycles/proposed_role_tasks.py
+++ b/src/squadops/cycles/proposed_role_tasks.py
@@ -119,6 +119,11 @@ class ProposedTask:
     expected_artifacts: list[str] = field(default_factory=list)
     acceptance_criteria: list[str | TypedCheck] = field(default_factory=list)
     depends_on_focus: list[str] = field(default_factory=list)
+    # SIP-0098 98.3 bind mode: verification-contract criterion ids this proposed
+    # task binds for its contract-covered expected_artifacts. The proposer *binds*
+    # (lists refs) instead of authoring typed criteria for covered files; the merger
+    # carries them onto the PlanTask. Empty in author mode — the default.
+    criteria_refs: list[str] = field(default_factory=list)
 
 
 _VALID_BRIEF_CONFLICT_SEVERITIES = frozenset({"warning", "blocking"})
@@ -353,6 +358,10 @@ def _parse_proposed_task(td: object, i: int, seen_keys: set[str]) -> ProposedTas
     if not isinstance(expected_artifacts, list):
         raise ValueError(f"Proposal task {i} expected_artifacts must be a list")
 
+    raw_refs = td.get("criteria_refs", [])
+    if not isinstance(raw_refs, list) or not all(isinstance(r, str) for r in raw_refs):
+        raise ValueError(f"Proposal task {i} criteria_refs must be a list of strings")
+
     return ProposedTask(
         task_type=str(td["task_type"]).strip(),
         role=role,
@@ -361,6 +370,7 @@ def _parse_proposed_task(td: object, i: int, seen_keys: set[str]) -> ProposedTas
         expected_artifacts=[str(a) for a in expected_artifacts],
         acceptance_criteria=criteria,
         depends_on_focus=depends_on_focus,
+        criteria_refs=list(raw_refs),
     )
 
 

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -15,6 +15,7 @@ Part of SIP-0066 Phase 4 + build capabilities extension + SIP-0071 + SIP-0078.
 from __future__ import annotations
 
 from collections import Counter
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from squadops.capabilities.handlers.build_profiles import (
@@ -34,6 +35,9 @@ from squadops.cycles.models import (
 )
 from squadops.cycles.proposed_role_tasks import role_to_id
 from squadops.tasks.models import TaskEnvelope
+
+if TYPE_CHECKING:
+    from squadops.cycles.verification_contract import VerificationContract
 
 # Pinned task_type → role mapping (SIP-0066 §5.4)
 CYCLE_TASK_STEPS: list[tuple[str, str]] = [
@@ -353,6 +357,7 @@ def generate_task_plan(
     run: Run,
     profile: SquadProfile,
     plan: ImplementationPlan | None = None,
+    contract: VerificationContract | None = None,
 ) -> list[TaskEnvelope]:
     """Generate a task plan for a cycle run.
 
@@ -370,6 +375,10 @@ def generate_task_plan(
         run: The run to generate tasks for.
         profile: The squad profile for agent resolution.
         plan: Optional approved implementation plan (SIP-0086 / SIP-0092).
+        contract: Optional seeded verification contract (SIP-0098 98.3). When
+            present the cycle is in bind mode: the plan is validated to *bind*
+            the contract's criteria by id (net-a, raises), and each task's
+            ``criteria_refs`` resolve into TypedChecks. Absent = author mode.
 
     Returns:
         Ordered list of TaskEnvelopes, one per pipeline step.
@@ -392,7 +401,7 @@ def generate_task_plan(
     # Only applies when the step list actually contains build steps.
     has_build_steps = any(s[0] in _BUILD_TASK_TYPES for s in steps)
     if plan is not None and has_build_steps:
-        steps = _replace_build_steps_with_plan(steps, plan, profile, profile_roles)
+        steps = _replace_build_steps_with_plan(steps, plan, profile, profile_roles, contract)
 
     # Shared lineage IDs for the entire plan
     correlation_id = uuid4().hex
@@ -518,6 +527,7 @@ def _replace_build_steps_with_plan(
     plan: ImplementationPlan,
     profile: SquadProfile,
     profile_roles: set[str],
+    contract: VerificationContract | None = None,
 ) -> list:
     """Replace static build steps with plan-derived PlanTask objects.
 
@@ -536,6 +546,15 @@ def _replace_build_steps_with_plan(
     scope_errors = plan.validate_criteria_scope()
     if scope_errors:
         raise CycleError("Plan validation failed (criteria scope): " + "; ".join(scope_errors))
+
+    # SIP-0098 98.3 bind-mode dispatch net: when a contract is seeded, the plan
+    # must bind the contract's covered-file criteria by id rather than author
+    # them. This is the raising backstop; the gate-time net records the graceful
+    # #473 rejection first. Contract absent = author mode = no-op.
+    if contract is not None:
+        ref_errors = plan.validate_criteria_refs(contract)
+        if ref_errors:
+            raise CycleError("Plan validation failed (contract binding): " + "; ".join(ref_errors))
 
     # Remove static build steps, keep everything else (planning steps)
     static_build_types = {s[0] for s in BUILD_TASK_STEPS} | {

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -23,7 +23,7 @@ from squadops.capabilities.handlers.build_profiles import (
     ROUTING_FALLBACK_NO_BUILDER,
 )
 from squadops.cycles.agent_config import resolve_agent_config
-from squadops.cycles.implementation_plan import ImplementationPlan
+from squadops.cycles.implementation_plan import ImplementationPlan, resolve_contract_refs
 from squadops.cycles.models import (
     REQUIRED_PLAN_ROLES,
     WORKLOAD_REQUIRED_ROLES,
@@ -488,7 +488,14 @@ def generate_task_plan(
             inputs["subtask_description"] = plan_task.description
             inputs["expected_artifacts"] = plan_task.expected_artifacts
             inputs["subtask_index"] = plan_task.task_index
-            inputs["acceptance_criteria"] = plan_task.acceptance_criteria
+            acceptance = list(plan_task.acceptance_criteria)
+            # SIP-0098 98.3: in bind mode, resolve the task's criteria_refs into
+            # TypedChecks (stamped with contract ids) and merge them in. The plan
+            # binds by id, dispatch materializes — evaluation is unchanged. Author
+            # mode (no contract / no refs) leaves acceptance_criteria as authored.
+            if contract is not None and plan_task.criteria_refs:
+                acceptance.extend(resolve_contract_refs(plan_task.criteria_refs, contract))
+            inputs["acceptance_criteria"] = acceptance
 
         envelope = TaskEnvelope(
             task_id=task_id,

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -93,6 +93,13 @@ _PLAN_AUTHORING_PROPOSER_STEPS: dict[str, tuple[str, str]] = {
 # config doesn't silently drop a proposer.
 _VALID_PLAN_AUTHORING_CONTRIBUTORS = frozenset({"development", "qa", "strategy"})
 
+# SIP-0098 98.3: proposer task types that receive the contract criteria index in
+# bind mode. dev/qa propose build tasks and so bind covered-file criteria; strategy
+# proposes guidance (no build tasks), so it is not indexed.
+_BIND_INDEX_PROPOSER_TASK_TYPES = frozenset(
+    {"development.propose_plan_tasks", "qa.propose_plan_tasks"}
+)
+
 
 def build_planning_steps(
     plan_authoring_contributors: list[str] | None,
@@ -496,6 +503,14 @@ def generate_task_plan(
             if contract is not None and plan_task.criteria_refs:
                 acceptance.extend(resolve_contract_refs(plan_task.criteria_refs, contract))
             inputs["acceptance_criteria"] = acceptance
+
+        # SIP-0098 98.3: bind-mode proposers receive the contract's criteria index so
+        # they can *bind* (list criteria_refs) rather than *author* covered-file
+        # criteria (§6.3). Only the index data is injected here; the bind instruction
+        # prose lives in the proposer's managed prompt asset (CLAUDE.md #448). dev/qa
+        # propose build tasks; strategy proposes guidance, so it is not indexed.
+        if contract is not None and task_type in _BIND_INDEX_PROPOSER_TASK_TYPES:
+            inputs["contract_criteria_index"] = "\n".join(contract.criteria_index_lines())
 
         envelope = TaskEnvelope(
             task_id=task_id,

--- a/src/squadops/cycles/verification_contract.py
+++ b/src/squadops/cycles/verification_contract.py
@@ -341,6 +341,45 @@ class VerificationContract:
         ids.extend(p.id for p in self.behavioral.probes)
         return tuple(ids)
 
+    # --- binding (98.3) --------------------------------------------------- #
+
+    def criterion_index(self) -> dict[str, tuple[Criterion, str]]:
+        """Map every typed criterion's stable id to ``(criterion, owning_fill_path)``.
+
+        The owning path is the ``fill_files`` key a file-targeting check applies to
+        (empty for behavioral ``build``/``suite`` checks, which are file-less). This
+        is the resolution table for plan ``criteria_refs`` — bind validation looks up
+        refs here, and dispatch enrichment (98.3 slice D) rebuilds each ref into a
+        ``TypedCheck`` stamped with the criterion id, targeting the owning path.
+
+        Probes are excluded: they are not ``TypedCheck``s and run via the probe
+        runner (98.4), not the ``criteria_refs`` seam. On a well-linted contract ids
+        are unique; if a duplicate slips through, last-writer wins (the linter is the
+        gate that prevents it, `lint()._lint_ids`)."""
+        index: dict[str, tuple[Criterion, str]] = {}
+        for ff in self.fill_files:
+            for crit in (*ff.interface, *ff.implementation):
+                index[crit.id] = (crit, ff.path)
+        for crit in (*self.behavioral.build, *self.behavioral.suite.checks):
+            index[crit.id] = (crit, "")
+        return index
+
+    def covered_fill_paths(self) -> frozenset[str]:
+        """The set of fill-file paths this contract owns the acceptance of. A plan
+        task whose ``expected_artifacts`` names one of these must bind that file's
+        criteria by ref rather than author its own typed checks (§6.3)."""
+        return frozenset(ff.path for ff in self.fill_files)
+
+    def required_ref_ids_for(self, path: str) -> tuple[str, ...]:
+        """Every ``interface`` + ``implementation`` criterion id for the fill file at
+        ``path``, in document order. A bind-mode plan task producing this file must
+        carry all of them — descoping verification is the #439 lesson at the criteria
+        level (§6.3). Unknown path ⇒ empty (the file is not contract-covered)."""
+        for ff in self.fill_files:
+            if ff.path == path:
+                return tuple(c.id for c in (*ff.interface, *ff.implementation))
+        return ()
+
     # --- linting ---------------------------------------------------------- #
 
     def lint(self) -> list[str]:

--- a/src/squadops/cycles/verification_contract.py
+++ b/src/squadops/cycles/verification_contract.py
@@ -380,6 +380,31 @@ class VerificationContract:
                 return tuple(c.id for c in (*ff.interface, *ff.implementation))
         return ()
 
+    def criteria_index_lines(self) -> list[str]:
+        """A human-readable per-covered-file index for the *bind, don't author*
+        proposer prompt (§6.3): one line per fill file naming the exact criterion ids
+        the proposing task must list in ``criteria_refs``. Files with no per-file typed
+        criteria (e.g. JSX views, covered by the behavioral build) are still listed so
+        the proposer knows they are contract-owned and must not author their own checks.
+
+        This is a rendering of contract *data* — the ``bind, don't author`` instruction
+        prose lives in the managed proposer prompt asset (CLAUDE.md #448), which takes
+        these lines as a variable."""
+        lines: list[str] = []
+        for ff in self.fill_files:
+            ids = [c.id for c in (*ff.interface, *ff.implementation)]
+            if ids:
+                pairs = ", ".join(
+                    f"{c.id} ({c.check})" for c in (*ff.interface, *ff.implementation)
+                )
+                lines.append(f"- {ff.path}: bind {pairs}")
+            else:
+                lines.append(
+                    f"- {ff.path}: contract-owned (no per-file typed criteria); "
+                    f"do not author your own for this file"
+                )
+        return lines
+
     # --- linting ---------------------------------------------------------- #
 
     def lint(self) -> list[str]:

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -157,6 +157,12 @@ class CheckResult:
     stub_disclosed: bool = False
     provenance: CheckProvenance | None = None
     subject: str | None = None
+    # SIP-0098 98.3: the verification-contract criterion id this result answers to,
+    # when the check was resolved from a plan ``criteria_ref`` in bind mode. Traces a
+    # row back to its contract criterion so cross-roll analysis can key on a stable id
+    # (§6.3); ``None`` in author mode / for framework-spine checks. The coverage
+    # accounting that consumes it (n-of-m criteria executed-and-passed) lands in 98.4.
+    criterion_id: str | None = None
     # The producing subject's identity (§6.3) — the plan-task id that emitted this
     # result. DISTINCT from ``provenance.subject_ref`` (the *thing* under test — a
     # file-set hash/artifact/endpoint, which legitimately *differs* between a failed

--- a/src/squadops/cycles/verification_normalize.py
+++ b/src/squadops/cycles/verification_normalize.py
@@ -87,11 +87,13 @@ def normalize_task_checks(
             continue
         if "status" in row:
             # Typed-acceptance row: carries a CheckOutcome status verbatim.
+            # SIP-0098 98.3: a bind-mode row also carries the contract criterion id.
             results.append(
                 CheckResult(
                     check_id=cid,
                     status=str(row.get("status") or ""),
                     reason=_str_or_none(row.get("reason")),
+                    criterion_id=_str_or_none(row.get("criterion_id")),
                 )
             )
         else:

--- a/src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md
+++ b/src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md
@@ -12,6 +12,7 @@ optional_variables:
   - builder_section
   - typed_acceptance_vocabulary
   - scaffold_section
+  - bind_criteria_section
 ---
 You are proposing development-domain plan tasks for the upcoming build.
 
@@ -70,3 +71,4 @@ confidence: ""  # low | medium | high
 ```
 
 {{scaffold_section}}
+{{bind_criteria_section}}

--- a/src/squadops/prompts/request_templates/request.plan_bind_criteria_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_bind_criteria_appendix.md
@@ -1,0 +1,42 @@
+---
+template_id: request.plan_bind_criteria_appendix
+version: "1"
+required_variables:
+  - criteria_index
+optional_variables: []
+---
+## Bind the verification contract — do NOT author acceptance criteria
+
+This build is governed by a **verification contract**: a pre-authored, frozen
+statement of what a correct fill must satisfy. The contract already owns the
+acceptance of the files below. Your job is to **bind** its criteria by id, not to
+invent your own.
+
+For every task whose `expected_artifacts` includes a contract-covered file, list
+that file's criterion ids in the task's `criteria_refs` — **all of them, exactly**.
+Do not author `acceptance_criteria` typed checks (`endpoint_defined`,
+`import_present`, `field_present`, `command_exit_zero`) for a covered file: the
+contract's are authoritative and yours would be rejected at plan validation. Prose
+`acceptance_criteria` (human-readable intent) and checks on files the contract does
+**not** cover remain welcome.
+
+**Contract criteria index — bind these ids:**
+
+{{criteria_index}}
+
+Example task shape (YAML):
+
+```yaml
+- task_type: development.develop
+  role: dev
+  focus: "Implement the API routes"
+  description: "Fill the route bodies in backend/routes.py."
+  expected_artifacts: ["backend/routes.py"]
+  criteria_refs: ["<the ids listed for backend/routes.py above>"]
+  acceptance_criteria:
+    - "Endpoints behave per the PRD's happy-path and error cases."   # prose is fine
+```
+
+Bind completely: a covered file that reaches the plan without all of its contract
+criterion ids in some task's `criteria_refs` is a silent descoping of verification
+and is rejected. When in doubt, bind more, author less.

--- a/src/squadops/prompts/request_templates/request.qa_propose_plan_tasks.md
+++ b/src/squadops/prompts/request_templates/request.qa_propose_plan_tasks.md
@@ -11,6 +11,7 @@ optional_variables:
   - roles_section
   - builder_section
   - typed_acceptance_vocabulary
+  - bind_criteria_section
 ---
 You are proposing QA-domain plan tasks for the upcoming build.
 
@@ -69,3 +70,5 @@ risks: []
 gaps_not_covered: []
 confidence: ""  # low | medium | high
 ```
+
+{{bind_criteria_section}}

--- a/tests/unit/capabilities/test_bind_criteria_proposer.py
+++ b/tests/unit/capabilities/test_bind_criteria_proposer.py
@@ -1,0 +1,297 @@
+"""Bind-mode proposer chain (SIP-0098 phase 98.3, slice D).
+
+In bind mode the dev/qa proposers receive the contract's criteria index and are told
+to *bind* (list criteria_refs) rather than author covered-file criteria; the proposal
+model + deterministic merger carry those refs onto the merged implementation plan.
+Data-driven: no seeded contract -> no index injected -> today's author-mode prompt and
+byte-identical merged plan.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities.handlers.planning_tasks import (
+    DevelopmentProposePlanTasksHandler,
+    QaProposePlanTasksHandler,
+    StrategyProposePlanGuidanceHandler,
+)
+from squadops.cycles.proposed_role_tasks import ProposedRoleTasks, ProposedTask
+from squadops.cycles.verification_contract import VerificationContract
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+def _contract() -> VerificationContract:
+    return VerificationContract.from_dict(
+        {
+            "contract_version": 1,
+            "skeleton": {
+                "expander": "fullstack_fastapi_react",
+                "interface_manifest_hash": "a" * 64,
+            },
+            "capabilities": ["python", "node"],
+            "frozen": [],
+            "fill_files": {
+                "backend/routes.py": {
+                    "interface": [
+                        {
+                            "check": "endpoint_defined",
+                            "id": "vc-routes-endpoints",
+                            "methods_paths": ["GET /x"],
+                        },
+                        {
+                            "check": "import_present",
+                            "id": "vc-routes-apierror",
+                            "module": ".errors",
+                            "symbol": "ApiError",
+                        },
+                    ],
+                    "implementation": [],
+                },
+                "frontend/src/views/ListView.jsx": {"interface": [], "implementation": []},
+            },
+            "behavioral": {
+                "build": [],
+                "suite": {"checks": [], "coverage_expectations": []},
+                "probes": [],
+            },
+        }
+    )
+
+
+# --------------------------------------------------------------------------- #
+# criteria_index_lines — the data the proposer prompt renders
+# --------------------------------------------------------------------------- #
+
+
+def test_criteria_index_lines_lists_ids_for_covered_files():
+    lines = _contract().criteria_index_lines()
+    assert lines == [
+        "- backend/routes.py: bind vc-routes-endpoints (endpoint_defined), "
+        "vc-routes-apierror (import_present)",
+        "- frontend/src/views/ListView.jsx: contract-owned (no per-file typed criteria); "
+        "do not author your own for this file",
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# _bind_criteria_section — dev/qa only, bind-mode only
+# --------------------------------------------------------------------------- #
+
+
+async def test_bind_section_rendered_for_dev_in_bind_mode():
+    handler = DevelopmentProposePlanTasksHandler()
+    renderer = AsyncMock()
+    renderer.render.return_value = MagicMock(content="BIND INSTRUCTION")
+
+    out = await handler._bind_criteria_section(
+        renderer, {"contract_criteria_index": "- backend/routes.py: bind x"}
+    )
+
+    assert out == "BIND INSTRUCTION"
+    renderer.render.assert_awaited_once_with(
+        "request.plan_bind_criteria_appendix", {"criteria_index": "- backend/routes.py: bind x"}
+    )
+
+
+async def test_bind_section_rendered_for_qa_in_bind_mode():
+    handler = QaProposePlanTasksHandler()
+    renderer = AsyncMock()
+    renderer.render.return_value = MagicMock(content="BIND INSTRUCTION")
+    out = await handler._bind_criteria_section(renderer, {"contract_criteria_index": "- x"})
+    assert out == "BIND INSTRUCTION"
+
+
+async def test_bind_section_empty_in_author_mode():
+    # no contract seeded -> executor injected no index -> today's author prompt exactly
+    handler = DevelopmentProposePlanTasksHandler()
+    renderer = AsyncMock()
+    out = await handler._bind_criteria_section(renderer, {})
+    assert out == ""
+    renderer.render.assert_not_awaited()
+
+
+async def test_bind_section_empty_for_strategy_proposer():
+    # strategy proposes guidance, not build tasks — it binds no fill-file criteria
+    handler = StrategyProposePlanGuidanceHandler()
+    renderer = AsyncMock()
+    out = await handler._bind_criteria_section(renderer, {"contract_criteria_index": "- x"})
+    assert out == ""
+    renderer.render.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# ProposedTask.criteria_refs — parse
+# --------------------------------------------------------------------------- #
+
+
+def _proposal_yaml(refs_line: str) -> str:
+    return f"""
+version: 1
+proposing_role: development
+proposal_id: prop-1
+source_brief_id: brief-1
+scope_statement: propose the routes task
+tasks:
+  - task_type: development.develop
+    role: dev
+    focus: routes
+    description: fill routes
+    expected_artifacts: [backend/routes.py]
+    {refs_line}
+    acceptance_criteria: []
+    depends_on_focus: []
+"""
+
+
+def test_proposed_task_parses_criteria_refs():
+    proposal = ProposedRoleTasks.from_yaml(
+        _proposal_yaml("criteria_refs: [vc-routes-endpoints, vc-routes-apierror]")
+    )
+    assert proposal.tasks[0].criteria_refs == ["vc-routes-endpoints", "vc-routes-apierror"]
+
+
+def test_proposed_task_criteria_refs_default_empty():
+    proposal = ProposedRoleTasks.from_yaml(_proposal_yaml("depends_on_focus: []"))
+    assert proposal.tasks[0].criteria_refs == []
+
+
+def test_proposed_task_rejects_non_string_refs():
+    with pytest.raises(ValueError, match="criteria_refs must be a list of strings"):
+        ProposedRoleTasks.from_yaml(_proposal_yaml("criteria_refs: [1, 2]"))
+
+
+# --------------------------------------------------------------------------- #
+# merger carries criteria_refs onto the PlanTask + serialized plan
+# --------------------------------------------------------------------------- #
+
+
+def test_merger_carries_criteria_refs_to_plan_task():
+    from squadops.capabilities.handlers._plan_merger import (
+        _build_canonical_pair,
+        _plan_task_to_dict,
+    )
+
+    ptask = ProposedTask(
+        task_type="development.develop",
+        role="dev",
+        focus="routes",
+        description="fill",
+        expected_artifacts=["backend/routes.py"],
+        criteria_refs=["vc-routes-endpoints", "vc-routes-apierror"],
+    )
+    plan_task, _, _ = _build_canonical_pair(ptask, proposing_role="development")
+    assert plan_task.criteria_refs == ["vc-routes-endpoints", "vc-routes-apierror"]
+    assert _plan_task_to_dict(plan_task)["criteria_refs"] == [
+        "vc-routes-endpoints",
+        "vc-routes-apierror",
+    ]
+
+
+def test_merger_omits_criteria_refs_when_absent():
+    # author-mode task -> serialized dict has no criteria_refs key (byte-identical to today)
+    from squadops.capabilities.handlers._plan_merger import (
+        _build_canonical_pair,
+        _plan_task_to_dict,
+    )
+
+    ptask = ProposedTask(
+        task_type="development.develop",
+        role="dev",
+        focus="f",
+        description="d",
+        expected_artifacts=["a.py"],
+    )
+    plan_task, _, _ = _build_canonical_pair(ptask, proposing_role="development")
+    assert plan_task.criteria_refs == []
+    assert "criteria_refs" not in _plan_task_to_dict(plan_task)
+
+
+# --------------------------------------------------------------------------- #
+# generate_task_plan injects the criteria index into dev/qa proposer inputs
+# --------------------------------------------------------------------------- #
+
+
+def _framing_setup():
+    from datetime import UTC, datetime
+
+    from squadops.cycles.models import (
+        AgentProfileEntry,
+        Cycle,
+        Run,
+        SquadProfile,
+        TaskFlowPolicy,
+        WorkloadType,
+    )
+
+    now = datetime(2026, 3, 31, tzinfo=UTC)
+    cycle = Cycle(
+        cycle_id="cy",
+        project_id="p",
+        created_at=now,
+        created_by="s",
+        prd_ref="prd",
+        squad_profile_id="full",
+        squad_profile_snapshot_ref="sha",
+        task_flow_policy=TaskFlowPolicy(mode="sequential"),
+        build_strategy="fresh",
+        applied_defaults={"plan_authoring_contributors": ["development", "qa", "strategy"]},
+        execution_overrides={"contract_ref": "art_c"},
+        expected_artifact_types=["source"],
+    )
+    run = Run(
+        run_id="run_abcdef123456",
+        cycle_id="cy",
+        run_number=1,
+        status="running",
+        initiated_by="api",
+        resolved_config_hash="h",
+        workload_type=WorkloadType.FRAMING,
+    )
+    profile = SquadProfile(
+        profile_id="full",
+        name="F",
+        description="d",
+        version=1,
+        agents=[
+            AgentProfileEntry(agent_id="max", role="lead", model="m", enabled=True),
+            AgentProfileEntry(agent_id="neo", role="dev", model="m", enabled=True),
+            AgentProfileEntry(agent_id="nat", role="strat", model="m", enabled=True),
+            AgentProfileEntry(agent_id="eve", role="qa", model="m", enabled=True),
+            AgentProfileEntry(agent_id="data", role="data", model="m", enabled=True),
+        ],
+        created_at=now,
+    )
+    return cycle, run, profile
+
+
+def test_bind_mode_injects_index_into_dev_and_qa_proposers_only():
+    from squadops.cycles.task_plan import generate_task_plan
+
+    cycle, run, profile = _framing_setup()
+    envs = generate_task_plan(cycle, run, profile, plan=None, contract=_contract())
+    injected = {
+        e.task_type: ("contract_criteria_index" in e.inputs)
+        for e in envs
+        if "propose_plan" in e.task_type
+    }
+    assert injected == {
+        "development.propose_plan_tasks": True,
+        "qa.propose_plan_tasks": True,
+        "strategy.propose_plan_guidance": False,  # strategy proposes guidance, not tasks
+    }
+    dev_env = next(e for e in envs if e.task_type == "development.propose_plan_tasks")
+    assert (
+        "backend/routes.py: bind vc-routes-endpoints" in dev_env.inputs["contract_criteria_index"]
+    )
+
+
+def test_author_mode_injects_no_index():
+    from squadops.cycles.task_plan import generate_task_plan
+
+    cycle, run, profile = _framing_setup()
+    envs = generate_task_plan(cycle, run, profile, plan=None, contract=None)
+    assert all("contract_criteria_index" not in e.inputs for e in envs)

--- a/tests/unit/capabilities/test_interface_manifest_framing.py
+++ b/tests/unit/capabilities/test_interface_manifest_framing.py
@@ -124,6 +124,10 @@ def _executor_for(manifest_yaml: str | None) -> tuple[DispatchedFlowExecutor, An
     run.artifact_refs = refs
     cycle = MagicMock()
     cycle.applied_defaults = {"implementation_plan": True}
+    # a real Cycle always has a dict here; without it MagicMock's .get() returns a
+    # truthy mock and the SIP-0098 98.3 bind-mode branch would misfire (author mode
+    # is keyed on contract_ref being absent).
+    cycle.execution_overrides = {}
     return executor, run, cycle
 
 

--- a/tests/unit/cycles/test_criteria_ref_binding.py
+++ b/tests/unit/cycles/test_criteria_ref_binding.py
@@ -18,8 +18,10 @@ from squadops.cycles.implementation_plan import (
     ImplementationPlan,
     TypedCheck,
     _serialize_acceptance_criterion,
+    resolve_contract_refs,
 )
 from squadops.cycles.verification_contract import VerificationContract
+from squadops.cycles.verification_normalize import normalize_task_checks
 
 pytestmark = [pytest.mark.domain_capabilities]
 
@@ -278,3 +280,67 @@ def test_task_not_touching_covered_files_imposes_no_binding():
     # a task producing only an uncovered artifact needs no refs at all
     plan = ImplementationPlan.from_yaml(_plan_yaml(artifacts="[backend/helpers.py]"))
     assert plan.validate_criteria_refs(_contract()) == []
+
+
+# --------------------------------------------------------------------------- #
+# Dispatch enrichment: resolve_contract_refs (criteria_refs -> TypedCheck)
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_contract_refs_builds_typed_checks_with_id_and_file():
+    c = _contract()
+    checks = resolve_contract_refs(list(c.required_ref_ids_for("backend/routes.py")), c)
+    by_id = {tc.id: tc for tc in checks}
+    assert set(by_id) == {"vc-routes-endpoints", "vc-routes-apierror", "vc-routes-compiles"}
+    # file-targeting checks get the owning fill path stamped as their `file` param
+    assert by_id["vc-routes-endpoints"].check == "endpoint_defined"
+    assert by_id["vc-routes-endpoints"].params["file"] == "backend/routes.py"
+    assert by_id["vc-routes-apierror"].params["file"] == "backend/routes.py"
+    # command_exit_zero targets via argv, not a file param — no file injected
+    assert "file" not in by_id["vc-routes-compiles"].params
+    assert by_id["vc-routes-compiles"].params["argv"][:3] == ["python", "-m", "py_compile"]
+
+
+def test_resolve_contract_refs_skips_behavioral_and_unresolvable():
+    c = _contract()
+    # vc-frontend-builds is a behavioral framework check (materialized by the qa/build
+    # handlers, not the typed-acceptance seam); an unknown id resolves to nothing.
+    assert resolve_contract_refs(["vc-frontend-builds", "nope"], c) == []
+
+
+def test_resolved_check_survives_wire_and_reaches_check_result():
+    # resolve -> asdict wire row -> split re-parse keeps the id; and a produced
+    # evidence row carrying that id normalizes onto CheckResult.criterion_id.
+    import dataclasses
+
+    c = _contract()
+    tc = resolve_contract_refs(["vc-routes-apierror"], c)[0]
+    reparsed = split_acceptance_criteria([dataclasses.asdict(tc)]).typed[0]
+    assert reparsed.id == "vc-routes-apierror"
+
+    outputs = {
+        "validation_result": {
+            "checks": [
+                {
+                    "check": "acceptance:import_present",
+                    "status": "passed",
+                    "criterion_id": "vc-routes-apierror",
+                }
+            ]
+        }
+    }
+    results = normalize_task_checks(outputs, subject="task-routes")
+    assert [(r.check_id, r.criterion_id) for r in results] == [
+        ("acceptance:import_present", "vc-routes-apierror")
+    ]
+
+
+def test_author_mode_check_result_has_no_criterion_id():
+    # a row without a criterion_id (author mode / framework check) normalizes to None
+    outputs = {
+        "validation_result": {
+            "checks": [{"check": "acceptance:endpoint_defined", "status": "passed"}]
+        }
+    }
+    results = normalize_task_checks(outputs, subject="t")
+    assert results[0].criterion_id is None

--- a/tests/unit/cycles/test_criteria_ref_binding.py
+++ b/tests/unit/cycles/test_criteria_ref_binding.py
@@ -1,0 +1,280 @@
+"""Bind-mode plan validation and contract-ref resolution (SIP-0098 phase 98.3, slice A).
+
+The verification contract owns the acceptance of contract-covered fill files; in bind
+mode a plan *binds* those criteria by stable id (``criteria_refs``) rather than authoring
+its own typed checks. This module's unit under test is the pure cycles-domain surface that
+makes that possible: the contract resolution helpers, the ``criteria_refs`` / ``TypedCheck.id``
+model fields (incl. their A2A-wire round-trip), and ``ImplementationPlan.validate_criteria_refs``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from squadops.cycles.acceptance_evaluation import split_acceptance_criteria
+from squadops.cycles.implementation_plan import (
+    ImplementationPlan,
+    TypedCheck,
+    _serialize_acceptance_criterion,
+)
+from squadops.cycles.verification_contract import VerificationContract
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+def _contract() -> VerificationContract:
+    """A two-fill-file contract: routes (2 interface + 1 implementation) and a view
+    (1 interface). Behavioral checks add a file-less id to prove the index handles them."""
+    return VerificationContract.from_dict(
+        {
+            "contract_version": 1,
+            "skeleton": {
+                "expander": "fullstack_fastapi_react",
+                "interface_manifest_hash": "a" * 64,
+            },
+            "capabilities": ["python", "node"],
+            "frozen": [{"path": "backend/errors.py", "sha256": "b" * 64}],
+            "fill_files": {
+                "backend/routes.py": {
+                    "interface": [
+                        {
+                            "check": "endpoint_defined",
+                            "id": "vc-routes-endpoints",
+                            "methods_paths": ["GET /items"],
+                        },
+                        {
+                            "check": "import_present",
+                            "id": "vc-routes-apierror",
+                            "module": ".errors",
+                            "symbol": "ApiError",
+                        },
+                    ],
+                    "implementation": [
+                        {
+                            "check": "command_exit_zero",
+                            "id": "vc-routes-compiles",
+                            "argv": ["python", "-m", "py_compile", "backend/routes.py"],
+                            "requires": "python",
+                        },
+                    ],
+                },
+                "frontend/src/views/ItemView.jsx": {
+                    "interface": [
+                        {
+                            "check": "import_present",
+                            "id": "vc-view-apifetch",
+                            "module": "../api",
+                            "symbol": "apiFetch",
+                        },
+                    ],
+                    "implementation": [],
+                },
+            },
+            "behavioral": {
+                "build": [
+                    {"check": "frontend_build", "id": "vc-frontend-builds", "requires": "node"}
+                ],
+                "suite": {"checks": [], "coverage_expectations": []},
+                "probes": [],
+            },
+        }
+    )
+
+
+def _plan_yaml(
+    *, refs: str = "", authored: str = "", artifacts: str = "[backend/routes.py]"
+) -> str:
+    return f"""
+version: 1
+project_id: p
+cycle_id: cy
+prd_hash: h
+tasks:
+  - task_index: 0
+    task_type: development.develop
+    role: neo
+    focus: routes
+    description: fill the routes module
+    expected_artifacts: {artifacts}
+    criteria_refs: {refs or "[]"}
+    acceptance_criteria:{authored or " []"}
+summary: {{total_dev_tasks: 1, total_qa_tasks: 0, total_tasks: 1}}
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Contract resolution helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_criterion_index_maps_id_to_criterion_and_owning_path():
+    idx = _contract().criterion_index()
+    # every typed criterion (not probes) is present, keyed by id
+    assert set(idx) == {
+        "vc-routes-endpoints",
+        "vc-routes-apierror",
+        "vc-routes-compiles",
+        "vc-view-apifetch",
+        "vc-frontend-builds",
+    }
+    # fill-file criteria carry their owning path; behavioral checks are file-less
+    assert idx["vc-routes-compiles"][1] == "backend/routes.py"
+    assert idx["vc-view-apifetch"][1] == "frontend/src/views/ItemView.jsx"
+    assert idx["vc-frontend-builds"][1] == ""
+    assert idx["vc-routes-endpoints"][0].check == "endpoint_defined"
+
+
+def test_covered_fill_paths_are_exactly_the_fill_file_keys():
+    assert _contract().covered_fill_paths() == frozenset(
+        {"backend/routes.py", "frontend/src/views/ItemView.jsx"}
+    )
+
+
+def test_required_ref_ids_for_lists_interface_then_implementation_in_order():
+    c = _contract()
+    assert c.required_ref_ids_for("backend/routes.py") == (
+        "vc-routes-endpoints",
+        "vc-routes-apierror",
+        "vc-routes-compiles",
+    )
+    # a view with no implementation criteria still returns its interface id
+    assert c.required_ref_ids_for("frontend/src/views/ItemView.jsx") == ("vc-view-apifetch",)
+
+
+def test_required_ref_ids_for_unknown_path_is_empty():
+    # a file the contract does not cover imposes no binding requirement
+    assert _contract().required_ref_ids_for("backend/uncovered.py") == ()
+
+
+# --------------------------------------------------------------------------- #
+# Model: criteria_refs + TypedCheck.id parsing / serialization
+# --------------------------------------------------------------------------- #
+
+
+def test_criteria_refs_parse_onto_plan_task():
+    plan = ImplementationPlan.from_yaml(
+        _plan_yaml(refs="[vc-routes-endpoints, vc-routes-compiles]")
+    )
+    assert plan.tasks[0].criteria_refs == ["vc-routes-endpoints", "vc-routes-compiles"]
+
+
+@pytest.mark.parametrize("bad", ["not-a-list", "[1, 2]", "[vc-ok, 3]"])
+def test_criteria_refs_must_be_a_list_of_strings(bad):
+    with pytest.raises(ValueError, match="criteria_refs must be a list of strings"):
+        ImplementationPlan.from_yaml(_plan_yaml(refs=bad))
+
+
+def test_absent_criteria_refs_defaults_to_empty():
+    # contract-less plans never author the field; it must default cleanly
+    y = _plan_yaml().replace("    criteria_refs: []\n", "")
+    assert ImplementationPlan.from_yaml(y).tasks[0].criteria_refs == []
+
+
+def test_typed_check_id_parses_and_round_trips_through_serialize():
+    authored = (
+        "\n      - {check: import_present, file: backend/other.py, "
+        "module: .errors, symbol: ApiError, id: vc-manual}"
+    )
+    plan = ImplementationPlan.from_yaml(
+        _plan_yaml(authored=authored, artifacts="[backend/other.py]")
+    )
+    crit = plan.tasks[0].acceptance_criteria[0]
+    assert isinstance(crit, TypedCheck)
+    assert crit.id == "vc-manual"
+    assert "id" not in crit.params  # id is a wrapper key, never a check param
+    # serialize keeps id at top level, alongside check/params/severity
+    assert _serialize_acceptance_criterion(crit)["id"] == "vc-manual"
+
+
+def test_typed_check_id_excluded_from_fingerprint():
+    # id labels provenance, not identity — two checks differing only by id must share
+    # a per-criterion error counter (SIP-0092 retry accounting must not reset).
+    a = TypedCheck(check="import_present", params={"file": "x.py", "module": "m", "symbol": "s"})
+    b = dataclasses.replace(a, id="vc-x")
+    assert a.fingerprint() == b.fingerprint()
+
+
+def test_resolved_typed_check_id_survives_the_a2a_wire():
+    # A TypedCheck resolved from a criteria_ref crosses the wire as a
+    # dataclasses.asdict row (params nested + id). split_acceptance_criteria must
+    # re-parse it with the contract id intact — else evidence loses its criterion id.
+    resolved = TypedCheck(
+        check="import_present",
+        params={"file": "backend/routes.py", "module": ".errors", "symbol": "ApiError"},
+        id="vc-routes-apierror",
+    )
+    wire_row = dataclasses.asdict(resolved)
+    assert wire_row["id"] == "vc-routes-apierror"  # asdict keeps it nested-with-params shape
+
+    split = split_acceptance_criteria([wire_row])
+    assert not split.unparseable
+    assert len(split.typed) == 1
+    assert split.typed[0].id == "vc-routes-apierror"
+    assert split.typed[0].check == "import_present"
+
+
+# --------------------------------------------------------------------------- #
+# validate_criteria_refs — the three rejection classes + the clean path
+# --------------------------------------------------------------------------- #
+
+
+def test_fully_bound_plan_validates_clean():
+    plan = ImplementationPlan.from_yaml(
+        _plan_yaml(refs="[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles]")
+    )
+    assert plan.validate_criteria_refs(_contract()) == []
+
+
+def test_unresolvable_ref_is_rejected():
+    plan = ImplementationPlan.from_yaml(
+        _plan_yaml(refs="[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles, vc-bogus]")
+    )
+    errors = plan.validate_criteria_refs(_contract())
+    assert any("vc-bogus" in e and "does not resolve" in e for e in errors)
+
+
+def test_missing_coverage_is_rejected_with_the_unbound_ids():
+    # binds only 1 of routes.py's 3 criteria → silent descoping of the other two
+    plan = ImplementationPlan.from_yaml(_plan_yaml(refs="[vc-routes-endpoints]"))
+    errors = plan.validate_criteria_refs(_contract())
+    assert len(errors) == 1
+    assert "backend/routes.py" in errors[0]
+    assert "vc-routes-apierror" in errors[0] and "vc-routes-compiles" in errors[0]
+
+
+def test_authored_typed_criterion_on_covered_file_is_rejected():
+    authored = (
+        "\n      - {check: import_present, file: backend/routes.py, "
+        "module: .errors, symbol: ApiError}"
+    )
+    plan = ImplementationPlan.from_yaml(
+        _plan_yaml(
+            refs="[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles]", authored=authored
+        )
+    )
+    errors = plan.validate_criteria_refs(_contract())
+    assert any("authored typed criterion" in e and "backend/routes.py" in e for e in errors)
+
+
+def test_authored_typed_criterion_on_uncovered_file_is_allowed():
+    # binding routes fully, and authoring a check on an UNCOVERED file, is legal —
+    # the contract only owns acceptance of the files it covers.
+    authored = (
+        "\n      - {check: import_present, file: backend/helpers.py, module: .util, symbol: helper}"
+    )
+    plan = ImplementationPlan.from_yaml(
+        _plan_yaml(
+            refs="[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles]",
+            authored=authored,
+            artifacts="[backend/routes.py, backend/helpers.py]",
+        )
+    )
+    assert plan.validate_criteria_refs(_contract()) == []
+
+
+def test_task_not_touching_covered_files_imposes_no_binding():
+    # a task producing only an uncovered artifact needs no refs at all
+    plan = ImplementationPlan.from_yaml(_plan_yaml(artifacts="[backend/helpers.py]"))
+    assert plan.validate_criteria_refs(_contract()) == []

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -1375,6 +1375,94 @@ class TestInterWorkloadGatePlanValidation:
         assert EventType.WORKLOAD_GATE_AWAITING not in emit_types
         assert EventType.GATE_DECIDED in emit_types
 
+    # SIP-0098 98.3: bind-mode contract validation rides the SAME #473 seam.
+    _CONTRACT_YAML_BIND = (
+        "contract_version: 1\n"
+        "skeleton:\n"
+        "  expander: fullstack_fastapi_react\n"
+        f"  interface_manifest_hash: {'a' * 64}\n"
+        "capabilities: [python]\n"
+        "frozen: []\n"
+        "fill_files:\n"
+        "  backend/routes.py:\n"
+        "    interface:\n"
+        "      - {check: import_present, id: vc-routes-apierror, module: .errors, symbol: ApiError}\n"
+        "    implementation: []\n"
+        "behavioral: {build: [], suite: {checks: [], coverage_expectations: []}, probes: []}\n"
+    )
+    # A plan that PRODUCES the covered file but binds NONE of its criteria — a silent
+    # descoping of verification that bind-mode validation must reject.
+    _PLAN_YAML_UNBOUND = (
+        "version: 1\n"
+        "project_id: proj_001\n"
+        "cycle_id: cyc_001\n"
+        "prd_hash: h\n"
+        "tasks:\n"
+        "  - task_index: 0\n"
+        "    task_type: development.develop\n"
+        "    role: dev\n"
+        "    focus: routes\n"
+        "    description: fill routes\n"
+        "    expected_artifacts: [backend/routes.py]\n"
+        "    acceptance_criteria: []\n"
+        "summary: {total_dev_tasks: 1, total_qa_tasks: 0, total_tasks: 1}\n"
+    )
+
+    def _contract_ref(self):
+        ref = ArtifactRef(
+            artifact_id="art_c",
+            project_id="proj_001",
+            artifact_type="verification_contract",
+            filename="verification_contract.yaml",
+            content_hash="h",
+            size_bytes=len(self._CONTRACT_YAML_BIND),
+            media_type="text/yaml",
+            created_at=NOW,
+            cycle_id="cyc_001",
+            run_id="run_001",
+        )
+        return ref, self._CONTRACT_YAML_BIND.encode()
+
+    async def test_bind_mode_unbound_plan_rejected_as_recorded_gate_decision(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        """A seeded contract_ref puts the cycle in bind mode; a framing plan that
+        fails to bind the contract's covered-file criteria is rejected at the same
+        #473 seam (system REJECTED gate decision, no implementation run, clean
+        return) — the exact 3.13-stall-avoiding shape as the #464 source-regex net."""
+        import dataclasses
+
+        cycle = dataclasses.replace(
+            self._cycle_with_gate(), execution_overrides={"contract_ref": "art_c"}
+        )
+        mock_registry.get_cycle.return_value = cycle
+
+        run1 = dataclasses.replace(
+            _make_run("run_001", 1, "completed", "framing"), artifact_refs=("art_plan",)
+        )
+        mock_registry.get_run.return_value = run1
+
+        store = {
+            "art_plan": self._plan_ref(self._PLAN_YAML_UNBOUND),
+            "art_c": self._contract_ref(),
+        }
+
+        async def _retrieve(ref_id):
+            return store[ref_id]
+
+        executor._artifact_vault.retrieve.side_effect = _retrieve
+
+        await executor.execute_cycle("cyc_001", "run_001")  # must NOT raise
+
+        mock_registry.record_gate_decision.assert_awaited_once()
+        _, decision = mock_registry.record_gate_decision.await_args.args
+        assert decision.decision == GateDecisionValue.REJECTED.value
+        assert decision.decided_by == "system:plan_validation"
+        assert "verification_contract" in (decision.notes or "")
+        assert "does not bind its criteria" in (decision.notes or "")
+        mock_registry.create_run.assert_not_called()
+        assert EventType.GATE_DECIDED in _emit_types(mock_event_bus)
+
     async def test_document_regex_plan_gates_normally(
         self, executor, mock_registry, mock_event_bus
     ):

--- a/tests/unit/cycles/test_executor_contract_binding.py
+++ b/tests/unit/cycles/test_executor_contract_binding.py
@@ -1,0 +1,283 @@
+"""Executor-side contract seeding + bind-mode plan validation (SIP-0098 phase 98.3, slice B).
+
+A seeded ``contract_ref`` switches a cycle to bind mode: the executor loads the
+verification contract, and the gate-time plan-validation net (net-b) rejects a plan
+that fails to bind the contract's covered-file criteria, or a contract bound to a
+different skeleton. Contract absent = author mode = byte-identical to today. Mirrors
+``test_executor_interface_manifest.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.capabilities.scaffold_contract import emit_contract_yaml
+from squadops.cycles.verification_contract import VerificationContract
+
+_MANIFEST_YAML = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+).read_text(encoding="utf-8")
+_MANIFEST = InterfaceManifest.from_yaml(_MANIFEST_YAML)
+_CONTRACT_YAML = emit_contract_yaml(_MANIFEST)
+_CONTRACT = VerificationContract.from_yaml(_CONTRACT_YAML)
+
+# A bind-mode plan: the routes task binds all three of routes.py's contract criteria.
+_ROUTES_REFS = list(_CONTRACT.required_ref_ids_for("backend/routes.py"))
+_BIND_PLAN_YAML = f"""
+version: 1
+project_id: group_run
+cycle_id: cyc
+prd_hash: h
+tasks:
+  - task_index: 0
+    task_type: development.develop
+    role: neo
+    focus: routes
+    description: fill routes
+    expected_artifacts: [backend/routes.py]
+    criteria_refs: [{", ".join(_ROUTES_REFS)}]
+    acceptance_criteria: []
+summary: {{total_dev_tasks: 1, total_qa_tasks: 0, total_tasks: 1}}
+"""
+
+
+@dataclass
+class _Ref:
+    artifact_id: str
+    filename: str
+    artifact_type: str
+    metadata: dict = field(default_factory=dict)
+
+
+def _make_executor(store: dict[str, tuple[_Ref, bytes]]) -> DispatchedFlowExecutor:
+    executor = DispatchedFlowExecutor.__new__(DispatchedFlowExecutor)
+    executor._artifact_vault = MagicMock()
+
+    async def _retrieve(ref_id: str):
+        return store[ref_id]
+
+    executor._artifact_vault.retrieve = AsyncMock(side_effect=_retrieve)
+    return executor
+
+
+def _make_cycle(**overrides) -> MagicMock:
+    cycle = MagicMock()
+    cycle.execution_overrides = {}
+    cycle.applied_defaults = {"implementation_plan": True}
+    cycle.project_id = "group_run"
+    cycle.cycle_id = "cyc"
+    for k, v in overrides.items():
+        setattr(cycle, k, v)
+    return cycle
+
+
+def _make_run(artifact_refs=()) -> MagicMock:
+    run = MagicMock()
+    run.run_id = "run_abcdef123456"
+    run.artifact_refs = list(artifact_refs)
+    return run
+
+
+# --------------------------------------------------------------------------- #
+# _is_bind_mode
+# --------------------------------------------------------------------------- #
+
+
+def test_is_bind_mode_true_only_when_contract_ref_present():
+    assert DispatchedFlowExecutor._is_bind_mode(
+        _make_cycle(execution_overrides={"contract_ref": "c"})
+    )
+    assert not DispatchedFlowExecutor._is_bind_mode(_make_cycle(execution_overrides={}))
+    # an empty/false ref is not bind mode (data-driven presence check)
+    assert not DispatchedFlowExecutor._is_bind_mode(
+        _make_cycle(execution_overrides={"contract_ref": ""})
+    )
+
+
+# --------------------------------------------------------------------------- #
+# _load_contract_for_run
+# --------------------------------------------------------------------------- #
+
+
+async def test_load_contract_returns_parsed_contract():
+    store = {
+        "art_c": (
+            _Ref("art_c", "verification_contract.yaml", "verification_contract"),
+            _CONTRACT_YAML.encode(),
+        )
+    }
+    executor = _make_executor(store)
+    cycle = _make_cycle(execution_overrides={"contract_ref": "art_c"})
+
+    contract = await executor._load_contract_for_run(cycle, _make_run())
+
+    assert contract is not None
+    assert contract.skeleton.expander == "fullstack_fastapi_react"
+    assert contract.covered_fill_paths() == _CONTRACT.covered_fill_paths()
+
+
+async def test_load_contract_accepts_single_element_list_ref():
+    store = {
+        "art_c": (
+            _Ref("art_c", "verification_contract.yaml", "verification_contract"),
+            _CONTRACT_YAML.encode(),
+        )
+    }
+    executor = _make_executor(store)
+    cycle = _make_cycle(execution_overrides={"contract_ref": ["art_c"]})
+    assert await executor._load_contract_for_run(cycle, _make_run()) is not None
+
+
+async def test_load_contract_none_when_no_ref():
+    executor = _make_executor({})
+    assert await executor._load_contract_for_run(_make_cycle(), _make_run()) is None
+
+
+async def test_load_contract_none_when_unparseable_but_stays_bind_mode():
+    # a seeded-but-broken contract loads to None, but bind mode is still on so the
+    # net records a rejection rather than silently reverting to author mode (§10).
+    store = {
+        "art_c": (
+            _Ref("art_c", "verification_contract.yaml", "verification_contract"),
+            b"::: not yaml :::",
+        )
+    }
+    executor = _make_executor(store)
+    cycle = _make_cycle(execution_overrides={"contract_ref": "art_c"})
+    assert await executor._load_contract_for_run(cycle, _make_run()) is None
+    assert DispatchedFlowExecutor._is_bind_mode(cycle) is True
+
+
+# --------------------------------------------------------------------------- #
+# _validate_contract_binding (hash-binding, §10 = FAIL on mismatch)
+# --------------------------------------------------------------------------- #
+
+
+def test_contract_binding_ok_when_manifest_hash_matches():
+    assert DispatchedFlowExecutor._validate_contract_binding(_CONTRACT, _MANIFEST_YAML) == []
+
+
+def test_contract_binding_rejects_hash_mismatch():
+    tampered = VerificationContract.from_dict(
+        {
+            **_CONTRACT.to_dict(),
+            "skeleton": {
+                "expander": "fullstack_fastapi_react",
+                "interface_manifest_hash": "f" * 64,
+            },
+        }
+    )
+    errors = DispatchedFlowExecutor._validate_contract_binding(tampered, _MANIFEST_YAML)
+    assert len(errors) == 1
+    assert "different skeleton" in errors[0]
+
+
+def test_contract_binding_noop_on_unparseable_manifest():
+    # the manifest's own parse rejection is recorded elsewhere; no duplicate here
+    assert DispatchedFlowExecutor._validate_contract_binding(_CONTRACT, "::: not yaml :::") == []
+
+
+# --------------------------------------------------------------------------- #
+# net-b: _reject_invalid_plan_before_workload_gate in bind mode
+# --------------------------------------------------------------------------- #
+
+
+def _bind_store(plan_yaml: str = _BIND_PLAN_YAML, contract_yaml: str = _CONTRACT_YAML) -> dict:
+    return {
+        "art_plan": (
+            _Ref("art_plan", "implementation_plan.yaml", "control_implementation_plan"),
+            plan_yaml.encode(),
+        ),
+        "art_iface": (
+            _Ref("art_iface", "interface_manifest.yaml", "interface_manifest"),
+            _MANIFEST_YAML.encode(),
+        ),
+        "art_c": (
+            _Ref("art_c", "verification_contract.yaml", "verification_contract"),
+            contract_yaml.encode(),
+        ),
+    }
+
+
+async def test_net_b_bind_mode_valid_plan_passes():
+    executor = _make_executor(_bind_store())
+    cycle = _make_cycle(execution_overrides={"contract_ref": "art_c"})
+    run = _make_run(["art_plan", "art_iface"])
+
+    errors = await executor._reject_invalid_plan_before_workload_gate(run, cycle, "plan-review")
+
+    assert errors == []
+
+
+async def test_net_b_rejects_when_contract_ref_unparseable():
+    executor = _make_executor(_bind_store(contract_yaml="::: not yaml :::"))
+    cycle = _make_cycle(execution_overrides={"contract_ref": "art_c"})
+    run = _make_run(["art_plan", "art_iface"])
+
+    errors = await executor._reject_invalid_plan_before_workload_gate(run, cycle, "plan-review")
+
+    assert any("contract_ref is seeded but the contract is" in e for e in errors)
+
+
+async def test_net_b_rejects_missing_coverage():
+    # the plan drops one required ref -> silent descoping -> rejection
+    thin_plan = _BIND_PLAN_YAML.replace(f"[{', '.join(_ROUTES_REFS)}]", f"[{_ROUTES_REFS[0]}]")
+    executor = _make_executor(_bind_store(plan_yaml=thin_plan))
+    cycle = _make_cycle(execution_overrides={"contract_ref": "art_c"})
+    run = _make_run(["art_plan", "art_iface"])
+
+    errors = await executor._reject_invalid_plan_before_workload_gate(run, cycle, "plan-review")
+
+    assert any("verification_contract:" in e and "does not bind its criteria" in e for e in errors)
+
+
+async def test_net_b_rejects_authored_criterion_on_covered_file():
+    authored_plan = _BIND_PLAN_YAML.replace(
+        "acceptance_criteria: []",
+        "acceptance_criteria:\n      - {check: import_present, file: backend/routes.py, module: .errors, symbol: ApiError}",
+    )
+    executor = _make_executor(_bind_store(plan_yaml=authored_plan))
+    cycle = _make_cycle(execution_overrides={"contract_ref": "art_c"})
+    run = _make_run(["art_plan", "art_iface"])
+
+    errors = await executor._reject_invalid_plan_before_workload_gate(run, cycle, "plan-review")
+
+    assert any("authored typed criterion" in e and "backend/routes.py" in e for e in errors)
+
+
+async def test_net_b_rejects_hash_mismatch():
+    tampered = VerificationContract.from_dict(
+        {
+            **_CONTRACT.to_dict(),
+            "skeleton": {
+                "expander": "fullstack_fastapi_react",
+                "interface_manifest_hash": "f" * 64,
+            },
+        }
+    )
+    import yaml
+
+    executor = _make_executor(_bind_store(contract_yaml=yaml.safe_dump(tampered.to_dict())))
+    cycle = _make_cycle(execution_overrides={"contract_ref": "art_c"})
+    run = _make_run(["art_plan", "art_iface"])
+
+    errors = await executor._reject_invalid_plan_before_workload_gate(run, cycle, "plan-review")
+
+    assert any("different skeleton" in e for e in errors)
+
+
+async def test_net_b_author_mode_ignores_contract_binding():
+    # no contract_ref -> author mode -> the bind-mode branch is a no-op (byte-identical).
+    # the plan here carries criteria_refs but author mode never validates them.
+    executor = _make_executor(_bind_store())
+    cycle = _make_cycle(execution_overrides={})  # no contract_ref
+    run = _make_run(["art_plan", "art_iface"])
+
+    errors = await executor._reject_invalid_plan_before_workload_gate(run, cycle, "plan-review")
+
+    # only the interface-manifest net runs (manifest is valid) -> no bind errors
+    assert not any("verification_contract" in e for e in errors)

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -649,3 +649,29 @@ class TestGenerateTaskPlanBindMode:
         plan = ImplementationPlan.from_yaml(MANIFEST_YAML)
         envelopes = generate_task_plan(_make_cycle(), _make_run(), _make_profile(), plan=plan)
         assert len(envelopes) == 9
+
+    def test_dispatch_resolves_refs_into_acceptance_criteria(self):
+        # 98.3 slice C: the bound ref materializes into the dispatched envelope's
+        # acceptance_criteria as a TypedCheck stamped with the contract id + file.
+        from squadops.cycles.implementation_plan import TypedCheck
+
+        plan = ImplementationPlan.from_yaml(_BIND_MANIFEST_YAML)
+        envelopes = generate_task_plan(
+            _make_cycle(), _make_run(), _make_profile(), plan=plan, contract=_models_contract()
+        )
+        models_env = next(e for e in envelopes if e.inputs.get("subtask_focus") == "Backend models")
+        typed = [c for c in models_env.inputs["acceptance_criteria"] if isinstance(c, TypedCheck)]
+        assert [c.id for c in typed] == ["vc-models-base"]
+        assert typed[0].check == "import_present"
+        assert typed[0].params["file"] == "backend/models.py"
+
+    def test_dispatch_author_mode_leaves_criteria_untouched(self):
+        # no contract -> the envelope carries only the plan's authored criteria (a prose
+        # string here), never a resolved TypedCheck.
+        from squadops.cycles.implementation_plan import TypedCheck
+
+        plan = ImplementationPlan.from_yaml(MANIFEST_YAML)
+        envelopes = generate_task_plan(_make_cycle(), _make_run(), _make_profile(), plan=plan)
+        models_env = next(e for e in envelopes if e.inputs.get("subtask_focus") == "Backend models")
+        assert models_env.inputs["acceptance_criteria"] == ["Models exist"]
+        assert not any(isinstance(c, TypedCheck) for c in models_env.inputs["acceptance_criteria"])

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -574,3 +574,78 @@ class TestWorkloadInvariantTail:
         # The surviving qa task is the plan's, not the static tuple's
         qa_env = next(e for e in envelopes if e.task_type == "qa.test")
         assert "-m003-" in qa_env.task_id
+
+
+# ---------------------------------------------------------------------------
+# SIP-0098 98.3 net-a: bind-mode plan validation raises at dispatch (backstop)
+# ---------------------------------------------------------------------------
+
+
+def _models_contract():
+    """A one-fill-file contract covering backend/models.py (the artifact MANIFEST_YAML's
+    task 0 produces) so a bind-mode plan must bind its criterion."""
+    from squadops.cycles.verification_contract import VerificationContract
+
+    return VerificationContract.from_dict(
+        {
+            "contract_version": 1,
+            "skeleton": {
+                "expander": "fullstack_fastapi_react",
+                "interface_manifest_hash": "a" * 64,
+            },
+            "capabilities": ["python"],
+            "frozen": [],
+            "fill_files": {
+                "backend/models.py": {
+                    "interface": [
+                        {
+                            "check": "import_present",
+                            "id": "vc-models-base",
+                            "module": "pydantic",
+                            "symbol": "BaseModel",
+                        }
+                    ],
+                    "implementation": [],
+                }
+            },
+            "behavioral": {
+                "build": [],
+                "suite": {"checks": [], "coverage_expectations": []},
+                "probes": [],
+            },
+        }
+    )
+
+
+_BIND_MANIFEST_YAML = MANIFEST_YAML.replace(
+    '    expected_artifacts: ["backend/models.py"]\n    acceptance_criteria: ["Models exist"]',
+    '    expected_artifacts: ["backend/models.py"]\n    criteria_refs: ["vc-models-base"]',
+)
+
+
+class TestGenerateTaskPlanBindMode:
+    def test_bound_plan_passes_net_a(self):
+        from squadops.cycles.models import CycleError  # noqa: F401 — imported for symmetry
+
+        plan = ImplementationPlan.from_yaml(_BIND_MANIFEST_YAML)
+        envelopes = generate_task_plan(
+            _make_cycle(), _make_run(), _make_profile(), plan=plan, contract=_models_contract()
+        )
+        # a correctly-bound plan is unaffected — same 9 envelopes as author mode
+        assert len(envelopes) == 9
+
+    def test_unbound_plan_raises_cycle_error(self):
+        from squadops.cycles.models import CycleError
+
+        # task 0 produces the covered file but binds nothing -> silent descoping
+        plan = ImplementationPlan.from_yaml(MANIFEST_YAML)
+        with pytest.raises(CycleError, match="contract binding"):
+            generate_task_plan(
+                _make_cycle(), _make_run(), _make_profile(), plan=plan, contract=_models_contract()
+            )
+
+    def test_author_mode_ignores_binding(self):
+        # no contract passed -> author mode -> the unbound plan is fine (byte-identical)
+        plan = ImplementationPlan.from_yaml(MANIFEST_YAML)
+        envelopes = generate_task_plan(_make_cycle(), _make_run(), _make_profile(), plan=plan)
+        assert len(envelopes) == 9


### PR DESCRIPTION
## SIP-0098 Phase 98.3 — Orchestration Binding (Mac)

Wires the verification contract into cycle orchestration: a seeded `contract_ref`
switches a cycle to **bind mode**, where framing *binds* the contract's covered-file
criteria by stable id instead of *authoring* its own. Data-driven, no flag (SIP §6.3
P9) — absent contract = today's author mode, byte-identical.

Plan: `docs/plans/SIP-0098-verification-contracts-plan.md` §98.3. Builds on 98.1
(contract schema+linter) and 98.2 (emitter + CI gates).

### The chain (5 commits)

- **Slice A — model + validation (pure).** `criteria_refs` on `PlanTask`, `id` on
  `TypedCheck` (excluded from fingerprint; survives the A2A wire via `reserved_keys_for`
  + `_SERIALIZED_ROW_KEYS`), contract resolution helpers (`criterion_index`,
  `covered_fill_paths`, `required_ref_ids_for`), and `validate_criteria_refs` — the
  three §6.3 rejection classes (unresolvable ref, missing coverage / no silent
  descoping, authored-typed-criterion on a covered file).
- **Slice B — seeding + both validation nets.** `_load_contract_for_run` resolves
  `contract_ref`; net-a (`generate_task_plan`) raises, net-b
  (`_reject_invalid_plan_before_workload_gate`) records the #473 `system:plan_validation`
  REJECTED. §10 decision: **FAIL** on `interface_manifest_hash` mismatch (stale binding).
  A seeded-but-unparseable contract stays bind mode → rejected, never a silent
  fall-through to author mode.
- **Slice C — dispatch enrichment + evidence IDs.** `resolve_contract_refs` materializes
  each ref into a `TypedCheck` stamped with its contract id + target file (the #420 seam);
  `criterion_id` rides `check_record → normalize_task_checks → CheckResult`.
- **Slice D — proposer chain (bind, don't author).** `criteria_index_lines`, index
  injected into dev/qa proposer inputs, `_bind_criteria_section` renders the managed
  `request.plan_bind_criteria_appendix` asset (#448), and `criteria_refs` thread through
  `ProposedTask` → merger → plan (emitted only when present).
- **E2E** — bind-mode rejection driven through the **real `execute_cycle`** entry point
  (#464/#473 pattern), not a hand-picked seam.

### Exit criteria (all met)

- ✅ bind-mode plan contains zero framing-authored typed criteria for covered files
- ✅ evidence rows carry contract IDs end-to-end
- ✅ plan validation records rejections (unresolvable / missing coverage / authored-on-covered / hash mismatch)
- ✅ contract-less cycles byte-identical (regression-guarded across seeding, validation, dispatch, proposer, merger)

### Tests

70 new tests; full regression **5099 green**. Author-mode no-op is guarded at every
seam. Layering respected: `verification_contract.py` is cycles-domain, so both nets and
`generate_task_plan` resolve against it with no cycles→capabilities violation.

### Live validation note

Bind mode is inert without a seeded `contract_ref`, and there is no runtime
contract-seeding path on the Mac lane yet — so a live Mac cycle can only exercise
**author mode** (byte-identical, proven by the regression + the `execute_cycle` E2E
test). The definitive live **bind-mode** yield validation is **98.5 (Spark)**, where the
PRD-v0.4 migration wires contract seeding and runs the N=5 baseline against a frozen
contract hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)