### PR TITLE
fix(#496): bind mode seeds the canonical interface manifest

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1348,8 +1348,17 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         for the ``interface_manifest.yaml`` a scaffolded framing run emitted (99.2) and
         parses it. Returns ``InterfaceManifest`` or ``None`` — a missing or unparseable
         manifest leaves the run on today's non-scaffolded path (graceful, data-driven).
+
+        Never loads for a framing run (#496): an operator-seeded manifest sits in
+        ``plan_artifact_refs`` from cycle creation, visible to EVERY workload — but the
+        skeleton is the implementation substrate. A framing run authors the plan and
+        must not expand or carry skeleton files. (Pre-#496 this was unreachable:
+        forwarding only populated ``plan_artifact_refs`` after framing completed.)
         """
         from squadops.capabilities.scaffold import InterfaceManifest
+
+        if getattr(run, "workload_type", None) == "framing":
+            return None
 
         plan_refs = cycle.execution_overrides.get("plan_artifact_refs", [])
         if not plan_refs:

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2324,20 +2324,25 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # the same returned list → identical system:plan_validation REJECTED recording.
         # Contract absent (author mode) → no-op = today's behavior.
         if self._is_bind_mode(cycle):
-            # #494: the contract binds to a skeleton, so bind mode REQUIRES a
-            # framing-emitted interface manifest. Without one, no skeleton is
-            # expanded at the implementation run — a plan whose criteria happen
-            # to bind would proceed UNSCAFFOLDED while claiming contract
-            # verification (the §10 stale-binding class through the front
-            # door; observed live: shakedown cyc_c8d3414a6bee ran sole-author,
-            # emitted no manifest, and this net said nothing about it).
+            # #494/#496: the contract binds to a skeleton, so bind mode REQUIRES an
+            # interface manifest — without one, no skeleton is expanded at the
+            # implementation run and contract checks would measure from-scratch code
+            # (the §10 stale-binding class through the front door). In bind mode the
+            # manifest is normally operator-SEEDED via plan_artifact_refs (#496 —
+            # framing cannot re-derive it from a product-only PRD without hash
+            # drift; emission is author-mode only). A framing-emitted manifest, if
+            # one appears anyway, still takes precedence and is still hash-checked.
+            seeded_content: str | None = None
             if interface_content is None:
+                seeded_content = await self._load_seeded_manifest_content(cycle)
+            if interface_content is None and seeded_content is None:
                 errors.append(
-                    "verification_contract: bind mode requires a framing-emitted "
-                    "interface manifest, and this run produced none — the contract "
-                    "binds to a skeleton; without a manifest the implementation "
-                    "would run unscaffolded while claiming contract verification "
-                    "(#494)"
+                    "verification_contract: bind mode requires an interface manifest "
+                    "and none exists — this run emitted none and no seeded "
+                    "interface_manifest.yaml is present in plan_artifact_refs; the "
+                    "contract binds to a skeleton, and without a manifest the "
+                    "implementation would run unscaffolded while claiming contract "
+                    "verification (#494, #496)"
                 )
             contract = await self._load_contract_for_run(cycle, run)
             if contract is None:
@@ -2346,14 +2351,36 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     "missing or unparseable — bind mode cannot validate the plan"
                 )
             else:
-                if interface_content is not None:
-                    errors.extend(self._validate_contract_binding(contract, interface_content))
+                binding_content = (
+                    interface_content if interface_content is not None else (seeded_content)
+                )
+                if binding_content is not None:
+                    errors.extend(self._validate_contract_binding(contract, binding_content))
                 if parsed_plan is not None:
                     errors.extend(
                         f"verification_contract: {e}"
                         for e in parsed_plan.validate_criteria_refs(contract)
                     )
         return errors
+
+    async def _load_seeded_manifest_content(self, cycle: Cycle) -> str | None:
+        """Raw content of an operator-seeded interface manifest, or ``None`` (#496).
+
+        Searches ``execution_overrides.plan_artifact_refs`` — the exact rail
+        ``_load_interface_manifest_for_run`` reads at the implementation run — so the
+        manifest the gate hash-checks against the contract is the same one the
+        skeleton will expand from. Unreadable refs are skipped, not fatal: an absent
+        seeded manifest is reported by the caller as the #494/#496 rejection."""
+        for ref_id in cycle.execution_overrides.get("plan_artifact_refs") or []:
+            try:
+                ref, content_bytes = await self._artifact_vault.retrieve(ref_id)
+            except Exception:
+                continue
+            if ref.filename == "interface_manifest.yaml" or (
+                getattr(ref, "artifact_type", None) == "interface_manifest"
+            ):
+                return content_bytes.decode(errors="replace")
+        return None
 
     @staticmethod
     def _validate_interface_manifest(content: str) -> list[str]:

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -819,6 +819,12 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
 
         if self._proposer_role != "development":
             return ""
+        # #496: bind mode (a contract_criteria_index was injected) means the manifest
+        # already exists — the contract was emitted from it and binds its exact hash.
+        # Asking framing to re-derive it from a product-only PRD is unwinnable (any
+        # naming drift breaks the hash), so emission is author-mode only.
+        if inputs.get("contract_criteria_index"):
+            return ""
         resolved_config = inputs.get("resolved_config") or {}
         stack = str(resolved_config.get("build_profile") or "")
         if not is_scaffoldable_stack(stack):

--- a/tests/unit/capabilities/test_interface_manifest_framing.py
+++ b/tests/unit/capabilities/test_interface_manifest_framing.py
@@ -198,6 +198,23 @@ async def test_scaffold_section_empty_for_non_dev_proposer():
     renderer.render.assert_not_awaited()
 
 
+async def test_scaffold_section_empty_in_bind_mode():
+    # #496: a contract_criteria_index means bind mode — the manifest already exists
+    # (the contract binds its exact hash), so asking dev to re-derive it from a
+    # product-only PRD is unwinnable drift. Emission must be author-mode only.
+    handler = DevelopmentProposePlanTasksHandler()
+    renderer = AsyncMock()
+    out = await handler._scaffold_section(
+        renderer,
+        {
+            "resolved_config": {"build_profile": "fullstack_fastapi_react"},
+            "contract_criteria_index": [{"id": "vc-routes-apierror"}],
+        },
+    )
+    assert out == ""
+    renderer.render.assert_not_awaited()
+
+
 def test_appendix_example_manifest_is_itself_valid_and_scaffoldable():
     # the schema example we teach the LLM must itself parse, lint clean, and be
     # scaffoldable — otherwise a squad copying it faithfully still gets rejected

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -1485,9 +1485,10 @@ class TestInterWorkloadGatePlanValidation:
     async def test_bind_mode_without_manifest_rejected_even_when_plan_binds(
         self, executor, mock_registry, mock_event_bus
     ):
-        """#494 — the shakedown gap: bind mode, correctly bound plan, but framing
-        emitted NO interface manifest. Pre-#494 this passed the net silently and
-        the implementation would have run unscaffolded while claiming contract
+        """#494/#496 — the shakedown gap: bind mode, correctly bound plan, but NO
+        interface manifest from either source (framing emitted none, nothing seeded
+        in plan_artifact_refs). Pre-#494 this passed the net silently and the
+        implementation would have run unscaffolded while claiming contract
         verification. Must record a system rejection naming the missing manifest."""
         import dataclasses
 
@@ -1517,8 +1518,9 @@ class TestInterWorkloadGatePlanValidation:
         _, decision = mock_registry.record_gate_decision.await_args.args
         assert decision.decision == GateDecisionValue.REJECTED.value
         assert decision.decided_by == "system:plan_validation"
-        assert "requires a framing-emitted interface manifest" in (decision.notes or "")
+        assert "bind mode requires an interface manifest" in (decision.notes or "")
         assert "#494" in (decision.notes or "")
+        assert "#496" in (decision.notes or "")
         mock_registry.create_run.assert_not_called()
         assert EventType.WORKLOAD_GATE_AWAITING not in _emit_types(mock_event_bus)
 
@@ -1555,6 +1557,93 @@ class TestInterWorkloadGatePlanValidation:
         run1 = dataclasses.replace(
             _make_run("run_001", 1, "completed", "framing", gate_decisions=(approved,)),
             artifact_refs=("art_plan", "art_manifest"),
+        )
+        run2 = _make_run("run_002", 2, "completed", "implementation")
+
+        async def _get_run(run_id):
+            return run1 if run_id == "run_001" else run2
+
+        mock_registry.get_run.side_effect = _get_run
+        mock_registry.list_runs.return_value = [run1]
+        mock_registry.create_run.side_effect = lambda r: r
+
+        def _art(ref_id, artifact_type, filename, text):
+            return (
+                ArtifactRef(
+                    artifact_id=ref_id,
+                    project_id="proj_001",
+                    artifact_type=artifact_type,
+                    filename=filename,
+                    content_hash="h",
+                    size_bytes=len(text),
+                    media_type="text/yaml",
+                    created_at=NOW,
+                    cycle_id="cyc_001",
+                    run_id="run_001",
+                ),
+                text.encode(),
+            )
+
+        store = {
+            "art_plan": self._plan_ref(plan_text),
+            "art_manifest": _art(
+                "art_manifest", "interface_manifest", "interface_manifest.yaml", manifest_text
+            ),
+            "art_c": _art(
+                "art_c", "verification_contract", "verification_contract.yaml", contract_text
+            ),
+        }
+
+        async def _retrieve(ref_id):
+            return store[ref_id]
+
+        executor._artifact_vault.retrieve.side_effect = _retrieve
+        executor._artifact_vault.list_artifacts.return_value = []
+
+        await executor.execute_cycle("cyc_001", "run_001")
+
+        mock_registry.record_gate_decision.assert_not_awaited()
+        assert EventType.WORKLOAD_GATE_AWAITING in _emit_types(mock_event_bus)
+
+    async def test_bind_mode_with_seeded_manifest_gates_normally(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        """#496 through the real path: bind mode, framing emits NO manifest (the
+        production shape once #496 gates the emission instruction off), but the
+        canonical manifest is operator-seeded in plan_artifact_refs. The #494
+        rejection must NOT fire — the seeded manifest is hash-checked against the
+        contract and the bound plan reaches the gate."""
+        import dataclasses
+        from pathlib import Path
+
+        from squadops.capabilities.scaffold import InterfaceManifest
+        from squadops.capabilities.scaffold_contract import emit_contract_yaml
+
+        manifest_text = (
+            Path(__file__).resolve().parents[3]
+            / "examples"
+            / "03_group_run"
+            / "interface_manifest.yaml"
+        ).read_text(encoding="utf-8")
+        contract_text = emit_contract_yaml(InterfaceManifest.from_yaml(manifest_text))
+        bound_refs = "[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles]"
+        plan_text = self._PLAN_YAML_BOUND.replace(
+            "criteria_refs: [vc-routes-apierror]", f"criteria_refs: {bound_refs}"
+        )
+
+        approved = _gate_decision("progress_plan_review", GateDecisionValue.APPROVED.value)
+        cycle = dataclasses.replace(
+            self._cycle_with_gate(),
+            execution_overrides={
+                "contract_ref": "art_c",
+                "plan_artifact_refs": ["art_manifest"],
+            },
+        )
+        mock_registry.get_cycle.return_value = cycle
+
+        run1 = dataclasses.replace(
+            _make_run("run_001", 1, "completed", "framing", gate_decisions=(approved,)),
+            artifact_refs=("art_plan",),  # NO framing-emitted manifest
         )
         run2 = _make_run("run_002", 2, "completed", "implementation")
 

--- a/tests/unit/cycles/test_executor_contract_binding.py
+++ b/tests/unit/cycles/test_executor_contract_binding.py
@@ -281,3 +281,71 @@ async def test_net_b_author_mode_ignores_contract_binding():
 
     # only the interface-manifest net runs (manifest is valid) -> no bind errors
     assert not any("verification_contract" in e for e in errors)
+
+
+# --------------------------------------------------------------------------- #
+# #496: bind mode falls back to the operator-seeded manifest
+# --------------------------------------------------------------------------- #
+
+# Parses and lints clean but hashes differently — the re-derivation-drift shape
+# shakedown cyc_59bfbd3f4a2a produced live (plausible rename, broken hash).
+_DRIFTED_MANIFEST_YAML = _MANIFEST_YAML.replace("name: Participant", "name: Attendee", 1)
+
+
+async def test_net_b_seeded_manifest_satisfies_when_framing_emits_none():
+    # bug caught: fallback not wired — bind mode without a framing-emitted manifest
+    # would reject (#494) even though the canonical manifest is seeded on the very
+    # rail (plan_artifact_refs) the implementation run scaffolds from.
+    executor = _make_executor(_bind_store())
+    cycle = _make_cycle(
+        execution_overrides={"contract_ref": "art_c", "plan_artifact_refs": ["art_iface"]}
+    )
+    run = _make_run(["art_plan"])  # framing emitted the plan only, no manifest
+
+    errors = await executor._reject_invalid_plan_before_workload_gate(run, cycle, "plan-review")
+
+    assert errors == []
+
+
+async def test_net_b_seeded_manifest_is_hash_checked():
+    # bug caught: fallback skipping validation — a seeded manifest the contract was
+    # NOT authored against must still trip the §10 stale-binding rejection.
+    import yaml
+
+    tampered = VerificationContract.from_dict(
+        {
+            **_CONTRACT.to_dict(),
+            "skeleton": {
+                "expander": "fullstack_fastapi_react",
+                "interface_manifest_hash": "f" * 64,
+            },
+        }
+    )
+    executor = _make_executor(_bind_store(contract_yaml=yaml.safe_dump(tampered.to_dict())))
+    cycle = _make_cycle(
+        execution_overrides={"contract_ref": "art_c", "plan_artifact_refs": ["art_iface"]}
+    )
+    run = _make_run(["art_plan"])
+
+    errors = await executor._reject_invalid_plan_before_workload_gate(run, cycle, "plan-review")
+
+    assert any("different skeleton" in e for e in errors)
+
+
+async def test_net_b_drifted_framing_manifest_rejects_despite_matching_seed():
+    # bug caught: precedence inversion — preferring the seed would silently mask a
+    # framing-emitted manifest that drifted from the contract (drift must still reject).
+    store = _bind_store()
+    store["art_iface_drift"] = (
+        _Ref("art_iface_drift", "interface_manifest.yaml", "interface_manifest"),
+        _DRIFTED_MANIFEST_YAML.encode(),
+    )
+    executor = _make_executor(store)
+    cycle = _make_cycle(
+        execution_overrides={"contract_ref": "art_c", "plan_artifact_refs": ["art_iface"]}
+    )
+    run = _make_run(["art_plan", "art_iface_drift"])  # framing emitted a drifted manifest
+
+    errors = await executor._reject_invalid_plan_before_workload_gate(run, cycle, "plan-review")
+
+    assert any("different skeleton" in e for e in errors)

--- a/tests/unit/cycles/test_executor_interface_manifest.py
+++ b/tests/unit/cycles/test_executor_interface_manifest.py
@@ -96,6 +96,23 @@ class TestLoadInterfaceManifestForRun:
         cycle = _make_cycle(execution_overrides={"plan_artifact_refs": ["art_iface"]})
         assert await executor._load_interface_manifest_for_run(cycle, _make_run()) is None
 
+    async def test_framing_run_never_loads_a_seeded_manifest(self):
+        # #496: an operator-seeded manifest is in plan_artifact_refs from cycle
+        # creation, visible to every workload — but the skeleton is the
+        # implementation substrate. Bug caught: a framing run expanding skeleton
+        # files into its own artifact list (pre-#496 unreachable, so untested).
+        executor = _make_executor()
+        executor._artifact_vault.retrieve.return_value = (
+            _FakeManifestRef(),
+            _GROUP_RUN_MANIFEST.encode(),
+        )
+        cycle = _make_cycle(execution_overrides={"plan_artifact_refs": ["art_iface"]})
+        run = _make_run()
+        run.workload_type = "framing"
+
+        assert await executor._load_interface_manifest_for_run(cycle, run) is None
+        executor._artifact_vault.retrieve.assert_not_awaited()
+
 
 class TestSeedSkeletonArtifacts:
     async def test_seeds_full_skeleton_set_as_source_artifacts(self):


### PR DESCRIPTION
## Problem

Shakedown attempt 2 (`cyc_59bfbd3f4a2a`) surfaced a design contradiction: bind mode required the framing run to **re-derive** the interface manifest and hash-match the frozen contract — from PRD v0.4, which deliberately no longer specifies interface details (the §6.7 product/interface split). The multi-role framing worked exactly as designed (manifest emitted, criteria bound, both nets fired) and still rejected on pure re-derivation naming drift (`729d2a…` ≠ `2eab74…`; `RunCreate` vs `RunEventCreate`, `base_path` variants). The task as posed is unwinnable — every bind-mode roll rejects the same way.

## Fix

In bind mode the manifest already exists — the contract was emitted *from* it. So bind mode **seeds** it, never re-authors it:

1. **`planning_tasks._scaffold_section`**: returns `""` when `contract_criteria_index` is present in inputs (bind mode). The emission instruction is author-mode only — where the manifest is being born.
2. **Executor pre-gate** (`_reject_invalid_plan_before_workload_gate`): when framing emits no manifest, falls back to an operator-seeded `interface_manifest.yaml` found in `execution_overrides.plan_artifact_refs` — the exact rail `_load_interface_manifest_for_run` already reads at the implementation run, so the manifest the gate hash-checks is the one the skeleton expands from. The #494 rejection now fires only when **neither** source exists.

Precedence and rigor preserved: a framing-emitted manifest (if one appears anyway) still takes precedence and drift still rejects (§10 stale binding). The seeded manifest is hash-checked too — a stale seed rejects identically. Author mode is byte-identical to today.

## Tests

- Seam (`test_executor_contract_binding.py`): seeded-manifest-satisfies, seeded-manifest-is-hash-checked (stale seed rejects), drifted-framing-manifest-rejects-despite-matching-seed (precedence).
- Real `execute_cycle` (`test_execute_cycle.py`): seeded manifest + bound plan gates normally with no framing-emitted manifest; the #494 neither-source rejection updated to the new message.
- Appendix gating (`test_interface_manifest_framing.py`): dev proposer + scaffoldable stack + criteria index → `""`, renderer never invoked.

Pre-existing, unrelated: 2 failures in `test_verification_contract_runner.py` on this box (`missing_tooling` — host lacks Node; fails identically on clean main; will raise separately).

Fixes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm