### PR TITLE
fix(sandbox): service boots under the locked dependency pair — shakedown finding #3 (SIP-0102)

### DIFF
--- a/src/squadops/sandbox/api.py
+++ b/src/squadops/sandbox/api.py
@@ -17,7 +17,6 @@ becomes the caller.
 from __future__ import annotations
 
 import hmac
-from typing import Annotated
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -163,7 +162,13 @@ def create_app(service: SandboxService, *, service_token: str) -> FastAPI:
             detail = {"error": {"code": "HTTP_ERROR", "message": str(detail), "details": None}}
         return JSONResponse(status_code=exc.status_code, content=detail)
 
-    def require_identity(authorization: Annotated[str | None, Header()] = None) -> None:
+    # Header(default=...) not Annotated[..., Header()]: under the LOCKED pair
+    # (fastapi 0.104.1 + pydantic 2.12.5, requirements/api.lock) the Annotated
+    # form crashes route registration (FieldInfo has no .in_) — the service
+    # container could never boot. The dev venv runs a newer fastapi where both
+    # forms work, so only the container image manifests it (Spark shakedown
+    # finding #3, 2026-07-28; minimal repro in the runtime-api container).
+    def require_identity(authorization: str | None = Header(default=None)) -> None:
         expected = f"Bearer {service_token}"
         if authorization is None or not hmac.compare_digest(authorization, expected):
             raise _error(401, "UNAUTHENTICATED", "valid service bearer token required")


### PR DESCRIPTION
## What

One-signature fix: the sandbox service container was **DOA under the locked dependency pair** — it crash-looped at startup and never served `/health`.

## Why

`requirements/api.lock` pins fastapi 0.104.1 + pydantic 2.12.5. Under that pair, the `Annotated[str | None, Header()]` dependency form crashes FastAPI route registration (`'FieldInfo' object has no attribute 'in_'`). Nothing caught it:

- the **dev venv runs fastapi 0.135**, where both forms work → all unit tests green
- **runtime-api** survives the same lock because its auth is middleware, not Header dependencies
- the Mac's 102.1 evidence was the in-process ASGI E2E (dev venv), not the container image

Minimal repro executed inside the runtime-api container (same locked versions): the Annotated form raises at registration; `Header(default=None)` registers and enforces correctly (401/401/200).

## Shakedown step 4 — now complete on Spark

Service image rebuilt from this branch: container **healthy**, `/health` returns the environment report (contract `637514e5…`, canonical image present), `squadops doctor local-spark --check sandbox` **1/1**, auth enforced (401 for no token and wrong token). Findings 1–2 were PR #635; this is finding #3, recorded here rather than the plan doc to keep the diff one-concern.

**⚠️ Mac-lane review requested** — sandbox-owned surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q