### PR TITLE
fix(cycles): cancel reaches the dispatch boundary — repairs stop on a cancelled run (#586)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -11,9 +11,13 @@ state — slice 5 retired the interim executor-supplied dispatch callables
 per AC#9). ``store_artifact`` remains a narrow executor-supplied callable:
 artifact plumbing is §6.7 executor residual, residual-but-watched.
 
-Cancellation: the protocol performs no cancellation checks of its own (it
-never did); it relies on the dispatch path's checks at dispatch/await
-boundaries per the §6 cancellation ownership rule.
+Cancellation: the protocol performs no cancellation checks of its own; it
+relies on the dispatch path's check per the §6 cancellation ownership rule.
+That check now exists — ``TaskDispatcher.dispatch_task`` probes before every
+publish (#586). Until it was wired, this delegation pointed at nothing: the
+transport documented the probe as "deliberately not wired" while this module
+documented itself as relying on it, so a run cancelled mid-correction ran to
+attempt exhaustion (2h20m, five attempts, observed 2026-07-25).
 
 Repair acceptance is deterministic-only (#556): the repair sequence has no
 LLM validation step — patch verification (#389) re-runs the typed criteria

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -164,6 +164,10 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             activity_port=activity_port,
             event_bus=event_bus,
             task_timeout=task_timeout,
+            # §6.1 cancellation probe (#586). Wired on the single dispatcher
+            # instance the correction and pulse runners below share, so cancel
+            # reaches every dispatch path, not just the sequential loop top.
+            is_cancelled=lambda run_id: self._is_cancelled(run_id),
         )
         # SIP-0097 §6.3: correction-protocol collaborator. store_artifact stays
         # an executor-supplied late-bound callable (artifact plumbing is §6.7

--- a/adapters/cycles/task_dispatcher.py
+++ b/adapters/cycles/task_dispatcher.py
@@ -18,13 +18,19 @@ loop (§6.1): ``dispatch_with_retry`` receives the executor's routing
 decision as a per-call ``handle_task_outcome`` closure and only acts on the
 returned action token — the decision logic never moves.
 
-Cancellation: the transport performs no cancellation checks of its own (it
-never did — the orchestration loops check between tasks); the §6.1
-cancellation probe is deliberately not wired until a dispatch-boundary
-check actually exists (defer-infra-completeness). Likewise the §6.1 LLM
-observability dependency: per-task generation traces are recorded
-agent-side today, so the port is not taken until this class has a real use
-for it.
+Cancellation (§6.1 probe, #586): this class owns the dispatch-boundary
+check. ``dispatch_task`` probes ``is_cancelled`` before publishing, so no
+agent work starts on a cancelled run — on *any* path through this
+transport, including the correction/repair and pulse-boundary dispatches
+whose runners depend on this class directly. The orchestration loops keep
+their own between-task checks; those alone left the long-running paths
+uncovered, because a correction loop dispatches many tasks without ever
+returning to the loop top (#586: a cancelled run burned five correction
+attempts over 2h20m).
+
+The §6.1 LLM observability dependency remains untaken: per-task generation
+traces are recorded agent-side today, so the port is not wired until this
+class has a real use for it.
 """
 
 from __future__ import annotations
@@ -36,6 +42,7 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
+from adapters.cycles.execution_errors import _CancellationError
 from adapters.cycles.task_naming import build_task_name
 from squadops.events.types import EventType
 from squadops.runtime import reasons
@@ -73,6 +80,7 @@ class TaskDispatcher:
         activity_port: RuntimeActivityPort | None = None,
         event_bus: CycleEventBusPort | None = None,
         task_timeout: float = 300.0,
+        is_cancelled: Callable[[str], Awaitable[bool]] | None = None,
     ) -> None:
         self._queue = queue
         self._reply_router = reply_router
@@ -80,6 +88,10 @@ class TaskDispatcher:
         self._activity_port = activity_port
         self._event_bus = event_bus
         self._task_timeout = task_timeout
+        # §6.1 cancellation probe (#586). Executor-supplied callable, the same
+        # idiom as ``store_artifact`` / ``handle_task_outcome``: the transport
+        # asks "is this run cancelled?" without taking a registry dependency.
+        self._is_cancelled = is_cancelled
 
     # SIP-0087: task-run lifecycle lives here (moved out of WorkflowTrackerBridge) so
     # the task_run_id is known before the agent starts producing logs.
@@ -126,6 +138,21 @@ class TaskDispatcher:
                 envelope.task_id,
             )
 
+    async def _raise_if_cancelled(self, run_id: str) -> None:
+        """Raise ``_CancellationError`` when the run has been cancelled (#586).
+
+        No-op when no probe is wired (standalone unit tests, in-memory
+        compositions). Probe errors propagate deliberately — the between-task
+        check this complements has always been fail-closed, and a probe that
+        silently swallowed registry errors would reintroduce the very
+        "cancel doesn't stop it" behaviour this exists to prevent.
+        """
+        if self._is_cancelled is None:
+            return
+        if await self._is_cancelled(run_id):
+            logger.info("Dispatch cancelled: run %s is cancelled", run_id)
+            raise _CancellationError(run_id)
+
     async def dispatch_task(
         self,
         envelope: TaskEnvelope,
@@ -145,7 +172,15 @@ class TaskDispatcher:
         ``PrefectLogHandler`` scopes handler logs to the right Prefect task
         pane, and spawns a periodic heartbeat coroutine so long-running LLM
         calls show liveness in the UI.
+
+        Raises:
+            _CancellationError — the run was cancelled before this dispatch
+                (§6.1 probe, #586). Raised before any Prefect task run is
+                created and before publish, so a cancelled run starts no
+                further agent work on any path through this transport.
         """
+        await self._raise_if_cancelled(run_id)
+
         if task_run_id is None:
             task_run_id = await self.create_task_run_if_enabled(flow_run_id, envelope)
 

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -735,3 +735,56 @@ class TestArtifactStorage:
                 continue
             assert "task_id" in ref.metadata
             assert "role" in ref.metadata
+
+
+# ---------------------------------------------------------------------------
+# Cancellation probe wiring (#586)
+# ---------------------------------------------------------------------------
+
+
+class TestCancellationProbeWiring:
+    """The §6.1 probe is only worth anything if the *composed* dispatcher gets
+    it — and if the correction/pulse runners share that same instance.
+
+    #586 was a mutual-delegation hole: ``CorrectionRunner`` documented itself as
+    relying on a dispatch-boundary check, ``TaskDispatcher`` documented that
+    check as not wired, and the only real probe sat at the sequential loop top —
+    which a correction loop never returns to until it exhausts.
+    """
+
+    async def test_composed_dispatcher_probe_reflects_registry_cancellation(
+        self, executor, mock_registry, run
+    ) -> None:
+        """Bug caught: the probe parameter exists but the executor's default
+        composition doesn't pass it, so the fix is inert in production."""
+        probe = executor._task_dispatcher._is_cancelled
+        assert probe is not None, "executor composed a dispatcher with no cancellation probe"
+
+        mock_registry.get_run.return_value = run  # status "queued"
+        assert await probe("run_001") is False
+
+        mock_registry.get_run.return_value = Run(
+            run_id="run_001",
+            cycle_id="cyc_001",
+            run_number=1,
+            status=RunStatus.CANCELLED.value,
+            initiated_by="api",
+            resolved_config_hash="hash",
+        )
+        assert await probe("run_001") is True
+
+    async def test_correction_and_pulse_runners_share_the_probed_dispatcher(self, executor) -> None:
+        """Bug caught: a runner composing its own unprobed TaskDispatcher would
+        leave the repair path — the exact #586 path — uncovered."""
+        shared = executor._task_dispatcher
+        assert executor._correction_runner._task_dispatcher is shared
+        assert executor._pulse_boundary_runner._task_dispatcher is shared
+
+    async def test_probe_honours_the_local_cancel_fast_path(self, executor) -> None:
+        """Bug caught: a probe that only reads the registry misses an in-process
+        ``cancel_run`` whose registry write failed (the method logs and
+        continues), letting dispatch proceed on a run the operator cancelled."""
+        executor._cycle_registry.cancel_run.side_effect = RuntimeError("registry down")
+        await executor.cancel_run("run_001")
+
+        assert await executor._task_dispatcher._is_cancelled("run_001") is True

--- a/tests/unit/cycles/test_task_dispatcher.py
+++ b/tests/unit/cycles/test_task_dispatcher.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from adapters.cycles.execution_errors import _CancellationError
 from adapters.cycles.task_dispatcher import TaskDispatcher
 from squadops.tasks.models import TaskEnvelope, TaskResult
 
@@ -598,4 +599,182 @@ class TestAcceptPatchToken:
         # The dispatcher hands back the raw failed result; the executor
         # substitutes the corrected one from its holder (#389).
         assert result.status == "FAILED"
+        assert mock_queue.publish.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Cancellation probe (#586)
+# ---------------------------------------------------------------------------
+
+
+class TestCancellationProbe:
+    """§6.1 dispatch-boundary cancellation check.
+
+    Before #586 this class documented the probe as "deliberately not wired"
+    while ``CorrectionRunner`` documented itself as relying on it — so the only
+    real check was the executor's between-task one, and a run cancelled inside
+    a correction loop kept dispatching repairs for 2h20m.
+    """
+
+    def _envelope(self):
+        return TaskEnvelope(
+            task_id="task_repair",
+            agent_id="neo",
+            cycle_id="cyc_001",
+            pulse_id="p1",
+            project_id="proj_001",
+            task_type="development.develop",
+            correlation_id="corr",
+            causation_id="cause",
+            trace_id="trace",
+            span_id="span",
+            metadata={"role": "dev"},
+        )
+
+    async def test_cancelled_run_raises_before_publishing(self, mock_queue, reply_router) -> None:
+        """Bug caught: a repair dispatched onto a cancelled run — the #586 shape.
+
+        The assertion that matters is ``publish`` never happening: raising after
+        publish would still hand the agent an LLM task to burn.
+        """
+        dispatcher = TaskDispatcher(
+            queue=mock_queue,
+            reply_router=reply_router,
+            task_timeout=5.0,
+            is_cancelled=AsyncMock(return_value=True),
+        )
+
+        with pytest.raises(_CancellationError) as exc_info:
+            await dispatcher.dispatch_task(self._envelope(), "run_001")
+
+        assert "run_001" in str(exc_info.value)
+        mock_queue.publish.assert_not_awaited()
+
+    async def test_cancelled_run_creates_no_prefect_task_run(
+        self, mock_queue, reply_router
+    ) -> None:
+        """Bug caught: probing after task-run creation orphans a RUNNING
+        task_run in the Prefect UI for every cancelled dispatch."""
+        tracker = AsyncMock()
+        dispatcher = TaskDispatcher(
+            queue=mock_queue,
+            reply_router=reply_router,
+            workflow_tracker=tracker,
+            task_timeout=5.0,
+            is_cancelled=AsyncMock(return_value=True),
+        )
+
+        with pytest.raises(_CancellationError):
+            await dispatcher.dispatch_task(self._envelope(), "run_001", flow_run_id="flow_001")
+
+        tracker.create_task_run.assert_not_awaited()
+        tracker.set_task_run_state.assert_not_awaited()
+
+    async def test_live_run_dispatches_normally(self, mock_queue, reply_router) -> None:
+        """Bug caught: a probe wired fail-closed (always raising) would kill
+        every healthy run — the inverse regression of the fix."""
+        probe = AsyncMock(return_value=False)
+        dispatcher = TaskDispatcher(
+            queue=mock_queue,
+            reply_router=reply_router,
+            task_timeout=5.0,
+            is_cancelled=probe,
+        )
+
+        with patch("adapters.cycles.task_dispatcher.asyncio.sleep", new_callable=AsyncMock):
+            result = await dispatcher.dispatch_task(self._envelope(), "run_001")
+
+        assert result.status == "SUCCEEDED"
+        mock_queue.publish.assert_awaited_once()
+        probe.assert_awaited_once_with("run_001")
+
+    async def test_probe_failure_propagates_rather_than_dispatching(
+        self, mock_queue, reply_router
+    ) -> None:
+        """Bug caught: swallowing probe errors silently restores the #586
+        behaviour — a registry blip would resume dispatching on a cancelled
+        run. The between-task check this complements is fail-closed too."""
+        dispatcher = TaskDispatcher(
+            queue=mock_queue,
+            reply_router=reply_router,
+            task_timeout=5.0,
+            is_cancelled=AsyncMock(side_effect=RuntimeError("registry down")),
+        )
+
+        with pytest.raises(RuntimeError, match="registry down"):
+            await dispatcher.dispatch_task(self._envelope(), "run_001")
+
+        mock_queue.publish.assert_not_awaited()
+
+    async def test_unwired_probe_dispatches(self, mock_queue, reply_router) -> None:
+        """Bug caught: making the probe mandatory breaks the standalone and
+        in-memory compositions that construct a dispatcher without one."""
+        dispatcher = TaskDispatcher(
+            queue=mock_queue,
+            reply_router=reply_router,
+            task_timeout=5.0,
+        )
+
+        with patch("adapters.cycles.task_dispatcher.asyncio.sleep", new_callable=AsyncMock):
+            result = await dispatcher.dispatch_task(self._envelope(), "run_001")
+
+        assert result.status == "SUCCEEDED"
+        mock_queue.publish.assert_awaited_once()
+
+    async def test_retry_loop_stops_when_cancelled_mid_flight(
+        self, mock_queue, reply_router
+    ) -> None:
+        """Bug caught: cancel landing during a retry/correction sequence lets the
+        loop re-dispatch anyway. Probing inside ``dispatch_task`` (not only at
+        the loop top) is what bounds post-cancel work to the in-flight task."""
+        from squadops.cycles.models import Cycle, TaskFlowPolicy
+
+        cancelled = {"now": False}
+
+        async def probe(run_id: str) -> bool:
+            return cancelled["now"]
+
+        dispatcher = TaskDispatcher(
+            queue=mock_queue,
+            reply_router=reply_router,
+            task_timeout=5.0,
+            event_bus=MagicMock(),
+            is_cancelled=probe,
+        )
+        envelope = self._envelope()
+        reply_router.responder = lambda env: TaskResult(
+            task_id=env["task_id"], status="FAILED", error="needs repair"
+        )
+
+        async def handle_outcome(result):
+            # Stands in for the correction protocol: the run is cancelled while
+            # the outcome is being routed, then the loop asks for a re-dispatch.
+            cancelled["now"] = True
+            return "continue"
+
+        cycle = Cycle(
+            cycle_id="cyc_001",
+            project_id="proj_001",
+            created_at=NOW,
+            created_by="system",
+            prd_ref="prd",
+            squad_profile_id="full",
+            squad_profile_snapshot_ref="sha256:abc",
+            task_flow_policy=TaskFlowPolicy(mode="sequential"),
+            build_strategy="fresh",
+        )
+
+        with (
+            patch("adapters.cycles.task_dispatcher.asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(_CancellationError),
+        ):
+            await dispatcher.dispatch_with_retry(
+                envelope,
+                envelope,
+                cycle,
+                "run_001",
+                handle_task_outcome=handle_outcome,
+            )
+
+        # One dispatch happened (the in-flight task); the retry never published.
         assert mock_queue.publish.await_count == 1


### PR DESCRIPTION
Cancelling a run marked it cancelled in the registry but did not stop execution.
Measured live on 2026-07-25: **2h 19m 39s of post-cancel execution**, all five
correction attempts burned after the cancel, contending for the GPU with the
successor measurement roll for its entire first two hours.

Closes #586

## Root cause

The only cancellation probe sat at the top of the per-task loop in
`_execute_sequential` (`dispatched_flow_executor.py:1147`). A correction loop
dispatches analyze / repair / patch-verification / retest tasks many times
without ever returning to that loop top, so nothing ended a cancelled run
except `max_correction_attempts` exhausting naturally.

The gap was a **mutual delegation** left by the SIP-0097 decomposition — both
extracted collaborators disclaimed the check and pointed at each other:

- `correction_runner.py` — "relies on **the dispatch path's checks at
  dispatch/await boundaries** per the §6 cancellation ownership rule."
- `task_dispatcher.py` — "the §6.1 cancellation probe is **deliberately not
  wired** until a dispatch-boundary check actually exists."

Neither docstring was wrong in isolation. Together they left every long-running
path uncovered, and the correction loop grew into the dominant time sink
afterward without anyone revisiting the ownership split.

## The fix — one seam, at the owner

`TaskDispatcher` owns the dispatch boundary, so the §6.1 probe goes there.
`dispatch_task` probes `is_cancelled` **before** creating a Prefect task run and
**before** publishing, so no agent work starts on a cancelled run.

This single seam covers every dispatch path because the executor composes **one**
`TaskDispatcher` instance (`:160`) and injects it into both `CorrectionRunner`
and `PulseBoundaryRunner` — sequential dispatch, correction/repair dispatch, and
pulse-boundary repair dispatch all pass through it.

`_CancellationError` is already the shared control-flow error and already maps
through `execute_run` → `resolve_terminal_outcome` → `CANCELLED`, so the terminal
path, lease release and `finalize` are untouched.

## Design notes

**Deliberately not added: a second probe in `_handle_task_outcome`.** The issue
listed that as fix candidate 1, but reading the wiring showed the dispatcher
probe subsumes it — and adding one would push cancellation policy back into the
god file the SIP-0097 decomposition was meant to drain. One concern, one owner.

**Probe errors propagate (fail-closed).** The between-task check this
complements has always been fail-closed; a probe that swallowed registry errors
would quietly restore the #586 behaviour. Pinned by a test.

**Probe is optional at construction.** Same idiom as every other injected
collaborator here (`activity_port`, `event_bus`, `workflow_tracker`) so
standalone and in-memory compositions keep working — with a construction-path
test asserting the *real* composition actually passes it. A probe that isn't
wired is cosmetic.

## Residual — stated, not fixed

A cancel landing while a task is **awaiting its reply** still waits out that one
in-flight task (~one LLM generation, 10–15 min on 27b) rather than interrupting
the await. Post-cancel work goes from **hours to a single task**, not to zero.

Racing the reply future against the probe is feasible (`_publish_and_await`
already cleans up on `CancelledError`) but it pairs with the open design
question in #586 candidate 3 — *should cancel terminate the flow, or remain
cooperative in-band?* — so it's left as an explicit decision rather than
inherited behaviour.

## Tests

9 new, all naming the bug they catch:

**Probe behaviour** (`test_task_dispatcher.py`) — raises before publish (the
assertion that matters: `publish` never awaited); creates no orphan RUNNING
Prefect task run; healthy runs still dispatch (guards the inverse regression);
probe errors propagate; unwired probe is a no-op; retry loop stops when cancel
lands mid-flight.

**Construction path** (`test_dispatched_flow_executor.py`) — the composed
dispatcher actually receives a probe and that probe reflects registry
cancellation; `CorrectionRunner` and `PulseBoundaryRunner` share that exact
instance; the probe honours the local `cancel_run` fast path even when the
registry write fails.

## Verification

- `tests/unit` — **5,821 passed**, 3 skipped
- `tests/unit/cycles` — 1,989 passed
- ruff check + ruff format — clean
- Pre-existing on main, unrelated: 2 failures in
  `test_verification_contract_runner.py` (`vc-routes-compiles` skips
  `missing_tooling` — host has no node by design, #419). Confirmed identical on
  a clean `main` checkout.

Not deployed — no rebuild, no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
