### PR TITLE
fix(correction): aim repairs at the fill slot that owns the failing probe (#688)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -127,6 +127,77 @@ def _widen_target_for_frontend_build(
     return list(dict.fromkeys([*target, *frontend_source]))
 
 
+def _failed_probe_ids(failure_evidence: Any) -> list[str]:
+    """Ids of the behavioral probes that FAILED, in evidence order (#688).
+
+    Probe rows enter ``validation_result.checks`` from ``probe_check_rows`` with
+    ``check`` == ``criterion_id`` == the probe id and a ``status`` of
+    passed/failed/skipped. Only ``failed`` counts: ``skipped`` means the subject
+    never booted, which indicts no particular endpoint.
+    """
+    if not isinstance(failure_evidence, dict):
+        return []
+    rows = (failure_evidence.get("validation_result") or {}).get("checks") or []
+    return [
+        str(row.get("check"))
+        for row in rows
+        if isinstance(row, dict) and row.get("status") == "failed" and row.get("check")
+    ]
+
+
+def _probe_owned_slots(failure_evidence: Any, failed_inputs: dict[str, Any]) -> list[str]:
+    """Fill-slot files owning the endpoints whose behavioral probes failed (#688).
+
+    The deterministic chain the shk-2 loss chain needed and did not have:
+    failed probe row → the probe's declared ``METHOD /path`` → the contract's
+    endpoint→fill-slot map → the file that owns the failing endpoint.
+
+    shk-2 (cyc_88162ecfd895): ``vc-probe-runs`` answered 500 because
+    ``backend/routes.py`` used ``RunEvent`` without importing it. Both repairs
+    emitted ``backend/main.py`` (named by interface-drift evidence) plus the
+    failed qa task's own suite, and never ``routes.py`` — the target set could
+    not name the defect site, so the loop reproduced the identical 500 and
+    exhausted. This resolution names it from contract data alone, independent of
+    the drift evidence and of where the squad chose to put its tests.
+
+    Empty whenever the inputs are absent (author mode, probe-less contracts,
+    pre-#688 envelopes) or no probe failed — the caller's target is then
+    byte-identical to its prior behavior.
+    """
+    owners = failed_inputs.get("contract_endpoint_owners") or {}
+    probes = failed_inputs.get("contract_probes") or []
+    if not owners or not probes:
+        return []
+    failed_ids = _failed_probe_ids(failure_evidence)
+    if not failed_ids:
+        return []
+
+    from squadops.cycles.verification_contract import Probe
+
+    tokens_by_id: dict[str, str] = {}
+    for raw in probes:
+        try:
+            probe = Probe.from_dict(raw)
+        except ValueError:  # a malformed row indicts nothing; it must not raise here
+            continue
+        token = probe.endpoint_token()
+        if token:
+            tokens_by_id[probe.id] = token
+
+    slots: list[str] = []
+    for probe_id in failed_ids:
+        owner = owners.get(tokens_by_id.get(probe_id, ""))
+        if owner and owner not in slots:
+            slots.append(owner)
+    if slots:
+        logger.info(
+            "correction_repair_target: probe-owned fill slots %s (failed probes: %s)",
+            ", ".join(slots),
+            ", ".join(failed_ids),
+        )
+    return slots
+
+
 def _resolve_repair_target(
     failure_evidence: Any, failed_inputs: dict[str, Any]
 ) -> tuple[list[str], str | None, str | None]:
@@ -160,7 +231,20 @@ def _resolve_repair_target(
     ``frontend/*`` (package-scoping bounds the blast radius). Absent that surface
     (author mode, non-build corrections) the target is byte-identical to the #531
     fallback below.
+
+    shk-2 (cyc_88162ecfd895) — #688: every surface above is *indirect*. The drift branch
+    names whatever files the drift evidence happened to name; the package-scoped union
+    reaches app source only when the failed qa task's own artifacts share a top-level
+    package with it. Both missed a one-line defect in ``backend/routes.py`` — drift
+    pointed at ``backend/main.py``, and the suite was authored at root-level ``tests/``,
+    so the scoped union came back empty (it matches on ``backend/tests/…``, which is what
+    fay-16…19 happened to author: the reach depended on an authoring coincidence). So the
+    target now LEADS with the fill slots that own the FAILING PROBES' endpoints, resolved
+    from contract data (``_probe_owned_slots``). Drift files and the failed task's own
+    artifacts still ride — they carry real defects too, the pf-21 lesson — but they can no
+    longer displace the defect site.
     """
+    probe_slots = _probe_owned_slots(failure_evidence, failed_inputs)
     drift = failure_evidence.get("interface_drift") if isinstance(failure_evidence, dict) else None
     drift_files = sorted(
         {d["file"] for d in (drift or []) if isinstance(d, dict) and d.get("file")}
@@ -187,7 +271,9 @@ def _resolve_repair_target(
         scoped_source = _scope_to_shared_packages(
             failed_inputs.get("implementation_artifacts", []) or [], failed_artifacts
         )
-        target = list(dict.fromkeys([*drift_files, *failed_artifacts, *scoped_source]))
+        target = list(
+            dict.fromkeys([*probe_slots, *drift_files, *failed_artifacts, *scoped_source])
+        )
         target = _widen_target_for_frontend_build(target, failure_evidence, failed_inputs)
         return (target, None, None)
     # RC2 no-drift path: union the failing task's own artifacts with the
@@ -197,7 +283,7 @@ def _resolve_repair_target(
     scoped_source = _scope_to_shared_packages(
         failed_inputs.get("implementation_artifacts", []) or [], failed_artifacts
     )
-    target = list(dict.fromkeys([*failed_artifacts, *scoped_source]))
+    target = list(dict.fromkeys([*probe_slots, *failed_artifacts, *scoped_source]))
     target = _widen_target_for_frontend_build(target, failure_evidence, failed_inputs)
     return (
         target,

--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -82,6 +82,54 @@ def _scope_to_shared_packages(candidates: list[str], anchors: list[str]) -> list
     return [c for c in candidates if c and _top_level_package(c) in anchor_pkgs]
 
 
+def _scope_to_shared_language(candidates: list[str], anchors: list[str]) -> list[str]:
+    """Keep ``candidates`` on the same side of the frontend/backend line as ``anchors``.
+
+    The guarantee RC2 was actually written to give — "a backend failure can never
+    regress frontend source" — expressed against the source language instead of the
+    directory tree, so it holds wherever the suite was authored.
+    """
+    from squadops.cycles.acceptance_check_spec import is_frontend_source
+
+    anchor_sides = {is_frontend_source(a) for a in anchors if a}
+    if len(anchor_sides) != 1:
+        # No anchors, or anchors straddling both sides — nothing is excluded, so
+        # scoping would not be bounding anything. Stay silent rather than widen.
+        return []
+    side = anchor_sides.pop()
+    return [c for c in candidates if c and is_frontend_source(c) is side]
+
+
+def _scoped_implementation_surface(candidates: list[str], anchors: list[str]) -> list[str]:
+    """The implementation source a failure in ``anchors`` may legitimately retarget.
+
+    Package scoping first — pf-24's rule, unchanged whenever it matches anything.
+    When it comes back EMPTY the anchor was uninformative, not exclusive, and #688
+    measured what that costs: shk-2's qa suite was authored at root-level ``tests/``,
+    so its anchor package was ``tests``, ``backend/routes.py`` was filtered out, and
+    the correction loop had no route to app source at all. fay-16…19 authored
+    ``backend/tests/…``, which matched — so whether pf-24 and pf-27 worked at all
+    depended on where the squad happened to put its tests.
+
+    So the empty case falls back to the language boundary, which bounds the blast
+    radius the way RC2 intended (a backend failure still cannot reach frontend
+    source) without depending on the authored layout. A non-empty package match is
+    strictly narrower, so it keeps winning.
+    """
+    scoped = _scope_to_shared_packages(candidates, anchors)
+    if scoped:
+        return scoped
+    widened = _scope_to_shared_language(candidates, anchors)
+    if widened:
+        logger.info(
+            "correction_repair_target: package scoping matched nothing for anchors %s — "
+            "falling back to same-language implementation source %s (#688)",
+            ", ".join(anchors),
+            ", ".join(widened),
+        )
+    return widened
+
+
 def _frontend_build_failed(failure_evidence: Any) -> bool:
     """#650 (fay-8): the failed task's validation shows the frontend build failing.
 
@@ -238,11 +286,17 @@ def _resolve_repair_target(
     package with it. Both missed a one-line defect in ``backend/routes.py`` — drift
     pointed at ``backend/main.py``, and the suite was authored at root-level ``tests/``,
     so the scoped union came back empty (it matches on ``backend/tests/…``, which is what
-    fay-16…19 happened to author: the reach depended on an authoring coincidence). So the
-    target now LEADS with the fill slots that own the FAILING PROBES' endpoints, resolved
-    from contract data (``_probe_owned_slots``). Drift files and the failed task's own
-    artifacts still ride — they carry real defects too, the pf-21 lesson — but they can no
-    longer displace the defect site.
+    fay-16…19 happened to author: the reach depended on an authoring coincidence). Two
+    changes, one per half of that:
+
+    * The target now LEADS with the fill slots that own the FAILING PROBES' endpoints,
+      resolved from contract data (``_probe_owned_slots``). Drift files and the failed
+      task's own artifacts still ride — they carry real defects too, the pf-21 lesson —
+      but they can no longer displace the defect site.
+    * The scoped implementation surface falls back from package to language when the
+      package anchor matches nothing (``_scoped_implementation_surface``), so a
+      SUITE-ONLY failure — one with no probe evidence to resolve — can still reach the
+      source under test on a root-level-``tests/`` layout.
     """
     probe_slots = _probe_owned_slots(failure_evidence, failed_inputs)
     drift = failure_evidence.get("interface_drift") if isinstance(failure_evidence, dict) else None
@@ -268,7 +322,7 @@ def _resolve_repair_target(
         # edits only the drifted file + the test and NEVER reaches routes.py →
         # non-convergence. Union it here too; empty surface (author mode) → the scoped
         # set is empty and the target is byte-identical to the pre-pf-27 union.
-        scoped_source = _scope_to_shared_packages(
+        scoped_source = _scoped_implementation_surface(
             failed_inputs.get("implementation_artifacts", []) or [], failed_artifacts
         )
         target = list(
@@ -280,7 +334,7 @@ def _resolve_repair_target(
     # package-scoped implementation surface so a behavioral failure can reach the
     # source under test. Empty surface → byte-identical to the #531 fallback
     # (failed_artifacts, focus, description).
-    scoped_source = _scope_to_shared_packages(
+    scoped_source = _scoped_implementation_surface(
         failed_inputs.get("implementation_artifacts", []) or [], failed_artifacts
     )
     target = list(dict.fromkeys([*probe_slots, *failed_artifacts, *scoped_source]))

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -198,6 +198,19 @@ def command_safelist_names() -> tuple[str, ...]:
     return tuple(pat.name for pat in COMMAND_SAFELIST)
 
 
+# The frontend source-file family. Two readers, so it lives with the vocabulary:
+# the evaluators skip AST analysis on these (JS/TS parsing is a follow-up), and
+# #688's repair targeting uses the same line to decide which implementation source
+# a failure may legitimately retarget — a backend failure must never reach frontend
+# source, and vice versa.
+FRONTEND_SUFFIXES: frozenset[str] = frozenset({".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"})
+
+
+def is_frontend_source(path: str) -> bool:
+    """True when ``path`` is a frontend source file by extension."""
+    return isinstance(path, str) and path.lower().endswith(tuple(FRONTEND_SUFFIXES))
+
+
 # The one vocabulary name read by a module that does not evaluate it: #688's
 # probe→fill-slot resolution filters contract criteria on it. Bound to the
 # CHECK_SPECS key below so a rename moves both together — a bare literal there

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -198,13 +198,54 @@ def command_safelist_names() -> tuple[str, ...]:
     return tuple(pat.name for pat in COMMAND_SAFELIST)
 
 
+# The one vocabulary name read by a module that does not evaluate it: #688's
+# probe→fill-slot resolution filters contract criteria on it. Bound to the
+# CHECK_SPECS key below so a rename moves both together — a bare literal there
+# would silently resolve to "no endpoints owned" and revert the fix to the
+# no-op it was written to end.
+CHECK_ENDPOINT_DEFINED = "endpoint_defined"
+
+
+# The `"METHOD /path"` endpoint-token grammar. `endpoint_defined.methods_paths`
+# is authored in it and the evaluator matches route decorators against it; #688
+# added a second reader — the contract resolves which fill slot owns a failing
+# probe's endpoint — so the grammar lives here with the rest of the vocabulary
+# rather than being duplicated or reached into privately.
+HTTP_METHODS: frozenset[str] = frozenset(
+    {"get", "post", "put", "delete", "patch", "options", "head"}
+)
+
+
+def normalize_route(path: str) -> str:
+    """Normalize trailing slash for tolerant route comparison."""
+    if path != "/" and path.endswith("/"):
+        return path[:-1]
+    return path
+
+
+def parse_method_path(token: str) -> tuple[str, str] | None:
+    """Parse a ``"METHOD /path"`` token; return ``(METHOD, /path)`` or ``None``.
+
+    ``None`` on anything that is not two whitespace-separated fields whose first
+    is an HTTP method — callers treat that as "not an endpoint token" rather
+    than an error, so a malformed entry is inert instead of fatal.
+    """
+    parts = token.strip().split(maxsplit=1)
+    if len(parts) != 2:
+        return None
+    method, path = parts[0].upper(), normalize_route(parts[1])
+    if method.lower() not in HTTP_METHODS:
+        return None
+    return method, path
+
+
 # Rev 1 vocabulary. Each entry's evaluator implementation lands in M1.2;
 # the parser already rejects authoring errors against this spec. The ``example``
 # on each entry is rendered into the proposer prompt (issue #182) and is
 # asserted parser-valid by test.
 CHECK_SPECS: dict[str, CheckSpec] = {
-    "endpoint_defined": CheckSpec(
-        name="endpoint_defined",
+    CHECK_ENDPOINT_DEFINED: CheckSpec(
+        name=CHECK_ENDPOINT_DEFINED,
         applicable_extensions=frozenset({".py"}),
         required_params=frozenset({"file", "methods_paths"}),
         param_types={"file": str, "methods_paths": list},

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -30,6 +30,7 @@ from typing import Any
 
 from squadops.cycles.acceptance_check_spec import (
     CHECK_SPECS,
+    FRONTEND_SUFFIXES,
     HTTP_METHODS,
     CheckSpec,
     argv_matches_safelist,
@@ -257,13 +258,13 @@ def _decorator_route(decorator: ast.expr) -> tuple[str, str] | None:
 # the contrast with pf-40 is the proof: same bad repairs, but there verification returned a
 # verdict, rejected them, and nothing landed. Skipping is the honest outcome for a file we
 # cannot analyse — `import_present` already did this; the other four did not (#605).
-_FRONTEND_SUFFIXES = frozenset({".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"})
+# Family definition lives in the spec module (two readers — see #688).
 
 
 def _unparseable_source_skip(file_path: Path) -> CheckOutcome | None:
     """A skip outcome when ``file_path`` is not Python, else None."""
     ext = file_path.suffix.lower()
-    if ext in _FRONTEND_SUFFIXES:
+    if ext in FRONTEND_SUFFIXES:
         # JS/TS analysis is gated behind the frontend_acceptance_checks follow-up.
         return CheckOutcome.skipped(reason="frontend_acceptance_checks_disabled")
     if ext != ".py":

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -30,8 +30,11 @@ from typing import Any
 
 from squadops.cycles.acceptance_check_spec import (
     CHECK_SPECS,
+    HTTP_METHODS,
     CheckSpec,
     argv_matches_safelist,
+    normalize_route,
+    parse_method_path,
 )
 
 logger = logging.getLogger(__name__)
@@ -230,27 +233,6 @@ def _skip_unsupported_stack() -> CheckOutcome:
 # ---------------------------------------------------------------------------
 
 
-_HTTP_METHODS = frozenset({"get", "post", "put", "delete", "patch", "options", "head"})
-
-
-def _normalize_route(path: str) -> str:
-    """Normalize trailing slash for tolerant route comparison."""
-    if path != "/" and path.endswith("/"):
-        return path[:-1]
-    return path
-
-
-def _parse_method_path(token: str) -> tuple[str, str] | None:
-    """Parse a `'METHOD /path'` token; return (method, path) or None."""
-    parts = token.strip().split(maxsplit=1)
-    if len(parts) != 2:
-        return None
-    method, path = parts[0].upper(), _normalize_route(parts[1])
-    if method.lower() not in _HTTP_METHODS:
-        return None
-    return method, path
-
-
 def _decorator_route(decorator: ast.expr) -> tuple[str, str] | None:
     """Extract (METHOD, path) from `@router.METHOD("/path")` or `@app.METHOD("/path")`."""
     if not isinstance(decorator, ast.Call):
@@ -258,13 +240,13 @@ def _decorator_route(decorator: ast.expr) -> tuple[str, str] | None:
     if not isinstance(decorator.func, ast.Attribute):
         return None
     method = decorator.func.attr.lower()
-    if method not in _HTTP_METHODS:
+    if method not in HTTP_METHODS:
         return None
     if not decorator.args:
         return None
     arg0 = decorator.args[0]
     if isinstance(arg0, ast.Constant) and isinstance(arg0.value, str):
-        return method.upper(), _normalize_route(arg0.value)
+        return method.upper(), normalize_route(arg0.value)
     return None
 
 
@@ -330,7 +312,7 @@ class EndpointDefinedCheck(BaseCheck):
         expected: list[tuple[str, str]] = []
         malformed: list[str] = []
         for token in params["methods_paths"]:
-            parsed = _parse_method_path(str(token))
+            parsed = parse_method_path(str(token))
             if parsed is None:
                 malformed.append(token)
             else:

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -512,6 +512,8 @@ def _inject_contract_inputs(
     ``Probe`` dicts — envelope inputs are JSON). The qa handler reconstructs and
     executes them against the built workspace, so probe evidence lands in
     live-cycle runs, not only the CI gate. Probe-less contracts inject no key.
+    #688 adds the endpoint→fill-slot ownership map alongside them, so a repair
+    born of a failing probe can be aimed at the slot that owns the endpoint.
 
     Author mode (``contract is None``) injects nothing — contract-less cycles
     stay byte-identical.
@@ -531,6 +533,14 @@ def _inject_contract_inputs(
     if task_type == "qa.test":
         if contract.behavioral.probes:
             inputs["contract_probes"] = [p.to_dict() for p in contract.behavioral.probes]
+            # #688: the endpoint→fill-slot ownership map, so a correction born of a
+            # FAILING probe can aim the repair at the slot that owns the failing
+            # endpoint. Threaded with the probes because it is only meaningful
+            # alongside them — probe-less contracts inject neither key and stay
+            # byte-identical. Data only; no prose (#448).
+            endpoint_owners = contract.endpoint_owners()
+            if endpoint_owners:
+                inputs["contract_endpoint_owners"] = endpoint_owners
         # #629 / pf-54: the contract's pinned statuses (probe expects + the
         # error-code→status map) never reached suite AUTHORING — five authored
         # suite versions asserted 200 where the probe pinned 201, an unwinnable

--- a/src/squadops/cycles/verification_contract.py
+++ b/src/squadops/cycles/verification_contract.py
@@ -196,6 +196,24 @@ class Probe:
         """``{var}`` names in this probe's request path, in order."""
         return re.findall(r"\{(\w+)\}", str(self.request.get("path", "")))
 
+    def endpoint_token(self) -> str | None:
+        """This probe's ``"METHOD /path"`` token, or ``None`` if it declares no HTTP
+        request (a non-HTTP subject, or a malformed method).
+
+        The path keeps its ``{var}`` placeholders unresolved: this token joins
+        against the *contract's* declared endpoints (#688), not against a live
+        request, and both sides are rendered from the same manifest endpoints, so
+        the placeholder form is what matches.
+        """
+        from squadops.cycles.acceptance_check_spec import parse_method_path
+
+        method = str(self.request.get("method", "")).strip()
+        path = str(self.request.get("path", "")).strip()
+        if not method or not path:
+            return None
+        parsed = parse_method_path(f"{method} {path}")
+        return f"{parsed[0]} {parsed[1]}" if parsed else None
+
 
 def resolve_probe_path(path: str, context: dict[str, str]) -> tuple[str, str | None]:
     """Resolve ``{var}`` placeholders from captured context (#651).
@@ -430,6 +448,45 @@ class VerificationContract:
         for crit in (*self.behavioral.build, *self.behavioral.suite.checks):
             index[crit.id] = (crit, "")
         return index
+
+    def endpoint_owners(self) -> dict[str, str]:
+        """Map each declared ``"METHOD /path"`` endpoint to the fill file that owns it.
+
+        Read off the ``endpoint_defined`` criteria the expander attaches per fill
+        slot. The contract is the only artifact that states this relation: the
+        interface manifest declares the endpoints, the blueprint decides which slot
+        implements them, and only the expander's output joins the two.
+
+        #688 consumes it to aim a repair at the fill slot behind a *failing
+        behavioral probe*. Before this, a behavioral failure could reach app source
+        only through ``implementation_artifacts`` package-scoping (pf-24/pf-27),
+        which anchors on the failed qa task's own artifacts — so whether the source
+        was reachable depended on where the squad happened to author the suite
+        (``backend/tests/...`` matched ``backend/routes.py``; a root-level
+        ``tests/...`` matched nothing and silently emptied the target). This
+        relation is authoring-independent: it comes from the contract.
+
+        Keys are normalized through the same token grammar ``endpoint_defined``
+        evaluates against, so a probe and a criterion differing only in a trailing
+        slash still join. First declaration wins if two slots claim one endpoint —
+        a well-linted contract has exactly one owner per endpoint, and ``lint()``
+        is the gate for that, not this accessor.
+        """
+        from squadops.cycles.acceptance_check_spec import (
+            CHECK_ENDPOINT_DEFINED,
+            parse_method_path,
+        )
+
+        owners: dict[str, str] = {}
+        for ff in self.fill_files:
+            for crit in ff.interface:
+                if crit.check != CHECK_ENDPOINT_DEFINED:
+                    continue
+                for token in crit.params.get("methods_paths", []) or []:
+                    parsed = parse_method_path(str(token))
+                    if parsed:
+                        owners.setdefault(f"{parsed[0]} {parsed[1]}", ff.path)
+        return owners
 
     def covered_fill_paths(self) -> frozenset[str]:
         """The set of fill-file paths this contract owns the acceptance of. A plan

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -2737,14 +2737,15 @@ class TestProbeOwnedRepairTarget:
 
         assert artifacts == ["backend/routes.py", "backend/main.py", "tests/test_api.py"]
 
-    def test_root_level_suite_defeats_package_scoping_without_probe_resolution(self):
-        """Pins the mechanism, so a regression is diagnosable: with the probe inputs
-        absent the target is exactly what shk-2's repairs emitted — the pf-24/pf-27
-        package-scoped union anchors on ``tests/`` and reaches no ``backend/`` source."""
+    def test_suite_only_failure_reaches_source_via_the_language_fallback(self):
+        """The other half of shk-2: a failure with NO probe evidence to resolve. The
+        pf-24/pf-27 package union anchors on ``tests/`` and matches no ``backend/``
+        source, so before the language fallback the target was exactly what shk-2's
+        repairs emitted — main.py + the suite, with routes.py unreachable."""
         from adapters.cycles.correction_runner import _resolve_repair_target
 
         evidence = self._evidence(
-            [{"check": "vc-probe-runs", "status": "failed"}],
+            [{"check": "tests_pass", "status": "failed"}],
             drift=[{"file": "backend/main.py"}],
         )
         stripped = self._inputs()
@@ -2752,7 +2753,58 @@ class TestProbeOwnedRepairTarget:
         del stripped["contract_endpoint_owners"]
 
         artifacts, _, _ = _resolve_repair_target(evidence, stripped)
-        assert artifacts == ["backend/main.py", "tests/test_api.py"]
+        assert artifacts == ["backend/main.py", "tests/test_api.py", "backend/routes.py"]
+        # The RC2 guarantee survives the widening: a backend failure still cannot
+        # reach frontend source.
+        assert "frontend/src/views/RunsListView.jsx" not in artifacts
+
+    def test_language_fallback_does_not_fire_when_packages_match(self):
+        """pf-24's tight rule is strictly narrower and must keep winning — the fallback
+        exists for the empty case only, not as a general widening."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        artifacts, _, _ = _resolve_repair_target(
+            {},
+            {
+                "expected_artifacts": ["backend/tests/test_runs.py"],
+                "implementation_artifacts": [
+                    "backend/routes.py",
+                    "scripts/tool.py",  # same language, different package
+                ],
+            },
+        )
+        assert artifacts == ["backend/tests/test_runs.py", "backend/routes.py"]
+
+    def test_frontend_suite_failure_stays_on_the_frontend_side(self):
+        """The mirror case: a root-level frontend suite must reach views and never
+        backend source — the language line, not the directory tree, is the bound."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        artifacts, _, _ = _resolve_repair_target(
+            {},
+            {
+                "expected_artifacts": ["e2e/runs.test.jsx"],
+                "implementation_artifacts": [
+                    "backend/routes.py",
+                    "frontend/src/views/RunsListView.jsx",
+                ],
+            },
+        )
+        assert artifacts == ["e2e/runs.test.jsx", "frontend/src/views/RunsListView.jsx"]
+
+    def test_mixed_language_anchors_widen_nothing(self):
+        """Anchors straddling both sides exclude nothing, so 'scoping' would be a
+        rename for 'take everything' — stay silent rather than widen blindly."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        artifacts, _, _ = _resolve_repair_target(
+            {},
+            {
+                "expected_artifacts": ["qa/suite.py", "qa/view.test.jsx"],
+                "implementation_artifacts": ["backend/routes.py", "frontend/src/App.jsx"],
+            },
+        )
+        assert artifacts == ["qa/suite.py", "qa/view.test.jsx"]
 
     def test_no_drift_probe_failure_still_reaches_the_owning_slot(self):
         """The RC2 branch: a behavioral failure with no drift at all. Without probe
@@ -2790,7 +2842,8 @@ class TestProbeOwnedRepairTarget:
     def test_non_failing_probe_indicts_no_slot(self, status):
         """A passing probe is not evidence, and a SKIPPED one means the subject never
         booted — blaming an endpoint for a boot failure would aim every repair at the
-        first route in the contract."""
+        first route in the contract. routes.py still arrives via the language fallback,
+        but BEHIND the failed artifact rather than leading it."""
         from adapters.cycles.correction_runner import _resolve_repair_target
 
         evidence = self._evidence(
@@ -2800,16 +2853,16 @@ class TestProbeOwnedRepairTarget:
             ]
         )
         artifacts, _, _ = _resolve_repair_target(evidence, self._inputs())
-        assert "backend/routes.py" not in artifacts
+        assert artifacts == ["tests/test_api.py", "backend/routes.py"]
 
     def test_unmapped_probe_id_adds_nothing(self):
         """A failing check that is not a probe (or a probe the contract map does not
-        cover) must not silently pull in an unrelated slot."""
+        cover) must not promote a slot to the front of the target."""
         from adapters.cycles.correction_runner import _resolve_repair_target
 
         evidence = self._evidence([{"check": "vc-suite-passes", "status": "failed"}])
         artifacts, _, _ = _resolve_repair_target(evidence, self._inputs())
-        assert artifacts == ["tests/test_api.py"]
+        assert artifacts == ["tests/test_api.py", "backend/routes.py"]
 
     @pytest.mark.parametrize(
         "inputs_over",
@@ -2821,13 +2874,14 @@ class TestProbeOwnedRepairTarget:
         ],
     )
     def test_degraded_probe_inputs_never_crash_or_retarget(self, inputs_over):
-        """Author mode, probe-less contracts, and malformed wire rows must leave the
-        target byte-identical — a correction path that raises here strands the run."""
+        """Author mode, probe-less contracts, and malformed wire rows must degrade to
+        the pre-#688 ordering rather than raise — a correction path that raises here
+        strands the run."""
         from adapters.cycles.correction_runner import _resolve_repair_target
 
         evidence = self._evidence([{"check": "vc-probe-runs", "status": "failed"}])
         artifacts, _, _ = _resolve_repair_target(evidence, self._inputs(**inputs_over))
-        assert artifacts == ["tests/test_api.py"]
+        assert artifacts == ["tests/test_api.py", "backend/routes.py"]
 
     def test_trailing_slash_still_joins_probe_to_owner(self):
         """The probe path and the criterion token are rendered from the same manifest,

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -2663,6 +2663,191 @@ class TestResolveRepairTarget:
         assert focus is None
 
 
+class TestProbeOwnedRepairTarget:
+    """#688: a failing behavioral probe aims the repair at the fill slot that owns
+    its endpoint, resolved from contract data.
+
+    shk-2 (cyc_88162ecfd895) is the loss this closes: ``backend/routes.py`` used
+    ``RunEvent`` without importing it, so ``vc-probe-runs`` answered 500. Both
+    repairs emitted ``backend/main.py`` (named by drift evidence) + the failing
+    suite, never ``routes.py`` — nothing in the target could name the defect site.
+    """
+
+    # Contract v9 (art_4f368ea08799) endpoint→slot map, and the probes that failed
+    # per run_verification_summaries for run_da25453895e3.
+    OWNERS = {
+        "GET /runs": "backend/routes.py",
+        "POST /runs": "backend/routes.py",
+        "GET /runs/{run_id}": "backend/routes.py",
+        "POST /runs/{run_id}/join": "backend/routes.py",
+        "POST /runs/{run_id}/leave": "backend/routes.py",
+    }
+    PROBES = [
+        {
+            "id": "vc-probe-runs",
+            "subject": "backend",
+            "request": {"method": "POST", "path": "/runs", "json": {"title": "sample"}},
+            "expect": {"status": 201},
+            "capture": {"run_id": "id"},
+        },
+        {
+            "id": "vc-probe-runs-join",
+            "subject": "backend",
+            "request": {"method": "POST", "path": "/runs/{run_id}/join", "json": {"name": "s"}},
+            "expect": {"status": 200},
+        },
+    ]
+
+    def _inputs(self, **over):
+        # The shk-2 qa.test envelope: the suite was authored at ROOT-level tests/,
+        # so package scoping against backend/ source yields nothing.
+        base = {
+            "expected_artifacts": ["tests/test_api.py"],
+            "implementation_artifacts": [
+                "backend/routes.py",
+                "frontend/src/views/RunsListView.jsx",
+            ],
+            "contract_probes": self.PROBES,
+            "contract_endpoint_owners": self.OWNERS,
+        }
+        base.update(over)
+        return base
+
+    @staticmethod
+    def _evidence(rows, drift=None):
+        ev = {"validation_result": {"passed": False, "checks": rows}}
+        if drift:
+            ev["interface_drift"] = drift
+        return ev
+
+    def test_failing_probe_leads_target_over_drift_and_failed_suite(self):
+        """The shk-2 replay. Both repairs targeted main.py + the suite and the loop
+        reproduced the identical 500; routes.py must now LEAD the target while the
+        drifted file and the failing suite still ride."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = self._evidence(
+            [
+                {"check": "vc-probe-runs", "status": "failed", "criterion_id": "vc-probe-runs"},
+                {"check": "tests_pass", "status": "failed"},
+            ],
+            drift=[{"kind": "extra_endpoint", "file": "backend/main.py", "extra": ["GET /health"]}],
+        )
+        artifacts, _, _ = _resolve_repair_target(evidence, self._inputs())
+
+        assert artifacts == ["backend/routes.py", "backend/main.py", "tests/test_api.py"]
+
+    def test_root_level_suite_defeats_package_scoping_without_probe_resolution(self):
+        """Pins the mechanism, so a regression is diagnosable: with the probe inputs
+        absent the target is exactly what shk-2's repairs emitted — the pf-24/pf-27
+        package-scoped union anchors on ``tests/`` and reaches no ``backend/`` source."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = self._evidence(
+            [{"check": "vc-probe-runs", "status": "failed"}],
+            drift=[{"file": "backend/main.py"}],
+        )
+        stripped = self._inputs()
+        del stripped["contract_probes"]
+        del stripped["contract_endpoint_owners"]
+
+        artifacts, _, _ = _resolve_repair_target(evidence, stripped)
+        assert artifacts == ["backend/main.py", "tests/test_api.py"]
+
+    def test_no_drift_probe_failure_still_reaches_the_owning_slot(self):
+        """The RC2 branch: a behavioral failure with no drift at all. Without probe
+        resolution this returned only the suite (scoped source empty), which is the
+        blind loop in a plainer form."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = self._evidence([{"check": "vc-probe-runs-join", "status": "failed"}])
+        artifacts, focus, description = _resolve_repair_target(
+            evidence,
+            self._inputs(subtask_focus="Backend API pytest suite", subtask_description="Write it"),
+        )
+
+        assert artifacts == ["backend/routes.py", "tests/test_api.py"]
+        # Retargeting must not swallow the no-drift branch's focus/description
+        # passthrough — the repair prompt loses its subject framing without them.
+        assert focus == "Backend API pytest suite"
+        assert description == "Write it"
+
+    def test_multiple_failing_probes_on_one_slot_name_it_once(self):
+        """shk-2 failed four probes, all owned by routes.py — the repair envelope
+        must not list the same file four times."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = self._evidence(
+            [
+                {"check": "vc-probe-runs", "status": "failed"},
+                {"check": "vc-probe-runs-join", "status": "failed"},
+            ]
+        )
+        artifacts, _, _ = _resolve_repair_target(evidence, self._inputs())
+        assert artifacts.count("backend/routes.py") == 1
+
+    @pytest.mark.parametrize("status", ["passed", "skipped"])
+    def test_non_failing_probe_indicts_no_slot(self, status):
+        """A passing probe is not evidence, and a SKIPPED one means the subject never
+        booted — blaming an endpoint for a boot failure would aim every repair at the
+        first route in the contract."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = self._evidence(
+            [
+                {"check": "vc-probe-runs", "status": status},
+                {"check": "tests_pass", "status": "failed"},
+            ]
+        )
+        artifacts, _, _ = _resolve_repair_target(evidence, self._inputs())
+        assert "backend/routes.py" not in artifacts
+
+    def test_unmapped_probe_id_adds_nothing(self):
+        """A failing check that is not a probe (or a probe the contract map does not
+        cover) must not silently pull in an unrelated slot."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = self._evidence([{"check": "vc-suite-passes", "status": "failed"}])
+        artifacts, _, _ = _resolve_repair_target(evidence, self._inputs())
+        assert artifacts == ["tests/test_api.py"]
+
+    @pytest.mark.parametrize(
+        "inputs_over",
+        [
+            {"contract_probes": []},  # probe-less contract
+            {"contract_endpoint_owners": {}},  # no endpoint_defined criteria
+            {"contract_probes": [{"id": "x"}]},  # probe declaring no HTTP request
+            {"contract_probes": ["not-a-mapping"]},  # malformed wire row
+        ],
+    )
+    def test_degraded_probe_inputs_never_crash_or_retarget(self, inputs_over):
+        """Author mode, probe-less contracts, and malformed wire rows must leave the
+        target byte-identical — a correction path that raises here strands the run."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        evidence = self._evidence([{"check": "vc-probe-runs", "status": "failed"}])
+        artifacts, _, _ = _resolve_repair_target(evidence, self._inputs(**inputs_over))
+        assert artifacts == ["tests/test_api.py"]
+
+    def test_trailing_slash_still_joins_probe_to_owner(self):
+        """The probe path and the criterion token are rendered from the same manifest,
+        but a hand-authored contract may differ by a trailing slash — a formatting
+        difference must not silently drop the defect site."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        probes = [
+            {
+                "id": "vc-probe-runs",
+                "subject": "backend",
+                "request": {"method": "post", "path": "/runs/"},
+                "expect": {"status": 201},
+            }
+        ]
+        evidence = self._evidence([{"check": "vc-probe-runs", "status": "failed"}])
+        artifacts, _, _ = _resolve_repair_target(evidence, self._inputs(contract_probes=probes))
+        assert artifacts[0] == "backend/routes.py"
+
+
 class TestOwnArtifactLocusRouting(TestCorrectionRunnerStandalone):
     """#568: a qa.test failure whose OWN artifact is the defect dispatches a
     qa.test_repair step targeted at the failed task's own contract; behavioral

--- a/tests/unit/cycles/test_task_plan_probe_injection.py
+++ b/tests/unit/cycles/test_task_plan_probe_injection.py
@@ -332,3 +332,37 @@ def test_manifest_without_testids_injects_no_dom_key():
         cycle, run, profile, plan=None, contract=_contract(), interface_manifest=bare
     )
     assert all("dom_testid_surface" not in e.inputs for e in envs)
+
+
+# ---------------------------------------------------------------------------
+# #688: endpoint → fill-slot ownership injection
+# ---------------------------------------------------------------------------
+
+
+def test_bind_mode_injects_endpoint_owners_into_qa_test_only():
+    """Bug caught (shk-2): without this key the correction runner has no way to name
+    the fill slot behind a failing probe, and the repair chases drift-named files
+    while the defect site sits untargeted for the whole correction budget."""
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(cycle, run, profile, plan=None, contract=_contract())
+
+    qa_envs = [e for e in envs if e.task_type == "qa.test"]
+    assert qa_envs, "implementation workload must contain a qa.test step"
+    assert qa_envs[0].inputs["contract_endpoint_owners"] == {"POST /items": "backend/routes.py"}
+    for env in envs:
+        if env.task_type != "qa.test":
+            assert "contract_endpoint_owners" not in env.inputs
+
+
+def test_author_mode_injects_no_endpoint_owners():
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(cycle, run, profile, plan=None, contract=None)
+    assert all("contract_endpoint_owners" not in e.inputs for e in envs)
+
+
+def test_probe_less_contract_injects_no_endpoint_owners():
+    # The map is only actionable alongside probe evidence; injecting it without
+    # probes would plant a key the correction path can never key on.
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(cycle, run, profile, plan=None, contract=_contract(with_probes=False))
+    assert all("contract_endpoint_owners" not in e.inputs for e in envs)

--- a/tests/unit/cycles/test_verification_contract.py
+++ b/tests/unit/cycles/test_verification_contract.py
@@ -421,3 +421,131 @@ def test_lint_accumulates_multiple_defects():
 
     errors = _lint(many)
     assert len(errors) >= 3
+
+
+# --------------------------------------------------------------------------- #
+# #688: endpoint → owning fill slot
+# --------------------------------------------------------------------------- #
+
+
+def test_endpoint_owners_maps_every_declared_endpoint_to_its_fill_slot():
+    # The relation only the contract states: the manifest declares endpoints, the
+    # blueprint decides which slot implements them. #688 aims a repair with it.
+    owners = VerificationContract.from_dict(_valid_contract_dict()).endpoint_owners()
+    assert owners == {
+        "GET /runs": "backend/routes.py",
+        "POST /runs": "backend/routes.py",
+        "GET /runs/{id}": "backend/routes.py",
+        "POST /runs/{id}/join": "backend/routes.py",
+        "POST /runs/{id}/leave": "backend/routes.py",
+    }
+
+
+def test_endpoint_owners_ignores_non_endpoint_criteria_and_implementation_class():
+    # import_present sits beside endpoint_defined in the same interface list, and a
+    # method-shaped token in an implementation criterion is not an endpoint
+    # declaration — reading either would map endpoints onto the wrong file.
+    def mutate(d):
+        d["fill_files"]["backend/routes.py"]["implementation"].append(
+            {
+                "check": "endpoint_defined",
+                "id": "vc-routes-impl-endpoints",
+                "methods_paths": ["DELETE /runs/{id}"],
+            }
+        )
+
+    data = _valid_contract_dict()
+    mutate(data)
+    owners = VerificationContract.from_dict(data).endpoint_owners()
+    assert "DELETE /runs/{id}" not in owners
+    assert set(owners.values()) == {"backend/routes.py"}
+
+
+def test_endpoint_owners_is_empty_without_endpoint_criteria():
+    # A frontend-only or author-mode contract yields no map, and the caller must
+    # degrade to its prior targeting rather than resolve nothing to something.
+    def strip(d):
+        d["fill_files"]["backend/routes.py"]["interface"] = [
+            c
+            for c in d["fill_files"]["backend/routes.py"]["interface"]
+            if c["check"] != "endpoint_defined"
+        ]
+
+    assert _contract_with(strip).endpoint_owners() == {}
+
+
+def test_endpoint_owners_first_declaration_wins_on_a_contested_endpoint():
+    # lint() is the gate against two slots claiming one endpoint; this accessor must
+    # be deterministic rather than order-dependent if one slips through.
+    def contest(d):
+        d["fill_files"]["frontend/src/views/RunDetailView.jsx"]["interface"].append(
+            {
+                "check": "endpoint_defined",
+                "id": "vc-detail-endpoints",
+                "methods_paths": ["POST /runs"],
+            }
+        )
+
+    assert _contract_with(contest).endpoint_owners()["POST /runs"] == "backend/routes.py"
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        ("", {}),
+        ("POST", {}),  # method only
+        ("/runs", {}),  # path only
+        ("TELEPORT /runs", {}),  # not an HTTP method
+        ("post /runs/", {"POST /runs": "backend/routes.py"}),  # normalized, not dropped
+    ],
+)
+def test_endpoint_owners_skips_malformed_tokens(token, expected):
+    # A malformed methods_paths entry must be inert, not fatal: raising here would
+    # break repair targeting for every other endpoint in the contract.
+    def inject(d):
+        d["fill_files"]["backend/routes.py"]["interface"][0]["methods_paths"] = [token]
+
+    assert _contract_with(inject).endpoint_owners() == expected
+
+
+def _contract_with(mutate) -> VerificationContract:
+    data = _valid_contract_dict()
+    mutate(data)
+    return VerificationContract.from_dict(data)
+
+
+def test_probe_endpoint_token_keeps_placeholders_and_normalizes_method():
+    # The token joins against CONTRACT endpoints, not a live request, so {run_id}
+    # must survive; a lowercase method in a hand-authored probe must still match.
+    probes = VerificationContract.from_dict(
+        _probe_contract(
+            [
+                {
+                    "id": "p1",
+                    "subject": "backend",
+                    "request": {"method": "post", "path": "/runs/{run_id}/join/"},
+                    "expect": {"status": 200},
+                }
+            ]
+        )
+    ).behavioral.probes
+    assert probes[0].endpoint_token() == "POST /runs/{run_id}/join"
+
+
+@pytest.mark.parametrize(
+    "request_body",
+    [{}, {"method": "POST"}, {"path": "/runs"}, {"method": "TELEPORT", "path": "/runs"}],
+)
+def test_probe_endpoint_token_is_none_without_a_usable_http_request(request_body):
+    # A probe that declares no usable HTTP request indicts no endpoint; returning a
+    # partial token would map it onto whichever slot sorts first.
+    probes = VerificationContract.from_dict(
+        _probe_contract([{"id": "p1", "subject": "backend", "request": request_body, "expect": {}}])
+    ).behavioral.probes
+    assert probes[0].endpoint_token() is None
+
+
+def _probe_contract(probes: list[dict]) -> dict:
+    data = _valid_contract_dict()
+    data["behavioral"]["probes"] = probes
+    return data


### PR DESCRIPTION
First fix of the 1.4.2 patch line (`docs/plans/1-4-2-correction-aim-patch-plan.md`). Hash-stable: no contract or manifest change.

## What shk-2 lost, and why

`backend/routes.py` used `RunEvent` without importing it → `NameError` at request time → `vc-probe-runs` answered 500. Both repairs emitted `backend/main.py` + `tests/test_api.py` and **never routes.py**, so each attempt reproduced the identical 500 and the correction budget ran out.

The root cause is not "the analyzer guessed" (that's #687). It's that **every path into the repair target was indirect**:

| Path | What it names | shk-2 |
|---|---|---|
| Drift branch (#531/#532) | files the interface-drift evidence named | `backend/main.py` — dev's unauthorized `/health` route. Real, but harmless to the failing probe |
| Failed task's own artifacts (#531) | the qa suite | `tests/test_api.py` |
| Package-scoped union (pf-24/pf-27) | dev source sharing a top-level package with the failed artifacts | **empty** |

That last row is the finding. `_scope_to_shared_packages` anchors on the failed qa task's own artifacts. shk-2's suite was authored at **root-level `tests/`**, so the anchor package was `tests`, and `backend/routes.py` (package `backend`) was filtered straight out. fay-16, fay-17, fay-18 and fay-19 all authored `backend/tests/…`, which matched — so pf-24's and pf-27's fixes worked in those rolls and were silently inert here. **The correction loop's reach into app source depended on where the squad happened to put its tests.**

## The fix

The direct chain the issue specifies: **failed probe row → the probe's declared `METHOD /path` → the contract's endpoint→fill-slot map → the file that owns the endpoint.** Those slots now *lead* the target set in both branches. Drift files and the failed task's own artifacts still ride — they carry real defects too (the pf-21 lesson) — but they can no longer displace the defect site.

- **`VerificationContract.endpoint_owners()`** — the endpoint→slot relation, read off the `endpoint_defined` criteria. The contract is the only artifact that states it: the interface manifest declares the endpoints, the blueprint decides which slot implements them, and only the expander's output joins the two. `Probe.endpoint_token()` renders the joining key (placeholders preserved — it joins against contract endpoints, not a live request).
- **`task_plan`** threads `contract_endpoint_owners` onto qa.test envelopes beside `contract_probes` — data only (#448), and only when probes exist, so probe-less contracts and author mode stay byte-identical.
- **`correction_runner._probe_owned_slots()`** resolves it. Only `failed` rows count: `skipped` means the subject never booted, which indicts no particular endpoint.
- The `"METHOD /path"` token grammar moves from `acceptance_checks` to **`acceptance_check_spec`** — its second reader is no longer an evaluator, so the grammar belongs with the rest of the vocabulary rather than duplicated or reached into privately. `CHECK_ENDPOINT_DEFINED` binds the filter to the `CHECK_SPECS` key so a rename can't silently degrade this to "no endpoints owned" (that would revert the fix to the no-op it exists to end).

## Replay verification

Rerun of target resolution against shk-2's stored artifacts — contract v9 `art_4f368ea08799`, plan `art_4b9606338510`, and the failed check ids from `run_verification_summaries` for `run_da25453895e3` (`vc-probe-runs`, `vc-probe-runs-join`, `vc-probe-runs-join-duplicate`, `vc-probe-runs-leave`, `tests_pass`):

```
endpoint_owners():
  GET /runs                    -> backend/routes.py
  POST /runs                   -> backend/routes.py
  GET /runs/{run_id}           -> backend/routes.py
  POST /runs/{run_id}/join     -> backend/routes.py
  POST /runs/{run_id}/leave    -> backend/routes.py

qa expected_artifacts    : ['tests/test_api.py']
implementation_artifacts : ['backend/routes.py', 'frontend/src/views/...']

OLD target : ['backend/main.py', 'tests/test_api.py']
             (package anchors ['tests'] -> scoped source [])
NEW target : ['backend/routes.py', 'backend/main.py', 'tests/test_api.py']
```

The OLD row reproduces exactly what both shipped repairs emitted (`art_deaec27453ae` main.py + `art_b74127a97e5b` tests/test_api.py) — the historical bug reproduced from stored evidence, then fixed.

## Tests

32 new across both commits. The ones that earn their place: the shk-2 replay (exact target list), a pin on the *mechanism* so a regression is diagnosable rather than mysterious, skipped-and-passing probes indicting nothing, malformed wire rows staying inert (a raise here strands the run), and the trailing-slash join. Added for the fallback: the suite-only case reaching routes.py while frontend source stays out, package scoping still winning when it matches, the mirror frontend case, and mixed-language anchors widening nothing. Regression suite **6021 passed, 1 skipped**.

## Second commit: the package-scoping hole itself (folded in on review)

The chain above is probe-backed by construction, so it doesn't cover a **suite-only** failure — no probes, or probes passed while `tests_pass` failed. On a root-level-`tests/` layout that case still had no route to app source at all.

`_scoped_implementation_surface` keeps package scoping as the primary rule — strictly narrower, unchanged whenever it matches anything — and falls back to the **language boundary** only when it comes back empty, because an anchor that matches nothing was uninformative, not exclusive. The language line is what RC2's stated guarantee actually means ("a backend failure can never regress frontend source"), and unlike the directory tree it holds wherever the suite was authored. Anchors straddling both sides widen nothing: excluding nothing is not scoping.

`FRONTEND_SUFFIXES` moves to `acceptance_check_spec` alongside the route grammar, now that repair targeting reads the same family the evaluators do.

Suite-only failure on the shk-2 layout, before and after:

```
OLD → ['backend/main.py', 'tests/test_api.py']
NEW → ['backend/main.py', 'tests/test_api.py', 'backend/routes.py']
      frontend views stay out — the RC2 guarantee survives the widening
```

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
