### PR TITLE
fix(#531): retarget patch-path repair onto the drifted source, not the failed check's tests

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -46,6 +46,36 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _resolve_repair_target(
+    failure_evidence: Any, failed_inputs: dict[str, Any]
+) -> tuple[list[str], str | None, str | None]:
+    """Choose ``(expected_artifacts, focus, description)`` for a patch-path repair.
+
+    #531: the target defaults to the *failed task's own* artifacts — but the
+    ``tests_pass`` check lives on the qa test task, so anchoring there regenerates
+    the tests (the symptom) while the drifted source (the cause) is never rewritten
+    and the loop can't converge. When the correction carries deterministic
+    interface-drift evidence (an AST diff, not the free-text ``affected_task_types``),
+    the drifted files ARE the target: retarget so the dev repair rewrites the source.
+    No drift → today's failed-task anchor, byte-identical.
+    """
+    drift = failure_evidence.get("interface_drift") if isinstance(failure_evidence, dict) else None
+    drift_files = sorted({d["file"] for d in (drift or []) if isinstance(d, dict) and d.get("file")})
+    if drift_files:
+        # The target is pure data (the drifted file paths). The instructional "how"
+        # is NOT authored here — it is the interface-drift `instruction`, already a
+        # managed/authored asset surfaced into the repair prompt's failure summary
+        # as the "INTERFACE CONFORMANCE" section. So focus/description are left unset
+        # (no inline prompt content — CLAUDE.md #448); the named artifacts + that
+        # instruction are what redirect the repair onto the source.
+        return (drift_files, None, None)
+    return (
+        failed_inputs.get("expected_artifacts", []),
+        failed_inputs.get("subtask_focus"),
+        failed_inputs.get("subtask_description"),
+    )
+
+
 @dataclass(frozen=True)
 class CorrectionProtocolResult:
     """Outcome of one correction-protocol run.
@@ -463,6 +493,11 @@ class CorrectionRunner:
         # dev repair handler.
         repair_artifacts: list[dict[str, Any]] = []
         if correction_path == "patch":
+            failed_inputs = envelope.inputs or {}
+            repair_expected_artifacts, repair_focus, repair_description = _resolve_repair_target(
+                failure_evidence, failed_inputs
+            )
+
             for step_idx, (task_type, role) in enumerate(repair_steps_for(envelope.task_type)):
                 repair_task_id = f"repair-{run_id[:12]}-{correction_attempts:02d}-{task_type}"
                 resolved = resolve_agent_config(role, profile)
@@ -470,12 +505,10 @@ class CorrectionRunner:
                 agent_model = resolved.model
                 agent_overrides = resolved.config_overrides
 
-                # Plumb the failed task's contract through to the repair
-                # envelope. Without this the repair handler only sees the
-                # PRD + failure evidence and produces a generic "repair_output.md"
-                # rather than re-emitting the named artifact (e.g. qa_handoff.md)
-                # that originally failed acceptance.
-                failed_inputs = envelope.inputs or {}
+                # Plumb the (retargeted) task contract through to the repair
+                # envelope. Without this the repair handler only sees the PRD +
+                # failure evidence and produces a generic "repair_output.md" rather
+                # than re-emitting the named artifact that must actually be fixed.
                 repair_inputs: dict[str, Any] = {
                     "prd": cycle.prd_ref,
                     "failed_task_type": envelope.task_type,
@@ -486,9 +519,9 @@ class CorrectionRunner:
                     "artifact_refs": list(all_artifact_refs),
                     "agent_model": agent_model,
                     "agent_config_overrides": agent_overrides,
-                    "subtask_focus": failed_inputs.get("subtask_focus"),
-                    "subtask_description": failed_inputs.get("subtask_description"),
-                    "expected_artifacts": failed_inputs.get("expected_artifacts", []),
+                    "subtask_focus": repair_focus,
+                    "subtask_description": repair_description,
+                    "expected_artifacts": repair_expected_artifacts,
                     "acceptance_criteria": failed_inputs.get("acceptance_criteria", []),
                 }
 

--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -60,7 +60,9 @@ def _resolve_repair_target(
     No drift → today's failed-task anchor, byte-identical.
     """
     drift = failure_evidence.get("interface_drift") if isinstance(failure_evidence, dict) else None
-    drift_files = sorted({d["file"] for d in (drift or []) if isinstance(d, dict) and d.get("file")})
+    drift_files = sorted(
+        {d["file"] for d in (drift or []) if isinstance(d, dict) and d.get("file")}
+    )
     if drift_files:
         # The target is pure data (the drifted file paths). The instructional "how"
         # is NOT authored here — it is the interface-drift `instruction`, already a

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -1923,3 +1923,88 @@ class TestReexecuteRepairedSuite:
 
         assert result is None
         assert dispatcher.dispatched == []
+
+
+class TestResolveRepairTarget:
+    """#531: a patch-path repair must target the DRIFTED SOURCE (from the
+    deterministic interface-drift evidence), not the failed check's own task —
+    otherwise a tests_pass failure caused by drifted models.py gets 'repaired'
+    by regenerating the tests, and the loop never converges."""
+
+    def test_drift_retargets_to_drifted_source_not_the_tests(self):
+        """Replay of pf-19 (cyc_3632da190fd2): tests_pass failed because
+        backend/models.py drifted (notes/pace vs route_notes/pace_target) and
+        main.py added GET /. The failed task is the qa pytest suite, but the
+        repair must target the drifted source files."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        failure_evidence = {
+            "interface_drift": [
+                {
+                    "kind": "field_drift",
+                    "file": "backend/models.py",
+                    "extra": ["notes", "pace"],
+                    "missing": ["route_notes", "pace_target"],
+                    "instruction": "rename notes->route_notes, pace->pace_target",
+                },
+                {
+                    "kind": "route_drift",
+                    "file": "backend/main.py",
+                    "extra": ["GET /"],
+                    "missing": [],
+                    "instruction": "remove the unauthorized GET / route",
+                },
+            ],
+            "validation_result": {"summary": "tests_pass exit 1"},
+        }
+        failed_inputs = {
+            "expected_artifacts": ["tests/test_runs.py", "tests/test_participants.py"],
+            "subtask_focus": "Backend run CRUD and validation pytest suite",
+            "subtask_description": "Write and run the backend pytest suite",
+        }
+        artifacts, focus, description = _resolve_repair_target(failure_evidence, failed_inputs)
+
+        assert artifacts == ["backend/main.py", "backend/models.py"]
+        assert "tests/test_runs.py" not in artifacts
+        assert "tests/test_participants.py" not in artifacts
+        # No inline prompt content is authored here (#448): the "how" is the managed
+        # drift instruction surfaced in the failure summary, so focus/description stay
+        # unset — the named source artifacts + that instruction do the redirect.
+        assert focus is None
+        assert description is None
+
+    def test_no_drift_falls_back_to_failed_task_artifacts(self):
+        """Absent interface drift, the target is byte-identical to today —
+        the failed task's own artifacts/focus/description."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        failed_inputs = {
+            "expected_artifacts": ["qa_handoff.md"],
+            "subtask_focus": "QA handoff",
+            "subtask_description": "Assemble the handoff doc",
+        }
+        artifacts, focus, description = _resolve_repair_target(
+            {"validation_result": {"summary": "missing sections"}}, failed_inputs
+        )
+        assert artifacts == ["qa_handoff.md"]
+        assert focus == "QA handoff"
+        assert description == "Assemble the handoff doc"
+
+    @pytest.mark.parametrize(
+        "evidence",
+        [
+            None,
+            {},
+            {"interface_drift": []},
+            {"interface_drift": [{"kind": "field_drift"}]},  # finding with no 'file'
+            "not-a-dict",
+        ],
+    )
+    def test_missing_or_fileless_drift_falls_back(self, evidence):
+        """Robustness: no usable drift evidence → fall back to the failed task's
+        artifacts, never crash or return an empty retarget."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        artifacts, focus, _ = _resolve_repair_target(evidence, {"expected_artifacts": ["a.py"]})
+        assert artifacts == ["a.py"]
+        assert focus is None


### PR DESCRIPTION
## What

On the correction **patch** path, the repair target was hard-anchored to the **failed check's own task**. The `tests_pass` check lives on the qa test task, so a `tests_pass` failure whose *cause* is a drifted source file got "repaired" by regenerating the **tests** (the symptom) while the drifted source (the cause) was never rewritten — the loop re-diagnosed the same drift every attempt and never converged. This is the dominant `tests_pass` non-convergence cause.

## Evidence — pf-19 (cyc_3632da190fd2)

`backend/models.py` drifted to `notes`/`pace` vs the contract's `route_notes`/`pace_target` (+ an unauthorized `GET /`). The **diagnosis was correct** — #527 interface-drift evidence named it, and the correction decision chose `affected_task_types: [backend_models, backend_api_routes]`. But across **3 attempts** the repair emitted only `tests/test_runs.py` + `tests/test_participants.py`; `models.py` was never regenerated and still held `notes`/`pace`.

## Fix

`_resolve_repair_target(failure_evidence, failed_inputs)`: when the correction carries **deterministic** interface-drift evidence (an AST diff — not the free-text `affected_task_types` that once mis-routed `["QA Handoff"]` and made them anchor to the failed task), the drifted files **are** the target → retarget `expected_artifacts` onto them. No drift → today's failed-task anchor, byte-identical. The dev repair role already runs, the current file content reaches the handler via `artifact_refs`, and #527's rename instruction is already in the failure summary — so pointing the target at `backend/models.py` is what's needed.

**No inline prompt content (#448):** the instructional "how" is the drift `instruction`, already a managed asset surfaced into the repair prompt's failure summary as the INTERFACE CONFORMANCE section — so `focus`/`description` are left unset rather than authored in Python.

## Verification (replay, no new cycle)

Unit test reconstructs pf-19's real `failure_evidence` (drift on `models.py` + `main.py`, failed task = the pytest suite) and asserts the repair now targets `[backend/main.py, backend/models.py]` — **not** the test files. Plus no-drift fallback and robustness (None / empty / file-less drift → fall back, never crash). Full `tests/unit/cycles/` suite: **1812 pass** (the 2 `test_verification_contract_runner` failures are a pre-existing `missing_tooling` env gap on this box — identical on clean `main`).

Closes #531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG
