### PR TITLE
fix(plan-validation): tolerate warning/info-severity criteria violations instead of rejecting the plan

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2356,6 +2356,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         errors: list[str] = []
         interface_content: str | None = None
         parsed_plan: ImplementationPlan | None = None
+        contract = None  # set in bind mode below; feeds the soft-violation log
         for ref_id in tuple(run.artifact_refs or ()):
             try:
                 ref, content_bytes = await self._artifact_vault.retrieve(ref_id)
@@ -2435,6 +2436,21 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         f"verification_contract: {e}"
                         for e in parsed_plan.validate_criteria_refs(contract)
                     )
+
+        # Soft (warning/info-severity) structural violations are tolerated, not
+        # rejected — but logged so the pass is never silent (a warning check can't
+        # block a build per RC-9, so it must not kill the cycle at plan validation).
+        if parsed_plan is not None:
+            soft = parsed_plan.soft_criteria_violations(contract)
+            if soft:
+                logger.warning(
+                    "Plan for gate %r on run %s: tolerated %d soft criteria "
+                    "violation(s) (warning/info severity — not rejecting): %s",
+                    gate_name,
+                    run.run_id,
+                    len(soft),
+                    "; ".join(soft),
+                )
         return errors
 
     async def _load_seeded_manifest_content(self, cycle: Cycle) -> str | None:

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -301,6 +301,30 @@ class ImplementationPlan:
                 errors.append(f"Task {task.task_index}: role '{task.role}' not in profile")
         return errors
 
+    def _regex_on_source_criteria(self):
+        """Yield ``(task, criterion, target)`` for every ``regex_match`` criterion
+        that targets a non-document file — the #464 violation shared by the fatal
+        scope check and the soft-violation collector."""
+        from squadops.cycles.acceptance_check_spec import regex_target_is_document
+
+        for task in self.tasks:
+            for criterion in task.acceptance_criteria:
+                if not isinstance(criterion, TypedCheck) or criterion.check != "regex_match":
+                    continue
+                target = criterion.params.get("file", "")
+                if not regex_target_is_document(target):
+                    yield task, criterion, target
+
+    @staticmethod
+    def _regex_on_source_message(task: PlanTask, target: str) -> str:
+        return (
+            f"Task {task.task_index} ({task.focus}): regex_match on source "
+            f"file {target!r} — regex criteria are allowed only on document "
+            "artifacts (.md/.txt/.rst); verify source files with "
+            "endpoint_defined/import_present/command_exit_zero or the "
+            "behavioral checks (#464)"
+        )
+
     def validate_criteria_scope(self) -> list[str]:
         """#464: regex_match criteria may only target document artifacts.
 
@@ -311,26 +335,20 @@ class ImplementationPlan:
         mechanical guard. Prose criteria and unparseable rows are out of
         scope here (non-blocking per #420).
 
+        Only ``severity=error`` violations reject the plan. A warning/info-severity
+        regex-on-source is a soft authoring slip that cannot block a build at
+        execution (RC-9), so it must not kill the cycle at plan validation either —
+        those are surfaced by ``soft_criteria_violations`` for a logged, tolerated
+        pass instead.
+
         Returns:
             List of validation error strings (empty = valid).
         """
-        from squadops.cycles.acceptance_check_spec import regex_target_is_document
-
-        errors: list[str] = []
-        for task in self.tasks:
-            for criterion in task.acceptance_criteria:
-                if not isinstance(criterion, TypedCheck) or criterion.check != "regex_match":
-                    continue
-                target = criterion.params.get("file", "")
-                if not regex_target_is_document(target):
-                    errors.append(
-                        f"Task {task.task_index} ({task.focus}): regex_match on source "
-                        f"file {target!r} — regex criteria are allowed only on document "
-                        "artifacts (.md/.txt/.rst); verify source files with "
-                        "endpoint_defined/import_present/command_exit_zero or the "
-                        "behavioral checks (#464)"
-                    )
-        return errors
+        return [
+            self._regex_on_source_message(task, target)
+            for task, criterion, target in self._regex_on_source_criteria()
+            if criterion.severity == "error"
+        ]
 
     def validate_criteria_refs(self, contract: VerificationContract) -> list[str]:
         """SIP-0098 §6.3: bind-mode plan validation against the seeded contract.
@@ -384,20 +402,66 @@ class ImplementationPlan:
                         f"(no silent descoping of verification)"
                     )
 
-            # 3. authored typed criteria targeting a covered file are rejected.
+        # 3. authored typed criteria targeting a covered file are rejected — but
+        #    only at severity=error. A warning/info-severity authored check on a
+        #    covered file is a soft slip (the contract owns the file; RC-9: a
+        #    warning can't block a build), tolerated + logged via
+        #    soft_criteria_violations rather than killing the whole cycle.
+        errors.extend(
+            self._authored_on_covered_message(task, criterion, target)
+            for task, criterion, target in self._authored_on_covered_criteria(contract)
+            if criterion.severity == "error"
+        )
+
+        return errors
+
+    def _authored_on_covered_criteria(self, contract: VerificationContract):
+        """Yield ``(task, criterion, target)`` for every authored ``TypedCheck``
+        whose target file is contract-covered (§6.3 rule 3) — shared by the fatal
+        refs check and the soft-violation collector."""
+        covered = contract.covered_fill_paths()
+        for task in self.tasks:
             for criterion in task.acceptance_criteria:
                 if not isinstance(criterion, TypedCheck):
                     continue
                 target = criterion.params.get("file", "")
                 if target in covered:
-                    errors.append(
-                        f"Task {task.task_index} ({task.focus}): authored typed criterion "
-                        f"{criterion.check!r} targets contract-covered file {target!r} — "
-                        f"bind the contract criteria by id (criteria_refs); do not author "
-                        f"typed criteria for covered files"
-                    )
+                    yield task, criterion, target
 
-        return errors
+    @staticmethod
+    def _authored_on_covered_message(task: PlanTask, criterion: TypedCheck, target: str) -> str:
+        return (
+            f"Task {task.task_index} ({task.focus}): authored typed criterion "
+            f"{criterion.check!r} targets contract-covered file {target!r} — "
+            f"bind the contract criteria by id (criteria_refs); do not author "
+            f"typed criteria for covered files"
+        )
+
+    def soft_criteria_violations(self, contract: VerificationContract | None = None) -> list[str]:
+        """Warning/info-severity structural criteria violations that are TOLERATED,
+        not rejected — regex-on-source (#464) and, when a contract is given (bind
+        mode), authored-on-covered (§6.3). Each note is prefixed with the criterion's
+        severity so the caller can log an audit trail; this method never rejects.
+
+        Error-severity violations are NOT returned here — they stay fatal in
+        ``validate_criteria_scope`` / ``validate_criteria_refs``. RC-9 anchors the
+        split: a warning check cannot block a build at execution, so it must not
+        kill the cycle at plan validation either.
+        """
+        notes: list[str] = [
+            f"tolerated (severity={criterion.severity}): "
+            + self._regex_on_source_message(task, target)
+            for task, criterion, target in self._regex_on_source_criteria()
+            if criterion.severity != "error"
+        ]
+        if contract is not None:
+            notes.extend(
+                f"tolerated (severity={criterion.severity}): "
+                + self._authored_on_covered_message(task, criterion, target)
+                for task, criterion, target in self._authored_on_covered_criteria(contract)
+                if criterion.severity != "error"
+            )
+        return notes
 
     def to_dict(self) -> dict:
         """Serialize to dict for YAML/JSON transport.

--- a/tests/unit/cycles/test_criteria_ref_binding.py
+++ b/tests/unit/cycles/test_criteria_ref_binding.py
@@ -260,6 +260,42 @@ def test_authored_typed_criterion_on_covered_file_is_rejected():
     assert any("authored typed criterion" in e and "backend/routes.py" in e for e in errors)
 
 
+def test_warning_severity_authored_on_covered_is_tolerated():
+    """§6.3 + RC-9: a warning-severity authored check on a covered file is a soft
+    slip, not fatal — tolerated (the contract owns the file) and surfaced via
+    soft_criteria_violations instead of killing the cycle at the plan gate."""
+    authored = (
+        "\n      - {check: import_present, file: backend/routes.py, "
+        "module: .errors, symbol: ApiError, severity: warning}"
+    )
+    plan = ImplementationPlan.from_yaml(
+        _plan_yaml(
+            refs="[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles]", authored=authored
+        )
+    )
+    contract = _contract()
+    assert plan.validate_criteria_refs(contract) == []
+    soft = plan.soft_criteria_violations(contract)
+    assert len(soft) == 1
+    assert "backend/routes.py" in soft[0]
+    assert "severity=warning" in soft[0]
+
+
+def test_error_severity_authored_on_covered_still_rejected():
+    authored = (
+        "\n      - {check: import_present, file: backend/routes.py, "
+        "module: .errors, symbol: ApiError, severity: error}"
+    )
+    plan = ImplementationPlan.from_yaml(
+        _plan_yaml(
+            refs="[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles]", authored=authored
+        )
+    )
+    contract = _contract()
+    assert any("do not author" in e for e in plan.validate_criteria_refs(contract))
+    assert plan.soft_criteria_violations(contract) == []
+
+
 def test_authored_typed_criterion_on_uncovered_file_is_allowed():
     # binding routes fully, and authoring a check on an UNCOVERED file, is legal —
     # the contract only owns acceptance of the files it covers.

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -739,3 +739,46 @@ summary:
         )
 
         assert regex_target_is_document(CHECK_SPECS["regex_match"].example["file"])
+
+    def test_warning_severity_regex_on_source_tolerated(self):
+        """A warning-severity regex-on-source is a soft slip — tolerated by the
+        scope validator (RC-9: a warning check can't block a build, so it must not
+        kill the cycle at plan validation), surfaced by soft_criteria_violations."""
+        plan = self._plan(
+            "      - {check: regex_match, file: frontend/src/views/RunDetailView.jsx, "
+            "pattern: 'apiFetch', severity: warning}"
+        )
+        assert plan.validate_criteria_scope() == []
+        soft = plan.soft_criteria_violations()
+        assert len(soft) == 1
+        assert "RunDetailView.jsx" in soft[0]
+        assert "severity=warning" in soft[0]
+
+    def test_info_severity_regex_on_source_tolerated(self):
+        plan = self._plan(
+            "      - {check: regex_match, file: frontend/src/views/RunDetailView.jsx, "
+            "pattern: 'x', severity: info}"
+        )
+        assert plan.validate_criteria_scope() == []
+        assert len(plan.soft_criteria_violations()) == 1
+
+    def test_error_severity_regex_on_source_still_rejected(self):
+        """The severity split keeps error-severity structural violations fatal —
+        the author asserted it matters, so honor the rejection."""
+        plan = self._plan(
+            "      - {check: regex_match, file: frontend/src/views/RunDetailView.jsx, "
+            "pattern: 'apiFetch', severity: error}"
+        )
+        errors = plan.validate_criteria_scope()
+        assert len(errors) == 1
+        assert "#464" in errors[0]
+        assert plan.soft_criteria_violations() == []
+
+    def test_document_regex_never_a_soft_violation(self):
+        """A document regex is legal at any severity — never fatal, never soft."""
+        plan = self._plan(
+            "      - {check: regex_match, file: qa_handoff.md, "
+            "pattern: '## How to Test', severity: warning}"
+        )
+        assert plan.validate_criteria_scope() == []
+        assert plan.soft_criteria_violations() == []


### PR DESCRIPTION
## What

A single over-eager *authored* acceptance check was hard-rejecting an entire framing plan and **killing the cycle** — even when the check was `severity: warning`. That's inconsistent with RC-9, which says only `severity=error` checks can fail a build at execution: a warning check *can't block a build*, yet at **plan validation** it detonated the whole cycle. This is what killed pf-18 after ~45 min of framing, on one `regex_match` (severity `warning`) the QA model tacked onto a frontend smoke-test task.

## Change

Split the two **per-criterion structural** rules by severity:
- `validate_criteria_scope` (#464 regex-on-source) and `validate_criteria_refs` **rule 3** (authored-on-contract-covered, §6.3) now emit a **fatal** error only when the criterion is `severity=error`.
- Rules that are **not** soft authoring slips — unresolvable `criteria_ref`, missing-coverage (silent descoping) — stay **always fatal**.
- New `ImplementationPlan.soft_criteria_violations()` surfaces the tolerated warning/info violations; the executor logs them at the gate seam so the tolerance is **never silent**.

Detection is shared between the fatal check and the soft collector via two generators (`_regex_on_source_criteria`, `_authored_on_covered_criteria`) so the two paths can't drift.

## Scope boundary

The tolerated check **stays in the plan artifact** but is inert (warning → can't block per RC-9). Physically stripping it from the artifact is a deliberate **follow-up**, not this change (agreed: confirm this opens the path to green first).

## Verification (replay of pf-18's real plan, no new cycle)

Ran pf-18's actual rejected `implementation_plan.yaml` (`art_34c6cda17e76`) through the patched validators against the seeded contract (`art_fdbb80b2667a`):

| | before | after |
|---|---|---|
| fatal `validate_criteria_scope` | 2 | **0** |
| fatal `validate_criteria_refs` | 2 | **0** |
| tolerated soft violations surfaced | — | **4** (all `severity=warning`) |
| same regex bumped to `severity=error` | — | **still rejects** (2 + 2) |

The cycle would have proceeded past framing instead of dying.

## Tests

`tests/unit/cycles/test_implementation_plan.py` (scope): warning/info regex-on-source tolerated + surfaced; explicit `error`-severity still rejects; document regex never a violation at any severity. `test_criteria_ref_binding.py` (bind mode): warning authored-on-covered tolerated + surfaced; `error`-severity still rejects. Full `tests/unit/cycles/` suite: **1811 pass**, my new tests green. (Two pre-existing `test_verification_contract_runner` failures — `missing_tooling` on this box — fail identically on clean `main`, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG
