### PR TITLE
feat: deterministic interface-drift diagnosis feeds the correction repair (piece 1)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -256,6 +256,8 @@ class CorrectionRunner:
         plan_delta_refs: list[str],
         profile: Any = None,
         flow_run_id: str | None = None,
+        interface_manifest: Any = None,
+        artifact_contents: dict[str, str] | None = None,
     ) -> CorrectionProtocolResult:
         """Run the correction protocol: analyze → decide → act.
 
@@ -285,6 +287,26 @@ class CorrectionRunner:
         failure_evidence = build_failure_evidence(
             envelope, result, prior_plan_deltas_count=len(plan_delta_refs)
         )
+
+        # Deterministic interface-drift diagnosis (piece 1): when the app renamed
+        # a model field or route the manifest pins, hand the repair agent the exact
+        # offending identifiers + interface targets instead of an opaque check
+        # status. Additive — a clean workspace or absent manifest injects nothing,
+        # leaving the LLM-analysis path unchanged.
+        from squadops.cycles.interface_conformance import detect_interface_drift
+
+        drift = detect_interface_drift(interface_manifest, artifact_contents)
+        if drift:
+            failure_evidence["interface_drift"] = [
+                {
+                    "kind": f.kind,
+                    "file": f.file,
+                    "extra": list(f.extra),
+                    "missing": list(f.missing),
+                    "instruction": f.instruction,
+                }
+                for f in drift
+            ]
 
         # Issue #95: capture each correction step's outputs in its own variable
         # so the analyzer's classification/analysis_summary survive past the

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -384,6 +384,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         profile=profile,
                         run_root=run_root,
                         ledger=ledger,
+                        interface_manifest=interface_manifest,
                     )
                 elif mode == "fan_out_fan_in":
                     await self._execute_fan_out(plan, run_id, cycle, flow_run_id)
@@ -398,6 +399,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         profile=profile,
                         run_root=run_root,
                         ledger=ledger,
+                        interface_manifest=interface_manifest,
                     )
                 else:
                     await self._execute_sequential(
@@ -409,6 +411,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         obs_ctx=obs_ctx,
                         run_root=run_root,
                         ledger=ledger,
+                        interface_manifest=interface_manifest,
                     )
 
                 # Success -> completed
@@ -1036,6 +1039,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         run_root: str = "",
         *,
         ledger: RunLedger,
+        interface_manifest: Any = None,
     ) -> None:
         """Sequential: dispatch one task at a time, fail-fast.
 
@@ -1184,6 +1188,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     profile=profile,
                     flow_run_id=flow_run_id,
                     patched_result_holder=_holder,
+                    interface_manifest=interface_manifest,
                 )
                 if action in ("continue", "accept_patch"):
                     # #379: this attempt failed — re-dispatched ("continue") or
@@ -1719,6 +1724,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         flow_run_id: str | None = None,
         patched_result_holder: dict[str, Any] | None = None,
         enriched_envelope: TaskEnvelope | None = None,
+        interface_manifest: Any = None,
     ) -> str:
         """Route a failed task outcome. Returns an action string.
 
@@ -1798,6 +1804,12 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             plan_delta_refs=plan_delta_refs,
             profile=profile,
             flow_run_id=flow_run_id,
+            interface_manifest=interface_manifest,
+            # The materialized workspace (path -> content) rides on the enriched
+            # envelope (#456); the drift detector parses model/route files from it.
+            artifact_contents=(
+                (enriched_envelope.inputs if enriched_envelope is not None else {}) or {}
+            ).get("artifact_contents"),
         )
         correction_path = protocol.correction_path
 

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -75,6 +75,17 @@ def _format_failure_summary(failure_evidence: Any, failure_analysis: Any) -> str
     """Compose a compact failure description from evidence + analysis."""
     parts: list[str] = []
     if isinstance(failure_evidence, dict):
+        # Interface-drift diagnosis is deterministic and authoritative — the
+        # manifest, not the analyzer's guess, is the source of truth. Lead with
+        # it so the repair renames to the interface names and stops thrashing.
+        drift = failure_evidence.get("interface_drift") or []
+        if drift:
+            lines = [str(d.get("instruction", "")).strip() for d in drift if d.get("instruction")]
+            if lines:
+                parts.append(
+                    "INTERFACE CONFORMANCE (authoritative — apply exactly):\n"
+                    + "\n".join(f"- {line}" for line in lines)
+                )
         vr = failure_evidence.get("validation_result") or {}
         summary = vr.get("summary") or failure_evidence.get("error") or ""
         if summary:

--- a/src/squadops/cycles/interface_conformance.py
+++ b/src/squadops/cycles/interface_conformance.py
@@ -1,0 +1,224 @@
+"""Deterministic interface-drift diagnosis for the correction loop (piece 1).
+
+When an app renames an interface *identifier* — a model field or a route path —
+the failure the correction loop sees is opaque ("status 404 != expected 201").
+The LLM analyzer then guesses from post-extraction artifacts and mislabels it, and
+the repair thrashes.
+
+This module makes the *diagnosis* exact and leaves the *reconciliation* to the
+agent — the right division of labor. It parses the app's generated model/route
+files, diffs the identifiers against the interface manifest, and when the app
+declares identifiers the interface does not define, emits a ``DriftFinding``
+carrying the offending set, the interface identifiers currently absent, and a
+precise instruction. The agent renames by meaning (which an LLM does well and a
+1:1 set-diff cannot do safely when several identifiers drift at once — the real
+case: pf-13 drifted both ``location`` and ``pace_target`` simultaneously).
+
+Conservative on both ends: a clean file, class-name drift, or an unparseable file
+yields NO finding and falls through to the existing loop. Pure (manifest +
+{path: content} → findings); AST-based; never raises.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import Any
+
+_ROUTE_METHODS = {"get", "post", "put", "patch", "delete"}
+# Pydantic/class internals that are not interface fields even if annotated.
+_NON_FIELD_NAMES = {"model_config"}
+
+
+@dataclass(frozen=True)
+class DriftFinding:
+    """Identifier drift for one file, with the sets the agent needs to reconcile.
+
+    ``extra`` are identifiers the app declares that the interface does not define
+    (the offenders). ``missing`` are interface identifiers absent from the app
+    (the rename targets). ``instruction`` is the precise, self-contained repair
+    directive handed to the agent.
+    """
+
+    kind: str  # "field_drift" | "route_drift"
+    file: str
+    extra: tuple[str, ...]
+    missing: tuple[str, ...]
+    instruction: str
+
+
+def detect_interface_drift(
+    manifest: Any, artifact_contents: dict[str, str] | None
+) -> list[DriftFinding]:
+    """Diagnose field/route identifier drift against the manifest.
+
+    ``manifest`` is an ``InterfaceManifest`` (duck-typed: ``entities`` and
+    ``api.endpoints``). ``artifact_contents`` maps workspace-relative path → file
+    text. Returns a finding per drifted file; empty on clean input, missing
+    manifest/content, or any parse error.
+    """
+    if manifest is None or not artifact_contents:
+        return []
+    try:
+        return _detect_field_drift(manifest, artifact_contents) + _detect_route_drift(
+            manifest, artifact_contents
+        )
+    except Exception:
+        # A diagnosis helper must never break the correction loop — a parse or
+        # attribute surprise degrades to "no finding", i.e. today's behavior.
+        return []
+
+
+# --------------------------------------------------------------------------- #
+# Field drift: manifest entity fields vs. Pydantic model class fields
+# --------------------------------------------------------------------------- #
+
+
+def _detect_field_drift(manifest: Any, contents: dict[str, str]) -> list[DriftFinding]:
+    entities = getattr(manifest, "entities", ()) or ()
+    if not entities:
+        return []
+    model_classes: dict[str, tuple[str, set[str]]] = {}
+    for path, text in contents.items():
+        if not path.endswith(".py") or not isinstance(text, str):
+            continue
+        for cls_name, fields in _model_classes(text):
+            model_classes.setdefault(cls_name, (path, fields))
+
+    findings: list[DriftFinding] = []
+    for entity in entities:
+        entity_name = getattr(entity, "name", None)
+        if entity_name is None or entity_name not in model_classes:
+            continue  # class-name drift or absent model — out of scope, fall through
+        expected = {f.name for f in getattr(entity, "fields", ()) or ()}
+        file, actual = model_classes[entity_name]
+        actual = {a for a in actual if a not in _NON_FIELD_NAMES and not a.startswith("_")}
+        extra = actual - expected  # app declares fields the interface doesn't define
+        if not extra:
+            continue
+        missing = expected - actual  # interface fields absent from the app
+        findings.append(
+            DriftFinding(
+                kind="field_drift",
+                file=file,
+                extra=tuple(sorted(extra)),
+                missing=tuple(sorted(missing)),
+                instruction=_field_instruction(entity_name, file, extra, missing, expected),
+            )
+        )
+    return findings
+
+
+def _field_instruction(
+    entity: str, file: str, extra: set[str], missing: set[str], expected: set[str]
+) -> str:
+    offenders = ", ".join(f"`{n}`" for n in sorted(extra))
+    iface = ", ".join(f"`{n}`" for n in sorted(expected))
+    base = (
+        f"The `{entity}` model in `{file}` declares field(s) {offenders} that are not part "
+        f"of the interface. The interface defines exactly these fields: {iface}. "
+    )
+    if missing:
+        targets = ", ".join(f"`{n}`" for n in sorted(missing))
+        base += (
+            f"Rename each non-interface field to its correct interface name — the interface "
+            f"fields currently absent from your model are {targets}. Match by meaning. "
+        )
+    else:
+        base += "Remove or rename the non-interface field(s) so the model matches the interface. "
+    return base + "Update every reference (routes, tests, frontend). Change nothing else."
+
+
+def _model_classes(text: str) -> list[tuple[str, set[str]]]:
+    """``(class_name, {annotated field names})`` for each class — the Pydantic surface."""
+    tree = ast.parse(text)
+    out: list[tuple[str, set[str]]] = []
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        fields = {
+            stmt.target.id
+            for stmt in node.body
+            if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+        }
+        out.append((node.name, fields))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Route drift: manifest endpoints vs. FastAPI route decorators
+# --------------------------------------------------------------------------- #
+
+
+def _detect_route_drift(manifest: Any, contents: dict[str, str]) -> list[DriftFinding]:
+    api = getattr(manifest, "api", None)
+    endpoints = getattr(api, "endpoints", ()) if api is not None else ()
+    if not endpoints:
+        return []
+    expected = {(getattr(e, "method", "").upper(), getattr(e, "path", "")) for e in endpoints}
+
+    actual: set[tuple[str, str]] = set()
+    file_by_route: dict[tuple[str, str], str] = {}
+    for path, text in contents.items():
+        if not path.endswith(".py") or not isinstance(text, str):
+            continue
+        for method, route in _route_decorators(text):
+            actual.add((method, route))
+            file_by_route.setdefault((method, route), path)
+    if not actual:
+        return []
+    extra = actual - expected  # app routes not in the interface
+    if not extra:
+        return []
+    missing = expected - actual
+    # All offending routes share a file in practice; name it from the first.
+    file = file_by_route[sorted(extra)[0]]
+    return [
+        DriftFinding(
+            kind="route_drift",
+            file=file,
+            extra=tuple(f"{m} {p}" for m, p in sorted(extra)),
+            missing=tuple(f"{m} {p}" for m, p in sorted(missing)),
+            instruction=_route_instruction(file, extra, missing, expected),
+        )
+    ]
+
+
+def _route_instruction(
+    file: str, extra: set[tuple[str, str]], missing: set[tuple[str, str]], expected: set
+) -> str:
+    offenders = ", ".join(f"`{m} {p}`" for m, p in sorted(extra))
+    iface = ", ".join(f"`{m} {p}`" for m, p in sorted(expected))
+    base = (
+        f"`{file}` declares route(s) {offenders} that are not part of the interface. "
+        f"The interface defines exactly these routes: {iface}. "
+    )
+    if missing:
+        targets = ", ".join(f"`{m} {p}`" for m, p in sorted(missing))
+        base += (
+            f"Correct the path/method of each non-interface route to match the interface — "
+            f"the interface routes currently absent are {targets}. Match by meaning. "
+        )
+    else:
+        base += "Remove or correct the non-interface route(s) so they match the interface. "
+    return base + "Update every reference (tests, frontend). Change nothing else."
+
+
+def _route_decorators(text: str) -> list[tuple[str, str]]:
+    """``(METHOD, path)`` for each ``@x.<method>("path", ...)`` route decorator."""
+    tree = ast.parse(text)
+    out: list[tuple[str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for dec in node.decorator_list:
+            if not isinstance(dec, ast.Call) or not isinstance(dec.func, ast.Attribute):
+                continue
+            method = dec.func.attr.lower()
+            if method not in _ROUTE_METHODS:
+                continue
+            if dec.args and isinstance(dec.args[0], ast.Constant):
+                value = dec.args[0].value
+                if isinstance(value, str):
+                    out.append((method.upper(), value))
+    return out

--- a/tests/unit/cycles/test_interface_conformance.py
+++ b/tests/unit/cycles/test_interface_conformance.py
@@ -1,0 +1,159 @@
+"""Interface-drift detector tests (correction-loop piece 1, set-report design).
+
+Bug caught: an app that renames interface identifiers (field `location` ->
+`meeting_location`, and simultaneously `pace_target` -> `pace` — the real pf-13
+case) fails the probe with an opaque "status 404/422", the LLM analyzer
+mislabels it, and the repair thrashes. The detector reports the offending set +
+the interface targets so the agent renames by meaning; clean / class-drift /
+unparseable cases yield NO finding and fall through to the existing loop.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from squadops.cycles.interface_conformance import detect_interface_drift
+
+
+def _manifest(fields: list[str], routes: list[tuple[str, str]]):
+    entity = SimpleNamespace(name="RunEvent", fields=[SimpleNamespace(name=n) for n in fields])
+    endpoints = [SimpleNamespace(method=m, path=p) for m, p in routes]
+    return SimpleNamespace(entities=[entity], api=SimpleNamespace(endpoints=endpoints))
+
+
+_FIELDS = ["id", "title", "datetime", "location", "pace_target", "participants"]
+_ROUTES = [("GET", "/runs"), ("POST", "/runs"), ("GET", "/runs/{id}")]
+
+
+def _model_src(field_names: list[str]) -> str:
+    lines = "\n".join(f"    {n}: str" for n in field_names)
+    return f"from pydantic import BaseModel\nclass RunEvent(BaseModel):\n{lines}\n"
+
+
+def _routes_src(routes: list[tuple[str, str]]) -> str:
+    body = "\n".join(
+        f'@router.{m.lower()}("{p}")\ndef f{i}(): ...' for i, (m, p) in enumerate(routes)
+    )
+    return f"from fastapi import APIRouter\nrouter = APIRouter()\n{body}\n"
+
+
+# --------------------------------------------------------------------------- #
+# field drift — the multi-drift case is the whole point (single-mismatch would
+# have missed pf-13, which drifted TWO fields at once)
+# --------------------------------------------------------------------------- #
+
+
+def test_two_field_drifts_are_both_reported():
+    manifest = _manifest(_FIELDS, _ROUTES)
+    app = ["id", "title", "datetime", "meeting_location", "pace", "participants"]
+    contents = {"backend/models.py": _model_src(app), "backend/routes.py": _routes_src(_ROUTES)}
+    findings = [f for f in detect_interface_drift(manifest, contents) if f.kind == "field_drift"]
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.extra == ("meeting_location", "pace")
+    assert f.missing == ("location", "pace_target")
+    assert "`meeting_location`" in f.instruction and "`pace`" in f.instruction
+    assert "`location`" in f.instruction and "`pace_target`" in f.instruction
+    assert "Change nothing else." in f.instruction
+
+
+def test_single_field_drift_still_reported():
+    manifest = _manifest(_FIELDS, _ROUTES)
+    app = ["id", "title", "datetime", "meeting_location", "pace_target", "participants"]
+    contents = {"backend/models.py": _model_src(app), "backend/routes.py": _routes_src(_ROUTES)}
+    findings = [f for f in detect_interface_drift(manifest, contents) if f.kind == "field_drift"]
+    assert len(findings) == 1
+    assert findings[0].extra == ("meeting_location",)
+    assert findings[0].missing == ("location",)
+
+
+def test_clean_model_yields_no_field_finding():
+    manifest = _manifest(_FIELDS, _ROUTES)
+    contents = {"backend/models.py": _model_src(_FIELDS), "backend/routes.py": _routes_src(_ROUTES)}
+    assert [f for f in detect_interface_drift(manifest, contents) if f.kind == "field_drift"] == []
+
+
+def test_model_config_and_dunder_are_not_fields():
+    manifest = _manifest(_FIELDS, _ROUTES)
+    src = (
+        "from pydantic import BaseModel, ConfigDict\n"
+        "class RunEvent(BaseModel):\n"
+        "    model_config: ConfigDict = ConfigDict()\n"
+        + "\n".join(f"    {n}: str" for n in _FIELDS)
+        + "\n"
+    )
+    contents = {"backend/models.py": src, "backend/routes.py": _routes_src(_ROUTES)}
+    assert [f for f in detect_interface_drift(manifest, contents) if f.kind == "field_drift"] == []
+
+
+def test_class_name_drift_is_skipped():
+    manifest = _manifest(_FIELDS, _ROUTES)
+    src = _model_src(["id", "title", "datetime", "meeting_location", "pace_target", "participants"])
+    src = src.replace("RunEvent", "Event")  # class renamed -> no matching entity
+    contents = {"backend/models.py": src, "backend/routes.py": _routes_src(_ROUTES)}
+    assert [f for f in detect_interface_drift(manifest, contents) if f.kind == "field_drift"] == []
+
+
+# --------------------------------------------------------------------------- #
+# route drift
+# --------------------------------------------------------------------------- #
+
+
+def test_route_path_drift_is_reported():
+    manifest = _manifest(_FIELDS, _ROUTES)
+    drifted = [("GET", "/runs"), ("POST", "/run"), ("GET", "/runs/{id}")]  # POST /runs -> /run
+    contents = {"backend/models.py": _model_src(_FIELDS), "backend/routes.py": _routes_src(drifted)}
+    findings = [f for f in detect_interface_drift(manifest, contents) if f.kind == "route_drift"]
+    assert len(findings) == 1
+    assert findings[0].extra == ("POST /run",)
+    assert findings[0].missing == ("POST /runs",)
+
+
+def test_conforming_routes_yield_no_finding():
+    # pf-15's real shape: routes match the manifest -> the 404 was NOT name drift
+    manifest = _manifest(_FIELDS, _ROUTES)
+    contents = {"backend/models.py": _model_src(_FIELDS), "backend/routes.py": _routes_src(_ROUTES)}
+    assert [f for f in detect_interface_drift(manifest, contents) if f.kind == "route_drift"] == []
+
+
+# --------------------------------------------------------------------------- #
+# robustness
+# --------------------------------------------------------------------------- #
+
+
+def test_none_manifest_or_empty_contents_yields_no_finding():
+    assert detect_interface_drift(None, {"x.py": "y"}) == []
+    assert detect_interface_drift(_manifest(_FIELDS, _ROUTES), {}) == []
+    assert detect_interface_drift(_manifest(_FIELDS, _ROUTES), None) == []
+
+
+def test_unparseable_file_never_raises():
+    manifest = _manifest(_FIELDS, _ROUTES)
+    contents = {"backend/models.py": "def (( not python", "backend/routes.py": "@@@"}
+    assert detect_interface_drift(manifest, contents) == []
+
+
+def test_real_group_run_manifest_pf13_multi_drift():
+    from pathlib import Path
+
+    from squadops.capabilities.scaffold import InterfaceManifest
+
+    manifest = InterfaceManifest.from_yaml(
+        Path("examples/03_group_run/interface_manifest.yaml").read_text(encoding="utf-8")
+    )
+    # pf-13's exact real drift: location->meeting_location AND pace_target->pace
+    app = [
+        "id",
+        "title",
+        "datetime",
+        "meeting_location",
+        "distance",
+        "pace",
+        "route_notes",
+        "participants",
+    ]
+    contents = {"backend/app/models.py": _model_src(app)}
+    findings = [f for f in detect_interface_drift(manifest, contents) if f.kind == "field_drift"]
+    assert len(findings) == 1
+    assert findings[0].extra == ("meeting_location", "pace")
+    assert findings[0].missing == ("location", "pace_target")


### PR DESCRIPTION
## Problem

When an app renames an interface identifier the manifest pins — a model field or a route path — the correction loop only saw an opaque check status (`status 404 != expected 201`). `analyze_failure` (pure LLM) guessed from post-extraction artifacts, mislabeled it, and the repair regenerated broadly and thrashed. pf-13 and pf-15 both died partly this way.

## Design: deterministic diagnosis, LLM reconciliation

`interface_conformance.detect_interface_drift(manifest, {path: content})` AST-parses the app's model/route files and diffs identifiers against the manifest. Per drifted file it reports the **offending set** (identifiers the app declares that the interface doesn't define) plus the **interface targets** — and a precise instruction. The agent renames by meaning.

**Set-report, not 1:1 rename** — because the real failures drift *several* identifiers at once. pf-13 renamed **both** `location`→`meeting_location` *and* `pace_target`→`pace`; a single-mismatch detector (my first cut) emits nothing on that, which the replay caught before any wiring. So the deterministic part reports the sets; the LLM does the meaning-based mapping it's good at and code can't do safely.

The finding is injected into `failure_evidence` and surfaced at the **top of the repair prompt** as authoritative ("INTERFACE CONFORMANCE — apply exactly").

## Wiring

The executor threads the already-loaded interface manifest + the enriched envelope's materialized workspace (`artifact_contents`, #456) through `_execute_sequential` → `_handle_task_outcome` → `run_correction_protocol`. **Additive and opt-in-by-data:** a clean workspace, absent manifest, or unparseable file injects nothing — today's path is byte-identical. No fragment change (rides the existing `failure_summary` variable).

## Validation — replay, not a new cycle

Verified against pf-13's **real stored artifacts**: the detector reports `extra={meeting_location, pace} missing={location, pace_target}`, and one isolated call to the 27b dev model (qwen3.6:27b) with the surgical instruction renamed **both** fields correctly, producing a model that matches the interface exactly. Deterministic input, reproducible, ~one model call vs a 3-hour cycle. The replay also confirmed pf-15's routes conform (its 404 was never name drift — separate cause, out of scope).

## Tests

Detector: multi-drift (the pf-13 case), single drift, clean, `model_config`/dunder exclusion, class-name-drift skip, route path drift, conforming routes, None/empty/unparseable robustness, plus a real-group-run-manifest case. Full regression green (5228 passed).

## Deploy note

Executor/handler change → needs **rebuild + restart** to run live (and per the #522 lesson I'll verify in-container, not trust the file). Not deployed yet.

Scope: fields + routes, set-report. Out of scope: agent drift-memory (piece 2), pf-15's non-name-drift 404, `#522`-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG