### PR TITLE
fix(checks): declare check applicability; behavioral retest decides when no structural check applies

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -49,6 +49,8 @@ from squadops.cycles.models import (
 from squadops.cycles.naming import flow_run_name
 from squadops.cycles.patch_verification import (
     PATCH_PASSED,
+    PATCH_UNVERIFIABLE,
+    STRUCTURALLY_UNEVALUABLE_REASONS,
     overlay_artifacts,
     verify_patched_artifacts,
 )
@@ -2045,7 +2047,28 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             len(verification.checks),
             ",".join(failed_checks) or "-",
         )
-        if verification.status != PATCH_PASSED:
+        # pf-47/pf-49: when a task's checks are structurally unevaluable (a frontend
+        # test file — every AST check skips by design), "unverifiable" is not caution,
+        # it is a deterministic repair deadlock: no repair can EVER produce an executed
+        # verdict, so the loop burns its whole budget rejecting repairs unheard. The
+        # behavioral retest below re-runs the actual failing suite against the patched
+        # workspace — stronger evidence than the checks it stands in for — so for
+        # exactly these reasons, and only with behavioral evidence to re-run, the
+        # retest verdict decides alone. Evaluator errors, parse failures, and real
+        # check failures keep failing closed, unchanged.
+        retest_decides = (
+            verification.status == PATCH_UNVERIFIABLE
+            and verification.reason in STRUCTURALLY_UNEVALUABLE_REASONS
+            and isinstance((result.outputs or {}).get("test_result"), dict)
+        )
+        if retest_decides:
+            logger.info(
+                "patch_verification task=%s structurally unevaluable (%s) — "
+                "behavioral retest decides",
+                envelope.task_id,
+                verification.reason,
+            )
+        if verification.status != PATCH_PASSED and not retest_decides:
             return "continue"
 
         corrected_outputs = dict(result.outputs or {})

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -67,6 +67,15 @@ class CheckSpec:
         notes: Free-text constraint rendered into the proposer vocabulary as a
             ``- Note:`` line. For constraints the param schema alone can't
             express (e.g. the command safelist).
+        applicable_extensions: File extensions (lowercase, with dot) the
+            evaluator can actually parse for this check's ``file`` target.
+            Empty = not file-scoped or applicable to any file. pf-47/pf-49: the
+            five AST checks read Python source only, but nothing told the plan
+            author, so QA tasks dressed ``.jsx`` test files in pytest-idiom
+            checks — every one skipped at evaluation, and a repair to such a
+            task could never produce an executed verdict. Declared here so the
+            authoring vocabulary renders it and dispatch can strip dead checks;
+            derived consumers cannot drift from this table.
     """
 
     name: str
@@ -78,10 +87,28 @@ class CheckSpec:
     path_params: frozenset[str] = frozenset()
     example: dict[str, object] = field(default_factory=dict)
     notes: str = ""
+    applicable_extensions: frozenset[str] = frozenset()
 
 
 # Allowed severity values. Anything else → ValueError at parse time.
 ALLOWED_SEVERITIES: frozenset[str] = frozenset({"error", "warning", "info"})
+
+
+def is_check_applicable(check_name: str, file_path: str) -> bool:
+    """Can ``check_name``'s evaluator ever parse ``file_path``?
+
+    True for checks that are not file-scoped (no ``applicable_extensions``) and
+    for unknown names (the parser rejects those elsewhere; this helper never
+    invents a second rejection path). A False here means the check would skip at
+    every evaluation forever — dead weight in a plan, and on a QA task whose
+    checks are ALL dead, a repair can never produce an executed verdict.
+    """
+    spec = CHECK_SPECS.get(check_name)
+    if spec is None or not spec.applicable_extensions:
+        return True
+    from pathlib import PurePosixPath
+
+    return PurePosixPath(file_path).suffix.lower() in spec.applicable_extensions
 
 
 # ---------------------------------------------------------------------------
@@ -178,6 +205,7 @@ def command_safelist_names() -> tuple[str, ...]:
 CHECK_SPECS: dict[str, CheckSpec] = {
     "endpoint_defined": CheckSpec(
         name="endpoint_defined",
+        applicable_extensions=frozenset({".py"}),
         required_params=frozenset({"file", "methods_paths"}),
         param_types={"file": str, "methods_paths": list},
         supported_stacks=frozenset({"fastapi"}),
@@ -187,6 +215,7 @@ CHECK_SPECS: dict[str, CheckSpec] = {
     ),
     "import_present": CheckSpec(
         name="import_present",
+        applicable_extensions=frozenset({".py"}),
         required_params=frozenset({"file", "module"}),
         optional_params=frozenset({"symbol"}),
         param_types={"file": str, "module": str, "symbol": str},
@@ -197,6 +226,7 @@ CHECK_SPECS: dict[str, CheckSpec] = {
     ),
     "field_present": CheckSpec(
         name="field_present",
+        applicable_extensions=frozenset({".py"}),
         required_params=frozenset({"file", "class_name", "fields"}),
         param_types={"file": str, "class_name": str, "fields": list},
         supported_stacks=frozenset({"python"}),
@@ -206,6 +236,7 @@ CHECK_SPECS: dict[str, CheckSpec] = {
     ),
     "function_defined": CheckSpec(
         name="function_defined",
+        applicable_extensions=frozenset({".py"}),
         required_params=frozenset({"file", "name_prefix"}),
         optional_params=frozenset({"min_count"}),
         param_types={"file": str, "name_prefix": str, "min_count": int},
@@ -225,6 +256,7 @@ CHECK_SPECS: dict[str, CheckSpec] = {
     ),
     "harness_boundary": CheckSpec(
         name="harness_boundary",
+        applicable_extensions=frozenset({".py"}),
         required_params=frozenset({"file", "entry_modules"}),
         optional_params=frozenset({"client_ctor"}),
         param_types={"file": str, "entry_modules": list, "client_ctor": str},
@@ -374,6 +406,13 @@ def render_typed_acceptance_vocabulary() -> str:
                 f"`{p}` ({_type_label(spec, p)})" for p in sorted(spec.optional_params)
             )
             out.append(f"- Optional: {optional}")
+        if spec.applicable_extensions:
+            exts = ", ".join(f"`{e}`" for e in sorted(spec.applicable_extensions))
+            out.append(
+                f"- Applies to: {exts} files ONLY — never attach to any other "
+                f"file type (e.g. `.js`/`.jsx`); it cannot be evaluated there "
+                f"and is stripped at dispatch."
+            )
         if spec.notes:
             out.append(f"- Note: {spec.notes}")
         out.append("- Example:")

--- a/src/squadops/cycles/patch_verification.py
+++ b/src/squadops/cycles/patch_verification.py
@@ -50,6 +50,19 @@ PATCH_PASSED = "passed"
 PATCH_FAILED = "failed"
 PATCH_UNVERIFIABLE = "unverifiable"
 
+# Unverifiable *reasons* that mean "no structural evidence is possible for this
+# task" — as opposed to "an evaluator broke". The distinction is load-bearing at
+# patch acceptance: a frontend test task's checks all skip by design (Python-AST
+# checks, non-Python file), so structural verification can never speak, and the
+# behavioral retest (#456) is the only evidence there will ever be. Fail-closed
+# on THESE reasons is not caution — it is a deterministic repair deadlock
+# (pf-47: 4 repairs rejected unheard; pf-49: same signature).
+REASON_NO_EXECUTED_BLOCKING_CHECKS = "no_executed_blocking_checks"
+REASON_NO_TYPED_CRITERIA = "no_typed_criteria"
+STRUCTURALLY_UNEVALUABLE_REASONS = frozenset(
+    {REASON_NO_EXECUTED_BLOCKING_CHECKS, REASON_NO_TYPED_CRITERIA}
+)
+
 
 @dataclass(frozen=True)
 class PatchCheckRecord:
@@ -285,7 +298,7 @@ async def verify_patched_artifacts(
     if typed is None:
         return PatchVerification(status=PATCH_UNVERIFIABLE, reason="unparseable_criteria")
     if not typed:
-        return PatchVerification(status=PATCH_UNVERIFIABLE, reason="no_typed_criteria")
+        return PatchVerification(status=PATCH_UNVERIFIABLE, reason=REASON_NO_TYPED_CRITERIA)
 
     records: list[PatchCheckRecord] = []
     blocking_failure = False
@@ -355,6 +368,6 @@ async def verify_patched_artifacts(
         return PatchVerification(
             status=PATCH_UNVERIFIABLE,
             checks=tuple(records),
-            reason="no_executed_blocking_checks",
+            reason=REASON_NO_EXECUTED_BLOCKING_CHECKS,
         )
     return PatchVerification(status=PATCH_PASSED, checks=tuple(records))

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -29,6 +29,7 @@ from squadops.capabilities.scaffold import (
     harness_entry_modules,
     is_qa_test_path_for_stack,
 )
+from squadops.cycles.acceptance_check_spec import is_check_applicable
 from squadops.cycles.agent_config import resolve_agent_config
 from squadops.cycles.failure_evidence import FailureLocus
 from squadops.cycles.implementation_plan import (
@@ -422,6 +423,36 @@ def _resolve_legacy_steps(
     return steps, builder_used
 
 
+def _applicable_acceptance(plan_task: Any) -> list:
+    """The task's authored acceptance criteria, minus checks that can never evaluate.
+
+    pf-47/pf-49: the author dresses non-Python files in Python-AST checks (pytest
+    idioms on ``.jsx`` test files) because the vocabulary never told it which checks
+    apply where. Such a check skips at every evaluation forever — and a QA task whose
+    checks are ALL dead can never land a repair (zero executed blocking checks →
+    unverifiable → fail closed): both rolls burned their full correction budgets
+    rejecting repairs unheard. Stripped at dispatch, loudly; the vocabulary now
+    teaches applicability so authored plans converge, and this is the deterministic
+    backstop.
+    """
+    acceptance: list = []
+    for criterion in plan_task.acceptance_criteria:
+        if isinstance(criterion, TypedCheck):
+            target = str(criterion.params.get("file", ""))
+            if target and not is_check_applicable(criterion.check, target):
+                logger.warning(
+                    "inapplicable_check_stripped task=%s check=%s file=%s — the "
+                    "evaluator cannot parse this file type; the check would skip "
+                    "at every evaluation (pf-47/pf-49 deadlock class)",
+                    plan_task.task_index,
+                    criterion.check,
+                    target,
+                )
+                continue
+        acceptance.append(criterion)
+    return acceptance
+
+
 def _inject_contract_inputs(
     inputs: dict,
     contract: VerificationContract | None,
@@ -642,7 +673,7 @@ def generate_task_plan(
             # artifact, so omitting the key keeps their corrections byte-identical.
             if task_type == "qa.test":
                 inputs["implementation_artifacts"] = implementation_artifacts
-            acceptance = list(plan_task.acceptance_criteria)
+            acceptance = _applicable_acceptance(plan_task)
             # SIP-0098 98.3: in bind mode, resolve the task's criteria_refs into
             # TypedChecks (stamped with contract ids) and merge them in. The plan
             # binds by id, dispatch materializes — evaluation is unchanged. Author

--- a/tests/unit/cycles/test_outcome_routing.py
+++ b/tests/unit/cycles/test_outcome_routing.py
@@ -882,3 +882,196 @@ class TestEmissionRetryFeedbackThreading:
         published = [json.loads(c.args[1]) for c in mock_queue.publish.call_args_list]
         retry_inputs = published[1]["payload"]["inputs"]
         assert "emission_retry_feedback" not in retry_inputs
+
+
+class TestAcceptPatchStructurallyUnevaluable:
+    """pf-47/pf-49: a task whose typed checks ALL skip (Python-AST checks, non-Python
+    file) could never land a repair — zero executed blocking checks → unverifiable →
+    fail closed, on every attempt, deterministically. Both rolls burned their full
+    correction budgets rejecting repairs unheard while the behavioral retest — which
+    re-runs the actual failing suite — sat one step downstream, gated behind the
+    structural verdict that could never come. For exactly the structurally-unevaluable
+    reasons, and only when behavioral evidence exists to re-run, the retest decides.
+    """
+
+    def _failed_frontend_qa_result(self):
+        return TaskResult(
+            task_id="task_7",
+            status="FAILED",
+            outputs={
+                "artifacts": [
+                    {
+                        "name": "frontend/src/__tests__/App.test.jsx",
+                        "content": "jest.mock('x')\n",  # the pf-49 Jest-in-Vitest emission
+                        "type": "test",
+                    }
+                ],
+                "test_result": {"executed": True, "exit_code": 1, "tests_passed": False},
+                "validation_result": {"passed": False, "checks": []},
+                "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
+            },
+            error="vitest cannot parse jest syntax",
+        )
+
+    def _frontend_qa_envelope(self):
+        from squadops.cycles.implementation_plan import TypedCheck
+        from squadops.tasks.models import TaskEnvelope
+
+        # The pf-49 criteria shape: every check Python-AST-shaped, every one skips
+        # on the .jsx target — structural verification can never speak.
+        return TaskEnvelope(
+            task_id="task_7",
+            agent_id="eve",
+            cycle_id="cyc_001",
+            pulse_id="p",
+            project_id="hello_squad",
+            task_type="qa.test",
+            correlation_id="corr",
+            causation_id=None,
+            trace_id="t",
+            span_id="s",
+            inputs={
+                "resolved_config": {},
+                "artifact_contents": {},
+                "acceptance_criteria": [
+                    TypedCheck(
+                        check="function_defined",
+                        params={
+                            "file": "frontend/src/__tests__/App.test.jsx",
+                            "name_prefix": "test",
+                        },
+                        severity="error",
+                        description="Defines tests",
+                    ),
+                    TypedCheck(
+                        check="import_present",
+                        params={
+                            "file": "frontend/src/__tests__/App.test.jsx",
+                            "module": "frontend/src/App",
+                        },
+                        severity="error",
+                        description="Imports the app",
+                    ),
+                ],
+            },
+            metadata={"role": "qa"},
+        )
+
+    def _repair(self):
+        return [
+            {
+                "name": "frontend/src/__tests__/App.test.jsx",
+                "content": "import { test, expect } from 'vitest'\ntest('x', () => {})\n",
+            }
+        ]
+
+    def _retest(self, passed):
+        return TaskResult(
+            task_id="retest",
+            status="SUCCEEDED" if passed else "FAILED",
+            outputs={
+                "test_result": {
+                    "executed": True,
+                    "exit_code": 0 if passed else 1,
+                    "tests_passed": passed,
+                }
+            },
+            error=None if passed else "still failing",
+        )
+
+    def _kwargs(self, cycle):
+        return {
+            "run_id": "run_001",
+            "cycle": cycle,
+            "correction_attempts": 0,
+            "prior_outputs": {},
+            "all_artifact_refs": [],
+            "stored_artifacts": [],
+            "completed_task_ids": [],
+            "plan_delta_refs": [],
+            "profile": None,
+            "flow_run_id": None,
+        }
+
+    async def test_retest_pass_breaks_the_deadlock(self, executor, cycle):
+        """The pf-47/pf-49 fix: all checks skip, but the repaired suite re-runs
+        and passes — the repair is accepted on behavioral evidence."""
+        executor._correction_runner.reexecute_repaired_suite = AsyncMock(
+            return_value=self._retest(True)
+        )
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            self._frontend_qa_envelope(),
+            self._failed_frontend_qa_result(),
+            self._repair(),
+            holder,
+            **self._kwargs(cycle),
+        )
+
+        assert action == "accept_patch"
+        corrected = holder["patched_result"]
+        assert corrected.outputs["test_result"]["tests_passed"] is True
+        # Evidence stays honest: the structural rows record skipped, not passed.
+        rows = corrected.outputs["validation_result"]["checks"]
+        skipped = [r for r in rows if r.get("status") == "skipped"]
+        assert skipped, "the skip rows must survive into evidence"
+
+    async def test_retest_failure_still_rejects(self, executor, cycle):
+        """The false-green guard survives: behavioral evidence decides, and it said no."""
+        executor._correction_runner.reexecute_repaired_suite = AsyncMock(
+            return_value=self._retest(False)
+        )
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            self._frontend_qa_envelope(),
+            self._failed_frontend_qa_result(),
+            self._repair(),
+            holder,
+            **self._kwargs(cycle),
+        )
+        assert action == "continue"
+        assert "patched_result" not in holder
+
+    async def test_no_behavioral_evidence_stays_fail_closed(self, executor, cycle):
+        """Unevaluable checks WITHOUT a test_result → nothing can decide → continue.
+        The §6.2 principle holds: never accept on absent evidence."""
+        import dataclasses as _dc
+
+        result = self._failed_frontend_qa_result()
+        outputs = dict(result.outputs)
+        outputs.pop("test_result")
+        result = _dc.replace(result, outputs=outputs)
+
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            self._frontend_qa_envelope(), result, self._repair(), holder, **self._kwargs(cycle)
+        )
+        assert action == "continue"
+        assert holder == {}
+
+    async def test_evaluator_error_stays_fail_closed(self, executor, cycle, monkeypatch):
+        """A broken checker proves nothing about the patch and does NOT unlock the
+        retest path — only the structurally-unevaluable reasons do."""
+        from squadops.cycles.patch_verification import PATCH_UNVERIFIABLE, PatchVerification
+
+        async def _broken_evaluator(*args, **kwargs):
+            return PatchVerification(
+                status=PATCH_UNVERIFIABLE, reason="evaluator_error:function_defined"
+            )
+
+        import adapters.cycles.dispatched_flow_executor as ex_mod
+
+        monkeypatch.setattr(ex_mod, "verify_patched_artifacts", _broken_evaluator)
+        executor._correction_runner.reexecute_repaired_suite = AsyncMock(
+            return_value=self._retest(True)
+        )
+        holder: dict = {}
+        action = await executor._try_accept_patch(
+            self._frontend_qa_envelope(),
+            self._failed_frontend_qa_result(),
+            self._repair(),
+            holder,
+            **self._kwargs(cycle),
+        )
+        assert action == "continue"
+        executor._correction_runner.reexecute_repaired_suite.assert_not_awaited()

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -746,3 +746,86 @@ class TestHarnessBoundaryInjection:
             for c in e.inputs.get("acceptance_criteria", [])
             if isinstance(c, TypedCheck) and c.check == "harness_boundary"
         ]
+
+
+class TestInapplicableCheckStripping:
+    """pf-47/pf-49: Python-AST checks authored against non-Python files are stripped
+    at dispatch. Such a check skips at every evaluation forever, and a QA task whose
+    checks are ALL dead can never land a repair (zero executed blocking checks →
+    unverifiable → fail closed) — the deadlock that burned both rolls' budgets.
+    """
+
+    PLAN = """\
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+tasks:
+  - task_index: 0
+    task_type: qa.test
+    role: qa
+    focus: "Frontend tests"
+    description: "Component tests"
+    expected_artifacts: ["frontend/src/__tests__/App.test.jsx"]
+    acceptance_criteria:
+      - check: function_defined
+        file: frontend/src/__tests__/App.test.jsx
+        name_prefix: "test"
+        min_count: 4
+      - check: import_present
+        file: frontend/src/__tests__/App.test.jsx
+        module: frontend/src/App
+      - check: command_exit_zero
+        severity: warning
+        argv: ["node", "--check", "frontend/src/__tests__/App.test.jsx"]
+      - "Renders each view without crashing."
+    depends_on: []
+  - task_index: 1
+    task_type: qa.test
+    role: qa
+    focus: "Backend tests"
+    description: "API tests"
+    expected_artifacts: ["backend/tests/test_api.py"]
+    acceptance_criteria:
+      - check: function_defined
+        file: backend/tests/test_api.py
+        name_prefix: "test_"
+        min_count: 3
+      - check: regex_match
+        file: qa_handoff.md
+        pattern: "## How to Test"
+    depends_on: []
+summary:
+  total_tasks: 2
+"""
+
+    def _envelopes(self):
+        plan = ImplementationPlan.from_yaml(self.PLAN)
+        return generate_task_plan(_make_cycle(), _make_run(), _make_profile(), plan=plan)
+
+    def _criteria(self, envelopes, focus):
+        env = next(e for e in envelopes if e.inputs.get("subtask_focus") == focus)
+        return env.inputs["acceptance_criteria"]
+
+    def test_python_ast_checks_on_jsx_are_stripped(self):
+        """The exact pf-49 shape: pytest-idiom checks dressed on a .jsx test file."""
+        criteria = self._criteria(self._envelopes(), "Frontend tests")
+        typed = [c for c in criteria if not isinstance(c, str)]
+
+        assert not any(c.check == "function_defined" for c in typed)
+        assert not any(c.check == "import_present" for c in typed)
+
+    def test_applicable_checks_and_prose_survive_the_strip(self):
+        criteria = self._criteria(self._envelopes(), "Frontend tests")
+
+        # command_exit_zero is not file-scoped; prose is untouched
+        assert any(not isinstance(c, str) and c.check == "command_exit_zero" for c in criteria)
+        assert "Renders each view without crashing." in criteria
+
+    def test_python_files_keep_their_ast_checks(self):
+        criteria = self._criteria(self._envelopes(), "Backend tests")
+        typed = [c for c in criteria if not isinstance(c, str)]
+
+        assert any(c.check == "function_defined" for c in typed)
+        # regex on a document is #464-legal and not file-type-mismatched
+        assert any(c.check == "regex_match" for c in typed)


### PR DESCRIPTION
Fixes the repair deadlock that killed pf-47 and is killing pf-49 as this PR opens —
two rolls, identical signature, deterministic once triggered.

## The root cause (authoring, not evaluation)

The system pressures the plan author to attach typed checks (the whole #464/#533 arc)
but hands it a **Python-only vocabulary and never says so**. So the QA proposer dresses
frontend test files in Python conventions — pf-49 literally authored `function_defined
name_prefix: "test"` against a Vitest `.jsx` file, where tests are *calls*, not named
functions. Every such check skips at evaluation (correctly, per #607). But repair
acceptance requires an **executed** check to accept a patch, so:

> a task whose checks all skip can never land a repair — zero executed blocking checks
> → unverifiable → fail closed, every attempt, until the budget is gone.

pf-47: 4 repairs rejected unheard, the 5th to the import gate, roll dead. pf-49: same
signature at 10:44 UTC. Meanwhile the **behavioral retest** — which re-runs the actual
failing suite against the patched workspace — sat one step downstream, gated behind a
structural verdict that could never come.

## Fix A — applicability declared once, enforced twice

- `CheckSpec` gains `applicable_extensions`; the five AST checks declare `{".py"}`.
- The authoring vocabulary is **generated from CHECK_SPECS**, so every proposer prompt
  now renders *"Applies to: `.py` files ONLY — never attach to `.js`/`.jsx`"* — no new
  prose asset, no drift possible.
- Dispatch **strips** a file-scoped check whose target the evaluator can never parse
  (one warning per strip). A dead check can no longer reach evaluation, evidence, or
  repair acceptance. Strip (not reject) so a mis-authored plan degrades gracefully
  instead of burning framing re-rolls while the author learns.

## Fix B — behavioral evidence decides when structural evidence cannot exist

- `patch_verification` exports the two *structurally-unevaluable* reasons
  (`no_executed_blocking_checks`, `no_typed_criteria`) as constants.
- At patch acceptance, **exactly those reasons — and only when the failed task carries a
  `test_result` to re-run** — fall through to the #456 retest, whose verdict alone
  decides. The retest is *stronger* evidence than the checks it stands in for: it runs
  the real suite in the QA agent's environment.
- Deliberately NOT unlocked: `evaluator_error:*` (a broken checker proves nothing),
  `unparseable_criteria`, and real check failures — all keep failing closed. §6.2
  survives intact: never accept on absent evidence; substitute stronger evidence for
  inapplicable evidence.

**A and B need each other.** After A strips the nonsense, a frontend QA task
legitimately has *no* structural checks — without B, that re-creates the deadlock
through the honest door (`no_typed_criteria`). B without A leaves meaningless pytest
idioms in plans. Together: the author is taught, the plans are cleaned, and the one
artifact class whose verification is inherently behavioral gets judged behaviorally.

## Verification

- **Replay against pf-49's real stored artifacts**: the exact criteria+emission shape
  that deadlocked returns `unverifiable/no_executed_blocking_checks` and now routes to
  the retest instead of auto-rejection.
- 7 new tests: the strip matrix (`.jsx` AST checks stripped; `.py` checks, doc-regex,
  `command_exit_zero`, and prose survive) + four acceptance-path cases (retest-pass
  breaks the deadlock; retest-fail still rejects; no behavioral evidence stays closed;
  `evaluator_error` stays closed and never reaches the retest).
- Evidence honesty on acceptance: skip rows keep `status: skipped` in the recorded
  checks; the retest rows carry the executed pass.
- Regression **5731 passed**, 1 skipped. ruff clean (strip loop extracted per C901).
- **Contract emission unchanged** (`content_hash` 26503867) — no re-seed.

## Deploy note

Executor + dispatch surface → deploying resets the N=5 baseline (currently 2/5).
Per the tripwire agreed this morning: second deadlock occurred → deploy when pf-49 goes
terminal, take the reset, relaunch on a machine that cannot deadlock this way.

Longer-term (unchanged): per-stack check vocabularies ride the Stack Blueprint work in
1.6 — a React stack eventually brings vitest-aware checks the way FastAPI brings
pytest-aware ones. This PR makes the system honest about the vocabulary it has today.
