### PR TITLE
test(sip-0100): Phase 4.5 — no-regression + flag D3 fail-open deviation

### DIFF
--- a/docs/plans/SIP-0100-scaffold-integrity-plan.md
+++ b/docs/plans/SIP-0100-scaffold-integrity-plan.md
@@ -118,7 +118,15 @@ Ordered so ownership (0.2) precedes the checks that consume it (Review #18).
 | 4.2 | ✅ **DONE** — pf-26 replay: a QA correction emitting frozen `backend/main.py` beside its corrected suite **cannot** mutate main.py (restored to the router-importing scaffold; suite kept). The suite reaching execution through the `client` fixture is the `harness_boundary` check (`test_acceptance_checks.py`: fixture passes, import/TestClient/dynamic-import fail). | `test_sip0100_phase4_replay.py::test_pf26_replay_*` — green. |
 | 4.3 | ✅ **DONE** — expander-change replay: a bound record pinned to sentinel bytes restores to **those** bytes (not a re-expansion) at both the enforcement seam and `restore_frozen_files` on disk — the record, not the live expander, is the D2 restore authority. | `test_sip0100_phase4_replay.py::test_restore_uses_bound_bytes_*` — green. |
 | 4.4 | **Live integration + enforcement trace** — ≥1 live bind-mode `group_run` completes with no package-root divergence and no frozen mutation, **and** a lightweight enforcement trace (ownership-record id, artifacts evaluated, grant id, integrity result) proves the seam actually ran (Review #22). "No violation" alone is weak if the seam might have been inactive. | one clean roll + trace present. |
-| 4.5 | **Legacy/unbound + no-regression** — unbound fill/repair retain current behavior; a bound flow lacking ownership fails binding (not partial enforcement); no caller silently omits authorization; capability/verification-contract/build-convergence suites green. | tests (Review #21). |
+| 4.5 | ✅ **DONE** (with one flagged deviation) — unbound/legacy retain current behavior (None manifest / non-scaffoldable → no record → enforcement skipped; unbound `materialize` byte-identical); binding is **all-or-nothing** (full frozen set or None, never partial); capability + correction (build-convergence) suites green (verification-contract's 2 `missing_tooling` skips are the known env gap, green in CI). **D3 deviation flagged:** `_build_bound_record_for_run` is **fail-OPEN** — a `build_bound_record` error disables enforcement rather than failing the run (a deliberate 2.4 rollout-safety choice), where D3 wants **fail-closed**. Pinned by test; hardening is a separate decision (§4.5 note below). | `test_sip0100_no_regression.py` — green. |
+
+> **§4.5 D3 deviation — fail-open vs fail-closed (open decision).** D3 says a scaffold-bound
+> flow whose binding fails must fail the run, so enforcement can't be bypassed by broken wiring.
+> The shipped 2.4 code chose fail-**open** (a binding error → `None` → enforcement disabled, run
+> continues) as a rollout-safety hedge. Reachable only when `build_bound_record` *throws* on a
+> scaffoldable stack (a bug), so the exposure is narrow — but it is a real D3 gap. Recommend
+> revisiting to fail-**closed** once the enforcement has a clean `full`-roll under its belt (4.4);
+> until then the deviation is documented and test-pinned, not silent.
 
 > **Run 4.4 on `full` (27b), not `lite` (7b) — 2026-07-23 finding.** A `lite` validation
 > roll (`cyc_3baf018e839c`) produced a plan that missed every scaffold fill slot (`.js` flat

--- a/tests/unit/cycles/test_sip0100_no_regression.py
+++ b/tests/unit/cycles/test_sip0100_no_regression.py
@@ -1,0 +1,89 @@
+"""SIP-0100 Phase 4.5 — legacy/unbound + no-regression guarantees.
+
+The "suites green" clause (capability / verification-contract / build-convergence) is a
+CI/regression gate, not asserted here. These tests pin the two binding-boundary properties
+that aren't covered elsewhere: enforcement is all-or-nothing, and the current fail-open
+behavior on a binding error (a documented D3 deviation).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import squadops.cycles.bound_scaffold_record as bsr
+from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+from squadops.capabilities.scaffold import InterfaceManifest
+
+_MANIFEST = Path(__file__).parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+
+
+def _manifest() -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_MANIFEST.read_text())
+
+
+def _unscaffoldable() -> InterfaceManifest:
+    return InterfaceManifest.from_dict(
+        {"version": 1, "kind": "interface_manifest", "project_id": "x", "stack": "cobol_cics"}
+    )
+
+
+def _scaffoldable_minimal() -> InterfaceManifest:
+    return InterfaceManifest.from_dict(
+        {
+            "version": 1,
+            "kind": "interface_manifest",
+            "project_id": "x",
+            "stack": "fullstack_fastapi_react",
+        }
+    )
+
+
+def test_binding_is_all_or_nothing_never_partial():
+    """Enforcement binds fully or not at all. A scaffoldable manifest yields a record whose frozen
+    set covers every scaffold-frozen file across BOTH stacks (backend + frontend + harness); a
+    non-scaffoldable stack yields None — never a partial record that would protect some frozen
+    files but silently leave others writable."""
+    rec = DispatchedFlowExecutor._build_bound_record_for_run(object(), _manifest(), "r")
+    assert rec is not None
+    frozen = set(rec.frozen_paths())
+    for p in (
+        "backend/main.py",
+        "backend/models.py",
+        "backend/errors.py",
+        "conftest.py",
+        "frontend/src/App.jsx",
+        "frontend/src/main.jsx",
+    ):
+        assert p in frozen, f"{p} missing from the frozen set — enforcement would be partial"
+    # A fill slot is NOT frozen (it's the writable surface) — completeness cuts both ways.
+    assert "backend/routes.py" not in frozen
+
+    # Unbound stack → no record at all (not a partial one).
+    assert (
+        DispatchedFlowExecutor._build_bound_record_for_run(object(), _unscaffoldable(), "r") is None
+    )
+
+
+def test_unbound_manifest_disables_enforcement():
+    """A None manifest (a genuinely unbound/legacy run) binds nothing — the executor guard then
+    skips enforcement entirely, preserving pre-SIP behavior."""
+    assert DispatchedFlowExecutor._build_bound_record_for_run(object(), None, "r") is None
+
+
+def test_binding_error_fails_open_documented_d3_deviation(monkeypatch):
+    """D3 deviation, pinned deliberately. D3 says a scaffold-bound flow whose binding fails must
+    FAIL the run (fail-closed — enforcement can't be bypassed by broken wiring). The 2.4
+    implementation chose fail-OPEN: a ``build_bound_record`` error disables enforcement (returns
+    None) and the run continues, a conscious rollout-safety choice ("a build failure disables
+    enforcement rather than failing the run"). This test locks the CURRENT behavior; hardening to
+    fail-closed is a separate decision (see the plan §4.5 note)."""
+
+    def _boom(*a, **k):
+        raise RuntimeError("binding blew up")
+
+    monkeypatch.setattr(bsr, "build_bound_record", _boom)
+    # A scaffoldable stack (so binding IS attempted) whose build then raises → fail-open None.
+    result = DispatchedFlowExecutor._build_bound_record_for_run(
+        object(), _scaffoldable_minimal(), "r"
+    )
+    assert result is None  # fail-OPEN: enforcement disabled, run continues (NOT D3 fail-closed)


### PR DESCRIPTION
## Summary

SIP-0100 Phase 4 Task **4.5** — legacy/unbound + no-regression. Test-only, plus a flagged D3 deviation. This closes out Phase 4's *deterministic* work (4.4, the live roll, is separate).

## What it pins
- **Unbound/legacy retain current behavior** — a `None` manifest or non-scaffoldable stack yields no bound record → the executor guard skips enforcement → pre-SIP behavior; unbound `materialize` stays byte-identical.
- **Binding is all-or-nothing** — a scaffoldable manifest binds the *full* frozen set (backend + frontend + harness), a non-scaffoldable one binds nothing. Never a partial record that would protect some frozen files and silently leave others writable.
- **Suites green** — capability + correction (build-convergence) suites pass (the 2 `verification_contract_runner` `missing_tooling` skips are the known local env gap; green in CI).

## Flagged: D3 deviation (fail-open vs fail-closed)
Grounding surfaced a real gap. `_build_bound_record_for_run` is **fail-open**: a `build_bound_record` error disables enforcement (returns `None`, run continues) rather than failing the run — a deliberate 2.4 rollout-safety choice. **D3 wants fail-closed** ("enforcement can't be bypassed by broken wiring").

- Reachable only when binding *throws* on a scaffoldable stack (a bug), so exposure is narrow.
- Pinned by `test_binding_error_fails_open_documented_d3_deviation` — documented, not silent.
- Plan §4.5 recommends hardening to fail-closed once the enforcement has a clean `full` roll (4.4) under it. **Not fixing it in this PR** — it's your call whether/when to flip it.

## Tests
3 new (`test_sip0100_no_regression.py`). Plan doc 4.5 marked done with the deviation note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG
