### PR TITLE
fix(runtime): reap stranded runtime_activities — finalize sweep + startup reaper (#672)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -148,6 +148,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             artifact_vault=artifact_vault,
             llm_observability=llm_observability,
             workflow_tracker=workflow_tracker,
+            activity_port=activity_port,
         )
 
         # SIP-0077: Cycle event bus (defaults to NoOp if not provided)

--- a/adapters/cycles/run_completion.py
+++ b/adapters/cycles/run_completion.py
@@ -39,6 +39,7 @@ from squadops.cycles.verification_integrity import (
     aggregate_verification,
 )
 from squadops.events.types import EventType
+from squadops.runtime.activity_reaper import abort_cycle_activities
 
 if TYPE_CHECKING:
     from squadops.cycles.models import Cycle
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
     from squadops.ports.cycles.artifact_vault import ArtifactVaultPort
     from squadops.ports.cycles.cycle_registry import CycleRegistryPort
     from squadops.ports.cycles.workflow_tracker import WorkflowTrackerPort
+    from squadops.ports.runtime.activity import RuntimeActivityPort
     from squadops.ports.telemetry.llm_observability import LLMObservabilityPort
     from squadops.tasks.models import TaskEnvelope
 
@@ -170,11 +172,13 @@ class RunCompletion:
         artifact_vault: ArtifactVaultPort | None = None,
         llm_observability: LLMObservabilityPort | None = None,
         workflow_tracker: WorkflowTrackerPort | None = None,
+        activity_port: RuntimeActivityPort | None = None,
     ) -> None:
         self._cycle_registry = cycle_registry
         self._artifact_vault = artifact_vault
         self._llm_observability = llm_observability
         self._workflow_tracker = workflow_tracker
+        self._activity_port = activity_port
 
     async def finalize(
         self,
@@ -251,6 +255,16 @@ class RunCompletion:
                 )
         except Exception:
             logger.warning("Run report generation failed", exc_info=True)
+
+        # #672: stranded-activity sweep. Task dispatch for this run is over, so
+        # any activity still active for its cycle was stranded by an interrupted
+        # task and would trip the one-active-per-agent index on every later
+        # dispatch. Best-effort (same contract as the report above).
+        if self._activity_port is not None and cycle_id:
+            try:
+                await abort_cycle_activities(self._activity_port, cycle_id)
+            except Exception:
+                logger.warning("Stranded-activity sweep failed", exc_info=True)
 
     @staticmethod
     def _aggregate_verification(

--- a/adapters/persistence/runtime/activity_postgres.py
+++ b/adapters/persistence/runtime/activity_postgres.py
@@ -147,6 +147,22 @@ class PostgresRuntimeActivity(RuntimeActivityPort):
             )
         return _row_to_activity(row) if row else None
 
+    async def list_active_activities(
+        self, *, cycle_id: str | None = None, conn: Any = None
+    ) -> tuple[RuntimeActivity, ...]:
+        query = (
+            f"SELECT {_COLUMNS} FROM runtime_activities "
+            "WHERE state IN ('pending', 'running', 'paused')"
+        )
+        args: list[Any] = []
+        if cycle_id is not None:
+            query += " AND cycle_id = $1"
+            args.append(cycle_id)
+        query += " ORDER BY started_at"
+        async with acquire(self._pool, conn) as conn:
+            rows = await conn.fetch(query, *args)
+        return tuple(_row_to_activity(row) for row in rows)
+
 
 def _loads_jsonb(value) -> list:
     """Decode a JSONB column value (asyncpg returns str by default)."""

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -357,6 +357,38 @@ async def _init_cycle_subsystem(config, pool) -> None:
 
         _runtime_coordinator = create_runtime_coordinator(pool)
 
+        # #672: startup reap — end active activities whose owning cycle is
+        # already terminal (rows stranded by a process death that skipped run
+        # finalize). One stranded row blocks all of that agent's future
+        # activity tracking. Best-effort: a reap failure never blocks startup.
+        if activity_port is not None:
+            try:
+                from squadops.cycles.lifecycle import derive_cycle_status
+                from squadops.cycles.models import CycleNotFoundError, CycleStatus
+                from squadops.runtime.activity_reaper import reap_stale_activities
+
+                async def _cycle_is_terminal(cid: str) -> bool:
+                    try:
+                        owning_cycle = await cycle_registry.get_cycle(cid)
+                    except CycleNotFoundError:
+                        # No owner on record → definitionally stranded.
+                        return True
+                    runs = await cycle_registry.list_runs(cid)
+                    derived = derive_cycle_status(runs, cycle_cancelled=owning_cycle.cancelled)
+                    return derived in (
+                        CycleStatus.COMPLETED,
+                        CycleStatus.FAILED,
+                        CycleStatus.CANCELLED,
+                    )
+
+                reaped = await reap_stale_activities(
+                    activity_port, cycle_is_terminal=_cycle_is_terminal
+                )
+                if reaped:
+                    logger.info("Startup reap ended %d stranded runtime activity row(s)", reaped)
+            except Exception:
+                logger.warning("Startup stranded-activity reap failed", exc_info=True)
+
         flow_executor = create_flow_executor(
             "dispatched",
             cycle_registry=cycle_registry,

--- a/src/squadops/ports/runtime/activity.py
+++ b/src/squadops/ports/runtime/activity.py
@@ -99,3 +99,16 @@ class RuntimeActivityPort(ABC):
         """Return the agent's current (active) activity, or `None`.
 
         `conn` (§4.5/D25): read on the caller's unit-of-work connection when given."""
+
+    @abstractmethod
+    async def list_active_activities(
+        self, *, cycle_id: str | None = None, conn: Any = None
+    ) -> tuple[RuntimeActivity, ...]:
+        """Return every active (`pending`/`running`/`paused`) activity, oldest first.
+
+        `cycle_id` narrows the result to activities owned by that cycle. At most
+        one active activity exists per agent (D9), so the result is bounded by
+        the roster size — callers iterate it without pagination. Backs the #672
+        stranded-activity sweeps (run-finalize + startup reap).
+
+        `conn` (§4.5/D25): read on the caller's unit-of-work connection when given."""

--- a/src/squadops/runtime/activity_reaper.py
+++ b/src/squadops/runtime/activity_reaper.py
@@ -1,0 +1,121 @@
+"""
+Stranded RuntimeActivity hygiene (#672 — the FocusLease #373 class, applied to activities).
+
+`runtime_activities` enforces one active activity per agent (D9, the §4.2
+partial unique index). The §4.4 instrumentation terminalizes each activity when
+its task replies — but an interrupted run strands the row in an active state
+with no expiry, and every later ``start_activity`` for that agent then trips
+``uq_runtime_activities_one_active_per_agent``. The write is best-effort, so
+runs proceed while activity tracking goes silently dead and the traceback
+recurs at every dispatch. Two complementary sweeps close the class:
+
+- :func:`abort_cycle_activities` — run finalize: task dispatch for the run is
+  over, so any activity still active for its cycle is stranded; end them all.
+  Called from the ``RunCompletion`` collaborator on every terminal path.
+- :func:`reap_stale_activities` — startup: end active activities whose owning
+  cycle is already terminal (rows stranded by a process death that skipped
+  finalize, and historic rows predating the sweep).
+
+Both are best-effort and per-row isolated, like ``admission.release_participants``:
+one bad row never blocks clearing the rest, and the adapter's active-only
+UPDATE guard makes a concurrent terminalization a harmless no-op (counted only
+when the row actually flipped).
+
+Pure orchestration: depends only on the activity port and ``runtime.reasons``.
+Cycle-status knowledge enters through the ``cycle_is_terminal`` predicate the
+composition root supplies — ``squadops.runtime`` never imports the cycles
+domain (D26 direction).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from squadops.runtime import reasons
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from squadops.ports.runtime.activity import RuntimeActivityPort
+
+logger = logging.getLogger(__name__)
+
+
+async def abort_cycle_activities(
+    activity_port: RuntimeActivityPort,
+    cycle_id: str,
+    *,
+    reason_code: str = reasons.ACTIVITY_STRANDED_AT_RUN_FINALIZE,
+) -> int:
+    """Abort every active activity owned by ``cycle_id``; return how many flipped.
+
+    Run-finalize sweep: the finishing run's dispatch loop has exited, so an
+    active row for its cycle has no owner left to terminalize it.
+    """
+    aborted = 0
+    for activity in await activity_port.list_active_activities(cycle_id=cycle_id):
+        try:
+            ended = await activity_port.abort_activity(activity.runtime_activity_id, reason_code)
+        except Exception:
+            logger.warning(
+                "best-effort abort of stranded activity %s (agent=%s, cycle=%s) failed",
+                activity.runtime_activity_id,
+                activity.agent_id,
+                cycle_id,
+                exc_info=True,
+            )
+            continue
+        if ended is not None:
+            aborted += 1
+            logger.info(
+                "aborted stranded activity %s (agent=%s, cycle=%s, type=%s)",
+                activity.runtime_activity_id,
+                activity.agent_id,
+                cycle_id,
+                activity.activity_type,
+            )
+    return aborted
+
+
+async def reap_stale_activities(
+    activity_port: RuntimeActivityPort,
+    *,
+    cycle_is_terminal: Callable[[str], Awaitable[bool]],
+) -> int:
+    """Abort active activities whose owning cycle is terminal; return how many flipped.
+
+    Startup reaper. Activities without a ``cycle_id`` (duty/ambient sources)
+    have no owning cycle to consult and are left alone. A predicate or abort
+    failure skips that row only — the reaper must clear what it can, since one
+    stranded row blocks all of that agent's future activity tracking.
+    """
+    reaped = 0
+    for activity in await activity_port.list_active_activities():
+        if activity.cycle_id is None:
+            continue
+        try:
+            if not await cycle_is_terminal(activity.cycle_id):
+                continue
+            ended = await activity_port.abort_activity(
+                activity.runtime_activity_id, reasons.ACTIVITY_STRANDED_CYCLE_TERMINAL
+            )
+        except Exception:
+            logger.warning(
+                "best-effort reap of stranded activity %s (agent=%s, cycle=%s) failed",
+                activity.runtime_activity_id,
+                activity.agent_id,
+                activity.cycle_id,
+                exc_info=True,
+            )
+            continue
+        if ended is not None:
+            reaped += 1
+            logger.info(
+                "reaped stranded activity %s (agent=%s, cycle=%s, type=%s)",
+                activity.runtime_activity_id,
+                activity.agent_id,
+                activity.cycle_id,
+                activity.activity_type,
+            )
+    return reaped

--- a/src/squadops/runtime/reasons.py
+++ b/src/squadops/runtime/reasons.py
@@ -52,6 +52,11 @@ ACTIVITY_COMPLETED: Final[str] = "activity_completed"
 ACTIVITY_FAILED: Final[str] = "activity_failed"
 # The coordinator aborts an activity orphaned by a mode change (§4.5 thin seam).
 ACTIVITY_PREEMPTED_BY_MODE_CHANGE: Final[str] = "activity_preempted_by_mode_change"
+# Stranded-activity hygiene (#672): an interrupted task leaves its activity
+# active with no owner to terminalize it. The run-finalize sweep and the
+# startup reaper (`runtime.activity_reaper`) abort such rows.
+ACTIVITY_STRANDED_AT_RUN_FINALIZE: Final[str] = "activity_stranded_at_run_finalize"
+ACTIVITY_STRANDED_CYCLE_TERMINAL: Final[str] = "activity_stranded_cycle_terminal"
 
 # Ambient irreversibility policy (Phase 4 §4.6 — v1.2 embodiment seam, no v1.1 callers)
 AMBIENT_IRREVERSIBLE_ACTION_FORBIDDEN: Final[str] = "ambient_irreversible_action_forbidden"

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -925,3 +925,29 @@ class TestErrorSeamThreading:
         )
 
         assert "error_contract" not in enriched.inputs
+
+
+class TestRunCompletionActivityWiring:
+    async def test_default_run_completion_receives_the_executor_activity_port(
+        self, mock_registry, mock_vault, mock_queue, mock_squad_profile, reply_router
+    ):
+        """Bug class (#672 silent no-op): the executor composes its default
+        RunCompletion — if the activity port isn't threaded into it, the
+        finalize stranded-activity sweep never runs in production while every
+        unit test of RunCompletion itself still passes."""
+        from unittest.mock import AsyncMock
+
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+        activity_port = AsyncMock()
+        executor = DispatchedFlowExecutor(
+            cycle_registry=mock_registry,
+            artifact_vault=mock_vault,
+            queue=mock_queue,
+            squad_profile=mock_squad_profile,
+            task_timeout=5.0,
+            reply_router=reply_router,
+            activity_port=activity_port,
+        )
+
+        assert executor._run_completion._activity_port is activity_port

--- a/tests/unit/cycles/test_run_completion.py
+++ b/tests/unit/cycles/test_run_completion.py
@@ -688,3 +688,60 @@ class TestBehavioralCriterionStamping:
         )
         summary = RunCompletion._aggregate_verification(None, ledger, "COMPLETED", None)
         assert summary.criteria_verified == ()
+
+
+class TestStrandedActivitySweep:
+    """#672: finalize ends the finishing cycle's still-active activities."""
+
+    def _completion_with_activity_port(self, activity_port):
+        from adapters.cycles.run_completion import RunCompletion
+
+        vault = AsyncMock()
+        vault.store = AsyncMock(side_effect=lambda ref, content: ref)
+        registry = AsyncMock()
+        return RunCompletion(
+            cycle_registry=registry,
+            artifact_vault=vault,
+            activity_port=activity_port,
+        )
+
+    async def test_finalize_aborts_the_cycles_active_activities(self):
+        """Bug class: an interrupted task strands its activity row; if finalize
+        doesn't end it, every later dispatch for that agent trips the
+        one-active-per-agent index. The sweep must query THIS cycle's active
+        rows and abort each."""
+        from unittest.mock import MagicMock
+
+        stranded = MagicMock()
+        stranded.runtime_activity_id = "act-stranded"
+        stranded.agent_id = "eve"
+        stranded.activity_type = "qa.test"
+        activity_port = AsyncMock()
+        activity_port.list_active_activities.return_value = (stranded,)
+
+        completion = self._completion_with_activity_port(activity_port)
+        await completion.finalize("cyc_001", "run_001", "FAILED", None, None)
+
+        activity_port.list_active_activities.assert_awaited_once_with(cycle_id="cyc_001")
+        args = activity_port.abort_activity.await_args.args
+        assert args[0] == "act-stranded"
+        assert args[1] == "activity_stranded_at_run_finalize"
+
+    async def test_finalize_survives_a_sweep_failure(self):
+        """Bug class: the sweep is hygiene — a DB error during it must not turn
+        a finalized run into a raised exception (finalize runs in the executor's
+        terminal path). The verification summary must still have been persisted."""
+        activity_port = AsyncMock()
+        activity_port.list_active_activities.side_effect = RuntimeError("db down")
+
+        completion = self._completion_with_activity_port(activity_port)
+        await completion.finalize("cyc_001", "run_001", "COMPLETED", None, None)
+
+        completion._cycle_registry.record_run_verification_summary.assert_awaited_once()
+
+    async def test_finalize_without_activity_port_skips_the_sweep(self, completion):
+        """Boundary: the memory-registry / pool-less composition wires no
+        activity port — finalize must complete without touching activities."""
+        await completion.finalize("cyc_001", "run_001", "COMPLETED", None, None)
+
+        completion._cycle_registry.record_run_verification_summary.assert_awaited_once()

--- a/tests/unit/cycles/test_task_dispatcher_activity.py
+++ b/tests/unit/cycles/test_task_dispatcher_activity.py
@@ -92,6 +92,9 @@ class _FakeActivityPort(RuntimeActivityPort):
     async def get_current_activity(self, agent_id, *, conn=None):
         raise NotImplementedError
 
+    async def list_active_activities(self, *, cycle_id=None, conn=None):
+        raise NotImplementedError
+
 
 # ---------------------------------------------------------------------------
 # _start_task_activity

--- a/tests/unit/runtime/test_activity_reaper.py
+++ b/tests/unit/runtime/test_activity_reaper.py
@@ -1,0 +1,244 @@
+"""Tests for the stranded-activity sweeps (#672 — `runtime.activity_reaper`).
+
+Bug classes guarded:
+- the startup reaper aborting an activity whose owning cycle is still live —
+  would kill real in-flight task tracking;
+- cycle-less (duty/ambient) activities swept by the cycle-scoped rules;
+- one bad row (predicate or abort failure) aborting the whole sweep — the
+  remaining stranded rows would then never clear, and one stranded row blocks
+  all of that agent's future activity tracking;
+- the finalize sweep reaching beyond its own cycle's activities (aborting a
+  concurrent cycle's live rows);
+- counting attempted rather than actually-flipped rows — a concurrent
+  terminalization returns None from `abort_activity` and must not be counted;
+- the wrong reason code on either sweep (the codes are event/log-surfaced
+  triage evidence).
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from squadops.ports.runtime.activity import RuntimeActivityPort
+from squadops.runtime import reasons
+from squadops.runtime.activity_reaper import abort_cycle_activities, reap_stale_activities
+from squadops.runtime.models import RuntimeActivity, is_active_activity_state
+
+pytestmark = [pytest.mark.domain_runtime]
+
+
+def _activity(activity_id="act-1", agent_id="max", cycle_id="cyc-1") -> RuntimeActivity:
+    return RuntimeActivity(
+        runtime_activity_id=activity_id,
+        agent_id=agent_id,
+        mode="cycle",
+        activity_type="development.develop",
+        goal="Fill the slot",
+        priority=0,
+        state="running",
+        source_kind="cycle_task",
+        source_ref="t1",
+        cycle_id=cycle_id,
+        workload_id=None,
+        task_id="t1",
+        can_pause=False,
+        can_resume=False,
+        can_abort=True,
+    )
+
+
+class _FakeActivityPort(RuntimeActivityPort):
+    def __init__(
+        self,
+        activities: tuple[RuntimeActivity, ...] = (),
+        *,
+        abort_raises_for: frozenset[str] = frozenset(),
+        abort_gone_for: frozenset[str] = frozenset(),
+    ) -> None:
+        self._activities = list(activities)
+        self._abort_raises_for = abort_raises_for
+        # Rows a concurrent writer already terminalized: abort returns None.
+        self._abort_gone_for = abort_gone_for
+        self.aborted: list[tuple[str, str]] = []
+        self.list_calls: list[str | None] = []
+
+    async def start_activity(self, agent_id, **kwargs):  # unused here
+        raise NotImplementedError
+
+    async def update_state(self, activity_id, state, *, conn=None):  # unused here
+        raise NotImplementedError
+
+    async def complete_activity(self, activity_id, *, evidence_ref=None):  # unused here
+        raise NotImplementedError
+
+    async def fail_activity(self, activity_id, reason_code):  # unused here
+        raise NotImplementedError
+
+    async def abort_activity(self, activity_id, reason_code, *, conn=None):
+        if activity_id in self._abort_raises_for:
+            raise RuntimeError("db down")
+        self.aborted.append((activity_id, reason_code))
+        if activity_id in self._abort_gone_for:
+            return None
+        for i, act in enumerate(self._activities):
+            if act.runtime_activity_id == activity_id:
+                self._activities[i] = replace(act, state="aborted")
+                return self._activities[i]
+        return None
+
+    async def get_current_activity(self, agent_id, *, conn=None):  # unused here
+        raise NotImplementedError
+
+    async def list_active_activities(self, *, cycle_id=None, conn=None):
+        self.list_calls.append(cycle_id)
+        active = [a for a in self._activities if is_active_activity_state(a.state)]
+        if cycle_id is not None:
+            active = [a for a in active if a.cycle_id == cycle_id]
+        return tuple(active)
+
+
+def _terminal_only(terminal_cycles: set[str], *, raises_for: set[str] | None = None):
+    calls: list[str] = []
+
+    async def cycle_is_terminal(cycle_id: str) -> bool:
+        calls.append(cycle_id)
+        if raises_for and cycle_id in raises_for:
+            raise RuntimeError("registry down")
+        return cycle_id in terminal_cycles
+
+    cycle_is_terminal.calls = calls  # type: ignore[attr-defined]
+    return cycle_is_terminal
+
+
+# ---------------------------------------------------------------------------
+# reap_stale_activities (startup)
+# ---------------------------------------------------------------------------
+
+
+async def test_reap_aborts_terminal_cycle_rows_and_spares_live_ones():
+    """Bug class: reaping a live cycle's activity kills real in-flight tracking;
+    sparing a terminal cycle's row leaves the collision class in place."""
+    port = _FakeActivityPort(
+        (
+            _activity("act-dead", agent_id="eve", cycle_id="cyc-dead"),
+            _activity("act-live", agent_id="neo", cycle_id="cyc-live"),
+        )
+    )
+
+    reaped = await reap_stale_activities(port, cycle_is_terminal=_terminal_only({"cyc-dead"}))
+
+    assert reaped == 1
+    assert port.aborted == [("act-dead", reasons.ACTIVITY_STRANDED_CYCLE_TERMINAL)]
+
+
+async def test_reap_leaves_cycle_less_activities_alone():
+    """Bug class: duty/ambient activities have no owning cycle — the cycle rule
+    must not consult the predicate for them, let alone abort them."""
+    port = _FakeActivityPort((_activity("act-duty", cycle_id=None),))
+    predicate = _terminal_only(set())
+
+    reaped = await reap_stale_activities(port, cycle_is_terminal=predicate)
+
+    assert reaped == 0
+    assert port.aborted == []
+    assert predicate.calls == []
+
+
+async def test_reap_survives_predicate_failure_and_clears_the_rest():
+    """Bug class: one unreadable cycle aborting the whole sweep — the other
+    stranded rows would never clear. The failing row itself must NOT be aborted
+    (its cycle's liveness is unknown)."""
+    port = _FakeActivityPort(
+        (
+            _activity("act-unknown", agent_id="max", cycle_id="cyc-unknown"),
+            _activity("act-dead", agent_id="eve", cycle_id="cyc-dead"),
+        )
+    )
+
+    reaped = await reap_stale_activities(
+        port,
+        cycle_is_terminal=_terminal_only({"cyc-dead"}, raises_for={"cyc-unknown"}),
+    )
+
+    assert reaped == 1
+    assert port.aborted == [("act-dead", reasons.ACTIVITY_STRANDED_CYCLE_TERMINAL)]
+
+
+async def test_reap_survives_abort_failure_and_clears_the_rest():
+    port = _FakeActivityPort(
+        (
+            _activity("act-a", agent_id="max", cycle_id="cyc-dead"),
+            _activity("act-b", agent_id="eve", cycle_id="cyc-dead"),
+        ),
+        abort_raises_for=frozenset({"act-a"}),
+    )
+
+    reaped = await reap_stale_activities(port, cycle_is_terminal=_terminal_only({"cyc-dead"}))
+
+    assert reaped == 1
+    assert ("act-b", reasons.ACTIVITY_STRANDED_CYCLE_TERMINAL) in port.aborted
+
+
+async def test_reap_does_not_count_concurrently_terminalized_rows():
+    """Bug class: `abort_activity` returns None when the row already left the
+    active states (the adapter's race guard) — counting it would report reaps
+    that never happened."""
+    port = _FakeActivityPort(
+        (_activity("act-gone", cycle_id="cyc-dead"),),
+        abort_gone_for=frozenset({"act-gone"}),
+    )
+
+    reaped = await reap_stale_activities(port, cycle_is_terminal=_terminal_only({"cyc-dead"}))
+
+    assert reaped == 0
+
+
+# ---------------------------------------------------------------------------
+# abort_cycle_activities (run finalize)
+# ---------------------------------------------------------------------------
+
+
+async def test_finalize_sweep_is_scoped_to_its_own_cycle():
+    """Bug class: an unscoped sweep aborts a concurrent cycle's live activity.
+    The port must be queried WITH the cycle filter, and only the finishing
+    cycle's rows flipped."""
+    port = _FakeActivityPort(
+        (
+            _activity("act-mine", agent_id="eve", cycle_id="cyc-finishing"),
+            _activity("act-other", agent_id="neo", cycle_id="cyc-other"),
+        )
+    )
+
+    aborted = await abort_cycle_activities(port, "cyc-finishing")
+
+    assert port.list_calls == ["cyc-finishing"]
+    assert aborted == 1
+    assert port.aborted == [("act-mine", reasons.ACTIVITY_STRANDED_AT_RUN_FINALIZE)]
+
+
+async def test_finalize_sweep_survives_abort_failure_and_clears_the_rest():
+    port = _FakeActivityPort(
+        (
+            _activity("act-a", agent_id="max", cycle_id="cyc-1"),
+            _activity("act-b", agent_id="eve", cycle_id="cyc-1"),
+        ),
+        abort_raises_for=frozenset({"act-a"}),
+    )
+
+    aborted = await abort_cycle_activities(port, "cyc-1")
+
+    assert aborted == 1
+    assert ("act-b", reasons.ACTIVITY_STRANDED_AT_RUN_FINALIZE) in port.aborted
+
+
+async def test_finalize_sweep_with_no_active_rows_is_a_quiet_no_op():
+    """The common case: every task terminalized its own activity. The sweep
+    must flip nothing and report zero."""
+    port = _FakeActivityPort(())
+
+    aborted = await abort_cycle_activities(port, "cyc-1")
+
+    assert aborted == 0
+    assert port.aborted == []

--- a/tests/unit/runtime/test_coordinator_with_activity.py
+++ b/tests/unit/runtime/test_coordinator_with_activity.py
@@ -109,6 +109,9 @@ class _FakeActivityPort(RuntimeActivityPort):
     async def get_current_activity(self, agent_id, *, conn=None):
         return self._current
 
+    async def list_active_activities(self, *, cycle_id=None, conn=None):  # unused here
+        raise NotImplementedError
+
 
 class _RecordingPublisher(RuntimeEventPublisher):
     def __init__(self) -> None:

--- a/tests/unit/runtime/test_runtime_activity.py
+++ b/tests/unit/runtime/test_runtime_activity.py
@@ -296,3 +296,55 @@ async def test_row_to_activity_decodes_jsonb_and_maps_all_fields():
         paused_at=None,
         ended_at=None,
     )
+
+
+# ---------------------------------------------------------------------------
+# list_active_activities (#672 sweeps)
+# ---------------------------------------------------------------------------
+
+
+async def test_list_active_activities_filters_to_active_states_oldest_first():
+    """Bug class: the sweep source query returning terminal rows (they'd be
+    'aborted' again and mis-counted) or newest-first (nondeterministic sweep
+    order). The WHERE must restrict to active states, ordered by started_at."""
+    conn = AsyncMock()
+    conn.fetch.return_value = [
+        _activity_row(runtime_activity_id="act-1", agent_id="max"),
+        _activity_row(runtime_activity_id="act-2", agent_id="eve"),
+    ]
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    activities = await adapter.list_active_activities()
+
+    query = conn.fetch.await_args.args[0]
+    assert "state IN ('pending', 'running', 'paused')" in query
+    assert "ORDER BY started_at" in query
+    assert [a.runtime_activity_id for a in activities] == ["act-1", "act-2"]
+
+
+async def test_list_active_activities_cycle_filter_binds_the_cycle_id():
+    """Bug class: the finalize sweep queries with a cycle filter — if the filter
+    isn't bound into the SQL, the sweep would abort OTHER cycles' live rows."""
+    conn = AsyncMock()
+    conn.fetch.return_value = []
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    result = await adapter.list_active_activities(cycle_id="cyc-9")
+
+    query = conn.fetch.await_args.args[0]
+    assert "cycle_id = $1" in query
+    assert conn.fetch.await_args.args[1] == "cyc-9"
+    assert result == ()
+
+
+async def test_list_active_activities_without_filter_binds_no_params():
+    """Bug class: a leftover bind param with no placeholder (or vice versa)
+    raises at query time — the startup reaper's unfiltered read must send none."""
+    conn = AsyncMock()
+    conn.fetch.return_value = []
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    await adapter.list_active_activities()
+
+    assert "cycle_id = $1" not in conn.fetch.await_args.args[0]
+    assert len(conn.fetch.await_args.args) == 1


### PR DESCRIPTION
1.4.1 hardening patch, fix 1 of 5 (`docs/plans/1-4-1-hardening-patch-plan.md`).

## Problem

`runtime_activities` rows stranded by interrupted runs are never reaped. Four rows sit in `state='running'` from July 21–25 cycles (data/eve/max/neo), so every subsequent run's first task per affected agent trips `uq_runtime_activities_one_active_per_agent`. The write is best-effort, so runs proceed — all of FAY windows 2–3 ran over it — but activity tracking is silently dead for those agents and the recurring traceback is dispatch-log noise that can mask a real failure. Leases got release-on-finalize hardening; activities got neither (exact sibling of the #373 class).

## Fix — both halves from the plan sketch

1. **Run-finalize sweep** (`RunCompletion.finalize`): task dispatch for the finishing run is over, so any activity still active for its cycle is stranded — abort them all. The executor threads its activity port into the default `RunCompletion`, so the sweep is live in the real composition. Prevents new strandings on every terminal path (completed/failed/cancelled/paused).
2. **Startup reaper** (runtime-api init): end active activities whose owning cycle is terminal — clears the four historic rows at first deploy, and covers process deaths that skipped finalize.

Machinery lives in a new runtime-domain module, `squadops/runtime/activity_reaper.py`, on a new bounded port read `RuntimeActivityPort.list_active_activities` (at most one active row per agent — D9 — so results are roster-bounded).

## Design notes

- **Per-row best-effort isolation**, same shape as `admission.release_participants`: one bad row (predicate or abort failure) never blocks clearing the rest, since one stranded row blocks all of that agent's future tracking.
- **Race-safe by construction**: both sweeps go through the existing `abort_activity` → `update_state` choke point, whose active-only `WHERE` makes a concurrent terminalization a no-op (`None`, not counted).
- **Layering**: `squadops.runtime` stays free of the cycles domain — cycle-terminal knowledge enters the reaper as an injected async predicate. The composition root builds it via `get_cycle` + `list_runs` + `derive_cycle_status`, the same fetch-and-derive shape the API routes use (no shared helper exists; none added).
- **New reason codes** (event/log-surfaced, not persisted, per the existing contract): `activity_stranded_at_run_finalize`, `activity_stranded_cycle_terminal`.

## Known conservative bounds (intentional)

- The startup reaper keys on derived `CycleStatus` ∈ {completed, failed, cancelled}. The all-runs-cancelled-but-cycle-not-cancelled edge derives `CREATED` and is left alone (can't prove the row is dead cheaply); none of the four historic rows are in it.
- A cancel that never reaches finalize (the #529/#481 orphaned-teardown class) clears at the next restart rather than immediately. In-scope fixes for those paths stay with their issues.

## Tests (15 new)

- `tests/unit/runtime/test_activity_reaper.py` (8): live-cycle rows spared / terminal-cycle rows reaped, cycle-less (duty/ambient) rows untouched, per-row survival of predicate and abort failures, concurrent-terminalization not counted, finalize sweep scoped to its own cycle, quiet no-op on clean runs.
- `tests/unit/runtime/test_runtime_activity.py` (3): new port read filters to active states + oldest-first, cycle filter actually binds, unfiltered read sends no params.
- `tests/unit/cycles/test_run_completion.py` (3): finalize aborts the cycle's active rows with the right reason, survives a sweep failure, no-port composition unchanged.
- `tests/unit/cycles/test_dispatched_flow_executor.py` (1): wiring seam — the executor's default `RunCompletion` receives the activity port (guards the silent-no-op class where the sweep never runs in production while all unit tests pass).

Existing `_FakeActivityPort` fakes extended with the new port method.

## Verification

Per the plan: no artifact replay applies (DB-state fix). Post-deploy checks at the single 1.4.1 deploy window: the four stranded rows are ended, and one fresh cycle logs zero `UniqueViolationError` / `best-effort start_activity failed` lines at dispatch. Regression suite green locally.

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
