### PR TITLE
fix(#508): coverage denominator comes from the bound contract, not dispatched checks

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -216,6 +216,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         ledger = RunLedger()
         cycle = None
         plan = None
+        verification_contract = None
         # SIP-0089 §3.5 (#233): agents this run transitioned ambient→cycle, to be
         # returned to ambient (releasing their cycle lease) in the finally. Stays
         # empty when recruitment defers (admission rolls its own recruits back) or
@@ -463,6 +464,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 cycle=cycle,
                 plan=plan,
                 ledger=ledger,
+                contract=verification_contract,
             )
 
     async def cancel_run(self, run_id: str) -> None:

--- a/adapters/cycles/run_completion.py
+++ b/adapters/cycles/run_completion.py
@@ -158,8 +158,14 @@ class RunCompletion:
         cycle: Cycle | None = None,
         plan: list[TaskEnvelope] | None = None,
         ledger: RunLedger | None = None,
+        contract: Any | None = None,
     ) -> None:
-        """Close observability traces and generate run report."""
+        """Close observability traces and generate run report.
+
+        ``contract`` is the bind-mode verification contract the executor loaded for
+        this run (None in author mode); its criterion ids become the coverage
+        denominator in the verification summary (#508).
+        """
         # LangFuse: close cycle trace
         if self._llm_observability and obs_ctx:
             from squadops.telemetry.models import StructuredEvent
@@ -190,7 +196,7 @@ class RunCompletion:
         # and no shipped profile declares required_checks — so this computes
         # `accepted` with zero recorded evidence and discloses it in the report.
         # Phase 2 wires the producers and per-profile required lists (the throttle).
-        summary = self._aggregate_verification(cycle, ledger, terminal_status)
+        summary = self._aggregate_verification(cycle, ledger, terminal_status, contract)
 
         # SIP-0096 Phase 3 (§10): persist the run's verdict as durable structured
         # evidence so the CycleOutcome roll-up can read it back — until now the
@@ -220,7 +226,10 @@ class RunCompletion:
 
     @staticmethod
     def _aggregate_verification(
-        cycle: Cycle | None, ledger: RunLedger | None, terminal_status: str
+        cycle: Cycle | None,
+        ledger: RunLedger | None,
+        terminal_status: str,
+        contract: Any | None = None,
     ) -> RunVerificationSummary:
         """Run the SIP-0096 aggregation over the ledger against the cycle's required set.
 
@@ -244,7 +253,17 @@ class RunCompletion:
                 required_check_ids = tuple(declared)
         results = ledger.check_results if ledger else ()
         run_succeeded = (terminal_status or "").upper() == RunStatus.COMPLETED.value.upper()
-        summary = aggregate_verification(results, required_check_ids, run_succeeded=run_succeeded)
+        # SIP-0098 #508: a bound contract supplies the coverage denominator — every
+        # criterion it declares, not just the ones whose checks got dispatched.
+        contract_criteria: tuple[str, ...] = ()
+        if contract is not None:
+            contract_criteria = tuple(contract.criterion_ids())
+        summary = aggregate_verification(
+            results,
+            required_check_ids,
+            run_succeeded=run_succeeded,
+            contract_criteria=contract_criteria,
+        )
         logger.info(
             "Verification integrity: verdict=%s executed=%d passed=%d unverified=%d required_unmet=%d",
             summary.verdict.value,

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -238,8 +238,10 @@ class RunVerificationSummary:
 
     @property
     def criteria_coverage(self) -> tuple[int, int]:
-        """``(n, m)`` — contract criteria executed-and-passed of criteria with evidence
-        (SIP-0098 §6.3). ``(0, 0)`` in author mode / when no criterion ids were carried."""
+        """``(n, m)`` — contract criteria executed-and-passed of the bound contract's
+        full criterion set (SIP-0098 §6.3; #508). In author mode / when no contract
+        was bound, ``m`` falls back to the criteria that carried evidence, and
+        ``(0, 0)`` when no criterion ids were carried at all."""
         return len(self.criteria_verified), len(self.criteria_total)
 
 
@@ -387,6 +389,7 @@ def aggregate_verification(
     required_check_ids: Collection[str] = (),
     *,
     run_succeeded: bool = True,
+    contract_criteria: Collection[str] = (),
 ) -> RunVerificationSummary:
     """Pure aggregation choke point (SIP-0096 §6.2, §6.4).
 
@@ -425,6 +428,14 @@ def aggregate_verification(
     A check that was repaired and re-verified is first resolved to its final state
     per ``(check_id, subject)`` (§6.5, #379) — the verdict reflects the outcome
     after correction, not the union of every attempt. See ``_resolve_final_state``.
+
+    ``contract_criteria`` is the bound verification contract's full criterion-id
+    set (SIP-0098; #508). When supplied, it is the coverage *denominator*:
+    ``criteria_total`` lists every contract criterion, whether or not any check
+    row produced evidence for it — a run that dies early must report 2/6, not
+    2-of-the-2-it-happened-to-reach. Criterion ids observed on check rows are
+    unioned in so unexpected evidence is never dropped. Empty (author mode /
+    unbound cycles) preserves the evidence-derived denominator.
     """
     required = frozenset(required_check_ids)
     verified: list[str] = []
@@ -503,7 +514,7 @@ def aggregate_verification(
         executed_count=executed_count,
         passed_count=passed_count,
         criteria_verified=tuple(sorted(criteria_passed - criteria_adverse)),
-        criteria_total=tuple(sorted(criteria_passed | criteria_adverse)),
+        criteria_total=tuple(sorted(set(contract_criteria) | criteria_passed | criteria_adverse)),
         failed_detail=tuple(failed_detail),
     )
 

--- a/tests/unit/cycles/test_run_completion.py
+++ b/tests/unit/cycles/test_run_completion.py
@@ -596,3 +596,55 @@ class TestVerificationIntegrityWiring:
         )
         # report still generated despite the persistence failure
         assert vault.store.call_args is not None
+
+
+# --------------------------------------------------------------------------- #
+# _aggregate_verification contract threading (#508) — bug caught: the executor
+# loaded the bind-mode contract but finalize never received it, so criteria_total
+# collapsed to whichever criteria happened to carry evidence (2/3 reported where
+# the truth was 2/6 against the contract).
+# --------------------------------------------------------------------------- #
+
+from pathlib import Path  # noqa: E402
+
+from adapters.cycles.run_completion import RunCompletion  # noqa: E402
+from squadops.capabilities.scaffold import InterfaceManifest  # noqa: E402
+from squadops.capabilities.scaffold_contract import emit_contract_yaml  # noqa: E402
+from squadops.cycles.run_ledger import RunLedger  # noqa: E402
+from squadops.cycles.verification_contract import VerificationContract  # noqa: E402
+from squadops.cycles.verification_integrity import CheckResult, ResultStatus  # noqa: E402
+
+_MANIFEST_YAML = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+).read_text(encoding="utf-8")
+_REAL_CONTRACT = VerificationContract.from_yaml(
+    emit_contract_yaml(InterfaceManifest.from_yaml(_MANIFEST_YAML))
+)
+
+
+class TestAggregateVerificationContractDenominator:
+    def _ledger_with_partial_evidence(self) -> RunLedger:
+        ledger = RunLedger()
+        some_id = _REAL_CONTRACT.criterion_ids()[0]
+        ledger.record_check_result(
+            CheckResult(
+                check_id="acceptance:import_present",
+                status=ResultStatus.PASSED,
+                criterion_id=some_id,
+            )
+        )
+        return ledger
+
+    def test_bound_contract_denominator_is_full_contract(self):
+        ledger = self._ledger_with_partial_evidence()
+        summary = RunCompletion._aggregate_verification(None, ledger, "COMPLETED", _REAL_CONTRACT)
+        assert summary.criteria_total == tuple(sorted(_REAL_CONTRACT.criterion_ids()))
+        n, m = summary.criteria_coverage
+        assert n == 1
+        assert m == len(_REAL_CONTRACT.criterion_ids())
+        assert m > 1  # the fixture contract declares more than the evidenced one
+
+    def test_author_mode_denominator_unchanged(self):
+        ledger = self._ledger_with_partial_evidence()
+        summary = RunCompletion._aggregate_verification(None, ledger, "COMPLETED", None)
+        assert summary.criteria_total == (_REAL_CONTRACT.criterion_ids()[0],)

--- a/tests/unit/cycles/test_verification_integrity.py
+++ b/tests/unit/cycles/test_verification_integrity.py
@@ -641,3 +641,57 @@ def test_aggregate_failed_without_reason_yields_empty_string_not_crash():
     s = aggregate_verification([_failed("b")])
     assert s.failed_detail[0].reason == ""
     assert s.failed_detail[0].required is False
+
+
+# --------------------------------------------------------------------------- #
+# contract_criteria denominator (#508) — bug caught: a bound contract with 6
+# criteria whose run died after dispatching checks for only 3 reported coverage
+# 2/3 instead of 2/6 (criteria_total derived from evidence, not the contract),
+# overstating coverage exactly when the run failed early.
+# --------------------------------------------------------------------------- #
+
+
+def test_bound_contract_supplies_full_denominator():
+    contract_ids = ["vc-a", "vc-b", "vc-frontend", "vc-suite", "vc-probes", "vc-c"]
+    s = aggregate_verification(
+        [
+            _passed("acceptance:import_present", criterion_id="vc-a"),
+            _passed("acceptance:command_exit_zero", criterion_id="vc-b"),
+            _failed("acceptance:endpoint_defined", criterion_id="vc-c"),
+        ],
+        contract_criteria=contract_ids,
+    )
+    assert s.criteria_verified == ("vc-a", "vc-b")
+    assert s.criteria_total == tuple(sorted(contract_ids))
+    assert s.criteria_coverage == (2, 6)
+
+
+def test_no_contract_keeps_evidence_derived_denominator():
+    s = aggregate_verification(
+        [
+            _passed("x", criterion_id="vc-a"),
+            _failed("y", criterion_id="vc-b"),
+        ]
+    )
+    assert s.criteria_total == ("vc-a", "vc-b")
+    assert s.criteria_coverage == (1, 2)
+
+
+def test_evidence_outside_contract_still_counted_in_denominator():
+    # A criterion id on a check row that the contract does not declare must not
+    # vanish from the totals — unexpected evidence is disclosed, never dropped.
+    s = aggregate_verification(
+        [_passed("x", criterion_id="vc-rogue")],
+        contract_criteria=["vc-a", "vc-b"],
+    )
+    assert s.criteria_total == ("vc-a", "vc-b", "vc-rogue")
+    assert s.criteria_verified == ("vc-rogue",)
+
+
+def test_bound_contract_with_zero_evidence_reports_zero_of_m():
+    # Run died before any criterion-bound check dispatched: coverage must read
+    # 0/m against the contract, not 0/0.
+    s = aggregate_verification([_passed("framework_check")], contract_criteria=["vc-a", "vc-b"])
+    assert s.criteria_verified == ()
+    assert s.criteria_total == ("vc-a", "vc-b")
+    assert s.criteria_coverage == (0, 2)


### PR DESCRIPTION
## Problem

Both night measurement rolls (run_689c2bb32a14, run_57807c247bb4) reported overstated criteria coverage: `criteria_total` was derived from whichever check rows happened to carry criterion ids, so a run that died early reported 2/3 where the truth against the seeded contract (art_97864f4daa5f, 6 criteria) was 2/6. Coverage inflated exactly when the run failed early — the case where the honest number matters most.

## Fix

- `aggregate_verification()` gains `contract_criteria` (keyword, default empty): when supplied, `criteria_total = contract ∪ observed` — every declared criterion counts in the denominator whether or not its checks dispatched; rogue evidence ids are never dropped.
- `RunCompletion.finalize()` accepts the bind-mode contract; `_aggregate_verification` extracts `criterion_ids()`.
- The executor threads the contract it already loads for bind mode into the finalize call (pre-initialized so an early-failing run stays safe).
- Author mode (no contract) is byte-identical to before.

## Tests

- Pure layer: full-denominator with partial evidence (2/6 not 2/3), author-mode unchanged, rogue-id union, zero-evidence 0/m (would each have caught the shipped bug).
- Adapter seam: real `VerificationContract` from the group_run example manifest through `RunCompletion._aggregate_verification` — catches the loaded-but-never-threaded gap specifically.
- `tests/unit/cycles/` + `tests/unit/capabilities/`: 3029 passed; the 2 failures in `test_verification_contract_runner.py` are pre-existing #498 (host-PATH), reproduced on clean main.

Part of the metric-integrity batch (#508/#509/#510/#512) preceding the canonical N=5 baseline. Runs on Spark per lane discussion — patches are lane-shared.

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG