### PR TITLE
fix(correction): drift branch reaches the fill-slot source (drift+behavioral-bug combo)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -116,7 +116,20 @@ def _resolve_repair_target(
         # the failing artifact's bug. So focus/description stay unset (no inline
         # prompt content — CLAUDE.md #448); the named artifacts + that instruction
         # redirect the repair onto both the drifted source and the failing file.
-        target = list(dict.fromkeys([*drift_files, *failed_artifacts]))
+        # pf-27 (cyc_d01810b2922f): a ``tests_pass`` failure can CO-OCCUR with
+        # interface drift on a scaffold-FROZEN file (there: backend/main.py — its
+        # /health route + the repair's own un-restored inline routes), which pins the
+        # target to this drift branch. But the behavioral fix still lives in the
+        # fill-slot source under test (routes.py), which is neither a drift file nor
+        # the failing qa.test's own artifact — so without the same package-scoped
+        # implementation surface the no-drift branch already unions (RC2), the repair
+        # edits only the drifted file + the test and NEVER reaches routes.py →
+        # non-convergence. Union it here too; empty surface (author mode) → the scoped
+        # set is empty and the target is byte-identical to the pre-pf-27 union.
+        scoped_source = _scope_to_shared_packages(
+            failed_inputs.get("implementation_artifacts", []) or [], failed_artifacts
+        )
+        target = list(dict.fromkeys([*drift_files, *failed_artifacts, *scoped_source]))
         return (target, None, None)
     # RC2 no-drift path: union the failing task's own artifacts with the
     # package-scoped implementation surface so a behavioral failure can reach the

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -2005,6 +2005,50 @@ class TestResolveRepairTarget:
         artifacts, _, _ = _resolve_repair_target(evidence, failed_inputs)
         assert artifacts == ["backend/models.py"]
 
+    def test_drift_qa_test_also_unions_package_scoped_source(self):
+        """pf-27 (cyc_d01810b2922f): a tests_pass failure that CO-OCCURS with interface
+        drift on a frozen file (backend/main.py) must STILL reach the fill-slot source
+        under test (backend/routes.py). The drift branch unions the same package-scoped
+        implementation surface as the no-drift RC2 branch — else the repair edits only
+        the drifted file + the failing test and the real validation bug in routes.py is
+        never fixed (the pf-27 non-convergence wall)."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = {
+            "interface_drift": [
+                {"file": "backend/main.py", "instruction": "remove undeclared GET /health"},
+            ],
+        }
+        failed_inputs = {
+            "expected_artifacts": ["backend/tests/test_runs_crud.py"],
+            "implementation_artifacts": [
+                "backend/models.py",
+                "backend/routes.py",
+                "backend/main.py",
+                "frontend/src/views/RunsListView.jsx",
+            ],
+        }
+        artifacts, focus, description = _resolve_repair_target(evidence, failed_inputs)
+
+        assert "backend/routes.py" in artifacts  # fill-slot validation fix now reachable
+        assert "backend/tests/test_runs_crud.py" in artifacts  # failing artifact still targeted
+        assert "backend/main.py" in artifacts  # drifted file still targeted
+        assert artifacts.count("backend/main.py") == 1  # deduped across drift + scoped source
+        assert "frontend/src/views/RunsListView.jsx" not in artifacts  # package-scoped
+        # drift branch: the "how" is the interface-drift instruction + failure summary.
+        assert focus is None and description is None
+
+    def test_drift_without_implementation_surface_is_byte_identical(self):
+        """Backward-compat: drift present but no implementation_artifacts key (author
+        mode / non-build corrections) → the target is exactly drift ∪ failed artifacts,
+        the pre-pf-27 union (empty scoped surface adds nothing)."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = {"interface_drift": [{"file": "backend/models.py", "instruction": "fix"}]}
+        failed_inputs = {"expected_artifacts": ["backend/tests/test_runs.py"]}
+        artifacts, _, _ = _resolve_repair_target(evidence, failed_inputs)
+        assert artifacts == ["backend/models.py", "backend/tests/test_runs.py"]
+
     def test_no_drift_falls_back_to_failed_task_artifacts(self):
         """Absent interface drift, the target is byte-identical to today —
         the failed task's own artifacts/focus/description."""
@@ -2095,9 +2139,15 @@ class TestResolveRepairTarget:
         ]
         assert "backend/main.py" not in artifacts
 
-    def test_drift_present_ignores_implementation_surface(self):
-        """When interface drift IS present the drift-union branch wins and the
-        implementation surface is not added — the drift path stays byte-identical."""
+    def test_drift_present_also_unions_implementation_surface(self):
+        """pf-27 (cyc_d01810b2922f) SUPERSEDED the earlier 'drift path stays
+        byte-identical' boundary: RC2's package-scoped implementation surface is now
+        unioned on the drift branch too. The old boundary assumed drift_files always
+        capture the fixable source cause — false when the drift is on a scaffold-FROZEN
+        file (main.py) while the behavioral bug lives in a non-drift fill slot
+        (routes.py), which then never enters the target → non-convergence. Ordering:
+        drifted source first, failed artifact, then scoped source; frontend stays out
+        (package-scoped); focus/description unset (#448)."""
         from adapters.cycles.correction_runner import _resolve_repair_target
 
         evidence = {"interface_drift": [{"file": "backend/models.py", "instruction": "fix fields"}]}
@@ -2106,8 +2156,8 @@ class TestResolveRepairTarget:
             "implementation_artifacts": ["backend/routes.py", "frontend/src/App.jsx"],
         }
         artifacts, focus, _ = _resolve_repair_target(evidence, failed_inputs)
-        assert artifacts == ["backend/models.py", "backend/tests/test_runs.py"]
-        assert "backend/routes.py" not in artifacts  # surface NOT added on the drift path
+        assert artifacts == ["backend/models.py", "backend/tests/test_runs.py", "backend/routes.py"]
+        assert "frontend/src/App.jsx" not in artifacts  # package-scoped: no cross-package regen
         assert focus is None  # drift path leaves focus/description unset (#448)
 
     def test_no_drift_scoped_source_dedups_against_failed_artifact(self):


### PR DESCRIPTION
## What

`_resolve_repair_target`'s **drift branch** now unions the RC2 package-scoped implementation surface (`_scope_to_shared_packages`), the same surface the no-drift branch already unions.

```
if drift_files:
-   target = drift_files ∪ failed_artifacts
+   target = drift_files ∪ failed_artifacts ∪ scope(implementation_artifacts, failed_artifacts)
```

## Why

Found live on the green-roll hunt (pf-27 `cyc_d01810b2922f`, pf-28 `cyc_eb02a1d01859`). A `tests_pass` failure **co-occurred** with interface drift on the scaffold-**frozen** `backend/main.py` (its `/health` route + the repair's own un-restored inline routes). That pinned the repair target to the `if drift_files` branch, whose target was `drift_files ∪ failed_artifacts` — which **omits** the package-scoped implementation surface that the no-drift RC2 branch (#536) unions.

The real bug (empty-title→422 / missing-404 validation) lived in the fill slot `backend/routes.py`, which is **neither** a drift file **nor** the failing qa.test's own artifact. So the repair edited only `main.py` + the test file on every attempt and **never reached `routes.py`** → the correction loop exhausted without ever touching the buggy source.

**Validated live:** with this fix deployed, pf-28 and pf-29's repairs emit `routes.py` on every attempt; pf-27 (pre-fix) never did.

## Change

- **`adapters/cycles/correction_runner.py`** — drift branch unions `_scope_to_shared_packages(implementation_artifacts, failed_artifacts)`. Empty surface (author mode / non-build corrections) → the scoped set is empty and the target is **byte-identical** to the prior union. Package-scoped (`backend/tests/*` → `backend/*` source, frontend excluded). `focus`/`description` stay unset (no inline prompt content, #448).

## ⚠️ Reviewer note — reversed a deliberate prior boundary

This **supersedes** the RC2 decision to scope the implementation surface to the no-drift branch only. A pre-existing test, `test_drift_present_ignores_implementation_surface`, locked in "the drift path stays byte-identical." That boundary assumed `drift_files` always capture the fixable source cause — **false** when the drift is on a *frozen* file while the behavioral bug is in a non-drift *fill slot*. I renamed/updated it to `test_drift_present_also_unions_implementation_surface` with a docstring documenting the supersession. **Please sanity-check this reversal.**

## Tests

- `tests/unit/cycles/test_correction_runner.py`: 43 pass — 2 new (`test_drift_qa_test_also_unions_package_scoped_source`, `test_drift_without_implementation_surface_is_byte_identical`) + 1 updated (the reversed-boundary test).
- Full `tests/unit/cycles/` domain: 1907 pass. `ruff` clean.

## Scope / risk

- Correction-loop targeting only; drift-detection (#532/#534) and the no-drift RC2 path (#536) are untouched.
- Additive union with de-dup — strictly widens the repair target when `implementation_artifacts` is present (bind mode); no-op otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG
