### PR TITLE
docs(runtime-status): requirements for RuntimeActivity lifecycle integrity

### DIFF
--- a/docs/agent-runtime-status-model.md
+++ b/docs/agent-runtime-status-model.md
@@ -50,6 +50,69 @@ Concretely:
   `network_status`/`lifecycle_state` for back-compat); `mode`/`runtime_status`
   are `null` when an agent has no runtime-state row (#230).
 
+## RuntimeActivity lifecycle integrity — open requirements (2026-07-23)
+
+**Status:** open — needs a design decision *before* a fix; not a one-line patch.
+Surfaced by a smoke cycle (`cyc_1d3960665af6`) where every agent's first cycle task
+logged `UniqueViolationError` on `uq_runtime_activities_one_active_per_agent`
+(`Key (agent_id)=(eve/data/max) already exists`), swallowed as a best-effort WARNING.
+
+**Why it belongs in this doc.** The canonical signals above derive an agent's
+*idle / busy / paused* state from `FocusLease` + `RuntimeActivity` (§10.5). When a
+`RuntimeActivity` row orphans (below), `get_current_activity` returns a stale row
+indefinitely, so the derived signal reports an agent **busy on a task that ended long
+ago**. RuntimeActivity integrity is therefore load-bearing for a claim *this* model makes.
+
+**The mechanism is not a missing close — it's the absence of recovery.** The cycle
+dispatcher opens and closes activities correctly on the happy path (`_start_task_activity`
+→ try/else/except `_finish_task_activity`, `adapters/cycles/task_dispatcher.py:176-188`).
+The failure is structural:
+
+1. **Orphaning.** If the process/container dies between `start_activity` and
+   `_finish_task_activity` (crash, `docker restart`, OOM kill), the row stays `running`.
+   Nothing terminalizes it on restart — there is no reconciliation. The code concedes it:
+   *"a leftover active row from a prior crashed task makes this conflict, which we swallow"*
+   (`task_dispatcher.py:199`).
+2. **Permanence + poisoning.** The partial unique index (`WHERE state IN
+   ('pending','running','paused')`) keeps that orphan "active" forever. From the first
+   orphan onward, **every** future `start_activity` for that agent collides and is
+   swallowed — the agent never records a new activity again and `get_current_activity`
+   is frozen on the orphan.
+3. **Advisory writes against a hard invariant.** `start_activity` is deliberately
+   best-effort/swallowed (§4.4 — "observability never breaks a real task"), yet the
+   invariant it violates is a hard DB constraint. A *dropped* write is silently promoted
+   to *permanent* corruption with no path back. The two stances don't compose.
+
+**Requirements to decide (each a fork, not a default):**
+
+1. **Authoritative or advisory?** If RuntimeActivity is advisory telemetry, a hard unique
+   index that poisons future writes is the wrong enforcement — replace it with
+   supersede-on-write / latest-wins-in-query. If authoritative, it needs a guaranteed close
+   **and** crash recovery. Today it is implicitly both. *(Lean: advisory-but-self-healing —
+   builds don't depend on it, so favor the lowest-risk coherent stance.)*
+2. **Orphan recovery — who heals a stale-active row, on what trigger?** Candidates:
+   (a) **supersede-on-start** — `start_activity` terminalizes any existing active row for
+   the agent (`aborted`, reason `superseded`) in the same transaction, then inserts
+   (self-healing; "current" = latest dispatch); (b) **restart/heartbeat reconciliation** —
+   a sweep aborts active rows whose owning process is gone, mirroring the offline
+   health-checker; (c) **TTL/lease** — activities expire like `focus_leases` (`expires_at`,
+   the `1120` pattern). Not exclusive; (a) is the minimal self-healing floor.
+3. **Single owner across writers.** SIP-0089 makes the `RuntimeCoordinator` the activity
+   lifecycle owner for mode transitions (`coordinator.py:571` aborts); the cycle dispatcher
+   independently opens/closes `mode="cycle"` activities. Two writers, one invariant. The
+   contract must state how a coordinator mode-abort and a dispatcher complete/fail interleave
+   without corrupting each other — the `update_state` active-only guard covers *some* races
+   but is not a stated ownership model.
+4. **Crash-recovery contract.** Name what terminalizes activities orphaned by process/
+   container death — today: nothing. This is the direct cause of the observed symptom and
+   follows from (2).
+
+**Scope.** If the resolution keeps the enforcement stance and adds recovery, it is an
+amendment here + a migration. If it changes the SIP-0089 activity lifecycle contract
+(§4.2–4.5 — e.g. supersede-on-start becomes normative, or ownership is reassigned), it is a
+**SIP-0089 addendum**, not just a doc note. Cycle correctness is unaffected either way: the
+swallow keeps builds green — this is agent-status *observability* only.
+
 ## Deferred (the rest of #231)
 
 A strangler, not a blocker: collapse `network_status` into `runtime_status` at the


### PR DESCRIPTION
## Summary

Grounds and writes up the `runtime_activities` design gap surfaced during SIP-0100 smoke validation. **Doc-only** — adds an open-requirements section to `docs/agent-runtime-status-model.md` (the canonical model all agent-status surfaces conform to). **No code, no fix yet** — the fix depends on decisions this section poses.

## What surfaced

Smoke cycle `cyc_1d3960665af6` logged `UniqueViolationError` on `uq_runtime_activities_one_active_per_agent` for every agent's *first* cycle task (`Key (agent_id)=(eve/data/max) already exists`), swallowed as a best-effort WARNING. The run completed fine — this is observability, not cycle correctness.

## Grounded root cause

The dispatcher's open→close is **correct** on the happy path (`task_dispatcher.py:176-188`). The gap is structural:

1. **Orphaning** — if the process/container dies between `start_activity` and `_finish_task_activity` (crash, `docker restart`, OOM), the row stays `running`; nothing terminalizes it on restart. The code comment concedes it (`:199`: *"a leftover active row from a prior crashed task makes this conflict, which we swallow"*).
2. **Permanence + poisoning** — the partial unique index keeps the orphan "active" forever, so **every** future `start_activity` for that agent collides and is swallowed. The agent never records another activity; `get_current_activity` freezes on the dead task.
3. **Advisory writes vs. hard invariant** — best-effort/swallowed writes against a hard DB constraint promote a *dropped* write into *permanent* corruption with no path back.

This corrupts the **idle/busy/paused** signal the canonical model derives from `RuntimeActivity` (§10.5) — hence the placement.

## The four forks the section poses

1. **Authoritative or advisory?** (today: implicitly both)
2. **Orphan recovery trigger** — supersede-on-start / restart reconciliation / TTL-lease
3. **Single owner** across the `RuntimeCoordinator` (mode transitions) and the cycle dispatcher (`mode="cycle"`) — two writers, one invariant
4. **Crash-recovery contract** — today: nothing

Lean noted in-doc: **advisory-but-self-healing** (supersede-on-start as the minimal floor). Flagged: a lifecycle-contract change would be a **SIP-0089 addendum**, not just this doc note.

These are open decisions for review — I did not prematurely pick them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG
