### PR TITLE
fix(#507): repair artifacts are re-homed onto expected paths before the overlay

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -517,7 +517,19 @@ class CorrectionRunner:
                 # it can't shadow a product file in the overlay.
                 if task_type != "qa.validate_repair":
                     step_artifacts = (repair_result.outputs or {}).get("artifacts") or []
-                    repair_artifacts.extend(a for a in step_artifacts if isinstance(a, dict))
+                    # #507: re-home repair files onto the failed task's expected
+                    # paths before they reach the overlay — a repair emitted under
+                    # the wrong directory otherwise lands as a net-new file, patch
+                    # verification runs on the un-patched original, and the
+                    # validated repair is discarded by re-dispatch.
+                    from squadops.cycles.patch_verification import rebase_artifact_paths
+
+                    repair_artifacts.extend(
+                        rebase_artifact_paths(
+                            [a for a in step_artifacts if isinstance(a, dict)],
+                            failed_inputs.get("expected_artifacts") or [],
+                        )
+                    )
 
         # 8. Emit CORRECTION_COMPLETED
         self._event_bus.emit(

--- a/src/squadops/cycles/patch_verification.py
+++ b/src/squadops/cycles/patch_verification.py
@@ -84,6 +84,38 @@ class PatchVerification:
     reason: str | None = None
 
 
+def rebase_artifact_paths(
+    artifacts: list[dict[str, Any]], expected_paths: list[str] | tuple[str, ...]
+) -> list[dict[str, Any]]:
+    """Deterministically re-home a repair artifact onto its expected path (#507).
+
+    Repair handlers re-derive the layout from prose and can emit the right file
+    under the wrong directory (roll cyc_22b14aeda70f: every repair landed
+    ``app/routes.py`` while the scaffold, contract, and typed checks target
+    ``backend/routes.py``) — the overlay then appends a net-new file instead of
+    superseding, typed patch verification runs against the un-patched original,
+    and a content-correct, QA-validated repair is discarded by re-dispatch. The
+    target path is not the model's to choose: when an emitted ``name`` is not an
+    expected path and exactly one expected path shares its basename, the entry
+    is rewritten to that path. Ambiguous or unmatched names pass through
+    unchanged (conservative — never a false re-home).
+    """
+    expected = [p for p in expected_paths if isinstance(p, str) and p]
+    by_base: dict[str, list[str]] = {}
+    for p in expected:
+        by_base.setdefault(Path(p).name, []).append(p)
+    out: list[dict[str, Any]] = []
+    for art in artifacts:
+        name = art.get("name")
+        if isinstance(name, str) and name and name not in expected:
+            candidates = by_base.get(Path(name).name, [])
+            if len(candidates) == 1 and candidates[0] != name:
+                logger.info("patch_rebase: repair artifact %r re-homed to %r", name, candidates[0])
+                art = {**art, "name": candidates[0]}
+        out.append(art)
+    return out
+
+
 def overlay_artifacts(
     base: list[dict[str, Any]] | None, patches: list[dict[str, Any]] | None
 ) -> list[dict[str, Any]]:

--- a/tests/unit/cycles/test_patch_verification.py
+++ b/tests/unit/cycles/test_patch_verification.py
@@ -156,3 +156,44 @@ class TestVerifyPatchedArtifacts:
         assert row["status"] == "passed"
         assert row["passed"] is True
         assert row["patch_verified"] is True
+
+
+# --------------------------------------------------------------------------- #
+# repair path rebase (#507) — bug caught: every roll-4 repair emitted
+# app/routes.py while checks target backend/routes.py; the overlay appended it
+# as net-new, typed verification ran on the un-patched original, and three
+# QA-validated repairs were discarded by re-dispatch until the time budget.
+# --------------------------------------------------------------------------- #
+
+from squadops.cycles.patch_verification import rebase_artifact_paths  # noqa: E402
+
+
+def test_wrong_directory_repair_is_rehomed_to_expected_path():
+    arts = [{"name": "app/routes.py", "content": "fixed"}]
+    out = rebase_artifact_paths(arts, ["backend/routes.py", "backend/models.py"])
+    assert out == [{"name": "backend/routes.py", "content": "fixed"}]
+
+
+def test_rehomed_repair_supersedes_in_overlay():
+    base = [{"name": "backend/routes.py", "content": "broken"}]
+    patches = rebase_artifact_paths(
+        [{"name": "app/routes.py", "content": "fixed"}], ["backend/routes.py"]
+    )
+    merged = {a["name"]: a["content"] for a in overlay_artifacts(base, patches)}
+    assert merged == {"backend/routes.py": "fixed"}
+
+
+def test_exact_expected_path_passes_through():
+    arts = [{"name": "backend/routes.py", "content": "x"}]
+    assert rebase_artifact_paths(arts, ["backend/routes.py"]) == arts
+
+
+def test_ambiguous_basename_is_never_rehomed():
+    arts = [{"name": "app/routes.py", "content": "x"}]
+    out = rebase_artifact_paths(arts, ["backend/routes.py", "frontend/routes.py"])
+    assert out[0]["name"] == "app/routes.py"
+
+
+def test_unmatched_and_net_new_files_pass_through():
+    arts = [{"name": "README.md", "content": "x"}, {"name": "", "content": "y"}, {"other": 1}]
+    assert rebase_artifact_paths(arts, ["backend/routes.py"]) == arts


### PR DESCRIPTION
## Root cause (found from night evidence)

The executor's `patch_verification` log lines show all three roll-4 m001 patches `status=failed reason= checks=3` while `qa.validate_repair` said PASS. Artifact metadata explains it: the scaffold seeds `backend/routes.py`, but **every `development.correction_repair` emitted its fix as `app/routes.py`** (art_55a4cd4fe95b, art_28776ee3334e, art_d653de792657). `overlay_artifacts` merges by `name`, so the repair appended as a net-new file, typed verification ran against the un-patched original, and `_try_accept_patch` conservatively fell back to "continue" — re-dispatching develop, which regenerated from scratch and discarded the validated fix. Three times, until the 2h budget.

Meas-1/meas-2's patches passed typed verification and were accepted — the #389 acceptance machinery works; the path mismatch was the killer.

## Fix

`rebase_artifact_paths` (pure, in `patch_verification`): when a repair artifact's `name` is not one of the failed task's `expected_artifacts` and exactly one expected path shares its basename, rewrite it to that path (logged). Ambiguous or unmatched names pass through — never a false re-home. Applied in the correction runner at repair-artifact collection, upstream of the overlay, patch verification, the #456 retest, and persistence.

The target path is not the model's to choose — this is the interface-vs-implementation line applied to repairs: enforce the known path deterministically instead of asking prose to reproduce it.

## Tests

The exact roll-4 shape (app/→backend/ re-home, then overlay supersedes), exact-path passthrough, ambiguous-basename passthrough, net-new/unmatched passthrough. Full `cycles` + `capabilities`: 3045 passed (2 pre-existing #498).

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG