### PR TITLE
fix(qa): harness_boundary expectation instructed the violation; qa prompt diet; failed-check names in patch logs

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1974,13 +1974,21 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             typed_acceptance_enabled=resolved_config.get("typed_acceptance", True),
             command_acceptance_enabled=resolved_config.get("command_acceptance_checks", True),
         )
+        # pf-33: name the failed checks — "status=failed reason= checks=7" forced
+        # a by-hand artifact replay to learn WHICH check rejected the patch.
+        failed_checks = [
+            str(c.get("check", "?"))
+            for c in verification.checks
+            if isinstance(c, dict) and c.get("passed") is False
+        ]
         logger.info(
-            "patch_verification task=%s task_type=%s status=%s reason=%s checks=%d",
+            "patch_verification task=%s task_type=%s status=%s reason=%s checks=%d failed=%s",
             envelope.task_id,
             envelope.task_type,
             verification.status,
             verification.reason or "",
             len(verification.checks),
+            ",".join(failed_checks) or "-",
         )
         if verification.status != PATCH_PASSED:
             return "continue"

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -307,6 +307,33 @@ class QATestHandler(_CycleTaskHandler):
         }
         return test_result, report_artifact
 
+    @staticmethod
+    def _prompt_scoped_contents(
+        artifact_contents: dict[str, str],
+        expected_artifacts: list[Any],
+    ) -> dict[str, str]:
+        """pf-33: scope the focused prompt's source dump to the top-level
+        package(s) the task's own artifacts live in (the RC2 package rule at
+        the prompt seam). m007's prompt carried all 16 files (~18k tokens,
+        every frontend .jsx included) into a backend suite task — prefill cost
+        plus rambling pressure against the 8192 completion clamp, and the
+        truncation crashed collection. No expected artifacts or no package
+        match → contents unchanged (never starve the prompt).
+        """
+        packages = {
+            str(e).strip().lstrip("./").partition("/")[0]
+            for e in (expected_artifacts or [])
+            if e
+        }
+        if not packages:
+            return artifact_contents
+        scoped = {
+            name: content
+            for name, content in artifact_contents.items()
+            if str(name).strip().lstrip("./").partition("/")[0] in packages
+        }
+        return scoped or artifact_contents
+
     def _build_focused_prompt(self, inputs: dict[str, Any]) -> str:
         """Build a focused prompt for manifest-driven QA subtasks (SIP-0086).
 
@@ -317,7 +344,9 @@ class QATestHandler(_CycleTaskHandler):
         description = inputs.get("subtask_description", "")
         expected_files = inputs.get("expected_artifacts", [])
         acceptance_criteria = inputs.get("acceptance_criteria", [])
-        artifact_contents = inputs.get("artifact_contents", {})
+        artifact_contents = self._prompt_scoped_contents(
+            inputs.get("artifact_contents", {}), expected_files
+        )
 
         parts = [f"## QA Task: {focus}\n\n{description}\n"]
 

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -321,9 +321,7 @@ class QATestHandler(_CycleTaskHandler):
         match → contents unchanged (never starve the prompt).
         """
         packages = {
-            str(e).strip().lstrip("./").partition("/")[0]
-            for e in (expected_artifacts or [])
-            if e
+            str(e).strip().lstrip("./").partition("/")[0] for e in (expected_artifacts or []) if e
         }
         if not packages:
             return artifact_contents

--- a/src/squadops/cycles/contract_expectations.py
+++ b/src/squadops/cycles/contract_expectations.py
@@ -91,10 +91,18 @@ def expectation_line(entry: Any) -> str | None:
         argv = params.get("argv") or []
         return f"the command `{' '.join(str(a) for a in argv)}` must exit 0"
     if check == "harness_boundary":
+        # pf-33 corr-00: the previous wording ("must build its TestClient against
+        # one of: backend.main...") read as an INSTRUCTION to import the entry
+        # module and construct the client — the exact violation the evaluator
+        # rejects. eve's repair obeyed it faithfully and was rejected for it.
+        # The line must state the prohibition and the sanctioned alternative.
         entries = ", ".join(f"`{m}`" for m in params.get("entry_modules", []))
+        ctor = params.get("client_ctor", "TestClient")
         return (
-            f"`{file}` must build its `{params.get('client_ctor', 'TestClient')}` "
-            f"against one of: {entries} (no ad-hoc app construction)"
+            f"`{file}` must NOT import the app entry module ({entries}) and must NOT "
+            f"construct `{ctor}(...)` itself — every test takes the scaffold-provided "
+            f"`client` fixture as an argument (it already exists in the frozen "
+            f"conftest; do not define your own)"
         )
     # Unknown/new check type: still surface it exactly rather than dropping it.
     kv = ", ".join(f"{k}={v!r}" for k, v in sorted(params.items()) if k != "file")

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -1573,3 +1573,62 @@ class TestEmissionRetryFeedback:
             if c.args and c.args[0] == "request.cycle_emission_retry_feedback"
         ]
         assert feedback_calls == []
+
+
+class TestPromptScopedContents:
+    """pf-33: the focused qa prompt scopes its source dump to the packages the
+    task's own artifacts live in — a backend suite prompt must not carry every
+    frontend .jsx into an 18k-token prefill that pressures the completion clamp."""
+
+    _CONTENTS = {
+        "backend/routes.py": "r",
+        "backend/models.py": "m",
+        "backend/tests/conftest.py": "c",
+        "frontend/src/App.jsx": "a",
+        "frontend/src/views/RunsListView.jsx": "v",
+    }
+
+    def test_backend_suite_excludes_frontend(self):
+        scoped = QATestHandler._prompt_scoped_contents(
+            self._CONTENTS, ["backend/tests/test_runs.py"]
+        )
+        assert set(scoped) == {
+            "backend/routes.py",
+            "backend/models.py",
+            "backend/tests/conftest.py",
+        }
+
+    def test_frontend_suite_excludes_backend(self):
+        scoped = QATestHandler._prompt_scoped_contents(
+            self._CONTENTS, ["frontend/src/__tests__/CoreFlow.test.jsx"]
+        )
+        assert set(scoped) == {
+            "frontend/src/App.jsx",
+            "frontend/src/views/RunsListView.jsx",
+        }
+
+    def test_no_expected_artifacts_keeps_everything(self):
+        assert QATestHandler._prompt_scoped_contents(self._CONTENTS, []) == self._CONTENTS
+
+    def test_no_package_match_keeps_everything(self):
+        """Never starve the prompt: an expected artifact in an unknown package
+        falls back to the full dump rather than an empty source section."""
+        assert (
+            QATestHandler._prompt_scoped_contents(self._CONTENTS, ["docs/qa_handoff.md"])
+            == self._CONTENTS
+        )
+
+    def test_focused_prompt_end_to_end_scoping(self):
+        handler = QATestHandler()
+        prompt = handler._build_focused_prompt(
+            {
+                "prd": "p",
+                "subtask_focus": "backend suite",
+                "subtask_description": "d",
+                "expected_artifacts": ["backend/tests/test_runs.py"],
+                "acceptance_criteria": ["covers endpoints"],
+                "artifact_contents": self._CONTENTS,
+            }
+        )
+        assert "backend/routes.py" in prompt
+        assert "App.jsx" not in prompt

--- a/tests/unit/cycles/test_contract_expectations.py
+++ b/tests/unit/cycles/test_contract_expectations.py
@@ -101,13 +101,34 @@ class TestExpectationLines:
                     "entry_modules": ["backend.main", "app.main"],
                     "client_ctor": "TestClient",
                 },
-                "`TestClient` against one of: `backend.main`, `app.main`",
+                "must NOT import the app entry module (`backend.main`, `app.main`)",
             ),
         ],
     )
     def test_known_check_types_render(self, entry, fragment):
         (line,) = expectation_lines([entry])
         assert fragment in line
+
+    def test_harness_boundary_states_prohibition_not_construction(self):
+        """pf-33 corr-00 regression: the old wording ("must build its TestClient
+        against one of: backend.main...") read as an instruction to import the
+        entry module and construct the client — eve's repair obeyed it and was
+        rejected by the very check the line rendered. The line must forbid the
+        import/construction and point at the scaffold `client` fixture."""
+        (line,) = expectation_lines(
+            [
+                {
+                    "check": "harness_boundary",
+                    "file": "backend/tests/test_runs.py",
+                    "entry_modules": ["backend.main", "app.main"],
+                    "client_ctor": "TestClient",
+                }
+            ]
+        )
+        assert "must NOT import" in line
+        assert "must NOT construct `TestClient(...)`" in line
+        assert "`client` fixture" in line
+        assert "must build its" not in line  # the misleading phrasing stays dead
 
     def test_unknown_check_type_still_surfaces(self):
         """A new check vocabulary entry must not be silently dropped from the


### PR DESCRIPTION
**Night-window fix (pf-33), deployed from this branch per the overnight rules — for morning merge.**

## The loop-killer (proven twice in one night, live)

The Fix-A CONTRACT EXPECTATIONS block rendered `harness_boundary` as *'must build its TestClient against one of: `backend.main`, `app.main`'* — which reads as an instruction to import the entry module and construct the client. That is **the exact violation the evaluator rejects**. In pf-33:
- corr-00: eve's re-authored suite (6 good tests, parses, imports routes — verified by artifact replay) was rejected SOLELY for `from backend.main import app` + a self-built `client` fixture.
- corr-01: neo's cross-role test rewrite did `client = TestClient(main.app)` — same violation, same obeyed instruction.

Two agents, two roles, both faithfully following the authoritative block into rejection. The line now states the prohibition + the sanctioned alternative (the frozen conftest's `client` fixture), with a regression test pinning the old phrasing dead.

## Also from the same triage

- **qa prompt diet**: the focused qa prompt scoped its source dump to the packages the task's own artifacts live in (RC2 package rule at the prompt seam). m007's prompt carried all 16 files (~18k tokens incl. every frontend .jsx) into a backend suite task — prefill waste + rambling pressure against the deliberate 8192 completion clamp; attempt 1 truncated mid-file and crashed collection.
- **patch_verification observability**: the log now names failed checks (`failed=...`) — 'status=failed reason= checks=7' cost a by-hand artifact replay per rejection tonight.

## pf-33 measurement wins before the cancel (for the record)

- #568 fired correctly in BOTH directions: exit-2 → own_artifact → `qa.test_repair`/eve (first ever), exit-1 → subject → dev chain. Target override correctly ignored /health drift noise on the own-artifact path.
- The contract-as-arbiter dynamic worked: eve's suite asserted the contract-correct 409 against the app's 400.
- Known next wall (documented, NOT fixed here): `ApiError(status_code=, detail=)` signature misuse re-appeared in a dev repair (pf-28 Finding-D class) — the call-signature knowledge lives only in the scaffold stub docstring, which dies with the first fill.

Tests: 124 pass across both touched suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXrSUPGsx5yxbsn19aDjXX