### PR TITLE
fix(#512): probe boot failures disclose exit state and stderr tail

### DIFF
--- a/src/squadops/capabilities/handlers/probe_runner.py
+++ b/src/squadops/capabilities/handlers/probe_runner.py
@@ -25,9 +25,11 @@ qa.test handler wraps it in a thread.
 from __future__ import annotations
 
 import contextlib
+import os
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -139,18 +141,24 @@ def _run_backend_probes(
 ) -> list[ProbeOutcome]:
     port = _free_port(profile.host)
     try:
-        proc = _boot(workspace, profile, port)
+        proc, stderr_spool = _boot(workspace, profile, port)
     except OSError as exc:
         # e.g. the boot command isn't on PATH, or the workspace is missing — a
         # not-executed result (skipped), never a probe failure or a crash.
         return [ProbeOutcome(p.id, "skipped", f"could not launch subject: {exc}") for p in probes]
     try:
         if not _wait_ready(profile, port):
-            return [ProbeOutcome(p.id, "skipped", "subject did not boot") for p in probes]
+            # #512: "subject did not boot" alone is undiagnosable — disclose the
+            # process state (crashed vs never-ready) and the captured stderr tail
+            # in the reason, which is the only channel the evidence row carries.
+            reason = _boot_failure_reason(proc, stderr_spool, profile)
+            return [ProbeOutcome(p.id, "skipped", reason) for p in probes]
         base = f"http://{profile.host}:{port}"
         return [_run_one(base, p, profile) for p in probes]
     finally:
         _terminate(proc)
+        with contextlib.suppress(Exception):
+            stderr_spool.close()
 
 
 def _free_port(host: str) -> int:
@@ -161,14 +169,55 @@ def _free_port(host: str) -> int:
         return int(s.getsockname()[1])
 
 
-def _boot(workspace: Path, profile: ExecutionProfile, port: int) -> subprocess.Popen:
+def _boot(workspace: Path, profile: ExecutionProfile, port: int) -> tuple[subprocess.Popen, Any]:
+    """Launch the subject, spooling stderr to an unbounded temp file (#512).
+
+    A pipe would deadlock a chatty subject once the ~64KB buffer fills; DEVNULL
+    (the previous behavior) destroyed the only diagnosis channel for a boot
+    failure. The spool is read only on ready-timeout and closed at teardown.
+    """
     argv = [arg.replace("{port}", str(port)) for arg in profile.boot_argv]
-    return subprocess.Popen(  # noqa: S603 — fixed profile argv, workspace-scoped verifier boot
-        argv,
-        cwd=str(workspace),
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+    stderr_spool = tempfile.TemporaryFile()
+    try:
+        proc = subprocess.Popen(  # noqa: S603 — fixed profile argv, workspace-scoped verifier boot
+            argv,
+            cwd=str(workspace),
+            stdout=subprocess.DEVNULL,
+            stderr=stderr_spool,
+        )
+    except OSError:
+        stderr_spool.close()
+        raise
+    return proc, stderr_spool
+
+
+def _boot_failure_reason(
+    proc: subprocess.Popen, stderr_spool: Any, profile: ExecutionProfile
+) -> str:
+    """Compose the disclosed reason for a subject that never became ready (#512)."""
+    exit_code = proc.poll()
+    state = (
+        f"exited {exit_code}"
+        if exit_code is not None
+        else f"no ready response within {profile.startup_timeout_s}s"
     )
+    reason = f"subject did not boot ({state})"
+    tail = _stderr_tail(stderr_spool)
+    if tail:
+        reason += f": {tail}"
+    return reason
+
+
+def _stderr_tail(stderr_spool: Any, limit: int = 500) -> str:
+    """Best-effort whitespace-collapsed tail of the spooled boot stderr."""
+    try:
+        stderr_spool.seek(0, os.SEEK_END)
+        size = stderr_spool.tell()
+        stderr_spool.seek(max(0, size - 4096))
+        text = stderr_spool.read().decode("utf-8", "replace")
+    except Exception:
+        return ""
+    return " ".join(text.split())[-limit:]
 
 
 def _wait_ready(profile: ExecutionProfile, port: int) -> bool:

--- a/tests/unit/capabilities/test_probe_runner.py
+++ b/tests/unit/capabilities/test_probe_runner.py
@@ -10,6 +10,7 @@ stubs do not (probes measure the fill, not the scaffold).
 from __future__ import annotations
 
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 
@@ -249,3 +250,52 @@ def test_bare_skeleton_fails_the_probe():
         outcomes = run_probes(ws, [_group_run_probe()])
     assert outcomes[0].status == "failed"
     assert "501" in outcomes[0].reason
+
+
+# --------------------------------------------------------------------------- #
+# boot-failure stderr disclosure (#512) — bug caught: both night measurement
+# rolls reported only "subject did not boot"; the uvicorn stderr (the actual
+# diagnosis) went to DEVNULL and diagnosis required manually rebuilding the
+# workspace and booting by hand.
+# --------------------------------------------------------------------------- #
+
+
+def test_boot_failure_reason_carries_stderr_tail(tmp_path):
+    # A subject that crashes on start with a distinctive stderr message: the
+    # disclosed reason must carry the exit state AND the message tail.
+    crash = pr.ExecutionProfile(
+        boot_argv=(
+            sys.executable,
+            "-c",
+            "import sys; sys.stderr.write('BOOM: no module backend'); sys.exit(3)",
+        ),
+        startup_timeout_s=2.0,
+        poll_interval_s=0.05,
+    )
+    outcomes = run_probes(tmp_path, [_probe(status=200)], profile=crash)
+    assert outcomes[0].status == "skipped"
+    assert "subject did not boot (exited 3)" in outcomes[0].reason
+    assert "BOOM: no module backend" in outcomes[0].reason
+
+
+def test_boot_hang_reason_discloses_timeout_not_exit(tmp_path):
+    # A subject that never becomes ready but stays alive: reason says so.
+    hang = pr.ExecutionProfile(
+        boot_argv=(sys.executable, "-c", "import time; time.sleep(30)"),
+        startup_timeout_s=0.5,
+        poll_interval_s=0.05,
+    )
+    outcomes = run_probes(tmp_path, [_probe(status=200)], profile=hang)
+    assert outcomes[0].status == "skipped"
+    assert "no ready response within 0.5s" in outcomes[0].reason
+
+
+def test_stderr_tail_is_bounded(tmp_path):
+    # A subject spewing >4KB of stderr must not blow up the reason string.
+    spew = pr.ExecutionProfile(
+        boot_argv=(sys.executable, "-c", "import sys; sys.stderr.write('x' * 100000); sys.exit(1)"),
+        startup_timeout_s=2.0,
+        poll_interval_s=0.05,
+    )
+    outcomes = run_probes(tmp_path, [_probe(status=200)], profile=spew)
+    assert len(outcomes[0].reason) < 600


### PR DESCRIPTION
## Problem

Both night measurement rolls reported `vc-probe-runs` unverified with only "subject did not boot" — the uvicorn stderr that would explain *why* was piped to DEVNULL. The night's remaining unknown (why the app never boots) is exactly this gap.

## Fix

- `_boot` spools subject stderr to an unbounded temp file (a PIPE would deadlock a chatty subject at ~64KB; DEVNULL destroyed the diagnosis channel). Closed at teardown; on launch OSError the spool is closed before re-raising.
- On readiness timeout, the disclosed reason becomes `subject did not boot (exited N | no ready response within Ts): <bounded stderr tail>` — crash-on-start and hung-but-alive are now distinguishable, and the tail (last 4KB read, 500 chars kept, whitespace collapsed) carries the traceback.
- The stable `"subject did not boot"` prefix is preserved for downstream matching.

## Tests

Live subprocess tests: crash-on-start carries `(exited 3)` + the stderr message; hang carries the timeout phrasing; a 100KB stderr spew stays bounded under 600 chars. Existing boot-failure tests (real uvicorn on an empty workspace) still pass — now with informative reasons. Full `tests/unit/capabilities/` + `tests/unit/cycles/`: 3026 passed (2 pre-existing #498 failures).

Part of the metric-integrity/disclosure batch (#513, #514) preceding the canonical N=5.

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG