### PR TITLE
fix(correction): give the dev repair the same scaffold fill-only constraint as develop

### DIFF
--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -14,10 +14,14 @@ correction-loop flows have distinct, non-overlapping capability ids.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from squadops.capabilities.handlers.cycle_tasks import _classify_file, _CycleTaskHandler
 from squadops.capabilities.handlers.fenced_parser import extract_fenced_files
+
+if TYPE_CHECKING:
+    from squadops.capabilities.handlers.base import HandlerResult
+    from squadops.capabilities.handlers.context import ExecutionContext
 
 
 def _artifacts_from_fenced_blocks(content: str, fallback_name: str) -> list[dict[str, Any]]:
@@ -203,7 +207,50 @@ class _RepairPromptMixin:
             "expected_artifacts": _format_bullets(inputs.get("expected_artifacts")),
             "acceptance_criteria": _format_bullets(inputs.get("acceptance_criteria")),
             "prior_outputs": self._format_prior_outputs(prior_outputs),
+            # Same scaffold fill-only constraint the develop handler injects (SIP-0099
+            # 99.3). Rendered in handle() and threaded via inputs; "" when absent.
+            "fill_only_section": str(inputs.get("fill_only_section") or ""),
         }
+
+    async def handle(
+        self,
+        context: ExecutionContext,
+        inputs: dict[str, Any],
+    ) -> HandlerResult:
+        """Inject the scaffold fill-only constraint before the base render.
+
+        The develop handler tells the dev to FILL the seeded skeleton's slots and NOT
+        rewrite scaffold-owned interface (route paths/decorators/signatures, the wired
+        ``ApiError`` seam) — but the correction/repair path previously got none of that
+        and was told to "re-produce the artifact", so repairs freely rewrote the seeded
+        interface (observed: ``ApiError(status_code=...)`` vs the seeded
+        ``ApiError(code, message)``; ``APIRouter(prefix=...)`` vs seeded absolute
+        decorators). Reuse the SAME managed appendix the dev gets so the repair honors
+        the same boundary. Dev-role repairs on a scaffoldable stack only; no-op otherwise.
+        """
+        fill_only = await self._render_fill_only_section(context, inputs)
+        if fill_only:
+            inputs = {**inputs, "fill_only_section": fill_only}
+        return await super().handle(context, inputs)
+
+    async def _render_fill_only_section(
+        self, context: ExecutionContext, inputs: dict[str, Any]
+    ) -> str:
+        """The dev fill-only appendix, or "" (non-dev role, non-scaffolded, no renderer)."""
+        if self._role != "dev":
+            return ""
+        renderer = getattr(context.ports, "request_renderer", None)
+        if renderer is None:
+            return ""
+        from squadops.capabilities.scaffold import is_scaffoldable_stack
+
+        stack = str((inputs.get("resolved_config") or {}).get("build_profile") or "")
+        if not is_scaffoldable_stack(stack):
+            return ""
+        rendered = await renderer.render(
+            "request.development_develop_fill_only_appendix", {"stack": stack}
+        )
+        return rendered.content
 
     def _build_user_prompt(
         self,

--- a/src/squadops/prompts/request_templates/request.cycle_repair_task.md
+++ b/src/squadops/prompts/request_templates/request.cycle_repair_task.md
@@ -13,10 +13,12 @@ optional_variables:
   - expected_artifacts
   - acceptance_criteria
   - prior_outputs
+  - fill_only_section
 ---
 ## Repair Task
 
 You are repairing a failed `{{failed_task_type}}` task. Your job is to re-produce the named output artifact(s) below so they satisfy the acceptance criteria. Do not rewrite the PRD, do not produce a status tracker, do not emit a generic narrative document.
+{{fill_only_section}}
 
 ### Failed Task Contract
 

--- a/tests/unit/capabilities/test_repair_fill_only.py
+++ b/tests/unit/capabilities/test_repair_fill_only.py
@@ -1,0 +1,109 @@
+"""Fill-only constraint on the correction/repair path.
+
+The develop handler tells the dev to FILL the seeded skeleton's slots and NOT rewrite
+the scaffold-owned interface (route decorators/signatures, the wired ``ApiError`` seam).
+The correction/repair path previously got none of that and was told to "re-produce the
+artifact", so repairs freely rewrote the seeded interface (observed live: pf-28/pf-29
+routes.py calling ``ApiError(status_code=...)`` vs the seeded ``ApiError(code, message)``,
+and ``APIRouter(prefix=...)`` vs seeded absolute decorators). This wires the SAME managed
+appendix into the dev correction-repair, scoped to the dev role on a scaffoldable stack.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities.handlers.impl.repair_handlers import (
+    BuilderAssembleRepairHandler,
+    DevelopmentCorrectionRepairHandler,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_TEMPLATE = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "squadops"
+    / "prompts"
+    / "request_templates"
+    / "request.cycle_repair_task.md"
+)
+
+
+def _context(renderer):
+    context = MagicMock()
+    context.ports.request_renderer = renderer
+    return context
+
+
+async def test_dev_repair_renders_fill_only_on_scaffoldable_stack():
+    handler = DevelopmentCorrectionRepairHandler()
+    renderer = AsyncMock()
+    renderer.render.return_value = MagicMock(content="FILL ONLY INSTRUCTION")
+    inputs = {"resolved_config": {"build_profile": "fullstack_fastapi_react"}}
+
+    out = await handler._render_fill_only_section(_context(renderer), inputs)
+
+    assert out == "FILL ONLY INSTRUCTION"
+    renderer.render.assert_awaited_once_with(
+        "request.development_develop_fill_only_appendix",
+        {"stack": "fullstack_fastapi_react"},
+    )
+
+
+async def test_dev_repair_fill_only_empty_on_non_scaffoldable_stack():
+    handler = DevelopmentCorrectionRepairHandler()
+    renderer = AsyncMock()
+    inputs = {"resolved_config": {"build_profile": "python_cli_builder"}}
+
+    assert await handler._render_fill_only_section(_context(renderer), inputs) == ""
+    renderer.render.assert_not_awaited()
+
+
+async def test_dev_repair_fill_only_empty_when_no_build_profile():
+    handler = DevelopmentCorrectionRepairHandler()
+    renderer = AsyncMock()
+    assert await handler._render_fill_only_section(_context(renderer), {}) == ""
+    renderer.render.assert_not_awaited()
+
+
+async def test_builder_repair_never_gets_fill_only_even_on_scaffoldable_stack():
+    # The appendix is about dev fill slots (routes.py/views); a builder/packaging repair
+    # must not receive it even on a scaffoldable stack — scoped to the dev role.
+    handler = BuilderAssembleRepairHandler()
+    renderer = AsyncMock()
+    inputs = {"resolved_config": {"build_profile": "fullstack_fastapi_react"}}
+
+    assert await handler._render_fill_only_section(_context(renderer), inputs) == ""
+    renderer.render.assert_not_awaited()
+
+
+async def test_handle_threads_fill_only_into_render_variables():
+    # End-to-end wiring: handle() renders the section and threads it so the template
+    # variable is populated (the base render path reads it from inputs).
+    handler = DevelopmentCorrectionRepairHandler()
+    renderer = AsyncMock()
+    renderer.render.return_value = MagicMock(content="FILL ONLY INSTRUCTION")
+    context = _context(renderer)
+    inputs = {"resolved_config": {"build_profile": "fullstack_fastapi_react"}}
+
+    fill_only = await handler._render_fill_only_section(context, inputs)
+    threaded = {**inputs, "fill_only_section": fill_only}
+    variables = handler._build_render_variables("prd", None, threaded)
+
+    assert variables["fill_only_section"] == "FILL ONLY INSTRUCTION"
+
+
+def test_render_variables_default_fill_only_empty_when_absent():
+    handler = DevelopmentCorrectionRepairHandler()
+    variables = handler._build_render_variables("prd", None, {})
+    assert variables["fill_only_section"] == ""
+
+
+def test_repair_template_declares_and_uses_fill_only_section():
+    text = _TEMPLATE.read_text(encoding="utf-8")
+    assert "- fill_only_section" in text  # declared optional var
+    assert "{{fill_only_section}}" in text  # placed in the body


### PR DESCRIPTION
## What

The **develop** handler injects a managed fill-only appendix on scaffoldable stacks (SIP-0099 99.3): *"fill the seeded skeleton's slots; do NOT change route paths/methods/decorators/signatures; `ApiError` is already wired — use it."* The **correction/repair** path got **none of it** — its template says *"re-produce the named output artifact(s) so they satisfy the acceptance criteria,"* which invites a full rewrite. So repairs freely rewrote the scaffold-seeded interface.

This wires the **same** appendix into the dev correction-repair.

## Why (observed live)

On the green-roll hunt, two independent rolls showed the same class of deviation — the repair rewriting the seeded interface:

- **pf-28 / pf-29:** `routes.py` repaired with `ApiError(status_code=404, detail=...)` — an invented signature — vs the frozen `errors.py` contract `ApiError(code, message)` (`"run_not_found"` → 404). The wrong call raises `TypeError` → HTTP 500 not 404 → the 404 test fails; the analyzer misreads it as "missing 404 handling," so the repair adds *more* wrong-signature calls → non-convergence.
- **pf-29:** `routes.py` rewritten to `APIRouter(prefix="/runs")` + relative decorators vs the seeded `APIRouter()` + absolute decorators → breaks the static `endpoint_defined` check.

The correct contract is sitting in the workspace (frozen `errors.py` + the skeleton's absolute decorators) — the agents just weren't told, on the repair path, to honor it. See the root-cause write-up in `night_findings.md` (Findings D/E + synthesis).

## Change

- **`repair_handlers.py`** (`_RepairPromptMixin`): `handle()` now renders `request.development_develop_fill_only_appendix` and threads it into the repair prompt via `inputs["fill_only_section"]`; `_build_render_variables` surfaces it. Scoped to the **dev** role on a **scaffoldable** stack (via `is_scaffoldable_stack(resolved_config.build_profile)`) — builder/qa repairs and non-scaffolded builds are unaffected.
- **`request.cycle_repair_task.md`**: adds the `{{fill_only_section}}` placeholder (declared optional) right after the repair intro.
- **No new prompt content** — reuses the dev's managed asset (CLAUDE.md #448 / ownership-before-extension).

## Scope / limits

This is the **cheap, prompt-level** half of the "fill-slot interface ownership" direction. It's advisory (LLM-dependent) — it should reduce the deviation on the repair path but won't *guarantee* it. The deterministic half (diff-guarding a fill slot's interface lines against the skeleton, and/or a typed check that `ApiError` is *called* with a valid code) is the larger follow-up SIP.

Independent of PR #554 (the drift-branch targeting fix) — different files; either can merge first.

## Tests

- `tests/unit/capabilities/test_repair_fill_only.py` — 7 new: render gating (dev+scaffoldable renders; non-scaffoldable / no-profile / builder-role → empty), variable threading, template contract.
- `test_impl_handlers` (58), `test_develop_fill_only`, template contracts (102) green. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEravWMKL7HCQ75GeB7fRG
