### PR TITLE
fix(correction): target the union of drift files + the failing check's artifact

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -56,23 +56,35 @@ def _resolve_repair_target(
     the tests (the symptom) while the drifted source (the cause) is never rewritten
     and the loop can't converge. When the correction carries deterministic
     interface-drift evidence (an AST diff, not the free-text ``affected_task_types``),
-    the drifted files ARE the target: retarget so the dev repair rewrites the source.
-    No drift → today's failed-task anchor, byte-identical.
+    the drifted files ARE part of the target so the dev repair rewrites the source.
+
+    pf-21 (cyc_2aac58b9f03d): drift is not always the *whole* story — the failing
+    check's OWN artifact can carry an independent bug too (there: models.py drift
+    AND a broken pytest ``client`` fixture in the test file). #532 targeted the
+    drift files EXCLUSIVELY, orphaning that file so the loop re-patched already-fixed
+    source every attempt and never touched the real test bug → non-convergence. So
+    when drift is present, target the UNION (drift files first, then the failed
+    task's artifacts): the drifted source is always in the set (no masking — the
+    cause is always fixable, the #531/#532 win holds), and the failing artifact's
+    own bug is fixable too. No drift → today's failed-task anchor, byte-identical.
     """
     drift = failure_evidence.get("interface_drift") if isinstance(failure_evidence, dict) else None
     drift_files = sorted(
         {d["file"] for d in (drift or []) if isinstance(d, dict) and d.get("file")}
     )
+    failed_artifacts = failed_inputs.get("expected_artifacts", []) or []
     if drift_files:
-        # The target is pure data (the drifted file paths). The instructional "how"
+        # Union, drift first, de-duplicated preserving order. The instructional "how"
         # is NOT authored here — it is the interface-drift `instruction`, already a
         # managed/authored asset surfaced into the repair prompt's failure summary
-        # as the "INTERFACE CONFORMANCE" section. So focus/description are left unset
-        # (no inline prompt content — CLAUDE.md #448); the named artifacts + that
-        # instruction are what redirect the repair onto the source.
-        return (drift_files, None, None)
+        # as the "INTERFACE CONFORMANCE" section, plus the failure summary itself for
+        # the failing artifact's bug. So focus/description stay unset (no inline
+        # prompt content — CLAUDE.md #448); the named artifacts + that instruction
+        # redirect the repair onto both the drifted source and the failing file.
+        target = list(dict.fromkeys([*drift_files, *failed_artifacts]))
+        return (target, None, None)
     return (
-        failed_inputs.get("expected_artifacts", []),
+        failed_artifacts,
         failed_inputs.get("subtask_focus"),
         failed_inputs.get("subtask_description"),
     )

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -1926,16 +1926,20 @@ class TestReexecuteRepairedSuite:
 
 
 class TestResolveRepairTarget:
-    """#531: a patch-path repair must target the DRIFTED SOURCE (from the
-    deterministic interface-drift evidence), not the failed check's own task —
-    otherwise a tests_pass failure caused by drifted models.py gets 'repaired'
-    by regenerating the tests, and the loop never converges."""
+    """#531/#532: a patch-path repair must include the DRIFTED SOURCE (from the
+    deterministic interface-drift evidence) so a tests_pass failure caused by
+    drifted models.py isn't 'repaired' by regenerating the tests. pf-21 refined
+    this to a UNION: the failing check's own artifact can carry an independent bug
+    (a broken pytest fixture) alongside drift, so it must be targeted too — else
+    the loop re-patches already-fixed source forever and never converges."""
 
-    def test_drift_retargets_to_drifted_source_not_the_tests(self):
-        """Replay of pf-19 (cyc_3632da190fd2): tests_pass failed because
-        backend/models.py drifted (notes/pace vs route_notes/pace_target) and
-        main.py added GET /. The failed task is the qa pytest suite, but the
-        repair must target the drifted source files."""
+    def test_drift_unions_drifted_source_with_the_failing_artifacts(self):
+        """Replay of pf-19 (cyc_3632da190fd2) + pf-21 (cyc_2aac58b9f03d):
+        tests_pass failed with backend/models.py drifted (notes/pace vs
+        route_notes/pace_target) and main.py adding GET /. The drifted source
+        MUST be in the target (the #531/#532 win), AND — because the failing test
+        file can have its own bug (pf-21's client fixture) — the failed task's
+        artifacts are unioned in, drift first."""
         from adapters.cycles.correction_runner import _resolve_repair_target
 
         failure_evidence = {
@@ -1964,14 +1968,35 @@ class TestResolveRepairTarget:
         }
         artifacts, focus, description = _resolve_repair_target(failure_evidence, failed_inputs)
 
-        assert artifacts == ["backend/main.py", "backend/models.py"]
-        assert "tests/test_runs.py" not in artifacts
-        assert "tests/test_participants.py" not in artifacts
+        # Drift files first (the cause, #531/#532 win — always fixable, no masking),
+        # then the failing task's own artifacts (pf-21: their own bug is fixable too).
+        assert artifacts == [
+            "backend/main.py",
+            "backend/models.py",
+            "tests/test_runs.py",
+            "tests/test_participants.py",
+        ]
+        assert "backend/models.py" in artifacts  # drifted source is targeted
+        assert "tests/test_runs.py" in artifacts  # failing artifact's own bug is fixable
+        assert artifacts.index("backend/models.py") < artifacts.index("tests/test_runs.py")
         # No inline prompt content is authored here (#448): the "how" is the managed
-        # drift instruction surfaced in the failure summary, so focus/description stay
-        # unset — the named source artifacts + that instruction do the redirect.
+        # drift instruction + failure summary, so focus/description stay unset.
         assert focus is None
         assert description is None
+
+    def test_drift_dedups_when_failing_artifact_is_also_drifted(self):
+        """If the failing check's artifact IS one of the drifted files, it appears
+        once — no duplicate target entry."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = {
+            "interface_drift": [
+                {"file": "backend/models.py", "instruction": "fix fields"},
+            ],
+        }
+        failed_inputs = {"expected_artifacts": ["backend/models.py"]}
+        artifacts, _, _ = _resolve_repair_target(evidence, failed_inputs)
+        assert artifacts == ["backend/models.py"]
 
     def test_no_drift_falls_back_to_failed_task_artifacts(self):
         """Absent interface drift, the target is byte-identical to today —


### PR DESCRIPTION
## What & why

pf-21 (`cyc_2aac58b9f03d`) — the first roll to get past framing after #533 — exposed a **non-convergence trap** in #532's repair retargeting.

`tests_pass` failed because of **two** independent bugs: (a) `backend/models.py` interface drift (`run_id`→`id`, `pace`→`pace_target`) and (b) a broken pytest fixture in `backend/tests/test_runs.py` (`client = TestClient(app)` as a module-level var instead of `@pytest.fixture`).

`_resolve_repair_target` returned **only** the interface-drift files when drift was present, **excluding** the failing check's own artifact. So every repair attempt re-patched the *already-correct* `models.py`+`main.py` and **never touched the test file** with the fixture bug. Attempts 00 and 01 both emitted only `models.py`+`main.py` → the loop can't converge and burns the whole correction budget.

This blocks convergence on **any** roll where a failing check's file has its own bug alongside drift.

## The fix

Target the **union** — drift files first (the cause), then the failed task's `expected_artifacts`, de-duplicated preserving order:

- The drifted source is **always** in the target set, so #531/#532's win holds (a drift-caused test failure is still fixed by rewriting the source, not by masking it in the tests).
- The failing check's own file is **also** targeted, so an independent bug there (the fixture) is fixable.

`#532` was right to *include* drift; it just made it *exclusive*. Union is strictly more capable and can't reintroduce the #531 masking problem (the source is always in the set).

## Tests

- `TestResolveRepairTarget` updated to the union behavior: drift source is targeted (asserted first) **and** the failing artifact is included; ordering (drift-first) and `focus/description=None` (#448) preserved.
- Added a dedup test (failing artifact already a drift file → appears once).
- No-drift fallback unchanged. 36 correction_runner tests pass; lint + `ruff format --check` clean.

## Notes

- Follow-up to #531/#532. Verified against the live pf-21 failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG
