### PR TITLE
fix(dev): the initial author gets the model surface, field-level (pf-45)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1700,11 +1700,22 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # to learn what the scaffold already knew. Data only; the block's prose
         # lives in a managed prompt asset.
         if envelope.task_type in self._ERROR_SEAM_TASK_TYPES:
-            from squadops.capabilities.scaffold import error_seam_instructions
+            from squadops.capabilities.scaffold import (
+                error_seam_instructions,
+                model_surface_instructions,
+            )
 
             error_lines = error_seam_instructions(interface_manifest)
             if error_lines:
                 extra_inputs["error_contract"] = error_lines
+            # pf-45: the model surface, to the INITIAL author on the same transport.
+            # Repairs have carried it since #604; the first fill never did, so the dev
+            # guessed a field name (`pace` for `pace_target`) and every POST /runs
+            # raised into a 500 — a correction spent learning what the scaffold already
+            # knew. Field-level since pf-45 for the same reason.
+            surface_lines = model_surface_instructions(interface_manifest)
+            if surface_lines:
+                extra_inputs["model_surface"] = surface_lines
 
         # Pre-resolve artifact contents for build tasks (D3). Fresh dispatches
         # see the ACCEPTED state only (pf-31 Fix E): rejected repair candidates

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -755,8 +755,31 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         error_contract = await self._error_contract_section(renderer, inputs)
         if error_contract:
             variables["error_contract"] = error_contract
+        # pf-45: the model surface, same transport and same reasoning as the error
+        # contract above — the first fill guessed a field name (`pace` for the frozen
+        # model's `pace_target`) and every POST /runs raised into a 500.
+        model_surface = await self._model_surface_section(renderer, inputs)
+        if model_surface:
+            variables["model_surface"] = model_surface
         rendered = await renderer.render(
             "request.development_develop_fill_only_appendix", variables
+        )
+        return rendered.content
+
+    async def _model_surface_section(self, renderer: Any, inputs: dict | None) -> str:
+        """Render the MODEL SURFACE block from executor-threaded lines, or "".
+
+        The lines are manifest-derived data (``scaffold.model_surface_instructions``,
+        field-level signatures + the frozen store); all prose lives in the appendix
+        asset (CLAUDE.md #448).
+        """
+        lines = [str(line).strip() for line in ((inputs or {}).get("model_surface") or [])]
+        lines = [line for line in lines if line]
+        if not lines:
+            return ""
+        rendered = await renderer.render(
+            "request.development_develop_model_surface_appendix",
+            {"surface_lines": "\n".join(f"- {line}" for line in lines)},
         )
         return rendered.content
 

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -482,19 +482,39 @@ def model_surface_instructions(manifest: InterfaceManifest | None) -> list[str]:
     ``failure_evidence`` → authoritative-block transport as the error seam and frozen
     ownership.
 
+    Field-level since pf-45: class names alone did not carry the surface a fill body
+    actually touches. pf-45's dev wrote ``pace=data.pace`` against a model declaring
+    ``pace_target`` — a one-token invention this block could not have prevented, because
+    it named the classes and not their fields. Every POST /runs raised into a 500. The
+    signature form makes the field vocabulary exact for both consumers of this transport
+    (the initial fill prompt and the repair prompt).
+
+    Also names the frozen store: pf-45's dev re-declared local store dicts in the fill
+    slot, shadowing ``backend/store.py`` — the scaffold's ``reset()`` then cleared the
+    unused stores, so test isolation silently broke.
+
     Empty when there is no manifest (author mode, non-scaffold stacks) — additive, like
     every other entry on that transport.
     """
     if manifest is None:
         return []
-    names = [e.name for e in manifest.entities] + [s.name for s in manifest.api.request_shapes]
-    if not names:
+    signatures = [f"`{e.name}({', '.join(f.name for f in e.fields)})`" for e in manifest.entities]
+    signatures += [
+        f"`{s.name}({', '.join(dict.fromkeys(list(s.required) + list(s.optional)))})`"
+        for s in manifest.api.request_shapes
+    ]
+    if not signatures:
         return []
-    exact = ", ".join(f"`{n}`" for n in dict.fromkeys(names))
-    return [
+    lines = [
         (
-            f"`backend/models.py` is scaffold-frozen and defines EXACTLY these names: {exact}. "
-            "Import only from this list — these are the complete contents of that module"
+            "`backend/models.py` is scaffold-frozen and defines EXACTLY these names: "
+            f"{', '.join(dict.fromkeys(signatures))}. Import only from this list — these "
+            "are the complete contents of that module"
+        ),
+        (
+            "field names are exact — construct and read models with the fields shown above; "
+            "a near-miss (`pace` for `pace_target`, `meeting_location` for `location`) raises "
+            "at request time and every affected endpoint returns HTTP 500"
         ),
         (
             "do NOT invent model names or aliases (`Run`, `RunCreate`, `RunResponse`, "
@@ -506,6 +526,16 @@ def model_surface_instructions(manifest: InterfaceManifest | None) -> list[str]:
             "and shape the response in the fill slot; do not edit or re-emit the model module"
         ),
     ]
+    if manifest.persistence == "in_memory":
+        stores = ", ".join(f"`{_snake(e.name)}_store`" for e in manifest.entities)
+        lines.append(
+            f"`backend/store.py` is scaffold-frozen and already defines the in-memory "
+            f"stores: {stores} (plus `reset()` for test isolation). Import them "
+            "(`from .store import ...`); do NOT declare your own store dicts — a shadow "
+            "store is invisible to `reset()`, so state leaks between tests and the suite "
+            "fails on isolation"
+        )
+    return lines
 
 
 def _class_field_names(node: ast.ClassDef) -> list[str]:

--- a/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix.md
@@ -1,10 +1,11 @@
 ---
 template_id: request.development_develop_fill_only_appendix
-version: "2"
+version: "3"
 required_variables:
   - stack
 optional_variables:
   - error_contract
+  - model_surface
 ---
 ## Fill-only: a walking skeleton is already in your workspace
 
@@ -31,6 +32,8 @@ the fixed slots** — never to rebuild, rewire, or regenerate the scaffold.
 - Do NOT rewire `App.jsx`'s import/route graph, rename or move views, or add/remove files.
 
 {{error_contract}}
+
+{{model_surface}}
 
 Filling the fixed slots — rather than regenerating the app — is the whole point: the
 skeleton already builds and boots, so a fill that preserves it stays green, while one

--- a/src/squadops/prompts/request_templates/request.development_develop_model_surface_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_model_surface_appendix.md
@@ -1,0 +1,15 @@
+---
+template_id: request.development_develop_model_surface_appendix
+version: "1"
+required_variables:
+  - surface_lines
+optional_variables: []
+---
+**MODEL SURFACE (authoritative — use these names exactly):**
+{{surface_lines}}
+
+These are the complete importable contents of the frozen data modules, generated from
+the interface manifest. Every class, field, and store above exists; nothing else does.
+A near-miss field name does not fail at import or compile — the call raises at request
+time and the endpoint returns HTTP 500, which only surfaces later as a behavioural test
+failure and a failed probe.

--- a/tests/unit/capabilities/handlers/test_focused_prompts.py
+++ b/tests/unit/capabilities/handlers/test_focused_prompts.py
@@ -250,6 +250,24 @@ class TestDevFocusedPromptRendered:
         assert "ApiError(code, message)" in prompt
         assert "run_not_found` → 404" in prompt
 
+    async def test_model_surface_lines_reach_the_initial_author(self):
+        """pf-45: the field vocabulary reaches repairs but not the first author, so the
+        dev guessed `pace` for the frozen model's `pace_target` and every POST /runs
+        raised into a 500 — through import- and compile-level checks untouched."""
+        handler = DevelopmentDevelopHandler()
+        handler._resolved_config = {"build_profile": "fullstack_fastapi_react"}
+        inputs = self._inputs(
+            model_surface=[
+                "`backend/models.py` defines EXACTLY: `RunEvent(id, title, pace_target)`",
+                "`backend/store.py` already defines `run_event_store` — import it",
+            ]
+        )
+        prompt = await handler._build_focused_prompt(inputs, self._renderer())
+
+        assert "MODEL SURFACE (authoritative" in prompt
+        assert "pace_target" in prompt
+        assert "run_event_store" in prompt
+
     async def test_non_scaffolded_stack_omits_scaffold_sections(self):
         """Bug caught: rendering fill-only/error-contract unconditionally would
         instruct an unscaffolded cycle to preserve a skeleton that isn't there."""

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -626,9 +626,45 @@ class TestModelSurfaceInstructions:
         ]
         assert defined, "fixture sanity: models.py should define classes"
         for name in defined:
-            assert f"`{name}`" in blob, (
+            # field-level since pf-45: names render as signatures, `RunEvent(id, ...)`
+            assert f"`{name}(" in blob, (
                 f"{name} is defined in models.py but not named to the repair"
             )
+
+    def test_field_names_are_exact_and_field_level(self):
+        """pf-45: class names alone did not carry the surface a fill body touches — the
+        dev wrote `pace=data.pace` against a model declaring `pace_target`, and every
+        POST /runs raised into a 500. The block must name the fields, not just the class."""
+        from squadops.capabilities.scaffold import model_surface_instructions
+
+        blob = " ".join(model_surface_instructions(_group_run_manifest()))
+
+        assert "pace_target" in blob
+        assert "`RunEvent(id, title, datetime, location, distance, pace_target" in blob
+        assert "`RunEventCreate(title, datetime, location" in blob
+
+    def test_the_frozen_store_is_named_with_its_actual_store_names(self):
+        """pf-45's second defect: the dev re-declared local store dicts, shadowing
+        backend/store.py — reset() then cleared the unused stores and test isolation
+        silently broke. The block names the real stores so there is nothing to invent."""
+        from squadops.capabilities.scaffold import model_surface_instructions
+
+        blob = " ".join(model_surface_instructions(_group_run_manifest()))
+
+        assert "`backend/store.py`" in blob
+        assert "`run_event_store`" in blob
+        assert "`participant_store`" in blob
+        assert "reset()" in blob
+
+    def test_non_memory_persistence_omits_the_store_line(self):
+        from squadops.capabilities.scaffold import model_surface_instructions
+
+        raw = _raw_manifest()
+        raw["persistence"] = "external"
+        lines = model_surface_instructions(InterfaceManifest.from_dict(raw))
+
+        assert lines, "model lines still render"
+        assert not any("store.py" in ln for ln in lines)
 
     def test_the_names_pf41_invented_are_not_presented_as_valid(self):
         """The five names pf-41's last repair imported do not exist. They may appear in

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -848,6 +848,31 @@ class TestErrorSeamThreading:
         assert "never `ApiError(status_code=..., detail=...)`" in joined
         assert "run_not_found` → 404" in joined
 
+    async def test_dev_envelope_carries_the_model_surface(self, executor) -> None:
+        """pf-45: repairs have had the model surface since #604; the first author did
+        not, guessed `pace` for the frozen model's `pace_target`, and every POST /runs
+        raised into a 500 — a correction spent learning what the scaffold already knew."""
+        enriched = await executor._enrich_envelope(
+            self._envelope("development.develop"),
+            {},
+            [],
+            [],
+            interface_manifest=self._manifest(),
+        )
+
+        lines = enriched.inputs.get("model_surface")
+        assert lines, "development.develop envelope carries no model surface"
+        joined = " ".join(lines)
+        assert "pace_target" in joined  # field-level — the exact pf-45 token
+        assert "run_event_store" in joined  # the frozen store the dev shadowed
+
+    async def test_model_surface_follows_the_same_gating_as_the_error_seam(self, executor) -> None:
+        for task_type, manifest in (("qa.test", self._manifest()), ("development.develop", None)):
+            enriched = await executor._enrich_envelope(
+                self._envelope(task_type), {}, [], [], interface_manifest=manifest
+            )
+            assert "model_surface" not in enriched.inputs
+
     async def test_non_authoring_task_types_are_not_given_the_seam(self, executor) -> None:
         """Bug caught: blanket attachment pushes fill-slot authoring instructions
         into roles that do not author into the scaffold (a qa suite told to raise


### PR DESCRIPTION
Companion to #618 — that one stops the correction loop from throwing away its budget on
pf-45's failure class; this one stops the class from happening.

## The defect, and why no check caught it early

pf-45's dev wrote `pace=data.pace` against a frozen model declaring `pace_target`. One
token. A wrong field name passes import and compile checks — it raises at *request*
time — so every POST /runs became a 500 and the suite failed downstream of creation.

The repair path has carried the authoritative model names since #604. **The author of
the first emission never has.** pf-38's dev guessed the fields right, pf-45's guessed
wrong; that variance is the whole difference between those rolls. Same shape as #588's
error-contract fix: same data, same transport, one step earlier.

## Two upgrades through one seam

Both consumers of `model_surface_instructions` — the initial fill prompt *and* the
repair prompt — get these together:

**Field-level signatures.** The block previously named classes only, so it could not
have prevented pf-45 even on the repair path — it said `RunEvent` but never
`pace_target`. Now:

```
`RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants)`
`RunEventCreate(title, datetime, location, distance, pace_target, route_notes)`
```

…with an explicit near-miss warning naming this exact failure (`pace` for `pace_target`
raises at request time, not load time).

**The frozen store.** pf-45's second defect: the dev re-declared local store dicts in
the fill slot, shadowing `backend/store.py` — the scaffold's `reset()` then cleared the
*unused* stores, silently breaking test isolation. The block now names
`participant_store` / `run_event_store` / `reset()` and says import, don't re-declare.
Rendered only for in-memory persistence.

## Transport

Mirrors the error seam exactly, no new pattern:
- executor threads **data-only** lines onto `development.develop` envelopes (same
  task-type gate; absent manifest attaches nothing — author mode byte-identical)
- the develop handler renders them through a new managed asset (#448); prose lives in
  `request.development_develop_model_surface_appendix.md`
- the fill-only appendix gains an optional `{{model_surface}}` variable (version 3)

## Verification

- 9 new/updated tests: field-level signatures carry `pace_target`; the store line names
  the real stores; non-memory persistence omits it; the envelope threading with the same
  gating as the error seam (qa.test / no-manifest attach nothing); a live render through
  the real asset reaching the prompt.
- Regression **5639 passed**, 1 skipped. ruff clean.
- **Contract emission unchanged** (`content_hash` 26503867) — prompt-side only, no
  re-seed.

## Honest limit

Same as #613: supplying the fact doesn't compel the model to read it. That's why #618
exists — if the dev still fumbles a field, the correction loop now keeps its budget and
the repair prompt carries the same upgraded surface with the exact token it needs.
