### PR TITLE
fix(plan): show the plan author what the frozen files declare

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -282,12 +282,29 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # TypedChecks. Absent contract = author mode = today's behavior.
             verification_contract = await self._load_contract_for_run(cycle, run)
 
+            # pf-42: the proposer binds criteria for the fill slots but is told nothing
+            # about the frozen files, so a check it wants on one is written against an
+            # invented interior. The manifest is what those files expand from, so it is
+            # the authority on their contents.
+            #
+            # Read from the OPERATOR-SEEDED rail, not `_load_interface_manifest_for_run`
+            # — that one returns None for a framing run by design (#496), and framing is
+            # exactly when the proposer needs this. The #496 rule is that a framing run
+            # must not expand or carry skeleton FILES; describing the interface in a
+            # prompt materializes nothing, so it stays inside that rule. Bind mode
+            # already requires a seeded manifest (#494), so this is the same document
+            # the gate hash-checks and the skeleton later expands from.
+            interface_manifest = None
+            if verification_contract is not None:
+                interface_manifest = await self._seeded_manifest_for_authoring(cycle)
+
             plan = generate_task_plan(
                 cycle,
                 run,
                 profile,
                 plan=implementation_plan,
                 contract=verification_contract,
+                interface_manifest=interface_manifest,
             )
             participating_agent_ids = {e.agent_id for e in plan}
 
@@ -2704,6 +2721,29 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             ):
                 return content_bytes.decode(errors="replace")
         return None
+
+    async def _seeded_manifest_for_authoring(self, cycle: Cycle) -> Any:
+        """The seeded manifest parsed, for describing the frozen surface to a proposer.
+
+        Distinct from ``_load_interface_manifest_for_run`` on purpose: that one refuses
+        framing runs (#496) because a framing run must not expand or carry skeleton
+        files, and framing is precisely when the plan is authored. Nothing is
+        materialized here — the manifest is read only to render an index of what the
+        frozen files declare into the authoring prompt (pf-42).
+
+        Returns ``InterfaceManifest`` or ``None``; unreadable/unparseable is not fatal,
+        the prompt simply falls back to today's shape.
+        """
+        from squadops.capabilities.scaffold import InterfaceManifest
+
+        content = await self._load_seeded_manifest_content(cycle)
+        if content is None:
+            return None
+        try:
+            return InterfaceManifest.from_yaml(content)
+        except Exception:
+            logger.warning("seeded interface manifest did not parse; frozen surface omitted")
+            return None
 
     @staticmethod
     def _validate_interface_manifest(content: str) -> list[str]:

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -854,6 +854,31 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
         )
         return rendered.content
 
+    async def _frozen_surface_section(self, renderer: Any, inputs: dict[str, Any]) -> str:
+        """What the scaffold-frozen files declare, or "" (pf-42).
+
+        The criteria index above names the fill slots only — four files of seventeen on
+        the group_run skeleton. The other thirteen are frozen, and nothing told the
+        proposer they exist, so a check it wanted on one was written against an invented
+        interior (``RunEvent.meeting_location`` for the declared ``location``;
+        ``backend.routes`` for a module that imports ``.routes``). Neither could pass and
+        neither could be repaired — a frozen emission is restored before the check
+        re-runs — so the plan was unwinnable before dispatch.
+
+        Same conditions as the bind section: bind mode only, dev/qa proposers only. The
+        index *data* is injected by the executor; the instruction prose is a managed
+        asset (CLAUDE.md #448). No index → "" → today's proposer prompt exactly.
+        """
+        if self._proposer_role not in ("development", "qa"):
+            return ""
+        index = inputs.get("frozen_surface_index")
+        if not index:
+            return ""
+        rendered = await renderer.render(
+            "request.plan_frozen_surface_appendix", {"frozen_surface_index": index}
+        )
+        return rendered.content
+
     async def handle(
         self,
         context: ExecutionContext,
@@ -902,6 +927,12 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
         bind_criteria_section = await self._bind_criteria_section(renderer, inputs)
         if bind_criteria_section:
             variables["bind_criteria_section"] = bind_criteria_section
+        # pf-42: the same bind-mode prompt names the fill slots but not the frozen files,
+        # so checks aimed at those were written against an invented interior. Data-driven
+        # and managed-asset prose, exactly like the section above.
+        frozen_surface_section = await self._frozen_surface_section(renderer, inputs)
+        if frozen_surface_section:
+            variables["frozen_surface_section"] = frozen_surface_section
         rendered = await renderer.render(self._request_template_id, variables)
         user_prompt = rendered.content
 

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -23,6 +23,7 @@ components exist, wire together, build, and boot, but their bodies are stubs.
 
 from __future__ import annotations
 
+import ast
 import hashlib
 import json
 from dataclasses import dataclass, field
@@ -505,6 +506,98 @@ def model_surface_instructions(manifest: InterfaceManifest | None) -> list[str]:
             "and shape the response in the fill slot; do not edit or re-emit the model module"
         ),
     ]
+
+
+def _class_field_names(node: ast.ClassDef) -> list[str]:
+    """Annotated attribute names declared directly on a class body."""
+    return [
+        stmt.target.id
+        for stmt in node.body
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+    ]
+
+
+def _imported_modules(tree: ast.AST) -> list[str]:
+    """Module strings as the source actually writes them — ``.routes`` stays relative.
+
+    The relative form is the point: pf-42's plan asserted ``import_present`` for
+    ``backend.routes`` against a frozen ``main.py`` that says ``from .routes import
+    router``. Rendering the *written* form is what makes that mismatch visible.
+    """
+    modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            modules.append("." * node.level + (node.module or ""))
+    # __future__ is on every emitted module and tells the author nothing.
+    return [m for m in modules if m != "__future__"]
+
+
+def _python_surface(source: str) -> str:
+    """One line describing what a frozen Python module declares, or "" if nothing useful."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:  # pragma: no cover - the expander emits valid Python
+        return ""
+
+    classes = [
+        f"{node.name}({', '.join(fields)})" if (fields := _class_field_names(node)) else node.name
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+    ]
+    functions = [
+        node.name
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and not node.name.startswith("_")
+    ]
+    modules = sorted(set(_imported_modules(tree)))
+
+    parts = []
+    if classes:
+        parts.append("defines " + ", ".join(classes))
+    if functions:
+        parts.append("functions " + ", ".join(functions))
+    if modules:
+        parts.append("imports " + ", ".join(f"`{m}`" for m in modules))
+    return "; ".join(parts)
+
+
+def frozen_surface_index_lines(manifest: InterfaceManifest | None) -> list[str]:
+    """One line per scaffold-frozen file, naming exactly what it declares (pf-42).
+
+    The plan author is shown a criteria index covering the *fill slots* and nothing else
+    — four files out of seventeen. The other thirteen are frozen, and the author has
+    never been told they exist, let alone what is in them. So when it wants a check on
+    one it invents the contents: pf-42 asserted a ``RunEvent`` field called
+    ``meeting_location`` (the manifest says ``location``) and an ``import_present`` for
+    ``backend.routes`` against a file that writes ``from .routes``. Neither could ever
+    pass, and neither could be repaired — a frozen emission is restored before the check
+    re-runs — so the plan was dead on arrival and cost a roll to discover.
+
+    Derived by parsing the *expanded skeleton itself* rather than describing it by hand,
+    so this index cannot drift from what the expander emits: change a template and the
+    lines change with it.
+
+    The companion to the plan-validation net (``cycles.frozen_check_validation``), and
+    the same pairing as the repair path's model surface + unresolved-import gate: supply
+    the authoritative fact so nothing has to guess, and verify deterministically so a
+    guess can never cost a roll.
+
+    Empty when there is no manifest (author mode, non-scaffold stacks) — additive.
+    """
+    if manifest is None:
+        return []
+    fills = set(fill_slot_paths(manifest))
+    lines = []
+    for f in expand(manifest):
+        name = f["name"]
+        if name in fills:
+            continue
+        detail = _python_surface(f["content"]) if name.endswith(".py") else ""
+        lines.append(f"- `{name}` — {detail}" if detail else f"- `{name}`")
+    return lines
 
 
 # SIP-0100 D1 (bounded-hybrid QA test ownership): the scaffold owns the *namespace* — the

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -23,7 +23,12 @@ from squadops.capabilities.handlers.build_profiles import (
     ROUTING_BUILDER_PRESENT,
     ROUTING_FALLBACK_NO_BUILDER,
 )
-from squadops.capabilities.scaffold import harness_entry_modules, is_qa_test_path_for_stack
+from squadops.capabilities.scaffold import (
+    InterfaceManifest,
+    frozen_surface_index_lines,
+    harness_entry_modules,
+    is_qa_test_path_for_stack,
+)
 from squadops.cycles.agent_config import resolve_agent_config
 from squadops.cycles.failure_evidence import FailureLocus
 from squadops.cycles.implementation_plan import (
@@ -418,7 +423,10 @@ def _resolve_legacy_steps(
 
 
 def _inject_contract_inputs(
-    inputs: dict, contract: VerificationContract | None, task_type: str
+    inputs: dict,
+    contract: VerificationContract | None,
+    task_type: str,
+    interface_manifest: InterfaceManifest | None = None,
 ) -> None:
     """Bind-mode envelope inputs derived from the seeded contract (SIP-0098).
 
@@ -440,6 +448,14 @@ def _inject_contract_inputs(
         return
     if task_type in _BIND_INDEX_PROPOSER_TASK_TYPES:
         inputs["contract_criteria_index"] = "\n".join(contract.criteria_index_lines())
+        # pf-42: the criteria index covers the fill slots only — four files of
+        # seventeen. The rest are frozen, and the proposer was never told they exist,
+        # so a check it wanted on one was written against an invented interior
+        # (``RunEvent.meeting_location`` for the declared ``location``). Same data-only
+        # injection as the index above; the instruction prose is a managed asset (#448).
+        frozen_index = frozen_surface_index_lines(interface_manifest)
+        if frozen_index:
+            inputs["frozen_surface_index"] = "\n".join(frozen_index)
     if task_type == "qa.test" and contract.behavioral.probes:
         inputs["contract_probes"] = [p.to_dict() for p in contract.behavioral.probes]
 
@@ -476,6 +492,7 @@ def generate_task_plan(
     profile: SquadProfile,
     plan: ImplementationPlan | None = None,
     contract: VerificationContract | None = None,
+    interface_manifest: InterfaceManifest | None = None,
 ) -> list[TaskEnvelope]:
     """Generate a task plan for a cycle run.
 
@@ -636,7 +653,7 @@ def generate_task_plan(
             acceptance.extend(_harness_boundary_criteria(task_type, plan_task, contract))
             inputs["acceptance_criteria"] = acceptance
 
-        _inject_contract_inputs(inputs, contract, task_type)
+        _inject_contract_inputs(inputs, contract, task_type, interface_manifest)
 
         envelope = TaskEnvelope(
             task_id=task_id,

--- a/src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md
+++ b/src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md
@@ -13,6 +13,7 @@ optional_variables:
   - typed_acceptance_vocabulary
   - scaffold_section
   - bind_criteria_section
+  - frozen_surface_section
 ---
 You are proposing development-domain plan tasks for the upcoming build.
 
@@ -72,3 +73,5 @@ confidence: ""  # low | medium | high
 
 {{scaffold_section}}
 {{bind_criteria_section}}
+
+{{frozen_surface_section}}

--- a/src/squadops/prompts/request_templates/request.plan_frozen_surface_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_frozen_surface_appendix.md
@@ -1,0 +1,42 @@
+---
+template_id: request.plan_frozen_surface_appendix
+version: "1"
+required_variables:
+  - frozen_surface_index
+optional_variables: []
+---
+## The scaffold already wrote these files — they are frozen
+
+Before any task runs, the build is expanded into a working skeleton. The files below
+are **already written and cannot be changed by anyone**. An agent that emits one has its
+emission discarded and the scaffold's version restored, every time.
+
+This is not a rule to work around — it is what makes the rest of the plan safe. The
+interfaces are settled before generation starts, so tasks can fill behaviour without
+negotiating structure.
+
+**Two things follow, and both matter.**
+
+**Do not assign a frozen file as a task's `expected_artifacts`.** The task cannot produce
+its own output. It will emit, be restored, and consume a slot for nothing.
+
+**Do not write typed checks against a frozen file unless the line below proves it passes.**
+A check on a frozen file has exactly two outcomes and neither is useful. If the scaffold
+satisfies it, the check can never fail, so it verifies nothing. If the scaffold does not,
+the plan is unwinnable: the task fails, the repair rewrites the file, the rewrite is
+restored, and the check fails identically until the correction budget is gone. Plan
+validation now runs these checks against the real skeleton before dispatch and rejects
+the plan if one cannot pass — so a guess here costs the whole framing, not just the task.
+
+**What the frozen files actually declare:**
+
+{{frozen_surface_index}}
+
+Read that index literally. The names in it are the only names that exist. If a model
+lists `location`, there is no `meeting_location`. If a module imports `` `.routes` ``,
+then `backend.routes` is not what it imports. Field names, class names and import paths
+are all exact — none of them are yours to choose, and near-misses fail as hard as
+inventions.
+
+Where the interface is not what the work needs, say so in prose in the task description.
+Do not encode the disagreement as a check: the check will simply fail.

--- a/src/squadops/prompts/request_templates/request.qa_propose_plan_tasks.md
+++ b/src/squadops/prompts/request_templates/request.qa_propose_plan_tasks.md
@@ -12,6 +12,7 @@ optional_variables:
   - builder_section
   - typed_acceptance_vocabulary
   - bind_criteria_section
+  - frozen_surface_section
 ---
 You are proposing QA-domain plan tasks for the upcoming build.
 
@@ -72,3 +73,5 @@ confidence: ""  # low | medium | high
 ```
 
 {{bind_criteria_section}}
+
+{{frozen_surface_section}}

--- a/tests/unit/capabilities/test_frozen_surface_index.py
+++ b/tests/unit/capabilities/test_frozen_surface_index.py
@@ -1,0 +1,117 @@
+"""The frozen-surface index the plan author is shown (pf-42).
+
+The bind-mode criteria index names the four fill slots. The other thirteen files the
+expander emits are frozen, and nothing put them in front of the proposer — so pf-42's
+plan asserted a ``RunEvent`` field called ``meeting_location`` (the manifest declares
+``location``) and an ``import_present`` for ``backend.routes`` against a module that
+writes ``from .routes``. Both checks targeted files no agent may change, so neither could
+pass and neither could be repaired.
+
+These assert the index answers exactly those two questions, and that it is derived from
+the expanded skeleton rather than described by hand — so it cannot drift from what the
+expander emits.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from squadops.capabilities.scaffold import (
+    InterfaceManifest,
+    expand,
+    fill_slot_paths,
+    frozen_surface_index_lines,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+
+
+def _manifest() -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _line_for(path: str) -> str:
+    return next(line for line in frozen_surface_index_lines(_manifest()) if f"`{path}`" in line)
+
+
+# --- the two questions pf-42 got wrong ----------------------------------------- #
+
+
+def test_model_fields_are_named_exactly_so_none_need_inventing():
+    line = _line_for("backend/models.py")
+
+    assert "RunEvent(id, title, datetime, location, distance, pace_target, route_notes" in line
+    assert "Participant(id, name)" in line
+    # the invented name must be absent — that is the whole point
+    assert "meeting_location" not in line
+
+
+def test_imports_render_as_written_so_relative_is_visible():
+    """pf-42 asserted ``backend.routes``; the file says ``from .routes``."""
+    line = _line_for("backend/main.py")
+
+    assert "`.routes`" in line
+    assert "`backend.routes`" not in line
+
+
+# --- derived from the skeleton, not described by hand -------------------------- #
+
+
+def test_every_frozen_file_appears_and_no_fill_slot_does():
+    manifest = _manifest()
+    lines = frozen_surface_index_lines(manifest)
+    emitted = {f["name"] for f in expand(manifest)}
+    fills = set(fill_slot_paths(manifest))
+
+    listed = {line.split("`")[1] for line in lines}
+    assert listed == emitted - fills
+    # the slots the author is meant to fill are governed by the criteria index instead
+    assert not (listed & fills)
+
+
+def test_index_tracks_the_expander_rather_than_a_hand_written_description(monkeypatch):
+    """Change what the expander emits and the index changes with it."""
+    import squadops.capabilities.scaffold as sc
+
+    monkeypatch.setattr(
+        sc,
+        "expand",
+        lambda _m: [{"name": "backend/invented.py", "content": "class Widget:\n    size: int\n"}],
+    )
+    assert frozen_surface_index_lines(_manifest()) == [
+        "- `backend/invented.py` — defines Widget(size)"
+    ]
+
+
+def test_noise_imports_are_dropped():
+    """``__future__`` is on every emitted module and tells the author nothing."""
+    assert all("__future__" not in line for line in frozen_surface_index_lines(_manifest()))
+
+
+# --- edges --------------------------------------------------------------------- #
+
+
+def test_no_manifest_yields_no_index():
+    """Author mode and non-scaffold stacks keep today's prompt byte-identical."""
+    assert frozen_surface_index_lines(None) == []
+
+
+def test_non_python_frozen_files_are_listed_without_a_surface():
+    # vite.config.js is frozen and load-bearing (it strips the /api prefix), but the
+    # index does not parse JS — it must still name the file rather than omit it.
+    assert _line_for("frontend/vite.config.js") == "- `frontend/vite.config.js`"
+
+
+def test_unparseable_python_degrades_to_a_bare_path(monkeypatch):
+    import squadops.capabilities.scaffold as sc
+
+    monkeypatch.setattr(
+        sc, "expand", lambda _m: [{"name": "backend/broken.py", "content": "def (:\n"}]
+    )
+    assert frozen_surface_index_lines(_manifest()) == ["- `backend/broken.py`"]

--- a/tests/unit/capabilities/test_frozen_surface_proposer.py
+++ b/tests/unit/capabilities/test_frozen_surface_proposer.py
@@ -1,0 +1,148 @@
+"""The frozen surface reaches the plan author (pf-42).
+
+Knowing what the frozen files declare is useless if the proposer never sees it. These
+cover the transport end to end: the executor-side injection that puts the index on the
+proposer's envelope, the handler section that renders it, and a real render of the
+managed asset proving the field names and relative imports actually arrive in the prompt.
+
+Same conditions as the bind-criteria section it sits beside — bind mode only, dev/qa
+only — so an author-mode cycle keeps today's prompt byte-identical.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities.handlers.planning_tasks import (
+    DevelopmentProposePlanTasksHandler,
+    QaProposePlanTasksHandler,
+    StrategyProposePlanGuidanceHandler,
+)
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.capabilities.scaffold_contract import emit_contract_dict
+from squadops.cycles.task_plan import _inject_contract_inputs
+from squadops.cycles.verification_contract import VerificationContract
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+
+
+def _manifest() -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _contract() -> VerificationContract:
+    return VerificationContract.from_dict(emit_contract_dict(_manifest()))
+
+
+# --- executor-side injection --------------------------------------------------- #
+
+
+def test_proposer_envelope_carries_the_frozen_surface():
+    inputs: dict = {}
+    _inject_contract_inputs(inputs, _contract(), "development.propose_plan_tasks", _manifest())
+
+    index = inputs["frozen_surface_index"]
+    assert "RunEvent(id, title, datetime, location" in index
+    assert "`.routes`" in index
+    assert "meeting_location" not in index
+
+
+def test_build_tasks_do_not_carry_it():
+    """Only the proposers author checks; a develop task has no use for the index."""
+    inputs: dict = {}
+    _inject_contract_inputs(inputs, _contract(), "development.develop", _manifest())
+
+    assert "frozen_surface_index" not in inputs
+
+
+def test_author_mode_injects_nothing():
+    inputs: dict = {}
+    _inject_contract_inputs(inputs, None, "development.propose_plan_tasks", _manifest())
+
+    assert inputs == {}
+
+
+def test_bind_mode_without_a_manifest_still_injects_the_criteria_index():
+    """The frozen surface is additive — losing it must not cost the bind index."""
+    inputs: dict = {}
+    _inject_contract_inputs(inputs, _contract(), "development.propose_plan_tasks", None)
+
+    assert "frozen_surface_index" not in inputs
+    assert inputs["contract_criteria_index"]
+
+
+# --- handler section ----------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "handler_cls", [DevelopmentProposePlanTasksHandler, QaProposePlanTasksHandler]
+)
+async def test_dev_and_qa_proposers_render_the_section(handler_cls):
+    renderer = AsyncMock()
+    renderer.render.return_value = MagicMock(content="FROZEN SURFACE")
+
+    out = await handler_cls()._frozen_surface_section(
+        renderer, {"frozen_surface_index": "- `backend/models.py` — defines RunEvent(id)"}
+    )
+
+    assert out == "FROZEN SURFACE"
+    renderer.render.assert_awaited_once_with(
+        "request.plan_frozen_surface_appendix",
+        {"frozen_surface_index": "- `backend/models.py` — defines RunEvent(id)"},
+    )
+
+
+async def test_strategy_proposer_does_not_render_it():
+    """Strategy proposes guidance, not build tasks — it authors no checks."""
+    renderer = AsyncMock()
+
+    out = await StrategyProposePlanGuidanceHandler()._frozen_surface_section(
+        renderer, {"frozen_surface_index": "- `backend/models.py`"}
+    )
+
+    assert out == ""
+    renderer.render.assert_not_awaited()
+
+
+async def test_absent_index_renders_nothing():
+    renderer = AsyncMock()
+
+    out = await DevelopmentProposePlanTasksHandler()._frozen_surface_section(renderer, {})
+
+    assert out == ""
+    renderer.render.assert_not_awaited()
+
+
+# --- the real asset ------------------------------------------------------------ #
+
+
+async def test_real_asset_renders_the_declarations_into_the_prompt():
+    """A live render — the facts must survive the template, not just the function."""
+    from adapters.prompts.filesystem_asset_adapter import FilesystemPromptAssetAdapter
+    from squadops.prompts.renderer import RequestTemplateRenderer
+
+    templates_dir = _MANIFEST_PATH.parents[2] / "src" / "squadops" / "prompts" / "request_templates"
+    renderer = RequestTemplateRenderer(
+        FilesystemPromptAssetAdapter(
+            fragments_path=templates_dir.parent / "fragments",
+            templates_path=templates_dir,
+        )
+    )
+
+    inputs: dict = {}
+    _inject_contract_inputs(inputs, _contract(), "development.propose_plan_tasks", _manifest())
+    section = await DevelopmentProposePlanTasksHandler()._frozen_surface_section(renderer, inputs)
+
+    # the two facts pf-42 invented
+    assert "RunEvent(id, title, datetime, location" in section
+    assert "`.routes`" in section
+    # and the rule that makes them matter
+    assert "frozen" in section.lower()
+    assert "expected_artifacts" in section


### PR DESCRIPTION
Companion to #612. That one proves a frozen-file check can pass before the run is
dispatched; this one means the author never had to guess in the first place.

## The root cause, which is narrower than "the model got it wrong"

Here is the **entire** file index a bind-mode plan author receives today:

```
- backend/routes.py: bind vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles
- frontend/src/views/RunsListView.jsx:  contract-owned (no per-file typed criteria)
- frontend/src/views/CreateRunView.jsx: contract-owned (no per-file typed criteria)
- frontend/src/views/RunDetailView.jsx: contract-owned (no per-file typed criteria)
```

Four fill slots. The group_run skeleton has **seventeen** files — the other thirteen are
frozen, and not one of them appears anywhere in the authoring prompt.

So pf-42's author wrote `field_present` on `backend/models.py` — a file it had never been
told exists, let alone what it declares. It guessed `meeting_location` because guessing
was the only move available. Same for `import_present` on `backend.routes` against a
module that writes `from .routes`.

There is a second edge: the existing appendix *does* say "do not author typed checks for
a **covered** file". But covered means the four fill slots. Frozen files aren't covered,
so that instruction never reached the files that caused this. **The rule was scoped to
the wrong surface.**

## What the author now sees

```
- `backend/main.py` — functions health; imports `.errors`, `.routes`, `fastapi`, ...
- `backend/models.py` — defines Participant(id, name), RunEvent(id, title, datetime,
  location, distance, pace_target, route_notes, participants), RunEventCreate(...),
  ParticipantName(name); imports `pydantic`
- `backend/errors.py` — defines ApiError; functions register_error_handlers; ...
- `conftest.py` — functions client; imports `backend.main`, `fastapi.testclient`, ...
- `frontend/vite.config.js`
...
```

Both pf-42 defects are answered on their face: `RunEvent` lists `location` and no
`meeting_location`; `main.py` imports `` `.routes` `` and not `backend.routes`. Imports
render **as written**, which is the point — the relative form is what makes the mismatch
visible.

Plus the rule, in the managed asset: don't assign a frozen file as `expected_artifacts`,
and don't write a check against one unless the index proves it passes — because a check
on a frozen file either can't fail (verifies nothing) or can't pass (kills the plan).

## Derived, not described

The index is produced by parsing the **expanded skeleton itself**. Nothing is
hand-maintained, so it cannot drift: change a template and the index changes with it.
There's a test that pins exactly this by swapping the expander and asserting the index
follows.

## Shape

Mirrors the bind-criteria section it sits beside, so there's no new pattern to learn:

- executor injects **data only**; instruction prose lives in a managed prompt asset (#448)
- bind mode only, dev/qa proposers only (strategy proposes guidance, authors no checks)
- author mode and non-scaffold stacks render **byte-identically** to today

One deliberate deviation worth review: the manifest is read from the **operator-seeded**
rail rather than `_load_interface_manifest_for_run`, which returns `None` for framing runs
by design (#496) — and framing is exactly when the plan is authored. #496 exists so a
framing run does not expand or carry skeleton *files*; describing the interface in a
prompt materializes nothing, so this stays inside that rule. Flagging it explicitly
because it looks like a bypass at a glance.

## Verification

- 17 new tests: the index answers both pf-42 questions, tracks the expander rather than a
  hand-written description, covers every frozen file and no fill slot, and degrades
  cleanly (no manifest, non-Python files, unparseable source).
- A **live render** of the real managed asset, asserting the field names and relative
  imports actually survive into the prompt — not just that the function returns them.
- Regression **5610 passed**, 1 skipped. ruff clean.
- Contract gates in-container: **lint GREEN, bare-skeleton 6/6, reference-fill 6/6**.
- **Contract emission unchanged** — `content_hash` still `26503867…`, so the seeded v6
  contract stays valid and **no re-seed** is needed before pf-43.

## What this does not do

It cannot guarantee the author reads the index — that's only knowable from a live framing
run, which is exactly why #612 exists as the deterministic backstop. Supply the fact,
verify the result; neither half replaces the other.
