### PR TITLE
feat(sip-0098/98.5): contract_gate emit mode — contract-seeding wiring (operator-seed decided)

### DIFF
--- a/docs/plans/SIP-0098-verification-contracts-plan.md
+++ b/docs/plans/SIP-0098-verification-contracts-plan.md
@@ -50,14 +50,21 @@ and **(C)** contract-criterion coverage accounting (`criteria_verified`/`criteri
 **Spark pick-up: 98.5 slice 3 (measurement) — do in this order:**
 1. **Preconditions:** #433/#434 landed; UPS question resolved/risk-accepted; **rebuild agent +
    runtime-api images from `756f692` or later** (restart alone does not pick up code).
-2. **Contract-seeding wiring** (the one unbuilt piece): live cycles have no path that sets
-   `contract_ref` yet. `_load_contract_for_run` retrieves it from the artifact vault via
-   `execution_overrides.contract_ref` (bare id or single-element list). Either operator-seed
-   (ingest the emitted `verification_contract.yaml` as an artifact, set `contract_ref` on the
-   cycle) or build the expander-emits-at-runtime path (emit contract beside the skeleton at the
-   `_seed_skeleton_artifacts` seam — a small PR; keep it data-driven, no flag). Emit the contract
-   deterministically with `scaffold_contract.emit_contract_yaml(manifest)`; freeze and record its
-   `content_hash` — the yield baseline is measured against that hash.
+2. **Contract-seeding wiring — DECIDED + BUILT (Spark, 2026-07-18): operator-seed; the
+   runtime-emit alternative is rejected.** Two reasons it cannot work: (a) framing consumes
+   the contract's criteria index at *proposer dispatch* (`_inject_contract_inputs`), so a
+   contract derived mid-cycle from framing's own manifest arrives after the plan was
+   authored — the bind net would reject every such plan; (b) the SIP's own doctrine
+   (§2: verifiers are *curated artifacts, not per-run emissions*) and the frozen-hash
+   baseline both require the contract to pre-exist the cycle. The wiring:
+   `contract_gate.py emit` writes the lint-gated, deterministic
+   `verification_contract.yaml` and prints its `content_hash` (the frozen baseline hash)
+   → `squadops artifacts ingest --type verification_contract` → cycle create with
+   `execution_overrides {"contract_ref": "<artifact_id>"}`. Determinism ties the seeded
+   bytes to the CI-validated contract; the hash check at plan validation
+   (`_validate_contract_binding`) then enforces that framing's per-roll manifest
+   semantically reproduces the frozen skeleton (`content_hash()` is canonical-JSON, so
+   formatting variance is tolerated, interface drift is rejected).
 3. **Shakedown:** one bind-mode roll of group_run on the full squad proving the pipeline E2E —
    including probe rows landing in run evidence with `criterion_id`s (the slice-1 live validation,
    deliberately co-located here per the built-next-to-its-validation call).

--- a/scripts/dev/contract_gate.py
+++ b/scripts/dev/contract_gate.py
@@ -12,6 +12,15 @@ correct code — the structural fix for the criteria lottery.
                   the behavior measures actually measure the fill.
   reference-fill  The FULL contract passes against skeleton + the checked-in reference
                   fill. The winnability proof.
+  emit            Write the lint-clean contract to a file for seeding into live cycles
+                  (98.5): ingest it (`squadops artifacts ingest --type
+                  verification_contract`) and set the returned artifact id as
+                  `execution_overrides.contract_ref` at cycle create. Emission is
+                  deterministic, so a contract emitted from a gate-green tree IS the
+                  gate-validated contract; the printed content_hash is the frozen hash
+                  the yield baseline measures against. The contract must pre-exist the
+                  cycle — framing consumes its criteria index at proposer dispatch, so
+                  it cannot be derived mid-cycle from framing's own manifest.
 
 Refinement of SIP §6.2 (approved 2026-07-17, noted on the PR): a walking skeleton
 compiles/builds/boots by design, so compile/build checks are regression guards that
@@ -21,13 +30,14 @@ the subject and issues the declared requests): they PASS against the reference f
 (winnability) and must NOT pass on the bare skeleton (its 501 stubs answer nothing).
 
 Usage:
-    python scripts/dev/contract_gate.py <lint|bare-skeleton|reference-fill> \
-        [--manifest PATH] [--reference-fill DIR]
+    python scripts/dev/contract_gate.py <lint|bare-skeleton|reference-fill|emit> \
+        [--manifest PATH] [--reference-fill DIR] [--out PATH]
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import shutil
 import subprocess
 import sys
@@ -36,7 +46,7 @@ from pathlib import Path
 
 from squadops.capabilities.handlers.probe_runner import run_probes
 from squadops.capabilities.scaffold import InterfaceManifest, expand
-from squadops.capabilities.scaffold_contract import emit_contract_dict
+from squadops.capabilities.scaffold_contract import emit_contract_dict, emit_contract_yaml
 from squadops.cycles.verification_contract import VerificationContract
 from squadops.cycles.verification_contract_runner import (
     FILL_BEHAVIOR_MEASURES,
@@ -180,17 +190,50 @@ def _mode_reference_fill(manifest_path: Path, ref_dir: Path) -> int:
     return 0 if result.ok() else 1
 
 
+def _mode_emit(manifest_path: Path, out_path: Path) -> int:
+    """Write the seeding artifact (98.5): lint-gated, deterministic, hash-reported."""
+    manifest = InterfaceManifest.from_yaml(manifest_path.read_text(encoding="utf-8"))
+    contract_yaml = emit_contract_yaml(manifest)
+    contract = VerificationContract.from_yaml(contract_yaml)
+    errors = contract.lint()
+    if errors:
+        print("emit: RED (refusing to write a contract that fails lint)")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    out_path.write_text(contract_yaml, encoding="utf-8")
+    content_hash = hashlib.sha256(contract_yaml.encode("utf-8")).hexdigest()
+    print(f"emit: GREEN -> {out_path} ({len(contract.criterion_ids())} criteria)")
+    print(f"  contract content_hash (the frozen yield-baseline hash): {content_hash}")
+    print(f"  skeleton.interface_manifest_hash: {manifest.content_hash()}")
+    print("Seed it:")
+    print(
+        f"  squadops artifacts ingest --project <project> "
+        f"--type verification_contract --file {out_path}"
+    )
+    print('  then create the cycle with execution_overrides {"contract_ref": "<artifact_id>"}')
+    return 0
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description="SIP-0098 contract emission-time gate")
-    parser.add_argument("mode", choices=["lint", "bare-skeleton", "reference-fill"])
+    parser.add_argument("mode", choices=["lint", "bare-skeleton", "reference-fill", "emit"])
     parser.add_argument("--manifest", type=Path, default=_DEFAULT_MANIFEST)
     parser.add_argument("--reference-fill", type=Path, default=_DEFAULT_REFERENCE_FILL)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("verification_contract.yaml"),
+        help="emit mode: output path for the contract artifact",
+    )
     args = parser.parse_args(argv)
 
     if args.mode == "lint":
         return _mode_lint(args.manifest)
     if args.mode == "bare-skeleton":
         return _mode_bare(args.manifest)
+    if args.mode == "emit":
+        return _mode_emit(args.manifest, args.out)
     return _mode_reference_fill(args.manifest, args.reference_fill)
 
 

--- a/tests/unit/capabilities/test_contract_gate_emit.py
+++ b/tests/unit/capabilities/test_contract_gate_emit.py
@@ -1,0 +1,65 @@
+"""Tests for contract_gate.py emit mode (SIP-0098 98.5 contract seeding).
+
+The emitted file is the artifact operators ingest and seed as ``contract_ref`` —
+wrong bytes here mean every bind-mode cycle binds against a contract the CI gate
+never validated, so the tests pin byte-identity with the canonical emitter and
+the no-file-on-failure guarantee.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.capabilities.scaffold_contract import emit_contract_yaml
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_GATE = _REPO_ROOT / "scripts" / "dev" / "contract_gate.py"
+_CANONICAL_MANIFEST = _REPO_ROOT / "examples" / "03_group_run" / "interface_manifest.yaml"
+
+
+def _run_emit(manifest: Path, out: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_GATE), "emit", "--manifest", str(manifest), "--out", str(out)],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+
+
+class TestEmitMode:
+    def test_emitted_file_is_byte_identical_to_canonical_emission(self, tmp_path):
+        # The seeded artifact must be exactly what the CI gate validated —
+        # a divergent writer would seed an unvalidated contract.
+        out = tmp_path / "verification_contract.yaml"
+        proc = _run_emit(_CANONICAL_MANIFEST, out)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+
+        manifest = InterfaceManifest.from_yaml(_CANONICAL_MANIFEST.read_text(encoding="utf-8"))
+        assert out.read_text(encoding="utf-8") == emit_contract_yaml(manifest)
+
+    def test_reported_hash_matches_file_bytes(self, tmp_path):
+        # The printed content_hash is what the yield baseline freezes; if it
+        # doesn't match the ingested bytes, the baseline measures nothing.
+        out = tmp_path / "verification_contract.yaml"
+        proc = _run_emit(_CANONICAL_MANIFEST, out)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+
+        actual = hashlib.sha256(out.read_bytes()).hexdigest()
+        assert actual in proc.stdout
+
+    def test_unreadable_manifest_writes_nothing(self, tmp_path):
+        # A garbage manifest must not leave a seedable file behind.
+        bad = tmp_path / "broken.yaml"
+        bad.write_text("kind: [unclosed", encoding="utf-8")
+        out = tmp_path / "verification_contract.yaml"
+        proc = _run_emit(bad, out)
+        assert proc.returncode != 0
+        assert not out.exists()


### PR DESCRIPTION
## What this is

98.5 slice-3 step 2 (the one unbuilt piece from the Mac handoff): the wiring that gets a real verification contract into a live cycle. Adds an `emit` mode to `scripts/dev/contract_gate.py`; seeding then rides entirely on existing rails.

```
python scripts/dev/contract_gate.py emit --out verification_contract.yaml
squadops artifacts ingest --project group_run --type verification_contract --file verification_contract.yaml
# cycle create with execution_overrides {"contract_ref": "<artifact_id>"}
```

`emit` refuses to write a contract that fails the 98.1 linter, and prints the contract's `content_hash` — **the frozen hash the N=5 yield baseline measures against** — plus `skeleton.interface_manifest_hash`. Against the canonical group_run manifest today: 6 criteria, deterministic output.

## The design decision (recorded in the handoff doc)

The handoff left two options open: operator-seed vs. expander-emits-at-runtime (at the `_seed_skeleton_artifacts` seam). **Runtime emission cannot work**, for two independent reasons:

1. **Ordering:** framing consumes the contract's criteria index at *proposer dispatch* (`_inject_contract_inputs` → dev/qa proposers bind instead of authoring). A contract derived at the impl-run seam — or even at the framing→impl transition — arrives after the plan was authored, so `validate_criteria_refs` would reject every such plan (authored-on-covered). The contract must exist before framing runs.
2. **Doctrine + measurement:** SIP-0098 §2's core lesson is that verifiers are *curated artifacts, not per-run emissions* — a contract re-derived per-roll from framing's own manifest is a per-run emission with a vacuous hash binding. The frozen-baseline hash requires one pre-existing contract; `_validate_contract_binding` then does its real job: rejecting any roll whose framing manifest drifts from the frozen interface (canonical-JSON hash, so formatting variance is tolerated, semantic drift is not).

Since emission is deterministic, a contract emitted from a gate-green tree **is** the CI-validated contract — no separate validation path needed at seed time (lint still runs as a belt-and-braces refusal gate).

## Tests

`tests/unit/capabilities/test_contract_gate_emit.py` (subprocess-driven, the script has no other harness): emitted file byte-identical to the canonical emitter (a divergent writer would seed an unvalidated contract), printed hash matches the file bytes (a mismatch would freeze a meaningless baseline hash), unreadable manifest writes nothing. Capabilities domain green (1244 passed); all three existing gate modes untouched.

## Next (not in this PR)

With this merged: image rebuild from current main → live emit+ingest+seed → shakedown bind-mode roll (probe rows in evidence = the slice-1 live validation) → N=5 yield baseline against the printed frozen hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm
