### PR TITLE
fix: behavioral check rows are stamped with their contract criterion ids

### DIFF
--- a/adapters/cycles/run_completion.py
+++ b/adapters/cycles/run_completion.py
@@ -129,6 +129,34 @@ def resolve_terminal_outcome(exc: BaseException, run_id: str) -> TerminalOutcome
     )
 
 
+def _stamp_behavioral_criteria(results: Any, contract: Any) -> Any:
+    """Stamp behavioral check rows with their contract criterion ids (#509 tail).
+
+    Behavioral criteria (``frontend_build``/``tests_pass`` vocabulary) execute in
+    the qa/build handlers, outside the ``criteria_refs``→TypedCheck materializer —
+    their rows carried no ``criterion_id``, so ``vc-frontend-builds``/``vc-suite-
+    passes`` could never be credited (or go adverse) in coverage, capping n at
+    the typed subset. The contract's behavioral section maps check name → stable
+    id; rows matching a behavioral check that don't already carry a criterion id
+    get stamped here, adapter-side, so the pure choke point stays
+    producer-agnostic. Probe rows (which carry their own ids) are untouched.
+    """
+    import dataclasses
+
+    behavioral = getattr(contract, "behavioral", None)
+    if behavioral is None:
+        return results
+    check_to_id = {c.check: c.id for c in list(behavioral.build) + list(behavioral.suite.checks)}
+    if not check_to_id:
+        return results
+    return tuple(
+        dataclasses.replace(r, criterion_id=check_to_id[r.check_id])
+        if r.criterion_id is None and r.check_id in check_to_id
+        else r
+        for r in results
+    )
+
+
 class RunCompletion:
     """Composes the executor's run-end path (SIP-0097 §6.4).
 
@@ -258,6 +286,7 @@ class RunCompletion:
         contract_criteria: tuple[str, ...] = ()
         if contract is not None:
             contract_criteria = tuple(contract.criterion_ids())
+            results = _stamp_behavioral_criteria(results, contract)
         summary = aggregate_verification(
             results,
             required_check_ids,

--- a/tests/unit/cycles/test_run_completion.py
+++ b/tests/unit/cycles/test_run_completion.py
@@ -648,3 +648,43 @@ class TestAggregateVerificationContractDenominator:
         ledger = self._ledger_with_partial_evidence()
         summary = RunCompletion._aggregate_verification(None, ledger, "COMPLETED", None)
         assert summary.criteria_total == (_REAL_CONTRACT.criterion_ids()[0],)
+
+
+class TestBehavioralCriterionStamping:
+    """#509 tail — bug caught: frontend_build/tests_pass rows carried no
+    criterion_id, so vc-frontend-builds/vc-suite-passes could never be credited
+    or go adverse; a fully-green roll could not reach n=6 coverage."""
+
+    def _behavioral_map(self):
+        b = _REAL_CONTRACT.behavioral
+        return {c.check: c.id for c in list(b.build) + list(b.suite.checks)}
+
+    def test_behavioral_rows_gain_contract_ids_and_credit_coverage(self):
+        cmap = self._behavioral_map()
+        assert cmap  # the example contract declares behavioral criteria
+        ledger = RunLedger()
+        ledger.record_check_result(
+            CheckResult(check_id="frontend_build", status=ResultStatus.PASSED)
+        )
+        ledger.record_check_result(CheckResult(check_id="tests_pass", status=ResultStatus.FAILED))
+        summary = RunCompletion._aggregate_verification(None, ledger, "COMPLETED", _REAL_CONTRACT)
+        assert cmap["frontend_build"] in summary.criteria_verified
+        # a failed suite goes adverse: present in the denominator, never credited
+        assert cmap["tests_pass"] in summary.criteria_total
+        assert cmap["tests_pass"] not in summary.criteria_verified
+
+    def test_existing_criterion_ids_are_not_overwritten(self):
+        ledger = RunLedger()
+        ledger.record_check_result(
+            CheckResult(check_id="tests_pass", status=ResultStatus.PASSED, criterion_id="vc-custom")
+        )
+        summary = RunCompletion._aggregate_verification(None, ledger, "COMPLETED", _REAL_CONTRACT)
+        assert "vc-custom" in summary.criteria_verified
+
+    def test_author_mode_rows_stay_unstamped(self):
+        ledger = RunLedger()
+        ledger.record_check_result(
+            CheckResult(check_id="frontend_build", status=ResultStatus.PASSED)
+        )
+        summary = RunCompletion._aggregate_verification(None, ledger, "COMPLETED", None)
+        assert summary.criteria_verified == ()


### PR DESCRIPTION
## Problem

The #516 follow-up: behavioral criteria (`frontend_build`/`tests_pass` vocabulary) execute via the qa/build handlers, outside `resolve_contract_refs`, so their evidence rows carried no `criterion_id`. `vc-frontend-builds` and `vc-suite-passes` could never be credited (or go adverse) — even a fully green roll capped coverage at the typed subset, and the night rolls' passing `frontend_build` earned no criterion credit.

## Fix

`_stamp_behavioral_criteria` (module-level, run_completion adapter): builds check-name → stable-id from the bound contract's behavioral section and stamps matching rows that don't already carry a criterion id, just before aggregation. Adapter-side deliberately — the pure choke point stays producer-agnostic (#513's layering). Probe rows keep their own ids; author mode is untouched.

With #513 (denominator) + #516 (typed residue) + this, `criteria_coverage` is a true n-of-contract: a green roll can reach 6/6, a failed suite drives `vc-suite-passes` adverse.

## Tests

Real example-manifest contract: passing `frontend_build` credits `vc-frontend-builds`; failing `tests_pass` lands `vc-suite-passes` in the denominator but never verified; pre-existing criterion ids are not overwritten; author mode stays unstamped. Full `cycles` + `capabilities`: 3051 passed (2 pre-existing #498).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG