### PR TITLE
fix(#494): bind mode requires a framing-emitted interface manifest

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2324,6 +2324,21 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # the same returned list → identical system:plan_validation REJECTED recording.
         # Contract absent (author mode) → no-op = today's behavior.
         if self._is_bind_mode(cycle):
+            # #494: the contract binds to a skeleton, so bind mode REQUIRES a
+            # framing-emitted interface manifest. Without one, no skeleton is
+            # expanded at the implementation run — a plan whose criteria happen
+            # to bind would proceed UNSCAFFOLDED while claiming contract
+            # verification (the §10 stale-binding class through the front
+            # door; observed live: shakedown cyc_c8d3414a6bee ran sole-author,
+            # emitted no manifest, and this net said nothing about it).
+            if interface_content is None:
+                errors.append(
+                    "verification_contract: bind mode requires a framing-emitted "
+                    "interface manifest, and this run produced none — the contract "
+                    "binds to a skeleton; without a manifest the implementation "
+                    "would run unscaffolded while claiming contract verification "
+                    "(#494)"
+                )
             contract = await self._load_contract_for_run(cycle, run)
             if contract is None:
                 errors.append(

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -1463,6 +1463,146 @@ class TestInterWorkloadGatePlanValidation:
         mock_registry.create_run.assert_not_called()
         assert EventType.GATE_DECIDED in _emit_types(mock_event_bus)
 
+    # #494: a plan that binds every covered-file criterion correctly — the shape
+    # that would have FALSE-PASSED the net when no manifest exists.
+    _PLAN_YAML_BOUND = (
+        "version: 1\n"
+        "project_id: proj_001\n"
+        "cycle_id: cyc_001\n"
+        "prd_hash: h\n"
+        "tasks:\n"
+        "  - task_index: 0\n"
+        "    task_type: development.develop\n"
+        "    role: dev\n"
+        "    focus: routes\n"
+        "    description: fill routes\n"
+        "    expected_artifacts: [backend/routes.py]\n"
+        "    acceptance_criteria: []\n"
+        "    criteria_refs: [vc-routes-apierror]\n"
+        "summary: {total_dev_tasks: 1, total_qa_tasks: 0, total_tasks: 1}\n"
+    )
+
+    async def test_bind_mode_without_manifest_rejected_even_when_plan_binds(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        """#494 — the shakedown gap: bind mode, correctly bound plan, but framing
+        emitted NO interface manifest. Pre-#494 this passed the net silently and
+        the implementation would have run unscaffolded while claiming contract
+        verification. Must record a system rejection naming the missing manifest."""
+        import dataclasses
+
+        cycle = dataclasses.replace(
+            self._cycle_with_gate(), execution_overrides={"contract_ref": "art_c"}
+        )
+        mock_registry.get_cycle.return_value = cycle
+
+        run1 = dataclasses.replace(
+            _make_run("run_001", 1, "completed", "framing"), artifact_refs=("art_plan",)
+        )
+        mock_registry.get_run.return_value = run1
+
+        store = {
+            "art_plan": self._plan_ref(self._PLAN_YAML_BOUND),
+            "art_c": self._contract_ref(),
+        }
+
+        async def _retrieve(ref_id):
+            return store[ref_id]
+
+        executor._artifact_vault.retrieve.side_effect = _retrieve
+
+        await executor.execute_cycle("cyc_001", "run_001")  # must NOT raise
+
+        mock_registry.record_gate_decision.assert_awaited_once()
+        _, decision = mock_registry.record_gate_decision.await_args.args
+        assert decision.decision == GateDecisionValue.REJECTED.value
+        assert decision.decided_by == "system:plan_validation"
+        assert "requires a framing-emitted interface manifest" in (decision.notes or "")
+        assert "#494" in (decision.notes or "")
+        mock_registry.create_run.assert_not_called()
+        assert EventType.WORKLOAD_GATE_AWAITING not in _emit_types(mock_event_bus)
+
+    async def test_bind_mode_with_manifest_and_bound_plan_gates_normally(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        """#494 inverse guard: the new manifest requirement must be conditional on
+        absence — a bind-mode run carrying a hash-matching manifest and a fully
+        bound plan still reaches the gate (no always-on rejection)."""
+        import dataclasses
+        from pathlib import Path
+
+        from squadops.capabilities.scaffold import InterfaceManifest
+        from squadops.capabilities.scaffold_contract import emit_contract_yaml
+
+        manifest_text = (
+            Path(__file__).resolve().parents[3]
+            / "examples"
+            / "03_group_run"
+            / "interface_manifest.yaml"
+        ).read_text(encoding="utf-8")
+        contract_text = emit_contract_yaml(InterfaceManifest.from_yaml(manifest_text))
+        bound_refs = "[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles]"
+        plan_text = self._PLAN_YAML_BOUND.replace(
+            "criteria_refs: [vc-routes-apierror]", f"criteria_refs: {bound_refs}"
+        )
+
+        approved = _gate_decision("progress_plan_review", GateDecisionValue.APPROVED.value)
+        cycle = dataclasses.replace(
+            self._cycle_with_gate(), execution_overrides={"contract_ref": "art_c"}
+        )
+        mock_registry.get_cycle.return_value = cycle
+
+        run1 = dataclasses.replace(
+            _make_run("run_001", 1, "completed", "framing", gate_decisions=(approved,)),
+            artifact_refs=("art_plan", "art_manifest"),
+        )
+        run2 = _make_run("run_002", 2, "completed", "implementation")
+
+        async def _get_run(run_id):
+            return run1 if run_id == "run_001" else run2
+
+        mock_registry.get_run.side_effect = _get_run
+        mock_registry.list_runs.return_value = [run1]
+        mock_registry.create_run.side_effect = lambda r: r
+
+        def _art(ref_id, artifact_type, filename, text):
+            return (
+                ArtifactRef(
+                    artifact_id=ref_id,
+                    project_id="proj_001",
+                    artifact_type=artifact_type,
+                    filename=filename,
+                    content_hash="h",
+                    size_bytes=len(text),
+                    media_type="text/yaml",
+                    created_at=NOW,
+                    cycle_id="cyc_001",
+                    run_id="run_001",
+                ),
+                text.encode(),
+            )
+
+        store = {
+            "art_plan": self._plan_ref(plan_text),
+            "art_manifest": _art(
+                "art_manifest", "interface_manifest", "interface_manifest.yaml", manifest_text
+            ),
+            "art_c": _art(
+                "art_c", "verification_contract", "verification_contract.yaml", contract_text
+            ),
+        }
+
+        async def _retrieve(ref_id):
+            return store[ref_id]
+
+        executor._artifact_vault.retrieve.side_effect = _retrieve
+        executor._artifact_vault.list_artifacts.return_value = []
+
+        await executor.execute_cycle("cyc_001", "run_001")
+
+        mock_registry.record_gate_decision.assert_not_awaited()
+        assert EventType.WORKLOAD_GATE_AWAITING in _emit_types(mock_event_bus)
+
     async def test_document_regex_plan_gates_normally(
         self, executor, mock_registry, mock_event_bus
     ):


### PR DESCRIPTION
Shakedown finding: in bind mode the pre-gate net silently skipped skeleton-binding checks when framing emitted no interface manifest — a correctly-bound plan would have run unscaffolded while claiming contract verification. Now records a #473-style system rejection naming the missing manifest. Tests cover the false-pass shape and the inverse guard (manifest present + bound plan still gates normally, using the real emitter against the canonical manifest). Cycles+events domains green (1949 passed).

Companion (non-code) fix: the shakedown recipe now sets plan_authoring_contributors — the production framing path rides the multi-role proposers.

Fixes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm