### PR TITLE
feat(manifest): rename group_run path param {id} -> {run_id}

### DIFF
--- a/examples/03_group_run/interface_manifest.yaml
+++ b/examples/03_group_run/interface_manifest.yaml
@@ -55,12 +55,12 @@ api:
     - { method: POST, path: /runs,              summary: create run,
         request: RunEventCreate, response: RunEvent,
         errors: [validation_error] }                                 # §5.1
-    - { method: GET,  path: "/runs/{id}",       summary: run details,
+    - { method: GET,  path: "/runs/{run_id}",       summary: run details,
         response: RunEvent, errors: [run_not_found] }                # §5.3
-    - { method: POST, path: "/runs/{id}/join",  summary: join run by participant name,
+    - { method: POST, path: "/runs/{run_id}/join",  summary: join run by participant name,
         request: ParticipantName, response: RunEvent,
         errors: [run_not_found, duplicate_participant, validation_error] }   # §5.4
-    - { method: POST, path: "/runs/{id}/leave", summary: leave run by participant name,
+    - { method: POST, path: "/runs/{run_id}/leave", summary: leave run by participant name,
         request: ParticipantName, response: RunEvent,
         errors: [run_not_found, participant_not_found, validation_error] }   # §5.5
   error_contract:  # §6 "clear error payloads"; shape pinned so both sides agree

--- a/src/squadops/prompts/fragments/manifest.yaml
+++ b/src/squadops/prompts/fragments/manifest.yaml
@@ -126,7 +126,7 @@ fragments:
   layer: task_type
   roles:
   - lead
-  sha256: b1ca45853d1622504a029ae787be8beec7a51334e785c052b05d340c4956f6a3
+  sha256: f3ebec88fc45159c24cb365e6f85897a54560fa43455f90a6e6ee795f8063d21
 - fragment_id: task_type.governance.incorporate_feedback
   path: shared/task_type/task_type.governance.incorporate_feedback.md
   layer: task_type
@@ -187,4 +187,4 @@ fragments:
   roles:
   - data
   sha256: fd44a28f65e449c6320b5ee5f1d8121013a03c7baa757965334c4e19c7904779
-manifest_hash: 5c80d8aa5e3c32ea3b93e0b5f56b54558c562b6a4a4450c9b1df44314f9d04e9
+manifest_hash: c193162099ae85f7b52fcaf68a7cdb302f955747502a7307076e4d3a8011d6c2

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.governance.prepare_plan_authoring_brief.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.governance.prepare_plan_authoring_brief.md
@@ -38,7 +38,7 @@ fail to parse and force the cycle to fall back to sole-author mode.
   for this cycle. Anything outside this map is out of bounds for proposers.
   Be explicit: `{frontend: "React+Vite", backend: "FastAPI+SQLite", ...}`.
 - `must_cover_requirements` — list of requirements every proposal must
-  honor. These are the non-negotiables (e.g., "POST /runs/{id}/join must
+  honor. These are the non-negotiables (e.g., "POST /runs/{run_id}/join must
   return 409 on duplicate"). Phrase each so it can be referenced by
   proposal `acceptance_criteria`.
 - `scope_cuts` — list of features explicitly deferred. Use this to

--- a/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/backend/routes.py
+++ b/tests/fixtures/reference_fills/fullstack_fastapi_react/group_run/backend/routes.py
@@ -41,16 +41,16 @@ def post_runs(payload: RunEventCreate):
     return run
 
 
-@router.get("/runs/{id}", response_model=RunEvent)
-def get_runs_id(id: str):
+@router.get("/runs/{run_id}", response_model=RunEvent)
+def get_runs_run_id(run_id: str):
     """run details."""
-    return _get_run(id)
+    return _get_run(run_id)
 
 
-@router.post("/runs/{id}/join", response_model=RunEvent)
-def post_runs_id_join(id: str, payload: ParticipantName):
+@router.post("/runs/{run_id}/join", response_model=RunEvent)
+def post_runs_run_id_join(run_id: str, payload: ParticipantName):
     """join run by participant name."""
-    run = _get_run(id)
+    run = _get_run(run_id)
     # Case-insensitive uniqueness; the stored name is NOT normalized (manifest decisions).
     if any(p.name.casefold() == payload.name.casefold() for p in run.participants):
         raise ApiError("duplicate_participant", f"{payload.name!r} has already joined")
@@ -58,10 +58,10 @@ def post_runs_id_join(id: str, payload: ParticipantName):
     return run
 
 
-@router.post("/runs/{id}/leave", response_model=RunEvent)
-def post_runs_id_leave(id: str, payload: ParticipantName):
+@router.post("/runs/{run_id}/leave", response_model=RunEvent)
+def post_runs_run_id_leave(run_id: str, payload: ParticipantName):
     """leave run by participant name."""
-    run = _get_run(id)
+    run = _get_run(run_id)
     match = next(
         (p for p in run.participants if p.name.casefold() == payload.name.casefold()), None
     )

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -69,9 +69,9 @@ def test_parses_group_run_manifest_structure():
     assert {(e.method, e.path) for e in m.api.endpoints} == {
         ("GET", "/runs"),
         ("POST", "/runs"),
-        ("GET", "/runs/{id}"),
-        ("POST", "/runs/{id}/join"),
-        ("POST", "/runs/{id}/leave"),
+        ("GET", "/runs/{run_id}"),
+        ("POST", "/runs/{run_id}/join"),
+        ("POST", "/runs/{run_id}/leave"),
     }
     assert [r.view for r in m.frontend.routes] == [
         "RunsListView",
@@ -103,7 +103,7 @@ def test_expand_defines_every_declared_endpoint_and_model():
     routes = files["backend/routes.py"]
     assert '@router.get("/runs", response_model=list[RunEvent])' in routes
     assert '@router.post("/runs", response_model=RunEvent)' in routes
-    assert '@router.post("/runs/{id}/join", response_model=RunEvent)' in routes
+    assert '@router.post("/runs/{run_id}/join", response_model=RunEvent)' in routes
     assert "payload: RunEventCreate" in routes
     assert "payload: ParticipantName" in routes
     # only referenced models are imported (no unused-import lint failure)

--- a/tests/unit/capabilities/test_scaffold_contract.py
+++ b/tests/unit/capabilities/test_scaffold_contract.py
@@ -114,9 +114,9 @@ def test_fill_slots_carry_interface_and_implementation_criteria():
     assert endpoints["methods_paths"] == [
         "GET /runs",
         "POST /runs",
-        "GET /runs/{id}",
-        "POST /runs/{id}/join",
-        "POST /runs/{id}/leave",
+        "GET /runs/{run_id}",
+        "POST /runs/{run_id}/join",
+        "POST /runs/{run_id}/leave",
     ]
     assert any(c["id"] == "vc-routes-apierror" for c in routes["interface"])
     compiles = next(c for c in routes["implementation"] if c["check"] == "command_exit_zero")


### PR DESCRIPTION
## Why

The plan proposer independently authored `{run_id}` prose in **pf-31 and pf-32** against the manifest's `{id}` — costing pf-31 seven rejected repairs (the prose-poisoning class behind fixes A/D/E, #563/#564). The model's prior for the descriptive name is strong — and correct. The manifest is the *single seam* that owns the interface name, so this aligns the authority with the prior instead of fighting it. From pf-33 on, the A3 conflict lint should simply go quiet on this token.

Bonus: the seeded skeleton handlers stop shadowing Python's builtin `id()` (`def get_runs_run_id(run_id: str)`).

## What changed

- `examples/03_group_run/interface_manifest.yaml` — the 3 path lines (the source of truth; everything below derives from it)
- reference fill `backend/routes.py` — decorators, function names, args track the expander's deterministic derivation
- `test_scaffold.py` / `test_scaffold_contract.py` — the only tests asserting against the *real* manifest
- plan-authoring brief fragment — the `/runs/{id}/join` example updated + fragment manifest hashes regenerated
- **Left unchanged**: self-contained synthetic `{id}` fixtures (incl. the A3 lint tests, which deliberately construct the `{run_id}`-vs-`{id}` conflict), historical SIPs/plan docs, entity field `RunEvent.id` (only the path *parameter* renames)

## Proof

- contract gate `lint`: GREEN (host)
- `bare-skeleton`: **6/6 GREEN** and `reference-fill` (winnability): **6/6 GREEN** — run in the qa container (node present; host lacks npm by design #419)
- `tests/unit/{capabilities,cycles,prompts}`: 3603 passed (2 pre-existing host missing_tooling failures, fail on main too, pass in CI)
- ruff clean

## Rollout (deliberately NOT in this PR)

Live seeded artifacts are untouched — pf-32 is mid-flight on frozen contract v3. After pf-32 goes terminal: `contract_gate.py emit` → `squadops artifacts ingest` the new manifest + contract v4 → update the launcher's `CONTRACT_REF`/`MANIFEST_REF` for pf-33. Deploy hash `edd124e3` is unaffected (pure data change; no agent rebuild needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXrSUPGsx5yxbsn19aDjXX