### PR TITLE
feat(checks): frontend_compiles — real bundler at view-task acceptance (#648)

### DIFF
--- a/agents/instances/dev/system-packages.txt
+++ b/agents/instances/dev/system-packages.txt
@@ -1,0 +1,10 @@
+# Dev agent role — system (apt) packages, the system-level analog of
+# requirements.txt. Installed at image build time for this role only.
+#
+# Node.js + npm: the frontend_compiles acceptance check (#648) runs the real
+# frontend build at dev-task acceptance time — fay-4/fay-8 shipped views with
+# rollup bind-time errors invisible to every static check, first surfacing at
+# final verification where no correction budget could reach them. The check
+# executes where dev typed acceptance executes: this container.
+nodejs
+npm

--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -139,18 +139,28 @@ def _routes_criteria(manifest: InterfaceManifest) -> dict[str, Any]:
     return {"interface": interface, "implementation": implementation}
 
 
-def _view_criteria(_path: str) -> dict[str, Any]:
-    # Views (.jsx) carry NO per-file criteria in v1:
-    #   - `node --check` cannot parse JSX (fails on correct code), so no per-view
-    #     implementation criterion is winnable; and
-    #   - the SIP-0092 `import_present` evaluator skips .js/.jsx ("frontend acceptance
-    #     checks disabled" — out of scope for M1.2), so a view interface criterion could
-    #     only ever *skip*, never verify anything.
-    # View compilation is verified by the behavioral `frontend_build` (vite is the
-    # JSX-aware compiler). Per-view frontend structural criteria arrive when the
-    # frontend-acceptance-checks follow-up lands; the slot is recorded here regardless so
-    # the fill/frozen partition stays complete.
-    return {"interface": [], "implementation": []}
+def _view_criteria(path: str) -> dict[str, Any]:
+    # Views carry ONE implementation criterion (#648): the real frontend build,
+    # run at task time. The v1 rationale for empty criteria stands for the
+    # static vocabulary — `node --check` cannot parse JSX and the AST checks
+    # skip .jsx — but fay-4 and fay-8 each shipped a view with a rollup
+    # bind-time error that no static check can see, invisible until final
+    # verification where no correction budget can reach it. `frontend_compiles`
+    # is the bundler itself (the only tool that sees the class), anchored to
+    # the view so #641 binds it onto the view's own task and a failure repairs
+    # where the defect lives.
+    stem = path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+    return {
+        "interface": [],
+        "implementation": [
+            {
+                "check": "frontend_compiles",
+                "id": f"vc-view-compiles-{_slug(stem)}",
+                "file": path,
+                "requires": CAP_NODE,
+            }
+        ],
+    }
 
 
 def _behavioral(manifest: InterfaceManifest) -> dict[str, Any]:

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -324,6 +324,31 @@ CHECK_SPECS: dict[str, CheckSpec] = {
             "plan validation): " + "; ".join(f"`{p.name}`" for p in COMMAND_SAFELIST)
         ),
     ),
+    "frontend_compiles": CheckSpec(
+        name="frontend_compiles",
+        applicable_extensions=frozenset({".js", ".jsx", ".ts", ".tsx"}),
+        required_params=frozenset({"file"}),
+        optional_params=frozenset({"timeout_s"}),
+        param_types={"file": str, "timeout_s": int},
+        supported_stacks=frozenset(),
+        requires_stack_context=False,
+        path_params=frozenset({"file"}),
+        example={"file": "frontend/src/views/RunsListView.jsx"},
+        # #648: fay-4 and fay-8 both shipped a view with a rollup bind-time
+        # error (an undefined identifier) — invisible to every static check
+        # AND to `node --check` (which refuses .jsx outright), first surfacing
+        # at final verification where no correction budget can reach it. This
+        # is the real bundler, run at task time against the acceptance
+        # workspace's full tree (#643).
+        notes=(
+            "Runs the actual frontend build (npm install + npm run build) in "
+            "the workspace's frontend/ tree and anchors blame to `file`. "
+            "Catches bundler-level errors (undefined identifiers, broken "
+            "imports) that no static check or `node --check` can see. Missing "
+            "npm or a workspace without frontend/package.json skips "
+            "(missing_tooling), it does not fail."
+        ),
+    ),
     "module_imports": CheckSpec(
         name="module_imports",
         applicable_extensions=frozenset({".py"}),

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -21,6 +21,7 @@ import ast
 import asyncio
 import logging
 import re
+import shutil
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -81,6 +82,12 @@ DEFAULT_COMMAND_TIMEOUT_S = 10
 MAX_COMMAND_TIMEOUT_S = 60
 DEFAULT_REGEX_INPUT_CAP_BYTES = 10 * 1024 * 1024  # 10 MiB
 DEFAULT_REGEX_PATTERN_CAP_CHARS = 4096
+# #648: the frontend build is the one check that runs a package manager — its
+# ceilings are its own (measured: install ~6s cold / ~0.9s with the agent
+# container's warm npm cache; build ~0.9s). The install ceiling absorbs a
+# first-ever cold-network install; the command ceilings above stay untouched.
+FRONTEND_INSTALL_TIMEOUT_S = 240
+FRONTEND_BUILD_TIMEOUT_S = 120
 
 
 class _SafetyError(Exception):
@@ -894,6 +901,102 @@ class ModuleImportsCheck(BaseCheck):
                 )
         return CheckOutcome.failed(
             reason="module_import_failed", module=module, stderr_tail=_tail(stderr)
+        )
+
+
+@register_check("frontend_compiles")
+class FrontendCompilesCheck(BaseCheck):
+    """Run the real frontend build against the workspace tree (#648).
+
+    fay-4 and fay-8 both shipped a view with a rollup bind-time error (an
+    undefined identifier) — invisible to every static check and to
+    ``node --check`` (which refuses ``.jsx`` outright, #645), first surfacing
+    at final verification where no correction budget can reach it. Only the
+    actual bundler sees this class, so this check runs it at task time: the
+    #643 acceptance workspace carries the full tree, ``npm install`` is
+    sub-second against the agent container's warm cache, and the build's
+    stderr tail becomes repair-relevant evidence.
+
+    ``file`` anchors blame (and #641 binding) to the view under evaluation;
+    the build necessarily covers the whole frontend. Skips, never fails, on
+    environment gaps (#462): npm absent, or a workspace without
+    ``frontend/package.json`` (pre-#643 envelopes, non-fullstack stacks).
+    An install failure also skips — ``package.json`` is scaffold-frozen, so a
+    failing install is a network/registry gap, not an artifact defect.
+    """
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        try:
+            file_path = _safe_resolve(params["file"], workspace_root)
+        except _SafetyError as exc:
+            return CheckOutcome.error(reason=exc.reason)
+        if not file_path.is_file():
+            return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
+
+        frontend_dir = workspace_root / "frontend"
+        if not (frontend_dir / "package.json").is_file():
+            return CheckOutcome.skipped(reason="no_frontend_tree")
+        if shutil.which("npm") is None:
+            return CheckOutcome.skipped(reason="missing_tooling", missing_module="npm")
+
+        if not (frontend_dir / "node_modules").is_dir():
+            rc, _, stderr = await self._run(
+                ["npm", "install", "--no-audit", "--no-fund"],
+                frontend_dir,
+                FRONTEND_INSTALL_TIMEOUT_S,
+            )
+            if rc is None:
+                return CheckOutcome.error(
+                    reason="command_timeout", timeout_s=FRONTEND_INSTALL_TIMEOUT_S
+                )
+            if rc != 0:
+                return CheckOutcome.skipped(reason="install_failed", stderr_tail=_tail(stderr))
+
+        timeout_s = int(params.get("timeout_s", FRONTEND_BUILD_TIMEOUT_S))
+        timeout_s = max(1, min(timeout_s, FRONTEND_BUILD_TIMEOUT_S))
+        rc, _, stderr = await self._run(["npm", "run", "build"], frontend_dir, timeout_s)
+        if rc is None:
+            return CheckOutcome.error(reason="command_timeout", timeout_s=timeout_s)
+        if rc != 0:
+            return CheckOutcome.failed(
+                reason="frontend_build_failed",
+                file=str(params["file"]),
+                stderr_tail=_tail(stderr),
+            )
+        return CheckOutcome.passed(file=str(params["file"]))
+
+    @staticmethod
+    async def _run(argv: list[str], cwd: Path, timeout_s: int) -> tuple[int | None, str, str]:
+        """Run one build step; ``(returncode, stdout, stderr)``, rc None on timeout."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                cwd=str(cwd),
+                env=_restricted_env(),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except (OSError, ValueError) as exc:
+            return 1, "", f"spawn failed: {exc}"
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+        except TimeoutError:
+            proc.kill()
+            try:
+                await proc.wait()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            return None, "", ""
+        return (
+            proc.returncode,
+            stdout_b.decode("utf-8", errors="replace"),
+            stderr_b.decode("utf-8", errors="replace"),
         )
 
 

--- a/src/squadops/cycles/verification_contract.py
+++ b/src/squadops/cycles/verification_contract.py
@@ -72,8 +72,12 @@ INTERFACE_CHECK_NAMES: frozenset[str] = frozenset(
 # module_imports (#628) is implementation-class by nature: it EXECUTES the
 # module's top level, so it cannot be an interface presence check — and unlike
 # the interface checks it need not pass on the bare skeleton (stub bodies
-# import cleanly, so in practice it does).
-IMPLEMENTATION_CHECK_NAMES: frozenset[str] = frozenset({"command_exit_zero", "module_imports"})
+# import cleanly, so in practice it does). frontend_compiles (#648) is the
+# same species one language over: it executes the real bundler, and the
+# skeleton's stub views compile by design.
+IMPLEMENTATION_CHECK_NAMES: frozenset[str] = frozenset(
+    {"command_exit_zero", "module_imports", "frontend_compiles"}
+)
 
 # Keys owned by the criterion wrapper; everything else on a criterion mapping is a
 # check param. (Contract criteria carry ``id``/``requires``; plan criteria carry

--- a/tests/unit/capabilities/test_scaffold_contract.py
+++ b/tests/unit/capabilities/test_scaffold_contract.py
@@ -123,11 +123,20 @@ def test_fill_slots_carry_interface_and_implementation_criteria():
     assert compiles["argv"] == ["python", "-m", "py_compile", "backend/routes.py"]
     assert compiles["requires"] == "python"
 
-    # views carry NO per-file criteria in v1: node --check can't parse JSX and the
-    # import_present evaluator skips .jsx — view compilation is verified by frontend_build
+    # #648: views carry the real-bundler criterion — fay-4/fay-8 shipped views
+    # with rollup bind-time errors no static check (or node --check) can see,
+    # invisible until final verification. Anchored to the view so #641 binds
+    # it onto the view's own task.
     detail = contract["fill_files"]["frontend/src/views/RunDetailView.jsx"]
     assert detail["interface"] == []
-    assert detail["implementation"] == []
+    assert detail["implementation"] == [
+        {
+            "check": "frontend_compiles",
+            "id": "vc-view-compiles-run-detail-view",
+            "file": "frontend/src/views/RunDetailView.jsx",
+            "requires": "node",
+        }
+    ]
 
 
 def test_behavioral_has_build_suite_and_self_contained_probe():

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -1194,3 +1194,111 @@ class TestModuleImports:
         (tmp_path / "App.jsx").write_text("export default 1;\n")
         outcome = await get_check("module_imports").evaluate({"file": "App.jsx"}, tmp_path)
         assert outcome.status == "skipped"
+
+
+class TestFrontendCompiles:
+    """#648 (fay-4/fay-8): a view with a rollup bind-time error passes every
+    static check and first fails at final verification, out of correction
+    reach. This check runs the real bundler at task time. Build execution is
+    stubbed here (no node in the unit environment); the real thing is proven
+    by the contract gate (bare-skeleton/reference-fill 14/14) and the fay-8
+    deliverable replay."""
+
+    def _workspace(self, tmp_path, *, with_frontend=True):
+        views = tmp_path / "frontend" / "src" / "views"
+        views.mkdir(parents=True)
+        (views / "RunsListView.jsx").write_text("export default function V() {}\n")
+        if with_frontend:
+            (tmp_path / "frontend" / "package.json").write_text('{"name": "x"}\n')
+        return tmp_path
+
+    async def test_no_frontend_tree_skips(self, tmp_path):
+        ws = self._workspace(tmp_path, with_frontend=False)
+        outcome = await get_check("frontend_compiles").evaluate(
+            {"file": "frontend/src/views/RunsListView.jsx"}, ws
+        )
+        assert outcome.status == "skipped"
+        assert outcome.reason == "no_frontend_tree"
+
+    async def test_missing_npm_skips_as_tooling(self, tmp_path, monkeypatch):
+        # #462: never fail correct code on tooling the evaluator lacks.
+        from squadops.cycles import acceptance_checks as ac
+
+        ws = self._workspace(tmp_path)
+        monkeypatch.setattr(ac.shutil, "which", lambda _: None)
+        outcome = await get_check("frontend_compiles").evaluate(
+            {"file": "frontend/src/views/RunsListView.jsx"}, ws
+        )
+        assert outcome.status == "skipped"
+        assert outcome.reason == "missing_tooling"
+
+    async def test_missing_view_file_fails(self, tmp_path):
+        ws = self._workspace(tmp_path)
+        outcome = await get_check("frontend_compiles").evaluate(
+            {"file": "frontend/src/views/Nope.jsx"}, ws
+        )
+        assert outcome.status == "failed"
+        assert outcome.reason == "file_not_found"
+
+    async def test_build_failure_fails_with_stderr_evidence(self, tmp_path, monkeypatch):
+        # The fay-8 shape: install fine, bundler rejects an undefined
+        # identifier — the stderr tail is the repair-relevant evidence.
+        from squadops.cycles import acceptance_checks as ac
+        from squadops.cycles.acceptance_checks import FrontendCompilesCheck
+
+        monkeypatch.setattr(ac.shutil, "which", lambda _: "/usr/bin/npm")
+
+        ws = self._workspace(tmp_path)
+        (ws / "frontend" / "node_modules").mkdir()
+
+        async def _fake_run(argv, cwd, timeout_s):
+            assert argv == ["npm", "run", "build"]
+            return 1, "", "RollupError: 'runId' is not defined"
+
+        monkeypatch.setattr(FrontendCompilesCheck, "_run", staticmethod(_fake_run))
+        outcome = await get_check("frontend_compiles").evaluate(
+            {"file": "frontend/src/views/RunsListView.jsx"}, ws
+        )
+        assert outcome.status == "failed"
+        assert outcome.reason == "frontend_build_failed"
+        assert "RollupError" in outcome.actual["stderr_tail"]
+
+    async def test_clean_build_passes_and_installs_when_needed(self, tmp_path, monkeypatch):
+        from squadops.cycles import acceptance_checks as ac
+        from squadops.cycles.acceptance_checks import FrontendCompilesCheck
+
+        monkeypatch.setattr(ac.shutil, "which", lambda _: "/usr/bin/npm")
+
+        ws = self._workspace(tmp_path)  # no node_modules -> install expected first
+        calls: list[list[str]] = []
+
+        async def _fake_run(argv, cwd, timeout_s):
+            calls.append(argv)
+            return 0, "", ""
+
+        monkeypatch.setattr(FrontendCompilesCheck, "_run", staticmethod(_fake_run))
+        outcome = await get_check("frontend_compiles").evaluate(
+            {"file": "frontend/src/views/RunsListView.jsx"}, ws
+        )
+        assert outcome.status == "passed"
+        assert calls == [["npm", "install", "--no-audit", "--no-fund"], ["npm", "run", "build"]]
+
+    async def test_install_failure_skips_not_fails(self, tmp_path, monkeypatch):
+        # package.json is scaffold-frozen: a failing install is a
+        # network/registry gap, never an artifact defect.
+        from squadops.cycles import acceptance_checks as ac
+        from squadops.cycles.acceptance_checks import FrontendCompilesCheck
+
+        monkeypatch.setattr(ac.shutil, "which", lambda _: "/usr/bin/npm")
+
+        ws = self._workspace(tmp_path)
+
+        async def _fake_run(argv, cwd, timeout_s):
+            return 1, "", "npm ERR! network ETIMEDOUT"
+
+        monkeypatch.setattr(FrontendCompilesCheck, "_run", staticmethod(_fake_run))
+        outcome = await get_check("frontend_compiles").evaluate(
+            {"file": "frontend/src/views/RunsListView.jsx"}, ws
+        )
+        assert outcome.status == "skipped"
+        assert outcome.reason == "install_failed"

--- a/tests/unit/cycles/test_verification_contract_runner.py
+++ b/tests/unit/cycles/test_verification_contract_runner.py
@@ -53,9 +53,26 @@ def _contract() -> VerificationContract:
     return VerificationContract.from_dict(emit_contract_dict(manifest))
 
 
+def _env_gap(criterion: dict, outcome) -> bool:
+    """#648/#462: a node-requiring criterion legitimately skips in an
+    environment without npm (this unit env / some CI). The real pass is
+    proven by the contract gate in the QA image (14/14 both modes)."""
+    return (
+        criterion.get("requires") == "node"
+        and outcome.status == "skipped"
+        and shutil.which("npm") is None
+    )
+
+
 def test_structural_criteria_selects_only_evaluator_backed_checks():
     checks = {c["check"] for c, _ in structural_criteria(_contract())}
-    assert checks == {"endpoint_defined", "import_present", "command_exit_zero", "module_imports"}
+    assert checks == {
+        "endpoint_defined",
+        "import_present",
+        "command_exit_zero",
+        "module_imports",
+        "frontend_compiles",
+    }
     # behavioral checks are the gate's subprocess job, never structural
     assert "tests_pass" not in checks
     assert "frontend_build" not in checks
@@ -76,6 +93,8 @@ def test_every_structural_criterion_passes_on_bare_skeleton(tmp_path):
     contract = _contract()
     for criterion, fill_file in structural_criteria(contract):
         outcome = evaluate_structural(criterion, tmp_path, fill_file=fill_file)
+        if _env_gap(criterion, outcome):
+            continue  # #462: node-requiring checks skip where npm is absent
         assert outcome.status == "passed", (
             f"{criterion['id']} -> {outcome.status} ({outcome.reason})"
         )
@@ -90,6 +109,8 @@ def test_structural_criteria_still_pass_with_reference_fill(tmp_path):
             shutil.copy2(src, out)
     for criterion, fill_file in structural_criteria(_contract()):
         outcome = evaluate_structural(criterion, tmp_path, fill_file=fill_file)
+        if _env_gap(criterion, outcome):
+            continue  # #462: node-requiring checks skip where npm is absent
         assert outcome.status == "passed"
 
 


### PR DESCRIPTION
Final item of the next-window fix package. **Moves the contract hash again — the next-window seed picks up #651 + #648 together (14 criteria).**

**The check**: `frontend_compiles` runs `npm install` (cache-warm: ~0.9s; cold: ~6s, measured in the agent image) + `npm run build` against the acceptance workspace's frontend tree (#643 makes the tree available at task time), anchored to the view under evaluation. Environment gaps skip per #462 — npm absent, no frontend tree, install failure (package.json is frozen, so install failures are network gaps). Build failure fails with the rollup stderr tail as evidence.

**Wiring that makes it land where it matters**:
- Contract emission gives each view `vc-view-compiles-*` → **#641 auto-binds it onto the view's own task**, and **#650 routes its failures at frontend source** — the three fixes compose.
- Dev image gains node via the **designed #306 data seam** (`agents/instances/dev/system-packages.txt`) — no Dockerfile edit.

**Proof**:
- Gate in the QA image: bare-skeleton GREEN **14/14** (stub views compile by design — implementation-class semantics like `vc-routes-compiles`); reference-fill GREEN **14/14**.
- **Deterministic replay**: fay-8's actual delivered tree fails the check with the exact rollup bind error that killed the roll — meaning the defect now surfaces at the view task itself, with correction budget available and correctly-scoped repairs.

6 evaluator tests (skip semantics, stderr evidence, install-when-needed) + emission/vocabulary updates. Structural-runner tests env-gate node-requiring criteria per #462 where npm is absent. Full regression 5863 passed.

Closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q