### PR TITLE
SIP-0102 phase 102.2: environment is a pinned, validated contract — live-smoke green

### DIFF
--- a/adapters/sandbox/container_backend.py
+++ b/adapters/sandbox/container_backend.py
@@ -200,6 +200,20 @@ class ContainerBackend(NoOpExecutionSandbox):
             **common, entries=_tail_lines(run.stdout + run.stderr) if run else ()
         )
 
+    async def environment_report(self) -> dict:
+        """Operational facts for /health and the 102.2c preflight
+        reconciliation. ``image_present`` is None when the daemon cannot
+        answer (unverifiable, never a guessed False)."""
+        try:
+            image_present: bool | None = await self._container.has_image(self._image)
+        except ToolContainerError:
+            image_present = None
+        return {
+            "contract_id": self._environment_contract_id,
+            "image": self._image,
+            "image_present": image_present,
+        }
+
     # -- runtime unit (slice c2) ---------------------------------------------
 
     async def _await_ready(self, base_url: str) -> bool:

--- a/adapters/sandbox/container_backend.py
+++ b/adapters/sandbox/container_backend.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Callable, Mapping
+from pathlib import Path
 
 import httpx
 
@@ -76,6 +77,7 @@ class ContainerBackend(NoOpExecutionSandbox):
         poll_interval_seconds: float = 0.5,
         http_client_factory: Callable[[], httpx.AsyncClient] | None = None,
         environment_contract_id: str | None = None,
+        cache_root: Path | None = None,
     ) -> None:
         self._container = container
         self._store = store
@@ -89,6 +91,7 @@ class ContainerBackend(NoOpExecutionSandbox):
         self._app_port = app_port
         self._ready_path = ready_path
         self._environment_contract_id = environment_contract_id
+        self._cache_root = cache_root
         self._readiness_timeout = readiness_timeout_seconds
         self._poll_interval = poll_interval_seconds
         self._http_client_factory = http_client_factory or (lambda: httpx.AsyncClient(timeout=5.0))
@@ -96,6 +99,21 @@ class ContainerBackend(NoOpExecutionSandbox):
         # a service restart orphans nothing durable (`--rm` containers), and
         # the labeled-container sweep is 102.2+ hardening.
         self._running: dict[str, tuple[str, int]] = {}
+
+    def _cache_volumes(self) -> tuple[tuple[str, str], ...]:
+        """Read-through download caches (§4.7): pip/npm download caches shared
+        across cycles — never installed-dependency dirs (those live in each
+        cycle's workspace), never semantic (a cold cache only means slower)."""
+        if self._cache_root is None:
+            return ()
+        pip_cache = self._cache_root / "pip"
+        npm_cache = self._cache_root / "npm"
+        for cache_dir in (pip_cache, npm_cache):
+            cache_dir.mkdir(parents=True, exist_ok=True)
+        return (
+            (str(pip_cache), "/root/.cache/pip"),
+            (str(npm_cache), "/root/.npm"),
+        )
 
     def _spec(self, operation: str, cycle_id: str, command: tuple[str, ...]) -> ContainerSpec:
         network = (
@@ -106,7 +124,10 @@ class ContainerBackend(NoOpExecutionSandbox):
         return ContainerSpec(
             image=self._image,
             command=list(command),
-            volumes=((str(self._store.workspace_dir(cycle_id)), _WORKSPACE_MOUNT),),
+            volumes=(
+                (str(self._store.workspace_dir(cycle_id)), _WORKSPACE_MOUNT),
+                *self._cache_volumes(),
+            ),
             working_dir=_WORKSPACE_MOUNT,
             timeout_seconds=self._timeout_seconds,
             network=network,

--- a/adapters/sandbox/container_backend.py
+++ b/adapters/sandbox/container_backend.py
@@ -71,7 +71,7 @@ class ContainerBackend(NoOpExecutionSandbox):
         pids_limit: int = 512,
         timeout_seconds: float = 600.0,
         app_port: int = 8000,
-        health_path: str = "/health",
+        ready_path: str = "/",
         readiness_timeout_seconds: float = 30.0,
         poll_interval_seconds: float = 0.5,
         http_client_factory: Callable[[], httpx.AsyncClient] | None = None,
@@ -86,7 +86,7 @@ class ContainerBackend(NoOpExecutionSandbox):
         self._pids_limit = pids_limit
         self._timeout_seconds = timeout_seconds
         self._app_port = app_port
-        self._health_path = health_path
+        self._ready_path = ready_path
         self._readiness_timeout = readiness_timeout_seconds
         self._poll_interval = poll_interval_seconds
         self._http_client_factory = http_client_factory or (lambda: httpx.AsyncClient(timeout=5.0))
@@ -200,13 +200,17 @@ class ContainerBackend(NoOpExecutionSandbox):
     # -- runtime unit (slice c2) ---------------------------------------------
 
     async def _await_ready(self, base_url: str) -> bool:
+        """Transport-level readiness (#520/#622): ANY HTTP response — 200 or
+        404 alike — proves the server is up and routing. Demanding a 2xx from
+        a health path made readiness a hidden product requirement (the
+        canonical PRD declares no /health). The probes are the behavioral
+        assertions; readiness only asks "is something answering?"."""
         deadline = time.monotonic() + self._readiness_timeout
         while True:
             try:
                 async with self._http_client_factory() as client:
-                    response = await client.request("GET", base_url + self._health_path)
-                if 200 <= response.status_code < 300:
-                    return True
+                    await client.request("GET", base_url + self._ready_path)
+                return True
             except (httpx.HTTPError, OSError):
                 pass  # connection refused while the app boots is expected
             if time.monotonic() >= deadline:

--- a/adapters/sandbox/container_backend.py
+++ b/adapters/sandbox/container_backend.py
@@ -75,6 +75,7 @@ class ContainerBackend(NoOpExecutionSandbox):
         readiness_timeout_seconds: float = 30.0,
         poll_interval_seconds: float = 0.5,
         http_client_factory: Callable[[], httpx.AsyncClient] | None = None,
+        environment_contract_id: str | None = None,
     ) -> None:
         self._container = container
         self._store = store
@@ -87,6 +88,7 @@ class ContainerBackend(NoOpExecutionSandbox):
         self._timeout_seconds = timeout_seconds
         self._app_port = app_port
         self._ready_path = ready_path
+        self._environment_contract_id = environment_contract_id
         self._readiness_timeout = readiness_timeout_seconds
         self._poll_interval = poll_interval_seconds
         self._http_client_factory = http_client_factory or (lambda: httpx.AsyncClient(timeout=5.0))
@@ -131,6 +133,7 @@ class ContainerBackend(NoOpExecutionSandbox):
             "operation": operation,
             "workspace_revision_id": revision.revision_id,
             "image_identity": self._image,  # §7 item 4
+            "environment_contract_id": self._environment_contract_id,
         }
         command = self._operation_commands.get(operation)
         if command is None:
@@ -227,6 +230,7 @@ class ContainerBackend(NoOpExecutionSandbox):
             "operation": OperationName.START_APPLICATION,
             "workspace_revision_id": revision.revision_id,
             "image_identity": self._image,
+            "environment_contract_id": self._environment_contract_id,
         }
         command = self._operation_commands.get(OperationName.START_APPLICATION)
         if command is None:
@@ -366,6 +370,7 @@ class ContainerBackend(NoOpExecutionSandbox):
             "operation": OperationName.STOP_APPLICATION,
             "workspace_revision_id": revision.revision_id,
             "image_identity": self._image,
+            "environment_contract_id": self._environment_contract_id,
         }
         self._running.pop(revision.cycle_id, None)
         try:

--- a/adapters/sandbox/container_backend.py
+++ b/adapters/sandbox/container_backend.py
@@ -352,6 +352,7 @@ class ContainerBackend(NoOpExecutionSandbox):
             "operation": OperationName.PROBE_HTTP_ENDPOINT,
             "workspace_revision_id": revision.revision_id,
             "image_identity": self._image,
+            "environment_contract_id": self._environment_contract_id,
             "probe_id": probe_id,
         }
         running = self._running.get(revision.cycle_id)

--- a/adapters/sandbox/factory.py
+++ b/adapters/sandbox/factory.py
@@ -47,6 +47,12 @@ def create_sandbox_service(config: SandboxConfig) -> SandboxService:
             install_network=contract.install_network,
             environment_contract_id=contract.contract_id(),
         )
+        return SandboxService(
+            store=store,
+            journal=journal,
+            backend=backend,
+            environment_report=backend.environment_report,
+        )
     else:
         raise ValueError(f"Unknown sandbox provider: {config.provider}")
     return SandboxService(store=store, journal=journal, backend=backend)

--- a/adapters/sandbox/factory.py
+++ b/adapters/sandbox/factory.py
@@ -8,7 +8,6 @@ configuration raises — never a fake-working default.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from pathlib import Path
 
 from adapters.sandbox.container_backend import ContainerBackend
@@ -16,22 +15,21 @@ from adapters.tools.docker import DockerAdapter
 from squadops.config.schema import SandboxConfig
 from squadops.core.secrets import SecretManager
 from squadops.ports.sandbox import ExecutionSandboxPort
+from squadops.sandbox.environment import get_environment_contract
 from squadops.sandbox.evidence import OperationEvidenceJournal
 from squadops.sandbox.noop import NoOpExecutionSandbox
 from squadops.sandbox.service import SandboxService
 from squadops.sandbox.workspace import WorkspaceStore
 
 
-def create_sandbox_service(
-    config: SandboxConfig,
-    *,
-    operation_commands: Mapping[str, tuple[str, ...]] | None = None,
-) -> SandboxService:
+def create_sandbox_service(config: SandboxConfig) -> SandboxService:
     """Build the service core for the configured provider.
 
-    ``operation_commands`` comes from the environment contract (102.2); until
-    it exists, a docker-backed service honestly reports execution operations
-    as not-run ("environment provides no command").
+    The docker provider is driven entirely by the checked-in environment
+    contract (§4.2): typed-operation commands, app port, install egress, and
+    the pinned image (``config.image`` may override — the actually-used image
+    rides every result as evidence), with the contract's identity stamped on
+    every result (§7 item 4).
     """
     root = Path(config.workspace_root)
     store = WorkspaceStore(root)
@@ -39,14 +37,15 @@ def create_sandbox_service(
     if config.provider == "noop":
         backend: ExecutionSandboxPort | None = None
     elif config.provider == "docker":
-        if not config.image:
-            raise ValueError("SQUADOPS__SANDBOX__IMAGE is required for sandbox provider 'docker'")
+        contract = get_environment_contract(config.environment)
         backend = ContainerBackend(
             container=DockerAdapter(),
             store=store,
-            image=config.image,
-            operation_commands=operation_commands or {},
-            app_port=config.app_port,
+            image=config.image or contract.image,
+            operation_commands=contract.commands(),
+            app_port=contract.app_port,
+            install_network=contract.install_network,
+            environment_contract_id=contract.contract_id(),
         )
     else:
         raise ValueError(f"Unknown sandbox provider: {config.provider}")

--- a/adapters/sandbox/factory.py
+++ b/adapters/sandbox/factory.py
@@ -46,6 +46,7 @@ def create_sandbox_service(config: SandboxConfig) -> SandboxService:
             app_port=contract.app_port,
             install_network=contract.install_network,
             environment_contract_id=contract.contract_id(),
+            cache_root=Path(config.cache_root) if config.cache_root else None,
         )
         return SandboxService(
             store=store,

--- a/adapters/tools/docker.py
+++ b/adapters/tools/docker.py
@@ -155,6 +155,16 @@ class DockerAdapter(ContainerPort):
             raise ToolContainerError("docker run -d returned no container id")
         return container_id
 
+    async def has_image(self, image: str) -> bool:
+        """Whether the image exists locally (distinguishes absent from
+        daemon-unreachable — only definitive absence returns False)."""
+        exit_code, _stdout, stderr = await self._run_docker("image", "inspect", image)
+        if exit_code == 0:
+            return True
+        if "no such image" in stderr.lower():
+            return False
+        raise ToolContainerError(f"Failed to inspect image: {stderr}")
+
     async def resolve_host_port(self, container_id: str, container_port: int) -> int:
         """Resolve a published container port to its ephemeral host port."""
         exit_code, stdout, stderr = await self._run_docker(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -792,19 +792,23 @@ services:
     environment:
       SQUADOPS__SANDBOX__PROVIDER: ${SQUADOPS_SANDBOX_PROVIDER:-noop}
       SQUADOPS__SANDBOX__IMAGE: ${SQUADOPS_SANDBOX_IMAGE:-}
-      SQUADOPS__SANDBOX__WORKSPACE_ROOT: /sandbox/cycles
+      SQUADOPS__SANDBOX__WORKSPACE_ROOT: ${SQUADOPS_SANDBOX_ROOT:-/tmp/squadops-sandbox}/cycles
+      SQUADOPS__SANDBOX__CACHE_ROOT: ${SQUADOPS_SANDBOX_ROOT:-/tmp/squadops-sandbox}/caches
       # No default: create_app refuses to start without a token.
       SQUADOPS__SANDBOX__SERVICE_TOKEN: ${SQUADOPS_SANDBOX_SERVICE_TOKEN:-}
     volumes:
       # The sandbox service is the ONLY socket holder (SIP-0102 §4.3).
       - /var/run/docker.sock:/var/run/docker.sock
-      - sandbox_workspaces:/sandbox/cycles
+      # Docker-outside-of-docker: workspace/cache paths are handed to the HOST
+      # daemon for bind-mounting into execution units, so the host path and
+      # the in-container path must be the IDENTICAL string — a named volume
+      # cannot satisfy that. Same-path bind, host dir configurable.
+      - ${SQUADOPS_SANDBOX_ROOT:-/tmp/squadops-sandbox}:${SQUADOPS_SANDBOX_ROOT:-/tmp/squadops-sandbox}
     networks:
       - squadnet
     restart: unless-stopped
 volumes:
   rabbitmq_data: {}
-  sandbox_workspaces: {}  # SIP-0102 cycle workspaces (sandbox-service only)
   postgres_data: {}
   redis_data: {}
   prometheus_data: {}

--- a/docs/plans/SIP-0102-ephemeral-application-sandbox-plan.md
+++ b/docs/plans/SIP-0102-ephemeral-application-sandbox-plan.md
@@ -17,7 +17,7 @@ The single in-repo source of truth for where SIP-0102 stands — read this first
 | Phase | Milestone unlocked | State |
 |---|---|---|
 | 102.1 Execution boundary (service skeleton + workspace + Docker adapter) | the execution boundary exists | ✅ slices a–d complete on the feature branch (PR open); exit proven by the ASGI client→API→service→store E2E + parity guards; compose entry profile-guarded (`--profile sandbox`); interim shared-secret auth (Keycloak #326 upgrade pinned to 102.3) |
-| 102.2 Environment contract + canonical image + preflight | environment is a pinned, validated contract | ⬜ |
+| 102.2 Environment contract + canonical image + preflight | environment is a pinned, validated contract | ✅ complete on the feature branch (PR open); exit proven: mismatched/missing environment blocks at cycle-create preflight AND doctor (same decision fn); every result carries image + contract identity; **live smoke on real docker: full floor E2E green** (install→build→boot→probe 501→teardown, pin intact) |
 | 102.3 Typed-op relocation of in-process exec sites | execution leaves the agent trust boundary | ⬜ |
 | 102.4 Clean-room verification + outcome integration | verdicts are clean-room and honestly named | ⬜ |
 | 102.5 Builder warm-unit convergence | convergence iterates inside the sandbox | ⬜ |
@@ -223,8 +223,11 @@ one canonical `full` cycle on the Spark deploy reaches clean-room
 3. **Compose service addition** (102.1): repo rule requires explicit approval for
    docker-compose changes — the service entry (name, port) gets proposed alongside the
    102.1 PR, not silently added.
-4. **Environment-image ownership + publish pipeline** (102.2): this repo vs
-   deployment-profile repo (moved out of the SIP at acceptance).
+4. **Environment-image ownership + publish pipeline** — **RESOLVED (Jason,
+   2026-07-26): local build per host** from the checked-in rendering
+   (`infra/sandbox/fastapi-react.Dockerfile` via
+   `scripts/dev/build_sandbox_env_image.sh`; Mac now, Spark at 102.6).
+   Registry publishing + digest pinning defer to 1.5 hardening.
 5. **Locus × mode scope + `FailureLocus` naming** (102.4): how much taxonomy lands here
    vs the correction-policy follow-up (#413 lineage), and the #568 name reconciliation.
 

--- a/infra/sandbox/fastapi-react.Dockerfile
+++ b/infra/sandbox/fastapi-react.Dockerfile
@@ -1,0 +1,26 @@
+# Canonical sandbox environment image: fullstack_fastapi_react (SIP-0102 §4.2)
+#
+# RENDERED FROM the environment contract in
+# src/squadops/sandbox/environment.py — the contract is the source of truth;
+# this Dockerfile is one adapter representation, checked in and deterministic,
+# never LLM-authored. Keep the toolchain versions in lockstep with the
+# contract's required_tools.
+#
+# The image carries TOOLCHAINS ONLY (python 3.12, node 20, npm). Per-cycle
+# dependencies install into the bind-mounted workspace (.sandbox-venv,
+# node_modules) so they persist across disposable one-shot containers and are
+# never baked as undeclared image state (§4.7).
+#
+# Build:  ./scripts/dev/build_sandbox_env_image.sh
+# Publish pipeline: open decision 4 in the SIP-0102 plan (resolve at 102.2 review).
+
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/scripts/dev/build_sandbox_env_image.sh
+++ b/scripts/dev/build_sandbox_env_image.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Build the canonical sandbox environment image (SIP-0102 phase 102.2).
+#
+# The tag matches the environment contract's pinned reference
+# (src/squadops/sandbox/environment.py) — keep them in lockstep. The publish
+# pipeline (registry vs local-only) is open decision 4 in the SIP-0102 plan.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+TAG="squadops-sandbox-env:fastapi-react-1.4-dev"
+docker build -t "$TAG" -f infra/sandbox/fastapi-react.Dockerfile infra/sandbox
+echo "Built $TAG"

--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -32,6 +32,7 @@ from squadops.cycles.models import (
 )
 from squadops.cycles.preflight import (
     Finding,
+    PreflightDecision,
     combine,
     model_availability_decision,
     required_check_tooling_decision,
@@ -65,6 +66,48 @@ async def _pulled_model_names() -> list[str] | None:
     return [name for m in raw if (name := m.get("name"))]
 
 
+async def _sandbox_preflight_decision() -> PreflightDecision:
+    """SIP-0102 102.2c: reconcile the configured sandbox environment before
+    dispatch. Dormant provider ⇒ empty decision (no IO); malformed sandbox
+    config ⇒ block (verifiable misconfiguration); unreachable service ⇒ the
+    pure decision warns and allows (never block on missing evidence)."""
+    import httpx
+
+    from squadops.sandbox.environment import get_environment_contract
+    from squadops.sandbox.main import sandbox_config_from_env
+    from squadops.sandbox.preflight import sandbox_environment_decision
+
+    try:
+        cfg = sandbox_config_from_env()
+    except ValueError as exc:
+        return PreflightDecision(
+            blocking=(
+                Finding(
+                    code="sandbox_config_invalid",
+                    severity="block",
+                    message=f"sandbox configuration is invalid: {exc}",
+                ),
+            )
+        )
+    if cfg.provider != "docker":
+        return PreflightDecision()
+    try:
+        expected: str | None = get_environment_contract(cfg.environment).contract_id()
+    except ValueError:
+        expected = None
+    report = None
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as client:
+            response = await client.get(f"{cfg.service_url.rstrip('/')}/health")
+        if response.status_code == 200:
+            report = response.json().get("environment")
+    except Exception as exc:  # unreachable/timeout/bad payload ⇒ unverifiable
+        logger.info("preflight_sandbox_unverifiable", extra={"error": str(exc)})
+    return sandbox_environment_decision(
+        provider=cfg.provider, expected_contract_id=expected, report=report
+    )
+
+
 async def _run_create_preflight(
     profile: SquadProfile, applied_defaults: dict
 ) -> tuple[Finding, ...]:
@@ -84,6 +127,9 @@ async def _run_create_preflight(
             applied_defaults.get("required_checks") or (),
             resolve_provisioned_tooling(),
         ),
+        # SIP-0102 102.2c: a skewed/unprovisioned sandbox environment is a
+        # create-time reject, never a mid-run environment stall (roll-4).
+        await _sandbox_preflight_decision(),
     )
     if decision.rejected:
         raise PreflightRejectedError(decision.summary())

--- a/src/squadops/bootstrap/setup/checks.py
+++ b/src/squadops/bootstrap/setup/checks.py
@@ -41,6 +41,7 @@ VALID_CATEGORIES = frozenset(
         "auth",
         "broker",
         "verification",
+        "sandbox",
     }
 )
 
@@ -975,6 +976,101 @@ def _collect_verification_checks(profile: BootstrapProfile) -> list[CheckResult]
     return results
 
 
+# ---------------------------------------------------------------------------
+# Sandbox checks (SIP-0102 phase 102.2c)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_sandbox_report(service_url: str) -> dict | None:
+    """Best-effort GET of the sandbox service's /health environment block;
+    None ⇒ unverifiable (the decision warns, never blocks on missing
+    evidence)."""
+    import httpx
+
+    try:
+        response = httpx.get(f"{service_url.rstrip('/')}/health", timeout=2.0)
+        if response.status_code == 200:
+            return response.json().get("environment")
+    except (httpx.HTTPError, ValueError):
+        pass
+    return None
+
+
+def _collect_sandbox_checks(profile: BootstrapProfile) -> list[CheckResult]:
+    """Sandbox environment reconciliation — the SAME decision the cycle-create
+    preflight applies (SIP-0102 102.2c), rendered as doctor results, so
+    doctor and create-time never disagree."""
+    from squadops.sandbox.environment import get_environment_contract
+    from squadops.sandbox.main import sandbox_config_from_env
+    from squadops.sandbox.preflight import sandbox_environment_decision
+
+    try:
+        cfg = sandbox_config_from_env()
+    except ValueError as exc:
+        return [
+            CheckResult(
+                name="sandbox_config",
+                category="sandbox",
+                passed=False,
+                message=f"sandbox configuration is invalid: {exc}",
+            )
+        ]
+    if cfg.provider != "docker":
+        return [
+            CheckResult(
+                name="sandbox_dormant",
+                category="sandbox",
+                passed=True,
+                message="sandbox provider is 'noop' (dormant) — nothing to verify",
+            )
+        ]
+    try:
+        expected: str | None = get_environment_contract(cfg.environment).contract_id()
+    except ValueError:
+        expected = None
+    decision = sandbox_environment_decision(
+        provider=cfg.provider,
+        expected_contract_id=expected,
+        report=_fetch_sandbox_report(cfg.service_url),
+    )
+    results = [
+        CheckResult(
+            name=f.code,
+            category="sandbox",
+            passed=False,
+            message=f.message,
+            fix_command=(
+                "./scripts/dev/build_sandbox_env_image.sh"
+                if f.code == "sandbox_image_missing"
+                else None
+            ),
+        )
+        for f in decision.blocking
+    ]
+    results += [
+        CheckResult(
+            name=f.code,
+            category="sandbox",
+            passed=False,
+            message=f.message,
+            heuristic=True,  # warn-and-allow parity with create-time preflight
+        )
+        for f in decision.warnings
+    ]
+    if not results:
+        results.append(
+            CheckResult(
+                name="sandbox_environment",
+                category="sandbox",
+                passed=True,
+                message=(
+                    f"sandbox environment verified (contract {expected[:12]}…, image present)"
+                ),
+            )
+        )
+    return results
+
+
 _CHECK_REGISTRY: list[tuple[str, object]] = [
     ("python", _collect_python_checks),
     ("platform", _collect_platform_checks),
@@ -986,6 +1082,7 @@ _CHECK_REGISTRY: list[tuple[str, object]] = [
     ("auth", _collect_auth_checks),
     ("broker", _collect_broker_checks),
     ("verification", _collect_verification_checks),
+    ("sandbox", _collect_sandbox_checks),
 ]
 
 

--- a/src/squadops/config/schema.py
+++ b/src/squadops/config/schema.py
@@ -266,6 +266,14 @@ class SandboxConfig(BaseModel):
         default=Path("cycle_data/sandbox"),
         description="Root directory for cycle workspaces (bind-mounted into execution units)",
     )
+    cache_root: Path | None = Field(
+        default=None,
+        description=(
+            "Read-through download caches (pip/npm) shared across cycles — §4.7: "
+            "download caches only, never installed-dependency dirs, never semantic. "
+            "None disables cache mounts."
+        ),
+    )
     image: str = Field(
         default="",
         description=(

--- a/src/squadops/config/schema.py
+++ b/src/squadops/config/schema.py
@@ -258,13 +258,20 @@ class SandboxConfig(BaseModel):
     """
 
     provider: str = Field(default="noop", description="Sandbox provider: 'noop' or 'docker'")
+    environment: str = Field(
+        default="fullstack_fastapi_react",
+        description="Environment-contract stack id (see squadops.sandbox.environment)",
+    )
     workspace_root: Path = Field(
         default=Path("cycle_data/sandbox"),
         description="Root directory for cycle workspaces (bind-mounted into execution units)",
     )
     image: str = Field(
         default="",
-        description="Pinned canonical environment image (required for provider 'docker')",
+        description=(
+            "Override of the environment contract's pinned image (empty = use the "
+            "contract's; the actually-used image rides every result as evidence)"
+        ),
     )
     app_port: int = Field(
         default=8000, description="Container port the application runtime listens on"

--- a/src/squadops/ports/tools/container.py
+++ b/src/squadops/ports/tools/container.py
@@ -90,3 +90,15 @@ class ContainerPort(ABC):
             ToolContainerError: Mapping could not be resolved
         """
         ...
+
+    @abstractmethod
+    async def has_image(self, image: str) -> bool:
+        """Whether the image is present locally (SIP-0102 preflight).
+
+        Returns:
+            True if present, False if definitively absent
+
+        Raises:
+            ToolContainerError: Presence could not be determined (daemon down)
+        """
+        ...

--- a/src/squadops/sandbox/api.py
+++ b/src/squadops/sandbox/api.py
@@ -170,7 +170,13 @@ def create_app(service: SandboxService, *, service_token: str) -> FastAPI:
 
     @app.get("/health")
     async def health() -> dict:
-        return {"status": "ok", "service": "sandbox"}
+        # Environment facts ride the probe (102.2c): the cycle-create
+        # preflight and doctor reconcile against them.
+        return {
+            "status": "ok",
+            "service": "sandbox",
+            "environment": await service.environment_report(),
+        }
 
     @app.post(
         "/api/v1/workspaces/{cycle_id}/seed",

--- a/src/squadops/sandbox/environment.py
+++ b/src/squadops/sandbox/environment.py
@@ -1,0 +1,139 @@
+"""Environment contract (SIP-0102 §4.2 — phase 102.2).
+
+The pinned, deterministic declaration of the environment the canonical stack
+builds and runs in: image identity, required tools, typed-operation commands,
+runtime endpoint facts. The Dockerfile (``infra/sandbox/``) is an adapter
+rendering of this contract, never the contract itself.
+
+Deliberately registry-shaped but NOT generalized: the ``StackBlueprint``
+schema is deferred until a second real stack exists
+(SIP-Stack-Blueprint-Contract); this module holds the one canonical contract
+and migrates into the blueprint when that SIP is accepted.
+
+``contract_id()`` is a content hash over the canonical serialization — the
+environment-contract identity every operation result records (§7 items 4/15).
+Commands may use ``sh -c`` internally (the SIP permits adapters to run shell
+underneath); the contract is checked in and never LLM-authored, so this is a
+fixed rendering, not a shell surface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+from squadops.sandbox.models import OperationName
+
+
+@dataclass(frozen=True)
+class EnvironmentContract:
+    """One stack's declared execution environment."""
+
+    stack: str
+    image: str
+    required_tools: tuple[tuple[str, str], ...]  # (tool, expected major.minor prefix)
+    operation_commands: tuple[tuple[str, tuple[str, ...]], ...]  # (operation, argv)
+    app_port: int
+    install_network: str
+
+    def __post_init__(self) -> None:
+        seen: set[str] = set()
+        for operation, argv in self.operation_commands:
+            if operation not in OperationName.ALL:
+                raise ValueError(f"unknown operation in environment contract: {operation!r}")
+            if operation in seen:
+                raise ValueError(f"duplicate operation in environment contract: {operation!r}")
+            if not argv:
+                raise ValueError(f"empty command for operation: {operation!r}")
+            seen.add(operation)
+        if not (0 < self.app_port < 65536):
+            raise ValueError(f"invalid app_port: {self.app_port}")
+        if not self.image:
+            raise ValueError("environment contract requires an image")
+
+    def commands(self) -> dict[str, tuple[str, ...]]:
+        return dict(self.operation_commands)
+
+    def provides(self, operation: str) -> bool:
+        return any(op == operation for op, _ in self.operation_commands)
+
+    def to_dict(self) -> dict:
+        return {
+            "stack": self.stack,
+            "image": self.image,
+            "required_tools": [list(pair) for pair in self.required_tools],
+            "operation_commands": [
+                {"operation": op, "argv": list(argv)} for op, argv in self.operation_commands
+            ],
+            "app_port": self.app_port,
+            "install_network": self.install_network,
+        }
+
+    def contract_id(self) -> str:
+        """Deterministic identity over the full declaration — any change to
+        image, tools, or commands is a different contract (§7 items 4/15)."""
+        canonical = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# The canonical stack's contract (v1.4 floor). Paths are the expander's actual
+# layout (coherence is test-enforced against a real expansion):
+#   backend/requirements.txt, frontend/package.json (no lockfile → npm install),
+#   uvicorn backend.main:app, pytest from the workspace root.
+# read_build_diagnostics is deliberately unprovided — the warm-loop inspect
+# step is 102.5's concern; unprovided operations are honest not_run.
+FULLSTACK_FASTAPI_REACT = EnvironmentContract(
+    stack="fullstack_fastapi_react",
+    image="squadops-sandbox-env:fastapi-react-1.4-dev",
+    required_tools=(("python", "3.12"), ("node", "20"), ("npm", "10")),
+    # Dependencies install INTO the cycle workspace (§4.7: no shared installed
+    # state; one-shot containers are disposable, the bind-mounted workspace is
+    # not) — a venv for python, node_modules for npm. Both are derived state,
+    # excluded from revision content by the workspace store. pytest/httpx are
+    # harness deps (the scaffolded test harness), not app deps.
+    operation_commands=(
+        (
+            OperationName.INSTALL_DEPENDENCIES,
+            (
+                "sh",
+                "-c",
+                "python -m venv .sandbox-venv"
+                " && .sandbox-venv/bin/pip install -r backend/requirements.txt pytest httpx"
+                " && npm --prefix frontend install",
+            ),
+        ),
+        (OperationName.BUILD_FRONTEND, ("npm", "--prefix", "frontend", "run", "build")),
+        (OperationName.RUN_BACKEND_TESTS, (".sandbox-venv/bin/python", "-m", "pytest", "-q")),
+        (
+            OperationName.START_APPLICATION,
+            (
+                ".sandbox-venv/bin/python",
+                "-m",
+                "uvicorn",
+                "backend.main:app",
+                "--host",
+                "0.0.0.0",  # noqa: S104 — inside the container; host publish is loopback-only
+                "--port",
+                "8000",
+            ),
+        ),
+    ),
+    app_port=8000,
+    install_network="bridge",
+)
+
+_CONTRACTS: dict[str, EnvironmentContract] = {
+    contract.stack: contract for contract in (FULLSTACK_FASTAPI_REACT,)
+}
+
+
+def get_environment_contract(stack: str) -> EnvironmentContract:
+    """The checked-in contract for a stack. Unknown stack raises — there is
+    no fallback environment."""
+    contract = _CONTRACTS.get(stack)
+    if contract is None:
+        raise ValueError(
+            f"no environment contract for stack {stack!r} (known: {sorted(_CONTRACTS)})"
+        )
+    return contract

--- a/src/squadops/sandbox/preflight.py
+++ b/src/squadops/sandbox/preflight.py
@@ -1,0 +1,108 @@
+"""Sandbox environment preflight (SIP-0102 — phase 102.2c).
+
+The advertised-vs-provided reconciliation on the SIP-0095 seam: when the
+sandbox provider is configured, a cycle must not dispatch into an environment
+that is unknown, skewed, or missing its image — the roll-4 failure class
+caught at create time, never at task time.
+
+Pure over caller-fetched evidence (the SIP-0095 D26 pattern): the
+cycle-create route and the doctor both fetch the sandbox service's ``/health``
+environment report and pass it in, so both surfaces render the SAME decision.
+Evidence doctrine mirrors SIP-0095 §6.2: unverifiable ⇒ warn and allow;
+verifiable absence or skew ⇒ block. Provider "noop" contributes nothing
+(dormant — the inert posture).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from squadops.cycles.preflight import Finding, PreflightDecision
+
+
+def sandbox_environment_decision(
+    *,
+    provider: str,
+    expected_contract_id: str | None,
+    report: Mapping | None,
+) -> PreflightDecision:
+    """Reconcile the deployment's expected environment contract against what
+    the sandbox service actually reports."""
+    if provider != "docker":
+        return PreflightDecision()
+
+    if expected_contract_id is None:
+        return PreflightDecision(
+            blocking=(
+                Finding(
+                    code="sandbox_environment_unknown",
+                    severity="block",
+                    message=(
+                        "sandbox provider 'docker' is configured but the configured stack "
+                        "has no checked-in environment contract. Fix "
+                        "SQUADOPS__SANDBOX__ENVIRONMENT or add the contract to "
+                        "squadops.sandbox.environment."
+                    ),
+                ),
+            )
+        )
+
+    if report is None:
+        return PreflightDecision(
+            warnings=(
+                Finding(
+                    code="sandbox_unverifiable",
+                    severity="warning",
+                    message=(
+                        "could not query the sandbox service — its environment was not "
+                        "verified and sandbox operations may fail at task time. Verify "
+                        "sandbox-service is up (GET /health) and reachable."
+                    ),
+                ),
+            )
+        )
+
+    blocking: list[Finding] = []
+    warnings: list[Finding] = []
+
+    reported = report.get("contract_id")
+    if reported != expected_contract_id:
+        blocking.append(
+            Finding(
+                code="sandbox_contract_mismatch",
+                severity="block",
+                message=(
+                    f"the sandbox service runs environment contract `{reported}`, but this "
+                    f"deployment expects `{expected_contract_id}` — the service is skewed "
+                    "against the current tree. Rebuild/restart sandbox-service so the "
+                    "contracts match."
+                ),
+            )
+        )
+
+    image_present = report.get("image_present")
+    if image_present is False:
+        blocking.append(
+            Finding(
+                code="sandbox_image_missing",
+                severity="block",
+                message=(
+                    f"the sandbox environment image `{report.get('image')}` is not present "
+                    "on the sandbox host. Build it: ./scripts/dev/build_sandbox_env_image.sh "
+                    "(local-build decision, SIP-0102 plan)."
+                ),
+            )
+        )
+    elif image_present is None:
+        warnings.append(
+            Finding(
+                code="sandbox_image_unverifiable",
+                severity="warning",
+                message=(
+                    "the sandbox service could not verify its environment image — sandbox "
+                    "operations may fail at task time."
+                ),
+            )
+        )
+
+    return PreflightDecision(blocking=tuple(blocking), warnings=tuple(warnings))

--- a/src/squadops/sandbox/service.py
+++ b/src/squadops/sandbox/service.py
@@ -16,7 +16,7 @@ execute it (§4.4).
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 
 from squadops.ports.sandbox import ExecutionSandboxPort
 from squadops.sandbox.evidence import OperationEvidenceJournal
@@ -49,10 +49,19 @@ class SandboxService(ExecutionSandboxPort):
         store: WorkspaceStore,
         journal: OperationEvidenceJournal,
         backend: ExecutionSandboxPort | None = None,
+        environment_report: Callable[[], Awaitable[dict | None]] | None = None,
     ) -> None:
         self._store = store
         self._journal = journal
         self._backend = backend
+        self._environment_report = environment_report
+
+    async def environment_report(self) -> dict | None:
+        """The backend's environment facts (contract id, image presence) for
+        /health and preflight reconciliation; None when no backend reports."""
+        if self._environment_report is None:
+            return None
+        return await self._environment_report()
 
     # -- workspace lifecycle (service-level, not port operations) ------------
 

--- a/src/squadops/sandbox/workspace.py
+++ b/src/squadops/sandbox/workspace.py
@@ -34,6 +34,16 @@ from squadops.sandbox.models import (
 
 _CYCLE_ID_RE = re.compile(r"[A-Za-z0-9_\-]+")
 
+# Derived/dependency state is NOT revision content (§4.6/§4.7): per-cycle
+# installs land inside the sandbox (venv, node_modules) and builds emit
+# outputs (dist) — all of it lives in the workspace but never in the pin,
+# or the first install would break every stale-base check and pin
+# verification. Promotion of build outputs is an explicit §4.6 boundary,
+# never implicit inclusion.
+_EXCLUDED_SEGMENTS = frozenset(
+    {".sandbox-venv", "node_modules", "dist", "__pycache__", ".pytest_cache", ".git"}
+)
+
 
 class WorkspaceStoreError(Exception):
     """Base error for workspace-store violations."""
@@ -61,6 +71,11 @@ def _safe_relpath(path: str) -> str:
     parts = [p for p in norm.split("/") if p not in ("", ".")]
     if not parts or ".." in parts or any(":" in p for p in parts):
         raise WorkspaceEscapeError(f"not a workspace-relative path: {path!r}")
+    if _EXCLUDED_SEGMENTS.intersection(parts):
+        raise WorkspaceEscapeError(
+            f"derived-state path is not revision content: {path!r} "
+            "(installs/build outputs live in the sandbox but are never seeded or patched)"
+        )
     return "/".join(parts)
 
 
@@ -101,15 +116,20 @@ class WorkspaceStore:
         return ws
 
     def current_files(self, cycle_id: str) -> dict[str, str]:
-        """The live tree as a path → content mapping."""
+        """The live tree as a path → content mapping, excluding derived state
+        (``_EXCLUDED_SEGMENTS``) — revision content is source, not installs."""
         ws = self.workspace_dir(cycle_id)
         if not ws.is_dir():
             return {}
-        return {
-            str(p.relative_to(ws)).replace("\\", "/"): p.read_text(encoding="utf-8")
-            for p in sorted(ws.rglob("*"))
-            if p.is_file()
-        }
+        files: dict[str, str] = {}
+        for p in sorted(ws.rglob("*")):
+            if not p.is_file():
+                continue
+            rel = p.relative_to(ws)
+            if _EXCLUDED_SEGMENTS.intersection(rel.parts):
+                continue
+            files[str(rel).replace("\\", "/")] = p.read_text(encoding="utf-8")
+        return files
 
     # -- revisions ----------------------------------------------------------
 

--- a/src/squadops/sandbox/workspace.py
+++ b/src/squadops/sandbox/workspace.py
@@ -35,13 +35,23 @@ from squadops.sandbox.models import (
 _CYCLE_ID_RE = re.compile(r"[A-Za-z0-9_\-]+")
 
 # Derived/dependency state is NOT revision content (§4.6/§4.7): per-cycle
-# installs land inside the sandbox (venv, node_modules) and builds emit
-# outputs (dist) — all of it lives in the workspace but never in the pin,
-# or the first install would break every stale-base check and pin
-# verification. Promotion of build outputs is an explicit §4.6 boundary,
-# never implicit inclusion.
+# installs land inside the sandbox (venv, node_modules, the lockfile npm
+# install generates) and builds emit outputs (dist) — all of it lives in the
+# workspace but never in the pin, or the first install would break every
+# stale-base check and pin verification (live-smoke-proven: npm install
+# writes frontend/package-lock.json). Promotion into revision content —
+# including lockfile-as-evidence capture (§4.7) — is an explicit §4.6
+# boundary, never implicit inclusion.
 _EXCLUDED_SEGMENTS = frozenset(
-    {".sandbox-venv", "node_modules", "dist", "__pycache__", ".pytest_cache", ".git"}
+    {
+        ".sandbox-venv",
+        "node_modules",
+        "dist",
+        "__pycache__",
+        ".pytest_cache",
+        ".git",
+        "package-lock.json",
+    }
 )
 
 

--- a/tests/unit/adapters/test_docker_hardening.py
+++ b/tests/unit/adapters/test_docker_hardening.py
@@ -86,6 +86,37 @@ async def test_run_detached_publishes_to_loopback_and_returns_id(monkeypatch):
     assert args[args.index("-p") + 1] == "127.0.0.1:0:8000"
 
 
+@pytest.mark.parametrize(
+    ("exit_code", "stderr", "expected"),
+    [(0, "", True), (1, "Error: No such image: img", False)],
+    ids=["present", "absent"],
+)
+async def test_has_image_distinguishes_present_from_absent(
+    monkeypatch, exit_code, stderr, expected
+):
+    """Bug caught: preflight's image evidence inverted or guessed — a missing
+    image passing preflight stalls the cycle at task time (#306 class)."""
+
+    async def fake_run_docker(self, *args, timeout=None):
+        return exit_code, "", stderr
+
+    monkeypatch.setattr(DockerAdapter, "_run_docker", fake_run_docker)
+    assert await DockerAdapter().has_image("img") is expected
+
+
+async def test_has_image_raises_when_the_daemon_cannot_answer(monkeypatch):
+    """Bug caught: daemon-down reported as image-absent — a false preflight
+    block on an environment that may be perfectly provisioned."""
+    from squadops.tools.exceptions import ToolContainerError
+
+    async def fake_run_docker(self, *args, timeout=None):
+        return 1, "", "Cannot connect to the Docker daemon"
+
+    monkeypatch.setattr(DockerAdapter, "_run_docker", fake_run_docker)
+    with pytest.raises(ToolContainerError, match="inspect image"):
+        await DockerAdapter().has_image("img")
+
+
 async def test_resolve_host_port_parses_docker_port_output(monkeypatch):
     """Bug caught: the ephemeral port mapping misparsed — every probe would
     target the wrong port and fail an app that is actually healthy."""

--- a/tests/unit/sandbox/test_container_backend.py
+++ b/tests/unit/sandbox/test_container_backend.py
@@ -104,6 +104,21 @@ class TestOutcomeClassification:
         assert result.image_identity == "sandbox:pinned"
         assert result.exit_code == 0
 
+    async def test_environment_contract_id_rides_every_result(self, store, seeded):
+        """Bug caught: §7 item 4's second half — results without the contract
+        identity cannot prove which environment declaration they ran under."""
+        backend = ContainerBackend(
+            container=FakeContainer(),
+            store=store,
+            image="sandbox:pinned",
+            operation_commands=COMMANDS,
+            environment_contract_id="env-123",
+        )
+        one_shot = await backend.run_backend_tests(revision=seeded)
+        assert one_shot.environment_contract_id == "env-123"
+        stop = await backend.stop_application(revision=seeded, cleanup_handle="h1")
+        assert stop.environment_contract_id == "env-123"
+
     async def test_nonzero_exit_is_a_deliverable_failure(self, store, seeded):
         """Bug caught: a failing build not routed to application correction."""
         container = FakeContainer(

--- a/tests/unit/sandbox/test_container_backend.py
+++ b/tests/unit/sandbox/test_container_backend.py
@@ -23,12 +23,23 @@ COMMANDS = {
 
 
 class FakeContainer(ContainerPort):
-    def __init__(self, result: ContainerResult | None = None, error: Exception | None = None):
+    def __init__(
+        self,
+        result: ContainerResult | None = None,
+        error: Exception | None = None,
+        image_present: bool | Exception = True,
+    ):
         self.specs: list[ContainerSpec] = []
         self._result = result or ContainerResult(
             container_id="", exit_code=0, stdout="ok\n", stderr=""
         )
         self._error = error
+        self._image_present = image_present
+
+    async def has_image(self, image: str) -> bool:
+        if isinstance(self._image_present, Exception):
+            raise self._image_present
+        return self._image_present
 
     async def run(self, spec: ContainerSpec) -> ContainerResult:
         self.specs.append(spec)
@@ -103,6 +114,31 @@ class TestOutcomeClassification:
         assert result.ran and result.status == OperationStatus.SUCCEEDED
         assert result.image_identity == "sandbox:pinned"
         assert result.exit_code == 0
+
+    @pytest.mark.parametrize(
+        ("image_present", "expected"),
+        [(True, True), (False, False), (ToolContainerError("no daemon"), None)],
+        ids=["present", "absent", "daemon-unreachable"],
+    )
+    async def test_environment_report_is_honest_about_image_presence(
+        self, store, image_present, expected
+    ):
+        """Bug caught: a daemon outage reported as image-absent (a false
+        preflight block) or as present (a false pass) — unverifiable must
+        stay None."""
+        backend = ContainerBackend(
+            container=FakeContainer(image_present=image_present),
+            store=store,
+            image="sandbox:pinned",
+            operation_commands=COMMANDS,
+            environment_contract_id="env-123",
+        )
+        report = await backend.environment_report()
+        assert report == {
+            "contract_id": "env-123",
+            "image": "sandbox:pinned",
+            "image_present": expected,
+        }
 
     async def test_environment_contract_id_rides_every_result(self, store, seeded):
         """Bug caught: §7 item 4's second half — results without the contract

--- a/tests/unit/sandbox/test_container_backend.py
+++ b/tests/unit/sandbox/test_container_backend.py
@@ -95,6 +95,31 @@ class TestHardenedSpecRendering:
         assert spec.cap_drop_all and spec.no_new_privileges
         assert spec.memory_limit and spec.cpu_limit and spec.pids_limit
 
+    async def test_cache_root_mounts_download_caches_only(self, tmp_path, store, seeded):
+        """Bug caught: §7 item 13's structural guarantee broken — mounting
+        installed-dependency dirs (site-packages/node_modules) instead of
+        download caches would let cached deps substitute for undeclared ones."""
+        container = FakeContainer()
+        backend = ContainerBackend(
+            container=container,
+            store=store,
+            image="sandbox:pinned",
+            operation_commands=COMMANDS,
+            cache_root=tmp_path / "caches",
+        )
+        await backend.install_dependencies(revision=seeded)
+        mounts = dict(container.specs[0].volumes)
+        assert mounts[str(tmp_path / "caches" / "pip")] == "/root/.cache/pip"
+        assert mounts[str(tmp_path / "caches" / "npm")] == "/root/.npm"
+        assert (tmp_path / "caches" / "pip").is_dir()  # pre-created, never root-owned
+        assert not any("site-packages" in c or "node_modules" in c for c in mounts.values())
+
+    async def test_no_cache_root_means_no_cache_mounts(self, store, seeded):
+        """Bug caught: phantom cache mounts when caching is disabled."""
+        container = FakeContainer()
+        await _backend(container, store).build_frontend(revision=seeded)
+        assert len(container.specs[0].volumes) == 1  # workspace only
+
     async def test_install_gets_deps_egress_build_does_not(self, store, seeded):
         """Bug caught: egress polarity flipped — installs starved of the
         network they need, or builds granted egress they must not have."""

--- a/tests/unit/sandbox/test_container_backend.py
+++ b/tests/unit/sandbox/test_container_backend.py
@@ -179,6 +179,11 @@ class TestOutcomeClassification:
         assert one_shot.environment_contract_id == "env-123"
         stop = await backend.stop_application(revision=seeded, cleanup_handle="h1")
         assert stop.environment_contract_id == "env-123"
+        # The probe base dict has its own shape — live-smoke caught it missing.
+        probe = await backend.probe_http_endpoint(
+            revision=seeded, probe_id="p1", method="GET", path="/x"
+        )
+        assert probe.environment_contract_id == "env-123"
 
     async def test_nonzero_exit_is_a_deliverable_failure(self, store, seeded):
         """Bug caught: a failing build not routed to application correction."""

--- a/tests/unit/sandbox/test_container_backend_runtime.py
+++ b/tests/unit/sandbox/test_container_backend_runtime.py
@@ -106,6 +106,16 @@ class TestStartApplication:
             revision=seeded
         )
         assert result.ran and result.ready
+
+    async def test_readiness_is_transport_level_any_response_counts(self, store, seeded):
+        """Bug caught: #520/#622 — readiness demanding a 2xx from a health
+        path the PRD never declared, so a perfectly booted app times out
+        'not ready' forever. A 404 proves the server is up and routing."""
+        container = RuntimeFakeContainer()
+        result = await _backend(container, store, [FakeResponse(404)]).start_application(
+            revision=seeded
+        )
+        assert result.ran and result.ready
         assert result.status == OperationStatus.SUCCEEDED
         assert result.endpoints == ("http://127.0.0.1:49999",)
         assert result.cleanup_handle == "cid-app"

--- a/tests/unit/sandbox/test_container_backend_runtime.py
+++ b/tests/unit/sandbox/test_container_backend_runtime.py
@@ -74,6 +74,9 @@ class RuntimeFakeContainer(ContainerPort):
     async def health(self) -> dict:  # pragma: no cover - unused
         return {"healthy": True}
 
+    async def has_image(self, image: str) -> bool:  # pragma: no cover - unused
+        return True
+
 
 @pytest.fixture
 def store(tmp_path):

--- a/tests/unit/sandbox/test_environment_contract.py
+++ b/tests/unit/sandbox/test_environment_contract.py
@@ -1,0 +1,115 @@
+"""Environment contract (SIP-0102 §4.2 — phase 102.2)."""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from squadops.capabilities.scaffold import InterfaceManifest, expand
+from squadops.sandbox.environment import (
+    FULLSTACK_FASTAPI_REACT,
+    EnvironmentContract,
+    get_environment_contract,
+)
+from squadops.sandbox.models import OperationName
+
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+
+
+def _minimal(**overrides) -> EnvironmentContract:
+    base = {
+        "stack": "test_stack",
+        "image": "img:pinned",
+        "required_tools": (("python", "3.12"),),
+        "operation_commands": ((OperationName.BUILD_FRONTEND, ("npm", "run", "build")),),
+        "app_port": 8000,
+        "install_network": "bridge",
+    }
+    return EnvironmentContract(**{**base, **overrides})
+
+
+class TestContractIdentity:
+    def test_contract_id_is_deterministic_and_covers_every_field(self):
+        """Bug caught: identity not covering a field — a changed image or
+        command would keep the same contract_id, silently invalidating §7
+        items 4/15 evidence pinning."""
+        assert _minimal().contract_id() == _minimal().contract_id()
+        assert _minimal(image="img:other").contract_id() != _minimal().contract_id()
+        changed_cmd = _minimal(
+            operation_commands=((OperationName.BUILD_FRONTEND, ("npm", "run", "build2")),)
+        )
+        assert changed_cmd.contract_id() != _minimal().contract_id()
+
+
+class TestValidation:
+    @pytest.mark.parametrize(
+        ("overrides", "match"),
+        [
+            ({"operation_commands": (("run_shell", ("sh",)),)}, "unknown operation"),
+            (
+                {
+                    "operation_commands": (
+                        (OperationName.BUILD_FRONTEND, ("a",)),
+                        (OperationName.BUILD_FRONTEND, ("b",)),
+                    )
+                },
+                "duplicate operation",
+            ),
+            ({"operation_commands": ((OperationName.BUILD_FRONTEND, ()),)}, "empty command"),
+            ({"app_port": 0}, "invalid app_port"),
+            ({"image": ""}, "requires an image"),
+        ],
+        ids=["unknown-op", "duplicate-op", "empty-argv", "bad-port", "no-image"],
+    )
+    def test_invalid_declarations_are_rejected(self, overrides, match):
+        """Bug caught: a malformed checked-in contract deploying silently —
+        the failure would surface mid-cycle instead of at import time."""
+        with pytest.raises(ValueError, match=match):
+            _minimal(**overrides)
+
+    def test_unknown_stack_has_no_fallback(self):
+        """Bug caught: an unregistered stack silently receiving some default
+        environment (the no-fake-working-defaults rule)."""
+        with pytest.raises(ValueError, match="no environment contract"):
+            get_environment_contract("fullstack_django_vue")
+
+
+class TestCanonicalContract:
+    def test_canonical_provides_exactly_the_floor_operations(self):
+        """Bug caught: the advertised operation set drifting — dropping an op
+        breaks the golden path; adding one un-implements advertised-vs-
+        provided (read_build_diagnostics is deliberately unprovided, 102.5)."""
+        provided = {op for op, _ in FULLSTACK_FASTAPI_REACT.operation_commands}
+        assert provided == {
+            OperationName.INSTALL_DEPENDENCIES,
+            OperationName.BUILD_FRONTEND,
+            OperationName.RUN_BACKEND_TESTS,
+            OperationName.START_APPLICATION,
+        }
+        assert not FULLSTACK_FASTAPI_REACT.provides(OperationName.READ_BUILD_DIAGNOSTICS)
+
+    def test_canonical_commands_cohere_with_the_real_skeleton(self):
+        """Bug caught: contract↔expander drift — commands referencing paths
+        the skeleton does not emit (requirements moved, frontend renamed,
+        uvicorn target changed) would fail every cycle at task time."""
+        raw = yaml.safe_load(_MANIFEST_PATH.read_text(encoding="utf-8"))
+        names = {f["name"] for f in expand(InterfaceManifest.from_dict(raw))}
+        assert "backend/requirements.txt" in names  # install references it
+        assert "backend/main.py" in names  # uvicorn backend.main:app
+        assert "frontend/package.json" in names  # npm --prefix frontend
+        package_json = next(
+            f["content"]
+            for f in expand(InterfaceManifest.from_dict(raw))
+            if f["name"] == "frontend/package.json"
+        )
+        assert "build" in json.loads(package_json)["scripts"]  # npm run build exists
+        # No lockfile in the skeleton — the contract must use `npm install`,
+        # never `npm ci` (which hard-fails without package-lock.json).
+        assert "frontend/package-lock.json" not in names
+        install_argv = dict(FULLSTACK_FASTAPI_REACT.operation_commands)[
+            OperationName.INSTALL_DEPENDENCIES
+        ]
+        assert "npm ci" not in " ".join(install_argv)

--- a/tests/unit/sandbox/test_factory_wiring.py
+++ b/tests/unit/sandbox/test_factory_wiring.py
@@ -20,11 +20,38 @@ def test_default_and_absent_config_yield_the_noop_sandbox(tmp_path):
     assert isinstance(default, NoOpExecutionSandbox)
 
 
-def test_docker_provider_without_image_raises(tmp_path):
-    """Bug caught: a fake-working default image masking missing config (the
-    _get_default_instances lesson) — must surface the error instead."""
-    config = SandboxConfig(provider="docker", workspace_root=tmp_path)
-    with pytest.raises(ValueError, match="IMAGE is required"):
+def test_docker_provider_is_contract_driven(tmp_path):
+    """Bug caught: the backend constructed from ad-hoc config instead of the
+    checked-in environment contract — commands/image/identity would drift
+    from what §7 item 4 evidence claims."""
+    from squadops.sandbox.environment import get_environment_contract
+
+    contract = get_environment_contract("fullstack_fastapi_react")
+    service = create_sandbox_service(SandboxConfig(provider="docker", workspace_root=tmp_path))
+    backend = service._backend
+    assert backend._image == contract.image
+    assert backend._operation_commands == contract.commands()
+    assert backend._environment_contract_id == contract.contract_id()
+
+
+def test_config_image_override_wins_but_identity_stays_contract(tmp_path):
+    """Bug caught: an image override silently ignored, or the override
+    mutating the contract identity — the id must name the contract while the
+    result's image_identity names what actually ran."""
+    from squadops.sandbox.environment import get_environment_contract
+
+    config = SandboxConfig(provider="docker", workspace_root=tmp_path, image="override:img")
+    backend = create_sandbox_service(config)._backend
+    assert backend._image == "override:img"
+    contract = get_environment_contract("fullstack_fastapi_react")
+    assert backend._environment_contract_id == contract.contract_id()
+
+
+def test_unknown_environment_raises(tmp_path):
+    """Bug caught: an unregistered stack silently degrading to some default
+    environment instead of surfacing the gap at construction."""
+    config = SandboxConfig(provider="docker", workspace_root=tmp_path, environment="nope")
+    with pytest.raises(ValueError, match="no environment contract"):
         create_sandbox_service(config)
 
 

--- a/tests/unit/sandbox/test_http_surface.py
+++ b/tests/unit/sandbox/test_http_surface.py
@@ -52,6 +52,28 @@ async def test_health_probe_is_unauthenticated(stack):
         response = await client.get("/health")
     assert response.status_code == 200
     assert response.json()["status"] == "ok"
+    assert response.json()["environment"] is None  # backendless: nothing to report
+
+
+async def test_health_carries_the_environment_report(tmp_path):
+    """Bug caught: 102.2c's reconciliation evidence not riding /health — the
+    cycle-create preflight and doctor would have nothing to reconcile."""
+    root = tmp_path / "cycles"
+
+    async def report():
+        return {"contract_id": "env-123", "image": "img", "image_present": True}
+
+    service = SandboxService(
+        store=WorkspaceStore(root),
+        journal=OperationEvidenceJournal(root),
+        environment_report=report,
+    )
+    app = create_app(service, service_token=TOKEN)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://exec"
+    ) as client:
+        response = await client.get("/health")
+    assert response.json()["environment"]["contract_id"] == "env-123"
 
 
 async def test_missing_bearer_is_401_in_the_resource_envelope(stack):

--- a/tests/unit/sandbox/test_sandbox_preflight.py
+++ b/tests/unit/sandbox/test_sandbox_preflight.py
@@ -1,0 +1,135 @@
+"""Sandbox preflight reconciliation (SIP-0102 — phase 102.2c)."""
+
+import pytest
+
+from squadops.bootstrap.setup import checks as doctor_checks
+from squadops.sandbox.environment import FULLSTACK_FASTAPI_REACT
+from squadops.sandbox.preflight import sandbox_environment_decision
+
+EXPECTED = "contract-abc"
+GOOD_REPORT = {"contract_id": EXPECTED, "image": "img:pinned", "image_present": True}
+
+
+class TestDecisionRules:
+    def test_dormant_provider_contributes_nothing(self):
+        """Bug caught: the inert posture broken — a noop deployment blocked or
+        warned by sandbox preflight it never opted into."""
+        decision = sandbox_environment_decision(
+            provider="noop", expected_contract_id=None, report=None
+        )
+        assert not decision.rejected and not decision.warnings
+
+    def test_unknown_environment_blocks(self):
+        """Bug caught: a configured-but-contractless stack dispatching anyway —
+        every sandbox op would be an unprovided-command stall at task time."""
+        decision = sandbox_environment_decision(
+            provider="docker", expected_contract_id=None, report=GOOD_REPORT
+        )
+        assert [f.code for f in decision.blocking] == ["sandbox_environment_unknown"]
+
+    def test_unreachable_service_warns_and_allows(self):
+        """Bug caught: blocking on missing evidence — SIP-0095 §6.2's doctrine
+        is warn-and-allow when the service cannot be queried."""
+        decision = sandbox_environment_decision(
+            provider="docker", expected_contract_id=EXPECTED, report=None
+        )
+        assert not decision.rejected
+        assert [f.code for f in decision.warnings] == ["sandbox_unverifiable"]
+
+    def test_contract_skew_blocks(self):
+        """Bug caught: the roll-4 class at create time — a service running an
+        older contract than the tree expects would execute wrong commands and
+        stamp wrong identity on every result."""
+        decision = sandbox_environment_decision(
+            provider="docker",
+            expected_contract_id=EXPECTED,
+            report={**GOOD_REPORT, "contract_id": "contract-OLD"},
+        )
+        assert [f.code for f in decision.blocking] == ["sandbox_contract_mismatch"]
+
+    def test_missing_image_blocks_with_the_build_remedy(self):
+        """Bug caught: dispatching into a host without the environment image —
+        three cycles stalled pre-builder on exactly this class (#306 lineage)."""
+        decision = sandbox_environment_decision(
+            provider="docker",
+            expected_contract_id=EXPECTED,
+            report={**GOOD_REPORT, "image_present": False},
+        )
+        assert [f.code for f in decision.blocking] == ["sandbox_image_missing"]
+        assert "build_sandbox_env_image.sh" in decision.blocking[0].message
+
+    def test_unverifiable_image_warns_and_allows(self):
+        """Bug caught: a daemon hiccup during preflight rejecting a cycle the
+        environment could actually run."""
+        decision = sandbox_environment_decision(
+            provider="docker",
+            expected_contract_id=EXPECTED,
+            report={**GOOD_REPORT, "image_present": None},
+        )
+        assert not decision.rejected
+        assert [f.code for f in decision.warnings] == ["sandbox_image_unverifiable"]
+
+    def test_matching_environment_is_clean(self):
+        """Bug caught: false findings on a healthy environment — preflight
+        noise that trains operators to ignore it."""
+        decision = sandbox_environment_decision(
+            provider="docker", expected_contract_id=EXPECTED, report=GOOD_REPORT
+        )
+        assert not decision.rejected and not decision.warnings
+
+
+class TestDoctorCategory:
+    """The doctor renders the SAME decision (exit-criterion parity)."""
+
+    def test_dormant_config_is_a_passing_check(self, monkeypatch):
+        monkeypatch.delenv("SQUADOPS__SANDBOX__PROVIDER", raising=False)
+        results = doctor_checks._collect_sandbox_checks(profile=None)
+        assert [(r.name, r.passed) for r in results] == [("sandbox_dormant", True)]
+
+    def test_missing_image_is_a_failing_check_with_fix_command(self, monkeypatch):
+        """Bug caught: doctor and create-time preflight disagreeing about the
+        same environment (the exit criterion demands the same finding)."""
+        monkeypatch.setenv("SQUADOPS__SANDBOX__PROVIDER", "docker")
+        monkeypatch.setattr(
+            doctor_checks,
+            "_fetch_sandbox_report",
+            lambda url: {
+                "contract_id": FULLSTACK_FASTAPI_REACT.contract_id(),
+                "image": FULLSTACK_FASTAPI_REACT.image,
+                "image_present": False,
+            },
+        )
+        results = doctor_checks._collect_sandbox_checks(profile=None)
+        assert [(r.name, r.passed) for r in results] == [("sandbox_image_missing", False)]
+        assert results[0].fix_command == "./scripts/dev/build_sandbox_env_image.sh"
+
+    def test_unreachable_service_is_heuristic_not_hard_failure(self, monkeypatch):
+        """Bug caught: doctor exiting 1 on unverifiable evidence — parity with
+        warn-and-allow requires heuristic, which doctor never counts as a
+        hard failure."""
+        monkeypatch.setenv("SQUADOPS__SANDBOX__PROVIDER", "docker")
+        monkeypatch.setattr(doctor_checks, "_fetch_sandbox_report", lambda url: None)
+        results = doctor_checks._collect_sandbox_checks(profile=None)
+        assert [(r.name, r.heuristic) for r in results] == [("sandbox_unverifiable", True)]
+
+    def test_healthy_environment_is_a_passing_check(self, monkeypatch):
+        monkeypatch.setenv("SQUADOPS__SANDBOX__PROVIDER", "docker")
+        monkeypatch.setattr(
+            doctor_checks,
+            "_fetch_sandbox_report",
+            lambda url: {
+                "contract_id": FULLSTACK_FASTAPI_REACT.contract_id(),
+                "image": FULLSTACK_FASTAPI_REACT.image,
+                "image_present": True,
+            },
+        )
+        results = doctor_checks._collect_sandbox_checks(profile=None)
+        assert [(r.name, r.passed) for r in results] == [("sandbox_environment", True)]
+
+
+@pytest.fixture(autouse=True)
+def _clean_sandbox_env(monkeypatch):
+    """Doctor collector reads live env — isolate every test from the host."""
+    for key in list(__import__("os").environ):
+        if key.startswith("SQUADOPS__SANDBOX__"):
+            monkeypatch.delenv(key, raising=False)

--- a/tests/unit/sandbox/test_workspace_store.py
+++ b/tests/unit/sandbox/test_workspace_store.py
@@ -93,6 +93,43 @@ class TestPatch:
             )
 
 
+class TestDerivedStateExclusion:
+    def test_installed_dependencies_do_not_break_the_pin(self, store):
+        """Bug caught: the first install (venv/node_modules into the
+        bind-mounted workspace, §4.7) breaking pin verification and every
+        subsequent stale-base check — the sandbox would refuse to build
+        anything it had just installed dependencies for."""
+        seed = store.seed("cyc_1", FILES, origin=RevisionOrigin.SCAFFOLD_SEED)
+        ws = store.workspace_dir("cyc_1")
+        (ws / "frontend/node_modules/react").mkdir(parents=True)
+        (ws / "frontend/node_modules/react/index.js").write_text("js", encoding="utf-8")
+        (ws / ".sandbox-venv/bin").mkdir(parents=True)
+        (ws / ".sandbox-venv/bin/python").write_text("bin", encoding="utf-8")
+        (ws / "backend/__pycache__").mkdir(parents=True)
+        (ws / "backend/__pycache__/main.pyc").write_text("pyc", encoding="utf-8")
+        assert store.verify_pinned("cyc_1", seed.revision_id)
+        rev, _ = store.apply_patch(
+            "cyc_1",
+            base_revision_id=seed.revision_id,
+            files={"backend/main.py": "print('b')\n"},
+            origin=RevisionOrigin.AGENT_PATCH,
+        )
+        assert store.verify_pinned("cyc_1", rev.revision_id)
+
+    def test_patching_derived_state_paths_is_rejected(self, store):
+        """Bug caught: a patch writing into node_modules/dist — content that
+        would exist on disk but never in any revision, silently diverging the
+        tree from every pin."""
+        seed = store.seed("cyc_1", FILES, origin=RevisionOrigin.SCAFFOLD_SEED)
+        with pytest.raises(WorkspaceEscapeError, match="derived-state"):
+            store.apply_patch(
+                "cyc_1",
+                base_revision_id=seed.revision_id,
+                files={"frontend/node_modules/evil.js": "x"},
+                origin=RevisionOrigin.AGENT_PATCH,
+            )
+
+
 class TestPinningAndRecovery:
     def test_verify_pinned_detects_out_of_band_mutation(self, store):
         """Bug caught: clean-room verification passing against a tree that no

--- a/tests/unit/sandbox/test_workspace_store.py
+++ b/tests/unit/sandbox/test_workspace_store.py
@@ -107,6 +107,8 @@ class TestDerivedStateExclusion:
         (ws / ".sandbox-venv/bin/python").write_text("bin", encoding="utf-8")
         (ws / "backend/__pycache__").mkdir(parents=True)
         (ws / "backend/__pycache__/main.pyc").write_text("pyc", encoding="utf-8")
+        # npm install generates a lockfile (live-smoke-proven) — derived, not pinned.
+        (ws / "frontend/package-lock.json").write_text("{}", encoding="utf-8")
         assert store.verify_pinned("cyc_1", seed.revision_id)
         rev, _ = store.apply_patch(
             "cyc_1",


### PR DESCRIPTION
## Summary

Phase **102.2** complete, plus a fix for a golden-path-blocking bug found in merged 102.1 code. The phase exit criterion is met on both halves, and the floor has now **executed end-to-end on real docker** — the informal engine-turns-over precursor.

## Live smoke (Mac, docker 29.5.3, canonical image built locally)

Real expander skeleton (17 files) → seed → `install_dependencies` (15s, caches warm) → `build_frontend` (real vite build, 1s) → `start_application` to readiness → `probe_http_endpoint` GET /runs → **501 observed = succeeded** (the bare-skeleton partition: routing works, behavior honestly unimplemented) → converging teardown. Pin verification intact through install/build. The smoke caught two real gaps unit tests missed (below).

## Commits

- **fix(#622)** — 102.1c2's readiness demanded a 2xx from `/health`, re-introducing the exact hidden-product-requirement class #520 fixed: the canonical app declares no /health, so `start_application` would have timed out forever on the golden path. Readiness is now transport-level (any HTTP response). **Closes #622**
- **102.2a+b** — `EnvironmentContract` (content-hashed `contract_id`, import-time validation) with the canonical `fullstack_fastapi_react` contract **coherence-tested against a real expander run**; contract-driven factory (config image = override only); `environment_contract_id` on every result (§7 item 4); **derived-state rule** (`.sandbox-venv`/`node_modules`/`dist`/lockfile are never revision content — §4.7 installs live in the workspace, so without this the first install breaks every pin); checked-in image rendering + build script (local-build decision recorded).
- **102.2c** — one pure `sandbox_environment_decision` rendered by BOTH the cycle-create preflight (SIP-0095 seam) and a new `doctor` **sandbox** category, so they can never disagree. Evidence doctrine per SIP-0095 §6.2: unreachable service / daemon-can't-answer ⇒ warn-and-allow; unknown environment / contract skew / missing image ⇒ block (fix command = the build script). Provider `noop` ⇒ empty decision — dormant on every existing deployment.
- **102.2d** — read-through download caches (pip/npm download caches only — cached deps structurally cannot substitute for undeclared ones, §7 item 13) + the docker-outside-of-docker fix: the containerized service hands workspace paths to the HOST daemon, so compose now uses an identical-string same-path bind instead of 102.1's named volume (which could never work).
- **live-smoke findings** — npm install generates `package-lock.json` (derived state, excluded; evidence capture = the explicit promotion path); the probe result was missing `environment_contract_id` (its base dict has its own shape). Both unit-covered now.

## Exit criterion

- ✅ a deliberately mismatched/missing environment blocks at cycle-create preflight, and doctor reports the same finding (same decision function by construction)
- ✅ every sandbox op result carries image + environment-contract identity
- ✅ (beyond the bar) full floor E2E on real docker

## Inert-to-merge

Route addition is dormant (env-driven; no `SQUADOPS__SANDBOX__*` set ⇒ empty decision, no IO). Doctor category is additive. Compose changes stay profile-guarded. Pure addition elsewhere. Regression **5758 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaFdkrgQ8F3UZ1DE7LDEU3