### PR TITLE
fix(scaffold): include success_status in the manifest content hash

### DIFF
--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -221,6 +221,11 @@ class InterfaceManifest:
                         "request": ep.request,
                         "response": ep.response,
                         "errors": list(ep.errors),
+                        # The expander emits this onto the decorator, so it changes the
+                        # skeleton and must move the hash — omitting it would let two
+                        # manifests that produce different skeletons hash identically
+                        # and silently keep a contract bound to the wrong one.
+                        "success_status": ep.success_status,
                     }
                     for ep in self.api.endpoints
                 ],

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -580,3 +580,20 @@ class TestDeclaredSuccessStatus:
             if p["id"] == "vc-probe-runs"
         )
         assert probe["expect"]["status"] == 201
+
+
+def test_success_status_moves_the_manifest_content_hash():
+    """``_canonical`` claims to project every field the expander reads. ``success_status``
+    lands on the emitted decorator, so a manifest that changes it produces a different
+    skeleton — if the hash ignored it, a verification contract could stay bound to a
+    manifest whose skeleton no longer matches, which is precisely the SIP-0098 §10 drift
+    the hash exists to prevent."""
+    raw = _raw_manifest()
+    baseline = InterfaceManifest.from_dict(raw).content_hash()
+
+    changed = _raw_manifest()
+    for ep in changed["api"]["endpoints"]:
+        if ep["method"] == "POST" and ep["path"] == "/runs":
+            ep["success_status"] = 202
+
+    assert InterfaceManifest.from_dict(changed).content_hash() != baseline


### PR DESCRIPTION
Follow-up to #600 — this commit was pushed a few seconds after the merge and missed the boat. One commit, one line of production code, one test.

## The defect

`_canonical()` documents itself as projecting "every field the expander reads to produce the skeleton, and nothing else." #600 made `expand()` read `success_status` and emit it onto the decorator — but left it out of that projection.

So two manifests that produce **different skeletons** hash **identically**.

## Why it matters concretely

Re-emitting the group_run contract on current main produces:

```
skeleton.interface_manifest_hash: e65aefaa...   <- unchanged from before the manifest edit
contract content_hash:            293cceeb...   <- byte-identical to the seeded v4
```

The manifest now declares `success_status: 201` and the skeleton now emits `status_code=201`, yet the hash the contract binds to has not moved. That is precisely the SIP-0098 §10 drift the hash exists to prevent: a verification contract can stay bound to a manifest whose skeleton no longer matches, and nothing detects it.

Rolls would still pass today — the skeleton emits 201 and the probe expects 201 — so this is not a green/red issue. It is a hole in the guard that is supposed to catch exactly this class.

With the fix, emission moves to `9dd4074e...` / `cb0e8fb4...`, and the diff against the seeded v4 contract is **exactly one line** (the manifest hash). Probe block, frozen hashes and criteria stay byte-identical.

## Operational note

This determines whether the next measurement roll needs new seeds. Without it the emitted contract equals the seeded v4, so re-ingesting is a no-op; with it, the contract genuinely changes and the manifest + contract must be re-ingested and the launcher refs updated before pf-40.

## Test

A manifest differing only in `success_status` must produce a different `content_hash`. Regression: 5513 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q