### PR TITLE
fix(#470): fenced parser tolerates path-prefix-on-first-body-line

### DIFF
--- a/src/squadops/capabilities/handlers/fenced_parser.py
+++ b/src/squadops/capabilities/handlers/fenced_parser.py
@@ -15,6 +15,13 @@ Recognized formats, in priority order (most explicit first):
 4. First-line filename comment inside the fence — ``# path/to/file.py`` or
    ``// path/to/file.py`` as the first line of the body. The comment line
    is stripped from the extracted content.
+5. First-line path *prefix* inside the fence (#470) — a bare ``` ```<lang>``` ```
+   fence whose first body line is ``path/to/file.py:<code>`` (the path as a
+   colon-prefix of the first code line, not a comment). The ``path:`` prefix is
+   stripped and the code after the colon becomes the first content line. Because
+   this variant carries no comment/heading marker, the path is accepted only when
+   it contains ``/`` or ends in a known source extension — a guard prose like
+   ``note:todo`` can't trip.
 
 Models naturally drift between these formats; the parser tolerates all of
 them so a one-character format slip doesn't drop the whole task on the floor.
@@ -65,8 +72,56 @@ _FILENAME_COMMENT_RE = re.compile(
     rf"^\s*(?:#|//|--|/\*)\s*(?P<path>[\w./-]+\.[a-zA-Z0-9]+|{_SPECIAL_NAMES_RE})\b",
 )
 
+# First line of fence body as a bare ``path:code`` prefix (#470). No comment
+# marker, so the path is disambiguated from prose by the extension guard below.
+_FILENAME_PREFIX_RE = re.compile(
+    rf"^(?P<path>[\w./-]+\.[a-zA-Z0-9]+|{_SPECIAL_NAMES_RE}):(?P<rest>.*)$",
+)
+
+# Source/deliverable extensions the build handlers emit — the guard that lets an
+# unmarked ``path:code`` first line (#470) be read as a filename without
+# mis-reading prose or config values (``example.com:8080``, ``note.txt:`` are
+# fine only when path-shaped). A path containing ``/`` is accepted regardless.
+_SOURCE_EXTENSIONS = frozenset(
+    {
+        "py",
+        "js",
+        "jsx",
+        "ts",
+        "tsx",
+        "mjs",
+        "cjs",
+        "vue",
+        "json",
+        "yaml",
+        "yml",
+        "toml",
+        "ini",
+        "cfg",
+        "env",
+        "md",
+        "rst",
+        "txt",
+        "html",
+        "htm",
+        "css",
+        "scss",
+        "sh",
+        "bash",
+        "sql",
+        "xml",
+        "svg",
+    }
+)
+
 # Filenames that LLMs often emit as the language slot (``` ```Dockerfile``` ```).
 _SPECIAL_FILENAMES_AS_LANG = set(_SPECIAL_NAMES)
+
+
+def _has_source_extension(path: str) -> bool:
+    ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+    return ext in _SOURCE_EXTENSIONS
+
 
 _HEADING_PROSE_DISTANCE_LINES = 4
 """Max newline count between a filename heading and the fence it labels.
@@ -153,6 +208,37 @@ def _resolve_filename_from_first_comment(body: str) -> tuple[str | None, str]:
     return match.group("path"), remainder
 
 
+def _resolve_filename_from_first_line_prefix(body: str) -> tuple[str | None, str]:
+    """#470: if the first line of ``body`` is ``path:code`` (a filename as a bare
+    colon-prefix of the first code line — no comment marker), return
+    ``(filename, body_with_the_prefix_stripped)`` so the code after the colon
+    becomes the first content line. Otherwise ``(None, body)``.
+
+    Guarded: the path is accepted only when it contains ``/`` or ends in a known
+    source extension (or is a special name), so a prose/config first line like
+    ``example.com:8080`` is never mistaken for a filename.
+    """
+    nl = body.find("\n")
+    first_line = body if nl == -1 else body[:nl]
+    match = _FILENAME_PREFIX_RE.match(first_line)
+    if match is None:
+        return None, body
+    path = match.group("path")
+    if not ("/" in path or _has_source_extension(path) or path in _SPECIAL_FILENAMES_AS_LANG):
+        return None, body
+    rest = match.group("rest")
+    remainder = "" if nl == -1 else body[nl + 1 :]
+    if nl == -1:
+        new_body = rest
+    elif rest == "":
+        # ``path:`` alone on the first line — the code starts on the next line,
+        # so don't prepend an empty first line.
+        new_body = remainder
+    else:
+        new_body = f"{rest}\n{remainder}"
+    return path, new_body
+
+
 def extract_fenced_files(response: str) -> list[dict]:
     """Parse fenced code blocks into structured file records.
 
@@ -219,6 +305,12 @@ def extract_fenced_files(response: str) -> list[dict]:
                 if comment_filename is not None:
                     filename = comment_filename
                     body = stripped_body
+                else:
+                    # Strategy 5 (#470): first-line ``path:code`` prefix inside body
+                    prefix_filename, prefixed_body = _resolve_filename_from_first_line_prefix(body)
+                    if prefix_filename is not None:
+                        filename = prefix_filename
+                        body = prefixed_body
 
         if filename is None or not _path_is_safe(filename):
             pos = close_match.end()

--- a/tests/unit/capabilities/test_fenced_parser.py
+++ b/tests/unit/capabilities/test_fenced_parser.py
@@ -549,3 +549,68 @@ class TestNestedFences:
         records = extract_fenced_files(response)
         assert [r["filename"] for r in records] == ["config.json"]
         assert records[0]["content"] == '{"ok": true}'
+
+
+class TestFirstLinePathPrefix:
+    """#470: a bare ```<lang> fence whose first body line is ``path:code`` (the
+    filename as a colon-prefix of the first code line, no comment marker). Each
+    occurrence otherwise dropped a whole task and cost a full generation round."""
+
+    def test_the_reported_variant_extracts_the_file(self):
+        # verbatim shape from the issue: qa suite emitted as ```python\npath:code
+        response = (
+            "```python\n"
+            "tests/test_api.py:import pytest\n"
+            "\n"
+            "def test_health():\n"
+            "    assert True\n"
+            "```\n"
+        )
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "tests/test_api.py"
+        # the code after the colon becomes the first content line — prefix stripped
+        assert result[0]["content"].startswith("import pytest\n")
+        assert "def test_health():" in result[0]["content"]
+
+    def test_bare_extension_filename_without_slash(self):
+        # a slash-less path is accepted via the source-extension guard
+        result = extract_fenced_files("```python\nmain.py:import sys\n```")
+        assert result == [{"filename": "main.py", "content": "import sys", "language": "python"}]
+
+    def test_path_colon_alone_takes_code_from_next_line(self):
+        # ``path:`` with nothing after the colon — code starts on the next line,
+        # and no empty first line is prepended
+        result = extract_fenced_files(
+            "```python\nbackend/main.py:\nfrom fastapi import FastAPI\n```"
+        )
+        assert result[0]["filename"] == "backend/main.py"
+        assert result[0]["content"] == "from fastapi import FastAPI"
+
+    def test_multiple_path_prefix_fences(self):
+        response = "```python\na/one.py:x = 1\n```\n```js\nb/two.js:y = 2\n```"
+        result = extract_fenced_files(response)
+        assert [(r["filename"], r["content"]) for r in result] == [
+            ("a/one.py", "x = 1"),
+            ("b/two.js", "y = 2"),
+        ]
+
+    def test_strict_header_still_wins_over_body_prefix(self):
+        # an explicit ```<lang>:<path> header is authoritative; a path:code first
+        # body line is left untouched as content, not treated as the filename
+        result = extract_fenced_files("```python:real.py\nother.py:import os\n```")
+        assert result[0]["filename"] == "real.py"
+        assert result[0]["content"] == "other.py:import os"
+
+    def test_host_port_first_line_is_not_a_filename(self):
+        # guard: no slash and a non-source extension (.com) -> not a file (would
+        # otherwise mis-read config/prose colon lines as filenames)
+        assert extract_fenced_files("```yaml\nexample.com:8080\nfoo: bar\n```") == []
+
+    def test_prose_colon_first_line_is_not_a_filename(self):
+        assert extract_fenced_files("```text\nNote:this is important\n```") == []
+
+    def test_absolute_and_traversal_prefixes_rejected(self):
+        # the shared safety check still applies to a strategy-5 path
+        assert extract_fenced_files("```python\n/etc/evil.py:import os\n```") == []
+        assert extract_fenced_files("```python\n../esc.py:bad\n```") == []


### PR DESCRIPTION
## Problem

A recurring LLM formatting variant defeats `extract_fenced_files`: a bare ` ```<lang> `
fence whose **first body line** is `path/to/file.py:<code>` — the filename as a bare
colon-prefix of the first code line, not a `#`/`//` comment. It matches none of the four
existing strategies (no `:` in the fence token, not a special-lang, no heading, not a
comment), so the parser returns **zero files** and the whole task is dropped and retried —
each miss costing a full generation round (~9 min on the 27b). Seen in Phase-0.5 attempt
3.12 (qa.test emitting the entire suite this way).

## Fix

Adds **Strategy 5**: read the `path:` prefix as the filename, and the code after the colon
as the first content line. Because the variant has no comment/heading marker to disambiguate
it, the path is accepted only when it **contains `/` or ends in a known source extension**
(or is a special name) — so a prose/config first line like `example.com:8080` or `Note:this`
is never mistaken for a filename. The shared safety check (reject absolute / `..` paths) still
applies, and an explicit ` ```<lang>:<path> ` header still wins over a body prefix.

## Tests

8 new tests: the verbatim reported variant, slash-less source-extension paths, `path:`-alone
(code on the next line), multiple files, strict-header precedence, and the guard/safety
rejections (`host:port`, prose, absolute, traversal). 45 existing parser tests unchanged;
**full regression 5130 green**.

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)