### PR TITLE
fix(#520): probe readiness accepts any HTTP response, not only 200 on /health

### DIFF
--- a/src/squadops/capabilities/handlers/probe_runner.py
+++ b/src/squadops/capabilities/handlers/probe_runner.py
@@ -221,12 +221,20 @@ def _stderr_tail(stderr_spool: Any, limit: int = 500) -> str:
 
 
 def _wait_ready(profile: ExecutionProfile, port: int) -> bool:
+    """Poll until the subject answers HTTP on the ready path (#520).
+
+    ANY response — 200 or 404 alike — proves the server is up and routing.
+    Demanding 200 from ``/health`` made readiness a hidden product requirement:
+    the group_run PRD declares no /health, so a perfectly booted app timed out
+    'not ready' and every probe was skipped, forever. Readiness is transport-
+    level; the probes themselves are the behavioral assertions.
+    """
     url = f"http://{profile.host}:{port}{profile.ready_path}"
     deadline = time.monotonic() + profile.startup_timeout_s
     while time.monotonic() < deadline:
         try:
-            if httpx.get(url, timeout=1.0).status_code == 200:
-                return True
+            httpx.get(url, timeout=1.0)
+            return True
         except httpx.HTTPError:
             pass
         time.sleep(profile.poll_interval_s)

--- a/tests/unit/capabilities/test_probe_runner.py
+++ b/tests/unit/capabilities/test_probe_runner.py
@@ -299,3 +299,32 @@ def test_stderr_tail_is_bounded(tmp_path):
     )
     outcomes = run_probes(tmp_path, [_probe(status=200)], profile=spew)
     assert len(outcomes[0].reason) < 600
+
+
+# --------------------------------------------------------------------------- #
+# readiness = any HTTP response (#520) — bug caught: pf-1's app booted and
+# served ("Uvicorn running") but has no /health endpoint; readiness demanded
+# 200 from /health, timed out, and every probe was skipped forever.
+# --------------------------------------------------------------------------- #
+
+
+def test_ready_on_404_response(tmp_path):
+    # An app WITHOUT the ready-path endpoint: server answers 404 -> ready,
+    # and the actual probe against a real endpoint passes.
+    (tmp_path / "backend").mkdir()
+    (tmp_path / "backend" / "__init__.py").write_text("")
+    (tmp_path / "backend" / "main.py").write_text(
+        "from fastapi import FastAPI\n"
+        "app = FastAPI()\n"
+        "@app.get('/items')\n"
+        "def items():\n"
+        "    return {'ok': True}\n"
+    )
+    probe = Probe(
+        id="vc-probe-items",
+        subject="backend",
+        request={"method": "GET", "path": "/items"},
+        expect={"status": 200},
+    )
+    outcomes = run_probes(tmp_path, [probe])
+    assert outcomes == [ProbeOutcome("vc-probe-items", "passed", None)]


### PR DESCRIPTION
Day-ops fix under the expanded green-odds authority (NOT merged by me — awaiting review).

pf-1 (cyc_794f0698b7e4) delivered the #515 payoff: the probe skip reason showed "Application startup complete. Uvicorn running" — the app booted, but readiness polls GET /health expecting 200 and the group_run PRD declares no /health. Readiness was silently a product requirement; probes could never run for this product.

_wait_ready now treats ANY HTTP response (404 included) as ready — transport-level readiness; the probes assert behavior. Live test: FastAPI app without the ready path → ready via 404 → real probe passes. Full domains: 3052 passed (2 pre-existing #498).

Deployed to the box from this branch for the day-ops rolls; deploy hash recorded in the ops ledger.

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG