### PR TITLE
fix(RC2): dependency-scoped repair target — no-drift qa.test failures reach the source under test

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -46,6 +46,29 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _top_level_package(path: str) -> str:
+    """First path segment of a repo-relative artifact path.
+
+    ``backend/tests/x.py`` → ``backend``; a bare filename is its own package.
+    """
+    head, _, _ = str(path).strip().lstrip("./").partition("/")
+    return head
+
+
+def _scope_to_shared_packages(candidates: list[str], anchors: list[str]) -> list[str]:
+    """Keep ``candidates`` whose top-level package matches some ``anchor``'s.
+
+    RC2 (pf-24) blast-radius control: a failing ``backend/tests/…`` test retargets
+    ``backend/…`` source but leaves ``frontend/…`` untouched, so a backend failure
+    can never regress frontend source. No anchors → nothing (the caller falls back
+    to the failed artifacts alone).
+    """
+    anchor_pkgs = {_top_level_package(a) for a in anchors if a}
+    if not anchor_pkgs:
+        return []
+    return [c for c in candidates if c and _top_level_package(c) in anchor_pkgs]
+
+
 def _resolve_repair_target(
     failure_evidence: Any, failed_inputs: dict[str, Any]
 ) -> tuple[list[str], str | None, str | None]:
@@ -66,7 +89,19 @@ def _resolve_repair_target(
     when drift is present, target the UNION (drift files first, then the failed
     task's artifacts): the drifted source is always in the set (no masking — the
     cause is always fixable, the #531/#532 win holds), and the failing artifact's
-    own bug is fixable too. No drift → today's failed-task anchor, byte-identical.
+    own bug is fixable too.
+
+    pf-24 (cyc_38415226ad82) — RC2: a ``tests_pass``/probe failure with NO interface
+    drift (a behavioral/runtime bug — there a missing ``/api`` router prefix in
+    main.py) has its fix in the *source under test*, which the failing qa.test does
+    NOT own (its artifacts are the test files). Anchoring on the failed task then
+    edits only the test and the loop exhausts. So with no drift, extend the target
+    with the plan's implementation source (``implementation_artifacts``, threaded
+    onto qa.test envelopes by task_plan) that shares a top-level package with a
+    failing artifact — ``backend/tests/*`` failure → ``backend/*`` source, never
+    ``frontend/*`` (package-scoping bounds the blast radius). Absent that surface
+    (author mode, non-build corrections) the target is byte-identical to the #531
+    fallback below.
     """
     drift = failure_evidence.get("interface_drift") if isinstance(failure_evidence, dict) else None
     drift_files = sorted(
@@ -83,8 +118,16 @@ def _resolve_repair_target(
         # redirect the repair onto both the drifted source and the failing file.
         target = list(dict.fromkeys([*drift_files, *failed_artifacts]))
         return (target, None, None)
+    # RC2 no-drift path: union the failing task's own artifacts with the
+    # package-scoped implementation surface so a behavioral failure can reach the
+    # source under test. Empty surface → byte-identical to the #531 fallback
+    # (failed_artifacts, focus, description).
+    scoped_source = _scope_to_shared_packages(
+        failed_inputs.get("implementation_artifacts", []) or [], failed_artifacts
+    )
+    target = list(dict.fromkeys([*failed_artifacts, *scoped_source]))
     return (
-        failed_artifacts,
+        target,
         failed_inputs.get("subtask_focus"),
         failed_inputs.get("subtask_description"),
     )

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -463,6 +463,19 @@ def generate_task_plan(
     lane_totals = Counter(r.agent_id for r in step_resolutions)
     lane_seen: dict[str, int] = {}
 
+    # RC2 (pf-24): the plan's implementation source surface — every
+    # development.develop task's expected_artifacts. Threaded onto qa.test envelopes
+    # (below) so a no-drift qa.test correction can retarget the source under test
+    # (package-scoped in _resolve_repair_target) instead of only re-emitting the
+    # test file, which orphaned the buggy source (missing /api prefix in main.py)
+    # and exhausted the loop. A static plan fact, computed once.
+    implementation_artifacts = [
+        artifact
+        for s in steps
+        if not isinstance(s, tuple) and getattr(s, "task_type", None) == "development.develop"
+        for artifact in (getattr(s, "expected_artifacts", None) or [])
+    ]
+
     for step_index, step in enumerate(steps):
         # Steps are either (task_type, role) tuples or PlanTask objects
         if isinstance(step, tuple):
@@ -522,6 +535,12 @@ def generate_task_plan(
             inputs["subtask_description"] = plan_task.description
             inputs["expected_artifacts"] = plan_task.expected_artifacts
             inputs["subtask_index"] = plan_task.task_index
+            # RC2: only qa.test failures need the source-under-test surface — their
+            # own artifacts are the test files, so a no-drift correction must reach
+            # past them to the dev source. Dev tasks already own their source
+            # artifact, so omitting the key keeps their corrections byte-identical.
+            if task_type == "qa.test":
+                inputs["implementation_artifacts"] = implementation_artifacts
             acceptance = list(plan_task.acceptance_criteria)
             # SIP-0098 98.3: in bind mode, resolve the task's criteria_refs into
             # TypedChecks (stamped with contract ids) and merge them in. The plan

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -2015,6 +2015,106 @@ class TestResolveRepairTarget:
         assert focus == "QA handoff"
         assert description == "Assemble the handoff doc"
 
+    def test_no_drift_qa_test_retargets_package_scoped_source(self):
+        """RC2 (pf-24): a no-drift qa.test failure (a behavioral bug whose fix lives
+        in the source under test, not the test file) unions the failing test artifact
+        with the plan's implementation source that shares its top-level package —
+        reaching backend/main.py (the /api-prefix fix) while excluding frontend."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        failed_inputs = {
+            "expected_artifacts": ["backend/tests/test_runs.py"],
+            "implementation_artifacts": [
+                "backend/models.py",
+                "backend/routes.py",
+                "backend/main.py",
+                "frontend/src/App.jsx",
+            ],
+            "subtask_focus": "Backend pytest suite",
+            "subtask_description": "Run the backend suite",
+        }
+        # No interface drift → the RC2 branch.
+        artifacts, focus, description = _resolve_repair_target(
+            {"validation_result": {"summary": "tests_pass exit 1; /api/runs 404"}},
+            failed_inputs,
+        )
+
+        assert artifacts == [
+            "backend/tests/test_runs.py",
+            "backend/models.py",
+            "backend/routes.py",
+            "backend/main.py",
+        ]
+        assert "backend/main.py" in artifacts  # the /api-prefix fix is now reachable
+        assert "frontend/src/App.jsx" not in artifacts  # package-scoped: no cross-package regen
+        assert focus == "Backend pytest suite"
+        assert description == "Run the backend suite"
+
+    def test_no_drift_without_surface_is_byte_identical(self):
+        """Backward-compat: no implementation_artifacts key → target is exactly the
+        failed task's own artifacts (the pre-RC2 #531 behavior)."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        failed_inputs = {
+            "expected_artifacts": ["backend/tests/test_runs.py"],
+            "subtask_focus": "suite",
+            "subtask_description": "run suite",
+        }
+        artifacts, focus, description = _resolve_repair_target(
+            {"validation_result": {"summary": "tests_pass exit 1"}}, failed_inputs
+        )
+        assert artifacts == ["backend/tests/test_runs.py"]
+        assert focus == "suite"
+        assert description == "run suite"
+
+    def test_no_drift_frontend_failure_scopes_to_frontend_only(self):
+        """Package-scoping is symmetric: a frontend test failure retargets frontend
+        source and leaves backend untouched (blast-radius containment both ways)."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        failed_inputs = {
+            "expected_artifacts": ["frontend/src/tests/flows.test.jsx"],
+            "implementation_artifacts": [
+                "backend/main.py",
+                "frontend/src/App.jsx",
+                "frontend/src/api.js",
+            ],
+        }
+        artifacts, _, _ = _resolve_repair_target({}, failed_inputs)
+        assert artifacts == [
+            "frontend/src/tests/flows.test.jsx",
+            "frontend/src/App.jsx",
+            "frontend/src/api.js",
+        ]
+        assert "backend/main.py" not in artifacts
+
+    def test_drift_present_ignores_implementation_surface(self):
+        """When interface drift IS present the drift-union branch wins and the
+        implementation surface is not added — the drift path stays byte-identical."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = {"interface_drift": [{"file": "backend/models.py", "instruction": "fix fields"}]}
+        failed_inputs = {
+            "expected_artifacts": ["backend/tests/test_runs.py"],
+            "implementation_artifacts": ["backend/routes.py", "frontend/src/App.jsx"],
+        }
+        artifacts, focus, _ = _resolve_repair_target(evidence, failed_inputs)
+        assert artifacts == ["backend/models.py", "backend/tests/test_runs.py"]
+        assert "backend/routes.py" not in artifacts  # surface NOT added on the drift path
+        assert focus is None  # drift path leaves focus/description unset (#448)
+
+    def test_no_drift_scoped_source_dedups_against_failed_artifact(self):
+        """If a surface file is also a failed artifact it appears once, failed
+        artifact first (order preserved)."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        failed_inputs = {
+            "expected_artifacts": ["backend/main.py"],
+            "implementation_artifacts": ["backend/main.py", "backend/routes.py"],
+        }
+        artifacts, _, _ = _resolve_repair_target({}, failed_inputs)
+        assert artifacts == ["backend/main.py", "backend/routes.py"]
+
     @pytest.mark.parametrize(
         "evidence",
         [

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -155,6 +155,26 @@ class TestGenerateTaskPlanWithManifest:
         assert by_agent["nat"] == [(1, 1)]  # strat
         assert by_agent["data"] == [(1, 1)]  # data
 
+    def test_qa_test_envelope_carries_implementation_surface_rc2(self):
+        """RC2 (pf-24): qa.test envelopes carry `implementation_artifacts` = every
+        development.develop task's source (backend + frontend), so a no-drift
+        correction can retarget the source under test instead of only re-emitting
+        the test file. Dev envelopes do NOT carry it — they own their source."""
+        manifest = ImplementationPlan.from_yaml(MANIFEST_YAML)
+        envelopes = generate_task_plan(_make_cycle(), _make_run(), _make_profile(), plan=manifest)
+
+        qa = [e for e in envelopes if e.task_type == "qa.test"]
+        assert len(qa) == 1
+        assert qa[0].inputs["implementation_artifacts"] == [
+            "backend/models.py",
+            "backend/main.py",
+            "frontend/App.jsx",
+        ]
+
+        dev = [e for e in envelopes if e.task_type == "development.develop"]
+        assert dev  # sanity: dev build tasks exist in this manifest
+        assert all("implementation_artifacts" not in e.inputs for e in dev)
+
     def test_without_manifest_produces_static_steps(self):
         cycle = _make_cycle()
         run = _make_run()


### PR DESCRIPTION
## RC2 — dependency-scoped repair target

The correction loop could only reach **source** files through the interface-drift
signal — `_resolve_repair_target`'s `if drift_files:` union (the #531 → #532 → #534
evolution). A behavioral/runtime bug that produces **no drift** — a missing `/api`
router prefix in `main.py`, a 400-vs-422 validation mismatch — surfaces on the
`qa.test` task, whose own `expected_artifacts` are the **test files**. With no drift,
the target fell back to the failing task's own artifacts, so the repair could only
ever edit the test file, never the buggy source. The loop exhausted every attempt.

### Evidence (pf-24, `cyc_38415226ad82`)
Attempts 00–04 all emitted `backend/tests/test_runs.py`; `main.py` stayed
`app.include_router(routes.router)` (no `/api` prefix) the whole time → the
`vc-probe-runs` 404 never cleared → rejected. The analyze step was *accurate and
advancing* each attempt (RC3 fix working), but the repair had no way to touch the
source.

### Fix — path-scoped implementation surface
When there is **no drift**, extend the repair target with the plan's
`development.develop` source that shares a **top-level package** with a failing
artifact:

- `backend/tests/test_runs.py` failure → `backend/models.py`, `backend/routes.py`,
  `backend/main.py` (reaches the `/api`-prefix fix)
- **never** `frontend/*` — package-scoping bounds the regression blast radius so a
  backend failure can't re-emit frontend source.

`task_plan` threads the source surface (`implementation_artifacts`) onto `qa.test`
envelopes only; `_resolve_repair_target` does the package-scoped union. **Absent the
surface** (author mode, non-build corrections) the target is byte-identical to the
prior #531 fallback, and the **drift-union path (#532/#534) is untouched** — the
extension is confined to the no-drift branch.

### Why path-scoping, not `depends_on`
Verified against pf-24's real plan: `qa.test` tasks carry `depends_on=[]` (the
proposer authors tests as DAG roots), so "target the qa.test's `depends_on`
artifacts" would be a **no-op**. The test→package path convention is the reliable
signal.

### Tests
- 5 `_resolve_repair_target` cases: core RC2 retarget, backward-compat
  byte-identical (no surface), symmetric frontend scoping, drift-path-unchanged,
  dedup.
- 1 wiring test: `qa.test` envelopes carry the surface, `development.develop`
  envelopes do not (guards against a cosmetic fix that doesn't wire up).
- Full `tests/unit/cycles/` domain: **1841 passed**. ruff clean.

Not tied to a filed issue (RC2 is the internal name for this correction-loop gap,
sibling to the #531/#532/#534 target evolution). Deploy held pending review — it
resets the N=5 measurement baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
