### PR TITLE
fix(framing): re-rolls carry the prior rejection — revise, don't re-dice (#669)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -648,6 +648,20 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     ):
                         framing_rerolls += 1
                         await self._cycle_registry.cancel_run(current_run_id)
+                        # #669: the re-roll must revise, not re-dice — thread
+                        # what died and why into the new framing's authoring
+                        # prompts on the §6.6 forwarding rail. The rail is
+                        # rebuilt at the next workload advance, so the context
+                        # never leaks past framing; a second re-roll replaces
+                        # the first's context with the latest rejection.
+                        rejected_plan_yaml = await self._load_rejected_plan_yaml(run)
+                        rejection_context: dict[str, Any] = {"rejection_reasons": list(plan_errors)}
+                        if rejected_plan_yaml:
+                            rejection_context["rejected_plan_yaml"] = rejected_plan_yaml
+                        forwarding_overrides = {
+                            **(forwarding_overrides or {}),
+                            "framing_rejection_context": rejection_context,
+                        }
                         reroll_run = await self._create_next_workload_run(
                             cycle,
                             run,
@@ -942,6 +956,26 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             workload_type=workload_entry.get("type"),
         )
         return await self._cycle_registry.create_run(next_run)
+
+    async def _load_rejected_plan_yaml(self, run: Run) -> str | None:
+        """The rejected run's implementation_plan.yaml content, or None (#669).
+
+        Same match rule as the gate-net loader — cancellation only flips run
+        status, so the rejected run's artifact refs stay readable. Best-effort:
+        an unreadable artifact degrades the re-roll context to reasons-only,
+        never blocks the re-roll.
+        """
+        for ref_id in tuple(run.artifact_refs or ()):
+            try:
+                ref, content_bytes = await self._artifact_vault.retrieve(ref_id)
+            except Exception:
+                continue
+            if (
+                ref.filename == "implementation_plan.yaml"
+                or getattr(ref, "artifact_type", None) == "control_implementation_plan"
+            ):
+                return content_bytes.decode(errors="replace")
+        return None
 
     # ------------------------------------------------------------------
     # Execution strategies

--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -138,6 +138,33 @@ class _PlanningTaskHandler(_CycleTaskHandler):
             variables["time_budget_section"] = budget_section
         return variables
 
+    async def _rejection_context_section(self, renderer: Any, inputs: dict[str, Any]) -> str:
+        """The prior-rejection appendix on a framing re-roll, or "" (#669).
+
+        A #522 re-roll previously started with fresh dice and zero context —
+        the validator's teaching message persisted in gate_decisions where no
+        model ever read it, so the re-roll was free to re-emit the exact
+        rejected shape (fay-10 tripped the same ownership class on all three
+        framings; fay-15's #658 rejection named file, rule, and consequence to
+        nobody). Data arrives as dispatch-injected inputs; all prose lives in
+        the appendix assets (CLAUDE.md #448).
+        """
+        reasons = [
+            str(r).strip() for r in (inputs.get("rejection_reasons") or []) if str(r).strip()
+        ]
+        if not reasons:
+            return ""
+        variables: dict[str, str] = {"rejection_reasons": "\n".join(f"- {r}" for r in reasons)}
+        plan_yaml = str(inputs.get("rejected_plan_yaml") or "").strip()
+        if plan_yaml:
+            plan_rendered = await renderer.render(
+                "request.plan_reroll_rejected_plan_appendix",
+                {"rejected_plan_yaml": plan_yaml},
+            )
+            variables["rejected_plan_section"] = plan_rendered.content
+        rendered = await renderer.render("request.plan_reroll_rejection_appendix", variables)
+        return rendered.content
+
     def _build_user_prompt(
         self,
         prd: str,
@@ -562,6 +589,11 @@ class GovernancePreparePlanAuthoringBriefHandler(_PlanningTaskHandler):
         renderer = getattr(context.ports, "request_renderer", None)
         if renderer is not None:
             variables = self._build_render_variables(prd, prior_outputs, inputs)
+            # #669: the brief pins the frame the proposers work from — on a
+            # re-roll it must know what died, or it re-pins the rejected shape.
+            rejection_section = await self._rejection_context_section(renderer, inputs)
+            if rejection_section:
+                variables["rejection_context_section"] = rejection_section
             rendered = await renderer.render(self._request_template_id, variables)
             user_prompt = rendered.content
         else:
@@ -943,6 +975,12 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
         frozen_surface_section = await self._frozen_surface_section(renderer, inputs)
         if frozen_surface_section:
             variables["frozen_surface_section"] = frozen_surface_section
+        # #669: on a framing re-roll, the prior attempt's rejection — revise,
+        # don't re-dice. Data-driven and managed-asset prose, exactly like the
+        # sections above; a first-roll framing has no input and renders nothing.
+        rejection_section = await self._rejection_context_section(renderer, inputs)
+        if rejection_section:
+            variables["rejection_context_section"] = rejection_section
         rendered = await renderer.render(self._request_template_id, variables)
         user_prompt = rendered.content
 

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -454,6 +454,46 @@ def _applicable_acceptance(plan_task: Any) -> list:
     return acceptance
 
 
+# #669: the plan-authoring tasks that receive the prior framing's rejection
+# context on a re-roll — the same four the #657 planning-artifact filter feeds.
+# The merger is excluded: its normal merge path is deterministic (no prompt).
+_PLAN_AUTHORING_CONTEXT_TASK_TYPES = frozenset(
+    {
+        "governance.prepare_plan_authoring_brief",
+        "development.propose_plan_tasks",
+        "qa.propose_plan_tasks",
+        "strategy.propose_plan_guidance",
+    }
+)
+
+
+def _inject_rejection_context(
+    inputs: dict[str, Any], rejection_context: Any, task_type: str
+) -> None:
+    """#669: thread the prior framing's rejection into plan-authoring inputs.
+
+    A #522 framing re-roll previously granted fresh dice with zero context —
+    the validator's teaching message was persisted in gate_decisions and read
+    by nobody, so the re-roll was free to re-emit the exact rejected shape
+    (fay-10 tripped the same ownership class on all three framings). Data-only
+    keys; the authoring handlers render them through a managed appendix asset
+    (CLAUDE.md #448). Non-re-roll runs carry no context and get no keys.
+    """
+    if not isinstance(rejection_context, dict):
+        return
+    if task_type not in _PLAN_AUTHORING_CONTEXT_TASK_TYPES:
+        return
+    reasons = [
+        str(r).strip() for r in (rejection_context.get("rejection_reasons") or []) if str(r).strip()
+    ]
+    if not reasons:
+        return
+    inputs["rejection_reasons"] = reasons
+    plan_yaml = str(rejection_context.get("rejected_plan_yaml") or "")
+    if plan_yaml.strip():
+        inputs["rejected_plan_yaml"] = plan_yaml
+
+
 def _inject_contract_inputs(
     inputs: dict,
     contract: VerificationContract | None,
@@ -585,6 +625,11 @@ def generate_task_plan(
     # through resolved_config so the proposer steps are added/skipped per
     # cycle config. Other workload types ignore the extra argument.
     resolved_config = {**cycle.applied_defaults, **cycle.execution_overrides}
+    # #669: a framing re-roll forwards the prior rejection on the §6.6 overrides
+    # rail. It is authoring CONTEXT, not config — lift it out so resolved_config
+    # stays config-shaped on every envelope, then inject it onto the
+    # plan-authoring tasks only (below).
+    framing_rejection_context = resolved_config.pop("framing_rejection_context", None)
 
     if run.workload_type is not None:
         steps, builder_used = _resolve_workload_steps(
@@ -716,6 +761,7 @@ def generate_task_plan(
             inputs["acceptance_criteria"] = acceptance
 
         _inject_contract_inputs(inputs, contract, task_type, interface_manifest)
+        _inject_rejection_context(inputs, framing_rejection_context, task_type)
 
         envelope = TaskEnvelope(
             task_id=task_id,

--- a/src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md
+++ b/src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.development_propose_plan_tasks
-version: "1"
+version: "2"
 required_variables:
   - brief_content
   - planning_content
@@ -14,6 +14,7 @@ optional_variables:
   - scaffold_section
   - bind_criteria_section
   - frozen_surface_section
+  - rejection_context_section
 ---
 You are proposing development-domain plan tasks for the upcoming build.
 
@@ -75,3 +76,4 @@ confidence: ""  # low | medium | high
 {{bind_criteria_section}}
 
 {{frozen_surface_section}}
+{{rejection_context_section}}

--- a/src/squadops/prompts/request_templates/request.plan_reroll_rejected_plan_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_reroll_rejected_plan_appendix.md
@@ -1,0 +1,11 @@
+---
+template_id: request.plan_reroll_rejected_plan_appendix
+version: "1"
+required_variables:
+  - rejected_plan_yaml
+---
+The rejected plan, for revision reference (fix the listed defects; keep what was sound):
+
+```yaml
+{{rejected_plan_yaml}}
+```

--- a/src/squadops/prompts/request_templates/request.plan_reroll_rejection_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_reroll_rejection_appendix.md
@@ -1,0 +1,15 @@
+---
+template_id: request.plan_reroll_rejection_appendix
+version: "1"
+required_variables:
+  - rejection_reasons
+optional_variables:
+  - rejected_plan_section
+---
+## PRIOR ATTEMPT REJECTED (authoritative — revise, do not repeat)
+
+An earlier framing of this cycle authored an implementation plan that failed system plan validation. The reasons below are deterministic validator rules, not reviewer taste — a plan with the same shape will be rejected again, and re-roll attempts are limited. Author a revised plan that fixes every listed defect. Keep whatever structure of the prior attempt was sound; do not discard good task decomposition because one rule fired.
+
+Rejection reasons:
+{{rejection_reasons}}
+{{rejected_plan_section}}

--- a/src/squadops/prompts/request_templates/request.planning_task_base.md
+++ b/src/squadops/prompts/request_templates/request.planning_task_base.md
@@ -1,16 +1,18 @@
 ---
 template_id: request.planning_task_base
-version: "1"
+version: "2"
 required_variables:
   - prd
   - role
 optional_variables:
   - time_budget_section
   - prior_outputs
+  - rejection_context_section
 ---
 ## Product Requirements Document
 
 {{prd}}
 {{time_budget_section}}
 {{prior_outputs}}
+{{rejection_context_section}}
 Please provide your {{role}} analysis and deliverables.

--- a/src/squadops/prompts/request_templates/request.qa_propose_plan_tasks.md
+++ b/src/squadops/prompts/request_templates/request.qa_propose_plan_tasks.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.qa_propose_plan_tasks
-version: "1"
+version: "2"
 required_variables:
   - brief_content
   - planning_content
@@ -13,6 +13,7 @@ optional_variables:
   - typed_acceptance_vocabulary
   - bind_criteria_section
   - frozen_surface_section
+  - rejection_context_section
 ---
 You are proposing QA-domain plan tasks for the upcoming build.
 
@@ -75,3 +76,4 @@ confidence: ""  # low | medium | high
 {{bind_criteria_section}}
 
 {{frozen_surface_section}}
+{{rejection_context_section}}

--- a/src/squadops/prompts/request_templates/request.strategy_propose_plan_guidance.md
+++ b/src/squadops/prompts/request_templates/request.strategy_propose_plan_guidance.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.strategy_propose_plan_guidance
-version: "1"
+version: "2"
 required_variables:
   - brief_content
   - planning_content
@@ -9,6 +9,7 @@ required_variables:
 optional_variables:
   - prd
   - roles_section
+  - rejection_context_section
 ---
 You are proposing cross-cutting plan-authoring guidance for the upcoming build.
 
@@ -63,3 +64,4 @@ must_not_skip: []             # Items the merger must preserve under budget pres
 defer_if_time_constrained: [] # Items the merger may drop first under pressure.
 confidence: ""                # low | medium | high
 ```
+{{rejection_context_section}}

--- a/tests/unit/capabilities/test_propose_plan_tasks.py
+++ b/tests/unit/capabilities/test_propose_plan_tasks.py
@@ -286,6 +286,34 @@ async def test_qa_proposer_renders_dev_proposal_in_planning_content():
     assert "brief-test-001" not in variables["planning_content"]
 
 
+async def test_proposer_renders_rejection_context_on_a_reroll():
+    """#669 wiring: when dispatch injected the prior rejection, the proposer's
+    main render must carry the rendered section — the silent-no-op class where
+    the section renders but never reaches the template variables."""
+    ctx = _make_context(_DEV_PROPOSAL_RESPONSE)
+    handler = DevelopmentProposePlanTasksHandler()
+    inputs = _seeded_inputs()
+    inputs["rejection_reasons"] = [
+        "Task 2 (Backend store): development.develop declares expected artifact "
+        "'backend/store.py', which is frozen (scaffold-owned)"
+    ]
+
+    await handler.handle(ctx, inputs)
+
+    variables = ctx.ports.request_renderer.render.call_args.args[1]
+    assert "rejection_context_section" in variables
+
+
+async def test_first_roll_renders_no_rejection_section():
+    ctx = _make_context(_DEV_PROPOSAL_RESPONSE)
+    handler = DevelopmentProposePlanTasksHandler()
+
+    await handler.handle(ctx, _seeded_inputs())
+
+    variables = ctx.ports.request_renderer.render.call_args.args[1]
+    assert "rejection_context_section" not in variables
+
+
 async def test_strategy_proposer_emits_parseable_guidance():
     ctx = _make_context(_STRATEGY_GUIDANCE_RESPONSE)
     handler = StrategyProposePlanGuidanceHandler()

--- a/tests/unit/capabilities/test_reroll_rejection_context.py
+++ b/tests/unit/capabilities/test_reroll_rejection_context.py
@@ -1,0 +1,191 @@
+"""#669 — the prior framing's rejection reaches the re-rolled plan authors.
+
+A #522 re-roll previously granted fresh dice with zero context: the validator's
+teaching message persisted in gate_decisions where no model ever read it, so the
+re-roll was free to re-emit the exact rejected shape (fay-10 tripped the same
+ownership class on all three framings; fay-15's framing-1 #658 rejection named
+the file, the rule, and the consequence — to nobody). These cover the transport
+end to end: the dispatch-side injection that puts the rejection on the authoring
+envelopes, the handler section that renders it, and a live render of the managed
+assets proving the teaching message and the rejected plan survive the templates.
+
+The rejection fixture is fay-15 framing-1's real defect shape (cyc_6c185cba4811:
+dev task claimed the frozen backend/store.py, #658-netted, blind re-roll).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities.handlers.planning_tasks import (
+    DevelopmentProposePlanTasksHandler,
+    GovernancePreparePlanAuthoringBriefHandler,
+    QaProposePlanTasksHandler,
+    StrategyProposePlanGuidanceHandler,
+)
+from squadops.cycles.task_plan import _inject_rejection_context
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_FAY15_REJECTION = (
+    "Task 2 (Backend store): development.develop declares expected artifact "
+    "'backend/store.py', which is frozen (scaffold-owned) — no task may claim a "
+    "frozen file as a deliverable; scaffold enforcement restores frozen bytes at "
+    "emission, so the task cannot satisfy its expected artifacts and a repair "
+    "scoped to it would target the wrong files"
+)
+_REJECTED_PLAN = "version: 1\ntasks:\n  - task_index: 2\n    focus: Backend store\n"
+
+_AUTHORING_TASK_TYPES = (
+    "governance.prepare_plan_authoring_brief",
+    "development.propose_plan_tasks",
+    "qa.propose_plan_tasks",
+    "strategy.propose_plan_guidance",
+)
+
+
+# --- dispatch-side injection --------------------------------------------------- #
+
+
+@pytest.mark.parametrize("task_type", _AUTHORING_TASK_TYPES)
+def test_authoring_tasks_receive_the_rejection_context(task_type):
+    inputs: dict = {}
+    _inject_rejection_context(
+        inputs,
+        {"rejection_reasons": [_FAY15_REJECTION], "rejected_plan_yaml": _REJECTED_PLAN},
+        task_type,
+    )
+
+    assert inputs["rejection_reasons"] == [_FAY15_REJECTION]
+    assert inputs["rejected_plan_yaml"] == _REJECTED_PLAN
+
+
+@pytest.mark.parametrize(
+    "task_type",
+    ["development.develop", "qa.test", "governance.merge_plan", "data.research_context"],
+)
+def test_non_authoring_tasks_do_not(task_type):
+    """The merger's normal path is deterministic (no prompt) and build tasks
+    author no plans — leaking a stale rejection there is pure prompt noise."""
+    inputs: dict = {}
+    _inject_rejection_context(inputs, {"rejection_reasons": [_FAY15_REJECTION]}, task_type)
+
+    assert inputs == {}
+
+
+def test_first_roll_injects_nothing():
+    inputs: dict = {}
+    _inject_rejection_context(inputs, None, "development.propose_plan_tasks")
+
+    assert inputs == {}
+
+
+def test_reasonless_context_injects_nothing():
+    """A context with no usable reasons must not inject the plan alone — the
+    appendix leads with the reasons; a plan without them is an instruction to
+    copy the rejected shape."""
+    inputs: dict = {}
+    _inject_rejection_context(
+        inputs,
+        {"rejection_reasons": ["", "  "], "rejected_plan_yaml": _REJECTED_PLAN},
+        "development.propose_plan_tasks",
+    )
+
+    assert inputs == {}
+
+
+# --- handler section ----------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "handler_cls",
+    [
+        DevelopmentProposePlanTasksHandler,
+        QaProposePlanTasksHandler,
+        StrategyProposePlanGuidanceHandler,
+        GovernancePreparePlanAuthoringBriefHandler,
+    ],
+)
+async def test_every_authoring_handler_renders_the_section(handler_cls):
+    renderer = AsyncMock()
+    renderer.render.side_effect = lambda template_id, variables: MagicMock(
+        content=f"RENDERED:{template_id}"
+    )
+
+    out = await handler_cls()._rejection_context_section(
+        renderer,
+        {"rejection_reasons": [_FAY15_REJECTION], "rejected_plan_yaml": _REJECTED_PLAN},
+    )
+
+    assert out == "RENDERED:request.plan_reroll_rejection_appendix"
+    calls = {c.args[0]: c.args[1] for c in renderer.render.await_args_list}
+    # stripped: the appendix wraps the plan in a fenced block, so surrounding
+    # whitespace would only add blank lines inside the fence
+    assert calls["request.plan_reroll_rejected_plan_appendix"] == {
+        "rejected_plan_yaml": _REJECTED_PLAN.strip()
+    }
+    main_vars = calls["request.plan_reroll_rejection_appendix"]
+    assert main_vars["rejection_reasons"].startswith("- Task 2 (Backend store)")
+    assert (
+        main_vars["rejected_plan_section"] == "RENDERED:request.plan_reroll_rejected_plan_appendix"
+    )
+
+
+async def test_reasons_only_renders_without_the_plan_block():
+    """An unreadable rejected-plan artifact degrades to reasons-only — the
+    appendix must still render rather than dropping the teaching message."""
+    renderer = AsyncMock()
+    renderer.render.return_value = MagicMock(content="REJECTION BLOCK")
+
+    out = await DevelopmentProposePlanTasksHandler()._rejection_context_section(
+        renderer, {"rejection_reasons": [_FAY15_REJECTION]}
+    )
+
+    assert out == "REJECTION BLOCK"
+    (template_id, variables) = renderer.render.await_args.args
+    assert template_id == "request.plan_reroll_rejection_appendix"
+    assert "rejected_plan_section" not in variables
+
+
+async def test_absent_input_renders_nothing():
+    renderer = AsyncMock()
+
+    out = await DevelopmentProposePlanTasksHandler()._rejection_context_section(renderer, {})
+
+    assert out == ""
+    renderer.render.assert_not_awaited()
+
+
+# --- the real assets ----------------------------------------------------------- #
+
+
+async def test_real_assets_carry_the_teaching_message_and_the_plan():
+    """A live render — the rejection must survive the templates, not just the
+    function: the fay-15 teaching line, the revise-don't-repeat instruction,
+    and the rejected plan body all present in the final section."""
+    from adapters.prompts.filesystem_asset_adapter import FilesystemPromptAssetAdapter
+    from squadops.prompts.renderer import RequestTemplateRenderer
+
+    templates_dir = (
+        Path(__file__).resolve().parents[3] / "src" / "squadops" / "prompts" / "request_templates"
+    )
+    renderer = RequestTemplateRenderer(
+        FilesystemPromptAssetAdapter(
+            fragments_path=templates_dir.parent / "fragments",
+            templates_path=templates_dir,
+        )
+    )
+
+    section = await DevelopmentProposePlanTasksHandler()._rejection_context_section(
+        renderer,
+        {"rejection_reasons": [_FAY15_REJECTION], "rejected_plan_yaml": _REJECTED_PLAN},
+    )
+
+    assert "PRIOR ATTEMPT REJECTED" in section
+    assert "backend/store.py" in section
+    assert "frozen (scaffold-owned)" in section
+    assert "focus: Backend store" in section  # the rejected plan body
+    assert "revise" in section.lower()

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -1897,6 +1897,83 @@ class TestFramingReroll:
             "implementation",
         ]
 
+    async def test_reroll_forwards_rejection_context(self, executor, mock_registry, mock_event_bus):
+        """#669: the re-roll's execute_run must receive the prior rejection
+        (reasons + rejected plan YAML) on the §6.6 forwarding rail — fay-10
+        tripped the same ownership class on three blind framings. The
+        implementation run's forwarding is rebuilt at the advance, so the
+        context must NOT leak past framing."""
+        import dataclasses as _dc
+        from unittest.mock import MagicMock as _MM
+
+        cycle = _make_cycle(
+            workload_sequence=self._seq(), applied_defaults_extra={"framing_max_rerolls": 1}
+        )
+        mock_registry.get_cycle.return_value = cycle
+        run1 = _dc.replace(
+            _make_run("run_001", 1, "completed", "framing"), artifact_refs=("art_plan",)
+        )
+        run2 = _make_run("run_002", 2, "completed", "framing")
+        run3 = _make_run("run_003", 3, "completed", "implementation")
+        mock_registry.get_run.side_effect = [run1, run2, run3]
+        mock_registry.list_runs.return_value = [run1]
+        rejection = [
+            "Task 2 (Backend store): development.develop declares expected artifact "
+            "'backend/store.py', which is frozen (scaffold-owned)"
+        ]
+        executor._reject_invalid_plan_before_workload_gate = AsyncMock(side_effect=[rejection, []])
+        executor._create_next_workload_run = AsyncMock(side_effect=[run2, run3])
+        executor._poll_inter_workload_gate = AsyncMock(
+            return_value=_gate_decision("progress_plan_review", GateDecisionValue.APPROVED)
+        )
+        plan_ref = _MM()
+        plan_ref.filename = "implementation_plan.yaml"
+        executor._artifact_vault.retrieve = AsyncMock(
+            return_value=(plan_ref, b"version: 1\ntasks: []\n")
+        )
+
+        await executor.execute_cycle("cyc_001", "run_001")
+
+        assert executor.execute_run.await_count == 3
+        reroll_forwarding = executor.execute_run.await_args_list[1].kwargs["forwarding_overrides"]
+        context = reroll_forwarding["framing_rejection_context"]
+        assert context["rejection_reasons"] == rejection
+        assert context["rejected_plan_yaml"] == "version: 1\ntasks: []\n"
+        impl_forwarding = (
+            executor.execute_run.await_args_list[2].kwargs.get("forwarding_overrides") or {}
+        )
+        assert "framing_rejection_context" not in impl_forwarding
+
+    async def test_reroll_context_degrades_to_reasons_when_plan_unreadable(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        """Best-effort plan loading: a vault failure must not block the re-roll
+        or drop the reasons — the context degrades to reasons-only."""
+        cycle = _make_cycle(
+            workload_sequence=self._seq(), applied_defaults_extra={"framing_max_rerolls": 1}
+        )
+        mock_registry.get_cycle.return_value = cycle
+        run1 = _make_run("run_001", 1, "completed", "framing")
+        run2 = _make_run("run_002", 2, "completed", "framing")
+        run3 = _make_run("run_003", 3, "completed", "implementation")
+        mock_registry.get_run.side_effect = [run1, run2, run3]
+        mock_registry.list_runs.return_value = [run1]
+        executor._reject_invalid_plan_before_workload_gate = AsyncMock(
+            side_effect=[["a teaching rejection"], []]
+        )
+        executor._create_next_workload_run = AsyncMock(side_effect=[run2, run3])
+        executor._poll_inter_workload_gate = AsyncMock(
+            return_value=_gate_decision("progress_plan_review", GateDecisionValue.APPROVED)
+        )
+
+        await executor.execute_cycle("cyc_001", "run_001")
+
+        context = executor.execute_run.await_args_list[1].kwargs["forwarding_overrides"][
+            "framing_rejection_context"
+        ]
+        assert context["rejection_reasons"] == ["a teaching rejection"]
+        assert "rejected_plan_yaml" not in context
+
     async def test_budget_exhausted_kills_cycle_no_impl_run(
         self, executor, mock_registry, mock_event_bus
     ):


### PR DESCRIPTION
1.4.1 hardening patch, fix 5 of 5 — the last item on the ledger (`docs/plans/1-4-1-hardening-patch-plan.md`).

## Problem

A #522 framing re-roll treats every system plan-validation rejection as a stochastic fault and grants fresh dice — but threads nothing about what died. The validator's teaching message lands in `gate_decisions` where no model ever reads it. Receipts: fay-10 tripped the same ownership class on all three framings → re-rolls exhausted → cycle death; fay-15's framing-1 #658 rejection named the file, the rule, and the consequence — to nobody. (The record already corrected fay-13's "validator-feedback success" credit: nothing threads; that was luck.)

## Fix — the lightest correct version from the issue

- **Executor re-roll branch**: before re-executing framing, thread `{rejection_reasons, rejected_plan_yaml}` onto the **§6.6 forwarding rail** (the same transport gate outcomes already ride). The rail is rebuilt at the next workload advance, so the context can never leak into the implementation run; a second re-roll replaces the first's context with the latest rejection. The rejected plan loads best-effort from the cancelled run's artifact refs — an unreadable artifact degrades to reasons-only, never blocks the re-roll.
- **`generate_task_plan`**: lifts the context out of `resolved_config` (it's authoring *context*, not config — every envelope's config stays clean) and injects data-only keys onto exactly the four plan-authoring tasks (#657's set: brief author + dev/qa/strategy proposers). The merger is excluded — its normal merge path is deterministic, no prompt to influence.
- **Handlers + assets**: brief author and all three proposers render a `rejection_context_section` via two new managed appendix assets — `request.plan_reroll_rejection_appendix` (authoritative "PRIOR ATTEMPT REJECTED — revise, do not repeat; keep what was sound" + the reasons) and `request.plan_reroll_rejected_plan_appendix` (the fenced prior plan for revision reference). Four templates gain the optional slot (v1→v2). All prose in assets (#448); the handlers move data only.

Net effect: `framing_max_rerolls` converts from a dice budget into a revision budget. The cross-cycle rung (rejection classes as behavioral memories) stays with the agent-memory direction per the issue.

## Verification — fay-15 framing-1 replay shape

- The end-to-end executor test rebuilds the re-roll: system rejection (the real #658 store.py teaching text) → re-roll's `execute_run` receives the context with reasons + plan YAML → **the implementation run's forwarding does not carry it** (leak boundary pinned). Plus the degrade-to-reasons-only path.
- Injection: four authoring task types receive the keys; build/merge/doc tasks never do; first-roll (no context) and reasonless-context inject nothing (a plan without its reasons would be an instruction to copy the rejected shape).
- Render: all four handlers produce the section through the real asset chain; live-render test proves the fay-15 teaching line, the revise instruction, and the rejected plan body survive the templates; handle-level wiring tests guard the renders-but-never-reaches-template no-op, plus a first-roll negative.

Regression suite green: 5974 passed. **Deploy note (single 1.4.1 window):** executor/task_plan ride runtime-api; handlers + templates ride agent images — standard rebuild-all; no re-seed (no contract/manifest content touched).

Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
