### PR TITLE
feat(sip-0098): behavioral probe runner + coverage accounting (98.4)

### DIFF
--- a/docs/plans/SIP-0098-verification-contracts-plan.md
+++ b/docs/plans/SIP-0098-verification-contracts-plan.md
@@ -16,6 +16,53 @@ extends its expander's output; the two ship as one contract surface (see Couplin
 **Arc:** v1.4 (even minor, feature release), Lane M Scaffold headline surface.
 **Evidence base:** Phase-0.5 spike attempts 3.5–3.14; the criteria-lottery record in SIP-0098 §2.
 
+## Status & handoff (updated 2026-07-18)
+
+The single in-repo source of truth for where the arc stands — read this first.
+
+| Phase | State | PR |
+|---|---|---|
+| 98.1 Schema + linter | ✅ merged | — |
+| 98.2 Expander emission + CI gates | ✅ merged | — |
+| 98.3 Orchestration binding | ✅ merged | #488 |
+| 98.4 Probe runner | ✅ merged **as A+B+C only** (see carve-out) | #489 |
+| 98.5 Migration + measurement | ⬜ **next — Spark** | — |
+
+**98.4 carve-out (decided 2026-07-18).** 98.4 shipped its CI-provable core:
+**(A)** the probe runner + default execution profile (`src/squadops/capabilities/handlers/probe_runner.py`),
+**(B)** the reference-fill/bare-skeleton CI gate running probes (the §8-bullet-1 exit criterion),
+and **(C)** contract-criterion coverage accounting (`criteria_verified`/`criteria_total`/
+`criteria_coverage` on `RunVerificationSummary`/`CycleOutcome`, keyed on `CheckResult.criterion_id`).
+
+**Deferred out of 98.4 → the 98.5 lead-in:** the *live* qa.test-handler probe emission (running
+probes inside a real cycle so probe rows land in run evidence). It boots uvicorn in the deployed
+qa container (a Spark-owned image dependency, #306-adjacent) and can only be validated by a live
+bind-mode cycle, so it is built next to its validation rather than landed unexercised on Mac —
+the same call made for 98.3's live-validation deferral.
+
+**Spark pick-up order for 98.5 (do in this sequence):**
+1. **qa-handler probe emission** (the deferred 98.4 piece): the executor injects the seeded
+   contract's `behavioral.probes` into the `qa.test` task inputs (mirror 98.3's criteria-index
+   injection in `generate_task_plan`); `QATestHandler` reconstructs `Probe`s, calls
+   `run_probes(workspace, probes)` against the materialized app workspace, and appends
+   `probe_check_rows(outcomes)` to `outputs["validation_result"]["checks"]`. Provision uvicorn in
+   the qa agent image so the boot succeeds (else probes degrade to `skipped`).
+2. **PRD v0.4 split** (§6.7): move file lists / frozen-file language / interface examples / test
+   mechanics out of the group_run PRD into the interface manifest + verification contract; human
+   gate-review the diff.
+3. **Shakedown + N=5 yield baseline** (§8 bullet 5): one bind-mode roll to prove the pipeline
+   end-to-end on the real deployment, then five bind-mode rolls against a **frozen contract hash**;
+   a run is green iff all contract criteria pass; report per-criterion failure counts. This is the
+   Functional App Yield metric and SIP-0098's acceptance evidence.
+
+**Reusable seams already built (98.1–98.4):** contract model + linter (`cycles/verification_contract.py`);
+emission (`capabilities/scaffold_contract.py`); the emission-time gate (`scripts/dev/contract_gate.py`);
+bind-mode seeding + both plan-validation nets + dispatch `criteria_refs`→`TypedCheck` + evidence
+`criterion_id` (98.3, in `cycles/` + `adapters/cycles/dispatched_flow_executor.py`); the probe runner
++ execution profile + rollup coverage (98.4). **Contract seeding is still operator/`contract_ref`-only**
+— 98.5 owns wiring a real contract into a live cycle (the expander-emits-at-runtime path or a
+migration-seeded `contract_ref`).
+
 ## Lane routing & session assignment
 
 | Phase | Lane / box | Rationale |

--- a/scripts/dev/contract_gate.py
+++ b/scripts/dev/contract_gate.py
@@ -15,8 +15,10 @@ correct code — the structural fix for the criteria lottery.
 
 Refinement of SIP §6.2 (approved 2026-07-17, noted on the PR): a walking skeleton
 compiles/builds/boots by design, so compile/build checks are regression guards that
-PASS on the bare skeleton; only behavior-exercising checks (tests_pass; probes, from
-98.4) fail on it. Probes are not executed here — the probe runner lands in 98.4.
+PASS on the bare skeleton; only behavior-exercising checks (tests_pass; probes) fail
+on it. As of 98.4 the behavioral probes are executed here too (the probe runner boots
+the subject and issues the declared requests): they PASS against the reference fill
+(winnability) and must NOT pass on the bare skeleton (its 501 stubs answer nothing).
 
 Usage:
     python scripts/dev/contract_gate.py <lint|bare-skeleton|reference-fill> \
@@ -32,6 +34,7 @@ import sys
 import tempfile
 from pathlib import Path
 
+from squadops.capabilities.handlers.probe_runner import run_probes
 from squadops.capabilities.scaffold import InterfaceManifest, expand
 from squadops.capabilities.scaffold_contract import emit_contract_dict
 from squadops.cycles.verification_contract import VerificationContract
@@ -114,6 +117,22 @@ def _evaluate(contract: VerificationContract, workspace: Path, result: _Result) 
         result.record(build[0].id, got, "passed")
 
 
+def _record_probes(
+    contract: VerificationContract, workspace: Path, result: _Result, *, bare: bool
+) -> None:
+    """Boot the subject and run every behavioral probe (SIP §6.4/§6.5, 98.4).
+
+    Reference-fill: each probe must ``passed``. Bare skeleton: a probe must NOT pass
+    (its stubs answer 501/nothing) — a probe that passes on the bare skeleton is a
+    false-green admitted at authoring time, exactly what this gate exists to catch."""
+    for outcome in run_probes(workspace, contract.behavioral.probes):
+        if bare:
+            got = "passed" if outcome.status == "passed" else "not_passed"
+            result.record(outcome.id, got, "not_passed")
+        else:
+            result.record(outcome.id, outcome.status, "passed")
+
+
 def _mode_lint(manifest_path: Path) -> int:
     manifest = InterfaceManifest.from_yaml(manifest_path.read_text(encoding="utf-8"))
     errors = VerificationContract.from_dict(emit_contract_dict(manifest)).lint()
@@ -138,6 +157,7 @@ def _mode_bare(manifest_path: Path) -> int:
             if crit.check in FILL_BEHAVIOR_MEASURES:
                 got = "passed" if _tests_pass(workspace) else "not_passed"
                 result.record(crit.id, got, "not_passed")
+        _record_probes(contract, workspace, result, bare=True)
     result.report("bare-skeleton")
     return 0 if result.ok() else 1
 
@@ -155,6 +175,7 @@ def _mode_reference_fill(manifest_path: Path, ref_dir: Path) -> int:
             if crit.check in FILL_BEHAVIOR_MEASURES:
                 got = "passed" if _tests_pass(workspace) else "failed"
                 result.record(crit.id, got, "passed")
+        _record_probes(contract, workspace, result, bare=False)
     result.report("reference-fill")
     return 0 if result.ok() else 1
 

--- a/src/squadops/capabilities/handlers/probe_runner.py
+++ b/src/squadops/capabilities/handlers/probe_runner.py
@@ -1,0 +1,259 @@
+"""Behavioral probe runner + default execution profile (SIP-0098 §6.4/§6.5, phase 98.4).
+
+A *probe* (``contract.behavioral.probes``) is the codified manual validation (#376): boot
+the declared subject, issue an HTTP request, assert the response status/shape. This module
+executes them — the first code that reads ``behavioral.probes`` for execution (98.1–98.3
+only lint/bind them).
+
+Two artifacts, deliberately separate (SIP §6.5):
+
+- The **contract's** ``Probe`` states *what must be true* — method, path, expected status/shape.
+  Declarative, roll-invariant, sandbox-portable.
+- The runner-owned **execution profile** states *how to make it run* — the boot procedure for a
+  subject, port allocation, readiness gate, and timeouts. One default ships here; the
+  Externalized-Build-Sandbox SIP later ships a second profile that re-homes execution to an
+  ephemeral container **without touching a single contract** (§6.5). Capability *requirements*
+  (``requires: node``) stay on the contract — they are facts about the check, validated at plan
+  time — so the profile only owns mechanics.
+
+Near-term the runner executes where ``frontend_build`` runs today (the qa container has the
+Python toolchain). The core is synchronous (boot via ``subprocess.Popen``, request via
+``httpx``) so the CI gate (``scripts/dev/contract_gate.py``) calls it directly; the async
+qa.test handler wraps it in a thread.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from squadops.cycles.verification_contract import Probe
+
+# The one subject the default profile knows how to boot: a FastAPI backend. A probe whose
+# subject the active profile cannot boot is reported skipped (not-executed), never a false pass.
+SUBJECT_BACKEND = "backend"
+
+
+@dataclass(frozen=True)
+class ExecutionProfile:
+    """How to make a contract's behavioral checks run (SIP §6.5) — intent-free mechanics.
+
+    ``boot_argv`` boots the subject with ``{port}`` substituted at launch; readiness is a
+    GET on ``ready_path`` returning 200 within ``startup_timeout_s``. One default ships;
+    the sandbox SIP later ships a second, re-homing execution without a contract revision.
+    """
+
+    boot_argv: tuple[str, ...]
+    ready_path: str = "/health"
+    host: str = "127.0.0.1"
+    startup_timeout_s: float = 25.0
+    request_timeout_s: float = 10.0
+    poll_interval_s: float = 0.1
+
+
+# The default profile: boot the FastAPI backend with uvicorn on an allocated port, using the
+# same interpreter (so the qa container's / CI's installed fastapi+uvicorn are on the path).
+DEFAULT_PROFILE = ExecutionProfile(
+    boot_argv=(
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "backend.main:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "{port}",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class ProbeOutcome:
+    """The result of one probe. ``status`` is a ``ResultStatus`` literal (passed/failed/
+    skipped) so it flows straight through ``normalize_task_checks``; ``skipped`` means
+    not-executed (boot failed / subject unbootable), never a silent pass."""
+
+    id: str
+    status: str  # "passed" | "failed" | "skipped"
+    reason: str | None = None
+
+
+def run_probes(
+    workspace: Path,
+    probes: tuple[Probe, ...] | list[Probe],
+    *,
+    profile: ExecutionProfile = DEFAULT_PROFILE,
+) -> list[ProbeOutcome]:
+    """Boot the subject once, run every probe against it, tear it down.
+
+    Bootable-subject probes (``SUBJECT_BACKEND``) drive a single booted process; a probe with
+    an unbootable subject is reported ``skipped`` (not-executed). If the subject never becomes
+    ready, every backend probe is ``skipped`` with a boot reason — a boot failure is a
+    not-executed result, not a probe failure. Returns one ``ProbeOutcome`` per probe, in
+    contract order.
+    """
+    backend = [p for p in probes if p.subject == SUBJECT_BACKEND]
+    other = [p for p in probes if p.subject != SUBJECT_BACKEND]
+    outcomes: dict[str, ProbeOutcome] = {
+        p.id: ProbeOutcome(p.id, "skipped", f"no execution profile boots subject {p.subject!r}")
+        for p in other
+    }
+
+    if backend:
+        outcomes.update({o.id: o for o in _run_backend_probes(workspace, backend, profile)})
+
+    # preserve contract order
+    return [outcomes[p.id] for p in probes]
+
+
+def probe_check_rows(outcomes: list[ProbeOutcome]) -> list[dict[str, Any]]:
+    """Adapt probe outcomes to the standard evidence check-row shape (SIP-0098 §6.4).
+
+    Each probe is its own uniquely-identified check: ``check`` (the aggregation key) and
+    ``criterion_id`` are both the probe id, so two probes in one task never collapse on
+    ``(check_id, subject)``. The ``status`` key is required — ``normalize_task_checks`` only
+    carries ``criterion_id`` on the status-bearing branch — so a probe row always traces back
+    to its contract criterion in the rollup.
+    """
+    return [
+        {"check": o.id, "status": o.status, "reason": o.reason, "criterion_id": o.id}
+        for o in outcomes
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Internals — boot, readiness, request/compare, teardown
+# --------------------------------------------------------------------------- #
+
+
+def _run_backend_probes(
+    workspace: Path, probes: list[Probe], profile: ExecutionProfile
+) -> list[ProbeOutcome]:
+    port = _free_port(profile.host)
+    try:
+        proc = _boot(workspace, profile, port)
+    except OSError as exc:
+        # e.g. the boot command isn't on PATH, or the workspace is missing — a
+        # not-executed result (skipped), never a probe failure or a crash.
+        return [ProbeOutcome(p.id, "skipped", f"could not launch subject: {exc}") for p in probes]
+    try:
+        if not _wait_ready(profile, port):
+            return [ProbeOutcome(p.id, "skipped", "subject did not boot") for p in probes]
+        base = f"http://{profile.host}:{port}"
+        return [_run_one(base, p, profile) for p in probes]
+    finally:
+        _terminate(proc)
+
+
+def _free_port(host: str) -> int:
+    """Allocate an ephemeral port. A small TOCTOU window exists between close and boot;
+    acceptable for a single-tenant verifier run (the suite runner accepts the same class)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, 0))
+        return int(s.getsockname()[1])
+
+
+def _boot(workspace: Path, profile: ExecutionProfile, port: int) -> subprocess.Popen:
+    argv = [arg.replace("{port}", str(port)) for arg in profile.boot_argv]
+    return subprocess.Popen(  # noqa: S603 — fixed profile argv, workspace-scoped verifier boot
+        argv,
+        cwd=str(workspace),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _wait_ready(profile: ExecutionProfile, port: int) -> bool:
+    url = f"http://{profile.host}:{port}{profile.ready_path}"
+    deadline = time.monotonic() + profile.startup_timeout_s
+    while time.monotonic() < deadline:
+        try:
+            if httpx.get(url, timeout=1.0).status_code == 200:
+                return True
+        except httpx.HTTPError:
+            pass
+        time.sleep(profile.poll_interval_s)
+    return False
+
+
+def _run_one(base_url: str, probe: Probe, profile: ExecutionProfile) -> ProbeOutcome:
+    method = str(probe.request.get("method", "GET")).upper()
+    path = str(probe.request.get("path", "/"))
+    body = probe.request.get("json")
+    try:
+        resp = httpx.request(method, base_url + path, json=body, timeout=profile.request_timeout_s)
+    except httpx.HTTPError as exc:
+        return ProbeOutcome(probe.id, "failed", f"request error: {exc}")
+
+    expect = probe.expect
+    exp_status = expect.get("status")
+    if exp_status is not None and resp.status_code != exp_status:
+        return ProbeOutcome(
+            probe.id, "failed", f"status {resp.status_code} != expected {exp_status}"
+        )
+
+    payload = _json_or_none(resp)
+
+    json_has = expect.get("json_has")
+    if json_has:
+        if payload is None:
+            return ProbeOutcome(probe.id, "failed", "response body is not JSON")
+        missing = [key for key in json_has if not _has_key(payload, key)]
+        if missing:
+            return ProbeOutcome(probe.id, "failed", f"response missing key(s): {missing}")
+
+    error_code = expect.get("error_code")
+    if error_code is not None:
+        actual = _error_code_of(payload)
+        if actual != error_code:
+            return ProbeOutcome(
+                probe.id, "failed", f"error_code {actual!r} != expected {error_code!r}"
+            )
+
+    return ProbeOutcome(probe.id, "passed", None)
+
+
+def _terminate(proc: subprocess.Popen) -> None:
+    with contextlib.suppress(Exception):
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            with contextlib.suppress(Exception):
+                proc.wait(timeout=5)
+
+
+def _json_or_none(resp: httpx.Response) -> Any:
+    try:
+        return resp.json()
+    except (ValueError, httpx.HTTPError):
+        return None
+
+
+def _has_key(payload: Any, key: str) -> bool:
+    """A probe's ``json_has`` asserts a top-level key is present in the response object,
+    or (for a list response) present in each element."""
+    if isinstance(payload, dict):
+        return key in payload
+    if isinstance(payload, list):
+        return all(isinstance(item, dict) and key in item for item in payload)
+    return False
+
+
+def _error_code_of(payload: Any) -> Any:
+    """Read the ``code`` from the skeleton's pinned error envelope ``{"error": {"code": …}}``."""
+    if isinstance(payload, dict):
+        err = payload.get("error")
+        if isinstance(err, dict):
+            return err.get("code")
+        return payload.get("error_code")
+    return None

--- a/src/squadops/cycles/run_report_builder.py
+++ b/src/squadops/cycles/run_report_builder.py
@@ -134,6 +134,9 @@ def _build_verification_lines(summary: RunVerificationSummary) -> list[str]:
         f"Executed: {summary.executed_count} "
         f"(passed {summary.passed_count}, pass-rate {summary.pass_rate:.0%})"
     )
+    if summary.criteria_total:
+        n, m = summary.criteria_coverage
+        lines.append(f"Contract criteria: {n}/{m} executed-and-passed")
     if summary.failed:
         lines.append(f"Failed: {', '.join(summary.failed)}")
     if summary.unverified:

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -199,6 +199,13 @@ class RunVerificationSummary:
     required_unmet: tuple[str, ...]  # required check_ids not-executed (drove blocked_unverified)
     executed_count: int
     passed_count: int
+    # SIP-0098 98.4: contract-criterion coverage — distinct verification-contract
+    # criterion ids (carried on CheckResult.criterion_id in bind mode) that
+    # executed-and-passed, vs every criterion that produced evidence. Makes "verified"
+    # quantitative (§6.3) and the Functional App Yield metric well-defined: a run is
+    # green iff every covered criterion passed. Empty in author mode (no criterion ids).
+    criteria_verified: tuple[str, ...] = ()
+    criteria_total: tuple[str, ...] = ()
 
     @property
     def pass_rate(self) -> float:
@@ -209,6 +216,12 @@ class RunVerificationSummary:
         denominator, so they can never inflate this toward success.
         """
         return self.passed_count / self.executed_count if self.executed_count else 0.0
+
+    @property
+    def criteria_coverage(self) -> tuple[int, int]:
+        """``(n, m)`` — contract criteria executed-and-passed of criteria with evidence
+        (SIP-0098 §6.3). ``(0, 0)`` in author mode / when no criterion ids were carried."""
+        return len(self.criteria_verified), len(self.criteria_total)
 
 
 @dataclass(frozen=True)
@@ -254,6 +267,16 @@ class CycleOutcome:
     run_count: int
     inert: tuple[str, ...] = ()  # §9 chronic not-executed — populated by the inert-detection slice
     waived: tuple[WaivedCheck, ...] = ()  # §6.5 operator waivers — populated by the waiver slice
+    # SIP-0098 98.4: contract-criterion coverage across the cycle's runs (union — a
+    # criterion verified in any run is honestly verified, matching verified/failed).
+    criteria_verified: tuple[str, ...] = ()
+    criteria_total: tuple[str, ...] = ()
+
+    @property
+    def criteria_coverage(self) -> tuple[int, int]:
+        """``(n, m)`` — contract criteria executed-and-passed of criteria with evidence
+        across the cycle (SIP-0098 §6.3)."""
+        return len(self.criteria_verified), len(self.criteria_total)
 
     @property
     def required_unmet(self) -> tuple[str, ...]:
@@ -389,6 +412,10 @@ def aggregate_verification(
     failed: list[str] = []
     unverified: list[UnverifiedCheck] = []
     seen_ids: set[str] = set()
+    # SIP-0098 98.4: contract-criterion coverage, keyed on CheckResult.criterion_id.
+    # A criterion is credited only if it executed-and-passed AND never went adverse.
+    criteria_passed: set[str] = set()
+    criteria_adverse: set[str] = set()
 
     # Resolve each producer's re-verified check to its final state first (§6.5, #379)
     # so a repaired-and-passed check no longer counts its superseded FAILED attempt.
@@ -406,6 +433,10 @@ def aggregate_verification(
                     reason=_not_executed_reason(r),
                     required=r.check_id in required,
                 )
+            )
+        if r.criterion_id:
+            (criteria_passed if family is EvidenceFamily.EXECUTED_PASSED else criteria_adverse).add(
+                r.criterion_id
             )
 
     # A required check that produced NO result is the strongest not-executed
@@ -444,6 +475,8 @@ def aggregate_verification(
         required_unmet=required_unmet,
         executed_count=executed_count,
         passed_count=passed_count,
+        criteria_verified=tuple(sorted(criteria_passed - criteria_adverse)),
+        criteria_total=tuple(sorted(criteria_passed | criteria_adverse)),
     )
 
 
@@ -551,6 +584,17 @@ def aggregate_cycle_outcome(
     else:
         verdict = RunVerdict.ACCEPTED
 
+    # SIP-0098 98.4: cycle criterion coverage — union of the runs' verified/total
+    # (a criterion verified in any run is verified, consistent with the verified/failed
+    # unions above; a criterion never verified but seen stays in total, uncredited).
+    criteria_verified: list[str] = []
+    criteria_total: list[str] = []
+    for s in run_summaries:
+        criteria_verified.extend(s.criteria_verified)
+        criteria_total.extend(s.criteria_total)
+    cycle_criteria_verified = _dedupe(criteria_verified)
+    cycle_criteria_total = _dedupe(criteria_total)
+
     return CycleOutcome(
         verdict=verdict,
         verified=_dedupe(verified),
@@ -559,4 +603,6 @@ def aggregate_cycle_outcome(
         run_count=len(run_summaries),
         inert=_dedupe(inert),
         waived=tuple(waived),
+        criteria_verified=cycle_criteria_verified,
+        criteria_total=cycle_criteria_total,
     )

--- a/tests/unit/capabilities/test_probe_runner.py
+++ b/tests/unit/capabilities/test_probe_runner.py
@@ -1,0 +1,251 @@
+"""Behavioral probe runner (SIP-0098 phase 98.4).
+
+The runner boots a contract subject, issues the declared HTTP requests, compares
+status/shape, and emits standard evidence rows keyed by criterion id. Two layers of
+test: fast request/compare logic against a stubbed httpx, and two real-boot integration
+proofs — the reference fill answers probes (winnability) and the bare skeleton's 501
+stubs do not (probes measure the fill, not the scaffold).
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import httpx
+import pytest
+
+from squadops.capabilities.handlers import probe_runner as pr
+from squadops.capabilities.handlers.probe_runner import (
+    DEFAULT_PROFILE,
+    ProbeOutcome,
+    probe_check_rows,
+    run_probes,
+)
+from squadops.capabilities.scaffold import InterfaceManifest, expand
+from squadops.cycles.verification_contract import Probe
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_REPO = Path(__file__).resolve().parents[3]
+_MANIFEST = _REPO / "examples" / "03_group_run" / "interface_manifest.yaml"
+_REF_FILL = (
+    _REPO / "tests" / "fixtures" / "reference_fills" / "fullstack_fastapi_react" / "group_run"
+)
+
+
+def _probe(**expect) -> Probe:
+    return Probe(
+        id="vc-probe-x",
+        subject="backend",
+        request={"method": "POST", "path": "/runs", "json": {"title": "x"}},
+        expect=expect,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Request / compare logic (stubbed httpx — no real boot)
+# --------------------------------------------------------------------------- #
+
+
+def _stub_response(monkeypatch, *, status: int, json_body=None):
+    def _fake_request(method, url, **kwargs):
+        return httpx.Response(status, json=json_body if json_body is not None else {})
+
+    monkeypatch.setattr(pr.httpx, "request", _fake_request)
+
+
+def test_status_match_passes(monkeypatch):
+    _stub_response(monkeypatch, status=200)
+    out = pr._run_one("http://x", _probe(status=200), DEFAULT_PROFILE)
+    assert out == ProbeOutcome("vc-probe-x", "passed", None)
+
+
+def test_status_mismatch_fails(monkeypatch):
+    _stub_response(monkeypatch, status=501)
+    out = pr._run_one("http://x", _probe(status=200), DEFAULT_PROFILE)
+    assert out.status == "failed"
+    assert "501" in out.reason and "200" in out.reason
+
+
+def test_json_has_missing_key_fails(monkeypatch):
+    _stub_response(monkeypatch, status=200, json_body={"id": "1"})
+    out = pr._run_one(
+        "http://x", _probe(status=200, json_has=["id", "participants"]), DEFAULT_PROFILE
+    )
+    assert out.status == "failed"
+    assert "participants" in out.reason
+
+
+def test_json_has_present_passes(monkeypatch):
+    _stub_response(monkeypatch, status=200, json_body={"id": "1", "participants": []})
+    out = pr._run_one(
+        "http://x", _probe(status=200, json_has=["id", "participants"]), DEFAULT_PROFILE
+    )
+    assert out.status == "passed"
+
+
+def test_error_code_match_passes(monkeypatch):
+    _stub_response(monkeypatch, status=409, json_body={"error": {"code": "duplicate_participant"}})
+    out = pr._run_one(
+        "http://x", _probe(status=409, error_code="duplicate_participant"), DEFAULT_PROFILE
+    )
+    assert out.status == "passed"
+
+
+def test_error_code_mismatch_fails(monkeypatch):
+    _stub_response(monkeypatch, status=409, json_body={"error": {"code": "run_not_found"}})
+    out = pr._run_one(
+        "http://x", _probe(status=409, error_code="duplicate_participant"), DEFAULT_PROFILE
+    )
+    assert out.status == "failed"
+    assert "run_not_found" in out.reason
+
+
+def test_request_error_fails(monkeypatch):
+    def _boom(method, url, **kwargs):
+        raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(pr.httpx, "request", _boom)
+    out = pr._run_one("http://x", _probe(status=200), DEFAULT_PROFILE)
+    assert out.status == "failed"
+    assert "request error" in out.reason
+
+
+# --------------------------------------------------------------------------- #
+# run_probes dispatch + unbootable subjects + check-row shape
+# --------------------------------------------------------------------------- #
+
+
+def test_unbootable_subject_is_skipped_not_failed(tmp_path):
+    # a probe whose subject the default profile can't boot is not-executed, never a pass
+    frontend_probe = Probe(
+        id="vc-probe-fe",
+        subject="frontend",
+        request={"method": "GET", "path": "/"},
+        expect={"status": 200},
+    )
+    outcomes = run_probes(tmp_path, [frontend_probe])
+    assert outcomes == [
+        ProbeOutcome("vc-probe-fe", "skipped", "no execution profile boots subject 'frontend'")
+    ]
+
+
+def test_boot_failure_skips_backend_probes(tmp_path):
+    # empty workspace -> uvicorn can't import backend.main -> never ready -> skipped (not failed)
+    outcomes = run_probes(tmp_path, [_probe(status=200)], profile=_fast_fail_profile())
+    assert outcomes[0].status == "skipped"
+    assert "did not boot" in outcomes[0].reason
+
+
+def test_probe_check_rows_carry_status_and_criterion_id():
+    rows = probe_check_rows(
+        [ProbeOutcome("vc-probe-x", "passed", None), ProbeOutcome("vc-probe-y", "failed", "bad")]
+    )
+    # status key is REQUIRED for criterion_id to survive normalize_task_checks; check==criterion_id
+    # so two probes in one task never collapse on (check_id, subject)
+    assert rows == [
+        {"check": "vc-probe-x", "status": "passed", "reason": None, "criterion_id": "vc-probe-x"},
+        {"check": "vc-probe-y", "status": "failed", "reason": "bad", "criterion_id": "vc-probe-y"},
+    ]
+
+
+def test_outcomes_preserve_contract_order(tmp_path):
+    p1 = Probe(
+        id="a", subject="backend", request={"method": "GET", "path": "/"}, expect={"status": 200}
+    )
+    p2 = Probe(
+        id="b", subject="frontend", request={"method": "GET", "path": "/"}, expect={"status": 200}
+    )
+    p3 = Probe(
+        id="c", subject="backend", request={"method": "GET", "path": "/"}, expect={"status": 200}
+    )
+    outcomes = run_probes(tmp_path, [p1, p2, p3], profile=_fast_fail_profile())
+    assert [o.id for o in outcomes] == ["a", "b", "c"]
+
+
+def test_missing_boot_command_skips(tmp_path):
+    # a boot command not on PATH -> OSError -> skipped (not-executed), never a crash
+    bad = pr.ExecutionProfile(boot_argv=("definitely-not-a-real-binary", "--port", "{port}"))
+    outcomes = run_probes(tmp_path, [_probe(status=200)], profile=bad)
+    assert outcomes[0].status == "skipped"
+    assert "could not launch" in outcomes[0].reason
+
+
+# --------------------------------------------------------------------------- #
+# pure helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_has_key_on_object_and_list():
+    assert pr._has_key({"id": 1, "participants": []}, "id")
+    assert not pr._has_key({"id": 1}, "participants")
+    # list response: key must be present in every element
+    assert pr._has_key([{"id": 1}, {"id": 2}], "id")
+    assert not pr._has_key([{"id": 1}, {"x": 2}], "id")
+    assert not pr._has_key("not-json", "id")
+
+
+def test_error_code_of_reads_pinned_envelope():
+    assert pr._error_code_of({"error": {"code": "run_not_found"}}) == "run_not_found"
+    assert pr._error_code_of({"error_code": "flat"}) == "flat"
+    assert pr._error_code_of({"nope": 1}) is None
+    assert pr._error_code_of(["x"]) is None
+
+
+def _fast_fail_profile() -> pr.ExecutionProfile:
+    # a short startup timeout so boot-failure tests don't wait the full 25s
+    return pr.ExecutionProfile(boot_argv=DEFAULT_PROFILE.boot_argv, startup_timeout_s=1.5)
+
+
+# --------------------------------------------------------------------------- #
+# Real-boot integration: the winnability + measures-the-fill proof
+# --------------------------------------------------------------------------- #
+
+
+def _materialize(dest: Path, *, overlay_fill: bool) -> None:
+    manifest = InterfaceManifest.from_yaml(_MANIFEST.read_text(encoding="utf-8"))
+    for f in expand(manifest):
+        out = dest / f["name"]
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(f["content"], encoding="utf-8")
+    if overlay_fill:
+        for src in _REF_FILL.rglob("*"):
+            if src.is_file():
+                out = dest / src.relative_to(_REF_FILL)
+                out.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, out)
+
+
+def _group_run_probe() -> Probe:
+    return Probe(
+        id="vc-probe-runs",
+        subject="backend",
+        request={
+            "method": "POST",
+            "path": "/runs",
+            "json": {"title": "T", "datetime": "D", "location": "L"},
+        },
+        expect={"status": 200},
+    )
+
+
+@pytest.mark.slow
+def test_reference_fill_answers_the_probe():
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        _materialize(ws, overlay_fill=True)
+        outcomes = run_probes(ws, [_group_run_probe()])
+    assert outcomes == [ProbeOutcome("vc-probe-runs", "passed", None)]
+
+
+@pytest.mark.slow
+def test_bare_skeleton_fails_the_probe():
+    # the skeleton's routes raise 501 — a probe expecting 200 must FAIL (measures the fill)
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        _materialize(ws, overlay_fill=False)
+        outcomes = run_probes(ws, [_group_run_probe()])
+    assert outcomes[0].status == "failed"
+    assert "501" in outcomes[0].reason

--- a/tests/unit/cycles/test_run_report_builder.py
+++ b/tests/unit/cycles/test_run_report_builder.py
@@ -69,3 +69,40 @@ def test_non_completed_statuses_unchanged(status, expected):
     # a rejected verdict must not mask the real terminal reason on non-COMPLETED runs
     text = _notes(status, [CheckResult(check_id="a", status=ResultStatus.FAILED)])
     assert expected in text
+
+
+# --- SIP-0098 98.4: contract-criteria coverage line in the verification section ---
+
+
+def test_verification_lines_show_criteria_coverage():
+    from squadops.cycles.run_report_builder import _build_verification_lines
+
+    summary = aggregate_verification(
+        [
+            CheckResult(
+                check_id="acceptance:import_present",
+                status=ResultStatus.PASSED,
+                criterion_id="vc-a",
+                subject="t",
+            ),
+            CheckResult(
+                check_id="vc-probe",
+                status=ResultStatus.FAILED,
+                criterion_id="vc-probe",
+                subject="t",
+            ),
+        ]
+    )
+    text = "\n".join(_build_verification_lines(summary))
+    assert "Contract criteria: 1/2 executed-and-passed" in text
+
+
+def test_verification_lines_omit_coverage_when_no_criteria():
+    # author-mode run (no criterion ids) shows no coverage line — nothing to count
+    from squadops.cycles.run_report_builder import _build_verification_lines
+
+    summary = aggregate_verification(
+        [CheckResult(check_id="tests_pass", status=ResultStatus.PASSED, subject="t")]
+    )
+    text = "\n".join(_build_verification_lines(summary))
+    assert "Contract criteria" not in text

--- a/tests/unit/cycles/test_verification_integrity.py
+++ b/tests/unit/cycles/test_verification_integrity.py
@@ -567,3 +567,51 @@ class TestCycleOutcomeReconciliation:
         outcome = aggregate_cycle_outcome([r1, r2])
         assert outcome.verdict is RunVerdict.REJECTED
         assert outcome.required_unmet == ()
+
+
+# ---------------------------------------------------------------------------
+# SIP-0098 98.4: contract-criterion coverage accounting
+# ---------------------------------------------------------------------------
+
+
+class TestContractCriteriaCoverage:
+    def test_run_coverage_counts_passed_criteria(self):
+        results = [
+            _passed("acceptance:import_present", criterion_id="vc-a", subject="t1"),
+            _passed("acceptance:endpoint_defined", criterion_id="vc-b", subject="t1"),
+            _failed("vc-probe-x", criterion_id="vc-probe-x", subject="t2"),
+        ]
+        s = aggregate_verification(results)
+        assert s.criteria_verified == ("vc-a", "vc-b")
+        assert s.criteria_total == ("vc-a", "vc-b", "vc-probe-x")
+        assert s.criteria_coverage == (2, 3)
+
+    def test_checks_without_criterion_id_are_excluded(self):
+        # author-mode / framework checks carry no criterion_id -> zero coverage
+        s = aggregate_verification([_passed("tests_pass", subject="t")])
+        assert s.criteria_coverage == (0, 0)
+        assert s.criteria_total == ()
+
+    def test_adverse_criterion_never_credited_within_a_run(self):
+        # a criterion with any adverse result in the run is not credited (adverse wins)
+        results = [
+            _failed("vc-x", criterion_id="vc-x", subject="t1"),
+            _passed("vc-x", criterion_id="vc-x", subject="t2"),
+        ]
+        s = aggregate_verification(results)
+        assert s.criteria_verified == ()
+        assert s.criteria_total == ("vc-x",)
+
+    def test_skipped_criterion_is_counted_but_uncredited(self):
+        s = aggregate_verification([_skipped("vc-p", criterion_id="vc-p", subject="t")])
+        assert s.criteria_verified == ()
+        assert s.criteria_total == ("vc-p",)
+
+    def test_cycle_union_credits_criterion_verified_in_any_run(self):
+        # a probe that failed in run 1 and passed in run 2 is verified at cycle scope
+        run1 = aggregate_verification([_failed("vc-p", criterion_id="vc-p", subject="t")])
+        run2 = aggregate_verification([_passed("vc-p", criterion_id="vc-p", subject="t")])
+        outcome = aggregate_cycle_outcome([run1, run2])
+        assert outcome.criteria_verified == ("vc-p",)
+        assert outcome.criteria_total == ("vc-p",)
+        assert outcome.criteria_coverage == (1, 1)


### PR DESCRIPTION
## SIP-0098 Phase 98.4 — Behavioral probe runner (Mac)

Lands the last unexecuted contract section: `behavioral.probes` now run. Boot the
declared subject, issue the declared HTTP requests, compare status/shape, emit evidence
rows keyed by criterion id — and count "n of m criteria executed-and-passed" in the rollup.

Plan: `docs/plans/SIP-0098-verification-contracts-plan.md` §98.4.

### Slices

- **A — probe runner + default execution profile.** `capabilities/handlers/probe_runner.py`:
  `run_probes(workspace, probes, profile)` boots `uvicorn backend.main:app` on an allocated
  port, gates on a `/health` readiness poll, issues each probe (status + `json_has` +
  `error_code`), tears the subject down. Boot failure / unbootable subject → `skipped`
  (not-executed), never a false pass or a crash. The runner-owned `ExecutionProfile` (§6.5)
  holds the mechanics so the sandbox SIP later re-homes execution with **zero** contract
  revisions. `probe_check_rows` emits status-bearing rows (`check == criterion_id`) so the
  criterion id survives `normalize_task_checks` and two probes never collapse on `(check_id, subject)`.
- **B — CI gate runs probes (§6.2 job 3 — the exit criterion).** `contract_gate.py` reference-fill
  now requires every probe to pass (winnability); bare-skeleton requires every probe to **not**
  pass (its 501 stubs answer nothing — a probe passing there is a false-green admitted at
  authoring time). No workflow change: the gate job already installs fastapi/uvicorn/httpx.
- **C — rollup coverage accounting.** `RunVerificationSummary` / `CycleOutcome` gain
  `criteria_verified` / `criteria_total` + `criteria_coverage`, computed in
  `aggregate_verification` / `aggregate_cycle_outcome` keyed on `CheckResult.criterion_id`
  (from 98.3). A criterion is credited only if it executed-and-passed and never went adverse;
  the cycle unions across runs. Run report shows `Contract criteria: n/m executed-and-passed`.

### Proof

30+ tests incl. **two real-boot integration proofs**: the reference fill answers the probe
(200, winnability); the bare skeleton's 501 stubs fail it (probes measure the fill). Both CI
gate modes are locally GREEN 6/6 with the probe row. Full regression **5122 green**. Author
mode carries no criterion ids → coverage `(0,0)`, report line omitted → byte-identical.

### Deliberately deferred: live qa-handler probe emission

Running probes inside the *live* qa.test handler (so probe rows land in a real cycle's
evidence) depends on the qa container image carrying uvicorn (Spark-owned provisioning) and
can only be validated by a live bind-mode cycle — which needs the 98.5 contract-seeding
migration and a capable model. It is the natural lead-in to **98.5 (Spark)**, where it is
immediately exercised by the N=5 Functional App Yield rolls. This PR delivers the CI-provable
core (§8 bullet 1) and the rollup the yield metric consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)