### PR TITLE
fix(#427): runtime-api application logging reaches stdout

### DIFF
--- a/src/squadops/api/runtime/logging_setup.py
+++ b/src/squadops/api/runtime/logging_setup.py
@@ -1,0 +1,61 @@
+"""Application logging configuration for the runtime-api process (#427).
+
+The runtime-api container runs the ``DispatchedFlowExecutor`` in-process but emitted
+only uvicorn access logs: the ``squadops``/``adapters`` application loggers had no
+handler, so a run's terminal exception (logged by the executor) never reached stdout
+and every failure had to be reconstructed by hand — the run was a black box.
+
+uvicorn configures only its own loggers (``uvicorn`` / ``uvicorn.error`` /
+``uvicorn.access``) and leaves the root logger untouched — its ``LOGGING_CONFIG`` has
+no ``root`` key and ``disable_existing_loggers=False`` (verified empirically) — so a
+root stdout handler installed at import time survives uvicorn's startup ``dictConfig``
+and captures every application logger, before and after boot.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+# Marks our handler so a re-import (or a second call under test) re-uses it rather
+# than stacking duplicates on the root logger.
+_HANDLER_NAME = "squadops-stdout"
+_DEFAULT_LEVEL = "INFO"
+_ENV_LEVEL = "SQUADOPS_LOG_LEVEL"
+
+
+def _resolve_level(level: str | None) -> int:
+    """Resolve a level name (arg → ``SQUADOPS_LOG_LEVEL`` → INFO) to a logging int.
+
+    An unknown name falls back to INFO rather than raising — a bad env value must
+    never crash the process at import, and silently dropping to no logging would
+    reintroduce exactly the swallow this fixes.
+    """
+    name = (level or os.getenv(_ENV_LEVEL) or _DEFAULT_LEVEL).upper()
+    resolved = logging.getLevelName(name)
+    return resolved if isinstance(resolved, int) else logging.INFO
+
+
+def configure_logging(level: str | None = None) -> None:
+    """Attach a stdout handler to the root logger so ``squadops``/``adapters``
+    application logs reach ``docker logs`` alongside uvicorn's (#427).
+
+    Idempotent: a second call re-uses the existing named handler and only updates the
+    level, so re-import under test (or a startup re-assert) never stacks duplicates.
+    Level comes from ``level``, else ``SQUADOPS_LOG_LEVEL``, else ``INFO``.
+    """
+    root = logging.getLogger()
+    resolved = _resolve_level(level)
+    root.setLevel(resolved)
+
+    existing = next((h for h in root.handlers if getattr(h, "name", None) == _HANDLER_NAME), None)
+    if existing is not None:
+        existing.setLevel(resolved)
+        return
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.set_name(_HANDLER_NAME)
+    handler.setLevel(resolved)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    root.addHandler(handler)

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -27,6 +27,14 @@ from .deps import (
     set_cycle_ports,
     set_health_checker,
 )
+from .logging_setup import configure_logging
+
+# #427: configure application logging before any module-level log fires. uvicorn
+# configures only its own loggers and leaves the root logger untouched, so without
+# this the executor's in-process logs (including a run's terminal exception) never
+# reach stdout and every failure is a black box. Installed at import so it survives
+# uvicorn's startup dictConfig (see logging_setup for the why).
+configure_logging()
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/api/test_logging_setup.py
+++ b/tests/unit/api/test_logging_setup.py
@@ -1,0 +1,95 @@
+"""Runtime-api application logging configuration (#427).
+
+The bug: the runtime-api container emitted only uvicorn access logs, so the
+in-process executor's application logs — including a run's terminal exception —
+never reached stdout and every failure was a black box. ``configure_logging``
+attaches a named stdout handler to the root logger so those logs surface.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+
+from squadops.api.runtime.logging_setup import _HANDLER_NAME, configure_logging
+
+pytestmark = [pytest.mark.domain_api]
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_logging():
+    """Save/restore the global root logger so these tests can't leak handlers or a
+    mutated level into the rest of the suite."""
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    yield
+    root.handlers[:] = saved_handlers
+    root.setLevel(saved_level)
+
+
+def _our_handlers() -> list[logging.Handler]:
+    return [h for h in logging.getLogger().handlers if getattr(h, "name", None) == _HANDLER_NAME]
+
+
+def test_attaches_a_named_stdout_handler_at_info_by_default(monkeypatch):
+    monkeypatch.delenv("SQUADOPS_LOG_LEVEL", raising=False)
+    configure_logging()
+    handlers = _our_handlers()
+    assert len(handlers) == 1
+    assert isinstance(handlers[0], logging.StreamHandler)
+    assert handlers[0].level == logging.INFO
+    assert logging.getLogger().level == logging.INFO
+
+
+def test_level_from_env(monkeypatch):
+    monkeypatch.setenv("SQUADOPS_LOG_LEVEL", "debug")  # case-insensitive
+    configure_logging()
+    assert logging.getLogger().level == logging.DEBUG
+    assert _our_handlers()[0].level == logging.DEBUG
+
+
+def test_explicit_level_arg_overrides_env(monkeypatch):
+    monkeypatch.setenv("SQUADOPS_LOG_LEVEL", "DEBUG")
+    configure_logging(level="WARNING")
+    assert logging.getLogger().level == logging.WARNING
+
+
+def test_unknown_level_falls_back_to_info_not_crash(monkeypatch):
+    # a bad env value must never crash the process at import or silently disable logging
+    monkeypatch.setenv("SQUADOPS_LOG_LEVEL", "NOT_A_LEVEL")
+    configure_logging()
+    assert logging.getLogger().level == logging.INFO
+
+
+def test_idempotent_reuses_handler_and_updates_level(monkeypatch):
+    monkeypatch.delenv("SQUADOPS_LOG_LEVEL", raising=False)
+    configure_logging()
+    configure_logging(level="ERROR")  # second call — re-import / re-assert
+    handlers = _our_handlers()
+    assert len(handlers) == 1  # no duplicate stacked on root
+    assert handlers[0].level == logging.ERROR
+
+
+def test_squadops_logger_message_reaches_the_stream(monkeypatch):
+    # the functional guarantee: an application log actually lands on our handler
+    monkeypatch.delenv("SQUADOPS_LOG_LEVEL", raising=False)
+    configure_logging()
+    buf = io.StringIO()
+    _our_handlers()[0].setStream(buf)
+    logging.getLogger("squadops.cycles.executor").info("run failed: CycleError boom")
+    assert "run failed: CycleError boom" in buf.getvalue()
+
+
+def test_below_level_message_is_suppressed(monkeypatch):
+    monkeypatch.delenv("SQUADOPS_LOG_LEVEL", raising=False)
+    configure_logging(level="WARNING")
+    buf = io.StringIO()
+    _our_handlers()[0].setStream(buf)
+    logging.getLogger("squadops.x").info("chatty")  # below WARNING
+    logging.getLogger("squadops.x").warning("important")
+    out = buf.getvalue()
+    assert "chatty" not in out
+    assert "important" in out


### PR DESCRIPTION
## Problem (the swallowed-logging half of #427)

The runtime-api container emitted **only uvicorn access logs**. The `squadops`/`adapters`
application loggers had no handler, so the in-process `DispatchedFlowExecutor`'s logs —
including a run's terminal exception (e.g. the `CycleError: build_profile is required…` it
had *already cleanly diagnosed*) — never reached stdout. Every failure was a black box:
`runs show` gave only `status: failed`, the run report said "check task artifacts" (there
were none), and `docker logs` showed nothing but access lines + the startup banner. Triage
meant re-deriving an error the executor had already produced.

## Fix

New `api/runtime/logging_setup.configure_logging()` attaches a **named stdout handler to the
root logger** at a level from `SQUADOPS_LOG_LEVEL` (default `INFO`), called at the top of
`main.py` before any module-level log fires.

Verified empirically that uvicorn's startup `dictConfig` does **not** clobber it: uvicorn's
`LOGGING_CONFIG` has no `root` key and `disable_existing_loggers=False`, so a root handler
installed at import time survives and captures every application logger before and after
boot. Idempotent (re-import/re-assert safe — no duplicate handlers); an unknown level falls
back to `INFO` rather than crashing at import or silently disabling logging.

## Scope — partial fix

This is fix-direction **2** (logging). Direction **1** — persisting the terminal failure
reason on the run record (`runs show` / run report) — touches `run_completion` and is a
separate follow-up, so **#427 stays open** for it.

## Tests

7 unit tests (default/env/arg level, unknown-level fallback, idempotency, and the functional
"an app log reaches the stream" + "below-level suppressed" guarantees). api suite (192) +
full regression (5144) green.

**Pre-merge check (not done here):** rebuild runtime-api → trigger a failing run → confirm
the exception now appears in `docker logs squadops-runtime-api`. Skipped to avoid disrupting
a concurrent session's shared docker stack; run it when the stack is free.

Refs #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)