### PR TITLE
fix(checks): AST checks skip non-Python files instead of erroring

### DIFF
--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -260,6 +260,27 @@ def _decorator_route(decorator: ast.expr) -> tuple[str, str] | None:
     return None
 
 
+# Every AST-based check parses Python. Handed anything else, `ast.parse` raises and the
+# check reports `error` — which `patch_verification` maps to `evaluator_error:<check>` and
+# turns into an UNVERIFIABLE patch: neither accepted nor rejected, so it lands unverified.
+# pf-41 lost a roll to exactly that (a `function_defined` aimed at a `.jsx` test file), and
+# the contrast with pf-40 is the proof: same bad repairs, but there verification returned a
+# verdict, rejected them, and nothing landed. Skipping is the honest outcome for a file we
+# cannot analyse — `import_present` already did this; the other four did not (#605).
+_FRONTEND_SUFFIXES = frozenset({".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"})
+
+
+def _unparseable_source_skip(file_path: Path) -> CheckOutcome | None:
+    """A skip outcome when ``file_path`` is not Python, else None."""
+    ext = file_path.suffix.lower()
+    if ext in _FRONTEND_SUFFIXES:
+        # JS/TS analysis is gated behind the frontend_acceptance_checks follow-up.
+        return CheckOutcome.skipped(reason="frontend_acceptance_checks_disabled")
+    if ext != ".py":
+        return CheckOutcome.skipped(reason="unsupported_file_extension")
+    return None
+
+
 @register_check("endpoint_defined")
 class EndpointDefinedCheck(BaseCheck):
     """FastAPI route decorator presence — `@app.METHOD('/path')` / `@router.METHOD('/path')`."""
@@ -277,6 +298,8 @@ class EndpointDefinedCheck(BaseCheck):
             file_path = _safe_resolve(params["file"], workspace_root)
         except _SafetyError as exc:
             return CheckOutcome.error(reason=exc.reason)
+        if (skip := _unparseable_source_skip(file_path)) is not None:
+            return skip
         if not file_path.is_file():
             return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
         try:
@@ -334,13 +357,8 @@ class ImportPresentCheck(BaseCheck):
         except _SafetyError as exc:
             return CheckOutcome.error(reason=exc.reason)
 
-        ext = file_path.suffix.lower()
-        if ext in {".ts", ".js"}:
-            # JS/TS regex fallback gated behind frontend_acceptance_checks
-            # follow-up flag — out of scope for M1.2.
-            return CheckOutcome.skipped(reason="frontend_acceptance_checks_disabled")
-        if ext != ".py":
-            return CheckOutcome.skipped(reason="unsupported_file_extension")
+        if (skip := _unparseable_source_skip(file_path)) is not None:
+            return skip
 
         if not file_path.is_file():
             return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
@@ -439,6 +457,8 @@ class FieldPresentCheck(BaseCheck):
             file_path = _safe_resolve(params["file"], workspace_root)
         except _SafetyError as exc:
             return CheckOutcome.error(reason=exc.reason)
+        if (skip := _unparseable_source_skip(file_path)) is not None:
+            return skip
         if not file_path.is_file():
             return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
         try:
@@ -504,6 +524,8 @@ class FunctionDefinedCheck(BaseCheck):
             file_path = _safe_resolve(params["file"], workspace_root)
         except _SafetyError as exc:
             return CheckOutcome.error(reason=exc.reason)
+        if (skip := _unparseable_source_skip(file_path)) is not None:
+            return skip
         if not file_path.is_file():
             return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
         try:
@@ -596,6 +618,8 @@ class HarnessBoundaryCheck(BaseCheck):
             file_path = _safe_resolve(params["file"], workspace_root)
         except _SafetyError as exc:
             return CheckOutcome.error(reason=exc.reason)
+        if (skip := _unparseable_source_skip(file_path)) is not None:
+            return skip
         if not file_path.is_file():
             return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
         try:

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -1003,3 +1003,105 @@ class TestHarnessBoundary:
     async def test_syntax_error_is_error(self, tmp_path):
         result = await self._run(tmp_path, "def test_x(:\n    pass\n")
         assert result.status == "error"
+
+
+class TestNonPythonFilesSkipRatherThanError:
+    """#605: an AST check handed a JavaScript file used to raise, and an erroring check
+    turns patch verification into `unverifiable` — neither accepted nor rejected, so the
+    unverified patch lands.
+
+    pf-41 lost a roll to it: `function_defined` was aimed at `run.test.jsx`, verification
+    never returned a verdict, and three bad repairs landed unchecked. pf-40 had the same
+    bad repairs but verification worked, rejected them, and nothing landed.
+
+    Only `import_present` guarded; its four siblings did not.
+    """
+
+    @staticmethod
+    def _params(check_name: str, file: str) -> dict:
+        base: dict[str, dict] = {
+            "endpoint_defined": {"methods_paths": [["GET", "/x"]]},
+            "import_present": {"module": "x"},
+            "field_present": {"class_name": "X", "fields": ["a"]},
+            "function_defined": {"name_prefix": "test_", "min_count": 1},
+            "harness_boundary": {"entry_modules": ["backend.main"], "client_ctor": "TestClient"},
+        }
+        return {"file": file, **base[check_name]}
+
+    @pytest.mark.parametrize(
+        "check_name",
+        [
+            "endpoint_defined",
+            "import_present",
+            "field_present",
+            "function_defined",
+            "harness_boundary",
+        ],
+    )
+    @pytest.mark.parametrize("suffix", [".jsx", ".js", ".ts", ".tsx"])
+    async def test_frontend_file_skips(self, check_name, suffix, tmp_path):
+        from squadops.cycles.acceptance_checks import get_check
+
+        target = tmp_path / f"thing{suffix}"
+        target.write_text("export default function Thing() { return null }\n")
+
+        outcome = await get_check(check_name).evaluate(
+            self._params(check_name, target.name), tmp_path, stack="fastapi"
+        )
+
+        assert outcome.status == "skipped", (
+            f"{check_name} on {suffix} returned {outcome.status}"
+            f"({getattr(outcome, 'reason', None)}) — an error makes the patch unverifiable"
+        )
+
+    @pytest.mark.parametrize(
+        "check_name",
+        [
+            "endpoint_defined",
+            "import_present",
+            "field_present",
+            "function_defined",
+            "harness_boundary",
+        ],
+    )
+    async def test_other_non_python_file_skips(self, check_name, tmp_path):
+        """Not just JS — a markdown or YAML target must skip too, not crash the verdict."""
+        from squadops.cycles.acceptance_checks import get_check
+
+        target = tmp_path / "notes.md"
+        target.write_text("# not python\n")
+
+        outcome = await get_check(check_name).evaluate(
+            self._params(check_name, target.name), tmp_path, stack="fastapi"
+        )
+        assert outcome.status == "skipped"
+
+    async def test_python_files_are_still_evaluated(self, tmp_path):
+        """The guard must not disable the checks it protects — a real Python file with
+        real test functions must still pass."""
+        from squadops.cycles.acceptance_checks import get_check
+
+        target = tmp_path / "test_thing.py"
+        target.write_text("def test_a():\n    pass\n\n\ndef test_b():\n    pass\n")
+
+        outcome = await get_check("function_defined").evaluate(
+            {"file": target.name, "name_prefix": "test_", "min_count": 2},
+            tmp_path,
+            stack="fastapi",
+        )
+        assert outcome.status == "passed"
+
+    async def test_broken_python_still_errors(self, tmp_path):
+        """A Python file that genuinely will not parse is a real problem and must NOT be
+        silently skipped — the guard is about file type, not about hiding failures."""
+        from squadops.cycles.acceptance_checks import get_check
+
+        target = tmp_path / "broken.py"
+        target.write_text("def oops(:\n")
+
+        outcome = await get_check("function_defined").evaluate(
+            {"file": target.name, "name_prefix": "test_", "min_count": 1},
+            tmp_path,
+            stack="fastapi",
+        )
+        assert outcome.status != "skipped"


### PR DESCRIPTION
Third in the stack: #604 → #606 → this. Addresses #605.

## The defect

Four of the five checks that parse Python had no file-extension guard:

| Check | Extension guard |
|---|---|
| `endpoint_defined` | none |
| `import_present` | **yes** |
| `field_present` | none |
| `function_defined` | none |
| `harness_boundary` | none |

Handed a `.jsx` file the four unguarded ones call `ast.parse`, raise, and return `error(parse_failed)` — which patch verification maps to `evaluator_error:<check>` and an `unverifiable` verdict.

The correct behaviour already existed, implemented once in `import_present`. Its siblings never got it. This extracts it into `_unparseable_source_skip` and applies it to all five, so `import_present` is single-sourced onto the same helper instead of keeping its own copy.

## Correcting my own framing

I originally filed #605 saying an unverifiable patch "lands unverified". **That was wrong**, and I've corrected the issue.

The executor already fails closed — `patched_artifacts` is assembled in memory and only applied on a pass; anything else returns `"continue"` and re-dispatches. pf-41's app also *booted* (404, not a startup failure), which independently confirms the invented-name file never reached the verified workspace.

What an evaluator error actually costs is a **wasted correction attempt**: a repair that may have been fine is discarded because verification cannot return a verdict. pf-41 burned three of five that way, which is why its loop could not converge. Real, worth fixing, but a convergence cost — not a correctness hole. The "verification must fail closed" item in the issue is already satisfied and has been struck.

## Deliberately untouched

`regex_match` and `count_at_least` legitimately target documents and globs. Guarding those would break the `qa_handoff.md` checks plans routinely author — pf-41's own plan had two.

Also extended the frontend suffix set to `.jsx/.tsx/.mjs/.cjs`; the original only listed `.ts/.js`, and `.jsx` is what the QA agent actually emits.

## Tests

27 new — every AST check across every frontend suffix, plus markdown, plus two that guard the guard:

- a real Python file with real test functions **still evaluates and passes** (the guard must not disable the checks it protects)
- a genuinely unparseable Python file **still errors** rather than being silently skipped — this is about file type, not about hiding failures

Regression: **5574 passed, 1 skipped**. `ruff check` clean.

## Stack

Deploying the tip of this stack gets all three fixes. #606 changes the frozen surface, so a re-emit + re-ingest + launcher ref update is required before the next roll.