### PR TITLE
fix(plan-validation): frozen files rejected as expected_artifacts for every role (#658)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2758,6 +2758,10 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         f"verification_contract: {e}"
                         for e in parsed_plan.validate_qa_artifact_ownership(contract)
                     )
+                    errors.extend(
+                        f"verification_contract: {e}"
+                        for e in parsed_plan.validate_frozen_artifact_ownership(contract)
+                    )
                     # pf-42: a typed check aimed at a frozen file is decidable right
                     # now — the skeleton those files will contain is deterministic.
                     # A failing one makes the plan unwinnable (frozen emissions are

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -640,6 +640,40 @@ class ImplementationPlan:
             if artifact in owned
         ]
 
+    def validate_frozen_artifact_ownership(self, contract: VerificationContract) -> list[str]:
+        """#658: no task, any role, may declare a frozen-surface file as an
+        ``expected_artifact``.
+
+        Frozen files are scaffold-owned: scaffold enforcement restores their
+        bytes at emission, so a task claiming one can never satisfy its own
+        expected artifacts through an accepted write, and a repair scoped to
+        it aims at files that were never the defect. The qa.test rule above
+        already covers this for qa tasks (alongside fill slots); this rule
+        closes the asymmetry for every other role — fay-12 shipped a
+        ``development.develop`` task claiming the frozen ``frontend/src/api.js``
+        with prose-only criteria, which slipped between the qa net and the
+        typed-criteria frozen-file rule.
+
+        Fill slots are deliberately NOT checked here: they are dev-owned
+        deliverables, and dev tasks claim them by design.
+
+        Returns:
+            List of validation error strings (empty = valid).
+        """
+        frozen = {ff.path for ff in contract.frozen_files}
+
+        return [
+            f"Task {task.task_index} ({task.focus}): {task.task_type} declares expected "
+            f"artifact {artifact!r}, which is frozen (scaffold-owned) — no task may claim "
+            f"a frozen file as a deliverable; scaffold enforcement restores frozen bytes "
+            f"at emission, so the task cannot satisfy its expected artifacts and a repair "
+            f"scoped to it would target the wrong files"
+            for task in self.tasks
+            if task.task_type != "qa.test"
+            for artifact in task.expected_artifacts
+            if artifact in frozen
+        ]
+
     def _authored_on_covered_criteria(self, contract: VerificationContract):
         """Yield ``(task, criterion, target)`` for every authored ``TypedCheck``
         whose target file is contract-covered (§6.3 rule 3) — shared by the fatal

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -830,6 +830,15 @@ def _replace_build_steps_with_plan(
             raise CycleError(
                 "Plan validation failed (qa artifact ownership): " + "; ".join(ownership_errors)
             )
+        # #658: the same referent for every other role — frozen files are
+        # claimable by nobody (fay-12's dev task on the frozen api.js slipped
+        # between the qa net and the typed-criteria frozen rule).
+        frozen_ownership_errors = plan.validate_frozen_artifact_ownership(contract)
+        if frozen_ownership_errors:
+            raise CycleError(
+                "Plan validation failed (frozen artifact ownership): "
+                + "; ".join(frozen_ownership_errors)
+            )
         # pf-31 Fix A3: warning-only prose-vs-contract conflict lint, surfaced for
         # the gate reviewer (never a rejection — reverted-#552 lesson).
         for warning in plan.lint_prose_contract_conflicts(contract):

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -875,6 +875,60 @@ class TestQaArtifactOwnership:
         )
 
 
+class TestFrozenArtifactOwnership:
+    """#658: frozen files are claimable by nobody, regardless of role.
+
+    fay-12's approved plan carried a ``development.develop`` task with
+    ``expected_artifacts: [frontend/src/api.js]`` and prose-only criteria — it
+    slipped between the qa.test ownership rule and the typed-criteria frozen
+    rule. Scaffold enforcement restores frozen bytes at emission, so such a
+    task can never satisfy its declared outputs through an accepted write.
+    """
+
+    _contract = staticmethod(TestQaArtifactOwnership._contract)
+    _plan_with = staticmethod(TestQaArtifactOwnership._plan_with)
+
+    def test_rejects_dev_task_declaring_a_frozen_file(self):
+        """The exact fay-12 shape: dev claiming the frozen api client."""
+        errors = self._plan_with(
+            "development.develop", "frontend/src/api.js"
+        ).validate_frozen_artifact_ownership(self._contract())
+
+        assert len(errors) == 1
+        assert "frontend/src/api.js" in errors[0]
+        assert "frozen (scaffold-owned)" in errors[0]
+        assert "development.develop" in errors[0]
+
+    def test_rejects_builder_task_declaring_a_frozen_file(self):
+        """Any role: the rule keys on the frozen surface, not the task type."""
+        errors = self._plan_with(
+            "builder.assemble", "backend/main.py"
+        ).validate_frozen_artifact_ownership(self._contract())
+
+        assert len(errors) == 1
+        assert "backend/main.py" in errors[0]
+
+    def test_dev_task_fill_slot_is_not_rejected(self):
+        """Fill slots are dev-owned deliverables — claiming them is bind mode
+        working as designed; rejecting them would break every plan."""
+        assert (
+            self._plan_with(
+                "development.develop", "backend/routes.py"
+            ).validate_frozen_artifact_ownership(self._contract())
+            == []
+        )
+
+    def test_qa_task_is_not_double_reported(self):
+        """qa.test frozen claims are the qa ownership rule's report — one
+        defect must not produce two rejection lines."""
+        assert (
+            self._plan_with("qa.test", "backend/main.py").validate_frozen_artifact_ownership(
+                self._contract()
+            )
+            == []
+        )
+
+
 # ---------------------------------------------------------------------------
 # #645: command-check executability + expected-artifact shape (FAY window)
 # ---------------------------------------------------------------------------

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -686,6 +686,30 @@ class TestGenerateTaskPlanBindMode:
         envelopes = generate_task_plan(_make_cycle(), _make_run(), _make_profile(), plan=plan)
         assert len(envelopes) == 9
 
+    def test_dev_task_claiming_frozen_file_raises_at_dispatch(self):
+        """#658 backstop: fay-12's shape — a development.develop task declaring a
+        frozen file as its expected artifact must never reach dispatch."""
+        import dataclasses
+
+        from squadops.cycles.models import CycleError
+        from squadops.cycles.verification_contract import FrozenFile
+
+        contract = _models_contract()
+        contract = dataclasses.replace(
+            contract, frozen_files=(FrozenFile(path="frontend/src/api.js", sha256="b" * 64),)
+        )
+        plan = ImplementationPlan.from_yaml(
+            _BIND_MANIFEST_YAML.replace(
+                'expected_artifacts: ["backend/models.py"]',
+                'expected_artifacts: ["backend/models.py", "frontend/src/api.js"]',
+                1,
+            )
+        )
+        with pytest.raises(CycleError, match="frozen artifact ownership"):
+            generate_task_plan(
+                _make_cycle(), _make_run(), _make_profile(), plan=plan, contract=contract
+            )
+
     def test_dispatch_resolves_refs_into_acceptance_criteria(self):
         # 98.3 slice C: the bound ref materializes into the dispatched envelope's
         # acceptance_criteria as a TypedCheck stamped with the contract id + file.


### PR DESCRIPTION
## Summary

Closes the validator asymmetry found at fay-12's gate review: `qa.test` tasks claiming frozen files are rejected at plan time, but a `development.develop` task declaring the frozen `frontend/src/api.js` with prose-only criteria passed validation (the older frozen-file rule keys on typed criteria only). Frozen files are claimable by **nobody** — scaffold enforcement restores their bytes at emission, so a task claiming one can never satisfy its own `expected_artifacts`, and repairs scoped to it aim at files that were never the defect.

- New `ImplementationPlan.validate_frozen_artifact_ownership(contract)`: any non-`qa.test` task declaring a contract-frozen file in `expected_artifacts` is a validation error. `qa.test` keeps its existing combined rule (no double reporting); fill slots are deliberately not checked (dev-owned deliverables, claimed by design).
- Wired at both existing nets: the gate-time graceful rejection (`_reject_invalid_plan_before_workload_gate`) and the dispatch-time `CycleError` backstop in `generate_task_plan`, directly alongside `validate_qa_artifact_ownership`.

## Tests

- 4 rule tests (fay-12 dev shape rejected, builder shape rejected, fill-slot claim accepted, qa.test not double-reported)
- 1 dispatch-net wiring test (dev-claims-frozen raises `CycleError` before dispatch)
- Full regression: **5868 passed, 1 skipped**

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
