### PR TITLE
fix(retest): contract probes ride the retest against the patched tree (#639)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -995,6 +995,11 @@ class CorrectionRunner:
             "expected_artifacts": failed_inputs.get("expected_artifacts", []),
             "acceptance_criteria": failed_inputs.get("acceptance_criteria", []),
         }
+        # #639: probes ride the retest or the final verdict carries stale
+        # probe evidence for a tree the repair changed. Presence-keyed, like
+        # the bind-mode injection (probe-less contracts thread no key).
+        if failed_inputs.get("contract_probes"):
+            retest_inputs["contract_probes"] = failed_inputs["contract_probes"]
 
         retest_envelope = TaskEnvelope(
             task_id=f"retest-{run_id[:12]}-{correction_attempts:02d}-{envelope.task_type}",

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -215,7 +215,10 @@ class QATestHandler(_CycleTaskHandler):
         return "\n".join(parts)
 
     async def _append_contract_probe_rows(
-        self, inputs: dict[str, Any], outputs: dict[str, Any]
+        self,
+        inputs: dict[str, Any],
+        outputs: dict[str, Any],
+        patched_files: list[dict[str, Any]] | None = None,
     ) -> None:
         """Execute the seeded contract's behavioral probes (SIP-0098 §6.4, phase 98.5).
 
@@ -250,6 +253,19 @@ class QATestHandler(_CycleTaskHandler):
 
         sources = self._get_source_artifacts(inputs)
         artifacts = [{"name": path, "content": content} for path, content in sources.items()]
+        if patched_files:
+            # #639: on the retest path the PATCHED tree must be under probe.
+            # Sources are the dispatch-time workspace — probing only them
+            # re-verifies the pre-repair app, and an accepted repair that
+            # regresses probed behavior sails through (pf-50 shipped 200
+            # against a pinned 201). materialize is last-wins, so the repaired
+            # files overwrite their dispatch-time versions — the same overlay
+            # order the retest suite run uses.
+            artifacts.extend(
+                {"name": f["filename"], "content": f.get("content", "")}
+                for f in patched_files
+                if isinstance(f, dict) and f.get("filename")
+            )
         with tempfile.TemporaryDirectory(prefix="qa_probes_") as tmp:
             workspace = Path(tmp)
             materialize_artifacts(artifacts, workspace)
@@ -541,8 +557,9 @@ class QATestHandler(_CycleTaskHandler):
             outputs["validation_result"]["checks"].append(fb_row)
 
         # SIP-0098 98.5: probe evidence rides the retest path too — a repaired
-        # suite's run must not under-count contract-criterion coverage.
-        await self._append_contract_probe_rows(inputs, outputs)
+        # suite's run must not under-count contract-criterion coverage. The
+        # patched files overlay the dispatch-time sources (#639).
+        await self._append_contract_probe_rows(inputs, outputs, patched_files=extracted)
 
         duration_ms = (time.perf_counter() - start_time) * 1000
         evidence = HandlerEvidence.create(

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -1770,3 +1770,62 @@ class TestBehaviorContractAppendix:
         messages = mock_context.ports.llm.chat_stream_with_usage.call_args.args[0]
         assert "API BEHAVIOR CONTRACT" not in messages[-1].content
         assert "## QA Task:" in messages[-1].content
+
+
+class TestRetestProbesPatchedTree:
+    """#639 second half: threading contract_probes into the retest is not
+    enough — the probe workspace built from dispatch-time sources alone would
+    re-verify the PRE-repair app (pf-50's probe would still see the 201 the
+    accepted repair had dropped). The patched files must overlay the sources,
+    last-wins, same as the retest suite run."""
+
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
+    async def test_retest_probe_workspace_carries_the_patched_tree(
+        self, _mock_run, mock_context, monkeypatch
+    ):
+        captured = {}
+
+        def fake_run_probes(workspace, probes):
+            from squadops.capabilities.handlers.probe_runner import ProbeOutcome
+
+            captured["probe_ids"] = [p.id for p in probes]
+            captured["routes"] = (workspace / "backend" / "routes.py").read_text()
+            return [ProbeOutcome("vc-probe-runs", "passed", None)]
+
+        monkeypatch.setattr(
+            "squadops.capabilities.handlers.probe_runner.run_probes", fake_run_probes
+        )
+        handler = QATestHandler()
+        await handler.handle(
+            mock_context,
+            {
+                "prd": "p",
+                "resolved_config": {},
+                "artifact_contents": {
+                    "backend/routes.py": "PRE-REPAIR (has status_code=201)",
+                    "backend/main.py": "app",
+                },
+                "retest_files": [
+                    {
+                        "filename": "backend/routes.py",
+                        "content": "REPAIRED (dropped the 201)",
+                    },
+                    {
+                        "filename": "backend/tests/test_runs.py",
+                        "content": "def test_a():\n    assert True\n",
+                    },
+                ],
+                "contract_probes": [
+                    {
+                        "id": "vc-probe-runs",
+                        "subject": "backend",
+                        "request": {"method": "POST", "path": "/runs", "json": {}},
+                        "expect": {"status": 201},
+                    }
+                ],
+            },
+        )
+        assert captured["probe_ids"] == ["vc-probe-runs"]
+        # The probe workspace must hold the tree the repair produced — probing
+        # the dispatch-time copy is exactly the pf-50 false green.
+        assert captured["routes"] == "REPAIRED (dropped the 201)"

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -2769,3 +2769,63 @@ class TestErrorContractEvidence(TestCorrectionRunnerStandalone):
             plan_delta_refs=[],
         )
         assert "error_contract" not in (analyze_inputs.get("failure_evidence") or {})
+
+
+class TestRetestProbeThreading:
+    """#639: the retest envelope must carry the failed task's contract_probes —
+    without them _append_contract_probe_rows no-ops on every retest, the final
+    verdict keeps the PRE-repair probe pass, and an accepted repair that
+    regresses probed behavior ships green (pf-50: 200 against a pinned 201)."""
+
+    _make_runner = TestReexecuteRepairedSuite._make_runner
+    _cycle = TestReexecuteRepairedSuite._cycle
+    _profile = TestReexecuteRepairedSuite._profile
+    _state_kwargs = TestReexecuteRepairedSuite._state_kwargs
+    _failed_qa_envelope = TestReexecuteRepairedSuite._failed_qa_envelope
+
+    async def test_contract_probes_thread_into_the_retest_envelope(self):
+        from squadops.tasks.models import TaskResult
+
+        runner, dispatcher = self._make_runner(
+            lambda env: TaskResult(task_id=env.task_id, status="SUCCEEDED", outputs={})
+        )
+        envelope = self._failed_qa_envelope()
+        probes = [
+            {
+                "id": "vc-probe-runs",
+                "subject": "backend",
+                "request": {"method": "POST", "path": "/runs", "json": {"title": "x"}},
+                "expect": {"status": 201},
+            }
+        ]
+        envelope.inputs["contract_probes"] = probes
+
+        await runner.reexecute_repaired_suite(
+            "run_001",
+            self._cycle(),
+            envelope,
+            [{"name": "tests/test_api.py", "content": "repaired", "type": "test"}],
+            0,
+            profile=self._profile(),
+            **self._state_kwargs(),
+        )
+        (env,) = dispatcher.dispatched
+        assert env.inputs["contract_probes"] == probes
+
+    async def test_probe_less_envelope_threads_no_key(self):
+        from squadops.tasks.models import TaskResult
+
+        runner, dispatcher = self._make_runner(
+            lambda env: TaskResult(task_id=env.task_id, status="SUCCEEDED", outputs={})
+        )
+        await runner.reexecute_repaired_suite(
+            "run_001",
+            self._cycle(),
+            self._failed_qa_envelope(),
+            [{"name": "tests/test_api.py", "content": "repaired", "type": "test"}],
+            0,
+            profile=self._profile(),
+            **self._state_kwargs(),
+        )
+        (env,) = dispatcher.dispatched
+        assert "contract_probes" not in env.inputs


### PR DESCRIPTION
## What

Closes the pf-50 false-green mechanism: accepted repairs now face the contract probes, executed against the **patched** tree.

## The two halves (both required)

1. **Threading** (`correction_runner.py`): `contract_probes` from the failed task's enriched envelope into `retest_inputs` — it was simply absent, so `_append_contract_probe_rows` no-opped on every retest despite its own "probe evidence rides the retest path too" comment. Same envelope-threading class as the earlier `artifact_contents` instant-fail fix in this file.
2. **Patched-tree overlay** (`qa_test.py`): the retest's probe workspace now overlays the patched files onto dispatch-time sources (last-wins, same order as the retest suite run). Threading alone would have probed the *pre-repair* tree and passed stale — pinned by a test asserting the probe workspace carries the repaired content.

## Effect

pf-50's accepted attempt-2 repair (which fixed the join bug but dropped `status_code=201`) would have produced a failing `vc-probe-runs` row at retest → repair rejected → the loop forced to produce one keeping both the fix and the pin.

## Verification

- Runner tests: probes thread into the retest envelope; probe-less envelopes thread no key
- Handler test: probe workspace carries the patched tree, not the dispatch-time copy (the exact pf-50 false-green shape)
- Full regression 5806; contract emission untouched — no re-seed needed

Pre-window fix per the FAY measurement decision — the window opens on the deploy that includes this.

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q