### PR TITLE
fix(correction): night-window stack — ERROR CONTRACT block, exit-4 locus, initial-qa expectations

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -155,6 +155,59 @@ def _resolve_repair_target(
     )
 
 
+def _inject_deterministic_evidence(
+    failure_evidence: dict[str, Any],
+    *,
+    envelope: TaskEnvelope,
+    interface_manifest: Any,
+    artifact_contents: dict[str, str] | None,
+    scaffold_enforcement_carry: list[str] | None,
+) -> None:
+    """Deterministic authoritative-evidence injection for the correction chain.
+
+    Every entry is data-derived (manifest / typed criteria / prior enforcement),
+    never LLM output, and each travels the same failure_evidence →
+    authoritative-prompt-block transport. Additive: absent sources inject nothing.
+
+    - ``interface_drift`` (piece 1): exact renamed identifiers vs the manifest.
+    - ``scaffold_enforcement`` (3.4b): prior attempts' frozen-restore instructions.
+    - ``contract_expectations`` (pf-31 Fix A): the failed task's typed criteria
+      as exact expectation lines.
+    - ``error_contract`` (pf-34): the ApiError raise convention + code→status
+      map — scaffold-owned knowledge that dies with the fill-slot stub's
+      docstring; without it dev repairs guess ``ApiError(status_code=...,
+      detail=...)`` and 500 every error path at the behavioral retest despite
+      passing all typed checks (pf-33 corr-01, pf-34 corr-00).
+    """
+    from squadops.capabilities.scaffold import error_seam_instructions
+    from squadops.cycles.contract_expectations import expectation_lines
+    from squadops.cycles.interface_conformance import detect_interface_drift
+
+    drift = detect_interface_drift(interface_manifest, artifact_contents)
+    if drift:
+        failure_evidence["interface_drift"] = [
+            {
+                "kind": f.kind,
+                "file": f.file,
+                "extra": list(f.extra),
+                "missing": list(f.missing),
+                "instruction": f.instruction,
+            }
+            for f in drift
+        ]
+
+    if scaffold_enforcement_carry:
+        failure_evidence["scaffold_enforcement"] = list(scaffold_enforcement_carry)
+
+    expectations = expectation_lines((envelope.inputs or {}).get("acceptance_criteria"))
+    if expectations:
+        failure_evidence["contract_expectations"] = expectations
+
+    error_lines = error_seam_instructions(interface_manifest)
+    if error_lines:
+        failure_evidence["error_contract"] = error_lines
+
+
 def _locus_and_repair_target(
     failed_task_type: str,
     failure_evidence: Any,
@@ -557,41 +610,13 @@ class CorrectionRunner:
         failure_evidence = build_failure_evidence(
             envelope, result, prior_plan_deltas_count=len(plan_delta_refs)
         )
-
-        # Deterministic interface-drift diagnosis (piece 1): when the app renamed
-        # a model field or route the manifest pins, hand the repair agent the exact
-        # offending identifiers + interface targets instead of an opaque check
-        # status. Additive — a clean workspace or absent manifest injects nothing,
-        # leaving the LLM-analysis path unchanged.
-        from squadops.cycles.interface_conformance import detect_interface_drift
-
-        drift = detect_interface_drift(interface_manifest, artifact_contents)
-        if drift:
-            failure_evidence["interface_drift"] = [
-                {
-                    "kind": f.kind,
-                    "file": f.file,
-                    "extra": list(f.extra),
-                    "missing": list(f.missing),
-                    "instruction": f.instruction,
-                }
-                for f in drift
-            ]
-
-        # 3.4b restore+signal: prior attempts' frozen-restore instructions reach this
-        # attempt's analyze/decision/repair prompts as authoritative evidence (the
-        # same deterministic-instruction pattern as interface_drift above).
-        if scaffold_enforcement_carry:
-            failure_evidence["scaffold_enforcement"] = list(scaffold_enforcement_carry)
-
-        # pf-31 Fix A: the failed task's typed criteria as exact expectation lines,
-        # so the analyzer/decision reason against the contract's letter (repairs get
-        # the same lines as an authoritative prompt block via the appendix asset).
-        from squadops.cycles.contract_expectations import expectation_lines
-
-        expectations = expectation_lines((envelope.inputs or {}).get("acceptance_criteria"))
-        if expectations:
-            failure_evidence["contract_expectations"] = expectations
+        _inject_deterministic_evidence(
+            failure_evidence,
+            envelope=envelope,
+            interface_manifest=interface_manifest,
+            artifact_contents=artifact_contents,
+            scaffold_enforcement_carry=scaffold_enforcement_carry,
+        )
 
         # Issue #95: capture each correction step's outputs in its own variable
         # so the analyzer's classification/analysis_summary survive past the

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -351,8 +351,22 @@ class QATestHandler(_CycleTaskHandler):
         parts.append("### Expected Output Files\n")
         parts.extend(f"- `{f}`\n" for f in expected_files)
 
+        # pf-36: typed criteria render ONLY through the authoritative expectations
+        # block; the narrative section carries prose alone. The raw dump rendered
+        # TypedChecks as dict-repr soup, so the corrected harness_boundary line
+        # (and every other exact expectation) never reached the INITIAL suite
+        # generation — eve self-built TestClient(app) on every fresh roll and only
+        # her repairs (which get the block) complied. Same A2 treatment the repair
+        # prompt received in pf-31 Fix A / pf-33.
+        from squadops.cycles.contract_expectations import expectation_lines, prose_criteria
+
+        typed_lines = expectation_lines(acceptance_criteria)
+        if typed_lines:
+            parts.append("\n### Contract Expectations (authoritative — apply exactly)\n")
+            parts.extend(f"- {line}\n" for line in typed_lines)
+            acceptance_criteria = prose_criteria(acceptance_criteria)
         if acceptance_criteria:
-            parts.append("\n### Acceptance Criteria\n")
+            parts.append("\n### Acceptance Criteria (narrative)\n")
             parts.extend(f"- {c}\n" for c in acceptance_criteria)
 
         parts.append(f"\n### Context\nPRD:\n{prd}\n")

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -98,6 +98,17 @@ def _format_failure_summary(failure_evidence: Any, failure_analysis: Any) -> str
                 "FROZEN OWNERSHIP (authoritative — apply exactly):\n"
                 + "\n".join(f"- {str(line).strip()}" for line in enforcement if str(line).strip())
             )
+        # pf-34: the ApiError(code, message) raise convention + code→status map,
+        # manifest-derived (scaffold.error_seam_instructions) — repairs otherwise
+        # guess the signature and 500 every error path at the behavioral retest.
+        error_contract = failure_evidence.get("error_contract") or []
+        if error_contract:
+            parts.append(
+                "ERROR CONTRACT (authoritative — apply exactly):\n"
+                + "\n".join(
+                    f"- {str(line).strip()}" for line in error_contract if str(line).strip()
+                )
+            )
         vr = failure_evidence.get("validation_result") or {}
         summary = vr.get("summary") or failure_evidence.get("error") or ""
         if summary:

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -391,6 +391,37 @@ def fill_slot_paths(manifest: InterfaceManifest) -> tuple[str, ...]:
     return ("backend/routes.py", *dict.fromkeys(views))
 
 
+def error_seam_instructions(manifest: InterfaceManifest | None) -> list[str]:
+    """Authoritative error-contract lines for correction/repair prompts (pf-34).
+
+    The ``ApiError(code, message)`` raise convention and the code→status map are
+    scaffold-owned interface knowledge; they live in the manifest's
+    ``error_contract`` and in the fill-slot STUB's docstring — which dies the
+    moment the first fill replaces the stub. Repairs then guess the seam:
+    ``ApiError(status_code=..., detail=...)`` appeared in dev repairs on two
+    consecutive rolls (pf-33 corr-01, pf-34 corr-00 — every error path
+    TypeError→500 at runtime, failing the behavioral retest AFTER passing all
+    typed checks, which cannot see call signatures). These lines travel the
+    same failure_evidence → authoritative-block transport as interface drift
+    and frozen-ownership instructions. Empty when the manifest declares no
+    error contract (author mode, non-scaffold stacks).
+    """
+    ec = manifest.api.error_contract if manifest is not None else None
+    if ec is None or not ec.codes:
+        return []
+    code_map = ", ".join(f"`{c.code}` → {c.http}" for c in ec.codes)
+    return [
+        (
+            "on failure raise `ApiError(code, message)` (imported from `.errors`): the "
+            "FIRST argument is the error-code STRING, the second a human message — "
+            "never `ApiError(status_code=..., detail=...)` and never `HTTPException` "
+            "for contract errors; the frozen `errors.py` maps the code to the HTTP "
+            "status and renders the pinned envelope"
+        ),
+        f"valid error codes (code → HTTP status, mapped by frozen `errors.py`): {code_map}",
+    ]
+
+
 # SIP-0100 D1 (bounded-hybrid QA test ownership): the scaffold owns the *namespace* — the
 # deterministic directory prefixes a bound plan may declare concrete QA test files within — while
 # the plan declares the concrete paths. A QA producer may write only inside this surface; a QA

--- a/src/squadops/cycles/failure_evidence.py
+++ b/src/squadops/cycles/failure_evidence.py
@@ -91,11 +91,16 @@ class FailureLocus:
     UNKNOWN = "unknown"
 
 
-# pytest exit codes that mean the SUITE could not run as a suite — collection
-# errors/interruption (2), usage error (4), no tests collected (5). Exit 1
-# (tests ran, some failed) is the subject's failure; 3 (pytest internal error)
-# stays UNKNOWN — neither artifact nor subject is implicated deterministically.
-_SUITE_DEFECT_EXIT_CODES = frozenset({2, 4, 5})
+# pytest exit codes that mean the SUITE ITSELF is the defect — collection
+# errors in the test files (2), no tests collected (5). Exit 1 (tests ran,
+# some failed) is the subject's failure. Exit 3 (pytest internal error) stays
+# UNKNOWN. Exit 4 (usage error) ALSO stays UNKNOWN → default dev chain:
+# pf-35 corr-01/02 proved it ambiguous — conftest/app-import failures (an
+# accepted routes.py importing names the frozen models.py never defined)
+# surface as exit 4, and classifying that own-artifact sent the qa role to
+# re-author a suite that could never fix the app's broken import. Ambiguity
+# falls toward the dev chain, per the same guard rationale as test-gaming.
+_SUITE_DEFECT_EXIT_CODES = frozenset({2, 5})
 
 
 def classify_failure_locus(failure_evidence: Any) -> str:

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -1632,3 +1632,53 @@ class TestPromptScopedContents:
         )
         assert "backend/routes.py" in prompt
         assert "App.jsx" not in prompt
+
+
+class TestFocusedPromptExpectations:
+    """pf-36: the INITIAL qa prompt renders typed criteria through the
+    authoritative expectations block (incl. the corrected harness_boundary
+    line) — the raw dict-soup dump meant every fresh suite generation
+    self-built TestClient(app) and only repairs complied."""
+
+    def test_typed_criteria_render_as_expectations_block(self):
+        handler = QATestHandler()
+        prompt = handler._build_focused_prompt(
+            {
+                "prd": "p",
+                "subtask_focus": "backend suite",
+                "subtask_description": "d",
+                "expected_artifacts": ["backend/tests/test_runs.py"],
+                "acceptance_criteria": [
+                    "covers all endpoints",
+                    {
+                        "check": "harness_boundary",
+                        "file": "backend/tests/test_runs.py",
+                        "entry_modules": ["backend.main", "app.main"],
+                        "client_ctor": "TestClient",
+                        "id": "scaffold-harness:backend/tests/test_runs.py",
+                    },
+                ],
+                "artifact_contents": {},
+            }
+        )
+        assert "### Contract Expectations (authoritative — apply exactly)" in prompt
+        assert "must NOT import the app entry module" in prompt
+        assert "`client` fixture" in prompt
+        assert "### Acceptance Criteria (narrative)" in prompt
+        assert "covers all endpoints" in prompt
+        assert "'check':" not in prompt  # no dict-repr soup
+
+    def test_prose_only_criteria_keep_plain_section(self):
+        handler = QATestHandler()
+        prompt = handler._build_focused_prompt(
+            {
+                "prd": "p",
+                "subtask_focus": "f",
+                "subtask_description": "d",
+                "expected_artifacts": ["backend/tests/t.py"],
+                "acceptance_criteria": ["only prose"],
+                "artifact_contents": {},
+            }
+        )
+        assert "Contract Expectations" not in prompt
+        assert "### Acceptance Criteria (narrative)" in prompt

--- a/tests/unit/capabilities/test_repair_contract_expectations.py
+++ b/tests/unit/capabilities/test_repair_contract_expectations.py
@@ -105,3 +105,27 @@ def test_templates_declare_and_use_the_variable():
     appendix = _APPENDIX.read_text()
     assert "authoritative" in appendix
     assert "{{expectations}}" in appendix
+
+
+def test_failure_summary_renders_error_contract_block():
+    """pf-34: the ERROR CONTRACT block renders authoritatively in the repair
+    prompt, above the analyzer prose — the ApiError signature stops being a
+    guess."""
+    from squadops.capabilities.handlers.impl.repair_handlers import _format_failure_summary
+
+    summary = _format_failure_summary(
+        {
+            "error_contract": [
+                "on failure raise `ApiError(code, message)` — never "
+                "`ApiError(status_code=..., detail=...)`",
+                "valid error codes: `run_not_found` → 404",
+            ],
+            "validation_result": {"summary": "tests failed"},
+        },
+        {"analysis_summary": "endpoint returns 400 instead of 404"},
+    )
+    assert "ERROR CONTRACT (authoritative — apply exactly):" in summary
+    assert "ApiError(code, message)" in summary
+    idx_block = summary.index("ERROR CONTRACT")
+    idx_analysis = summary.index("Analyzer summary")
+    assert idx_block < idx_analysis

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -486,3 +486,29 @@ async def test_scaffold_harness_resolves_under_the_production_test_runner():
     assert result.executed is True, getattr(result, "output", result)
     assert result.exit_code == 0, getattr(result, "output", result)
     assert result.tests_passed is True
+
+
+class TestErrorSeamInstructions:
+    """pf-34: the ApiError raise convention must survive the stub's death and
+    reach correction prompts — dev repairs guessed ApiError(status_code=...,
+    detail=...) on two consecutive rolls and 500'd every error path."""
+
+    def test_lines_derive_from_manifest_error_contract(self):
+        from squadops.capabilities.scaffold import error_seam_instructions
+
+        lines = error_seam_instructions(_group_run_manifest())
+        assert len(lines) == 2
+        assert "ApiError(code, message)" in lines[0]
+        assert "never `ApiError(status_code=..., detail=...)`" in lines[0]
+        assert "HTTPException" in lines[0]
+        assert "`run_not_found` → 404" in lines[1]
+        assert "`duplicate_participant` → 409" in lines[1]
+        assert "`validation_error` → 422" in lines[1]
+
+    def test_empty_without_error_contract_or_manifest(self):
+        from squadops.capabilities.scaffold import error_seam_instructions
+
+        raw = _raw_manifest()
+        raw["api"].pop("error_contract", None)
+        assert error_seam_instructions(InterfaceManifest.from_dict(raw)) == []
+        assert error_seam_instructions(None) == []

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -2688,3 +2688,84 @@ class TestOwnArtifactLocusRouting(TestCorrectionRunnerStandalone):
 
         repair_envelopes = [e for e in captured if e.task_type.endswith("_repair")]
         assert [e.task_type for e in repair_envelopes] == ["development.correction_repair"]
+
+
+class TestErrorContractEvidence(TestCorrectionRunnerStandalone):
+    """pf-34: the manifest's error-contract raise convention travels into
+    failure_evidence so analyze AND the repair prompt state the ApiError
+    signature authoritatively (the pf-33/pf-34 repair 500-class killer)."""
+
+    async def test_error_contract_injected_when_manifest_present(self, cycle):
+        from pathlib import Path as _Path
+
+        from squadops.capabilities.scaffold import InterfaceManifest
+
+        manifest = InterfaceManifest.from_yaml(
+            _Path("examples/03_group_run/interface_manifest.yaml").read_text(encoding="utf-8")
+        )
+        analyze_inputs: dict = {}
+
+        def responder(envelope):
+            if envelope.task_type == "data.analyze_failure":
+                analyze_inputs.update(envelope.inputs or {})
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={"classification": "work_product", "analysis_summary": "x"},
+                )
+            return TaskResult(
+                task_id=envelope.task_id,
+                status="SUCCEEDED",
+                outputs={"correction_path": "continue", "decision_rationale": "r"},
+            )
+
+        runner, _r, _v, _b = self._make_runner(responder)
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=self._failed_envelope(),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="bad"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+            interface_manifest=manifest,
+        )
+        evidence = analyze_inputs.get("failure_evidence") or {}
+        lines = evidence.get("error_contract") or []
+        assert any("ApiError(code, message)" in ln for ln in lines)
+        assert any("run_not_found" in ln for ln in lines)
+
+    async def test_absent_manifest_injects_nothing(self, cycle):
+        analyze_inputs: dict = {}
+
+        def responder(envelope):
+            if envelope.task_type == "data.analyze_failure":
+                analyze_inputs.update(envelope.inputs or {})
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={"classification": "work_product", "analysis_summary": "x"},
+                )
+            return TaskResult(
+                task_id=envelope.task_id,
+                status="SUCCEEDED",
+                outputs={"correction_path": "continue", "decision_rationale": "r"},
+            )
+
+        runner, _r, _v, _b = self._make_runner(responder)
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=self._failed_envelope(),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="bad"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+        assert "error_contract" not in (analyze_inputs.get("failure_evidence") or {})

--- a/tests/unit/cycles/test_failure_evidence.py
+++ b/tests/unit/cycles/test_failure_evidence.py
@@ -304,9 +304,9 @@ class TestClassifyFailureLocus:
         }
         assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.OWN_ARTIFACT
 
-    @pytest.mark.parametrize("exit_code", [2, 4, 5])
+    @pytest.mark.parametrize("exit_code", [2, 5])
     def test_suite_defect_exit_codes_are_own_artifact(self, exit_code):
-        """pytest 2=collection/interrupted, 4=usage error, 5=no tests collected:
+        """pytest 2=collection error in the test files, 5=no tests collected:
         the suite itself cannot run as a suite — the test artifact is the defect
         (pf-31's truncated-test collection crash lands here)."""
         row = {"check": "tests_pass", "executed": True, "exit_code": exit_code, "passed": False}
@@ -320,6 +320,15 @@ class TestClassifyFailureLocus:
 
     def test_pytest_internal_error_is_unknown(self):
         row = {"check": "tests_pass", "executed": True, "exit_code": 3, "passed": False}
+        assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.UNKNOWN
+
+    def test_exit_four_is_unknown_dev_chain(self):
+        """pf-35 corr-01/02 regression: exit 4 (usage error) is AMBIGUOUS — a
+        conftest/app-import failure (accepted routes.py importing names the
+        frozen models.py never defined) surfaces as exit 4, and own-artifact
+        classification sent the qa role to re-author a suite that could never
+        fix the app's import. Ambiguity falls to the dev chain."""
+        row = {"check": "tests_pass", "executed": True, "exit_code": 4, "passed": False}
         assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.UNKNOWN
 
     def test_not_executed_suite_is_unknown(self):


### PR DESCRIPTION
**The remaining three night-window fixes, stacked on the just-merged #584.** Each was built live from a diagnosed roll failure, deployed from its branch, and validated in the following roll (deploy currently runs these — merging re-unifies main with what's on the box).

## 1. `fix/error-contract-salience` (pf-34's killer)
Dev repairs guessed `ApiError(status_code=..., detail=...)` — the frozen contract is `ApiError(code, message)`, so every error path TypeError'd into a 500 *after* passing all typed checks (call signatures are invisible to them). The raise convention lives in the manifest's `error_contract` and the fill-stub's docstring, which dies at first fill. Now: `scaffold.error_seam_instructions(manifest)` (pure, manifest-derived: convention + code→status map) → `failure_evidence["error_contract"]` → an **ERROR CONTRACT (authoritative)** block in repair prompts, same transport as INTERFACE CONFORMANCE / FROZEN OWNERSHIP. Plus a C901 extraction (`_inject_deterministic_evidence`) unifying all deterministic evidence injection.

## 2. `fix/exit4-locus-and-qa-harness-injection` (pf-35's killer)
pytest exit 4 was classified own-artifact — but a conftest/app-import failure (an accepted routes.py importing names the frozen models.py never defines) also surfaces as exit 4, and that misroute sent eve to re-author a suite that could never fix the app, twice. Exit 4 now classifies UNKNOWN → default dev chain (ambiguity never routes toward qa re-authoring, same rationale as the test-gaming guard). Verified live on pf-36: the identical failure shape routed to a dev repair.

## 3. `fix/qa-initial-prompt-expectations` (pf-36's killer)
The INITIAL qa focused prompt dumped typed criteria as dict-repr soup, so the corrected harness_boundary line only ever reached eve via *repair* prompts — every fresh suite self-built `TestClient(app)` (0-for-3 overnight), the broken suite failed a likely-correct app as exit-1/SUBJECT, and dev repairs can't fix a test file. Initial prompts now render the same authoritative **Contract Expectations** block the repair path uses (pf-31 Fix A treatment, completed). Known follow-up (not here): the dev initial prompt has the same soup, but its repair path recovers in one shot — proven twice tonight.

## Verification
Per-fix unit + regression suites at each commit (3293+/1315+ passing; only the 2 known host missing_tooling failures); each fix behaviorally verified in-container post-rebuild; #2 additionally validated by live routing on the next roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXrSUPGsx5yxbsn19aDjXX