### PR TITLE
fix(correction): repair-path hardening — resolved_config threading + SIP-0100 3.4b frozen enforcement (restore+signal)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -266,6 +266,23 @@ class CorrectionRunner:
             },
         )
 
+    def _emit_scaffold_integrity_evidence(self, record: Any, envelope: TaskEnvelope) -> None:
+        """SIP-0100 3.3/3.4b: surface one repair-path enforcement as a structured event + log
+        (best-effort — observability must never break the correction loop). Mirrors the
+        executor's emitter for the regular storage path."""
+        payload = record.to_dict()
+        logger.warning("SIP-0100 scaffold_integrity (repair path): %s", payload)
+        try:
+            self._event_bus.emit(
+                EventType.ARTIFACT_OWNERSHIP_ENFORCED,
+                entity_type="artifact",
+                entity_id=record.normalized_path or record.attempted_path,
+                context={"cycle_id": envelope.cycle_id, "run_id": record.bound_run_id},
+                payload=payload,
+            )
+        except Exception:
+            logger.debug("SIP-0100: scaffold_integrity event emit failed", exc_info=True)
+
     async def _dispatch_protocol_step(
         self,
         step_envelope: TaskEnvelope,
@@ -278,6 +295,8 @@ class CorrectionRunner:
         stored_artifacts: list[tuple[str, ArtifactRef]],
         completed_task_ids: list[str],
         plan_delta_refs: list[str],
+        bound_record: Any = None,
+        enforcement_carry: list[str] | None = None,
     ) -> TaskResult:
         """Dispatch one correction/repair step and handle its outcome.
 
@@ -288,6 +307,15 @@ class CorrectionRunner:
         guard), or on failure emit TASK_FAILED. Returns the step's result;
         output collection stays with the caller (the two loops bucket
         outputs differently — issue #95 vs. repair prior_outputs).
+
+        SIP-0100 3.4b: when ``bound_record`` is set, the step's emitted
+        artifacts pass through the same frozen-ownership enforcement as
+        regular task storage BEFORE they land anywhere — the enforced list
+        replaces ``result.outputs["artifacts"]`` in place, so registry
+        storage, the caller's repair overlay, and patch verification all
+        see restored bytes, never the clobber. Each restore appends its
+        authoritative instruction to ``enforcement_carry`` for the next
+        attempt's evidence (restore+signal).
         """
         task_run_id = await self._task_dispatcher.create_task_run_if_enabled(
             flow_run_id, step_envelope
@@ -321,6 +349,32 @@ class CorrectionRunner:
                 context=task_context,
                 payload={"task_type": step_envelope.task_type},
             )
+            # SIP-0100 3.4b: enforce frozen ownership on the step's emissions
+            # before ANY landing point (registry store below, the caller's
+            # repair overlay, patch verification). In-place replacement of
+            # the artifacts list is deliberate — both consumers read
+            # result.outputs.
+            step_artifacts = (result.outputs or {}).get("artifacts") or []
+            if bound_record is not None and step_artifacts:
+                from squadops.cycles.scaffold_enforcement import (
+                    enforce_frozen_ownership,
+                    frozen_restore_instruction,
+                )
+
+                enforced, integrity_evidence = enforce_frozen_ownership(
+                    step_artifacts, bound_record, step_envelope
+                )
+                if integrity_evidence:
+                    result.outputs["artifacts"] = enforced
+                    for record in integrity_evidence:
+                        self._emit_scaffold_integrity_evidence(record, step_envelope)
+                        if (
+                            enforcement_carry is not None
+                            and record.violation_code == "frozen_path_emission"
+                        ):
+                            instruction = frozen_restore_instruction(record)
+                            if instruction not in enforcement_carry:
+                                enforcement_carry.append(instruction)
             # Persist the step's output artifacts BEFORE checkpointing —
             # _checkpoint_correction_task only snapshots existing refs and
             # would otherwise drop these silently.
@@ -367,6 +421,7 @@ class CorrectionRunner:
         flow_run_id: str | None = None,
         interface_manifest: Any = None,
         artifact_contents: dict[str, str] | None = None,
+        scaffold_enforcement_carry: list[str] | None = None,
     ) -> CorrectionProtocolResult:
         """Run the correction protocol: analyze → decide → act.
 
@@ -374,10 +429,20 @@ class CorrectionRunner:
         on the patch path, the repair steps' emitted artifacts (#389).
         Side effects: dispatches correction/repair tasks, stores plan delta,
         emits correction events.
+
+        ``scaffold_enforcement_carry`` is an executor-owned, run-lived list
+        (3.4b restore+signal): instructions from prior attempts' frozen-path
+        restores are injected into this attempt's ``failure_evidence``, and
+        this attempt's restores append new instructions for the next.
         """
         from uuid import uuid4
 
+        from squadops.cycles.scaffold_enforcement import bound_record_or_none
         from squadops.cycles.task_plan import CORRECTION_TASK_STEPS, repair_steps_for
+
+        # SIP-0100 3.4b: repair emissions are subject to the same frozen-ownership
+        # enforcement as regular task storage — None on unbound runs (no-op).
+        bound_record = bound_record_or_none(interface_manifest, run_id)
 
         # 1. Emit CORRECTION_INITIATED
         self._event_bus.emit(
@@ -416,6 +481,12 @@ class CorrectionRunner:
                 }
                 for f in drift
             ]
+
+        # 3.4b restore+signal: prior attempts' frozen-restore instructions reach this
+        # attempt's analyze/decision/repair prompts as authoritative evidence (the
+        # same deterministic-instruction pattern as interface_drift above).
+        if scaffold_enforcement_carry:
+            failure_evidence["scaffold_enforcement"] = list(scaffold_enforcement_carry)
 
         # Issue #95: capture each correction step's outputs in its own variable
         # so the analyzer's classification/analysis_summary survive past the
@@ -640,6 +711,10 @@ class CorrectionRunner:
                     stored_artifacts=stored_artifacts,
                     completed_task_ids=completed_task_ids,
                     plan_delta_refs=plan_delta_refs,
+                    # 3.4b: repair emissions get the same frozen-ownership
+                    # enforcement as regular storage (restore + carry signal).
+                    bound_record=bound_record,
+                    enforcement_carry=scaffold_enforcement_carry,
                 )
 
                 # Collect repair outputs under the role key, matching the

--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -360,6 +360,7 @@ class CorrectionRunner:
                     enforce_frozen_ownership,
                     frozen_restore_instruction,
                 )
+                from squadops.cycles.task_outcome import ContractComplianceViolation
 
                 enforced, integrity_evidence = enforce_frozen_ownership(
                     step_artifacts, bound_record, step_envelope
@@ -370,7 +371,8 @@ class CorrectionRunner:
                         self._emit_scaffold_integrity_evidence(record, step_envelope)
                         if (
                             enforcement_carry is not None
-                            and record.violation_code == "frozen_path_emission"
+                            and record.violation_code
+                            == ContractComplianceViolation.FROZEN_PATH_EMISSION
                         ):
                             instruction = frozen_restore_instruction(record)
                             if instruction not in enforcement_carry:

--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -598,6 +598,14 @@ class CorrectionRunner:
                     "artifact_refs": list(all_artifact_refs),
                     "agent_model": agent_model,
                     "agent_config_overrides": agent_overrides,
+                    # The repair handler's scaffold fill-only appendix gates on
+                    # resolved_config.build_profile (is_scaffoldable_stack) — without
+                    # this the gate sees an empty profile and silently no-ops, and
+                    # repairs freely rewrite scaffold-owned interface (pf-30:
+                    # attempts 1-3 re-emitted routes.py with relative decorator
+                    # paths against a correct diagnosis). Mirrors the retest
+                    # threading in reexecute_repaired_suite below.
+                    "resolved_config": failed_inputs.get("resolved_config", {}),
                     "subtask_focus": repair_focus,
                     "subtask_description": repair_description,
                     "expected_artifacts": repair_expected_artifacts,

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -81,18 +81,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _artifact_raw_path(art: dict) -> str | None:
-    """The producer-emitted path of an artifact, accepting both the ``{name}`` and ``{path}``
-    shapes the two materializers use (SIP-0100 0.1)."""
-    return art.get("name") if art.get("name") is not None else art.get("path")
-
-
-def _is_qa_producer(task_type: str) -> bool:
-    """SIP-0100 3.1: QA task types (``qa.test``, ``qa.validate``) are scoped to the QA test
-    namespace — they write tests, not the source under test."""
-    return task_type.startswith("qa.")
-
-
 class DispatchedFlowExecutor(FlowExecutionPort):
     """Flow executor that dispatches tasks to agent containers via RabbitMQ.
 
@@ -1080,6 +1068,11 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # each inner-loop correction (not just once per outer iteration) to bound it
         # (max_correction_attempts) and keep corr-/plan_delta- ids unique across re-runs.
         correction_counter: dict[str, int] = {"n": 0}
+        # SIP-0100 3.4b (restore+signal): run-lived instruction carry — frozen-path
+        # restores on the repair path append here; the next correction attempt's
+        # failure_evidence surfaces them so the loop is TOLD the edit was rejected
+        # instead of silently fighting the restore.
+        scaffold_enforcement_carry: list[str] = []
         # SIP-0100 3.4a: run-level contract-compliance counter, SEPARATE from the convergence
         # counter (D6) — cross-lane (unauthorized-slot) emissions don't fail a task on their own,
         # so this bounded budget is the only thing that stops a producer chronically writing
@@ -1202,6 +1195,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     task_attempt_counts=task_attempt_counts,
                     consecutive_failures=_consecutive_failures,
                     correction_counter=correction_counter,
+                    scaffold_enforcement_carry=scaffold_enforcement_carry,
                     prior_outputs=prior_outputs,
                     all_artifact_refs=all_artifact_refs,
                     stored_artifacts=stored_artifacts,
@@ -1739,6 +1733,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         task_attempt_counts: dict[str, int],
         consecutive_failures: int,
         correction_counter: dict[str, int],
+        scaffold_enforcement_carry: list[str],
         prior_outputs: dict[str, Any],
         all_artifact_refs: list[str],
         stored_artifacts: list[tuple[str, ArtifactRef]],
@@ -1829,6 +1824,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             profile=profile,
             flow_run_id=flow_run_id,
             interface_manifest=interface_manifest,
+            # 3.4b: run-lived restore+signal carry (created beside correction_counter).
+            scaffold_enforcement_carry=scaffold_enforcement_carry,
             # RC3 (pf-23): re-resolve the workspace from the LIVE stored_artifacts
             # instead of the enriched envelope's copy captured once at the original
             # dispatch. stored_artifacts accumulates each attempt's repair outputs
@@ -2027,25 +2024,9 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         """SIP-0100 2.4: build the bound scaffold record (frozen paths + bytes) for a scaffold-bound
         run, or None for unbound/legacy runs (no manifest / non-scaffoldable stack → no enforcement,
         plan §10). Best-effort: a build failure disables enforcement rather than failing the run."""
-        if interface_manifest is None:
-            return None
-        try:
-            from squadops.capabilities.scaffold import is_scaffoldable_stack
-            from squadops.cycles.bound_scaffold_record import build_bound_record
+        from squadops.cycles.scaffold_enforcement import bound_record_or_none
 
-            if not is_scaffoldable_stack(getattr(interface_manifest, "stack", "")):
-                return None
-            return build_bound_record(
-                interface_manifest, run_id=run_id, attempt_id=run_id, created_at=""
-            )
-        except Exception:
-            logger.warning(
-                "SIP-0100: could not build bound scaffold record for run %s; frozen-ownership "
-                "enforcement disabled for this run",
-                run_id,
-                exc_info=True,
-            )
-            return None
+        return bound_record_or_none(interface_manifest, run_id)
 
     def _enforce_frozen_ownership(
         self, artifacts: list[dict], bound_record: Any, envelope: TaskEnvelope
@@ -2071,85 +2052,9 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         source under test to agree with its own test (the pf-26 class, one step past ``main.py``).
         QA emissions in its namespace, and undeclared paths (deliverables like ``test_report.md``),
         pass through. Non-QA producers are unaffected here (frozen-restore only)."""
-        from squadops.cycles.scaffold_integrity_evidence import (
-            frozen_restore_evidence,
-            unauthorized_slot_evidence,
-        )
-        from squadops.cycles.write_authorization import (
-            AuthzDecision,
-            WorkspaceOwnership,
-            WriteAuthorization,
-            WriteGrant,
-            normalize_ws_path,
-        )
+        from squadops.cycles.scaffold_enforcement import enforce_frozen_ownership
 
-        frozen = {
-            n: fa.content
-            for fa in bound_record.frozen
-            if (n := normalize_ws_path(fa.path)) is not None
-        }
-        # A QA producer gets a namespace-scoped grant; the 2.1 authorization classes decide whether
-        # a non-frozen emission is inside its lane (allow), another producer's slot (drop), or
-        # undeclared (allow — could be a deliverable, §4.6 undeclared-reject stays gated on 3.4).
-        qa_authz = None
-        if _is_qa_producer(envelope.task_type):
-            ownership = WorkspaceOwnership.from_record(bound_record)
-            grant = WriteGrant.for_qa(envelope.task_type, ownership)
-            qa_authz = WriteAuthorization(ownership, grant)
-
-        # Classify first so each evidence record can report how many sibling artifacts in the SAME
-        # response were left untouched (per-artifact disposition — restore/drop keep the rest; a
-        # response-atomic reject would not — that difference is exactly what the field captures).
-        norms = [
-            normalize_ws_path(raw) if isinstance(raw := _artifact_raw_path(art), str) else None
-            for art in artifacts
-        ]
-
-        def _disposition(art: dict, norm: str | None) -> str:
-            if norm is not None and norm in frozen:
-                return "restore"
-            if qa_authz is not None and (
-                qa_authz.authorize(_artifact_raw_path(art) or "")
-                == AuthzDecision.FORBIDDEN_UNAUTHORIZED
-            ):
-                return "drop"
-            return "pass"
-
-        dispositions = [_disposition(art, norm) for art, norm in zip(artifacts, norms, strict=True)]
-        siblings_retained = sum(1 for d in dispositions if d == "pass")
-
-        enforced: list[dict] = []
-        evidence: list[Any] = []
-        for art, norm, disposition in zip(artifacts, norms, dispositions, strict=True):
-            if disposition == "restore":
-                evidence.append(
-                    frozen_restore_evidence(
-                        producer_task_id=envelope.task_id,
-                        producer_task_type=envelope.task_type,
-                        record=bound_record,
-                        attempted_path=_artifact_raw_path(art) or norm,
-                        normalized_path=norm,
-                        attempted_content=art.get("content"),
-                        siblings_retained=siblings_retained,
-                    )
-                )
-                enforced.append({**art, "content": frozen[norm]})  # restore scaffold bytes (D2)
-            elif disposition == "drop":
-                evidence.append(
-                    unauthorized_slot_evidence(
-                        producer_task_id=envelope.task_id,
-                        producer_task_type=envelope.task_type,
-                        record=bound_record,
-                        attempted_path=_artifact_raw_path(art) or (norm or ""),
-                        normalized_path=norm,
-                        attempted_content=art.get("content"),
-                        siblings_retained=siblings_retained,
-                    )
-                )
-                # dropped: NOT appended — the owning producer's already-stored version stays.
-            else:
-                enforced.append(art)
-        return enforced, evidence
+        return enforce_frozen_ownership(artifacts, bound_record, envelope)
 
     def _emit_scaffold_integrity_evidence(self, record: Any, envelope: TaskEnvelope) -> None:
         """SIP-0100 3.3: surface one enforcement event as a structured event + log (best-effort —

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -90,6 +90,14 @@ def _format_failure_summary(failure_evidence: Any, failure_analysis: Any) -> str
                     "INTERFACE CONFORMANCE (authoritative — apply exactly):\n"
                     + "\n".join(f"- {line}" for line in lines)
                 )
+        # SIP-0100 3.4b restore+signal: a prior repair's edit to a frozen file was
+        # rejected and restored — tell this repair instead of silently fighting it.
+        enforcement = failure_evidence.get("scaffold_enforcement") or []
+        if enforcement:
+            parts.append(
+                "FROZEN OWNERSHIP (authoritative — apply exactly):\n"
+                + "\n".join(f"- {str(line).strip()}" for line in enforcement if str(line).strip())
+            )
         vr = failure_evidence.get("validation_result") or {}
         summary = vr.get("summary") or failure_evidence.get("error") or ""
         if summary:

--- a/src/squadops/cycles/scaffold_enforcement.py
+++ b/src/squadops/cycles/scaffold_enforcement.py
@@ -15,6 +15,12 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Per-artifact enforcement dispositions (internal protocol; named so comparison
+# sites never carry raw literals that shadow unrelated enums — #380/#559).
+_DISP_RESTORE = "restore"
+_DISP_DROP = "drop"
+_DISP_PASS = "pass"
+
 
 def _artifact_raw_path(art: dict) -> str | None:
     """The producer-emitted path of an artifact, accepting both the ``{name}`` and ``{path}``
@@ -126,21 +132,21 @@ def enforce_frozen_ownership(
 
     def _disposition(art: dict, norm: str | None) -> str:
         if norm is not None and norm in frozen:
-            return "restore"
+            return _DISP_RESTORE
         if qa_authz is not None and (
             qa_authz.authorize(_artifact_raw_path(art) or "")
             == AuthzDecision.FORBIDDEN_UNAUTHORIZED
         ):
-            return "drop"
-        return "pass"
+            return _DISP_DROP
+        return _DISP_PASS
 
     dispositions = [_disposition(art, norm) for art, norm in zip(artifacts, norms, strict=True)]
-    siblings_retained = sum(1 for d in dispositions if d == "pass")
+    siblings_retained = sum(1 for d in dispositions if d == _DISP_PASS)
 
     enforced: list[dict] = []
     evidence: list[Any] = []
     for art, norm, disposition in zip(artifacts, norms, dispositions, strict=True):
-        if disposition == "restore":
+        if disposition == _DISP_RESTORE:
             evidence.append(
                 frozen_restore_evidence(
                     producer_task_id=envelope.task_id,
@@ -153,7 +159,7 @@ def enforce_frozen_ownership(
                 )
             )
             enforced.append({**art, "content": frozen[norm]})  # restore scaffold bytes (D2)
-        elif disposition == "drop":
+        elif disposition == _DISP_DROP:
             evidence.append(
                 unauthorized_slot_evidence(
                     producer_task_id=envelope.task_id,

--- a/src/squadops/cycles/scaffold_enforcement.py
+++ b/src/squadops/cycles/scaffold_enforcement.py
@@ -1,0 +1,171 @@
+"""SIP-0100 frozen-ownership enforcement, shared by every artifact-landing path.
+
+Lifted from ``DispatchedFlowExecutor`` (3.4b) so the correction runner's
+repair-emission path can enforce the same scaffold ownership the executor's
+regular storage path does — pf-27/pf-30 both showed repairs re-emitting
+frozen files un-restored because enforcement lived only on the executor
+side. Pure functions: callers emit the returned evidence records as events
+and decide what to do with the enforced artifact list.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _artifact_raw_path(art: dict) -> str | None:
+    """The producer-emitted path of an artifact, accepting both the ``{name}`` and ``{path}``
+    shapes the two materializers use (SIP-0100 0.1)."""
+    return art.get("name") if art.get("name") is not None else art.get("path")
+
+
+def _is_qa_producer(task_type: str) -> bool:
+    """SIP-0100 3.1: QA task types (``qa.test``, ``qa.validate``) are scoped to the QA test
+    namespace — they write tests, not the source under test."""
+    return task_type.startswith("qa.")
+
+
+def bound_record_or_none(interface_manifest: Any, run_id: str) -> Any:
+    """SIP-0100 2.4: the bound scaffold record (frozen paths + bytes) for a scaffold-bound
+    run, or None for unbound/legacy runs (no manifest / non-scaffoldable stack → no
+    enforcement, plan §10). Best-effort: a build failure disables enforcement rather than
+    failing the run."""
+    if interface_manifest is None:
+        return None
+    try:
+        from squadops.capabilities.scaffold import is_scaffoldable_stack
+        from squadops.cycles.bound_scaffold_record import build_bound_record
+
+        if not is_scaffoldable_stack(getattr(interface_manifest, "stack", "")):
+            return None
+        return build_bound_record(
+            interface_manifest, run_id=run_id, attempt_id=run_id, created_at=""
+        )
+    except Exception:
+        logger.warning(
+            "SIP-0100: could not build bound scaffold record for run %s; frozen-ownership "
+            "enforcement disabled for this run",
+            run_id,
+            exc_info=True,
+        )
+        return None
+
+
+def frozen_restore_instruction(record: Any) -> str:
+    """Authoritative next-attempt instruction for a restored frozen emission (3.4b restore+signal).
+
+    Injected into the following correction attempt's ``failure_evidence`` (the
+    ``scaffold_enforcement`` key) so the analyzer and repair are TOLD the edit was rejected
+    instead of silently fighting the restore — the same deterministic-instruction pattern
+    interface-drift uses. Mirrors ``interface_conformance``'s generated instructions."""
+    path = record.normalized_path or record.attempted_path
+    return (
+        f"`{path}` is scaffold-frozen and canonical; a prior repair's edit to it was "
+        "rejected and the scaffold bytes restored. Do NOT re-emit this file — implement "
+        "the fix in the writable fill slots instead."
+    )
+
+
+def enforce_frozen_ownership(
+    artifacts: list[dict], bound_record: Any, envelope: Any
+) -> tuple[list[dict], list[Any]]:
+    """SIP-0100 2.4: a producer must not overwrite a scaffold-frozen file. Any emitted artifact
+    whose normalized path is frozen has its content RESTORED to the bound record's bytes (D2
+    restoration authority — never re-derive), so the producer cannot clobber the scaffold
+    (pf-26). The attempt is recorded (not silent). Non-frozen artifacts pass through unchanged.
+
+    Restore (not response-atomic reject) is the deliberate first enforcement: the current squad
+    still re-emits frozen files, so a reject would break every bind-mode build; restore is
+    non-breaking and correct.
+
+    SIP-0100 3.3: each enforcement produces a structured ``ScaffoldIntegrityEvidence`` record
+    (returned alongside the artifacts). Pure — the caller emits it as an
+    ``artifact.ownership_enforced`` event + structured log — so enforcement stays testable and
+    3.4 can drive the compliance counter off the returned records.
+
+    SIP-0100 3.1: a **QA** producer is additionally scoped to its own namespace. A QA emission
+    of a path writable in principle but owned by another producer's slot (e.g. dev's
+    ``routes.py``) is **dropped** — the owning producer's version stays; QA cannot rewrite the
+    source under test to agree with its own test (the pf-26 class, one step past ``main.py``).
+    QA emissions in its namespace, and undeclared paths (deliverables like ``test_report.md``),
+    pass through. Non-QA producers are unaffected here (frozen-restore only)."""
+    from squadops.cycles.scaffold_integrity_evidence import (
+        frozen_restore_evidence,
+        unauthorized_slot_evidence,
+    )
+    from squadops.cycles.write_authorization import (
+        AuthzDecision,
+        WorkspaceOwnership,
+        WriteAuthorization,
+        WriteGrant,
+        normalize_ws_path,
+    )
+
+    frozen = {
+        n: fa.content for fa in bound_record.frozen if (n := normalize_ws_path(fa.path)) is not None
+    }
+    # A QA producer gets a namespace-scoped grant; the 2.1 authorization classes decide whether
+    # a non-frozen emission is inside its lane (allow), another producer's slot (drop), or
+    # undeclared (allow — could be a deliverable, §4.6 undeclared-reject stays gated on 3.4).
+    qa_authz = None
+    if _is_qa_producer(envelope.task_type):
+        ownership = WorkspaceOwnership.from_record(bound_record)
+        grant = WriteGrant.for_qa(envelope.task_type, ownership)
+        qa_authz = WriteAuthorization(ownership, grant)
+
+    # Classify first so each evidence record can report how many sibling artifacts in the SAME
+    # response were left untouched (per-artifact disposition — restore/drop keep the rest; a
+    # response-atomic reject would not — that difference is exactly what the field captures).
+    norms = [
+        normalize_ws_path(raw) if isinstance(raw := _artifact_raw_path(art), str) else None
+        for art in artifacts
+    ]
+
+    def _disposition(art: dict, norm: str | None) -> str:
+        if norm is not None and norm in frozen:
+            return "restore"
+        if qa_authz is not None and (
+            qa_authz.authorize(_artifact_raw_path(art) or "")
+            == AuthzDecision.FORBIDDEN_UNAUTHORIZED
+        ):
+            return "drop"
+        return "pass"
+
+    dispositions = [_disposition(art, norm) for art, norm in zip(artifacts, norms, strict=True)]
+    siblings_retained = sum(1 for d in dispositions if d == "pass")
+
+    enforced: list[dict] = []
+    evidence: list[Any] = []
+    for art, norm, disposition in zip(artifacts, norms, dispositions, strict=True):
+        if disposition == "restore":
+            evidence.append(
+                frozen_restore_evidence(
+                    producer_task_id=envelope.task_id,
+                    producer_task_type=envelope.task_type,
+                    record=bound_record,
+                    attempted_path=_artifact_raw_path(art) or norm,
+                    normalized_path=norm,
+                    attempted_content=art.get("content"),
+                    siblings_retained=siblings_retained,
+                )
+            )
+            enforced.append({**art, "content": frozen[norm]})  # restore scaffold bytes (D2)
+        elif disposition == "drop":
+            evidence.append(
+                unauthorized_slot_evidence(
+                    producer_task_id=envelope.task_id,
+                    producer_task_type=envelope.task_type,
+                    record=bound_record,
+                    attempted_path=_artifact_raw_path(art) or (norm or ""),
+                    normalized_path=norm,
+                    attempted_content=art.get("content"),
+                    siblings_retained=siblings_retained,
+                )
+            )
+            # dropped: NOT appended — the owning producer's already-stored version stays.
+        else:
+            enforced.append(art)
+    return enforced, evidence

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -817,3 +817,42 @@ class TestRepairHandlers:
         prompt = captured["user"]
         assert "test" in prompt
         assert "Repair Task" in prompt
+
+
+# ---------------------------------------------------------------------------
+# _format_failure_summary — deterministic authoritative-instruction blocks
+# ---------------------------------------------------------------------------
+
+
+class TestFailureSummaryEnforcementBlock:
+    def test_scaffold_enforcement_rendered_as_authoritative_block(self):
+        """SIP-0100 3.4b: frozen-restore instructions carried from a prior attempt
+        must reach the repair prompt as an authoritative block — without this the
+        repair silently fights the restore (pf-30: three attempts re-emitting
+        frozen files against a correct diagnosis)."""
+        from squadops.capabilities.handlers.impl.repair_handlers import (
+            _format_failure_summary,
+        )
+
+        evidence = {
+            "scaffold_enforcement": [
+                "`backend/main.py` is scaffold-frozen and canonical; do not re-emit it."
+            ],
+            "validation_result": {"summary": "tests_pass failed"},
+        }
+        rendered = _format_failure_summary(evidence, None)
+        assert "FROZEN OWNERSHIP (authoritative" in rendered
+        assert "backend/main.py" in rendered
+        # The rest of the evidence still renders alongside it.
+        assert "tests_pass failed" in rendered
+
+    def test_no_enforcement_key_renders_no_block(self):
+        """Absent/empty scaffold_enforcement must not inject the block."""
+        from squadops.capabilities.handlers.impl.repair_handlers import (
+            _format_failure_summary,
+        )
+
+        assert "FROZEN OWNERSHIP" not in _format_failure_summary(
+            {"validation_result": {"summary": "x"}}, None
+        )
+        assert "FROZEN OWNERSHIP" not in _format_failure_summary({"scaffold_enforcement": []}, None)

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -1675,6 +1675,112 @@ class TestCorrectionRunnerStandalone:
         assert protocol_result.correction_path == "patch"
         assert protocol_result.repair_artifacts == [repaired]
 
+    async def test_repair_envelope_threads_resolved_config_from_failed_task(self, cycle):
+        """pf-30 regression: the repair handler's scaffold fill-only appendix
+        gates on ``inputs["resolved_config"]["build_profile"]``
+        (``is_scaffoldable_stack``). The repair envelope previously omitted
+        ``resolved_config``, so the gate saw an empty profile and silently
+        no-opped — repairs freely rewrote scaffold-owned interface (pf-30
+        attempts 1-3 re-emitted routes.py with relative decorator paths
+        against a correct diagnosis, never converging). The retest path
+        already threaded the field; this pins the repair path too."""
+        import dataclasses as _dc
+
+        captured: list = []
+
+        def responder(envelope):
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "patch",
+                        "decision_rationale": "patchable",
+                        "affected_task_types": ["development.develop"],
+                    },
+                )
+            if envelope.task_type == "development.correction_repair":
+                captured.append(envelope)
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={"artifacts": [], "summary": "repaired"},
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, _vault, _bus = self._make_runner(responder)
+        resolved_config = {"build_profile": "fullstack_fastapi_react"}
+        failed = _dc.replace(
+            self._failed_envelope(),
+            task_type="development.develop",
+            inputs={
+                "resolved_config": resolved_config,
+                "expected_artifacts": ["backend/routes.py"],
+            },
+        )
+
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=failed,
+            result=TaskResult(task_id="task_failed", status="FAILED", error="typed check failed"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+        assert len(captured) == 1
+        assert captured[0].inputs["resolved_config"] == resolved_config
+
+    async def test_repair_envelope_resolved_config_defaults_empty(self, cycle):
+        """A failed envelope with no resolved_config threads {} — the
+        fill-only gate no-ops cleanly instead of the handler KeyErroring."""
+        import dataclasses as _dc
+
+        captured: list = []
+
+        def responder(envelope):
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "patch",
+                        "decision_rationale": "patchable",
+                        "affected_task_types": ["development.develop"],
+                    },
+                )
+            if envelope.task_type == "development.correction_repair":
+                captured.append(envelope)
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={"artifacts": [], "summary": "repaired"},
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, _vault, _bus = self._make_runner(responder)
+        failed = _dc.replace(self._failed_envelope(), task_type="development.develop")
+
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=failed,
+            result=TaskResult(task_id="task_failed", status="FAILED", error="bad"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+        assert len(captured) == 1
+        assert captured[0].inputs["resolved_config"] == {}
+
     async def test_non_patch_path_returns_no_repair_artifacts(self, cycle):
         """#389: a 'continue' decision dispatches no repair steps — surfacing
         stale/empty artifacts here would make the executor 'verify' nothing

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -1781,6 +1781,138 @@ class TestCorrectionRunnerStandalone:
         assert len(captured) == 1
         assert captured[0].inputs["resolved_config"] == {}
 
+    async def test_repair_frozen_emission_restored_and_signaled(self, cycle):
+        """SIP-0100 3.4b (pf-27/pf-30 regression): a repair emitting a scaffold-frozen
+        path has its content RESTORED before any landing point — the registry store
+        AND the repair_artifacts overlay both see scaffold bytes, never the clobber —
+        the enforcement is evidenced, and the restore instruction lands on the carry
+        for the next attempt (restore+signal). Un-enforced repair emissions were how
+        pf-27's drift signal got polluted and pf-30's repairs fought the scaffold."""
+        from pathlib import Path
+
+        from squadops.capabilities.scaffold import InterfaceManifest
+        from squadops.events.types import EventType as _ET
+
+        manifest = InterfaceManifest.from_yaml(
+            (
+                Path(__file__).parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+            ).read_text()
+        )
+
+        def responder(envelope):
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "patch",
+                        "decision_rationale": "patchable",
+                        "affected_task_types": ["development.develop"],
+                    },
+                )
+            if envelope.task_type == "development.correction_repair":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "artifacts": [
+                            {"name": "backend/main.py", "content": "TAMPERED = 1\n"},
+                            {"name": "backend/routes.py", "content": "def fill(): return 1\n"},
+                        ],
+                        "summary": "repaired",
+                    },
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, vault, bus = self._make_runner(responder)
+        carry: list[str] = []
+
+        protocol_result = await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=self._failed_envelope(),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="tests failed"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+            interface_manifest=manifest,
+            scaffold_enforcement_carry=carry,
+        )
+
+        # Overlay landing point: main.py restored to scaffold bytes, fill slot untouched.
+        by_name = {a["name"]: a["content"] for a in protocol_result.repair_artifacts}
+        assert "from .routes import router" in by_name["backend/main.py"]
+        assert "TAMPERED" not in by_name["backend/main.py"]
+        assert by_name["backend/routes.py"] == "def fill(): return 1\n"
+
+        # Registry landing point: the stored main.py bytes are the scaffold's, not the tamper.
+        stored = {
+            call.args[0].filename: call.args[1]
+            for call in vault.store.call_args_list
+            if call.args[0].filename in ("backend/main.py", "backend/routes.py")
+        }
+        assert b"TAMPERED" not in stored["backend/main.py"]
+        assert b"from .routes import router" in stored["backend/main.py"]
+
+        # Signal: exactly one instruction carried, naming the frozen path.
+        assert len(carry) == 1
+        assert "backend/main.py" in carry[0]
+        assert "fill slots" in carry[0]
+
+        # Evidence: the enforcement was surfaced as an event, not silent.
+        enforce_events = [
+            c
+            for c in bus.emit.call_args_list
+            if c.args and c.args[0] == _ET.ARTIFACT_OWNERSHIP_ENFORCED
+        ]
+        assert len(enforce_events) == 1
+
+    async def test_carry_instructions_reach_next_attempt_failure_evidence(self, cycle):
+        """3.4b restore+signal, second half: instructions already on the carry are
+        injected into this attempt's failure_evidence (scaffold_enforcement key), so
+        the analyze/decision/repair prompts are TOLD about prior frozen restores
+        instead of rediscovering the fight."""
+        captured: list = []
+
+        def responder(envelope):
+            if envelope.task_type == "data.analyze_failure":
+                captured.append(envelope)
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "continue",
+                        "decision_rationale": "keep going",
+                        "affected_task_types": [],
+                    },
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, _vault, _bus = self._make_runner(responder)
+        carry = ["`backend/main.py` is scaffold-frozen and canonical; do not re-emit it."]
+
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=self._failed_envelope(),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="bad"),
+            correction_attempts=1,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+            scaffold_enforcement_carry=carry,
+        )
+
+        assert len(captured) == 1
+        evidence = captured[0].inputs["failure_evidence"]
+        assert evidence["scaffold_enforcement"] == carry
+
     async def test_non_patch_path_returns_no_repair_artifacts(self, cycle):
         """#389: a 'continue' decision dispatches no repair steps — surfacing
         stale/empty artifacts here would make the executor 'verify' nothing

--- a/tests/unit/events/test_event_emission.py
+++ b/tests/unit/events/test_event_emission.py
@@ -192,6 +192,9 @@ class TestCorrectionRunnerEmissionPoints:
             "TASK_SUCCEEDED",
             "TASK_FAILED",
             "CHECKPOINT_CREATED",
+            # SIP-0100 3.4b: frozen-ownership enforcement on the repair path
+            # surfaces each restore as an event (mirrors the executor's emitter).
+            "ARTIFACT_OWNERSHIP_ENFORCED",
         ],
     )
     def test_correction_runner_emits(self, attr: str, correction_runner_refs: set[str]) -> None:
@@ -330,11 +333,13 @@ class TestEmitCallSitePayloadFields:
         assert with_payload >= 35
 
     def test_total_emit_call_count(self) -> None:
-        """Sanity check: 20 executor + 7 correction-runner +
-        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 44 total
+        """Sanity check: 20 executor + 8 correction-runner +
+        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 45 total
         emit calls (#473 added the pre-gate rejection's GATE_DECIDED emit;
         #522 added the framing re-roll's WORKLOAD_ADVANCED emit; SIP-0100 3.3
-        added the scaffold-integrity ARTIFACT_OWNERSHIP_ENFORCED emit).
+        added the scaffold-integrity ARTIFACT_OWNERSHIP_ENFORCED emit;
+        SIP-0100 3.4b added the correction runner's repair-path
+        ARTIFACT_OWNERSHIP_ENFORCED emit, 44 → 45).
 
         SIP-0097 slice 2c collapsed execute_run's five per-exception-class
         terminal emits into one emit driven by the RunCompletion terminal
@@ -347,4 +352,4 @@ class TestEmitCallSitePayloadFields:
         total = 0
         for path in _ALL_EMISSION_FILES:
             total += len(self._extract_emit_calls(path))
-        assert total == 44
+        assert total == 45


### PR DESCRIPTION
Two repair-path fixes from the pf-30 triage, one deploy-window unit. Both address the same failure: the correction loop's repairs rewriting scaffold-owned interface.

## Commit 1 — thread `resolved_config` onto repair envelopes (`03740268`)

The dev repair's scaffold **fill-only appendix (#555) never fired on the repair path**: `_render_fill_only_section` gates on `inputs["resolved_config"]["build_profile"]`, and the repair envelope omitted the field — empty profile → silent no-op. pf-30 attempts 1–3 each re-emitted `routes.py` with decorators flipped from manifest-mandated absolute paths to relative ones, registering every endpoint at root, non-converging against a correct diagnosis. One line, mirroring the retest path's existing threading; regression tests at the wiring level (the level #555's own handler tests couldn't see).

## Commit 2 — SIP-0100 3.4b: frozen enforcement on the repair path, restore + signal (`665a59f8`)

Frozen-ownership enforcement lived only on the executor's regular storage path; repair emissions bypassed it (deferred 3.4b, confirmed live in pf-27 and pf-30 — zero `scaffold_integrity` restores while repairs emitted frozen `models.py`/`main.py` every attempt).

- New **`squadops/cycles/scaffold_enforcement.py`**: `enforce_frozen_ownership`, `bound_record_or_none`, `frozen_restore_instruction` — lifted verbatim from `DispatchedFlowExecutor`, which now delegates (its 10 enforcement tests pass unchanged).
- **`correction_runner`** enforces on repair emissions **before any landing point** — in-place on `result.outputs["artifacts"]`, so registry store, the `repair_artifacts` overlay, and patch verification all see restored bytes.
- **Restore + signal, not silent restore**: each restore appends an authoritative instruction to an executor-owned run-lived carry (created beside `correction_counter`); the next attempt injects it as `failure_evidence["scaffold_enforcement"]`, and the repair prompt renders a `FROZEN OWNERSHIP (authoritative)` block — the same deterministic-instruction pattern as `interface_drift`. Silent restore would trade the clobber for a restore-fight thrash.
- Unbound/legacy runs: `bound_record` is None → byte-identical behavior. Enforcement hooks the repair loop only; analyze/decision (document emitters) and the retest path (QA-namespace semantics out of 3.4b scope) are untouched.

## Verification

- 3195 passed across `tests/unit/cycles` + `tests/unit/capabilities`; only the two known pre-existing `missing_tooling` environment failures. ruff check + format clean.
- New tests: frozen repair emission restored at both landing points + evidence event + carry append; carry reaches the next attempt's `failure_evidence`; prompt-block rendering (+ absent-key negative); `resolved_config` threading + `{}` default.
- Deploy-time obligation: verify **in-container** that a dispatched repair envelope renders the fill-only appendix and that a frozen repair emission logs `scaffold_integrity (repair path)` — gate-condition checks, not file-loaded checks (the pf-30 lesson).

## Context

pf-30 triage (green-roll hunt). Lands with #558 (merged) in the next deploy window; deploying resets the N=5 baseline hash → pf-31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXrSUPGsx5yxbsn19aDjXX
