### PR TITLE
fix(plan-validation): reject two tasks claiming the same expected artifact (#673)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2756,6 +2756,11 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     # rejection would end the cycle (#522).
                     errors.extend(parsed_plan.validate_command_checks())
                     errors.extend(parsed_plan.validate_expected_artifact_shapes())
+                    # #673: a dual-claimed expected artifact aliases two tasks
+                    # onto one file's fate (repair mis-scoping, last-wins
+                    # emission) — provable plan-wide right here, and a system
+                    # rejection re-rolls framing for free (#522).
+                    errors.extend(parsed_plan.validate_unique_expected_artifacts())
             elif ref.filename == "interface_manifest.yaml" or artifact_type == "interface_manifest":
                 interface_content = content_bytes.decode(errors="replace")
 

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -456,6 +456,48 @@ class ImplementationPlan:
                     )
         return errors
 
+    def validate_unique_expected_artifacts(self) -> list[str]:
+        """#673: an artifact path may appear in only one task's ``expected_artifacts``.
+
+        Expected artifacts are load-bearing task identity — they drive write
+        authorization, repair scoping (#650) and missing-artifact locus routing
+        (#665) — so a dual claim quietly aliases two tasks onto one file's fate:
+        a failing non-producing claimant aims its repair at a file another task
+        owns, and if both produce, last-wins ordering silently decides whose
+        emission ships (the #389 class fay-14's repair chain replayed).
+
+        fay-18's approved framing-2 plan carried the shape live: qa task 5
+        declared dev task 4's ``backend/tests/test_runs.py`` with an explicit
+        do-not-produce instruction. The dice were kind (zero corrections); the
+        hazard rode anyway. There is no legitimate dual-claim the artifact-less
+        form doesn't cover, so no warn tier — the legal shape for a
+        verification-only task is ``expected_artifacts: []`` plus
+        ``criteria_refs`` (the fay-13 framing-2 receipt).
+
+        Plan-wide cross-task pass — the first of its kind in this family; the
+        per-task rules above stay per-task. A path repeated *within* one task
+        is a benign echo, not a claim conflict, and is not reported here.
+        """
+        claimants: dict[str, list[PlanTask]] = {}
+        for task in self.tasks:
+            seen_in_task: set[str] = set()
+            for name in task.expected_artifacts:
+                if not isinstance(name, str) or name in seen_in_task:
+                    continue
+                seen_in_task.add(name)
+                claimants.setdefault(name, []).append(task)
+
+        return [
+            f"Tasks {' and '.join(f'{t.task_index} ({t.focus})' for t in tasks)} both declare "
+            f"expected artifact {name!r} — expected artifacts are load-bearing task identity "
+            f"(write authorization, repair scoping, missing-artifact routing), so a dual claim "
+            f"aims repairs at another task's file and lets last-wins ordering decide whose "
+            f"emission ships. Exactly one task owns each file; a verification-only task "
+            f"declares expected_artifacts: [] and binds acceptance via criteria_refs"
+            for name, tasks in claimants.items()
+            if len(tasks) > 1
+        ]
+
     def lint_prose_contract_conflicts(self, contract: VerificationContract) -> list[str]:
         """pf-31 Fix A3: WARNING-only lint for prose that contradicts bound criteria.
 

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -858,6 +858,14 @@ def _replace_build_steps_with_plan(
     shape_errors = plan.validate_expected_artifact_shapes()
     if shape_errors:
         raise CycleError("Plan validation failed (expected artifacts): " + "; ".join(shape_errors))
+    # #673: two tasks claiming the same expected artifact alias themselves onto
+    # one file's fate — repairs mis-scope and last-wins ordering decides whose
+    # emission ships (fay-18's dual-claimed test suite).
+    duplicate_errors = plan.validate_unique_expected_artifacts()
+    if duplicate_errors:
+        raise CycleError(
+            "Plan validation failed (duplicate expected artifacts): " + "; ".join(duplicate_errors)
+        )
 
     # SIP-0098 98.3 bind-mode dispatch net: when a contract is seeded, the plan
     # must bind the contract's covered-file criteria by id rather than author

--- a/tests/fixtures/fay_plans/fay18_framing2_implementation_plan.yaml
+++ b/tests/fixtures/fay_plans/fay18_framing2_implementation_plan.yaml
@@ -1,0 +1,200 @@
+version: 1
+project_id: group_run
+cycle_id: cyc_42c44ad3af91
+prd_hash: 9903beaa1e21faf202bbf185e6dca69d51d185bb3670843dc859646afc158894
+tasks:
+- task_index: 0
+  task_type: development.develop
+  role: dev
+  focus: Backend API routes
+  description: Implement FastAPI routes in backend/routes.py to handle run creation,
+    listing, detail retrieval, and participant join/leave. Leverages frozen backend/models.py,
+    backend/store.py, and backend/errors.py. Enforces 422 for validation failures,
+    404 for missing resources, and 409 for duplicate participant names (case-insensitive,
+    whitespace-trimmed).
+  expected_artifacts:
+  - backend/routes.py
+  acceptance_criteria:
+  - POST /runs creates run with required fields and returns 201.
+  - GET /runs returns all runs with participant counts.
+  - GET /runs/{id} returns run detail; returns 404 for unknown IDs.
+  - POST /runs/{id}/join adds participant; rejects duplicates with 409.
+  - POST /runs/{id}/leave removes participant; returns 404/409 if not found.
+  - Missing or empty required fields trigger 422 validation errors.
+  depends_on: []
+  criteria_refs:
+  - vc-routes-endpoints
+  - vc-routes-apierror
+  - vc-routes-compiles
+  - vc-routes-imports
+- task_index: 1
+  task_type: development.develop
+  role: dev
+  focus: Frontend runs list view
+  description: Implement frontend/src/views/RunsListView.jsx to fetch and display
+    available runs. Renders title, datetime, location, and participant count per run.
+    Provides navigation to run detail and create forms.
+  expected_artifacts:
+  - frontend/src/views/RunsListView.jsx
+  acceptance_criteria:
+  - Fetches runs list on component mount.
+  - Renders each run with title, datetime, location, and participant count.
+  - Provides links to create new run and view run details.
+  depends_on:
+  - 0
+  criteria_refs:
+  - vc-view-compiles-runs-list-view
+- task_index: 2
+  task_type: development.develop
+  role: dev
+  focus: Frontend create run view
+  description: Implement frontend/src/views/CreateRunView.jsx with a form for run
+    title, datetime, location, and optional fields. Validates required fields client-side,
+    posts to POST /runs, and redirects to the list on success.
+  expected_artifacts:
+  - frontend/src/views/CreateRunView.jsx
+  acceptance_criteria:
+  - Form blocks submit if required fields are empty.
+  - Successfully posts payload to /runs and handles response.
+  - Redirects user to runs list after creation.
+  depends_on:
+  - 0
+  criteria_refs:
+  - vc-view-compiles-create-run-view
+- task_index: 3
+  task_type: development.develop
+  role: dev
+  focus: Frontend run detail view
+  description: Implement frontend/src/views/RunDetailView.jsx to display full run
+    details, participant list, and join/leave forms. Re-fetches state after mutations
+    to reflect updates. Uses frozen frontend/src/api.js for HTTP calls.
+  expected_artifacts:
+  - frontend/src/views/RunDetailView.jsx
+  acceptance_criteria:
+  - Extracts run id from URL params and fetches detail.
+  - Displays participant list and join/leave input forms.
+  - Refreshes view state after join or leave actions.
+  depends_on:
+  - 0
+  criteria_refs:
+  - vc-view-compiles-run-detail-view
+- task_index: 4
+  task_type: development.develop
+  role: dev
+  focus: Backend test suite
+  description: Implement pytest suite in backend/tests/test_runs.py covering happy
+    paths, validation boundaries, and duplicate/error handling. Uses the frozen conftest.py
+    client fixture to exercise backend/routes.py endpoints.
+  expected_artifacts:
+  - backend/tests/test_runs.py
+  acceptance_criteria:
+  - check: function_defined
+    file: backend/tests/test_runs.py
+    name_prefix: test_
+    min_count: 6
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/tests/test_runs.py
+  - Tests verify create, list, join, and leave happy paths.
+  - Tests assert 422 on empty required fields and 409/404 on duplicates/missing entities.
+  depends_on:
+  - 0
+- task_index: 5
+  task_type: qa.test
+  role: qa
+  focus: Validate backend test suite coverage
+  description: 'Verify that the dev-authored backend/tests/test_runs.py satisfies
+    the brief''s
+
+    must_cover_requirements for test coverage: POST /runs (201), GET /runs, GET /runs/{id}
+
+    (404), POST join (409 duplicate), POST leave (404/409 not-found), and 422 validation
+
+    on empty required fields. Confirm the suite has sufficient test function density
+    and
+
+    compiles without syntax errors. This task does NOT produce new tests — it gates
+    the
+
+    existing suite against the brief''s coverage expectations.'
+  expected_artifacts:
+  - backend/tests/test_runs.py
+  acceptance_criteria:
+  - check: function_defined
+    file: backend/tests/test_runs.py
+    name_prefix: test_
+    min_count: 8
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/tests/test_runs.py
+  - Suite includes tests for run creation (201), listing (200), detail retrieval (200/404),
+    join with duplicate rejection (409), leave with not-found handling (404/409),
+    and empty-field validation (422).
+  - All tests use the scaffold client fixture and do not directly import backend.app
+    or backend.main.
+  depends_on:
+  - 0
+  - 4
+- task_index: 6
+  task_type: qa.test
+  role: qa
+  focus: API integration flow test
+  description: 'Produce backend/tests/test_integration_flows.py with an integration
+    test that chains
+
+    the complete API lifecycle: create a run → list runs to confirm presence → fetch
+    run
+
+    detail → join with a participant → verify participant appears → attempt duplicate
+    join
+
+    (expect 409) → leave participant → verify participant removed → fetch unknown
+    run ID
+
+    (expect 404) → submit create/join/leave with empty required fields (expect 422).
+
+    This directly mitigates the brief''s risk_areas for API↔Frontend contract drift
+    and
+
+    in-memory state consistency during mutations. Uses the scaffold''s client fixture
+    from
+
+    conftest.py; does NOT import backend.main or app.main directly.'
+  expected_artifacts:
+  - backend/tests/test_integration_flows.py
+  acceptance_criteria:
+  - check: function_defined
+    file: backend/tests/test_integration_flows.py
+    name_prefix: test_
+    min_count: 1
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/tests/test_integration_flows.py
+  - check: harness_boundary
+    file: backend/tests/test_integration_flows.py
+    entry_modules:
+    - backend.main
+    - app.main
+    client_ctor: TestClient
+  - Integration test chains create → list → detail → join → duplicate-reject → leave
+    → not-found → empty-field-validation in a single session.
+  - 'Verifies HTTP status codes match contract: 201 (create), 200 (list/detail/join/leave),
+    404 (unknown run/participant), 409 (duplicate/not-found), 422 (validation).'
+  - Verifies response payload shapes include expected fields (run id, title, datetime,
+    location, participant count, participant list).
+  depends_on:
+  - 0
+summary:
+  total_dev_tasks: 5
+  total_qa_tasks: 2
+  total_tasks: 7
+  estimated_layers: []

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -1064,6 +1064,104 @@ class TestValidateModuleExistence:
         )
 
 
+class TestValidateUniqueExpectedArtifacts:
+    """#673: an artifact path may appear in only one task's expected_artifacts.
+
+    fay-18's approved framing-2 plan (cyc_42c44ad3af91) carried the live shape:
+    qa task 5 declared dev task 4's ``backend/tests/test_runs.py`` with an
+    explicit do-not-produce instruction. Benign that roll by luck — but a
+    failing non-producing claimant aims its repair at another task's file, and
+    dual producers hand the shipped suite to last-wins ordering (the #389
+    class). A regression here means that exact plan would be admitted again.
+    """
+
+    _fay_plan = staticmethod(TestValidateModuleExistence._fay_plan)
+
+    @staticmethod
+    def _plan_with_artifacts(*artifact_lists: list[str]) -> ImplementationPlan:
+        tasks = []
+        for i, artifacts in enumerate(artifact_lists):
+            entries = "".join(f'      - "{a}"\n' for a in artifacts)
+            tasks.append(
+                f"  - task_index: {i}\n"
+                "    task_type: development.develop\n"
+                "    role: dev\n"
+                f'    focus: "Task {i}"\n'
+                '    description: "build the thing"\n'
+                + (
+                    f"    expected_artifacts:\n{entries}"
+                    if artifacts
+                    else "    expected_artifacts: []\n"
+                )
+                + "    depends_on: []\n"
+            )
+        return ImplementationPlan.from_yaml(
+            "version: 1\n"
+            "project_id: group_run\n"
+            "cycle_id: cyc_test\n"
+            "prd_hash: abc123\n"
+            "tasks:\n" + "".join(tasks) + "summary:\n"
+            f"  total_dev_tasks: {len(artifact_lists)}\n"
+            "  total_qa_tasks: 0\n"
+            f"  total_tasks: {len(artifact_lists)}\n"
+            "  estimated_layers: []\n"
+        )
+
+    def test_fay18_stored_plan_trips_on_the_dual_claim(self):
+        """Stored-artifact replay: the real fay-18 framing-2 plan must reject,
+        solely on tasks 4/5 both claiming the backend test suite."""
+        errors = self._fay_plan(
+            "fay18_framing2_implementation_plan.yaml"
+        ).validate_unique_expected_artifacts()
+
+        assert len(errors) == 1
+        assert "Tasks 4 (Backend test suite) and 5" in errors[0]
+        assert "'backend/tests/test_runs.py'" in errors[0]
+        assert "criteria_refs" in errors[0]
+
+    def test_fay19_clean_stored_plan_passes(self):
+        """Stored-artifact replay: the window's cleanest accepted plan has
+        disjoint artifact sets and must pass untouched."""
+        assert (
+            self._fay_plan(
+                "fay19_framing2_implementation_plan.yaml"
+            ).validate_unique_expected_artifacts()
+            == []
+        )
+
+    def test_disjoint_artifacts_pass(self):
+        assert (
+            self._plan_with_artifacts(
+                ["backend/routes.py"], ["backend/tests/test_api.py"], []
+            ).validate_unique_expected_artifacts()
+            == []
+        )
+
+    def test_three_way_claim_reports_one_error_naming_every_claimant(self):
+        """One duplicated path is one defect — three claimants must not produce
+        three rejection lines, and every claimant must be named so the re-roll
+        knows which tasks to untangle."""
+        errors = self._plan_with_artifacts(
+            ["backend/tests/test_api.py"],
+            ["backend/tests/test_api.py"],
+            ["backend/tests/test_api.py"],
+        ).validate_unique_expected_artifacts()
+
+        assert len(errors) == 1
+        assert "0 (Task 0) and 1 (Task 1) and 2 (Task 2)" in errors[0]
+
+    def test_repeat_within_a_single_task_is_not_a_claim_conflict(self):
+        """Scope pin: a path listed twice in ONE task's expected_artifacts is a
+        benign echo (presence-checking is set-shaped), not a cross-task claim —
+        flagging it would reject plans over a formatting slip."""
+        assert (
+            self._plan_with_artifacts(
+                ["backend/routes.py", "backend/routes.py"]
+            ).validate_unique_expected_artifacts()
+            == []
+        )
+
+
 # ---------------------------------------------------------------------------
 # #645: command-check executability + expected-artifact shape (FAY window)
 # ---------------------------------------------------------------------------

--- a/tests/unit/cycles/test_task_plan_with_plan.py
+++ b/tests/unit/cycles/test_task_plan_with_plan.py
@@ -710,6 +710,22 @@ class TestGenerateTaskPlanBindMode:
                 _make_cycle(), _make_run(), _make_profile(), plan=plan, contract=contract
             )
 
+    def test_dual_claimed_expected_artifact_raises_at_dispatch(self):
+        """#673 backstop: fay-18's shape — two tasks declaring the same expected
+        artifact must never reach dispatch (contract-free net, fires in author
+        mode too)."""
+        from squadops.cycles.models import CycleError
+
+        plan = ImplementationPlan.from_yaml(
+            MANIFEST_YAML.replace(
+                'expected_artifacts: ["backend/main.py"]',
+                'expected_artifacts: ["backend/models.py"]',
+                1,
+            )
+        )
+        with pytest.raises(CycleError, match="duplicate expected artifacts"):
+            generate_task_plan(_make_cycle(), _make_run(), _make_profile(), plan=plan)
+
     def test_import_present_on_nonexistent_module_raises_at_dispatch(self):
         """#671 backstop: fay-17's shape — an error-severity import_present
         requiring a module the contract's surface cannot provide must never


### PR DESCRIPTION
1.4.1 hardening patch, fix 3 of 5 (`docs/plans/1-4-1-hardening-patch-plan.md`). Validator pair with #671.

**Stacked on #677** (same seam and test files) — base is `fix/671-module-existence-validation`, so this diff shows only the #673 change; GitHub retargets to main when #677 merges.

## Problem

Nothing rejected two tasks declaring the same `expected_artifacts` entry. fay-18's approved framing-2 plan (`cyc_42c44ad3af91`) carried it live: qa task 5 declared dev task 4's `backend/tests/test_runs.py` with an explicit "does NOT produce, gates the existing suite" instruction. Benign that roll by dice. The hazard: expected artifacts are load-bearing task identity — write authorization, repair scoping (#650), and missing-artifact locus routing (#665) all key on them — so a failing non-producing claimant aims its repair at a file another task owns, and dual producers hand the shipped suite to last-wins ordering (the #389 class fay-14's repair chain replayed).

## Fix

`ImplementationPlan.validate_unique_expected_artifacts()` — the family's first plan-wide cross-task rule (the ownership rules stay per-task). One error per duplicated path, naming **every** claimant and teaching the legal form: a verification-only task declares `expected_artifacts: []` and binds acceptance via `criteria_refs` (the fay-13 framing-2 receipt). No warn tier — dual-claim has no legitimate use the artifact-less form doesn't cover. Within-task repeats are deliberately not flagged (benign echo, presence-checking is set-shaped — pinned by test). Contract-free, so it fires in author mode too; wired at both nets (gate reject-and-teach, dispatch `CycleError` backstop).

## Verification — stored-artifact replay

- fay-18 framing-2 (`art_d0f7b45ad57d`, committed fixture): **trips**, exactly one error, naming tasks 4 and 5 and the duplicated path.
- fay-19 framing-2 (clean green plan): passes untouched.
- Synthetic: disjoint sets pass; three-way claim → one error naming all three claimants; within-task repeat not flagged; dispatch-backstop wiring test (author mode).

Regression suite green: 5943 passed (+6).

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
