### PR TITLE
feat: deterministic fill-slot binding at plan authoring (Phases A+B)

### DIFF
--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -93,6 +93,25 @@ def _build_refinement_time_budget_section(time_budget_seconds: int | None) -> st
     )
 
 
+def _format_writable_surfaces(surfaces: dict[str, Any]) -> str:
+    """Render the Phase-A writable-surface DATA into named sections for the bind appendix. Data
+    only — the instruction ("write ONLY these paths") lives in the asset (#448)."""
+    sections = (
+        ("DEV_WRITABLE_SLOTS", surfaces.get("dev_writable_slots", [])),
+        ("QA_WRITABLE_NAMESPACES", surfaces.get("qa_writable_namespaces", [])),
+        ("REQUIRED_SLOT_COVERAGE", surfaces.get("required_slot_coverage", [])),
+        ("READ_ONLY_CONTEXT_PATHS", surfaces.get("read_only_context_paths", [])),
+    )
+    lines: list[str] = []
+    for name, items in sections:
+        lines.append(f"{name}:")
+        if items:
+            lines.extend(f"  - {p}" for p in items)
+        else:
+            lines.append("  (none)")
+    return "\n".join(lines)
+
+
 class _PlanningTaskHandler(_CycleTaskHandler):
     """Base class for planning and refinement task handlers.
 
@@ -849,9 +868,14 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
         index = inputs.get("contract_criteria_index")
         if not index:
             return ""
-        rendered = await renderer.render(
-            "request.plan_bind_criteria_appendix", {"criteria_index": index}
-        )
+        variables = {"criteria_index": index}
+        # SIP-0100 follow-up (Phase A): pass the authoritative writable surfaces as DATA; the asset
+        # carries the "write ONLY these paths" instruction (#448). Present whenever a contract is
+        # seeded (injected alongside contract_criteria_index).
+        surfaces = inputs.get("writable_surfaces")
+        if surfaces:
+            variables["writable_slots"] = _format_writable_surfaces(surfaces)
+        rendered = await renderer.render("request.plan_bind_criteria_appendix", variables)
         return rendered.content
 
     async def handle(

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -422,6 +422,14 @@ def qa_test_namespace(manifest: InterfaceManifest) -> tuple[str, ...]:
     return _QA_TEST_NAMESPACES.get(manifest.stack, ())
 
 
+def qa_test_namespace_for_stack(stack: str) -> tuple[str, ...]:
+    """QA test-namespace directory prefixes for ``stack`` (empty for an unknown stack).
+
+    Stack-keyed sibling of ``qa_test_namespace`` that needs no manifest — plan-authoring
+    binding has the stack from the contract skeleton, not the manifest."""
+    return _QA_TEST_NAMESPACES.get(stack, ())
+
+
 def is_qa_test_path_for_stack(path: str, stack: str) -> bool:
     """True when a workspace-relative ``path`` falls within ``stack``'s QA test namespace.
 

--- a/src/squadops/cycles/plan_authorization.py
+++ b/src/squadops/cycles/plan_authorization.py
@@ -1,0 +1,268 @@
+"""SIP-0100 follow-up — deterministic fill-slot binding at plan authoring.
+
+A **read-only projection** of the scaffold ownership surfaces (the same source the runtime write
+enforcement uses), applied at plan-authoring time so a bind-mode plan's dev/qa targets are gated
+against the fill slots *before* generation lands (Phase B), and the surfaces can be published to the
+proposer (Phase A).
+
+Architectural boundary (plan review #3): the plan domain model consumes this projection; it never
+constructs runtime ``WriteGrant`` objects. Reason codes are a ``PLAN_TARGET_*`` family — deterministic
+plan-contract violations, not proposer-quality or implementation failures.
+"""
+
+from __future__ import annotations
+
+import posixpath
+from dataclasses import dataclass
+
+from squadops.capabilities.scaffold import qa_test_namespace_for_stack
+from squadops.cycles.verification_contract import VerificationContract
+from squadops.cycles.write_authorization import normalize_ws_path
+
+
+class PlanTargetViolation:
+    """Stable codes for a deterministic plan-contract violation (constants-class, not enum)."""
+
+    UNAUTHORIZED = (
+        "plan_target_unauthorized"  # target isn't an authorized writable path for the role
+    )
+    MISSING_REQUIRED_SLOT = (
+        "plan_target_missing_required_slot"  # a required fill slot is unassigned
+    )
+    DUPLICATE_OWNERSHIP = "plan_target_duplicate_ownership"  # two tasks own the same slot
+    AMBIGUOUS_SCOPE = (
+        "plan_target_ambiguous_scope"  # glob/dir/absolute — not a concrete workspace file
+    )
+
+
+@dataclass(frozen=True)
+class PlanTargetRejection:
+    """One rejected target (or coverage defect), carrying everything the re-roll prompt + metrics need."""
+
+    code: str
+    task_index: int
+    role: str
+    raw_target: str
+    canonical_target: str | None
+    detail: str
+    nearest_slots: tuple[str, ...]
+    contract_hash: str
+
+    def to_dict(self) -> dict:
+        return {
+            "code": self.code,
+            "task_index": self.task_index,
+            "role": self.role,
+            "raw_target": self.raw_target,
+            "canonical_target": self.canonical_target,
+            "detail": self.detail,
+            "nearest_slots": list(self.nearest_slots),
+            "contract_hash": self.contract_hash,
+        }
+
+
+def _is_glob_or_dir(raw: str) -> bool:
+    """A concrete workspace file has no glob metacharacter and no trailing separator."""
+    return any(ch in raw for ch in "*?[") or raw.rstrip().endswith("/")
+
+
+@dataclass(frozen=True)
+class PlanAuthorization:
+    """Read-only planning authorization projection derived from the bound contract.
+
+    ``read_only_paths`` = frozen files; ``dev_writable`` = fill slots; ``qa_namespace`` = QA test
+    prefixes; ``required_coverage`` = the fill slots the plan MUST assign; ``source_prefixes`` = the
+    workspace source-tree directory prefixes (so an off-slot source file is caught as *undeclared
+    source* rather than waved through as a deliverable)."""
+
+    read_only_paths: frozenset[str]
+    dev_writable: frozenset[str]
+    qa_namespace: tuple[str, ...]
+    required_coverage: frozenset[str]
+    source_prefixes: tuple[str, ...]
+    contract_hash: str
+
+    @classmethod
+    def from_contract(cls, contract: VerificationContract) -> PlanAuthorization:
+        frozen = frozenset(
+            n for f in contract.frozen_files if (n := normalize_ws_path(f.path)) is not None
+        )
+        fill = frozenset(
+            n for f in contract.fill_files if (n := normalize_ws_path(f.path)) is not None
+        )
+        # Source-tree prefixes: the parent dir of every scaffold source file. A dev/qa target under
+        # one of these that is neither a slot nor frozen is undeclared *source* (reject), vs a
+        # root-level deliverable (e.g. qa_handoff.md) which sits under no source prefix.
+        prefixes = {posixpath.dirname(p) + "/" for p in (frozen | fill) if posixpath.dirname(p)}
+        return cls(
+            read_only_paths=frozen,
+            dev_writable=fill,
+            qa_namespace=qa_test_namespace_for_stack(contract.skeleton.expander),
+            required_coverage=fill,
+            source_prefixes=tuple(sorted(prefixes)),
+            contract_hash=contract.skeleton.interface_manifest_hash,
+        )
+
+    def _in_qa_namespace(self, norm: str) -> bool:
+        return any(norm.startswith(ns) for ns in self.qa_namespace)
+
+    def _is_source_tree(self, norm: str) -> bool:
+        return any(norm.startswith(p) for p in self.source_prefixes)
+
+
+_DEV_TASK_TYPES = frozenset({"development.develop"})
+
+
+def _role_of(task_type: str) -> str | None:
+    """The write-authority role a task is gated as, or None (not gated in v1 — e.g. builder)."""
+    if task_type in _DEV_TASK_TYPES:
+        return "dev"
+    if task_type.startswith("qa."):
+        return "qa"
+    return None
+
+
+def _authorize_target(
+    authz: PlanAuthorization, role: str, raw: str, task_index: int
+) -> PlanTargetRejection | None:
+    """Authorize one workspace target for a dev/qa task, or None if allowed. Returns a rejection for
+    frozen, cross-role slot, undeclared source, or ambiguous (glob/dir/escape) targets. A path under
+    no source prefix and in no owned surface is treated as a (non-workspace) deliverable — allowed."""
+    if _is_glob_or_dir(raw):
+        return PlanTargetRejection(
+            PlanTargetViolation.AMBIGUOUS_SCOPE,
+            task_index,
+            role,
+            raw,
+            None,
+            "glob/directory targets are not concrete workspace files; name each fill slot explicitly",
+            tuple(sorted(authz.dev_writable if role == "dev" else ())),
+            authz.contract_hash,
+        )
+    norm = normalize_ws_path(raw)
+    if norm is None:
+        return PlanTargetRejection(
+            PlanTargetViolation.AMBIGUOUS_SCOPE,
+            task_index,
+            role,
+            raw,
+            None,
+            "absolute or workspace-escaping path",
+            (),
+            authz.contract_hash,
+        )
+    if norm in authz.read_only_paths:
+        return PlanTargetRejection(
+            PlanTargetViolation.UNAUTHORIZED,
+            task_index,
+            role,
+            raw,
+            norm,
+            "frozen scaffold file — read-only; put logic in a fill slot",
+            tuple(sorted(authz.dev_writable)),
+            authz.contract_hash,
+        )
+    if role == "dev":
+        if norm in authz.dev_writable:
+            return None
+        if authz._in_qa_namespace(norm):
+            return PlanTargetRejection(
+                PlanTargetViolation.UNAUTHORIZED,
+                task_index,
+                role,
+                raw,
+                norm,
+                "QA test namespace — dev does not author tests",
+                tuple(sorted(authz.dev_writable)),
+                authz.contract_hash,
+            )
+        if authz._is_source_tree(norm):
+            return PlanTargetRejection(
+                PlanTargetViolation.UNAUTHORIZED,
+                task_index,
+                role,
+                raw,
+                norm,
+                "undeclared workspace source — not a fill slot",
+                tuple(sorted(authz.dev_writable)),
+                authz.contract_hash,
+            )
+        return None  # under no source prefix, not frozen → deliverable (allowed, v1-permissive)
+    # role == "qa"
+    if authz._in_qa_namespace(norm):
+        return None
+    if norm in authz.dev_writable:
+        return PlanTargetRejection(
+            PlanTargetViolation.UNAUTHORIZED,
+            task_index,
+            role,
+            raw,
+            norm,
+            "dev fill slot — QA writes tests, not source (needs an explicit correction grant)",
+            tuple(authz.qa_namespace),
+            authz.contract_hash,
+        )
+    if authz._is_source_tree(norm):
+        return PlanTargetRejection(
+            PlanTargetViolation.UNAUTHORIZED,
+            task_index,
+            role,
+            raw,
+            norm,
+            "workspace source — QA writes only its test namespace",
+            tuple(authz.qa_namespace),
+            authz.contract_hash,
+        )
+    return None  # deliverable (allowed)
+
+
+def validate_plan_write_targets(tasks: list, authz: PlanAuthorization) -> list[PlanTargetRejection]:
+    """Bind-mode plan target validation (Phase B). Returns per-target rejections plus coverage
+    defects (missing required slot / duplicate ownership). Empty ⇒ the plan's targets are authorized
+    and complete. The caller rejects the whole plan atomically on any rejection (never silent-strips)."""
+    rejections: list[PlanTargetRejection] = []
+    slot_owners: dict[str, list[int]] = {}
+    for task in tasks:
+        role = _role_of(task.task_type)
+        if role is None:
+            continue
+        for raw in task.expected_artifacts:
+            rej = _authorize_target(authz, role, str(raw), task.task_index)
+            if rej is not None:
+                rejections.append(rej)
+                continue
+            if role == "dev":
+                norm = normalize_ws_path(str(raw))
+                if norm in authz.dev_writable:
+                    slot_owners.setdefault(norm, []).append(task.task_index)
+
+    # Coverage: every required slot assigned exactly once.
+    for slot in sorted(authz.required_coverage):
+        owners = slot_owners.get(slot, [])
+        if not owners:
+            rejections.append(
+                PlanTargetRejection(
+                    PlanTargetViolation.MISSING_REQUIRED_SLOT,
+                    -1,
+                    "dev",
+                    slot,
+                    slot,
+                    "required fill slot is not assigned by any dev task",
+                    (slot,),
+                    authz.contract_hash,
+                )
+            )
+        elif len(owners) > 1:
+            rejections.append(
+                PlanTargetRejection(
+                    PlanTargetViolation.DUPLICATE_OWNERSHIP,
+                    owners[-1],
+                    "dev",
+                    slot,
+                    slot,
+                    f"fill slot assigned by multiple dev tasks {owners}",
+                    (slot,),
+                    authz.contract_hash,
+                )
+            )
+    return rejections

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -387,6 +387,19 @@ def _inject_contract_inputs(
         return
     if task_type in _BIND_INDEX_PROPOSER_TASK_TYPES:
         inputs["contract_criteria_index"] = "\n".join(contract.criteria_index_lines())
+        # SIP-0100 follow-up (Phase A): publish the authoritative writable surfaces (data only,
+        # #448) so the proposer targets fill slots deterministically instead of inventing paths.
+        # The bind appendix asset carries the "write ONLY these paths" instruction. Same source
+        # (the contract) that Phase B validates against and the runtime enforces against.
+        from squadops.cycles.plan_authorization import PlanAuthorization
+
+        authz = PlanAuthorization.from_contract(contract)
+        inputs["writable_surfaces"] = {
+            "read_only_context_paths": sorted(authz.read_only_paths),
+            "dev_writable_slots": sorted(authz.dev_writable),
+            "qa_writable_namespaces": list(authz.qa_namespace),
+            "required_slot_coverage": sorted(authz.required_coverage),
+        }
     if task_type == "qa.test" and contract.behavioral.probes:
         inputs["contract_probes"] = [p.to_dict() for p in contract.behavioral.probes]
 
@@ -688,6 +701,27 @@ def _replace_build_steps_with_plan(
         ref_errors = plan.validate_criteria_refs(contract)
         if ref_errors:
             raise CycleError("Plan validation failed (contract binding): " + "; ".join(ref_errors))
+
+        # SIP-0100 follow-up (Phase B): bind-mode target authorization — every dev/qa
+        # workspace target must resolve to an authorized fill slot / QA namespace, and every
+        # required slot must be assigned exactly once. Reuses the same ownership surface the
+        # runtime write-enforcement uses (a read-only projection), so authoring and enforcement
+        # can't diverge. Raising routes to the bounded framing re-roll (#522); exhaustion is a
+        # distinct authoring-bind failure, never a build-convergence failure.
+        from squadops.cycles.plan_authorization import (
+            PlanAuthorization,
+            validate_plan_write_targets,
+        )
+
+        target_rejections = validate_plan_write_targets(
+            plan.tasks, PlanAuthorization.from_contract(contract)
+        )
+        if target_rejections:
+            summary = "; ".join(
+                f"task {r.task_index} [{r.code}] {r.raw_target} — {r.detail}"
+                for r in target_rejections
+            )
+            raise CycleError("Plan validation failed (target binding): " + summary)
 
     # Remove static build steps, keep everything else (planning steps)
     static_build_types = {s[0] for s in BUILD_TASK_STEPS} | {

--- a/src/squadops/prompts/request_templates/request.plan_bind_criteria_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_bind_criteria_appendix.md
@@ -1,10 +1,36 @@
 ---
 template_id: request.plan_bind_criteria_appendix
-version: "2"
+version: "3"
 required_variables:
   - criteria_index
-optional_variables: []
+optional_variables:
+  - writable_slots
 ---
+## Write ONLY the scaffold's fill slots — the layout is fixed
+
+The scaffold owns the file layout. These are the **only** paths a build task may write, and
+every required slot must be filled. Anything else is rejected at plan validation before the
+build runs.
+
+{{writable_slots}}
+
+Rules — follow them exactly:
+
+- Every `development.develop` task that writes source MUST list one or more `DEV_WRITABLE_SLOTS`
+  paths in `expected_artifacts`, **verbatim**. Every `qa.*` task writes only within
+  `QA_WRITABLE_NAMESPACES`.
+- `READ_ONLY_CONTEXT_PATHS` are the scaffold's frozen files — read them for context, but **never**
+  list one as an `expected_artifact`. Writing one is discarded and rejected.
+- Do **not** translate the layout: no swapping `backend/routes.py` for `backend/routers/…`, no
+  `.tsx` for a `.jsx` slot, no `src/components/` or `src/pages/` for `src/views/`, no inventing
+  `store.py`/`services/`. Use the exact slot paths above.
+- Do not replace a concrete slot with a "similar" file, and do not add extra source files — if a
+  file is not a listed slot, it does not belong in `expected_artifacts`.
+- Assign **every** `REQUIRED_SLOT_COVERAGE` path to exactly one dev task — no missing slots, no two
+  tasks writing the same slot.
+- A task that produces only a non-source deliverable (a report, a handoff doc) names that
+  deliverable, not a fabricated source file.
+
 ## Bind the verification contract — do NOT author acceptance criteria
 
 This build is governed by a **verification contract**: a pre-authored, frozen

--- a/tests/unit/capabilities/test_bind_criteria_proposer.py
+++ b/tests/unit/capabilities/test_bind_criteria_proposer.py
@@ -152,6 +152,80 @@ async def test_bind_section_empty_in_author_mode():
     renderer.render.assert_not_awaited()
 
 
+# --------------------------------------------------------------------------- #
+# SIP-0100 follow-up Phase A — publish the writable surfaces to the proposer
+# --------------------------------------------------------------------------- #
+
+
+def test_format_writable_surfaces_sections_and_empty_marker():
+    from squadops.capabilities.handlers.planning_tasks import _format_writable_surfaces
+
+    out = _format_writable_surfaces(
+        {
+            "dev_writable_slots": ["backend/routes.py"],
+            "qa_writable_namespaces": ["backend/tests/"],
+            "required_slot_coverage": ["backend/routes.py"],
+            "read_only_context_paths": [],
+        }
+    )
+    assert "DEV_WRITABLE_SLOTS:" in out and "  - backend/routes.py" in out
+    assert "QA_WRITABLE_NAMESPACES:" in out and "  - backend/tests/" in out
+    assert "READ_ONLY_CONTEXT_PATHS:" in out and "  (none)" in out  # empty surface marked
+
+
+async def test_bind_section_passes_writable_slots_when_surfaces_present():
+    handler = DevelopmentProposePlanTasksHandler()
+    renderer = AsyncMock()
+    renderer.render.return_value = MagicMock(content="BIND")
+    await handler._bind_criteria_section(
+        renderer,
+        {
+            "contract_criteria_index": "- backend/routes.py: bind x",
+            "writable_surfaces": {
+                "dev_writable_slots": ["backend/routes.py"],
+                "qa_writable_namespaces": ["backend/tests/"],
+                "required_slot_coverage": ["backend/routes.py"],
+                "read_only_context_paths": ["backend/main.py"],
+            },
+        },
+    )
+    variables = renderer.render.await_args.args[1]
+    assert variables["criteria_index"] == "- backend/routes.py: bind x"
+    assert "backend/routes.py" in variables["writable_slots"]
+    assert "backend/main.py" in variables["writable_slots"]  # read-only context surface
+
+
+async def test_bind_appendix_names_slots_and_forbids_translation():
+    """The rendered appendix names the fill slots and forbids swapping them for similar paths."""
+    from pathlib import Path
+
+    from adapters.prompts.filesystem_asset_adapter import FilesystemPromptAssetAdapter
+    from squadops.prompts.renderer import RequestTemplateRenderer
+
+    templates_dir = (
+        Path(__file__).parent.parent.parent.parent
+        / "src"
+        / "squadops"
+        / "prompts"
+        / "request_templates"
+    )
+    source = FilesystemPromptAssetAdapter(
+        fragments_path=templates_dir.parent / "fragments",
+        templates_path=templates_dir,
+    )
+    rendered = await RequestTemplateRenderer(source).render(
+        "request.plan_bind_criteria_appendix",
+        {
+            "criteria_index": "- backend/routes.py: bind",
+            "writable_slots": "DEV_WRITABLE_SLOTS:\n  - backend/routes.py",
+        },
+    )
+    body = rendered.content
+    assert "backend/routes.py" in body
+    assert "ONLY" in body  # the write-only instruction
+    assert "routers/" in body  # the "do not translate" guidance names the bad pattern
+
+
 async def test_bind_section_empty_for_strategy_proposer():
     # strategy proposes guidance, not build tasks — it binds no fill-file criteria
     handler = StrategyProposePlanGuidanceHandler()

--- a/tests/unit/cycles/test_plan_authorization.py
+++ b/tests/unit/cycles/test_plan_authorization.py
@@ -1,0 +1,159 @@
+"""SIP-0100 follow-up — plan-authoring target authorization (Phase B validation)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from squadops.cycles.plan_authorization import (
+    PlanAuthorization,
+    PlanTargetViolation,
+    validate_plan_write_targets,
+)
+from squadops.cycles.verification_contract import (
+    Behavioral,
+    FillFile,
+    FrozenFile,
+    Skeleton,
+    VerificationContract,
+)
+
+_AUTHZ = PlanAuthorization(
+    read_only_paths=frozenset({"backend/main.py", "backend/models.py", "frontend/src/App.jsx"}),
+    dev_writable=frozenset({"backend/routes.py", "frontend/src/views/RunCreationForm.jsx"}),
+    qa_namespace=("backend/tests/", "frontend/src/tests/"),
+    required_coverage=frozenset({"backend/routes.py", "frontend/src/views/RunCreationForm.jsx"}),
+    source_prefixes=("backend/", "frontend/src/", "frontend/src/views/"),
+    contract_hash="mh123",
+)
+
+
+def _task(task_type, targets, idx=0, role="dev"):
+    return SimpleNamespace(
+        task_type=task_type, expected_artifacts=list(targets), task_index=idx, role=role
+    )
+
+
+def _full_coverage_dev():
+    """Two dev tasks that assign both required slots exactly once (a clean baseline)."""
+    return [
+        _task("development.develop", ["backend/routes.py"], idx=0),
+        _task("development.develop", ["frontend/src/views/RunCreationForm.jsx"], idx=1),
+    ]
+
+
+def _codes(rejections):
+    return {r.code for r in rejections}
+
+
+def test_valid_plan_passes_clean():
+    assert validate_plan_write_targets(_full_coverage_dev(), _AUTHZ) == []
+
+
+def test_frozen_target_rejected():
+    tasks = _full_coverage_dev() + [_task("development.develop", ["backend/main.py"], idx=2)]
+    rej = validate_plan_write_targets(tasks, _AUTHZ)
+    hits = [r for r in rej if r.canonical_target == "backend/main.py"]
+    assert hits and hits[0].code == PlanTargetViolation.UNAUTHORIZED
+    assert "frozen" in hits[0].detail
+    # frozen rejection offers the fill slots as alternatives
+    assert "backend/routes.py" in hits[0].nearest_slots
+
+
+def test_undeclared_workspace_source_rejected():
+    tasks = _full_coverage_dev() + [
+        _task("development.develop", ["backend/store.py", "frontend/src/components/X.tsx"], idx=2)
+    ]
+    rej = validate_plan_write_targets(tasks, _AUTHZ)
+    bad = {r.canonical_target for r in rej if r.code == PlanTargetViolation.UNAUTHORIZED}
+    assert "backend/store.py" in bad  # under backend/, not a slot
+    assert "frontend/src/components/X.tsx" in bad  # under frontend/src/, not a slot
+
+
+def test_glob_and_directory_targets_are_ambiguous():
+    tasks = [
+        _task("development.develop", ["frontend/src/components/*.tsx"], idx=0),
+        _task("development.develop", ["frontend/src/views/"], idx=1),
+    ]
+    rej = validate_plan_write_targets(tasks, _AUTHZ)
+    ambiguous = [r for r in rej if r.code == PlanTargetViolation.AMBIGUOUS_SCOPE]
+    assert {r.raw_target for r in ambiguous} == {
+        "frontend/src/components/*.tsx",
+        "frontend/src/views/",
+    }
+
+
+def test_normalized_and_traversal_aliases_authorize_as_the_slot():
+    """./ and ../ aliases of a fill slot resolve to the slot (D7) — authorized, and they satisfy
+    coverage so no MISSING_REQUIRED_SLOT fires for that slot."""
+    tasks = [
+        _task("development.develop", ["./backend/routes.py"], idx=0),
+        _task("development.develop", ["frontend/src/foo/../views/RunCreationForm.jsx"], idx=1),
+    ]
+    assert validate_plan_write_targets(tasks, _AUTHZ) == []
+
+
+def test_root_deliverable_is_allowed():
+    tasks = _full_coverage_dev() + [
+        _task("development.develop", ["qa_handoff.md", "requirements.txt"], idx=2)
+    ]
+    # deliverables sit under no source prefix → allowed (v1-permissive); no rejection for them
+    rej = validate_plan_write_targets(tasks, _AUTHZ)
+    assert not any(r.raw_target in ("qa_handoff.md", "requirements.txt") for r in rej)
+
+
+def test_qa_namespace_ok_but_cross_role_rejected():
+    qa_ok = _task("qa.test", ["backend/tests/test_runs.py"], idx=5, role="qa")
+    qa_source = _task("qa.test", ["backend/routes.py"], idx=6, role="qa")
+    dev_test = _task("development.develop", ["backend/tests/test_x.py"], idx=7)
+    rej = validate_plan_write_targets([qa_ok, qa_source, dev_test], _AUTHZ)
+    by_target = {r.canonical_target: r for r in rej if r.code == PlanTargetViolation.UNAUTHORIZED}
+    assert "backend/tests/test_runs.py" not in by_target  # QA in its namespace is fine
+    assert "backend/routes.py" in by_target  # QA writing dev's slot
+    assert "backend/tests/test_x.py" in by_target  # dev writing a test
+
+
+def test_missing_required_slot():
+    tasks = [_task("development.develop", ["backend/routes.py"], idx=0)]  # view slot unassigned
+    rej = validate_plan_write_targets(tasks, _AUTHZ)
+    missing = [r for r in rej if r.code == PlanTargetViolation.MISSING_REQUIRED_SLOT]
+    assert [r.canonical_target for r in missing] == ["frontend/src/views/RunCreationForm.jsx"]
+
+
+def test_duplicate_slot_ownership():
+    tasks = [
+        _task("development.develop", ["backend/routes.py"], idx=0),
+        _task("development.develop", ["backend/routes.py"], idx=1),
+        _task("development.develop", ["frontend/src/views/RunCreationForm.jsx"], idx=2),
+    ]
+    rej = validate_plan_write_targets(tasks, _AUTHZ)
+    assert PlanTargetViolation.DUPLICATE_OWNERSHIP in _codes(rej)
+
+
+def test_all_defects_returned_atomically():
+    """A plan with several defects returns them all — the caller rejects the whole plan, never
+    silently strips a target."""
+    tasks = [_task("development.develop", ["backend/main.py", "backend/store.py"], idx=0)]
+    rej = validate_plan_write_targets(tasks, _AUTHZ)
+    # 2 unauthorized targets + 2 missing required slots
+    assert len([r for r in rej if r.code == PlanTargetViolation.UNAUTHORIZED]) == 2
+    assert len([r for r in rej if r.code == PlanTargetViolation.MISSING_REQUIRED_SLOT]) == 2
+
+
+def test_from_contract_derives_the_surfaces():
+    contract = VerificationContract(
+        contract_version=1,
+        skeleton=Skeleton(expander="fullstack_fastapi_react", interface_manifest_hash="mh9"),
+        capabilities=(),
+        frozen_files=(FrozenFile("backend/main.py", "h"), FrozenFile("frontend/src/App.jsx", "h")),
+        fill_files=(FillFile("backend/routes.py"), FillFile("frontend/src/views/X.jsx")),
+        behavioral=Behavioral(),
+    )
+    authz = PlanAuthorization.from_contract(contract)
+    assert authz.read_only_paths == {"backend/main.py", "frontend/src/App.jsx"}
+    assert authz.dev_writable == {"backend/routes.py", "frontend/src/views/X.jsx"}
+    assert authz.qa_namespace == ("backend/tests/", "frontend/src/tests/")
+    assert authz.required_coverage == authz.dev_writable
+    assert authz.contract_hash == "mh9"
+    # source prefixes cover both stacks so undeclared source is caught
+    assert "backend/" in authz.source_prefixes
+    assert "frontend/src/" in authz.source_prefixes

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -602,8 +602,9 @@ class TestWorkloadInvariantTail:
 
 
 def _models_contract():
-    """A one-fill-file contract covering backend/models.py (the artifact MANIFEST_YAML's
-    task 0 produces) so a bind-mode plan must bind its criterion."""
+    """A contract covering the bind plan's fill slots (backend/models.py with a criterion,
+    backend/routes.py with none) so a bind-mode plan binds models.py's criterion AND every dev
+    target resolves to a fill slot (SIP-0100 follow-up target binding)."""
     from squadops.cycles.verification_contract import VerificationContract
 
     return VerificationContract.from_dict(
@@ -626,7 +627,8 @@ def _models_contract():
                         }
                     ],
                     "implementation": [],
-                }
+                },
+                "backend/routes.py": {"interface": [], "implementation": []},
             },
             "behavioral": {
                 "build": [],
@@ -637,10 +639,12 @@ def _models_contract():
     )
 
 
+# Bind variant: task 0 binds its criterion by id; task 1 targets the routes.py fill slot (not the
+# frozen main.py) so every dev target resolves to a fill slot under the target-binding gate.
 _BIND_MANIFEST_YAML = MANIFEST_YAML.replace(
     '    expected_artifacts: ["backend/models.py"]\n    acceptance_criteria: ["Models exist"]',
     '    expected_artifacts: ["backend/models.py"]\n    criteria_refs: ["vc-models-base"]',
-)
+).replace('expected_artifacts: ["backend/main.py"]', 'expected_artifacts: ["backend/routes.py"]')
 
 
 class TestGenerateTaskPlanBindMode:


### PR DESCRIPTION
## Summary

Implements **Phases A+B** of the authoring-target-binding plan (PR #551): the same scaffold ownership surface that SIP-0100's runtime enforcement uses is now a **read-only projection** consumed at plan authoring, so a bind-mode plan's dev/qa targets are gated against the fill slots *before* generation — instead of the proposer guessing and hitting them only by luck.

### Phase B — the guarantee (`cycles/plan_authorization.py`)
- `PlanAuthorization.from_contract` — read-only projection: frozen paths, fill slots, QA namespace, required coverage, source prefixes.
- `validate_plan_write_targets` — canonicalizes every dev/qa workspace target (D7 `normalize_ws_path`, shared with runtime), rejects **frozen**, **cross-role slot**, **undeclared source**, and **glob/dir/absolute**; enforces **coverage** (every required slot assigned exactly once, no duplicate ownership). **Atomic** (returns all defects, never silent-strips). Stable `PLAN_TARGET_*` codes + rich rejection records.
- Wired at `task_plan.py:688`; a violating plan raises `CycleError` → bounded framing re-roll → a distinct authoring-bind failure, not a build failure.

### Phase A — inform (`task_plan.py`, `planning_tasks.py`, asset v3)
Injects the writable surfaces as **data** alongside `contract_criteria_index`; the bind appendix asset carries the prose instruction (#448): *write ONLY these paths, do not translate the layout* (names the exact bad patterns: `routers/`, `.tsx`-for-`.jsx`, `src/pages/`, invented `store.py`). Separated `DEV_WRITABLE_SLOTS` / `QA_WRITABLE_NAMESPACES` / `REQUIRED_SLOT_COVERAGE` / `READ_ONLY_CONTEXT_PATHS`.

### Architectural boundary (review #3)
The plan model consumes the projection; it never constructs runtime `WriteGrant` objects. One authority, read-only at the plan layer.

## v1 scope (deferred per the v2 plan, called out honestly)
- **Deliverable-trust**: v1 uses the source-tree heuristic (off-slot source under a scaffold dir → reject; root-level → deliverable). The pre-proposer *trusted-declaration* source is deferred.
- **Globs**: v1 rejects all globs/dirs; the namespaced-slot subset-proof is deferred (`fill_slot_paths` is concrete files today).
- **Builder role** not gated (packaging).
- **Re-roll feedback**: bounded re-roll works; feeding the specific rejection into the *next proposer prompt* is a follow-up (Phase A informs up front, so first-pass yield should carry it).

## Tests
11 plan-authorization matrix tests (frozen / undeclared-source / glob / normalized-alias / deliverable / cross-role / coverage / duplicate / atomic / from_contract) + Phase A render/format + updated bind fixtures. **3582 cycles/capabilities/prompts green** (2 pre-existing `missing_tooling` env failures aside).

## Next
On merge: rebuild+deploy and re-run the `full` `validated-fullstack` roll — the plan must clear framing with **zero** unauthorized targets and **complete** coverage (the manual gate check I ran on `cyc_8a61a853f979` is now automatic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG
