### PR TITLE
fix(correction): re-resolve the correction workspace from live stored_artifacts (RC3)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1805,11 +1805,21 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             profile=profile,
             flow_run_id=flow_run_id,
             interface_manifest=interface_manifest,
-            # The materialized workspace (path -> content) rides on the enriched
-            # envelope (#456); the drift detector parses model/route files from it.
+            # RC3 (pf-23): re-resolve the workspace from the LIVE stored_artifacts
+            # instead of the enriched envelope's copy captured once at the original
+            # dispatch. stored_artifacts accumulates each attempt's repair outputs
+            # (appended last → last-wins on filename), so re-resolving hands the
+            # drift detector + repair analysis the ACCUMULATED patches. Reading the
+            # stale enriched copy made the deterministic drift detector re-report
+            # already-fixed drift every attempt, so the loop re-targeted the fixed
+            # file and never converged. Fall back to the enriched copy for task
+            # types with no build-artifact filter (non-build corrections unchanged).
             artifact_contents=(
-                (enriched_envelope.inputs if enriched_envelope is not None else {}) or {}
-            ).get("artifact_contents"),
+                await self._resolve_artifact_contents(envelope.task_type, stored_artifacts)
+                or ((enriched_envelope.inputs if enriched_envelope is not None else {}) or {}).get(
+                    "artifact_contents"
+                )
+            ),
         )
         correction_path = protocol.correction_path
 

--- a/tests/unit/cycles/test_executor_build_wiring.py
+++ b/tests/unit/cycles/test_executor_build_wiring.py
@@ -194,6 +194,44 @@ class TestArtifactContentsPreResolution:
         # First two fit (256+256=512), third would exceed limit
         assert len(contents) == 2
 
+    async def test_repair_patch_wins_over_original_on_filename_collision(self, executor):
+        """RC3 (pf-23): when stored_artifacts accumulates a correction repair's
+        patched file AFTER the original (same filename), re-resolution returns the
+        PATCH — not the stale original. This is the property the correction loop
+        relies on after the RC3 fix: re-resolving artifact_contents from the live
+        stored_artifacts hands the drift detector the accumulated fix, so it stops
+        re-reporting drift the prior attempt already corrected. Note the repair's
+        producing_task_type (development.correction_repair) is NOT in the qa.test
+        by_producing_task list — it survives only via by_type=source."""
+        ref_orig = _make_artifact_ref(
+            "art_001",
+            "backend/models.py",
+            "source",
+            producing_task_type="development.develop",
+        )
+        ref_patch = _make_artifact_ref(
+            "art_002",
+            "backend/models.py",
+            "source",
+            producing_task_type="development.correction_repair",
+        )
+        # Append order: original dev output first, repair patch last (as the
+        # executor accumulates them across attempts).
+        stored = [("art_001", ref_orig), ("art_002", ref_patch)]
+        executor._artifact_vault.retrieve = AsyncMock(
+            side_effect=[
+                (ref_orig, b"class RunEvent:\n    pace: str\n"),
+                (ref_patch, b"class RunEvent:\n    pace_target: str\n"),
+            ]
+        )
+
+        contents = await executor._resolve_artifact_contents("qa.test", stored)
+
+        # Last-wins: the repair's patched content supersedes the original.
+        assert contents["backend/models.py"] == "class RunEvent:\n    pace_target: str\n"
+        assert "pace_target" in contents["backend/models.py"]
+        assert "    pace:" not in contents["backend/models.py"]
+
 
 class TestProducingTaskTypeMetadata:
     async def test_store_artifact_includes_producing_task_type(self, executor):


### PR DESCRIPTION
## What & why

**RC3 — the correction loop couldn't converge even on the *coverable* drift class.** pf-23 (`cyc_de020f3d8412`) failed `tests_pass` on a `backend/models.py` field drift (`pace`/`notes` vs `pace_target`/`route_notes`) — a drift file the repair *does* target. Repairs produced a **correct** `models.py` (verified) and self-validation passed, yet every retest failed and the **deterministic** drift detector **re-reported the same drift it had just fixed** → the loop re-targeted the already-fixed file forever and exhausted its budget.

## Root cause

`run_correction_protocol` (in `dispatched_flow_executor.py`) received `artifact_contents` — the workspace the drift detector and repair analysis read — from the **enriched envelope**, resolved **once** at the original `qa.test` dispatch. `stored_artifacts` (passed live alongside it) **does** accumulate each attempt's repair output (appended last, at L2016), but the analyze step read the stale captured copy. So every attempt analyzed the *original* files.

## The fix

Re-resolve `artifact_contents` from the live `stored_artifacts` before each correction attempt:

```python
artifact_contents=(
    await self._resolve_artifact_contents(envelope.task_type, stored_artifacts)
    or (<enriched-envelope fallback for non-build task types>)
),
```

`_resolve_artifact_contents` keys `contents[filename]` **last-wins**, and repair outputs append *after* the originals, so the patched file wins → the drift detector sees the fix → the loop **advances to the real next issue instead of re-fixing the same one**. The fallback preserves behavior for task types with no build-artifact filter.

## Validation (deterministic — no live cycle)

- **Last-wins unit test** (`test_repair_patch_wins_over_original_on_filename_collision`): with the original `models.py` then a `development.correction_repair` patch in `stored_artifacts`, re-resolution returns the **patch** (survives via `by_type=source`, since `*_repair` isn't in `by_producing_task`).
- **Replay against pf-23's real files:** `detect_interface_drift` on the **original** `models.py` → `['backend/models.py']` (flagged); on the **patched** `models.py` → `[]` (empty). So once the fix puts the patch in the workspace, the drift clears and the loop advances.
- **Regression:** 121 executor + correction tests pass; lint + `ruff format --check` clean.

## Notes

- **Stacked on #534** (union repair-target) — the branch is based on `fix/repair-target-union-pf21`. Merge #534 first; this diff resolves to just the RC3 change once #534 lands.
- Follow-up: RC2 (repair can't reach a *non-drift* source file, pf-22's `routes.py`) is **not** addressed here — deliberately measuring RC3 alone first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG
