### PR TITLE
docs: fix stale CLI syntax in CLAUDE.md cheatsheet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,11 +82,11 @@ squadops doctor dev-mac --json                     # Machine-readable output
 ```bash
 squadops login                             # Authenticate via Keycloak
 squadops cycles create <project> --squad-profile full --request-profile selftest
-squadops cycles show <cycle-id>            # Show cycle status + runs
-squadops cycles list <project-id>          # List cycles for project
-squadops runs list <cycle-id>              # List runs for cycle
-squadops gate decide <run-id> <gate-name> --approve  # Approve a gate
-squadops artifacts list <run-id>           # List artifacts for run
+squadops cycles show <project> <cycle-id>  # Show cycle status + runs
+squadops cycles list <project>             # List cycles for project
+squadops runs list <project> <cycle-id>    # List runs for cycle
+squadops runs gate <project> <cycle-id> <run-id> <gate-name> --approve  # Approve a gate
+squadops artifacts list --project <project> --cycle <cycle-id> --run <run-id>  # List artifacts for run
 ```
 
 ## Architecture


### PR DESCRIPTION
4 of the 7 lines in CLAUDE.md's cycle-execution CLI block didn't match the real CLI (each verified against `--help` output):

| Cheatsheet said | Real syntax |
|---|---|
| `squadops cycles show <cycle-id>` | `squadops cycles show <project> <cycle-id>` |
| `squadops runs list <cycle-id>` | `squadops runs list <project> <cycle-id>` |
| `squadops gate decide <run-id> <gate-name> --approve` | `squadops runs gate <project> <cycle-id> <run-id> <gate-name> --approve` |
| `squadops artifacts list <run-id>` | `squadops artifacts list --project <project> --cycle <cycle-id> --run <run-id>` |

There is no `gate` top-level command at all — hit live while approving the shakedown-3 gate (the wrong form costs a failed invocation + a `--help` round-trip every time a fresh session trusts the cheatsheet).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm