### PR TITLE
fix(docker): init: true on agent containers to reap subprocess zombies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,6 +214,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-max
+    init: true  # tini as PID 1 reaps orphaned build subprocesses (esbuild/vite/node) — no zombie pileup
     restart: unless-stopped
     secrets:
       - agent_client_secret
@@ -267,6 +268,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-nat
+    init: true  # tini as PID 1 reaps orphaned build subprocesses (esbuild/vite/node) — no zombie pileup
     restart: unless-stopped
     secrets:
       - agent_client_secret
@@ -339,6 +341,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-neo
+    init: true  # tini as PID 1 reaps orphaned build subprocesses (esbuild/vite/node) — no zombie pileup
     restart: unless-stopped
     secrets:
       - agent_client_secret
@@ -394,6 +397,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-eve
+    init: true  # tini as PID 1 reaps orphaned build subprocesses (esbuild/vite/node) — no zombie pileup
     restart: unless-stopped
     secrets:
       - agent_client_secret
@@ -445,6 +449,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-data
+    init: true  # tini as PID 1 reaps orphaned build subprocesses (esbuild/vite/node) — no zombie pileup
     restart: unless-stopped
     secrets:
       - agent_client_secret
@@ -500,6 +505,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-bob
+    init: true  # tini as PID 1 reaps orphaned build subprocesses (esbuild/vite/node) — no zombie pileup
     restart: unless-stopped
     secrets:
       - agent_client_secret
@@ -576,6 +582,7 @@ services:
         BUILD_HASH: ${BUILD_HASH:-unknown}
         SOURCE_HASH: ${SOURCE_HASH:-unknown}
     container_name: squadops-joi
+    init: true  # tini as PID 1 reaps orphaned build subprocesses (esbuild/vite/node) — no zombie pileup
     restart: unless-stopped
     secrets:
       - agent_client_secret


### PR DESCRIPTION
## Problem
The agent containers run `python -m squadops.agents.entrypoint` as **PID 1 with no init**. When an agent runs a frontend build (`vite` → `esbuild`), the `esbuild` subprocesses get orphaned and reparent to PID 1 — but a normal Python app as PID 1 never `wait()`s to reap them, so they pile up as `<defunct>` zombies. Found **11 `esbuild` zombies** under `squadops-eve` after 16h uptime; a `docker restart` clears them but the next build starts the pile again.

## Fix
Add `init: true` to all 7 agent services (max/nat/neo/eve/data/bob/joi). Docker injects **tini** as PID 1, which reaps orphaned children automatically — the canonical remedy for the PID-1-doesn't-reap problem. Applied to all agents defensively (any can spawn a subprocess: node/tsc/eslint/vite).

## Apply
Takes effect on `docker compose up -d` (container **recreate**), not a plain restart. `docker compose config` validates.

Explicitly requested (CLAUDE.md guards docker-compose edits). Zombies were already cleared live via `docker restart squadops-eve`; this stops the recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)