### PR TITLE
feat(scaffold): frontend test harness is scaffold-owned (#627)

### DIFF
--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -995,7 +995,8 @@ _PACKAGE_JSON = """{{
   "scripts": {{
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   }},
   "dependencies": {{
     "react": "^18.3.1",
@@ -1003,8 +1004,13 @@ _PACKAGE_JSON = """{{
     "react-router-dom": "^6.26.2"
   }},
   "devDependencies": {{
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^16.0.1",
     "@vitejs/plugin-react": "^4.3.1",
-    "vite": "^5.4.2"
+    "jsdom": "^25.0.1",
+    "vite": "^5.4.2",
+    "vitest": "^2.1.9"
   }}
 }}
 """
@@ -1025,6 +1031,47 @@ export default defineConfig({
       },
     },
   },
+  // #627: the frontend test harness is scaffold-owned, mirroring the backend
+  // conftest. vitest reads this key; `vite build` ignores it.
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['src/test-setup.js'],
+  },
+})
+"""
+
+# Scaffold-owned vitest setup (frozen) — registers jest-dom matchers for every
+# suite. The frontend mirror of the conftest ``client`` fixture: harness wiring
+# is a workspace invariant, never a per-suite guess (#627 / pf-53: with no
+# seeded harness, qa either refused to test or invented one that could not run).
+_TEST_SETUP_JS = """// The /vitest entry registers jest-dom matchers on vitest's expect — the
+// bare entry assumes a GLOBAL expect and crashes collection under vitest's
+// default globals:false (caught on the real toolchain, not in review).
+import '@testing-library/jest-dom/vitest'
+"""
+
+# Scaffold-owned harness proof (frozen). Renders the app shell at a path no
+# route claims, so it passes on the bare skeleton AND after any fill — it
+# asserts harness wiring (vitest + jsdom + Testing Library + router), never
+# app behavior. Doubles as the in-workspace example of the testing idiom.
+_HARNESS_TEST_JSX = """// Scaffold-owned harness proof (frozen): vitest + jsdom + Testing Library +
+// router wiring all work in this workspace. Write real UI tests in NEW files
+// beside this one (e.g. views.test.jsx) — render with MemoryRouter exactly as
+// below; jest-dom matchers are already registered via src/test-setup.js.
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import App from '../App.jsx'
+
+describe('frontend test harness', () => {
+  it('renders the app shell under a memory router', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/__harness__']}>
+        <App />
+      </MemoryRouter>,
+    )
+    expect(container.querySelector('.app')).toBeInTheDocument()
+  })
 })
 """
 
@@ -1228,6 +1275,8 @@ def _expand_fullstack_fastapi_react(manifest: InterfaceManifest) -> list[dict[st
         }
     )
     files.append({"name": "frontend/vite.config.js", "content": _VITE_CONFIG})
+    files.append({"name": "frontend/src/test-setup.js", "content": _TEST_SETUP_JS})
+    files.append({"name": "frontend/src/__tests__/harness.test.jsx", "content": _HARNESS_TEST_JSX})
     files.append({"name": "frontend/src/main.jsx", "content": _MAIN_JSX})
     files.append({"name": "frontend/src/api.js", "content": _API_JS})
     files.append({"name": "frontend/src/App.jsx", "content": _app_jsx(manifest)})

--- a/src/squadops/prompts/fragments/manifest.yaml
+++ b/src/squadops/prompts/fragments/manifest.yaml
@@ -90,7 +90,7 @@ fragments:
   layer: task_type
   roles:
   - qa
-  sha256: dc388f7a1ad544545c598670259d71238cfa608e84d6e561c93874c661088486
+  sha256: f973870c17d206787faaed8ab56db0d37c105922d67395028ebbf1c6ceae04be
 - fragment_id: task_type.development.propose_plan_tasks
   path: shared/task_type/task_type.development.propose_plan_tasks.md
   layer: task_type
@@ -187,4 +187,4 @@ fragments:
   roles:
   - data
   sha256: fd44a28f65e449c6320b5ee5f1d8121013a03c7baa757965334c4e19c7904779
-manifest_hash: c193162099ae85f7b52fcaf68a7cdb302f955747502a7307076e4d3a8011d6c2
+manifest_hash: 4506ea215761b7d46b669d02d08ec4fa02487c35ceb4da4f5e2bce44fc0e42dc

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.qa.test.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.qa.test.md
@@ -1,7 +1,7 @@
 ---
 fragment_id: task_type.qa.test
 layer: task_type
-version: "0.9.22"
+version: "0.9.23"
 roles: ["qa"]
 ---
 # Task: Generate and Execute Tests (qa.test)
@@ -40,11 +40,26 @@ an unavailable library, cover that behavior from the other side of the stack
   that runs before each test (e.g. an autouse fixture clearing the store) —
   a test asserting "empty" must establish empty, not hope to run first.
 
+## Frontend Tests (when the workspace declares a runner)
+
+When `frontend/package.json` declares a `test` script (scaffolded workspaces
+declare vitest), frontend UI tests are real deliverables:
+
+- Files are `*.test.jsx` under `frontend/src/__tests__/`, executed with
+  `vitest run` in a jsdom environment.
+- The workspace seeds a frozen harness proof (`harness.test.jsx`) and setup
+  file (`src/test-setup.js`, registers jest-dom matchers). Follow the harness
+  example exactly: render components inside a `MemoryRouter`; never edit the
+  frozen harness files — write NEW test files beside them.
+- Component tests must not depend on a running backend: jsdom has no server.
+  Mock the workspace's `apiFetch` (from `frontend/src/api.js`) instead of
+  calling `fetch` against real URLs.
+
 ## Scope Discipline
 
 - Test the deliverable that exists, against the interfaces it actually
   exposes — do not test aspirational behavior the PRD excludes.
-- If the frontend dependency manifest declares no test runner, generate no
-  frontend test files; the frontend build check covers compile-level
-  integrity.
+- If the frontend dependency manifest declares no test runner and no `test`
+  script, generate no frontend test files; the frontend build check covers
+  compile-level integrity.
 - Prefer fewer tests that exercise real code paths over many shallow ones.

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -781,3 +781,50 @@ class TestScaffoldOwnedStore:
 
         compile(store, "backend/store.py", "exec")  # must not emit a bodyless reset()
         assert "from .models import" not in store  # nothing to import
+
+
+class TestFrontendTestHarness:
+    """#627 / pf-53: the frontend test harness is scaffold-owned — deps, runner
+    script, jsdom config, setup file, and a frozen harness-proof test. Without
+    it, qa either refused to test ("no runner available" — which matched the
+    workspace) or invented harnesses that could not run (five repair attempts,
+    all environment-killed)."""
+
+    def test_package_json_declares_the_runner_and_harness_deps(self):
+        import json
+
+        pkg = json.loads(_by_name(expand(_group_run_manifest()))["frontend/package.json"])
+        assert pkg["scripts"]["test"] == "vitest run"
+        for dep in (
+            "vitest",
+            "jsdom",
+            "@testing-library/react",
+            "@testing-library/jest-dom",
+            "@testing-library/dom",
+        ):
+            assert dep in pkg["devDependencies"], f"missing devDependency: {dep}"
+
+    def test_vite_config_wires_jsdom_and_the_emitted_setup_file(self):
+        files = _by_name(expand(_group_run_manifest()))
+        config = files["frontend/vite.config.js"]
+        assert "environment: 'jsdom'" in config
+        # The setupFiles entry must point at a file the expansion actually emits —
+        # a renamed setup file would break every suite at collection.
+        assert "setupFiles: ['src/test-setup.js']" in config
+        assert "frontend/src/test-setup.js" in files
+        assert "@testing-library/jest-dom" in files["frontend/src/test-setup.js"]
+
+    def test_harness_proof_imports_only_emitted_modules(self):
+        files = _by_name(expand(_group_run_manifest()))
+        harness = files["frontend/src/__tests__/harness.test.jsx"]
+        # ../App.jsx from __tests__/ must resolve to the emitted App
+        assert "from '../App.jsx'" in harness
+        assert "frontend/src/App.jsx" in files
+        assert "MemoryRouter" in harness
+
+    def test_harness_files_are_frozen_not_fill_slots(self):
+        from squadops.capabilities.scaffold import fill_slot_paths
+
+        slots = fill_slot_paths(_group_run_manifest())
+        assert "frontend/src/__tests__/harness.test.jsx" not in slots
+        assert "frontend/src/test-setup.js" not in slots


### PR DESCRIPTION
## What

Scaffold-owns the frontend test harness — the frontend mirror of SIP-0100's backend conftest move.

## Why

pf-53 (`cyc_86211da4786d`): the scaffolded frontend workspace had **no `test` script, no vitest, no testing-library, no jsdom** — vitest only executed because `npx` ad-hoc-fetched it from the registry. The QA agent either refused to test ("no runner available" — an assumption that *matched the workspace's own signals*) or authored five substantive, distinct test implementations that **all died on the missing environment**. Test-writing capability was never the gap; provisioning was 100% of it.

## How

- **package.json**: `vitest`, `@testing-library/react` (+ its `@testing-library/dom` peer), `@testing-library/jest-dom`, `jsdom` devDependencies; `"test": "vitest run"` script
- **vite.config.js**: `test` key with jsdom environment + `setupFiles` (vitest reads it; `vite build` ignores it)
- **`frontend/src/test-setup.js`** (frozen): registers jest-dom matchers via the **`/vitest` entry** — the bare entry assumes a global `expect` and crashes collection under vitest's default `globals:false`; caught by running the real toolchain, not review
- **`frontend/src/__tests__/harness.test.jsx`** (frozen): renders the app shell under a `MemoryRouter` at a path no route claims — so it passes on the bare skeleton **and** after any fill; it asserts harness wiring, never app behavior, and doubles as the in-workspace idiom example QA is told to follow
- **`task_type.qa.test` fragment** (v0.9.23): new Frontend Tests section — discovery convention, follow-the-harness rule, and *mock `apiFetch`, jsdom has no server* (the exact failure shape of pf-53's fetch-integration repair attempts); the "no runner declared → no frontend tests" scope rule survives for unscaffolded stacks

## Verification (real toolchain, eve container)

- `npm install` clean (174 packages); **harness test passes on the bare skeleton and on the reference fill**; `npm run build` unaffected
- Contract gate `lint` / `bare-skeleton` / `reference-fill` all **GREEN at 7/7 criteria** (including #628's `vc-routes-imports`, first gate run with it live)
- `run_node_tests` early-exits when QA authors no frontend test files (the harness rides as a *source* artifact), so backend-only rolls pay no new install cost
- Full regression: 5794 passed

## Deploy note

The skeleton gains 2 frozen files → manifest + contract hashes move (re-emit + re-seed at the next measurement, same window as #630's hash move). Agent images need a rebuild (fragment manifest updated). Gate runs against a stale container image will under-count criteria — run post-rebuild or with the repo on PYTHONPATH.

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
