### PR TITLE
fix(#509): unbound contract criteria attach to the tail qa.test at dispatch

### DIFF
--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -562,7 +562,45 @@ def generate_task_plan(
             "no default (a builder must not assemble for an assumed stack)."
         )
 
+    _attach_unbound_contract_criteria(envelopes, plan, contract)
+
     return envelopes
+
+
+def _attach_unbound_contract_criteria(
+    envelopes: list[TaskEnvelope],
+    plan: ImplementationPlan | None,
+    contract: VerificationContract | None,
+) -> None:
+    """Attach every contract criterion no plan task bound to the tail qa.test (#509).
+
+    The bind nets key on exact string matches between LLM-authored plan fields
+    (``expected_artifacts``, typed-check ``file`` params) and contract fill paths,
+    so a plan that names a covered file differently binds nothing for it and
+    sails through — criterion coverage then varies roll to roll with plan
+    authoring (criteria_total went 3 → 1 → 1 across identical contracts in the
+    night rolls). The contract, not the plan, is the last word on verification:
+    the residue resolves into criterion-stamped TypedChecks on the final qa.test
+    envelope, where the assembled workspace is complete — so every criterion
+    produces an evidence row with its ``criterion_id`` on every roll. Bound
+    criteria keep their item-level attachment (better repair locality); this is
+    the deterministic floor, not a replacement for binding.
+    """
+    if contract is None:
+        return
+    bound: set[str] = set()
+    if plan is not None:
+        for task in plan.tasks:
+            bound.update(task.criteria_refs)
+    residue = [rid for rid in contract.criterion_index() if rid not in bound]
+    if not residue:
+        return
+    tail_qa = next((e for e in reversed(envelopes) if e.task_type == "qa.test"), None)
+    if tail_qa is None:
+        return
+    existing = list(tail_qa.inputs.get("acceptance_criteria") or [])
+    existing.extend(resolve_contract_refs(residue, contract))
+    tail_qa.inputs["acceptance_criteria"] = existing
 
 
 def _replace_build_steps_with_plan(

--- a/tests/unit/cycles/test_criteria_ref_binding.py
+++ b/tests/unit/cycles/test_criteria_ref_binding.py
@@ -344,3 +344,91 @@ def test_author_mode_check_result_has_no_criterion_id():
     }
     results = normalize_task_checks(outputs, subject="t")
     assert results[0].criterion_id is None
+
+
+# --------------------------------------------------------------------------- #
+# dispatch-time residue attachment (#509) — bug caught: binding keyed on exact
+# LLM-authored path strings, so a plan that named a covered file differently
+# bound nothing and criterion coverage varied roll to roll (criteria_total went
+# 3 -> 1 -> 1 across identical seeded contracts in the night rolls).
+# --------------------------------------------------------------------------- #
+
+from squadops.cycles.implementation_plan import CHECK_SPECS  # noqa: E402
+from squadops.cycles.task_plan import _attach_unbound_contract_criteria  # noqa: E402
+from squadops.tasks.models import TaskEnvelope  # noqa: E402
+
+
+def _envelope(task_type: str, inputs: dict | None = None) -> TaskEnvelope:
+    return TaskEnvelope(
+        task_id=f"t-{task_type}",
+        agent_id="qa",
+        cycle_id="cyc_x",
+        pulse_id="p1",
+        project_id="proj",
+        task_type=task_type,
+        correlation_id="c",
+        causation_id="c",
+        trace_id="t",
+        span_id="s",
+        inputs=inputs if inputs is not None else {},
+        metadata={},
+    )
+
+
+def _typed_ids(contract: VerificationContract) -> set[str]:
+    # resolve_contract_refs materializes only typed-acceptance criteria; behavioral
+    # ones (frontend_build / tests_pass vocabulary) run via the qa/build handlers.
+    return {
+        rid for rid, (crit, _) in contract.criterion_index().items() if crit.check in CHECK_SPECS
+    }
+
+
+def _criterion_ids(envelope: TaskEnvelope) -> set[str]:
+    return {
+        c.id
+        for c in envelope.inputs.get("acceptance_criteria", ())
+        if isinstance(c, TypedCheck) and c.id
+    }
+
+
+def test_unbound_criteria_attach_to_tail_qa_test_with_ids():
+    contract = _contract()
+    dev = _envelope("development.develop")
+    qa = _envelope("qa.test", inputs={"acceptance_criteria": []})
+    _attach_unbound_contract_criteria([dev, qa], None, contract)
+    # every typed criterion in the contract lands on the tail qa.test, stamped
+    assert _criterion_ids(qa) == _typed_ids(contract)
+    assert dev.inputs.get("acceptance_criteria") is None
+
+
+def test_bound_refs_are_excluded_from_residue():
+    contract = _contract()
+    plan = ImplementationPlan.from_yaml(
+        _plan_yaml(refs=["vc-routes-endpoints", "vc-routes-apierror", "vc-routes-compiles"])
+    )
+    qa = _envelope("qa.test")
+    _attach_unbound_contract_criteria([qa], plan, contract)
+    ids = _criterion_ids(qa)
+    assert "vc-routes-endpoints" not in ids
+    assert ids == _typed_ids(contract) - {
+        "vc-routes-endpoints",
+        "vc-routes-apierror",
+        "vc-routes-compiles",
+    }
+
+
+def test_residue_attaches_to_last_qa_test_only():
+    contract = _contract()
+    qa1 = _envelope("qa.test")
+    qa2 = _envelope("qa.test")
+    _attach_unbound_contract_criteria([qa1, qa2], None, contract)
+    assert _criterion_ids(qa1) == set()
+    assert _criterion_ids(qa2) == _typed_ids(contract)
+
+
+def test_author_mode_and_missing_qa_are_no_ops():
+    dev = _envelope("development.develop")
+    _attach_unbound_contract_criteria([dev], None, None)  # author mode
+    assert "acceptance_criteria" not in dev.inputs
+    _attach_unbound_contract_criteria([dev], None, _contract())  # no qa.test envelope
+    assert "acceptance_criteria" not in dev.inputs


### PR DESCRIPTION
## Problem

Criterion binding varied per roll on the identical frozen contract: `criteria_total` went 3 → 1 → 1 across the night rolls, and checks that executed-and-passed earned no criterion credit. Root cause: all three bind-net rejection classes key on **exact string matches** between LLM-authored plan fields (`expected_artifacts`, typed-check `file` params) and contract fill paths. A plan that names `backend/routes.py` any other way binds nothing for it and sails through validation — coverage then measures plan-authoring luck.

## Fix

`generate_task_plan` computes the **residue** — every typed contract criterion no plan task bound — and resolves it onto the tail `qa.test` envelope (assembled workspace, criterion-stamped `TypedCheck`s via the existing `resolve_contract_refs` materializer). The contract, not the plan, is now the last word on verification: every typed criterion produces an evidence row with its `criterion_id` on every roll. Bound criteria keep item-level attachment (repair locality); the nets stay as-is (belt) — this is the deterministic floor (suspenders).

**Scope note:** behavioral criteria (`frontend_build`/`tests_pass` vocabulary) are deliberately outside `resolve_contract_refs` (they execute via the qa/build handlers); stamping their criterion ids onto those rows is the follow-up slice once #513's contract-threading merges — together with #513 that gets `criteria_coverage` to a true n/6.

## Tests

Residue attachment: full typed set on an unbound plan, exclusion of bound refs, last-qa.test-only placement, author-mode/no-qa no-ops — all against the real two-fill-file contract fixture. Full `tests/unit/cycles/` + `tests/unit/capabilities/`: 3027 passed (2 pre-existing #498).

Addresses #509 (denominator side in #513; behavioral stamping tracked there before N=5 is canonical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG