### PR TITLE
sip: propose Cycle Replay Harness — pinned fast-forward for phase-targeted iteration

### DIFF
--- a/sips/proposed/SIP-Cycle-Replay-Harness.md
+++ b/sips/proposed/SIP-Cycle-Replay-Harness.md
@@ -1,0 +1,237 @@
+# SIP-0XXX: Cycle Replay Harness — Pinned Fast-Forward for Phase-Targeted Iteration
+
+**Status:** Proposed
+**Authors:** SquadOps Architecture
+**Created:** 2026-07-25
+**Revision:** 1
+
+## 1. Abstract
+
+Every investigation into the correction loop currently costs a full cycle. pf-37 —
+a representative measurement roll — spent **2h 06m in framing, 30m in dev, and 6m in
+builder before the first QA task dispatched**, and the QA phase is the only part
+anyone was studying. Three hours of wall clock and roughly 40k generated tokens to
+reach minute one of the interesting part, repeated once per hypothesis.
+
+The phases being paid for are the phases that no longer fail. Framing has produced a
+clean, lint-quiet plan on four consecutive rolls; the dev phase has run 7/7 clean on
+four consecutive rolls. They are re-derived from scratch every time anyway.
+
+This SIP introduces a **replay pin point**: a cycle may be configured to start with a
+prior run's stored artifacts already in place, skipping every workload up to a chosen
+boundary and executing everything after it for real. Iteration on the correction loop
+drops from ~3 hours to minutes.
+
+The mechanism is deliberately small. Seeding artifacts into a run from the vault
+already exists and is load-bearing (`execution_overrides.plan_artifact_refs` +
+`_seed_prior_artifacts` / `_seed_skeleton_artifacts` — the same seam that seeds the
+interface manifest on every measurement roll, and that seeded an entire walking
+skeleton during the Phase-0.5 spike with zero new framework code). This SIP
+generalises that seam to a declared pin point and adds the one thing that must not be
+optional: **a replayed run is structurally barred from counting as evidence.**
+
+## 2. Problem Statement
+
+### 2.1 The iteration tax, measured
+
+pf-37 (`run_010825617319`, 2026-07-25), phase boundaries from the executor log:
+
+| Phase | Wall clock | Outcome |
+|---|---|---|
+| Framing | 2h 06m | clean plan, gate approved |
+| Dev (7 tasks) | 30m | 7/7 pass, 0 corrections |
+| Builder | 6m | clean assembly |
+| **QA + correction** | **the subject of study** | 2 corrections, both false-accepted |
+
+Four of the last five rolls died in the QA/correction phase. Every one of them paid
+the same ~3h entry fee to get there, and the entry fee is spent re-deriving outputs
+that have been stable for a week.
+
+### 2.2 What the tax actually costs
+
+- **Hypothesis latency.** A one-line change to a repair prompt takes three hours to
+  test. In practice this means one or two experiments per working session.
+- **Coupled variables.** Because every roll re-generates everything, a QA-phase
+  experiment is contaminated by fresh framing and dev variance. pf-36 and pf-37 drew
+  opposite `{id}`/`{run_id}` priors from an identical contract — noise in the phase
+  nobody was studying.
+- **Serialised debugging.** The Spark is single-GPU and bandwidth-bound; parallel
+  rolls are ~sequential in wall clock. The iteration loop cannot be widened by
+  running more cycles at once.
+
+### 2.3 Why not just make cycles faster
+
+Smaller models degrade exactly the output-quality signal the rolls exist to measure
+(and are already understood as a poor substitute for full-squad measurement). Shorter
+budgets truncate the correction loop under study. Neither addresses the actual waste,
+which is *re-computing a known-good prefix*.
+
+## 3. Design
+
+### 3.1 The pin point
+
+A cycle request may declare a **replay pin**: the workload boundary at which real
+execution begins.
+
+```yaml
+execution_overrides:
+  replay:
+    source_run_id: run_010825617319     # the run whose artifacts are replayed
+    resume_at: qa                        # first workload executed for real
+```
+
+Everything before `resume_at` is **not dispatched**. Its stored artifacts are loaded
+from the vault into the run's workspace exactly as `_seed_prior_artifacts` already
+does, so the resumed phase begins against a workspace byte-identical to the source
+run's state at that boundary.
+
+Everything at and after `resume_at` executes normally: real dispatch, real generation,
+real typed acceptance, real scaffold enforcement, real correction loop.
+
+### 3.2 Why artifact-level, not LLM-level
+
+The intuitive design intercepts the LLM port and replays recorded completions. This
+SIP deliberately does not, for v1:
+
+- **You skip a phase because you are not testing it.** Re-running the fenced parser
+  over a recorded completion tests the parser — the thing the pin point exists to stop
+  paying for.
+- **Raw completions are not durably persisted today.** That gap is real and is
+  addressed by the LLM Emission Contracts SIP (its P0 evidence rule). Depending on it
+  would block this work behind an unaccepted SIP.
+- **Artifacts already are persisted**, completely, for every historical run. The
+  corpus for replay exists today for pf-27 … pf-38 with no new capture path.
+
+Building no recorder is the point: **v1 introduces zero new capture mechanisms**, so
+there is nothing to reconcile when raw persistence lands. Higher-fidelity modes are
+purely additive (§5).
+
+### 3.3 Prefix compatibility — the correctness gate
+
+A replayed prefix is only valid against a compatible present. The harness refuses to
+replay when the source run's bindings differ from the requested cycle's:
+
+| Pinned | Compared on |
+|---|---|
+| Verification contract | `contract_ref` + content hash |
+| Interface manifest | `plan_artifact_refs` + `interface_manifest_hash` |
+| PRD | `prd_ref` |
+| Build profile / stack | `resolved_config.build_profile` |
+| Squad profile | `squad_profile_id` |
+
+A mismatch is a **hard refusal at create time**, not a warning — the failure mode it
+prevents (a dev prefix written against contract v3 replayed under v4) produces
+confusing, wrong results that look plausible. This reuses the existing create-time
+preflight seam (SIP-0095) rather than adding a new rejection path.
+
+### 3.4 Evidence integrity — non-negotiable
+
+This framework's central defect has been runs that report success for deliverables
+that do not work. A replay harness manufactures convincing-looking runs cheaply and is
+therefore a direct threat to the evidence chain. Three structural requirements:
+
+1. **The outcome carries the pin.** `CycleOutcome` records `replay: {source_run_id,
+   resume_at}`, or its absence. Not a note field — a typed attribute.
+2. **Replayed runs cannot be measurements.** The N=5 green baseline and Functional App
+   Yield must *refuse* a run with a replay pin, at the aggregation seam
+   (`verification_integrity`), not by operator discipline. A replayed run is never
+   "green"; it produces a verdict about a *phase*, never about a cycle.
+3. **Visible everywhere the run is.** CLI listings, console, and the run report render
+   the pin. An operator must never have to check config to know whether a result was
+   earned.
+
+The bar: it should be impossible to accidentally cite a replayed run as evidence that
+the system works.
+
+### 3.5 What replay does not give you
+
+Stated plainly so the harness is not misused:
+
+- **It pins LLM variance.** A replayed roll answers "does this fix work against *this*
+  input," never "does this fix work." Convergence rates, first-pass yield, and prior
+  distributions require real rolls.
+- **It cannot validate the skipped phases.** A fix to framing or dev prompts (e.g.
+  #588) is untestable under a pin that skips them — by construction.
+- **It is a debugging accelerator, not a measurement instrument.** Every claim about
+  system capability still comes from unpinned rolls.
+
+## 4. Phasing
+
+**Phase 1 — replay pin (this SIP's v1).** Pin point in `execution_overrides`, prefix
+seeding via the existing seam, compatibility gate at create time, outcome marking, and
+aggregation refusal. No new capture path, no LLM-port changes.
+
+**Phase 2 — fault injection.** Synthetic responses reproducing known failure shapes
+(truncated fence, `ApiError(status_code=…)`, unresolvable imports) so every defect
+found in the field becomes a repeatable regression test. Strictly better than today's
+reliance on small models to produce faults organically. **Depends on** a raw-emission
+format (LLM Emission Contracts).
+
+**Phase 3 — LLM-level replay.** Intercept at `LLMPort` to exercise parsing and
+extraction against recorded raw output; enables provider A/B (identical inputs through
+Ollama and Atlas) as migration conformance evidence. **Depends on** the same format.
+
+Phases 2 and 3 are named here so the v1 seam does not foreclose them; neither is in
+scope for acceptance of this SIP.
+
+## 5. Alternatives Considered
+
+**Prompt-hash-keyed response cache.** Rejected. Our fixes *are* prompt changes (#584,
+#585, #588 were all prompt edits), so a prompt-keyed cache invalidates on exactly the
+commits worth iterating on, silently falling through to live inference and quietly
+restoring the 3h loop.
+
+**Checkpoint/resume of a real run.** `run_checkpoints` already exists and resumes a
+*paused* run in place. It cannot serve here: it resumes the same run rather than
+starting a fresh one against a recorded prefix, so it cannot re-run a phase repeatedly
+against varying code, which is the entire use case.
+
+**Just cache the framing artifacts manually.** Already possible via
+`plan_artifact_refs`, and effectively what the measurement launcher does for the
+manifest. Rejected as the whole answer because it has no compatibility gate and no
+outcome marking — i.e. it is this design minus the two parts that keep it honest.
+
+**Make cycles cheaper instead (smaller models, shorter budgets).** Degrades the signal
+the rolls exist to produce. Addressed in §2.3.
+
+## 6. Compatibility & Risks
+
+- **Backward compatible by construction.** Absent `execution_overrides.replay`,
+  behaviour is byte-identical to today — the same data-driven pattern the manifest
+  seeding uses.
+- **Risk: false confidence.** The dominant risk; §3.4 is the mitigation and is
+  non-optional.
+- **Risk: stale prefixes.** A pinned prefix ages as contracts evolve. §3.3's hard
+  refusal converts silent wrongness into a loud failure.
+- **Risk: harness gravity.** Tooling attracts polish. v1 is scoped to a pin point and
+  a refusal rule; Phases 2–3 require their own justification.
+- **Risk: over-reliance.** If pinned iteration becomes the default, real-roll evidence
+  thins. Mitigation is cultural, but §3.4's aggregation refusal ensures the release
+  gates still consume only earned runs.
+
+## 7. Relationship to Existing Work
+
+- **LLM Emission Contracts (proposed).** Supplies the raw-emission persistence Phases
+  2–3 need. Explicitly *not* a dependency of Phase 1 — see §3.2.
+- **SIP-0095 Cycle Create Preflight.** §3.3's compatibility gate belongs in that
+  existing seam, not a new one.
+- **SIP-0096 Verification Evidence Integrity.** Owns `CycleOutcome` and the
+  aggregation choke point where §3.4's refusal is enforced.
+- **SIP-0099 / SIP-0100 (scaffolding, frozen enforcement).** The artifacts a pin seeds
+  include the bound skeleton; the bound-record hash participates in §3.3.
+- **Ephemeral Application Sandbox (proposed).** Orthogonal. The sandbox changes *where*
+  verification executes; this changes *how much of the cycle precedes it*. A pinned
+  cycle reaching sandbox verification in minutes compounds both.
+
+## 8. Open Questions
+
+1. **Pin granularity.** Workload boundaries (`framing` / `implementation` / `qa`) are
+   the obvious unit. Is a mid-workload pin (e.g. "after dev, before builder") worth the
+   extra surface, or does workload granularity cover the real cases?
+2. **Prefix provenance.** Should a pin reference a *run* (today's proposal) or a
+   curated, named **fixture** promoted from a run? The latter is more stable and more
+   citable; the former needs no new artifact lifecycle.
+3. **Recording retention.** Replay depends on vault artifacts persisting; no retention
+   policy exists today. Worth stating before pins are built on top of it.
+4. **Does the compatibility gate belong at create time or run start?** Create-time
+   fails fastest; run-start sees the fully resolved config.

--- a/sips/proposed/SIP-Cycle-Replay-Harness.md
+++ b/sips/proposed/SIP-Cycle-Replay-Harness.md
@@ -1,237 +1,287 @@
-# SIP-0XXX: Cycle Replay Harness — Pinned Fast-Forward for Phase-Targeted Iteration
+# SIP-0XXX: Cycle Replay Harness — Resuming a Cycle From a Recorded Execution Boundary
 
 **Status:** Proposed
 **Authors:** SquadOps Architecture
 **Created:** 2026-07-25
-**Revision:** 1
+**Revision:** 2 (review round 1 incorporated)
 
 ## 1. Abstract
 
-Every investigation into the correction loop currently costs a full cycle. pf-37 —
-a representative measurement roll — spent **2h 06m in framing, 30m in dev, and 6m in
-builder before the first QA task dispatched**, and the QA phase is the only part
-anyone was studying. Three hours of wall clock and roughly 40k generated tokens to
-reach minute one of the interesting part, repeated once per hypothesis.
+A cycle re-derives every phase from scratch, including phases that have been stable for
+weeks. pf-37 spent **2h 06m in framing, 30m in dev and 6m in builder before the first QA
+task dispatched** — and the QA phase was the only part under study. That entry fee is
+paid once per hypothesis.
 
-The phases being paid for are the phases that no longer fail. Framing has produced a
-clean, lint-quiet plan on four consecutive rolls; the dev phase has run 7/7 clean on
-four consecutive rolls. They are re-derived from scratch every time anyway.
+This SIP defines **replay**: a cycle execution mode that resumes from a recorded
+execution boundary of a prior run. Phases before the boundary are not dispatched; their
+execution state is restored from that run's durable checkpoint. Everything at and after
+the boundary executes normally.
 
-This SIP introduces a **replay pin point**: a cycle may be configured to start with a
-prior run's stored artifacts already in place, skipping every workload up to a chosen
-boundary and executing everything after it for real. Iteration on the correction loop
-drops from ~3 hours to minutes.
+The invariant the design rests on:
 
-The mechanism is deliberately small. Seeding artifacts into a run from the vault
-already exists and is load-bearing (`execution_overrides.plan_artifact_refs` +
-`_seed_prior_artifacts` / `_seed_skeleton_artifacts` — the same seam that seeds the
-interface manifest on every measurement roll, and that seeded an entire walking
-skeleton during the Phase-0.5 spike with zero new framework code). This SIP
-generalises that seam to a declared pin point and adds the one thing that must not be
-optional: **a replayed run is structurally barred from counting as evidence.**
+> **Replay removes deterministic prefix recomputation. It changes nothing else.**
+
+The mechanism is small because the state representation already exists. `RunCheckpoint`
+is a durable snapshot of run execution state at a task boundary (SIP-0079), and
+`_restore_checkpoint_state` already rehydrates all of it. Replay is that restore, sourced
+from a *different* run. Most of this document is therefore contract, invariant, and
+policy rather than mechanism — including the requirement that a replayed run can never be
+counted as evidence.
 
 ## 2. Problem Statement
 
-### 2.1 The iteration tax, measured
+Four of the last five measurement rolls failed in the QA/correction phase. Each paid the
+same ~3h entry fee to reach it, re-deriving a framing plan that has been clean and
+lint-quiet for four consecutive rolls and a dev phase that has run 7/7 clean for four.
 
-pf-37 (`run_010825617319`, 2026-07-25), phase boundaries from the executor log:
+The costs compound:
 
-| Phase | Wall clock | Outcome |
-|---|---|---|
-| Framing | 2h 06m | clean plan, gate approved |
-| Dev (7 tasks) | 30m | 7/7 pass, 0 corrections |
-| Builder | 6m | clean assembly |
-| **QA + correction** | **the subject of study** | 2 corrections, both false-accepted |
+- **Hypothesis latency.** A one-line repair-prompt change takes three hours to test — in
+  practice one or two experiments per working session.
+- **Coupled variables.** A QA-phase experiment is contaminated by fresh framing and dev
+  variance. pf-36 and pf-37 drew opposite `{id}`/`{run_id}` priors from an identical
+  contract: noise in a phase nobody was studying.
+- **No parallel escape.** The target is single-GPU and bandwidth-bound; concurrent rolls
+  are ~sequential in wall clock.
 
-Four of the last five rolls died in the QA/correction phase. Every one of them paid
-the same ~3h entry fee to get there, and the entry fee is spent re-deriving outputs
-that have been stable for a week.
-
-### 2.2 What the tax actually costs
-
-- **Hypothesis latency.** A one-line change to a repair prompt takes three hours to
-  test. In practice this means one or two experiments per working session.
-- **Coupled variables.** Because every roll re-generates everything, a QA-phase
-  experiment is contaminated by fresh framing and dev variance. pf-36 and pf-37 drew
-  opposite `{id}`/`{run_id}` priors from an identical contract — noise in the phase
-  nobody was studying.
-- **Serialised debugging.** The Spark is single-GPU and bandwidth-bound; parallel
-  rolls are ~sequential in wall clock. The iteration loop cannot be widened by
-  running more cycles at once.
-
-### 2.3 Why not just make cycles faster
-
-Smaller models degrade exactly the output-quality signal the rolls exist to measure
-(and are already understood as a poor substitute for full-squad measurement). Shorter
-budgets truncate the correction loop under study. Neither addresses the actual waste,
-which is *re-computing a known-good prefix*.
+Cheaper cycles are not the answer — smaller models degrade the output-quality signal the
+rolls exist to measure, and shorter budgets truncate the correction loop under study.
+The waste is specifically *recomputing a known-good prefix*.
 
 ## 3. Design
 
-### 3.1 The pin point
+### 3.1 Replay as an execution mode
 
-A cycle request may declare a **replay pin**: the workload boundary at which real
-execution begins.
+A run executes in exactly one **execution mode**:
+
+| Mode | Scheduling | State origin | Evidence |
+|---|---|---|---|
+| `normal` | every task dispatched | produced by this run | eligible |
+| `replay` | tasks before the boundary skipped | restored from a source run's checkpoint | **ineligible** (§4) |
+
+Mode is declared at cycle creation and is immutable for the run's lifetime. Modelling
+this as a mode rather than a bag of overrides means later capabilities (§6) extend one
+concept instead of accumulating flags.
 
 ```yaml
-execution_overrides:
-  replay:
-    source_run_id: run_010825617319     # the run whose artifacts are replayed
-    resume_at: qa                        # first workload executed for real
+execution_mode: replay
+replay:
+  source_run_id: run_010825617319
+  boundary: checkpoint:7          # or the terminal boundary of a named workload
 ```
 
-Everything before `resume_at` is **not dispatched**. Its stored artifacts are loaded
-from the vault into the run's workspace exactly as `_seed_prior_artifacts` already
-does, so the resumed phase begins against a workspace byte-identical to the source
-run's state at that boundary.
+### 3.2 The replay boundary
 
-Everything at and after `resume_at` executes normally: real dispatch, real generation,
-real typed acceptance, real scaffold enforcement, real correction loop.
+A **replay boundary** is a persisted `RunCheckpoint` of the source run. Checkpoints are
+written after every successful task and record exactly the state downstream execution
+consumes:
 
-### 3.2 Why artifact-level, not LLM-level
+```
+run_id · checkpoint_index · completed_task_ids · prior_outputs
+       · artifact_refs · plan_delta_refs · created_at
+```
 
-The intuitive design intercepts the LLM port and replays recorded completions. This
-SIP deliberately does not, for v1:
+Resuming at a boundary is the existing `_restore_checkpoint_state` operation — restore
+`prior_outputs`, `completed_task_ids`, `plan_delta_refs`, and the referenced vault
+artifacts — with `completed_task_ids` populating `skip_task_ids`, which already
+suppresses dispatch. The only novelty is that the checkpoint comes from a different run.
 
-- **You skip a phase because you are not testing it.** Re-running the fenced parser
-  over a recorded completion tests the parser — the thing the pin point exists to stop
-  paying for.
-- **Raw completions are not durably persisted today.** That gap is real and is
-  addressed by the LLM Emission Contracts SIP (its P0 evidence rule). Depending on it
-  would block this work behind an unaccepted SIP.
-- **Artifacts already are persisted**, completely, for every historical run. The
-  corpus for replay exists today for pf-27 … pf-38 with no new capture path.
+**Granularity is per task, not per workload**, because checkpoints are. No additional
+state capture is required to support finer boundaries.
 
-Building no recorder is the point: **v1 introduces zero new capture mechanisms**, so
-there is nothing to reconcile when raw persistence lands. Higher-fidelity modes are
-purely additive (§5).
+### 3.3 Boundary invariant
 
-### 3.3 Prefix compatibility — the correctness gate
+> **A boundary is replayable only if every downstream dependency is represented entirely
+> by the persisted checkpoint and the artifacts it references.**
 
-A replayed prefix is only valid against a compatible present. The harness refuses to
-replay when the source run's bindings differ from the requested cycle's:
+This is the load-bearing invariant and it is not automatically true. Verified during
+review: downstream prompts consume `prior_outputs`, which is populated as
 
-| Pinned | Compared on |
+```python
+prior_outputs[role] = {k: v for k, v in (result.outputs or {}).items() if k != "artifacts"}
+```
+
+— explicitly *everything except artifacts*. A replay that seeded only stored artifacts
+would hand the resumed phase an empty `prior_outputs` and silently violate §3.4.
+Checkpoint-sourcing satisfies the invariant today precisely because `RunCheckpoint`
+already captures that field.
+
+The invariant's ongoing value is as a **review rule**: any future run-scoped state that
+influences downstream execution and is not in the checkpoint is a defect in the
+checkpoint, not a special case for replay. New artifact types need no replay support so
+long as they are reachable from `artifact_refs`.
+
+### 3.4 Determinism contract
+
+> **For every skipped task, replay SHALL present downstream execution with state
+> byte-equivalent to that produced by the source run at the same boundary.**
+
+Byte-equivalence covers restored artifact content, `prior_outputs`, `completed_task_ids`
+and `plan_delta_refs`. It is directly testable: replay a source run at its terminal
+boundary and assert the resumed run's initial state equals the source run's state at that
+index.
+
+### 3.5 Compatibility policy
+
+A prefix is only valid against a compatible present. Rather than one global hash list,
+**each boundary declares the compatibility set its replay requires** — the bindings that
+actually influence the phases at and after it.
+
+| Boundary class | Compatibility set |
 |---|---|
-| Verification contract | `contract_ref` + content hash |
-| Interface manifest | `plan_artifact_refs` + `interface_manifest_hash` |
-| PRD | `prd_ref` |
-| Build profile / stack | `resolved_config.build_profile` |
-| Squad profile | `squad_profile_id` |
+| post-framing | PRD ref, contract ref + hash, manifest ref + hash, build profile, squad profile |
+| post-dev | the above, plus the bound scaffold record hash |
+| post-builder | the above, plus build profile required-file set |
 
-A mismatch is a **hard refusal at create time**, not a warning — the failure mode it
-prevents (a dev prefix written against contract v3 replayed under v4) produces
-confusing, wrong results that look plausible. This reuses the existing create-time
-preflight seam (SIP-0095) rather than adding a new rejection path.
+Artifacts and config that demonstrably cannot affect the resumed phases — logging,
+documentation, unrelated metadata — are outside every set by construction, so unrelated
+commits do not invalidate a prefix.
 
-### 3.4 Evidence integrity — non-negotiable
+A mismatch is a **hard refusal at cycle creation**, not a warning: the failure it prevents
+(a dev prefix authored against contract v3 replayed under v4) produces plausible-looking
+wrong results. This extends the existing SIP-0095 create-time preflight rather than adding
+a rejection path.
 
-This framework's central defect has been runs that report success for deliverables
-that do not work. A replay harness manufactures convincing-looking runs cheaply and is
-therefore a direct threat to the evidence chain. Three structural requirements:
+### 3.6 Required change: checkpoint retention
 
-1. **The outcome carries the pin.** `CycleOutcome` records `replay: {source_run_id,
-   resume_at}`, or its absence. Not a note field — a typed attribute.
-2. **Replayed runs cannot be measurements.** The N=5 green baseline and Functional App
-   Yield must *refuse* a run with a replay pin, at the aggregation seam
-   (`verification_integrity`), not by operator discipline. A replayed run is never
-   "green"; it produces a verdict about a *phase*, never about a cycle.
-3. **Visible everywhere the run is.** CLI listings, console, and the run report render
-   the pin. An operator must never have to check config to know whether a result was
-   earned.
+`save_checkpoint(..., max_keep=5)` prunes all but the latest five checkpoints per run. A
+ten-task run therefore **deletes the post-framing and post-dev boundaries before it
+finishes** — exactly the boundaries worth replaying.
 
-The bar: it should be impossible to accidentally cite a replayed run as evidence that
-the system works.
+Phase 1 must make boundary checkpoints durable. Two candidate mechanisms, either
+acceptable:
 
-### 3.5 What replay does not give you
+- retain all checkpoints for runs flagged as replay sources, or
+- mark boundary checkpoints exempt from pruning at write time.
 
-Stated plainly so the harness is not misused:
+Unbounded retention for every run is not proposed; the pruning default exists for a
+reason and this SIP does not relitigate it.
 
-- **It pins LLM variance.** A replayed roll answers "does this fix work against *this*
-  input," never "does this fix work." Convergence rates, first-pass yield, and prior
-  distributions require real rolls.
-- **It cannot validate the skipped phases.** A fix to framing or dev prompts (e.g.
-  #588) is untestable under a pin that skips them — by construction.
-- **It is a debugging accelerator, not a measurement instrument.** Every claim about
-  system capability still comes from unpinned rolls.
+## 4. Evidence Policy
 
-## 4. Phasing
+This framework's defining defect has been runs reporting success for deliverables that do
+not work. Replay manufactures convincing-looking runs cheaply and is therefore a direct
+threat to the evidence chain. These are requirements, not guidance.
 
-**Phase 1 — replay pin (this SIP's v1).** Pin point in `execution_overrides`, prefix
-seeding via the existing seam, compatibility gate at create time, outcome marking, and
-aggregation refusal. No new capture path, no LLM-port changes.
+1. Replay metadata (`source_run_id`, `boundary`, resolved compatibility set) **SHALL** be
+   a typed attribute of `CycleOutcome`, not a free-text note.
+2. Replay metadata **SHALL** be immutable after run creation.
+3. Replayed runs **SHALL NOT** satisfy baseline aggregation (the N=5 green baseline).
+4. Replayed runs **SHALL NOT** count toward Functional App Yield.
+5. Requirements 3–4 **SHALL** be enforced at the `verification_integrity` aggregation
+   seam — refusal in code, not operator discipline.
+6. Replay metadata **SHALL** be rendered on every surface that reports the run: CLI
+   listings, console, and the run report.
 
-**Phase 2 — fault injection.** Synthetic responses reproducing known failure shapes
-(truncated fence, `ApiError(status_code=…)`, unresolvable imports) so every defect
-found in the field becomes a repeatable regression test. Strictly better than today's
-reliance on small models to produce faults organically. **Depends on** a raw-emission
-format (LLM Emission Contracts).
+**Acceptance bar:** it must be impossible to accidentally cite a replayed run as evidence
+that the system works.
 
-**Phase 3 — LLM-level replay.** Intercept at `LLMPort` to exercise parsing and
-extraction against recorded raw output; enables provider A/B (identical inputs through
-Ollama and Atlas) as migration conformance evidence. **Depends on** the same format.
+### 4.1 What replay cannot tell you
 
-Phases 2 and 3 are named here so the v1 seam does not foreclose them; neither is in
-scope for acceptance of this SIP.
+- **It pins model variance.** A replayed roll answers "does this fix work against *this*
+  input," never "does this fix work." Convergence rates, first-pass yield and prior
+  distributions require `normal` runs.
+- **It cannot validate a skipped phase.** A fix to framing or dev prompts is untestable
+  under a boundary that skips them — by construction. #588 is a live example.
+- **It is a debugging accelerator, not a measurement instrument.**
 
-## 5. Alternatives Considered
+## 5. Acceptance Criteria (Phase 1)
+
+Phase 1 is complete when:
+
+1. A cycle can be created in `replay` mode against a source run and boundary.
+2. Tasks at or before the boundary perform **no dispatch** — verifiable as zero
+   `Dispatched task` records for those task ids.
+3. Tasks after the boundary execute normally: real dispatch, typed acceptance, scaffold
+   enforcement, correction loop.
+4. The resumed run's initial state is byte-equivalent to the source run's state at that
+   boundary (§3.4), asserted by test.
+5. An incompatible prefix is **rejected at cycle creation** with the failing element
+   named (§3.5).
+6. A boundary checkpoint survives to the end of its source run (§3.6).
+7. Replay metadata is present, typed, and immutable on `CycleOutcome`.
+8. A replayed run is **refused** by baseline aggregation and FAY at the
+   `verification_integrity` seam, asserted by test.
+9. Replay status is visible in CLI, console and run report output.
+10. Absent `execution_mode: replay`, behaviour is byte-identical to today.
+
+## 6. Extension Layers
+
+Replay is layered by **what feeds the execution seam**, not by delivery order. Phase 1
+establishes the seam; later phases change the source.
+
+| Layer | Substitutes | Source | Status |
+|---|---|---|---|
+| **Workspace state** | whole tasks | recorded checkpoint | **Phase 1 (this SIP)** |
+| **Model output** | LLM responses within an executed task | recorded raw emissions | future |
+| **Model output** | LLM responses within an executed task | synthetic (fault injection) | future |
+
+The lower layer is a single seam at `LLMPort`, parameterised by source: *recorded*
+enables provider A/B (identical inputs through Ollama and Atlas, as migration conformance
+evidence), *synthetic* turns every field defect — truncated fence, `ApiError(status_code=…)`,
+unresolvable imports — into a repeatable regression test.
+
+Both require durable raw-emission capture, which this SIP deliberately does not build
+(§7). They are named so the Phase 1 seam does not foreclose them; **neither is in scope
+for acceptance.**
+
+## 7. Alternatives Considered
+
+**Replay at `LLMPort` for Phase 1.** Rejected. A phase is skipped *because it is not
+under test*, so re-running the fenced parser over a recorded completion tests the parser —
+the cost the boundary exists to avoid. Raw completions are also not durably persisted
+today; that gap belongs to the LLM Emission Contracts SIP, and depending on it would block
+this behind an unaccepted proposal. Phase 1 therefore introduces **no new capture path**,
+so nothing must be un-built when raw persistence lands.
 
 **Prompt-hash-keyed response cache.** Rejected. Our fixes *are* prompt changes (#584,
 #585, #588 were all prompt edits), so a prompt-keyed cache invalidates on exactly the
-commits worth iterating on, silently falling through to live inference and quietly
-restoring the 3h loop.
+commits worth iterating on, then silently falls through to live inference.
 
-**Checkpoint/resume of a real run.** `run_checkpoints` already exists and resumes a
-*paused* run in place. It cannot serve here: it resumes the same run rather than
-starting a fresh one against a recorded prefix, so it cannot re-run a phase repeatedly
-against varying code, which is the entire use case.
+**Checkpoint resume as-is.** SIP-0079 resume rehydrates a *paused* run in place and cannot
+re-run a phase repeatedly against changing code, which is the entire use case. This SIP
+adopts its **state representation** while rejecting its resume-in-place semantics — the
+reason Phase 1 is small.
 
-**Just cache the framing artifacts manually.** Already possible via
-`plan_artifact_refs`, and effectively what the measurement launcher does for the
-manifest. Rejected as the whole answer because it has no compatibility gate and no
-outcome marking — i.e. it is this design minus the two parts that keep it honest.
+**Cheaper cycles (smaller models, shorter budgets).** Degrades the signal the rolls exist
+to produce (§2).
 
-**Make cycles cheaper instead (smaller models, shorter budgets).** Degrades the signal
-the rolls exist to produce. Addressed in §2.3.
+## 8. Compatibility & Risks
 
-## 6. Compatibility & Risks
+- **Backward compatible by construction** — absent `execution_mode: replay`, behaviour is
+  unchanged (criterion 10).
+- **False confidence** — the dominant risk; §4 is the mitigation and is non-optional.
+- **Stale prefixes** — §3.5 converts silent wrongness into a loud create-time refusal.
+- **Checkpoint growth** — §3.6 changes retention; scoped to replay sources rather than
+  globally unbounded.
+- **Harness gravity** — tooling attracts polish. Phase 1 is a mode, a refusal rule and a
+  retention change; §6 layers require their own justification.
+- **Thinning real evidence** — if pinned iteration becomes the default, `normal`-run
+  evidence thins. §4.3–4.5 ensure release gates still consume only earned runs.
 
-- **Backward compatible by construction.** Absent `execution_overrides.replay`,
-  behaviour is byte-identical to today — the same data-driven pattern the manifest
-  seeding uses.
-- **Risk: false confidence.** The dominant risk; §3.4 is the mitigation and is
-  non-optional.
-- **Risk: stale prefixes.** A pinned prefix ages as contracts evolve. §3.3's hard
-  refusal converts silent wrongness into a loud failure.
-- **Risk: harness gravity.** Tooling attracts polish. v1 is scoped to a pin point and
-  a refusal rule; Phases 2–3 require their own justification.
-- **Risk: over-reliance.** If pinned iteration becomes the default, real-roll evidence
-  thins. Mitigation is cultural, but §3.4's aggregation refusal ensures the release
-  gates still consume only earned runs.
+## 9. Relationship to Existing Work
 
-## 7. Relationship to Existing Work
+- **SIP-0079** — owns `RunCheckpoint` and `_restore_checkpoint_state`; this SIP reuses
+  both and changes their retention (§3.6).
+- **SIP-0095 Cycle Create Preflight** — hosts the §3.5 compatibility gate.
+- **SIP-0096 Verification Evidence Integrity** — owns `CycleOutcome` and the aggregation
+  choke point enforcing §4.
+- **SIP-0099 / SIP-0100** — the bound scaffold record participates in post-dev
+  compatibility sets.
+- **LLM Emission Contracts (proposed)** — supplies the raw-emission capture the §6 lower
+  layer needs. Explicitly *not* a dependency of Phase 1.
+- **Ephemeral Application Sandbox (proposed)** — orthogonal; it changes *where*
+  verification executes, this changes *how much of the cycle precedes it*.
 
-- **LLM Emission Contracts (proposed).** Supplies the raw-emission persistence Phases
-  2–3 need. Explicitly *not* a dependency of Phase 1 — see §3.2.
-- **SIP-0095 Cycle Create Preflight.** §3.3's compatibility gate belongs in that
-  existing seam, not a new one.
-- **SIP-0096 Verification Evidence Integrity.** Owns `CycleOutcome` and the
-  aggregation choke point where §3.4's refusal is enforced.
-- **SIP-0099 / SIP-0100 (scaffolding, frozen enforcement).** The artifacts a pin seeds
-  include the bound skeleton; the bound-record hash participates in §3.3.
-- **Ephemeral Application Sandbox (proposed).** Orthogonal. The sandbox changes *where*
-  verification executes; this changes *how much of the cycle precedes it*. A pinned
-  cycle reaching sandbox verification in minutes compounds both.
+## 10. Open Questions
 
-## 8. Open Questions
+1. **Retention mechanism (§3.6)** — flag replay-source runs, or exempt boundary
+   checkpoints at write time?
+2. **Compatibility set ownership** — should each boundary class declare its set in code,
+   or should the set be derived from the resumed workloads' declared inputs?
+3. **Cross-project replay** — is a source run from another project ever valid, or should
+   replay be project-scoped by rule?
 
-1. **Pin granularity.** Workload boundaries (`framing` / `implementation` / `qa`) are
-   the obvious unit. Is a mid-workload pin (e.g. "after dev, before builder") worth the
-   extra surface, or does workload granularity cover the real cases?
-2. **Prefix provenance.** Should a pin reference a *run* (today's proposal) or a
-   curated, named **fixture** promoted from a run? The latter is more stable and more
-   citable; the former needs no new artifact lifecycle.
-3. **Recording retention.** Replay depends on vault artifacts persisting; no retention
-   policy exists today. Worth stating before pins are built on top of it.
-4. **Does the compatibility gate belong at create time or run start?** Create-time
-   fails fastest; run-start sees the fully resolved config.
+**Explicitly out of scope:** promoting a boundary into a named, curated **fixture** with
+its own lifecycle. Replay references a run. Fixtures are a separate proposal if the need
+proves real.


### PR DESCRIPTION
Draft SIP for design review — adds `sips/proposed/SIP-Cycle-Replay-Harness.md`. No code.

## The case, measured

pf-37's phase boundaries from the executor log:

| Phase | Wall clock |
|---|---|
| Framing | **2h 06m** |
| Dev (7 tasks) | 30m |
| Builder | 6m |
| **QA + correction** | the only part under study |

~3 hours and ~40k generated tokens to reach minute one of the interesting part, once
per hypothesis. And the phases being paid for are the ones that no longer fail —
framing has produced a clean lint-quiet plan on four consecutive rolls; dev has run
7/7 clean on four.

## What it proposes

A cycle may declare a **replay pin**:

```yaml
execution_overrides:
  replay:
    source_run_id: run_010825617319
    resume_at: qa
```

Everything before the boundary is seeded from the source run's stored artifacts and
never dispatched. Everything at and after it runs for real — real generation, typed
acceptance, scaffold enforcement, correction loop.

## Why it's small

Seeding artifacts from the vault **already exists and is load-bearing**:
`execution_overrides.plan_artifact_refs` + `_seed_prior_artifacts` /
`_seed_skeleton_artifacts` is the same seam that seeds the interface manifest on every
measurement roll, and that seeded an entire walking skeleton during the Phase-0.5 spike
with zero new framework code. This generalises that seam to a declared pin point and
adds the one part that must not be optional.

## Two decisions worth reviewing

**Artifact-level, not LLM-level, for v1.** The intuitive design intercepts `LLMPort` and
replays recorded completions. Rejected for v1: you skip a phase *because you are not
testing it*, so re-running the fenced parser over a recorded completion buys nothing —
it tests the parser, which is what the pin exists to stop paying for. Raw completions
also aren't durably persisted today; that gap belongs to the LLM Emission Contracts SIP,
and depending on it would block this behind an unaccepted SIP. Artifacts already persist
completely for pf-27…pf-38, so **v1 introduces zero new capture paths** and nothing needs
un-building when raw persistence lands.

**Keyed on run + workload boundary, not prompt hash.** Our fixes *are* prompt changes —
#584, #585 and #588 were all prompt edits — so a prompt-keyed cache invalidates on
exactly the commits worth iterating on, silently falls through to live inference, and
quietly restores the 3-hour loop.

## Evidence integrity — the part I'd most like reviewed

This framework's central wound is runs reporting success for deliverables that don't
work. A replay harness manufactures convincing-looking runs cheaply, so §3.4 makes the
guardrail structural rather than procedural:

1. The pin is a **typed `CycleOutcome` attribute**, not a note field.
2. The N=5 baseline and FAY must **refuse** a pinned run at the `verification_integrity`
   aggregation seam — not by operator discipline.
3. The pin renders everywhere the run does (CLI, console, run report).

Bar: it should be impossible to accidentally cite a replayed run as evidence the system
works.

§3.5 states plainly what replay *cannot* tell you — it pins LLM variance (so it answers
"does this fix work against *this* input," never "does this fix work"), it cannot
validate a fix to a skipped phase (#588 is untestable under a pin that skips dev), and
it is a debugging accelerator rather than a measurement instrument.

## Phasing

- **Phase 1 (this SIP's v1):** pin point, prefix seeding, compatibility gate, outcome
  marking, aggregation refusal. No new capture path, no LLM-port changes.
- **Phase 2 — fault injection:** synthetic malformed emissions so every field defect
  becomes a repeatable regression test. Depends on the emission format.
- **Phase 3 — LLM-level replay:** parsing/extraction against recorded raw output, and
  Ollama↔Atlas A/B on identical inputs as migration conformance evidence. Same
  dependency.

2 and 3 are named so the v1 seam doesn't foreclose them; neither is in scope for
acceptance.

## Open questions in the draft

Pin granularity (workload boundary vs mid-workload), whether a pin should reference a
run or a curated promoted **fixture**, vault retention policy (none exists today, and
replay depends on it), and whether the compatibility gate belongs at create time or run
start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
