### PR TITLE
fix(#522): system plan-validation rejection re-rolls framing instead of killing the cycle

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -514,7 +514,14 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             forwarding_overrides = await self._rebuild_forwarding_overrides_on_entry(
                 cycle, cycle_id, start_index
             )
-        for i in range(start_index, len(workload_sequence)):
+        # #522: framing re-rolls on a system plan-validation rejection. `while`
+        # (not `for`) so a re-roll can re-process the SAME workload index — the
+        # re-roll path `continue`s without the tail `i += 1`. Zero re-rolls
+        # (default) is byte-identical to the old `for` loop.
+        framing_rerolls = 0
+        max_framing_rerolls = cycle.applied_defaults.get("framing_max_rerolls", 0)
+        i = start_index
+        while i < len(workload_sequence):
             workload_entry = workload_sequence[i]
             await self.execute_run(
                 cycle_id,
@@ -597,6 +604,48 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         current_run_id,
                         "; ".join(plan_errors),
                     )
+                    # #522: a *system* plan-validation rejection is a stochastic
+                    # framing fault (the rule the model tripped is already in its
+                    # prompt), not an operator's verdict — the retry a human would
+                    # grant instantly. Re-roll framing, bounded by
+                    # ``framing_max_rerolls``, rather than killing the cycle. The
+                    # rejection stays in gate_decisions (evidence, #473); the
+                    # superseded framing run is CANCELLED so the positional
+                    # run↔workload invariant (#257/D14) holds — exactly one
+                    # non-cancelled run per position. A human --reject is a
+                    # different decided_by and never reaches this branch.
+                    if (
+                        workload_entry.get("type") == "framing"
+                        and framing_rerolls < max_framing_rerolls
+                    ):
+                        framing_rerolls += 1
+                        await self._cycle_registry.cancel_run(current_run_id)
+                        reroll_run = await self._create_next_workload_run(
+                            cycle,
+                            run,
+                            workload_entry,
+                            config_hash=run.resolved_config_hash,
+                        )
+                        current_run_id = reroll_run.run_id
+                        self._cycle_event_bus.emit(
+                            EventType.WORKLOAD_ADVANCED,
+                            entity_type="workload",
+                            entity_id=current_run_id,
+                            context={"cycle_id": cycle_id, "run_id": current_run_id},
+                            payload={
+                                "workload_type": "framing",
+                                "reason": "framing_reroll_on_system_rejection",
+                                "reroll": framing_rerolls,
+                            },
+                        )
+                        logger.info(
+                            "Framing re-roll %d/%d on cycle %s: new framing run %s",
+                            framing_rerolls,
+                            max_framing_rerolls,
+                            cycle_id,
+                            current_run_id,
+                        )
+                        continue  # same index — re-execute framing
                     break
                 self._cycle_event_bus.emit(
                     EventType.WORKLOAD_GATE_AWAITING,
@@ -704,6 +753,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 context={"cycle_id": cycle_id, "run_id": current_run_id},
                 payload={"workload_type": next_workload.get("type")},
             )
+            i += 1
 
     async def _starting_workload_index(self, cycle_id: str, first_run_id: str) -> int:
         """Workload-sequence index that ``first_run_id`` occupies (#257).

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -36,9 +36,13 @@ NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
 # ---------------------------------------------------------------------------
 
 
-def _make_cycle(workload_sequence: list[dict] | None = None, **kwargs) -> Cycle:
+def _make_cycle(
+    workload_sequence: list[dict] | None = None,
+    applied_defaults_extra: dict | None = None,
+    **kwargs,
+) -> Cycle:
     """Build a Cycle with optional workload_sequence in applied_defaults."""
-    applied_defaults = {}
+    applied_defaults = dict(applied_defaults_extra or {})
     if workload_sequence is not None:
         applied_defaults["workload_sequence"] = workload_sequence
     return Cycle(
@@ -273,6 +277,20 @@ class TestStartingWorkloadIndex:
         ]
         ex = self._bare_executor(mock_registry)
         # run_003 is the 2nd non-cancelled run → index 1, not 2
+        assert await ex._starting_workload_index("cyc_001", "run_003") == 1
+
+    async def test_framing_reroll_preserves_positional_index(self, mock_registry):
+        """#522 resume-safety: a re-rolled cycle has a CANCELLED rejected framing
+        run plus the live one; the implementation run must still resolve to index
+        1, not 2 — the invariant that lets the re-roll reuse _create_next_workload_run
+        and the duplicate guard without corrupting resume."""
+        mock_registry.list_runs.return_value = [
+            _make_run("run_001", 1, "cancelled", "framing"),  # rejected attempt
+            _make_run("run_002", 2, "completed", "framing"),  # the re-roll
+            _make_run("run_003", 3, "running", "implementation"),
+        ]
+        ex = self._bare_executor(mock_registry)
+        assert await ex._starting_workload_index("cyc_001", "run_002") == 0
         assert await ex._starting_workload_index("cyc_001", "run_003") == 1
 
     async def test_unknown_run_defaults_to_zero(self, mock_registry):
@@ -1730,3 +1748,123 @@ class TestInterWorkloadGatePlanValidation:
 
         assert executor.execute_run.await_count == 2
         mock_registry.create_run.assert_called_once()
+
+
+class TestFramingReroll:
+    """#522 — a system plan-validation rejection re-rolls framing (bounded by
+    framing_max_rerolls) instead of killing the cycle. Bug caught: 3 of 9 live
+    rolls (pf-2/5/9) died at the gate on a stochastic framing fault the model's
+    own prompt already forbids, with no retry and no implementation run."""
+
+    def _seq(self):
+        return [
+            {"type": "framing", "gate": "progress_plan_review"},
+            {"type": "implementation", "gate": None},
+        ]
+
+    async def test_system_rejection_rerolls_then_advances(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        cycle = _make_cycle(
+            workload_sequence=self._seq(), applied_defaults_extra={"framing_max_rerolls": 1}
+        )
+        mock_registry.get_cycle.return_value = cycle
+        run1 = _make_run("run_001", 1, "completed", "framing")
+        run2 = _make_run("run_002", 2, "completed", "framing")  # the re-roll
+        run3 = _make_run("run_003", 3, "completed", "implementation")
+        mock_registry.get_run.side_effect = [run1, run2, run3]
+        mock_registry.list_runs.return_value = [run1]
+        # plan invalid on attempt 1, clean on attempt 2
+        executor._reject_invalid_plan_before_workload_gate = AsyncMock(
+            side_effect=[["regex_match on source file 'x.py'"], []]
+        )
+        executor._create_next_workload_run = AsyncMock(side_effect=[run2, run3])
+        executor._poll_inter_workload_gate = AsyncMock(
+            return_value=_gate_decision("progress_plan_review", GateDecisionValue.APPROVED)
+        )
+
+        await executor.execute_cycle("cyc_001", "run_001")
+
+        # framing ran twice, implementation once
+        assert executor.execute_run.await_count == 3
+        # the rejected framing run was CANCELLED to preserve the positional
+        # run<->workload invariant (#257/D14): one non-cancelled run per position
+        mock_registry.cancel_run.assert_awaited_once_with("run_001")
+        # the re-roll created a fresh framing run before reaching implementation
+        assert [c.args[2]["type"] for c in executor._create_next_workload_run.await_args_list] == [
+            "framing",
+            "implementation",
+        ]
+
+    async def test_budget_exhausted_kills_cycle_no_impl_run(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        cycle = _make_cycle(
+            workload_sequence=self._seq(), applied_defaults_extra={"framing_max_rerolls": 1}
+        )
+        mock_registry.get_cycle.return_value = cycle
+        run1 = _make_run("run_001", 1, "completed", "framing")
+        run2 = _make_run("run_002", 2, "completed", "framing")
+        mock_registry.get_run.side_effect = [run1, run2]
+        mock_registry.list_runs.return_value = [run1]
+        # plan invalid on every attempt
+        executor._reject_invalid_plan_before_workload_gate = AsyncMock(
+            return_value=["regex_match on source file 'x.py'"]
+        )
+        executor._create_next_workload_run = AsyncMock(side_effect=[run2])
+        executor._poll_inter_workload_gate = AsyncMock()
+
+        await executor.execute_cycle("cyc_001", "run_001")
+
+        # one re-roll (2 framing executions), then the cycle dies — no impl run
+        assert executor.execute_run.await_count == 2
+        mock_registry.cancel_run.assert_awaited_once_with("run_001")
+        assert executor._create_next_workload_run.await_count == 1  # only the re-roll
+        executor._poll_inter_workload_gate.assert_not_awaited()
+
+    async def test_default_zero_rerolls_is_unchanged_behavior(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        # no framing_max_rerolls set -> default 0 -> first rejection kills the
+        # cycle exactly as before (no cancel, no re-roll)
+        cycle = _make_cycle(workload_sequence=self._seq())
+        mock_registry.get_cycle.return_value = cycle
+        run1 = _make_run("run_001", 1, "completed", "framing")
+        mock_registry.get_run.side_effect = [run1]
+        mock_registry.list_runs.return_value = [run1]
+        executor._reject_invalid_plan_before_workload_gate = AsyncMock(
+            return_value=["regex_match on source file 'x.py'"]
+        )
+        executor._create_next_workload_run = AsyncMock()
+
+        await executor.execute_cycle("cyc_001", "run_001")
+
+        assert executor.execute_run.await_count == 1
+        mock_registry.cancel_run.assert_not_awaited()
+        executor._create_next_workload_run.assert_not_awaited()
+
+    async def test_non_framing_workload_never_rerolls(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        # a system rejection on a non-framing gated workload must not re-roll even
+        # with budget — the type guard is explicit
+        seq = [
+            {"type": "implementation", "gate": "impl_review"},
+            {"type": "wrapup", "gate": None},
+        ]
+        cycle = _make_cycle(
+            workload_sequence=seq, applied_defaults_extra={"framing_max_rerolls": 2}
+        )
+        mock_registry.get_cycle.return_value = cycle
+        run1 = _make_run("run_001", 1, "completed", "implementation")
+        mock_registry.get_run.side_effect = [run1]
+        mock_registry.list_runs.return_value = [run1]
+        executor._reject_invalid_plan_before_workload_gate = AsyncMock(
+            return_value=["some plan error"]
+        )
+        executor._create_next_workload_run = AsyncMock()
+
+        await executor.execute_cycle("cyc_001", "run_001")
+
+        assert executor.execute_run.await_count == 1
+        mock_registry.cancel_run.assert_not_awaited()

--- a/tests/unit/events/test_event_emission.py
+++ b/tests/unit/events/test_event_emission.py
@@ -326,9 +326,10 @@ class TestEmitCallSitePayloadFields:
         assert with_payload >= 35
 
     def test_total_emit_call_count(self) -> None:
-        """Sanity check: 18 executor + 7 correction-runner +
-        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 42 total
-        emit calls (#473 added the pre-gate rejection's GATE_DECIDED emit).
+        """Sanity check: 19 executor + 7 correction-runner +
+        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 43 total
+        emit calls (#473 added the pre-gate rejection's GATE_DECIDED emit;
+        #522 added the framing re-roll's WORKLOAD_ADVANCED emit).
 
         SIP-0097 slice 2c collapsed execute_run's five per-exception-class
         terminal emits into one emit driven by the RunCompletion terminal
@@ -341,4 +342,4 @@ class TestEmitCallSitePayloadFields:
         total = 0
         for path in _ALL_EMISSION_FILES:
             total += len(self._extract_emit_calls(path))
-        assert total == 42
+        assert total == 43


### PR DESCRIPTION
## Problem

A `system:plan_validation` gate rejection killed the cycle with **no implementation run**. In the overnight green-hunt, **3 of 9 rolls (pf-2, pf-5, pf-9) died this way** — every time, framing authored a `regex_match` on a source file, the #464 net correctly rejected the plan, and the cycle just... stopped. The rule the model tripped is already stated verbatim in the proposer prompts, so it's a stochastic fault, not a fixable-by-prompting one — exactly the retry a human operator would grant in one click.

## Design (the non-obvious part)

Naive re-rolling collides with a core invariant: the **positional run↔workload mapping** (#257/D14) assumes exactly one non-cancelled run per workload position. Creating a second framing run would make `_starting_workload_index` (resume) and the advancement duplicate-guard (`len(non_cancelled) > i+1`) miscompute — the 2nd framing run would be mistaken for the implementation run.

So the re-roll **cancels the rejected framing run** (its rejection persists in `gate_decisions` as evidence, #473) before creating a fresh one. Cancelled runs are already excluded from positional indexing, so the invariant holds. The workload `for` loop became a `while` so a re-roll can re-process the same index (`continue` without the tail `i += 1`).

## Safety

- **Opt-in, zero default behavior change**: gated on `framing_max_rerolls` (default `0`) — the whole path is inert until a profile sets it. All 69 pre-existing execute_cycle/binding tests pass unchanged.
- **Human rejections untouched**: a `--reject` carries a different `decided_by` and reaches a different code path (the gate-poll REJECTED branch), never this one.

## Tests (through the real `execute_cycle`, #464/#473 pattern)

reroll-then-advance · budget-exhausted-kills-cycle (no impl run) · default-zero-unchanged · non-framing-never-rerolls · **resume-safety** (cancelled attempt preserves the positional index → impl still resolves to index 1). Full `cycles` domain green except the 2 pre-existing #498 host-PATH failures.

## Deploy note

Framework/executor change → needs a runtime-api + agent rebuild to take effect live, and a profile/launcher setting `framing_max_rerolls` (I'd suggest 2). Not deployed yet — flagging for when you resume the hunt.

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG