### PR TITLE
feat(correction): pf-31 convergence fixes A+D+E — contract expectations, emission integrity, candidate-free workspaces

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -367,6 +367,7 @@ class CorrectionRunner:
                 )
                 if integrity_evidence:
                     result.outputs["artifacts"] = enforced
+                    step_artifacts = enforced
                     for record in integrity_evidence:
                         self._emit_scaffold_integrity_evidence(record, step_envelope)
                         if (
@@ -375,6 +376,47 @@ class CorrectionRunner:
                             == ContractComplianceViolation.FROZEN_PATH_EMISSION
                         ):
                             instruction = frozen_restore_instruction(record)
+                            if instruction not in enforcement_carry:
+                                enforcement_carry.append(instruction)
+
+            # pf-31 Fix D: drop syntactically invalid .py emissions (truncation
+            # guard) — the prior stored version (last known parseable) stays
+            # current for RC3 and the retest; the next attempt is told what was
+            # discarded via the same carry transport as the frozen restores.
+            if step_artifacts:
+                from squadops.cycles.emission_integrity import (
+                    emission_integrity_instruction,
+                    syntax_gate_python_artifacts,
+                )
+
+                kept, rejected = syntax_gate_python_artifacts(step_artifacts)
+                if rejected:
+                    result.outputs["artifacts"] = kept
+                    for art, error in rejected:
+                        name = art.get("name") or art.get("path") or "(unnamed)"
+                        payload = {
+                            "producer_task_id": step_envelope.task_id,
+                            "producer_task_type": step_envelope.task_type,
+                            "artifact": name,
+                            "error": error,
+                            "disposition": "dropped",
+                        }
+                        logger.warning("pf-31 emission_integrity (repair path): %s", payload)
+                        try:
+                            self._event_bus.emit(
+                                EventType.ARTIFACT_EMISSION_REJECTED,
+                                entity_type="artifact",
+                                entity_id=name,
+                                context={
+                                    "cycle_id": step_envelope.cycle_id,
+                                    "run_id": run_id,
+                                },
+                                payload=payload,
+                            )
+                        except Exception:
+                            logger.debug("emission_integrity event emit failed", exc_info=True)
+                        if enforcement_carry is not None:
+                            instruction = emission_integrity_instruction(name, error)
                             if instruction not in enforcement_carry:
                                 enforcement_carry.append(instruction)
             # Persist the step's output artifacts BEFORE checkpointing —

--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -283,6 +283,89 @@ class CorrectionRunner:
         except Exception:
             logger.debug("SIP-0100: scaffold_integrity event emit failed", exc_info=True)
 
+    def _enforce_step_emissions(
+        self,
+        result: TaskResult,
+        step_envelope: TaskEnvelope,
+        run_id: str,
+        bound_record: Any,
+        enforcement_carry: list[str] | None,
+    ) -> None:
+        """Apply the 3.4b frozen-ownership restore and the pf-31 Fix D syntax
+        gate to a protocol step's emitted artifacts, in place (both landing
+        paths read ``result.outputs``), with evidence events and next-attempt
+        carry instructions for every enforcement."""
+        # SIP-0100 3.4b: enforce frozen ownership on the step's emissions
+        # before ANY landing point (registry store below, the caller's
+        # repair overlay, patch verification). In-place replacement of
+        # the artifacts list is deliberate — both consumers read
+        # result.outputs.
+        step_artifacts = (result.outputs or {}).get("artifacts") or []
+        if bound_record is not None and step_artifacts:
+            from squadops.cycles.scaffold_enforcement import (
+                enforce_frozen_ownership,
+                frozen_restore_instruction,
+            )
+            from squadops.cycles.task_outcome import ContractComplianceViolation
+
+            enforced, integrity_evidence = enforce_frozen_ownership(
+                step_artifacts, bound_record, step_envelope
+            )
+            if integrity_evidence:
+                result.outputs["artifacts"] = enforced
+                step_artifacts = enforced
+                for record in integrity_evidence:
+                    self._emit_scaffold_integrity_evidence(record, step_envelope)
+                    if (
+                        enforcement_carry is not None
+                        and record.violation_code
+                        == ContractComplianceViolation.FROZEN_PATH_EMISSION
+                    ):
+                        instruction = frozen_restore_instruction(record)
+                        if instruction not in enforcement_carry:
+                            enforcement_carry.append(instruction)
+
+        # pf-31 Fix D: drop syntactically invalid .py emissions (truncation
+        # guard) — the prior stored version (last known parseable) stays
+        # current for RC3 and the retest; the next attempt is told what was
+        # discarded via the same carry transport as the frozen restores.
+        if step_artifacts:
+            from squadops.cycles.emission_integrity import (
+                emission_integrity_instruction,
+                syntax_gate_python_artifacts,
+            )
+
+            kept, rejected = syntax_gate_python_artifacts(step_artifacts)
+            if rejected:
+                result.outputs["artifacts"] = kept
+                for art, error in rejected:
+                    name = art.get("name") or art.get("path") or "(unnamed)"
+                    payload = {
+                        "producer_task_id": step_envelope.task_id,
+                        "producer_task_type": step_envelope.task_type,
+                        "artifact": name,
+                        "error": error,
+                        "disposition": "dropped",
+                    }
+                    logger.warning("pf-31 emission_integrity (repair path): %s", payload)
+                    try:
+                        self._event_bus.emit(
+                            EventType.ARTIFACT_EMISSION_REJECTED,
+                            entity_type="artifact",
+                            entity_id=name,
+                            context={
+                                "cycle_id": step_envelope.cycle_id,
+                                "run_id": run_id,
+                            },
+                            payload=payload,
+                        )
+                    except Exception:
+                        logger.debug("emission_integrity event emit failed", exc_info=True)
+                    if enforcement_carry is not None:
+                        instruction = emission_integrity_instruction(name, error)
+                        if instruction not in enforcement_carry:
+                            enforcement_carry.append(instruction)
+
     async def _dispatch_protocol_step(
         self,
         step_envelope: TaskEnvelope,
@@ -349,76 +432,11 @@ class CorrectionRunner:
                 context=task_context,
                 payload={"task_type": step_envelope.task_type},
             )
-            # SIP-0100 3.4b: enforce frozen ownership on the step's emissions
-            # before ANY landing point (registry store below, the caller's
-            # repair overlay, patch verification). In-place replacement of
-            # the artifacts list is deliberate — both consumers read
-            # result.outputs.
-            step_artifacts = (result.outputs or {}).get("artifacts") or []
-            if bound_record is not None and step_artifacts:
-                from squadops.cycles.scaffold_enforcement import (
-                    enforce_frozen_ownership,
-                    frozen_restore_instruction,
-                )
-                from squadops.cycles.task_outcome import ContractComplianceViolation
-
-                enforced, integrity_evidence = enforce_frozen_ownership(
-                    step_artifacts, bound_record, step_envelope
-                )
-                if integrity_evidence:
-                    result.outputs["artifacts"] = enforced
-                    step_artifacts = enforced
-                    for record in integrity_evidence:
-                        self._emit_scaffold_integrity_evidence(record, step_envelope)
-                        if (
-                            enforcement_carry is not None
-                            and record.violation_code
-                            == ContractComplianceViolation.FROZEN_PATH_EMISSION
-                        ):
-                            instruction = frozen_restore_instruction(record)
-                            if instruction not in enforcement_carry:
-                                enforcement_carry.append(instruction)
-
-            # pf-31 Fix D: drop syntactically invalid .py emissions (truncation
-            # guard) — the prior stored version (last known parseable) stays
-            # current for RC3 and the retest; the next attempt is told what was
-            # discarded via the same carry transport as the frozen restores.
-            if step_artifacts:
-                from squadops.cycles.emission_integrity import (
-                    emission_integrity_instruction,
-                    syntax_gate_python_artifacts,
-                )
-
-                kept, rejected = syntax_gate_python_artifacts(step_artifacts)
-                if rejected:
-                    result.outputs["artifacts"] = kept
-                    for art, error in rejected:
-                        name = art.get("name") or art.get("path") or "(unnamed)"
-                        payload = {
-                            "producer_task_id": step_envelope.task_id,
-                            "producer_task_type": step_envelope.task_type,
-                            "artifact": name,
-                            "error": error,
-                            "disposition": "dropped",
-                        }
-                        logger.warning("pf-31 emission_integrity (repair path): %s", payload)
-                        try:
-                            self._event_bus.emit(
-                                EventType.ARTIFACT_EMISSION_REJECTED,
-                                entity_type="artifact",
-                                entity_id=name,
-                                context={
-                                    "cycle_id": step_envelope.cycle_id,
-                                    "run_id": run_id,
-                                },
-                                payload=payload,
-                            )
-                        except Exception:
-                            logger.debug("emission_integrity event emit failed", exc_info=True)
-                        if enforcement_carry is not None:
-                            instruction = emission_integrity_instruction(name, error)
-                            if instruction not in enforcement_carry:
-                                enforcement_carry.append(instruction)
+            # SIP-0100 3.4b + pf-31 Fix D: frozen-ownership restore and the
+            # invalid-emission syntax gate, applied before ANY landing point.
+            self._enforce_step_emissions(
+                result, step_envelope, run_id, bound_record, enforcement_carry
+            )
             # Persist the step's output artifacts BEFORE checkpointing —
             # _checkpoint_correction_task only snapshots existing refs and
             # would otherwise drop these silently.

--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -490,6 +490,15 @@ class CorrectionRunner:
         if scaffold_enforcement_carry:
             failure_evidence["scaffold_enforcement"] = list(scaffold_enforcement_carry)
 
+        # pf-31 Fix A: the failed task's typed criteria as exact expectation lines,
+        # so the analyzer/decision reason against the contract's letter (repairs get
+        # the same lines as an authoritative prompt block via the appendix asset).
+        from squadops.cycles.contract_expectations import expectation_lines
+
+        expectations = expectation_lines((envelope.inputs or {}).get("acceptance_criteria"))
+        if expectations:
+            failure_evidence["contract_expectations"] = expectations
+
         # Issue #95: capture each correction step's outputs in its own variable
         # so the analyzer's classification/analysis_summary survive past the
         # subsequent governance.correction_decision step (which doesn't carry

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -963,12 +963,22 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         self,
         task_type: str,
         stored_artifacts: list[tuple[str, ArtifactRef]],
+        *,
+        include_repair_candidates: bool = True,
     ) -> dict[str, str]:
         """Pre-resolve artifact content for build tasks (D3).
 
         Args:
             task_type: The build task type being dispatched.
             stored_artifacts: List of (artifact_id, ArtifactRef) from prior tasks.
+            include_repair_candidates: pf-31 Fix E — repair-typed emissions are
+                CANDIDATES: an accepted patch is re-stored under the repaired
+                task's own type (#389 swap), so candidate-typed artifacts are
+                in-flight or rejected. The correction loop keeps them (RC3
+                accumulation needs every attempt's content); fresh task
+                dispatches exclude them, so a rejected candidate can never
+                supersede the accepted state in a later task's workspace —
+                the pf-31 endpoint_defined final-verification regression.
 
         Returns:
             Dict of filename → content string. Empty if task_type not a build task.
@@ -976,6 +986,15 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         filter_spec = self._BUILD_ARTIFACT_FILTER.get(task_type)
         if not filter_spec:
             return {}
+
+        if not include_repair_candidates:
+            from squadops.cycles.task_plan import REPAIR_TASK_TYPES
+
+            stored_artifacts = [
+                (art_id, ref)
+                for art_id, ref in stored_artifacts
+                if ref.metadata.get("producing_task_type", "") not in REPAIR_TASK_TYPES
+            ]
 
         producing_tasks = set(filter_spec.get("by_producing_task", []))
         type_filter = set(filter_spec.get("by_type", []))
@@ -1643,11 +1662,15 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             "artifact_refs": list(all_artifact_refs),
         }
 
-        # Pre-resolve artifact contents for build tasks (D3)
+        # Pre-resolve artifact contents for build tasks (D3). Fresh dispatches
+        # see the ACCEPTED state only (pf-31 Fix E): rejected repair candidates
+        # stay out of task workspaces; the correction loop's own re-resolution
+        # keeps them for RC3.
         if envelope.task_type in self._BUILD_ARTIFACT_FILTER:
             artifact_contents = await self._resolve_artifact_contents(
                 envelope.task_type,
                 stored_artifacts,
+                include_repair_candidates=False,
             )
             if artifact_contents:
                 extra_inputs["artifact_contents"] = artifact_contents

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -149,6 +149,14 @@ class _RepairPromptMixin:
         prior_outputs: dict[str, Any] | None,
         inputs: dict[str, Any],
     ) -> dict[str, str]:
+        from squadops.cycles.contract_expectations import expectation_lines, prose_criteria
+
+        criteria = inputs.get("acceptance_criteria") or []
+        # pf-31 Fix A2: typed criteria render ONLY through the authoritative
+        # Contract Expectations block; the narrative section carries prose alone.
+        # Rendering TypedCheck dicts through _format_bullets produced the repr
+        # soup every pf-31 repair ignored in favor of contradicting prose.
+        narrative = prose_criteria(criteria) if expectation_lines(criteria) else criteria
         return {
             "prd": prd,
             "role": self._role,
@@ -161,11 +169,14 @@ class _RepairPromptMixin:
             "subtask_focus": str(inputs.get("subtask_focus") or ""),
             "subtask_description": str(inputs.get("subtask_description") or ""),
             "expected_artifacts": _format_bullets(inputs.get("expected_artifacts")),
-            "acceptance_criteria": _format_bullets(inputs.get("acceptance_criteria")),
+            "acceptance_criteria": _format_bullets(narrative),
             "prior_outputs": self._format_prior_outputs(prior_outputs),
             # Same scaffold fill-only constraint the develop handler injects (SIP-0099
             # 99.3). Rendered in handle() and threaded via inputs; "" when absent.
             "fill_only_section": str(inputs.get("fill_only_section") or ""),
+            # pf-31 Fix A1: authoritative typed-expectations block, rendered in
+            # handle() from the managed appendix asset; "" when no typed criteria.
+            "contract_expectations": str(inputs.get("contract_expectations_section") or ""),
         }
 
     async def handle(
@@ -187,7 +198,34 @@ class _RepairPromptMixin:
         fill_only = await self._render_fill_only_section(context, inputs)
         if fill_only:
             inputs = {**inputs, "fill_only_section": fill_only}
+        expectations = await self._render_contract_expectations_section(context, inputs)
+        if expectations:
+            inputs = {**inputs, "contract_expectations_section": expectations}
         return await super().handle(context, inputs)
+
+    async def _render_contract_expectations_section(
+        self, context: ExecutionContext, inputs: dict[str, Any]
+    ) -> str:
+        """The authoritative typed-expectations appendix, or "" (pf-31 Fix A1).
+
+        Rendered whenever the failed task's acceptance criteria carry typed
+        checks — the resolved contract expectations were already delivered to
+        repairs but as low-salience dict reprs below contradicting prose (the
+        pf-31 ``{run_id}``-vs-``{id}`` poisoning: 7 of 7 repairs rejected).
+        """
+        renderer = getattr(context.ports, "request_renderer", None)
+        if renderer is None:
+            return ""
+        from squadops.cycles.contract_expectations import expectation_lines
+
+        lines = expectation_lines(inputs.get("acceptance_criteria"))
+        if not lines:
+            return ""
+        rendered = await renderer.render(
+            "request.cycle_repair_contract_expectations_appendix",
+            {"expectations": "\n".join(f"- {line}" for line in lines)},
+        )
+        return rendered.content
 
     async def _render_fill_only_section(
         self, context: ExecutionContext, inputs: dict[str, Any]
@@ -239,9 +277,18 @@ class _RepairPromptMixin:
                 "` ```language:path/to/file `:\n" + _format_bullets(expected)
             )
 
-        criteria = inputs.get("acceptance_criteria")
+        from squadops.cycles.contract_expectations import expectation_lines, prose_criteria
+
+        criteria = inputs.get("acceptance_criteria") or []
+        typed_lines = expectation_lines(criteria)
+        if typed_lines:
+            parts.append(
+                "### Contract Expectations (authoritative — apply exactly)\n"
+                + "\n".join(f"- {line}" for line in typed_lines)
+            )
+            criteria = prose_criteria(criteria)
         if criteria:
-            parts.append("### Acceptance Criteria\n" + _format_bullets(criteria))
+            parts.append("### Acceptance Criteria (narrative)\n" + _format_bullets(criteria))
 
         failure_summary = _format_failure_summary(
             inputs.get("failure_evidence"),

--- a/src/squadops/cycles/contract_expectations.py
+++ b/src/squadops/cycles/contract_expectations.py
@@ -1,0 +1,111 @@
+"""Render typed acceptance criteria as authoritative, human-legible expectation lines.
+
+pf-31 Fix A (docs/plans/pf31-correction-convergence-fixes.md): the resolved
+TypedChecks reach the repair envelope but rendered as dict-repr soup below the
+plan's contradicting prose — every pf-31 repair followed the prose's
+``{run_id}`` over the contract's ``{id}``. These formatters turn the typed
+entries into one exact line per check so prompts can lead with them as an
+authoritative block. Pure data-in/lines-out — all prompt heading/instruction
+text lives in the request-template assets.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_RESERVED_KEYS = {"check", "severity", "description", "id"}
+
+
+def _check_and_params(entry: Any) -> tuple[str, dict] | None:
+    """Normalize the three shapes a typed criterion travels in.
+
+    In-process: a ``TypedCheck`` dataclass (``check``/``params`` attributes).
+    On the wire: either the resolved form ``{"check": ..., "params": {...}}``
+    or the plan-authored flat form ``{"check": ..., <param keys inline>}``.
+    Returns None for prose strings and anything else non-typed.
+    """
+    check = getattr(entry, "check", None)
+    params = getattr(entry, "params", None)
+    if isinstance(check, str) and isinstance(params, dict):
+        return check, params
+    if isinstance(entry, dict) and isinstance(entry.get("check"), str):
+        raw_params = entry.get("params")
+        if isinstance(raw_params, dict):
+            return entry["check"], raw_params
+        return entry["check"], {k: v for k, v in entry.items() if k not in _RESERVED_KEYS}
+    return None
+
+
+def is_typed_criterion(entry: Any) -> bool:
+    return _check_and_params(entry) is not None
+
+
+def prose_criteria(acceptance_criteria: list[Any] | None) -> list[str]:
+    """The non-typed (narrative) entries, as strings, in original order."""
+    return [
+        str(entry)
+        for entry in (acceptance_criteria or [])
+        if not is_typed_criterion(entry) and str(entry).strip()
+    ]
+
+
+def _fmt_methods_paths(raw: Any) -> str:
+    parts: list[str] = []
+    for item in raw or []:
+        if isinstance(item, (list, tuple)) and len(item) == 2:
+            parts.append(f"`{item[0]} {item[1]}`")
+        else:
+            parts.append(f"`{item}`")
+    return ", ".join(parts)
+
+
+def expectation_line(entry: Any) -> str | None:
+    """One exact, imperative line for a typed criterion; None for prose."""
+    normalized = _check_and_params(entry)
+    if normalized is None:
+        return None
+    check, params = normalized
+    file = params.get("file", "")
+    where = f" in `{file}`" if file else ""
+
+    if check == "endpoint_defined":
+        return (
+            f"`{file}` must define exactly these routes (method, absolute path, and "
+            f"path-parameter names are all literal): {_fmt_methods_paths(params.get('methods_paths'))}"
+        )
+    if check == "import_present":
+        module = params.get("module", "")
+        symbol = params.get("symbol")
+        if symbol:
+            return f"`{file}` must contain the direct import `from {module} import {symbol}`"
+        return f"`{file}` must import module `{module}`"
+    if check == "field_present":
+        fields = ", ".join(f"`{f}`" for f in params.get("fields", []))
+        return f"class `{params.get('class_name', '?')}`{where} must define fields: {fields}"
+    if check == "function_defined":
+        return (
+            f"`{file}` must define at least {params.get('min_count', 1)} functions "
+            f"named `{params.get('name_prefix', '')}*`"
+        )
+    if check == "command_exit_zero":
+        argv = params.get("argv") or []
+        return f"the command `{' '.join(str(a) for a in argv)}` must exit 0"
+    if check == "harness_boundary":
+        entries = ", ".join(f"`{m}`" for m in params.get("entry_modules", []))
+        return (
+            f"`{file}` must build its `{params.get('client_ctor', 'TestClient')}` "
+            f"against one of: {entries} (no ad-hoc app construction)"
+        )
+    # Unknown/new check type: still surface it exactly rather than dropping it.
+    kv = ", ".join(f"{k}={v!r}" for k, v in sorted(params.items()) if k != "file")
+    return f"{check}{where}: {kv}" if kv else f"{check}{where}"
+
+
+def expectation_lines(acceptance_criteria: list[Any] | None) -> list[str]:
+    """Authoritative lines for every typed criterion, in original order."""
+    lines: list[str] = []
+    for entry in acceptance_criteria or []:
+        line = expectation_line(entry)
+        if line:
+            lines.append(line)
+    return lines

--- a/src/squadops/cycles/emission_integrity.py
+++ b/src/squadops/cycles/emission_integrity.py
@@ -1,0 +1,71 @@
+"""Syntax gate for repair-path Python emissions (pf-31 Fix D).
+
+pf-31 repair-03 emitted a truncated ``backend/tests/test_runs.py`` (SyntaxError
+mid-function) — the repair itself re-imported the pytest collection-crash class
+it was dispatched to fix, and the broken file superseded the last good version.
+The gate parses each repair-emitted ``.py`` artifact and DROPS syntactically
+invalid ones before any landing point: the previously stored version (the last
+known parseable one) stays current for RC3 accumulation and the retest, and the
+next attempt is told exactly what was discarded (the 3.4b carry transport).
+
+Related, not a substitute: the fenced-parser EOF-recovery (#528) salvages an
+unterminated fence; a truncated function body is invalid however the fence ends.
+
+Pure functions — the caller owns storage, events, and the carry.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import Any
+
+
+def _python_artifact_name(art: Any) -> str | None:
+    if not isinstance(art, dict):
+        return None
+    name = art.get("name") if art.get("name") is not None else art.get("path")
+    if isinstance(name, str) and name.endswith(".py"):
+        return name
+    return None
+
+
+def syntax_gate_python_artifacts(
+    artifacts: list[Any],
+) -> tuple[list[Any], list[tuple[dict, str]]]:
+    """Split *artifacts* into (kept, rejected) by Python parseability.
+
+    Non-Python and non-dict entries always pass through unchanged. A ``.py``
+    artifact whose content fails ``ast.parse`` is rejected with a one-line
+    error description (type, line, message).
+    """
+    kept: list[Any] = []
+    rejected: list[tuple[dict, str]] = []
+    for art in artifacts:
+        name = _python_artifact_name(art)
+        if name is None:
+            kept.append(art)
+            continue
+        content = art.get("content")
+        if not isinstance(content, str):
+            kept.append(art)
+            continue
+        try:
+            ast.parse(content, filename=name)
+        except SyntaxError as exc:
+            rejected.append((art, f"SyntaxError at line {exc.lineno}: {exc.msg}"))
+            continue
+        kept.append(art)
+    return kept, rejected
+
+
+def emission_integrity_instruction(name: str, error: str) -> str:
+    """Authoritative next-attempt instruction for a discarded invalid emission.
+
+    Travels the same carry → ``failure_evidence`` → prompt-block transport as
+    the 3.4b frozen-restore instructions."""
+    return (
+        f"your previously emitted `{name}` was syntactically invalid ({error}) and was "
+        "DISCARDED — the prior version of the file is still in effect. Re-emit the "
+        "COMPLETE file, and keep it small enough to finish: do not start more files "
+        "than you can fully emit."
+    )

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -351,6 +351,66 @@ class ImplementationPlan:
             if criterion.severity == "error"
         ]
 
+    def lint_prose_contract_conflicts(self, contract: VerificationContract) -> list[str]:
+        """pf-31 Fix A3: WARNING-only lint for prose that contradicts bound criteria.
+
+        The two observed poisonings were gate-visible in the plan text: pf-31's
+        description said ``/runs/{run_id}/join`` where the bound ``endpoint_defined``
+        pins ``{id}`` (all 7 repairs followed the prose and were rejected over that
+        one token); pf-30's prose said ``DELETE /runs/{run_id}/leave`` vs the
+        contract's ``POST``. This flags path-parameter names and methods used in a
+        task's description/prose criteria that conflict with the task's resolved
+        ``endpoint_defined`` expectations. Heuristic and conservative: warnings for
+        the gate reviewer's eyes (surfaced via log at dispatch validation), never a
+        rejection — the reverted #552 lesson bars new hard gates on prompt prose.
+        """
+        import re as _re
+
+        from squadops.cycles.task_plan import resolve_contract_refs
+
+        warnings: list[str] = []
+        for task in self.tasks:
+            if not task.criteria_refs:
+                continue
+            endpoint_paths: list[str] = []
+            for check in resolve_contract_refs(list(task.criteria_refs), contract):
+                if check.check == "endpoint_defined":
+                    for item in check.params.get("methods_paths", []) or []:
+                        endpoint_paths.append(
+                            f"{item[0]} {item[1]}"
+                            if isinstance(item, (list, tuple)) and len(item) == 2
+                            else str(item)
+                        )
+            if not endpoint_paths:
+                continue
+            allowed_params = {m for p in endpoint_paths for m in _re.findall(r"\{(\w+)\}", p)}
+            prose = " ".join([task.description, *[str(c) for c in task.acceptance_criteria]])
+            for token in sorted(set(_re.findall(r"/\S*?\{(\w+)\}", prose))):
+                if token not in allowed_params:
+                    warnings.append(
+                        f"Task {task.task_index} ({task.focus}): prose uses path "
+                        f"parameter {{{token}}} but the bound contract paths use "
+                        f"{sorted(allowed_params)} — prose-steered emissions will "
+                        f"fail endpoint_defined (pf-31 class)"
+                    )
+            normalized = {
+                (m.split()[0].upper(), _re.sub(r"\{\w+\}", "{}", m.split(maxsplit=1)[1]))
+                for m in endpoint_paths
+                if " " in m
+            }
+            for method, path in _re.findall(r"\b(GET|POST|PUT|PATCH|DELETE)\s+(/\S+)", prose):
+                norm = _re.sub(r"\{\w+\}", "{}", path).rstrip(".,;:)")
+                if (
+                    any(p == norm for _m, p in normalized)
+                    and (method.upper(), norm) not in normalized
+                ):
+                    warnings.append(
+                        f"Task {task.task_index} ({task.focus}): prose says "
+                        f"{method} {path} but the bound contract requires a "
+                        f"different method for that path (pf-30 DELETE-/leave class)"
+                    )
+        return warnings
+
     def validate_criteria_refs(self, contract: VerificationContract) -> list[str]:
         """SIP-0098 §6.3: bind-mode plan validation against the seeded contract.
 

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -211,6 +211,16 @@ _REPAIR_STEPS_BY_FAILED_TASK_TYPE: dict[str, list[tuple[str, str]]] = {
     ],
 }
 
+# pf-31 Fix E: every task type that produces repair-CANDIDATE emissions, derived
+# from the dispatch tables above (never re-typed — #559). Candidates land in the
+# artifact store for the correction loop's accumulation (RC3), but an ACCEPTED
+# patch is re-stored under the repaired task's own type by the #389 accept path —
+# so candidate-typed artifacts are, by construction, in-flight or rejected, and
+# workspace views for fresh dispatches exclude them by this provenance.
+REPAIR_TASK_TYPES: frozenset[str] = frozenset(
+    task_type for steps in _REPAIR_STEPS_BY_FAILED_TASK_TYPE.values() for task_type, _ in steps
+) | frozenset(task_type for task_type, _ in REPAIR_TASK_STEPS)
+
 
 def repair_steps_for(failed_task_type: str) -> list[tuple[str, str]]:
     """Return the repair (task_type, role) sequence for a failed task.

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -14,6 +14,7 @@ Part of SIP-0066 Phase 4 + build capabilities extension + SIP-0071 + SIP-0078.
 
 from __future__ import annotations
 
+import logging
 from collections import Counter
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
@@ -40,6 +41,8 @@ from squadops.cycles.models import (
 )
 from squadops.cycles.proposed_role_tasks import role_to_id
 from squadops.tasks.models import TaskEnvelope
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from squadops.cycles.verification_contract import VerificationContract
@@ -692,6 +695,10 @@ def _replace_build_steps_with_plan(
         ref_errors = plan.validate_criteria_refs(contract)
         if ref_errors:
             raise CycleError("Plan validation failed (contract binding): " + "; ".join(ref_errors))
+        # pf-31 Fix A3: warning-only prose-vs-contract conflict lint, surfaced for
+        # the gate reviewer (never a rejection — reverted-#552 lesson).
+        for warning in plan.lint_prose_contract_conflicts(contract):
+            logger.warning("Plan prose/contract conflict: %s", warning)
 
     # Remove static build steps, keep everything else (planning steps)
     static_build_types = {s[0] for s in BUILD_TASK_STEPS} | {

--- a/src/squadops/events/types.py
+++ b/src/squadops/events/types.py
@@ -47,6 +47,9 @@ class EventType:
     # SIP-0100 3.3: a producer's emission was evaluated against scaffold write-ownership
     # (frozen restored / unauthorized dropped / integrity fault). Payload = ScaffoldIntegrityEvidence.
     ARTIFACT_OWNERSHIP_ENFORCED = "artifact.ownership_enforced"
+    # pf-31 Fix D: a repair-path Python emission failed ast.parse and was discarded
+    # (truncation guard) — the prior stored version stays current.
+    ARTIFACT_EMISSION_REJECTED = "artifact.emission_rejected"
 
     # --- Checkpoint (2) — SIP-0079 ---
     CHECKPOINT_CREATED = "checkpoint.created"

--- a/src/squadops/prompts/request_templates/request.cycle_repair_contract_expectations_appendix.md
+++ b/src/squadops/prompts/request_templates/request.cycle_repair_contract_expectations_appendix.md
@@ -1,0 +1,15 @@
+---
+template_id: request.cycle_repair_contract_expectations_appendix
+version: "1"
+required_variables:
+  - expectations
+---
+### Contract Expectations (authoritative — apply exactly)
+
+The following requirements are the machine-verified contract for this task. They are
+extracted from the verification checks that will judge your output. Where any other
+text in this request (the task description, narrative criteria, or prior discussion)
+disagrees with a line below — including method names, path spellings, and
+path-parameter names — the line below wins. Copy these literally.
+
+{{expectations}}

--- a/src/squadops/prompts/request_templates/request.cycle_repair_task.md
+++ b/src/squadops/prompts/request_templates/request.cycle_repair_task.md
@@ -14,11 +14,13 @@ optional_variables:
   - acceptance_criteria
   - prior_outputs
   - fill_only_section
+  - contract_expectations
 ---
 ## Repair Task
 
 You are repairing a failed `{{failed_task_type}}` task. Your job is to re-produce the named output artifact(s) below so they satisfy the acceptance criteria. Do not rewrite the PRD, do not produce a status tracker, do not emit a generic narrative document.
 {{fill_only_section}}
+{{contract_expectations}}
 
 ### Failed Task Contract
 
@@ -32,9 +34,9 @@ The repair MUST produce the following file(s) by name, using fenced code blocks 
 
 {{expected_artifacts}}
 
-### Acceptance Criteria
+### Acceptance Criteria (narrative)
 
-The output must satisfy every criterion below. Each criterion was the original spec — if the prior attempt failed because a section was missing or empty, your repair must include it explicitly.
+The narrative criteria below describe intent. They are context, not letter-of-the-law: where a Contract Expectations line above covers the same ground, the Contract Expectations line is authoritative and the narrative may be imprecise.
 
 {{acceptance_criteria}}
 

--- a/tests/unit/capabilities/test_repair_contract_expectations.py
+++ b/tests/unit/capabilities/test_repair_contract_expectations.py
@@ -1,0 +1,107 @@
+"""pf-31 Fix A — the authoritative Contract Expectations block on the repair path.
+
+Guards the salience fix: typed criteria must render as an exact authoritative
+block ABOVE prose, never as dict-repr soup inside the narrative bullets (how all
+7 pf-31 repairs came to follow the prose's ``{run_id}`` over the contract's
+``{id}`` and get rejected at patch verification).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities.handlers.impl.repair_handlers import (
+    DevelopmentCorrectionRepairHandler,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_TEMPLATE = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "squadops"
+    / "prompts"
+    / "request_templates"
+    / "request.cycle_repair_task.md"
+)
+_APPENDIX = _TEMPLATE.parent / "request.cycle_repair_contract_expectations_appendix.md"
+
+_TYPED = {
+    "check": "endpoint_defined",
+    "params": {
+        "file": "backend/routes.py",
+        "methods_paths": ["POST /runs", "GET /runs/{id}", "POST /runs/{id}/join"],
+    },
+    "id": "vc-routes-endpoints",
+}
+_PROSE = "GET /runs/{run_id} returns run detail"
+
+
+def _context(renderer):
+    context = MagicMock()
+    context.ports.request_renderer = renderer
+    return context
+
+
+async def test_appendix_rendered_with_exact_paths():
+    handler = DevelopmentCorrectionRepairHandler()
+    renderer = AsyncMock()
+    renderer.render.return_value = MagicMock(content="EXPECTATIONS BLOCK")
+    inputs = {"acceptance_criteria": [_PROSE, _TYPED]}
+
+    out = await handler._render_contract_expectations_section(_context(renderer), inputs)
+
+    assert out == "EXPECTATIONS BLOCK"
+    (template_id, variables) = renderer.render.await_args.args
+    assert template_id == "request.cycle_repair_contract_expectations_appendix"
+    # The literal contract spelling — the token pf-31 lost 7 repairs over.
+    assert "`GET /runs/{id}`" in variables["expectations"]
+    assert "{run_id}" not in variables["expectations"]
+
+
+async def test_no_typed_criteria_renders_nothing():
+    handler = DevelopmentCorrectionRepairHandler()
+    renderer = AsyncMock()
+    out = await handler._render_contract_expectations_section(
+        _context(renderer), {"acceptance_criteria": [_PROSE]}
+    )
+    assert out == ""
+    renderer.render.assert_not_awaited()
+
+
+def test_render_variables_demote_typed_criteria_out_of_narrative():
+    """Typed entries must not reach the narrative bullets as dict reprs."""
+    handler = DevelopmentCorrectionRepairHandler()
+    variables = handler._build_render_variables(
+        "PRD", None, {"acceptance_criteria": [_PROSE, _TYPED]}
+    )
+    assert "methods_paths" not in variables["acceptance_criteria"]
+    assert _PROSE in variables["acceptance_criteria"]
+
+
+def test_fallback_prompt_places_expectations_above_narrative():
+    """No-renderer path: the block still appears, above the demoted prose."""
+    handler = DevelopmentCorrectionRepairHandler()
+    prompt = handler._build_user_prompt(
+        "PRD",
+        None,
+        {"acceptance_criteria": [_PROSE, _TYPED], "failed_task_type": "development.develop"},
+    )
+    block = prompt.index("Contract Expectations (authoritative")
+    narrative = prompt.index("Acceptance Criteria (narrative)")
+    assert block < narrative
+    assert "`GET /runs/{id}`" in prompt
+
+
+def test_templates_declare_and_use_the_variable():
+    """The asset side of the seam: the repair template renders the block and the
+    appendix asset owns the heading text (prompts-in-assets rule, #448)."""
+    template = _TEMPLATE.read_text()
+    assert "contract_expectations" in template
+    assert "{{contract_expectations}}" in template
+    appendix = _APPENDIX.read_text()
+    assert "authoritative" in appendix
+    assert "{{expectations}}" in appendix

--- a/tests/unit/cycles/test_contract_expectations.py
+++ b/tests/unit/cycles/test_contract_expectations.py
@@ -1,0 +1,227 @@
+"""pf-31 Fix A — authoritative contract-expectation rendering + prose-conflict lint.
+
+The bug these guard against: the resolved TypedChecks reached every pf-31 repair
+as low-salience dict reprs below contradicting prose, so all 7 repairs emitted the
+prose's ``{run_id}`` where the contract pins ``{id}`` and were rejected over that
+one token (docs/plans/pf31-correction-convergence-fixes.md, Fix A).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.contract_expectations import (
+    expectation_lines,
+    is_typed_criterion,
+    prose_criteria,
+)
+from squadops.cycles.implementation_plan import (
+    ImplementationPlan,
+    PlanSummary,
+    PlanTask,
+    TypedCheck,
+)
+from squadops.cycles.verification_contract import VerificationContract
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+class TestExpectationLines:
+    def test_endpoint_defined_renders_exact_paths_with_param_names(self):
+        """The line must carry the literal path-parameter spelling — the exact
+        token every pf-31 repair got wrong."""
+        entry = TypedCheck(
+            check="endpoint_defined",
+            params={
+                "file": "backend/routes.py",
+                "methods_paths": ["POST /runs", "GET /runs/{id}", "POST /runs/{id}/join"],
+            },
+            id="vc-routes-endpoints",
+        )
+        (line,) = expectation_lines([entry])
+        assert "`GET /runs/{id}`" in line
+        assert "`POST /runs/{id}/join`" in line
+        assert "path-parameter names" in line
+
+    def test_endpoint_defined_accepts_pair_shape(self):
+        entry = {
+            "check": "endpoint_defined",
+            "file": "b/m.py",
+            "methods_paths": [["POST", "/users"]],
+        }
+        (line,) = expectation_lines([entry])
+        assert "`POST /users`" in line
+
+    def test_import_present_with_symbol_renders_direct_import_form(self):
+        """pf-31 corr-00 class: `from . import errors` failed where the check
+        demands the direct symbol import."""
+        entry = {
+            "check": "import_present",
+            "params": {"file": "backend/routes.py", "module": ".errors", "symbol": "ApiError"},
+            "id": "vc-routes-apierror",
+        }
+        (line,) = expectation_lines([entry])
+        assert "`from .errors import ApiError`" in line
+
+    def test_import_present_module_only(self):
+        (line,) = expectation_lines(
+            [{"check": "import_present", "file": "m.py", "module": "fastapi"}]
+        )
+        assert "import module `fastapi`" in line
+
+    @pytest.mark.parametrize(
+        "entry,fragment",
+        [
+            (
+                {
+                    "check": "field_present",
+                    "file": "m.py",
+                    "class_name": "RunEvent",
+                    "fields": ["id", "title"],
+                },
+                "class `RunEvent`",
+            ),
+            (
+                {
+                    "check": "function_defined",
+                    "file": "t.py",
+                    "name_prefix": "test_",
+                    "min_count": 8,
+                },
+                "at least 8 functions named `test_*`",
+            ),
+            (
+                {"check": "command_exit_zero", "argv": ["python", "-m", "py_compile", "x.py"]},
+                "`python -m py_compile x.py` must exit 0",
+            ),
+            (
+                {
+                    "check": "harness_boundary",
+                    "file": "t.py",
+                    "entry_modules": ["backend.main", "app.main"],
+                    "client_ctor": "TestClient",
+                },
+                "`TestClient` against one of: `backend.main`, `app.main`",
+            ),
+        ],
+    )
+    def test_known_check_types_render(self, entry, fragment):
+        (line,) = expectation_lines([entry])
+        assert fragment in line
+
+    def test_unknown_check_type_still_surfaces(self):
+        """A new check vocabulary entry must not be silently dropped from the
+        authoritative block — that would recreate the invisibility bug."""
+        (line,) = expectation_lines([{"check": "future_check", "file": "x.py", "threshold": 3}])
+        assert "future_check" in line and "threshold=3" in line
+
+    def test_prose_and_typed_split(self):
+        criteria = [
+            "POST /runs validates required fields",
+            {"check": "import_present", "file": "m.py", "module": "fastapi"},
+        ]
+        assert prose_criteria(criteria) == ["POST /runs validates required fields"]
+        assert len(expectation_lines(criteria)) == 1
+        assert not is_typed_criterion(criteria[0])
+        assert is_typed_criterion(criteria[1])
+
+    def test_empty_and_none_inputs(self):
+        assert expectation_lines(None) == []
+        assert expectation_lines([]) == []
+        assert prose_criteria(None) == []
+
+
+def _contract() -> VerificationContract:
+    return VerificationContract.from_dict(
+        {
+            "contract_version": 1,
+            "skeleton": {
+                "expander": "fullstack_fastapi_react",
+                "interface_manifest_hash": "a" * 64,
+            },
+            "capabilities": ["python"],
+            "frozen": [{"path": "backend/errors.py", "sha256": "b" * 64}],
+            "fill_files": {
+                "backend/routes.py": {
+                    "interface": [
+                        {
+                            "check": "endpoint_defined",
+                            "id": "vc-routes-endpoints",
+                            "methods_paths": [
+                                "POST /runs",
+                                "GET /runs/{id}",
+                                "POST /runs/{id}/join",
+                                "POST /runs/{id}/leave",
+                            ],
+                        },
+                    ],
+                    "implementation": [],
+                },
+            },
+        }
+    )
+
+
+def _plan(description: str, prose: list[str]) -> ImplementationPlan:
+    task = PlanTask(
+        task_index=0,
+        task_type="development.develop",
+        role="dev",
+        focus="backend API routes",
+        description=description,
+        expected_artifacts=["backend/routes.py"],
+        acceptance_criteria=list(prose),
+        criteria_refs=["vc-routes-endpoints"],
+    )
+    return ImplementationPlan(
+        version=1,
+        project_id="p",
+        cycle_id="c",
+        prd_hash="h",
+        tasks=[task],
+        summary=PlanSummary(total_dev_tasks=1, total_qa_tasks=0, total_tasks=1),
+    )
+
+
+class TestProseContractConflictLint:
+    def test_pf31_param_name_conflict_warns(self):
+        plan = _plan(
+            "Implement GET /runs/{run_id} (detail) and POST /runs/{run_id}/join.",
+            ["GET /runs/{run_id} returns run detail"],
+        )
+        warnings = plan.lint_prose_contract_conflicts(_contract())
+        assert any("{run_id}" in w and "pf-31" in w for w in warnings)
+
+    def test_pf30_method_conflict_warns(self):
+        plan = _plan(
+            "Implement DELETE /runs/{id}/leave to remove a participant.",
+            [],
+        )
+        warnings = plan.lint_prose_contract_conflicts(_contract())
+        assert any("DELETE" in w and "different method" in w for w in warnings)
+
+    def test_consistent_prose_is_silent(self):
+        plan = _plan(
+            "Implement POST /runs, GET /runs/{id}, POST /runs/{id}/join, POST /runs/{id}/leave.",
+            ["GET /runs/{id} returns run detail; POST /runs/{id}/join adds a participant"],
+        )
+        assert plan.lint_prose_contract_conflicts(_contract()) == []
+
+    def test_no_refs_no_warnings(self):
+        task = PlanTask(
+            task_index=0,
+            task_type="development.develop",
+            role="dev",
+            focus="x",
+            description="GET /whatever/{weird_param}",
+            expected_artifacts=["a.py"],
+        )
+        plan = ImplementationPlan(
+            version=1,
+            project_id="p",
+            cycle_id="c",
+            prd_hash="h",
+            tasks=[task],
+            summary=PlanSummary(total_dev_tasks=1, total_qa_tasks=0, total_tasks=1),
+        )
+        assert plan.lint_prose_contract_conflicts(_contract()) == []

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -1913,6 +1913,66 @@ class TestCorrectionRunnerStandalone:
         evidence = captured[0].inputs["failure_evidence"]
         assert evidence["scaffold_enforcement"] == carry
 
+    async def test_failure_evidence_carries_contract_expectations(self, cycle):
+        """pf-31 Fix A: the failed task's typed criteria reach the analyzer as
+        exact expectation lines — without this the analyzer/decision reason from
+        prose while the contract's letter ({id} vs {run_id}) stays invisible."""
+        import dataclasses as _dc
+
+        captured: list = []
+
+        def responder(envelope):
+            if envelope.task_type == "data.analyze_failure":
+                captured.append(envelope)
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "continue",
+                        "decision_rationale": "x",
+                        "affected_task_types": [],
+                    },
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, _vault, _bus = self._make_runner(responder)
+        failed = _dc.replace(
+            self._failed_envelope(),
+            task_type="development.develop",
+            inputs={
+                "acceptance_criteria": [
+                    "GET /runs/{run_id} returns run detail",
+                    {
+                        "check": "endpoint_defined",
+                        "params": {
+                            "file": "backend/routes.py",
+                            "methods_paths": ["GET /runs/{id}"],
+                        },
+                        "id": "vc-routes-endpoints",
+                    },
+                ],
+            },
+        )
+
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=failed,
+            result=TaskResult(task_id="task_failed", status="FAILED", error="typed check failed"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+        assert len(captured) == 1
+        lines = captured[0].inputs["failure_evidence"]["contract_expectations"]
+        assert len(lines) == 1
+        assert "`GET /runs/{id}`" in lines[0]
+
     async def test_non_patch_path_returns_no_repair_artifacts(self, cycle):
         """#389: a 'continue' decision dispatches no repair steps — surfacing
         stale/empty artifacts here would make the executor 'verify' nothing

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -1973,6 +1973,79 @@ class TestCorrectionRunnerStandalone:
         assert len(lines) == 1
         assert "`GET /runs/{id}`" in lines[0]
 
+    async def test_repair_truncated_python_emission_dropped_and_signaled(self, cycle):
+        """pf-31 Fix D: a syntactically invalid .py repair emission is DROPPED
+        before any landing point — the overlay and registry never see it (the
+        prior stored version stays current) — and the next attempt is told via
+        the carry. pf-31 repair-03's truncated test file re-imported the
+        collection crash it was dispatched to fix."""
+        import dataclasses as _dc
+
+        truncated = "def test_join(client):\n    resp = client.post(\n"
+
+        def responder(envelope):
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "patch",
+                        "decision_rationale": "patchable",
+                        "affected_task_types": ["development.develop"],
+                    },
+                )
+            if envelope.task_type == "development.correction_repair":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "artifacts": [
+                            {"name": "backend/tests/test_runs.py", "content": truncated},
+                            {"name": "backend/routes.py", "content": "ROUTES = []\n"},
+                        ],
+                        "summary": "repaired",
+                    },
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, vault, bus = self._make_runner(responder)
+        carry: list[str] = []
+        failed = _dc.replace(self._failed_envelope(), task_type="development.develop")
+
+        protocol_result = await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=failed,
+            result=TaskResult(task_id="task_failed", status="FAILED", error="tests failed"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+            scaffold_enforcement_carry=carry,
+        )
+
+        # Overlay: only the valid file survives.
+        names = [a["name"] for a in protocol_result.repair_artifacts]
+        assert names == ["backend/routes.py"]
+        # Registry: the truncated file was never stored.
+        stored_names = [c.args[0].filename for c in vault.store.call_args_list]
+        assert "backend/tests/test_runs.py" not in stored_names
+        assert "backend/routes.py" in stored_names
+        # Signal: carried instruction names the file and demands completeness.
+        assert len(carry) == 1
+        assert "backend/tests/test_runs.py" in carry[0] and "DISCARDED" in carry[0]
+        # Evidence: surfaced as an event, not silent.
+        from squadops.events.types import EventType as _ET
+
+        rejected_events = [
+            c
+            for c in bus.emit.call_args_list
+            if c.args and c.args[0] == _ET.ARTIFACT_EMISSION_REJECTED
+        ]
+        assert len(rejected_events) == 1
+
     async def test_non_patch_path_returns_no_repair_artifacts(self, cycle):
         """#389: a 'continue' decision dispatches no repair steps — surfacing
         stale/empty artifacts here would make the executor 'verify' nothing

--- a/tests/unit/cycles/test_emission_integrity.py
+++ b/tests/unit/cycles/test_emission_integrity.py
@@ -1,0 +1,70 @@
+"""pf-31 Fix D — syntax gate for repair-path Python emissions.
+
+Guards against the pf-31 repair-03 class: a truncated test-file emission
+(SyntaxError mid-function) superseding the last good version and re-importing
+the pytest collection-crash the repair was dispatched to fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.emission_integrity import (
+    emission_integrity_instruction,
+    syntax_gate_python_artifacts,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_TRUNCATED = "def test_join_run(client):\n    resp = client.post(\n"
+_VALID = "def test_join_run(client):\n    assert client is not None\n"
+
+
+def test_truncated_python_artifact_rejected_with_line_info():
+    kept, rejected = syntax_gate_python_artifacts(
+        [{"name": "backend/tests/test_runs.py", "content": _TRUNCATED}]
+    )
+    assert kept == []
+    ((art, error),) = rejected
+    assert art["name"] == "backend/tests/test_runs.py"
+    assert "SyntaxError at line" in error
+
+
+def test_valid_python_and_non_python_pass_through():
+    artifacts = [
+        {"name": "backend/tests/test_runs.py", "content": _VALID},
+        {"name": "frontend/src/App.jsx", "content": "const x = {"},  # not python — not parsed
+        {"name": "notes.md", "content": "# hi"},
+        "not-a-dict-entry",
+    ]
+    kept, rejected = syntax_gate_python_artifacts(artifacts)
+    assert kept == artifacts
+    assert rejected == []
+
+
+def test_mixed_emission_drops_only_the_broken_file():
+    """The pf-31 shape: one broken test file riding with a good source file —
+    only the broken one is dropped, the good one lands."""
+    good = {"name": "backend/routes.py", "content": "ROUTES = []\n"}
+    bad = {"name": "backend/tests/test_runs.py", "content": _TRUNCATED}
+    kept, rejected = syntax_gate_python_artifacts([good, bad])
+    assert kept == [good]
+    assert rejected[0][0] is bad
+
+
+def test_py_artifact_without_content_passes_through():
+    art = {"name": "x.py"}
+    kept, rejected = syntax_gate_python_artifacts([art])
+    assert kept == [art] and rejected == []
+
+
+def test_path_key_shape_also_gated():
+    kept, rejected = syntax_gate_python_artifacts([{"path": "a.py", "content": _TRUNCATED}])
+    assert kept == [] and len(rejected) == 1
+
+
+def test_instruction_names_file_error_and_completeness_demand():
+    line = emission_integrity_instruction("backend/tests/test_runs.py", "SyntaxError at line 2: x")
+    assert "backend/tests/test_runs.py" in line
+    assert "DISCARDED" in line
+    assert "COMPLETE" in line

--- a/tests/unit/cycles/test_executor_build_wiring.py
+++ b/tests/unit/cycles/test_executor_build_wiring.py
@@ -834,3 +834,81 @@ class TestSeededScaffoldReachesVerification:
         executor._artifact_vault.retrieve = AsyncMock()
         contents = await executor._resolve_artifact_contents("qa.test", [("art_001", ref_framing)])
         assert contents == {}
+
+
+class TestRepairCandidateExclusion:
+    """pf-31 Fix E: fresh dispatches see the ACCEPTED state only.
+
+    A rejected repair candidate's emission (stored for RC3 accumulation)
+    must not supersede the accepted version in a later task's workspace —
+    the pf-31 endpoint_defined final-verification regression: repair-04's
+    rejected {run_id} routes.py was the last-stored version, so the final
+    qa attempt evaluated (and failed) the discarded candidate."""
+
+    async def test_fresh_dispatch_excludes_rejected_candidate(self, executor):
+        accepted = _make_artifact_ref(
+            "art_ok",
+            "backend/routes.py",
+            "source",
+            producing_task_type="development.develop",
+        )
+        candidate = _make_artifact_ref(
+            "art_candidate",
+            "backend/routes.py",
+            "source",
+            producing_task_type="development.correction_repair",
+        )
+        stored = [("art_ok", accepted), ("art_candidate", candidate)]
+        executor._artifact_vault.retrieve = AsyncMock(
+            side_effect=[(accepted, b"ACCEPTED = True\n")]
+        )
+
+        contents = await executor._resolve_artifact_contents(
+            "qa.test", stored, include_repair_candidates=False
+        )
+
+        # Last-wins would have given the candidate; the accepted version survives.
+        assert contents["backend/routes.py"] == "ACCEPTED = True\n"
+
+    async def test_correction_path_keeps_candidates_by_default(self, executor):
+        """RC3: the correction loop's own re-resolution must keep candidate
+        accumulation — analyze needs each attempt's content."""
+        accepted = _make_artifact_ref(
+            "art_ok",
+            "backend/routes.py",
+            "source",
+            producing_task_type="development.develop",
+        )
+        candidate = _make_artifact_ref(
+            "art_candidate",
+            "backend/routes.py",
+            "source",
+            producing_task_type="development.correction_repair",
+        )
+        stored = [("art_ok", accepted), ("art_candidate", candidate)]
+        executor._artifact_vault.retrieve = AsyncMock(
+            side_effect=[(accepted, b"ACCEPTED = True\n"), (candidate, b"CANDIDATE = True\n")]
+        )
+
+        contents = await executor._resolve_artifact_contents("qa.test", stored)
+
+        assert contents["backend/routes.py"] == "CANDIDATE = True\n"
+
+
+class TestRepairTaskTypesDerivation:
+    def test_repair_task_types_derived_from_dispatch_tables(self):
+        """The provenance filter and the dispatch tables must never drift: a
+        new repair step type added to the tables is automatically a candidate
+        type (#559 — no re-typed literals)."""
+        from squadops.cycles.task_plan import (
+            _REPAIR_STEPS_BY_FAILED_TASK_TYPE,
+            REPAIR_TASK_TYPES,
+        )
+
+        table_types = {
+            task_type
+            for steps in _REPAIR_STEPS_BY_FAILED_TASK_TYPE.values()
+            for task_type, _ in steps
+        }
+        assert table_types <= REPAIR_TASK_TYPES
+        assert "development.develop" not in REPAIR_TASK_TYPES

--- a/tests/unit/events/test_event_emission.py
+++ b/tests/unit/events/test_event_emission.py
@@ -98,8 +98,8 @@ class TestEmissionCoverage:
             f"in any emission source file"
         )
 
-    def test_all_29_types_defined(self, all_emitted_types: set[str]) -> None:
-        assert len(_ALL_EVENT_TYPE_ATTRS) == 29
+    def test_all_30_types_defined(self, all_emitted_types: set[str]) -> None:
+        assert len(_ALL_EVENT_TYPE_ATTRS) == 30
 
     def test_wired_types_covered(self, all_emitted_types: set[str]) -> None:
         wired = set(_ALL_EVENT_TYPE_ATTRS) - _SIP_0083_PENDING_EMISSION
@@ -195,6 +195,8 @@ class TestCorrectionRunnerEmissionPoints:
             # SIP-0100 3.4b: frozen-ownership enforcement on the repair path
             # surfaces each restore as an event (mirrors the executor's emitter).
             "ARTIFACT_OWNERSHIP_ENFORCED",
+            # pf-31 Fix D: discarded invalid .py emissions are evidenced too.
+            "ARTIFACT_EMISSION_REJECTED",
         ],
     )
     def test_correction_runner_emits(self, attr: str, correction_runner_refs: set[str]) -> None:
@@ -333,13 +335,14 @@ class TestEmitCallSitePayloadFields:
         assert with_payload >= 35
 
     def test_total_emit_call_count(self) -> None:
-        """Sanity check: 20 executor + 8 correction-runner +
-        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 45 total
+        """Sanity check: 20 executor + 9 correction-runner +
+        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 46 total
         emit calls (#473 added the pre-gate rejection's GATE_DECIDED emit;
         #522 added the framing re-roll's WORKLOAD_ADVANCED emit; SIP-0100 3.3
         added the scaffold-integrity ARTIFACT_OWNERSHIP_ENFORCED emit;
         SIP-0100 3.4b added the correction runner's repair-path
-        ARTIFACT_OWNERSHIP_ENFORCED emit, 44 → 45).
+        ARTIFACT_OWNERSHIP_ENFORCED emit, 44 → 45; pf-31 Fix D added its
+        ARTIFACT_EMISSION_REJECTED emit, 45 → 46).
 
         SIP-0097 slice 2c collapsed execute_run's five per-exception-class
         terminal emits into one emit driven by the RunCompletion terminal
@@ -352,4 +355,4 @@ class TestEmitCallSitePayloadFields:
         total = 0
         for path in _ALL_EMISSION_FILES:
             total += len(self._extract_emit_calls(path))
-        assert total == 45
+        assert total == 46

--- a/tests/unit/events/test_event_type_extensions.py
+++ b/tests/unit/events/test_event_type_extensions.py
@@ -8,8 +8,8 @@ pytestmark = [pytest.mark.domain_events]
 
 
 class TestSIP0079EventTypes:
-    def test_all_returns_29_items(self):
-        assert len(EventType.all()) == 29
+    def test_all_returns_30_items(self):
+        assert len(EventType.all()) == 30
 
     def test_no_duplicate_values(self):
         all_values = EventType.all()

--- a/tests/unit/events/test_types.py
+++ b/tests/unit/events/test_types.py
@@ -7,9 +7,9 @@ from squadops.events.types import EventType
 
 @pytest.mark.domain_events
 class TestEventType:
-    def test_all_returns_29_events(self):
+    def test_all_returns_30_events(self):
         all_types = EventType.all()
-        assert len(all_types) == 29
+        assert len(all_types) == 30
 
     def test_entity_transition_format(self):
         for event_type in EventType.all():
@@ -44,7 +44,7 @@ class TestEventType:
             "gate": 1,
             "task": 3,
             "pulse": 5,
-            "artifact": 3,
+            "artifact": 4,
             "checkpoint": 2,
             "correction": 3,
             "workload": 3,


### PR DESCRIPTION
## Summary

Implements all three fixes from the approved pf-31 plan (#563 / `docs/plans/pf31-correction-convergence-fixes.md`), in the planned sequence, one commit per fix (plus one C901 extraction). Branch name says fix-a; it carries A, D, and E.

## Fix A — authoritative Contract Expectations (commit `5b553ea9`)

- New `squadops/cycles/contract_expectations.py`: pure formatters — typed criteria (TypedCheck objects, resolved dicts, flat authored dicts) → one exact line per check; prose/typed splitter.
- **A1**: the repair prompt leads with a Contract Expectations appendix (managed template asset, #448 rule), rendered in the mixin exactly like the fill-only appendix; fallback prompt covered; `correction_runner` injects the same lines into `failure_evidence["contract_expectations"]` for the analyzer/decision.
- **A2**: typed entries no longer render into the narrative bullets (the repr soup all 7 pf-31 repairs ignored); the template's criteria section is explicitly demoted to narrative.
- **A3**: warning-only prose-vs-contract lint (`ImplementationPlan.lint_prose_contract_conflicts`) catching both observed poisonings ({run_id} params, DELETE-vs-POST methods), surfaced via log at the dispatch validation seam — never a rejection.

## Fix D — repair-emission syntax gate (commits `010f36de`, `1e9bf771`)

- New `squadops/cycles/emission_integrity.py`: pure `ast.parse` gate + carry instruction.
- Invalid `.py` repair emissions are dropped before any landing point (prior stored version stays current), evidenced as new `ARTIFACT_EMISSION_REJECTED` events, and carried to the next attempt via the 3.4b transport. Bound and unbound runs alike.
- The 3.4b restore + D gate now live in one `_enforce_step_emissions` helper (C901).

## Fix E — rejected candidates out of fresh workspaces (commit `6d99c938`)

**Investigation refined the plan's E1/E2 split**: nothing records candidate verification evidence directly — the poison route is workspace assembly. The final failed qa attempt's workspace took repair-04's rejected `{run_id}` routes.py via last-wins; its evidence rows then sent `endpoint_defined` adverse at aggregation (verified against the stored `run_verification_summaries` row: `reason: endpoints_missing`). Fixing the workspace input heals the ledger — no aggregation change needed.

Key structural fact making this bookkeeping-free: the #389 accept path swaps the patched result before collection, so **accepted** patch artifacts re-store under the repaired task's own producing type. Repair-typed artifacts are therefore in-flight or rejected by construction.

- `task_plan.REPAIR_TASK_TYPES` derived from the repair dispatch tables (#559 — table-derived, drift-proofed by test).
- `_resolve_artifact_contents(include_repair_candidates=)`: enrichment (fresh dispatches) excludes candidates; the correction loop's re-resolution keeps them (RC3 accumulation untouched); retest path untouched.

## Verification

- Full regression suite after each fix; final: **5380 passed**. Events meta-suites updated for the new event type (30 types, 46 audited emit sites).
- New tests: 15 formatter/lint, 5 handler-side A, runner-side A evidence injection, 7 emission-integrity unit, runner-side D drop/carry/event, 2 workspace-exclusion E, 1 table-derivation drift-proof.
- Replay obligations at deploy (per plan): A prompt replay from pf-31 artifacts (one-shot emission uses `{id}`), D against repair-03's real truncated artifact, in-container gate-condition checks for the appendix render and the emission gate.

Deploy note: lands as one window; rebuild resets the N=5 baseline → pf-32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXrSUPGsx5yxbsn19aDjXX
