### PR TITLE
fix(correction): tell repairs the real model names instead of letting them guess

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -182,8 +182,16 @@ def _inject_deterministic_evidence(
       docstring; without it dev repairs guess ``ApiError(status_code=...,
       detail=...)`` and 500 every error path at the behavioral retest despite
       passing all typed checks (pf-33 corr-01, pf-34 corr-00).
+    - ``model_surface`` (pf-41): the exact importable names from the frozen
+      ``models.py``. Repairs invented them on three consecutive attempts,
+      degrading working imports into unimportable ones; the unresolved-import
+      gate rejects such a patch but never says what the right names are, so the
+      next attempt guesses again.
     """
-    from squadops.capabilities.scaffold import error_seam_instructions
+    from squadops.capabilities.scaffold import (
+        error_seam_instructions,
+        model_surface_instructions,
+    )
     from squadops.cycles.contract_expectations import expectation_lines
     from squadops.cycles.interface_conformance import detect_interface_drift
 
@@ -210,6 +218,10 @@ def _inject_deterministic_evidence(
     error_lines = error_seam_instructions(interface_manifest)
     if error_lines:
         failure_evidence["error_contract"] = error_lines
+
+    model_lines = model_surface_instructions(interface_manifest)
+    if model_lines:
+        failure_evidence["model_surface"] = model_lines
 
 
 def _locus_and_repair_target(

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -75,40 +75,62 @@ def _format_bullets(items: Any) -> str:
         return str(items)
 
 
+# Deterministic, data-derived evidence the correction runner injects, each rendered as an
+# authoritative block. Order is deliberate — conformance first, then ownership, then the two
+# scaffold-knowledge seams — and it is a table rather than four copy-pasted branches so a
+# fifth seam is one row, not another clause (and does not push this function past C901).
+#
+#   interface_drift      — exact renamed identifiers vs the manifest (deterministic, not the
+#                          analyzer's guess), so the repair renames to interface names.
+#   scaffold_enforcement — SIP-0100 3.4b: a prior repair's edit to a frozen file was rejected
+#                          and restored; tell this repair rather than let it silently fight.
+#   error_contract       — pf-34: the ApiError(code, message) convention + code→status map.
+#                          Without it repairs guess the signature and 500 every error path at
+#                          the behavioral retest despite passing every typed check.
+#   model_surface        — pf-41: the exact importable names from the frozen models.py.
+#                          Repairs invented them on three consecutive attempts, degrading
+#                          working imports into unimportable ones; the unresolved-import gate
+#                          rejects such a patch but never says what the real names are.
+_AUTHORITATIVE_EVIDENCE_BLOCKS: tuple[tuple[str, str], ...] = (
+    ("interface_drift", "INTERFACE CONFORMANCE"),
+    ("scaffold_enforcement", "FROZEN OWNERSHIP"),
+    ("error_contract", "ERROR CONTRACT"),
+    ("model_surface", "MODEL SURFACE"),
+)
+
+
+def _evidence_lines(value: Any) -> list[str]:
+    """Normalize one evidence entry to its instruction lines.
+
+    Interface drift arrives as dicts carrying an ``instruction``; the rest arrive as plain
+    strings. Blank entries are dropped so an empty list never renders a bare header.
+    """
+    lines: list[str] = []
+    for item in value or []:
+        text = item.get("instruction", "") if isinstance(item, dict) else item
+        if text := str(text).strip():
+            lines.append(text)
+    return lines
+
+
+def _authoritative_blocks(failure_evidence: dict) -> list[str]:
+    """Render every present authoritative evidence block, in table order."""
+    blocks: list[str] = []
+    for key, header in _AUTHORITATIVE_EVIDENCE_BLOCKS:
+        lines = _evidence_lines(failure_evidence.get(key))
+        if lines:
+            blocks.append(
+                f"{header} (authoritative — apply exactly):\n"
+                + "\n".join(f"- {line}" for line in lines)
+            )
+    return blocks
+
+
 def _format_failure_summary(failure_evidence: Any, failure_analysis: Any) -> str:
     """Compose a compact failure description from evidence + analysis."""
     parts: list[str] = []
     if isinstance(failure_evidence, dict):
-        # Interface-drift diagnosis is deterministic and authoritative — the
-        # manifest, not the analyzer's guess, is the source of truth. Lead with
-        # it so the repair renames to the interface names and stops thrashing.
-        drift = failure_evidence.get("interface_drift") or []
-        if drift:
-            lines = [str(d.get("instruction", "")).strip() for d in drift if d.get("instruction")]
-            if lines:
-                parts.append(
-                    "INTERFACE CONFORMANCE (authoritative — apply exactly):\n"
-                    + "\n".join(f"- {line}" for line in lines)
-                )
-        # SIP-0100 3.4b restore+signal: a prior repair's edit to a frozen file was
-        # rejected and restored — tell this repair instead of silently fighting it.
-        enforcement = failure_evidence.get("scaffold_enforcement") or []
-        if enforcement:
-            parts.append(
-                "FROZEN OWNERSHIP (authoritative — apply exactly):\n"
-                + "\n".join(f"- {str(line).strip()}" for line in enforcement if str(line).strip())
-            )
-        # pf-34: the ApiError(code, message) raise convention + code→status map,
-        # manifest-derived (scaffold.error_seam_instructions) — repairs otherwise
-        # guess the signature and 500 every error path at the behavioral retest.
-        error_contract = failure_evidence.get("error_contract") or []
-        if error_contract:
-            parts.append(
-                "ERROR CONTRACT (authoritative — apply exactly):\n"
-                + "\n".join(
-                    f"- {str(line).strip()}" for line in error_contract if str(line).strip()
-                )
-            )
+        parts.extend(_authoritative_blocks(failure_evidence))
         vr = failure_evidence.get("validation_result") or {}
         summary = vr.get("summary") or failure_evidence.get("error") or ""
         if summary:

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -438,6 +438,51 @@ def error_seam_instructions(manifest: InterfaceManifest | None) -> list[str]:
     ]
 
 
+def model_surface_instructions(manifest: InterfaceManifest | None) -> list[str]:
+    """Authoritative importable names from the frozen ``models.py`` (pf-41).
+
+    ``models.py`` is scaffold-frozen and its contents are fully determined by the
+    manifest's entities and request shapes — yet nothing puts those names in front of a
+    repair. So repairs guess them, and the guesses compound: on pf-41 the dev agent
+    imported the correct names, then three consecutive repairs replaced them with
+    ``Run``/``CreateRun``, then ``RunCreate``, then a five-name invention
+    (``RunCreate``, ``RunResponse``, ``RunJoin``, ``RunLeave``, ``RunDetailResponse``) —
+    none of which exist. Working code degraded into unimportable code across the
+    correction loop.
+
+    Detection already exists (``emission_integrity.unresolved_imports`` rejects a patch
+    whose intra-package imports do not resolve) and it works — on pf-40 it caught every
+    bad repair. But detection only throws the repair away; it never tells the model what
+    the right names ARE, so the next attempt guesses again. These lines close that: same
+    ``failure_evidence`` → authoritative-block transport as the error seam and frozen
+    ownership.
+
+    Empty when there is no manifest (author mode, non-scaffold stacks) — additive, like
+    every other entry on that transport.
+    """
+    if manifest is None:
+        return []
+    names = [e.name for e in manifest.entities] + [s.name for s in manifest.api.request_shapes]
+    if not names:
+        return []
+    exact = ", ".join(f"`{n}`" for n in dict.fromkeys(names))
+    return [
+        (
+            f"`backend/models.py` is scaffold-frozen and defines EXACTLY these names: {exact}. "
+            "Import only from this list — these are the complete contents of that module"
+        ),
+        (
+            "do NOT invent model names or aliases (`Run`, `RunCreate`, `RunResponse`, "
+            "`RunJoin` and similar do not exist); an import of a name absent from the list "
+            "above fails at load, the app never starts, and the patch is rejected"
+        ),
+        (
+            "`models.py` is frozen — if a name you want is missing, use the declared names "
+            "and shape the response in the fill slot; do not edit or re-emit the model module"
+        ),
+    ]
+
+
 # SIP-0100 D1 (bounded-hybrid QA test ownership): the scaffold owns the *namespace* — the
 # deterministic directory prefixes a bound plan may declare concrete QA test files within — while
 # the plan declares the concrete paths. A QA producer may write only inside this surface; a QA

--- a/tests/unit/capabilities/test_repair_handlers.py
+++ b/tests/unit/capabilities/test_repair_handlers.py
@@ -181,3 +181,66 @@ class TestRepairHandlerHandle:
             result = await h.handle(ctx, {"prd": "test"})
             assert result.success is True
             assert result.outputs["artifacts"][0]["name"] == expected_name
+
+
+class TestModelSurfaceReachesTheRepairPrompt:
+    """The pure lines are useless unless they land in the prompt the repair agent reads.
+
+    This is the #588 lesson in test form: that fix was correct and wired to a code path
+    nothing used, so it changed no outcome until the wiring was fixed. Assert the whole
+    path — manifest → failure_evidence → rendered prompt text.
+    """
+
+    @staticmethod
+    def _manifest():
+        from pathlib import Path
+
+        from squadops.capabilities.scaffold import InterfaceManifest
+
+        path = (
+            Path(__file__).resolve().parents[3]
+            / "examples"
+            / "03_group_run"
+            / "interface_manifest.yaml"
+        )
+        return InterfaceManifest.from_yaml(path.read_text(encoding="utf-8"))
+
+    def test_evidence_lines_render_into_the_failure_summary(self):
+        from squadops.capabilities.handlers.impl.repair_handlers import _format_failure_summary
+        from squadops.capabilities.scaffold import model_surface_instructions
+
+        evidence = {"model_surface": model_surface_instructions(self._manifest())}
+
+        rendered = _format_failure_summary(evidence, None)
+
+        assert "MODEL SURFACE (authoritative" in rendered
+        # the real names the pf-41 repairs failed to use
+        for real in ("RunEvent", "RunEventCreate", "Participant", "ParticipantName"):
+            assert real in rendered
+
+    def test_absent_evidence_renders_no_section(self):
+        """Author-mode runs carry no manifest, so the block must not appear at all —
+        an empty authoritative header would be noise in every non-scaffold repair."""
+        from squadops.capabilities.handlers.impl.repair_handlers import _format_failure_summary
+
+        assert "MODEL SURFACE" not in _format_failure_summary({"error": "boom"}, None)
+
+    def test_correction_runner_populates_the_evidence_key(self):
+        """The executor-side half: the runner must actually put the lines on the
+        envelope's failure_evidence, or the renderer above never sees them."""
+        from types import SimpleNamespace
+
+        from adapters.cycles.correction_runner import _inject_deterministic_evidence
+
+        manifest = self._manifest()
+        evidence: dict = {}
+        _inject_deterministic_evidence(
+            failure_evidence=evidence,
+            interface_manifest=manifest,
+            artifact_contents={},
+            scaffold_enforcement_carry=[],
+            envelope=SimpleNamespace(inputs={}),
+        )
+
+        assert evidence.get("model_surface"), "model_surface must be injected for a bound run"
+        assert "RunEvent" in " ".join(evidence["model_surface"])

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -597,3 +597,71 @@ def test_success_status_moves_the_manifest_content_hash():
             ep["success_status"] = 202
 
     assert InterfaceManifest.from_dict(changed).content_hash() != baseline
+
+
+class TestModelSurfaceInstructions:
+    """pf-41: repairs invent model names, and the guesses compound.
+
+    The dev agent imported the correct names; three consecutive repairs then replaced
+    them with `Run`/`CreateRun`, then `RunCreate`, then a five-name invention — turning
+    working code into code that cannot import. The unresolved-import gate rejects such a
+    patch but never says what the real names ARE, so the next attempt guesses again.
+    """
+
+    def test_lines_name_every_model_the_scaffold_emits(self):
+        from squadops.capabilities.scaffold import model_surface_instructions
+
+        manifest = _group_run_manifest()
+        lines = model_surface_instructions(manifest)
+        blob = " ".join(lines)
+
+        # every class the frozen models.py actually defines must be named
+        emitted = next(f["content"] for f in expand(manifest) if f["name"] == "backend/models.py")
+        defined = [
+            ln.split("class ", 1)[1].split("(", 1)[0]
+            for ln in emitted.splitlines()
+            if ln.startswith("class ")
+        ]
+        assert defined, "fixture sanity: models.py should define classes"
+        for name in defined:
+            assert f"`{name}`" in blob, (
+                f"{name} is defined in models.py but not named to the repair"
+            )
+
+    def test_the_names_pf41_invented_are_not_presented_as_valid(self):
+        """The five names pf-41's last repair imported do not exist. They may appear in
+        the do-not-invent warning, but never in the authoritative list of what exists."""
+        from squadops.capabilities.scaffold import model_surface_instructions
+
+        available = next(
+            ln for ln in model_surface_instructions(_group_run_manifest()) if "EXACTLY these" in ln
+        )
+        for invented in ("RunResponse", "RunJoin", "RunLeave", "RunDetailResponse", "CreateRun"):
+            assert f"`{invented}`" not in available
+
+    def test_states_the_module_is_frozen(self):
+        """Without this a repair 'fixes' a missing name by editing models.py — which is
+        restored by scaffold enforcement, so the repair silently accomplishes nothing."""
+        from squadops.capabilities.scaffold import model_surface_instructions
+
+        assert any("frozen" in ln for ln in model_surface_instructions(_group_run_manifest()))
+
+    def test_absent_manifest_contributes_nothing(self):
+        """Author mode and non-scaffold stacks inject nothing — additive, like every
+        other entry on this transport."""
+        from squadops.capabilities.scaffold import model_surface_instructions
+
+        assert model_surface_instructions(None) == []
+
+    def test_manifest_without_entities_or_shapes_contributes_nothing(self):
+        from squadops.capabilities.scaffold import model_surface_instructions
+
+        bare = InterfaceManifest.from_dict(
+            {
+                "version": 1,
+                "kind": "interface_manifest",
+                "project_id": "x",
+                "stack": "fullstack_fastapi_react",
+            }
+        )
+        assert model_surface_instructions(bare) == []


### PR DESCRIPTION
pf-41 died because repairs invented class names, and the guesses **compounded**. Here is the same file across one roll:

```
21:46  scaffold  ParticipantName, RunEvent, RunEventCreate
22:18  dev       RunEventCreate, ParticipantName                              <- correct
23:44  repair    Run, CreateRun, ParticipantJoin, ParticipantLeave
00:27  repair    RunCreate, ParticipantJoin, ParticipantLeave
00:53  repair    RunCreate, RunResponse, RunJoin, RunLeave, RunDetailResponse
```

**The dev agent wrote working imports. Three consecutive repairs turned them into code that cannot load.** None of the invented names exist — the real ones are `Participant`, `RunEvent`, `RunEventCreate`, `ParticipantName`, and they are fully determined by the manifest the run is already holding.

## Detection existed; instruction didn't

The unresolved-import gate (#591) catches exactly this and rejects the patch. On pf-40 it worked perfectly — it caught every bad repair and nothing landed.

But **detection only throws the patch away. It never says what the right names are**, so the next attempt guesses again, and the loop can burn its whole budget without converging. That is precisely how pf-40 died.

This adds the missing half. `model_surface_instructions(manifest)` derives the exact importable names and travels the same `failure_evidence` → authoritative-block transport already used by the error seam (pf-34), frozen ownership (SIP-0100 3.4b) and interface drift.

What a pf-41 repair would now have been told:

```
MODEL SURFACE (authoritative — apply exactly):
- `backend/models.py` is scaffold-frozen and defines EXACTLY these names:
  `Participant`, `RunEvent`, `RunEventCreate`, `ParticipantName`. Import only
  from this list — these are the complete contents of that module
- do NOT invent model names or aliases (`Run`, `RunCreate`, `RunResponse`,
  `RunJoin` and similar do not exist); an import of a name absent from the list
  above fails at load, the app never starts, and the patch is rejected
- `models.py` is frozen — if a name you want is missing, use the declared names
  and shape the response in the fill slot; do not edit or re-emit the model module
```

That third line matters as much as the first two: without it a repair "fixes" a missing name by editing `models.py`, scaffold enforcement restores the file, and the repair silently accomplishes nothing.

## Refactor

The four authoritative blocks in `_format_failure_summary` were copy-pasted branches, and a fifth pushed the function past the complexity limit. They are now a table plus a shared renderer, so the next seam is one row rather than another clause — and `interface_drift`'s dict-shaped entries are normalised in one place instead of having their own branch.

## Tests

8 new, and they assert the **whole path** — manifest → `failure_evidence` → rendered prompt text — not just the pure function. That is the #588 lesson in test form: that fix was correct and wired to a code path nothing used, so it changed no outcome until the wiring was found.

Specifically covered: every class the scaffold actually emits is named to the repair (derived from `expand()`, so it cannot drift); the five names pf-41 invented never appear in the authoritative list; the frozen statement is present; author-mode runs with no manifest inject nothing and render no empty header; and the correction runner really does populate the evidence key.

Regression: **5539 passed, 1 skipped**. `ruff check` clean.

## Not deployed

Baseline is paused at 0/5. Nothing deploys until you decide.

## Follow-up worth filing separately

pf-41 also showed a check that **errored** rather than passing or failing — `function_defined` pointed at a `.jsx` file — which turned patch verification into `unverifiable` and let the bad repairs land. That is why pf-41's damage accumulated while pf-40's did not. It is a distinct defect from this one and a route to shipping unverified code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q