### PR TITLE
fix(#524): probe request bodies carry type/name-appropriate sample values, not "x"

### DIFF
--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -169,17 +169,52 @@ def _coverage_expectations(manifest: InterfaceManifest) -> list[str]:
     return out
 
 
+def _probe_sample_value(field_name: str, field_type: str) -> Any:
+    """A plausible sample value for a probe request field (#524).
+
+    ``"x"`` for every field failed apps that validate their inputs: a field named
+    ``datetime`` typed ``string`` still gets parsed as a datetime by a reasonable
+    app, which then 422s the bogus ``"x"`` — penalizing a *correct* app for
+    validating (pf-12: the app passed its own suite yet failed the probe on
+    "status 422 != expected 201"). Semantic name hints win over the declared type
+    (a string-typed ``datetime`` still wants an ISO value); type is the fallback.
+    """
+    n = field_name.lower()
+    t = (field_type or "").lower()
+    if "datetime" in n or "timestamp" in n or n.endswith("_at") or n in ("date", "time"):
+        return "2026-08-01T08:00:00"
+    if "email" in n:
+        return "sample@example.com"
+    if "url" in n or "uri" in n:
+        return "https://example.com"
+    if t in ("int", "integer"):
+        return 1
+    if t in ("float", "number", "decimal"):
+        return 1.0
+    if t in ("bool", "boolean"):
+        return True
+    if t.startswith("list") or t.startswith("array"):
+        return []
+    return "sample"
+
+
 def _probes(manifest: InterfaceManifest) -> list[dict[str, Any]]:
     """Self-contained probes only (POST endpoints with no path params). Sequenced
     probes (join/leave requiring a prior create) and richer response assertions land
     with the probe runner in 98.4; these are emitted now so the contract is complete."""
     shapes = {s.name: s for s in manifest.api.request_shapes}
+    # #524: resolve each required field's declared type (from entity fields) so the
+    # probe body carries type/name-appropriate sample values, not a blanket "x".
+    field_types = {f.name: f.type for e in manifest.entities for f in e.fields}
     probes: list[dict[str, Any]] = []
     for ep in manifest.api.endpoints:
         if ep.method != "POST" or "{" in ep.path:
             continue
         shape = shapes.get(ep.request or "")
-        json_body = {field: "x" for field in (shape.required if shape else ())}
+        json_body = {
+            field: _probe_sample_value(field, field_types.get(field, "string"))
+            for field in (shape.required if shape else ())
+        }
         probes.append(
             {
                 "id": f"vc-probe-{_slug(ep.path) or 'root'}",

--- a/tests/unit/capabilities/test_scaffold_contract.py
+++ b/tests/unit/capabilities/test_scaffold_contract.py
@@ -17,7 +17,11 @@ import pytest
 import yaml
 
 from squadops.capabilities.scaffold import InterfaceManifest, expand, fill_slot_paths
-from squadops.capabilities.scaffold_contract import emit_contract_dict, emit_contract_yaml
+from squadops.capabilities.scaffold_contract import (
+    _probe_sample_value,
+    emit_contract_dict,
+    emit_contract_yaml,
+)
 from squadops.cycles.verification_contract import VerificationContract
 
 pytestmark = [pytest.mark.domain_capabilities]
@@ -139,7 +143,12 @@ def test_behavioral_has_build_suite_and_self_contained_probe():
     assert probe_paths == {"/runs"}
     create = behavioral["probes"][0]
     assert create["request"]["method"] == "POST"
-    assert set(create["request"]["json"]) == {"title", "datetime", "location"}
+    body = create["request"]["json"]
+    assert set(body) == {"title", "datetime", "location"}
+    # #524: the datetime field gets an ISO value, not "x" — an app that validates
+    # datetime (pf-12) must not 422 the probe. Non-date fields get a plain string.
+    assert body["datetime"] == "2026-08-01T08:00:00"
+    assert body["title"] == "sample"
     assert (
         create["expect"]["status"] == 201
     )  # creates return 201 (pf-3: contract contradicted the PRD)
@@ -159,3 +168,40 @@ def test_emission_is_deterministic():
         VerificationContract.from_dict(a).content_hash()
         == VerificationContract.from_dict(b).content_hash()
     )
+
+
+# --------------------------------------------------------------------------- #
+# probe sample-value generator (#524) — bug caught: "x" for every field made an
+# app that validates its inputs (e.g. a datetime field) 422 the probe, failing a
+# correct app. pf-12: app passed its own suite yet failed the probe on 422/201.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("name", "type_", "expected"),
+    [
+        ("datetime", "string", "2026-08-01T08:00:00"),
+        ("start_at", "string", "2026-08-01T08:00:00"),
+        ("timestamp", "string", "2026-08-01T08:00:00"),
+        ("email", "string", "sample@example.com"),
+        ("callback_url", "string", "https://example.com"),
+        ("count", "int", 1),
+        ("ratio", "number", 1.0),
+        ("active", "bool", True),
+        ("tags", "list[str]", []),
+        ("title", "string", "sample"),
+    ],
+)
+def test_probe_sample_value_is_type_and_name_appropriate(name, type_, expected):
+    assert _probe_sample_value(name, type_) == expected
+
+
+def test_datetime_name_beats_string_type():
+    # the manifest declares datetime as type 'string' (MVP); the name must still
+    # win so the value is a real ISO datetime, not a bare string
+    assert _probe_sample_value("datetime", "string") == "2026-08-01T08:00:00"
+
+
+def test_unknown_field_defaults_to_plain_string():
+    assert _probe_sample_value("location", "string") == "sample"
+    assert _probe_sample_value("whatever", "") == "sample"


### PR DESCRIPTION
## Problem (now demonstrated, not hypothetical)

The probe emitter put `"x"` in every required request field. An app that validates its inputs — e.g. parses a field named `datetime` as a real datetime — 422s the bogus `"x"`, so the probe fails a **correct** app.

**pf-12 is the proof.** That roll's app passed its own pytest suite (`vc-suite-passes` verified — first suite convergence of the arc), built the frontend, and implemented every route correctly. The *only* failure was `vc-probe-runs: status 422 != expected 201`, because the app validated the `datetime` field and rejected `"x"`. This also resolves the ambiguity #524 was filed with: the "app over-validates" horn is refuted — the app validates *appropriately* (it passed its suite), so the probe is what's wrong.

It was also intermittent by app luck: pf-4/pf-8's apps were lax enough to accept `"x"` (probe passed); pf-7/pf-12's validated (422). The fix removes the coin-flip.

## Fix

`_probe_sample_value(name, type)` generates a plausible value: semantic **name** hints win over declared type (a string-typed `datetime` still gets an ISO value — the manifest calls datetime a string for MVP, but real apps parse it), then int/float/bool/list by type, plain string default. `datetime` now emits `2026-08-01T08:00:00`, which both validating and non-validating apps accept → 201.

## Tests

Parametrized generator coverage (datetime/`*_at`/timestamp → ISO, email, url, int, float, bool, list, default), the name-beats-string-type case, and the emitted group_run probe body asserting `datetime == "2026-08-01T08:00:00"`. Full regression green locally (5218 passed).

## Deploy note

Changes the contract hash → **re-emit + re-ingest a new frozen contract** for live rolls (host-side, no rebuild). This is the last known blocker between the current system and a green roll (pf-12).

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG