### PR TITLE
feat(sip-0100): Phase 3 (3.3 evidence + 3.1 QA write-scope)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -87,6 +87,12 @@ def _artifact_raw_path(art: dict) -> str | None:
     return art.get("name") if art.get("name") is not None else art.get("path")
 
 
+def _is_qa_producer(task_type: str) -> bool:
+    """SIP-0100 3.1: QA task types (``qa.test``, ``qa.validate``) are scoped to the QA test
+    namespace — they write tests, not the source under test."""
+    return task_type.startswith("qa.")
+
+
 class DispatchedFlowExecutor(FlowExecutionPort):
     """Flow executor that dispatches tasks to agent containers via RabbitMQ.
 
@@ -2047,30 +2053,68 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         non-breaking and correct. The stricter reject + targeted correction is gated on fill-only
         (plan §4.6 / 3.4).
 
-        SIP-0100 3.3: each restore now also produces a structured ``ScaffoldIntegrityEvidence``
-        record (returned alongside the artifacts). Pure — the caller emits it as an
+        SIP-0100 3.3: each enforcement produces a structured ``ScaffoldIntegrityEvidence`` record
+        (returned alongside the artifacts). Pure — the caller emits it as an
         ``artifact.ownership_enforced`` event + structured log — so enforcement stays testable and
-        3.4 can drive the compliance counter off the returned records."""
-        from squadops.cycles.scaffold_integrity_evidence import frozen_restore_evidence
-        from squadops.cycles.write_authorization import normalize_ws_path
+        3.4 can drive the compliance counter off the returned records.
+
+        SIP-0100 3.1: a **QA** producer is additionally scoped to its own namespace. A QA emission
+        of a path writable in principle but owned by another producer's slot (e.g. dev's
+        ``routes.py``) is **dropped** — the owning producer's version stays; QA cannot rewrite the
+        source under test to agree with its own test (the pf-26 class, one step past ``main.py``).
+        QA emissions in its namespace, and undeclared paths (deliverables like ``test_report.md``),
+        pass through. Non-QA producers are unaffected here (frozen-restore only)."""
+        from squadops.cycles.scaffold_integrity_evidence import (
+            frozen_restore_evidence,
+            unauthorized_slot_evidence,
+        )
+        from squadops.cycles.write_authorization import (
+            AuthzDecision,
+            WorkspaceOwnership,
+            WriteAuthorization,
+            WriteGrant,
+            normalize_ws_path,
+        )
 
         frozen = {
             n: fa.content
             for fa in bound_record.frozen
             if (n := normalize_ws_path(fa.path)) is not None
         }
-        # Identify violations first so each evidence record can report how many sibling artifacts in
-        # the SAME response were retained (restore keeps all; a future response-atomic reject would
-        # not — that difference is exactly what the field captures).
+        # A QA producer gets a namespace-scoped grant; the 2.1 authorization classes decide whether
+        # a non-frozen emission is inside its lane (allow), another producer's slot (drop), or
+        # undeclared (allow — could be a deliverable, §4.6 undeclared-reject stays gated on 3.4).
+        qa_authz = None
+        if _is_qa_producer(envelope.task_type):
+            ownership = WorkspaceOwnership.from_record(bound_record)
+            grant = WriteGrant.for_qa(envelope.task_type, ownership)
+            qa_authz = WriteAuthorization(ownership, grant)
+
+        # Classify first so each evidence record can report how many sibling artifacts in the SAME
+        # response were left untouched (per-artifact disposition — restore/drop keep the rest; a
+        # response-atomic reject would not — that difference is exactly what the field captures).
         norms = [
             normalize_ws_path(raw) if isinstance(raw := _artifact_raw_path(art), str) else None
             for art in artifacts
         ]
-        violation_count = sum(1 for n in norms if n is not None and n in frozen)
+
+        def _disposition(art: dict, norm: str | None) -> str:
+            if norm is not None and norm in frozen:
+                return "restore"
+            if qa_authz is not None and (
+                qa_authz.authorize(_artifact_raw_path(art) or "")
+                == AuthzDecision.FORBIDDEN_UNAUTHORIZED
+            ):
+                return "drop"
+            return "pass"
+
+        dispositions = [_disposition(art, norm) for art, norm in zip(artifacts, norms, strict=True)]
+        siblings_retained = sum(1 for d in dispositions if d == "pass")
+
         enforced: list[dict] = []
         evidence: list[Any] = []
-        for art, norm in zip(artifacts, norms, strict=True):
-            if norm is not None and norm in frozen:
+        for art, norm, disposition in zip(artifacts, norms, dispositions, strict=True):
+            if disposition == "restore":
                 evidence.append(
                     frozen_restore_evidence(
                         producer_task_id=envelope.task_id,
@@ -2079,10 +2123,23 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         attempted_path=_artifact_raw_path(art) or norm,
                         normalized_path=norm,
                         attempted_content=art.get("content"),
-                        siblings_retained=len(artifacts) - violation_count,
+                        siblings_retained=siblings_retained,
                     )
                 )
                 enforced.append({**art, "content": frozen[norm]})  # restore scaffold bytes (D2)
+            elif disposition == "drop":
+                evidence.append(
+                    unauthorized_slot_evidence(
+                        producer_task_id=envelope.task_id,
+                        producer_task_type=envelope.task_type,
+                        record=bound_record,
+                        attempted_path=_artifact_raw_path(art) or (norm or ""),
+                        normalized_path=norm,
+                        attempted_content=art.get("content"),
+                        siblings_retained=siblings_retained,
+                    )
+                )
+                # dropped: NOT appended — the owning producer's already-stored version stays.
             else:
                 enforced.append(art)
         return enforced, evidence

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -81,6 +81,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _artifact_raw_path(art: dict) -> str | None:
+    """The producer-emitted path of an artifact, accepting both the ``{name}`` and ``{path}``
+    shapes the two materializers use (SIP-0100 0.1)."""
+    return art.get("name") if art.get("name") is not None else art.get("path")
+
+
 class DispatchedFlowExecutor(FlowExecutionPort):
     """Flow executor that dispatches tasks to agent containers via RabbitMQ.
 
@@ -2030,7 +2036,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
     def _enforce_frozen_ownership(
         self, artifacts: list[dict], bound_record: Any, envelope: TaskEnvelope
-    ) -> list[dict]:
+    ) -> tuple[list[dict], list[Any]]:
         """SIP-0100 2.4: a producer must not overwrite a scaffold-frozen file. Any emitted artifact
         whose normalized path is frozen has its content RESTORED to the bound record's bytes (D2
         restoration authority — never re-derive), so the producer cannot clobber the scaffold
@@ -2039,7 +2045,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         Restore (not response-atomic reject) is the deliberate first enforcement: the current squad
         still re-emits frozen files, so a reject would break every bind-mode build; restore is
         non-breaking and correct. The stricter reject + targeted correction is gated on fill-only
-        (plan §4.6 / 3.4)."""
+        (plan §4.6 / 3.4).
+
+        SIP-0100 3.3: each restore now also produces a structured ``ScaffoldIntegrityEvidence``
+        record (returned alongside the artifacts). Pure — the caller emits it as an
+        ``artifact.ownership_enforced`` event + structured log — so enforcement stays testable and
+        3.4 can drive the compliance counter off the returned records."""
+        from squadops.cycles.scaffold_integrity_evidence import frozen_restore_evidence
         from squadops.cycles.write_authorization import normalize_ws_path
 
         frozen = {
@@ -2047,26 +2059,49 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             for fa in bound_record.frozen
             if (n := normalize_ws_path(fa.path)) is not None
         }
+        # Identify violations first so each evidence record can report how many sibling artifacts in
+        # the SAME response were retained (restore keeps all; a future response-atomic reject would
+        # not — that difference is exactly what the field captures).
+        norms = [
+            normalize_ws_path(raw) if isinstance(raw := _artifact_raw_path(art), str) else None
+            for art in artifacts
+        ]
+        violation_count = sum(1 for n in norms if n is not None and n in frozen)
         enforced: list[dict] = []
-        violated: list[str] = []
-        for art in artifacts:
-            raw = art.get("name") if art.get("name") is not None else art.get("path")
-            norm = normalize_ws_path(raw) if isinstance(raw, str) else None
+        evidence: list[Any] = []
+        for art, norm in zip(artifacts, norms, strict=True):
             if norm is not None and norm in frozen:
-                violated.append(norm)
-                enforced.append({**art, "content": frozen[norm]})  # restore scaffold bytes
+                evidence.append(
+                    frozen_restore_evidence(
+                        producer_task_id=envelope.task_id,
+                        producer_task_type=envelope.task_type,
+                        record=bound_record,
+                        attempted_path=_artifact_raw_path(art) or norm,
+                        normalized_path=norm,
+                        attempted_content=art.get("content"),
+                        siblings_retained=len(artifacts) - violation_count,
+                    )
+                )
+                enforced.append({**art, "content": frozen[norm]})  # restore scaffold bytes (D2)
             else:
                 enforced.append(art)
-        if violated:
-            logger.warning(
-                "SIP-0100 scaffold_integrity: task %s (%s) emitted %d frozen path(s); content "
-                "restored to scaffold bytes: %s",
-                envelope.task_id,
-                envelope.task_type,
-                len(violated),
-                sorted(violated),
+        return enforced, evidence
+
+    def _emit_scaffold_integrity_evidence(self, record: Any, envelope: TaskEnvelope) -> None:
+        """SIP-0100 3.3: surface one enforcement event as a structured event + log (best-effort —
+        observability must never break artifact storage)."""
+        payload = record.to_dict()
+        logger.warning("SIP-0100 scaffold_integrity: %s", payload)
+        try:
+            self._cycle_event_bus.emit(
+                EventType.ARTIFACT_OWNERSHIP_ENFORCED,
+                entity_type="artifact",
+                entity_id=record.normalized_path or record.attempted_path,
+                context={"cycle_id": envelope.cycle_id, "run_id": record.bound_run_id},
+                payload=payload,
             )
-        return enforced
+        except Exception:
+            logger.debug("SIP-0100: scaffold_integrity event emit failed", exc_info=True)
 
     async def _collect_artifacts_and_checkpoint(
         self,
@@ -2087,8 +2122,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # SIP-0100 2.4: on a scaffold-bound run, a producer's emission of a scaffold-frozen path
         # has its content restored to the bound scaffold bytes (D2 authority) — the producer
         # cannot overwrite a frozen file (pf-26). Recorded, not silent; no-op when unbound.
+        # 3.3: enforcement returns structured evidence; emit it (event + log) before storage.
         if bound_record is not None and artifacts:
-            artifacts = self._enforce_frozen_ownership(artifacts, bound_record, envelope)
+            artifacts, integrity_evidence = self._enforce_frozen_ownership(
+                artifacts, bound_record, envelope
+            )
+            for record in integrity_evidence:
+                self._emit_scaffold_integrity_evidence(record, envelope)
         new_refs: list[str] = []
         for art in artifacts:
             ref = await self._store_artifact(

--- a/src/squadops/cycles/scaffold_integrity_evidence.py
+++ b/src/squadops/cycles/scaffold_integrity_evidence.py
@@ -1,0 +1,147 @@
+"""SIP-0100 Phase 3 (Task 3.3) — structured scaffold write-authority evidence.
+
+Turns the executor's bare "frozen path restored" WARNING into a structured,
+queryable record — one per authority event. Review #10 requires three cases be
+kept *separate*, never collapsed into one message; this model separates them on
+two axes:
+
+- ``kind`` — **what class of event this is**:
+  - ``attempted_emission`` — a producer emitted a scaffold-owned path (recorded
+    with the 0.5 reason code: ``frozen_path_emission`` / ``unauthorized_slot_emission``
+    / ``undeclared_path_emission``). Producer-correctable.
+  - ``post_write_integrity_fault`` — frozen bytes changed *after* materialization
+    with no accepted emission (``post_write_integrity_fault``, plan D4): a system
+    fault (bypass / concurrent writer / bug), not producer misconduct.
+- ``disposition`` — **what the enforcer did** (``restored`` / ``dropped`` /
+  ``stopped`` / ``allowed``): the *system restoration*, never conflated with the
+  attempt that triggered it.
+
+Pure model (no I/O): the executor builds and emits these. Reason codes are taken
+from ``task_outcome.ContractComplianceViolation`` — this module never mints its own.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+from squadops.cycles.bound_scaffold_record import BoundScaffoldRecord
+from squadops.cycles.task_outcome import ContractComplianceViolation
+from squadops.cycles.write_authorization import normalize_ws_path
+
+# ``kind`` values — the event-class axis (Review #10). Kept distinct from the 0.5
+# reason codes (which say *why* a path was unauthorized) and from ``disposition``
+# (which says what the system did).
+KIND_ATTEMPTED_EMISSION = "attempted_emission"
+KIND_POST_WRITE_INTEGRITY_FAULT = "post_write_integrity_fault"
+
+# ``disposition`` values — the system-action axis.
+DISPOSITION_RESTORED = "restored"
+DISPOSITION_DROPPED = "dropped"
+DISPOSITION_STOPPED = "stopped"
+DISPOSITION_ALLOWED = "allowed"
+
+
+def sha256_of(content: Any) -> str | None:
+    """SHA-256 hex of artifact content (``str``/``bytes``), or ``None`` if not hashable.
+
+    Shares the encoding convention with materialization: text is UTF-8. Non-text,
+    non-bytes content (a structured artifact with no file body) hashes to ``None``."""
+    if isinstance(content, str):
+        data: bytes = content.encode("utf-8")
+    elif isinstance(content, (bytes, bytearray)):
+        data = bytes(content)
+    else:
+        return None
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass(frozen=True)
+class ScaffoldIntegrityEvidence:
+    """One scaffold write-authority event (plan Task 3.3 / review #10).
+
+    Immutable. ``to_dict`` is the wire/log/event shape; field order there is stable
+    so downstream (run report, telemetry, 3.4 counter) can rely on it.
+    """
+
+    # Producer + stage
+    producer_task_id: str
+    producer_task_type: str
+    stage: str  # where enforcement ran, e.g. "artifact_storage"
+    # Event-class axis (Review #10) + the 0.5 reason code
+    kind: str
+    violation_code: str
+    # What was attempted
+    attempted_path: str  # raw, exactly as the producer emitted it
+    normalized_path: str | None  # D7 canonical target (None = unnormalizable/escaping)
+    # Bound identity — which scaffold binding this was evaluated against
+    bound_run_id: str
+    bound_attempt_id: str
+    manifest_hash: str
+    # Integrity comparison
+    expected_sha256: str | None  # scaffold's bytes for a frozen path
+    attempted_sha256: str | None  # the producer's emitted bytes
+    # Disposition + retention
+    disposition: str  # system action taken (never conflated with the attempt)
+    siblings_retained: int  # sibling artifacts in the SAME response left untouched
+    # Set by 3.4 when a targeted correction is issued for this violation.
+    correction_requested: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "producer_task_id": self.producer_task_id,
+            "producer_task_type": self.producer_task_type,
+            "stage": self.stage,
+            "kind": self.kind,
+            "violation_code": self.violation_code,
+            "attempted_path": self.attempted_path,
+            "normalized_path": self.normalized_path,
+            "bound_run_id": self.bound_run_id,
+            "bound_attempt_id": self.bound_attempt_id,
+            "manifest_hash": self.manifest_hash,
+            "expected_sha256": self.expected_sha256,
+            "attempted_sha256": self.attempted_sha256,
+            "disposition": self.disposition,
+            "siblings_retained": self.siblings_retained,
+            "correction_requested": self.correction_requested,
+        }
+
+
+def frozen_restore_evidence(
+    *,
+    producer_task_id: str,
+    producer_task_type: str,
+    record: BoundScaffoldRecord,
+    attempted_path: str,
+    normalized_path: str,
+    attempted_content: Any,
+    siblings_retained: int,
+    stage: str = "artifact_storage",
+) -> ScaffoldIntegrityEvidence:
+    """Build the evidence for the current 2.4 case: a producer emitted a frozen path
+    and the enforcer **restored** it to the bound scaffold bytes.
+
+    ``expected_sha256`` comes from the bound record's persisted hash for that path
+    (D2 — the authority is the bound bytes, never a re-derivation). Frozen paths are
+    normalized to the D7 canonical identity so the lookup matches ``normalized_path``,
+    exactly as the enforcer keys its restore map."""
+    frozen_sha = {
+        n: fa.sha256 for fa in record.frozen if (n := normalize_ws_path(fa.path)) is not None
+    }
+    return ScaffoldIntegrityEvidence(
+        producer_task_id=producer_task_id,
+        producer_task_type=producer_task_type,
+        stage=stage,
+        kind=KIND_ATTEMPTED_EMISSION,
+        violation_code=ContractComplianceViolation.FROZEN_PATH_EMISSION,
+        attempted_path=attempted_path,
+        normalized_path=normalized_path,
+        bound_run_id=record.run_id,
+        bound_attempt_id=record.attempt_id,
+        manifest_hash=record.manifest_hash,
+        expected_sha256=frozen_sha.get(normalized_path),
+        attempted_sha256=sha256_of(attempted_content),
+        disposition=DISPOSITION_RESTORED,
+        siblings_retained=siblings_retained,
+    )

--- a/src/squadops/cycles/scaffold_integrity_evidence.py
+++ b/src/squadops/cycles/scaffold_integrity_evidence.py
@@ -145,3 +145,39 @@ def frozen_restore_evidence(
         disposition=DISPOSITION_RESTORED,
         siblings_retained=siblings_retained,
     )
+
+
+def unauthorized_slot_evidence(
+    *,
+    producer_task_id: str,
+    producer_task_type: str,
+    record: BoundScaffoldRecord,
+    attempted_path: str,
+    normalized_path: str,
+    attempted_content: Any,
+    siblings_retained: int,
+    stage: str = "artifact_storage",
+) -> ScaffoldIntegrityEvidence:
+    """Build the evidence for the 3.1 case: a producer emitted a path that is writable *in
+    principle* but belongs to a **different** producer's slot (e.g. a QA task writing dev's
+    ``routes.py``). The enforcer **drops** the emission — the owning producer's version stays.
+
+    ``expected_sha256`` is ``None``: a fill slot has no canonical scaffold bytes to compare
+    against (its legitimate content is the owner's implementation, not a scaffold constant).
+    Only the attempted bytes are recorded, for forensics."""
+    return ScaffoldIntegrityEvidence(
+        producer_task_id=producer_task_id,
+        producer_task_type=producer_task_type,
+        stage=stage,
+        kind=KIND_ATTEMPTED_EMISSION,
+        violation_code=ContractComplianceViolation.UNAUTHORIZED_SLOT_EMISSION,
+        attempted_path=attempted_path,
+        normalized_path=normalized_path,
+        bound_run_id=record.run_id,
+        bound_attempt_id=record.attempt_id,
+        manifest_hash=record.manifest_hash,
+        expected_sha256=None,
+        attempted_sha256=sha256_of(attempted_content),
+        disposition=DISPOSITION_DROPPED,
+        siblings_retained=siblings_retained,
+    )

--- a/src/squadops/events/types.py
+++ b/src/squadops/events/types.py
@@ -1,6 +1,6 @@
 """Canonical event type constants for the cycle lifecycle event taxonomy.
 
-28 event types across 9 entity types (cycle, run, gate, task, pulse, artifact, checkpoint, correction, workload).
+29 event types across 9 entity types (cycle, run, gate, task, pulse, artifact, checkpoint, correction, workload).
 Follows the WorkloadType / ArtifactType constants-class pattern (not enum).
 """
 
@@ -41,9 +41,12 @@ class EventType:
     PULSE_REPAIR_STARTED = "pulse.repair_started"
     PULSE_REPAIR_EXHAUSTED = "pulse.repair_exhausted"
 
-    # --- Artifact (2) ---
+    # --- Artifact (3) ---
     ARTIFACT_STORED = "artifact.stored"
     ARTIFACT_PROMOTED = "artifact.promoted"
+    # SIP-0100 3.3: a producer's emission was evaluated against scaffold write-ownership
+    # (frozen restored / unauthorized dropped / integrity fault). Payload = ScaffoldIntegrityEvidence.
+    ARTIFACT_OWNERSHIP_ENFORCED = "artifact.ownership_enforced"
 
     # --- Checkpoint (2) — SIP-0079 ---
     CHECKPOINT_CREATED = "checkpoint.created"
@@ -61,7 +64,7 @@ class EventType:
 
     @classmethod
     def all(cls) -> tuple[str, ...]:
-        """Return all 28 event type constants."""
+        """Return all 29 event type constants."""
         return tuple(
             v
             for k, v in vars(cls).items()

--- a/tests/unit/cycles/test_scaffold_integrity_evidence.py
+++ b/tests/unit/cycles/test_scaffold_integrity_evidence.py
@@ -1,0 +1,133 @@
+"""SIP-0100 Task 3.3 — scaffold write-authority evidence model."""
+
+from __future__ import annotations
+
+import hashlib
+
+from squadops.cycles.bound_scaffold_record import BoundScaffoldRecord, FrozenArtifact
+from squadops.cycles.scaffold_integrity_evidence import (
+    DISPOSITION_RESTORED,
+    KIND_ATTEMPTED_EMISSION,
+    frozen_restore_evidence,
+    sha256_of,
+)
+from squadops.cycles.task_outcome import ContractComplianceViolation
+
+
+def _record(*frozen: FrozenArtifact) -> BoundScaffoldRecord:
+    return BoundScaffoldRecord(
+        run_id="run_1",
+        attempt_id="att_1",
+        stack="fullstack_fastapi_react",
+        manifest_hash="mh_abc",
+        contract_hash="ch",
+        expander_id="exp",
+        created_at="",
+        frozen=tuple(frozen),
+        fill_slots=("backend/routes.py",),
+        qa_namespace=("backend/tests/",),
+    )
+
+
+def _frozen(path: str, content: str) -> FrozenArtifact:
+    return FrozenArtifact(
+        path=path, sha256=hashlib.sha256(content.encode()).hexdigest(), content=content
+    )
+
+
+def test_frozen_restore_evidence_captures_the_full_record():
+    rec = _record(_frozen("backend/main.py", "SCAFFOLD BYTES"))
+    ev = frozen_restore_evidence(
+        producer_task_id="t1",
+        producer_task_type="qa.test",
+        record=rec,
+        attempted_path="./backend/main.py",  # un-normalized as emitted
+        normalized_path="backend/main.py",
+        attempted_content="QA OVERWRITE",
+        siblings_retained=3,
+    )
+    assert ev.violation_code == ContractComplianceViolation.FROZEN_PATH_EMISSION
+    assert ev.kind == KIND_ATTEMPTED_EMISSION
+    assert ev.disposition == DISPOSITION_RESTORED
+    assert ev.producer_task_type == "qa.test"
+    assert ev.attempted_path == "./backend/main.py"  # raw preserved
+    assert ev.normalized_path == "backend/main.py"
+    assert ev.bound_run_id == "run_1"
+    assert ev.bound_attempt_id == "att_1"
+    assert ev.manifest_hash == "mh_abc"
+    assert ev.siblings_retained == 3
+    assert ev.correction_requested is False  # 3.4 populates this
+    # Expected hash is the bound record's persisted scaffold hash; attempted is the emitted bytes.
+    assert ev.expected_sha256 == hashlib.sha256(b"SCAFFOLD BYTES").hexdigest()
+    assert ev.attempted_sha256 == hashlib.sha256(b"QA OVERWRITE").hexdigest()
+
+
+def test_expected_hash_matches_via_normalized_frozen_path():
+    """The record stores an un-normalized frozen path; the lookup must still resolve it so the
+    expected hash is populated (else every restore would report expected=None)."""
+    rec = _record(_frozen("./backend/main.py", "S"))  # stored with a leading ./
+    ev = frozen_restore_evidence(
+        producer_task_id="t",
+        producer_task_type="development.develop",
+        record=rec,
+        attempted_path="backend/main.py",
+        normalized_path="backend/main.py",
+        attempted_content="X",
+        siblings_retained=0,
+    )
+    assert ev.expected_sha256 == hashlib.sha256(b"S").hexdigest()
+
+
+def test_unhashable_attempted_content_yields_none_hash():
+    """A structured artifact with no text/bytes body must not crash evidence building."""
+    rec = _record(_frozen("backend/main.py", "S"))
+    ev = frozen_restore_evidence(
+        producer_task_id="t",
+        producer_task_type="development.develop",
+        record=rec,
+        attempted_path="backend/main.py",
+        normalized_path="backend/main.py",
+        attempted_content={"structured": "no body"},
+        siblings_retained=0,
+    )
+    assert ev.attempted_sha256 is None
+    assert ev.expected_sha256 is not None  # the scaffold side is still known
+
+
+def test_to_dict_is_stable_and_complete():
+    rec = _record(_frozen("conftest.py", "client fixture"))
+    d = frozen_restore_evidence(
+        producer_task_id="t",
+        producer_task_type="qa.test",
+        record=rec,
+        attempted_path="conftest.py",
+        normalized_path="conftest.py",
+        attempted_content="tampered",
+        siblings_retained=1,
+    ).to_dict()
+    assert set(d) == {
+        "producer_task_id",
+        "producer_task_type",
+        "stage",
+        "kind",
+        "violation_code",
+        "attempted_path",
+        "normalized_path",
+        "bound_run_id",
+        "bound_attempt_id",
+        "manifest_hash",
+        "expected_sha256",
+        "attempted_sha256",
+        "disposition",
+        "siblings_retained",
+        "correction_requested",
+    }
+    assert d["stage"] == "artifact_storage"
+
+
+def test_sha256_of_handles_str_bytes_and_non_hashable():
+    assert sha256_of("abc") == hashlib.sha256(b"abc").hexdigest()
+    assert sha256_of(b"abc") == hashlib.sha256(b"abc").hexdigest()
+    assert sha256_of("abc") == sha256_of(b"abc")  # str/bytes converge on UTF-8
+    assert sha256_of(None) is None
+    assert sha256_of(42) is None

--- a/tests/unit/cycles/test_sip0100_executor_enforcement.py
+++ b/tests/unit/cycles/test_sip0100_executor_enforcement.py
@@ -31,7 +31,7 @@ def test_frozen_emission_is_restored_others_pass_through():
         {"name": "backend/main.py", "content": "TAMPERED = 1\n"},
         {"name": "backend/routes.py", "content": "def real_route(): return 1\n"},
     ]
-    enforced = DispatchedFlowExecutor._enforce_frozen_ownership(
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
         object(), artifacts, _record(), _env()
     )
     by_name = {a["name"]: a["content"] for a in enforced}
@@ -40,14 +40,38 @@ def test_frozen_emission_is_restored_others_pass_through():
     assert by_name["backend/main.py"] != "TAMPERED = 1\n"
     # routes.py (a fill slot) is untouched.
     assert by_name["backend/routes.py"] == "def real_route(): return 1\n"
+    # 3.3: exactly one evidence record (the frozen violation), the sibling routes.py is retained.
+    assert len(evidence) == 1
+    ev = evidence[0]
+    assert ev.normalized_path == "backend/main.py"
+    assert ev.violation_code == "frozen_path_emission"
+    assert ev.kind == "attempted_emission"
+    assert ev.disposition == "restored"
+    assert ev.siblings_retained == 1  # routes.py kept
+    assert ev.producer_task_id == "task-1"
+    # attempted hash reflects the tamper; expected hash reflects the scaffold bytes — they differ.
+    assert ev.attempted_sha256 is not None
+    assert ev.expected_sha256 is not None
+    assert ev.attempted_sha256 != ev.expected_sha256
 
 
 def test_conftest_is_frozen_and_restored_too():
     """The SIP-0100 harness (conftest.py) is frozen — a producer can't overwrite it either."""
-    enforced = DispatchedFlowExecutor._enforce_frozen_ownership(
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
         object(), [{"path": "conftest.py", "content": "import os  # tampered"}], _record(), _env()
     )
     assert "client" in enforced[0]["content"]  # restored to the scaffold conftest (has the fixture)
+    assert evidence[0].normalized_path == "conftest.py"
+    assert evidence[0].siblings_retained == 0  # the only artifact in the response
+
+
+def test_clean_response_yields_no_evidence():
+    """A producer that writes only its fill slot emits no violation and no evidence."""
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
+        object(), [{"name": "backend/routes.py", "content": "x = 1\n"}], _record(), _env()
+    )
+    assert evidence == []
+    assert enforced[0]["content"] == "x = 1\n"
 
 
 def test_build_bound_record_none_for_unbound_and_unscaffoldable():

--- a/tests/unit/cycles/test_sip0100_executor_enforcement.py
+++ b/tests/unit/cycles/test_sip0100_executor_enforcement.py
@@ -74,6 +74,82 @@ def test_clean_response_yields_no_evidence():
     assert enforced[0]["content"] == "x = 1\n"
 
 
+# ---- 3.1: QA producers are scoped to the QA test namespace ----
+
+
+def test_qa_write_to_dev_fill_slot_is_dropped():
+    """3.1: a qa.test task rewriting dev's routes.py (the source under test) is DROPPED — the
+    owning producer's version stays. This is the pf-26 class one step past the frozen main.py."""
+    artifacts = [
+        {"name": "backend/tests/test_api.py", "content": "def test_x(): assert True\n"},
+        {"name": "backend/routes.py", "content": "def sneaky(): return 1\n"},
+    ]
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
+        object(), artifacts, _record(), _env("qa.test")
+    )
+    names = {a["name"] for a in enforced}
+    assert "backend/routes.py" not in names  # dropped
+    assert "backend/tests/test_api.py" in names  # QA's own test kept
+    assert len(evidence) == 1
+    ev = evidence[0]
+    assert ev.normalized_path == "backend/routes.py"
+    assert ev.violation_code == "unauthorized_slot_emission"
+    assert ev.disposition == "dropped"
+    assert ev.expected_sha256 is None  # a fill slot has no canonical scaffold bytes
+    assert ev.attempted_sha256 is not None
+    assert ev.siblings_retained == 1  # the test file passed through
+
+
+def test_qa_write_in_its_namespace_passes():
+    """A QA task writing its own tests is authorized — no evidence, content untouched."""
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
+        object(),
+        [{"name": "backend/tests/test_api.py", "content": "T = 1\n"}],
+        _record(),
+        _env("qa.test"),
+    )
+    assert evidence == []
+    assert enforced[0]["content"] == "T = 1\n"
+
+
+def test_qa_undeclared_deliverable_is_allowed():
+    """An undeclared path (a QA deliverable like test_report.md) is NOT dropped — we can't tell it
+    from a rogue file here, so leaving it be keeps QA's reports safe (undeclared-reject is 3.4)."""
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
+        object(),
+        [{"name": "test_report.md", "content": "# report\n"}],
+        _record(),
+        _env("qa.test"),
+    )
+    assert evidence == []
+    assert enforced[0]["content"] == "# report\n"
+
+
+def test_qa_write_to_frozen_is_still_restored():
+    """3.1 does not weaken 2.4: a QA emission of frozen main.py is still restored, not dropped."""
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
+        object(),
+        [{"name": "backend/main.py", "content": "TAMPER\n"}],
+        _record(),
+        _env("qa.test"),
+    )
+    assert "from .routes import router" in enforced[0]["content"]  # restored, not dropped
+    assert evidence[0].violation_code == "frozen_path_emission"
+    assert evidence[0].disposition == "restored"
+
+
+def test_dev_write_to_its_own_fill_slot_is_not_dropped():
+    """3.1 scopes QA only: a dev task writing dev's routes.py is legitimate and untouched."""
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
+        object(),
+        [{"name": "backend/routes.py", "content": "def real(): return 1\n"}],
+        _record(),
+        _env("development.develop"),
+    )
+    assert evidence == []
+    assert enforced[0]["content"] == "def real(): return 1\n"
+
+
 def test_build_bound_record_none_for_unbound_and_unscaffoldable():
     assert DispatchedFlowExecutor._build_bound_record_for_run(object(), None, "r") is None
     bad = InterfaceManifest.from_dict(

--- a/tests/unit/events/test_event_emission.py
+++ b/tests/unit/events/test_event_emission.py
@@ -18,7 +18,7 @@ pytestmark = [pytest.mark.domain_events]
 
 # ---- Source-level coverage: every EventType constant appears in an emit() call ----
 
-# Collect all 28 event type constant names
+# Collect all 29 event type constant names
 _ALL_EVENT_TYPE_ATTRS = [
     attr
     for attr in dir(EventType)
@@ -98,8 +98,8 @@ class TestEmissionCoverage:
             f"in any emission source file"
         )
 
-    def test_all_28_types_defined(self, all_emitted_types: set[str]) -> None:
-        assert len(_ALL_EVENT_TYPE_ATTRS) == 28
+    def test_all_29_types_defined(self, all_emitted_types: set[str]) -> None:
+        assert len(_ALL_EVENT_TYPE_ATTRS) == 29
 
     def test_wired_types_covered(self, all_emitted_types: set[str]) -> None:
         wired = set(_ALL_EVENT_TYPE_ATTRS) - _SIP_0083_PENDING_EMISSION
@@ -130,12 +130,13 @@ class TestExecutorEmissionPoints:
             "WORKLOAD_GATE_AWAITING",
             "WORKLOAD_ADVANCED",
             "GATE_DECIDED",
+            "ARTIFACT_OWNERSHIP_ENFORCED",
         ],
     )
     def test_executor_emits(self, attr: str, executor_refs: set[str]) -> None:
         assert attr in executor_refs
 
-    def test_executor_has_13_types(self, executor_refs: set[str]) -> None:
+    def test_executor_has_14_types(self, executor_refs: set[str]) -> None:
         """13 = the post-slice-5 twelve plus GATE_DECIDED (#473): the
         inter-workload pre-gate validation records a system REJECTED gate
         decision and emits GATE_DECIDED, so a mechanically rejected plan is
@@ -151,8 +152,11 @@ class TestExecutorEmissionPoints:
         in the executor. (Slice 5 moved the retry loop's TASK_SUCCEEDED/
         FAILED emits to TaskDispatcher, but the fan-out path still
         references all three TASK_* types here, so the count is unchanged.)
+
+        SIP-0100 3.3 added ARTIFACT_OWNERSHIP_ENFORCED (the scaffold-integrity
+        enforcement event), emitted by _emit_scaffold_integrity_evidence — 13 → 14.
         """
-        assert len(executor_refs) == 13
+        assert len(executor_refs) == 14
 
 
 class TestRunCompletionEmissionPoints:
@@ -326,10 +330,11 @@ class TestEmitCallSitePayloadFields:
         assert with_payload >= 35
 
     def test_total_emit_call_count(self) -> None:
-        """Sanity check: 19 executor + 7 correction-runner +
-        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 43 total
+        """Sanity check: 20 executor + 7 correction-runner +
+        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 44 total
         emit calls (#473 added the pre-gate rejection's GATE_DECIDED emit;
-        #522 added the framing re-roll's WORKLOAD_ADVANCED emit).
+        #522 added the framing re-roll's WORKLOAD_ADVANCED emit; SIP-0100 3.3
+        added the scaffold-integrity ARTIFACT_OWNERSHIP_ENFORCED emit).
 
         SIP-0097 slice 2c collapsed execute_run's five per-exception-class
         terminal emits into one emit driven by the RunCompletion terminal
@@ -342,4 +347,4 @@ class TestEmitCallSitePayloadFields:
         total = 0
         for path in _ALL_EMISSION_FILES:
             total += len(self._extract_emit_calls(path))
-        assert total == 43
+        assert total == 44

--- a/tests/unit/events/test_event_type_extensions.py
+++ b/tests/unit/events/test_event_type_extensions.py
@@ -8,8 +8,8 @@ pytestmark = [pytest.mark.domain_events]
 
 
 class TestSIP0079EventTypes:
-    def test_all_returns_28_items(self):
-        assert len(EventType.all()) == 28
+    def test_all_returns_29_items(self):
+        assert len(EventType.all()) == 29
 
     def test_no_duplicate_values(self):
         all_values = EventType.all()

--- a/tests/unit/events/test_types.py
+++ b/tests/unit/events/test_types.py
@@ -7,9 +7,9 @@ from squadops.events.types import EventType
 
 @pytest.mark.domain_events
 class TestEventType:
-    def test_all_returns_28_events(self):
+    def test_all_returns_29_events(self):
         all_types = EventType.all()
-        assert len(all_types) == 28
+        assert len(all_types) == 29
 
     def test_entity_transition_format(self):
         for event_type in EventType.all():
@@ -44,7 +44,7 @@ class TestEventType:
             "gate": 1,
             "task": 3,
             "pulse": 5,
-            "artifact": 2,
+            "artifact": 3,
             "checkpoint": 2,
             "correction": 3,
             "workload": 3,


### PR DESCRIPTION
## Summary

SIP-0100 Phase 3, tasks **3.3** (evidence) and **3.1** (QA write-scope) — the observability layer plus the first per-producer authority enforcement. Builds directly on the 2.4 seam; non-QA producers and unbound runs are unaffected.

### 3.3 — structured scaffold-integrity evidence
The 2.4 enforcement emitted only a bare count WARNING. Now each enforcement produces a structured `ScaffoldIntegrityEvidence` record (new pure module `scaffold_integrity_evidence.py`), separating the three cases Review #10 requires kept apart — *attempted-emission* vs *post-write integrity fault* (`kind`) vs the *system restoration* (`disposition`) — carrying producer/stage, attempted+normalized path, bound identity, expected-vs-attempted `sha256`, sibling retention, and a `correction_requested` slot for 3.4. `_enforce_frozen_ownership` is now pure (returns artifacts + evidence); the async caller emits each as a new `artifact.ownership_enforced` event + structured log. Reason codes reuse the 0.5 `ContractComplianceViolation` taxonomy.

### 3.1 — QA producers scoped to their namespace
Wires the 2.1 authorization classes (`WorkspaceOwnership` / `WriteGrant.for_qa` / `WriteAuthorization`) into the seam. A QA producer emitting a path owned by another producer's slot (dev's `routes.py`) is **dropped** — the owning producer's version stays, so QA can't rewrite the source under test to agree with its own test (the pf-26 class, one step past the frozen `main.py`). Disposition:

| QA emits… | Disposition |
|---|---|
| frozen path | restore to scaffold bytes (unchanged 2.4) |
| another producer's slot (`routes.py`) | **drop** + `unauthorized_slot_emission` evidence |
| its own QA namespace | allow |
| undeclared path (`test_report.md`) | allow — a deliverable can't be told from a rogue file here; undeclared-reject stays gated on 3.4 |

Per-artifact disposition keeps QA's legitimate tests and deliverables; only the offending emission is dropped. **Drop-now** was chosen deliberately (3.3 evidence is the safety net): it can only "break" a build that was converging via QA-rewrites-source — a tautological green we *want* surfaced — and a genuine source bug still gets fixed by a dev repair, which owns the slot.

## Tests
5 new 3.1 tests + 5 evidence tests; event-taxonomy guards updated (28→29, artifact 2→3, executor 13→14, emit sites 43→44). **2075 cycles+events green.** (Two `verification_contract_runner` failures are pre-existing/environmental — `missing_tooling` on the dev box, confirmed by stashing this branch.)

## Not in this PR
3.2 (delegation safeguards) next; **3.4 (compliance counter) needs loop-owner sign-off** before implementation — it touches the SIP-0086 correction counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG
