### PR TITLE
fix(sandbox): run operations as the workspace owner — Spark shakedown findings (SIP-0102)

### DIFF
--- a/adapters/sandbox/container_backend.py
+++ b/adapters/sandbox/container_backend.py
@@ -301,6 +301,11 @@ class ContainerBackend(NoOpExecutionSandbox):
         spec = ContainerSpec(
             image=self._image,
             command=list(command),
+            # Same identity/env posture as the one-shot ops: the runtime unit
+            # executes the UNTRUSTED generated app — it deserves least
+            # privilege most of all, and as root-sans-DAC it could not write
+            # its own workspace (pycache, app state) on native Linux anyway.
+            env=(("HOME", "/tmp"),),
             volumes=((str(self._store.workspace_dir(revision.cycle_id)), _WORKSPACE_MOUNT),),
             working_dir=_WORKSPACE_MOUNT,
             timeout_seconds=self._timeout_seconds,
@@ -312,6 +317,7 @@ class ContainerBackend(NoOpExecutionSandbox):
             pids_limit=self._pids_limit,
             cap_drop_all=True,
             no_new_privileges=True,
+            user=self._workspace_user(revision.cycle_id),
             publish_ports=(self._app_port,),
         )
         started = time.monotonic()

--- a/adapters/sandbox/container_backend.py
+++ b/adapters/sandbox/container_backend.py
@@ -110,9 +110,14 @@ class ContainerBackend(NoOpExecutionSandbox):
         npm_cache = self._cache_root / "npm"
         for cache_dir in (pip_cache, npm_cache):
             cache_dir.mkdir(parents=True, exist_ok=True)
+        # User-neutral mount points, pinned via env in _spec (PIP_CACHE_DIR /
+        # npm_config_cache): the old /root/.* paths only worked while the
+        # container ran as root — as the workspace owner (uid 1000), npm
+        # resolved $HOME/.npm -> /.npm and could not write it (Spark
+        # shakedown finding #2, 2026-07-28).
         return (
-            (str(pip_cache), "/root/.cache/pip"),
-            (str(npm_cache), "/root/.npm"),
+            (str(pip_cache), "/cache/pip"),
+            (str(npm_cache), "/cache/npm"),
         )
 
     def _spec(self, operation: str, cycle_id: str, command: tuple[str, ...]) -> ContainerSpec:
@@ -124,6 +129,14 @@ class ContainerBackend(NoOpExecutionSandbox):
         return ContainerSpec(
             image=self._image,
             command=list(command),
+            env=(
+                # HOME for a passwd-less uid; cache paths independent of user.
+                ("HOME", "/tmp"),
+                ("PIP_CACHE_DIR", "/cache/pip"),
+                ("npm_config_cache", "/cache/npm"),
+            )
+            if self._cache_root is not None
+            else (("HOME", "/tmp"),),
             volumes=(
                 (str(self._store.workspace_dir(cycle_id)), _WORKSPACE_MOUNT),
                 *self._cache_volumes(),
@@ -136,7 +149,17 @@ class ContainerBackend(NoOpExecutionSandbox):
             pids_limit=self._pids_limit,
             cap_drop_all=True,
             no_new_privileges=True,
+            user=self._workspace_user(cycle_id),
         )
+
+    def _workspace_user(self, cycle_id: str) -> str:
+        """uid:gid owning the live tree — the container runs as the workspace
+        owner so cap_drop_all (which strips DAC_OVERRIDE from root) and a
+        host-owned bind mount coexist on native Linux. On Docker Desktop the
+        virtiofs layer masked the mismatch; Spark's kernel enforces it
+        (shakedown finding, 2026-07-28)."""
+        st = self._store.workspace_dir(cycle_id).stat()
+        return f"{st.st_uid}:{st.st_gid}"
 
     async def _one_shot(
         self, operation: str, revision: WorkspaceRevision

--- a/adapters/tools/docker.py
+++ b/adapters/tools/docker.py
@@ -80,6 +80,27 @@ class DockerAdapter(ContainerPort):
             raise ToolContainerError(f"Docker command failed: {e}") from e
 
     @staticmethod
+    def _render_hardening_args(spec: ContainerSpec) -> list[str]:
+        """Hardening flags (SIP-0102): emitted only when the spec sets them, so
+        pre-0102 callers keep byte-identical docker invocations."""
+        args: list[str] = []
+        if spec.network is not None:
+            args.extend(["--network", spec.network])
+        if spec.memory_limit is not None:
+            args.extend(["--memory", spec.memory_limit])
+        if spec.cpu_limit is not None:
+            args.extend(["--cpus", str(spec.cpu_limit)])
+        if spec.pids_limit is not None:
+            args.extend(["--pids-limit", str(spec.pids_limit)])
+        if spec.cap_drop_all:
+            args.extend(["--cap-drop", "ALL"])
+        if spec.no_new_privileges:
+            args.extend(["--security-opt", "no-new-privileges"])
+        if spec.user is not None:
+            args.extend(["--user", spec.user])
+        return args
+
+    @staticmethod
     def _render_run_args(spec: ContainerSpec) -> list[str]:
         """Render a spec into `docker run` arguments (shared by foreground and
         detached runs)."""
@@ -97,20 +118,7 @@ class DockerAdapter(ContainerPort):
         if spec.working_dir:
             args.extend(["-w", spec.working_dir])
 
-        # Hardening flags (SIP-0102): emitted only when the spec sets them, so
-        # pre-0102 callers keep byte-identical docker invocations.
-        if spec.network is not None:
-            args.extend(["--network", spec.network])
-        if spec.memory_limit is not None:
-            args.extend(["--memory", spec.memory_limit])
-        if spec.cpu_limit is not None:
-            args.extend(["--cpus", str(spec.cpu_limit)])
-        if spec.pids_limit is not None:
-            args.extend(["--pids-limit", str(spec.pids_limit)])
-        if spec.cap_drop_all:
-            args.extend(["--cap-drop", "ALL"])
-        if spec.no_new_privileges:
-            args.extend(["--security-opt", "no-new-privileges"])
+        args.extend(DockerAdapter._render_hardening_args(spec))
         for port in spec.publish_ports:
             args.extend(["-p", f"127.0.0.1:0:{port}"])
 

--- a/docs/plans/SIP-0102-ephemeral-application-sandbox-plan.md
+++ b/docs/plans/SIP-0102-ephemeral-application-sandbox-plan.md
@@ -42,6 +42,29 @@ campaigns run):**
    behavior) here — that is exactly the drift the local-build decision accepted;
    findings feed the 1.5 digest-pinning revisit.
 
+**Spark shakedown results (2026-07-28, Spark lane):** image built locally
+(361MB); floor smoke initially FAILED, root-caused to two native-Linux
+divergences that Docker Desktop's virtiofs masked on Mac — exactly the drift
+class this shakedown existed to catch:
+
+1. **cap_drop_all vs host-owned bind mount:** the container ran as root, and
+   `--cap-drop ALL` strips `CAP_DAC_OVERRIDE` — on native Linux root then
+   cannot write the uid-1000-owned workspace mount (`python -m venv` died in
+   0.3s, `Permission denied`). Isolated three ways: cap-drop+root fails,
+   no-cap-drop works, cap-drop+`--user 1000:1000` works. Fix: the spec runs
+   every operation as the workspace owner's uid:gid (keeps §7 hardening
+   intact; `ContainerSpec.user` is inert-default for pre-0102 callers).
+2. **Cache mounts assumed root's home:** as uid 1000, npm resolved
+   `$HOME/.npm → /.npm` (unwritable). Fix: user-neutral mount points
+   (`/cache/pip`, `/cache/npm`) pinned via env (`HOME=/tmp`, `PIP_CACHE_DIR`,
+   `npm_config_cache`).
+
+With both fixes: **floor smoke GREEN on Spark's docker** (seed → install →
+vite build → boot → 501 probe → teardown, pin intact) — and the install now
+exercises the post-#633 expander output (vitest/testing-library devDeps)
+without issue. Service boot (step 4) deferred until the fix merges, so the
+service image bakes merged code. Digest-pinning note for 1.5 stands.
+
 Steps 1–5 need no coordination window. The next *merge* that needs one is
 102.3 (below).
 

--- a/src/squadops/tools/models.py
+++ b/src/squadops/tools/models.py
@@ -29,6 +29,11 @@ class ContainerSpec:
     pids_limit: int | None = None
     cap_drop_all: bool = False
     no_new_privileges: bool = False
+    # uid:gid to run as (docker --user). None = image default. The sandbox sets
+    # this to the workspace owner: with cap_drop_all, root loses DAC_OVERRIDE
+    # and cannot write a host-owned bind mount on native Linux (Spark
+    # shakedown finding, 2026-07-28); running as the owner needs no capability.
+    user: str | None = None
     # Container ports to publish to loopback-only ephemeral host ports
     # (rendered as `-p 127.0.0.1:0:<port>`). Empty = nothing published.
     publish_ports: tuple[int, ...] = ()

--- a/tests/unit/adapters/test_docker_hardening.py
+++ b/tests/unit/adapters/test_docker_hardening.py
@@ -31,6 +31,7 @@ async def test_hardened_spec_renders_every_flag(captured):
             pids_limit=512,
             cap_drop_all=True,
             no_new_privileges=True,
+            user="1000:1000",
         )
     )
     args = list(captured[0])
@@ -41,6 +42,7 @@ async def test_hardened_spec_renders_every_flag(captured):
         ("--pids-limit", "512"),
         ("--cap-drop", "ALL"),
         ("--security-opt", "no-new-privileges"),
+        ("--user", "1000:1000"),
     ]:
         i = args.index(flag)
         assert args[i + 1] == value
@@ -61,6 +63,7 @@ async def test_default_spec_emits_no_hardening_flags(captured):
         "--pids-limit",
         "--cap-drop",
         "--security-opt",
+        "--user",
         "-p",
     ):
         assert flag not in args

--- a/tests/unit/sandbox/test_container_backend.py
+++ b/tests/unit/sandbox/test_container_backend.py
@@ -109,8 +109,10 @@ class TestHardenedSpecRendering:
         )
         await backend.install_dependencies(revision=seeded)
         mounts = dict(container.specs[0].volumes)
-        assert mounts[str(tmp_path / "caches" / "pip")] == "/root/.cache/pip"
-        assert mounts[str(tmp_path / "caches" / "npm")] == "/root/.npm"
+        # User-neutral mount points (Spark shakedown 2026-07-28): /root/.* paths
+        # only resolved while the container ran as root.
+        assert mounts[str(tmp_path / "caches" / "pip")] == "/cache/pip"
+        assert mounts[str(tmp_path / "caches" / "npm")] == "/cache/npm"
         assert (tmp_path / "caches" / "pip").is_dir()  # pre-created, never root-owned
         assert not any("site-packages" in c or "node_modules" in c for c in mounts.values())
 
@@ -239,3 +241,37 @@ class TestContractAndPinning:
         assert result.ran is False
         assert result.status == OperationStatus.NOT_RUN
         assert "provides no command" in result.unavailable_reason
+
+
+class TestWorkspaceOwnerUser:
+    """Spark shakedown (2026-07-28): with cap_drop_all, root loses DAC_OVERRIDE
+    and cannot write a host-owned bind mount on native Linux — the floor smoke
+    failed at `python -m venv` in 0.3s. Docker Desktop's virtiofs masked the
+    mismatch on Mac. The container must run as the workspace owner."""
+
+    async def test_operations_run_as_the_workspace_owner(self, tmp_path, store, seeded):
+        import os
+
+        container = FakeContainer()
+        backend = _backend(container, store)
+        await backend.install_dependencies(revision=seeded)
+        spec = container.specs[0]
+        st = os.stat(store.workspace_dir(seeded.cycle_id))
+        assert spec.user == f"{st.st_uid}:{st.st_gid}"
+
+    async def test_env_pins_home_and_user_neutral_caches(self, tmp_path, store, seeded):
+        container = FakeContainer()
+        backend = ContainerBackend(
+            container=container,
+            store=store,
+            image="sandbox:pinned",
+            operation_commands=COMMANDS,
+            cache_root=tmp_path / "caches",
+        )
+        await backend.install_dependencies(revision=seeded)
+        env = dict(container.specs[0].env)
+        # A passwd-less uid resolves $HOME to '/' — npm then writes /.npm and
+        # fails; HOME plus explicit cache env decouple caching from identity.
+        assert env["HOME"] == "/tmp"
+        assert env["PIP_CACHE_DIR"] == "/cache/pip"
+        assert env["npm_config_cache"] == "/cache/npm"

--- a/tests/unit/sandbox/test_container_backend_runtime.py
+++ b/tests/unit/sandbox/test_container_backend_runtime.py
@@ -125,6 +125,12 @@ class TestStartApplication:
         spec = container.specs[0]
         assert spec.publish_ports == (8000,)
         assert spec.cap_drop_all and spec.no_new_privileges
+        # Runtime-unit parity with the one-shot ops (Spark shakedown + Mac
+        # review): the untrusted app runs as the workspace owner, never
+        # root-sans-DAC, with HOME pinned for the passwd-less uid.
+        st = __import__("os").stat(store.workspace_dir("cyc_1"))
+        assert spec.user == f"{st.st_uid}:{st.st_gid}"
+        assert dict(spec.env)["HOME"] == "/tmp"
 
     async def test_never_ready_app_is_stopped_and_fails_with_diagnostics(self, store, seeded):
         """Bug caught: a hung startup leaving an orphan container running, or


### PR DESCRIPTION
## What

SIP-0102 Spark shakedown (handoff steps 1–3 + 5) — executed, two native-Linux divergences found, root-caused, fixed, and the floor smoke is now **GREEN on Spark's docker** end-to-end.

**⚠️ Mac-lane review requested:** this touches `adapters/sandbox/container_backend.py`, a Mac-driven surface per the recorded lane note. This PR is the coordination vehicle — treat it as the shakedown's findings + proposed fix, not a unilateral merge.

## Findings (both masked by Docker Desktop's virtiofs on Mac)

**1. `cap_drop_all` vs host-owned bind mounts.** The env image runs as root; `--cap-drop ALL` strips `CAP_DAC_OVERRIDE`, so on native Linux root cannot write the uid-1000-owned workspace mount — install died at `python -m venv` in 0.3s with `Permission denied`. Proven by three-way isolation: cap-drop+root **fails**, no-cap-drop **works**, cap-drop+`--user 1000:1000` **works**.

**2. Cache mounts assumed root's home.** Once the container runs as uid 1000, npm resolves `$HOME/.npm → /.npm` (unwritable, no passwd entry → `HOME=/`).

## Fix

- `ContainerSpec.user` (inert default `None`; adapter renders `--user` only when set — the pre-0102 byte-identical guarantee holds, pinned by the existing no-flags test)
- The backend runs every operation as the **workspace owner's uid:gid** (`_workspace_user`), keeping the §7 hardening fully intact
- Cache mounts move to user-neutral `/cache/pip` + `/cache/npm`, pinned via env (`HOME=/tmp`, `PIP_CACHE_DIR`, `npm_config_cache`)

## Verification

- **Floor smoke GREEN on Spark**: seed → install → vite build → boot → 501 probe → teardown, pin intact — and the install exercises the post-#633 expander output (vitest/testing-library devDeps) without issue
- New tests: workspace-owner user on operation specs, HOME/cache env pinning, `--user` in the hardened-flag render matrix + absent-by-default; cache-mount test updated to the neutral paths
- Full regression: 5803 passed; C901 on the adapter resolved by extracting `_render_hardening_args` (decompose, not exempt)

## Shakedown status

Steps 1–3 done (image built locally, 361MB). Step 4 (service boot + doctor) deferred until this merges so the service image bakes merged code. Step 5's report is written into the plan-doc handoff section in this PR. Digest-pinning revisit for 1.5 stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
