### PR TITLE
fix(scaffold): hold the scaffold-owned status code inside fill slots

### DIFF
--- a/src/squadops/cycles/bound_scaffold_record.py
+++ b/src/squadops/cycles/bound_scaffold_record.py
@@ -62,6 +62,12 @@ class BoundScaffoldRecord:
     frozen: tuple[FrozenArtifact, ...] = ()
     fill_slots: tuple[str, ...] = ()
     qa_namespace: tuple[str, ...] = ()
+    # The scaffold's ORIGINAL bytes for each fill slot. A fill slot is producer-owned in
+    # its body but scaffold-owned in its decorators/signatures, and enforcing that split
+    # needs the seed to compare against. Pinned here for the same reason ``frozen`` is:
+    # restoration must never re-derive (D2). Defaults empty so records bound before this
+    # field existed deserialize cleanly and simply enforce nothing.
+    fill_seeds: tuple[FrozenArtifact, ...] = ()
 
     def frozen_paths(self) -> frozenset[str]:
         return frozenset(f.path for f in self.frozen)
@@ -70,6 +76,15 @@ class BoundScaffoldRecord:
         """The bound bytes for a frozen path (the restoration/replay authority), or None."""
         norm = _normalize(path)
         for f in self.frozen:
+            if f.path == norm:
+                return f.content
+        return None
+
+    def fill_seed_bytes(self, path: str) -> str | None:
+        """The scaffold's original bytes for a fill slot, or None when unseeded (older
+        records, or a path that is not a slot)."""
+        norm = _normalize(path)
+        for f in self.fill_seeds:
             if f.path == norm:
                 return f.content
         return None
@@ -86,6 +101,7 @@ class BoundScaffoldRecord:
             "frozen": [f.to_dict() for f in self.frozen],
             "fill_slots": list(self.fill_slots),
             "qa_namespace": list(self.qa_namespace),
+            "fill_seeds": [f.to_dict() for f in self.fill_seeds],
         }
 
     @classmethod
@@ -101,6 +117,7 @@ class BoundScaffoldRecord:
             frozen=tuple(FrozenArtifact.from_dict(f) for f in d.get("frozen", [])),
             fill_slots=tuple(d.get("fill_slots", [])),
             qa_namespace=tuple(d.get("qa_namespace", [])),
+            fill_seeds=tuple(FrozenArtifact.from_dict(f) for f in d.get("fill_seeds", [])),
         )
 
 
@@ -134,4 +151,9 @@ def build_bound_record(
         frozen=frozen,
         fill_slots=fill,
         qa_namespace=qa_test_namespace(manifest),
+        fill_seeds=tuple(
+            FrozenArtifact(path=name, sha256=_sha256(files[name]), content=files[name])
+            for name in sorted(fill_set)
+            if name in files
+        ),
     )

--- a/src/squadops/cycles/fill_slot_integrity.py
+++ b/src/squadops/cycles/fill_slot_integrity.py
@@ -1,0 +1,271 @@
+"""Fill-slot decorator integrity — enforcing what the scaffold *says* it owns.
+
+SIP-0100 enforces scaffold ownership at **file** granularity: a frozen path is restored
+wholesale. A fill slot has no such enforcement, because the producer legitimately rewrites
+the file — it is the slot's whole point. But a fill slot is not uniformly producer-owned.
+The emitted stub says so in its own header:
+
+    "API route stubs — scaffold-owned signatures, fill-only bodies."
+
+That is **instruction, not enforcement**, and pf-40 measured the difference. The scaffold
+seeded::
+
+    @router.post("/runs", response_model=RunEvent, status_code=201)
+
+and the dev agent's emission replaced it with::
+
+    @router.post("/runs")
+
+dropping the status code (and the response models, and the scaffold's function and
+parameter names). ``POST /runs`` then answered 200 while the contract's probe demanded 201
+— the identical failure that rejected pf-39, on a deploy that had just fixed the scaffold
+to emit 201 in the first place. Emitting the right skeleton is necessary and not
+sufficient: something has to hold it there.
+
+Scope — deliberately narrow, because the safe surface is smaller than the owned one:
+
+* **Restored:** ``status_code``. It is body-independent. Injecting it cannot break the
+  producer's implementation, because nothing in a function body depends on the success
+  code its decorator declares.
+* **Reported, not rewritten:** everything else — path, method, ``response_model``,
+  function name, parameter names. Restoring those is *not* safe from here. The producer
+  renamed ``payload`` to ``data`` and used it throughout its body; restoring the scaffold
+  signature would leave the body referencing a name that no longer exists. Rewriting
+  ``response_model`` can turn a working handler into a 500 if the body returns a shape the
+  model rejects. Those divergences are surfaced as evidence so the class stays visible, and
+  the typed criteria (``endpoint_defined``) already fail a wrong path or method.
+
+Matching is by ``(method, path-with-parameters-normalized)``, so a producer that renamed a
+path parameter still matches its scaffold counterpart and still gets its status code back.
+A route the scaffold never declared, or one the producer dropped, is left alone — that is
+``endpoint_defined``'s job, not this module's.
+
+Pure: ``(seed_source, emitted_source) -> (corrected_source, divergences)``. No I/O, no
+ports. The caller decides what to do with the divergences.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+
+_ROUTER_METHODS = frozenset({"get", "post", "put", "patch", "delete", "head", "options"})
+_PARAM = re.compile(r"\{[^}]*\}")
+
+
+@dataclass(frozen=True)
+class DecoratorDivergence:
+    """One scaffold-owned decorator detail the producer changed.
+
+    ``restored`` distinguishes what this module put back from what it only observed —
+    the evidence record needs both, and conflating them would overstate enforcement.
+    """
+
+    method: str
+    path: str
+    detail: str
+    restored: bool
+
+
+@dataclass(frozen=True)
+class _Route:
+    method: str
+    path: str
+    status_code: int | None
+    response_model: str | None
+    func_name: str
+    arg_names: tuple[str, ...]
+    # byte offsets of the decorator call's closing paren, for splicing
+    end_lineno: int
+    end_col_offset: int
+
+
+def _route_key(method: str, path: str) -> tuple[str, str]:
+    """Method + path with parameter *names* erased, so a renamed path parameter still
+    matches its scaffold counterpart (the pf-31 ``{id}``/``{run_id}`` class renames these
+    routinely, and a status code should survive that)."""
+    return method.upper(), _PARAM.sub("{}", path)
+
+
+def _routes(source: str) -> list[_Route]:
+    """Every ``@router.<method>("<path>", ...)``-decorated function in ``source``.
+
+    Returns an empty list for unparseable source — a syntactically broken emission is the
+    test runner's failure to report, not this module's, and raising here would convert a
+    visible test failure into an opaque enforcement crash.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    out: list[_Route] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for dec in node.decorator_list:
+            route = _route_from_decorator(dec, node)
+            if route is not None:
+                out.append(route)
+    return out
+
+
+def _route_decorator_path(dec: ast.expr) -> str | None:
+    """The literal path of a ``@router.<method>("...")`` decorator, or None when ``dec`` is
+    not one (a bare ``@staticmethod``, a non-router call, a computed path)."""
+    if not isinstance(dec, ast.Call) or not isinstance(dec.func, ast.Attribute):
+        return None
+    if dec.func.attr not in _ROUTER_METHODS:
+        return None
+    if not dec.args or not isinstance(dec.args[0], ast.Constant):
+        return None
+    path = dec.args[0].value
+    return path if isinstance(path, str) else None
+
+
+def _decorator_kwargs(dec: ast.Call) -> tuple[int | None, str | None]:
+    """``(status_code, response_model)`` as declared on the decorator."""
+    status: int | None = None
+    response_model: str | None = None
+    for kw in dec.keywords:
+        if kw.arg == "status_code" and isinstance(kw.value, ast.Constant):
+            status = kw.value.value if isinstance(kw.value.value, int) else None
+        elif kw.arg == "response_model":
+            response_model = ast.unparse(kw.value)
+    return status, response_model
+
+
+def _route_from_decorator(
+    dec: ast.expr, node: ast.FunctionDef | ast.AsyncFunctionDef
+) -> _Route | None:
+    path = _route_decorator_path(dec)
+    if path is None:
+        return None
+    assert isinstance(dec, ast.Call)  # guaranteed by _route_decorator_path
+    if dec.end_lineno is None or dec.end_col_offset is None:
+        return None
+    status, response_model = _decorator_kwargs(dec)
+    return _Route(
+        method=dec.func.attr,  # type: ignore[union-attr]  # Attribute, per the guard above
+        path=path,
+        status_code=status,
+        response_model=response_model,
+        func_name=node.name,
+        arg_names=tuple(a.arg for a in node.args.args),
+        end_lineno=dec.end_lineno,
+        end_col_offset=dec.end_col_offset,
+    )
+
+
+def restore_declared_status_codes(
+    seed_source: str, emitted_source: str
+) -> tuple[str, list[DecoratorDivergence]]:
+    """Put back every ``status_code`` the scaffold declared and the producer dropped.
+
+    Args:
+        seed_source: the scaffold's original bytes for this fill slot (the bound record's
+            authority — never re-derived).
+        emitted_source: what the producer emitted for the same path.
+
+    Returns:
+        ``(corrected_source, divergences)``. ``corrected_source`` is ``emitted_source``
+        unchanged when nothing needed restoring, so a compliant producer is byte-identical
+        through this function.
+    """
+    seed_routes = {_route_key(r.method, r.path): r for r in _routes(seed_source)}
+    if not seed_routes:
+        return emitted_source, []
+
+    emitted = _routes(emitted_source)
+    divergences: list[DecoratorDivergence] = []
+    # (line, col) -> text to insert. Collected first, applied bottom-up so earlier splices
+    # cannot shift the offsets of later ones.
+    splices: list[tuple[int, int, str]] = []
+
+    for got in emitted:
+        want = seed_routes.get(_route_key(got.method, got.path))
+        if want is None:
+            continue
+
+        if want.status_code is not None and got.status_code != want.status_code:
+            divergences.append(
+                DecoratorDivergence(
+                    method=got.method.upper(),
+                    path=got.path,
+                    detail=(
+                        f"status_code={want.status_code} declared by the scaffold, "
+                        f"emitted as {got.status_code if got.status_code is not None else 'absent'}"
+                    ),
+                    restored=True,
+                )
+            )
+            splices.append(
+                (got.end_lineno, got.end_col_offset, f", status_code={want.status_code}")
+            )
+
+        # Reported only — see the module docstring for why these are not rewritten.
+        if want.response_model and got.response_model != want.response_model:
+            divergences.append(
+                DecoratorDivergence(
+                    method=got.method.upper(),
+                    path=got.path,
+                    detail=(
+                        f"response_model={want.response_model} declared by the scaffold, "
+                        f"emitted as {got.response_model or 'absent'}"
+                    ),
+                    restored=False,
+                )
+            )
+        if want.func_name != got.func_name:
+            divergences.append(
+                DecoratorDivergence(
+                    method=got.method.upper(),
+                    path=got.path,
+                    detail=(
+                        f"scaffold-owned handler name {want.func_name!r} emitted as "
+                        f"{got.func_name!r}"
+                    ),
+                    restored=False,
+                )
+            )
+        if want.arg_names != got.arg_names:
+            divergences.append(
+                DecoratorDivergence(
+                    method=got.method.upper(),
+                    path=got.path,
+                    detail=(
+                        f"scaffold-owned parameters {list(want.arg_names)} emitted as "
+                        f"{list(got.arg_names)}"
+                    ),
+                    restored=False,
+                )
+            )
+
+    if not splices:
+        return emitted_source, divergences
+
+    lines = emitted_source.splitlines(keepends=True)
+    for lineno, col, text in sorted(splices, reverse=True):
+        idx = lineno - 1
+        if idx < 0 or idx >= len(lines):
+            continue
+        line = lines[idx]
+        # end_col_offset points just past the decorator call's ``)``; insert before it.
+        cut = col - 1
+        if cut < 0 or cut > len(line) or line[cut : cut + 1] != ")":
+            continue  # offsets did not land where expected — leave the line untouched
+        lines[idx] = line[:cut] + text + line[cut:]
+
+    return "".join(lines), divergences
+
+
+def divergence_summary(divergences: list[DecoratorDivergence]) -> str:
+    """One-line, log-safe rendering; restored items first so the log leads with what changed."""
+    if not divergences:
+        return ""
+    ordered = sorted(divergences, key=lambda d: (not d.restored, d.method, d.path))
+    return "; ".join(
+        f"{'restored' if d.restored else 'observed'} {d.method} {d.path}: {d.detail}"
+        for d in ordered
+    )

--- a/src/squadops/cycles/scaffold_enforcement.py
+++ b/src/squadops/cycles/scaffold_enforcement.py
@@ -173,5 +173,45 @@ def enforce_frozen_ownership(
             )
             # dropped: NOT appended — the owning producer's already-stored version stays.
         else:
-            enforced.append(art)
+            enforced.append(_restore_fill_slot_ownership(art, norm, bound_record, envelope))
     return enforced, evidence
+
+
+def _restore_fill_slot_ownership(
+    art: dict, norm: str | None, bound_record: Any, envelope: Any
+) -> dict:
+    """Hold the scaffold-owned parts of a *fill slot* in place (pf-40).
+
+    A frozen file is restored wholesale; a fill slot cannot be, because rewriting it is the
+    producer's job. But the slot's decorators and signatures are scaffold-owned — the stub
+    says so in its own header — and pf-40 showed that saying so is not enough: the producer
+    replaced ``@router.post("/runs", response_model=RunEvent, status_code=201)`` with
+    ``@router.post("/runs")``, so the app answered 200 against a contract demanding 201 and
+    the run was rejected for it, on the very deploy that had just fixed the scaffold to emit
+    201.
+
+    Only ``status_code`` is put back — see ``fill_slot_integrity`` for why the rest is
+    reported rather than rewritten. No seed (older bound records) means no enforcement, and
+    a non-Python or unparseable artifact passes through untouched.
+    """
+    if norm is None or norm not in set(bound_record.fill_slots) or not norm.endswith(".py"):
+        return art
+    seed = bound_record.fill_seed_bytes(norm)
+    content = art.get("content")
+    if not seed or not isinstance(content, str):
+        return art
+
+    from squadops.cycles.fill_slot_integrity import (
+        divergence_summary,
+        restore_declared_status_codes,
+    )
+
+    corrected, divergences = restore_declared_status_codes(seed, content)
+    if divergences:
+        logger.warning(
+            "SIP-0100 fill_slot_integrity: task=%s path=%s %s",
+            getattr(envelope, "task_id", "?"),
+            norm,
+            divergence_summary(divergences),
+        )
+    return art if corrected == content else {**art, "content": corrected}

--- a/tests/unit/cycles/test_fill_slot_integrity.py
+++ b/tests/unit/cycles/test_fill_slot_integrity.py
@@ -1,0 +1,284 @@
+"""Fill-slot decorator integrity (pf-40).
+
+The scaffold seeded ``@router.post("/runs", response_model=RunEvent, status_code=201)``
+and the dev agent's emission replaced it with ``@router.post("/runs")``. POST /runs then
+answered 200 against a contract pinning 201 — the same failure that rejected pf-39, on the
+deploy that had just fixed the scaffold to emit 201. Emitting the right skeleton is not
+enough; something has to hold it there.
+
+These cases are written against the shapes actually observed in that roll.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.fill_slot_integrity import (
+    divergence_summary,
+    restore_declared_status_codes,
+)
+
+pytestmark = [pytest.mark.domain_cycles]
+
+# The scaffold's seed, as expand() emits it.
+SEED = '''"""API route stubs — scaffold-owned signatures, fill-only bodies."""
+
+from fastapi import APIRouter, HTTPException
+
+from .models import RunEvent, RunEventCreate
+
+router = APIRouter()
+
+
+@router.get("/runs", response_model=list[RunEvent])
+def list_runs():
+    """list runs — TODO: implement (scaffold stub)."""
+    raise HTTPException(status_code=501, detail="not implemented")
+
+
+@router.post("/runs", response_model=RunEvent, status_code=201)
+def create_run(payload: RunEventCreate):
+    """create run — TODO: implement (scaffold stub)."""
+    raise HTTPException(status_code=501, detail="not implemented")
+
+
+@router.post("/runs/{run_id}/join", response_model=RunEvent)
+def join_run(run_id: str, payload: ParticipantName):
+    """join run — TODO: implement (scaffold stub)."""
+    raise HTTPException(status_code=501, detail="not implemented")
+'''
+
+# pf-40's actual emission: status_code gone, response_model gone, handler and parameter
+# renamed.
+PF40_EMISSION = '''from fastapi import APIRouter
+
+from .models import RunEventCreate
+from .store import create_run
+
+router = APIRouter()
+
+
+@router.get("/runs")
+def list_runs_endpoint():
+    return list_all()
+
+
+@router.post("/runs")
+def create_run_endpoint(data: RunEventCreate):
+    """Create a new run event."""
+    return create_run(title=data.title, datetime=data.datetime, location=data.location)
+
+
+@router.post("/runs/{id}/join")
+def join_run_endpoint(id: str, body: ParticipantName):
+    return join(id, body.name)
+'''
+
+
+class TestStatusCodeRestoration:
+    def test_dropped_status_code_is_put_back(self):
+        """The pf-40 defect itself. Without this the app answers 200 and vc-probe-runs
+        rejects the run."""
+        corrected, divergences = restore_declared_status_codes(SEED, PF40_EMISSION)
+
+        assert '@router.post("/runs", status_code=201)' in corrected
+        restored = [d for d in divergences if d.restored]
+        assert len(restored) == 1
+        assert restored[0].path == "/runs"
+        assert "status_code=201" in restored[0].detail
+
+    def test_restoration_preserves_the_producer_body(self):
+        """Enforcement must not cost the implementation — the body, its renamed parameter,
+        and the producer's imports all survive untouched."""
+        corrected, _ = restore_declared_status_codes(SEED, PF40_EMISSION)
+
+        assert "def create_run_endpoint(data: RunEventCreate):" in corrected
+        assert "title=data.title, datetime=data.datetime, location=data.location" in corrected
+        assert "from .store import create_run" in corrected
+
+    def test_corrected_source_still_parses(self):
+        import ast
+
+        corrected, _ = restore_declared_status_codes(SEED, PF40_EMISSION)
+        ast.parse(corrected)  # a splice landing in the wrong column would raise here
+
+    def test_renamed_path_parameter_still_matches(self):
+        """The producer wrote ``{id}`` where the scaffold declared ``{run_id}`` — the
+        pf-31 class. Matching is by normalized path, so the status code is still enforced
+        rather than silently skipped because the key did not match."""
+        seed = '@router.post("/runs/{run_id}/x", status_code=201)\ndef f(run_id: str):\n    pass\n'
+        emitted = '@router.post("/runs/{id}/x")\ndef f(id: str):\n    pass\n'
+
+        corrected, divergences = restore_declared_status_codes(seed, emitted)
+
+        assert "status_code=201" in corrected
+        assert any(d.restored for d in divergences)
+
+    def test_compliant_emission_is_byte_identical(self):
+        """A producer that kept the decorator must pass through untouched — otherwise
+        enforcement would rewrite every compliant roll and mask its own no-op."""
+        emitted = (
+            '@router.post("/runs", response_model=RunEvent, status_code=201)\n'
+            "def create_run(payload: RunEventCreate):\n    return {}\n"
+        )
+        corrected, divergences = restore_declared_status_codes(SEED, emitted)
+
+        assert corrected == emitted
+        assert [d for d in divergences if d.restored] == []
+
+    def test_wrong_status_code_is_corrected_not_only_absent_one(self):
+        """A producer that declared 200 explicitly is as broken as one that declared
+        nothing; only checking for absence would let this through."""
+        emitted = (
+            '@router.post("/runs", status_code=200)\ndef create_run(payload):\n    return {}\n'
+        )
+        corrected, divergences = restore_declared_status_codes(SEED, emitted)
+
+        assert "status_code=201" in corrected
+        assert any("emitted as 200" in d.detail for d in divergences)
+
+
+class TestReportedButNotRewritten:
+    def test_response_model_and_renames_are_reported_unrestored(self):
+        """These are real divergences but unsafe to rewrite — restoring the signature would
+        leave the body referencing a parameter that no longer exists. They must surface as
+        evidence rather than silently vanish."""
+        _, divergences = restore_declared_status_codes(SEED, PF40_EMISSION)
+        observed = {d.detail for d in divergences if not d.restored}
+
+        assert any("response_model" in d for d in observed)
+        assert any("create_run" in d and "create_run_endpoint" in d for d in observed)
+        assert any("payload" in d and "data" in d for d in observed)
+
+    def test_reported_divergences_do_not_alter_the_source(self):
+        emitted = '@router.get("/runs")\ndef list_runs_endpoint():\n    return []\n'
+        corrected, divergences = restore_declared_status_codes(SEED, emitted)
+
+        # GET /runs declares response_model but no status_code — nothing to restore.
+        assert corrected == emitted
+        assert divergences and all(not d.restored for d in divergences)
+
+
+class TestEdgeCases:
+    def test_unparseable_emission_passes_through(self):
+        """A syntax error is the test runner's failure to report. Raising here would turn a
+        visible test failure into an opaque enforcement crash."""
+        broken = '@router.post("/runs")\ndef create_run(  # truncated mid-signature\n'
+        corrected, divergences = restore_declared_status_codes(SEED, broken)
+
+        assert corrected == broken
+        assert divergences == []
+
+    def test_route_absent_from_the_scaffold_is_left_alone(self):
+        """An endpoint the scaffold never declared is endpoint_defined's problem, not this
+        module's — inventing a status code for it would be enforcement without a referent."""
+        emitted = '@router.post("/invented")\ndef invented():\n    return {}\n'
+        corrected, divergences = restore_declared_status_codes(SEED, emitted)
+
+        assert corrected == emitted
+        assert divergences == []
+
+    def test_empty_seed_disables_enforcement(self):
+        emitted = '@router.post("/runs")\ndef create_run(payload):\n    return {}\n'
+        assert restore_declared_status_codes("", emitted) == (emitted, [])
+
+    def test_summary_leads_with_restorations(self):
+        _, divergences = restore_declared_status_codes(SEED, PF40_EMISSION)
+        summary = divergence_summary(divergences)
+
+        assert summary.startswith("restored POST /runs")
+        assert "observed" in summary
+
+    def test_summary_of_nothing_is_empty(self):
+        assert divergence_summary([]) == ""
+
+
+class TestEnforcementWiring:
+    """The pure function is useless unless the enforcement seam actually calls it — pf-40's
+    lesson is precisely that a correct component wired to nothing changes no outcome."""
+
+    @staticmethod
+    def _record_and_envelope(tmp_seed: str):
+        from types import SimpleNamespace
+
+        from squadops.cycles.bound_scaffold_record import BoundScaffoldRecord, FrozenArtifact
+
+        record = BoundScaffoldRecord(
+            run_id="run_x",
+            attempt_id="run_x",
+            stack="fullstack_fastapi_react",
+            manifest_hash="m",
+            contract_hash="c",
+            expander_id="fullstack_fastapi_react",
+            created_at="2026-01-01T00:00:00+00:00",
+            frozen=(),
+            fill_slots=("backend/routes.py",),
+            fill_seeds=(FrozenArtifact(path="backend/routes.py", sha256="s", content=tmp_seed),),
+        )
+        envelope = SimpleNamespace(task_id="t1", task_type="development.develop")
+        return record, envelope
+
+    def test_enforcement_restores_through_the_seam(self):
+        from squadops.cycles.scaffold_enforcement import enforce_frozen_ownership
+
+        record, envelope = self._record_and_envelope(SEED)
+        artifacts = [{"name": "backend/routes.py", "content": PF40_EMISSION}]
+
+        enforced, _ = enforce_frozen_ownership(artifacts, record, envelope)
+
+        assert '@router.post("/runs", status_code=201)' in enforced[0]["content"]
+
+    def test_non_slot_artifacts_are_untouched(self):
+        from squadops.cycles.scaffold_enforcement import enforce_frozen_ownership
+
+        record, envelope = self._record_and_envelope(SEED)
+        artifacts = [{"name": "backend/tests/test_x.py", "content": PF40_EMISSION}]
+
+        enforced, _ = enforce_frozen_ownership(artifacts, record, envelope)
+
+        assert enforced[0]["content"] == PF40_EMISSION
+
+    def test_record_without_seeds_enforces_nothing(self):
+        """Records bound before ``fill_seeds`` existed must degrade to today's behaviour
+        rather than crashing an in-flight run."""
+        from squadops.cycles.scaffold_enforcement import enforce_frozen_ownership
+
+        record, envelope = self._record_and_envelope(SEED)
+        record = type(record)(**{**record.__dict__, "fill_seeds": ()})
+        artifacts = [{"name": "backend/routes.py", "content": PF40_EMISSION}]
+
+        enforced, _ = enforce_frozen_ownership(artifacts, record, envelope)
+
+        assert enforced[0]["content"] == PF40_EMISSION
+
+    def test_bound_record_round_trips_fill_seeds(self):
+        from squadops.cycles.bound_scaffold_record import BoundScaffoldRecord
+
+        record, _ = self._record_and_envelope(SEED)
+        back = BoundScaffoldRecord.from_dict(record.to_dict())
+
+        assert back.fill_seed_bytes("backend/routes.py") == SEED
+        assert back.fill_seed_bytes("./backend/routes.py") == SEED  # normalized lookup
+        assert back.fill_seed_bytes("backend/models.py") is None
+
+    def test_build_bound_record_seeds_every_fill_slot(self):
+        from pathlib import Path
+
+        from squadops.capabilities.scaffold import InterfaceManifest, fill_slot_paths
+        from squadops.cycles.bound_scaffold_record import build_bound_record
+
+        path = (
+            Path(__file__).resolve().parents[3]
+            / "examples"
+            / "03_group_run"
+            / "interface_manifest.yaml"
+        )
+        manifest = InterfaceManifest.from_yaml(path.read_text(encoding="utf-8"))
+        record = build_bound_record(
+            manifest, run_id="r", attempt_id="r", created_at="2026-01-01T00:00:00+00:00"
+        )
+
+        for slot in fill_slot_paths(manifest):
+            assert record.fill_seed_bytes(slot), f"no seed pinned for fill slot {slot}"
+        # the seed is the real scaffold stub, carrying the status code the producer must keep
+        assert "status_code=201" in record.fill_seed_bytes("backend/routes.py")


### PR DESCRIPTION
**pf-40 proved that emitting the right skeleton is necessary and not sufficient.**

#600/#601 made the expander emit the status code, and I verified it loaded in-container before launching:

```python
# what the scaffold seeded at 17:44
@router.post("/runs", response_model=RunEvent, status_code=201)
```

```python
# what the dev agent emitted at 17:57
@router.post("/runs")
```

`POST /runs` answers 200 against a contract pinning 201 — the identical failure that rejected pf-39, on the deploy that had just fixed it. The agent also stripped `response_model` from every decorator and renamed both the handlers and their parameters.

## Why it happened

The stub says so in its own header — *"API route stubs — scaffold-owned signatures, fill-only bodies"* — and that is **instruction, not enforcement**. A fill slot is a whole-file emission, and nothing compares the result against the seed.

SIP-0100 enforces ownership at **file** granularity: a frozen path is restored wholesale. A fill slot cannot be, because rewriting the file is the producer's job. What it needs is enforcement at **line** granularity, on the parts the scaffold declares it owns.

## Scope: narrower than the owned surface, on purpose

| | |
|---|---|
| **Restored** | `status_code` |
| **Reported, not rewritten** | path, method, `response_model`, handler name, parameter names |

`status_code` is body-independent — nothing in a function body depends on the success code its decorator declares, so injecting it cannot break an implementation.

The rest is genuinely unsafe to rewrite from here. The producer renamed `payload` to `data` and used it throughout its body; restoring the scaffold signature would leave the body referencing a name that no longer exists. Rewriting `response_model` can turn a working handler into a 500 if the body returns a shape the model rejects. Those divergences surface as evidence so the class stays visible, and `endpoint_defined` already fails a wrong path or method.

Matching is by `(method, path-with-parameters-normalized)`, so a producer that renamed a path parameter — the pf-31 `{id}`/`{run_id}` class — still matches its scaffold counterpart and still gets its status code back.

## The record change

`BoundScaffoldRecord` gains `fill_seeds`, pinning the scaffold's original bytes per slot for exactly the reason `frozen` pins them: **restoration must never re-derive** (D2). Defaults empty, so records bound before this field deserialize cleanly and simply enforce nothing — an in-flight run cannot crash on it.

## Verification

**Replay-verified against pf-40's actual stored artifacts** (`art_10a07c22963f` seed vs `art_cb3054f9ea6f` emission), not a synthetic fixture:

```
@router.post("/runs", status_code=201)     <- restored
body intact: title=data.title ...          <- producer's implementation untouched
result parses                              <- splice landed in the right column
```

18 new tests, including the cases that would let this regress silently: a compliant emission passing through byte-identical (so enforcement can't mask its own no-op), an explicitly-wrong `status_code=200` rather than only an absent one, an unparseable emission, a route the scaffold never declared, and a record with no seeds.

Regression: **5531 passed, 1 skipped**. `ruff check` clean (decomposed `_routes` rather than adding a C901 exemption).

## Not deployed

The baseline is mid-measurement on `ccd6dda2`. This does not deploy until the current roll finishes and you decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q