### PR TITLE
feat(scaffold): DOM testid contract — manifest-pinned anchors into both dev and qa prompts (#659)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1715,6 +1715,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             from squadops.capabilities.scaffold import (
                 error_seam_instructions,
                 model_surface_instructions,
+                testid_surface_instructions,
             )
 
             error_lines = error_seam_instructions(interface_manifest)
@@ -1728,6 +1729,12 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             surface_lines = model_surface_instructions(interface_manifest)
             if surface_lines:
                 extra_inputs["model_surface"] = surface_lines
+            # #659: the DOM anchor inventory, same transport — dev is told the
+            # manifest-pinned testids to attach/preserve so the qa suite (which
+            # receives the same inventory) has a stable surface to query.
+            testid_lines = testid_surface_instructions(interface_manifest)
+            if testid_lines:
+                extra_inputs["testid_surface"] = testid_lines
 
         # Pre-resolve artifact contents for build tasks (D3). Fresh dispatches
         # see the ACCEPTED state only (pf-31 Fix E): rejected repair candidates

--- a/examples/03_group_run/interface_manifest.yaml
+++ b/examples/03_group_run/interface_manifest.yaml
@@ -78,9 +78,23 @@ frontend:
   language: javascript  # §9: no TypeScript requirement this cycle
   api_client: fetch     # §7: prefer simple fetch over heavier abstractions
   routes:
-    - { path: "/",          view: RunsListView,  purpose: "upcoming runs list + participant counts + CTA to create" }  # §7.1, §5.2
-    - { path: "/create",    view: CreateRunView, purpose: "create form, required-field validation, submit" }          # §7.2, §5.1
-    - { path: "/runs/:id",  view: RunDetailView, purpose: "event details, participant list, join form, leave action, not-found state" }  # §7.3, §5.3–5.5
+    # testids = the view's DOM anchor contract (#659): first entry is the root
+    # container (stamped on the scaffold stub); dev attaches the rest while
+    # filling; qa queries ONLY these. Names are behavioral roles, not layout.
+    - path: "/"
+      view: RunsListView
+      purpose: "upcoming runs list + participant counts + CTA to create"  # §7.1, §5.2
+      testids: [runs-list, run-item, run-participant-count, empty-state, create-run-link]
+    - path: "/create"
+      view: CreateRunView
+      purpose: "create form, required-field validation, submit"  # §7.2, §5.1
+      testids: [create-run-view, create-run-form, field-title, field-datetime, field-location,
+                field-distance, field-pace-target, field-route-notes, submit-create, form-error]
+    - path: "/runs/:id"
+      view: RunDetailView
+      purpose: "event details, participant list, join form, leave action, not-found state"  # §7.3, §5.3–5.5
+      testids: [run-detail, participant-list, participant-item, join-form, join-name-input,
+                join-submit, leave-form, leave-name-input, leave-submit, action-error, not-found]
 
 persistence: in_memory  # §8: required for this cycle; no DB/migrations (§9)
 

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -761,8 +761,30 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         model_surface = await self._model_surface_section(renderer, inputs)
         if model_surface:
             variables["model_surface"] = model_surface
+        # #659: the DOM anchor contract, same transport — the qa suite receives
+        # the same inventory with a query-only-these instruction, so the two
+        # prompts finally share a DOM arbiter (fay-6/fay-12 churn class).
+        testid_surface = await self._testid_surface_section(renderer, inputs)
+        if testid_surface:
+            variables["testid_surface"] = testid_surface
         rendered = await renderer.render(
             "request.development_develop_fill_only_appendix", variables
+        )
+        return rendered.content
+
+    async def _testid_surface_section(self, renderer: Any, inputs: dict | None) -> str:
+        """Render the DOM ANCHOR CONTRACT block from executor-threaded lines, or "".
+
+        The lines are manifest-derived data (``scaffold.testid_surface_instructions``);
+        all prose lives in the appendix asset (CLAUDE.md #448).
+        """
+        lines = [str(line).strip() for line in ((inputs or {}).get("testid_surface") or [])]
+        lines = [line for line in lines if line]
+        if not lines:
+            return ""
+        rendered = await renderer.render(
+            "request.development_develop_testid_surface_appendix",
+            {"testid_lines": "\n".join(f"- {line}" for line in lines)},
         )
         return rendered.content
 

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -373,6 +373,30 @@ class QATestHandler(_CycleTaskHandler):
         )
         return rendered.content
 
+    async def _dom_anchor_section(self, context: ExecutionContext, inputs: dict[str, Any]) -> str:
+        """Render the DOM ANCHOR CONTRACT block from executor-threaded lines, or "".
+
+        #659 / fay-6, fay-12: frontend suites churned every correction round on
+        invented render details (roles, text, structure) because nothing
+        arbitrates the DOM the way the api_behavior_contract arbitrates
+        statuses. The lines are manifest-derived data
+        (``scaffold.testid_surface_instructions``) and the view author receives
+        the same inventory with an attach-and-preserve instruction; all prose
+        lives in the appendix asset (CLAUDE.md #448).
+        """
+        lines = [str(line).strip() for line in (inputs.get("dom_testid_surface") or [])]
+        lines = [line for line in lines if line]
+        if not lines:
+            return ""
+        renderer = getattr(context.ports, "request_renderer", None)
+        if renderer is None:
+            return ""
+        rendered = await renderer.render(
+            "request.qa_test_dom_anchor_appendix",
+            {"testid_lines": "\n".join(f"- {line}" for line in lines)},
+        )
+        return rendered.content
+
     def _build_focused_prompt(self, inputs: dict[str, Any]) -> str:
         """Build a focused prompt for manifest-driven QA subtasks (SIP-0086).
 
@@ -615,6 +639,9 @@ class QATestHandler(_CycleTaskHandler):
             behavior_section = await self._behavior_contract_section(context, inputs)
             if behavior_section:
                 user_prompt = f"{user_prompt}\n{behavior_section}"
+            dom_anchor_section = await self._dom_anchor_section(context, inputs)
+            if dom_anchor_section:
+                user_prompt = f"{user_prompt}\n{dom_anchor_section}"
             rendered = None
             sources = self._get_source_artifacts(inputs)
         else:

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -112,6 +112,10 @@ class Route:
     path: str
     view: str
     purpose: str = ""
+    # #659: the view's DOM anchor contract — scaffold-owned data-testid names
+    # both prompt sides receive (dev: attach/preserve; qa: query only these).
+    # First entry is the ROOT anchor, stamped on the expanded stub's container.
+    testids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -247,7 +251,12 @@ class InterfaceManifest:
                 "language": self.frontend.language,
                 "api_client": self.frontend.api_client,
                 "routes": [
-                    {"path": r.path, "view": r.view, "purpose": r.purpose}
+                    {
+                        "path": r.path,
+                        "view": r.view,
+                        "purpose": r.purpose,
+                        **({"testids": list(r.testids)} if r.testids else {}),
+                    }
                     for r in self.frontend.routes
                 ],
             },
@@ -364,6 +373,7 @@ def _parse_frontend(raw: dict[str, Any]) -> Frontend:
             path=str(r["path"]),
             view=str(r["view"]),
             purpose=str(r.get("purpose", "")),
+            testids=tuple(str(t) for t in r.get("testids", [])),
         )
         for r in raw.get("routes", [])
     )
@@ -536,6 +546,32 @@ def model_surface_instructions(manifest: InterfaceManifest | None) -> list[str]:
             "fails on isolation"
         )
     return lines
+
+
+def testid_surface_instructions(manifest: InterfaceManifest | None) -> list[str]:
+    """The manifest-pinned DOM anchor inventory, one line per view (#659).
+
+    Frontend suites never converge because nothing arbitrates the DOM: qa
+    asserts invented render details (roles, text, structure), dev patches the
+    view toward the last suite, and the re-dispatched suite re-rolls its
+    expectations — two models chasing a moving target (fay-6, fay-12: five
+    correction rounds, all on the frontend suite, backend green throughout).
+    The backend converges because the contract is injected into BOTH prompts;
+    these lines are that move applied to the DOM.
+
+    Data only, per the same transport as ``model_surface_instructions`` — the
+    dev-side "attach and preserve" and qa-side "query only these" prose lives
+    in the managed appendix assets (CLAUDE.md #448). Empty when no manifest or
+    no route declares testids — additive.
+    """
+    if manifest is None:
+        return []
+    return [
+        f"`{r.view}` (route `{r.path}`): root container `{r.testids[0]}`; "
+        f"anchors: {', '.join(f'`{t}`' for t in r.testids)}"
+        for r in manifest.frontend.routes
+        if r.testids
+    ]
 
 
 def _class_field_names(node: ast.ClassDef) -> list[str]:
@@ -1157,13 +1193,24 @@ def _app_jsx(manifest: InterfaceManifest) -> str:
 
 def _view_stub(route: Route) -> str:
     purpose = route.purpose or route.view
+    # #659: the root anchor is stamped on the stub container so it exists from
+    # the bare skeleton onward; the fill inherits it in place. The full anchor
+    # inventory rides as a comment because the stub has no other elements yet —
+    # the dev prompt (testid surface appendix) carries the binding instruction.
+    root_attr = f' data-testid="{route.testids[0]}"' if route.testids else ""
+    anchor_comment = (
+        f"  // DOM anchors (manifest-pinned, keep every one): {', '.join(route.testids)}\n"
+        if route.testids
+        else ""
+    )
     return (
         "// Scaffold-owned slot: fill this component's body. The default export\n"
         "// name and file path are fixed by the interface manifest. Fetch backend\n"
         "// data via apiFetch from '../api.js' (handles the /api prefix + errors).\n"
         f"export default function {route.view}() {{\n"
         f"  // TODO: {purpose}\n"
-        f"  return <div>{route.view}</div>\n"
+        f"{anchor_comment}"
+        f"  return <div{root_attr}>{route.view}</div>\n"
         "}\n"
     )
 

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -28,6 +28,7 @@ from squadops.capabilities.scaffold import (
     frozen_surface_index_lines,
     harness_entry_modules,
     is_qa_test_path_for_stack,
+    testid_surface_instructions,
 )
 from squadops.cycles.acceptance_check_spec import is_check_applicable
 from squadops.cycles.agent_config import resolve_agent_config
@@ -498,6 +499,14 @@ def _inject_contract_inputs(
         behavior_lines = contract.behavior_expectation_lines()
         if behavior_lines:
             inputs["api_behavior_contract"] = behavior_lines
+        # #659: the DOM anchor inventory — the api_behavior_contract move
+        # applied to the frontend. Suites that query manifest-pinned testids
+        # assert a surface dev is told to preserve, instead of inventing
+        # roles/text the view never promised (fay-6/fay-12 churn). Data only;
+        # the query-only-these prose is a managed asset (#448).
+        testid_lines = testid_surface_instructions(interface_manifest)
+        if testid_lines:
+            inputs["dom_testid_surface"] = testid_lines
 
 
 def _harness_boundary_criteria(

--- a/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix.md
@@ -1,11 +1,12 @@
 ---
 template_id: request.development_develop_fill_only_appendix
-version: "3"
+version: "4"
 required_variables:
   - stack
 optional_variables:
   - error_contract
   - model_surface
+  - testid_surface
 ---
 ## Fill-only: a walking skeleton is already in your workspace
 
@@ -34,6 +35,8 @@ the fixed slots** — never to rebuild, rewire, or regenerate the scaffold.
 {{error_contract}}
 
 {{model_surface}}
+
+{{testid_surface}}
 
 Filling the fixed slots — rather than regenerating the app — is the whole point: the
 skeleton already builds and boots, so a fill that preserves it stays green, while one

--- a/src/squadops/prompts/request_templates/request.development_develop_testid_surface_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_testid_surface_appendix.md
@@ -1,0 +1,17 @@
+---
+template_id: request.development_develop_testid_surface_appendix
+version: "1"
+required_variables:
+  - testid_lines
+optional_variables: []
+---
+**DOM ANCHOR CONTRACT (authoritative — attach and preserve these data-testid attributes):**
+{{testid_lines}}
+
+These anchors are pinned by the interface manifest and are the surface the QA
+suite queries. The root anchor is already stamped on each view stub's container
+— keep it there. Attach every other listed anchor to the element that plays that
+role as you build the view (a list gets its list anchor, each item its item
+anchor, each form and input its own). Do not rename, remove, or invent anchors:
+a missing anchor fails the suite against a correct-looking view, and an
+unlisted one is invisible to verification.

--- a/src/squadops/prompts/request_templates/request.qa_test_dom_anchor_appendix.md
+++ b/src/squadops/prompts/request_templates/request.qa_test_dom_anchor_appendix.md
@@ -1,0 +1,19 @@
+---
+template_id: request.qa_test_dom_anchor_appendix
+version: "1"
+required_variables:
+  - testid_lines
+optional_variables: []
+---
+**DOM ANCHOR CONTRACT (authoritative — query ONLY these anchors):**
+{{testid_lines}}
+
+These data-testid anchors are pinned by the interface manifest and injected
+into the view author's prompt — they are the only DOM surface the views
+promise. Locate elements exclusively via these anchors
+(`screen.getByTestId(...)` / `[data-testid="..."]`). Do NOT assert roles,
+visible text, tag structure, element counts, or CSS — the views promise none
+of that, so such assertions fail against correct implementations and send
+repairs chasing render details instead of behavior. Assert behavior through
+the anchors: what an anchored element contains after an action, appears after
+a load, or shows after an error.

--- a/tests/unit/capabilities/handlers/test_focused_prompts.py
+++ b/tests/unit/capabilities/handlers/test_focused_prompts.py
@@ -268,6 +268,25 @@ class TestDevFocusedPromptRendered:
         assert "pace_target" in prompt
         assert "run_event_store" in prompt
 
+    async def test_testid_surface_lines_reach_the_initial_author(self):
+        """#659 (fay-6/fay-12): the DOM anchor inventory must reach the view
+        author — a dev who never sees the pinned testids ships views the qa
+        suite (told to query only those anchors) cannot locate, and the
+        correction loop chases render details for five rounds."""
+        handler = DevelopmentDevelopHandler()
+        handler._resolved_config = {"build_profile": "fullstack_fastapi_react"}
+        inputs = self._inputs(
+            testid_surface=[
+                "`RunsListView` (route `/`): root container `runs-list`; "
+                "anchors: `runs-list`, `run-item`, `empty-state`",
+            ]
+        )
+        prompt = await handler._build_focused_prompt(inputs, self._renderer())
+
+        assert "DOM ANCHOR CONTRACT (authoritative" in prompt
+        assert "`runs-list`" in prompt
+        assert "`empty-state`" in prompt
+
     async def test_non_scaffolded_stack_omits_scaffold_sections(self):
         """Bug caught: rendering fill-only/error-contract unconditionally would
         instruct an unscaffolded cycle to preserve a skeleton that isn't there."""

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -1772,6 +1772,76 @@ class TestBehaviorContractAppendix:
         assert "## QA Task:" in messages[-1].content
 
 
+class TestDomAnchorAppendix:
+    """#659 (fay-6/fay-12): the manifest-pinned testid inventory reaches the
+    INITIAL suite-authoring prompt through the DOM-anchor appendix asset, so
+    the suite queries the surface the view author was told to preserve instead
+    of inventing roles/text — the churn that burned all five of fay-12's
+    correction rounds. Data lines come from the executor; all prose lives in
+    the template asset."""
+
+    class _Rendered:
+        content = "**DOM ANCHOR CONTRACT (RENDERED-DOM-APPENDIX)**"
+        template_id = "request.qa_test_dom_anchor_appendix"
+        template_version = "1"
+        render_hash = "h"
+
+    def _focused_inputs(self, qa_inputs, **extra):
+        return {
+            **qa_inputs,
+            "subtask_focus": "Frontend run flow suite",
+            "subtask_description": "d",
+            "expected_artifacts": ["frontend/src/__tests__/Runs.test.jsx"],
+            "acceptance_criteria": [],
+            **extra,
+        }
+
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
+    async def test_testid_lines_reach_the_focused_prompt(self, _mock_run, mock_context, qa_inputs):
+        inputs = self._focused_inputs(
+            qa_inputs,
+            dom_testid_surface=[
+                "`RunsListView` (route `/`): root container `runs-list`; "
+                "anchors: `runs-list`, `run-item`",
+            ],
+        )
+        mock_context.ports.request_renderer = MagicMock()
+        mock_context.ports.request_renderer.render = AsyncMock(return_value=self._Rendered())
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=LLM_TEST_FILE_RESPONSE),
+        )
+        handler = QATestHandler()
+        await handler.handle(mock_context, inputs)
+
+        calls = [
+            c
+            for c in mock_context.ports.request_renderer.render.call_args_list
+            if c.args and c.args[0] == "request.qa_test_dom_anchor_appendix"
+        ]
+        assert len(calls) == 1
+        testid_lines = calls[0].args[1]["testid_lines"]
+        assert "- `RunsListView`" in testid_lines
+        assert "`run-item`" in testid_lines
+        messages = mock_context.ports.llm.chat_stream_with_usage.call_args.args[0]
+        assert "RENDERED-DOM-APPENDIX" in messages[-1].content
+
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
+    async def test_no_testid_input_renders_no_appendix(self, _mock_run, mock_context, qa_inputs):
+        inputs = self._focused_inputs(qa_inputs)
+        mock_context.ports.request_renderer = MagicMock()
+        mock_context.ports.request_renderer.render = AsyncMock(return_value=self._Rendered())
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=LLM_TEST_FILE_RESPONSE),
+        )
+        handler = QATestHandler()
+        await handler.handle(mock_context, inputs)
+        assert not [
+            c
+            for c in mock_context.ports.request_renderer.render.call_args_list
+            if c.args and c.args[0] == "request.qa_test_dom_anchor_appendix"
+        ]
+
+
 class TestRetestProbesPatchedTree:
     """#639 second half: threading contract_probes into the retest is not
     enough — the probe workspace built from dispatch-time sources alone would

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -868,3 +868,61 @@ class TestNonBlankRequestFields:
             title="  Morning 5K  ", datetime="2026-08-01T08:00:00", location="Park"
         )
         assert run.title == "Morning 5K"
+
+
+# --------------------------------------------------------------------------- #
+# #659: DOM anchor contract (route testids)
+# --------------------------------------------------------------------------- #
+
+
+class TestDomAnchorContract:
+    """The manifest pins per-view data-testid inventories; the stub stamps the
+    root anchor; the surface deriver feeds both prompt sides.
+
+    Bug caught (fay-6/fay-12): with no shared DOM arbiter, qa suites assert
+    invented render details, dev patches toward the last suite, and every
+    correction round re-rolls the mismatch — five rounds on fay-12, all on
+    the frontend suite, backend green throughout.
+    """
+
+    def test_manifest_parses_and_round_trips_route_testids(self):
+        m = _group_run_manifest()
+        runs_list = next(r for r in m.frontend.routes if r.view == "RunsListView")
+        assert runs_list.testids[0] == "runs-list"  # root-anchor convention
+        assert "empty-state" in runs_list.testids
+
+        # testids participate in the canonical form, so content_hash() moves
+        # with them — the re-seed driver for this contract change.
+        emitted = next(
+            r for r in m._canonical()["frontend"]["routes"] if r["view"] == "RunsListView"
+        )
+        assert emitted["testids"] == list(runs_list.testids)
+
+    def test_view_stub_stamps_root_anchor_and_inventory(self):
+        files = _by_name(expand(_group_run_manifest()))
+        stub = files["frontend/src/views/RunsListView.jsx"]
+        assert 'data-testid="runs-list"' in stub
+        # the full inventory rides as a comment for the fill author
+        assert "run-item" in stub
+        assert "empty-state" in stub
+
+    def test_route_without_testids_renders_the_plain_stub(self):
+        stub = scaffold._view_stub(scaffold.Route(path="/x", view="XView"))
+        assert "data-testid" not in stub
+        assert "DOM anchors" not in stub
+        assert "export default function XView()" in stub
+
+    def test_testid_surface_instructions_one_line_per_view(self):
+        lines = scaffold.testid_surface_instructions(_group_run_manifest())
+        assert len(lines) == 3
+        assert lines[0].startswith("`RunsListView` (route `/`): root container `runs-list`")
+        assert any("`join-name-input`" in line for line in lines)
+
+    def test_testid_surface_instructions_empty_without_manifest_or_testids(self):
+        assert scaffold.testid_surface_instructions(None) == []
+        import dataclasses
+
+        m = _group_run_manifest()
+        bare_routes = tuple(dataclasses.replace(r, testids=()) for r in m.frontend.routes)
+        bare = dataclasses.replace(m, frontend=dataclasses.replace(m.frontend, routes=bare_routes))
+        assert scaffold.testid_surface_instructions(bare) == []

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -873,6 +873,32 @@ class TestErrorSeamThreading:
             )
             assert "model_surface" not in enriched.inputs
 
+    async def test_dev_envelope_carries_the_testid_surface(self, executor) -> None:
+        """#659 (fay-6/fay-12): the anchor inventory must reach the view author on
+        the same transport as the model surface — a dev who never sees the pinned
+        testids ships views the qa suite (which queries only those) cannot find."""
+        enriched = await executor._enrich_envelope(
+            self._envelope("development.develop"),
+            {},
+            [],
+            [],
+            interface_manifest=self._manifest(),
+        )
+
+        lines = enriched.inputs.get("testid_surface")
+        assert lines, "development.develop envelope carries no testid surface"
+        joined = " ".join(lines)
+        assert "`RunsListView`" in joined
+        assert "`runs-list`" in joined
+        assert "`join-name-input`" in joined
+
+    async def test_testid_surface_follows_the_same_gating(self, executor) -> None:
+        for task_type, manifest in (("qa.test", self._manifest()), ("development.develop", None)):
+            enriched = await executor._enrich_envelope(
+                self._envelope(task_type), {}, [], [], interface_manifest=manifest
+            )
+            assert "testid_surface" not in enriched.inputs
+
     async def test_non_authoring_task_types_are_not_given_the_seam(self, executor) -> None:
         """Bug caught: blanket attachment pushes fill-slot authoring instructions
         into roles that do not author into the scaffold (a qa suite told to raise

--- a/tests/unit/cycles/test_task_plan_probe_injection.py
+++ b/tests/unit/cycles/test_task_plan_probe_injection.py
@@ -279,3 +279,56 @@ def test_generate_task_plan_binds_before_resolving_refs():
     ]
     assert checks, "contract-resolved endpoint_defined must reach the envelope"
     assert checks[0].id == "vc-routes-endpoints"
+
+
+# ---------------------------------------------------------------------------
+# #659: DOM anchor surface injection
+# ---------------------------------------------------------------------------
+
+
+def _testid_manifest():
+    from pathlib import Path
+
+    from squadops.capabilities.scaffold import InterfaceManifest
+
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "examples"
+        / "03_group_run"
+        / "interface_manifest.yaml"
+    )
+    return InterfaceManifest.from_yaml(path.read_text(encoding="utf-8"))
+
+
+def test_bind_mode_injects_dom_testid_surface_into_qa_test_only():
+    """Bug caught (fay-6/fay-12): the anchor inventory reaching only one prompt
+    side (or neither) re-opens the DOM war — suites invent render details and
+    every correction round chases them."""
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(
+        cycle, run, profile, plan=None, contract=_contract(), interface_manifest=_testid_manifest()
+    )
+
+    qa_envs = [e for e in envs if e.task_type == "qa.test"]
+    assert qa_envs, "implementation workload must contain a qa.test step"
+    lines = qa_envs[0].inputs["dom_testid_surface"]
+    assert any("`RunsListView`" in line and "`runs-list`" in line for line in lines)
+    for env in envs:
+        if env.task_type != "qa.test":
+            assert "dom_testid_surface" not in env.inputs
+
+
+def test_manifest_without_testids_injects_no_dom_key():
+    """The handler keys on presence — an empty inventory must not render an
+    authoritative header over nothing."""
+    import dataclasses
+
+    m = _testid_manifest()
+    bare_routes = tuple(dataclasses.replace(r, testids=()) for r in m.frontend.routes)
+    bare = dataclasses.replace(m, frontend=dataclasses.replace(m.frontend, routes=bare_routes))
+
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(
+        cycle, run, profile, plan=None, contract=_contract(), interface_manifest=bare
+    )
+    assert all("dom_testid_surface" not in e.inputs for e in envs)


### PR DESCRIPTION
## Summary

The backend-convergence move applied to the DOM (#659). Frontend suites churned every correction round (fay-6; all five of fay-12's rounds) because nothing arbitrates the DOM the way the injected contract arbitrates routes/statuses — qa invents render details, dev patches toward the last suite, the re-dispatched suite re-rolls its expectations. This pins a scaffold-owned `data-testid` inventory in the interface manifest and injects it into **both** prompts.

**Manifest** — `Route.testids` (first entry = root-anchor convention), parsed + canonical + hash-bearing; the group_run manifest declares inventories for all three views. The manifest content hash moves → re-seed rides the window-3 deploy (already scheduled).

**Scaffold** — view stubs stamp the root anchor on the container (exists from the bare skeleton onward; the fill inherits it in place) and carry the full inventory as a comment; `testid_surface_instructions()` derives the per-view data lines.

**Threading** — dev: executor fill-slot seam (`testid_surface`, same transport as `model_surface`/`error_contract`); qa: `_inject_contract_inputs` (`dom_testid_surface`, same transport as `api_behavior_contract`). Data only in Python; all instruction prose in managed assets (#448).

**Prompt assets** — `request.development_develop_testid_surface_appendix` ("attach and preserve these anchors"), `request.qa_test_dom_anchor_appendix` ("query ONLY these anchors — roles/text/structure are not promised"), fill-only appendix bumped to v4 with the optional section.

No enforcement/lint in this pass (pre-registered in the issue): the prompts + stamped anchors are the load-bearing parts; an anchor-presence check is a natural follow-up if churn persists.

## Verification

- Contract gate in-container: **lint, bare-skeleton, reference-fill all GREEN 14/14** with the stamped stubs (skeleton still builds; probes unchanged).
- 5 scaffold tests (parse/round-trip/hash-bearing, stub stamping, plain-stub fallback, deriver lines, empty-inventory guard), 2 qa-threading tests, 2 executor dev-threading tests, 1 real-renderer dev appendix test, 2 qa appendix tests.
- Full regression: **5885 passed, 1 skipped**.

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
