### PR TITLE
fix(locus): missing test suite routes to its owning role — zero-suite verdict survives the executed gate (#665)

### DIFF
--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -41,9 +41,10 @@ class RunTestsResult:
     # HERE because this module owns test-framework knowledge. The locus
     # classifier (cycles/failure_evidence) consumes the neutral fact instead of
     # applying pytest exit-code semantics to every runner. suite_broken:
-    # True = the suite itself cannot run (collection/transform/import death —
-    # the producing role re-authors); False = the suite ran and judged the
-    # subject; None = ambiguous (falls back to legacy exit-code semantics).
+    # True = the suite itself cannot run (collection/transform/import death,
+    # or no collectable suite exists at all (#665) — the producing role
+    # re-authors); False = the suite ran and judged the subject; None =
+    # ambiguous (falls back to legacy exit-code semantics).
     runner: str = ""
     suite_broken: bool | None = None
     # #407: the fullstack frontend build outcome, surfaced distinctly so qa.test
@@ -153,11 +154,15 @@ async def run_generated_tests(
     Returns a ``RunTestsResult`` — never raises.
     """
     if not test_files:
+        # #665: zero suite = the producing role's own artifact is missing, an
+        # explicit verdict, not ambiguity — without it fay-13's absent suite
+        # classified UNKNOWN and burned every correction round on dev repairs.
         return RunTestsResult(
             executed=False,
             error="no test files provided",
             test_file_count=0,
             source_file_count=len(source_files),
+            suite_broken=True,
         )
 
     # Test-authorship guard: pytest discovers only test_*.py / *_test.py. Both
@@ -181,6 +186,9 @@ async def run_generated_tests(
             ),
             test_file_count=len(test_files),
             source_file_count=len(source_files),
+            # #665: nothing collectable exists — same own-artifact verdict as
+            # the empty case (this is the pre-emptive form of pytest exit 5).
+            suite_broken=True,
         )
 
     workspace = tempfile.mkdtemp(prefix="qa_run_")
@@ -261,11 +269,13 @@ async def run_node_tests(
     Returns a ``RunTestsResult`` — never raises.
     """
     if not test_files:
+        # #665: zero suite = own-artifact verdict, same as the pytest runner.
         return RunTestsResult(
             executed=False,
             error="no test files provided",
             test_file_count=0,
             source_file_count=len(source_files),
+            suite_broken=True,
         )
 
     workspace = tempfile.mkdtemp(prefix="qa_node_")

--- a/src/squadops/cycles/failure_evidence.py
+++ b/src/squadops/cycles/failure_evidence.py
@@ -127,15 +127,26 @@ def classify_failure_locus(failure_evidence: Any) -> str:
         if check == "expected_artifacts" and row.get("passed") is False:
             # The task's own named output files are missing from its emission.
             return FailureLocus.OWN_ARTIFACT
-        if check == "tests_pass" and row.get("passed") is False and row.get("executed"):
+        if check == "tests_pass" and row.get("passed") is False:
             # #626: prefer the runner's OWN suite-health verdict (test_runner
             # owns test-framework knowledge; vitest cannot express suite-broken
             # through exit codes, so pytest exit semantics misrouted every
             # frontend suite defect to the dev chain — pf-53). Absent/None
             # falls back to the legacy pytest exit-code table.
+            #
+            # #665: the verdict is read BEFORE the executed guard. A suite that
+            # never ran because it does not exist (zero collectable files) is
+            # the producing role's own artifact, but the old executed gate
+            # skipped every own-artifact signal for exactly that case — fay-13's
+            # missing suite (executed:false, exit -1) fell to UNKNOWN and five
+            # dev-chain repairs churned on files only the qa role could author.
             suite_broken = row.get("suite_broken")
             if suite_broken is True:
                 return FailureLocus.OWN_ARTIFACT
+            if not row.get("executed"):
+                # Every other never-executed case (env/runner errors, timeouts,
+                # legacy rows with no verdict) stays ambiguous → dev chain.
+                continue
             if suite_broken is False:
                 return FailureLocus.SUBJECT
             exit_code = row.get("exit_code")

--- a/tests/unit/capabilities/test_node_test_runner.py
+++ b/tests/unit/capabilities/test_node_test_runner.py
@@ -53,6 +53,8 @@ class TestRunNodeTestsNoFiles:
         result = await run_node_tests(_SOURCE_FILES, [])
         assert result.executed is False
         assert "no test files" in result.error
+        # #665: zero suite = own-artifact verdict, same as the pytest runner.
+        assert result.suite_broken is True
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +109,8 @@ class TestRunNodeTestsNpmInstallFailure:
             result = await run_node_tests(_SOURCE_FILES, _TEST_FILES)
         assert result.executed is False
         assert "npm install failed" in result.error
+        # #665 boundary: env failures stay ambiguous, never own-artifact.
+        assert result.suite_broken is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/capabilities/test_test_runner.py
+++ b/tests/unit/capabilities/test_test_runner.py
@@ -125,6 +125,21 @@ class TestRunGeneratedTestsNoFiles:
         assert "no test files" in result.error
         assert result.source_file_count == 1
         assert result.test_file_count == 0
+        # #665: zero suite is an explicit own-artifact verdict, not ambiguity —
+        # without it the locus classifier routed fay-13's missing suite to the
+        # dev chain, which can never author the qa role's test files.
+        assert result.suite_broken is True
+
+    async def test_non_discoverable_files_carry_the_zero_suite_verdict(self):
+        """fay-13's actual emission shape: a doc artifact rode as the only
+        test-file candidate — nothing pytest can collect exists."""
+        result = await run_generated_tests(
+            source_files=[{"path": "main.py", "content": "x = 1"}],
+            test_files=[{"path": "qa_handoff.md", "content": "# QA Handoff\n"}],
+        )
+        assert result.executed is False
+        assert "no pytest-discoverable" in result.error
+        assert result.suite_broken is True
 
 
 class TestRunGeneratedTestsPassing:
@@ -213,6 +228,9 @@ class TestRunGeneratedTestsTimeout:
         result = await run_generated_tests(source_files=[], test_files=tests, timeout_seconds=2)
         assert result.executed is False
         assert "timed out" in result.error
+        # #665 boundary: a timeout is env-ambiguous — it must NOT read as the
+        # zero-suite own-artifact verdict.
+        assert result.suite_broken is None
 
 
 class TestRunGeneratedTestsCleanup:

--- a/tests/unit/cycles/test_failure_evidence.py
+++ b/tests/unit/cycles/test_failure_evidence.py
@@ -336,11 +336,86 @@ class TestClassifyFailureLocus:
         row = {"check": "tests_pass", "executed": False, "exit_code": None, "passed": False}
         assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.UNKNOWN
 
+    def test_missing_suite_verdict_survives_the_executed_gate(self):
+        """#665 (fay-13): a suite that never ran because it does not EXIST is
+        the producing role's own artifact. The old executed gate skipped the
+        runner's verdict for exactly that case — executed:false / exit -1
+        classified UNKNOWN and five dev-chain repairs churned on files only
+        the qa role could author."""
+        row = {
+            "check": "tests_pass",
+            "executed": False,
+            "exit_code": -1,
+            "tests_passed": False,
+            "passed": False,
+            "runner": "",
+            "suite_broken": True,
+        }
+        assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.OWN_ARTIFACT
+
+    def test_not_executed_never_reads_subject_from_contradictory_verdict(self):
+        """suite_broken False means the suite RAN and judged the subject — on a
+        never-executed row that combination is contradictory, so it must stay
+        ambiguous (dev chain), never implicate the app as SUBJECT."""
+        row = {
+            "check": "tests_pass",
+            "executed": False,
+            "exit_code": -1,
+            "passed": False,
+            "suite_broken": False,
+        }
+        assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.UNKNOWN
+
     def test_passed_rows_and_junk_are_unknown(self):
         assert classify_failure_locus(None) == FailureLocus.UNKNOWN
         assert classify_failure_locus({}) == FailureLocus.UNKNOWN
         row = {"check": "tests_pass", "executed": True, "exit_code": 1, "passed": True}
         assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.UNKNOWN
+
+
+class TestFay13MissingSuiteReplay:
+    """#665 deterministic replay of fay-13 (cyc_9a760526e420): eve's suite task
+    emitted qa_handoff.md and zero test_*.py; the stored evidence row read
+    executed:false / exit -1 with no suite-health verdict, classified UNKNOWN,
+    and all five correction rounds dispatched dev repairs that could never
+    author the missing suite. Both halves of the fix are required — the runner
+    must emit the zero-suite verdict AND the classifier must read it before the
+    executed gate — so the replay exercises the whole chain:
+    runner → evidence row (as qa.test builds it) → locus → repair route."""
+
+    @pytest.mark.parametrize(
+        "test_files",
+        [
+            [],
+            [{"path": "qa_handoff.md", "content": "# QA Handoff\n"}],
+        ],
+        ids=["extraction-dropped-the-doc", "doc-rode-as-only-candidate"],
+    )
+    async def test_zero_suite_routes_to_qa_test_repair(self, test_files):
+        from squadops.capabilities.handlers.test_runner import run_generated_tests
+        from squadops.cycles.task_plan import repair_steps_for
+
+        result = await run_generated_tests(
+            source_files=[{"path": "backend/routes.py", "content": "router = None\n"}],
+            test_files=test_files,
+        )
+        assert result.executed is False
+        assert result.exit_code == -1
+
+        # The row exactly as qa.test builds it (#626 threading in qa_test.py).
+        row = {
+            "check": "tests_pass",
+            "executed": result.executed,
+            "exit_code": result.exit_code,
+            "tests_passed": result.tests_passed,
+            "passed": False,
+            "runner": result.runner,
+            "suite_broken": result.suite_broken,
+        }
+        evidence = {"validation_result": {"passed": False, "checks": [row]}}
+        locus = classify_failure_locus(evidence)
+        assert locus == FailureLocus.OWN_ARTIFACT
+        assert repair_steps_for("qa.test", locus) == [("qa.test_repair", "qa")]
 
 
 class TestEmissionFailurePassthrough:


### PR DESCRIPTION
## Class
Correction-routing fix, sibling of #650: a qa task whose suite artifact is **missing entirely** routed into the default dev repair chain — non-convergent by construction, since dev repairs cannot author the qa role's test files.

## Mechanism
`classify_failure_locus` gated the entire `tests_pass` branch on `executed` truthy, so every own-artifact signal — including the #626 `suite_broken` verdict — was unreadable for exactly the case where the suite never ran because it does not exist (`test_runner` returns `executed=False`, exit `-1` for zero collectable files). fay-13 (`cyc_9a760526e420`) burned all five correction rounds on dev-typed repairs (three attempting frozen `backend/main.py`, SIP-0100 restored each) and died `blocked_unverified` with an audit-functional app. The stored failure analysis confirms the row shape verbatim: "tests_pass check returned executed: false with exit_code -1 … absence of pytest-discoverable test files."

## Fix — both halves, per the #626 runner-owns-the-verdict pattern
1. **Runner** (`test_runner.py`): the three zero-suite returns stamp `suite_broken=True` — pytest no-files, pytest none-discoverable (fay-13's actual branch: `qa_handoff.md` rode as the only candidate), vitest no-files. Timeouts, env errors, and missing `package.json` stay `None`; post-#633 a missing `package.json` is scaffold provisioning, not the qa role's artifact.
2. **Classifier** (`failure_evidence.py`): the verdict is read **before** the executed gate. Every other never-executed row (env errors, legacy rows without a verdict) continues to UNKNOWN → dev chain, and a contradictory `suite_broken=False` on a not-executed row can never implicate the subject.

The routing itself needed nothing: locus `OWN_ARTIFACT` on `qa.test` already selects `qa.test_repair` (#568) — this evidence shape just never reached it.

## Guard rails preserved
- Test-gaming guard untouched: exit 1 (real failures) still never routes to qa, and the new OWN_ARTIFACT case is one where nothing ran — there are no failing tests to rewrite.
- Stored pre-fix rows intentionally keep classifying UNKNOWN (no reinterpretation of terminal history).

## Verification
- **Deterministic replay of fay-13's emission shape** through the full fixed chain — `run_generated_tests` (real runner, both variants: `qa_handoff.md` as sole candidate, and extraction-dropped) → evidence row exactly as `qa.test` builds it → `OWN_ARTIFACT` → `repair_steps_for` routes `("qa.test_repair", "qa")`. Both halves are required: threading alone leaves the row verdict-less, the verdict alone dies at the executed gate.
- Boundary tests: timeout → `suite_broken None`; npm-install failure → `None`; not-executed + `suite_broken False` → UNKNOWN; legacy not-executed row → UNKNOWN (existing test unchanged).
- Regression: 5868 passed, 1 skipped. Ruff clean.

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2uftutg8i7a94Kaf7RD6q
