### PR TITLE
fix(fenced_parser): recover path:-labelled headers and unterminated-at-EOF fences

### DIFF
--- a/src/squadops/capabilities/handlers/fenced_parser.py
+++ b/src/squadops/capabilities/handlers/fenced_parser.py
@@ -6,7 +6,10 @@ and QATestHandler to parse multi-file output.
 
 Recognized formats, in priority order (most explicit first):
 
-1. Strict tagged fence — ``` ``` <language>:<filepath>``` ```
+1. Strict tagged fence — ``` ``` <language>:<filepath>``` ```. A redundant
+   ``path:``/``file:`` label wedged before the path (#431 —
+   ``` ```python:path:backend/main.py``` ```) is stripped; the residual colon
+   would otherwise fail the safety check and drop the whole file.
 2. Filename in language slot for special names — ``` ``` Dockerfile``` ```,
    ``` ``` Makefile``` ```, etc.
 3. Filename heading immediately preceding the fence — ``#`` through ``######``
@@ -39,6 +42,15 @@ opens a nested level and a bare ``` ``` ``` ``` closes the innermost one; the
 block ends only when the depth returns to zero. Trade-off: a body containing
 an *unmatched* tokened opener leaves the block unclosed and it is abandoned
 whole — rarer and louder than the silent mid-document clip it replaces.
+
+Implicit close at EOF (#431): a model sometimes drops only the closing
+``` ``` ``` ```, leaving a valid header and a complete body that runs to the end
+of the response. When the text after an unclosed opener contains *no further
+fence markers at all*, the body unambiguously ends at EOF and that is taken as
+the close — recovering a file that would otherwise be lost. The no-inner-fence
+guard is deliberate: if any fence remains, a close may merely be missing
+*between* two files, and abandoning the opener is safer than swallowing the next
+file's content into this one.
 
 Part of SIP-Enhanced-Agent-Build-Capabilities, Phase 1.
 """
@@ -83,6 +95,14 @@ _FILENAME_PREFIX_RE = re.compile(
     rf"^(?P<path>[\w./-]+\.[a-zA-Z0-9]+|{_SPECIAL_NAMES_RE}):(?P<rest>.*)$",
 )
 
+# Redundant path label a model sometimes wedges into a strict header (#431):
+# ``` ```python:path:backend/main.py``` ```. Strategy 1 partitions on the first
+# colon and is left with ``path:backend/main.py`` as the filename — the residual
+# colon then trips ``_path_is_safe`` and the whole file is dropped. A real path
+# can never contain a colon, so a leading ``path:``/``file:`` label is always
+# spurious and safe to strip.
+_PATH_LABEL_RE = re.compile(r"^(?:path|file|filename|filepath)\s*:\s*", re.IGNORECASE)
+
 # Source/deliverable extensions the build handlers emit — the guard that lets an
 # unmarked ``path:code`` first line (#470) be read as a filename without
 # mis-reading prose or config values (``example.com:8080``, ``note.txt:`` are
@@ -126,6 +146,17 @@ _SPECIAL_FILENAMES_AS_LANG = set(_SPECIAL_NAMES)
 def _has_source_extension(path: str) -> bool:
     ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
     return ext in _SOURCE_EXTENSIONS
+
+
+def _strip_path_label(filename: str) -> str:
+    """#431: drop a redundant ``path:``/``file:`` label from a strict-header
+    filename (``python:path:backend/main.py`` → ``backend/main.py``).
+
+    Strictly additive: a well-formed strict filename never starts with one of
+    these label words followed by a colon, so conforming headers are untouched;
+    only the malformed ones — which ``_path_is_safe`` rejects today — are healed.
+    """
+    return _PATH_LABEL_RE.sub("", filename, count=1)
 
 
 _HEADING_PROSE_DISTANCE_LINES = 4
@@ -199,6 +230,21 @@ def _find_block_close(response: str, body_start: int) -> re.Match[str] | None:
         pos = fence.end()
 
 
+def _is_implicit_eof_close(response: str, body_start: int) -> bool:
+    """#431: True when the text from ``body_start`` to EOF is a *clean* single
+    unterminated block — it contains no further fence markers at all.
+
+    A model sometimes drops only the closing ``` ``` ```, leaving a valid header
+    and a complete body that runs to EOF (real cases: two of three sampled
+    extraction losses). When nothing else in the remainder looks like a fence,
+    the body unambiguously ends at EOF and the close can be inferred. But if the
+    remainder *does* carry a fence, boundaries are ambiguous — a close fence may
+    merely be missing *between* two files — so we decline and let the block be
+    abandoned rather than risk swallowing the next file's content.
+    """
+    return _OPEN_FENCE_RE.search(response, body_start) is None
+
+
 def _resolve_filename_from_first_comment(body: str) -> tuple[str | None, str]:
     """If the first line of ``body`` is a comment containing a filename,
     return ``(filename, body_with_first_line_stripped)``. Otherwise
@@ -269,6 +315,60 @@ def _resolve_filename_from_first_line_bare(body: str) -> tuple[str | None, str]:
     return first_line, remainder
 
 
+def _resolve_block(
+    response: str,
+    fence_start: int,
+    token: str,
+    body: str,
+    last_used_heading_pos: int,
+) -> tuple[str | None, str, str, int]:
+    """Resolve ``(filename, language, body, last_used_heading_pos)`` for one
+    fenced block by trying the resolution strategies in priority order (see the
+    module docstring). ``filename`` is ``None`` when no strategy resolves a path.
+    ``body`` is returned possibly trimmed (strategies 4-6 strip their first-line
+    marker); ``last_used_heading_pos`` advances when strategy 3 consumes a
+    heading so it is not reused by a later fence.
+    """
+    filename: str | None = None
+    language: str = token
+
+    if ":" in token:
+        # Strategy 1: strict ```<lang>:<path>
+        language, _, filename = token.partition(":")
+        filename = _strip_path_label(filename)  # #431: heal ```lang:path:<file>
+    elif token in _SPECIAL_FILENAMES_AS_LANG:
+        # Strategy 2: ```Dockerfile (filename in language slot)
+        filename = token
+        language = token.lower()
+    else:
+        # Strategy 3: filename heading immediately preceding the fence
+        heading_filename, last_used_heading_pos = _resolve_filename_from_heading(
+            response, fence_start, last_used_heading_pos
+        )
+        if heading_filename is not None:
+            filename = heading_filename
+        else:
+            # Strategy 4: first-line filename comment inside body
+            comment_filename, stripped_body = _resolve_filename_from_first_comment(body)
+            if comment_filename is not None:
+                filename = comment_filename
+                body = stripped_body
+            else:
+                # Strategy 5 (#470): first-line ``path:code`` prefix inside body
+                prefix_filename, prefixed_body = _resolve_filename_from_first_line_prefix(body)
+                if prefix_filename is not None:
+                    filename = prefix_filename
+                    body = prefixed_body
+                else:
+                    # Strategy 6 (#502): bare filename alone on the first line
+                    bare_filename, bare_body = _resolve_filename_from_first_line_bare(body)
+                    if bare_filename is not None:
+                        filename = bare_filename
+                        body = bare_body
+
+    return filename, language, body, last_used_heading_pos
+
+
 def extract_fenced_files(response: str) -> list[dict]:
     """Parse fenced code blocks into structured file records.
 
@@ -305,51 +405,25 @@ def extract_fenced_files(response: str) -> list[dict]:
 
         body_start = open_match.end() + 1  # skip newline after header
         close_match = _find_block_close(response, body_start)
-        if not close_match:
-            # No closing fence — abandon this opener and resume past it
+        if close_match:
+            body = response[body_start : close_match.start()]
+            next_pos = close_match.end()
+        elif _is_implicit_eof_close(response, body_start):
+            # #431: a single unterminated fence whose body runs cleanly to EOF —
+            # infer the dropped close rather than losing the whole file.
+            body = response[body_start:]
+            next_pos = len(response)
+        else:
+            # No closing fence and inferring one is unsafe — abandon this opener.
             pos = body_start
             continue
 
-        body = response[body_start : close_match.start()]
-        token = open_match.group(1)
-        filename: str | None = None
-        language: str = token
-
-        if ":" in token:
-            # Strategy 1: strict ```<lang>:<path>
-            language, _, filename = token.partition(":")
-        elif token in _SPECIAL_FILENAMES_AS_LANG:
-            # Strategy 2: ```Dockerfile (filename in language slot)
-            filename = token
-            language = token.lower()
-        else:
-            # Strategy 3: filename heading immediately preceding the fence
-            heading_filename, last_used_heading_pos = _resolve_filename_from_heading(
-                response, open_match.start(), last_used_heading_pos
-            )
-            if heading_filename is not None:
-                filename = heading_filename
-            else:
-                # Strategy 4: first-line filename comment inside body
-                comment_filename, stripped_body = _resolve_filename_from_first_comment(body)
-                if comment_filename is not None:
-                    filename = comment_filename
-                    body = stripped_body
-                else:
-                    # Strategy 5 (#470): first-line ``path:code`` prefix inside body
-                    prefix_filename, prefixed_body = _resolve_filename_from_first_line_prefix(body)
-                    if prefix_filename is not None:
-                        filename = prefix_filename
-                        body = prefixed_body
-                    else:
-                        # Strategy 6 (#502): bare filename alone on the first line
-                        bare_filename, bare_body = _resolve_filename_from_first_line_bare(body)
-                        if bare_filename is not None:
-                            filename = bare_filename
-                            body = bare_body
+        filename, language, body, last_used_heading_pos = _resolve_block(
+            response, open_match.start(), open_match.group(1), body, last_used_heading_pos
+        )
 
         if filename is None or not _path_is_safe(filename):
-            pos = close_match.end()
+            pos = next_pos
             continue
 
         results.append(
@@ -359,6 +433,6 @@ def extract_fenced_files(response: str) -> list[dict]:
                 "language": language or "text",
             }
         )
-        pos = close_match.end()
+        pos = next_pos
 
     return results

--- a/tests/unit/capabilities/test_fenced_parser.py
+++ b/tests/unit/capabilities/test_fenced_parser.py
@@ -221,11 +221,15 @@ class TestEdgeCases:
         result = extract_fenced_files(response)
         assert len(result) == 0
 
-    def test_no_closing_fence(self):
-        """Unclosed fence is skipped."""
+    def test_no_closing_fence_recovers_at_eof(self):
+        """#431: a single unterminated fence whose body runs cleanly to EOF (no
+        further fence markers) infers the dropped close rather than losing the
+        file — the model dropped only the closing ```."""
         response = "```python:main.py\nprint('hi')\n"
         result = extract_fenced_files(response)
-        assert len(result) == 0
+        assert len(result) == 1
+        assert result[0]["filename"] == "main.py"
+        assert result[0]["content"] == "print('hi')"
 
     def test_malformed_header_with_space(self):
         """Fence headers with spaces in the path are not matched."""
@@ -667,3 +671,95 @@ class TestFirstLineBareFilename:
         result = extract_fenced_files("```python\n# real.py\nimport os\n```")
         assert result[0]["filename"] == "real.py"
         assert result[0]["content"] == "import os"
+
+
+class TestPathLabelHeal:
+    """#431: strict headers with a redundant ``path:``/``file:`` label
+    (``` ```python:path:backend/main.py``` ```) — the residual colon would fail
+    the safety check and drop the whole file. Replay-derived from real losses
+    (cyc_40dd251ff9b8 emitted two such files, both dropped)."""
+
+    def test_path_label_stripped(self):
+        result = extract_fenced_files("```python:path:backend/main.py\nx = 1\n```\n")
+        assert len(result) == 1
+        assert result[0]["filename"] == "backend/main.py"
+        assert result[0]["language"] == "python"
+        assert result[0]["content"] == "x = 1"
+
+    def test_file_label_stripped(self):
+        result = extract_fenced_files("```js:file:src/api.js\nconst x = 1;\n```\n")
+        assert result[0]["filename"] == "src/api.js"
+        assert result[0]["content"] == "const x = 1;"
+
+    def test_two_labelled_files_both_recovered(self):
+        """The real cyc_40dd251ff9b8 shape: two path:-labelled blocks, both
+        properly closed — before #431 both were dropped, now both recover."""
+        response = (
+            "```python:path:backend/tests/conftest.py\n"
+            "import pytest\n"
+            "```\n"
+            "```python:path:backend/tests/test_runs.py\n"
+            "assert True\n"
+            "```\n"
+        )
+        result = extract_fenced_files(response)
+        assert [r["filename"] for r in result] == [
+            "backend/tests/conftest.py",
+            "backend/tests/test_runs.py",
+        ]
+
+    def test_plain_strict_header_unaffected(self):
+        """A conforming header without a label is untouched (no regression)."""
+        result = extract_fenced_files("```python:backend/main.py\ny = 2\n```\n")
+        assert result[0]["filename"] == "backend/main.py"
+
+    def test_filename_starting_with_label_word_not_mangled(self):
+        """A real path whose basename merely begins with ``file``/``path`` (no
+        colon after the word) must not be truncated."""
+        result = extract_fenced_files("```python:backend/fileutils.py\nz = 3\n```\n")
+        assert result[0]["filename"] == "backend/fileutils.py"
+
+
+class TestImplicitEofClose:
+    """#431: a single unterminated fence whose body runs cleanly to EOF infers
+    the dropped close; the no-inner-fence guard prevents swallowing a following
+    file when a close is merely missing between two blocks."""
+
+    def test_clean_unterminated_block_recovered(self):
+        response = "```python:backend/routes.py\ndef handler():\n    return 1\n"
+        result = extract_fenced_files(response)
+        assert len(result) == 1
+        assert result[0]["filename"] == "backend/routes.py"
+        assert result[0]["content"] == "def handler():\n    return 1"
+
+    def test_labelled_unterminated_block_recovered(self):
+        """Both fixes compose: path: label + missing close on one block."""
+        response = "```python:path:backend/x.py\nvalue = 42\n"
+        result = extract_fenced_files(response)
+        assert result[0]["filename"] == "backend/x.py"
+        assert result[0]["content"] == "value = 42"
+
+    def test_inner_fence_blocks_implicit_close_no_swallow(self):
+        """Guard: an unterminated opener followed by another fenced block must
+        NOT swallow that block into the first file's content. The ambiguous
+        first opener is abandoned; the clean trailing block still recovers —
+        crucially, no file ever contains the other file's code."""
+        response = "```python:a.py\ncode_a\n```python:b.py\ncode_b\n"
+        result = extract_fenced_files(response)
+        filenames = [r["filename"] for r in result]
+        assert "b.py" in filenames
+        b = next(r for r in result if r["filename"] == "b.py")
+        assert b["content"] == "code_b"
+        # No emitted file smuggles the other block's header/content.
+        assert all("```" not in r["content"] for r in result)
+        assert all("code_a" not in r["content"] for r in result if r["filename"] == "b.py")
+
+    def test_empty_output_stays_unrecovered(self):
+        """A genuinely empty response is a real failure, not a format slip —
+        it must remain unrecovered (cyc_571c5ea5a426 was 0 bytes)."""
+        assert extract_fenced_files("") == []
+
+    def test_bare_unterminated_fence_no_filename_still_dropped(self):
+        """Implicit close only helps when a filename resolves — an untagged
+        unterminated fence has no path and is still dropped."""
+        assert extract_fenced_files("```\nsome loose text at eof\n") == []


### PR DESCRIPTION
## What

Two fenced-parser malformation classes were silently dropping **whole recoverable files** into `build_warnings.md`, so the correction loop then burned a repair attempt regenerating output that was never wrong — a formatting miss misclassified as a work-product failure.

Both classes were **replay-diagnosed** from real stored `build_warnings.md` artifacts (no new cycles), and the fix is verified by replaying those same bytes.

### 1. Redundant `path:`/`file:` label in a strict header
````
```python:path:backend/main.py
````
Strategy 1 partitions on the first colon → filename `path:backend/main.py`; the residual colon trips `_path_is_safe` and the file is lost. `_strip_path_label` removes the label. **Strictly additive** — a conforming filename never starts with `path:`/`file:`, and a real path can't contain a colon anyway, so healthy headers and the existing colon-rejection security tests are untouched.

### 2. Unterminated fence at EOF
The model drops only the closing ```` ``` ````, leaving a valid header and a complete body running to end-of-response. `_is_implicit_eof_close` infers the close **only when the remainder holds no further fence markers** — so a close merely missing *between* two files can never swallow the next file's content into this one (that ambiguous case is still abandoned, as before).

Also extracted the strategy-1..6 resolution into `_resolve_block` to keep `extract_fenced_files` under the C901 threshold after the added branch — no behavior change.

## Replay evidence (real artifacts)

| sample | shape | before | after |
|---|---|---|---|
| `cyc_40dd251ff9b8` | two `path:`-labelled blocks, both closed | 0 files | **2 files** (676 + 7802 chars) |
| `cyc_3e66234ad996` | strict header, unterminated at EOF | 0 files | **1 file** (3530 chars, complete) |
| `cyc_571c5ea5a426` | 0 bytes | 0 files | **0 files** (correctly stays unrecovered — empty output is a real failure) |

## Tests

`tests/unit/capabilities/test_fenced_parser.py`: rewrote `test_no_closing_fence` to the new recovery contract, added `TestPathLabelHeal` (label heal, two-file, no-regression on plain headers and `file`-prefixed basenames) and `TestImplicitEofClose` (recovery, compose-with-label, **no-swallow guard**, empty-stays-unrecovered, untagged-fence-still-dropped). 70 pass; full `tests/unit/capabilities/` suite (1284) green; ruff clean.

## Scope

Refs #431 — reduces the extraction loss that #431's diagnosis blindness misclassifies as work-product failure; does **not** implement #431's raw-vs-stored evidence rule (separate change). Refs #430 (prior nested-fence recovery in the same parser, closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG
