### PR TITLE
fix(correction): frontend_build failures widen repair scope to frontend source (#650)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -82,6 +82,51 @@ def _scope_to_shared_packages(candidates: list[str], anchors: list[str]) -> list
     return [c for c in candidates if c and _top_level_package(c) in anchor_pkgs]
 
 
+def _frontend_build_failed(failure_evidence: Any) -> bool:
+    """#650 (fay-8): the failed task's validation shows the frontend build failing.
+
+    A failing ``frontend_build`` row places the defect in frontend source no
+    matter which task reported it — the check runs inside the backend qa.test
+    task, so ownership-anchored targeting never reaches the broken view.
+    """
+    from squadops.cycles.check_registry import CHECK_FRONTEND_BUILD
+
+    if not isinstance(failure_evidence, dict):
+        return False
+    checks = (failure_evidence.get("validation_result") or {}).get("checks") or []
+    return any(
+        isinstance(row, dict)
+        and row.get("check") == CHECK_FRONTEND_BUILD
+        and row.get("passed") is False
+        for row in checks
+    )
+
+
+def _widen_target_for_frontend_build(
+    target: list[str], failure_evidence: Any, failed_inputs: dict[str, Any]
+) -> list[str]:
+    """#650 minimal provenance targeting: a failing ``frontend_build`` unions the
+    plan's frontend implementation source into the repair target.
+
+    fay-8 (cyc_7f5f1b8b1790): five correction rounds, four identical
+    ``frontend_build`` failures, every repair emitted backend/test files only —
+    RC2's package scoping is deliberately conservative (``backend/tests/*`` →
+    ``backend/*``, never ``frontend/*``), which is exactly the trap: the loop
+    polished a passing backend while the build-breaking view sat outside every
+    target. The general provenance-driven scope seam stays deferred (1.5);
+    this widens exactly the measured case, derived from the same
+    ``implementation_artifacts`` surface RC2 already threads.
+    """
+    if not _frontend_build_failed(failure_evidence):
+        return target
+    frontend_source = [
+        p
+        for p in (failed_inputs.get("implementation_artifacts") or [])
+        if isinstance(p, str) and p.startswith("frontend/")
+    ]
+    return list(dict.fromkeys([*target, *frontend_source]))
+
+
 def _resolve_repair_target(
     failure_evidence: Any, failed_inputs: dict[str, Any]
 ) -> tuple[list[str], str | None, str | None]:
@@ -143,6 +188,7 @@ def _resolve_repair_target(
             failed_inputs.get("implementation_artifacts", []) or [], failed_artifacts
         )
         target = list(dict.fromkeys([*drift_files, *failed_artifacts, *scoped_source]))
+        target = _widen_target_for_frontend_build(target, failure_evidence, failed_inputs)
         return (target, None, None)
     # RC2 no-drift path: union the failing task's own artifacts with the
     # package-scoped implementation surface so a behavioral failure can reach the
@@ -152,6 +198,7 @@ def _resolve_repair_target(
         failed_inputs.get("implementation_artifacts", []) or [], failed_artifacts
     )
     target = list(dict.fromkeys([*failed_artifacts, *scoped_source]))
+    target = _widen_target_for_frontend_build(target, failure_evidence, failed_inputs)
     return (
         target,
         failed_inputs.get("subtask_focus"),

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -2882,3 +2882,98 @@ class TestRetestWorkspaceThreading:
         )
         (env,) = dispatcher.dispatched
         assert "acceptance_workspace_files" not in env.inputs
+
+
+class TestFrontendBuildProvenanceTargeting:
+    """#650 (fay-8, cyc_7f5f1b8b1790): four identical frontend_build failures,
+    every repair emitted backend/test files — RC2's package scoping is
+    deliberately backend-bounded, so the build-breaking view sat outside every
+    target and the loop could not converge. A failing frontend_build row now
+    unions the plan's frontend implementation source into the target."""
+
+    _FAY8_INPUTS = {
+        "expected_artifacts": ["backend/tests/test_runs.py", "backend/tests/test_validation.py"],
+        "implementation_artifacts": [
+            "backend/routes.py",
+            "frontend/src/views/RunsListView.jsx",
+            "frontend/src/views/CreateRunView.jsx",
+            "frontend/src/views/RunDetailView.jsx",
+        ],
+        "subtask_focus": "Backend API test suite",
+        "subtask_description": "pytest suites",
+    }
+
+    def test_failing_frontend_build_row_widens_target_to_frontend_source(self):
+        # The fay-8 shape, replayed: backend qa.test reports, frontend is broken.
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = {
+            "validation_result": {
+                "summary": "tests_pass exit 1",
+                "checks": [
+                    {"check": "frontend_build", "passed": False},
+                    {"check": "tests_pass", "passed": False},
+                ],
+            }
+        }
+        artifacts, _, _ = _resolve_repair_target(evidence, dict(self._FAY8_INPUTS))
+        assert "frontend/src/views/RunsListView.jsx" in artifacts
+        assert "frontend/src/views/CreateRunView.jsx" in artifacts
+        assert "frontend/src/views/RunDetailView.jsx" in artifacts
+        # The failing task's own artifacts stay targeted (pf-21: their own bug
+        # is fixable too) and backend source stays via RC2 package scoping.
+        assert "backend/tests/test_runs.py" in artifacts
+        assert "backend/routes.py" in artifacts
+
+    def test_passing_frontend_build_row_does_not_widen(self):
+        # fay-3's shape: real backend test failures, frontend fine — the
+        # backend-bounded RC2 scope must stay exactly as it is (no frontend
+        # noise diluting the repair).
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = {
+            "validation_result": {
+                "summary": "tests_pass exit 1",
+                "checks": [
+                    {"check": "frontend_build", "passed": True},
+                    {"check": "tests_pass", "passed": False},
+                ],
+            }
+        }
+        artifacts, _, _ = _resolve_repair_target(evidence, dict(self._FAY8_INPUTS))
+        assert not any(a.startswith("frontend/") for a in artifacts)
+
+    def test_widening_applies_on_the_drift_branch_too(self):
+        # Drift and a broken frontend can co-occur; the widening must not be
+        # lost to the drift branch's earlier return.
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = {
+            "interface_drift": [
+                {
+                    "kind": "route_drift",
+                    "file": "backend/main.py",
+                    "extra": ["GET /"],
+                    "missing": [],
+                    "instruction": "remove the unauthorized GET / route",
+                }
+            ],
+            "validation_result": {
+                "checks": [{"check": "frontend_build", "passed": False}],
+            },
+        }
+        artifacts, _, _ = _resolve_repair_target(evidence, dict(self._FAY8_INPUTS))
+        assert "backend/main.py" in artifacts  # drift stays first-class
+        assert "frontend/src/views/RunsListView.jsx" in artifacts
+
+    def test_skipped_frontend_build_row_does_not_widen(self):
+        # A not-executed row (#306 Node-absent skip shape) is not a failure.
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = {
+            "validation_result": {
+                "checks": [{"check": "frontend_build", "executed": False, "reason": "skipped"}],
+            }
+        }
+        artifacts, _, _ = _resolve_repair_target(evidence, dict(self._FAY8_INPUTS))
+        assert not any(a.startswith("frontend/") for a in artifacts)


### PR DESCRIPTION
Third item of the next-window fix package — the minimal version per the owner call.

**Mechanism**: `_resolve_repair_target` gains one provenance rule: when the failed task's validation carries a `frontend_build` row with `passed: false`, the plan's frontend implementation source (the existing `implementation_artifacts` threading — no new envelope surface) is unioned into the repair target. Applied on both the drift and no-drift branches. Everything else — RC2 package scoping, drift-first ordering, pf-21 own-artifact union — is unchanged.

**Receipt**: fay-8 (`cyc_7f5f1b8b1790`) — four identical `frontend_build` failures across five rounds; every repair emitted backend/test files because the reporting task owns only those; structurally non-convergent. The new test replays exactly that shape (real plan surface) and asserts the views enter the target.

**Guard rails pinned by test**: passing `frontend_build` widens nothing (fay-3's backend-only scoping preserved); skipped/not-executed rows (#306 Node-absent shape) widen nothing; drift co-occurrence keeps drift files first-class.

4 new tests. Full regression 5848 passed.

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q