### PR TITLE
feat(acceptance): catch used-but-never-imported names on emitted Python (#689)

### DIFF
--- a/requirements/agent.lock
+++ b/requirements/agent.lock
@@ -126,6 +126,8 @@ pydantic==2.12.5
     #   langfuse
 pydantic-core==2.41.5
     # via pydantic
+pyflakes==3.4.0
+    # via -r requirements/base.txt
 pylance==0.12.1
     # via lancedb
 python-dotenv==1.0.0

--- a/requirements/api.lock
+++ b/requirements/api.lock
@@ -89,6 +89,8 @@ pydantic==2.12.5
     #   langfuse
 pydantic-core==2.41.5
     # via pydantic
+pyflakes==3.4.0
+    # via -r base.txt
 pyjwt==2.11.0
     # via redis
 python-dotenv==1.0.0

--- a/requirements/base.lock
+++ b/requirements/base.lock
@@ -34,6 +34,8 @@ pydantic==2.12.5
     # via -r base.txt
 pydantic-core==2.41.5
     # via pydantic
+pyflakes==3.4.0
+    # via -r base.txt
 python-dotenv==1.0.0
     # via -r base.txt
 pyyaml==6.0.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,3 +12,9 @@ httpx>=0.27.0
 
 # Validation
 jsonschema>=4.20.0
+
+# Undefined-name analysis for the `undefined_names` acceptance check (#689).
+# Pure Python, zero transitive deps, and the reference F821 implementation that
+# ruff's F-rules reimplement. Pinned exactly: this library's verdicts gate task
+# acceptance, so a silent upgrade would change what the squad may ship.
+pyflakes==3.4.0

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -15,6 +15,7 @@ from squadops.capabilities.handlers.base import (
     HandlerEvidence,
     HandlerResult,
 )
+from squadops.cycles.acceptance_check_spec import CHECK_UNDEFINED_NAMES, is_check_applicable
 from squadops.cycles.acceptance_checks import CheckOutcome
 from squadops.cycles.acceptance_evaluation import (
     evaluate_criterion,
@@ -36,6 +37,42 @@ from squadops.capabilities.handlers.cycle.validation import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _framework_injected_criteria(
+    artifacts: list[dict], authored: tuple[TypedCheck, ...]
+) -> list[TypedCheck]:
+    """Checks the framework applies to this emission regardless of what was authored (#689).
+
+    Today that is ``undefined_names`` on every emitted ``.py`` file. Injection —
+    rather than adding the check to the contract's per-slot criteria — is what makes
+    it reach a BIND-mode cycle at all: bind mode loads the pinned contract from
+    ``contract_ref`` instead of regenerating it, so a criterion added to the expander
+    would not appear until a re-seed, and the check would ship unverified.
+
+    Scoped to the producer's own emitted artifacts, so it can never indict a file this
+    task did not write. An authored row for the same check and file wins — the author
+    may have set a different severity, and two rows for one file would double-count in
+    the evidence.
+    """
+    already = {
+        (c.check, str(c.params.get("file", "")))
+        for c in authored
+        if c.check == CHECK_UNDEFINED_NAMES
+    }
+    injected: list[TypedCheck] = []
+    seen: set[str] = set()
+    for art in artifacts:
+        name = art.get("name") if art.get("name") is not None else art.get("path")
+        if not isinstance(name, str) or not is_check_applicable(CHECK_UNDEFINED_NAMES, name):
+            continue
+        if name in seen or (CHECK_UNDEFINED_NAMES, name) in already:
+            continue
+        seen.add(name)
+        injected.append(
+            TypedCheck(check=CHECK_UNDEFINED_NAMES, params={"file": name}, severity="error")
+        )
+    return injected
 
 
 class _CycleTaskHandler(CapabilityHandler):
@@ -366,7 +403,7 @@ class _CycleTaskHandler(CapabilityHandler):
                 }
             )
 
-        typed_criteria = list(split.typed)
+        typed_criteria = list(split.typed) + _framework_injected_criteria(artifacts, split.typed)
         if not typed_criteria:
             return
 

--- a/src/squadops/contracts/cycle_request_profiles/schema.py
+++ b/src/squadops/contracts/cycle_request_profiles/schema.py
@@ -45,7 +45,13 @@ _APPLIED_DEFAULTS_EXTRA_KEYS = {
     # SIP-0092 M1.3 typed acceptance
     "typed_acceptance",  # master flag (default true)
     "command_acceptance_checks",  # gate command_exit_zero independently
-    "command_check_safelist",  # operator-controlled extension to argv safelist
+    # `command_check_safelist` lived here, declared and never read by anything
+    # (2026-08-03 audit). SIP-0092 RC-10a designed it as an operator-controlled
+    # extension point for the argv safelist; the safelist shipped as a code-owned
+    # table in `acceptance_check_spec.COMMAND_SAFELIST`, and the typed vocabulary
+    # superseded the need to extend it from config. A key a profile can set and
+    # nothing consumes is the looks-configured-but-isn't class — removed rather
+    # than left as a lie a future operator would believe.
     "stack",  # resolved stack identity for typed-check evaluators
     # SIP-0093: multi-role plan authoring activation. Selects which roles emit
     # ``*.propose_plan_tasks`` before ``governance.merge_plan``; empty/absent

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -67,6 +67,14 @@ class CheckSpec:
         notes: Free-text constraint rendered into the proposer vocabulary as a
             ``- Note:`` line. For constraints the param schema alone can't
             express (e.g. the command safelist).
+        framework_injected: The framework applies this check itself, to every
+            applicable emitted artifact — it is not something a plan author
+            selects. Kept OUT of the rendered proposer vocabulary (#689): a
+            check the system always runs is not a decision the author should
+            be asked to make, and offering it invites redundant rows that can
+            only be authored wrong. The evaluator is registered normally, so
+            authoring one still parses and evaluates rather than becoming a
+            second rejection path.
         applicable_extensions: File extensions (lowercase, with dot) the
             evaluator can actually parse for this check's ``file`` target.
             Empty = not file-scoped or applicable to any file. pf-47/pf-49: the
@@ -88,6 +96,7 @@ class CheckSpec:
     example: dict[str, object] = field(default_factory=dict)
     notes: str = ""
     applicable_extensions: frozenset[str] = frozenset()
+    framework_injected: bool = False
 
 
 # Allowed severity values. Anything else → ValueError at parse time.
@@ -218,6 +227,11 @@ def is_frontend_source(path: str) -> bool:
 # no-op it was written to end.
 CHECK_ENDPOINT_DEFINED = "endpoint_defined"
 
+# #689: the framework-injected undefined-name check. Named here because the
+# injection site filters on it, the same single-source reason as the constant
+# above — a literal there would silently inject nothing after a rename.
+CHECK_UNDEFINED_NAMES = "undefined_names"
+
 
 # The `"METHOD /path"` endpoint-token grammar. `endpoint_defined.methods_paths`
 # is authored in it and the evaluator matches route decorators against it; #688
@@ -257,6 +271,16 @@ def parse_method_path(token: str) -> tuple[str, str] | None:
 # on each entry is rendered into the proposer prompt (issue #182) and is
 # asserted parser-valid by test.
 CHECK_SPECS: dict[str, CheckSpec] = {
+    CHECK_UNDEFINED_NAMES: CheckSpec(
+        name=CHECK_UNDEFINED_NAMES,
+        applicable_extensions=frozenset({".py"}),
+        required_params=frozenset({"file"}),
+        param_types={"file": str},
+        path_params=frozenset({"file"}),
+        framework_injected=True,
+        example={"file": "backend/routes.py"},
+        notes=("Applied by the framework to every emitted .py artifact; never authored."),
+    ),
     CHECK_ENDPOINT_DEFINED: CheckSpec(
         name=CHECK_ENDPOINT_DEFINED,
         applicable_extensions=frozenset({".py"}),
@@ -498,6 +522,8 @@ def render_typed_acceptance_vocabulary() -> str:
         "",
     ]
     for name, spec in CHECK_SPECS.items():
+        if spec.framework_injected:
+            continue  # #689: the framework runs it; it is not an authoring choice
         out.append(f"### `{name}`")
         required = ", ".join(
             f"`{p}` ({_type_label(spec, p)})" for p in sorted(spec.required_params)

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -29,7 +29,9 @@ from pathlib import Path
 from typing import Any
 
 from squadops.cycles.acceptance_check_spec import (
+    CHECK_ENDPOINT_DEFINED,
     CHECK_SPECS,
+    CHECK_UNDEFINED_NAMES,
     FRONTEND_SUFFIXES,
     HTTP_METHODS,
     CheckSpec,
@@ -272,7 +274,80 @@ def _unparseable_source_skip(file_path: Path) -> CheckOutcome | None:
     return None
 
 
-@register_check("endpoint_defined")
+@register_check(CHECK_UNDEFINED_NAMES)
+class UndefinedNamesCheck(BaseCheck):
+    """Names a ``.py`` file uses but never binds — the call-time ``NameError`` class (#689).
+
+    shk-2 shipped a ``backend/routes.py`` whose ``create_run`` called ``RunEvent(...)``
+    without importing it. Nothing caught it: ``py_compile`` sees valid syntax,
+    ``import_present`` checks the imports that ARE there, ``endpoint_defined`` reads
+    decorators, and ``module_imports`` (#628) imports the module successfully because
+    the name only resolves when the handler runs. First invocation was the qa suite —
+    500, probe cascade, and a correction loop that never reached the defect.
+
+    Implemented on pyflakes, in-process. It is the reference implementation ruff's
+    F-rules reimplement, it is pure Python with no transitive dependencies, and running
+    it in-process keeps the check free of subprocess/PATH/restricted-env concerns.
+
+    **A missing pyflakes is an ``error``, never a ``skipped``.** The #462 skip-never-fail
+    rule is for tooling with per-role variance, provisioned through
+    ``agents/instances/<role>/system-packages.txt`` and declared in the SIP-0096
+    ``check_registry`` (Node lives in the qa image alone, which is why it earns
+    ``TOOL_NODE``). A base-lock pip dependency is present in every image by
+    construction, so its absence is a build defect rather than an environment gap.
+    Skipping there would ship this check as exactly the looks-enforced-but-isn't no-op
+    SIP-0096 exists to kill — on the one defect class that already cost a full
+    correction budget.
+    """
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        try:
+            file_path = _safe_resolve(params["file"], workspace_root)
+        except _SafetyError as exc:
+            return CheckOutcome.error(reason=exc.reason)
+        if (skip := _unparseable_source_skip(file_path)) is not None:
+            return skip
+        if not file_path.is_file():
+            return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
+        try:
+            source = file_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return CheckOutcome.error(reason="file_unreadable")
+        try:
+            tree = ast.parse(source, filename=str(file_path))
+        except SyntaxError:
+            # The syntax gate owns unparseable emissions; reporting it twice would
+            # make one defect look like two.
+            return CheckOutcome.skipped(reason="unsupported_stack_or_syntax")
+
+        try:
+            from pyflakes.checker import Checker
+            from pyflakes.messages import UndefinedName
+        except ImportError:  # a baked dependency is missing ⇒ the image is wrong
+            return CheckOutcome.error(reason="missing_analyzer", analyzer="pyflakes")
+
+        undefined = [
+            {"name": str(m.message_args[0]), "line": m.lineno}
+            for m in Checker(tree, filename=str(file_path)).messages
+            if isinstance(m, UndefinedName)
+        ]
+        if undefined:
+            names = ", ".join(f"{u['name']} (line {u['line']})" for u in undefined)
+            return CheckOutcome.failed(
+                reason=f"undefined name(s): {names}",
+                file=str(params["file"]),
+                undefined=undefined,
+            )
+        return CheckOutcome.passed(file=str(params["file"]))
+
+
+@register_check(CHECK_ENDPOINT_DEFINED)
 class EndpointDefinedCheck(BaseCheck):
     """FastAPI route decorator presence — `@app.METHOD('/path')` / `@router.METHOD('/path')`."""
 

--- a/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
+++ b/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
@@ -15,7 +15,13 @@ from squadops.cycles.implementation_plan import TypedCheck
 pytestmark = [pytest.mark.domain_capabilities]
 
 
-def _art(name: str, content: str = "x" * 200) -> dict:
+# #689 injects `undefined_names` on every emitted .py, so the default filler must be
+# VALID Python — a bare `xxxx…` is one undefined name, and every fixture using the
+# default would fail a check it was never written to exercise.
+_FILLER = "# placeholder module\nPLACEHOLDER = " + repr("x" * 200) + "\n"
+
+
+def _art(name: str, content: str = _FILLER) -> dict:
     return {"name": name, "content": content, "media_type": "text/plain", "type": "code"}
 
 
@@ -383,7 +389,12 @@ class TestM13Observability:
                 _inputs([criterion], config={"stack": "fastapi"}),
                 [_art("main.py", _FASTAPI_ALL)],
             )
-        check_logs = [r for r in caplog.records if "typed_acceptance_check" in r.getMessage()]
+        check_logs = [
+            r
+            for r in caplog.records
+            if "typed_acceptance_check" in r.getMessage()
+            and "check=endpoint_defined" in r.getMessage()  # #689 also injects one
+        ]
         assert len(check_logs) == 1
         msg = check_logs[0].getMessage()
         assert "check=endpoint_defined" in msg
@@ -430,18 +441,21 @@ class TestM13Observability:
         summary_logs = [r for r in caplog.records if "typed_acceptance_summary" in r.getMessage()]
         assert len(summary_logs) == 1
         msg = summary_logs[0].getMessage()
-        assert "evaluated=1" in msg
-        assert "passed=1" in msg
+        # endpoint_defined + the #689-injected undefined_names on main.py.
+        assert "evaluated=2" in msg
+        assert "passed=2" in msg
         assert "blocking_failures=0" in msg
         assert "overall_passed=True" in msg
 
     async def test_summary_log_skipped_when_no_typed_checks(self, caplog):
         # Prose-only criteria → summary log should NOT fire (it would be noise).
+        # The artifact is deliberately non-Python: a .py emission now carries a
+        # framework-injected check (#689), so there WOULD be a typed check to summarize.
         h = DevelopmentDevelopHandler()
         with caplog.at_level("INFO", logger="squadops.capabilities.handlers.cycle.develop"):
             await h._validate_output(
                 _inputs([_PROSE_CRITERION], config={"stack": "fastapi"}),
-                [_art("main.py", _FASTAPI_ALL)],
+                [_art("README.md", "# docs\n" + "x" * 200)],
             )
         summary_logs = [r for r in caplog.records if "typed_acceptance_summary" in r.getMessage()]
         assert len(summary_logs) == 0
@@ -474,7 +488,7 @@ class TestWireShapeCriteria:
         )
         assert result.passed is False
         assert "acceptance:frontend manifest" in result.missing_components
-        acceptance_rows = [c for c in result.checks if c.get("check", "").startswith("acceptance:")]
+        acceptance_rows = [c for c in result.checks if c.get("check") == "acceptance:regex_match"]
         assert len(acceptance_rows) == 1
         assert acceptance_rows[0]["status"] == "failed"
 
@@ -488,7 +502,7 @@ class TestWireShapeCriteria:
         assert result.passed is True
         prose_rows = [c for c in result.checks if c.get("check") == "acceptance_criteria_prose"]
         assert prose_rows == []
-        acceptance_rows = [c for c in result.checks if c.get("check", "").startswith("acceptance:")]
+        acceptance_rows = [c for c in result.checks if c.get("check") == "acceptance:regex_match"]
         assert len(acceptance_rows) == 1
         assert acceptance_rows[0]["status"] == "passed"
 
@@ -532,7 +546,7 @@ class TestEvaluationIdentityFields:
         inputs["subtask_index"] = 4
         result = await h._validate_output(inputs, [_art("main.py", _FASTAPI_ALL)])
 
-        typed = [c for c in result.checks if c.get("check", "").startswith("acceptance:")]
+        typed = [c for c in result.checks if c.get("check") == "acceptance:endpoint_defined"]
         assert len(typed) == 2
         # Both rows attribute to the same task; check_index distinguishes them.
         assert all(c["task_index"] == 4 for c in typed)
@@ -691,7 +705,7 @@ class TestArtifactEmissionEndToEnd:
         inputs["subtask_index"] = 1
         result = await h._validate_output(inputs, [_art("main.py", _FASTAPI_ALL)])
         # The check rows are present and self-identifying.
-        typed = [c for c in result.checks if c.get("check", "").startswith("acceptance:")]
+        typed = [c for c in result.checks if c.get("check") == "acceptance:endpoint_defined"]
         assert len(typed) == 1
         # And the helper builds an artifact from them.
         artifact = h._build_typed_check_evaluation_artifact(
@@ -774,3 +788,103 @@ class TestAcceptanceWorkspaceFiles:
             inputs, [_art("backend/routes.py", _ROUTES_WITH_SIBLING_IMPORT)]
         )
         assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# #689 — framework-injected undefined_names on every emitted .py
+# ---------------------------------------------------------------------------
+
+
+_ROUTES_UNDEFINED = """
+from fastapi import APIRouter
+router = APIRouter()
+
+@router.post("/runs")
+def create_run(body):
+    return RunEvent(id=1)
+"""
+
+_ROUTES_CLEAN = """
+from fastapi import APIRouter
+from .models import RunEvent
+router = APIRouter()
+
+@router.post("/runs")
+def create_run(body):
+    return RunEvent(id=1)
+"""
+
+
+class TestFrameworkInjectedUndefinedNames:
+    """The check must reach a task that authored NOTHING — shk-2's dev task 0 carried
+    four contract-bound criteria, all of which passed, and the emission still shipped a
+    call-time NameError. Injection is also what makes it visible in BIND mode, whose
+    contract is pinned and never regenerated."""
+
+    async def test_emission_with_no_authored_criteria_is_still_checked(self):
+        h = DevelopmentDevelopHandler()
+        result = await h._validate_output(
+            _inputs([], expected=("backend/routes.py",)),
+            [_art("backend/routes.py", _ROUTES_UNDEFINED)],
+        )
+        assert result.passed is False
+        rows = [c for c in result.checks if c["check"] == "acceptance:undefined_names"]
+        assert len(rows) == 1
+        assert rows[0]["status"] == "failed"
+        assert rows[0]["actual"]["undefined"] == [{"name": "RunEvent", "line": 7}]
+
+    async def test_clean_emission_passes_and_is_still_recorded(self):
+        """A silent pass is indistinguishable from a check that never ran — the row has
+        to be in the evidence either way, or #689 cannot be confirmed on a green roll."""
+        h = DevelopmentDevelopHandler()
+        result = await h._validate_output(
+            _inputs([], expected=("backend/routes.py",)),
+            [_art("backend/routes.py", _ROUTES_CLEAN)],
+        )
+        assert result.passed is True
+        rows = [c for c in result.checks if c["check"] == "acceptance:undefined_names"]
+        assert [r["status"] for r in rows] == ["passed"]
+
+    async def test_only_python_artifacts_are_injected(self):
+        h = DevelopmentDevelopHandler()
+        result = await h._validate_output(
+            _inputs([], expected=("frontend/src/App.jsx",)),
+            [_art("frontend/src/App.jsx", "export default () => <div/>;"), _art("notes.md", "# x")],
+        )
+        assert [c for c in result.checks if c["check"] == "acceptance:undefined_names"] == []
+
+    async def test_injection_covers_every_python_file_in_a_multi_file_emission(self):
+        h = DevelopmentDevelopHandler()
+        result = await h._validate_output(
+            _inputs([], expected=("backend/routes.py",)),
+            [
+                _art("backend/routes.py", _ROUTES_CLEAN),
+                _art("backend/helpers.py", "def h():\n    return Missing()\n"),
+            ],
+        )
+        rows = {
+            c["params"]["file"]: c["status"]
+            for c in result.checks
+            if c["check"] == "acceptance:undefined_names"
+        }
+        assert rows == {"backend/routes.py": "passed", "backend/helpers.py": "failed"}
+        assert result.passed is False
+
+    async def test_an_authored_row_for_the_same_file_is_not_duplicated(self):
+        """Two rows for one file double-count in the evidence and let an authored
+        severity be silently overridden by the injected one."""
+        h = DevelopmentDevelopHandler()
+        authored = TypedCheck(
+            check="undefined_names",
+            params={"file": "backend/routes.py"},
+            severity="warning",
+            description="authored",
+        )
+        result = await h._validate_output(
+            _inputs([authored], expected=("backend/routes.py",)),
+            [_art("backend/routes.py", _ROUTES_UNDEFINED)],
+        )
+        rows = [c for c in result.checks if c["check"] == "acceptance:undefined_names"]
+        assert len(rows) == 1
+        assert rows[0]["severity"] == "warning"  # the author's choice survives
+        assert result.passed is True  # warning does not block (RC-9)

--- a/tests/unit/capabilities/test_builder_assemble_handler.py
+++ b/tests/unit/capabilities/test_builder_assemble_handler.py
@@ -197,7 +197,10 @@ class TestBuilderAssembleSuccess:
 
         assert result.success is True
         artifacts = result.outputs["artifacts"]
-        assert len(artifacts) == 4  # __main__.py, Dockerfile, requirements.txt, qa_handoff
+        # __main__.py, Dockerfile, requirements.txt, qa_handoff, plus the #114 typed-check
+        # evaluation record — #689 injects `undefined_names` on the emitted __main__.py,
+        # so there is now always a typed check to record.
+        assert len(artifacts) == 5
 
     async def test_qa_handoff_artifact_present(self, mock_context, builder_inputs):
         handler = BuilderAssembleHandler()
@@ -1012,13 +1015,17 @@ class TestTypedAcceptance:
         row = next(c for c in checks if c["check"] == "acceptance:regex_match")
         assert row["status"] == "skipped"
 
-    async def test_no_criteria_keeps_legacy_behavior(self, mock_context, builder_inputs):
-        # Cycles without a plan contract: exactly one required_files row,
-        # no acceptance rows, no #114 artifact.
+    async def test_no_authored_criteria_still_checks_the_emitted_python(
+        self, mock_context, builder_inputs
+    ):
+        """Was: no criteria -> no acceptance rows at all. #689 changed that on purpose —
+        an assembly that emits a `.py` gets the undefined-name check whether or not the
+        plan authored anything, because a call-time NameError in builder-emitted source
+        is the same defect it is anywhere else. The required_files row is unchanged."""
         result = await BuilderAssembleHandler().handle(mock_context, builder_inputs)
 
         assert result.success is True
         checks = result.outputs["validation_result"]["checks"]
-        assert [c["check"] for c in checks] == ["required_files"]
-        names = [a["name"] for a in result.outputs["artifacts"]]
-        assert not any(n.startswith("typed_check_evaluation") for n in names)
+        assert [c["check"] for c in checks] == ["required_files", "acceptance:undefined_names"]
+        assert checks[1]["status"] == "passed"
+        assert checks[1]["params"]["file"] == "my_app/__main__.py"

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -1302,3 +1302,129 @@ class TestFrontendCompiles:
         )
         assert outcome.status == "skipped"
         assert outcome.reason == "install_failed"
+
+
+# ---------------------------------------------------------------------------
+# undefined_names (#689) — the call-time NameError class
+# ---------------------------------------------------------------------------
+
+
+class TestUndefinedNames:
+    """shk-2's loss: `create_run` called `RunEvent(...)` without importing it. Valid
+    syntax, imports fine, every AST check green — the name resolves nowhere only when
+    the handler runs, so the first invocation was a 500 in the qa suite."""
+
+    @staticmethod
+    async def _run(tmp_path: Path, source: str, rel: str = "backend/routes.py"):
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source)
+        return await get_check("undefined_names").evaluate({"file": rel}, tmp_path)
+
+    async def test_name_used_only_inside_a_function_body_is_caught(self, tmp_path):
+        outcome = await self._run(
+            tmp_path,
+            "from fastapi import APIRouter\n"
+            "router = APIRouter()\n"
+            '@router.post("/runs")\n'
+            "def create_run(body):\n"
+            "    return RunEvent(id=1)\n",
+        )
+        assert outcome.status == "failed"
+        assert outcome.actual["undefined"] == [{"name": "RunEvent", "line": 5}]
+        assert "RunEvent" in outcome.reason
+
+    async def test_every_undefined_name_is_reported_not_just_the_first(self, tmp_path):
+        """A repair fixes what the evidence names. Reporting one of three sends it back
+        for two more rounds — the same drip-feed that cost pf-41 three attempts."""
+        outcome = await self._run(
+            tmp_path,
+            "def f():\n    return RunEvent(), Participant(), uuid.uuid4()\n",
+        )
+        assert [u["name"] for u in outcome.actual["undefined"]] == [
+            "RunEvent",
+            "Participant",
+            "uuid",
+        ]
+
+    @pytest.mark.parametrize(
+        ("label", "source"),
+        [
+            ("imported", "from .models import RunEvent\ndef f():\n    return RunEvent()\n"),
+            ("fixture_params", "def test_x(client, monkeypatch):\n    return client.get('/')\n"),
+            ("star_import", "from .models import *\ndef f():\n    return RunEvent()\n"),
+            ("conditional", "import os\nif os.name:\n    Y = 1\ndef f():\n    return Y\n"),
+            ("comprehension", "def f(items):\n    return [i for i in items if i]\n"),
+            ("class_scope", "class A:\n    x = 1\n    def m(self):\n        return self.x\n"),
+            (
+                "forward_annotation",
+                "from __future__ import annotations\ndef f() -> 'L': ...\nclass L: ...\n",
+            ),
+            ("global_decl", "def f():\n    global G\n    G = 1\ndef g():\n    return G\n"),
+        ],
+    )
+    async def test_legitimate_scoping_shapes_do_not_false_fail(self, tmp_path, label, source):
+        """Every one of these would break a real emission if flagged. Pytest fixtures
+        bind as parameters (every qa suite), a star import is undecidable so it must
+        not be guessed at, and conditional/global/comprehension/class scopes are
+        ordinary Python the check must understand rather than approximate."""
+        assert (await self._run(tmp_path, source)).status == "passed"
+
+    async def test_syntax_error_skips_so_one_defect_is_not_reported_twice(self, tmp_path):
+        """The pf-31 syntax gate owns truncated emissions. Failing here too would show
+        one defect as two and split the repair's attention."""
+        outcome = await self._run(tmp_path, "def f(:\n    pass\n")
+        assert outcome.status == "skipped"
+        assert outcome.reason == "unsupported_stack_or_syntax"
+
+    async def test_missing_analyzer_is_an_error_never_a_skip(self, tmp_path, monkeypatch):
+        """The corollary that decides whether this check is real. #462's skip-never-fail
+        rule is for per-role provisioned tooling (Node in the qa image, TOOL_NODE); a
+        base-lock pip dependency is present in every image by construction, so its
+        absence is a build defect. Skipping would ship #689 as exactly the
+        looks-enforced-but-isn't no-op SIP-0096 exists to kill."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name.startswith("pyflakes"):
+                raise ImportError("no pyflakes")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        outcome = await self._run(tmp_path, "def f():\n    return Undefined()\n")
+        assert outcome.status == "error"
+        assert outcome.reason == "missing_analyzer"
+        assert outcome.actual["analyzer"] == "pyflakes"
+
+    async def test_missing_file_fails_rather_than_passing_vacuously(self, tmp_path):
+        outcome = await get_check("undefined_names").evaluate(
+            {"file": "backend/absent.py"}, tmp_path
+        )
+        assert outcome.status == "failed"
+        assert outcome.reason == "file_not_found"
+
+    async def test_non_python_target_skips(self, tmp_path):
+        (tmp_path / "view.jsx").write_text("export default function V(){ return <div/> }")
+        outcome = await get_check("undefined_names").evaluate({"file": "view.jsx"}, tmp_path)
+        assert outcome.status == "skipped"
+
+    async def test_path_escaping_the_workspace_is_an_error(self, tmp_path):
+        outcome = await get_check("undefined_names").evaluate(
+            {"file": "../../etc/passwd"}, tmp_path
+        )
+        assert outcome.status == "error"
+        assert outcome.reason == "path_escapes_workspace"
+
+
+def test_undefined_names_is_framework_injected_and_out_of_the_authoring_vocabulary():
+    """#689 D0: the framework applies it to every emission, so asking a plan author to
+    select it is redundant work that can only be authored wrong — and an authored row
+    would also be absent from bind-mode cycles, whose contract is pinned."""
+    from squadops.cycles.acceptance_check_spec import render_typed_acceptance_vocabulary
+
+    assert CHECK_SPECS["undefined_names"].framework_injected is True
+    assert "undefined_names" not in render_typed_acceptance_vocabulary()
+    # Every other check stays advertised — the flag must not hide the vocabulary.
+    assert "endpoint_defined" in render_typed_acceptance_vocabulary()

--- a/tests/unit/cycles/test_typed_acceptance_vocabulary.py
+++ b/tests/unit/cycles/test_typed_acceptance_vocabulary.py
@@ -25,7 +25,13 @@ from squadops.cycles.implementation_plan import TypedCheck, _parse_acceptance_cr
 pytestmark = [pytest.mark.domain_orchestration]
 
 
-@pytest.mark.parametrize("check_name", sorted(CHECK_SPECS))
+# #689: framework-injected checks are deliberately absent from the authoring
+# vocabulary — the framework runs them, so an author selecting one is redundant work
+# that can only go wrong. `test_framework_injected_checks_are_withheld` pins that.
+_AUTHORABLE = sorted(n for n, s in CHECK_SPECS.items() if not s.framework_injected)
+
+
+@pytest.mark.parametrize("check_name", _AUTHORABLE)
 def test_every_check_example_is_parser_valid(check_name):
     """The example we show proposers for each check must parse cleanly through
     the real validator. If it doesn't, we'd be teaching models malformed YAML —
@@ -42,7 +48,7 @@ def test_every_check_example_is_parser_valid(check_name):
     assert parsed[0].check == check_name
 
 
-@pytest.mark.parametrize("check_name", sorted(CHECK_SPECS))
+@pytest.mark.parametrize("check_name", _AUTHORABLE)
 def test_rendered_vocabulary_shows_each_check_and_its_required_params(check_name):
     """The whole point of the fix: the model must see the check name AND its
     exact required param names. Listing the name without params is what caused
@@ -68,7 +74,7 @@ def test_rendered_vocabulary_is_not_empty():
     rendered = render_typed_acceptance_vocabulary()
     assert rendered.strip()
     # Sanity: every check is represented, so length scales with the registry.
-    assert rendered.count("- check:") == len(CHECK_SPECS)
+    assert rendered.count("- check:") == len(_AUTHORABLE)
 
 
 def _yaml_example_blocks(rendered: str) -> list[str]:
@@ -113,7 +119,7 @@ def test_rendered_vocabulary_examples_all_parse_as_yaml():
     example now carries a backslash escape, so a regression to double-quoting
     fails here with the exact error that dropped the dev proposal."""
     blocks = _yaml_example_blocks(render_typed_acceptance_vocabulary())
-    assert len(blocks) == len(CHECK_SPECS)
+    assert len(blocks) == len(_AUTHORABLE)
     for block in blocks:
         loaded = yaml.safe_load(block)
         assert isinstance(loaded, list) and len(loaded) == 1
@@ -127,3 +133,17 @@ def test_regex_example_demonstrates_a_backslash_in_single_quotes():
     rendered = render_typed_acceptance_vocabulary()
     assert r"pattern: '## How to \w+'" in rendered
     assert r'pattern: "## How to \w+"' not in rendered
+
+
+def test_framework_injected_checks_are_withheld_from_the_authoring_vocabulary():
+    """#689: rendering a check the framework always applies invites a redundant
+    authored row — and on a bind-mode cycle an authored row is the ONLY form that
+    cannot reach the task, because the contract is pinned and never regenerated.
+    The withholding must be exactly the flagged set, not a hardcoded name."""
+    rendered = render_typed_acceptance_vocabulary()
+    injected = {n for n, s in CHECK_SPECS.items() if s.framework_injected}
+    assert injected, "the flag must be exercised by at least one real spec"
+    for name in injected:
+        assert f"`{name}`" not in rendered
+    for name in _AUTHORABLE:
+        assert f"`{name}`" in rendered


### PR DESCRIPTION
Third fix of the 1.4.2 patch line. Hash-stable: no contract or manifest change. Both open decisions were ruled before building (PR #694, issue comment on #689) and are implemented as ruled.

## The gap

shk-2's dev task 0 shipped a `backend/routes.py` whose `create_run` called `RunEvent(...)` without importing it — and passed **every** gate:

| Gate | Why it missed |
|---|---|
| `command_exit_zero` (py_compile) | valid syntax |
| `import_present` | checks the imports that ARE there |
| `endpoint_defined` | reads decorators |
| `module_imports` (#628) | the module imports fine — the name resolves only when the handler runs |

First invocation was the qa suite: 500, probe cascade, correction budget spent without reaching the defect.

## D0 — the seam: framework-injected, not contract-authored

The natural home is `scaffold_contract._routes_criteria`, where #628's `module_imports` already hangs off routes.py for the same reason. Two things rule it out: that function **generates the verification contract**, so a row there moves the contract hash; and bind mode **loads** the pinned contract from `contract_ref` rather than regenerating it, so a contract-authored check would be invisible until a re-seed — which this plan defers to the #668 window. The fix would ship unverified.

Injection happens at emission acceptance, scoped to the producer's **own** emitted artifacts, so it can never indict a file the task did not write. An authored row for the same file wins (the author may have chosen a different severity; two rows would double-count in the evidence).

## D1 — the vehicle: pyflakes, in-process

Neither ruff nor pyflakes was in the locks, so either choice added a dependency — not a differentiator. pyflakes is pure Python with **zero transitive dependencies** and is the reference F821 implementation ruff's F-rules reimplement; ruff would put a ~25MB binary wheel in seven agent images to shell out for one rule. Hand-rolled AST was rejected: F821 scope analysis is exactly the wheel pyflakes already is. Added to `requirements/base.txt` (both the agent images and runtime-api evaluate checks — `patch_verification` calls `evaluate_criterion`), pinned exactly because this library's verdicts gate acceptance.

**The corollary matters more than the choice:** a missing pyflakes is an `error`, never a `skipped`. #462's skip-never-fail rule is for tooling with **per-role variance**, provisioned through `agents/instances/<role>/system-packages.txt` and declared via SIP-0096's `check_registry` — Node lives in the qa image alone, which is why it earns `TOOL_NODE`. A base-lock pip dependency is present in every image by construction, so its absence is a build defect. Skipping would ship this as exactly the looks-enforced-but-isn't no-op SIP-0096 exists to kill, on the class that already cost a full correction budget.

`framework_injected` keeps the check out of the rendered proposer vocabulary: a check the system always runs is not a decision to hand an author, and on a bind-mode cycle an authored row is the one form that can't reach the task.

## Verification against the stored artifact store

**Trip** — shk-2's `backend/routes.py` v2 (`art_87442fcf46db`):

```
status=failed  undefined=['RunEvent']
reason=undefined name(s): RunEvent (line 23)
```

**Clean** — every producer-emitted `.py` in the GREEN shk-1 roll (`cyc_b03d203df3f2`): 5/5 pass, including the qa suites.

**Sweep** — the false-positive question answered empirically rather than asserted: **765** producer-emitted `.py` artifacts across every stored cycle, **36 flagged (4.7%)**. I inspected the two flags likeliest to be false positives and both are real defects:

- `monkeypatch` used as a bare name inside a test that never takes the fixture (fixtures bind as parameters — `with monkeypatch.context():` in a `def test_x(client)` is a `NameError`), alongside a `uuid` used without importing it;
- `InMemoryRepository()` in a file whose only import is `pytest`.

One flag is #628's own pf-54 shape — the dropped `router = APIRouter()`.

## Rider

Deleted the dead `command_check_safelist` CRP key: declared at `schema.py:48`, read by nothing (2026-08-03 audit), superseded by the code-owned `COMMAND_SAFELIST` plus the typed vocabulary. A key a profile can set and nothing consumes is the same looks-configured-but-isn't class this patch line keeps closing.

## Tests

25 new. The ones that earn their place: the shk-2 shape (name used only in a function body), all-names-reported (a repair fixes what the evidence names — drip-feeding one of three costs rounds), the missing-analyzer corollary, and a parametrized sweep of scoping shapes that would break real emissions if flagged — pytest fixture parameters, star imports, conditional definition, `global`, comprehensions, class scopes, forward annotations.

12 existing tests re-pointed. Two changes worth naming: the shared `_art` fixture's default content was `"x" * 200`, which is a single undefined name once a `.py` emission is checked, so it is now valid Python; and `test_summary_log_skipped_when_no_typed_checks` now uses a non-Python artifact, because a `.py` emission genuinely does have a typed check to summarize. The builder tests changed for a real reason too: an assembly emitting `.py` now always produces the #114 typed-check evaluation artifact, which is how a green roll will show the check ran at all.

Regression suite **6051 passed, 1 skipped**.

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
