### PR TITLE
fix(verification): passing dev tasks record validation evidence — criteria credit on success (#597)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -668,7 +668,14 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
 
             outputs["outcome_class"] = TaskOutcome.SEMANTIC_FAILURE
             outputs["failure_classification"] = FailureClassification.WORK_PRODUCT
-            outputs["validation_result"] = evidence_extra.get("validation_result", {})
+
+        # #597: validation evidence rides BOTH branches. It was failure-only, so a
+        # PASSING dev task recorded no rows into the run ledger and contract
+        # criteria bound only to dev tasks could never be credited — pf-38's green
+        # roll reported 3/6 criteria verified where 6/6 had passing evidence (the
+        # qa handler has always populated this on success; the two diverged here).
+        if "validation_result" in evidence_extra:
+            outputs["validation_result"] = evidence_extra["validation_result"]
 
         duration_ms = (time.perf_counter() - start_time) * 1000
         evidence = HandlerEvidence.create(

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -172,6 +172,66 @@ class TestDevBuildMultiFile:
         assert result.outputs["role"] == "dev"
 
 
+class TestDevSuccessEvidence:
+    """#597: a PASSING dev task must carry ``validation_result`` in outputs so
+    ``normalize_task_checks`` records its rows — including bind-mode
+    ``criterion_id``s — into the run ledger. It was failure-branch-only, so
+    contract criteria bound exclusively to dev tasks could never be credited:
+    pf-38's green roll reported 3/6 criteria verified where 6/6 had passing
+    evidence (the qa handler has always populated it on success)."""
+
+    def _focused_inputs(self, build_inputs):
+        return {
+            **build_inputs,
+            "subtask_focus": "Backend source",
+            "subtask_description": "d",
+            "subtask_index": 0,
+            "expected_artifacts": ["src/main.py", "src/utils.py"],
+            "acceptance_criteria": [],
+            "resolved_config": {"output_validation": True},
+        }
+
+    async def test_passing_focused_task_outputs_carry_validation_result(
+        self, mock_context, build_inputs
+    ):
+        handler = DevelopmentDevelopHandler()
+        result = await handler.handle(mock_context, self._focused_inputs(build_inputs))
+
+        assert result.success is True
+        vr = result.outputs["validation_result"]
+        assert vr["passed"] is True
+        assert any(c["check"] == "expected_artifacts" for c in vr["checks"])
+
+    async def test_passing_task_evidence_is_recordable(self, mock_context, build_inputs):
+        """The downstream contract: normalize_task_checks must yield rows for a
+        passing dev task — an empty list is exactly the #597 under-count."""
+        from squadops.cycles.verification_normalize import normalize_task_checks
+
+        handler = DevelopmentDevelopHandler()
+        result = await handler.handle(mock_context, self._focused_inputs(build_inputs))
+
+        rows = normalize_task_checks(result.outputs, subject="task-m000")
+        assert rows, "passing dev task produced no recordable evidence"
+        assert all(r.subject == "task-m000" for r in rows)
+
+    async def test_failing_task_still_carries_validation_result(self, mock_context, build_inputs):
+        """Regression guard: moving the assignment must not strip the failure
+        branch — correction failure_evidence is built from these outputs."""
+        from squadops.cycles.task_outcome import TaskOutcome
+
+        inputs = self._focused_inputs(build_inputs)
+        inputs["expected_artifacts"] = ["src/main.py", "src/missing.py"]
+        handler = DevelopmentDevelopHandler()
+        result = await handler.handle(mock_context, inputs)
+
+        assert result.success is False
+        assert result.outputs["outcome_class"] == TaskOutcome.SEMANTIC_FAILURE
+        vr = result.outputs["validation_result"]
+        assert vr["passed"] is False
+        ea = next(c for c in vr["checks"] if c["check"] == "expected_artifacts")
+        assert ea["missing"] == ["src/missing.py"]
+
+
 class TestDevBuildParseFailure:
     async def test_dev_build_parse_failure_returns_failed(self, mock_context, build_inputs):
         mock_context.ports.llm.chat_stream_with_usage = AsyncMock(


### PR DESCRIPTION
## Summary

One-branch fix for the roll-up under-count (#597). `develop.py` populated `outputs["validation_result"]` only inside the failure branch, so a **passing** dev task recorded no verification evidence and contract criteria bound exclusively to dev tasks could never be credited — pf-38's green roll reported 3/6 criteria verified where 6/6 had passing evidence, and every FAY window green read had to bypass the counter and re-derive truth from the `typed_check_evaluation_*` artifacts.

The assignment now rides both branches, guarded on `"validation_result" in evidence_extra` so the validation-disabled path stays byte-identical (no empty dict planted). Per the issue's analysis, everything downstream — `criterion_id` stamping, `normalize_task_checks`, integrity crediting, the executor's recorder — was already correct; the qa handler has always populated this key on success, and the two handlers diverged on exactly this line.

## Tests

- Passing focused dev task: `outputs["validation_result"]` present with `passed: true` and check rows
- Downstream contract: `normalize_task_checks` yields subject-stamped rows for the passing task (empty list = the exact #597 under-count)
- Regression guard: failing task still carries `validation_result` (correction `failure_evidence` is built from it)
- Full regression: **5866 passed, 1 skipped**

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
