### PR TITLE
feat(scaffold): blank-input rejection is scaffold-owned AND probe-pinned (#593)

### DIFF
--- a/scripts/dev/contract_gate.py
+++ b/scripts/dev/contract_gate.py
@@ -129,13 +129,19 @@ def _record_probes(
 ) -> None:
     """Boot the subject and run every behavioral probe (SIP §6.4/§6.5, 98.4).
 
-    Reference-fill: each probe must ``passed``. Bare skeleton: a probe must NOT pass
-    (its stubs answer 501/nothing) — a probe that passes on the bare skeleton is a
-    false-green admitted at authoring time, exactly what this gate exists to catch."""
+    Reference-fill: each probe must ``passed``. Bare skeleton: a fill-behavior probe
+    must NOT pass (its stubs answer 501/nothing) — a probe that passes on the bare
+    skeleton is a false-green admitted at authoring time, exactly what this gate
+    exists to catch. The exception is ``guards: scaffold`` probes (#593): they pin
+    behavior the skeleton itself provides (e.g. model-layer blank rejection, which
+    fires before any stub body), so they must pass in BOTH modes — the probe analog
+    of the frontend_build regression guard."""
+    guards_by_id = {p.id: p.guards for p in contract.behavioral.probes}
     for outcome in run_probes(workspace, contract.behavioral.probes):
         if bare:
             got = "passed" if outcome.status == "passed" else "not_passed"
-            result.record(outcome.id, got, "not_passed")
+            expected = "passed" if guards_by_id.get(outcome.id) == "scaffold" else "not_passed"
+            result.record(outcome.id, got, expected)
         else:
             result.record(outcome.id, outcome.status, "passed")
 

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -744,7 +744,15 @@ def _model_source(manifest: InterfaceManifest) -> str:
         "",
         "from __future__ import annotations",
         "",
-        "from pydantic import BaseModel, Field",
+        "from typing import Annotated",
+        "",
+        "from pydantic import BaseModel, Field, StringConstraints",
+        "",
+        "# #593: required request fields reject blank/whitespace-only input at the",
+        "# model layer — the contract pins validation_error → 422 for it, and the",
+        "# blank-input probe enforces it against the running app. Whitespace is",
+        "# stripped before the length check, so '  ' is as blank as ''.",
+        "NonBlankStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]",
         "",
     ]
     for entity in manifest.entities:
@@ -768,7 +776,7 @@ def _model_source(manifest: InterfaceManifest) -> str:
         if not shape.required and not shape.optional:
             lines.append("    pass")
         for name in shape.required:
-            lines.append(f"    {name}: str")
+            lines.append(f"    {name}: NonBlankStr")
         for name in shape.optional:
             lines.append(f"    {name}: str | None = None")
         lines.append("")

--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -245,6 +245,29 @@ def _probes(manifest: InterfaceManifest) -> list[dict[str, Any]]:
                 "expect": {"status": ep.success_status or 201},
             }
         )
+        # #593: the blank-input rejection probe. pf-38 volunteered blank-field
+        # guards and pf-39 didn't — both green, because nothing required OR
+        # tested the behavior. The scaffold model now owns the constraint
+        # (NonBlankStr on required request fields), so this probe is a
+        # scaffold-owned regression guard: pydantic rejects the blank body
+        # before any stub or fill body runs, hence guards="scaffold" (passes
+        # on the bare skeleton by design — the frontend_build class, not the
+        # tests_pass class). Emitted only alongside an error contract, whose
+        # frozen handler shapes the 422 validation_error envelope.
+        if shape and shape.required and manifest.api.error_contract:
+            probes.append(
+                {
+                    "id": f"vc-probe-{_slug(ep.path) or 'root'}-rejects-blank",
+                    "subject": "backend",
+                    "request": {
+                        "method": ep.method,
+                        "path": ep.path,
+                        "json": dict.fromkeys(shape.required, ""),
+                    },
+                    "expect": {"status": 422, "error_code": "validation_error"},
+                    "guards": "scaffold",
+                }
+            )
     return probes
 
 

--- a/src/squadops/cycles/verification_contract.py
+++ b/src/squadops/cycles/verification_contract.py
@@ -143,6 +143,12 @@ class Probe:
     subject: str
     request: dict[str, Any]
     expect: dict[str, Any]
+    # #593: "" = fill-behavior probe (must NOT pass on the bare skeleton — stubs
+    # answer nothing); "scaffold" = the skeleton itself satisfies it (a
+    # scaffold-owned regression guard, the probe analog of frontend_build —
+    # e.g. blank-input rejection enforced at the emitted model layer, which
+    # fires before any stub body runs).
+    guards: str = ""
 
     @classmethod
     def from_dict(cls, raw: Any) -> Probe:
@@ -155,15 +161,20 @@ class Probe:
             subject=str(raw.get("subject", "")),
             request=dict(request) if isinstance(request, dict) else {},
             expect=dict(expect) if isinstance(expect, dict) else {},
+            guards=str(raw.get("guards", "")),
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        out: dict[str, Any] = {
             "id": self.id,
             "subject": self.subject,
             "request": self.request,
             "expect": self.expect,
         }
+        # Omitted when unset: pre-#593 probe dicts round-trip byte-identical.
+        if self.guards:
+            out["guards"] = self.guards
+        return out
 
 
 @dataclass(frozen=True)
@@ -428,7 +439,11 @@ class VerificationContract:
             status = probe.expect.get("status")
             if not (method and path) or status is None:
                 continue
-            line = f"{method} {path} → HTTP {status}"
+            # A 4xx-expecting probe is a rejection case — without the label, a
+            # contract with a create probe (201) and a blank-input probe (422)
+            # renders two contradictory-looking lines for the same endpoint.
+            case = " (rejection case)" if isinstance(status, int) and status >= 400 else ""
+            line = f"{method} {path}{case} → HTTP {status}"
             error_code = probe.expect.get("error_code")
             if error_code:
                 line += f" (error_code: {error_code})"
@@ -643,6 +658,8 @@ class VerificationContract:
                 errors.append(f"{label}: request must declare 'method' and 'path'")
             if "status" not in probe.expect:
                 errors.append(f"{label}: expect must declare a 'status'")
+            if probe.guards not in ("", "scaffold"):
+                errors.append(f"{label}: guards must be '' or 'scaffold', got {probe.guards!r}")
 
     def _labelled_criteria(self) -> list[tuple[str, Criterion]]:
         out: list[tuple[str, Criterion]] = []

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -828,3 +828,43 @@ class TestFrontendTestHarness:
         slots = fill_slot_paths(_group_run_manifest())
         assert "frontend/src/__tests__/harness.test.jsx" not in slots
         assert "frontend/src/test-setup.js" not in slots
+
+
+class TestNonBlankRequestFields:
+    """#593: the emitted request models must actually enforce the constraint —
+    a template typo (wrong alias, misplaced annotation) would compile fine and
+    silently restore the blank-201 gap."""
+
+    def _models_module(self):
+        import sys
+        import types
+
+        src = _by_name(expand(_group_run_manifest()))["backend/models.py"]
+        mod = types.ModuleType("scaffold_emitted_models")
+        # Registered so pydantic can resolve the module's deferred annotations
+        # (`from __future__ import annotations`) exactly as a real import does.
+        sys.modules["scaffold_emitted_models"] = mod
+        try:
+            exec(compile(src, "backend/models.py", "exec"), mod.__dict__)
+        except Exception:
+            sys.modules.pop("scaffold_emitted_models", None)
+            raise
+        return mod
+
+    def test_blank_and_whitespace_required_fields_are_rejected(self):
+        import pydantic
+
+        mod = self._models_module()
+        for bad in ("", "   "):
+            try:
+                mod.RunEventCreate(title=bad, datetime="2026-08-01T08:00:00", location="Park")
+            except pydantic.ValidationError:
+                continue
+            raise AssertionError(f"blank title {bad!r} was accepted")
+
+    def test_valid_input_is_accepted_and_whitespace_stripped(self):
+        mod = self._models_module()
+        run = mod.RunEventCreate(
+            title="  Morning 5K  ", datetime="2026-08-01T08:00:00", location="Park"
+        )
+        assert run.title == "Morning 5K"

--- a/tests/unit/capabilities/test_scaffold_contract.py
+++ b/tests/unit/capabilities/test_scaffold_contract.py
@@ -215,3 +215,60 @@ def test_behavior_expectation_lines_carry_the_pinned_statuses():
     assert "POST /runs → HTTP 201" in lines
     assert "validation_error -> HTTP 422" in lines
     assert "duplicate_participant -> HTTP 409" in lines
+
+
+class TestBlankInputProbe:
+    """#593: pf-38 volunteered blank-field guards and pf-39 didn't — both went
+    green, because nothing required OR tested blank rejection. Now the scaffold
+    model owns the constraint and this probe pins it against the running app."""
+
+    def test_create_endpoint_emits_a_blank_rejection_probe(self):
+        contract = VerificationContract.from_dict(emit_contract_dict(_manifest()))
+        blank = [p for p in contract.behavioral.probes if p.id.endswith("-rejects-blank")]
+        assert len(blank) == 1
+        probe = blank[0]
+        assert probe.request["method"] == "POST"
+        assert probe.request["path"] == "/runs"
+        # Every required create field sent blank — the exact pf-39 gap
+        # (its suite posted ABSENT fields, a different behavior).
+        assert probe.request["json"] == {"title": "", "datetime": "", "location": ""}
+        assert probe.expect == {"status": 422, "error_code": "validation_error"}
+        assert probe.guards == "scaffold"
+
+    def test_blank_probe_contract_lints_clean_and_roundtrips(self):
+        contract = VerificationContract.from_dict(emit_contract_dict(_manifest()))
+        assert contract.lint() == []
+        rt = VerificationContract.from_dict(contract.to_dict())
+        blank = [p for p in rt.behavioral.probes if p.guards == "scaffold"]
+        assert len(blank) == 1
+
+    def test_bad_guards_value_is_a_lint_error(self):
+        raw = emit_contract_dict(_manifest())
+        for probe in raw["behavioral"]["probes"]:
+            if probe["id"].endswith("-rejects-blank"):
+                probe["guards"] = "skeleton"  # not a valid class
+        errors = VerificationContract.from_dict(raw).lint()
+        assert any("guards must be" in e for e in errors)
+
+    def test_no_error_contract_emits_no_blank_probe(self):
+        # Without the error contract there is no frozen 422-envelope handler to
+        # pin error_code against — the probe is conditional on the seam.
+        raw = _raw()
+        raw["api"].pop("error_contract", None)
+        manifest = InterfaceManifest.from_dict(raw)
+        contract = VerificationContract.from_dict(emit_contract_dict(manifest))
+        assert not [p for p in contract.behavioral.probes if p.id.endswith("-rejects-blank")]
+
+    def test_emitted_model_constrains_required_request_fields(self):
+        from squadops.capabilities.scaffold import expand
+
+        files = {f["name"]: f["content"] for f in expand(_manifest())}
+        models = files["backend/models.py"]
+        assert (
+            "NonBlankStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]"
+            in models
+        )
+        assert "    title: NonBlankStr" in models
+        # Optional fields stay unconstrained — blankness only matters where
+        # presence is required.
+        assert "    distance: str | None = None" in models

--- a/tests/unit/cycles/test_task_plan_probe_injection.py
+++ b/tests/unit/cycles/test_task_plan_probe_injection.py
@@ -161,7 +161,7 @@ def test_bind_mode_injects_behavior_expectations_into_qa_test_only():
     assert qa_envs, "implementation workload must contain a qa.test step"
     assert qa_envs[0].inputs["api_behavior_contract"] == [
         "POST /items → HTTP 200",
-        "POST /items → HTTP 409 (error_code: duplicate_item)",
+        "POST /items (rejection case) → HTTP 409 (error_code: duplicate_item)",
     ]
     for env in envs:
         if env.task_type != "qa.test":


### PR DESCRIPTION
## What

Option (c) for the blank-string gap: the scaffold **owns the constraint** and the contract **pins the behavior** with a probe.

## Why

pf-38 volunteered blank-field guards; pf-39 didn't — both went green on identical seeds, because nothing *required* blank rejection and nothing *tested* it. pf-39's suite posted **absent** fields (a different behavior — pydantic's required-field 422 satisfied the narrative criterion), so the gap shipped: `POST /runs {"title":"","datetime":"","location":""}` → 201, blank run created. The N=5 sample was measuring an unenforced behavior.

## How

**Constraint (scaffold model):** required request-shape fields emit as `NonBlankStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]` — whitespace-only is as blank as empty; optional fields stay unconstrained.

**Probe (contract):** every create probe gains a companion `vc-probe-*-rejects-blank` — all required fields sent blank → expect `422` + `error_code: validation_error` (the envelope the frozen `errors.py` handler shapes). Emitted only alongside an error contract.

**New probe classification — `guards: "scaffold"`:** the constraint fires at the model layer *before any stub or fill body runs*, so this probe passes on the **bare skeleton by design**. That's the probe analog of `frontend_build`'s regression-guard class (vs. `tests_pass`'s fill-behavior class). The `Probe` schema carries the optional field (omitted when unset — pre-#593 probe dicts round-trip byte-identical, wire compatibility proven by the existing exact-dict injection tests), the linter validates its values, and the contract gate expects guards-scaffold probes to pass in **both** modes.

Side alignment with #629: `behavior_expectation_lines` labels 4xx probes "(rejection case)" so the QA-authoring block doesn't render two contradictory-looking lines for the same endpoint (`POST /runs → 201` and `POST /runs → 422`).

## Verification

- Contract gate `bare-skeleton` and `reference-fill` **GREEN at 8/8** on this branch in the eve container — the blank probe passes pre-fill via the constraint alone, and against the **booted reference app** (a real HTTP POST with blank strings answered 422 + the pinned envelope)
- Emitted-model exec tests: `""` and `"   "` rejected, valid input accepted with whitespace stripped
- Lint validates `guards` values; malformed value is a lint error
- Full domain suites green (3494)

## Deploy note

Contract emit changes again (new probe row) — same re-emit + re-seed window as #630/#633. Independent of PR #633 (different regions); either merge order is clean.

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
