### PR TITLE
fix: create-probes expect 201 — the contract contradicted the PRD it verifies

### DIFF
--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -185,7 +185,12 @@ def _probes(manifest: InterfaceManifest) -> list[dict[str, Any]]:
                 "id": f"vc-probe-{_slug(ep.path) or 'root'}",
                 "subject": "backend",
                 "request": {"method": ep.method, "path": ep.path, "json": json_body},
-                "expect": {"status": 200},
+                # Emitted probes are parameterless POSTs — resource creates by
+                # construction — and REST (and the PRD/QA suite) say a create
+                # returns 201. Expecting 200 made the contract contradict the
+                # PRD: a PRD-conformant app could never pass its own probe
+                # (pf-3: "status 201 != expected 200" on a correct app).
+                "expect": {"status": 201},
             }
         )
     return probes

--- a/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/backend/routes.py
+++ b/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/backend/routes.py
@@ -33,7 +33,7 @@ def get_runs():
     return list(_RUNS.values())
 
 
-@router.post("/runs", response_model=RunEvent)
+@router.post("/runs", response_model=RunEvent, status_code=201)
 def post_runs(payload: RunEventCreate):
     """create run."""
     run = RunEvent(id=uuid.uuid4().hex, participants=[], **payload.model_dump())

--- a/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/backend/tests/test_routes.py
+++ b/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/backend/tests/test_routes.py
@@ -21,7 +21,7 @@ def _create(title="Saturday Long Run"):
     resp = client.post(
         "/runs", json={"title": title, "datetime": "2026-08-01T08:00", "location": "Park Gate"}
     )
-    assert resp.status_code == 200
+    assert resp.status_code == 201
     return resp.json()
 
 

--- a/tests/unit/capabilities/test_probe_runner.py
+++ b/tests/unit/capabilities/test_probe_runner.py
@@ -125,7 +125,8 @@ def test_unbootable_subject_is_skipped_not_failed(tmp_path):
         id="vc-probe-fe",
         subject="frontend",
         request={"method": "GET", "path": "/"},
-        expect={"status": 200},
+        # creates return 201 (PR #523: the contract contradicted the PRD at 200)
+        expect={"status": 201},
     )
     outcomes = run_probes(tmp_path, [frontend_probe])
     assert outcomes == [

--- a/tests/unit/capabilities/test_probe_runner.py
+++ b/tests/unit/capabilities/test_probe_runner.py
@@ -125,8 +125,7 @@ def test_unbootable_subject_is_skipped_not_failed(tmp_path):
         id="vc-probe-fe",
         subject="frontend",
         request={"method": "GET", "path": "/"},
-        # creates return 201 (PR #523: the contract contradicted the PRD at 200)
-        expect={"status": 201},
+        expect={"status": 200},
     )
     outcomes = run_probes(tmp_path, [frontend_probe])
     assert outcomes == [
@@ -229,7 +228,8 @@ def _group_run_probe() -> Probe:
             "path": "/runs",
             "json": {"title": "T", "datetime": "D", "location": "L"},
         },
-        expect={"status": 200},
+        # creates return 201 (PR #523: the contract contradicted the PRD at 200)
+        expect={"status": 201},
     )
 
 

--- a/tests/unit/capabilities/test_scaffold_contract.py
+++ b/tests/unit/capabilities/test_scaffold_contract.py
@@ -140,7 +140,7 @@ def test_behavioral_has_build_suite_and_self_contained_probe():
     create = behavioral["probes"][0]
     assert create["request"]["method"] == "POST"
     assert set(create["request"]["json"]) == {"title", "datetime", "location"}
-    assert create["expect"]["status"] == 200
+    assert create["expect"]["status"] == 201  # creates return 201 (pf-3: contract contradicted the PRD)
 
 
 def test_capabilities_derived_from_what_criteria_require():

--- a/tests/unit/capabilities/test_scaffold_contract.py
+++ b/tests/unit/capabilities/test_scaffold_contract.py
@@ -140,7 +140,9 @@ def test_behavioral_has_build_suite_and_self_contained_probe():
     create = behavioral["probes"][0]
     assert create["request"]["method"] == "POST"
     assert set(create["request"]["json"]) == {"title", "datetime", "location"}
-    assert create["expect"]["status"] == 201  # creates return 201 (pf-3: contract contradicted the PRD)
+    assert (
+        create["expect"]["status"] == 201
+    )  # creates return 201 (pf-3: contract contradicted the PRD)
 
 
 def test_capabilities_derived_from_what_criteria_require():


### PR DESCRIPTION
Day-ops fix under expanded green-odds authority (NOT merged by me).

pf-3 was the first roll where probes executed (thanks to #521's readiness fix) — and the probe failed a **correct** app: POST /runs returned 201 per the PRD (and per QA's own tests), while the emitted probe expects 200. The emitter's probe class is parameterless POSTs — creates by construction — so `expect 200` guaranteed that a PRD-conformant app fails `vc-probe-runs` forever: green was structurally impossible on the old contract.

- `_probes` emits `expect: {"status": 201}` with the rationale in-line.
- The reference fill's create route gains `status_code=201` (it was PRD-divergent the same way — worth noting the CI probe gate was green only because fill and contract shared the same wrong status).
- Corrected contract re-emitted (lint GREEN), ingested as `art_7c7d9ca2e54a` — the day-ops baseline from pf-4 on; old `art_97864f4daa5f` retired.

Tests: scaffold-contract expectation updated to 201; contract-runner suite green except the 2 pre-existing #498 host-PATH failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG