### PR TITLE
fix(plan-validation): reject import_present on modules the scaffold surface cannot provide (#671)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2756,6 +2756,11 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     # rejection would end the cycle (#522).
                     errors.extend(parsed_plan.validate_command_checks())
                     errors.extend(parsed_plan.validate_expected_artifact_shapes())
+                    # #673: a dual-claimed expected artifact aliases two tasks
+                    # onto one file's fate (repair mis-scoping, last-wins
+                    # emission) — provable plan-wide right here, and a system
+                    # rejection re-rolls framing for free (#522).
+                    errors.extend(parsed_plan.validate_unique_expected_artifacts())
             elif ref.filename == "interface_manifest.yaml" or artifact_type == "interface_manifest":
                 interface_content = content_bytes.decode(errors="replace")
 

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2829,6 +2829,15 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         f"verification_contract: {e}"
                         for e in parsed_plan.validate_frozen_artifact_ownership(contract)
                     )
+                    # #671: import_present against a module the closed scaffold
+                    # surface cannot provide is provably unwinnable here, in
+                    # microseconds — a system rejection re-rolls framing for
+                    # free where the doomed roll would burn its correction
+                    # budget (#522).
+                    errors.extend(
+                        f"verification_contract: {e}"
+                        for e in parsed_plan.validate_module_existence(contract)
+                    )
                     # pf-42: a typed check aimed at a frozen file is decidable right
                     # now — the skeleton those files will contain is deterministic.
                     # A failing one makes the plan unwinnable (frozen emissions are

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -19,6 +19,7 @@ import dataclasses
 import hashlib
 import json
 from dataclasses import dataclass, field
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
 import yaml
@@ -60,6 +61,28 @@ _CHECK_ENV_EXECUTABLES = frozenset({"python", "python3", "pytest", "node", "npm"
 # exit 1 before parsing) — `node --check view.jsx` fails on ANY content,
 # correct or not (fay-2's killer; verified in the QA container).
 _NODE_UNPARSEABLE_SUFFIXES = (".jsx", ".tsx")
+
+
+def _importable_module_surface(paths: frozenset[str] | set[str]) -> frozenset[str]:
+    """The dotted module paths the scaffold surface can ever provide.
+
+    Path→module conversion mirrors ``ModuleImportsCheck.evaluate``
+    (acceptance_checks.py) — ``backend/routes.py`` → ``backend.routes``,
+    ``backend/__init__.py`` → ``backend``; non-Python files and
+    non-identifier segments contribute nothing.
+    """
+    modules: set[str] = set()
+    for path in paths:
+        pure = PurePosixPath(path)
+        if pure.suffix != ".py":
+            continue
+        parts = list(pure.with_suffix("").parts)
+        if parts and parts[-1] == "__init__":
+            parts = parts[:-1]
+        if not parts or not all(part.isidentifier() for part in parts):
+            continue
+        modules.add(".".join(parts))
+    return frozenset(modules)
 
 
 def planner_build_task_types(*, has_builder: bool) -> set[str]:
@@ -673,6 +696,69 @@ class ImplementationPlan:
             for artifact in task.expected_artifacts
             if artifact in frozen
         ]
+
+    def validate_module_existence(self, contract: VerificationContract) -> list[str]:
+        """#671: an error-severity ``import_present`` may not require a module the
+        scaffold surface provably cannot provide.
+
+        fay-17's framing-2 plan authored a blocking ``import_present: module:
+        app.routes`` — the ``app`` package does not exist (the scaffold root is
+        ``backend``, the pf-26 package-root class). Satisfying the check
+        guarantees a collection-dead suite; omitting the import fails
+        acceptance. Contradictory by construction, and provable at authoring
+        time from the contract's file surface.
+
+        Two rejected classes, both zero-false-positive on third-party imports:
+
+        - a module under a scaffold package root that the closed surface does
+          not contain (``backend.handlers`` — the scaffold owns everything
+          under ``backend/``, so absence is proof);
+        - a real scaffold module leaf under a package root that does not exist
+          (``app.routes``, ``src.backend.main`` — the wrong-root hallucination).
+
+        Everything else is out of scope by design: relative specs (``.errors``
+        — the contract authors this form itself) and dotless specs (``errors``
+        — #441 author-intent-relative semantics) validate at evaluation depth
+        we don't have here, and dotted third-party modules
+        (``fastapi.testclient``) are legitimately outside the scaffold surface.
+
+        ``harness_boundary.entry_modules`` is deliberately NOT validated:
+        entry modules are a FORBIDDEN-import list (the check fails a test that
+        imports one), and the scaffold's own convention seeds nonexistent
+        wrong-guess traps (``app.main``, ``main`` — ``_HARNESS_ENTRY_MODULES``)
+        on purpose. A nonexistent entry there is protective, not doomed.
+
+        Only ``severity=error`` rejects (RC-9, same split as the #645 rules).
+        """
+        surface = _importable_module_surface(
+            {ff.path for ff in contract.frozen_files} | {ff.path for ff in contract.fill_files}
+        )
+        roots = {module.split(".", 1)[0] for module in surface}
+        leaves = {module.rsplit(".", 1)[-1] for module in surface}
+
+        errors: list[str] = []
+        for task in self.tasks:
+            for criterion in task.acceptance_criteria:
+                if not isinstance(criterion, TypedCheck):
+                    continue
+                if criterion.check != "import_present" or criterion.severity != "error":
+                    continue
+                module = criterion.params.get("module")
+                if not isinstance(module, str) or module.startswith(".") or "." not in module:
+                    continue  # relative / dotless / malformed: out of scope (see docstring)
+                if module in surface:
+                    continue
+                root, leaf = module.split(".", 1)[0], module.rsplit(".", 1)[-1]
+                if root not in roots and leaf not in leaves:
+                    continue  # third-party shaped (fastapi.testclient): out of scope
+                errors.append(
+                    f"Task {task.task_index} ({task.focus}): import_present requires "
+                    f"module {module!r}, which the scaffold surface does not provide — "
+                    f"the import can never succeed, so the check fails on any content "
+                    f"and satisfying it kills the suite at collection instead. The "
+                    f"importable scaffold modules are {sorted(surface)}"
+                )
+        return errors
 
     def _authored_on_covered_criteria(self, contract: VerificationContract):
         """Yield ``(task, criterion, target)`` for every authored ``TypedCheck``

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -456,6 +456,48 @@ class ImplementationPlan:
                     )
         return errors
 
+    def validate_unique_expected_artifacts(self) -> list[str]:
+        """#673: an artifact path may appear in only one task's ``expected_artifacts``.
+
+        Expected artifacts are load-bearing task identity — they drive write
+        authorization, repair scoping (#650) and missing-artifact locus routing
+        (#665) — so a dual claim quietly aliases two tasks onto one file's fate:
+        a failing non-producing claimant aims its repair at a file another task
+        owns, and if both produce, last-wins ordering silently decides whose
+        emission ships (the #389 class fay-14's repair chain replayed).
+
+        fay-18's approved framing-2 plan carried the shape live: qa task 5
+        declared dev task 4's ``backend/tests/test_runs.py`` with an explicit
+        do-not-produce instruction. The dice were kind (zero corrections); the
+        hazard rode anyway. There is no legitimate dual-claim the artifact-less
+        form doesn't cover, so no warn tier — the legal shape for a
+        verification-only task is ``expected_artifacts: []`` plus
+        ``criteria_refs`` (the fay-13 framing-2 receipt).
+
+        Plan-wide cross-task pass — the first of its kind in this family; the
+        per-task rules above stay per-task. A path repeated *within* one task
+        is a benign echo, not a claim conflict, and is not reported here.
+        """
+        claimants: dict[str, list[PlanTask]] = {}
+        for task in self.tasks:
+            seen_in_task: set[str] = set()
+            for name in task.expected_artifacts:
+                if not isinstance(name, str) or name in seen_in_task:
+                    continue
+                seen_in_task.add(name)
+                claimants.setdefault(name, []).append(task)
+
+        return [
+            f"Tasks {' and '.join(f'{t.task_index} ({t.focus})' for t in tasks)} both declare "
+            f"expected artifact {name!r} — expected artifacts are load-bearing task identity "
+            f"(write authorization, repair scoping, missing-artifact routing), so a dual claim "
+            f"aims repairs at another task's file and lets last-wins ordering decide whose "
+            f"emission ships. Exactly one task owns each file; a verification-only task "
+            f"declares expected_artifacts: [] and binds acceptance via criteria_refs"
+            for name, tasks in claimants.items()
+            if len(tasks) > 1
+        ]
+
     def lint_prose_contract_conflicts(self, contract: VerificationContract) -> list[str]:
         """pf-31 Fix A3: WARNING-only lint for prose that contradicts bound criteria.
 

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -858,6 +858,14 @@ def _replace_build_steps_with_plan(
     shape_errors = plan.validate_expected_artifact_shapes()
     if shape_errors:
         raise CycleError("Plan validation failed (expected artifacts): " + "; ".join(shape_errors))
+    # #673: two tasks claiming the same expected artifact alias themselves onto
+    # one file's fate — repairs mis-scope and last-wins ordering decides whose
+    # emission ships (fay-18's dual-claimed test suite).
+    duplicate_errors = plan.validate_unique_expected_artifacts()
+    if duplicate_errors:
+        raise CycleError(
+            "Plan validation failed (duplicate expected artifacts): " + "; ".join(duplicate_errors)
+        )
 
     # SIP-0098 98.3 bind-mode dispatch net: when a contract is seeded, the plan
     # must bind the contract's covered-file criteria by id rather than author

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -787,6 +787,43 @@ def _attach_unbound_contract_criteria(
     tail_qa.inputs["acceptance_criteria"] = existing
 
 
+def _validate_plan_against_contract(plan: ImplementationPlan, contract: VerificationContract):
+    """Bind-mode dispatch nets: every contract-gated plan validator, raising
+    ``CycleError`` on the first failing category (same backstop contract as the
+    contract-free nets in ``_replace_build_steps_with_plan``)."""
+    ref_errors = plan.validate_criteria_refs(contract)
+    if ref_errors:
+        raise CycleError("Plan validation failed (contract binding): " + "; ".join(ref_errors))
+    # pf-39: a qa.test task declaring scaffold-/dev-owned files as its expected
+    # artifacts is unsatisfiable (write authorization refuses the emission) and
+    # misdirects any repair scoped to it. Same referent as write authorization,
+    # applied at authoring time.
+    ownership_errors = plan.validate_qa_artifact_ownership(contract)
+    if ownership_errors:
+        raise CycleError(
+            "Plan validation failed (qa artifact ownership): " + "; ".join(ownership_errors)
+        )
+    # #658: the same referent for every other role — frozen files are
+    # claimable by nobody (fay-12's dev task on the frozen api.js slipped
+    # between the qa net and the typed-criteria frozen rule).
+    frozen_ownership_errors = plan.validate_frozen_artifact_ownership(contract)
+    if frozen_ownership_errors:
+        raise CycleError(
+            "Plan validation failed (frozen artifact ownership): "
+            + "; ".join(frozen_ownership_errors)
+        )
+    # #671: an import_present requiring a module the scaffold surface cannot
+    # provide (fay-17's app.routes) is unwinnable by construction — the
+    # surface is closed, so absence is provable at authoring time.
+    module_errors = plan.validate_module_existence(contract)
+    if module_errors:
+        raise CycleError("Plan validation failed (module existence): " + "; ".join(module_errors))
+    # pf-31 Fix A3: warning-only prose-vs-contract conflict lint, surfaced for
+    # the gate reviewer (never a rejection — reverted-#552 lesson).
+    for warning in plan.lint_prose_contract_conflicts(contract):
+        logger.warning("Plan prose/contract conflict: %s", warning)
+
+
 def _replace_build_steps_with_plan(
     steps: list,
     plan: ImplementationPlan,
@@ -827,31 +864,7 @@ def _replace_build_steps_with_plan(
     # them. This is the raising backstop; the gate-time net records the graceful
     # #473 rejection first. Contract absent = author mode = no-op.
     if contract is not None:
-        ref_errors = plan.validate_criteria_refs(contract)
-        if ref_errors:
-            raise CycleError("Plan validation failed (contract binding): " + "; ".join(ref_errors))
-        # pf-39: a qa.test task declaring scaffold-/dev-owned files as its expected
-        # artifacts is unsatisfiable (write authorization refuses the emission) and
-        # misdirects any repair scoped to it. Same referent as write authorization,
-        # applied at authoring time.
-        ownership_errors = plan.validate_qa_artifact_ownership(contract)
-        if ownership_errors:
-            raise CycleError(
-                "Plan validation failed (qa artifact ownership): " + "; ".join(ownership_errors)
-            )
-        # #658: the same referent for every other role — frozen files are
-        # claimable by nobody (fay-12's dev task on the frozen api.js slipped
-        # between the qa net and the typed-criteria frozen rule).
-        frozen_ownership_errors = plan.validate_frozen_artifact_ownership(contract)
-        if frozen_ownership_errors:
-            raise CycleError(
-                "Plan validation failed (frozen artifact ownership): "
-                + "; ".join(frozen_ownership_errors)
-            )
-        # pf-31 Fix A3: warning-only prose-vs-contract conflict lint, surfaced for
-        # the gate reviewer (never a rejection — reverted-#552 lesson).
-        for warning in plan.lint_prose_contract_conflicts(contract):
-            logger.warning("Plan prose/contract conflict: %s", warning)
+        _validate_plan_against_contract(plan, contract)
 
     # Remove static build steps, keep everything else (planning steps)
     static_build_types = {s[0] for s in BUILD_TASK_STEPS} | {

--- a/tests/fixtures/fay_plans/fay16_implementation_plan.yaml
+++ b/tests/fixtures/fay_plans/fay16_implementation_plan.yaml
@@ -1,0 +1,213 @@
+version: 1
+project_id: group_run
+cycle_id: cyc_c51568b00b64
+prd_hash: 9903beaa1e21faf202bbf185e6dca69d51d185bb3670843dc859646afc158894
+tasks:
+- task_index: 0
+  task_type: development.develop
+  role: dev
+  focus: Backend API routes
+  description: 'Implement all FastAPI endpoints in backend/routes.py:
+
+    - POST /runs: create a run, validate required fields, return 201 with generated
+    id
+
+    - GET /runs: return list of all runs
+
+    - GET /runs/{id}: return full run details, 404 if not found
+
+    - POST /runs/{id}/join: add participant, reject empty names and case-insensitive
+    duplicates (409), return 404 for unknown run
+
+    - POST /runs/{id}/leave: remove participant, reject empty names and non-existent
+    participants (404), return 404 for unknown run
+
+    Interact with the frozen in-memory store (run_event_store, participant_store)
+    and use Pydantic models from frozen backend/models.py. Register error handlers
+    if needed via frozen backend/errors.py.'
+  expected_artifacts:
+  - backend/routes.py
+  acceptance_criteria:
+  - Endpoints return correct HTTP status codes (201, 200, 404, 409, 422) per PRD behavior.
+  - Case-insensitive duplicate participant detection rejects joins with 409.
+  - Missing runs or participants return 404 with clear error payloads.
+  - Pydantic validation returns 422 for missing required fields (title, datetime,
+    location).
+  - In-memory state persists across requests within the same process lifecycle.
+  depends_on: []
+  criteria_refs:
+  - vc-routes-endpoints
+  - vc-routes-apierror
+  - vc-routes-compiles
+  - vc-routes-imports
+- task_index: 1
+  task_type: development.develop
+  role: dev
+  focus: Runs list view
+  description: Implement frontend/src/views/RunsListView.jsx to fetch runs from the
+    backend API and display them in a list. Show title, datetime, location, and participant
+    count for each run. Handle empty state when no runs exist. Use the frozen api.js
+    client for data fetching. Minimal styling, functional layout.
+  expected_artifacts:
+  - frontend/src/views/RunsListView.jsx
+  acceptance_criteria:
+  - View renders a list of runs fetched from GET /runs.
+  - Displays title, datetime, location, and participant count for each run.
+  - Shows an empty state message when no runs exist.
+  - Links to detail view at /run/:id for each run.
+  depends_on: []
+  criteria_refs:
+  - vc-view-compiles-runs-list-view
+- task_index: 2
+  task_type: development.develop
+  role: dev
+  focus: Create run view
+  description: Implement frontend/src/views/CreateRunView.jsx with a form for creating
+    a run. Validate required fields (title, datetime, location) before submission.
+    POST to /runs and redirect to / on success. Display backend validation errors
+    if the request fails. Use frozen api.js for submission.
+  expected_artifacts:
+  - frontend/src/views/CreateRunView.jsx
+  acceptance_criteria:
+  - Form requires title, datetime, and location fields.
+  - Submits a POST request to /runs with the form data.
+  - Redirects to / on successful creation (201 response).
+  - Displays backend validation errors (422) in the UI if the request fails.
+  depends_on: []
+  criteria_refs:
+  - vc-view-compiles-create-run-view
+- task_index: 3
+  task_type: development.develop
+  role: dev
+  focus: Run detail view
+  description: Implement frontend/src/views/RunDetailView.jsx to display full run
+    details, list of participants, and forms for joining and leaving. Fetch run data
+    via GET /runs/{id}. Handle join/leave actions with proper error feedback (409
+    duplicates, 404 not found) and update the UI state accordingly. Use frozen api.js
+    for all network calls.
+  expected_artifacts:
+  - frontend/src/views/RunDetailView.jsx
+  acceptance_criteria:
+  - Displays run details and participant list from GET /runs/{id}.
+  - Join form submits to POST /runs/{id}/join and updates the participant list on
+    success.
+  - Leave form submits to POST /runs/{id}/leave and removes the participant on success.
+  - Handles and displays errors for duplicate names (409) and not-found cases (404)
+    in the UI.
+  - Shows 404 state if the run does not exist.
+  depends_on: []
+  criteria_refs:
+  - vc-view-compiles-run-detail-view
+- task_index: 4
+  task_type: qa.test
+  role: qa
+  focus: Backend API pytest suite
+  description: 'Author pytest-based integration tests in backend/tests/test_api.py
+    exercising the full vertical slice:
+
+    - POST /runs (201 creation, 422 validation errors)
+
+    - GET /runs (200 list with participant count)
+
+    - GET /runs/{id} (200 details, 404 unknown ID)
+
+    - POST /runs/{id}/join (200 success, 409 duplicate, 404 unknown run)
+
+    - POST /runs/{id}/leave (200 success, 404 missing participant/run)
+
+    Validates structured JSON responses, payload shape alignment with Pydantic models,
+    and error contract consistency. Uses scaffold-owned conftest client fixture to
+    verify FE/BE payload shape alignment risk area.'
+  expected_artifacts:
+  - backend/tests/test_api.py
+  acceptance_criteria:
+  - check: function_defined
+    file: backend/tests/test_api.py
+    name_prefix: test_
+    min_count: 8
+  - check: harness_boundary
+    file: backend/tests/test_api.py
+    entry_modules:
+    - backend.main
+    - app.main
+    client_ctor: TestClient
+  - All endpoint tests return correct HTTP status codes (201, 200, 404, 409, 422)
+    per PRD behavior.
+  - Response payloads match Pydantic model shapes and error contract specifications.
+  depends_on:
+  - 0
+- task_index: 5
+  task_type: qa.test
+  role: qa
+  focus: State persistence and isolation tests
+  description: 'Author tests in backend/tests/test_state_isolation.py to verify in-memory
+    store behavior:
+
+    - Confirms state persists across sequential HTTP requests within a single test
+    client session.
+
+    - Validates test isolation prevents cross-test data leakage (e.g., runs created
+    in one test do not leak into another).
+
+    - Exercises conftest store reset mechanisms or session scoping to guarantee deterministic
+    assertions.
+
+    Directly addresses risk area: in-memory test state isolation preventing flaky
+    assertions.'
+  expected_artifacts:
+  - backend/tests/test_state_isolation.py
+  acceptance_criteria:
+  - check: function_defined
+    file: backend/tests/test_state_isolation.py
+    name_prefix: test_
+    min_count: 4
+  - check: harness_boundary
+    file: backend/tests/test_state_isolation.py
+    entry_modules:
+    - backend.main
+    - app.main
+    client_ctor: TestClient
+  - In-memory store correctly retains created runs and participants across multiple
+    client requests.
+  - Test execution order independence is verified; no cross-test data leakage occurs.
+  depends_on:
+  - 0
+- task_index: 6
+  task_type: qa.test
+  role: qa
+  focus: Duplicate participant validation tests
+  description: 'Author tests in backend/tests/test_validation.py targeting case-insensitive
+    duplicate detection and empty-input rejection:
+
+    - Validates join/leave operations reject duplicate participant names regardless
+    of casing (e.g., "Alice" vs "alice").
+
+    - Confirms empty string or whitespace-only participant names are rejected with
+    appropriate status codes.
+
+    - Verifies leave operations for non-existent participants return 404 as specified
+    in technical design.
+
+    Directly addresses risk area: case-insensitive duplicate validation edge cases.'
+  expected_artifacts:
+  - backend/tests/test_validation.py
+  acceptance_criteria:
+  - check: function_defined
+    file: backend/tests/test_validation.py
+    name_prefix: test_
+    min_count: 5
+  - check: harness_boundary
+    file: backend/tests/test_validation.py
+    entry_modules:
+    - backend.main
+    - app.main
+    client_ctor: TestClient
+  - Case-insensitive duplicate join attempts are consistently rejected with 409.
+  - Empty or invalid participant names on join/leave trigger correct validation errors.
+  depends_on:
+  - 0
+summary:
+  total_dev_tasks: 4
+  total_qa_tasks: 3
+  total_tasks: 7
+  estimated_layers: []

--- a/tests/fixtures/fay_plans/fay17_framing2_implementation_plan.yaml
+++ b/tests/fixtures/fay_plans/fay17_framing2_implementation_plan.yaml
@@ -1,0 +1,160 @@
+version: 1
+project_id: group_run
+cycle_id: cyc_e175cae83a6f
+prd_hash: 9903beaa1e21faf202bbf185e6dca69d51d185bb3670843dc859646afc158894
+tasks:
+- task_index: 0
+  task_type: development.develop
+  role: dev
+  focus: Implement backend API routes
+  description: 'Fill backend/routes.py with all required endpoints: POST /runs, GET
+    /runs, GET /runs/{id}, POST /runs/{id}/join, POST /runs/{id}/leave.
+
+    Integrate with frozen store.py (run_event_store, participant_store) and models.py.
+
+    Enforce required-field validation (422), case-insensitive duplicate participant
+    prevention, and proper error responses via frozen errors.py.
+
+    Ensure endpoints match the interface manifest contract.'
+  expected_artifacts:
+  - backend/routes.py
+  acceptance_criteria:
+  - All five endpoints respond correctly with valid JSON per contract.
+  - POST /runs rejects empty required fields with 422 status.
+  - POST /runs/{id}/join enforces case-insensitive name uniqueness.
+  - Unknown run IDs return clear error responses.
+  depends_on: []
+  criteria_refs:
+  - vc-routes-endpoints
+  - vc-routes-apierror
+  - vc-routes-compiles
+  - vc-routes-imports
+- task_index: 1
+  task_type: development.develop
+  role: dev
+  focus: Create Run UI view
+  description: 'Implement frontend/src/views/CreateRunView.jsx.
+
+    Renders a form for title, datetime, location (required) and optional distance/pace/notes.
+
+    Performs frontend validation for required fields before submit.
+
+    Uses frozen api.js client to POST to backend, then navigates to list on success
+    or shows inline error.'
+  expected_artifacts:
+  - frontend/src/views/CreateRunView.jsx
+  acceptance_criteria:
+  - Form correctly validates and submits required fields.
+  - Displays backend validation errors inline if submitted with missing data.
+  - Navigates to runs list upon successful creation.
+  depends_on: []
+  criteria_refs:
+  - vc-view-compiles-create-run-view
+- task_index: 2
+  task_type: development.develop
+  role: dev
+  focus: Runs List UI view
+  description: 'Implement frontend/src/views/RunsListView.jsx.
+
+    Fetches runs from GET /runs on mount.
+
+    Renders a list of run cards with title, datetime, location, and participant count.
+
+    Provides links/buttons to navigate to run detail and create run views.
+
+    Handles empty state gracefully.'
+  expected_artifacts:
+  - frontend/src/views/RunsListView.jsx
+  acceptance_criteria:
+  - Fetches and displays runs from backend API on load.
+  - Shows required fields and participant count per run.
+  - Provides navigation to detail and create views.
+  depends_on: []
+  criteria_refs:
+  - vc-view-compiles-runs-list-view
+- task_index: 3
+  task_type: development.develop
+  role: dev
+  focus: Run Detail UI view
+  description: 'Implement frontend/src/views/RunDetailView.jsx.
+
+    Fetches run detail from GET /runs/{id} on mount.
+
+    Displays event details, participant list, join form (name input), and leave form
+    (name input).
+
+    Handles mutations via api.js, refetches detail on success, and displays inline
+    validation/errors.
+
+    Shows clear not-found state for invalid IDs.'
+  expected_artifacts:
+  - frontend/src/views/RunDetailView.jsx
+  acceptance_criteria:
+  - Displays full run details and current participant list.
+  - Join form validates name, calls backend, updates UI on success, and shows duplicate/validation
+    errors.
+  - Leave form removes participant and updates UI or shows clear error if name not
+    found.
+  - Handles unknown run ID with a clear error state.
+  depends_on: []
+  criteria_refs:
+  - vc-view-compiles-run-detail-view
+- task_index: 4
+  task_type: qa.test
+  role: qa
+  focus: Backend API pytest suite
+  description: "Create backend/tests/test_api.py exercising all five core endpoints:\n\
+    \n- POST /runs: happy path with required fields, rejection of empty required fields\
+    \ (422),\n  optional fields accepted as empty/null, returned run includes generated\
+    \ id\n- GET /runs: empty list initially, populates after creation, returns title/datetime/location/participant_count\n\
+    - GET /runs/{id}: full run details with participant list, unknown ID returns 404\n\
+    - POST /runs/{id}/join: happy path with valid name, case-insensitive duplicate\
+    \ rejection\n  (\"Alice\" vs \"alice\"), empty name rejection (422), participant\
+    \ count increments\n- POST /runs/{id}/leave: happy path removing existing participant,\
+    \ empty name rejection,\n  non-existent participant returns 404 per technical\
+    \ design decision, count decrements\n\nUse the frozen conftest.py client fixture\
+    \ (do NOT construct TestClient directly).\nExercise backend.routes via the TestClient,\
+    \ not by importing route functions directly.\nReset in-memory store between test\
+    \ groups using store.reset() for isolation.\n\nVerify the full create→list→detail→join→leave\
+    \ lifecycle with count accuracy assertions."
+  expected_artifacts:
+  - backend/tests/test_api.py
+  acceptance_criteria:
+  - check: function_defined
+    file: backend/tests/test_api.py
+    name_prefix: test_
+    min_count: 12
+  - check: import_present
+    file: backend/tests/test_api.py
+    module: app.routes
+  - check: harness_boundary
+    file: backend/tests/test_api.py
+    entry_modules:
+    - backend.main
+    - app.main
+    client_ctor: TestClient
+  - Tests cover all five endpoints with both success and error cases.
+  - POST /runs rejects empty title, datetime, or location with 422 status.
+  - POST /runs/{id}/join rejects case-insensitive duplicates (e.g., 'Alice' vs 'alice').
+  - GET /runs/{id} returns 404 for unknown run IDs.
+  - POST /runs/{id}/leave returns 404 for non-existent participant (per technical
+    design decision).
+  - Participant count accurately reflects joins and leaves throughout the lifecycle.
+  - Tests isolate in-memory store state between groups via store.reset().
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/tests/test_api.py
+  - 'qa_handoff.md (builder-owned) includes: backend/frontend startup commands, test
+    execution steps, core scope summary, known limitations (in-memory persistence),
+    and documented answer to open question about leave-non-existent-participant behavior
+    (should return 404).'
+  depends_on:
+  - 0
+summary:
+  total_dev_tasks: 4
+  total_qa_tasks: 1
+  total_tasks: 5
+  estimated_layers: []

--- a/tests/fixtures/fay_plans/fay18_framing2_implementation_plan.yaml
+++ b/tests/fixtures/fay_plans/fay18_framing2_implementation_plan.yaml
@@ -1,0 +1,200 @@
+version: 1
+project_id: group_run
+cycle_id: cyc_42c44ad3af91
+prd_hash: 9903beaa1e21faf202bbf185e6dca69d51d185bb3670843dc859646afc158894
+tasks:
+- task_index: 0
+  task_type: development.develop
+  role: dev
+  focus: Backend API routes
+  description: Implement FastAPI routes in backend/routes.py to handle run creation,
+    listing, detail retrieval, and participant join/leave. Leverages frozen backend/models.py,
+    backend/store.py, and backend/errors.py. Enforces 422 for validation failures,
+    404 for missing resources, and 409 for duplicate participant names (case-insensitive,
+    whitespace-trimmed).
+  expected_artifacts:
+  - backend/routes.py
+  acceptance_criteria:
+  - POST /runs creates run with required fields and returns 201.
+  - GET /runs returns all runs with participant counts.
+  - GET /runs/{id} returns run detail; returns 404 for unknown IDs.
+  - POST /runs/{id}/join adds participant; rejects duplicates with 409.
+  - POST /runs/{id}/leave removes participant; returns 404/409 if not found.
+  - Missing or empty required fields trigger 422 validation errors.
+  depends_on: []
+  criteria_refs:
+  - vc-routes-endpoints
+  - vc-routes-apierror
+  - vc-routes-compiles
+  - vc-routes-imports
+- task_index: 1
+  task_type: development.develop
+  role: dev
+  focus: Frontend runs list view
+  description: Implement frontend/src/views/RunsListView.jsx to fetch and display
+    available runs. Renders title, datetime, location, and participant count per run.
+    Provides navigation to run detail and create forms.
+  expected_artifacts:
+  - frontend/src/views/RunsListView.jsx
+  acceptance_criteria:
+  - Fetches runs list on component mount.
+  - Renders each run with title, datetime, location, and participant count.
+  - Provides links to create new run and view run details.
+  depends_on:
+  - 0
+  criteria_refs:
+  - vc-view-compiles-runs-list-view
+- task_index: 2
+  task_type: development.develop
+  role: dev
+  focus: Frontend create run view
+  description: Implement frontend/src/views/CreateRunView.jsx with a form for run
+    title, datetime, location, and optional fields. Validates required fields client-side,
+    posts to POST /runs, and redirects to the list on success.
+  expected_artifacts:
+  - frontend/src/views/CreateRunView.jsx
+  acceptance_criteria:
+  - Form blocks submit if required fields are empty.
+  - Successfully posts payload to /runs and handles response.
+  - Redirects user to runs list after creation.
+  depends_on:
+  - 0
+  criteria_refs:
+  - vc-view-compiles-create-run-view
+- task_index: 3
+  task_type: development.develop
+  role: dev
+  focus: Frontend run detail view
+  description: Implement frontend/src/views/RunDetailView.jsx to display full run
+    details, participant list, and join/leave forms. Re-fetches state after mutations
+    to reflect updates. Uses frozen frontend/src/api.js for HTTP calls.
+  expected_artifacts:
+  - frontend/src/views/RunDetailView.jsx
+  acceptance_criteria:
+  - Extracts run id from URL params and fetches detail.
+  - Displays participant list and join/leave input forms.
+  - Refreshes view state after join or leave actions.
+  depends_on:
+  - 0
+  criteria_refs:
+  - vc-view-compiles-run-detail-view
+- task_index: 4
+  task_type: development.develop
+  role: dev
+  focus: Backend test suite
+  description: Implement pytest suite in backend/tests/test_runs.py covering happy
+    paths, validation boundaries, and duplicate/error handling. Uses the frozen conftest.py
+    client fixture to exercise backend/routes.py endpoints.
+  expected_artifacts:
+  - backend/tests/test_runs.py
+  acceptance_criteria:
+  - check: function_defined
+    file: backend/tests/test_runs.py
+    name_prefix: test_
+    min_count: 6
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/tests/test_runs.py
+  - Tests verify create, list, join, and leave happy paths.
+  - Tests assert 422 on empty required fields and 409/404 on duplicates/missing entities.
+  depends_on:
+  - 0
+- task_index: 5
+  task_type: qa.test
+  role: qa
+  focus: Validate backend test suite coverage
+  description: 'Verify that the dev-authored backend/tests/test_runs.py satisfies
+    the brief''s
+
+    must_cover_requirements for test coverage: POST /runs (201), GET /runs, GET /runs/{id}
+
+    (404), POST join (409 duplicate), POST leave (404/409 not-found), and 422 validation
+
+    on empty required fields. Confirm the suite has sufficient test function density
+    and
+
+    compiles without syntax errors. This task does NOT produce new tests — it gates
+    the
+
+    existing suite against the brief''s coverage expectations.'
+  expected_artifacts:
+  - backend/tests/test_runs.py
+  acceptance_criteria:
+  - check: function_defined
+    file: backend/tests/test_runs.py
+    name_prefix: test_
+    min_count: 8
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/tests/test_runs.py
+  - Suite includes tests for run creation (201), listing (200), detail retrieval (200/404),
+    join with duplicate rejection (409), leave with not-found handling (404/409),
+    and empty-field validation (422).
+  - All tests use the scaffold client fixture and do not directly import backend.app
+    or backend.main.
+  depends_on:
+  - 0
+  - 4
+- task_index: 6
+  task_type: qa.test
+  role: qa
+  focus: API integration flow test
+  description: 'Produce backend/tests/test_integration_flows.py with an integration
+    test that chains
+
+    the complete API lifecycle: create a run → list runs to confirm presence → fetch
+    run
+
+    detail → join with a participant → verify participant appears → attempt duplicate
+    join
+
+    (expect 409) → leave participant → verify participant removed → fetch unknown
+    run ID
+
+    (expect 404) → submit create/join/leave with empty required fields (expect 422).
+
+    This directly mitigates the brief''s risk_areas for API↔Frontend contract drift
+    and
+
+    in-memory state consistency during mutations. Uses the scaffold''s client fixture
+    from
+
+    conftest.py; does NOT import backend.main or app.main directly.'
+  expected_artifacts:
+  - backend/tests/test_integration_flows.py
+  acceptance_criteria:
+  - check: function_defined
+    file: backend/tests/test_integration_flows.py
+    name_prefix: test_
+    min_count: 1
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/tests/test_integration_flows.py
+  - check: harness_boundary
+    file: backend/tests/test_integration_flows.py
+    entry_modules:
+    - backend.main
+    - app.main
+    client_ctor: TestClient
+  - Integration test chains create → list → detail → join → duplicate-reject → leave
+    → not-found → empty-field-validation in a single session.
+  - 'Verifies HTTP status codes match contract: 201 (create), 200 (list/detail/join/leave),
+    404 (unknown run/participant), 409 (duplicate/not-found), 422 (validation).'
+  - Verifies response payload shapes include expected fields (run id, title, datetime,
+    location, participant count, participant list).
+  depends_on:
+  - 0
+summary:
+  total_dev_tasks: 5
+  total_qa_tasks: 2
+  total_tasks: 7
+  estimated_layers: []

--- a/tests/fixtures/fay_plans/fay19_framing2_implementation_plan.yaml
+++ b/tests/fixtures/fay_plans/fay19_framing2_implementation_plan.yaml
@@ -1,0 +1,195 @@
+version: 1
+project_id: group_run
+cycle_id: cyc_96e72accb2b3
+prd_hash: 9903beaa1e21faf202bbf185e6dca69d51d185bb3670843dc859646afc158894
+tasks:
+- task_index: 0
+  task_type: development.develop
+  role: dev
+  focus: Backend REST endpoints and validation
+  description: "Implement all five REST endpoints in backend/routes.py using the frozen\n\
+    in-memory store (run_event_store, participant_store) and Pydantic models\n(RunEvent,\
+    \ RunEventCreate, ParticipantName).\n\nEndpoints to implement:\n- GET /runs: list\
+    \ all runs with participant counts\n- GET /runs/{run_id}: detail view for a single\
+    \ run (404 if missing)\n- POST /runs: create a run from RunEventCreate payload;\
+    \ return 201 with\n  the created RunEvent including generated id\n- POST /runs/{run_id}/join:\
+    \ accept ParticipantName, validate non-empty\n  name, check for case-insensitive\
+    \ duplicate (strip whitespace, lowercase\n  compare), return updated RunEvent\
+    \ on success; 404 if run missing; 409\n  if duplicate name\n- POST /runs/{run_id}/leave:\
+    \ accept ParticipantName, validate non-empty\n  name, remove participant by case-insensitive\
+    \ match; 404 if run missing\n  or participant not found\n\nAll write mutations\
+    \ must be guarded by asyncio.Lock on the store to\nprevent race conditions on\
+    \ concurrent join/leave.\n\nThis satisfies the brief requirements for:\n- In-memory\
+    \ state only (uses frozen store.py dicts)\n- REST endpoints for create, list,\
+    \ detail, join, and leave\n- Required field validation on run creation; non-empty\
+    \ participant name\n  on join/leave\n- Case-insensitive, whitespace-trimmed duplicate\
+    \ participant prevention\n- Server-side error feedback for validation failures,\
+    \ not-found, and\n  duplicates"
+  expected_artifacts:
+  - backend/routes.py
+  acceptance_criteria:
+  - POST /runs returns 422 when required fields (title, datetime, location) are empty
+  - POST /runs/{id}/join and /leave return 422 when participant name is empty or whitespace-only
+  - Duplicate name join (case-insensitive, whitespace-trimmed) returns 409
+  - Non-existent run_id returns 404 on GET, join, and leave
+  - Non-existent participant on leave returns 404
+  - asyncio.Lock guards all store mutations to prevent count drift under concurrent
+    requests
+  depends_on: []
+  criteria_refs:
+  - vc-routes-endpoints
+  - vc-routes-apierror
+  - vc-routes-compiles
+  - vc-routes-imports
+- task_index: 1
+  task_type: development.develop
+  role: dev
+  focus: Runs list view
+  description: 'Implement the runs list view in frontend/src/views/RunsListView.jsx.
+
+    On mount, fetch GET /runs via the frozen api.js client. Render each run
+
+    as a clickable link to /runs/:id showing title, datetime, location, and
+
+    participant count. Show an empty-state message when no runs exist.
+
+    Include a navigation link to the create run page.
+
+
+    This satisfies the brief requirement for browsing upcoming runs and
+
+    provides the client-side list behavior tied to the backend GET /runs
+
+    endpoint.'
+  expected_artifacts:
+  - frontend/src/views/RunsListView.jsx
+  acceptance_criteria:
+  - Fetches and displays all runs from the backend list endpoint on mount
+  - Each run shows title, datetime, location, and participant count
+  - Clicking a run navigates to its detail page via react-router
+  - Shows a clear empty state message when no runs exist
+  - Includes navigation to the create run page
+  depends_on:
+  - 0
+  criteria_refs:
+  - vc-view-compiles-runs-list-view
+- task_index: 2
+  task_type: development.develop
+  role: dev
+  focus: Create run view
+  description: 'Implement the create run form in frontend/src/views/CreateRunView.jsx.
+
+    Fields: title (required), datetime (required), location (required),
+
+    distance (optional), pace target (optional), route notes (optional).
+
+    Validate non-empty required fields before submitting POST /runs via the
+
+    frozen api.js client. On success, navigate to the runs list. On failure,
+
+    display the server error message inline. Redirect on successful creation
+
+    so the user sees the new run in the list.
+
+
+    This satisfies the brief requirement for client-side required-field
+
+    validation and the create run happy path.'
+  expected_artifacts:
+  - frontend/src/views/CreateRunView.jsx
+  acceptance_criteria:
+  - Form includes required fields (title, datetime, location) and optional fields
+    (distance, pace, notes)
+  - Client-side validation prevents submission when required fields are empty
+  - Successful creation redirects user to the runs list where the new run appears
+  - Server validation errors are displayed as clear inline messages
+  depends_on:
+  - 0
+  criteria_refs:
+  - vc-view-compiles-create-run-view
+- task_index: 3
+  task_type: development.develop
+  role: dev
+  focus: Run detail view
+  description: 'Implement the run detail view in frontend/src/views/RunDetailView.jsx.
+
+    Fetch the run by id from the backend on mount. Display all run details
+
+    (title, datetime, location, distance, pace, notes) and the participant
+
+    list with count. Provide a join form (participant name input + submit)
+
+    and a leave form (participant name input + submit). After a successful
+
+    join or leave, re-fetch the run to update the display. Handle 404 by
+
+    showing a not-found message. Handle 409 (duplicate name) and 422
+
+    (validation) errors by displaying them as clear inline messages.
+
+
+    This satisfies the brief requirements for viewing run details, joining,
+
+    leaving, and clear client-side error feedback for validation failures,
+
+    not-found, and duplicates.'
+  expected_artifacts:
+  - frontend/src/views/RunDetailView.jsx
+  acceptance_criteria:
+  - Displays all run event details including optional fields when present
+  - Shows participant list and count
+  - Join form accepts a name and submits to the backend join endpoint
+  - Leave form accepts a name and submits to the backend leave endpoint
+  - After join or leave, the view refreshes to reflect updated state
+  - 404 displays a clear not-found message; 409 displays a duplicate-name error
+  - 422 validation errors from the server are displayed as inline messages
+  depends_on:
+  - 0
+  criteria_refs:
+  - vc-view-compiles-run-detail-view
+- task_index: 4
+  task_type: qa.test
+  role: qa
+  focus: Backend REST pytest suite
+  description: "Author backend/tests/test_runs.py — a comprehensive pytest + httpx\n\
+    integration suite exercising the five REST endpoints defined in\nbackend/routes.py.\
+    \ All tests must use the scaffold's conftest `client`\nfixture (FastAPI TestClient)\
+    \ — never construct TestClient manually or\nimport backend.main/app.main at module\
+    \ level.\n\nTest categories to cover (aligned to brief must_cover_requirements):\n\
+    \n1. **Happy path CRUD** — create run, list runs, get run detail, join\n   run,\
+    \ leave run, verify participant count updates correctly after\n   each mutation.\n\
+    \n2. **Required-field validation** — POST /runs with empty/missing title,\n  \
+    \ datetime, location returns 422; POST /runs/{id}/join and /leave\n   with empty\
+    \ participant name returns 422.\n\n3. **Duplicate prevention** — case-insensitive\
+    \ (Alice vs alice),\n   whitespace-trimmed (\"Alice \" vs \"Alice\"), and combined\n\
+    \   case+whitespace duplicates all return 409 on join.\n\n4. **Not-found handling**\
+    \ — GET/join/leave for non-existent run_id\n   returns 404; leave for non-existent\
+    \ participant returns 404.\n\n5. **State mutation consistency** — sequential join-then-leave\
+    \ for\n   the same participant preserves correct count (count_after_leave ==\n\
+    \   count_before_join); rapid sequential mutations do not drift.\n\nEach test\
+    \ is independent (creates its own run/joins via the client)\nto avoid cross-test\
+    \ state contamination in the in-memory store."
+  expected_artifacts:
+  - backend/tests/test_runs.py
+  acceptance_criteria:
+  - At least 10 test functions covering CRUD happy path, validation boundaries, duplicate
+    edge cases, not-found handling, and state consistency
+  - All tests use the conftest `client` fixture — no manual TestClient construction
+    or direct backend.main import
+  - 'Happy path: create → list → detail → join → leave flow succeeds with correct
+    status codes and payload shapes'
+  - 'Validation: empty required fields on create return 422; empty name on join/leave
+    returns 422'
+  - 'Duplicates: case-insensitive and whitespace-trimmed joins return 409'
+  - 'Not-found: missing run returns 404 on GET, join, leave; missing participant on
+    leave returns 404'
+  - 'State consistency: participant count is accurate after each join/leave mutation;
+    no drift after sequential operations'
+  - Test module imports the backend production module it exercises
+  depends_on:
+  - 0
+summary:
+  total_dev_tasks: 4
+  total_qa_tasks: 1
+  total_tasks: 5
+  estimated_layers: []

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -1064,6 +1064,104 @@ class TestValidateModuleExistence:
         )
 
 
+class TestValidateUniqueExpectedArtifacts:
+    """#673: an artifact path may appear in only one task's expected_artifacts.
+
+    fay-18's approved framing-2 plan (cyc_42c44ad3af91) carried the live shape:
+    qa task 5 declared dev task 4's ``backend/tests/test_runs.py`` with an
+    explicit do-not-produce instruction. Benign that roll by luck — but a
+    failing non-producing claimant aims its repair at another task's file, and
+    dual producers hand the shipped suite to last-wins ordering (the #389
+    class). A regression here means that exact plan would be admitted again.
+    """
+
+    _fay_plan = staticmethod(TestValidateModuleExistence._fay_plan)
+
+    @staticmethod
+    def _plan_with_artifacts(*artifact_lists: list[str]) -> ImplementationPlan:
+        tasks = []
+        for i, artifacts in enumerate(artifact_lists):
+            entries = "".join(f'      - "{a}"\n' for a in artifacts)
+            tasks.append(
+                f"  - task_index: {i}\n"
+                "    task_type: development.develop\n"
+                "    role: dev\n"
+                f'    focus: "Task {i}"\n'
+                '    description: "build the thing"\n'
+                + (
+                    f"    expected_artifacts:\n{entries}"
+                    if artifacts
+                    else "    expected_artifacts: []\n"
+                )
+                + "    depends_on: []\n"
+            )
+        return ImplementationPlan.from_yaml(
+            "version: 1\n"
+            "project_id: group_run\n"
+            "cycle_id: cyc_test\n"
+            "prd_hash: abc123\n"
+            "tasks:\n" + "".join(tasks) + "summary:\n"
+            f"  total_dev_tasks: {len(artifact_lists)}\n"
+            "  total_qa_tasks: 0\n"
+            f"  total_tasks: {len(artifact_lists)}\n"
+            "  estimated_layers: []\n"
+        )
+
+    def test_fay18_stored_plan_trips_on_the_dual_claim(self):
+        """Stored-artifact replay: the real fay-18 framing-2 plan must reject,
+        solely on tasks 4/5 both claiming the backend test suite."""
+        errors = self._fay_plan(
+            "fay18_framing2_implementation_plan.yaml"
+        ).validate_unique_expected_artifacts()
+
+        assert len(errors) == 1
+        assert "Tasks 4 (Backend test suite) and 5" in errors[0]
+        assert "'backend/tests/test_runs.py'" in errors[0]
+        assert "criteria_refs" in errors[0]
+
+    def test_fay19_clean_stored_plan_passes(self):
+        """Stored-artifact replay: the window's cleanest accepted plan has
+        disjoint artifact sets and must pass untouched."""
+        assert (
+            self._fay_plan(
+                "fay19_framing2_implementation_plan.yaml"
+            ).validate_unique_expected_artifacts()
+            == []
+        )
+
+    def test_disjoint_artifacts_pass(self):
+        assert (
+            self._plan_with_artifacts(
+                ["backend/routes.py"], ["backend/tests/test_api.py"], []
+            ).validate_unique_expected_artifacts()
+            == []
+        )
+
+    def test_three_way_claim_reports_one_error_naming_every_claimant(self):
+        """One duplicated path is one defect — three claimants must not produce
+        three rejection lines, and every claimant must be named so the re-roll
+        knows which tasks to untangle."""
+        errors = self._plan_with_artifacts(
+            ["backend/tests/test_api.py"],
+            ["backend/tests/test_api.py"],
+            ["backend/tests/test_api.py"],
+        ).validate_unique_expected_artifacts()
+
+        assert len(errors) == 1
+        assert "0 (Task 0) and 1 (Task 1) and 2 (Task 2)" in errors[0]
+
+    def test_repeat_within_a_single_task_is_not_a_claim_conflict(self):
+        """Scope pin: a path listed twice in ONE task's expected_artifacts is a
+        benign echo (presence-checking is set-shaped), not a cross-task claim —
+        flagging it would reject plans over a formatting slip."""
+        assert (
+            self._plan_with_artifacts(
+                ["backend/routes.py", "backend/routes.py"]
+            ).validate_unique_expected_artifacts()
+            == []
+        )
+
+
 # ---------------------------------------------------------------------------
 # #645: command-check executability + expected-artifact shape (FAY window)
 # ---------------------------------------------------------------------------

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -929,6 +929,141 @@ class TestFrozenArtifactOwnership:
         )
 
 
+class TestValidateModuleExistence:
+    """#671: an error-severity import_present may not require a module the closed
+    scaffold surface cannot provide.
+
+    fay-17's approved framing-2 plan (cyc_e175cae83a6f, art_b12c08f02557)
+    authored a blocking ``import_present: module: app.routes`` — no ``app``
+    package exists, so satisfying the check guarantees a collection-dead suite
+    while omitting it fails acceptance. A regression here means that exact plan
+    would be admitted again. Scope is deliberately narrow (zero third-party
+    false positives): only wrong-root hallucinations of real scaffold leaves
+    and nonexistent submodules under a scaffold root reject; relative/dotless
+    specs (#441 author-intent semantics, the contract's own ``.errors`` form)
+    and third-party dotted modules stay out of scope, and
+    ``harness_boundary.entry_modules`` is exempt — entries there are a
+    FORBIDDEN-import list whose scaffold convention seeds nonexistent
+    wrong-guess traps (``app.main``) on purpose.
+    """
+
+    _contract = staticmethod(TestQaArtifactOwnership._contract)
+
+    @staticmethod
+    def _fay_plan(name: str) -> ImplementationPlan:
+        from pathlib import Path
+
+        path = Path(__file__).resolve().parents[2] / "fixtures" / "fay_plans" / name
+        return ImplementationPlan.from_yaml(path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _plan_with_import(module: str, severity: str = "error") -> ImplementationPlan:
+        return ImplementationPlan.from_yaml(
+            "version: 1\n"
+            "project_id: group_run\n"
+            "cycle_id: cyc_test\n"
+            "prd_hash: abc123\n"
+            "tasks:\n"
+            "  - task_index: 0\n"
+            "    task_type: qa.test\n"
+            "    role: qa\n"
+            '    focus: "Backend API pytest suite"\n'
+            '    description: "exercise the routes"\n'
+            "    expected_artifacts:\n"
+            '      - "backend/tests/test_api.py"\n'
+            "    acceptance_criteria:\n"
+            '      - {check: import_present, file: "backend/tests/test_api.py", '
+            f'module: "{module}", severity: "{severity}"}}\n'
+            "    depends_on: []\n"
+            "summary:\n"
+            "  total_dev_tasks: 0\n"
+            "  total_qa_tasks: 1\n"
+            "  total_tasks: 1\n"
+            "  estimated_layers: []\n"
+        )
+
+    def test_fay17_stored_plan_trips_on_app_routes(self):
+        """Stored-artifact replay: the real fay-17 framing-2 plan must reject,
+        solely on its task-4 ``app.routes`` import."""
+        errors = self._fay_plan(
+            "fay17_framing2_implementation_plan.yaml"
+        ).validate_module_existence(self._contract())
+
+        assert len(errors) == 1
+        assert "Task 4" in errors[0]
+        assert "'app.routes'" in errors[0]
+        assert "scaffold surface does not provide" in errors[0]
+
+    def test_wrong_root_hallucination_of_a_scaffold_leaf_rejected(self):
+        """``app.routes``: the leaf is a real scaffold module, the root is not —
+        the pf-26 wrong-package-root class as an authored check."""
+        errors = self._plan_with_import("app.routes").validate_module_existence(self._contract())
+
+        assert len(errors) == 1
+        assert "'app.routes'" in errors[0]
+
+    def test_nonexistent_submodule_under_scaffold_root_rejected(self):
+        """``backend.handlers``: the scaffold owns everything under backend/, so
+        the closed surface proves absence."""
+        errors = self._plan_with_import("backend.handlers").validate_module_existence(
+            self._contract()
+        )
+
+        assert len(errors) == 1
+        assert "'backend.handlers'" in errors[0]
+
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "backend.routes",  # surface module
+            "conftest",  # dotless surface module
+            "fastapi.testclient",  # third-party dotted: out of scope by design
+            ".errors",  # relative — the contract authors this form itself
+            "errors",  # dotless (#441 author-intent-relative)
+            "pytest",  # dotless third-party
+        ],
+    )
+    def test_legitimate_modules_accepted(self, module):
+        """Must not over-reject: surface modules, relative/dotless specs, and
+        third-party imports all pass — a false positive here would reject
+        working plans (and the contract's own resolved criteria)."""
+        assert self._plan_with_import(module).validate_module_existence(self._contract()) == []
+
+    def test_warning_severity_tolerated(self):
+        """RC-9 parity with the #645 rules: a warning check cannot block a build,
+        so it must not kill the cycle at plan validation."""
+        assert (
+            self._plan_with_import("app.routes", severity="warning").validate_module_existence(
+                self._contract()
+            )
+            == []
+        )
+
+    def test_fay16_entry_modules_are_exempt(self):
+        """Stored-artifact replay pinning the narrowed scope: fay-16's plan
+        (cyc_c51568b00b64) lists ``app.main`` in harness_boundary entry_modules
+        at three sites — a forbidden-import list where nonexistent entries are
+        protective, matching the scaffold's own ``_HARNESS_ENTRY_MODULES``
+        convention. Existence-netting it would reject plans for copying the
+        scaffold's own convention (see #671 scope note)."""
+        assert (
+            self._fay_plan("fay16_implementation_plan.yaml").validate_module_existence(
+                self._contract()
+            )
+            == []
+        )
+
+    def test_fay19_clean_stored_plan_passes(self):
+        """Stored-artifact replay: the window's cleanest accepted plan (green,
+        cyc_96e72accb2b3 framing-2) must pass untouched."""
+        assert (
+            self._fay_plan("fay19_framing2_implementation_plan.yaml").validate_module_existence(
+                self._contract()
+            )
+            == []
+        )
+
+
 # ---------------------------------------------------------------------------
 # #645: command-check executability + expected-artifact shape (FAY window)
 # ---------------------------------------------------------------------------

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -710,6 +710,25 @@ class TestGenerateTaskPlanBindMode:
                 _make_cycle(), _make_run(), _make_profile(), plan=plan, contract=contract
             )
 
+    def test_import_present_on_nonexistent_module_raises_at_dispatch(self):
+        """#671 backstop: fay-17's shape — an error-severity import_present
+        requiring a module the contract's surface cannot provide must never
+        reach dispatch (the suite would be collection-dead if satisfied)."""
+        from squadops.cycles.models import CycleError
+
+        plan = ImplementationPlan.from_yaml(
+            MANIFEST_YAML.replace(
+                'acceptance_criteria: ["Models exist"]',
+                'acceptance_criteria: ["Models exist", {check: import_present, '
+                'file: "backend/tests/test_models.py", module: "app.models"}]',
+                1,
+            )
+        )
+        with pytest.raises(CycleError, match="module existence"):
+            generate_task_plan(
+                _make_cycle(), _make_run(), _make_profile(), plan=plan, contract=_models_contract()
+            )
+
     def test_dispatch_resolves_refs_into_acceptance_criteria(self):
         # 98.3 slice C: the bound ref materializes into the dispatched envelope's
         # acceptance_criteria as a TypedCheck stamped with the contract id + file.

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -710,6 +710,22 @@ class TestGenerateTaskPlanBindMode:
                 _make_cycle(), _make_run(), _make_profile(), plan=plan, contract=contract
             )
 
+    def test_dual_claimed_expected_artifact_raises_at_dispatch(self):
+        """#673 backstop: fay-18's shape — two tasks declaring the same expected
+        artifact must never reach dispatch (contract-free net, fires in author
+        mode too)."""
+        from squadops.cycles.models import CycleError
+
+        plan = ImplementationPlan.from_yaml(
+            MANIFEST_YAML.replace(
+                'expected_artifacts: ["backend/main.py"]',
+                'expected_artifacts: ["backend/models.py"]',
+                1,
+            )
+        )
+        with pytest.raises(CycleError, match="duplicate expected artifacts"):
+            generate_task_plan(_make_cycle(), _make_run(), _make_profile(), plan=plan)
+
     def test_import_present_on_nonexistent_module_raises_at_dispatch(self):
         """#671 backstop: fay-17's shape — an error-severity import_present
         requiring a module the contract's surface cannot provide must never


### PR DESCRIPTION
1.4.1 hardening patch, fix 2 of 5 (`docs/plans/1-4-1-hardening-patch-plan.md`). Validator pair with #673.

## Problem

fay-17's approved framing-2 plan (`cyc_e175cae83a6f`) carried a blocking `import_present: module: app.routes` — the `app` package doesn't exist (scaffold root is `backend`, the pf-26 package-root class). Satisfying the check guarantees a collection-dead suite; omitting it fails acceptance. Contradictory by construction, invisible to the #645-era validators (which cover command executability and artifact shapes, not import-shaped params).

## Fix

New `ImplementationPlan.validate_module_existence(contract)`, wired at both nets like its #645/#658 siblings (gate reject-and-teach → free framing re-roll per #522; dispatch `CycleError` backstop). It proves absence from the contract's **closed** file surface (frozen + fill paths → importable module paths, the same conversion `ModuleImportsCheck` uses):

- **Rejects** a module under a scaffold package root that the surface doesn't contain (`backend.handlers` — the scaffold owns everything under `backend/`, so absence is proof), and a real scaffold leaf under a nonexistent root (`app.routes`, `src.backend.main` — the wrong-root hallucination).
- **Out of scope by design** (zero third-party false positives): relative specs (`.errors` — the contract authors this form itself), dotless specs (`errors` — #441 author-intent-relative semantics), and dotted third-party modules (`fastapi.testclient`).
- Only `severity=error` rejects (RC-9, same split as the #645 rules).

## Scope narrowed vs the issue sketch — entry_modules is exempt (deliberate)

The issue (and the plan doc's verify line) wanted `harness_boundary.entry_modules` existence-netted too, on the fay-16/18 `app.main` receipts. Reading the evaluator killed that premise:

- `HarnessBoundaryCheck` **fails a test that imports an entry module** — `entry_modules` is a *forbidden-import* list, not a "build against one of" list (that reading died with pf-33's wrong-directional expectation line, and the current rendering states the prohibition).
- The scaffold's own convention deliberately seeds nonexistent wrong-guess traps: `_HARNESS_ENTRY_MODULES = ("backend.main", "app.main", "main")`. A nonexistent entry is *protective* — it catches the doomed import at acceptance instead of at collection.
- An existence net there would reject plans for copying the scaffold's own convention.

So fay-16 (which listed `app.main` at three sites and scored **green**) now has a pinned regression test asserting it **passes** — the opposite of the plan doc's sketch, with the receipt in the test docstring. Flagging this explicitly for review since it amends the pre-registered verification expectations.

## Verification — stored-artifact replay

Real fay plans committed as fixtures (`tests/fixtures/fay_plans/`, artifact ids in docstrings):
- fay-17 framing-2 (`art_b12c08f02557`): **trips**, exactly one error, on task 4's `app.routes`.
- fay-16 (`art_4c38a3a19418`): passes — pins the entry_modules exemption.
- fay-19 framing-2 (`art_ff352e740f93`, the window's cleanest green): passes untouched.

Plus unit cases per class, a must-not-over-reject parametrized set, RC-9 warning tolerance, and a dispatch-backstop wiring test. Mechanical note: the contract-gated dispatch chain moved verbatim into `_validate_plan_against_contract` (C901 remedy, same pattern as prior extractions). Regression suite green: 5937 passed (+13).

Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
