### PR TITLE
feat(checks): module_imports — runtime-level check static analysis cannot fake (#628)

### DIFF
--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -124,7 +124,17 @@ def _routes_criteria(manifest: InterfaceManifest) -> dict[str, Any]:
             "id": "vc-routes-compiles",
             "argv": ["python", "-m", "py_compile", _ROUTES_PATH],
             "requires": CAP_PYTHON,
-        }
+        },
+        # #628: py_compile validates syntax only — pf-54's routes.py passed it
+        # (and both AST checks) while NameError-ing at import because the
+        # scaffold's `router = APIRouter()` line was dropped. module_imports is
+        # the runtime-level complement: the module must actually import.
+        {
+            "check": "module_imports",
+            "id": "vc-routes-imports",
+            "file": _ROUTES_PATH,
+            "requires": CAP_PYTHON,
+        },
     ]
     return {"interface": interface, "implementation": implementation}
 

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -324,6 +324,29 @@ CHECK_SPECS: dict[str, CheckSpec] = {
             "plan validation): " + "; ".join(f"`{p.name}`" for p in COMMAND_SAFELIST)
         ),
     ),
+    "module_imports": CheckSpec(
+        name="module_imports",
+        applicable_extensions=frozenset({".py"}),
+        required_params=frozenset({"file"}),
+        optional_params=frozenset({"timeout_s"}),
+        param_types={"file": str, "timeout_s": int},
+        supported_stacks=frozenset({"python"}),
+        requires_stack_context=False,
+        path_params=frozenset({"file"}),
+        example={"file": "backend/routes.py"},
+        # #628: every other check is static (AST / syntax) — pf-54 shipped a
+        # routes.py that passed endpoint_defined + import_present + py_compile
+        # yet NameError'd at import (the scaffold's `router = APIRouter()` line
+        # was dropped). This is the one check that actually executes the
+        # module's top level, in a subprocess, the way the app import will.
+        notes=(
+            "Imports the file's module in an isolated subprocess (workspace "
+            "root on sys.path). Catches module-level runtime errors — NameError, "
+            "missing symbols — that AST and py_compile cannot see. A dependency "
+            "missing from the evaluating environment skips (missing_tooling), "
+            "it does not fail."
+        ),
+    ),
 }
 
 

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -21,6 +21,7 @@ import ast
 import asyncio
 import logging
 import re
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -807,6 +808,92 @@ class CommandExitZeroCheck(BaseCheck):
             exit_code=exit_code,
             stdout_tail=_tail(stdout),
             stderr_tail=_tail(stderr),
+        )
+
+
+_MODULE_NOT_FOUND_RE = re.compile(r"ModuleNotFoundError: No module named '([^']+)'")
+
+
+@register_check("module_imports")
+class ModuleImportsCheck(BaseCheck):
+    """Import the file's module in a subprocess — the only runtime-level check.
+
+    pf-54 (#628): a fill file can satisfy every static check (AST finds the
+    decorators and imports, py_compile accepts the syntax) while raising at
+    import time — module-level NameError is invisible until something actually
+    imports the module, which until this check was the QA conftest, five
+    correction attempts too late.
+    """
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        try:
+            file_path = _safe_resolve(params["file"], workspace_root)
+        except _SafetyError as exc:
+            return CheckOutcome.error(reason=exc.reason)
+        if (skip := _unparseable_source_skip(file_path)) is not None:
+            return skip
+        if not file_path.is_file():
+            return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
+
+        root = workspace_root.resolve()
+        parts = list(file_path.relative_to(root).with_suffix("").parts)
+        if parts and parts[-1] == "__init__":
+            parts = parts[:-1]
+        if not parts or not all(p.isidentifier() for p in parts):
+            return CheckOutcome.error(
+                reason="not_an_importable_module_path", file=str(params["file"])
+            )
+        module = ".".join(parts)
+
+        timeout_s = int(params.get("timeout_s", DEFAULT_COMMAND_TIMEOUT_S))
+        timeout_s = max(1, min(timeout_s, MAX_COMMAND_TIMEOUT_S))
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-c",
+                f"import {module}",
+                cwd=str(root),
+                env=_restricted_env(),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except (OSError, ValueError) as exc:
+            return CheckOutcome.error(reason="command_spawn_failed", detail=str(exc))
+        try:
+            _stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+        except TimeoutError:
+            proc.kill()
+            try:
+                await proc.wait()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            return CheckOutcome.error(reason="command_timeout", timeout_s=timeout_s)
+
+        if proc.returncode == 0:
+            return CheckOutcome.passed(module=module)
+
+        stderr = stderr_b.decode("utf-8", errors="replace")
+        not_found = _MODULE_NOT_FOUND_RE.search(stderr)
+        if not_found is not None:
+            missing_top = not_found.group(1).split(".")[0]
+            in_workspace = (root / missing_top).exists() or (root / f"{missing_top}.py").exists()
+            if not in_workspace and missing_top != module.split(".")[0]:
+                # A third-party dependency the evaluating container lacks is an
+                # environment gap, not an app defect (#462): never fail correct
+                # code on tooling the evaluator doesn't have. A missing module
+                # whose top-level package IS in the workspace stays a failure —
+                # that is the app referencing itself wrongly.
+                return CheckOutcome.skipped(
+                    reason="missing_tooling", missing_module=not_found.group(1)
+                )
+        return CheckOutcome.failed(
+            reason="module_import_failed", module=module, stderr_tail=_tail(stderr)
         )
 
 

--- a/src/squadops/cycles/verification_contract.py
+++ b/src/squadops/cycles/verification_contract.py
@@ -69,7 +69,11 @@ KNOWN_CAPABILITIES: frozenset[str] = frozenset({CAP_PYTHON, TOOL_NODE})
 INTERFACE_CHECK_NAMES: frozenset[str] = frozenset(
     {"endpoint_defined", "import_present", "field_present"}
 )
-IMPLEMENTATION_CHECK_NAMES: frozenset[str] = frozenset({"command_exit_zero"})
+# module_imports (#628) is implementation-class by nature: it EXECUTES the
+# module's top level, so it cannot be an interface presence check — and unlike
+# the interface checks it need not pass on the bare skeleton (stub bodies
+# import cleanly, so in practice it does).
+IMPLEMENTATION_CHECK_NAMES: frozenset[str] = frozenset({"command_exit_zero", "module_imports"})
 
 # Keys owned by the criterion wrapper; everything else on a criterion mapping is a
 # check param. (Contract criteria carry ``id``/``requires``; plan criteria carry

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -1105,3 +1105,92 @@ class TestNonPythonFilesSkipRatherThanError:
             stack="fastapi",
         )
         assert outcome.status != "skipped"
+
+
+# ---------------------------------------------------------------------------
+# module_imports (#628)
+# ---------------------------------------------------------------------------
+
+
+class TestModuleImports:
+    async def test_module_level_name_error_fails(self, tmp_path):
+        # The pf-54 shape: decorators reference a name the module never defines.
+        # AST checks and py_compile both pass this file; import cannot.
+        (tmp_path / "backend").mkdir()
+        (tmp_path / "backend" / "__init__.py").write_text("")
+        (tmp_path / "backend" / "routes.py").write_text(
+            "@router.get('/runs')\ndef list_runs():\n    return []\n"
+        )
+        outcome = await get_check("module_imports").evaluate(
+            {"file": "backend/routes.py"}, tmp_path
+        )
+        assert outcome.status == "failed"
+        assert outcome.reason == "module_import_failed"
+        assert "NameError" in outcome.actual["stderr_tail"]
+
+    async def test_clean_module_passes(self, tmp_path):
+        (tmp_path / "backend").mkdir()
+        (tmp_path / "backend" / "__init__.py").write_text("")
+        (tmp_path / "backend" / "util.py").write_text("X = 1\n")
+        (tmp_path / "backend" / "routes.py").write_text("from .util import X\nY = X + 1\n")
+        outcome = await get_check("module_imports").evaluate(
+            {"file": "backend/routes.py"}, tmp_path
+        )
+        assert outcome.status == "passed"
+        assert outcome.actual["module"] == "backend.routes"
+
+    async def test_missing_third_party_dependency_skips(self, tmp_path):
+        # #462 philosophy: a dep the evaluating container lacks must not fail
+        # correct code — it is an environment gap, reported as such.
+        (tmp_path / "app.py").write_text("import nonexistent_dep_zq91\n")
+        outcome = await get_check("module_imports").evaluate({"file": "app.py"}, tmp_path)
+        assert outcome.status == "skipped"
+        assert outcome.reason == "missing_tooling"
+        assert outcome.actual["missing_module"] == "nonexistent_dep_zq91"
+
+    async def test_missing_workspace_internal_module_fails(self, tmp_path):
+        # The missing module's top-level package IS in the workspace — that is
+        # the app referencing itself wrongly, not an environment gap.
+        (tmp_path / "backend").mkdir()
+        (tmp_path / "backend" / "__init__.py").write_text("")
+        (tmp_path / "backend" / "routes.py").write_text("from backend.storee import reset\n")
+        outcome = await get_check("module_imports").evaluate(
+            {"file": "backend/routes.py"}, tmp_path
+        )
+        assert outcome.status == "failed"
+        assert outcome.reason == "module_import_failed"
+
+    async def test_self_import_not_found_fails(self, tmp_path):
+        # Root-level module importing a sibling that does not exist anywhere:
+        # the missing top-level equals the module's own package guard branch.
+        (tmp_path / "solo.py").write_text("import solo_helper\n")
+        outcome = await get_check("module_imports").evaluate({"file": "solo.py"}, tmp_path)
+        assert outcome.status == "skipped"  # helper is not in workspace → env-gap semantics
+        (tmp_path / "solo_helper.py").write_text("raise RuntimeError('boom')\n")
+        outcome = await get_check("module_imports").evaluate({"file": "solo.py"}, tmp_path)
+        assert outcome.status == "failed"
+
+    async def test_init_py_imports_the_package(self, tmp_path):
+        (tmp_path / "backend").mkdir()
+        (tmp_path / "backend" / "__init__.py").write_text("PKG = True\n")
+        outcome = await get_check("module_imports").evaluate(
+            {"file": "backend/__init__.py"}, tmp_path
+        )
+        assert outcome.status == "passed"
+        assert outcome.actual["module"] == "backend"
+
+    async def test_file_not_found_fails(self, tmp_path):
+        outcome = await get_check("module_imports").evaluate(
+            {"file": "backend/absent.py"}, tmp_path
+        )
+        assert outcome.status == "failed"
+        assert outcome.reason == "file_not_found"
+
+    async def test_path_traversal_errors(self, tmp_path):
+        outcome = await get_check("module_imports").evaluate({"file": "../outside.py"}, tmp_path)
+        assert outcome.status == "error"
+
+    async def test_frontend_extension_skips(self, tmp_path):
+        (tmp_path / "App.jsx").write_text("export default 1;\n")
+        outcome = await get_check("module_imports").evaluate({"file": "App.jsx"}, tmp_path)
+        assert outcome.status == "skipped"

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -1561,7 +1561,9 @@ class TestInterWorkloadGatePlanValidation:
             / "interface_manifest.yaml"
         ).read_text(encoding="utf-8")
         contract_text = emit_contract_yaml(InterfaceManifest.from_yaml(manifest_text))
-        bound_refs = "[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles]"
+        bound_refs = (
+            "[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles, vc-routes-imports]"
+        )
         plan_text = self._PLAN_YAML_BOUND.replace(
             "criteria_refs: [vc-routes-apierror]", f"criteria_refs: {bound_refs}"
         )
@@ -1644,7 +1646,9 @@ class TestInterWorkloadGatePlanValidation:
             / "interface_manifest.yaml"
         ).read_text(encoding="utf-8")
         contract_text = emit_contract_yaml(InterfaceManifest.from_yaml(manifest_text))
-        bound_refs = "[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles]"
+        bound_refs = (
+            "[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles, vc-routes-imports]"
+        )
         plan_text = self._PLAN_YAML_BOUND.replace(
             "criteria_refs: [vc-routes-apierror]", f"criteria_refs: {bound_refs}"
         )

--- a/tests/unit/cycles/test_verification_contract_runner.py
+++ b/tests/unit/cycles/test_verification_contract_runner.py
@@ -55,7 +55,7 @@ def _contract() -> VerificationContract:
 
 def test_structural_criteria_selects_only_evaluator_backed_checks():
     checks = {c["check"] for c, _ in structural_criteria(_contract())}
-    assert checks == {"endpoint_defined", "import_present", "command_exit_zero"}
+    assert checks == {"endpoint_defined", "import_present", "command_exit_zero", "module_imports"}
     # behavioral checks are the gate's subprocess job, never structural
     assert "tests_pass" not in checks
     assert "frontend_build" not in checks


### PR DESCRIPTION
## What

Adds `module_imports` — the first runtime-level typed check — and binds it into the contract as `vc-routes-imports`.

## Why

pf-54 (`cyc_01dbcc1bb3ab`) shipped a routes.py missing the two scaffold header lines (`from fastapi import APIRouter`, `router = APIRouter()`). It passed **all three** bound checks legitimately — `endpoint_defined` (AST finds the decorators), `import_present` (AST finds the import), `py_compile` (syntax is valid) — because the entire vocabulary is static and nothing ever imports the module. First import was the QA conftest → NameError → pytest exit 4 → 5-attempt correction death.

## How

- **Spec** (`acceptance_check_spec.py`): `.py`-scoped, `file` param, vocabulary notes auto-render the semantics.
- **Evaluator** (`acceptance_checks.py`): `python -c "import <module>"` in an isolated subprocess — workspace root as cwd (on sys.path), restricted env, timeout clamp. Module name derived from the file path (`backend/routes.py` → `backend.routes`, `__init__.py` → package). Outcomes:
  - exit 0 → **passed**
  - `ModuleNotFoundError` whose top-level package is **not** in the workspace → **skipped** `missing_tooling` (#462: an environment gap never fails correct code)
  - everything else (incl. missing modules whose top-level IS in the workspace — the app referencing itself wrongly) → **failed** with stderr tail
- **Contract** (`scaffold_contract.py`): `vc-routes-imports` added to the routes fill-file implementation criteria; linter's implementation-class allowlist extended (`verification_contract.py`).

## Verification

- 9 new evaluator tests (NameError fail, clean pass, third-party-dep skip, workspace-internal-miss fail, `__init__` derivation, file-not-found, traversal, frontend-extension skip, missing-then-broken sibling)
- **Bare skeleton passes** the new check (verified by materializing the real group_run manifest — stub bodies import by design, so the criterion is winnable pre-fill)
- **Replay on pf-54's stored artifacts**: the shipped fragment (art_1544d6ba68c9) → `failed / module_import_failed` with the exact production NameError; the repair version (art_3e011ea16382) → `passed`
- Full regression suite: 5742 passed

## Deploy note

Contract emit changes → the next seeded measurement run needs a re-emitted contract (content_hash moves, criteria count 6 → 7). Deliberate — the N=5 freeze is closed; this is step 2 of the 1.4 cut sequence.

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
