### PR TITLE
fix(verification): reject patches whose intra-package imports can't resolve (#591)

### DIFF
--- a/src/squadops/cycles/emission_integrity.py
+++ b/src/squadops/cycles/emission_integrity.py
@@ -17,6 +17,7 @@ Pure functions — the caller owns storage, events, and the carry.
 from __future__ import annotations
 
 import ast
+from pathlib import Path
 from typing import Any
 
 
@@ -107,3 +108,152 @@ def emission_retry_reason_line(marker: dict[str, Any]) -> str:
             f"from the {chars}-character response."
         )
     return f"the response failed emission extraction ({reason})."
+
+
+# ---------------------------------------------------------------------------
+# Intra-package import resolution (#591)
+# ---------------------------------------------------------------------------
+#
+# The syntax gate above proves each file parses ALONE. pf-37 showed that is not
+# enough: correction-00 emitted a coherent PAIR — its own ``backend/models.py``
+# plus a ``backend/routes.py`` written against it — SIP-0100 correctly restored
+# the frozen ``models.py``, and the surviving ``routes.py`` imported seven names
+# (``RunCreate``, ``RunResponse``, …) that the frozen module never defined.
+# Every typed check passed (they read one file at a time; the import statement is
+# syntactically perfect) and the patch was ACCEPTED. The suite then failed to
+# collect at all, and the correction budget went to re-rolling a test file
+# against source that could never import.
+#
+# The defect was manufactured by enforcement, not by the model: each half was
+# individually valid and nothing checked the pair. This resolves imports across
+# the assembled workspace, which is the only place the mismatch is visible.
+
+
+def _names_bound_by(node: ast.stmt) -> set[str] | None:
+    """Names one module-level statement binds, or None when undecidable.
+
+    None propagates: a star-import, a module-level ``__getattr__`` (PEP 562), or
+    a conditional definition can bind names a flat walk cannot see.
+    """
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return None if node.name == "__getattr__" else {node.name}
+    if isinstance(node, ast.Assign):
+        return {t.id for t in node.targets if isinstance(t, ast.Name)}
+    if isinstance(node, ast.AnnAssign):
+        return {node.target.id} if isinstance(node.target, ast.Name) else set()
+    if isinstance(node, ast.Import):
+        return {a.asname or a.name.split(".")[0] for a in node.names}
+    if isinstance(node, ast.ImportFrom):
+        if any(a.name == "*" for a in node.names):
+            return None
+        return {a.asname or a.name for a in node.names}
+    if isinstance(node, (ast.If, ast.Try)):
+        # TYPE_CHECKING blocks, optional-dependency fallbacks.
+        return None
+    return set()
+
+
+def _module_level_names(tree: ast.Module) -> set[str] | None:
+    """Names a module binds at import time, or None when it can't be decided.
+
+    None means "do not judge this module" — a false rejection of a good patch is
+    worse than a missed one.
+    """
+    names: set[str] = set()
+    for node in tree.body:
+        bound = _names_bound_by(node)
+        if bound is None:
+            return None
+        names |= bound
+    return names
+
+
+def _resolve_module_path(
+    workspace_root: Path, source_rel: str, node: ast.ImportFrom
+) -> Path | None:
+    """Workspace path for an intra-package ``from ... import`` target, else None.
+
+    Returns None for anything not resolvable *within the workspace* — stdlib,
+    third-party, and absolute imports rooted outside it are none of this check's
+    business.
+    """
+    source_dir = (workspace_root / source_rel).parent
+    if node.level:
+        base = source_dir
+        for _ in range(node.level - 1):
+            base = base.parent
+        parts = (node.module or "").split(".") if node.module else []
+    else:
+        if not node.module:
+            return None
+        parts = node.module.split(".")
+        base = workspace_root
+        # Absolute, but rooted at a package that lives in this workspace
+        # (``from backend.models import X`` beside ``backend/``).
+        if not (workspace_root / parts[0]).is_dir():
+            return None
+    target = base
+    for part in parts:
+        target = target / part
+    for candidate in (target.with_suffix(".py"), target / "__init__.py"):
+        try:
+            if candidate.is_file() and candidate.resolve().is_relative_to(workspace_root.resolve()):
+                return candidate
+        except (OSError, ValueError):
+            continue
+    return None
+
+
+def unresolved_imports(workspace_root: Path | str) -> list[tuple[str, str, tuple[str, ...]]]:
+    """Intra-package imports the workspace cannot satisfy (#591).
+
+    Returns ``(source_file, module, missing_names)`` per offending statement,
+    sorted for stable reporting. Empty means every intra-package import resolves.
+
+    Deliberately conservative — it only reports a name when the target module is
+    present, parses, and demonstrably does not bind it. Unreadable or
+    undecidable modules are skipped, and imports pointing outside the workspace
+    are ignored entirely, so third-party and stdlib imports never appear here.
+    """
+    workspace_root = Path(workspace_root)
+    findings: list[tuple[str, str, tuple[str, ...]]] = []
+    parsed: dict[Path, set[str] | None] = {}
+
+    for source in sorted(workspace_root.rglob("*.py")):
+        try:
+            tree = ast.parse(source.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, SyntaxError, ValueError):
+            continue  # the syntax gate owns unparseable emissions
+        source_rel = source.relative_to(workspace_root).as_posix()
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if any(alias.name == "*" for alias in node.names):
+                continue
+            target = _resolve_module_path(workspace_root, source_rel, node)
+            if target is None:
+                continue
+            if target not in parsed:
+                try:
+                    parsed[target] = _module_level_names(
+                        ast.parse(target.read_text(encoding="utf-8"))
+                    )
+                except (OSError, UnicodeDecodeError, SyntaxError, ValueError):
+                    parsed[target] = None
+            defined = parsed[target]
+            if defined is None:
+                continue
+            missing = tuple(sorted(a.name for a in node.names if a.name not in defined))
+            if missing:
+                label = ("." * node.level) + (node.module or "")
+                findings.append((source_rel, label, missing))
+    return sorted(set(findings))
+
+
+def unresolved_import_summary(findings: list[tuple[str, str, tuple[str, ...]]]) -> str:
+    """One-line, operator-readable rendering of :func:`unresolved_imports`."""
+    return "; ".join(
+        f"{src} imports {', '.join(names)} from {module} (not defined there)"
+        for src, module, names in findings
+    )

--- a/src/squadops/cycles/patch_verification.py
+++ b/src/squadops/cycles/patch_verification.py
@@ -35,6 +35,10 @@ from squadops.cycles.acceptance_evaluation import (
     split_acceptance_criteria,
 )
 from squadops.cycles.bound_scaffold_record import BoundScaffoldRecord
+from squadops.cycles.emission_integrity import (
+    unresolved_import_summary,
+    unresolved_imports,
+)
 from squadops.cycles.implementation_plan import TypedCheck
 from squadops.cycles.write_authorization import WriteAuthorization
 
@@ -289,6 +293,23 @@ async def verify_patched_artifacts(
     with tempfile.TemporaryDirectory(prefix="squadops-patch-verify-") as tmpdir:
         workspace_root = Path(tmpdir)
         materialize_artifacts(artifacts, workspace_root)
+
+        # #591: typed criteria read one file at a time, so a patch whose imports
+        # cannot resolve passes every one of them and is accepted — then the
+        # suite fails to collect. pf-37: the repair emitted a coherent
+        # models.py/routes.py pair, SIP-0100 restored the frozen models.py, and
+        # the surviving routes.py imported seven names it never defined.
+        # Deliberately BEFORE the criteria loop: an unimportable workspace makes
+        # every downstream verdict meaningless, and this is the one place the
+        # restored-plus-repaired combination actually exists.
+        unresolved = unresolved_imports(workspace_root)
+        if unresolved:
+            summary = unresolved_import_summary(unresolved)
+            logger.info("patch_verification: unresolved intra-package imports — %s", summary)
+            return PatchVerification(
+                status=PATCH_FAILED,
+                reason=f"unresolved_imports:{summary}",
+            )
 
         for criterion in typed:
             outcome = await evaluate_criterion(

--- a/tests/unit/cycles/test_emission_integrity.py
+++ b/tests/unit/cycles/test_emission_integrity.py
@@ -12,6 +12,8 @@ import pytest
 from squadops.cycles.emission_integrity import (
     emission_integrity_instruction,
     syntax_gate_python_artifacts,
+    unresolved_import_summary,
+    unresolved_imports,
 )
 
 pytestmark = [pytest.mark.domain_capabilities]
@@ -96,3 +98,170 @@ def test_emission_retry_reason_line_known_and_unknown():
     assert "no fenced code block" in line
     # Unknown reason still yields a usable factual line, never a KeyError.
     assert "other_reason" in emission_retry_reason_line({"reason": "other_reason"})
+
+
+# ---------------------------------------------------------------------------
+# Intra-package import resolution (#591)
+# ---------------------------------------------------------------------------
+
+
+class TestUnresolvedImports:
+    """The syntax gate proves each file parses ALONE. pf-37 proved that isn't
+    enough: a repair emitted a coherent models.py/routes.py pair, SIP-0100
+    restored the frozen models.py, and the surviving routes.py imported seven
+    names the frozen module never defined. Every typed check passed — they read
+    one file at a time — and the patch was accepted.
+    """
+
+    @staticmethod
+    def _write(root, files: dict[str, str]) -> None:
+        for name, content in files.items():
+            path = root / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+
+    def test_pf37_restored_frozen_model_leaves_routes_unimportable(self, tmp_path) -> None:
+        """Bug caught: THE #591 defect, replayed from pf-37's real shape — the
+        exact name set correction-00 imported against the frozen module."""
+        self._write(
+            tmp_path,
+            {
+                "backend/__init__.py": "",
+                "backend/models.py": (
+                    "from pydantic import BaseModel\n\n"
+                    "class Participant(BaseModel):\n    id: str\n    name: str\n\n"
+                    "class RunEvent(BaseModel):\n    id: str\n    title: str\n\n"
+                    "class RunEventCreate(BaseModel):\n    title: str\n\n"
+                    "class ParticipantName(BaseModel):\n    name: str\n"
+                ),
+                "backend/routes.py": (
+                    "from .models import (\n"
+                    "    RunCreate,\n"
+                    "    RunResponse,\n"
+                    "    RunListResponse,\n"
+                    "    ParticipantJoin,\n"
+                    ")\n"
+                ),
+            },
+        )
+
+        findings = unresolved_imports(tmp_path)
+
+        assert len(findings) == 1
+        source, module, missing = findings[0]
+        assert source == "backend/routes.py"
+        assert module == ".models"
+        assert missing == ("ParticipantJoin", "RunCreate", "RunListResponse", "RunResponse")
+
+        summary = unresolved_import_summary(findings)
+        assert "backend/routes.py" in summary
+        assert "RunCreate" in summary
+
+    def test_resolvable_package_reports_nothing(self, tmp_path) -> None:
+        """Bug caught: a check that flags healthy workspaces rejects every good
+        patch — worse than the defect it fixes."""
+        self._write(
+            tmp_path,
+            {
+                "backend/__init__.py": "",
+                "backend/models.py": "class RunEvent:\n    pass\n\nSTORE = {}\n",
+                "backend/routes.py": "from .models import RunEvent, STORE\n",
+            },
+        )
+
+        assert unresolved_imports(tmp_path) == []
+
+    def test_third_party_and_stdlib_imports_are_ignored(self, tmp_path) -> None:
+        """Bug caught: resolving imports that point outside the workspace turns
+        every fastapi/pydantic import into a false rejection."""
+        self._write(
+            tmp_path,
+            {
+                "backend/__init__.py": "",
+                "backend/routes.py": (
+                    "import json\n"
+                    "from pathlib import Path\n"
+                    "from fastapi import APIRouter, status\n"
+                    "from pydantic import BaseModel\n"
+                ),
+            },
+        )
+
+        assert unresolved_imports(tmp_path) == []
+
+    def test_absolute_intra_workspace_import_is_resolved(self, tmp_path) -> None:
+        """Bug caught: only handling relative imports misses `from backend.models
+        import X`, which the scaffold's own test harness uses."""
+        self._write(
+            tmp_path,
+            {
+                "backend/__init__.py": "",
+                "backend/models.py": "class RunEvent:\n    pass\n",
+                "backend/tests/test_x.py": "from backend.models import RunEvent, Missing\n",
+            },
+        )
+
+        findings = unresolved_imports(tmp_path)
+
+        assert [(s, m, n) for s, m, n in findings] == [
+            ("backend/tests/test_x.py", "backend.models", ("Missing",))
+        ]
+
+    def test_star_import_target_is_not_judged(self, tmp_path) -> None:
+        """Bug caught: a module doing `from .base import *` binds names this walk
+        can't see; judging it would reject valid code."""
+        self._write(
+            tmp_path,
+            {
+                "backend/__init__.py": "",
+                "backend/base.py": "class Thing:\n    pass\n",
+                "backend/models.py": "from .base import *\n",
+                "backend/routes.py": "from .models import Thing, Anything\n",
+            },
+        )
+
+        assert unresolved_imports(tmp_path) == []
+
+    def test_conditional_definitions_are_not_judged(self, tmp_path) -> None:
+        """Bug caught: TYPE_CHECKING blocks and optional-dependency fallbacks
+        bind names conditionally — flagging them rejects idiomatic code."""
+        self._write(
+            tmp_path,
+            {
+                "backend/__init__.py": "",
+                "backend/compat.py": (
+                    "try:\n    from fast import Impl\nexcept ImportError:\n"
+                    "    class Impl:\n        pass\n"
+                ),
+                "backend/routes.py": "from .compat import Impl\n",
+            },
+        )
+
+        assert unresolved_imports(tmp_path) == []
+
+    def test_unparseable_target_is_skipped(self, tmp_path) -> None:
+        """Bug caught: double-reporting a truncated file the syntax gate already
+        owns, instead of leaving that concern to it."""
+        self._write(
+            tmp_path,
+            {
+                "backend/__init__.py": "",
+                "backend/models.py": "class RunEvent:\n    def broken(\n",
+                "backend/routes.py": "from .models import RunEvent\n",
+            },
+        )
+
+        assert unresolved_imports(tmp_path) == []
+
+    def test_missing_target_module_is_not_reported(self, tmp_path) -> None:
+        """Bug caught: treating an absent module as a name failure — it may be a
+        third-party package that merely shares a directory name."""
+        self._write(
+            tmp_path,
+            {
+                "backend/__init__.py": "",
+                "backend/routes.py": "from .nonexistent import Thing\n",
+            },
+        )
+
+        assert unresolved_imports(tmp_path) == []

--- a/tests/unit/cycles/test_patch_verification.py
+++ b/tests/unit/cycles/test_patch_verification.py
@@ -197,3 +197,102 @@ def test_ambiguous_basename_is_never_rehomed():
 def test_unmatched_and_net_new_files_pass_through():
     arts = [{"name": "README.md", "content": "x"}, {"name": "", "content": "y"}, {"other": 1}]
     assert rebase_artifact_paths(arts, ["backend/routes.py"]) == arts
+
+
+# The pf-37 shape (#591): correction-00 emitted a coherent models.py/routes.py
+# pair, SIP-0100 restored the frozen models.py, and the surviving routes.py
+# imported names the frozen module never defines. Every typed check passed —
+# routes.py compiles perfectly alone — and the patch was ACCEPTED, then the
+# suite failed to collect.
+FROZEN_MODELS = (
+    "from pydantic import BaseModel\n\n"
+    "class RunEvent(BaseModel):\n    id: str\n    title: str\n\n"
+    "class RunEventCreate(BaseModel):\n    title: str\n"
+)
+REPAIR_ROUTES = (
+    "from .models import RunCreate, RunResponse\n\ndef create_run(body):\n    return body\n"
+)
+GOOD_ROUTES = (
+    "from .models import RunEvent, RunEventCreate\n\ndef create_run(body):\n    return body\n"
+)
+
+
+def _routes_criteria() -> list[TypedCheck]:
+    """The checks pf-37 actually ran against routes.py — all file-local."""
+    return [
+        TypedCheck(
+            check="function_defined",
+            params={"file": "backend/routes.py", "name_prefix": "create_", "min_count": 1},
+            severity="error",
+            description="routes.py defines a create_ handler",
+        ),
+    ]
+
+
+class TestUnresolvedImportsBlockAcceptance:
+    async def test_patch_with_unresolvable_imports_is_rejected(self):
+        """Bug caught: THE #591 defect — every file-local check passes, the patch
+        is accepted, and the assembled app cannot import at all."""
+        artifacts = [
+            {"name": "backend/__init__.py", "content": ""},
+            {"name": "backend/models.py", "content": FROZEN_MODELS},
+            {"name": "backend/routes.py", "content": REPAIR_ROUTES},
+        ]
+        result = await verify_patched_artifacts(_routes_criteria(), artifacts, stack="python")
+
+        assert result.status == PATCH_FAILED
+        assert "unresolved_imports" in (result.reason or "")
+        assert "RunCreate" in (result.reason or "")
+        assert "backend/routes.py" in (result.reason or "")
+
+    async def test_same_patch_would_pass_every_typed_check(self):
+        """Pins WHY the defect was invisible: the file-local criterion passes on
+        the very artifacts the check above rejects. Without this, a future
+        refactor could weaken the criteria and call #591 'fixed'."""
+        import tempfile
+        from pathlib import Path
+
+        from squadops.cycles.acceptance_evaluation import evaluate_criterion
+        from squadops.cycles.patch_verification import materialize_artifacts
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            materialize_artifacts(
+                [
+                    {"name": "backend/models.py", "content": FROZEN_MODELS},
+                    {"name": "backend/routes.py", "content": REPAIR_ROUTES},
+                ],
+                root,
+            )
+            outcome = await evaluate_criterion(
+                _routes_criteria()[0],
+                root,
+                stack="python",
+                typed_acceptance_enabled=True,
+                command_acceptance_enabled=True,
+            )
+
+        assert outcome.status == "passed"
+
+    async def test_resolvable_patch_still_accepted(self):
+        """Bug caught: the new gate rejecting healthy patches — it must only bite
+        on genuinely unimportable combinations."""
+        artifacts = [
+            {"name": "backend/__init__.py", "content": ""},
+            {"name": "backend/models.py", "content": FROZEN_MODELS},
+            {"name": "backend/routes.py", "content": GOOD_ROUTES},
+        ]
+        result = await verify_patched_artifacts(_routes_criteria(), artifacts, stack="python")
+
+        assert result.status == PATCH_PASSED
+
+    async def test_non_python_patches_are_unaffected(self):
+        """Bug caught: the doc/markdown repair path (the original #389 case)
+        regressing because an import walk runs over a workspace with no Python."""
+        artifacts = overlay_artifacts(
+            [{"name": "qa_handoff.md", "content": BROKEN_DOC}],
+            [{"name": "qa_handoff.md", "content": REPAIRED_DOC}],
+        )
+        result = await verify_patched_artifacts(_heading_criteria(), artifacts)
+
+        assert result.status == PATCH_PASSED


### PR DESCRIPTION
Closes #591.

Patch verification evaluated typed criteria **file by file**, so a patch whose imports
could not resolve passed every check and was **accepted**. The failure then surfaced as
a whole-suite collection crash with no attributable cause, and the correction budget
went to re-rolling a test file against source that could never import.

## The pf-37 case — enforcement manufactured the defect

Correction-00 emitted a coherent *pair*: its own `backend/models.py` plus a
`backend/routes.py` written against it. SIP-0100 correctly restored the frozen
`models.py` and kept `routes.py`. Each file is individually valid. The combination
imports seven names the frozen module never defines — `RunCreate`, `RunResponse`,
`RunListResponse`, `ParticipantJoin`, `ParticipantLeave`, `runs_db`, `_next_id`.

```
13:49:25  scaffold_integrity (repair path): frozen_path_emission backend/models.py
13:49:25  patch_verification  status=passed  checks=4  failed=-
13:49:28  patch_retest        status=FAILED
```

Nothing checked the pair. SIP-0100 has no notion of leaving the workspace resolvable,
and the typed checks read one file at a time — `routes.py` compiles perfectly alone,
and `from .models import RunCreate` is syntactically valid whatever `models.py`
contains. It's the same blind spot as the `ApiError` signature class (#588): **typed
checks cannot see cross-module agreement.**

## The change

`unresolved_imports(workspace_root)` walks the assembled workspace and resolves
intra-package imports against the modules actually present.

**Where it lives:** `emission_integrity.py`, beside the pf-31 Fix D syntax gate — same
concern (structural integrity of emitted Python), one step up from per-file
parseability. No new module for an existing concern.

**Where it runs:** inside `verify_patched_artifacts`, **before** the criteria loop. An
unimportable workspace makes every downstream verdict meaningless, and that temp
workspace is the one place the restored-plus-repaired combination actually exists.
Placement matters and is load-bearing: 3.4b enforcement replaces
`result.outputs["artifacts"]` in place *before* the repair overlay reaches verification
(`correction_runner.py` says so explicitly), so the check sees the true post-restore
pair. No executor changes were needed.

**Verdict:** `PATCH_FAILED` with a reason naming the file, module, and every missing
name — actionable in the log instead of another artifact archaeology session.

## Conservative by construction

A false rejection of a good patch is worse than a missed one, so it declines to judge:

- modules with a star-import or a module-level `__getattr__` (PEP 562)
- conditional definitions — `TYPE_CHECKING` blocks, `try/except ImportError` fallbacks
- unparseable targets (the syntax gate owns those)
- anything resolving outside the workspace — stdlib and third-party never appear

## Replay-verified against pf-37's real stored artifacts

| Workspace | Result |
|---|---|
| correction-00 (restored frozen + repaired routes) | **REJECTED** — names all seven missing symbols. Production accepted it. |
| original dev output (suite passed 11/11 live) | **clean** — no findings |

## Tests — 12 new

**Eight on the resolver:** the pf-37 shape, healthy packages, third-party/stdlib
ignored, absolute intra-workspace imports (`from backend.models import X`, which the
scaffold harness uses), star-import and conditional-definition abstention, unparseable
and absent targets.

**Four on the verifier**, including one that pins *why* the defect was invisible: the
same file-local `function_defined` criterion still passes on the very artifacts the new
gate rejects. A future refactor cannot weaken the criteria and call #591 fixed.

## Verification

- `tests/unit` — **5,833 passed**, 3 skipped
- ruff check + format — clean (`_module_level_names` decomposed to stay under the C901
  budget rather than adding an exemption)
- Pre-existing on main, unrelated: 2 failures in `test_verification_contract_runner.py`
  (host has no node by design, #419)

Not deployed — no rebuild, no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
