### PR TITLE
feat(qa): contract's pinned HTTP behavior reaches suite authoring (#629)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -332,6 +332,31 @@ class QATestHandler(_CycleTaskHandler):
         }
         return scoped or artifact_contents
 
+    async def _behavior_contract_section(
+        self, context: ExecutionContext, inputs: dict[str, Any]
+    ) -> str:
+        """Render the API BEHAVIOR CONTRACT block from executor-threaded lines, or "".
+
+        #629 / pf-54: the contract pinned POST /runs → 201 and the error-code→status
+        map, but only probes and repair prompts ever saw them — the INITIAL suite
+        generation did not, and all five authored suite versions asserted 200-on-create
+        (three added an undeclared /api prefix). The lines are contract-derived data
+        (``VerificationContract.behavior_expectation_lines``); all instruction prose
+        lives in the appendix asset (CLAUDE.md #448).
+        """
+        lines = [str(line).strip() for line in (inputs.get("api_behavior_contract") or [])]
+        lines = [line for line in lines if line]
+        if not lines:
+            return ""
+        renderer = getattr(context.ports, "request_renderer", None)
+        if renderer is None:
+            return ""
+        rendered = await renderer.render(
+            "request.qa_test_behavior_contract_appendix",
+            {"behavior_lines": "\n".join(f"- {line}" for line in lines)},
+        )
+        return rendered.content
+
     def _build_focused_prompt(self, inputs: dict[str, Any]) -> str:
         """Build a focused prompt for manifest-driven QA subtasks (SIP-0086).
 
@@ -565,6 +590,9 @@ class QATestHandler(_CycleTaskHandler):
         # SIP-0086 RC-6: focused prompt path for manifest-driven subtasks
         if inputs.get("subtask_focus") is not None:
             user_prompt = self._build_focused_prompt(inputs)
+            behavior_section = await self._behavior_contract_section(context, inputs)
+            if behavior_section:
+                user_prompt = f"{user_prompt}\n{behavior_section}"
             rendered = None
             sources = self._get_source_artifacts(inputs)
         else:

--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -124,7 +124,17 @@ def _routes_criteria(manifest: InterfaceManifest) -> dict[str, Any]:
             "id": "vc-routes-compiles",
             "argv": ["python", "-m", "py_compile", _ROUTES_PATH],
             "requires": CAP_PYTHON,
-        }
+        },
+        # #628: py_compile validates syntax only — pf-54's routes.py passed it
+        # (and both AST checks) while NameError-ing at import because the
+        # scaffold's `router = APIRouter()` line was dropped. module_imports is
+        # the runtime-level complement: the module must actually import.
+        {
+            "check": "module_imports",
+            "id": "vc-routes-imports",
+            "file": _ROUTES_PATH,
+            "requires": CAP_PYTHON,
+        },
     ]
     return {"interface": interface, "implementation": implementation}
 

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -324,6 +324,29 @@ CHECK_SPECS: dict[str, CheckSpec] = {
             "plan validation): " + "; ".join(f"`{p.name}`" for p in COMMAND_SAFELIST)
         ),
     ),
+    "module_imports": CheckSpec(
+        name="module_imports",
+        applicable_extensions=frozenset({".py"}),
+        required_params=frozenset({"file"}),
+        optional_params=frozenset({"timeout_s"}),
+        param_types={"file": str, "timeout_s": int},
+        supported_stacks=frozenset({"python"}),
+        requires_stack_context=False,
+        path_params=frozenset({"file"}),
+        example={"file": "backend/routes.py"},
+        # #628: every other check is static (AST / syntax) — pf-54 shipped a
+        # routes.py that passed endpoint_defined + import_present + py_compile
+        # yet NameError'd at import (the scaffold's `router = APIRouter()` line
+        # was dropped). This is the one check that actually executes the
+        # module's top level, in a subprocess, the way the app import will.
+        notes=(
+            "Imports the file's module in an isolated subprocess (workspace "
+            "root on sys.path). Catches module-level runtime errors — NameError, "
+            "missing symbols — that AST and py_compile cannot see. A dependency "
+            "missing from the evaluating environment skips (missing_tooling), "
+            "it does not fail."
+        ),
+    ),
 }
 
 

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -21,6 +21,7 @@ import ast
 import asyncio
 import logging
 import re
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -807,6 +808,92 @@ class CommandExitZeroCheck(BaseCheck):
             exit_code=exit_code,
             stdout_tail=_tail(stdout),
             stderr_tail=_tail(stderr),
+        )
+
+
+_MODULE_NOT_FOUND_RE = re.compile(r"ModuleNotFoundError: No module named '([^']+)'")
+
+
+@register_check("module_imports")
+class ModuleImportsCheck(BaseCheck):
+    """Import the file's module in a subprocess — the only runtime-level check.
+
+    pf-54 (#628): a fill file can satisfy every static check (AST finds the
+    decorators and imports, py_compile accepts the syntax) while raising at
+    import time — module-level NameError is invisible until something actually
+    imports the module, which until this check was the QA conftest, five
+    correction attempts too late.
+    """
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        try:
+            file_path = _safe_resolve(params["file"], workspace_root)
+        except _SafetyError as exc:
+            return CheckOutcome.error(reason=exc.reason)
+        if (skip := _unparseable_source_skip(file_path)) is not None:
+            return skip
+        if not file_path.is_file():
+            return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
+
+        root = workspace_root.resolve()
+        parts = list(file_path.relative_to(root).with_suffix("").parts)
+        if parts and parts[-1] == "__init__":
+            parts = parts[:-1]
+        if not parts or not all(p.isidentifier() for p in parts):
+            return CheckOutcome.error(
+                reason="not_an_importable_module_path", file=str(params["file"])
+            )
+        module = ".".join(parts)
+
+        timeout_s = int(params.get("timeout_s", DEFAULT_COMMAND_TIMEOUT_S))
+        timeout_s = max(1, min(timeout_s, MAX_COMMAND_TIMEOUT_S))
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-c",
+                f"import {module}",
+                cwd=str(root),
+                env=_restricted_env(),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except (OSError, ValueError) as exc:
+            return CheckOutcome.error(reason="command_spawn_failed", detail=str(exc))
+        try:
+            _stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+        except TimeoutError:
+            proc.kill()
+            try:
+                await proc.wait()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            return CheckOutcome.error(reason="command_timeout", timeout_s=timeout_s)
+
+        if proc.returncode == 0:
+            return CheckOutcome.passed(module=module)
+
+        stderr = stderr_b.decode("utf-8", errors="replace")
+        not_found = _MODULE_NOT_FOUND_RE.search(stderr)
+        if not_found is not None:
+            missing_top = not_found.group(1).split(".")[0]
+            in_workspace = (root / missing_top).exists() or (root / f"{missing_top}.py").exists()
+            if not in_workspace and missing_top != module.split(".")[0]:
+                # A third-party dependency the evaluating container lacks is an
+                # environment gap, not an app defect (#462): never fail correct
+                # code on tooling the evaluator doesn't have. A missing module
+                # whose top-level package IS in the workspace stays a failure —
+                # that is the app referencing itself wrongly.
+                return CheckOutcome.skipped(
+                    reason="missing_tooling", missing_module=not_found.group(1)
+                )
+        return CheckOutcome.failed(
+            reason="module_import_failed", module=module, stderr_tail=_tail(stderr)
         )
 
 

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -487,8 +487,17 @@ def _inject_contract_inputs(
         frozen_index = frozen_surface_index_lines(interface_manifest)
         if frozen_index:
             inputs["frozen_surface_index"] = "\n".join(frozen_index)
-    if task_type == "qa.test" and contract.behavioral.probes:
-        inputs["contract_probes"] = [p.to_dict() for p in contract.behavioral.probes]
+    if task_type == "qa.test":
+        if contract.behavioral.probes:
+            inputs["contract_probes"] = [p.to_dict() for p in contract.behavioral.probes]
+        # #629 / pf-54: the contract's pinned statuses (probe expects + the
+        # error-code→status map) never reached suite AUTHORING — five authored
+        # suite versions asserted 200 where the probe pinned 201, an unwinnable
+        # loop no source repair could satisfy. Data-only injection; the
+        # "assertions must match" prose is a managed asset (#448).
+        behavior_lines = contract.behavior_expectation_lines()
+        if behavior_lines:
+            inputs["api_behavior_contract"] = behavior_lines
 
 
 def _harness_boundary_criteria(

--- a/src/squadops/cycles/verification_contract.py
+++ b/src/squadops/cycles/verification_contract.py
@@ -69,7 +69,11 @@ KNOWN_CAPABILITIES: frozenset[str] = frozenset({CAP_PYTHON, TOOL_NODE})
 INTERFACE_CHECK_NAMES: frozenset[str] = frozenset(
     {"endpoint_defined", "import_present", "field_present"}
 )
-IMPLEMENTATION_CHECK_NAMES: frozenset[str] = frozenset({"command_exit_zero"})
+# module_imports (#628) is implementation-class by nature: it EXECUTES the
+# module's top level, so it cannot be an interface presence check — and unlike
+# the interface checks it need not pass on the bare skeleton (stub bodies
+# import cleanly, so in practice it does).
+IMPLEMENTATION_CHECK_NAMES: frozenset[str] = frozenset({"command_exit_zero", "module_imports"})
 
 # Keys owned by the criterion wrapper; everything else on a criterion mapping is a
 # check param. (Contract criteria carry ``id``/``requires``; plan criteria carry

--- a/src/squadops/cycles/verification_contract.py
+++ b/src/squadops/cycles/verification_contract.py
@@ -410,6 +410,32 @@ class VerificationContract:
                 lines.append(f"- {ff.path}: contract-owned (no per-file typed criteria)")
         return lines
 
+    def behavior_expectation_lines(self) -> list[str]:
+        """The contract's pinned HTTP behavior as one-line facts for the qa.test
+        authoring prompt (#629): probe request → expected status, then the suite's
+        ``coverage_expectations`` verbatim.
+
+        pf-54: the contract pinned ``POST /runs → 201`` (probe) and the full
+        error-code→status map (coverage_expectations), yet all five authored
+        suite versions asserted 200-on-create — the pins existed only where the
+        suite author never saw them. This is a rendering of contract *data*; the
+        "your assertions must match" instruction prose lives in the managed
+        prompt asset (CLAUDE.md #448), which takes these lines as a variable."""
+        lines: list[str] = []
+        for probe in self.behavioral.probes:
+            method = str(probe.request.get("method", "")).upper()
+            path = str(probe.request.get("path", ""))
+            status = probe.expect.get("status")
+            if not (method and path) or status is None:
+                continue
+            line = f"{method} {path} → HTTP {status}"
+            error_code = probe.expect.get("error_code")
+            if error_code:
+                line += f" (error_code: {error_code})"
+            lines.append(line)
+        lines.extend(str(exp) for exp in self.behavioral.suite.coverage_expectations)
+        return lines
+
     # --- linting ---------------------------------------------------------- #
 
     def lint(self) -> list[str]:

--- a/src/squadops/prompts/request_templates/request.qa_test_behavior_contract_appendix.md
+++ b/src/squadops/prompts/request_templates/request.qa_test_behavior_contract_appendix.md
@@ -1,0 +1,17 @@
+---
+template_id: request.qa_test_behavior_contract_appendix
+version: "1"
+required_variables:
+  - behavior_lines
+optional_variables: []
+---
+**API BEHAVIOR CONTRACT (authoritative — your assertions MUST match these):**
+{{behavior_lines}}
+
+These statuses are pinned by the verification contract and enforced by probes
+against the running app. A test that expects a different status for one of
+these behaviors is asserting a bug: it will fail against a correct
+implementation, and no change to the application code can ever make it pass.
+Request paths are exactly as written above — do not add a URL prefix (such as
+`/api`) that the contract does not declare; prefixes belong to the frontend
+proxy, not the backend under test.

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -1682,3 +1682,91 @@ class TestFocusedPromptExpectations:
         )
         assert "Contract Expectations" not in prompt
         assert "### Acceptance Criteria (narrative)" in prompt
+
+
+class TestBehaviorContractAppendix:
+    """#629 / pf-54: the contract's pinned HTTP statuses reach the INITIAL
+    suite-authoring prompt through the behavior-contract appendix asset. All
+    five of pf-54's authored suite versions asserted 200-on-create against a
+    pinned 201 — the pin existed only where the author never saw it. Data
+    lines come from the executor; all prose lives in the template asset."""
+
+    class _Rendered:
+        content = "**API BEHAVIOR CONTRACT (RENDERED-BEHAVIOR-APPENDIX)**"
+        template_id = "request.qa_test_behavior_contract_appendix"
+        template_version = "1"
+        render_hash = "h"
+
+    def _focused_inputs(self, qa_inputs, **extra):
+        return {
+            **qa_inputs,
+            "subtask_focus": "Backend API pytest suite",
+            "subtask_description": "d",
+            "expected_artifacts": ["backend/tests/test_runs.py"],
+            "acceptance_criteria": [],
+            **extra,
+        }
+
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
+    async def test_behavior_lines_reach_the_focused_prompt(
+        self, _mock_run, mock_context, qa_inputs
+    ):
+        inputs = self._focused_inputs(
+            qa_inputs,
+            api_behavior_contract=[
+                "POST /runs → HTTP 201",
+                "validation_error -> HTTP 422",
+            ],
+        )
+        mock_context.ports.request_renderer = MagicMock()
+        mock_context.ports.request_renderer.render = AsyncMock(return_value=self._Rendered())
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=LLM_TEST_FILE_RESPONSE),
+        )
+        handler = QATestHandler()
+        await handler.handle(mock_context, inputs)
+
+        calls = [
+            c
+            for c in mock_context.ports.request_renderer.render.call_args_list
+            if c.args and c.args[0] == "request.qa_test_behavior_contract_appendix"
+        ]
+        assert len(calls) == 1
+        behavior_lines = calls[0].args[1]["behavior_lines"]
+        assert "- POST /runs → HTTP 201" in behavior_lines
+        assert "- validation_error -> HTTP 422" in behavior_lines
+        messages = mock_context.ports.llm.chat_stream_with_usage.call_args.args[0]
+        assert "RENDERED-BEHAVIOR-APPENDIX" in messages[-1].content
+
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
+    async def test_no_behavior_input_renders_no_appendix(self, _mock_run, mock_context, qa_inputs):
+        inputs = self._focused_inputs(qa_inputs)
+        mock_context.ports.request_renderer = MagicMock()
+        mock_context.ports.request_renderer.render = AsyncMock(return_value=self._Rendered())
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=LLM_TEST_FILE_RESPONSE),
+        )
+        handler = QATestHandler()
+        await handler.handle(mock_context, inputs)
+        assert not [
+            c
+            for c in mock_context.ports.request_renderer.render.call_args_list
+            if c.args and c.args[0] == "request.qa_test_behavior_contract_appendix"
+        ]
+
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
+    async def test_no_renderer_degrades_to_bare_focused_prompt(
+        self, _mock_run, mock_context, qa_inputs
+    ):
+        # Renderer-less contexts (author mode, minimal harnesses) must not crash
+        # and must still produce the focused prompt without the block.
+        inputs = self._focused_inputs(qa_inputs, api_behavior_contract=["POST /runs → HTTP 201"])
+        mock_context.ports.request_renderer = None
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=LLM_TEST_FILE_RESPONSE),
+        )
+        handler = QATestHandler()
+        await handler.handle(mock_context, inputs)
+        messages = mock_context.ports.llm.chat_stream_with_usage.call_args.args[0]
+        assert "API BEHAVIOR CONTRACT" not in messages[-1].content
+        assert "## QA Task:" in messages[-1].content

--- a/tests/unit/capabilities/test_scaffold_contract.py
+++ b/tests/unit/capabilities/test_scaffold_contract.py
@@ -205,3 +205,13 @@ def test_datetime_name_beats_string_type():
 def test_unknown_field_defaults_to_plain_string():
     assert _probe_sample_value("location", "string") == "sample"
     assert _probe_sample_value("whatever", "") == "sample"
+
+
+def test_behavior_expectation_lines_carry_the_pinned_statuses():
+    # #629 / pf-54: the emitted contract must be able to state its own HTTP pins
+    # as authoring-prompt lines — the create probe's 201 and the error-code map.
+    contract = VerificationContract.from_dict(emit_contract_dict(_manifest()))
+    lines = contract.behavior_expectation_lines()
+    assert "POST /runs → HTTP 201" in lines
+    assert "validation_error -> HTTP 422" in lines
+    assert "duplicate_participant -> HTTP 409" in lines

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -1105,3 +1105,92 @@ class TestNonPythonFilesSkipRatherThanError:
             stack="fastapi",
         )
         assert outcome.status != "skipped"
+
+
+# ---------------------------------------------------------------------------
+# module_imports (#628)
+# ---------------------------------------------------------------------------
+
+
+class TestModuleImports:
+    async def test_module_level_name_error_fails(self, tmp_path):
+        # The pf-54 shape: decorators reference a name the module never defines.
+        # AST checks and py_compile both pass this file; import cannot.
+        (tmp_path / "backend").mkdir()
+        (tmp_path / "backend" / "__init__.py").write_text("")
+        (tmp_path / "backend" / "routes.py").write_text(
+            "@router.get('/runs')\ndef list_runs():\n    return []\n"
+        )
+        outcome = await get_check("module_imports").evaluate(
+            {"file": "backend/routes.py"}, tmp_path
+        )
+        assert outcome.status == "failed"
+        assert outcome.reason == "module_import_failed"
+        assert "NameError" in outcome.actual["stderr_tail"]
+
+    async def test_clean_module_passes(self, tmp_path):
+        (tmp_path / "backend").mkdir()
+        (tmp_path / "backend" / "__init__.py").write_text("")
+        (tmp_path / "backend" / "util.py").write_text("X = 1\n")
+        (tmp_path / "backend" / "routes.py").write_text("from .util import X\nY = X + 1\n")
+        outcome = await get_check("module_imports").evaluate(
+            {"file": "backend/routes.py"}, tmp_path
+        )
+        assert outcome.status == "passed"
+        assert outcome.actual["module"] == "backend.routes"
+
+    async def test_missing_third_party_dependency_skips(self, tmp_path):
+        # #462 philosophy: a dep the evaluating container lacks must not fail
+        # correct code — it is an environment gap, reported as such.
+        (tmp_path / "app.py").write_text("import nonexistent_dep_zq91\n")
+        outcome = await get_check("module_imports").evaluate({"file": "app.py"}, tmp_path)
+        assert outcome.status == "skipped"
+        assert outcome.reason == "missing_tooling"
+        assert outcome.actual["missing_module"] == "nonexistent_dep_zq91"
+
+    async def test_missing_workspace_internal_module_fails(self, tmp_path):
+        # The missing module's top-level package IS in the workspace — that is
+        # the app referencing itself wrongly, not an environment gap.
+        (tmp_path / "backend").mkdir()
+        (tmp_path / "backend" / "__init__.py").write_text("")
+        (tmp_path / "backend" / "routes.py").write_text("from backend.storee import reset\n")
+        outcome = await get_check("module_imports").evaluate(
+            {"file": "backend/routes.py"}, tmp_path
+        )
+        assert outcome.status == "failed"
+        assert outcome.reason == "module_import_failed"
+
+    async def test_self_import_not_found_fails(self, tmp_path):
+        # Root-level module importing a sibling that does not exist anywhere:
+        # the missing top-level equals the module's own package guard branch.
+        (tmp_path / "solo.py").write_text("import solo_helper\n")
+        outcome = await get_check("module_imports").evaluate({"file": "solo.py"}, tmp_path)
+        assert outcome.status == "skipped"  # helper is not in workspace → env-gap semantics
+        (tmp_path / "solo_helper.py").write_text("raise RuntimeError('boom')\n")
+        outcome = await get_check("module_imports").evaluate({"file": "solo.py"}, tmp_path)
+        assert outcome.status == "failed"
+
+    async def test_init_py_imports_the_package(self, tmp_path):
+        (tmp_path / "backend").mkdir()
+        (tmp_path / "backend" / "__init__.py").write_text("PKG = True\n")
+        outcome = await get_check("module_imports").evaluate(
+            {"file": "backend/__init__.py"}, tmp_path
+        )
+        assert outcome.status == "passed"
+        assert outcome.actual["module"] == "backend"
+
+    async def test_file_not_found_fails(self, tmp_path):
+        outcome = await get_check("module_imports").evaluate(
+            {"file": "backend/absent.py"}, tmp_path
+        )
+        assert outcome.status == "failed"
+        assert outcome.reason == "file_not_found"
+
+    async def test_path_traversal_errors(self, tmp_path):
+        outcome = await get_check("module_imports").evaluate({"file": "../outside.py"}, tmp_path)
+        assert outcome.status == "error"
+
+    async def test_frontend_extension_skips(self, tmp_path):
+        (tmp_path / "App.jsx").write_text("export default 1;\n")
+        outcome = await get_check("module_imports").evaluate({"file": "App.jsx"}, tmp_path)
+        assert outcome.status == "skipped"

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -1561,7 +1561,9 @@ class TestInterWorkloadGatePlanValidation:
             / "interface_manifest.yaml"
         ).read_text(encoding="utf-8")
         contract_text = emit_contract_yaml(InterfaceManifest.from_yaml(manifest_text))
-        bound_refs = "[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles]"
+        bound_refs = (
+            "[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles, vc-routes-imports]"
+        )
         plan_text = self._PLAN_YAML_BOUND.replace(
             "criteria_refs: [vc-routes-apierror]", f"criteria_refs: {bound_refs}"
         )
@@ -1644,7 +1646,9 @@ class TestInterWorkloadGatePlanValidation:
             / "interface_manifest.yaml"
         ).read_text(encoding="utf-8")
         contract_text = emit_contract_yaml(InterfaceManifest.from_yaml(manifest_text))
-        bound_refs = "[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles]"
+        bound_refs = (
+            "[vc-routes-endpoints, vc-routes-apierror, vc-routes-compiles, vc-routes-imports]"
+        )
         plan_text = self._PLAN_YAML_BOUND.replace(
             "criteria_refs: [vc-routes-apierror]", f"criteria_refs: {bound_refs}"
         )

--- a/tests/unit/cycles/test_task_plan_probe_injection.py
+++ b/tests/unit/cycles/test_task_plan_probe_injection.py
@@ -143,3 +143,41 @@ def test_probe_less_contract_injects_no_key():
     cycle, run, profile = _implementation_setup()
     envs = generate_task_plan(cycle, run, profile, plan=None, contract=_contract(with_probes=False))
     assert all("contract_probes" not in e.inputs for e in envs)
+
+
+# ---------------------------------------------------------------------------
+# #629: behavior-expectation injection (pf-54)
+# ---------------------------------------------------------------------------
+
+
+def test_bind_mode_injects_behavior_expectations_into_qa_test_only():
+    # pf-54: five authored suite versions asserted 200-on-create against a pinned
+    # 201 — the pins never reached suite AUTHORING. Exact rendered lines, probe
+    # order preserved, error_code carried.
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(cycle, run, profile, plan=None, contract=_contract())
+
+    qa_envs = [e for e in envs if e.task_type == "qa.test"]
+    assert qa_envs, "implementation workload must contain a qa.test step"
+    assert qa_envs[0].inputs["api_behavior_contract"] == [
+        "POST /items → HTTP 200",
+        "POST /items → HTTP 409 (error_code: duplicate_item)",
+    ]
+    for env in envs:
+        if env.task_type != "qa.test":
+            assert "api_behavior_contract" not in env.inputs
+
+
+def test_author_mode_injects_no_behavior_expectations():
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(cycle, run, profile, plan=None, contract=None)
+    assert all("api_behavior_contract" not in e.inputs for e in envs)
+
+
+def test_behaviorless_contract_injects_no_behavior_key():
+    # No probes and no coverage_expectations → no key; the handler keys on
+    # presence, and an empty block would render an authoritative header over
+    # nothing.
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(cycle, run, profile, plan=None, contract=_contract(with_probes=False))
+    assert all("api_behavior_contract" not in e.inputs for e in envs)

--- a/tests/unit/cycles/test_verification_contract_runner.py
+++ b/tests/unit/cycles/test_verification_contract_runner.py
@@ -55,7 +55,7 @@ def _contract() -> VerificationContract:
 
 def test_structural_criteria_selects_only_evaluator_backed_checks():
     checks = {c["check"] for c, _ in structural_criteria(_contract())}
-    assert checks == {"endpoint_defined", "import_present", "command_exit_zero"}
+    assert checks == {"endpoint_defined", "import_present", "command_exit_zero", "module_imports"}
     # behavioral checks are the gate's subprocess job, never structural
     assert "tests_pass" not in checks
     assert "frontend_build" not in checks

--- a/tests/unit/prompts/test_request_template_renderer.py
+++ b/tests/unit/prompts/test_request_template_renderer.py
@@ -236,3 +236,31 @@ class TestCaching:
         await renderer.render("request.test", {"prd": "A", "role": "dev"}, environment="production")
 
         assert source.resolve_request_template.call_count == 2
+
+
+class TestBehaviorContractAppendixAsset:
+    """#629 / pf-54: render the REAL behavior-contract appendix through the real
+    filesystem source — the block eve's pf-54 prompt lacked. Proves the asset
+    carries both halves of the fix: the pinned-status authority and the
+    no-undeclared-prefix instruction (three of five pf-54 suite versions
+    prefixed /api; all five asserted 200 against the pinned 201)."""
+
+    async def test_real_asset_renders_pins_and_prefix_rule(self):
+        from adapters.prompts.factory import create_prompt_asset_source
+
+        renderer = RequestTemplateRenderer(create_prompt_asset_source())
+        rendered = await renderer.render(
+            "request.qa_test_behavior_contract_appendix",
+            {
+                "behavior_lines": (
+                    "- POST /runs → HTTP 201\n"
+                    "- validation_error -> HTTP 422\n"
+                    "- duplicate_participant -> HTTP 409"
+                )
+            },
+        )
+        assert "API BEHAVIOR CONTRACT" in rendered.content
+        assert "- POST /runs → HTTP 201" in rendered.content
+        assert "assertions MUST match" in rendered.content
+        assert "`/api`" in rendered.content
+        assert "do not add a URL prefix" in rendered.content


### PR DESCRIPTION
## What

Renders the verification contract's pinned HTTP behavior — probe expectations plus the error-code→status map — into the qa.test **initial authoring prompt** as an authoritative "API BEHAVIOR CONTRACT" block, via a new managed prompt asset.

## Why

pf-54 (`cyc_01dbcc1bb3ab`): the contract pinned `POST /runs → 201` and `validation_error → 422 / run_not_found → 404 / duplicate_participant → 409`, yet **all five** authored suite versions asserted 200-on-create and three of five prefixed every call with `/api` (undeclared — proxy-owned). The suite was unwinnable against any contract-correct app, and five honest retest rejections burned the full correction budget repairing the wrong artifact. Contract-as-arbiter existed at probe level (run end) but not at suite-author level (where the tests are written).

## How

- `VerificationContract.behavior_expectation_lines()` — the contract states its own pins as one-line facts: `POST /runs → HTTP 201`, `POST /items → HTTP 409 (error_code: duplicate_item)`, then `coverage_expectations` verbatim. Data rendering only.
- `_inject_contract_inputs` — `api_behavior_contract` injected on qa.test envelopes in bind mode, folded into the existing qa.test branch (no new task-type literal; the string-branching itself remains #559's 1.5 sweep). Author mode stays byte-identical.
- `QATestHandler._behavior_contract_section` — appends the rendered block to the focused authoring prompt. All instruction prose lives in the asset (`request.qa_test_behavior_contract_appendix`, CLAUDE.md #448): assertions must match the pins, and no undeclared URL prefix. Renderer-less contexts degrade to the bare prompt.

## Verification

- Real-manifest test: the emitted group_run contract renders exactly `POST /runs → HTTP 201` + the 422/409 map lines
- Envelope injection: qa.test-only, exact wire lines, author-mode and behaviorless-contract absence
- Handler: template id + variables + rendered block landing in the LLM prompt; no-input and no-renderer paths
- Real-filesystem-asset render: final content carries both pf-54 failure axes (status authority + prefix rule)
- Full regression: 5755 passed

## Scope note

Partially addresses #629 — this is the salience layer (the biggest-lever half). Remaining, deliberately separate: the **enforcement** layer (diffing authored suite assertions against contract pins / contract-aware failure locus — coordinate with #626) and threading the same block into `qa.test_repair` prompts. Agent images need a rebuild at deploy for the new asset (standard).

References #629 (does not close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
