### PR TITLE
fix(scaffold): name a frozen module's state, not only its functions

### DIFF
--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -546,6 +546,18 @@ def _python_surface(source: str) -> str:
         for node in tree.body
         if isinstance(node, ast.ClassDef)
     ]
+    # Module-level state is the whole public API of some frozen modules, and omitting it
+    # is how pf-43 died: `store.py` is two annotated dicts plus `reset()`, so an index
+    # listing only functions read as "an empty stub", and the plan author wrote a task to
+    # build the store it already had — five typed checks against a file no agent may
+    # change. A name the author cannot see is a name it will invent.
+    state = [
+        f"{stmt.target.id}: {ast.unparse(stmt.annotation)}"
+        for stmt in tree.body
+        if isinstance(stmt, ast.AnnAssign)
+        and isinstance(stmt.target, ast.Name)
+        and not stmt.target.id.startswith("_")
+    ]
     functions = [
         node.name
         for node in tree.body
@@ -557,6 +569,8 @@ def _python_surface(source: str) -> str:
     parts = []
     if classes:
         parts.append("defines " + ", ".join(classes))
+    if state:
+        parts.append("module state " + ", ".join(state))
     if functions:
         parts.append("functions " + ", ".join(functions))
     if modules:

--- a/tests/unit/capabilities/test_frozen_surface_index.py
+++ b/tests/unit/capabilities/test_frozen_surface_index.py
@@ -115,3 +115,22 @@ def test_unparseable_python_degrades_to_a_bare_path(monkeypatch):
         sc, "expand", lambda _m: [{"name": "backend/broken.py", "content": "def (:\n"}]
     )
     assert frozen_surface_index_lines(_manifest()) == ["- `backend/broken.py`"]
+
+
+def test_module_state_is_named_so_a_data_module_does_not_read_as_a_stub():
+    """pf-43: store.py is two annotated dicts plus reset(). An index listing only
+    functions read as an empty stub, so the plan author wrote a task to build the store
+    it already had — five typed checks against a file no agent may change."""
+    line = _line_for("backend/store.py")
+
+    assert "participant_store: dict[str, Participant]" in line
+    assert "run_event_store: dict[str, RunEvent]" in line
+    # the function is still named; state does not displace it
+    assert "reset" in line
+
+
+def test_private_module_state_is_omitted():
+    import squadops.capabilities.scaffold as sc
+
+    src = "public: int = 1\n_private: int = 2\n"
+    assert sc._python_surface(src) == "module state public: int"


### PR DESCRIPTION
Follow-up to #613, found by its first live roll.

## What happened on pf-43

The plan authored **five** `function_defined` checks on `backend/store.py` —
`create_run`, `list_runs`, `get_run`, `join_run`, `leave_run` — against a frozen file
that defines none of them. #612 rejected the plan at the gate, correctly, **45 minutes in
rather than three hours**. That part worked.

But the reason the author wrote them is a gap in the index #613 added.

## The gap

`store.py` is a data module:

```python
participant_store: dict[str, Participant] = {}
run_event_store: dict[str, RunEvent] = {}

def reset() -> None: ...
```

The index rendered classes, functions and imports — **not module-level assignments**. So
the author saw:

```
- `backend/store.py` — functions reset; imports `.models`
```

…and reasonably concluded the store was an unimplemented stub. Its entire public surface
was invisible, so it planned a task to build the API the file already had.

This is #613's own failure mode one level down: **a name the author cannot see is a name
it will invent.** Showing a partial interface is not much better than showing none — it
actively implies the rest is missing.

## After

```
- `backend/store.py` — module state participant_store: dict[str, Participant],
  run_event_store: dict[str, RunEvent]; functions reset; imports `.models`
```

Which is what the file is: two named dicts to fill route bodies against, plus a test-reset
seam. Private names (leading underscore) stay out — not the author's to reference.

## Verification

- Two new tests: the store line names both dicts with their types and still names `reset`;
  private module state is omitted.
- Regression **5612 passed**, 1 skipped. ruff clean.
- Contract emission untouched by this change (index is prompt-side only) — **no re-seed**.

## Not fixed here

pf-43 also exposed why the framing re-roll never fires: the re-roll's first act is
`cancel_run()`, but the framing run is already `COMPLETED` when the gate evaluates, and
`COMPLETED → CANCELLED` is an illegal transition. That is a separate fix and gets its own
PR — worth noting because without it, a rejection still ends the cycle rather than
re-rolling.
