### PR TITLE
fix: test-authorship gap — runner refuses non-pytest suites precisely; qa fragment gains the discovery contract

### DIFF
--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -18,6 +18,7 @@ import shutil
 import sys
 import tempfile
 from dataclasses import dataclass, replace
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -143,6 +144,29 @@ async def run_generated_tests(
             executed=False,
             error="no test files provided",
             test_file_count=0,
+            source_file_count=len(source_files),
+        )
+
+    # Test-authorship guard: pytest discovers only test_*.py / *_test.py. Both
+    # night measurement rolls shipped a single qa/test_smoke.js — pytest
+    # collected nothing (exit 5) and the red surfaced at run end with no
+    # actionable reason. Refuse up front with a repair-precise message so the
+    # correction loop fixes authorship, not symptoms.
+    discoverable = [
+        f
+        for f in test_files
+        if f.get("path", "").endswith(".py")
+        and (Path(f["path"]).name.startswith("test_") or f["path"].endswith("_test.py"))
+    ]
+    if not discoverable:
+        got = ", ".join(sorted(f.get("path", "?") for f in test_files)) or "none"
+        return RunTestsResult(
+            executed=False,
+            error=(
+                "no pytest-discoverable test files — backend tests must be Python "
+                f"files named test_*.py (got: {got})"
+            ),
+            test_file_count=len(test_files),
             source_file_count=len(source_files),
         )
 

--- a/src/squadops/prompts/fragments/manifest.yaml
+++ b/src/squadops/prompts/fragments/manifest.yaml
@@ -90,7 +90,7 @@ fragments:
   layer: task_type
   roles:
   - qa
-  sha256: 93b862c5e1482750e3f6ee8e31b59ffd862b7b9ebac07c774de2da89ceb74262
+  sha256: dc388f7a1ad544545c598670259d71238cfa608e84d6e561c93874c661088486
 - fragment_id: task_type.development.propose_plan_tasks
   path: shared/task_type/task_type.development.propose_plan_tasks.md
   layer: task_type
@@ -187,4 +187,4 @@ fragments:
   roles:
   - data
   sha256: fd44a28f65e449c6320b5ee5f1d8121013a03c7baa757965334c4e19c7904779
-manifest_hash: f2c4d643cf5d9d36f2628767c386f113a4e9262fa6426fedb4c051be94d30848
+manifest_hash: 5c80d8aa5e3c32ea3b93e0b5f56b54558c562b6a4a4450c9b1df44314f9d04e9

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.qa.test.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.qa.test.md
@@ -1,7 +1,7 @@
 ---
 fragment_id: task_type.qa.test
 layer: task_type
-version: "0.9.21"
+version: "0.9.22"
 roles: ["qa"]
 ---
 # Task: Generate and Execute Tests (qa.test)
@@ -10,6 +10,17 @@ You are generating test files that will be executed immediately, as-is, in the
 workspace they are written for. Your tests are themselves a deliverable that
 can fail the build — a test suite that cannot load is a failed check, not a
 neutral outcome.
+
+## Discovery Contract (hard rule)
+
+Backend tests MUST be Python pytest files whose names match pytest discovery:
+`test_*.py` (e.g. `tests/test_api.py`). The suite is executed with `pytest .`
+from the workspace root — a JavaScript file, a shell script, or a Python file
+named any other way is invisible to the runner: pytest collects zero tests,
+the required `tests_pass` check fails, and the whole run is rejected. Never
+write backend smoke tests in JavaScript. Frontend test files are only
+generated when the frontend manifest declares a test runner (see Scope
+Discipline), and they never satisfy the backend suite requirement.
 
 ## Dependency Constraint (hard rule)
 

--- a/tests/unit/capabilities/test_node_test_runner.py
+++ b/tests/unit/capabilities/test_node_test_runner.py
@@ -421,3 +421,42 @@ class TestFullstackTestsFileSplit:
             result.source_file_count
             == _BACKEND_PASS.source_file_count + _FRONTEND_PASS.source_file_count
         )
+
+
+# --------------------------------------------------------------------------- #
+# test-authorship guard — bug caught: both night measurement rolls shipped only
+# qa/test_smoke.js; pytest collected nothing (exit 5) and the failure surfaced
+# at run end as an unexplained tests_pass red. The runner must refuse up front
+# with a repair-precise reason.
+# --------------------------------------------------------------------------- #
+
+from squadops.capabilities.handlers.test_runner import run_generated_tests  # noqa: E402
+
+
+async def test_js_only_suite_refused_with_authorship_reason():
+    result = await run_generated_tests(
+        [{"path": "backend/main.py", "content": "app = None"}],
+        [{"path": "qa/test_smoke.js", "content": "console.log('hi')"}],
+    )
+    assert result.executed is False
+    assert "no pytest-discoverable test files" in result.error
+    assert "qa/test_smoke.js" in result.error
+    assert result.tests_passed is False
+
+
+async def test_misnamed_python_file_refused():
+    result = await run_generated_tests(
+        [{"path": "backend/main.py", "content": "app = None"}],
+        [{"path": "tests/smoke.py", "content": "def test_x(): pass"}],
+    )
+    assert result.executed is False
+    assert "test_*.py" in result.error
+
+
+async def test_discoverable_pytest_file_still_runs():
+    result = await run_generated_tests(
+        [{"path": "backend/main.py", "content": "VALUE = 3"}],
+        [{"path": "tests/test_value.py", "content": "def test_v():\n    assert 1 + 2 == 3\n"}],
+    )
+    assert result.executed is True
+    assert result.exit_code == 0


### PR DESCRIPTION
## Problem

The convergent night signal: both measurement rolls failed `tests_pass` with pytest exit 5 — zero tests collected — because qa authored a single `qa/test_smoke.js` and no pytest files. The red surfaced at the end of a 2h run with (pre-#514) no reason at all, and the correction loop had nothing precise to act on.

## Fix (two layers, interface enforced deterministically)

1. **Runner guard** — `run_generated_tests` refuses up front when no provided test file matches pytest discovery (`test_*.py` / `*_test.py`): `executed=False` with `"no pytest-discoverable test files — backend tests must be Python files named test_*.py (got: qa/test_smoke.js)"`. Through `_tests_pass_from_result` this becomes a disclosed not-executed row, and the correction loop gets a repair-precise instruction instead of a bare exit code.
2. **Fragment** — `task_type.qa.test` (0.9.21 → 0.9.22, via the fragment system per the #448 rule) gains a **Discovery Contract (hard rule)** section: backend tests must be pytest-named Python files; JS never satisfies the backend suite; frontend tests only when the manifest declares a runner. Manifest hashes regenerated with `regen_fragment_manifest.py --write`.

## Tests

The exact night shape (`qa/test_smoke.js` only → refused, reason names the file), a misnamed `.py` (`tests/smoke.py` → refused), and a discoverable `tests/test_*.py` still executing to exit 0 (live pytest subprocess). Full `capabilities` + `prompts` + `cycles`: green except the 2 pre-existing #498 failures.

Last item of the morning-report fix sequence before rebuild + fresh frozen deploy + canonical N=5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG