### PR TITLE
fix(cycles): let the framing re-roll supersede a completed run (#522 never fired live)

### DIFF
--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -17,13 +17,18 @@ from squadops.api.routes.cycles.dtos import (
 from squadops.api.routes.cycles.errors import handle_cycle_error
 from squadops.api.routes.cycles.mapping import compute_workload_progress, run_to_response
 from squadops.auth.models import Scope
-from squadops.cycles.lifecycle import compute_config_hash, resolve_cycle_status
+from squadops.cycles.lifecycle import (
+    TERMINAL_STATES,
+    compute_config_hash,
+    resolve_cycle_status,
+)
 from squadops.cycles.models import (
     Cycle,
     CycleError,
     CycleStatus,
     GateDecision,
     GateDecisionValue,
+    IllegalStateTransitionError,
     Run,
     RunStatus,
     RunTerminalError,
@@ -169,6 +174,16 @@ async def cancel_run(project_id: str, cycle_id: str, run_id: str):
 
     try:
         registry = get_cycle_registry()
+        # The run state machine gained a COMPLETED -> CANCELLED edge so the executor can
+        # supersede a framing run whose plan was auto-rejected (#522). That edge is for
+        # the orchestrator, not for operators: cancelling a run that already finished is
+        # not a cancel, it is a rewrite of what happened. Refuse it here so this surface
+        # behaves exactly as it did before that edge existed.
+        existing = await registry.get_run(run_id)
+        if RunStatus(existing.status) in TERMINAL_STATES:
+            raise IllegalStateTransitionError(
+                f"Cannot transition Run from '{existing.status}' to 'cancelled'"
+            )
         await registry.cancel_run(run_id)
 
         # #77: stop the orphaned Prefect flow run for this run.

--- a/src/squadops/cycles/lifecycle.py
+++ b/src/squadops/cycles/lifecycle.py
@@ -32,6 +32,16 @@ _RUN_TRANSITIONS: list[tuple[str, RunStatus, RunStatus]] = [
     ("cancel", RunStatus.RUNNING, RunStatus.CANCELLED),
     ("cancel", RunStatus.PAUSED, RunStatus.CANCELLED),
     ("resume_from_failed", RunStatus.FAILED, RunStatus.RUNNING),
+    # #522 / pf-43: a framing run whose inter-workload gate is REJECTED by system plan
+    # validation is superseded by its re-roll. Inter-workload gates are decided on
+    # COMPLETED runs by design (SIP-0083 D15 — see GATE_REJECTED_STATES below, which
+    # excludes COMPLETED for exactly that reason), so by the time the rejection is
+    # recorded the run is already terminal. The re-roll cancels it to keep the positional
+    # run<->workload invariant (#257/D14: exactly one non-cancelled run per position) —
+    # and without this edge that cancel raised IllegalStateTransitionError, killing the
+    # re-roll before it created the replacement run. That is why #522 passed its harness
+    # (which drives a still-RUNNING run) and never once fired live.
+    ("supersede", RunStatus.COMPLETED, RunStatus.CANCELLED),
 ]
 
 # Derived lookup: source → set of valid destinations

--- a/tests/unit/cycles/test_framing_reroll_supersede.py
+++ b/tests/unit/cycles/test_framing_reroll_supersede.py
@@ -1,0 +1,60 @@
+"""Framing re-roll supersedes a COMPLETED run (#522, root-caused on pf-43).
+
+#522 gave a system plan-validation rejection a bounded framing re-roll instead of killing
+the cycle. It passed its harness and **never once fired live**. pf-43 showed why: the
+re-roll's first act is ``cancel_run`` on the superseded framing run, but inter-workload
+gates are decided on COMPLETED runs by design (SIP-0083 D15 — ``GATE_REJECTED_STATES``
+excludes COMPLETED for exactly that reason). So the run is already terminal when the
+rejection lands, ``COMPLETED -> CANCELLED`` was not a legal transition, and the raise
+killed the re-roll before it created the replacement run.
+
+Observed on pf-43 (``cyc_e83829c268a6``): framing finished 16:47:10.65, the REJECTED gate
+decision was recorded 16:47:10.73, and then nothing — no re-roll log, no WORKLOAD_ADVANCED
+event, no second run, and a cycle that simply stopped with two of its two re-rolls unused.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.lifecycle import TERMINAL_STATES, validate_run_transition
+from squadops.cycles.models import IllegalStateTransitionError, RunStatus
+
+pytestmark = [pytest.mark.domain_cycles]
+
+
+def test_completed_run_can_be_superseded():
+    """The exact transition the re-roll needs, and the one pf-43 died on."""
+    validate_run_transition(RunStatus.COMPLETED, RunStatus.CANCELLED)
+
+
+def test_a_gate_rejection_lands_on_a_completed_run():
+    """Pins the premise: if COMPLETED ever became gate-rejecting, the edge is moot."""
+    from squadops.cycles.lifecycle import GATE_REJECTED_STATES
+
+    assert RunStatus.COMPLETED not in GATE_REJECTED_STATES
+    assert RunStatus.COMPLETED in TERMINAL_STATES
+
+
+@pytest.mark.parametrize(
+    "source",
+    [RunStatus.CANCELLED, RunStatus.FAILED],
+)
+def test_other_terminal_states_still_cannot_be_cancelled(source):
+    """Only COMPLETED gains the edge — this is a supersede, not a general unlock."""
+    with pytest.raises(IllegalStateTransitionError):
+        validate_run_transition(source, RunStatus.CANCELLED)
+
+
+def test_completed_still_cannot_go_anywhere_else():
+    for dest in (RunStatus.RUNNING, RunStatus.PAUSED, RunStatus.QUEUED, RunStatus.COMPLETED):
+        with pytest.raises(IllegalStateTransitionError):
+            validate_run_transition(RunStatus.COMPLETED, dest)
+
+
+def test_the_pf43_sequence_now_completes():
+    """Replay of the real state sequence: run completes, gate rejects, re-roll supersedes."""
+    validate_run_transition(RunStatus.QUEUED, RunStatus.RUNNING)
+    validate_run_transition(RunStatus.RUNNING, RunStatus.COMPLETED)
+    # the gate decision is recorded here (COMPLETED is not gate-rejecting)
+    validate_run_transition(RunStatus.COMPLETED, RunStatus.CANCELLED)

--- a/tests/unit/cycles/test_lifecycle.py
+++ b/tests/unit/cycles/test_lifecycle.py
@@ -84,9 +84,16 @@ class TestValidateRunTransition:
         with pytest.raises(IllegalStateTransitionError):
             validate_run_transition(RunStatus.COMPLETED, RunStatus.FAILED)
 
-    def test_completed_to_cancelled_illegal(self):
-        with pytest.raises(IllegalStateTransitionError):
-            validate_run_transition(RunStatus.COMPLETED, RunStatus.CANCELLED)
+    def test_completed_to_cancelled_legal_as_supersede(self):
+        """#522 / pf-43: REVERSES the prior assertion that this was illegal.
+
+        Inter-workload gates are decided on COMPLETED runs by design (SIP-0083 D15), so a
+        framing run whose plan is auto-rejected is already terminal when its re-roll needs
+        to supersede it. With no edge, the re-roll's cancel raised and killed the re-roll
+        — which is why #522 passed its harness and never fired live. The edge is named
+        ``supersede``; operator-facing cancel refuses terminal runs at the API boundary.
+        """
+        validate_run_transition(RunStatus.COMPLETED, RunStatus.CANCELLED)
 
     def test_failed_to_running_legal(self):
         """SIP-0079: resume_from_failed allows FAILED → RUNNING."""
@@ -144,12 +151,20 @@ class TestValidateRunTransition:
             {RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELLED}
         )
 
-    def test_completed_and_cancelled_reject_all_targets(self):
-        """COMPLETED and CANCELLED have no outgoing transitions."""
-        for terminal in (RunStatus.COMPLETED, RunStatus.CANCELLED):
-            for target in RunStatus:
+    def test_cancelled_rejects_all_targets(self):
+        """CANCELLED has no outgoing transitions."""
+        for target in RunStatus:
+            with pytest.raises(IllegalStateTransitionError):
+                validate_run_transition(RunStatus.CANCELLED, target)
+
+    def test_completed_rejects_all_targets_except_supersede(self):
+        """COMPLETED gained exactly one outgoing edge (#522), and no more."""
+        for target in RunStatus:
+            if target == RunStatus.CANCELLED:
+                validate_run_transition(RunStatus.COMPLETED, RunStatus.CANCELLED)  # legal
+            else:
                 with pytest.raises(IllegalStateTransitionError):
-                    validate_run_transition(terminal, target)
+                    validate_run_transition(RunStatus.COMPLETED, target)
 
     def test_failed_rejects_all_except_running(self):
         """FAILED only allows resume_from_failed → RUNNING (SIP-0079)."""


### PR DESCRIPTION
Root-causes why the #522 framing re-roll **has never fired in production**, using the
deterministic repro that #612 handed us.

## The bug, in one sentence

The re-roll's first act is `cancel_run()` on the superseded framing run — but
inter-workload gates are decided on **COMPLETED** runs by design, and
`COMPLETED -> CANCELLED` was not a legal transition, so the cancel raised and killed the
re-roll before it created the replacement run.

`lifecycle.py` says the quiet part out loud, two lines below the transition table:

```python
# States that reject gate decisions — COMPLETED is intentionally excluded
# because inter-workload gates are decided on completed runs (SIP-0083 D15).
GATE_REJECTED_STATES = frozenset({RunStatus.FAILED, RunStatus.CANCELLED})
```

So the run is *always* terminal when a plan rejection lands. The re-roll could never have
worked live. It passes its harness because the harness drives a still-RUNNING run, where
the cancel is legal — a textbook harness-vs-live divergence.

## Evidence from pf-43 (`cyc_e83829c268a6`)

| time | event |
|---|---|
| 16:47:10.65 | framing run finishes → `completed` |
| 16:47:10.73 | REJECTED gate decision recorded by `system:plan_validation` |
| — | no re-roll log, no `WORKLOAD_ADVANCED` event, no second run |

`framing_max_rerolls` was 2 and zero were used. The guard's conditions were all
satisfiable — I confirmed `workload_entry["type"] == "framing"` straight from the cycle
row and that the re-roll branch is present in the **loaded** executor code, not just on
disk — so the failure had to be inside the branch. It was the first statement in it.

## The fix

One named edge: `("supersede", COMPLETED, CANCELLED)`.

Cancelling the superseded run is what preserves the positional run↔workload invariant
(#257/D14: exactly one non-cancelled run per position), so the re-roll needs it; the state
machine simply didn't model a real thing that happens.

There is precedent in the same table — `resume_from_failed` already gives FAILED an
outgoing edge — so "terminal" was never absolute here.

## ⚠️ This reverses a deliberate prior boundary

Two tests asserted `COMPLETED -> CANCELLED` was illegal. **Flagging explicitly rather than
quietly editing them.** Both are re-expressed rather than deleted, and the remaining
boundary is pinned harder than before:

- COMPLETED now has **exactly one** outgoing edge and no more (parametrized over every
  status)
- CANCELLED still has **none**

If you'd rather model supersession as its own status than widen this edge, that's a
reasonable alternative and I'd take the note — it's a bigger change (DB enum, DTOs,
console) which is why I didn't reach for it.

## Operator-facing cancel is unchanged

The edge is for the orchestrator. Cancelling a run that already finished is not a cancel,
it's a rewrite of what happened. The API cancel route now refuses terminal runs
explicitly, so `squadops runs cancel` on a completed run still returns the same conflict
it does today.

## Verification

- 6 new tests, including a replay of pf-43's exact state sequence (queued → running →
  completed → gate rejection → supersede).
- The two reversed assertions re-expressed, plus the "exactly one edge" pin.
- Regression **5617 passed**, 1 skipped. ruff clean.

## Why it matters now

Without this, #612 converts a three-hour loss into a 45-minute loss but the cycle still
dies. With it, a rejected plan re-rolls framing up to `framing_max_rerolls` times and the
cycle continues — which is what #522 intended and what the measurement rolls need.
