### PR TITLE
fix(#510): failed test suites disclose exit-code meaning in the check reason

### DIFF
--- a/src/squadops/cycles/verification_normalize.py
+++ b/src/squadops/cycles/verification_normalize.py
@@ -143,9 +143,39 @@ def _tests_pass_from_result(tr: Mapping[str, Any], *, is_stub: bool) -> CheckRes
     return CheckResult(
         check_id=CHECK_TESTS_PASS,
         status=ResultStatus.PASSED if tests_passed else ResultStatus.FAILED,
+        # #510: a failed suite must disclose WHY in the row itself — failed_detail
+        # reads CheckResult.reason, and an empty reason made the run's only
+        # required failure undiagnosable from evidence.
+        reason=None if tests_passed else _failed_tests_reason(tr),
         is_stub=is_stub,
         provenance=CheckProvenance(exit_code=_int_or_none(tr.get("exit_code"))),
     )
+
+
+# pytest's documented exit-code semantics. Best-effort annotation only — the
+# suite runner is usually pytest, and code 5 ("no tests collected") is the one
+# that repeatedly cost live diagnosis time; a non-pytest runner still gets the
+# bare exit code plus its own summary.
+_PYTEST_EXIT_MEANINGS = {
+    1: "test failures",
+    2: "execution interrupted",
+    3: "internal error",
+    4: "usage error",
+    5: "no tests collected",
+}
+
+
+def _failed_tests_reason(tr: Mapping[str, Any]) -> str:
+    """Compose the disclosed reason for an executed-and-failed suite (#510)."""
+    exit_code = _int_or_none(tr.get("exit_code"))
+    reason = f"exit_code {exit_code}" if exit_code is not None else "test suite failed"
+    meaning = _PYTEST_EXIT_MEANINGS.get(exit_code)
+    if meaning:
+        reason += f": {meaning}"
+    summary = _str_or_none(tr.get("summary"))
+    if summary:
+        reason += f" — {summary}"
+    return reason
 
 
 def _not_executed_reason(tr: Mapping[str, Any]) -> str:

--- a/tests/unit/cycles/test_verification_normalize.py
+++ b/tests/unit/cycles/test_verification_normalize.py
@@ -316,3 +316,52 @@ def test_generic_skip_row_without_reason_defaults_to_subject_missing():
     out = {"validation_result": {"checks": [{"check": "frontend_build", "executed": False}]}}
     r = _by_id(normalize_task_checks(out))["frontend_build"]
     assert r.reason == NotExecutedReason.SUBJECT_MISSING
+
+
+# --------------------------------------------------------------------------- #
+# failed tests_pass reason disclosure (#510) — bug caught: both night
+# measurement rolls' only required failure read `reason: ""`; diagnosing pytest
+# exit 5 (zero tests collected) required manually reproducing the workspace.
+# --------------------------------------------------------------------------- #
+
+
+def test_failed_suite_reason_discloses_exit_meaning_and_summary():
+    out = {
+        "test_result": {
+            "executed": True,
+            "exit_code": 5,
+            "tests_passed": False,
+            "summary": "tests failed (exit code 5, 1 test file(s), 8 source file(s))",
+        }
+    }
+    r = _by_id(normalize_task_checks(out))[CHECK_TESTS_PASS]
+    assert r.status == ResultStatus.FAILED
+    assert r.reason == (
+        "exit_code 5: no tests collected — "
+        "tests failed (exit code 5, 1 test file(s), 8 source file(s))"
+    )
+
+
+def test_failed_suite_unknown_exit_code_still_discloses_code():
+    out = {"test_result": {"executed": True, "exit_code": 137, "tests_passed": False}}
+    r = _by_id(normalize_task_checks(out))[CHECK_TESTS_PASS]
+    assert r.reason == "exit_code 137"
+
+
+def test_passing_suite_carries_no_reason():
+    out = {"test_result": {"executed": True, "exit_code": 0, "tests_passed": True}}
+    r = _by_id(normalize_task_checks(out))[CHECK_TESTS_PASS]
+    assert r.reason is None
+
+
+def test_failed_reason_flows_through_aggregation_to_failed_detail():
+    # End-to-end through the choke point: the reason must land in failed_detail,
+    # not just on the raw row.
+    from squadops.cycles.verification_integrity import aggregate_verification
+
+    out = {"test_result": {"executed": True, "exit_code": 5, "tests_passed": False}}
+    rows = normalize_task_checks(out)
+    summary = aggregate_verification(rows, required_check_ids=[CHECK_TESTS_PASS])
+    detail = summary.failed_detail[0]
+    assert detail.check_id == CHECK_TESTS_PASS
+    assert detail.reason == "exit_code 5: no tests collected"


### PR DESCRIPTION
## Problem

Both night measurement rolls' only required failure read `failed_detail: [{"reason": "", "check_id": "tests_pass", ...}]`. Diagnosing that the real cause was pytest exit 5 — zero tests collected — required manually excavating artifacts (the run's own failure_analysis eventually said it, but the evidence row an operator reads first said nothing).

## Fix

`_tests_pass_from_result` (the single synthesizer both qa paths funnel through — failure-only dict rows are deliberately skipped in its favor) now composes a reason on the FAILED path: `exit_code N`, the documented pytest meaning when known (`5: no tests collected` being the load-bearing one), and the runner's own summary. Passing rows remain reason-less. Not-executed rows already disclosed via #500.

## Tests

Exact-value reason assertions for exit 5 with summary, unknown exit codes, reason-less pass, and an end-to-end flow through `aggregate_verification` into `failed_detail` (the exact row that read empty in run_57807c247bb4). Full `tests/unit/cycles/` + `tests/unit/capabilities/`: 3027 passed (2 pre-existing #498 failures, reproduced on clean main).

Part of the metric-integrity/disclosure batch (#508 = PR #513, #509, #512) preceding the canonical N=5.

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG