### PR TITLE
docs: Functional App Yield measurement design — the 1.4 exit number

### DIFF
--- a/docs/plans/functional-app-yield-measurement.md
+++ b/docs/plans/functional-app-yield-measurement.md
@@ -44,9 +44,14 @@ green-but-not-functional (that gap is the #374/#376 class the sandbox exists
 to close — every such case is a finding) and, in principle,
 functional-but-not-green (over-strict criteria — also a finding).
 
-The audit is **post-hoc, not in-cycle**: SIP-0102 phases 102.3–102.4 (in-cycle
+The audit is **post-hoc, not in-cycle** — **SIGNED OFF (Jason, 2026-07-28)**:
+the fix-package changes are what this window validates, and folding a freshly
+integrated sandbox into the execution path would pollute that signal with
+first-exposure integration teething. SIP-0102 phases 102.3–102.4 (in-cycle
 clean-room verification) are Mac-lane work still in flight, and this
-measurement deliberately does not couple to their timeline. The sandbox acts
+measurement deliberately does not couple to their timeline. A post-integration
+re-run of this same pre-registered design is the natural 1.5-era baseline and
+isolates the integration's own effect. The sandbox acts
 as the independent auditor of each deliverable — its actual purpose — and
 when 102.4 lands, in-cycle enforcement supersedes the audit for future
 measurements.

--- a/docs/plans/functional-app-yield-measurement.md
+++ b/docs/plans/functional-app-yield-measurement.md
@@ -1,0 +1,134 @@
+# Functional App Yield — the 1.4 exit measurement
+
+**Status: DRAFT — pre-registration pending owner sign-off.** Once the window
+opens, changes to anything in §2–§6 require a recorded amendment *before* the
+affected roll launches; silent mid-window changes void the measurement.
+
+## 1. Purpose and lineage
+
+One pre-registered number gates the 1.4 cut: **given a PRD and frozen seeds,
+how often does the system deliver a working application end-to-end?**
+
+This replaces the retired 5/5 consecutive-greens design (closed 2026-07-28 at
+3/5 banked). That design certified the *machinery* — layered patch acceptance,
+retest-decides, framing re-roll, scaffold restore, plan validation, locus
+routing, each validated live — and punished every change with a reset, which
+was right for certification and wrong for improvement tracking. The question
+now is different: *did the fix package (#628/#629/#627/#593) and the
+provisioning work raise the yield?* — and that question wants a fixed budget
+of rolls where **every roll is a data point and nothing resets**.
+
+**Pre-1.4 reference: 3 greens / 5 implementation-reaching rolls (60%
+unfiltered) on deploy 35f1fc51**, under the *old* green definition
+(checks + suite + probes; nothing ever built or booted the deliverable).
+The numbers below use a stricter definition, so the 60% is historical
+context, not an A/B comparand.
+
+## 2. The two numbers
+
+Per roll, two binary outcomes:
+
+- **In-cycle green** — verdict `accepted` AND all 8 contract criteria hold
+  passing evidence (the campaign bar, now including `vc-routes-imports` and
+  `vc-probe-runs-rejects-blank`). Verified against stored evidence, never the
+  roll-up counter (the #597 lesson).
+- **Functional** — the *delivered* application, assembled from the final
+  accepted fill files over the canonical skeleton, passes a scripted
+  **sandbox audit** in the SIP-0102 canonical environment:
+  install → frontend build → boot → the contract v7 probe set (create → 201,
+  blank-input → 422 envelope). Pin-verified, cap-dropped, workspace-owner
+  identity — the same floor the shakedown proved on this host.
+
+**Functional App Yield (FAY) = functional rolls / total rolls.** A roll can be
+green-but-not-functional (that gap is the #374/#376 class the sandbox exists
+to close — every such case is a finding) and, in principle,
+functional-but-not-green (over-strict criteria — also a finding).
+
+The audit is **post-hoc, not in-cycle**: SIP-0102 phases 102.3–102.4 (in-cycle
+clean-room verification) are Mac-lane work still in flight, and this
+measurement deliberately does not couple to their timeline. The sandbox acts
+as the independent auditor of each deliverable — its actual purpose — and
+when 102.4 lands, in-cycle enforcement supersedes the audit for future
+measurements.
+
+## 3. Budget and decision rule
+
+- **N = 6 rolls**, pre-registered. At ~2.5–3 h per roll this is roughly two
+  days of elapsed rolling.
+- **Pre-declared extension**: if FAY lands in the ambiguous zone (4/6), the
+  window extends by exactly 2 rolls (total 8) under identical conditions.
+  Declared now so the extension is part of the design, not a post-hoc rescue.
+- **1.4 cut bar (proposed, owner confirms):** FAY ≥ 4/6 (or ≥ 6/8 after an
+  extension) **and** zero machinery-class defects discovered during the
+  window. Every loss must be root-caused to an artifact/provisioning class
+  and filed. A machinery defect (framework bug, not app/plan defect) pauses
+  the window for an owner decision — fixing it mid-window voids the run.
+
+## 4. Frozen conditions
+
+| Element | Value |
+|---|---|
+| Deploy | main as of window open (currently `6a8a4883`-era images) — frozen for the window; any deploy ends the window |
+| Contract | v7 `art_af9ddc104b03` (content_hash `e8dca2cf…`, 8 criteria) |
+| Manifest | v3 `art_c208ed0da314` |
+| PRD | `art_bfa4435f4ddd` (group_run canonical) |
+| Squad / model | `full` / 27b |
+| Budget | 3 h, 5 correction attempts, `framing_max_rerolls=2` |
+| Gate policy | **Standard bar only — NO plan-shape filtering.** The campaign's frontend-qa-task rejection policy is retired: #627 makes those tasks winnable, and their outcomes are now measurement signal, not noise |
+| Audit environment | `squadops-sandbox-env:fastapi-react-1.4-dev`, environment contract `637514e5…` |
+
+## 5. Per-roll protocol
+
+1. **Launch** (auto after the previous roll's record is written — non-green
+   does *not* stop the train; that is the design).
+2. **Gate review** (delegated): the standard bar — frozen-check rerun 0, real
+   refs, no source-regex, applicability count, no deadlock shape. Approve or
+   reject on plan validity only, never on plan *shape*. System-validator
+   rejections and re-rolls are recorded, not intervened in.
+3. **Implementation to terminal.**
+4. **Green verification** against stored evidence: verdict, 8 criteria, zero
+   silent skips (#423 discipline).
+5. **Sandbox audit** of the delivered app (scripted; see §7): assemble final
+   accepted fill files over the skeleton → install → build → boot → probes.
+   Record pass/fail with failure detail.
+6. **Record** the roll row (§6) in the measurement log; update the master
+   state; launch the next roll.
+
+**Infra-void rolls** (excluded and re-run, pre-declared narrowly): the cycle
+died from host/infra failure *before an implementation run produced any task
+result* — box crash, LLM backend down, queue outage — evidenced in logs.
+Anything the pipeline itself did, including framing exhaustion, **counts as a
+roll**.
+
+## 6. Recorded per roll
+
+Verdict; per-criterion evidence (8); corrections used and their classes;
+framing re-rolls and rejection classes; plan shape (task counts, frontend
+qa.test present — measurement (a) continuation); sandbox audit result and
+failure detail; wall-clock. Aggregates at close: in-cycle green rate, FAY,
+loss-mode census (each loss → existing issue # or new filing), and the
+qualitative comparison to the 60% reference with the definition caveat stated.
+
+## 7. Prerequisite work items (before the window opens)
+
+1. **`scripts/dev/audit_delivered_app.py`** — the scripted sandbox audit:
+   vault-pull a run's final accepted fill artifacts → seed skeleton + overlay
+   via the SIP-0102 workspace store → run install/build/boot/probes via the
+   container backend → one-line PASS/FAIL + detail. Reuses the floor-smoke
+   pattern; Spark-side; small.
+   *Shakedown of the auditor itself*: positive control = a pf-50/51/52 green
+   deliverable; negative control = a deliberately broken fill (drop the
+   router header — the pf-54 artifact is stored and perfect for this).
+2. **Launcher NOTES rewrite** — the campaign-era notes block is stale; the
+   window's notes state this doc as the protocol.
+3. **Owner sign-offs**: N and the cut bar (§3), the audit-not-in-cycle
+   decision (§2), and the standing window authorization (first
+   `cycles create` included).
+
+## 8. Relation to the 1.4 release
+
+1.4 ships with Scaffold (M) + Sandbox (S) headlines and the fix package as
+hardening. This measurement is the release's evidence section: the FAY number,
+the loss-mode census, and the machinery-defect count (which must be zero).
+The measurement does not require 102.3–102.6; it requires only what is already
+deployed plus the §7 audit script.

--- a/scripts/dev/audit_delivered_app.py
+++ b/scripts/dev/audit_delivered_app.py
@@ -1,0 +1,201 @@
+"""Sandbox audit of a run's DELIVERED application (FAY measurement §2/§7).
+
+Answers "does the app this run delivered actually work?" independently of the
+run's own verdict: assemble the deliverable from stored artifacts, stand it up
+in the SIP-0102 canonical environment, and make it answer its contract's
+probes over real HTTP.
+
+Selection mirrors the executor's acceptance-aware rule (pf-31 Fix E,
+dispatched_flow_executor ~L1026): per filename, the LATEST stored artifact
+whose ``producing_task_type`` is NOT a repair-candidate type — accepted
+repairs are re-stored under the task's own type (#389 swap), so rejected
+candidates never enter the tree. pf-54 is the canonical trap this rule
+survives: last-wins-by-time would pick a *rejected* repair that boots.
+
+The assembly uses the run's OWN stored skeleton files (the seeding rail stores
+them), so an audit of an old run reflects that run's era, not today's expander.
+
+Probes come from the contract the run was seeded with (--contract): status
+plus, when pinned, the error envelope's code. Issued directly over HTTP
+against the sandbox-started app — the backend's probe op has no body/envelope
+support yet; 102.4's relocation subsumes this.
+
+Usage:
+    .venv/bin/python scripts/dev/audit_delivered_app.py CYCLE_ID RUN_ID \
+        --contract path/to/contract.yaml [--project group_run]
+
+Exit 0 = PASS (install, build, boot, every probe). Exit 1 = FAIL, with the
+step and detail on stdout. Exit 2 = auditor error (could not assemble).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import httpx
+
+from adapters.sandbox.container_backend import ContainerBackend
+from adapters.tools.docker import DockerAdapter
+from squadops.cycles.task_plan import REPAIR_TASK_TYPES
+from squadops.cycles.verification_contract import VerificationContract
+from squadops.sandbox.environment import FULLSTACK_FASTAPI_REACT
+from squadops.sandbox.models import RevisionOrigin
+from squadops.sandbox.workspace import WorkspaceStore
+
+_VAULT_CONTAINER = "squadops-runtime-api"
+_WORKSPACE_ARTIFACT_TYPES = frozenset({"source", "test", "config"})
+_AUDIT_ROOT = Path("/tmp/squadops-sandbox-audit")
+
+
+def _pull_run_artifacts(project: str, cycle_id: str, run_id: str, dest: Path) -> None:
+    """Copy the run's vault subtree (contents + metadata.json) out of the
+    runtime-api container in one shot."""
+    vault_path = f"data/artifacts/{project}/{cycle_id}/{run_id}"
+    tar = subprocess.run(  # noqa: S603 - fixed argv, dev tooling
+        ["docker", "exec", _VAULT_CONTAINER, "sh", "-c", f"cd {vault_path} && tar cf - ."],
+        capture_output=True,
+    )
+    if tar.returncode != 0:
+        raise SystemExit(f"AUDITOR ERROR: cannot read vault for {run_id}: {tar.stderr.decode()!r}")
+    subprocess.run(  # noqa: S603
+        ["tar", "xf", "-", "-C", str(dest)], input=tar.stdout, check=True
+    )
+
+
+def _select_deliverable(pulled: Path) -> dict[str, str]:
+    """filename -> content, acceptance-aware last-wins (the executor's rule)."""
+    latest: dict[str, tuple[str, Path]] = {}
+    for meta_path in pulled.glob("*/metadata.json"):
+        meta = json.loads(meta_path.read_text())
+        if meta.get("artifact_type") not in _WORKSPACE_ARTIFACT_TYPES:
+            continue
+        producing = (meta.get("metadata") or {}).get("producing_task_type", "")
+        if producing in REPAIR_TASK_TYPES:
+            continue  # rejected candidate — accepted repairs re-store under the task type
+        filename = meta["filename"]
+        content_file = meta_path.parent / filename
+        if not content_file.is_file():
+            continue
+        created = str(meta.get("created_at", ""))
+        if filename not in latest or created > latest[filename][0]:
+            latest[filename] = (created, content_file)
+    return {name: path.read_text() for name, (_, path) in latest.items()}
+
+
+async def _run_probes(contract: VerificationContract, base_url: str) -> list[str]:
+    """Issue every contract probe over HTTP; return failure detail lines."""
+    failures: list[str] = []
+    async with httpx.AsyncClient(base_url=base_url, timeout=15.0) as client:
+        for probe in contract.behavioral.probes:
+            method = str(probe.request.get("method", "GET")).upper()
+            path = str(probe.request.get("path", "/"))
+            body = probe.request.get("json")
+            try:
+                resp = await client.request(method, path, json=body)
+            except httpx.HTTPError as exc:
+                failures.append(f"probe {probe.id}: transport error {exc!r}")
+                continue
+            expected = probe.expect.get("status")
+            if expected is not None and resp.status_code != expected:
+                failures.append(
+                    f"probe {probe.id}: status {resp.status_code} != expected {expected}"
+                )
+                continue
+            error_code = probe.expect.get("error_code")
+            if error_code is not None:
+                try:
+                    payload = resp.json()
+                except ValueError:
+                    payload = None
+                actual = (
+                    (payload.get("error") or {}).get("code") if isinstance(payload, dict) else None
+                )
+                if actual != error_code:
+                    failures.append(
+                        f"probe {probe.id}: error_code {actual!r} != expected {error_code!r}"
+                    )
+    return failures
+
+
+async def _audit(args: argparse.Namespace) -> int:
+    contract = VerificationContract.from_yaml(Path(args.contract).read_text(encoding="utf-8"))
+
+    pulled = Path(tempfile.mkdtemp(prefix="fay_audit_pull_"))
+    try:
+        _pull_run_artifacts(args.project, args.cycle_id, args.run_id, pulled)
+        files = _select_deliverable(pulled)
+    finally:
+        shutil.rmtree(pulled, ignore_errors=True)
+    if "backend/routes.py" not in files:
+        print(f"AUDITOR ERROR: no backend/routes.py among {len(files)} selected files")
+        return 2
+    print(f"assembled {len(files)} files (acceptance-aware last-wins)")
+
+    audit_cycle = f"audit_{args.run_id[:16]}"
+    shutil.rmtree(_AUDIT_ROOT / "cycles" / audit_cycle, ignore_errors=True)
+    store = WorkspaceStore(_AUDIT_ROOT / "cycles")
+    env = FULLSTACK_FASTAPI_REACT
+    backend = ContainerBackend(
+        container=DockerAdapter(),
+        store=store,
+        image=env.image,
+        operation_commands=env.commands(),
+        app_port=env.app_port,
+        install_network=env.install_network,
+        environment_contract_id=env.contract_id(),
+        cache_root=_AUDIT_ROOT / "caches",
+        timeout_seconds=420.0,
+        readiness_timeout_seconds=30.0,
+    )
+    revision = store.seed(audit_cycle, files, origin=RevisionOrigin.SCAFFOLD_SEED)
+
+    install = await backend.install_dependencies(revision=revision)
+    if install.status != "succeeded":
+        print(f"FAIL install: {install.exit_classification}")
+        return 1
+    build = await backend.build_frontend(revision=revision)
+    if build.status != "succeeded":
+        print(f"FAIL build: {'; '.join(build.diagnostics[-3:])}")
+        return 1
+    start = await backend.start_application(revision=revision)
+    if not start.ready:
+        print(f"FAIL boot: {'; '.join(start.startup_diagnostics[-3:])}")
+        return 1
+    try:
+        if not start.endpoints:
+            print("FAIL boot: app ready but no endpoint reported")
+            return 1
+        base_url = start.endpoints[0]
+        failures = await _run_probes(contract, base_url)
+    finally:
+        await backend.stop_application(revision=revision, cleanup_handle=start.cleanup_handle)
+    if failures:
+        for line in failures:
+            print(f"FAIL {line}")
+        return 1
+    print(
+        f"PASS — delivered app installs, builds, boots, and answers "
+        f"{len(contract.behavioral.probes)} contract probe(s) "
+        f"[image {env.image}, contract {env.contract_id()[:12]}]"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cycle_id")
+    parser.add_argument("run_id")
+    parser.add_argument("--contract", required=True, help="the contract the run was seeded with")
+    parser.add_argument("--project", default="group_run")
+    return asyncio.run(_audit(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/cli_tools/test_audit_deliverable_selection.py
+++ b/tests/unit/cli_tools/test_audit_deliverable_selection.py
@@ -1,0 +1,109 @@
+"""The FAY auditor's acceptance-aware artifact selection (audit_delivered_app).
+
+The rule mirrors the executor's (pf-31 Fix E): per filename, latest artifact
+whose producing_task_type is not a repair-candidate type. pf-54 is the trap
+that makes this worth pinning: naive last-wins-by-time selects a REJECTED
+repair that happens to boot, flipping the audit verdict from FAIL to PASS.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "dev" / "audit_delivered_app.py"
+_spec = importlib.util.spec_from_file_location("audit_delivered_app", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["audit_delivered_app"] = _mod
+_spec.loader.exec_module(_mod)
+
+
+def _store(tmp_path, art_id, filename, content, producing, created, artifact_type="source"):
+    d = tmp_path / art_id
+    (d / Path(filename).parent).mkdir(parents=True, exist_ok=True)
+    (d / filename).write_text(content)
+    (d / "metadata.json").write_text(
+        json.dumps(
+            {
+                "artifact_id": art_id,
+                "artifact_type": artifact_type,
+                "filename": filename,
+                "created_at": created,
+                "metadata": {"producing_task_type": producing},
+            }
+        )
+    )
+
+
+def test_rejected_repair_never_wins_even_when_newest(tmp_path):
+    # The pf-54 shape: accepted original (broken) + newer rejected repairs (bootable).
+    _store(
+        tmp_path,
+        "art_a",
+        "backend/routes.py",
+        "ACCEPTED",
+        "development.develop",
+        "2026-01-01T10:00",
+    )
+    _store(
+        tmp_path,
+        "art_b",
+        "backend/routes.py",
+        "REJECTED-1",
+        "development.correction_repair",
+        "2026-01-01T11:00",
+    )
+    _store(
+        tmp_path,
+        "art_c",
+        "backend/routes.py",
+        "REJECTED-2",
+        "development.correction_repair",
+        "2026-01-01T12:00",
+    )
+    files = _mod._select_deliverable(tmp_path)
+    assert files["backend/routes.py"] == "ACCEPTED"
+
+
+def test_accepted_repair_restored_under_task_type_wins(tmp_path):
+    # The pf-50 shape: the #389 swap re-stores the accepted patch under the
+    # failing task's own type — that copy IS the deliverable.
+    _store(
+        tmp_path,
+        "art_a",
+        "backend/routes.py",
+        "ORIGINAL",
+        "development.develop",
+        "2026-01-01T10:00",
+    )
+    _store(
+        tmp_path,
+        "art_b",
+        "backend/routes.py",
+        "CANDIDATE",
+        "development.correction_repair",
+        "2026-01-01T11:00",
+    )
+    _store(tmp_path, "art_c", "backend/routes.py", "ACCEPTED-SWAP", "qa.test", "2026-01-01T11:01")
+    files = _mod._select_deliverable(tmp_path)
+    assert files["backend/routes.py"] == "ACCEPTED-SWAP"
+
+
+def test_non_workspace_types_excluded(tmp_path):
+    _store(
+        tmp_path, "art_a", "backend/routes.py", "CODE", "development.develop", "2026-01-01T10:00"
+    )
+    _store(
+        tmp_path,
+        "art_b",
+        "report.md",
+        "REPORT",
+        "qa.test",
+        "2026-01-01T11:00",
+        artifact_type="document",
+    )
+    files = _mod._select_deliverable(tmp_path)
+    assert "report.md" not in files
+    assert files == {"backend/routes.py": "CODE"}


### PR DESCRIPTION
Pre-registration draft of the measurement that gates the 1.4 cut. Key decisions surfaced for owner sign-off (§7.3):

1. **N = 6** rolls, with a pre-declared +2 extension only on an ambiguous 4/6 — sequential design declared up front, no post-hoc rescue.
2. **Two outcomes per roll**: in-cycle green (8-criterion contract v7 bar, evidence-verified) and **functional** — the delivered app passes a scripted **post-hoc sandbox audit** (install → build → boot → v7 probes incl. blank-rejection) in the canonical SIP-0102 environment. **FAY = functional/total** is the exit number.
3. **Audit is post-hoc, not in-cycle** — deliberately decoupled from the Mac lane's 102.3–102.4 timeline; the sandbox acts as independent auditor until in-cycle clean-room verification lands.
4. **Unfiltered**: the campaign's frontend-qa-task gate filter is retired — #627 made those tasks winnable, so their outcomes are signal.
5. **Proposed cut bar**: FAY ≥ 4/6 and zero machinery-class defects (every loss root-caused to an artifact class and filed).
6. **No resets**: non-greens don't stop the train; only a machinery defect pauses for an owner decision. Infra-void defined narrowly (§5).

Prerequisites before the window opens: the audit script (with pf-50-era green as positive control and pf-54's stored router-header fragment as the negative control), launcher notes rewrite, and the sign-offs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q