### PR TITLE
Shakedown-3 findings: four fixes that raise genuine roll-success odds

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -33,6 +33,7 @@ from adapters.cycles.pulse_boundary_runner import PulseBoundaryRunner
 from adapters.cycles.run_completion import RunCompletion, resolve_terminal_outcome
 from adapters.cycles.task_dispatcher import TaskDispatcher
 from adapters.cycles.task_naming import build_task_name
+from squadops.cycles.acceptance_evaluation import resolve_check_stack
 from squadops.cycles.agent_config import build_agent_resolver
 from squadops.cycles.build_completeness import compute_missing_required_files
 from squadops.cycles.checkpoint import RunCheckpoint
@@ -1827,7 +1828,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         verification = await verify_patched_artifacts(
             criteria,
             patched_artifacts,
-            stack=resolved_config.get("stack"),
+            stack=resolve_check_stack(resolved_config),
             typed_acceptance_enabled=resolved_config.get("typed_acceptance", True),
             command_acceptance_enabled=resolved_config.get("command_acceptance_checks", True),
         )

--- a/adapters/cycles/postgres_cycle_registry.py
+++ b/adapters/cycles/postgres_cycle_registry.py
@@ -37,6 +37,7 @@ from squadops.cycles.models import (
 )
 from squadops.cycles.pulse_models import PulseVerificationRecord
 from squadops.cycles.verification_integrity import (
+    FailedCheck,
     RunVerdict,
     RunVerificationSummary,
     UnverifiedCheck,
@@ -593,6 +594,11 @@ def _verification_summary_to_dict(summary: RunVerificationSummary) -> dict:
         "verdict": summary.verdict.value,
         "verified": list(summary.verified),
         "failed": list(summary.failed),
+        # #500: failed entries disclose their reasons, same as unverified always has.
+        "failed_detail": [
+            {"check_id": f.check_id, "reason": f.reason, "required": f.required}
+            for f in summary.failed_detail
+        ],
         "unverified": [
             {"check_id": u.check_id, "reason": u.reason, "required": u.required}
             for u in summary.unverified
@@ -600,6 +606,11 @@ def _verification_summary_to_dict(summary: RunVerificationSummary) -> dict:
         "required_unmet": list(summary.required_unmet),
         "executed_count": summary.executed_count,
         "passed_count": summary.passed_count,
+        # SIP-0098 98.4 criterion coverage — was omitted here, so stored summaries
+        # reconstructed to 0/0 coverage and any roll-up counting yield from
+        # Postgres (rather than the in-memory summary) undercounted (#500).
+        "criteria_verified": list(summary.criteria_verified),
+        "criteria_total": list(summary.criteria_total),
     }
 
 
@@ -612,6 +623,10 @@ def _verification_summary_from_dict(d: dict) -> RunVerificationSummary:
         verdict=RunVerdict(d["verdict"]),
         verified=tuple(d.get("verified", [])),
         failed=tuple(d.get("failed", [])),
+        failed_detail=tuple(
+            FailedCheck(check_id=f["check_id"], reason=f["reason"], required=bool(f["required"]))
+            for f in d.get("failed_detail", [])
+        ),
         unverified=tuple(
             UnverifiedCheck(
                 check_id=u["check_id"], reason=u["reason"], required=bool(u["required"])
@@ -621,4 +636,6 @@ def _verification_summary_from_dict(d: dict) -> RunVerificationSummary:
         required_unmet=tuple(d.get("required_unmet", [])),
         executed_count=int(d.get("executed_count", 0)),
         passed_count=int(d.get("passed_count", 0)),
+        criteria_verified=tuple(d.get("criteria_verified", [])),
+        criteria_total=tuple(d.get("criteria_total", [])),
     )

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -18,6 +18,7 @@ from squadops.capabilities.handlers.base import (
 from squadops.cycles.acceptance_checks import CheckOutcome
 from squadops.cycles.acceptance_evaluation import (
     evaluate_criterion,
+    resolve_check_stack,
     split_acceptance_criteria,
 )
 from squadops.cycles.implementation_plan import TypedCheck
@@ -321,7 +322,7 @@ class _CycleTaskHandler(CapabilityHandler):
         resolved_config = inputs.get("resolved_config", {})
         typed_acceptance_enabled = resolved_config.get("typed_acceptance", True)
         command_acceptance_enabled = resolved_config.get("command_acceptance_checks", True)
-        stack = resolved_config.get("stack")
+        stack = resolve_check_stack(resolved_config)
 
         with tempfile.TemporaryDirectory(prefix="squadops-typed-acc-") as tmpdir_str:
             workspace_root = Path(tmpdir_str)

--- a/src/squadops/capabilities/handlers/fenced_parser.py
+++ b/src/squadops/capabilities/handlers/fenced_parser.py
@@ -22,6 +22,11 @@ Recognized formats, in priority order (most explicit first):
    this variant carries no comment/heading marker, the path is accepted only when
    it contains ``/`` or ends in a known source extension — a guard prose like
    ``note:todo`` can't trip.
+6. Bare filename alone on the first body line (#502) — the whole first line is
+   the path, nothing else: ``` ```jsx``` ``` then ``frontend/src/api.js`` on its
+   own line, then code. Same acceptance guard as #470 (contains ``/``, known
+   source extension, or special name). A lone path line is not valid code in any
+   emitted language, so stripping it never eats real content.
 
 Models naturally drift between these formats; the parser tolerates all of
 them so a one-character format slip doesn't drop the whole task on the floor.
@@ -239,6 +244,31 @@ def _resolve_filename_from_first_line_prefix(body: str) -> tuple[str | None, str
     return path, new_body
 
 
+def _resolve_filename_from_first_line_bare(body: str) -> tuple[str | None, str]:
+    """#502: if the first line of ``body`` is *exactly* a path-shaped token —
+    the bare filename on its own line, no comment marker, no colon — return
+    ``(filename, body_with_the_line_stripped)``. Otherwise ``(None, body)``.
+
+    Same guard as #470: accepted only when the token contains ``/``, has a known
+    source extension, or is a special name. A lone path line is not valid code in
+    any language the build handlers emit, so this never eats real content.
+    """
+    nl = body.find("\n")
+    first_line = (body if nl == -1 else body[:nl]).strip()
+    if not first_line or " " in first_line or ":" in first_line:
+        return None, body
+    if not re.fullmatch(rf"[\w./-]+\.[a-zA-Z0-9]+|{_SPECIAL_NAMES_RE}", first_line):
+        return None, body
+    if not (
+        "/" in first_line
+        or _has_source_extension(first_line)
+        or first_line in _SPECIAL_FILENAMES_AS_LANG
+    ):
+        return None, body
+    remainder = "" if nl == -1 else body[nl + 1 :]
+    return first_line, remainder
+
+
 def extract_fenced_files(response: str) -> list[dict]:
     """Parse fenced code blocks into structured file records.
 
@@ -311,6 +341,12 @@ def extract_fenced_files(response: str) -> list[dict]:
                     if prefix_filename is not None:
                         filename = prefix_filename
                         body = prefixed_body
+                    else:
+                        # Strategy 6 (#502): bare filename alone on the first line
+                        bare_filename, bare_body = _resolve_filename_from_first_line_bare(body)
+                        if bare_filename is not None:
+                            filename = bare_filename
+                            body = bare_body
 
         if filename is None or not _path_is_safe(filename):
             pos = close_match.end()

--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -643,6 +643,22 @@ async def run_backend_import_check(
         shutil.rmtree(workspace, ignore_errors=True)
 
 
+def _merged_exit_code(backend: RunTestsResult, frontend: RunTestsResult) -> int:
+    """D13 merge: backend controls the combined outcome — *when it executed*.
+
+    #501: the old fallback hardcoded exit 0 whenever the backend suite didn't
+    execute, discarding the only evidence there was (a failing vitest run
+    reported "all tests passed" while zero tests executed anywhere). When the
+    frontend is the sole executed suite it controls; when nothing executed the
+    result is not a pass — "0 tests ran" must never verify ``tests_pass``.
+    """
+    if backend.executed:
+        return backend.exit_code
+    if frontend.executed:
+        return frontend.exit_code
+    return -1
+
+
 async def run_fullstack_tests(
     source_files: list[dict[str, str]],
     test_files: list[dict[str, str]],
@@ -699,9 +715,8 @@ async def run_fullstack_tests(
     if frontend_result.stderr:
         combined_stderr_parts.append(f"=== Frontend (vitest) ===\n{frontend_result.stderr}")
 
-    # D13: backend exit code controls combined outcome
     combined_executed = backend_result.executed or frontend_result.executed
-    combined_exit_code = backend_result.exit_code if backend_result.executed else 0
+    combined_exit_code = _merged_exit_code(backend_result, frontend_result)
 
     # Build combined error
     error_parts = []

--- a/src/squadops/cycles/acceptance_evaluation.py
+++ b/src/squadops/cycles/acceptance_evaluation.py
@@ -47,6 +47,33 @@ class SplitCriteria:
 
 _SERIALIZED_ROW_KEYS = frozenset({"check", "params", "severity", "description", "id"})
 
+# #503: check-stack derivation from the build profile. Live configs carry
+# ``build_profile``/``dev_capability`` but never a ``stack`` key, so every
+# consumer that read ``resolved_config.get("stack")`` fed ``None`` into the
+# evaluators and the AST checks (endpoint_defined, field_present, ...) silently
+# skipped in every live cycle — while CI passed them via an explicit stack.
+# Conservative mapping: only profiles deliberately verified against the check
+# implementations; unmapped profiles keep today's skip behavior.
+_BUILD_PROFILE_CHECK_STACKS: dict[str, str] = {
+    "fullstack_fastapi_react": "fastapi",
+}
+
+
+def resolve_check_stack(resolved_config: Mapping[str, Any]) -> str | None:
+    """The stack passed to typed-check evaluators, derived in ONE place (#503).
+
+    An explicit ``stack`` key wins (operator override / future configs); else the
+    ``build_profile`` maps through ``_BUILD_PROFILE_CHECK_STACKS``; else ``None``
+    (checks skip with ``unsupported_stack_or_syntax``, today's behavior).
+    """
+    explicit = resolved_config.get("stack")
+    if explicit:
+        return str(explicit)
+    profile = resolved_config.get("build_profile")
+    if profile:
+        return _BUILD_PROFILE_CHECK_STACKS.get(str(profile))
+    return None
+
 
 def _flatten_serialized_row(item: Mapping[str, Any]) -> dict[str, Any]:
     """Normalize a ``dataclasses.asdict``-shaped row to the flat authored shape.

--- a/src/squadops/cycles/run_report_builder.py
+++ b/src/squadops/cycles/run_report_builder.py
@@ -138,7 +138,12 @@ def _build_verification_lines(summary: RunVerificationSummary) -> list[str]:
         n, m = summary.criteria_coverage
         lines.append(f"Contract criteria: {n}/{m} executed-and-passed")
     if summary.failed:
-        lines.append(f"Failed: {', '.join(summary.failed)}")
+        # #500: reasons inline when the aggregation carried them, so a failed
+        # probe is classifiable from the report alone (bare-name fallback kept
+        # for summaries reconstructed from pre-#500 storage).
+        reasons = {f.check_id: f.reason for f in summary.failed_detail if f.reason}
+        rendered = [f"{c} ({reasons[c]})" if c in reasons else c for c in summary.failed]
+        lines.append(f"Failed: {', '.join(rendered)}")
     if summary.unverified:
         lines.append("")
         lines.append("### Unverified (not executed)")

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -184,6 +184,21 @@ class UnverifiedCheck:
 
 
 @dataclass(frozen=True)
+class FailedCheck:
+    """An executed-and-failed result with its producer's reason (#500).
+
+    ``unverified`` entries always carried their reasons; ``failed`` entries were
+    bare names, so a failed contract probe left no classifiable detail in
+    evidence (the 422-vs-200 had to be manually reproduced). ``reason`` may be
+    empty — a producer that reports failure without one — but is never dropped
+    when supplied."""
+
+    check_id: str
+    reason: str
+    required: bool
+
+
+@dataclass(frozen=True)
 class RunVerificationSummary:
     """Per-run verification roll-up — the honest evidence contract (§6.2, §10).
 
@@ -206,6 +221,10 @@ class RunVerificationSummary:
     # green iff every covered criterion passed. Empty in author mode (no criterion ids).
     criteria_verified: tuple[str, ...] = ()
     criteria_total: tuple[str, ...] = ()
+    # #500: per-failure reasons for the ``failed`` list — same disclosure the
+    # ``unverified`` entries always had. Default-empty so pre-#500 stored
+    # summaries reconstruct unchanged.
+    failed_detail: tuple[FailedCheck, ...] = ()
 
     @property
     def pass_rate(self) -> float:
@@ -410,6 +429,7 @@ def aggregate_verification(
     required = frozenset(required_check_ids)
     verified: list[str] = []
     failed: list[str] = []
+    failed_detail: list[FailedCheck] = []
     unverified: list[UnverifiedCheck] = []
     seen_ids: set[str] = set()
     # SIP-0098 98.4: contract-criterion coverage, keyed on CheckResult.criterion_id.
@@ -426,6 +446,13 @@ def aggregate_verification(
             verified.append(r.check_id)
         elif family is EvidenceFamily.EXECUTED_FAILED:
             failed.append(r.check_id)
+            failed_detail.append(
+                FailedCheck(
+                    check_id=r.check_id,
+                    reason=r.reason or "",
+                    required=r.check_id in required,
+                )
+            )
         else:  # NOT_EXECUTED — non-creditable, always disclosed
             unverified.append(
                 UnverifiedCheck(
@@ -477,6 +504,7 @@ def aggregate_verification(
         passed_count=passed_count,
         criteria_verified=tuple(sorted(criteria_passed - criteria_adverse)),
         criteria_total=tuple(sorted(criteria_passed | criteria_adverse)),
+        failed_detail=tuple(failed_detail),
     )
 
 

--- a/tests/unit/capabilities/test_fenced_parser.py
+++ b/tests/unit/capabilities/test_fenced_parser.py
@@ -614,3 +614,56 @@ class TestFirstLinePathPrefix:
         # the shared safety check still applies to a strategy-5 path
         assert extract_fenced_files("```python\n/etc/evil.py:import os\n```") == []
         assert extract_fenced_files("```python\n../esc.py:bad\n```") == []
+
+
+class TestFirstLineBareFilename:
+    """Strategy 6 (#502): the whole first body line is the bare path — no
+    comment marker, no colon. The live shape that burned shakedown-3's
+    m009 qa.test attempt 1 (eve emitted ```jsx, then the path on its own
+    line, then code; zero blocks extracted)."""
+
+    def test_bare_path_first_line_resolves_filename(self):
+        # verbatim shape from the live failure
+        response = (
+            "```jsx\n"
+            "frontend/src/views/CreateRunView.jsx\n"
+            'import { useState } from "react";\n'
+            "\n"
+            "export default function CreateRunView() {}\n"
+            "```\n"
+        )
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "frontend/src/views/CreateRunView.jsx"
+        # the path line is stripped; content starts at the real code
+        assert result[0]["content"].startswith('import { useState } from "react";')
+
+    def test_slashless_bare_filename_accepted_via_extension_guard(self):
+        result = extract_fenced_files("```python\nmain.py\nimport sys\n```")
+        assert result == [{"filename": "main.py", "content": "import sys", "language": "python"}]
+
+    def test_multiple_bare_filename_fences(self):
+        response = "```python\na/one.py\nx = 1\n```\n```js\nb/two.js\ny = 2\n```"
+        assert [(r["filename"], r["content"]) for r in extract_fenced_files(response)] == [
+            ("a/one.py", "x = 1"),
+            ("b/two.js", "y = 2"),
+        ]
+
+    def test_code_first_line_is_never_stolen(self):
+        # a real first code line must not be mis-read as a filename and stripped
+        assert extract_fenced_files("```python\nimport os\n```") == []
+        assert extract_fenced_files("```text\nplain prose here\n```") == []
+
+    def test_prose_word_with_dot_is_not_a_filename(self):
+        # no slash + non-source extension -> guard rejects (same as #470)
+        assert extract_fenced_files("```text\nversion.1a\nbody\n```") == []
+
+    def test_traversal_and_absolute_bare_paths_rejected(self):
+        assert extract_fenced_files("```python\n/etc/evil.py\nimport os\n```") == []
+        assert extract_fenced_files("```python\n../esc.py\nbad\n```") == []
+
+    def test_comment_strategy_still_wins_over_bare(self):
+        # a first-line COMMENT filename resolves via strategy 4, not 6
+        result = extract_fenced_files("```python\n# real.py\nimport os\n```")
+        assert result[0]["filename"] == "real.py"
+        assert result[0]["content"] == "import os"

--- a/tests/unit/capabilities/test_node_test_runner.py
+++ b/tests/unit/capabilities/test_node_test_runner.py
@@ -276,6 +276,12 @@ _FRONTEND_NOT_RUN = RunTestsResult(
     test_file_count=1,
     source_file_count=2,
 )
+_BACKEND_NOT_RUN = RunTestsResult(
+    executed=False,
+    error="no test files provided",
+    test_file_count=0,
+    source_file_count=3,
+)
 
 
 class TestFullstackTestsBothPass:
@@ -331,6 +337,41 @@ class TestFullstackTestsD13MergePolicy:
         )
         assert result.exit_code == 0
         assert "non-blocking" in result.error
+
+    @patch(_RUN_NODE_PATH, return_value=_FRONTEND_FAIL)
+    @patch(_RUN_PYTEST_PATH, return_value=_BACKEND_NOT_RUN)
+    async def test_backend_not_run_frontend_fail_combined_fails(self, _mock_pytest, _mock_node):
+        """#501 — the shakedown-3 false green: backend never executed, frontend
+        vitest exited 1, yet the merge hardcoded exit 0 and reported 'all tests
+        passed'. The sole executed suite's failure must control."""
+        result = await run_fullstack_tests(
+            [{"path": "frontend/src/App.jsx", "content": "export default () => {}"}],
+            [{"path": "frontend/src/App.test.jsx", "content": "test('ok', () => {})"}],
+        )
+        assert result.exit_code == 1
+        assert result.tests_passed is False
+
+    @patch(_RUN_NODE_PATH, return_value=_FRONTEND_PASS)
+    @patch(_RUN_PYTEST_PATH, return_value=_BACKEND_NOT_RUN)
+    async def test_backend_not_run_frontend_pass_combined_passes(self, _mock_pytest, _mock_node):
+        """#501 inverse guard: when the frontend is the only executed suite and it
+        passed, the combined result is an honest pass (frontend controls)."""
+        result = await run_fullstack_tests(
+            [{"path": "frontend/src/App.jsx", "content": "export default () => {}"}],
+            [{"path": "frontend/src/App.test.jsx", "content": "test('ok', () => {})"}],
+        )
+        assert result.exit_code == 0
+        assert result.tests_passed is True
+
+    @patch(_RUN_NODE_PATH, return_value=_FRONTEND_NOT_RUN)
+    @patch(_RUN_PYTEST_PATH, return_value=_BACKEND_NOT_RUN)
+    async def test_neither_suite_executed_is_not_a_pass(self, _mock_pytest, _mock_node):
+        """#501: zero tests executed anywhere must never read 'all tests passed' —
+        tests_pass verifying on no evidence is the false-green class itself."""
+        result = await run_fullstack_tests([], [])
+        assert result.executed is False
+        assert result.exit_code != 0
+        assert result.tests_passed is False
 
 
 class TestFullstackTestsFileSplit:

--- a/tests/unit/cycles/test_acceptance_evaluation.py
+++ b/tests/unit/cycles/test_acceptance_evaluation.py
@@ -192,3 +192,34 @@ def test_split_keeps_non_safelisted_command_rows_typed():
     assert len(result.typed) == 1
     assert result.typed[0].params["argv"] == ["npm", "test"]
     assert not result.unparseable
+
+
+# --------------------------------------------------------------------------- #
+# resolve_check_stack (#503) — bug caught: live cycles fed stack=None into every
+# AST evaluator (resolved_config never carries a "stack" key), so endpoint/field
+# checks silently skipped in production while CI passed them with an explicit stack.
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_check_stack_maps_fullstack_profile_to_fastapi():
+    from squadops.cycles.acceptance_evaluation import resolve_check_stack
+
+    # the live shakedown-3 config shape: build_profile present, no stack key
+    assert resolve_check_stack({"build_profile": "fullstack_fastapi_react"}) == "fastapi"
+
+
+def test_resolve_check_stack_explicit_key_wins_over_profile():
+    from squadops.cycles.acceptance_evaluation import resolve_check_stack
+
+    assert (
+        resolve_check_stack({"stack": "django", "build_profile": "fullstack_fastapi_react"})
+        == "django"
+    )
+
+
+def test_resolve_check_stack_unmapped_profile_and_empty_config_stay_none():
+    from squadops.cycles.acceptance_evaluation import resolve_check_stack
+
+    # unmapped profiles keep today's skip behavior — never a guessed stack
+    assert resolve_check_stack({"build_profile": "python_cli_builder"}) is None
+    assert resolve_check_stack({}) is None

--- a/tests/unit/cycles/test_postgres_cycle_registry.py
+++ b/tests/unit/cycles/test_postgres_cycle_registry.py
@@ -783,3 +783,63 @@ class TestListRunVerificationSummaries:
         )
         restored = _verification_summary_from_dict(_verification_summary_to_dict(original))
         assert restored == original  # frozen dataclass equality — lossless
+
+
+class TestVerificationSummarySerializationFidelity:
+    """#500: failed_detail + 98.4 criteria coverage must survive the Postgres
+    round-trip. Bug caught: criteria_verified/criteria_total were never
+    serialized, so any roll-up counting yield from stored summaries read 0/0
+    coverage; failed entries were bare names, so a failed probe's reason was
+    unrecoverable from evidence."""
+
+    def test_round_trip_preserves_failed_detail_and_criteria_coverage(self):
+        from adapters.cycles.postgres_cycle_registry import (
+            _verification_summary_from_dict,
+            _verification_summary_to_dict,
+        )
+        from squadops.cycles.verification_integrity import CheckResult, aggregate_verification
+
+        summary = aggregate_verification(
+            [
+                CheckResult(
+                    check_id="vc-probe-runs",
+                    status="failed",
+                    reason="status 422 != expected 200",
+                    criterion_id="vc-probe-runs",
+                ),
+                CheckResult(
+                    check_id="acceptance:import_present",
+                    status="passed",
+                    criterion_id="vc-routes-apierror",
+                ),
+            ],
+            required_check_ids=["vc-probe-runs"],
+        )
+
+        rebuilt = _verification_summary_from_dict(
+            json.loads(json.dumps(_verification_summary_to_dict(summary)))
+        )
+
+        assert rebuilt.failed_detail == summary.failed_detail
+        assert rebuilt.failed_detail[0].reason == "status 422 != expected 200"
+        assert rebuilt.criteria_verified == ("vc-routes-apierror",)
+        assert rebuilt.criteria_total == ("vc-probe-runs", "vc-routes-apierror")
+        assert rebuilt.criteria_coverage == (1, 2)
+
+    def test_pre_500_stored_dict_reconstructs_with_empty_detail(self):
+        from adapters.cycles.postgres_cycle_registry import _verification_summary_from_dict
+
+        # a summary persisted before #500 has none of the new keys
+        old = {
+            "verdict": "rejected",
+            "verified": ["a"],
+            "failed": ["vc-probe-runs"],
+            "unverified": [],
+            "required_unmet": [],
+            "executed_count": 2,
+            "passed_count": 1,
+        }
+        rebuilt = _verification_summary_from_dict(old)
+        assert rebuilt.failed == ("vc-probe-runs",)
+        assert rebuilt.failed_detail == ()
+        assert rebuilt.criteria_coverage == (0, 0)

--- a/tests/unit/cycles/test_verification_integrity.py
+++ b/tests/unit/cycles/test_verification_integrity.py
@@ -615,3 +615,29 @@ class TestContractCriteriaCoverage:
         assert outcome.criteria_verified == ("vc-p",)
         assert outcome.criteria_total == ("vc-p",)
         assert outcome.criteria_coverage == (1, 1)
+
+
+# --------------------------------------------------------------------------- #
+# failed_detail (#500) — bug caught: a failed contract probe's reason died at
+# aggregation (failed = bare names), so evidence couldn't say WHY vc-probe-runs
+# failed and diagnosis required manually re-running the probe.
+# --------------------------------------------------------------------------- #
+
+
+def test_aggregate_carries_failed_reasons_in_failed_detail():
+    s = aggregate_verification(
+        [_passed("a"), _failed("vc-probe-runs", reason="status 422 != expected 200")],
+        required_check_ids=["vc-probe-runs"],
+    )
+    assert s.failed == ("vc-probe-runs",)
+    assert len(s.failed_detail) == 1
+    d = s.failed_detail[0]
+    assert d.check_id == "vc-probe-runs"
+    assert d.reason == "status 422 != expected 200"
+    assert d.required is True
+
+
+def test_aggregate_failed_without_reason_yields_empty_string_not_crash():
+    s = aggregate_verification([_failed("b")])
+    assert s.failed_detail[0].reason == ""
+    assert s.failed_detail[0].required is False


### PR DESCRIPTION
Four fixes from shakedown-3 (cyc_2f6adb235041) triage — each targets a defect that either burned budget, hid a failure, or blinded a net that would have repaired the roll in-run. One commit per issue.

## fix(#502) — fenced_parser strategy 6
A fence whose first body line is the **bare file path** (no comment marker, no colon) matched no strategy; the live m009 qa.test response was dropped whole and burned a full retry (~10 min of 27b inference + retry budget). New strategy accepts a lone path-shaped first line under the same guard as #470.

## fix(#501) — tests_pass false green
`run_fullstack_tests` hardcoded exit 0 whenever the backend suite didn't execute — a failing vitest run (exit 1, "No test files found") merged into "all tests passed / exit 0" and `tests_pass` verified on **zero executed tests**. Now: backend controls when executed (D13 unchanged), else the frontend controls, else nonzero. An honest failure here triggers the in-run correction loop instead of shipping unverified code.

## fix(#503) — AST typed checks dead in live cycles
Both evaluation call sites read `resolved_config["stack"]`, which no config path ever sets — so `endpoint_defined`/`field_present` silently skipped in every live cycle (CI passed them via an explicit stack). This is the net that would have caught shakedown-3's `date_time`-vs-`datetime` routes drift at develop time. One derivation seam: `resolve_check_stack` (explicit key wins → `build_profile` mapping → None). Conservative mapping: only `fullstack_fastapi_react → fastapi` for now.

## fix(#500) — evidence fidelity
`failed` entries were bare names; a failed contract probe left no reason in evidence (the 422-vs-200 required manual reproduction). `failed_detail` now carries producer reasons (additive; pre-#500 stored rows reconstruct unchanged), and run_report renders them inline. Also found en route: the 98.4 `criteria_verified`/`criteria_total` fields were **never serialized** to Postgres — stored summaries reconstructed to 0/0 coverage, which would have undercounted the N=5 baseline yield. Now round-trips.

## Not fixed here (by design)
- #504 fill discipline — design rung, needs an enforcement-location decision first.
- qa source-regex lottery — deliberately unfixed; the baseline measures it.

Tests: 18 new across the four suites; full capabilities+cycles sweep green (the 2 known #498 env-dependent failures excepted).

Closes #500
Closes #501
Closes #502
Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLizrDWsHR393EJyaCcuLm