### PR TITLE
SIP-0102: Spark shakedown handoff — floor smoke promoted to scripts/dev

### DIFF
--- a/docs/plans/SIP-0102-ephemeral-application-sandbox-plan.md
+++ b/docs/plans/SIP-0102-ephemeral-application-sandbox-plan.md
@@ -16,12 +16,34 @@ The single in-repo source of truth for where SIP-0102 stands — read this first
 
 | Phase | Milestone unlocked | State |
 |---|---|---|
-| 102.1 Execution boundary (service skeleton + workspace + Docker adapter) | the execution boundary exists | ✅ slices a–d complete on the feature branch (PR open); exit proven by the ASGI client→API→service→store E2E + parity guards; compose entry profile-guarded (`--profile sandbox`); interim shared-secret auth (Keycloak #326 upgrade pinned to 102.3) |
-| 102.2 Environment contract + canonical image + preflight | environment is a pinned, validated contract | ✅ complete on the feature branch (PR open); exit proven: mismatched/missing environment blocks at cycle-create preflight AND doctor (same decision fn); every result carries image + contract identity; **live smoke on real docker: full floor E2E green** (install→build→boot→probe 501→teardown, pin intact) |
-| 102.3 Typed-op relocation of in-process exec sites | execution leaves the agent trust boundary | ⬜ |
+| 102.1 Execution boundary (service skeleton + workspace + Docker adapter) | the execution boundary exists | ✅ **MERGED** (#620 + rename #621); exit proven by the ASGI client→API→service→store E2E + parity guards; compose entry profile-guarded (`--profile sandbox`); interim shared-secret auth (Keycloak #326 upgrade pinned to 102.3) |
+| 102.2 Environment contract + canonical image + preflight | environment is a pinned, validated contract | ✅ **MERGED** (#623, incl. the #622 readiness fix); exit proven: mismatched/missing environment blocks at cycle-create preflight AND doctor (same decision fn); every result carries image + contract identity; **live smoke on real docker (Mac): full floor E2E green** (install→build→boot→probe 501→teardown, pin intact) |
+| 102.3 Typed-op relocation of in-process exec sites | execution leaves the agent trust boundary | ⬜ next — **coordination-gated**: edits Spark-owned hot files; merges between campaigns with Spark review |
 | 102.4 Clean-room verification + outcome integration | verdicts are clean-room and honestly named | ⬜ |
 | 102.5 Builder warm-unit convergence | convergence iterates inside the sandbox | ⬜ |
 | 102.6 Retirement + golden-path live validation | lean agent images; engine-turns-over proven | ⬜ |
+
+**Spark pick-up: standalone shakedown (do any time — touches nothing the
+campaigns run):**
+1. Pull main (≥ the #623 merge). Everything is dormant: no `SQUADOPS__SANDBOX__*`
+   set ⇒ byte-identical behavior; the compose service is invisible without
+   `--profile sandbox`.
+2. Build the canonical environment image locally (the recorded publish decision):
+   `./scripts/dev/build_sandbox_env_image.sh` (needs network; ~505MB).
+3. Run the floor smoke on Spark's docker:
+   `.venv/bin/python scripts/dev/smoke_sandbox_floor.py` — expected output ends
+   `SMOKE PASSED`; it walks seed → install → vite build → boot → 501 probe →
+   teardown against the real expander skeleton, pin-verified throughout.
+4. Optionally boot the service:
+   `SQUADOPS_SANDBOX_SERVICE_TOKEN=<token> docker compose --profile sandbox up -d sandbox-service`
+   then `curl http://127.0.0.1:8002/health` and
+   `SQUADOPS__SANDBOX__PROVIDER=docker squadops doctor local-spark --check sandbox`.
+5. Report divergences from the Mac results (install/build timings, node/vite
+   behavior) here — that is exactly the drift the local-build decision accepted;
+   findings feed the 1.5 digest-pinning revisit.
+
+Steps 1–5 need no coordination window. The next *merge* that needs one is
+102.3 (below).
 
 **Lane note (recorded deviation):** SIP-0102 is the Lane-S headline (test-runner /
 build-check / agent-image / deploy-infra file ownership), but implementation is being

--- a/scripts/dev/smoke_sandbox_floor.py
+++ b/scripts/dev/smoke_sandbox_floor.py
@@ -1,0 +1,102 @@
+"""Live smoke of the SIP-0102 sandbox floor against real docker.
+
+The shakedown instrument (102.2 wrap; Spark pick-up step 3): materialize the
+canonical expander skeleton, seed it, then walk the floor — install →
+build_frontend → start_application → probe (bare-skeleton 501 partition) →
+converging teardown — asserting the pin holds throughout. In-process backend
+(the HTTP surface is ASGI-tested); this validates the CONTAINER layer on the
+host it runs on.
+
+Prereqs: docker daemon up; the canonical image built
+(./scripts/dev/build_sandbox_env_image.sh). Network needed on first run
+(pip/npm installs; the read-through caches warm under the smoke root).
+
+Usage:  .venv/bin/python scripts/dev/smoke_sandbox_floor.py
+        SQUADOPS_SANDBOX_SMOKE_ROOT=/somewhere ... (default /tmp/squadops-sandbox-smoke)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import yaml
+
+from adapters.sandbox.container_backend import ContainerBackend
+from adapters.tools.docker import DockerAdapter
+from squadops.capabilities.scaffold import InterfaceManifest, expand
+from squadops.sandbox.environment import FULLSTACK_FASTAPI_REACT
+from squadops.sandbox.models import RevisionOrigin
+from squadops.sandbox.workspace import WorkspaceStore
+
+ROOT = Path(os.environ.get("SQUADOPS_SANDBOX_SMOKE_ROOT", "/tmp/squadops-sandbox-smoke"))
+MANIFEST = Path("examples/03_group_run/interface_manifest.yaml")
+
+
+async def main() -> int:
+    shutil.rmtree(ROOT / "cycles", ignore_errors=True)  # keep caches warm across runs
+    store = WorkspaceStore(ROOT / "cycles")
+    contract = FULLSTACK_FASTAPI_REACT
+    backend = ContainerBackend(
+        container=DockerAdapter(),
+        store=store,
+        image=contract.image,
+        operation_commands=contract.commands(),
+        app_port=contract.app_port,
+        install_network=contract.install_network,
+        environment_contract_id=contract.contract_id(),
+        cache_root=ROOT / "caches",
+        timeout_seconds=420.0,
+        readiness_timeout_seconds=30.0,
+    )
+
+    raw = yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
+    files = {f["name"]: f["content"] for f in expand(InterfaceManifest.from_dict(raw))}
+    revision = store.seed("smoke_1", files, origin=RevisionOrigin.SCAFFOLD_SEED)
+    print(f"seeded {len(files)} files, revision {revision.revision_id[:12]}")
+
+    report = await backend.environment_report()
+    print(f"environment_report: image_present={report['image_present']}")
+    assert report["image_present"] is True, (
+        "environment image missing — run ./scripts/dev/build_sandbox_env_image.sh"
+    )
+
+    install = await backend.install_dependencies(revision=revision)
+    print(f"install: ran={install.ran} status={install.status} {install.duration_seconds:.0f}s")
+    assert install.status == "succeeded", f"install failed: {install}"
+    assert store.verify_pinned("smoke_1", revision.revision_id), "install broke the pin"
+
+    build = await backend.build_frontend(revision=revision)
+    print(f"build_frontend: ran={build.ran} status={build.status} {build.duration_seconds:.0f}s")
+    assert build.status == "succeeded", f"build failed: {build.diagnostics}"
+
+    start = await backend.start_application(revision=revision)
+    print(f"start: ready={start.ready} endpoints={start.endpoints}")
+    assert start.ready, f"app never ready: {start.startup_diagnostics}"
+
+    # Bare-skeleton partition (SIP-0098 §6.2): a declared route answers 501 —
+    # routing works, behavior honestly unimplemented.
+    probe = await backend.probe_http_endpoint(
+        revision=revision,
+        probe_id="bare-skeleton-501",
+        method="GET",
+        path="/runs",
+        expected_status=501,
+    )
+    print(f"probe GET /runs: observed={probe.observed_status_code} status={probe.status}")
+    assert probe.status == "succeeded", f"probe: {probe.detail}"
+    assert probe.environment_contract_id == contract.contract_id()
+
+    stop = await backend.stop_application(revision=revision, cleanup_handle=start.cleanup_handle)
+    print(f"stop: status={stop.status}")
+    assert stop.status == "succeeded"
+
+    print("\nSMOKE PASSED — the sandbox floor executes end-to-end on this host's docker.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
Baton-pass housekeeping after #623:

- `scripts/dev/smoke_sandbox_floor.py` — the live smoke that validated 102.2 promoted from scratchpad to the repo, so Spark runs the identical instrument (re-verified green from its new home on this Mac).
- Plan handoff block: **Spark pick-up = standalone shakedown**, five steps needing no coordination window (everything dormant/profile-guarded); 102.1/102.2 rows marked merged; 102.3 flagged as the next merge that needs a campaign gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaFdkrgQ8F3UZ1DE7LDEU3