### PR TITLE
fix(scaffold): builder write authorization — refuse net-new source at assembly (#649)

### DIFF
--- a/src/squadops/cycles/scaffold_enforcement.py
+++ b/src/squadops/cycles/scaffold_enforcement.py
@@ -34,6 +34,18 @@ def _is_qa_producer(task_type: str) -> bool:
     return task_type.startswith("qa.")
 
 
+# #649: source suffixes a builder may not author. Assembly re-packages accepted
+# code; net-new source is how fay-7's uninstructed start.py entered the tree
+# (import-time RuntimeError in every test workspace, unrepairable — dev-scoped
+# repairs never touch builder artifacts). Docs/reports pass through.
+_BUILDER_FORBIDDEN_SOURCE_SUFFIXES = (".py", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")
+
+
+def _is_builder_producer(task_type: str) -> bool:
+    """#649: builder task types are scoped to re-packaging the declared fill surface."""
+    return task_type.startswith("builder.")
+
+
 def bound_record_or_none(interface_manifest: Any, run_id: str) -> Any:
     """SIP-0100 2.4: the bound scaffold record (frozen paths + bytes) for a scaffold-bound
     run, or None for unbound/legacy runs (no manifest / non-scaffoldable stack → no
@@ -122,6 +134,15 @@ def enforce_frozen_ownership(
         grant = WriteGrant.for_qa(envelope.task_type, ownership)
         qa_authz = WriteAuthorization(ownership, grant)
 
+    # #649: a builder producer gets a fill-surface grant. Net-new SOURCE and
+    # QA-namespace writes are dropped with evidence; undeclared non-source
+    # paths (handoff docs, reports) remain deliverables and pass.
+    builder_authz = None
+    if _is_builder_producer(envelope.task_type):
+        ownership = WorkspaceOwnership.from_record(bound_record)
+        grant = WriteGrant.for_builder(envelope.task_type, ownership)
+        builder_authz = WriteAuthorization(ownership, grant)
+
     # Classify first so each evidence record can report how many sibling artifacts in the SAME
     # response were left untouched (per-artifact disposition — restore/drop keep the rest; a
     # response-atomic reject would not — that difference is exactly what the field captures).
@@ -138,6 +159,14 @@ def enforce_frozen_ownership(
             == AuthzDecision.FORBIDDEN_UNAUTHORIZED
         ):
             return _DISP_DROP
+        if builder_authz is not None:
+            decision = builder_authz.authorize(_artifact_raw_path(art) or "")
+            if decision == AuthzDecision.FORBIDDEN_UNAUTHORIZED:
+                return _DISP_DROP  # another producer's lane (e.g. the QA namespace)
+            if decision == AuthzDecision.FORBIDDEN_UNDECLARED and (norm or "").endswith(
+                _BUILDER_FORBIDDEN_SOURCE_SUFFIXES
+            ):
+                return _DISP_DROP  # net-new source (the fay-7 start.py class)
         return _DISP_PASS
 
     dispositions = [_disposition(art, norm) for art, norm in zip(artifacts, norms, strict=True)]

--- a/src/squadops/cycles/write_authorization.py
+++ b/src/squadops/cycles/write_authorization.py
@@ -95,6 +95,14 @@ class WriteGrant:
         """A QA fill/correction may write only the QA test namespace (plan §4.4)."""
         return cls(producer=producer, stage="qa", writable=ownership.qa_namespace)
 
+    @classmethod
+    def for_builder(cls, producer: str, ownership: WorkspaceOwnership) -> WriteGrant:
+        """#649: assembly re-packages the accepted fill files — that is its whole
+        writable surface. It may not author source (fay-7's uninstructed
+        ``start.py``) nor write the QA namespace; undeclared non-source paths
+        (``qa_handoff.md``, reports) pass through as deliverables."""
+        return cls(producer=producer, stage="builder", writable=ownership.fill_slots)
+
 
 @dataclass(frozen=True)
 class ResponseAuthz:

--- a/tests/unit/cycles/test_sip0100_executor_enforcement.py
+++ b/tests/unit/cycles/test_sip0100_executor_enforcement.py
@@ -162,3 +162,86 @@ def test_build_bound_record_for_scaffoldable_manifest():
     rec = DispatchedFlowExecutor._build_bound_record_for_run(object(), _manifest(), "r")
     assert rec is not None
     assert "backend/main.py" in rec.frozen_paths()
+
+
+# ---------------------------------------------------------------------------
+# #649: builder write authorization — assembly re-packages, it does not author
+# ---------------------------------------------------------------------------
+
+
+def test_builder_net_new_source_is_dropped():
+    """fay-7: bob authored an uninstructed root start.py (StaticFiles mount on
+    frontend/dist) — import-time RuntimeError in every test workspace, and
+    dev-scoped repairs structurally never touch a builder artifact. Net-new
+    source at assembly is refused at emission, with evidence."""
+    artifacts = [
+        {"name": "start.py", "content": "from backend.main import app\n"},
+        {"name": "qa_handoff.md", "content": "## How to Run\n"},
+    ]
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
+        object(), artifacts, _record(), _env("builder.assemble")
+    )
+    names = {a["name"] for a in enforced}
+    assert "start.py" not in names  # dropped
+    assert "qa_handoff.md" in names  # the deliverable passes
+    assert len(evidence) == 1
+    ev = evidence[0]
+    assert ev.normalized_path == "start.py"
+    assert ev.disposition == "dropped"
+    assert ev.siblings_retained == 1
+
+
+def test_builder_fill_surface_reemission_passes():
+    """Assembly's whole job: re-packaging the accepted fill files stays authorized."""
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
+        object(),
+        [{"name": "backend/routes.py", "content": "def assembled(): return 1\n"}],
+        _record(),
+        _env("builder.assemble"),
+    )
+    assert evidence == []
+    assert enforced[0]["content"] == "def assembled(): return 1\n"
+
+
+def test_builder_write_into_qa_namespace_is_dropped():
+    """The QA namespace is another producer's lane — a builder emission there is
+    refused the same way QA's writes to dev slots are."""
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
+        object(),
+        [{"name": "backend/tests/test_sneaky.py", "content": "def test_x(): pass\n"}],
+        _record(),
+        _env("builder.assemble"),
+    )
+    assert enforced == []
+    assert len(evidence) == 1
+    assert evidence[0].violation_code == "unauthorized_slot_emission"
+
+
+def test_builder_undeclared_non_source_passes_and_frozen_still_restores():
+    """Docs/reports remain deliverables; frozen restoration is unchanged for builders."""
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
+        object(),
+        [
+            {"name": "deploy_notes.md", "content": "# notes\n"},
+            {"name": "backend/main.py", "content": "TAMPERED = 1\n"},
+        ],
+        _record(),
+        _env("builder.assemble"),
+    )
+    by_name = {a["name"]: a["content"] for a in enforced}
+    assert by_name["deploy_notes.md"] == "# notes\n"
+    assert "from .routes import router" in by_name["backend/main.py"]  # restored
+    assert len(evidence) == 1 and evidence[0].violation_code == "frozen_path_emission"
+
+
+def test_dev_producer_unaffected_by_builder_rule():
+    """A dev task emitting an undeclared .py helper keeps today's behavior (passes) —
+    the #649 rule scopes builders only; dev undeclared-reject stays gated on 3.4."""
+    enforced, evidence = DispatchedFlowExecutor._enforce_frozen_ownership(
+        object(),
+        [{"name": "backend/helpers.py", "content": "X = 1\n"}],
+        _record(),
+        _env("development.develop"),
+    )
+    assert evidence == []
+    assert enforced[0]["content"] == "X = 1\n"


### PR DESCRIPTION
Second item of the next-window fix package.

**The rule**: `builder.*` producers get a fill-surface `WriteGrant` (SIP-0100 pattern, same seam as QA namespace scoping). Dispositions:
- net-new **source** file (fay-7's `start.py` class) → **dropped with evidence**
- write into the **QA namespace** → dropped with evidence (another producer's lane)
- undeclared **non-source** (`qa_handoff.md`, reports) → passes (deliverables)
- frozen restoration + fill-slot re-emission → unchanged
- **dev producers unaffected** (pinned by test — undeclared-reject stays gated on 3.4)

**Receipt**: fay-7 (`cyc_e44057df71d2`) — the uninstructed `start.py` mounted `frontend/dist`, raising at import in every test workspace; 15/15 backend tests passed while `tests_pass` failed every attempt; repairs could never reach a builder artifact. Under this rule the file is refused at emission and the roll never sees it.

5 new tests. Full regression 5837 passed.

Closes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q