### PR TITLE
fix(emission): #566 recovery + aimed retry, #568 locus-keyed qa repair routing

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -155,6 +155,40 @@ def _resolve_repair_target(
     )
 
 
+def _locus_and_repair_target(
+    failed_task_type: str,
+    failure_evidence: Any,
+    failed_inputs: dict[str, Any],
+) -> tuple[str, list[str], str | None, str | None]:
+    """#568: classify the failure locus and choose the repair target for it.
+
+    Returns ``(locus, expected_artifacts, focus, description)``. An
+    OWN_ARTIFACT failure (the failed task's own emission is missing or
+    uncollectable) targets the failed task's own contract — pointing
+    ``_resolve_repair_target``'s subject-implementation union at a test
+    re-author would aim it at app source files. Every other locus keeps the
+    existing target resolution unchanged.
+    """
+    from squadops.cycles.failure_evidence import FailureLocus, classify_failure_locus
+
+    failure_locus = classify_failure_locus(failure_evidence)
+    own_expected = [str(e) for e in (failed_inputs.get("expected_artifacts") or []) if e]
+    if failure_locus == FailureLocus.OWN_ARTIFACT and own_expected:
+        logger.info(
+            "correction_repair_locus: own_artifact — %s re-produces %s",
+            failed_task_type,
+            ", ".join(own_expected),
+        )
+        return (
+            failure_locus,
+            own_expected,
+            failed_inputs.get("subtask_focus"),
+            failed_inputs.get("subtask_description"),
+        )
+    expected, focus, description = _resolve_repair_target(failure_evidence, failed_inputs)
+    return (failure_locus, expected, focus, description)
+
+
 @dataclass(frozen=True)
 class CorrectionProtocolResult:
     """Outcome of one correction-protocol run.
@@ -712,14 +746,26 @@ class CorrectionRunner:
         # field, which is free-text and previously caused builder failures
         # (`affected_task_types: ["QA Handoff"]`) to silently route to the
         # dev repair handler.
+        #
+        # #568: selection is additionally keyed on the deterministic failure
+        # locus — a task whose OWN artifact is missing/uncollectable is repaired
+        # by its own role re-producing that artifact (qa.test → qa.test_repair),
+        # and the repair target is the failed task's own contract, not the
+        # subject-implementation surface (_resolve_repair_target aims repairs at
+        # the SUBJECT and would point a test re-author at app source files).
         repair_artifacts: list[dict[str, Any]] = []
         if correction_path == "patch":
             failed_inputs = envelope.inputs or {}
-            repair_expected_artifacts, repair_focus, repair_description = _resolve_repair_target(
-                failure_evidence, failed_inputs
-            )
+            (
+                failure_locus,
+                repair_expected_artifacts,
+                repair_focus,
+                repair_description,
+            ) = _locus_and_repair_target(envelope.task_type, failure_evidence, failed_inputs)
 
-            for step_idx, (task_type, role) in enumerate(repair_steps_for(envelope.task_type)):
+            for step_idx, (task_type, role) in enumerate(
+                repair_steps_for(envelope.task_type, failure_locus)
+            ):
                 repair_task_id = f"repair-{run_id[:12]}-{correction_attempts:02d}-{task_type}"
                 resolved = resolve_agent_config(role, profile)
                 agent_id = resolved.agent_id

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1806,6 +1806,20 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             raise _PausedError(f"Task {envelope.task_id} ({envelope.task_type}) blocked")
 
         if outcome == TaskOutcome.RETRYABLE_FAILURE:
+            # #566: a zero-extraction failure carries a machine marker — thread
+            # it into the retry envelope so the handler appends the aimed
+            # format-feedback appendix instead of re-rolling blind. The retry
+            # loop re-dispatches the ENRICHED envelope, so the marker must land
+            # there (the base envelope is mutated too for evidence parity).
+            emission_failure = (result.outputs or {}).get("emission_failure")
+            if isinstance(emission_failure, dict):
+                feedback = {
+                    **emission_failure,
+                    "attempt": task_attempt_counts.get(envelope.task_id, 1),
+                }
+                envelope.inputs["emission_retry_feedback"] = feedback
+                if enriched_envelope is not None:
+                    enriched_envelope.inputs["emission_retry_feedback"] = feedback
             logger.info(
                 "Retryable failure for %s (attempt %d), retrying",
                 envelope.task_id,

--- a/src/squadops/bootstrap/handlers.py
+++ b/src/squadops/bootstrap/handlers.py
@@ -33,6 +33,7 @@ from squadops.capabilities.handlers.impl.define_done import (
 from squadops.capabilities.handlers.impl.repair_handlers import (
     BuilderAssembleRepairHandler,
     DevelopmentCorrectionRepairHandler,
+    QATestRepairHandler,
 )
 from squadops.capabilities.handlers.planning_tasks import (
     DataResearchContextHandler,
@@ -99,6 +100,8 @@ HANDLER_CONFIGS: list[tuple[type[CapabilityHandler], tuple[str, ...]]] = [
     # deterministically (patch verification #389 + retest #456).
     (DevelopmentCorrectionRepairHandler, ("dev",)),
     (BuilderAssembleRepairHandler, ("builder",)),
+    # #568: own-artifact-locus qa.test repairs — eve re-authors her own suite.
+    (QATestRepairHandler, ("qa",)),
     # Planning handlers (SIP-0078: Planning Workload Protocol)
     (DataResearchContextHandler, ("data",)),
     (StrategyFrameObjectiveHandler, ("strat",)),

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -209,6 +209,44 @@ class _CycleTaskHandler(CapabilityHandler):
             content[:excerpt],
         )
 
+    async def _apply_emission_retry_feedback(
+        self,
+        context: ExecutionContext,
+        inputs: dict[str, Any],
+        user_prompt: str,
+    ) -> str:
+        """#566: append the parse-failure feedback appendix to a retry prompt.
+
+        The executor sets ``inputs["emission_retry_feedback"]`` (the prior
+        attempt's ``emission_failure`` marker) when re-dispatching after a
+        zero-extraction failure — without it the retry re-rolls blind on the
+        same prior. All instruction prose renders from the managed template
+        asset; this method only supplies the data lines. No renderer or no
+        marker → prompt unchanged.
+        """
+        marker = inputs.get("emission_retry_feedback")
+        if not isinstance(marker, dict):
+            return user_prompt
+        renderer = getattr(context.ports, "request_renderer", None)
+        if renderer is None:
+            return user_prompt
+        from squadops.cycles.emission_integrity import emission_retry_reason_line
+
+        expected = [
+            str(e)
+            for e in (marker.get("expected_artifacts") or inputs.get("expected_artifacts") or [])
+            if e
+        ]
+        expected_files = "\n".join(f"  - `{e}`" for e in expected) or "  - (as named in the task)"
+        rendered = await renderer.render(
+            "request.cycle_emission_retry_feedback",
+            {
+                "reason_line": emission_retry_reason_line(marker),
+                "expected_files": expected_files,
+            },
+        )
+        return f"{user_prompt}\n\n{rendered.content}"
+
     def _resolve_model_budget(
         self,
         inputs: dict[str, Any],

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -387,6 +387,9 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         agent_overrides = inputs.get("agent_config_overrides", {})
         agent_model = inputs.get("agent_model") or None
 
+        # #566: aimed retry after a zero-extraction failure (see qa_test.py).
+        user_prompt = await self._apply_emission_retry_feedback(context, inputs, user_prompt)
+
         # SIP-0073: guard prompt size against context window
         try:
             user_prompt = _guard_prompt_size(
@@ -437,9 +440,13 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         )
 
         # Parse fenced code blocks
-        extracted = extract_fenced_files(content)
+        extracted = extract_fenced_files(
+            content, expected_artifacts=inputs.get("expected_artifacts")
+        )
 
         if not extracted:
+            from squadops.cycles.emission_integrity import no_fenced_blocks_failure
+
             self._log_no_fenced_blocks(content)
             return self._fail_result(
                 start_time,
@@ -454,6 +461,11 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
                             "type": "document",
                         },
                     ],
+                    # #566: marker for the executor's aimed retry + the
+                    # correction loop's failure-locus classifier.
+                    "emission_failure": no_fenced_blocks_failure(
+                        len(content), inputs.get("expected_artifacts")
+                    ),
                 },
             )
 

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -562,6 +562,11 @@ class QATestHandler(_CycleTaskHandler):
             inputs, capability.max_completion_tokens, context.ports.llm.default_model
         )
 
+        # #566: a re-dispatch after a zero-extraction failure carries the prior
+        # marker — tell the model exactly what was discarded and the required
+        # fence format instead of re-rolling blind.
+        user_prompt = await self._apply_emission_retry_feedback(context, inputs, user_prompt)
+
         try:
             user_prompt = _guard_prompt_size(
                 system_prompt,
@@ -608,8 +613,12 @@ class QATestHandler(_CycleTaskHandler):
             chat_response=response,
         )
 
-        extracted = extract_fenced_files(content)
+        extracted = extract_fenced_files(
+            content, expected_artifacts=inputs.get("expected_artifacts")
+        )
         if not extracted:
+            from squadops.cycles.emission_integrity import no_fenced_blocks_failure
+
             self._log_no_fenced_blocks(content)
             return self._fail_result(
                 start_time,
@@ -623,7 +632,13 @@ class QATestHandler(_CycleTaskHandler):
                             "media_type": "text/markdown",
                             "type": "document",
                         }
-                    ]
+                    ],
+                    # #566: machine-readable marker — the executor's retry path
+                    # turns it into aimed feedback; the correction loop's locus
+                    # classifier reads it as a test-artifact-locus signal.
+                    "emission_failure": no_fenced_blocks_failure(
+                        len(content), inputs.get("expected_artifacts")
+                    ),
                 },
             )
 

--- a/src/squadops/capabilities/handlers/fenced_parser.py
+++ b/src/squadops/capabilities/handlers/fenced_parser.py
@@ -369,18 +369,32 @@ def _resolve_block(
     return filename, language, body, last_used_heading_pos
 
 
-def extract_fenced_files(response: str) -> list[dict]:
+def extract_fenced_files(
+    response: str,
+    expected_artifacts: list[str] | None = None,
+) -> list[dict]:
     """Parse fenced code blocks into structured file records.
 
     Tries multiple resolution strategies per fence (see module docstring).
     Returns a list of ``{filename, content, language}`` dicts. Empty list
     if no resolvable, security-safe fences are found.
 
+    Single-expected-artifact fallback (#566): when NO strategy resolves any
+    file, the task expects exactly ONE artifact, and the response holds exactly
+    ONE substantial filename-less fence, that fence is mapped to the expected
+    path — a bare ``` ```python``` ``` emission with the whole file inside has
+    exactly one place it can belong. Guarded to unambiguous cardinality only:
+    it never fires when any fence resolved a filename (even an unsafe one),
+    when two or more expected artifacts exist, or when the response holds two
+    or more candidate fences.
+
     Security: rejects absolute paths, paths containing ``..`` segments,
     and paths containing ``:``.
 
     Args:
         response: Raw LLM response text.
+        expected_artifacts: The task envelope's expected output paths, used
+            only by the #566 fallback. ``None``/empty disables the fallback.
 
     Returns:
         List of dicts with keys ``filename``, ``content``, ``language``.
@@ -395,6 +409,8 @@ def extract_fenced_files(response: str) -> list[dict]:
     response = _strip_think_blocks(response)
 
     results: list[dict] = []
+    unlabeled: list[dict] = []  # #566 fallback candidates: no strategy resolved a name
+    saw_labeled = False  # any fence that DID resolve a name (safe or not)
     pos = 0
     last_used_heading_pos = -1
 
@@ -423,9 +439,14 @@ def extract_fenced_files(response: str) -> list[dict]:
         )
 
         if filename is None or not _path_is_safe(filename):
+            if filename is None and body.strip():
+                unlabeled.append({"content": body, "language": language or "text"})
+            else:
+                saw_labeled = True
             pos = next_pos
             continue
 
+        saw_labeled = True
         results.append(
             {
                 "filename": filename,
@@ -435,4 +456,34 @@ def extract_fenced_files(response: str) -> list[dict]:
         )
         pos = next_pos
 
+    if not results:
+        fallback = _single_expected_artifact_fallback(unlabeled, expected_artifacts, saw_labeled)
+        if fallback is not None:
+            return [fallback]
+
     return results
+
+
+def _single_expected_artifact_fallback(
+    unlabeled: list[dict],
+    expected_artifacts: list[str] | None,
+    saw_labeled: bool,
+) -> dict | None:
+    """#566: map the sole filename-less fence to the sole expected artifact.
+
+    Fires only when every cardinality is exactly one and nothing labeled was
+    seen anywhere in the response — any resolved filename (even a rejected
+    unsafe one) means the model IS labeling its fences and a missing label is
+    ambiguity, not convention drift. Returns the mapped record or ``None``.
+    """
+    if saw_labeled or len(unlabeled) != 1:
+        return None
+    expected = [e for e in (expected_artifacts or []) if isinstance(e, str) and e]
+    if len(expected) != 1 or not _path_is_safe(expected[0]):
+        return None
+    candidate = unlabeled[0]
+    return {
+        "filename": expected[0],
+        "content": _strip_trailing_newline(candidate["content"]),
+        "language": candidate["language"],
+    }

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -351,3 +351,27 @@ class BuilderAssembleRepairHandler(_RepairPromptMixin, _CycleTaskHandler):
 
     def _build_artifacts_from_content(self, content: str) -> list[dict[str, Any]]:
         return _artifacts_from_fenced_blocks(content, self._artifact_name)
+
+
+class QATestRepairHandler(_RepairPromptMixin, _CycleTaskHandler):
+    """Correction-loop repair handler for failed qa.test tasks (#568).
+
+    Reachable ONLY via the own-artifact failure locus (the test suite itself
+    is missing, unparseable, or uncollectable — deterministic signals, never
+    LLM judgment): the qa role re-authors its own test artifact(s). Behavioral
+    failures (the suite ran and the app failed it) never route here — they
+    stay on the default dev chain, because "repairing" an app bug by
+    rewriting tests until they pass is a manufactured false green.
+
+    Acceptance is the same deterministic pair as every correction repair:
+    patch verification against the failed task's typed criteria (#389), then
+    the behavioral retest executes the re-authored suite (#456).
+    """
+
+    _handler_name = "qa_test_repair_handler"
+    _capability_id = "qa.test_repair"
+    _role = "qa"
+    _artifact_name = "repair_output.md"
+
+    def _build_artifacts_from_content(self, content: str) -> list[dict[str, Any]]:
+        return _artifacts_from_fenced_blocks(content, self._artifact_name)

--- a/src/squadops/cycles/emission_integrity.py
+++ b/src/squadops/cycles/emission_integrity.py
@@ -69,3 +69,41 @@ def emission_integrity_instruction(name: str, error: str) -> str:
         "COMPLETE file, and keep it small enough to finish: do not start more files "
         "than you can fully emit."
     )
+
+
+# ---------------------------------------------------------------------------
+# Emission-failure marker (#566): machine-readable classification of a
+# zero-extraction handler failure, emitted in the handler's failure outputs and
+# consumed by the executor's retry path (aimed-retry feedback) and by the
+# correction loop's failure-locus classifier. The marker is DATA — every
+# instruction the model reads renders from the managed template asset.
+
+EMISSION_FAILURE_KEY = "emission_failure"
+EMISSION_FAILURE_NO_FENCED_BLOCKS = "no_fenced_blocks"
+
+
+def no_fenced_blocks_failure(
+    response_chars: int,
+    expected_artifacts: list[str] | None,
+) -> dict[str, Any]:
+    """Build the ``emission_failure`` marker for a zero-extraction failure."""
+    return {
+        "reason": EMISSION_FAILURE_NO_FENCED_BLOCKS,
+        "response_chars": response_chars,
+        "expected_artifacts": [str(e) for e in (expected_artifacts or [])],
+    }
+
+
+def emission_retry_reason_line(marker: dict[str, Any]) -> str:
+    """One factual sentence describing the marker, for the retry-feedback
+    template's ``reason_line`` variable (same deterministic-instruction genre
+    as ``emission_integrity_instruction`` above — data-derived line, section
+    framing owned by the template asset)."""
+    reason = marker.get("reason")
+    if reason == EMISSION_FAILURE_NO_FENCED_BLOCKS:
+        chars = marker.get("response_chars", 0)
+        return (
+            f"no fenced code block carrying a file path could be extracted "
+            f"from the {chars}-character response."
+        )
+    return f"the response failed emission extraction ({reason})."

--- a/src/squadops/cycles/failure_evidence.py
+++ b/src/squadops/cycles/failure_evidence.py
@@ -51,7 +51,7 @@ def build_failure_evidence(
                 "content_snippet": snippet,
             }
         )
-    return {
+    evidence = {
         "failed_task_id": envelope.task_id,
         "failed_task_type": envelope.task_type,
         "error": result.error or "",
@@ -66,6 +66,69 @@ def build_failure_evidence(
         "rejected_artifacts": rejected_artifacts,
         "prior_plan_deltas_count": prior_plan_deltas_count,
     }
+    # #566/#568: the zero-extraction marker travels into evidence so the locus
+    # classifier (and the analyzer) see "no artifact was ever produced" as a
+    # machine fact instead of inferring a work-product story from its absence.
+    emission_failure = result_outputs.get("emission_failure")
+    if isinstance(emission_failure, dict):
+        evidence["emission_failure"] = emission_failure
+    return evidence
+
+
+class FailureLocus:
+    """Where a failed task's defect lives, relative to the task itself (#568).
+
+    Constants-class pattern like ``TaskOutcome``. Drives repair routing: a task
+    whose OWN emitted artifact is missing/unparseable/uncollectable should be
+    repaired by its own role (re-produce the artifact); only a failure in the
+    SUBJECT under test/verification belongs to the subject's producing role.
+    For ``qa.test``: OWN_ARTIFACT = the test suite itself is broken (eve
+    re-authors); SUBJECT = the suite ran and the app failed it (dev repairs).
+    """
+
+    OWN_ARTIFACT = "own_artifact"
+    SUBJECT = "subject"
+    UNKNOWN = "unknown"
+
+
+# pytest exit codes that mean the SUITE could not run as a suite — collection
+# errors/interruption (2), usage error (4), no tests collected (5). Exit 1
+# (tests ran, some failed) is the subject's failure; 3 (pytest internal error)
+# stays UNKNOWN — neither artifact nor subject is implicated deterministically.
+_SUITE_DEFECT_EXIT_CODES = frozenset({2, 4, 5})
+
+
+def classify_failure_locus(failure_evidence: Any) -> str:
+    """Deterministic failure-locus classification from evidence alone (#568).
+
+    Conservative by design (the test-gaming guard): only explicit machine
+    signals produce ``OWN_ARTIFACT``; ambiguity returns ``UNKNOWN``, which
+    routes to the default (dev) repair chain — never toward a qa re-author
+    that could "fix" an app bug by rewriting the tests.
+    """
+    if not isinstance(failure_evidence, dict):
+        return FailureLocus.UNKNOWN
+
+    # Zero-extraction marker (#566): the task produced no artifact at all.
+    if isinstance(failure_evidence.get("emission_failure"), dict):
+        return FailureLocus.OWN_ARTIFACT
+
+    validation_result = failure_evidence.get("validation_result") or {}
+    checks = validation_result.get("checks") or []
+    for row in checks:
+        if not isinstance(row, dict):
+            continue
+        check = row.get("check")
+        if check == "expected_artifacts" and row.get("passed") is False:
+            # The task's own named output files are missing from its emission.
+            return FailureLocus.OWN_ARTIFACT
+        if check == "tests_pass" and row.get("passed") is False and row.get("executed"):
+            exit_code = row.get("exit_code")
+            if exit_code in _SUITE_DEFECT_EXIT_CODES:
+                return FailureLocus.OWN_ARTIFACT
+            if exit_code == 1:
+                return FailureLocus.SUBJECT
+    return FailureLocus.UNKNOWN
 
 
 def compose_failure_trigger(

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -25,6 +25,7 @@ from squadops.capabilities.handlers.build_profiles import (
 )
 from squadops.capabilities.scaffold import harness_entry_modules, is_qa_test_path_for_stack
 from squadops.cycles.agent_config import resolve_agent_config
+from squadops.cycles.failure_evidence import FailureLocus
 from squadops.cycles.implementation_plan import (
     ImplementationPlan,
     TypedCheck,
@@ -211,18 +212,44 @@ _REPAIR_STEPS_BY_FAILED_TASK_TYPE: dict[str, list[tuple[str, str]]] = {
     ],
 }
 
+# #568: repair sequences reachable ONLY when the failure locus is the failed
+# task's OWN artifact (missing/unparseable/uncollectable emission) — the owning
+# role re-produces its own artifact. Deliberately a separate table from the
+# default above: a qa.test entry in the default table would route BEHAVIORAL
+# failures (app failed the tests) to qa re-authoring, i.e. "fix the app by
+# rewriting tests until green" — a manufactured false green. Locus is computed
+# deterministically (failure_evidence.classify_failure_locus); ambiguity falls
+# through to the default table.
+QA_TEST_REPAIR_STEPS: list[tuple[str, str]] = [
+    ("qa.test_repair", "qa"),
+]
+_REPAIR_STEPS_BY_FAILED_TASK_TYPE_OWN_ARTIFACT: dict[str, list[tuple[str, str]]] = {
+    "qa.test": QA_TEST_REPAIR_STEPS,
+}
+
 # pf-31 Fix E: every task type that produces repair-CANDIDATE emissions, derived
 # from the dispatch tables above (never re-typed — #559). Candidates land in the
 # artifact store for the correction loop's accumulation (RC3), but an ACCEPTED
 # patch is re-stored under the repaired task's own type by the #389 accept path —
 # so candidate-typed artifacts are, by construction, in-flight or rejected, and
 # workspace views for fresh dispatches exclude them by this provenance.
-REPAIR_TASK_TYPES: frozenset[str] = frozenset(
-    task_type for steps in _REPAIR_STEPS_BY_FAILED_TASK_TYPE.values() for task_type, _ in steps
-) | frozenset(task_type for task_type, _ in REPAIR_TASK_STEPS)
+REPAIR_TASK_TYPES: frozenset[str] = (
+    frozenset(
+        task_type for steps in _REPAIR_STEPS_BY_FAILED_TASK_TYPE.values() for task_type, _ in steps
+    )
+    | frozenset(
+        task_type
+        for steps in _REPAIR_STEPS_BY_FAILED_TASK_TYPE_OWN_ARTIFACT.values()
+        for task_type, _ in steps
+    )
+    | frozenset(task_type for task_type, _ in REPAIR_TASK_STEPS)
+)
 
 
-def repair_steps_for(failed_task_type: str) -> list[tuple[str, str]]:
+def repair_steps_for(
+    failed_task_type: str,
+    failure_locus: str | None = None,
+) -> list[tuple[str, str]]:
     """Return the repair (task_type, role) sequence for a failed task.
 
     Looked up by the failed task's `task_type`, which is authoritative —
@@ -231,7 +258,16 @@ def repair_steps_for(failed_task_type: str) -> list[tuple[str, str]]:
     failure tagged `["QA Handoff"]` would mis-route to the dev repair
     handler. Falls back to `REPAIR_TASK_STEPS` (dev) for any task type
     without a specialized sequence.
+
+    #568: when ``failure_locus`` is ``FailureLocus.OWN_ARTIFACT``, the
+    own-artifact table takes precedence — the failed task's own role
+    re-produces its own artifact. Any other locus (including ``None`` and
+    ``UNKNOWN``) uses the default tables unchanged.
     """
+    if failure_locus == FailureLocus.OWN_ARTIFACT:
+        specialized = _REPAIR_STEPS_BY_FAILED_TASK_TYPE_OWN_ARTIFACT.get(failed_task_type)
+        if specialized is not None:
+            return specialized
     return _REPAIR_STEPS_BY_FAILED_TASK_TYPE.get(failed_task_type, REPAIR_TASK_STEPS)
 
 

--- a/src/squadops/prompts/request_templates/request.cycle_emission_retry_feedback.md
+++ b/src/squadops/prompts/request_templates/request.cycle_emission_retry_feedback.md
@@ -1,0 +1,23 @@
+---
+template_id: request.cycle_emission_retry_feedback
+version: "1"
+required_variables:
+  - reason_line
+  - expected_files
+---
+### Prior Attempt Failed — Output Format (authoritative — apply exactly)
+
+Your previous response to this exact task was DISCARDED before any of its content
+was used: {{reason_line}}
+
+The extraction step maps each fenced code block to a file path taken from the
+fence header. A fence without a path cannot be stored. Re-emit your work now,
+following these rules exactly:
+
+- Emit ONE fenced code block per required file, and nothing outside the fences
+  except brief notes.
+- Every fence header MUST carry the file path in the form ` ```language:path/to/file `
+  — for example ` ```python:backend/tests/test_runs.py `.
+- Close every fence with ` ``` ` on its own line.
+- Required files:
+{{expected_files}}

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -186,6 +186,11 @@ class TestDevBuildParseFailure:
         artifacts = result.outputs.get("artifacts", [])
         assert len(artifacts) == 1
         assert artifacts[0]["name"] == "build_warnings.md"
+        # #566: machine-readable marker for the executor's aimed retry and the
+        # correction loop's locus classifier.
+        marker = result.outputs["emission_failure"]
+        assert marker["reason"] == "no_fenced_blocks"
+        assert marker["response_chars"] == len(LLM_NO_FENCES_RESPONSE)
 
 
 class TestDevBuildLLMError:
@@ -309,6 +314,31 @@ class TestQABuildParseFailure:
 
         assert result.success is False
         assert "No valid fenced code blocks found" in result.error
+        # #566: marker present on the qa path too (the pf-32 live class).
+        assert result.outputs["emission_failure"]["reason"] == "no_fenced_blocks"
+
+    async def test_qa_bare_fence_recovered_via_expected_artifact(self, mock_context, qa_inputs):
+        """#566 end-to-end at the handler: the pf-32 emission shape (bare
+        ```python fence, no filename, unterminated) succeeds when the task
+        expects exactly one artifact — no failure, no retry burned."""
+        qa_inputs = {
+            **qa_inputs,
+            "subtask_focus": "runs API suite",
+            "subtask_description": "pytest suite",
+            "expected_artifacts": ["backend/tests/test_runs.py"],
+        }
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(
+                role="assistant",
+                content="```python\nimport pytest\n\ndef test_ok(client):\n    assert True\n",
+            ),
+        )
+        handler = QATestHandler()
+        result = await handler.handle(mock_context, qa_inputs)
+
+        names = [a["name"] for a in result.outputs["artifacts"]]
+        assert "backend/tests/test_runs.py" in names
+        assert "emission_failure" not in result.outputs
 
 
 class TestQABuildPromptContent:
@@ -1482,3 +1512,64 @@ class TestQAContractProbeEmission:
         result = await handler.handle(mock_context, qa_inputs)
 
         assert "validation_result" not in result.outputs
+
+
+class TestEmissionRetryFeedback:
+    """#566: a retry envelope carrying ``emission_retry_feedback`` gets the
+    rendered format-feedback appendix appended to its user prompt — the retry
+    is an aimed shot, not a blind re-roll. All prose comes from the template
+    asset; the handler supplies only data lines."""
+
+    class _Rendered:
+        content = "### Prior Attempt Failed — Output Format (RENDERED-APPENDIX)"
+        template_id = "request.cycle_emission_retry_feedback"
+        template_version = "1"
+        render_hash = "h"
+
+    async def test_feedback_appendix_reaches_the_prompt(self, mock_context, qa_inputs):
+        qa_inputs = {
+            **qa_inputs,
+            "emission_retry_feedback": {
+                "reason": "no_fenced_blocks",
+                "response_chars": 6203,
+                "expected_artifacts": ["backend/tests/test_runs.py"],
+                "attempt": 1,
+            },
+        }
+        mock_context.ports.request_renderer = MagicMock()
+        mock_context.ports.request_renderer.render = AsyncMock(return_value=self._Rendered())
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=LLM_TEST_FILE_RESPONSE),
+        )
+        handler = QATestHandler()
+        await handler.handle(mock_context, qa_inputs)
+
+        render_calls = [
+            c
+            for c in mock_context.ports.request_renderer.render.call_args_list
+            if c.args and c.args[0] == "request.cycle_emission_retry_feedback"
+        ]
+        assert len(render_calls) == 1
+        variables = render_calls[0].args[1]
+        assert "6203-character" in variables["reason_line"]
+        assert "backend/tests/test_runs.py" in variables["expected_files"]
+
+        messages = mock_context.ports.llm.chat_stream_with_usage.call_args.args[0]
+        user_prompt = messages[-1].content
+        assert "RENDERED-APPENDIX" in user_prompt
+
+    async def test_no_marker_means_no_render_call(self, mock_context, qa_inputs):
+        mock_context.ports.request_renderer = MagicMock()
+        mock_context.ports.request_renderer.render = AsyncMock(return_value=self._Rendered())
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=LLM_TEST_FILE_RESPONSE),
+        )
+        handler = QATestHandler()
+        await handler.handle(mock_context, qa_inputs)
+
+        feedback_calls = [
+            c
+            for c in mock_context.ports.request_renderer.render.call_args_list
+            if c.args and c.args[0] == "request.cycle_emission_retry_feedback"
+        ]
+        assert feedback_calls == []

--- a/tests/unit/capabilities/test_fenced_parser.py
+++ b/tests/unit/capabilities/test_fenced_parser.py
@@ -763,3 +763,80 @@ class TestImplicitEofClose:
         """Implicit close only helps when a filename resolves — an untagged
         unterminated fence has no path and is still dropped."""
         assert extract_fenced_files("```\nsome loose text at eof\n") == []
+
+
+class TestSingleExpectedArtifactFallback:
+    """#566: a filename-less fence maps to the task's sole expected artifact —
+    but only at exactly-one cardinality everywhere. Live case: pf-32 qa.test
+    emitted the whole suite in one bare ```python fence (no path label,
+    unterminated at EOF) twice in a row; 0 blocks extracted, ~10 min of
+    generation discarded per attempt, and a dev repair burned on a failure
+    whose artifact never existed."""
+
+    _EXPECTED = ["backend/tests/test_runs.py"]
+
+    def test_pf32_live_shape_recovered(self):
+        """Bare language-only fence, no filename anywhere, unterminated at
+        EOF — the exact live emission — maps to the sole expected artifact."""
+        response = "```python\nimport pytest\n\ndef test_create(client):\n    assert True\n"
+        result = extract_fenced_files(response, expected_artifacts=self._EXPECTED)
+        assert len(result) == 1
+        assert result[0]["filename"] == "backend/tests/test_runs.py"
+        assert result[0]["content"].startswith("import pytest")
+        assert result[0]["language"] == "python"
+
+    def test_terminated_bare_fence_recovered(self):
+        response = "```python\ndef test_x():\n    pass\n```\n"
+        result = extract_fenced_files(response, expected_artifacts=self._EXPECTED)
+        assert [r["filename"] for r in result] == ["backend/tests/test_runs.py"]
+        assert result[0]["content"] == "def test_x():\n    pass"
+
+    def test_no_expected_artifacts_disables_fallback(self):
+        response = "```python\ndef test_x():\n    pass\n```\n"
+        assert extract_fenced_files(response) == []
+        assert extract_fenced_files(response, expected_artifacts=[]) == []
+
+    def test_two_expected_artifacts_decline(self):
+        response = "```python\ndef test_x():\n    pass\n```\n"
+        result = extract_fenced_files(response, expected_artifacts=["a/test_a.py", "b/test_b.py"])
+        assert result == []
+
+    def test_two_unlabeled_fences_decline(self):
+        """Two candidate fences → the mapping is ambiguous, never guessed."""
+        response = "```python\ncode_a\n```\n\n```python\ncode_b\n```\n"
+        assert extract_fenced_files(response, expected_artifacts=self._EXPECTED) == []
+
+    def test_never_fires_when_any_fence_resolved(self):
+        """A resolved fence means the model IS labeling — an unlabeled sibling
+        is ambiguity, not convention drift; it stays dropped."""
+        response = (
+            "```python:backend/tests/test_runs.py\ndef test_a():\n    pass\n```\n\n"
+            "```python\norphan_code\n```\n"
+        )
+        result = extract_fenced_files(response, expected_artifacts=self._EXPECTED)
+        assert [r["filename"] for r in result] == ["backend/tests/test_runs.py"]
+        assert all("orphan_code" not in r["content"] for r in result)
+
+    def test_labeled_but_unsafe_fence_blocks_fallback(self):
+        """A fence that resolved an UNSAFE path still counts as labeling —
+        remapping its sibling would trust a response that mislabels."""
+        response = "```python:/etc/passwd\nnope\n```\n\n```python\ndef test_x():\n    pass\n```\n"
+        assert extract_fenced_files(response, expected_artifacts=self._EXPECTED) == []
+
+    def test_whitespace_only_fence_is_not_a_candidate(self):
+        assert (
+            extract_fenced_files("```python\n   \n```\n", expected_artifacts=self._EXPECTED) == []
+        )
+
+    def test_unsafe_expected_path_declines(self):
+        response = "```python\ncode\n```\n"
+        assert extract_fenced_files(response, expected_artifacts=["../escape.py"]) == []
+        assert extract_fenced_files(response, expected_artifacts=["/abs/path.py"]) == []
+
+    def test_strategy_resolution_still_wins_over_fallback(self):
+        """A fence the strategies CAN resolve keeps its own name even when it
+        differs from the expected artifact — the fallback only rescues, never
+        renames."""
+        response = "```python:backend/tests/test_other.py\ndef test_a():\n    pass\n```\n"
+        result = extract_fenced_files(response, expected_artifacts=self._EXPECTED)
+        assert [r["filename"] for r in result] == ["backend/tests/test_other.py"]

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -2540,3 +2540,151 @@ class TestResolveRepairTarget:
         artifacts, focus, _ = _resolve_repair_target(evidence, {"expected_artifacts": ["a.py"]})
         assert artifacts == ["a.py"]
         assert focus is None
+
+
+class TestOwnArtifactLocusRouting(TestCorrectionRunnerStandalone):
+    """#568: a qa.test failure whose OWN artifact is the defect dispatches a
+    qa.test_repair step targeted at the failed task's own contract; behavioral
+    failures stay on the dev chain with the subject-scoped repair target."""
+
+    def _failed_qa_envelope(self):
+        from squadops.tasks.models import TaskEnvelope
+
+        return TaskEnvelope(
+            task_id="task_qa_failed",
+            agent_id="eve",
+            cycle_id="cyc_001",
+            pulse_id="p",
+            project_id="hello_squad",
+            task_type="qa.test",
+            correlation_id="corr",
+            causation_id=None,
+            trace_id="t",
+            span_id="s",
+            inputs={
+                "expected_artifacts": ["backend/tests/test_runs.py"],
+                "subtask_focus": "Backend runs API pytest suite",
+                "subtask_description": "Comprehensive pytest test file.",
+                "acceptance_criteria": ["suite covers all endpoints"],
+                "resolved_config": {"dev_capability": "python_fastapi"},
+            },
+            metadata={"role": "qa"},
+        )
+
+    @staticmethod
+    def _patch_responder(captured):
+        def responder(envelope):
+            captured.append(envelope)
+            if envelope.task_type == "data.analyze_failure":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={"classification": "execution", "analysis_summary": "no artifact"},
+                )
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "patch",
+                        "decision_rationale": "re-author",
+                        "affected_task_types": ["qa.test"],
+                    },
+                )
+            return TaskResult(
+                task_id=envelope.task_id,
+                status="SUCCEEDED",
+                outputs={
+                    "artifacts": [
+                        {
+                            "name": "backend/tests/test_runs.py",
+                            "content": "def test_ok(client):\n    assert True\n",
+                            "media_type": "text/x-python",
+                            "type": "test",
+                        }
+                    ]
+                },
+            )
+
+        return responder
+
+    async def test_emission_failure_routes_to_qa_test_repair(self, cycle):
+        """Zero-extraction qa.test failure (the pf-32 class): the repair step
+        is qa.test_repair aimed at the failed task's OWN artifact — not a dev
+        repair aimed at the implementation surface."""
+        captured: list = []
+        runner, _registry, _vault, _bus = self._make_runner(self._patch_responder(captured))
+
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=self._failed_qa_envelope(),
+            result=TaskResult(
+                task_id="task_qa_failed",
+                status="FAILED",
+                error="No valid fenced code blocks found",
+                outputs={
+                    "emission_failure": {
+                        "reason": "no_fenced_blocks",
+                        "response_chars": 6203,
+                        "expected_artifacts": ["backend/tests/test_runs.py"],
+                    }
+                },
+            ),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+        repair_envelopes = [e for e in captured if e.task_type.endswith("_repair")]
+        assert [e.task_type for e in repair_envelopes] == ["qa.test_repair"]
+        repair = repair_envelopes[0]
+        assert repair.metadata.get("role") == "qa" or "qa" in repair.agent_id
+        assert repair.inputs["expected_artifacts"] == ["backend/tests/test_runs.py"]
+        assert repair.inputs["subtask_focus"] == "Backend runs API pytest suite"
+        assert repair.inputs["failed_task_type"] == "qa.test"
+
+    async def test_behavioral_failure_stays_on_dev_chain(self, cycle):
+        """Exit-1 (tests ran, app failed them) must NEVER reach qa re-authoring
+        — the test-gaming guard. The dev chain repairs the subject."""
+        captured: list = []
+        runner, _registry, _vault, _bus = self._make_runner(self._patch_responder(captured))
+
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=self._failed_qa_envelope(),
+            result=TaskResult(
+                task_id="task_qa_failed",
+                status="FAILED",
+                error="Tests failed (exit 1)",
+                outputs={
+                    "validation_result": {
+                        "passed": False,
+                        "summary": "Tests failed (exit 1)",
+                        "missing_components": ["tests_failed:exit_1"],
+                        "checks": [
+                            {
+                                "check": "tests_pass",
+                                "executed": True,
+                                "exit_code": 1,
+                                "tests_passed": False,
+                                "passed": False,
+                            }
+                        ],
+                    }
+                },
+            ),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+        repair_envelopes = [e for e in captured if e.task_type.endswith("_repair")]
+        assert [e.task_type for e in repair_envelopes] == ["development.correction_repair"]

--- a/tests/unit/cycles/test_emission_integrity.py
+++ b/tests/unit/cycles/test_emission_integrity.py
@@ -68,3 +68,31 @@ def test_instruction_names_file_error_and_completeness_demand():
     assert "backend/tests/test_runs.py" in line
     assert "DISCARDED" in line
     assert "COMPLETE" in line
+
+
+def test_no_fenced_blocks_marker_shape():
+    from squadops.cycles.emission_integrity import (
+        EMISSION_FAILURE_NO_FENCED_BLOCKS,
+        no_fenced_blocks_failure,
+    )
+
+    marker = no_fenced_blocks_failure(6203, ["backend/tests/test_runs.py"])
+    assert marker == {
+        "reason": EMISSION_FAILURE_NO_FENCED_BLOCKS,
+        "response_chars": 6203,
+        "expected_artifacts": ["backend/tests/test_runs.py"],
+    }
+    assert no_fenced_blocks_failure(0, None)["expected_artifacts"] == []
+
+
+def test_emission_retry_reason_line_known_and_unknown():
+    from squadops.cycles.emission_integrity import (
+        emission_retry_reason_line,
+        no_fenced_blocks_failure,
+    )
+
+    line = emission_retry_reason_line(no_fenced_blocks_failure(6203, ["x.py"]))
+    assert "6203-character" in line
+    assert "no fenced code block" in line
+    # Unknown reason still yields a usable factual line, never a KeyError.
+    assert "other_reason" in emission_retry_reason_line({"reason": "other_reason"})

--- a/tests/unit/cycles/test_failure_evidence.py
+++ b/tests/unit/cycles/test_failure_evidence.py
@@ -9,7 +9,12 @@ from __future__ import annotations
 
 import pytest
 
-from squadops.cycles.failure_evidence import build_failure_evidence, compose_failure_trigger
+from squadops.cycles.failure_evidence import (
+    FailureLocus,
+    build_failure_evidence,
+    classify_failure_locus,
+    compose_failure_trigger,
+)
 from squadops.tasks.models import TaskEnvelope, TaskResult
 
 pytestmark = [pytest.mark.domain_orchestration]
@@ -277,3 +282,90 @@ class TestComposeFailureTrigger:
         evidence = self._evidence(["not a dict", None, 42])  # type: ignore[list-item]
         trigger = compose_failure_trigger(self._envelope("qa.test"), evidence)
         assert trigger == "task_failure:qa.test"
+
+
+class TestClassifyFailureLocus:
+    """#568: deterministic locus classification — the routing key that decides
+    whether a failed task's own role re-authors its artifact or the default
+    (dev) chain repairs the subject. Conservative: ambiguity → UNKNOWN."""
+
+    def _evidence_with_check(self, row):
+        return {"validation_result": {"passed": False, "checks": [row]}}
+
+    def test_emission_failure_marker_is_own_artifact(self):
+        evidence = {"emission_failure": {"reason": "no_fenced_blocks", "response_chars": 6203}}
+        assert classify_failure_locus(evidence) == FailureLocus.OWN_ARTIFACT
+
+    def test_missing_expected_artifacts_is_own_artifact(self):
+        row = {
+            "check": "expected_artifacts",
+            "missing": ["backend/tests/test_runs.py"],
+            "passed": False,
+        }
+        assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.OWN_ARTIFACT
+
+    @pytest.mark.parametrize("exit_code", [2, 4, 5])
+    def test_suite_defect_exit_codes_are_own_artifact(self, exit_code):
+        """pytest 2=collection/interrupted, 4=usage error, 5=no tests collected:
+        the suite itself cannot run as a suite — the test artifact is the defect
+        (pf-31's truncated-test collection crash lands here)."""
+        row = {"check": "tests_pass", "executed": True, "exit_code": exit_code, "passed": False}
+        assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.OWN_ARTIFACT
+
+    def test_exit_one_is_subject(self):
+        """Tests ran and failed — the app is implicated, NEVER the qa re-author
+        route (the test-gaming guard: rewriting tests to green a broken app)."""
+        row = {"check": "tests_pass", "executed": True, "exit_code": 1, "passed": False}
+        assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.SUBJECT
+
+    def test_pytest_internal_error_is_unknown(self):
+        row = {"check": "tests_pass", "executed": True, "exit_code": 3, "passed": False}
+        assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.UNKNOWN
+
+    def test_not_executed_suite_is_unknown(self):
+        """Runner/environment failures implicate neither artifact nor subject."""
+        row = {"check": "tests_pass", "executed": False, "exit_code": None, "passed": False}
+        assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.UNKNOWN
+
+    def test_passed_rows_and_junk_are_unknown(self):
+        assert classify_failure_locus(None) == FailureLocus.UNKNOWN
+        assert classify_failure_locus({}) == FailureLocus.UNKNOWN
+        row = {"check": "tests_pass", "executed": True, "exit_code": 1, "passed": True}
+        assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.UNKNOWN
+
+
+class TestEmissionFailurePassthrough:
+    """#566/#568: the zero-extraction marker must travel into failure evidence
+    so the analyzer and the locus classifier see a machine fact."""
+
+    @staticmethod
+    def _envelope() -> TaskEnvelope:
+        return TaskEnvelope(
+            task_id="t1",
+            agent_id="eve",
+            cycle_id="cyc_001",
+            pulse_id="p",
+            project_id="proj",
+            task_type="qa.test",
+            correlation_id="c",
+            causation_id=None,
+            trace_id="tr",
+            span_id="sp",
+            inputs={},
+            metadata={"role": "qa"},
+        )
+
+    def test_marker_passes_through(self):
+        result = TaskResult(
+            task_id="t1",
+            status="FAILED",
+            error="No valid fenced code blocks found",
+            outputs={"emission_failure": {"reason": "no_fenced_blocks", "response_chars": 42}},
+        )
+        evidence = build_failure_evidence(self._envelope(), result, prior_plan_deltas_count=0)
+        assert evidence["emission_failure"] == {"reason": "no_fenced_blocks", "response_chars": 42}
+
+    def test_absent_marker_stays_absent(self):
+        result = TaskResult(task_id="t1", status="FAILED", error="x", outputs={})
+        evidence = build_failure_evidence(self._envelope(), result, prior_plan_deltas_count=0)
+        assert "emission_failure" not in evidence

--- a/tests/unit/cycles/test_outcome_routing.py
+++ b/tests/unit/cycles/test_outcome_routing.py
@@ -7,6 +7,7 @@ NEEDS_REPLAN from contract aborts immediately, and the D5 fallback table.
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
@@ -829,3 +830,55 @@ class TestAcceptPatchRetestWorkspaceThreading:
         assert action == "accept_patch"
         retest_envelope = executor._correction_runner.reexecute_repaired_suite.await_args.args[2]
         assert retest_envelope.inputs["artifact_contents"] == {"src/main.py": "app = 1\n"}
+
+
+class TestEmissionRetryFeedbackThreading:
+    """#566: a zero-extraction failure's machine marker must reach the RETRY
+    dispatch's envelope inputs — that is what turns the blind re-roll (pf-32:
+    two identical bare-fence failures in a row) into an aimed retry."""
+
+    async def test_marker_threads_into_retry_envelope(self, executor, mock_queue, mock_registry):
+        marker = {
+            "reason": "no_fenced_blocks",
+            "response_chars": 6203,
+            "expected_artifacts": ["backend/tests/test_runs.py"],
+        }
+        responses = {
+            0: ("FAILED", {"emission_failure": marker}, "No valid fenced code blocks found"),
+        }
+        mock_queue.reply_router.responder = _scripted_responder(responses)
+
+        with patch(
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        published = [json.loads(c.args[1]) for c in mock_queue.publish.call_args_list]
+        first_inputs = published[0]["payload"]["inputs"]
+        retry_inputs = published[1]["payload"]["inputs"]
+        assert published[0]["payload"]["task_id"] == published[1]["payload"]["task_id"]
+        assert "emission_retry_feedback" not in first_inputs
+        assert retry_inputs["emission_retry_feedback"]["reason"] == "no_fenced_blocks"
+        assert retry_inputs["emission_retry_feedback"]["attempt"] == 1
+        assert retry_inputs["emission_retry_feedback"]["expected_artifacts"] == [
+            "backend/tests/test_runs.py"
+        ]
+
+    async def test_plain_retryable_failure_adds_no_marker(
+        self, executor, mock_queue, mock_registry
+    ):
+        """A transport-style failure with no marker keeps the retry envelope
+        untouched — feedback is strictly opt-in via the machine marker."""
+        responses = {0: ("FAILED", None, "transient")}
+        mock_queue.reply_router.responder = _scripted_responder(responses)
+
+        with patch(
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        published = [json.loads(c.args[1]) for c in mock_queue.publish.call_args_list]
+        retry_inputs = published[1]["payload"]["inputs"]
+        assert "emission_retry_feedback" not in retry_inputs

--- a/tests/unit/cycles/test_task_plan_implementation.py
+++ b/tests/unit/cycles/test_task_plan_implementation.py
@@ -153,6 +153,41 @@ class TestRepairStepsFor:
         assert repair_steps_for("") == REPAIR_TASK_STEPS
 
 
+class TestRepairStepsForFailureLocus:
+    """#568: the own-artifact locus routes qa.test repairs to the qa role;
+    every other locus keeps the default dev chain — a behavioral failure
+    routed to qa re-authoring would be the test-gaming false green."""
+
+    def test_qa_test_own_artifact_routes_to_qa_repair(self):
+        from squadops.cycles.failure_evidence import FailureLocus
+
+        assert repair_steps_for("qa.test", FailureLocus.OWN_ARTIFACT) == [
+            ("qa.test_repair", "qa"),
+        ]
+
+    def test_qa_test_subject_and_unknown_stay_on_dev_chain(self):
+        from squadops.cycles.failure_evidence import FailureLocus
+
+        assert repair_steps_for("qa.test", FailureLocus.SUBJECT) == REPAIR_TASK_STEPS
+        assert repair_steps_for("qa.test", FailureLocus.UNKNOWN) == REPAIR_TASK_STEPS
+        assert repair_steps_for("qa.test", None) == REPAIR_TASK_STEPS
+        assert repair_steps_for("qa.test") == REPAIR_TASK_STEPS
+
+    def test_own_artifact_without_specialized_entry_uses_default(self):
+        from squadops.cycles.failure_evidence import FailureLocus
+
+        assert repair_steps_for("development.develop", FailureLocus.OWN_ARTIFACT) == (
+            REPAIR_TASK_STEPS
+        )
+
+    def test_qa_test_repair_joins_repair_task_types(self):
+        # Fix E composition: the candidate type derives from the table, so the
+        # provenance filter and #389 re-typing cover it with zero bookkeeping.
+        from squadops.cycles.task_plan import REPAIR_TASK_TYPES
+
+        assert "qa.test_repair" in REPAIR_TASK_TYPES
+
+
 class TestDeterministicTaskIds:
     def test_implementation_uses_deterministic_ids(self, impl_cycle, impl_run, profile):
         plan = generate_task_plan(impl_cycle, impl_run, profile)


### PR DESCRIPTION
Closes #566
Closes #568

## Live driver (pf-32, tonight)

m007-qa.test emitted a complete test suite in one bare ```python fence — no filename — **twice in a row**: 0 blocks extracted, ~10 min of generation discarded per attempt, then the correction loop dispatched a **dev** repair for a failure whose artifact eve never delivered. The repair emitted only frozen files (3.4b restored them) and was rejected. Two correction attempts burned on a parser gap + a routing gap.

## #566 — emission recovery + aimed retry (three deterministic layers)

1. **Parser fallback**: when no strategy resolves any file, the task expects exactly ONE artifact, and exactly ONE substantial filename-less fence exists → map it. Declines on any resolved fence (even a rejected unsafe one), 2+ candidate fences, or 2+ expected artifacts — cardinality-1-everywhere only.
2. **Machine marker**: develop + qa.test zero-extraction failures emit `emission_failure` (data, built in `emission_integrity.py`), which also passes through `build_failure_evidence` so the analyzer sees "no artifact was ever produced" as a fact.
3. **Aimed retry**: the executor threads the marker into the re-dispatched (enriched) envelope; handlers append a format-feedback appendix rendered from the new `request.cycle_emission_retry_feedback` template asset (all prose in the asset, per #448).

## #568 — locus-keyed repair routing

- `FailureLocus` + `classify_failure_locus` (pure, deterministic): emission marker / missing expected artifacts / pytest exit 2·4·5 → **OWN_ARTIFACT**; exit 1 → **SUBJECT**; everything else **UNKNOWN**.
- Own-artifact table: `qa.test → qa.test_repair` (qa role, new `QATestRepairHandler` — a `_RepairPromptMixin` subclass, so it gets the Contract Expectations block and the same deterministic acceptance: patch verification #389 + behavioral retest #456).
- **Test-gaming guard**: SUBJECT and UNKNOWN never reach qa re-authoring — an app bug "fixed" by rewriting tests is a manufactured false green. Ambiguity falls toward the dev chain.
- Own-artifact repairs target the failed task's OWN contract (its expected_artifacts/focus), not `_resolve_repair_target`'s subject-implementation union.
- `REPAIR_TASK_TYPES` derives over both tables (#559) — the new candidate type joins the Fix-E provenance filter and #389 re-typing with zero bookkeeping.

## Verification

- 20 new tests: parser fallback guards (incl. the exact pf-32 live emission shape), locus classifier (incl. exit-code table), routing (incl. the never-route-behavioral-to-qa guard), end-to-end runner dispatch, handler markers, executor retry threading, template render variables.
- Touched domains (capabilities/cycles/prompts/bootstrap): **3756 passed**; only the 2 pre-existing host `missing_tooling` failures (fail on main, pass in CI).
- ruff check + format clean.

## Deploy note

Needs agents + runtime-api rebuild to take effect — natural fold into the pf-33 deploy window alongside the #565 rebuild (greens 0/5, baseline reset free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXrSUPGsx5yxbsn19aDjXX