### PR TITLE
fix(plan): prove frozen-file checks can pass before dispatching the run

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -37,6 +37,7 @@ from squadops.cycles.acceptance_evaluation import resolve_check_stack
 from squadops.cycles.agent_config import build_agent_resolver
 from squadops.cycles.build_completeness import compute_missing_required_files
 from squadops.cycles.checkpoint import RunCheckpoint
+from squadops.cycles.frozen_check_validation import frozen_check_violations
 from squadops.cycles.models import (
     ArtifactRef,
     Cycle,
@@ -2656,6 +2657,18 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         f"verification_contract: {e}"
                         for e in parsed_plan.validate_qa_artifact_ownership(contract)
                     )
+                    # pf-42: a typed check aimed at a frozen file is decidable right
+                    # now — the skeleton those files will contain is deterministic.
+                    # A failing one makes the plan unwinnable (frozen emissions are
+                    # restored, so the repair loop can never converge), and it costs
+                    # milliseconds to prove instead of a three-hour roll.
+                    if binding_content is not None:
+                        errors.extend(
+                            f"verification_contract: {e}"
+                            for e in await frozen_check_violations(
+                                parsed_plan, contract, binding_content
+                            )
+                        )
 
         # Soft (warning/info-severity) structural violations are tolerated, not
         # rejected — but logged so the pass is never silent (a warning check can't

--- a/scripts/dev/contract_gate.py
+++ b/scripts/dev/contract_gate.py
@@ -45,7 +45,7 @@ import tempfile
 from pathlib import Path
 
 from squadops.capabilities.handlers.probe_runner import run_probes
-from squadops.capabilities.scaffold import InterfaceManifest, expand
+from squadops.capabilities.scaffold import InterfaceManifest, materialize
 from squadops.capabilities.scaffold_contract import emit_contract_dict, emit_contract_yaml
 from squadops.cycles.verification_contract import VerificationContract
 from squadops.cycles.verification_contract_runner import (
@@ -81,10 +81,7 @@ class _Result:
 
 def _materialize(manifest_path: Path, dest: Path) -> InterfaceManifest:
     manifest = InterfaceManifest.from_yaml(manifest_path.read_text(encoding="utf-8"))
-    for f in expand(manifest):
-        out = dest / f["name"]
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(f["content"], encoding="utf-8")
+    materialize(manifest, dest)
     return manifest
 
 

--- a/scripts/dev/materialize_skeleton.py
+++ b/scripts/dev/materialize_skeleton.py
@@ -17,25 +17,18 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from squadops.capabilities.scaffold import InterfaceManifest, expand
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.capabilities.scaffold import materialize as materialize_skeleton
 
 
 def materialize(manifest_path: Path, out_dir: Path) -> int:
     manifest = InterfaceManifest.from_yaml(manifest_path.read_text(encoding="utf-8"))
-    files = expand(manifest)
-    out_root = out_dir.resolve()
-    for f in files:
-        dest = (out_dir / f["name"]).resolve()
-        # chroot safety: an expander must never write outside the target root.
-        if out_root != dest and out_root not in dest.parents:
-            raise ValueError(f"refusing to write outside {out_root}: {f['name']!r}")
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(f["content"], encoding="utf-8")
+    count = materialize_skeleton(manifest, out_dir)
     print(
-        f"materialized {len(files)} files from {manifest_path} "
-        f"(manifest_hash={manifest.content_hash()[:12]}) -> {out_root}"
+        f"materialized {count} files from {manifest_path} "
+        f"(manifest_hash={manifest.content_hash()[:12]}) -> {out_dir.resolve()}"
     )
-    return len(files)
+    return count
 
 
 def main(argv: list[str]) -> int:

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import yaml
@@ -388,6 +389,29 @@ def expand(manifest: InterfaceManifest) -> list[dict[str, str]]:
             f"no scaffold expander for stack {manifest.stack!r}; available: {sorted(_EXPANDERS)}"
         )
     return expander(manifest)
+
+
+def materialize(manifest: InterfaceManifest, dest: Path) -> int:
+    """Write the expanded skeleton under ``dest``. Returns the file count.
+
+    The canonical writer for ``expand`` output. Two copies of this loop had grown in
+    ``scripts/dev/`` (one with the chroot guard, one without); callers that need a
+    skeleton on disk use this instead of re-implementing the walk, so the safety check
+    below can never be the one that gets left out.
+
+    Raises:
+        ValueError: if an expander emits a name that escapes ``dest``.
+    """
+    root = dest.resolve()
+    files = expand(manifest)
+    for f in files:
+        out = (dest / f["name"]).resolve()
+        # chroot safety: an expander must never write outside the target root.
+        if root != out and root not in out.parents:
+            raise ValueError(f"refusing to write outside {root}: {f['name']!r}")
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(f["content"], encoding="utf-8")
+    return len(files)
 
 
 def fill_slot_paths(manifest: InterfaceManifest) -> tuple[str, ...]:

--- a/src/squadops/cycles/frozen_check_validation.py
+++ b/src/squadops/cycles/frozen_check_validation.py
@@ -1,0 +1,139 @@
+"""Plan-time proof that authored checks on frozen files can actually pass.
+
+A bind-mode plan may hang typed checks on files the *scaffold* owns. Those files are
+not a guess: the interface manifest expands to them deterministically, byte for byte,
+before any agent runs. So a check aimed at one of them is decidable at authoring time —
+run it against the skeleton the run will actually contain and see.
+
+When such a check fails, the plan is unwinnable and nothing downstream can rescue it.
+Frozen-file emissions are restored by scaffold ownership enforcement, so the repair
+loop's only move — rewrite the file — is undone before the check re-runs. The task
+fails identically on every correction attempt until the budget is spent.
+
+pf-42 is the motivating case. Its plan asserted ``field_present`` for a ``RunEvent``
+field named ``meeting_location`` on the frozen ``backend/models.py``; the manifest
+declares that field as ``location``. A second task asserted ``import_present`` for
+``backend.routes`` on the frozen ``backend/main.py``, which imports ``from .routes``.
+Both are error-severity, both target files no agent may change, and both were provable
+in under a second — but the plan was gated on human review, so the only thing that
+would have caught them was someone reading a 317-line YAML closely enough to notice a
+field name that reads perfectly plausibly.
+
+This is the same shape as the rest of the bind-mode nets (SIP-0098 98.3): the system
+holds the authoritative answer and the check is written against a guess. Here the
+authoritative answer is on disk in milliseconds.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from squadops.capabilities.scaffold import InterfaceManifest, materialize
+from squadops.cycles.acceptance_checks import get_check
+from squadops.cycles.implementation_plan import TypedCheck
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from squadops.cycles.implementation_plan import ImplementationPlan
+    from squadops.cycles.verification_contract import VerificationContract
+
+logger = logging.getLogger(__name__)
+
+
+async def frozen_check_violations(
+    plan: ImplementationPlan,
+    contract: VerificationContract,
+    manifest_content: str,
+) -> list[str]:
+    """Return one error per error-severity typed check that a frozen file cannot satisfy.
+
+    Only ``severity=error`` checks are considered — a warning cannot block a build
+    (RC-9), so a warning that fails costs nothing and is not worth rejecting a plan for.
+
+    Only ``status == "failed"`` rejects. An evaluator that *errors* (unreadable file,
+    a bug in a checker) has proved nothing about the plan, and rejecting on it would let
+    one broken checker block every plan in the system. Those are logged and skipped —
+    the same check still runs for real at task verification, where fail-closed applies.
+
+    Args:
+        plan: The authored implementation plan.
+        contract: The bound verification contract, whose ``frozen_files`` name the
+            scaffold-owned surface.
+        manifest_content: The interface manifest YAML this run's skeleton expands from.
+
+    Returns:
+        List of validation error strings (empty = nothing provably unwinnable).
+    """
+    frozen = {ff.path for ff in contract.frozen_files}
+    targeted = [
+        (task, check)
+        for task in plan.tasks
+        for check in task.acceptance_criteria
+        if isinstance(check, TypedCheck)
+        and check.severity == "error"
+        and check.params.get("file") in frozen
+    ]
+    if not targeted:
+        return []
+
+    try:
+        manifest = InterfaceManifest.from_yaml(manifest_content)
+    except Exception:
+        # The manifest has its own validation net upstream; a parse failure there is
+        # reported by that net, not silently re-reported as a plan defect here.
+        logger.warning("frozen-check validation skipped: interface manifest did not parse")
+        return []
+
+    errors: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="frozen-check-") as tmp:
+        root = Path(tmp)
+        try:
+            materialize(manifest, root)
+        except Exception:
+            logger.warning("frozen-check validation skipped: skeleton did not materialize")
+            return []
+
+        for task, check in targeted:
+            path = check.params.get("file")
+            try:
+                outcome = await get_check(check.check).evaluate(
+                    dict(check.params), root, stack=manifest.stack
+                )
+            except Exception:
+                logger.warning(
+                    "frozen-check validation: %s on %r raised; not treating as a plan defect",
+                    check.check,
+                    path,
+                )
+                continue
+
+            if outcome.status != "failed":
+                continue
+
+            errors.append(
+                f"Task {task.task_index} ({task.focus}): {check.check} on {path!r} can never "
+                f"pass — that file is frozen (scaffold-owned), and the skeleton it will "
+                f"actually contain fails this check ({outcome.reason}"
+                f"{_detail(outcome)}). No repair can fix it: a frozen-file emission is "
+                f"restored before the check re-runs, so this fails identically on every "
+                f"correction attempt until the budget is spent. Assert what the scaffold "
+                f"declares, or drop the check"
+            )
+
+    return errors
+
+
+def _detail(outcome) -> str:
+    """Render the actionable part of an outcome — what is missing versus what is there."""
+    actual = getattr(outcome, "actual", None)
+    if not isinstance(actual, dict):
+        return ""
+    missing = actual.get("missing")
+    declared = actual.get("declared")
+    if missing and declared:
+        return f"; missing {sorted(missing)}, file declares {sorted(declared)}"
+    if missing:
+        return f"; missing {sorted(missing)}"
+    return ""

--- a/tests/unit/architecture/test_no_enum_shadow_comparisons.py
+++ b/tests/unit/architecture/test_no_enum_shadow_comparisons.py
@@ -49,6 +49,9 @@ _ALLOWLIST: set[tuple[str, str]] = {
     # verification (#389).
     ("src/squadops/cycles/patch_verification.py", "failed"),
     ("src/squadops/cycles/patch_verification.py", "error"),
+    # Same CheckOutcome.status vocabulary again, evaluated at plan-authoring time to
+    # prove a frozen-file check can pass before the run is dispatched (pf-42).
+    ("src/squadops/cycles/frozen_check_validation.py", "failed"),
     # External Ollama model-pull job status — a vendor vocabulary, not a domain enum.
     ("src/squadops/cli/commands/models.py", "failed"),
     # window_state() returns a duty-window lifecycle token ("active"/

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from squadops.capabilities import scaffold
 from squadops.capabilities.handlers.build_profiles import get_profile
 from squadops.capabilities.scaffold import InterfaceManifest, expand
 
@@ -273,11 +274,12 @@ def test_materialize_writes_every_expanded_file(tmp_path):
 
 def test_materialize_refuses_path_traversal(tmp_path, monkeypatch):
     # Defense-in-depth: even if a future expander emitted an escaping name, the
-    # materializer must refuse to write outside the target root.
-    mod = _load_materialize_module()
-    monkeypatch.setattr(mod, "expand", lambda _m: [{"name": "../escape.txt", "content": "x"}])
+    # materializer must refuse to write outside the target root. The guard lives on
+    # the canonical helper, so every caller inherits it — the two copies of this loop
+    # in scripts/dev/ (only one of which HAD the guard) now delegate here.
+    monkeypatch.setattr(scaffold, "expand", lambda _m: [{"name": "../escape.txt", "content": "x"}])
     with pytest.raises(ValueError, match="refusing to write outside"):
-        mod.materialize(_MANIFEST_PATH, tmp_path)
+        scaffold.materialize(_group_run_manifest(), tmp_path)
     assert not (tmp_path.parent / "escape.txt").exists()
 
 

--- a/tests/unit/cycles/test_frozen_check_validation.py
+++ b/tests/unit/cycles/test_frozen_check_validation.py
@@ -1,0 +1,227 @@
+"""Frozen-file check validation (pf-42).
+
+pf-42's plan asserted ``field_present`` for a ``RunEvent`` field called
+``meeting_location`` on ``backend/models.py``, and ``import_present`` for the module
+``backend.routes`` on ``backend/main.py``. Both files are frozen — the manifest declares
+the field as ``location``, and the frozen main.py imports ``from .routes``. Both checks
+were error-severity, and neither could ever pass: a repair rewriting a frozen file has
+its emission restored before the check re-runs, so the correction loop burns its whole
+budget failing identically.
+
+The checks below use the real group_run manifest and the two real failing specs, so a
+regression here means the actual pf-42 plan would be admitted again.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.capabilities.scaffold_contract import emit_contract_dict
+from squadops.cycles.frozen_check_validation import frozen_check_violations
+from squadops.cycles.implementation_plan import ImplementationPlan
+from squadops.cycles.verification_contract import VerificationContract
+
+pytestmark = [pytest.mark.domain_cycles]
+
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+
+
+def _manifest_content() -> str:
+    return _MANIFEST_PATH.read_text(encoding="utf-8")
+
+
+def _contract() -> VerificationContract:
+    manifest = InterfaceManifest.from_yaml(_manifest_content())
+    return VerificationContract.from_dict(emit_contract_dict(manifest))
+
+
+def _plan(criteria_yaml: str, *, artifact: str = "backend/models.py") -> ImplementationPlan:
+    return ImplementationPlan.from_yaml(
+        f"""\
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+
+tasks:
+  - task_index: 0
+    task_type: development.develop
+    role: dev
+    focus: "Backend models"
+    description: "Create data models"
+    expected_artifacts:
+      - "{artifact}"
+    acceptance_criteria:
+{criteria_yaml}
+    depends_on: []
+
+summary:
+  total_tasks: 1
+  total_dev_tasks: 1
+  total_qa_tasks: 0
+  estimated_layers: []
+"""
+    )
+
+
+# --- the two real pf-42 defects ------------------------------------------------ #
+
+
+async def test_pf42_invented_field_name_on_frozen_models_is_rejected():
+    """The exact check that would have cost pf-42 its roll."""
+    plan = _plan(
+        """\
+      - check: field_present
+        file: backend/models.py
+        class_name: RunEvent
+        fields: [id, title, datetime, meeting_location, participants]
+"""
+    )
+    errors = await frozen_check_violations(plan, _contract(), _manifest_content())
+
+    assert len(errors) == 1
+    msg = errors[0]
+    assert "field_present" in msg
+    assert "backend/models.py" in msg
+    # the operator needs the real name, not just "it failed"
+    assert "meeting_location" in msg
+    assert "location" in msg
+    assert "frozen" in msg
+
+
+async def test_pf42_absolute_import_against_relative_frozen_import_is_rejected():
+    """Frozen main.py imports ``from .routes``; the plan asserted ``backend.routes``."""
+    plan = _plan(
+        """\
+      - check: import_present
+        file: backend/main.py
+        module: backend.routes
+""",
+        artifact="backend/main.py",
+    )
+    errors = await frozen_check_violations(plan, _contract(), _manifest_content())
+
+    assert len(errors) == 1
+    assert "import_present" in errors[0]
+    assert "backend/main.py" in errors[0]
+
+
+# --- the checks that must still be admitted ------------------------------------ #
+
+
+async def test_check_the_frozen_file_actually_satisfies_is_admitted():
+    """Same check, real field name — the scaffold satisfies it, so the plan stands."""
+    plan = _plan(
+        """\
+      - check: field_present
+        file: backend/models.py
+        class_name: RunEvent
+        fields: [id, title, datetime, location, participants]
+"""
+    )
+    assert await frozen_check_violations(plan, _contract(), _manifest_content()) == []
+
+
+async def test_checks_on_fill_slots_are_not_pre_validated():
+    """A fill slot is empty at authoring time — judging it now would reject every plan."""
+    plan = _plan(
+        """\
+      - check: endpoint_defined
+        file: backend/routes.py
+        methods_paths: ["POST /runs"]
+""",
+        artifact="backend/routes.py",
+    )
+    assert await frozen_check_violations(plan, _contract(), _manifest_content()) == []
+
+
+async def test_warning_severity_failure_does_not_reject():
+    """A warning cannot block a build (RC-9), so a failing one must not block a plan."""
+    plan = _plan(
+        """\
+      - check: field_present
+        severity: warning
+        file: backend/models.py
+        class_name: RunEvent
+        fields: [meeting_location]
+"""
+    )
+    assert await frozen_check_violations(plan, _contract(), _manifest_content()) == []
+
+
+async def test_prose_criteria_are_ignored():
+    plan = _plan(
+        """\
+      - "RunEvent carries every field the PRD lists"
+"""
+    )
+    assert await frozen_check_violations(plan, _contract(), _manifest_content()) == []
+
+
+# --- failing open where proving nothing ---------------------------------------- #
+
+
+async def test_unparseable_manifest_does_not_reject_the_plan():
+    """The manifest has its own upstream net; a parse failure is not a plan defect."""
+    plan = _plan(
+        """\
+      - check: field_present
+        file: backend/models.py
+        class_name: RunEvent
+        fields: [meeting_location]
+"""
+    )
+    assert await frozen_check_violations(plan, _contract(), ":\n  not: [valid") == []
+
+
+async def test_multiple_violations_are_all_reported():
+    """One rejection per defect — an operator fixing a plan should see every problem."""
+    plan = ImplementationPlan.from_yaml(
+        """\
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+
+tasks:
+  - task_index: 0
+    task_type: development.develop
+    role: dev
+    focus: "Backend models"
+    description: "models"
+    expected_artifacts: ["backend/models.py"]
+    acceptance_criteria:
+      - check: field_present
+        file: backend/models.py
+        class_name: RunEvent
+        fields: [meeting_location]
+    depends_on: []
+  - task_index: 1
+    task_type: development.develop
+    role: dev
+    focus: "Backend app"
+    description: "app"
+    expected_artifacts: ["backend/main.py"]
+    acceptance_criteria:
+      - check: import_present
+        file: backend/main.py
+        module: backend.routes
+    depends_on: [0]
+
+summary:
+  total_tasks: 1
+  total_dev_tasks: 1
+  total_qa_tasks: 0
+  estimated_layers: []
+"""
+    )
+    errors = await frozen_check_violations(plan, _contract(), _manifest_content())
+
+    assert len(errors) == 2
+    assert "Task 0" in errors[0]
+    assert "Task 1" in errors[1]


### PR DESCRIPTION
## What broke

pf-42's plan was gated on human review, passed every existing net, and was
**unwinnable before it started.**

Two dev tasks carried error-severity typed checks aimed at files the scaffold owns:

| Task | Check | Reality |
|---|---|---|
| 0 | `field_present` — `RunEvent.meeting_location` in `backend/models.py` | the manifest declares it `location` |
| 2 | `import_present` — `backend.routes` in `backend/main.py` | the frozen file imports `from .routes` |

Both files are frozen. Scaffold ownership enforcement restores a frozen-file emission
before the check re-runs, so the repair loop's only move is undone every time. The tasks
fail identically on all five correction attempts, and a three-hour roll is lost to a
plausible-looking field name.

## What this adds

Frozen files aren't a guess — the manifest expands to them deterministically before any
agent runs. So a check aimed at one is **decidable at authoring time**: materialize the
skeleton, run the check, see.

`frozen_check_violations()` does exactly that, wired into the gate-time plan validation
that records a graceful system rejection (#473), beside the criteria-refs and
qa-ownership nets it belongs with. With `framing_max_rerolls=2` configured, a rejection
re-rolls framing instead of burning the afternoon.

Replaying the **real stored pf-42 plan** through it:

```
REPLAY OF THE REAL pf-42 PLAN -> 2 violation(s)

 * Task 0 (backend run model): field_present on 'backend/models.py' can never pass —
   that file is frozen (scaffold-owned), and the skeleton it will actually contain
   fails this check (fields_missing; missing ['meeting_location'], file declares
   ['datetime', 'distance', 'id', 'location', 'pace_target', 'participants',
   'route_notes', 'title']). No repair can fix it: a frozen-file emission is restored
   before the check re-runs, so this fails identically on every correction attempt
   until the budget is spent. Assert what the scaffold declares, or drop the check

 * Task 2 (backend app main): import_present on 'backend/main.py' can never pass — ...
```

The message names the missing field *and* what the file actually declares, so the fix is
obvious rather than a hunt.

## Two deliberate limits

**Only `severity=error`.** A warning cannot block a build (RC-9), so a failing warning
costs nothing and is not worth rejecting a plan over.

**Only `status=failed` rejects.** An evaluator that *errors* has proved nothing about the
plan, and rejecting on it would let a single broken checker block every plan in the
system. Those are logged and skipped — the same check still runs for real at task
verification, where fail-closed applies. This is the one place where failing open is the
right call, and it is scoped to "we could not decide", never to "we decided it fails".

## Why this shape and not another detector

The recurring defect all week has been: *the system holds the authoritative answer and
never puts it in front of the thing that needs it.* A detector that merely rejects the
guess doesn't supply the answer, so the next attempt guesses again. Here the authoritative
answer is the frozen file itself, and the rejection quotes it back.

## Drive-by: one materializer, not three

Two copies of the expand-and-write loop had grown in `scripts/dev/`, and **only one
carried the chroot guard**. `scaffold.materialize()` is now the single writer; both
scripts delegate to it, so the safety check can't be the thing a third caller forgets.
The traversal test moves onto the canonical helper. (A third copy lives in
`tests/unit/cycles/test_verification_contract_runner.py`; left alone to keep this diff
honest.)

## Verification

- **Replay** against pf-42's real stored plan artifact — both violations, no false ones.
- 8 new tests, including both real failing specs, plus the cases that must still be
  admitted: the same check with the correct field name, checks on fill slots (empty at
  authoring time — judging them would reject every plan), warning severity, prose
  criteria, and an unparseable manifest.
- Regression **5588 passed**, 1 skipped. ruff clean.
- Contract gates re-run in-container against this tree: **lint GREEN, bare-skeleton 6/6,
  reference-fill 6/6**.
- **Contract emission unchanged** — `content_hash` stays `26503867…`, so the seeded v6
  contract remains valid and **no re-seed is needed** before the next roll.
