### PR TITLE
fix(planning): thread brief + upstream docs + peer proposal into planning-chain prompts (#657)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -969,6 +969,48 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         "by_type_fallback": ["document"],
     }
 
+    # #657: planning-chain context threading (the RC-22 pre-resolution the
+    # proposer handlers were written against). The executor's role-keyed
+    # ``prior_outputs`` strips artifact content, so the brief author and the
+    # plan-task proposers rendered "(brief not yet provided)" and PRD-prefix
+    # stubs while their templates instructed them to operate on the brief and
+    # gap-catch against Development's proposal. Contents resolve into an
+    # ENVELOPE-LOCAL ``prior_outputs["artifact_contents"]`` copy — never the
+    # loop-level dict, which is checkpointed per task (RC-4) and must stay lean.
+    # The merger is deliberately absent: it consumes ``brief_outcome`` /
+    # ``proposal_outcome`` output keys, and by merge time the two proposals
+    # collide on the ``proposed_plan_tasks.yaml`` filename.
+    _PLANNING_ARTIFACT_FILTER: dict[str, dict[str, list[str]]] = {
+        "governance.prepare_plan_authoring_brief": {
+            "by_producing_task": [
+                "data.research_context",
+                "strategy.frame_objective",
+                "development.design_plan",
+                "qa.define_test_strategy",
+            ],
+        },
+        "development.propose_plan_tasks": {
+            "by_producing_task": [
+                "governance.prepare_plan_authoring_brief",
+                "development.design_plan",
+            ],
+        },
+        "qa.propose_plan_tasks": {
+            "by_producing_task": [
+                "governance.prepare_plan_authoring_brief",
+                "development.design_plan",
+                "qa.define_test_strategy",
+                "development.propose_plan_tasks",
+            ],
+        },
+        "strategy.propose_plan_guidance": {
+            "by_producing_task": [
+                "governance.prepare_plan_authoring_brief",
+                "strategy.frame_objective",
+            ],
+        },
+    }
+
     # Maps build task_type → which prior artifacts to inject.
     # by_producing_task: match on producing_task_type metadata
     # by_type / by_type_fallback: match on artifact_type for artifacts without provenance
@@ -1003,7 +1045,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         include_repair_candidates: bool = True,
         filter_spec: dict[str, list[str]] | None = None,
     ) -> dict[str, str]:
-        """Pre-resolve artifact content for build tasks (D3).
+        """Pre-resolve artifact content for build tasks (D3) and planning context (#657).
 
         Args:
             task_type: The build task type being dispatched.
@@ -1728,6 +1770,23 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             surface_lines = model_surface_instructions(interface_manifest)
             if surface_lines:
                 extra_inputs["model_surface"] = surface_lines
+
+        # #657: planning-chain tasks get the upstream framing documents the
+        # RC-22 contract promised them, on an envelope-local prior_outputs
+        # copy (checkpoints keep the lean role-keyed dict). Filename keys
+        # last-win in storage order, so a proposer retry's failure artifact
+        # cannot shadow a successful peer document.
+        if envelope.task_type in self._PLANNING_ARTIFACT_FILTER:
+            planning_contents = await self._resolve_artifact_contents(
+                envelope.task_type,
+                stored_artifacts,
+                filter_spec=self._PLANNING_ARTIFACT_FILTER[envelope.task_type],
+            )
+            if planning_contents:
+                extra_inputs["prior_outputs"] = {
+                    **prior_outputs,
+                    "artifact_contents": planning_contents,
+                }
 
         # Pre-resolve artifact contents for build tasks (D3). Fresh dispatches
         # see the ACCEPTED state only (pf-31 Fix E): rejected repair candidates

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -112,11 +112,24 @@ class _CycleTaskHandler(CapabilityHandler):
 
     @staticmethod
     def _format_prior_outputs(prior_outputs: dict[str, Any] | None) -> str:
-        """Format prior outputs dict as a prompt section string for template injection."""
+        """Format prior outputs dict as a prompt section string for template injection.
+
+        #657: ``artifact_contents`` (executor-threaded upstream documents, RC-22)
+        renders as full named sections; role entries render their ``summary``
+        field — the raw outputs dict carries provenance hashes and wire keys
+        that are noise as prompt context.
+        """
         if not prior_outputs:
             return ""
         parts = ["\n\n## Prior Analysis from Upstream Roles\n"]
-        for role, summary in prior_outputs.items():
+        contents = prior_outputs.get("artifact_contents")
+        if isinstance(contents, dict):
+            for name, content in contents.items():
+                parts.append(f"### {name}\n{content}\n")
+        for role, value in prior_outputs.items():
+            if role == "artifact_contents":
+                continue
+            summary = value.get("summary", "") if isinstance(value, dict) else value
             parts.append(f"### {role}\n{summary}\n")
         return "\n".join(parts)
 

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -44,6 +44,17 @@ _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 _VALID_READINESS = {"go", "revise", "no-go"}
 
 
+def _content_summary(content: str, limit: int = 240) -> str:
+    """First ``limit`` chars of the produced document, whitespace-collapsed.
+
+    #657: the chained ``summary`` is the only cross-task context the executor
+    keeps once artifacts are stripped — a PRD-prefix summary said nothing
+    about the document this task actually produced.
+    """
+    collapsed = " ".join(content.split())
+    return collapsed[:limit]
+
+
 # ---------------------------------------------------------------------------
 # Time budget awareness helpers (SIP-0082)
 # ---------------------------------------------------------------------------
@@ -138,10 +149,9 @@ class _PlanningTaskHandler(_CycleTaskHandler):
         budget_section = _build_time_budget_section(time_budget_seconds)
         if budget_section:
             parts.append(budget_section)
-        if prior_outputs:
-            parts.append("\n\n## Prior Analysis from Upstream Roles\n")
-            for role, summary in prior_outputs.items():
-                parts.append(f"### {role}\n{summary}\n")
+        formatted = self._format_prior_outputs(prior_outputs)
+        if formatted:
+            parts.append(formatted)
         parts.append(f"\nPlease provide your {self._role} analysis and deliverables.")
         return "\n".join(parts)
 
@@ -248,7 +258,7 @@ class _PlanningTaskHandler(_CycleTaskHandler):
             )
             llm_obs.record_generation(context.correlation_context, gen_record, layers)
 
-        prd_summary = str(prd)[:80] if prd else "(no PRD)"
+        doc_summary = _content_summary(content) or "(empty document)"
 
         # SIP-0084 §10: build prompt provenance for artifact traceability
         provenance: dict[str, Any] = {
@@ -261,7 +271,7 @@ class _PlanningTaskHandler(_CycleTaskHandler):
             provenance["prompt_environment"] = "production"
 
         outputs = {
-            "summary": f"[{self._role}] {prd_summary}",
+            "summary": f"[{self._role}] {doc_summary}",
             "role": self._role,
             "artifacts": [
                 {

--- a/tests/unit/capabilities/test_planning_handlers.py
+++ b/tests/unit/capabilities/test_planning_handlers.py
@@ -1395,3 +1395,38 @@ class TestTimeBudgetAwareness:
         user_msg = call_args[0][0][1].content
         assert "Time Budget" in user_msg
         assert "30 minutes" in user_msg
+
+
+# ---------------------------------------------------------------------------
+# #657: chained summary derives from the produced document, not the PRD
+# ---------------------------------------------------------------------------
+
+
+class TestChainedSummaryContent:
+    """Bug caught: outputs["summary"] was ``[role] <first 80 chars of PRD>``,
+    so the executor's role-keyed chain context said nothing about the document
+    each framing task produced — every downstream prompt saw identical stubs."""
+
+    async def test_summary_derives_from_produced_content(self):
+        ctx = _make_context(llm_response="# Technical Design\nThe API exposes five run endpoints.")
+        h = DevelopmentDesignPlanHandler()
+        result = await h.handle(ctx, {"prd": "Build a run tracker for local groups"})
+
+        summary = result.outputs["summary"]
+        assert summary.startswith("[dev] ")
+        assert "Technical Design" in summary
+        assert "Build a run tracker" not in summary
+
+    async def test_summary_collapses_whitespace_and_truncates(self):
+        from squadops.capabilities.handlers.planning_tasks import _content_summary
+
+        collapsed = _content_summary("a\n\n  b\tc", limit=240)
+        assert collapsed == "a b c"
+        assert len(_content_summary("word " * 100, limit=240)) == 240
+
+    async def test_empty_document_summary_placeholder(self):
+        ctx = _make_context(llm_response="")
+        h = DevelopmentDesignPlanHandler()
+        result = await h.handle(ctx, {"prd": "Build a widget"})
+
+        assert result.outputs["summary"] == "[dev] (empty document)"

--- a/tests/unit/capabilities/test_propose_plan_tasks.py
+++ b/tests/unit/capabilities/test_propose_plan_tasks.py
@@ -265,6 +265,27 @@ async def test_qa_proposer_emits_parseable_proposal():
     assert parsed.tasks[0].depends_on_focus == ["dev:user crud routes"]
 
 
+async def test_qa_proposer_renders_dev_proposal_in_planning_content():
+    """Bug caught (#657): the qa template instructs gap-catching against
+    Development's proposal; if the threaded document stops reaching
+    planning_content, qa re-proposes coverage for files dev already owns."""
+    ctx = _make_context(_QA_PROPOSAL_RESPONSE)
+    handler = QaProposePlanTasksHandler()
+    dev_proposal = "proposing_role: development\ntasks:\n  - focus: user crud routes\n"
+    inputs = _seeded_inputs()
+    inputs["prior_outputs"]["artifact_contents"]["proposed_plan_tasks.yaml"] = dev_proposal
+    inputs["prior_outputs"]["artifact_contents"]["technical_design.md"] = "## Design\nRouters."
+
+    await handler.handle(ctx, inputs)
+
+    variables = ctx.ports.request_renderer.render.call_args.args[1]
+    assert "### proposed_plan_tasks.yaml" in variables["planning_content"]
+    assert "focus: user crud routes" in variables["planning_content"]
+    assert "### technical_design.md" in variables["planning_content"]
+    # the brief renders in its own dedicated section, not duplicated here
+    assert "brief-test-001" not in variables["planning_content"]
+
+
 async def test_strategy_proposer_emits_parseable_guidance():
     ctx = _make_context(_STRATEGY_GUIDANCE_RESPONSE)
     handler = StrategyProposePlanGuidanceHandler()

--- a/tests/unit/cycles/test_executor_build_wiring.py
+++ b/tests/unit/cycles/test_executor_build_wiring.py
@@ -975,3 +975,176 @@ class TestRepairTaskTypesDerivation:
         }
         assert table_types <= REPAIR_TASK_TYPES
         assert "development.develop" not in REPAIR_TASK_TYPES
+
+
+# ---------------------------------------------------------------------------
+# #657: planning-chain context threading (RC-22 pre-resolution)
+# ---------------------------------------------------------------------------
+
+
+class TestPlanningContextThreading:
+    """The brief author and plan-task proposers receive upstream documents.
+
+    Bug caught: the executor drops planning artifact content when chaining
+    ``prior_outputs`` (role-keyed summaries only), so the qa proposer is
+    instructed to gap-catch against Development's proposal while rendering
+    "(brief not yet provided)" and PRD-prefix stubs — the #657 blindness that
+    produced the fill-slot-claiming qa tasks across FAY windows 1–2.
+    """
+
+    @staticmethod
+    def _envelope(task_type: str, agent_id: str = "eve"):
+        from squadops.tasks.models import TaskEnvelope
+
+        return TaskEnvelope(
+            task_id="t1",
+            agent_id=agent_id,
+            cycle_id="cyc_001",
+            pulse_id="p1",
+            project_id="proj_001",
+            task_type=task_type,
+            correlation_id="c",
+            causation_id="ca",
+            trace_id="tr",
+            span_id="s",
+        )
+
+    @staticmethod
+    def _planning_stored():
+        refs = [
+            _make_artifact_ref(
+                "art_ctx",
+                "context_research.md",
+                producing_task_type="data.research_context",
+            ),
+            _make_artifact_ref(
+                "art_objective",
+                "objective_frame.md",
+                producing_task_type="strategy.frame_objective",
+            ),
+            _make_artifact_ref(
+                "art_design",
+                "technical_design.md",
+                producing_task_type="development.design_plan",
+            ),
+            _make_artifact_ref(
+                "art_strategy",
+                "test_strategy.md",
+                producing_task_type="qa.define_test_strategy",
+            ),
+            _make_artifact_ref(
+                "art_brief",
+                "plan_authoring_brief.yaml",
+                producing_task_type="governance.prepare_plan_authoring_brief",
+            ),
+            _make_artifact_ref(
+                "art_dev_prop",
+                "proposed_plan_tasks.yaml",
+                producing_task_type="development.propose_plan_tasks",
+            ),
+        ]
+        return [(r.artifact_id, r) for r in refs]
+
+    @staticmethod
+    def _wire_vault(executor, stored):
+        by_id = {art_id: (ref, f"body of {ref.filename}".encode()) for art_id, ref in stored}
+
+        async def retrieve(art_id):
+            return by_id[art_id]
+
+        executor._artifact_vault.retrieve = AsyncMock(side_effect=retrieve)
+
+    async def test_qa_proposer_receives_upstream_documents(self, executor):
+        """Brief + design + test strategy + dev proposal reach the qa proposer;
+        out-of-map documents (context research) stay excluded."""
+        stored = self._planning_stored()
+        self._wire_vault(executor, stored)
+
+        enriched = await executor._enrich_envelope(
+            self._envelope("qa.propose_plan_tasks"),
+            {"dev": {"summary": "[dev] designed"}},
+            [],
+            stored,
+        )
+
+        contents = enriched.inputs["prior_outputs"]["artifact_contents"]
+        assert set(contents) == {
+            "plan_authoring_brief.yaml",
+            "technical_design.md",
+            "test_strategy.md",
+            "proposed_plan_tasks.yaml",
+        }
+        assert contents["plan_authoring_brief.yaml"] == "body of plan_authoring_brief.yaml"
+        assert contents["proposed_plan_tasks.yaml"] == "body of proposed_plan_tasks.yaml"
+        # role-keyed chain context is preserved alongside
+        assert enriched.inputs["prior_outputs"]["dev"] == {"summary": "[dev] designed"}
+
+    async def test_loop_prior_outputs_dict_not_mutated(self, executor):
+        """The threaded contents live on an envelope-local copy — the loop-level
+        dict is checkpointed per task (RC-4) and must stay lean."""
+        stored = self._planning_stored()
+        self._wire_vault(executor, stored)
+        loop_dict = {"dev": {"summary": "[dev] designed"}}
+
+        await executor._enrich_envelope(
+            self._envelope("qa.propose_plan_tasks"),
+            loop_dict,
+            [],
+            stored,
+        )
+
+        assert "artifact_contents" not in loop_dict
+
+    async def test_brief_author_receives_all_four_framing_documents(self, executor):
+        """The brief distills must_cover_requirements from the framing docs —
+        authored blind, it pins requirements no one researched."""
+        stored = self._planning_stored()
+        self._wire_vault(executor, stored)
+
+        enriched = await executor._enrich_envelope(
+            self._envelope("governance.prepare_plan_authoring_brief", agent_id="max"),
+            {},
+            [],
+            stored,
+        )
+
+        contents = enriched.inputs["prior_outputs"]["artifact_contents"]
+        assert set(contents) == {
+            "context_research.md",
+            "objective_frame.md",
+            "technical_design.md",
+            "test_strategy.md",
+        }
+        assert "proposed_plan_tasks.yaml" not in contents
+        assert "plan_authoring_brief.yaml" not in contents
+
+    async def test_merger_gets_no_artifact_contents(self, executor):
+        """The merger consumes brief_outcome/proposal_outcome output keys; by
+        merge time both proposals collide on the proposed_plan_tasks.yaml
+        filename, so threading there would silently drop one proposal."""
+        stored = self._planning_stored()
+        self._wire_vault(executor, stored)
+
+        enriched = await executor._enrich_envelope(
+            self._envelope("governance.merge_plan", agent_id="max"),
+            {"lead": {"brief_outcome": {"yaml_content": "brief_id: b1"}}},
+            [],
+            stored,
+        )
+
+        assert "artifact_contents" not in enriched.inputs["prior_outputs"]
+
+    async def test_build_task_prior_outputs_untouched(self, executor):
+        """D3's top-level artifact_contents channel for build tasks is a
+        different transport — the planning branch must not leak into it."""
+        stored = self._planning_stored()
+        self._wire_vault(executor, stored)
+
+        enriched = await executor._enrich_envelope(
+            self._envelope("development.develop", agent_id="neo"),
+            {"strat": {"summary": "[strat] framed"}},
+            [],
+            stored,
+        )
+
+        assert "artifact_contents" not in enriched.inputs["prior_outputs"]

--- a/tests/unit/prompts/test_handler_renderer_parity.py
+++ b/tests/unit/prompts/test_handler_renderer_parity.py
@@ -445,6 +445,35 @@ class TestFormatPriorOutputs:
         assert "### qa" in result
         assert "### strat" in result
 
+    def test_dict_values_render_summary_not_dict_repr(self):
+        """Bug caught (#657): chained outputs are dicts, so the prompt showed
+        raw dict reprs full of provenance hashes instead of the summary."""
+        result = _CycleTaskHandler._format_prior_outputs(
+            {
+                "dev": {
+                    "summary": "[dev] Designed the run API",
+                    "prompt_provenance": {"system_prompt_bundle_hash": "deadbeef"},
+                }
+            }
+        )
+        assert "[dev] Designed the run API" in result
+        assert "deadbeef" not in result
+        assert "prompt_provenance" not in result
+
+    def test_artifact_contents_render_as_named_sections(self):
+        """Bug caught (#657): executor-threaded upstream documents (RC-22) must
+        surface as full named sections, not leak as a dict under a role header."""
+        result = _CycleTaskHandler._format_prior_outputs(
+            {
+                "artifact_contents": {"technical_design.md": "The API uses routers."},
+                "dev": {"summary": "[dev] designed"},
+            }
+        )
+        assert "### technical_design.md" in result
+        assert "The API uses routers." in result
+        assert "### artifact_contents" not in result
+        assert "### dev" in result
+
 
 # ---------------------------------------------------------------------------
 # Phase 5: Prompt provenance recording


### PR DESCRIPTION
## Summary

Implements the RC-22 pre-resolution the planning handlers were written against but the dispatched executor never delivered (#657). The brief author and the three plan-task proposers now receive the upstream documents their templates already instruct them to use.

**Executor** (`adapters/cycles/dispatched_flow_executor.py`)
- New `_PLANNING_ARTIFACT_FILTER`: per-task-type map of which upstream framing documents resolve into `prior_outputs["artifact_contents"]` — brief author gets the four framing docs; dev proposer gets brief + technical design; qa proposer gets brief + technical design + test strategy + **Development's proposal** (the gap-catching input); strategy proposer gets brief + objective frame.
- Contents ride an **envelope-local copy** of `prior_outputs` — the loop-level dict is checkpointed per task (RC-4) and stays lean.
- The merger is deliberately excluded: it consumes `brief_outcome`/`proposal_outcome` output keys, and by merge time both proposals collide on the `proposed_plan_tasks.yaml` filename.

**Handlers**
- `_format_prior_outputs` renders threaded documents as named sections and extracts `summary` from dict-valued role entries (previously the prompt got raw dict reprs with provenance hashes).
- Planning-task chained `summary` now derives from the produced document; it was `[role] <first 80 chars of the PRD>` — identical stubs for every task.
- No proposer code changes needed: `brief_content`, `source_brief_id`, and `planning_content` light up through the existing read paths, and the dormant proposer-side `source_brief_id` retry enforcement self-activates (`expected_brief_id` was always `None` before).

## Receipts

- Live: fay-13 framing proposals shipped `source_brief_id: "unknown"` against actual `brief-cycle-grouprun-001`; qa proposer prompts rendered "(brief not yet provided — direct-invocation context)".
- Loss-mode mapping: the fill-slot-claiming qa "compilation" tasks (fay-2, fay-10 ×3, fay-11, fay-13 framings) are the blind gap-catcher proposing coverage for criteria it cannot see are already bound to dev tasks.

## Tests

- 5 executor threading tests (qa proposer doc set, brief author doc set, loop-dict non-mutation, merger exclusion, build-channel isolation)
- 2 formatter tests (summary extraction vs dict repr; artifact sections)
- 3 summary tests (content-derived, whitespace/truncation, empty-document placeholder)
- 1 seam test: dev proposal + technical design render into the qa proposer's `planning_content`
- Full regression: **5874 passed, 1 skipped**

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
