### PR TITLE
fix(correction): a work_product rewind is escalated to patch (pf-45)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -716,13 +716,23 @@ class CorrectionRunner:
             decision_outputs.get("correction_path", "abort"),
             failure_evidence,
             cycle.applied_defaults,
+            # pf-45: the rewind anchor keys on the analyzer's classification — a
+            # work_product rewind dies as a run failure with the repair budget unspent,
+            # so the guard substitutes the patch the classification says is possible.
+            classification=str(analysis_outputs.get("classification", "")),
         )
         correction_path = resolution.path
         if resolution.overridden_from:
             logger.warning(
-                "correction_policy_override: %s -> patch (executed-failed required checks: %s)",
+                "correction_policy_override: %s -> %s (%s%s)",
                 resolution.overridden_from,
-                ", ".join(resolution.failed_required_checks),
+                resolution.path,
+                resolution.override_reason,
+                (
+                    "; checks: " + ", ".join(resolution.failed_required_checks)
+                    if resolution.failed_required_checks
+                    else ""
+                ),
             )
 
         # 5. Emit CORRECTION_DECIDED
@@ -733,7 +743,7 @@ class CorrectionRunner:
         if resolution.overridden_from:
             decided_payload["policy_override"] = {
                 "from": resolution.overridden_from,
-                "reason": "executed_failed_required_checks",
+                "reason": resolution.override_reason,
                 "checks": list(resolution.failed_required_checks),
             }
         self._event_bus.emit(

--- a/src/squadops/cycles/correction_policy.py
+++ b/src/squadops/cycles/correction_policy.py
@@ -1,4 +1,4 @@
-"""Deterministic correction-path policy (#447).
+"""Deterministic correction-path policy (#447, pf-45).
 
 The correction *decision* is LLM judgment; this layer bounds it with evidence
 the model cannot overrule. First anchor (#447): a ``continue`` that would
@@ -10,6 +10,19 @@ runner errors) are exempt: repairing correct code against harness config
 burns budget for nothing (the attempt-3.5 case, where ``continue`` was
 right). ``abort`` is never overridden — it is a deliberate hard stop.
 
+Second anchor (pf-45): a ``rewind`` on a **work_product** classification is
+escalated to ``patch`` while the chain's repair slot is unspent. Rewind is
+implemented as run death (the executor raises "Rewinding to checkpoint"),
+so accepting it discards every remaining correction attempt. On pf-45 the
+analyzer correctly diagnosed a one-token defect — ``pace`` for the frozen
+model's ``pace_target`` — squarely in a fill slot, exactly what the repair
+path exists for; the lead called it "systemic contract violations", chose
+rewind, and the run died with four of five attempts unused. A narrative
+escalation of severity cannot outvote a classification that says the code
+is reachable by a patch. Non-work_product classifications (environment,
+infrastructure, unknown) keep their rewind: patching correct code against
+a broken world is the opposite failure.
+
 This module is the intended home for the #435 convergence policy
 (signature strikes, progress requirement, artifact-delta guard).
 """
@@ -20,7 +33,11 @@ from dataclasses import dataclass, field
 from typing import Any
 
 #: Correction paths the guard may escalate. ``abort`` is deliberately absent.
-_ESCALATABLE_PATHS = frozenset({"continue"})
+_ESCALATABLE_PATHS = frozenset({"continue", "rewind"})
+
+#: ``data.analyze_failure``'s classification meaning "the defect is in emitted
+#: code" — the one classification whose rewind a patch can always substitute for.
+_WORK_PRODUCT_CLASSIFICATION = "work_product"
 
 
 @dataclass(frozen=True)
@@ -28,11 +45,13 @@ class CorrectionPathResolution:
     """The policy's final word on a correction path.
 
     ``overridden_from`` is set when the guard escalated the decision;
-    ``failed_required_checks`` carries the evidence that justified it.
+    ``override_reason`` names which anchor fired (event-payload vocabulary);
+    ``failed_required_checks`` carries the evidence when anchor 1 justified it.
     """
 
     path: str
     overridden_from: str | None = None
+    override_reason: str = ""
     failed_required_checks: tuple[str, ...] = field(default_factory=tuple)
 
 
@@ -66,6 +85,8 @@ def resolve_correction_path(
     decision_path: str,
     failure_evidence: dict[str, Any],
     applied_defaults: dict[str, Any],
+    *,
+    classification: str = "",
 ) -> CorrectionPathResolution:
     """Apply the deterministic guard to the LLM-chosen correction path.
 
@@ -74,11 +95,22 @@ def resolve_correction_path(
         failure_evidence: the payload handed to ``data.analyze_failure``
             (``build_failure_evidence`` shape).
         applied_defaults: the cycle's resolved defaults (``required_checks``).
+        classification: the analyzer's failure classification. Only consulted for
+            the rewind anchor; "" (older callers, missing analysis) never fires it.
 
     Returns:
         The path to act on, with override provenance when the guard fired.
     """
     if decision_path not in _ESCALATABLE_PATHS:
+        return CorrectionPathResolution(path=decision_path)
+
+    if decision_path == "rewind":
+        if classification == _WORK_PRODUCT_CLASSIFICATION:
+            return CorrectionPathResolution(
+                path="patch",
+                overridden_from="rewind",
+                override_reason="work_product_rewind_with_unspent_repair",
+            )
         return CorrectionPathResolution(path=decision_path)
 
     required = frozenset(applied_defaults.get("required_checks") or [])
@@ -92,5 +124,6 @@ def resolve_correction_path(
     return CorrectionPathResolution(
         path="patch",
         overridden_from=decision_path,
+        override_reason="executed_failed_required_checks",
         failed_required_checks=failed_required,
     )

--- a/tests/unit/cycles/test_correction_policy.py
+++ b/tests/unit/cycles/test_correction_policy.py
@@ -80,3 +80,53 @@ class TestResolveCorrectionPath:
         res = resolve_correction_path("continue", ev, DEFAULTS)
         assert res.path == "patch"
         assert res.failed_required_checks == ("tests_pass",)
+
+
+class TestRewindAnchor:
+    """pf-45: a work_product rewind is escalated to patch while the repair slot is unspent.
+
+    Rewind is implemented as run death, so accepting it discards every remaining
+    correction attempt. pf-45's analyzer correctly diagnosed a one-token fill-slot defect
+    (``pace`` for the frozen model's ``pace_target``); the lead called it "systemic
+    contract violations", chose rewind, and the run died with four of five attempts
+    unused — on the exact failure shape the repair path was built for.
+    """
+
+    def test_work_product_rewind_becomes_patch(self):
+        resolution = resolve_correction_path("rewind", {}, {}, classification="work_product")
+
+        assert resolution.path == "patch"
+        assert resolution.overridden_from == "rewind"
+        assert resolution.override_reason == "work_product_rewind_with_unspent_repair"
+        assert resolution.failed_required_checks == ()
+
+    @pytest.mark.parametrize("classification", ["environment", "infrastructure", "unknown", ""])
+    def test_non_work_product_rewind_stands(self, classification):
+        """Patching correct code against a broken world is the opposite failure."""
+        resolution = resolve_correction_path("rewind", {}, {}, classification=classification)
+
+        assert resolution.path == "rewind"
+        assert resolution.overridden_from is None
+
+    def test_abort_is_never_overridden_even_for_work_product(self):
+        resolution = resolve_correction_path("abort", {}, {}, classification="work_product")
+
+        assert resolution.path == "abort"
+        assert resolution.overridden_from is None
+
+    def test_patch_passes_through_untouched(self):
+        resolution = resolve_correction_path("patch", {}, {}, classification="work_product")
+
+        assert resolution.path == "patch"
+        assert resolution.overridden_from is None
+
+    def test_continue_anchor_still_reports_its_reason(self):
+        """Anchor 1's provenance now rides the same field the event payload reads."""
+        evidence = {"validation_result": {"checks": [{"check": "tests_pass", "passed": False}]}}
+        resolution = resolve_correction_path(
+            "continue", evidence, {"required_checks": ["tests_pass"]}
+        )
+
+        assert resolution.path == "patch"
+        assert resolution.override_reason == "executed_failed_required_checks"
+        assert resolution.failed_required_checks == ("tests_pass",)


### PR DESCRIPTION
## What killed pf-45

Not the bug — the decision about the bug.

pf-45 got further than any roll since pf-38: app booted, probe answered (a real HTTP 500,
not a connection failure), test suite collected and ran. The defect was **one token** —
`pace` where the frozen model declares `pace_target` — squarely in a fill slot, correctly
diagnosed by the analyzer, correctly classified `work_product`. The repair prompt would
have carried the authoritative model surface. This is the exact failure the repair path
was built for.

The lead called it "systemic contract violations" and chose **rewind**. Rewind is
implemented as run death (`Run failed: Rewinding to checkpoint after qa.test failure`).
One correction attempt used, **four discarded**, roll over. Same shape as pf-32 — noted
then, never fixed.

## The fix

A second anchor on the existing #447 deterministic policy seam (`correction_policy.py` —
no new pattern, same guard that already bounds `continue`):

> a `rewind` whose classification is `work_product` is escalated to `patch` while the
> chain's repair slot is unspent.

A narrative escalation of severity cannot outvote a classification that says the code is
reachable by a patch.

**Deliberately narrow:**
- Non-work_product classifications (environment / infrastructure / unknown / absent)
  **keep their rewind** — patching correct code against a broken world is the opposite
  failure, and the locus×mode direction on the arc says infrastructure never patches.
- `abort` remains never overridden — a deliberate hard stop stays one.
- The model's original rationale stays intact in the decision artifact; the override is
  disclosed in the CORRECTION_DECIDED payload and the log line names which anchor fired
  (`override_reason` now rides the resolution instead of a hardcoded string at the call
  site).

## Why bound the decision instead of fixing rewind semantics

Rewind-as-run-death is arguably its own defect, but making rewind actually rewind is
executor surgery mid-campaign. Under current semantics, accepting a work_product rewind
is *strictly worse* than patching while budget remains — if patches exhaust, the run
fails anyway, so rewind buys nothing and costs everything. The guard encodes exactly
that dominance argument, nothing more.

## Verification

- **Replayed pf-45's real stored artifacts**: the exact (`rewind`, `work_product`) pair
  from `failure_analysis.md` + `correction_decision.md` resolves to `patch` with full
  provenance.
- 6 new tests: the escalation, all four non-work_product classifications stand,
  abort untouched, patch passthrough, anchor-1 provenance on the new field.
- Regression **5636 passed**, 1 skipped. ruff clean.
- No contract/scaffold surface touched — no re-seed.
