### PR TITLE
fix(dev): the initial focused prompt carries the scaffold contract it was filling (#588)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -930,6 +930,12 @@ class DispatchedFlowExecutor(FlowExecutionPort):
     # Build task artifact filter (D3, §2.2)
     # ------------------------------------------------------------------
 
+    # Task types that author into the scaffold's fill slots and therefore need the
+    # manifest-derived error seam in their prompt (#588). A table, not a literal
+    # test at the branch — the repair path's equivalent lives in CorrectionRunner's
+    # failure_evidence assembly.
+    _ERROR_SEAM_TASK_TYPES: frozenset[str] = frozenset({"development.develop"})
+
     # Maps build task_type → which prior artifacts to inject.
     # by_producing_task: match on producing_task_type metadata
     # by_type / by_type_fallback: match on artifact_type for artifacts without provenance
@@ -1160,6 +1166,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 prior_outputs,
                 all_artifact_refs,
                 stored_artifacts,
+                interface_manifest=interface_manifest,
             )
 
             # SIP-0087: executor owns Prefect task-run creation so task_run_id
@@ -1658,6 +1665,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         prior_outputs: dict[str, Any],
         all_artifact_refs: list[str],
         stored_artifacts: list[tuple[str, ArtifactRef]],
+        interface_manifest: Any = None,
     ) -> TaskEnvelope:
         """Build chain context inputs and return an enriched envelope."""
 
@@ -1665,6 +1673,20 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             "prior_outputs": prior_outputs,
             "artifact_refs": list(all_artifact_refs),
         }
+
+        # #588: the manifest-derived error-seam lines the correction path has
+        # carried since pf-34, threaded to the INITIAL author too. The raise
+        # convention lives in the fill-slot stub's docstring, which the first
+        # fill overwrites — so without this the author guesses the signature,
+        # every error path TypeErrors into a 500, and the run pays a correction
+        # to learn what the scaffold already knew. Data only; the block's prose
+        # lives in a managed prompt asset.
+        if envelope.task_type in self._ERROR_SEAM_TASK_TYPES:
+            from squadops.capabilities.scaffold import error_seam_instructions
+
+            error_lines = error_seam_instructions(interface_manifest)
+            if error_lines:
+                extra_inputs["error_contract"] = error_lines
 
         # Pre-resolve artifact contents for build tasks (D3). Fresh dispatches
         # see the ACCEPTED state only (pf-31 Fix E): rejected repair candidates

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -283,35 +283,109 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
 
         return "\n".join(parts)
 
-    def _build_focused_prompt(self, inputs: dict[str, Any]) -> str:
+    async def _build_focused_prompt(self, inputs: dict[str, Any], renderer: Any = None) -> str:
         """Build a focused prompt for manifest-driven subtasks (SIP-0086 §6.1.5).
 
         RC-6: When subtask_focus is present, this path is used exclusively.
-        The legacy monolithic prompt path is NOT used.
+        The legacy monolithic prompt path is NOT used — which is why #588 lands
+        here: this is the ONLY prompt a plan-driven dev task ever sees, and it
+        previously carried neither the SIP-0099 fill-only instruction (wired
+        only into the monolithic path) nor the manifest-derived error seam. The
+        initial author was told nothing about the frozen surface it was filling.
+
+        Three changes, all the treatment #585 gave the qa twin:
+        - Typed criteria render as the authoritative Contract Expectations block
+          instead of ``f"- {dict}"`` repr soup, with narrative prose demoted below.
+        - The fill-only + ERROR CONTRACT sections reach the initial author.
+        - Every block of prose lives in a managed asset (CLAUDE.md #448); this
+          method assembles DATA and nothing else.
+
+        Falls back to unrendered plain text only when no renderer is wired
+        (the same degraded path ``_build_dev_prompt`` has always had).
         """
-        prd = inputs.get("prd", "")
+        from squadops.cycles.contract_expectations import expectation_lines, prose_criteria
+
         focus = inputs["subtask_focus"]
-        description = inputs.get("subtask_description", "")
-        expected_files = inputs.get("expected_artifacts", [])
-        acceptance_criteria = inputs.get("acceptance_criteria", [])
-        artifact_contents = inputs.get("artifact_contents", {})
+        description = str(inputs.get("subtask_description", "") or "")
+        prd = str(inputs.get("prd", "") or "")
+        expected_files = inputs.get("expected_artifacts", []) or []
+        acceptance_criteria = inputs.get("acceptance_criteria", []) or []
+        artifact_contents = inputs.get("artifact_contents", {}) or {}
 
+        expected_block = "\n".join(f"- `{f}`" for f in expected_files)
+        typed_lines = expectation_lines(acceptance_criteria)
+        narrative = prose_criteria(acceptance_criteria)
+        artifacts_block = "\n".join(
+            f"**{name}:**\n```\n{content}\n```" for name, content in artifact_contents.items()
+        )
+
+        if renderer is None:
+            return self._focused_prompt_fallback(
+                focus, description, expected_block, typed_lines, narrative, prd, artifacts_block
+            )
+
+        variables: dict[str, str] = {
+            "focus": str(focus),
+            "expected_files": expected_block,
+            "prd": prd,
+        }
+        if description:
+            variables["description"] = description
+        fill_only = await self._fill_only_section(renderer, inputs)
+        if fill_only:
+            variables["fill_only_section"] = fill_only
+        if typed_lines:
+            expectations = await renderer.render(
+                "request.cycle_repair_contract_expectations_appendix",
+                {"expectations": "\n".join(f"- {line}" for line in typed_lines)},
+            )
+            variables["contract_expectations"] = expectations.content
+        if narrative:
+            rendered_narrative = await renderer.render(
+                "request.development_develop_narrative_criteria_appendix",
+                {"criteria": "\n".join(f"- {c}" for c in narrative)},
+            )
+            variables["narrative_criteria"] = rendered_narrative.content
+        if artifacts_block:
+            rendered_artifacts = await renderer.render(
+                "request.development_develop_prior_artifacts_appendix",
+                {"artifacts": artifacts_block},
+            )
+            variables["prior_artifacts"] = rendered_artifacts.content
+
+        rendered = await renderer.render(
+            "request.development_develop.focused_build_task", variables
+        )
+        return rendered.content
+
+    @staticmethod
+    def _focused_prompt_fallback(
+        focus: Any,
+        description: str,
+        expected_block: str,
+        typed_lines: list[str],
+        narrative: list[str],
+        prd: str,
+        artifacts_block: str,
+    ) -> str:
+        """Degraded-mode assembly when no request renderer is wired.
+
+        Structure mirrors the managed asset so the two never drift in meaning;
+        the asset is the authority whenever a renderer exists.
+        """
         parts = [f"## Build Task: {focus}\n\n{description}\n"]
-
-        parts.append("### Expected Output Files\n")
-        parts.extend(f"- `{f}`\n" for f in expected_files)
-
-        if acceptance_criteria:
-            parts.append("\n### Acceptance Criteria\n")
-            parts.extend(f"- {c}\n" for c in acceptance_criteria)
-
+        parts.append(f"### Expected Output Files\n{expected_block}\n")
+        if typed_lines:
+            parts.append("\n### Contract Expectations (authoritative — apply exactly)\n")
+            parts.extend(f"- {line}\n" for line in typed_lines)
+        if narrative:
+            parts.append("\n### Acceptance Criteria (narrative)\n")
+            parts.extend(f"- {c}\n" for c in narrative)
         parts.append(f"\n### Context\nPRD:\n{prd}\n")
-
-        if artifact_contents:
-            parts.append("\n### Prior Artifacts (already built — do not reproduce)\n")
-            for name, content in artifact_contents.items():
-                parts.append(f"**{name}:**\n```\n{content}\n```\n")
-
+        if artifacts_block:
+            parts.append(
+                f"\n### Prior Artifacts (already built — do not reproduce)\n{artifacts_block}\n"
+            )
         parts.append(
             "\nProduce ONLY the files listed in Expected Output Files. "
             "Use fenced code blocks with ```language:path/to/file``` format. "
@@ -336,7 +410,9 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
 
         # SIP-0086 RC-6: focused prompt path for manifest-driven subtasks
         if inputs.get("subtask_focus") is not None:
-            user_prompt = self._build_focused_prompt(inputs)
+            user_prompt = await self._build_focused_prompt(
+                inputs, getattr(context.ports, "request_renderer", None)
+            )
             rendered = None
             try:
                 capability = get_capability(
@@ -375,6 +451,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
                 capability,
                 impl_plan,
                 strategy,
+                inputs=inputs,
             )
 
         assembled = context.ports.prompt_service.get_system_prompt(self._role)
@@ -618,6 +695,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         capability: Any,
         impl_plan: str | None,
         strategy: str | None,
+        inputs: dict[str, Any] | None = None,
     ) -> tuple[Any, str]:
         """Build the dev prompt via renderer or fallback. Returns (rendered, user_prompt)."""
         rendered = None
@@ -636,7 +714,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
             # SIP-0099 99.3 (part 2): on a scaffoldable stack a walking skeleton was
             # seeded into the workspace (part 1), so instruct the dev to FILL the fixed
             # slots rather than rewire. Data-driven — "" for a non-scaffolded cycle.
-            fill_only = await self._fill_only_section(renderer)
+            fill_only = await self._fill_only_section(renderer, inputs)
             if fill_only:
                 variables["fill_only_section"] = fill_only
             rendered = await renderer.render(
@@ -653,20 +731,47 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         )
         return None, user_prompt
 
-    async def _fill_only_section(self, renderer: Any) -> str:
+    async def _fill_only_section(self, renderer: Any, inputs: dict | None = None) -> str:
         """The fill-only instruction, or "" (SIP-0099 99.3 part 2).
 
         Non-empty only on a scaffoldable stack — a walking skeleton has been seeded into
         the workspace (part 1), so the dev fills fixed slots instead of rewiring. The
         instruction lives in a managed prompt asset, not an inline literal (CLAUDE.md
         #448). Frozen-surface *enforcement* is SIP-0098's `frozen:` contract, not here.
+
+        Carries the manifest-derived ERROR CONTRACT block when the executor threaded one
+        onto the envelope (#588). The repair path has had this since pf-34; the *initial*
+        author never did, so every roll re-made the same mistake — routes.py raising
+        ``ApiError(status_code=…, detail=…)`` against a frozen seam whose signature is
+        ``ApiError(code, message)`` — and paid a correction to undo it. Same data, same
+        transport, one step earlier.
         """
         from squadops.capabilities.scaffold import is_scaffoldable_stack
 
         stack = str(self._resolved_config.get("build_profile") or "")
         if not is_scaffoldable_stack(stack):
             return ""
+        variables = {"stack": stack}
+        error_contract = await self._error_contract_section(renderer, inputs)
+        if error_contract:
+            variables["error_contract"] = error_contract
         rendered = await renderer.render(
-            "request.development_develop_fill_only_appendix", {"stack": stack}
+            "request.development_develop_fill_only_appendix", variables
+        )
+        return rendered.content
+
+    async def _error_contract_section(self, renderer: Any, inputs: dict | None) -> str:
+        """Render the ERROR CONTRACT block from executor-threaded lines, or "".
+
+        The lines are manifest-derived data (``scaffold.error_seam_instructions``);
+        all prose lives in the appendix asset (CLAUDE.md #448).
+        """
+        lines = [str(line).strip() for line in ((inputs or {}).get("error_contract") or [])]
+        lines = [line for line in lines if line]
+        if not lines:
+            return ""
+        rendered = await renderer.render(
+            "request.development_develop_error_contract_appendix",
+            {"error_lines": "\n".join(f"- {line}" for line in lines)},
         )
         return rendered.content

--- a/src/squadops/prompts/request_templates/request.development_develop.focused_build_task.md
+++ b/src/squadops/prompts/request_templates/request.development_develop.focused_build_task.md
@@ -1,0 +1,38 @@
+---
+template_id: request.development_develop.focused_build_task
+version: "1"
+required_variables:
+  - focus
+  - expected_files
+  - prd
+optional_variables:
+  - description
+  - fill_only_section
+  - contract_expectations
+  - narrative_criteria
+  - prior_artifacts
+---
+## Build Task: {{focus}}
+
+{{description}}
+
+{{fill_only_section}}
+
+### Expected Output Files
+
+{{expected_files}}
+
+{{contract_expectations}}
+
+{{narrative_criteria}}
+
+### Context
+
+PRD:
+
+{{prd}}
+
+{{prior_artifacts}}
+
+Produce ONLY the files listed in Expected Output Files. Use fenced code blocks with
+```language:path/to/file``` format. Do not reproduce files from prior artifacts.

--- a/src/squadops/prompts/request_templates/request.development_develop_error_contract_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_error_contract_appendix.md
@@ -1,0 +1,16 @@
+---
+template_id: request.development_develop_error_contract_appendix
+version: "1"
+required_variables:
+  - error_lines
+optional_variables: []
+---
+**ERROR CONTRACT (authoritative — apply exactly):**
+{{error_lines}}
+
+This is the scaffold's own error seam, generated from the interface manifest. The
+frozen `backend/errors.py` owns the envelope shape and the code→status mapping — you
+raise the code, it renders the response. Getting the raise wrong does not fail loudly
+at generation: the call raises `TypeError` at request time and every error path
+returns HTTP 500, which passes import- and compile-level checks and only surfaces
+later as a behavioural test failure.

--- a/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix.md
@@ -1,9 +1,10 @@
 ---
 template_id: request.development_develop_fill_only_appendix
-version: "1"
+version: "2"
 required_variables:
   - stack
-optional_variables: []
+optional_variables:
+  - error_contract
 ---
 ## Fill-only: a walking skeleton is already in your workspace
 
@@ -28,6 +29,8 @@ the fixed slots** — never to rebuild, rewire, or regenerate the scaffold.
   `frontend/src/api.js`, `vite.config.js`, `package.json`, `index.html`, or the
   requirements/manifest files.
 - Do NOT rewire `App.jsx`'s import/route graph, rename or move views, or add/remove files.
+
+{{error_contract}}
 
 Filling the fixed slots — rather than regenerating the app — is the whole point: the
 skeleton already builds and boots, so a fill that preserves it stays green, while one

--- a/src/squadops/prompts/request_templates/request.development_develop_narrative_criteria_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_narrative_criteria_appendix.md
@@ -1,0 +1,13 @@
+---
+template_id: request.development_develop_narrative_criteria_appendix
+version: "1"
+required_variables:
+  - criteria
+optional_variables: []
+---
+### Acceptance Criteria (narrative)
+
+Supporting intent, stated in prose. Machine-verified requirements are stated separately
+and take precedence over anything here.
+
+{{criteria}}

--- a/src/squadops/prompts/request_templates/request.development_develop_prior_artifacts_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_prior_artifacts_appendix.md
@@ -1,0 +1,13 @@
+---
+template_id: request.development_develop_prior_artifacts_appendix
+version: "1"
+required_variables:
+  - artifacts
+optional_variables: []
+---
+### Prior Artifacts (already built — do not reproduce)
+
+These files already exist in the workspace. Read them for the interfaces you must call
+and conform to; do not re-emit them.
+
+{{artifacts}}

--- a/tests/unit/capabilities/handlers/test_focused_prompts.py
+++ b/tests/unit/capabilities/handlers/test_focused_prompts.py
@@ -33,56 +33,56 @@ class TestDevFocusedPrompt:
         defaults.update(overrides)
         return defaults
 
-    def test_focused_prompt_includes_subtask_focus(self):
+    async def test_focused_prompt_includes_subtask_focus(self):
         handler = DevelopmentDevelopHandler()
-        prompt = handler._build_focused_prompt(self._make_inputs())
+        prompt = await handler._build_focused_prompt(self._make_inputs())
 
         assert "## Build Task: Backend models" in prompt
 
-    def test_focused_prompt_includes_description(self):
+    async def test_focused_prompt_includes_description(self):
         handler = DevelopmentDevelopHandler()
-        prompt = handler._build_focused_prompt(self._make_inputs())
+        prompt = await handler._build_focused_prompt(self._make_inputs())
 
         assert "Create Pydantic models for RunEvent and Participant" in prompt
 
-    def test_focused_prompt_includes_expected_output_files(self):
+    async def test_focused_prompt_includes_expected_output_files(self):
         handler = DevelopmentDevelopHandler()
-        prompt = handler._build_focused_prompt(self._make_inputs())
+        prompt = await handler._build_focused_prompt(self._make_inputs())
 
         assert "- `backend/models.py`" in prompt
         assert "- `backend/repository.py`" in prompt
 
-    def test_focused_prompt_includes_acceptance_criteria(self):
+    async def test_focused_prompt_includes_acceptance_criteria(self):
         handler = DevelopmentDevelopHandler()
-        prompt = handler._build_focused_prompt(self._make_inputs())
+        prompt = await handler._build_focused_prompt(self._make_inputs())
 
         assert "### Acceptance Criteria" in prompt
         assert "- RunEvent has id and title fields" in prompt
         assert "- Repository supports CRUD" in prompt
 
-    def test_focused_prompt_includes_prior_artifacts(self):
+    async def test_focused_prompt_includes_prior_artifacts(self):
         handler = DevelopmentDevelopHandler()
-        prompt = handler._build_focused_prompt(self._make_inputs())
+        prompt = await handler._build_focused_prompt(self._make_inputs())
 
         assert "### Prior Artifacts" in prompt
         assert "strategy_analysis.md" in prompt
         assert "Strategy content here" in prompt
 
-    def test_focused_prompt_includes_prd(self):
+    async def test_focused_prompt_includes_prd(self):
         handler = DevelopmentDevelopHandler()
-        prompt = handler._build_focused_prompt(self._make_inputs())
+        prompt = await handler._build_focused_prompt(self._make_inputs())
 
         assert "Build a group run app" in prompt
 
-    def test_focused_prompt_no_acceptance_criteria_omits_section(self):
+    async def test_focused_prompt_no_acceptance_criteria_omits_section(self):
         handler = DevelopmentDevelopHandler()
-        prompt = handler._build_focused_prompt(self._make_inputs(acceptance_criteria=[]))
+        prompt = await handler._build_focused_prompt(self._make_inputs(acceptance_criteria=[]))
 
         assert "### Acceptance Criteria" not in prompt
 
-    def test_focused_prompt_no_prior_artifacts_omits_section(self):
+    async def test_focused_prompt_no_prior_artifacts_omits_section(self):
         handler = DevelopmentDevelopHandler()
-        prompt = handler._build_focused_prompt(self._make_inputs(artifact_contents={}))
+        prompt = await handler._build_focused_prompt(self._make_inputs(artifact_contents={}))
 
         assert "### Prior Artifacts" not in prompt
 
@@ -150,3 +150,136 @@ class TestQAFocusedPrompt:
 
         assert "## QA Task:" not in prompt
         assert "Expected Output Files" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Dev focused prompt — RENDERED path (#588)
+# ---------------------------------------------------------------------------
+
+
+class TestDevFocusedPromptRendered:
+    """The rendered path is the one production uses, and it was the one carrying
+    the defect: plan tasks always set ``subtask_focus``, so ``_build_focused_prompt``
+    is the ONLY prompt a plan-driven dev task sees — and it previously omitted both
+    the SIP-0099 fill-only instruction (wired only into the monolithic path a
+    plan-driven cycle never takes) and the manifest-derived error seam.
+
+    These drive the REAL renderer against the REAL asset files, so handler/asset
+    drift — an undeclared variable, a renamed placeholder — fails here rather than
+    silently rendering an empty section in production.
+    """
+
+    @staticmethod
+    def _renderer():
+        from adapters.prompts.factory import DEFAULT_TEMPLATES_PATH, create_prompt_asset_source
+        from squadops.prompts.renderer import RequestTemplateRenderer
+
+        return RequestTemplateRenderer(
+            asset_source=create_prompt_asset_source(
+                provider="filesystem", templates_path=DEFAULT_TEMPLATES_PATH
+            )
+        )
+
+    def _inputs(self, **overrides) -> dict[str, Any]:
+        defaults = {
+            "prd": "Build a group run app.",
+            "subtask_focus": "Backend routes",
+            "subtask_description": "Implement the run endpoints.",
+            "expected_artifacts": ["backend/routes.py"],
+            "acceptance_criteria": [
+                "Endpoints round-trip end to end.",
+                {
+                    "check": "function_defined",
+                    "file": "backend/routes.py",
+                    "name_prefix": "create_",
+                    "min_count": 2,
+                },
+            ],
+            "artifact_contents": {},
+            "resolved_config": {"build_profile": "fullstack_fastapi_react"},
+        }
+        defaults.update(overrides)
+        return defaults
+
+    async def test_typed_criteria_render_as_expectations_not_dict_soup(self):
+        """Bug caught: the initial author receives TypedChecks as `f"- {dict}"`
+        repr soup, so exact expectations only ever reach it via the repair
+        prompt — the #585 wall, on the dev role."""
+        handler = DevelopmentDevelopHandler()
+        handler._resolved_config = {"build_profile": "fullstack_fastapi_react"}
+        prompt = await handler._build_focused_prompt(self._inputs(), self._renderer())
+
+        assert "Contract Expectations (authoritative" in prompt
+        assert "'check': 'function_defined'" not in prompt, "typed criterion leaked as a dict repr"
+        assert "{" not in prompt.split("### Context")[0].split("Contract Expectations")[1]
+        # Narrative prose survives, demoted below the authoritative block.
+        assert "Acceptance Criteria (narrative)" in prompt
+        assert "Endpoints round-trip end to end." in prompt
+        assert prompt.index("Contract Expectations") < prompt.index(
+            "Acceptance Criteria (narrative)"
+        )
+
+    async def test_scaffolded_stack_gets_the_fill_only_instruction(self):
+        """Bug caught: THE #588 defect — a plan-driven dev task is never told the
+        scaffold surface is frozen, so it rewrites entry/model files (three frozen
+        emissions in pf-37's seven dev tasks) and pays corrections to undo them."""
+        handler = DevelopmentDevelopHandler()
+        handler._resolved_config = {"build_profile": "fullstack_fastapi_react"}
+        prompt = await handler._build_focused_prompt(self._inputs(), self._renderer())
+
+        assert "Fill-only" in prompt
+        assert "frozen" in prompt.lower()
+        assert "backend/main.py" in prompt
+
+    async def test_error_contract_lines_reach_the_initial_author(self):
+        """Bug caught: the ApiError raise convention reaches repairs but not the
+        first author, so every roll re-emits `ApiError(status_code=, detail=)`,
+        TypeErrors at request time, and 500s every error path past every typed
+        check (pf-28/33/34, and pf-37's routes.py)."""
+        handler = DevelopmentDevelopHandler()
+        handler._resolved_config = {"build_profile": "fullstack_fastapi_react"}
+        inputs = self._inputs(
+            error_contract=[
+                "on failure raise `ApiError(code, message)` (imported from `.errors`)",
+                "valid error codes: `run_not_found` → 404",
+            ]
+        )
+        prompt = await handler._build_focused_prompt(inputs, self._renderer())
+
+        assert "ERROR CONTRACT (authoritative" in prompt
+        assert "ApiError(code, message)" in prompt
+        assert "run_not_found` → 404" in prompt
+
+    async def test_non_scaffolded_stack_omits_scaffold_sections(self):
+        """Bug caught: rendering fill-only/error-contract unconditionally would
+        instruct an unscaffolded cycle to preserve a skeleton that isn't there."""
+        handler = DevelopmentDevelopHandler()
+        handler._resolved_config = {"build_profile": "python_cli"}
+        inputs = self._inputs(resolved_config={"build_profile": "python_cli"})
+        prompt = await handler._build_focused_prompt(inputs, self._renderer())
+
+        assert "Fill-only" not in prompt
+        assert "ERROR CONTRACT" not in prompt
+        assert "## Build Task: Backend routes" in prompt
+
+    async def test_no_typed_criteria_omits_the_expectations_block(self):
+        """Bug caught: a dangling authoritative header with nothing under it
+        reads as 'there are no requirements'."""
+        handler = DevelopmentDevelopHandler()
+        handler._resolved_config = {"build_profile": "fullstack_fastapi_react"}
+        inputs = self._inputs(acceptance_criteria=["Just prose."])
+        prompt = await handler._build_focused_prompt(inputs, self._renderer())
+
+        assert "Contract Expectations" not in prompt
+        assert "Just prose." in prompt
+
+    async def test_prior_artifacts_carry_the_do_not_reproduce_instruction(self):
+        """Bug caught: dropping the prior-artifacts framing makes the author
+        re-emit files it was only meant to read interfaces from."""
+        handler = DevelopmentDevelopHandler()
+        handler._resolved_config = {"build_profile": "fullstack_fastapi_react"}
+        inputs = self._inputs(artifact_contents={"backend/models.py": "class RunEvent: ..."})
+        prompt = await handler._build_focused_prompt(inputs, self._renderer())
+
+        assert "do not reproduce" in prompt.lower()
+        assert "class RunEvent: ..." in prompt

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -788,3 +788,89 @@ class TestCancellationProbeWiring:
         await executor.cancel_run("run_001")
 
         assert await executor._task_dispatcher._is_cancelled("run_001") is True
+
+
+# ---------------------------------------------------------------------------
+# Error-seam threading onto dev envelopes (#588)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorSeamThreading:
+    """The manifest-derived error seam has reached repairs since pf-34 but never
+    the INITIAL author, so every scaffolded roll re-made the same mistake —
+    ``ApiError(status_code=…, detail=…)`` against a frozen
+    ``ApiError(code, message)`` seam — TypeErroring into a 500 on every error
+    path, invisible to import- and compile-level checks.
+    """
+
+    @staticmethod
+    def _manifest():
+        from pathlib import Path
+
+        from squadops.capabilities.scaffold import InterfaceManifest
+
+        repo_root = Path(__file__).resolve().parents[3]
+        path = repo_root / "examples" / "03_group_run" / "interface_manifest.yaml"
+        return InterfaceManifest.from_yaml(path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _envelope(task_type: str):
+        from squadops.tasks.models import TaskEnvelope
+
+        return TaskEnvelope(
+            task_id="t1",
+            agent_id="neo",
+            cycle_id="cyc_001",
+            pulse_id="p1",
+            project_id="proj_001",
+            task_type=task_type,
+            correlation_id="c",
+            causation_id="ca",
+            trace_id="tr",
+            span_id="s",
+        )
+
+    async def test_dev_envelope_carries_the_error_seam(self, executor) -> None:
+        """Bug caught: the seam stays repair-only, so the first author keeps
+        guessing the ApiError signature (pf-28/33/34, and pf-37's routes.py)."""
+        enriched = await executor._enrich_envelope(
+            self._envelope("development.develop"),
+            {},
+            [],
+            [],
+            interface_manifest=self._manifest(),
+        )
+
+        lines = enriched.inputs.get("error_contract")
+        assert lines, "development.develop envelope carries no error contract"
+        joined = " ".join(lines)
+        assert "ApiError(code, message)" in joined
+        assert "never `ApiError(status_code=..., detail=...)`" in joined
+        assert "run_not_found` → 404" in joined
+
+    async def test_non_authoring_task_types_are_not_given_the_seam(self, executor) -> None:
+        """Bug caught: blanket attachment pushes fill-slot authoring instructions
+        into roles that do not author into the scaffold (a qa suite told to raise
+        ApiError writes assertions against the wrong thing)."""
+        enriched = await executor._enrich_envelope(
+            self._envelope("qa.test"),
+            {},
+            [],
+            [],
+            interface_manifest=self._manifest(),
+        )
+
+        assert "error_contract" not in enriched.inputs
+
+    async def test_unscaffolded_run_attaches_nothing(self, executor) -> None:
+        """Bug caught: author-mode cycles have no manifest, so attaching a
+        fabricated or empty seam would state a contract that does not exist."""
+        enriched = await executor._enrich_envelope(
+            self._envelope("development.develop"),
+            {},
+            [],
+            [],
+            interface_manifest=None,
+        )
+
+        assert "error_contract" not in enriched.inputs


### PR DESCRIPTION
## Summary

On a scaffolded bind-mode roll, the **initial** dev author receives neither the
SIP-0099 fill-only instruction nor the manifest-derived error seam. It is told
nothing about the frozen surface it is filling, and nothing about how to raise a
contract error. Both pieces of knowledge exist and are already wired — but only into
paths a plan-driven cycle never takes.

## Root cause — the fill-only appendix is wired to a dead path

1. Every plan task carries `focus:`.
2. `src/squadops/cycles/task_plan.py:618` turns that into `inputs["subtask_focus"]`.
3. `src/squadops/capabilities/handlers/cycle/develop.py:338` routes on `subtask_focus`
   to `_build_focused_prompt`, which its own docstring (RC-6) describes as used
   **"exclusively"** — "The legacy monolithic prompt path is NOT used."
4. `_fill_only_section` (SIP-0099 99.3) is called **only** from `_build_dev_prompt` —
   the monolithic path.

So the fill-only instruction reaches only the path plan-driven cycles never execute.

## Root cause — the error seam is repair-only

`scaffold.error_seam_instructions` (shipped in `dc69b88b` for pf-34) has exactly two
consumers, both on the repair path:

- `adapters/cycles/correction_runner.py:186,210`
- `src/squadops/capabilities/handlers/impl/repair_handlers.py:102`

Zero consumers on the initial generation path. The convention also lives in the
fill-slot stub's docstring — which the first fill overwrites, as
`scaffold.py:399` already notes. So the first author has no source for it.

## Live evidence (pf-37, `run_010825617319`)

**Frozen-surface violations — three in seven dev tasks**, each caught and restored by
SIP-0100: `backend/models.py` (m000), `backend/main.py` (m002),
`frontend/src/App.jsx` (m006). These restores have been read as "enforcement
working" — it is, but they are equally a signal that the *instruction never arrived*.

**Error seam — the pf-28/33/34 wall, re-made by the first author.** The generated
`backend/routes.py`:

```python
raise ApiError(status_code=404, detail="Run not found")              # :50
raise ApiError(status_code=422, detail="Participant name cannot be empty")  # :59, :80
raise ApiError(status_code=422, detail="...already exists on this run")     # :68
```

against the frozen `backend/errors.py`:

```python
def __init__(self, code: str, message: str) -> None:
```

`TypeError` at request time → **HTTP 500 on every error path**.

## Why no check catches it

`vc-routes-apierror` is an import-presence check (`module: .errors, symbol: ApiError`).
It confirms the import exists; it cannot see call signatures. `routes.py` passes it
cleanly while every error path 500s. The defect only surfaces later, as a behavioural
test failure at the QA phase, where it costs a correction cycle to undo something the
system already knew how to prevent.

## Third defect in the same method — dict-repr soup

`_build_focused_prompt` renders `acceptance_criteria` as `f"- {c}\n"` where `c` may be
a TypedCheck dict. This is the identical defect #585 just fixed on the QA side, and it
was item 4 on the 2026-07-25 morning list. Exact expectations reach dev only through
the repair prompt's authoritative block.

The method also builds every line of its prose from inline Python string literals
(CLAUDE.md #448).

## Fix

Give the initial focused prompt the treatment #585 gave the QA twin, plus the two
missing sections:

- Typed criteria → authoritative Contract Expectations block; narrative prose demoted.
- Fill-only + ERROR CONTRACT sections reach the initial author (executor threads
  manifest-derived error-seam lines onto `development.develop` envelopes).
- All prose moved into managed prompt assets; the handler assembles data only.

## Follow-up, not in the fix

`request.cycle_repair_contract_expectations_appendix` is reused by the dev initial
path rather than duplicated, so its `cycle_repair`-scoped `template_id` is now a
misnomer. `scripts/maintainer/upload_prompts_to_langfuse.py` publishes by
`template_id`, so renaming orphans the registry entry (the #327 class) — it wants its
own PR alongside a registry re-sync.

Worth considering separately: a typed check that verifies `ApiError` is *called*
correctly (arity/kwargs), not merely imported. That would catch this class
deterministically at emission instead of relying on prompt salience.

---

## What this PR changes

Closes #588.

- **`_build_focused_prompt` is now renderer-driven and async.** It assembles data;
  every block of prose lives in a managed prompt asset.
- **Typed criteria → authoritative Contract Expectations block**, narrative prose
  demoted below it (the #585 treatment, on the dev role).
- **Fill-only + ERROR CONTRACT sections reach the initial author.** The executor
  threads `scaffold.error_seam_instructions` onto `development.develop` envelopes via
  `_ERROR_SEAM_TASK_TYPES` — a table, not a string-literal test at the branch.
- **Four new prompt assets**; the existing Contract Expectations appendix is reused
  rather than duplicated.
- A degraded-mode fallback preserves today's plain-text assembly when no renderer is
  wired — the same shape `_build_dev_prompt` has always had.

## Tests — 9 new

**Six drive the REAL renderer against the REAL asset files** rather than a mock, so
handler/asset drift (an undeclared variable, a renamed placeholder) fails in CI
instead of silently rendering an empty section in production. That mattered here:
one of them caught a wrong stack id I had written (`fastapi_react` vs
`fullstack_fastapi_react`), and another caught a genuine wording bug — the narrative
appendix referenced an authoritative block that does not exist when a task has no
typed criteria.

**Three cover the executor threading**: dev task types get the seam, other task types
do not (a qa suite told to raise `ApiError` writes assertions against the wrong
thing), and author-mode runs with no manifest attach nothing.

Existing focused-prompt tests updated to await the now-async method. None weakened.

## Verification

- `tests/unit` — **5,841 passed**, 3 skipped
- ruff check + ruff format — clean
- Pre-existing on main, unrelated: 2 failures in `test_verification_contract_runner.py`
  (host has no node by design, #419) — confirmed identical on a clean `main`.

Not deployed — no rebuild, no restart. Agents would need rebuilding for the prompt
assets to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
