### PR TITLE
feat(plan): criterion binding derived from the contract, not transcribed by the author (#509)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2700,6 +2700,15 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 if binding_content is not None:
                     errors.extend(self._validate_contract_binding(contract, binding_content))
                 if parsed_plan is not None:
+                    # #509: bind the contract's covered-file criteria
+                    # deterministically BEFORE validating — the descoping rule
+                    # then guards against binding bugs instead of taxing every
+                    # roll on the author's transcription. Dispatch applies the
+                    # same normalization (generate_task_plan), so the validated
+                    # plan and the executed plan cannot drift.
+                    parsed_plan, auto_bound = parsed_plan.with_contract_criteria_bound(contract)
+                    for note in auto_bound:
+                        logger.info("criteria_auto_bound (gate %s): %s", gate_name, note)
                     errors.extend(
                         f"verification_contract: {e}"
                         for e in parsed_plan.validate_criteria_refs(contract)

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -476,6 +476,53 @@ class ImplementationPlan:
 
         return errors
 
+    def with_contract_criteria_bound(
+        self, contract: VerificationContract
+    ) -> tuple[ImplementationPlan, list[str]]:
+        """Deterministically bind every contract-covered fill file's criteria (#509).
+
+        Criterion linkage previously rode the framing LLM's plan authoring: a
+        roll that under-listed ``criteria_refs`` either under-counted coverage
+        (pre-descoping-validator) or burned a framing re-roll on an auto-
+        rejection (pf-54 run 2 died exactly there, one draw from cycle death).
+        The contract already states the authoritative answer — this puts it in
+        the plan instead of asking the author to transcribe it.
+
+        For each task, each expected artifact that is a contract-covered fill
+        file has its interface+implementation criterion ids unioned into
+        ``criteria_refs`` (authored refs keep their order; missing ids append
+        sorted). Idempotent; a fully-bound plan returns unchanged content.
+        ``validate_criteria_refs`` stays in force behind this as the guard —
+        binding makes its descoping rule vacuous, not absent.
+
+        Returns:
+            (bound_plan, notes) — one human-readable note per task that gained
+            refs, for the plan-validation log and the gate record.
+        """
+        covered = contract.covered_fill_paths()
+        notes: list[str] = []
+        new_tasks: list[PlanTask] = []
+        for task in self.tasks:
+            missing: list[str] = []
+            bound = set(task.criteria_refs)
+            for artifact in task.expected_artifacts:
+                if artifact not in covered:
+                    continue
+                for rid in contract.required_ref_ids_for(artifact):
+                    if rid not in bound:
+                        bound.add(rid)
+                        missing.append(rid)
+            if missing:
+                new_tasks.append(
+                    dataclasses.replace(task, criteria_refs=[*task.criteria_refs, *sorted(missing)])
+                )
+                notes.append(f"Task {task.task_index} ({task.focus}): auto-bound {sorted(missing)}")
+            else:
+                new_tasks.append(task)
+        if not notes:
+            return self, []
+        return dataclasses.replace(self, tasks=new_tasks), notes
+
     def validate_qa_artifact_ownership(self, contract: VerificationContract) -> list[str]:
         """pf-39: a ``qa.test`` task may not declare scaffold- or dev-owned files as
         its ``expected_artifacts``.

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -526,6 +526,18 @@ def _harness_boundary_criteria(
     ]
 
 
+def _bind_plan_criteria(plan, contract):
+    """#509: same deterministic binding the plan-validation gate applies —
+    dispatch and validation must see one plan. Criterion linkage comes from
+    the contract, never from the author's transcription."""
+    if contract is None:
+        return plan
+    bound, notes = plan.with_contract_criteria_bound(contract)
+    for note in notes:
+        logger.info("criteria_auto_bound (dispatch): %s", note)
+    return bound
+
+
 def generate_task_plan(
     cycle: Cycle,
     run: Run,
@@ -576,6 +588,7 @@ def generate_task_plan(
     # Only applies when the step list actually contains build steps.
     has_build_steps = any(s[0] in _BUILD_TASK_TYPES for s in steps)
     if plan is not None and has_build_steps:
+        plan = _bind_plan_criteria(plan, contract)
         steps = _replace_build_steps_with_plan(steps, plan, profile, profile_roles, contract)
 
     # Shared lineage IDs for the entire plan

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -1423,6 +1423,23 @@ class TestInterWorkloadGatePlanValidation:
         "    description: fill routes\n"
         "    expected_artifacts: [backend/routes.py]\n"
         "    acceptance_criteria: []\n"
+        "    criteria_refs: [vc-does-not-exist]\n"
+        "summary: {total_dev_tasks: 1, total_qa_tasks: 0, total_tasks: 1}\n"
+    )
+
+    _PLAN_YAML_NO_REFS = (
+        "version: 1\n"
+        "project_id: proj_001\n"
+        "cycle_id: cyc_001\n"
+        "prd_hash: h\n"
+        "tasks:\n"
+        "  - task_index: 0\n"
+        "    task_type: development.develop\n"
+        "    role: dev\n"
+        "    focus: routes\n"
+        "    description: fill routes\n"
+        "    expected_artifacts: [backend/routes.py]\n"
+        "    acceptance_criteria: []\n"
         "summary: {total_dev_tasks: 1, total_qa_tasks: 0, total_tasks: 1}\n"
     )
 
@@ -1441,13 +1458,14 @@ class TestInterWorkloadGatePlanValidation:
         )
         return ref, self._CONTRACT_YAML_BIND.encode()
 
-    async def test_bind_mode_unbound_plan_rejected_as_recorded_gate_decision(
+    async def test_bind_mode_unresolvable_ref_rejected_as_recorded_gate_decision(
         self, executor, mock_registry, mock_event_bus
     ):
-        """A seeded contract_ref puts the cycle in bind mode; a framing plan that
-        fails to bind the contract's covered-file criteria is rejected at the same
+        """A seeded contract_ref puts the cycle in bind mode; a framing plan whose
+        criteria_ref does not resolve against the contract is rejected at the same
         #473 seam (system REJECTED gate decision, no implementation run, clean
-        return) — the exact 3.13-stall-avoiding shape as the #464 source-regex net."""
+        return). Missing covered-file coverage no longer rejects — #509 binds it
+        deterministically (see the refless auto-bind test)."""
         import dataclasses
 
         cycle = dataclasses.replace(
@@ -1477,7 +1495,7 @@ class TestInterWorkloadGatePlanValidation:
         assert decision.decision == GateDecisionValue.REJECTED.value
         assert decision.decided_by == "system:plan_validation"
         assert "verification_contract" in (decision.notes or "")
-        assert "does not bind its criteria" in (decision.notes or "")
+        assert "does not resolve" in (decision.notes or "")
         mock_registry.create_run.assert_not_called()
         assert EventType.GATE_DECIDED in _emit_types(mock_event_bus)
 
@@ -1541,6 +1559,85 @@ class TestInterWorkloadGatePlanValidation:
         assert "#496" in (decision.notes or "")
         mock_registry.create_run.assert_not_called()
         assert EventType.WORKLOAD_GATE_AWAITING not in _emit_types(mock_event_bus)
+
+    async def test_bind_mode_refless_plan_auto_binds_and_gates_normally(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        """#509: a plan with NO criteria_refs on a covered fill file used to be
+        auto-rejected (a burned framing re-roll — pf-54 run 2 died there);
+        binding is now derived from the contract before validation, so the
+        same plan gates normally."""
+        import dataclasses
+        from pathlib import Path
+
+        from squadops.capabilities.scaffold import InterfaceManifest
+        from squadops.capabilities.scaffold_contract import emit_contract_yaml
+
+        manifest_text = (
+            Path(__file__).resolve().parents[3]
+            / "examples"
+            / "03_group_run"
+            / "interface_manifest.yaml"
+        ).read_text(encoding="utf-8")
+        contract_text = emit_contract_yaml(InterfaceManifest.from_yaml(manifest_text))
+        plan_text = self._PLAN_YAML_NO_REFS
+
+        approved = _gate_decision("progress_plan_review", GateDecisionValue.APPROVED.value)
+        cycle = dataclasses.replace(
+            self._cycle_with_gate(), execution_overrides={"contract_ref": "art_c"}
+        )
+        mock_registry.get_cycle.return_value = cycle
+
+        run1 = dataclasses.replace(
+            _make_run("run_001", 1, "completed", "framing", gate_decisions=(approved,)),
+            artifact_refs=("art_plan", "art_manifest"),
+        )
+        run2 = _make_run("run_002", 2, "completed", "implementation")
+
+        async def _get_run(run_id):
+            return run1 if run_id == "run_001" else run2
+
+        mock_registry.get_run.side_effect = _get_run
+        mock_registry.list_runs.return_value = [run1]
+        mock_registry.create_run.side_effect = lambda r: r
+
+        def _art(ref_id, artifact_type, filename, text):
+            return (
+                ArtifactRef(
+                    artifact_id=ref_id,
+                    project_id="proj_001",
+                    artifact_type=artifact_type,
+                    filename=filename,
+                    content_hash="h",
+                    size_bytes=len(text),
+                    media_type="text/yaml",
+                    created_at=NOW,
+                    cycle_id="cyc_001",
+                    run_id="run_001",
+                ),
+                text.encode(),
+            )
+
+        store = {
+            "art_plan": self._plan_ref(plan_text),
+            "art_manifest": _art(
+                "art_manifest", "interface_manifest", "interface_manifest.yaml", manifest_text
+            ),
+            "art_c": _art(
+                "art_c", "verification_contract", "verification_contract.yaml", contract_text
+            ),
+        }
+
+        async def _retrieve(ref_id):
+            return store[ref_id]
+
+        executor._artifact_vault.retrieve.side_effect = _retrieve
+        executor._artifact_vault.list_artifacts.return_value = []
+
+        await executor.execute_cycle("cyc_001", "run_001")
+
+        mock_registry.record_gate_decision.assert_not_awaited()
+        assert EventType.WORKLOAD_GATE_AWAITING in _emit_types(mock_event_bus)
 
     async def test_bind_mode_with_manifest_and_bound_plan_gates_normally(
         self, executor, mock_registry, mock_event_bus

--- a/tests/unit/cycles/test_executor_contract_binding.py
+++ b/tests/unit/cycles/test_executor_contract_binding.py
@@ -223,8 +223,11 @@ async def test_net_b_rejects_when_contract_ref_unparseable():
     assert any("contract_ref is seeded but the contract is" in e for e in errors)
 
 
-async def test_net_b_rejects_missing_coverage():
-    # the plan drops one required ref -> silent descoping -> rejection
+async def test_net_b_auto_binds_missing_coverage_instead_of_rejecting():
+    # #509: an under-listed plan no longer burns a framing re-roll — the
+    # contract's covered-file refs bind deterministically before validation
+    # (pf-54 run 2 died on exactly this rejection). Unresolvable refs and
+    # authored-on-covered still reject below.
     thin_plan = _BIND_PLAN_YAML.replace(f"[{', '.join(_ROUTES_REFS)}]", f"[{_ROUTES_REFS[0]}]")
     executor = _make_executor(_bind_store(plan_yaml=thin_plan))
     cycle = _make_cycle(execution_overrides={"contract_ref": "art_c"})
@@ -232,7 +235,7 @@ async def test_net_b_rejects_missing_coverage():
 
     errors = await executor._reject_invalid_plan_before_workload_gate(run, cycle, "plan-review")
 
-    assert any("verification_contract:" in e and "does not bind its criteria" in e for e in errors)
+    assert not any("does not bind its criteria" in e for e in errors)
 
 
 async def test_net_b_rejects_authored_criterion_on_covered_file():

--- a/tests/unit/cycles/test_task_plan_probe_injection.py
+++ b/tests/unit/cycles/test_task_plan_probe_injection.py
@@ -181,3 +181,101 @@ def test_behaviorless_contract_injects_no_behavior_key():
     cycle, run, profile = _implementation_setup()
     envs = generate_task_plan(cycle, run, profile, plan=None, contract=_contract(with_probes=False))
     assert all("api_behavior_contract" not in e.inputs for e in envs)
+
+
+# ---------------------------------------------------------------------------
+# #509: deterministic criterion binding
+# ---------------------------------------------------------------------------
+
+
+def _plan_with_refs(refs):
+    import yaml as _yaml
+
+    from squadops.cycles.implementation_plan import ImplementationPlan
+
+    return ImplementationPlan.from_yaml(
+        _yaml.safe_dump(
+            {
+                "version": 1,
+                "project_id": "p",
+                "cycle_id": "cy",
+                "prd_hash": "h",
+                "tasks": [
+                    {
+                        "task_index": 0,
+                        "task_type": "development.develop",
+                        "role": "dev",
+                        "focus": "routes",
+                        "description": "d",
+                        "expected_artifacts": ["backend/routes.py"],
+                        "acceptance_criteria": [],
+                        "depends_on": [],
+                        "criteria_refs": refs,
+                    },
+                    {
+                        "task_index": 1,
+                        "task_type": "qa.test",
+                        "role": "qa",
+                        "focus": "suite",
+                        "description": "d",
+                        "expected_artifacts": ["backend/tests/test_runs.py"],
+                        "acceptance_criteria": [],
+                        "depends_on": [],
+                        "criteria_refs": [],
+                    },
+                ],
+                "summary": {"total_dev_tasks": 1, "total_qa_tasks": 1, "total_tasks": 2},
+            }
+        )
+    )
+
+
+def test_under_bound_plan_gains_the_missing_refs_and_passes_validation():
+    # The pf-54 run-2 killer: one missing ref auto-rejected the whole plan and
+    # burned a framing re-roll. Binding is now derived, not transcribed.
+    contract = _contract()
+    plan = _plan_with_refs([])
+    bound, notes = plan.with_contract_criteria_bound(contract)
+    assert bound.tasks[0].criteria_refs == ["vc-routes-endpoints"]
+    assert notes == ["Task 0 (routes): auto-bound ['vc-routes-endpoints']"]
+    assert bound.validate_criteria_refs(contract) == []
+    # Non-covered artifacts (the qa namespace) gain nothing.
+    assert bound.tasks[1].criteria_refs == []
+
+
+def test_fully_bound_plan_is_unchanged_and_binding_is_idempotent():
+    contract = _contract()
+    plan = _plan_with_refs(["vc-routes-endpoints"])
+    bound, notes = plan.with_contract_criteria_bound(contract)
+    assert notes == []
+    assert bound is plan
+    again, notes2 = bound.with_contract_criteria_bound(contract)
+    assert notes2 == []
+    assert again.tasks[0].criteria_refs == ["vc-routes-endpoints"]
+
+
+def test_authored_ref_order_is_preserved_missing_appended():
+    # Authors may bind extra-file refs (e.g. a qa task binding routes criteria);
+    # binding appends what's missing, never reorders what was written.
+    contract = _contract()
+    plan = _plan_with_refs(["vc-probe-create"])  # resolvable id, not the file's own
+    bound, _ = plan.with_contract_criteria_bound(contract)
+    assert bound.tasks[0].criteria_refs == ["vc-probe-create", "vc-routes-endpoints"]
+
+
+def test_generate_task_plan_binds_before_resolving_refs():
+    # End-to-end: an under-bound plan still dispatches routes tasks with the
+    # contract's typed checks resolved into acceptance.
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(cycle, run, profile, plan=_plan_with_refs([]), contract=_contract())
+    dev_envs = [e for e in envs if e.task_type == "development.develop"]
+    assert dev_envs, "plan-derived dev step expected"
+    from squadops.cycles.implementation_plan import TypedCheck
+
+    checks = [
+        c
+        for c in dev_envs[0].inputs.get("acceptance_criteria", [])
+        if isinstance(c, TypedCheck) and c.check == "endpoint_defined"
+    ]
+    assert checks, "contract-resolved endpoint_defined must reach the envelope"
+    assert checks[0].id == "vc-routes-endpoints"

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -654,11 +654,27 @@ class TestGenerateTaskPlanBindMode:
         # a correctly-bound plan is unaffected — same 9 envelopes as author mode
         assert len(envelopes) == 9
 
-    def test_unbound_plan_raises_cycle_error(self):
+    def test_unbound_plan_is_auto_bound_at_dispatch(self):
+        # #509: task 0 produces the covered file but binds nothing — dispatch
+        # now derives the binding from the contract instead of raising (the
+        # rejection burned framing re-rolls for a fact the contract already
+        # stated). Unresolvable refs still raise below.
+        plan = ImplementationPlan.from_yaml(MANIFEST_YAML)
+        envelopes = generate_task_plan(
+            _make_cycle(), _make_run(), _make_profile(), plan=plan, contract=_models_contract()
+        )
+        assert envelopes, "auto-bound plan must dispatch"
+
+    def test_unresolvable_ref_still_raises_cycle_error(self):
         from squadops.cycles.models import CycleError
 
-        # task 0 produces the covered file but binds nothing -> silent descoping
-        plan = ImplementationPlan.from_yaml(MANIFEST_YAML)
+        plan = ImplementationPlan.from_yaml(
+            MANIFEST_YAML.replace(
+                'acceptance_criteria: ["Models exist"]',
+                'acceptance_criteria: ["Models exist"]\n    criteria_refs: [vc-does-not-exist]',
+                1,
+            )
+        )
         with pytest.raises(CycleError, match="contract binding"):
             generate_task_plan(
                 _make_cycle(), _make_run(), _make_profile(), plan=plan, contract=_models_contract()


### PR DESCRIPTION
## What

Deterministic criteria binding: every contract-covered fill file's criterion ids are unioned into the producing task's `criteria_refs` before validation and before dispatch — the contract states the linkage; the plan author no longer transcribes it.

## Why

pf-54's run 2 was auto-rejected (a burned ~45-min framing re-roll, one draw from cycle death) for omitting one ref the contract already declared. Pre-validator, the same variance under-counted coverage (#509's original observation: `criteria_total` 3 → 1 across identical seeded rolls). Either way, criterion linkage measured plan-authoring luck.

## How

- `ImplementationPlan.with_contract_criteria_bound(contract)` — pure, idempotent, order-preserving; returns `(bound_plan, notes)`
- Applied at the inter-workload plan-validation gate (bind → validate → log `criteria_auto_bound`) **and** in `generate_task_plan` — validated plan and executed plan cannot drift
- `validate_criteria_refs` unchanged as the guard: unresolvable refs and authored-on-covered still reject; only the missing-coverage rule becomes structurally vacuous

## Tests

Binding matrix incl. idempotence and authored-order preservation; refless plan gates normally (the flipped pf-54 scenario); unresolvable ref still rejects at the gate and raises at the dispatch net; end-to-end envelope resolution from a refless plan. Full regression 5809.

Pre-window fix for the FAY measurement (removes a framing-rejection class). No contract emission change — no re-seed.

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q