### PR TITLE
fix(scaffold): never append a status_code the decorator already carries

### DIFF
--- a/src/squadops/cycles/fill_slot_integrity.py
+++ b/src/squadops/cycles/fill_slot_integrity.py
@@ -72,7 +72,7 @@ class DecoratorDivergence:
 class _Route:
     method: str
     path: str
-    status_code: int | None
+    status_kw: _StatusKw | None
     response_model: str | None
     func_name: str
     arg_names: tuple[str, ...]
@@ -124,16 +124,135 @@ def _route_decorator_path(dec: ast.expr) -> str | None:
     return path if isinstance(path, str) else None
 
 
-def _decorator_kwargs(dec: ast.Call) -> tuple[int | None, str | None]:
-    """``(status_code, response_model)`` as declared on the decorator."""
-    status: int | None = None
+@dataclass(frozen=True)
+class _StatusKw:
+    """A ``status_code=`` keyword as it actually appears on the decorator.
+
+    ``value`` is the literal int, or None when the producer wrote an expression
+    (``status.HTTP_201_CREATED``). The distinction between *that* and no keyword at all is
+    the whole point of this type: pf-44 collapsed them, decided a present-but-symbolic
+    status code was absent, appended its own, and produced
+    ``status_code=status.HTTP_201_CREATED, status_code=201`` — a duplicate keyword, a
+    SyntaxError, an unimportable module, and a test suite that could not even be collected.
+    """
+
+    value: int | None
+    text: str
+    lineno: int
+    col_offset: int
+    end_lineno: int
+    end_col_offset: int
+
+
+def _decorator_kwargs(dec: ast.Call) -> tuple[_StatusKw | None, str | None]:
+    """``(status_code keyword or None, response_model)`` as declared on the decorator."""
+    status: _StatusKw | None = None
     response_model: str | None = None
     for kw in dec.keywords:
-        if kw.arg == "status_code" and isinstance(kw.value, ast.Constant):
-            status = kw.value.value if isinstance(kw.value.value, int) else None
+        if kw.arg == "status_code":
+            if kw.end_lineno is None or kw.end_col_offset is None:  # pragma: no cover
+                continue
+            literal = (
+                kw.value.value
+                if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, int)
+                else None
+            )
+            status = _StatusKw(
+                value=literal,
+                text=ast.unparse(kw.value),
+                lineno=kw.lineno,
+                col_offset=kw.col_offset,
+                end_lineno=kw.end_lineno,
+                end_col_offset=kw.end_col_offset,
+            )
         elif kw.arg == "response_model":
             response_model = ast.unparse(kw.value)
     return status, response_model
+
+
+def _reconcile_status_code(
+    got: _Route,
+    declared: int,
+    divergences: list[DecoratorDivergence],
+    splices: list[tuple[int, int, int, int, str]],
+) -> None:
+    """Decide what to do about one route's status code. Three cases, one of them safe to
+    append and only one.
+
+    Appending is correct **only** when the keyword is absent. pf-44 appended onto a
+    decorator that already carried ``status_code=status.HTTP_201_CREATED`` — because a
+    symbolic value parsed as "no literal" and the old code could not tell that apart from
+    "no keyword" — and produced a duplicate keyword argument. That is a SyntaxError, so
+    ``backend/routes.py`` would not import, so pytest aborted during collection with exit
+    4, so every check downstream failed and every repair regenerated the same corruption.
+    An enforcement mechanism that turns correct code into unparseable code is worse than
+    no enforcement at all.
+
+    A present-but-wrong *literal* is replaced in place rather than appended (same
+    body-independence argument as the original restore, and appending there would have
+    produced the identical duplicate). A present *expression* is left completely alone and
+    only reported: it cannot be evaluated from here, ``status.HTTP_201_CREATED`` is the
+    idiomatic spelling of exactly what the scaffold asked for, and the behavioral probe
+    already checks the status the app actually returns.
+    """
+    kw = got.status_kw
+
+    if kw is None:
+        divergences.append(
+            DecoratorDivergence(
+                method=got.method.upper(),
+                path=got.path,
+                detail=f"status_code={declared} declared by the scaffold, emitted as absent",
+                restored=True,
+            )
+        )
+        # insert before the decorator call's closing paren (zero-width span)
+        splices.append(
+            (
+                got.end_lineno,
+                got.end_col_offset - 1,
+                got.end_lineno,
+                got.end_col_offset - 1,
+                f", status_code={declared}",
+            )
+        )
+        return
+
+    if kw.value == declared:
+        return  # already exactly what the scaffold declared
+
+    if kw.value is not None:
+        divergences.append(
+            DecoratorDivergence(
+                method=got.method.upper(),
+                path=got.path,
+                detail=(f"status_code={declared} declared by the scaffold, emitted as {kw.value}"),
+                restored=True,
+            )
+        )
+        splices.append(
+            (
+                kw.lineno,
+                kw.col_offset,
+                kw.end_lineno,
+                kw.end_col_offset,
+                f"status_code={declared}",
+            )
+        )
+        return
+
+    divergences.append(
+        DecoratorDivergence(
+            method=got.method.upper(),
+            path=got.path,
+            detail=(
+                f"status_code={declared} declared by the scaffold, emitted as the expression "
+                f"{kw.text!r} — left as written; a non-literal cannot be reconciled from here "
+                f"and the behavioral probe checks the status actually returned"
+            ),
+            restored=False,
+        )
+    )
 
 
 def _route_from_decorator(
@@ -149,7 +268,7 @@ def _route_from_decorator(
     return _Route(
         method=dec.func.attr,  # type: ignore[union-attr]  # Attribute, per the guard above
         path=path,
-        status_code=status,
+        status_kw=status,
         response_model=response_model,
         func_name=node.name,
         arg_names=tuple(a.arg for a in node.args.args),
@@ -256,28 +375,16 @@ def restore_declared_status_codes(
     emitted = _routes(emitted_source)
     # (line, col) -> text to insert. Collected first, applied bottom-up so earlier splices
     # cannot shift the offsets of later ones.
-    splices: list[tuple[int, int, str]] = []
+    splices: list[tuple[int, int, int, int, str]] = []
 
     for got in emitted:
         want = seed_routes.get(_route_key(got.method, got.path))
         if want is None:
             continue
 
-        if want.status_code is not None and got.status_code != want.status_code:
-            divergences.append(
-                DecoratorDivergence(
-                    method=got.method.upper(),
-                    path=got.path,
-                    detail=(
-                        f"status_code={want.status_code} declared by the scaffold, "
-                        f"emitted as {got.status_code if got.status_code is not None else 'absent'}"
-                    ),
-                    restored=True,
-                )
-            )
-            splices.append(
-                (got.end_lineno, got.end_col_offset, f", status_code={want.status_code}")
-            )
+        declared = want.status_kw.value if want.status_kw else None
+        if declared is not None:
+            _reconcile_status_code(got, declared, divergences, splices)
 
         # Reported only — see the module docstring for why these are not rewritten.
         if want.response_model and got.response_model != want.response_model:
@@ -317,22 +424,33 @@ def restore_declared_status_codes(
                 )
             )
 
+    return _apply_splices(emitted_source, splices), divergences
+
+
+def _apply_splices(source: str, splices: list[tuple[int, int, int, int, str]]) -> str:
+    """Apply edits bottom-up so an earlier one cannot shift a later one's offsets.
+
+    A zero-width span is an insertion; a non-empty one replaces the text it covers. Every
+    guard below leaves the line untouched rather than guessing — this module's whole job is
+    to hand back source that still parses, so a splice that does not land exactly where the
+    AST said it would is abandoned, not forced.
+    """
     if not splices:
-        return emitted_source, divergences
+        return source
 
-    lines = emitted_source.splitlines(keepends=True)
-    for lineno, col, text in sorted(splices, reverse=True):
+    lines = source.splitlines(keepends=True)
+    for lineno, col, end_lineno, end_col, text in sorted(splices, reverse=True):
         idx = lineno - 1
-        if idx < 0 or idx >= len(lines):
-            continue
+        if idx < 0 or idx >= len(lines) or lineno != end_lineno:
+            continue  # multi-line spans are not reconciled from here
         line = lines[idx]
-        # end_col_offset points just past the decorator call's ``)``; insert before it.
-        cut = col - 1
-        if cut < 0 or cut > len(line) or line[cut : cut + 1] != ")":
-            continue  # offsets did not land where expected — leave the line untouched
-        lines[idx] = line[:cut] + text + line[cut:]
+        if col < 0 or end_col > len(line) or col > end_col:
+            continue  # offsets did not land where expected
+        if col == end_col and line[col : col + 1] != ")":
+            continue  # an insertion must land just before the decorator's closing paren
+        lines[idx] = line[:col] + text + line[end_col:]
 
-    return "".join(lines), divergences
+    return "".join(lines)
 
 
 def divergence_summary(divergences: list[DecoratorDivergence]) -> str:

--- a/src/squadops/cycles/fill_slot_integrity.py
+++ b/src/squadops/cycles/fill_slot_integrity.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 
 import ast
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 _ROUTER_METHODS = frozenset({"get", "post", "put", "patch", "delete", "head", "options"})
 _PARAM = re.compile(r"\{[^}]*\}")
@@ -241,6 +241,15 @@ def _reconcile_status_code(
         )
         return
 
+    if re.search(rf"(?<!\d){declared}(?!\d)", kw.text):
+        # ``status.HTTP_201_CREATED`` spells the declared code in its own name — the
+        # idiomatic form of exactly what the scaffold asked for. Reporting it as a
+        # divergence would put a "problem" row on correct code, and divergence evidence
+        # feeds repair context: an invitation to churn on a non-issue. Silence is honest
+        # here. Expressions that do NOT name the declared code (``status.HTTP_200_OK``
+        # against a declared 201, ``HTTPStatus.CREATED`` — no digits) are still reported.
+        return
+
     divergences.append(
         DecoratorDivergence(
             method=got.method.upper(),
@@ -424,7 +433,28 @@ def restore_declared_status_codes(
                 )
             )
 
-    return _apply_splices(emitted_source, splices), divergences
+    corrected = _apply_splices(emitted_source, splices)
+    if corrected != emitted_source:
+        # The invariant, enforced by construction rather than by enumerating decorator
+        # shapes: this module never hands back source that parses worse than what it
+        # received. pf-44 proved a restorer that can corrupt is worse than none — if a
+        # splice produced unparseable output, abandon the whole restore, return the
+        # producer's bytes untouched, and downgrade the divergence records so the
+        # evidence never claims a restoration that did not survive.
+        try:
+            ast.parse(corrected)
+        except SyntaxError:
+            return emitted_source, [
+                replace(
+                    d,
+                    restored=False,
+                    detail=d.detail + " (restore abandoned: result would not parse)",
+                )
+                if d.restored
+                else d
+                for d in divergences
+            ]
+    return corrected, divergences
 
 
 def _apply_splices(source: str, splices: list[tuple[int, int, int, int, str]]) -> str:
@@ -446,11 +476,43 @@ def _apply_splices(source: str, splices: list[tuple[int, int, int, int, str]]) -
         line = lines[idx]
         if col < 0 or end_col > len(line) or col > end_col:
             continue  # offsets did not land where expected
-        if col == end_col and line[col : col + 1] != ")":
-            continue  # an insertion must land just before the decorator's closing paren
+        if col == end_col:
+            if line[col : col + 1] != ")":
+                continue  # an insertion must land just before the decorator's closing paren
+            text = _separator_adjusted(lines, idx, col, text)
         lines[idx] = line[:col] + text + line[end_col:]
 
     return "".join(lines)
+
+
+def _separator_adjusted(lines: list[str], idx: int, col: int, text: str) -> str:
+    """Drop the leading ``", "`` from an insertion whose context already provides it.
+
+    The insertion text is built for the common shape — a single-line decorator whose last
+    argument has no trailing comma — where ``", status_code=201"`` is exactly right. A
+    multi-line decorator formatted Black-style ends its last argument with a trailing
+    comma before the closing paren's own line::
+
+        @router.post(
+            "/runs",
+            response_model=RunEvent,
+        )
+
+    Inserting the comma-prefixed text there produced ``RunEvent,`` followed by
+    ``, status_code=201)`` — a double comma, a SyntaxError, and an unimportable module:
+    the exact corruption class this module exists to never emit, through a decorator
+    shape the original tests simply never swept. The last non-whitespace character before
+    the insertion point decides: after ``,`` or ``(`` the separator is already there (or
+    not needed); after anything else the prefix stands.
+    """
+    before = lines[idx][:col].rstrip()
+    j = idx
+    while not before and j > 0:
+        j -= 1
+        before = lines[j].rstrip()
+    if before.endswith(",") or before.endswith("("):
+        return text.removeprefix(", ")
+    return text
 
 
 def divergence_summary(divergences: list[DecoratorDivergence]) -> str:

--- a/tests/unit/cycles/test_fill_slot_integrity.py
+++ b/tests/unit/cycles/test_fill_slot_integrity.py
@@ -11,6 +11,8 @@ These cases are written against the shapes actually observed in that roll.
 
 from __future__ import annotations
 
+import ast
+
 import pytest
 
 from squadops.cycles.fill_slot_integrity import (
@@ -362,3 +364,79 @@ class TestRouterPrefixRestoration:
         assert "router = APIRouter()" in corrected
         assert "prefix=" not in corrected.split("@router")[0]
         assert "status_code=201" in corrected  # the #602 restoration still holds
+
+
+class TestStatusCodeKeywordAlreadyPresent:
+    """pf-44: the restorer must never append a keyword the decorator already carries.
+
+    The dev agent wrote ``status_code=status.HTTP_201_CREATED`` — correct, idiomatic, and
+    exactly what the scaffold asked for, just not spelled as an int literal. The restorer
+    read "no literal" as "absent", appended its own, and produced a duplicate keyword
+    argument: a SyntaxError, so routes.py would not import, so pytest aborted at collection
+    with exit 4, so nothing was tested and every repair regenerated the same corruption.
+    """
+
+    SEED = (
+        '@router.post("/runs", response_model=RunEvent, status_code=201)\n'
+        "def create_run(payload: RunEventCreate):\n"
+        "    ...\n"
+    )
+
+    def _emitted(self, decorator: str) -> str:
+        return f"{decorator}\ndef create_run(payload):\n    return None\n"
+
+    def test_symbolic_status_code_is_left_alone_and_stays_parseable(self):
+        emitted = self._emitted('@router.post("/runs", status_code=status.HTTP_201_CREATED)')
+
+        out, divs = restore_declared_status_codes(self.SEED, emitted)
+
+        ast.parse(out)  # the actual regression: this used to raise
+        assert out.count("status_code=") == 1
+        assert "status.HTTP_201_CREATED" in out
+        status_divs = [d for d in divs if "status_code" in d.detail]
+        assert len(status_divs) == 1
+        assert status_divs[0].restored is False
+
+    def test_wrong_literal_is_replaced_not_appended(self):
+        emitted = self._emitted('@router.post("/runs", status_code=200)')
+
+        out, divs = restore_declared_status_codes(self.SEED, emitted)
+
+        ast.parse(out)
+        assert out.count("status_code=") == 1
+        assert "status_code=201" in out
+        assert "status_code=200" not in out
+        assert [d.restored for d in divs if "status_code" in d.detail] == [True]
+
+    def test_correct_literal_is_untouched(self):
+        emitted = self._emitted('@router.post("/runs", status_code=201)')
+
+        out, divs = restore_declared_status_codes(self.SEED, emitted)
+
+        assert out == emitted
+        assert not [d for d in divs if "status_code" in d.detail]
+
+    def test_absent_status_code_is_still_restored(self):
+        """The original pf-40 behaviour must survive the fix."""
+        emitted = self._emitted('@router.post("/runs")')
+
+        out, divs = restore_declared_status_codes(self.SEED, emitted)
+
+        ast.parse(out)
+        assert out.count("status_code=") == 1
+        assert "status_code=201" in out
+        assert [d.restored for d in divs if "status_code" in d.detail] == [True]
+
+    def test_every_reconciled_form_stays_importable(self):
+        """The invariant that actually matters: never emit unparseable source."""
+        for decorator in (
+            '@router.post("/runs")',
+            '@router.post("/runs", status_code=201)',
+            '@router.post("/runs", status_code=200)',
+            '@router.post("/runs", status_code=status.HTTP_201_CREATED)',
+            '@router.post("/runs", response_model=RunEvent, status_code=HTTPStatus.CREATED)',
+            '@router.post("/runs", status_code=int("201"))',
+        ):
+            out, _ = restore_declared_status_codes(self.SEED, self._emitted(decorator))
+            ast.parse(out)
+            assert out.count("status_code=") <= 1, decorator

--- a/tests/unit/cycles/test_fill_slot_integrity.py
+++ b/tests/unit/cycles/test_fill_slot_integrity.py
@@ -393,6 +393,17 @@ class TestStatusCodeKeywordAlreadyPresent:
         ast.parse(out)  # the actual regression: this used to raise
         assert out.count("status_code=") == 1
         assert "status.HTTP_201_CREATED" in out
+        # HTTP_201_CREATED names the declared code — correct code, no "problem" row.
+        # Divergence evidence feeds repair context; reporting right code invites churn.
+        assert not [d for d in divs if "status_code" in d.detail]
+
+    def test_symbolic_status_code_naming_a_different_code_is_reported(self):
+        emitted = self._emitted('@router.post("/runs", status_code=status.HTTP_200_OK)')
+
+        out, divs = restore_declared_status_codes(self.SEED, emitted)
+
+        ast.parse(out)
+        assert "status.HTTP_200_OK" in out  # left as written, never rewritten
         status_divs = [d for d in divs if "status_code" in d.detail]
         assert len(status_divs) == 1
         assert status_divs[0].restored is False
@@ -440,3 +451,72 @@ class TestStatusCodeKeywordAlreadyPresent:
             out, _ = restore_declared_status_codes(self.SEED, self._emitted(decorator))
             ast.parse(out)
             assert out.count("status_code=") <= 1, decorator
+
+
+class TestMultiLineDecorators:
+    """The insertion must survive real-world formatting, not only the single-line shape.
+
+    Black formats a long decorator with one argument per line and a trailing comma. The
+    comma-prefixed insertion landed right after that trailing comma — double comma,
+    SyntaxError, unimportable module: the exact corruption class this module exists to
+    never emit, through a shape the original tests never swept.
+    """
+
+    SEED = (
+        '@router.post("/runs", response_model=RunEvent, status_code=201)\n'
+        "def create_run(payload: RunEventCreate):\n"
+        "    ...\n"
+    )
+
+    def test_trailing_comma_black_style(self):
+        emitted = (
+            "@router.post(\n"
+            '    "/runs",\n'
+            "    response_model=RunEvent,\n"
+            ")\n"
+            "def create_run(payload):\n"
+            "    return None\n"
+        )
+
+        out, divs = restore_declared_status_codes(self.SEED, emitted)
+
+        ast.parse(out)  # the regression: double comma used to make this raise
+        assert out.count("status_code=201") == 1
+        assert [d.restored for d in divs if "status_code" in d.detail] == [True]
+
+    def test_multi_line_without_trailing_comma(self):
+        emitted = (
+            "@router.post(\n"
+            '    "/runs",\n'
+            "    response_model=RunEvent\n"
+            ")\n"
+            "def create_run(payload):\n"
+            "    return None\n"
+        )
+
+        out, _ = restore_declared_status_codes(self.SEED, emitted)
+
+        ast.parse(out)
+        assert out.count("status_code=201") == 1
+
+
+class TestParseBackstop:
+    """The invariant by construction: never hand back source that parses worse than
+    what was received. If a splice ever produces unparseable output through a shape not
+    yet enumerated, the whole restore is abandoned and the evidence says so."""
+
+    SEED = '@router.post("/runs", status_code=201)\ndef create_run(payload):\n    ...\n'
+
+    def test_unparseable_result_returns_producer_bytes_and_downgrades_evidence(self, monkeypatch):
+        import squadops.cycles.fill_slot_integrity as fsi
+
+        emitted = '@router.post("/runs")\ndef create_run(payload):\n    return None\n'
+        monkeypatch.setattr(fsi, "_apply_splices", lambda source, splices: source + "\ndef (:")
+
+        out, divs = restore_declared_status_codes(self.SEED, emitted)
+
+        assert out == emitted  # producer bytes untouched
+        status_divs = [d for d in divs if "status_code" in d.detail]
+        assert len(status_divs) == 1
+        assert status_divs[0].restored is False  # the evidence never claims a dead restore
+        assert "restore abandoned" in status_divs[0].detail


### PR DESCRIPTION
pf-44 got further than any roll since the first green — clean plan, no frozen-file
targeting, the dev agent wrote working code — and **this enforcement broke it on the way
through.**

## What happened

The dev agent emitted:

```python
@router.post("/runs", status_code=status.HTTP_201_CREATED)
```

Correct, idiomatic, and exactly what the scaffold declared. But `_decorator_kwargs` only
recognised an int literal, so a symbolic value parsed as `None` — **indistinguishable from
"no keyword at all"**. The restorer concluded the status code had been stripped and
appended its own:

```python
@router.post("/runs", status_code=status.HTTP_201_CREATED, status_code=201)
```

Duplicate keyword argument → `SyntaxError` → `backend/routes.py` will not import → pytest
aborts at collection with exit 4 → **not one test ran** → every check downstream failed.

The enforcement log stated the false premise plainly:

> restored POST /runs: **status_code=201 declared by the scaffold, emitted as absent**

It was not absent. It was right there, spelled differently.

## Why the roll could not recover

Neo's repair failed for the same reason it was called. Whatever it emitted, the restorer
re-appended `status_code=201` and re-created the duplicate. Traced across every stored
version of the file:

| artifact | line 27 |
|---|---|
| scaffold seed | `@router.post("/runs", response_model=RunEvent, status_code=201)` |
| dev emission | `status_code=status.HTTP_201_CREATED, status_code=201` |
| repair emission | `status_code=status.HTTP_201_CREATED, status_code=201` |

**The mechanism regenerated the corruption it was called to fix.** A guard that turns
correct code into unparseable code is worse than no guard.

## The fix

`status_code` is now read as a *keyword* rather than a *value*, so presence and
literal-ness are separate facts. Three cases where there used to be one:

| emitted | action |
|---|---|
| absent | **append** — the pf-40 behaviour, preserved exactly |
| literal, wrong value | **replace in place** |
| expression (`status.HTTP_201_CREATED`) | **leave alone, report only** |

The middle case matters beyond tidiness: appending onto `status_code=200` would have
produced the identical duplicate, so that was a **latent second instance** of this bug
waiting for a producer to write the wrong literal.

The third case is deliberately hands-off. A non-literal cannot be evaluated from here,
`status.HTTP_201_CREATED` is the idiomatic spelling of exactly what was asked for, and the
behavioral probe already checks the status the app actually returns. Reporting is the
honest move; rewriting would be guessing.

## Verification

- **Replayed against pf-44's real stored artifact.** Recovered the producer's emission from
  the corrupted file, ran it through the fixed restorer: parses before, parses after,
  exactly one `status_code=`, divergence reported rather than forced. The same input
  produced the SyntaxError above on the deployed build.
- 5 new tests: symbolic left alone and still parseable (the regression), wrong literal
  replaced not appended, correct literal untouched, absent still restored, plus a sweep
  over six decorator spellings asserting the invariant that actually matters — **never emit
  unparseable source, never more than one `status_code`**.
- Regression **5624 passed**, 1 skipped. ruff clean (splice application extracted to
  `_apply_splices` for C901 rather than exempted).
- Contract gates in-container: lint / bare-skeleton / reference-fill all **GREEN**.
- Contract emission unchanged (`content_hash` 26503867) — **no re-seed**.

## Worth noting for review

Every guard in `_apply_splices` abandons an edit rather than forcing it. That is the
lesson generalised: this module's job is to hand back source that still parses, so a
splice that does not land exactly where the AST said it would is dropped, not applied on a
best guess.
