### PR TITLE
fix(scaffold): declare success status in the manifest; reject qa tasks owning others' files

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2652,6 +2652,10 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         f"verification_contract: {e}"
                         for e in parsed_plan.validate_criteria_refs(contract)
                     )
+                    errors.extend(
+                        f"verification_contract: {e}"
+                        for e in parsed_plan.validate_qa_artifact_ownership(contract)
+                    )
 
         # Soft (warning/info-severity) structural violations are tolerated, not
         # rejected — but logged so the pass is never silent (a warning check can't

--- a/examples/03_group_run/interface_manifest.yaml
+++ b/examples/03_group_run/interface_manifest.yaml
@@ -54,7 +54,8 @@ api:
         response: "list[RunEvent]" }                                 # §5.2
     - { method: POST, path: /runs,              summary: create run,
         request: RunEventCreate, response: RunEvent,
-        errors: [validation_error] }                                 # §5.1
+        success_status: 201,                                         # pf-39: the probe
+        errors: [validation_error] }                                 # §5.1  pins 201
     - { method: GET,  path: "/runs/{run_id}",       summary: run details,
         response: RunEvent, errors: [run_not_found] }                # §5.3
     - { method: POST, path: "/runs/{run_id}/join",  summary: join run by participant name,

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -75,6 +75,14 @@ class Endpoint:
     request: str | None = None  # names a RequestShape
     response: str | None = None  # e.g. "RunEvent" or "list[RunEvent]"
     errors: tuple[str, ...] = ()
+    # Success status the endpoint must return. ``ErrorCode.http`` already models the
+    # *error* statuses, so before pf-39 the manifest could declare "422 on validation
+    # failure" but not "201 on create" — the expander emitted a bare
+    # ``@router.post(path)`` (FastAPI default 200) while the derived contract probe
+    # pinned 201, making the skeleton unable to satisfy its own contract. Green then
+    # depended on the dev agent volunteering ``status_code=201``: pf-38 did, pf-39 did
+    # not, and that single token was the whole difference. None = framework default.
+    success_status: int | None = None
 
 
 @dataclass(frozen=True)
@@ -321,6 +329,9 @@ def _parse_api(raw: dict[str, Any]) -> Api:
             request=(str(ep["request"]) if ep.get("request") else None),
             response=(str(ep["response"]) if ep.get("response") else None),
             errors=tuple(str(x) for x in ep.get("errors", [])),
+            success_status=(
+                int(ep["success_status"]) if ep.get("success_status") is not None else None
+            ),
         )
         for ep in raw.get("endpoints", [])
     )
@@ -615,6 +626,10 @@ def _routes_source(manifest: InterfaceManifest) -> str:
         decorator = f'@router.{ep.method.lower()}("{ep.path}"'
         if ep.response:
             decorator += f", response_model={_py_type(ep.response)}"
+        # The success status is *interface*, not implementation — it belongs to the
+        # scaffold-owned decorator so the fill dev cannot drop it (pf-39).
+        if ep.success_status is not None:
+            decorator += f", status_code={ep.success_status}"
         decorator += ")"
         lines.append(decorator)
         lines.append(f"def {fn}({sig}):")

--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -225,7 +225,14 @@ def _probes(manifest: InterfaceManifest) -> list[dict[str, Any]]:
                 # returns 201. Expecting 200 made the contract contradict the
                 # PRD: a PRD-conformant app could never pass its own probe
                 # (pf-3: "status 201 != expected 200" on a correct app).
-                "expect": {"status": 201},
+                #
+                # pf-39: read the endpoint's declared success status so the probe and
+                # the emitted decorator cannot disagree. Previously this was hardcoded
+                # 201 while ``_routes_source`` emitted no ``status_code`` at all, so
+                # the skeleton contradicted its own contract and only a dev agent
+                # volunteering ``status_code=201`` could close the gap. A manifest that
+                # declares no success status keeps the historical 201 expectation.
+                "expect": {"status": ep.success_status or 201},
             }
         )
     return probes

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -476,6 +476,41 @@ class ImplementationPlan:
 
         return errors
 
+    def validate_qa_artifact_ownership(self, contract: VerificationContract) -> list[str]:
+        """pf-39: a ``qa.test`` task may not declare scaffold- or dev-owned files as
+        its ``expected_artifacts``.
+
+        Write authorization already refuses these at *emission* time
+        (``unauthorized_slot_emission``), so a plan that declares them admits a task
+        that provably cannot produce its own outputs. The cost is not the wasted task:
+        a correction repair is scoped to the **failing task's** expected artifacts, so
+        when such a task fails the repair is aimed at files that were never the defect.
+        In pf-39 a ``qa.test`` task declared the three view fill slots; the analyzer
+        correctly diagnosed a backend status-code defect in another task's file, and
+        the repair rewrote the views instead — one whole correction attempt that could
+        not have fixed anything.
+
+        Same referent as write authorization (the contract's frozen + fill surfaces),
+        applied at authoring time instead of emission time. Documents and test files
+        are unaffected — only files the contract says someone else owns are rejected.
+
+        Returns:
+            List of validation error strings (empty = valid).
+        """
+        owned: dict[str, str] = {ff.path: "frozen (scaffold-owned)" for ff in contract.frozen_files}
+        owned.update({ff.path: "a fill slot (dev-owned)" for ff in contract.fill_files})
+
+        return [
+            f"Task {task.task_index} ({task.focus}): qa.test declares expected artifact "
+            f"{artifact!r}, which is {owned[artifact]} — write authorization refuses it at "
+            f"emission, and a repair scoped to this task would target the wrong files. "
+            f"QA tasks own their test files only"
+            for task in self.tasks
+            if task.task_type == "qa.test"
+            for artifact in task.expected_artifacts
+            if artifact in owned
+        ]
+
     def _authored_on_covered_criteria(self, contract: VerificationContract):
         """Yield ``(task, criterion, target)`` for every authored ``TypedCheck``
         whose target file is contract-covered (§6.3 rule 3) — shared by the fatal

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -741,6 +741,15 @@ def _replace_build_steps_with_plan(
         ref_errors = plan.validate_criteria_refs(contract)
         if ref_errors:
             raise CycleError("Plan validation failed (contract binding): " + "; ".join(ref_errors))
+        # pf-39: a qa.test task declaring scaffold-/dev-owned files as its expected
+        # artifacts is unsatisfiable (write authorization refuses the emission) and
+        # misdirects any repair scoped to it. Same referent as write authorization,
+        # applied at authoring time.
+        ownership_errors = plan.validate_qa_artifact_ownership(contract)
+        if ownership_errors:
+            raise CycleError(
+                "Plan validation failed (qa artifact ownership): " + "; ".join(ownership_errors)
+            )
         # pf-31 Fix A3: warning-only prose-vs-contract conflict lint, surfaced for
         # the gate reviewer (never a rejection — reverted-#552 lesson).
         for warning in plan.lint_prose_contract_conflicts(contract):

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -102,7 +102,10 @@ def test_expand_defines_every_declared_endpoint_and_model():
 
     routes = files["backend/routes.py"]
     assert '@router.get("/runs", response_model=list[RunEvent])' in routes
-    assert '@router.post("/runs", response_model=RunEvent)' in routes
+    # /runs declares success_status: 201, so the decorator carries it (pf-39); join
+    # declares none, so its decorator stays bare — the two together pin that the
+    # status is emitted from the manifest rather than blanket-applied.
+    assert '@router.post("/runs", response_model=RunEvent, status_code=201)' in routes
     assert '@router.post("/runs/{run_id}/join", response_model=RunEvent)' in routes
     assert "payload: RunEventCreate" in routes
     assert "payload: ParticipantName" in routes
@@ -512,3 +515,68 @@ class TestErrorSeamInstructions:
         raw["api"].pop("error_contract", None)
         assert error_seam_instructions(InterfaceManifest.from_dict(raw)) == []
         assert error_seam_instructions(None) == []
+
+
+class TestDeclaredSuccessStatus:
+    """pf-39: the success status is *interface*, so the scaffold must own it.
+
+    Before this, ``Endpoint`` had no success-status field, ``_routes_source`` emitted a
+    bare ``@router.post(path)`` (FastAPI default 200), and ``_probes`` hardcoded
+    ``expect: status 201`` — a skeleton that contradicted its own contract. Green then
+    depended on the dev agent *volunteering* ``status_code=201``: pf-38 did, pf-39 did
+    not, and that single token was the entire difference between accepted and rejected.
+    """
+
+    def test_declared_status_lands_on_the_decorator(self):
+        routes = next(
+            f["content"] for f in expand(_group_run_manifest()) if f["name"] == "backend/routes.py"
+        )
+        post_runs = next(ln for ln in routes.splitlines() if ln.startswith('@router.post("/runs"'))
+        assert "status_code=201" in post_runs
+
+    def test_undeclared_status_emits_no_status_code(self):
+        """A GET declares no success status, so the decorator must stay bare — the
+        fix must not blanket every route with a status it did not ask for."""
+        routes = next(
+            f["content"] for f in expand(_group_run_manifest()) if f["name"] == "backend/routes.py"
+        )
+        get_runs = next(ln for ln in routes.splitlines() if ln.startswith('@router.get("/runs"'))
+        assert "status_code" not in get_runs
+
+    def test_probe_expectation_follows_the_manifest_not_a_constant(self):
+        """The probe must *derive* its expectation from the same field the decorator
+        reads. If it stayed hardcoded at 201, a manifest declaring anything else would
+        emit a contract its own skeleton could never satisfy — the pf-39 defect with
+        the numbers changed."""
+        from squadops.capabilities.scaffold_contract import emit_contract_dict
+
+        raw = _raw_manifest()
+        for ep in raw["api"]["endpoints"]:
+            if ep["method"] == "POST" and ep["path"] == "/runs":
+                ep["success_status"] = 202
+        manifest = InterfaceManifest.from_dict(raw)
+
+        probe = next(
+            p
+            for p in emit_contract_dict(manifest)["behavioral"]["probes"]
+            if p["id"] == "vc-probe-runs"
+        )
+        assert probe["expect"]["status"] == 202
+
+        routes = next(f["content"] for f in expand(manifest) if f["name"] == "backend/routes.py")
+        assert "status_code=202" in routes
+
+    def test_manifest_without_success_status_keeps_the_historical_probe_default(self):
+        """Backward compatibility: manifests predating the field still get 201."""
+        from squadops.capabilities.scaffold_contract import emit_contract_dict
+
+        raw = _raw_manifest()
+        for ep in raw["api"]["endpoints"]:
+            ep.pop("success_status", None)
+
+        probe = next(
+            p
+            for p in emit_contract_dict(InterfaceManifest.from_dict(raw))["behavioral"]["probes"]
+            if p["id"] == "vc-probe-runs"
+        )
+        assert probe["expect"]["status"] == 201

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -782,3 +782,94 @@ summary:
         )
         assert plan.validate_criteria_scope() == []
         assert plan.soft_criteria_violations() == []
+
+
+class TestQaArtifactOwnership:
+    """pf-39: a qa.test task declaring scaffold- or dev-owned files is unsatisfiable.
+
+    Write authorization already refuses those emissions (``unauthorized_slot_emission``),
+    so the plan admits a task that cannot produce its own declared outputs. The real
+    damage is downstream: a correction repair is scoped to the *failing task's*
+    expected artifacts, so when such a task fails the repair is aimed at files that were
+    never the defect. In pf-39 a qa.test task declared the three view fill slots, the
+    analyzer correctly diagnosed a backend status-code defect in another task's file,
+    and the repair rewrote the views — an entire correction attempt that could not have
+    fixed anything.
+    """
+
+    @staticmethod
+    def _contract():
+        from pathlib import Path
+
+        from squadops.capabilities.scaffold import InterfaceManifest
+        from squadops.capabilities.scaffold_contract import emit_contract_dict
+        from squadops.cycles.verification_contract import VerificationContract
+
+        path = (
+            Path(__file__).resolve().parents[3]
+            / "examples"
+            / "03_group_run"
+            / "interface_manifest.yaml"
+        )
+        manifest = InterfaceManifest.from_yaml(path.read_text(encoding="utf-8"))
+        return VerificationContract.from_dict(emit_contract_dict(manifest))
+
+    @staticmethod
+    def _plan_with(task_type: str, artifact: str) -> ImplementationPlan:
+        return ImplementationPlan.from_yaml(
+            "version: 1\n"
+            "project_id: group_run\n"
+            "cycle_id: cyc_test\n"
+            "prd_hash: abc123\n"
+            "tasks:\n"
+            "  - task_index: 0\n"
+            f"    task_type: {task_type}\n"
+            f"    role: {'qa' if task_type == 'qa.test' else 'dev'}\n"
+            '    focus: "Frontend compilation and view sanity"\n'
+            '    description: "check the views"\n'
+            "    expected_artifacts:\n"
+            f'      - "{artifact}"\n'
+            "    depends_on: []\n"
+            "summary:\n"
+            "  total_dev_tasks: 0\n"
+            "  total_qa_tasks: 1\n"
+            "  total_tasks: 1\n"
+            "  estimated_layers: []\n"
+        )
+
+    def test_rejects_qa_task_declaring_a_dev_fill_slot(self):
+        """The exact pf-39 shape: qa.test declaring a view component."""
+        errors = self._plan_with(
+            "qa.test", "frontend/src/views/RunsListView.jsx"
+        ).validate_qa_artifact_ownership(self._contract())
+
+        assert len(errors) == 1
+        assert "RunsListView.jsx" in errors[0]
+        assert "fill slot (dev-owned)" in errors[0]
+
+    def test_rejects_qa_task_declaring_a_frozen_scaffold_file(self):
+        errors = self._plan_with("qa.test", "backend/main.py").validate_qa_artifact_ownership(
+            self._contract()
+        )
+
+        assert len(errors) == 1
+        assert "frozen (scaffold-owned)" in errors[0]
+
+    def test_accepts_qa_task_declaring_its_own_test_file(self):
+        """Must not over-reject: a QA task owning a test file is the normal case."""
+        assert (
+            self._plan_with("qa.test", "backend/tests/test_runs.py").validate_qa_artifact_ownership(
+                self._contract()
+            )
+            == []
+        )
+
+    def test_dev_task_may_declare_a_fill_slot(self):
+        """The rule is scoped to qa.test — a dev task owning routes.py is exactly
+        how bind mode is supposed to work, and rejecting it would break every plan."""
+        assert (
+            self._plan_with(
+                "development.develop", "backend/routes.py"
+            ).validate_qa_artifact_ownership(self._contract())
+            == []
+        )


### PR DESCRIPTION
Two defects measured directly on pf-39 (`run_1e13c7b137a3`), both of which made a green roll depend on luck rather than on the pipeline working.

## 1. The skeleton could not satisfy its own contract

`Endpoint` had no success-status field. So:

- `_routes_source` emitted `@router.post("/runs", response_model=RunEvent)` — FastAPI defaults POST to **200**
- `_probes` hardcoded `"expect": {"status": 201}`

The two sides contradicted each other by construction. The only way a run went green was **a dev agent volunteering `status_code=201`** in the fill slot. pf-38's did. pf-39's did not, and that single token was the entire difference between `accepted` and `rejected` — same seeds, same frozen deploy, `vc-probe-runs` failing four times with `status 200 != expected 201`.

The asymmetry is the giveaway: `ErrorCode.http` already modelled *error* statuses, so the manifest could say "422 on validation failure" but not "201 on create."

Fix: add `Endpoint.success_status`, emit it on the scaffold-owned decorator, and make the probe **read the same field** so the contract and the skeleton can no longer disagree. A manifest that declares nothing keeps the historical 201 probe expectation.

An HTTP success status is *interface*, not implementation — it belongs on the frozen decorator where the fill dev cannot drop it.

## 2. Plan validation admitted an unsatisfiable QA task

pf-39's plan gave a `qa.test` task the three view fill slots as its `expected_artifacts`. Write authorization refused those emissions at runtime (`unauthorized_slot_emission` ×3) — so the task provably could not produce its own declared outputs.

The wasted task isn't the real cost. **A correction repair is scoped to the failing task's expected artifacts.** So when that task failed, `analyze_failure` correctly diagnosed the backend status-code defect in *another* task's file, and the repair rewrote the three frontend views instead. `patch_verification` passed it (file-local, `checks=2`); `patch_retest` rejected it 9 seconds later. One entire correction attempt that could not have fixed anything.

Fix: `validate_qa_artifact_ownership` rejects a `qa.test` task declaring any file the contract marks frozen or as a fill slot — **the same referent write authorization already uses**, applied at authoring time instead of emission time. Wired at both existing nets: dispatch raises, gate records a graceful rejection.

Deliberately narrow: it keys on the contract's owned surfaces rather than the QA namespace, so test files and documents are unaffected, and it does not apply to dev tasks (a dev task owning `routes.py` is exactly how bind mode works).

## Deploy note

The manifest now declares `success_status: 201` on `POST /runs`. **The group_run manifest + contract must be re-emitted and re-ingested** before the next measurement roll, and the launcher refs updated — same procedure as the #565 rename.

## Tests

8 new, all deterministic — no cycle needed to validate either fix:

- status lands on the decorator; endpoints declaring none stay bare (guards against blanket-applying it)
- **the probe follows the manifest rather than a constant** — a manifest declaring 202 yields a probe expecting 202 and a decorator emitting 202; had this stayed hardcoded, the pf-39 defect would simply recur with different numbers
- back-compat: no declaration → 201
- the four ownership cases, including the two that guard against over-rejection (a QA task owning its test file, a dev task owning a fill slot)

Full regression: **5512 passed, 1 skipped**. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q