### PR TITLE
feat(locus): runner-owned suite-health verdict — vitest failures stop reading as pytest exit codes (#626)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -472,6 +472,11 @@ class QATestHandler(_CycleTaskHandler):
                     "exit_code": test_result.exit_code,
                     "tests_passed": test_result.tests_passed,
                     "passed": False,
+                    # #626: runner identity + the runner-neutral suite-health
+                    # verdict, so locus routing stops reading pytest exit
+                    # semantics into vitest failures.
+                    "runner": test_result.runner,
+                    "suite_broken": test_result.suite_broken,
                 }
             )
             missing.append(detail)
@@ -800,6 +805,11 @@ class QATestHandler(_CycleTaskHandler):
                     "exit_code": test_result.exit_code,
                     "tests_passed": test_result.tests_passed,
                     "passed": False,
+                    # #626: runner identity + the runner-neutral suite-health
+                    # verdict, so locus routing stops reading pytest exit
+                    # semantics into vitest failures.
+                    "runner": test_result.runner,
+                    "suite_broken": test_result.suite_broken,
                 }
             )
             validation.passed = False

--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -36,6 +37,15 @@ class RunTestsResult:
     error: str = ""
     test_file_count: int = 0
     source_file_count: int = 0
+    # #626: runner identity + a runner-NEUTRAL suite-health verdict, classified
+    # HERE because this module owns test-framework knowledge. The locus
+    # classifier (cycles/failure_evidence) consumes the neutral fact instead of
+    # applying pytest exit-code semantics to every runner. suite_broken:
+    # True = the suite itself cannot run (collection/transform/import death —
+    # the producing role re-authors); False = the suite ran and judged the
+    # subject; None = ambiguous (falls back to legacy exit-code semantics).
+    runner: str = ""
+    suite_broken: bool | None = None
     # #407: the fullstack frontend build outcome, surfaced distinctly so qa.test
     # can emit a frontend_build SIP-0096 CheckResult. None when no frontend was in
     # scope (non-fullstack run). A skip (``ran=False``) is otherwise folded away by
@@ -210,13 +220,20 @@ async def run_generated_tests(
         stdout = raw_stdout.decode(errors="replace")[:_STDOUT_LIMIT]
         stderr = raw_stderr.decode(errors="replace")[:_STDOUT_LIMIT]
 
+        exit_code = proc.returncode or 0
         return RunTestsResult(
             executed=True,
-            exit_code=proc.returncode or 0,
+            exit_code=exit_code,
             stdout=stdout,
             stderr=stderr,
             test_file_count=len(test_files),
             source_file_count=len(source_files),
+            runner="pytest",
+            # pytest speaks suite-health through exit codes: 2/5 = the suite
+            # itself is broken; 1 = it ran and judged the subject; 3/4 stay
+            # ambiguous (the pf-35 exit-4 lesson — app-import failures surface
+            # there too).
+            suite_broken={2: True, 5: True, 1: False, 0: False}.get(exit_code),
         )
 
     except Exception as exc:
@@ -345,13 +362,20 @@ async def run_node_tests(
         stdout = raw_stdout.decode(errors="replace")[:_STDOUT_LIMIT]
         stderr = raw_stderr.decode(errors="replace")[:_STDOUT_LIMIT]
 
+        exit_code = proc.returncode or 0
         return RunTestsResult(
             executed=True,
-            exit_code=proc.returncode or 0,
+            exit_code=exit_code,
             stdout=stdout,
             stderr=stderr,
             test_file_count=len(test_files),
             source_file_count=len(source_files),
+            runner="vitest",
+            # vitest cannot speak suite-health through exit codes (everything
+            # is 1) — classify from output signatures instead (#626; pf-53's
+            # "No test suite found" routed repairs to dev for a defect in the
+            # qa role's own file).
+            suite_broken=_vitest_suite_broken(exit_code, stdout, stderr),
         )
 
     except Exception as exc:
@@ -670,6 +694,35 @@ async def run_backend_import_check(
         shutil.rmtree(workspace, ignore_errors=True)
 
 
+_VITEST_SUITE_BROKEN_MARKERS = (
+    "No test suite found",
+    "Failed to resolve import",
+    "Failed to load",
+    "Transform failed",
+    "Cannot find module",
+    "Error: Cannot find package",
+)
+
+
+def _vitest_suite_broken(exit_code: int, stdout: str, stderr: str) -> bool | None:
+    """Runner-owned suite-health verdict for vitest (#626).
+
+    True = the suite could not run (missing/unloadable/untransformable test
+    modules — the authoring role's defect). False = tests executed and some
+    failed (the subject's defect). None = ambiguous; the consumer falls back
+    to legacy semantics (which route toward the dev chain, the conservative
+    test-gaming direction).
+    """
+    if exit_code == 0:
+        return False
+    combined = stdout + "\n" + stderr
+    if any(marker in combined for marker in _VITEST_SUITE_BROKEN_MARKERS):
+        return True
+    if re.search(r"Tests\s+\d+ failed", combined):
+        return False
+    return None
+
+
 def _merged_exit_code(backend: RunTestsResult, frontend: RunTestsResult) -> int:
     """D13 merge: backend controls the combined outcome — *when it executed*.
 
@@ -752,9 +805,14 @@ async def run_fullstack_tests(
     if frontend_result.error:
         error_parts.append(f"frontend (non-blocking): {frontend_result.error}")
 
+    # #626: the controlling side (D13 — backend when it executed, else the
+    # frontend) supplies runner identity and the suite-health verdict.
+    controlling = backend_result if backend_result.executed else frontend_result
     return RunTestsResult(
         executed=combined_executed,
         exit_code=combined_exit_code,
+        runner=controlling.runner,
+        suite_broken=controlling.suite_broken,
         stdout="\n\n".join(combined_stdout_parts)[:_STDOUT_LIMIT],
         stderr="\n\n".join(combined_stderr_parts)[:_STDOUT_LIMIT],
         error="; ".join(error_parts) if error_parts else "",

--- a/src/squadops/cycles/failure_evidence.py
+++ b/src/squadops/cycles/failure_evidence.py
@@ -128,6 +128,16 @@ def classify_failure_locus(failure_evidence: Any) -> str:
             # The task's own named output files are missing from its emission.
             return FailureLocus.OWN_ARTIFACT
         if check == "tests_pass" and row.get("passed") is False and row.get("executed"):
+            # #626: prefer the runner's OWN suite-health verdict (test_runner
+            # owns test-framework knowledge; vitest cannot express suite-broken
+            # through exit codes, so pytest exit semantics misrouted every
+            # frontend suite defect to the dev chain — pf-53). Absent/None
+            # falls back to the legacy pytest exit-code table.
+            suite_broken = row.get("suite_broken")
+            if suite_broken is True:
+                return FailureLocus.OWN_ARTIFACT
+            if suite_broken is False:
+                return FailureLocus.SUBJECT
             exit_code = row.get("exit_code")
             if exit_code in _SUITE_DEFECT_EXIT_CODES:
                 return FailureLocus.OWN_ARTIFACT

--- a/tests/unit/capabilities/test_test_runner.py
+++ b/tests/unit/capabilities/test_test_runner.py
@@ -355,3 +355,83 @@ class TestPackageRelativeImports:
         _materialize_files(ws, sources)
         path = _source_dir_pythonpath(ws, sources)
         assert str(tmp_path / "backend") in path.split(os.pathsep)  # #303 preserved
+
+
+class TestVitestSuiteBroken:
+    """#626: vitest speaks suite-health through output, not exit codes —
+    misreading exit 1 as 'subject failed' routed pf-53's own-artifact defect
+    (a comment-only test file) to the dev repair chain five times."""
+
+    def test_no_test_suite_found_is_broken(self):
+        from squadops.capabilities.handlers.test_runner import _vitest_suite_broken
+
+        assert _vitest_suite_broken(1, "No test suite found in file x.test.jsx", "") is True
+
+    def test_unresolvable_import_is_broken(self):
+        from squadops.capabilities.handlers.test_runner import _vitest_suite_broken
+
+        assert _vitest_suite_broken(1, "", "Error: Failed to resolve import '../Appp.jsx'") is True
+
+    def test_real_test_failures_are_not_broken(self):
+        from squadops.capabilities.handlers.test_runner import _vitest_suite_broken
+
+        out = " Test Files  1 failed (1)\n      Tests  3 failed | 2 passed (5)\n"
+        assert _vitest_suite_broken(1, out, "") is False
+
+    def test_exit_zero_is_not_broken(self):
+        from squadops.capabilities.handlers.test_runner import _vitest_suite_broken
+
+        assert _vitest_suite_broken(0, "Tests  5 passed", "") is False
+
+    def test_unrecognized_failure_is_ambiguous(self):
+        from squadops.capabilities.handlers.test_runner import _vitest_suite_broken
+
+        assert _vitest_suite_broken(1, "something exploded", "") is None
+
+
+class TestMergedRunnerIdentity:
+    """#626: the combined D12 result carries the CONTROLLING side's runner
+    identity and suite-health verdict (backend when it executed, else the
+    frontend) — asserted through the real merge, not a re-derivation."""
+
+    async def test_backend_controls_when_executed(self, monkeypatch):
+        import squadops.capabilities.handlers.test_runner as tr
+
+        async def _backend(*_a, **_k):
+            return tr.RunTestsResult(executed=True, exit_code=2, runner="pytest", suite_broken=True)
+
+        async def _frontend(*_a, **_k):
+            return tr.RunTestsResult(
+                executed=True, exit_code=1, runner="vitest", suite_broken=False
+            )
+
+        monkeypatch.setattr(tr, "run_generated_tests", _backend)
+        monkeypatch.setattr(tr, "run_node_tests", _frontend)
+        result = await tr.run_fullstack_tests(
+            [{"path": "backend/a.py", "content": "x"}],
+            [
+                {"path": "backend/tests/test_a.py", "content": "x"},
+                {"path": "frontend/src/__tests__/a.test.jsx", "content": "x"},
+            ],
+        )
+        assert result.exit_code == 2
+        assert result.runner == "pytest"
+        assert result.suite_broken is True
+
+    async def test_frontend_controls_when_backend_did_not_execute(self, monkeypatch):
+        import squadops.capabilities.handlers.test_runner as tr
+
+        async def _backend(*_a, **_k):
+            return tr.RunTestsResult(executed=False, error="no test files provided")
+
+        async def _frontend(*_a, **_k):
+            return tr.RunTestsResult(executed=True, exit_code=1, runner="vitest", suite_broken=True)
+
+        monkeypatch.setattr(tr, "run_generated_tests", _backend)
+        monkeypatch.setattr(tr, "run_node_tests", _frontend)
+        result = await tr.run_fullstack_tests(
+            [], [{"path": "frontend/src/__tests__/a.test.jsx", "content": "x"}]
+        )
+        assert result.exit_code == 1
+        assert result.runner == "vitest"
+        assert result.suite_broken is True

--- a/tests/unit/cycles/test_failure_evidence.py
+++ b/tests/unit/cycles/test_failure_evidence.py
@@ -378,3 +378,49 @@ class TestEmissionFailurePassthrough:
         result = TaskResult(task_id="t1", status="FAILED", error="x", outputs={})
         evidence = build_failure_evidence(self._envelope(), result, prior_plan_deltas_count=0)
         assert "emission_failure" not in evidence
+
+
+class TestRunnerAwareLocus:
+    """#626: the runner's own suite-health verdict outranks exit-code folklore.
+    vitest reports everything as exit 1, so pytest semantics routed every
+    frontend suite defect to the dev chain — pf-53's comment-stub test file
+    ("No test suite found") burned dev repair attempts on the qa role's own
+    artifact."""
+
+    _evidence_with_check = TestClassifyFailureLocus._evidence_with_check
+
+    def test_suite_broken_true_is_own_artifact_regardless_of_exit(self):
+        # The pf-53 shape: vitest exit 1 + "No test suite found" → the test
+        # file itself is the defect; the qa role re-authors it.
+        row = {
+            "check": "tests_pass",
+            "executed": True,
+            "exit_code": 1,
+            "passed": False,
+            "runner": "vitest",
+            "suite_broken": True,
+        }
+        assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.OWN_ARTIFACT
+
+    def test_suite_broken_false_is_subject_even_on_pytest_suite_codes(self):
+        # An explicit ran-and-judged verdict outranks the exit table.
+        row = {
+            "check": "tests_pass",
+            "executed": True,
+            "exit_code": 2,
+            "passed": False,
+            "runner": "pytest",
+            "suite_broken": False,
+        }
+        assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.SUBJECT
+
+    def test_suite_broken_none_falls_back_to_exit_table(self):
+        row = {
+            "check": "tests_pass",
+            "executed": True,
+            "exit_code": 1,
+            "passed": False,
+            "runner": "vitest",
+            "suite_broken": None,
+        }
+        assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.SUBJECT


### PR DESCRIPTION
## What

The failure-locus classifier stops applying pytest exit-code semantics to every runner. `test_runner` — the module that owns test-framework knowledge — now classifies suite health per runner and emits a runner-neutral `suite_broken` verdict; the cycles-layer classifier consumes the fact.

## Why

vitest reports everything as exit 1, so every frontend suite defect classified SUBJECT → dev repair chain. pf-53's comment-stub test file ("No test suite found") burned dev attempts on the qa role's own artifact. With #627 making frontend tests routine, this misroute would fire constantly during the FAY window.

## How

- `RunTestsResult.runner` + `suite_broken` (True = suite can't run → producing role re-authors; False = ran and judged the subject → dev; None = ambiguous → legacy exit-table fallback, which keeps falling toward the dev chain per the test-gaming guard)
- pytest verdict from its exit table (2/5 broken, 0/1 ran, 3/4 ambiguous — the pf-35 exit-4 lesson preserved); vitest verdict from output signatures
- Combined D12 result threads the controlling side's identity + verdict (backend when executed, else frontend)
- Both `tests_pass` row sites carry the fields; classifier prefers the explicit verdict, old evidence unaffected

## Tests

vitest signature matrix (incl. ambiguous → None), controlling-side threading asserted through the real merge with monkeypatched sub-runners, locus decision matrix (explicit verdict outranks the exit table in both directions). Full regression 5813.

Pre-window fix for the FAY measurement, paired with #641 (#509). No contract emission change — no re-seed.

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q