### PR TITLE
fix(acceptance): typed checks evaluate inside the accepted workspace tree (#643)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -1000,6 +1000,13 @@ class CorrectionRunner:
         # the bind-mode injection (probe-less contracts thread no key).
         if failed_inputs.get("contract_probes"):
             retest_inputs["contract_probes"] = failed_inputs["contract_probes"]
+        # #643: same presence-keyed threading for the typed-acceptance
+        # workspace — the retest's evaluation needs the scaffold siblings
+        # exactly like the original dispatch did.
+        if failed_inputs.get("acceptance_workspace_files"):
+            retest_inputs["acceptance_workspace_files"] = failed_inputs[
+                "acceptance_workspace_files"
+            ]
 
         retest_envelope = TaskEnvelope(
             task_id=f"retest-{run_id[:12]}-{correction_attempts:02d}-{envelope.task_type}",

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -956,6 +956,19 @@ class DispatchedFlowExecutor(FlowExecutionPort):
     # failure_evidence assembly.
     _ERROR_SEAM_TASK_TYPES: frozenset[str] = frozenset({"development.develop"})
 
+    # #643: the full accepted source/config tree — scaffold included via
+    # by_type (#443). Threaded to every build task as
+    # ``acceptance_workspace_files``: module_imports is runtime-level, so the
+    # typed-acceptance workspace must hold every sibling a fill file imports —
+    # exactly what the per-task prompt filters below deliberately omit
+    # (prompt diet). fay-1: dev's module_imports evaluated in a
+    # routes.py-only workspace and false-failed every attempt.
+    _ACCEPTANCE_WORKSPACE_FILTER: dict[str, list[str]] = {
+        "by_producing_task": ["qa.validate", "builder.assemble", "development.develop"],
+        "by_type": ["source", "config"],
+        "by_type_fallback": ["document"],
+    }
+
     # Maps build task_type → which prior artifacts to inject.
     # by_producing_task: match on producing_task_type metadata
     # by_type / by_type_fallback: match on artifact_type for artifacts without provenance
@@ -977,16 +990,9 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # fill-contract files) — without them assembly packages a partial app.
             "by_type_fallback": ["document"],
         },
-        "qa.test": {
-            # SIP-0086: include development.develop for manifest-driven QA
-            # subtasks that need to see all prior build artifacts
-            "by_producing_task": ["qa.validate", "builder.assemble", "development.develop"],
-            "by_type": ["source", "config"],
-            # #443: same fallback development.develop already has — the seeded
-            # scaffold must reach verification or frontend_build/tests_pass run
-            # against a workspace missing package.json and the backend modules.
-            "by_type_fallback": ["document"],
-        },
+        # SIP-0086/#443: QA verification needs the whole accepted tree —
+        # the same selection the acceptance workspace uses (single-sourced).
+        "qa.test": _ACCEPTANCE_WORKSPACE_FILTER,
     }
 
     async def _resolve_artifact_contents(
@@ -995,6 +1001,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         stored_artifacts: list[tuple[str, ArtifactRef]],
         *,
         include_repair_candidates: bool = True,
+        filter_spec: dict[str, list[str]] | None = None,
     ) -> dict[str, str]:
         """Pre-resolve artifact content for build tasks (D3).
 
@@ -1009,11 +1016,14 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 dispatches exclude them, so a rejected candidate can never
                 supersede the accepted state in a later task's workspace —
                 the pf-31 endpoint_defined final-verification regression.
+            filter_spec: explicit selection override (#643 — the acceptance
+                workspace uses the full-tree spec regardless of task type).
+                Defaults to the task type's prompt-context filter.
 
         Returns:
             Dict of filename → content string. Empty if task_type not a build task.
         """
-        filter_spec = self._BUILD_ARTIFACT_FILTER.get(task_type)
+        filter_spec = filter_spec or self._BUILD_ARTIFACT_FILTER.get(task_type)
         if not filter_spec:
             return {}
 
@@ -1731,6 +1741,18 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             )
             if artifact_contents:
                 extra_inputs["artifact_contents"] = artifact_contents
+            # #643: the typed-acceptance workspace rides separately from the
+            # curated prompt context — evaluation needs the full accepted tree
+            # (scaffold siblings included) or runtime-level checks false-fail
+            # correct fill files on their own contract-mandated imports.
+            workspace_files = await self._resolve_artifact_contents(
+                envelope.task_type,
+                stored_artifacts,
+                include_repair_candidates=False,
+                filter_spec=self._ACCEPTANCE_WORKSPACE_FILTER,
+            )
+            if workspace_files:
+                extra_inputs["acceptance_workspace_files"] = workspace_files
 
         return dataclasses.replace(
             envelope,
@@ -2024,9 +2046,20 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         patched_artifacts = overlay_artifacts(
             (result.outputs or {}).get("artifacts") or [], repair_artifacts
         )
+        # #643: verify against the accepted workspace tree, not just the task's
+        # own files — module_imports and the #591 import pre-gate need the
+        # scaffold siblings present or a correct repair can never be accepted
+        # (fay-1: both candidates rejected in a routes.py-only workspace).
+        # Workspace rides as a separate base: patched_artifacts is what an
+        # accepted patch RE-STORES (#389 swap below), and the tree must never
+        # be re-stored under the repaired task's type.
+        workspace_files = ((enriched_envelope or envelope).inputs or {}).get(
+            "acceptance_workspace_files"
+        ) or {}
         verification = await verify_patched_artifacts(
             criteria,
             patched_artifacts,
+            workspace_files=workspace_files,
             stack=resolve_check_stack(resolved_config),
             typed_acceptance_enabled=resolved_config.get("typed_acceptance", True),
             command_acceptance_enabled=resolved_config.get("command_acceptance_checks", True),

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -364,6 +364,20 @@ class _CycleTaskHandler(CapabilityHandler):
 
         with tempfile.TemporaryDirectory(prefix="squadops-typed-acc-") as tmpdir_str:
             workspace_root = Path(tmpdir_str)
+            # #643: materialize the accepted workspace tree first (executor
+            # threads it — scaffold siblings included), then this task's own
+            # artifacts on top so the candidate supersedes its own slots.
+            # Runtime-level checks (module_imports) false-fail contract-
+            # mandated sibling imports in a task-artifacts-only workspace.
+            workspace_files = inputs.get("acceptance_workspace_files") or {}
+            if workspace_files:
+                self._materialize_artifacts(
+                    [
+                        {"name": name, "content": content}
+                        for name, content in workspace_files.items()
+                    ],
+                    workspace_root,
+                )
             self._materialize_artifacts(artifacts, workspace_root)
 
             for check_index, criterion in enumerate(typed_criteria):

--- a/src/squadops/cycles/patch_verification.py
+++ b/src/squadops/cycles/patch_verification.py
@@ -283,6 +283,7 @@ async def verify_patched_artifacts(
     criteria: list[Any],
     artifacts: list[dict[str, Any]],
     *,
+    workspace_files: dict[str, str] | None = None,
     stack: str | None = None,
     typed_acceptance_enabled: bool = True,
     command_acceptance_enabled: bool = True,
@@ -293,6 +294,12 @@ async def verify_patched_artifacts(
     criteria can block; ``skipped`` never blocks. Any evaluator ``error`` on
     a blocking criterion makes the whole patch UNVERIFIABLE (the executor
     environment may lack tooling the agent container has — never guess).
+
+    ``workspace_files`` (#643) is the accepted workspace tree the patch lands
+    in, materialized FIRST so *artifacts* supersede their own slots. It is a
+    verification substrate only — never part of what an accepted patch stores.
+    Runtime-level checks (module_imports, the #591 import pre-gate) are
+    meaningless without the scaffold siblings the patched file imports.
     """
     typed = _coerce_typed_criteria(criteria)
     if typed is None:
@@ -305,6 +312,11 @@ async def verify_patched_artifacts(
     blocking_passed = 0
     with tempfile.TemporaryDirectory(prefix="squadops-patch-verify-") as tmpdir:
         workspace_root = Path(tmpdir)
+        if workspace_files:
+            materialize_artifacts(
+                [{"name": name, "content": content} for name, content in workspace_files.items()],
+                workspace_root,
+            )
         materialize_artifacts(artifacts, workspace_root)
 
         # #591: typed criteria read one file at a time, so a patch whose imports

--- a/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
+++ b/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
@@ -699,3 +699,78 @@ class TestArtifactEmissionEndToEnd:
         )
         assert artifact is not None
         assert artifact["name"] == "typed_check_evaluation_task_1.json"
+
+
+# ---------------------------------------------------------------------------
+# #643: the acceptance workspace — scaffold siblings under the task's artifacts
+# ---------------------------------------------------------------------------
+
+
+_ROUTES_WITH_SIBLING_IMPORT = """\
+from backend.errors import ApiError
+
+
+def not_found() -> ApiError:
+    return ApiError()
+"""
+
+_ERRORS_MODULE = """\
+class ApiError(Exception):
+    pass
+"""
+
+
+class TestAcceptanceWorkspaceFiles:
+    """#643 (fay-1): module_imports evaluated in a task-artifacts-only
+    workspace, so a fill file importing its frozen scaffold siblings
+    false-failed every dev attempt — the check was structurally unwinnable
+    in-cycle. The executor threads the accepted tree as
+    ``acceptance_workspace_files``; evaluation materializes it FIRST, the
+    task's own artifacts on top."""
+
+    def _criterion(self) -> TypedCheck:
+        return TypedCheck(
+            check="module_imports",
+            params={"file": "backend/routes.py"},
+            severity="error",
+            description="routes module imports",
+        )
+
+    async def test_sibling_import_passes_with_threaded_workspace(self):
+        h = DevelopmentDevelopHandler()
+        inputs = _inputs([self._criterion()], expected=("backend/routes.py",))
+        inputs["acceptance_workspace_files"] = {
+            "backend/__init__.py": "",
+            "backend/errors.py": _ERRORS_MODULE,
+        }
+        result = await h._validate_output(
+            inputs, [_art("backend/routes.py", _ROUTES_WITH_SIBLING_IMPORT)]
+        )
+        assert result.passed is True
+
+    async def test_sibling_import_fails_without_workspace(self):
+        # The fay-1 mechanism itself: identical artifact, no threaded
+        # workspace — the sibling import cannot resolve and blocks.
+        h = DevelopmentDevelopHandler()
+        inputs = _inputs([self._criterion()], expected=("backend/routes.py",))
+        result = await h._validate_output(
+            inputs, [_art("backend/routes.py", _ROUTES_WITH_SIBLING_IMPORT)]
+        )
+        assert result.passed is False
+        assert "acceptance:routes module imports" in result.missing_components
+
+    async def test_task_artifact_supersedes_its_workspace_slot(self):
+        # The tree's copy of the task's own slot (the skeleton's 501 stub)
+        # must not shadow the candidate under evaluation: here the workspace
+        # copy raises at import and only the candidate is clean.
+        h = DevelopmentDevelopHandler()
+        inputs = _inputs([self._criterion()], expected=("backend/routes.py",))
+        inputs["acceptance_workspace_files"] = {
+            "backend/__init__.py": "",
+            "backend/errors.py": _ERRORS_MODULE,
+            "backend/routes.py": "raise RuntimeError('skeleton stub was evaluated')\n",
+        }
+        result = await h._validate_output(
+            inputs, [_art("backend/routes.py", _ROUTES_WITH_SIBLING_IMPORT)]
+        )
+        assert result.passed is True

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -2829,3 +2829,56 @@ class TestRetestProbeThreading:
         )
         (env,) = dispatcher.dispatched
         assert "contract_probes" not in env.inputs
+
+
+class TestRetestWorkspaceThreading:
+    """#643: the retest envelope must carry the failed task's
+    acceptance_workspace_files — without them the retest's typed acceptance
+    re-evaluates in a task-artifacts-only workspace and re-fails a correct
+    repair on its contract-mandated sibling imports (the fay-1 loop)."""
+
+    _make_runner = TestReexecuteRepairedSuite._make_runner
+    _cycle = TestReexecuteRepairedSuite._cycle
+    _profile = TestReexecuteRepairedSuite._profile
+    _state_kwargs = TestReexecuteRepairedSuite._state_kwargs
+    _failed_qa_envelope = TestReexecuteRepairedSuite._failed_qa_envelope
+
+    async def test_workspace_files_thread_into_the_retest_envelope(self):
+        from squadops.tasks.models import TaskResult
+
+        runner, dispatcher = self._make_runner(
+            lambda env: TaskResult(task_id=env.task_id, status="SUCCEEDED", outputs={})
+        )
+        envelope = self._failed_qa_envelope()
+        workspace = {"backend/__init__.py": "", "backend/errors.py": "class ApiError: ..."}
+        envelope.inputs["acceptance_workspace_files"] = workspace
+
+        await runner.reexecute_repaired_suite(
+            "run_001",
+            self._cycle(),
+            envelope,
+            [{"name": "tests/test_api.py", "content": "repaired", "type": "test"}],
+            0,
+            profile=self._profile(),
+            **self._state_kwargs(),
+        )
+        (env,) = dispatcher.dispatched
+        assert env.inputs["acceptance_workspace_files"] == workspace
+
+    async def test_workspace_less_envelope_threads_no_key(self):
+        from squadops.tasks.models import TaskResult
+
+        runner, dispatcher = self._make_runner(
+            lambda env: TaskResult(task_id=env.task_id, status="SUCCEEDED", outputs={})
+        )
+        await runner.reexecute_repaired_suite(
+            "run_001",
+            self._cycle(),
+            self._failed_qa_envelope(),
+            [{"name": "tests/test_api.py", "content": "repaired", "type": "test"}],
+            0,
+            profile=self._profile(),
+            **self._state_kwargs(),
+        )
+        (env,) = dispatcher.dispatched
+        assert "acceptance_workspace_files" not in env.inputs

--- a/tests/unit/cycles/test_executor_build_wiring.py
+++ b/tests/unit/cycles/test_executor_build_wiring.py
@@ -233,6 +233,69 @@ class TestArtifactContentsPreResolution:
         assert "    pace:" not in contents["backend/models.py"]
 
 
+class TestAcceptanceWorkspaceResolution:
+    """#643 (fay-1): the dev prompt filter has no by_type clause, so scaffold
+    source files never reached the dev envelope and module_imports evaluated
+    in a routes.py-only workspace. The acceptance workspace resolves with the
+    full-tree spec regardless of task type."""
+
+    async def test_full_tree_spec_includes_scaffold_source_for_dev(self, executor):
+        # The scaffold sibling (source, scaffold.expand provenance) is exactly
+        # what development.develop's own filter excludes.
+        ref_scaffold = _make_artifact_ref(
+            "art_001",
+            "backend/errors.py",
+            "source",
+            producing_task_type="scaffold.expand",
+        )
+        stored = [("art_001", ref_scaffold)]
+        executor._artifact_vault.retrieve = AsyncMock(
+            side_effect=[(ref_scaffold, b"class ApiError(Exception):\n    pass\n")]
+        )
+
+        default = await executor._resolve_artifact_contents("development.develop", stored)
+        assert "backend/errors.py" not in default
+
+        executor._artifact_vault.retrieve = AsyncMock(
+            side_effect=[(ref_scaffold, b"class ApiError(Exception):\n    pass\n")]
+        )
+        workspace = await executor._resolve_artifact_contents(
+            "development.develop",
+            stored,
+            filter_spec=executor._ACCEPTANCE_WORKSPACE_FILTER,
+        )
+        assert workspace["backend/errors.py"] == "class ApiError(Exception):\n    pass\n"
+
+    async def test_workspace_spec_excludes_rejected_repair_candidates(self, executor):
+        # pf-31 Fix E composes with #643: a rejected repair candidate must not
+        # enter the acceptance workspace of a fresh dispatch.
+        ref_scaffold = _make_artifact_ref(
+            "art_001",
+            "backend/errors.py",
+            "source",
+            producing_task_type="scaffold.expand",
+        )
+        ref_candidate = _make_artifact_ref(
+            "art_002",
+            "backend/routes.py",
+            "source",
+            producing_task_type="development.correction_repair",
+        )
+        stored = [("art_001", ref_scaffold), ("art_002", ref_candidate)]
+        executor._artifact_vault.retrieve = AsyncMock(
+            side_effect=[(ref_scaffold, b"class ApiError(Exception):\n    pass\n")]
+        )
+
+        workspace = await executor._resolve_artifact_contents(
+            "development.develop",
+            stored,
+            include_repair_candidates=False,
+            filter_spec=executor._ACCEPTANCE_WORKSPACE_FILTER,
+        )
+        assert "backend/errors.py" in workspace
+        assert "backend/routes.py" not in workspace
+
+
 class TestProducingTaskTypeMetadata:
     async def test_store_artifact_includes_producing_task_type(self, executor):
         from squadops.tasks.models import TaskEnvelope

--- a/tests/unit/cycles/test_patch_verification.py
+++ b/tests/unit/cycles/test_patch_verification.py
@@ -296,3 +296,70 @@ class TestUnresolvedImportsBlockAcceptance:
         result = await verify_patched_artifacts(_heading_criteria(), artifacts)
 
         assert result.status == PATCH_PASSED
+
+
+# ---------------------------------------------------------------------------
+# #643: the workspace substrate — patched files verified inside the accepted tree
+# ---------------------------------------------------------------------------
+
+
+_ROUTES_IMPORTING_SIBLING = """\
+from backend.errors import ApiError
+
+
+def not_found() -> ApiError:
+    return ApiError()
+"""
+
+_ERRORS_MODULE = "class ApiError(Exception):\n    pass\n"
+
+
+def _module_imports_criterion() -> list[TypedCheck]:
+    return [
+        TypedCheck(
+            check="module_imports",
+            params={"file": "backend/routes.py"},
+            severity="error",
+            description="routes module imports",
+        )
+    ]
+
+
+class TestWorkspaceFiles:
+    """#643 (fay-1): patch verification materialized ONLY failed-outputs +
+    repairs, so a repaired fill file importing its frozen scaffold siblings
+    could never be accepted — both fay-1 candidates were rejected in a
+    routes.py-only workspace despite importing clean in the real tree."""
+
+    async def test_sibling_import_accepted_with_workspace_substrate(self):
+        result = await verify_patched_artifacts(
+            _module_imports_criterion(),
+            [{"name": "backend/routes.py", "content": _ROUTES_IMPORTING_SIBLING}],
+            workspace_files={
+                "backend/__init__.py": "",
+                "backend/errors.py": _ERRORS_MODULE,
+            },
+        )
+        assert result.status == PATCH_PASSED
+
+    async def test_sibling_import_rejected_without_workspace_substrate(self):
+        # The fay-1 rejection, pinned: identical patch, no substrate.
+        result = await verify_patched_artifacts(
+            _module_imports_criterion(),
+            [{"name": "backend/routes.py", "content": _ROUTES_IMPORTING_SIBLING}],
+        )
+        assert result.status == PATCH_FAILED
+
+    async def test_patched_artifact_supersedes_its_workspace_slot(self):
+        # The substrate's stale copy of the repaired file (the pre-repair
+        # tree) must not shadow the patch under verification.
+        result = await verify_patched_artifacts(
+            _module_imports_criterion(),
+            [{"name": "backend/routes.py", "content": _ROUTES_IMPORTING_SIBLING}],
+            workspace_files={
+                "backend/__init__.py": "",
+                "backend/errors.py": _ERRORS_MODULE,
+                "backend/routes.py": "raise RuntimeError('pre-repair tree was evaluated')\n",
+            },
+        )
+        assert result.status == PATCH_PASSED


### PR DESCRIPTION
## What

Fixes the fay-1 window-killer: `module_imports` (and the #591 import pre-gate) evaluated in a workspace containing **only the task's own emitted artifacts**, so any fill file importing its frozen scaffold siblings — which the contract mandates (`vc-routes-apierror` requires `ApiError` from `.errors`) — false-failed on every dev attempt and every repair candidate. Structurally unwinnable in-cycle; the correction chain escalated toward regenerating a frozen scaffold file.

## How

One selection, three consumption sites, all presence-keyed and inert when absent:

- **Executor dispatch** (`dispatched_flow_executor.py`): threads `acceptance_workspace_files` — the full accepted `source`/`config` tree (scaffold included via `by_type`, repair candidates excluded per pf-31 Fix E) — into every build-task envelope. The spec is single-sourced as `_ACCEPTANCE_WORKSPACE_FILTER`; `qa.test`'s prompt filter now references it (it was already this exact selection, #443).
- **Handler typed acceptance** (`base.py`): materializes the tree first, the task's artifacts on top — the candidate supersedes its own slots.
- **Patch verification** (`patch_verification.py` via `_try_accept_patch`): same substrate, passed as a separate parameter so `patched_artifacts` — what an accepted patch re-stores under the task's type (#389 swap) — never absorbs the tree.
- **Retest** (`correction_runner.py`): inherits the key from the failed envelope, same pattern as #639's `contract_probes`.

Deliberately NOT widened: `development.develop`'s `artifact_contents` prompt filter — the verification workspace and the curated prompt context are different concerns (prompt diet).

## Why the gate didn't catch it

The contract gate validates `vc-routes-imports` against the full expanded tree (bare-skeleton / reference-fill modes), and the #630 pf-54 replay was full-workspace too. The in-cycle path was first exercised by fay-1 — the campaign ended before #628/#630 went live.

## Verification

- 10 new tests across the four seams, each pinning the fay-1 mechanism (fails-without / passes-with / candidate-supersedes-slot; scaffold-source inclusion + repair-candidate exclusion; presence-keyed retest threading).
- **Deterministic replay with fay-1's real artifacts**: rejected candidate `art_c1ae4ec3942a` + the run's stored scaffold tree → patch verification `passed` under the fix, still `failed` without it.
- Full regression: 5832 passed, 1 skipped.

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
