### PR TITLE
fix(plan): reject unexecutable command checks + directory expected artifacts (#645)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2681,6 +2681,14 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     )
                 else:
                     errors.extend(parsed_plan.validate_criteria_scope())
+                    # #645: contract-independent winnability nets — an
+                    # unexecutable command check or a directory-shaped
+                    # expected artifact dooms the roll deterministically;
+                    # both are provable here in microseconds, and a system
+                    # rejection re-rolls framing for free where a human
+                    # rejection would end the cycle (#522).
+                    errors.extend(parsed_plan.validate_command_checks())
+                    errors.extend(parsed_plan.validate_expected_artifact_shapes())
             elif ref.filename == "interface_manifest.yaml" or artifact_type == "interface_manifest":
                 interface_content = content_bytes.decode(errors="replace")
 

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -48,6 +48,19 @@ _KNOWN_BUILD_TASK_TYPES = {
 # regardless of the authoring squad.
 _BUILDER_ROLE_BUILD_TASK_TYPES = {"builder.assemble"}
 
+# #645: the executable surface of the environment typed checks run in (the QA
+# agent image). A command check whose argv[0] is not here can never execute
+# where checks execute — it fails identically on every correction attempt
+# (fay-2's plan wanted `tsc`; two later plans reached for it again). This
+# mirrors the image's installed tooling, not a policy preference; extend it
+# when the image gains a tool.
+_CHECK_ENV_EXECUTABLES = frozenset({"python", "python3", "pytest", "node", "npm", "npx"})
+
+# #645: node refuses these extensions outright (ERR_UNKNOWN_FILE_EXTENSION,
+# exit 1 before parsing) — `node --check view.jsx` fails on ANY content,
+# correct or not (fay-2's killer; verified in the QA container).
+_NODE_UNPARSEABLE_SUFFIXES = (".jsx", ".tsx")
+
 
 def planner_build_task_types(*, has_builder: bool) -> set[str]:
     """Build task types the plan-authoring prompt may offer for a given squad.
@@ -350,6 +363,75 @@ class ImplementationPlan:
             for task, criterion, target in self._regex_on_source_criteria()
             if criterion.severity == "error"
         ]
+
+    def validate_command_checks(self) -> list[str]:
+        """#645: an error-severity command check must be executable where checks run.
+
+        Two deterministic classes from the FAY measurement window, both provable
+        at authoring time without running anything:
+
+        - an executable the check environment does not ship (fay-2's ``tsc``) —
+          the spawn fails on every attempt until the correction budget is spent;
+        - ``node`` pointed at a ``.jsx``/``.tsx`` file — node refuses the
+          extension before parsing (``ERR_UNKNOWN_FILE_EXTENSION``), so the check
+          fails on ANY content, correct or not.
+
+        Only ``severity=error`` rejects (RC-9: a warning cannot block a build, so
+        a doomed warning check costs nothing — fay-6 and fay-8 both carried one
+        harmlessly). Non-list/odd-shaped argv is the parser's concern, not ours.
+        """
+        errors: list[str] = []
+        for task in self.tasks:
+            for criterion in task.acceptance_criteria:
+                if not isinstance(criterion, TypedCheck):
+                    continue
+                if criterion.check != "command_exit_zero" or criterion.severity != "error":
+                    continue
+                argv = criterion.params.get("argv") or []
+                if not argv or not all(isinstance(a, str) for a in argv):
+                    continue
+                executable = argv[0]
+                if executable not in _CHECK_ENV_EXECUTABLES:
+                    errors.append(
+                        f"Task {task.task_index} ({task.focus}): command_exit_zero invokes "
+                        f"{executable!r}, which the check environment does not provide — "
+                        f"the check can never execute, so no repair can fix it and the "
+                        f"task fails identically on every correction attempt. Use one of "
+                        f"{sorted(_CHECK_ENV_EXECUTABLES)} or a named check"
+                    )
+                elif executable == "node" and any(
+                    arg.endswith(_NODE_UNPARSEABLE_SUFFIXES) for arg in argv[1:]
+                ):
+                    errors.append(
+                        f"Task {task.task_index} ({task.focus}): command_exit_zero runs "
+                        f"node against a .jsx/.tsx file — node refuses the extension "
+                        f"before parsing (ERR_UNKNOWN_FILE_EXTENSION), so this fails on "
+                        f"any content, correct or not. JSX compilation is verified by "
+                        f"the frontend build; drop the check or target plain .js"
+                    )
+        return errors
+
+    def validate_expected_artifact_shapes(self) -> list[str]:
+        """fay-9: an ``expected_artifacts`` entry must be a file, not a directory.
+
+        The presence check compares entries against emitted artifact *names*; a
+        directory entry (``backend/tests/``) can never appear there, so the task
+        fails on every attempt — fay-9 went 16/17 with frontend built, suite
+        passing, and both probes green, rejected solely on this shape. A
+        verification-only task declares ``[]``.
+        """
+        errors: list[str] = []
+        for task in self.tasks:
+            for name in task.expected_artifacts:
+                if isinstance(name, str) and name.endswith("/"):
+                    errors.append(
+                        f"Task {task.task_index} ({task.focus}): expected artifact "
+                        f"{name!r} is a directory — expected_artifacts are the FILES "
+                        f"the task emits, and the presence check reads a directory as "
+                        f"a permanently missing file. A verification-only task "
+                        f"declares expected_artifacts: []"
+                    )
+        return errors
 
     def lint_prose_contract_conflicts(self, contract: VerificationContract) -> list[str]:
         """pf-31 Fix A3: WARNING-only lint for prose that contradicts bound criteria.

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -803,6 +803,16 @@ def _replace_build_steps_with_plan(
     if scope_errors:
         raise CycleError("Plan validation failed (criteria scope): " + "; ".join(scope_errors))
 
+    # #645 dispatch-time nets (contract-independent, same raising backstop
+    # pattern): unexecutable command checks and directory-shaped expected
+    # artifacts are both provable at authoring time and unwinnable at runtime.
+    command_errors = plan.validate_command_checks()
+    if command_errors:
+        raise CycleError("Plan validation failed (command checks): " + "; ".join(command_errors))
+    shape_errors = plan.validate_expected_artifact_shapes()
+    if shape_errors:
+        raise CycleError("Plan validation failed (expected artifacts): " + "; ".join(shape_errors))
+
     # SIP-0098 98.3 bind-mode dispatch net: when a contract is seeded, the plan
     # must bind the contract's covered-file criteria by id rather than author
     # them. This is the raising backstop; the gate-time net records the graceful

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -873,3 +873,126 @@ class TestQaArtifactOwnership:
             ).validate_qa_artifact_ownership(self._contract())
             == []
         )
+
+
+# ---------------------------------------------------------------------------
+# #645: command-check executability + expected-artifact shape (FAY window)
+# ---------------------------------------------------------------------------
+
+
+def _qa_verification_plan(criteria_yaml: str, *, expected: str = '["backend/tests/test_x.py"]'):
+    return ImplementationPlan.from_yaml(
+        f"""\
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+tasks:
+  - task_index: 0
+    task_type: qa.test
+    role: qa
+    focus: "Verification"
+    description: "check things"
+    expected_artifacts: {expected}
+    acceptance_criteria:
+{criteria_yaml}
+    depends_on: []
+
+summary:
+  total_dev_tasks: 0
+  total_qa_tasks: 1
+  total_tasks: 1
+"""
+    )
+
+
+class TestValidateCommandChecks:
+    """#645: fay-2 was killed by a plan whose blocking checks could never run —
+    `tsc` absent from the check environment, `node --check` on .jsx refused
+    before parsing. Both are provable at authoring time; a validator rejection
+    re-rolls framing for free where a human gate rejection ends the cycle."""
+
+    def test_unknown_executable_rejected(self):
+        plan = _qa_verification_plan(
+            """\
+      - check: command_exit_zero
+        argv: [tsc, --noEmit]
+"""
+        )
+        errors = plan.validate_command_checks()
+        assert len(errors) == 1
+        assert "'tsc'" in errors[0] and "never execute" in errors[0]
+
+    def test_node_on_jsx_rejected_even_though_node_exists(self):
+        plan = _qa_verification_plan(
+            """\
+      - check: command_exit_zero
+        argv: [node, --check, frontend/src/views/RunsListView.jsx]
+"""
+        )
+        errors = plan.validate_command_checks()
+        assert len(errors) == 1
+        assert "ERR_UNKNOWN_FILE_EXTENSION" in errors[0]
+
+    def test_warning_severity_doomed_command_tolerated(self):
+        # RC-9: a warning cannot block a build — fay-6/fay-8 carried exactly
+        # this shape harmlessly and must keep passing validation.
+        plan = _qa_verification_plan(
+            """\
+      - check: command_exit_zero
+        argv: [node, --check, frontend/src/__tests__/runs.test.jsx]
+        severity: warning
+"""
+        )
+        assert plan.validate_command_checks() == []
+
+    def test_legitimate_py_compile_command_passes(self):
+        # fay-5/fay-7/fay-9 all used this exact shape correctly.
+        plan = _qa_verification_plan(
+            """\
+      - check: command_exit_zero
+        argv: [python, -m, py_compile, backend/tests/test_x.py]
+"""
+        )
+        assert plan.validate_command_checks() == []
+
+    def test_node_on_plain_js_passes(self):
+        plan = _qa_verification_plan(
+            """\
+      - check: command_exit_zero
+        argv: [node, --check, frontend/src/api.js]
+"""
+        )
+        assert plan.validate_command_checks() == []
+
+
+class TestValidateExpectedArtifactShapes:
+    """fay-9: rejected 16/17 solely because a verification-only task declared
+    expected_artifacts: ['backend/tests/'] and the presence check read the
+    directory as a permanently missing file."""
+
+    def test_directory_entry_rejected(self):
+        plan = _qa_verification_plan(
+            """\
+      - check: count_at_least
+        glob: backend/tests/test_*.py
+        min_count: 2
+""",
+            expected='["backend/tests/"]',
+        )
+        errors = plan.validate_expected_artifact_shapes()
+        assert len(errors) == 1
+        assert "'backend/tests/'" in errors[0] and "expected_artifacts: []" in errors[0]
+
+    def test_file_entries_and_empty_list_pass(self):
+        plan = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
+        assert plan.validate_expected_artifact_shapes() == []
+        empty = _qa_verification_plan(
+            """\
+      - check: count_at_least
+        glob: backend/tests/test_*.py
+        min_count: 2
+""",
+            expected="[]",
+        )
+        assert empty.validate_expected_artifact_shapes() == []


### PR DESCRIPTION
First item of the next-window fix package.

**Two validator rules** (both #612-family nets, gate + dispatch):

1. **Unexecutable command checks** — `command_exit_zero` invoking an executable the check environment doesn't ship (fay-2's `tsc`), or `node` against `.jsx/.tsx` (refused before parsing — verified `ERR_UNKNOWN_FILE_EXTENSION` in the eve container). Error-severity only per RC-9; the warning-severity doomed checks fay-6/fay-8 carried stay tolerated, pinned by test.
2. **Directory-shaped expected artifacts** — fay-9 went 16/17 (frontend built, suite passed, probes green) and was rejected solely because a verification-only task declared `expected_artifacts: ['backend/tests/']`.

Both fire at the workload gate first — a **system** rejection consumes a free framing re-roll, where the identical defect surfaced to a human reviewer kills the cycle (#522, fay-2's fate).

7 new tests incl. the RC-9 tolerance case and the exact fay-2/fay-9 shapes. Full regression 5839 passed.

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q