### PR TITLE
feat(planning): state the plan-shape rules in the authoring prompts (#686)

### DIFF
--- a/src/squadops/capabilities/handlers/planning_tasks.py
+++ b/src/squadops/capabilities/handlers/planning_tasks.py
@@ -138,6 +138,20 @@ class _PlanningTaskHandler(_CycleTaskHandler):
             variables["time_budget_section"] = budget_section
         return variables
 
+    async def _authoring_rules_section(self, renderer: Any) -> str:
+        """The plan-shape rules every deterministic validator enforces (#686).
+
+        Unconditional — unlike the sections around it there is no input to key on,
+        because these rules hold for every plan on every roll. shk-1's first framing
+        authored the #673 dual-claim shape with the contract, the manifest and the
+        typed-acceptance vocabulary all present, because the rules themselves appeared
+        in no prompt: the validator knew, the author never did (#629's pattern). Prose
+        is the managed asset; which validators are author-facing is the data table in
+        ``squadops.cycles.plan_authoring_rules``, and a test binds the two (#448).
+        """
+        rendered = await renderer.render("request.plan_authoring_rules_appendix", {})
+        return rendered.content
+
     async def _rejection_context_section(self, renderer: Any, inputs: dict[str, Any]) -> str:
         """The prior-rejection appendix on a framing re-roll, or "" (#669).
 
@@ -589,6 +603,9 @@ class GovernancePreparePlanAuthoringBriefHandler(_PlanningTaskHandler):
         renderer = getattr(context.ports, "request_renderer", None)
         if renderer is not None:
             variables = self._build_render_variables(prd, prior_outputs, inputs)
+            # #686: the brief pins the frame the proposers author against, so the
+            # plan-shape rules belong here as much as on the proposers themselves.
+            variables["authoring_rules_section"] = await self._authoring_rules_section(renderer)
             # #669: the brief pins the frame the proposers work from — on a
             # re-roll it must know what died, or it re-pins the rejected shape.
             rejection_section = await self._rejection_context_section(renderer, inputs)
@@ -975,6 +992,9 @@ class _ProposeBaseHandler(_PlanningTaskHandler):
         frozen_surface_section = await self._frozen_surface_section(renderer, inputs)
         if frozen_surface_section:
             variables["frozen_surface_section"] = frozen_surface_section
+        # #686: the plan-shape rules the deterministic validators enforce. No input
+        # to key on — they hold for every plan, so this one renders unconditionally.
+        variables["authoring_rules_section"] = await self._authoring_rules_section(renderer)
         # #669: on a framing re-roll, the prior attempt's rejection — revise,
         # don't re-dice. Data-driven and managed-asset prose, exactly like the
         # sections above; a first-roll framing has no input and renders nothing.

--- a/src/squadops/cycles/plan_authoring_rules.py
+++ b/src/squadops/cycles/plan_authoring_rules.py
@@ -1,0 +1,58 @@
+"""Which plan validators are author-facing, and where each one is taught (#686).
+
+Every deterministic plan validator encodes a rule, and until this module existed the
+authors were never shown the rule — only the rejection. shk-1 measured the cost: its
+first framing authored the fay-18 dual-claim shape with the contract, the manifest and
+the typed-acceptance vocabulary all in its inputs, because the *plan-shape rules*
+appeared in no authoring prompt. #673 caught it at the gate; the teaching arrived one
+framing re-roll and 45 minutes late, and one more authoring defect would have exhausted
+``framing_max_rerolls`` and hard-failed a cycle whose every mechanism worked. This is the
+#629 pattern — the system holds the answer and never shows the author — applied to plan
+authoring.
+
+This module is the CLASSIFICATION, which is data. The rule prose lives in the managed
+asset ``request.plan_authoring_rules_appendix`` (#448: prose in assets, Python renders
+data only). ``tests/unit/cycles/test_plan_authoring_rules.py`` binds the two together:
+every ``ImplementationPlan.validate_*`` method must appear in exactly one table here, and
+every rule id in ``AUTHOR_FACING`` must appear in the asset. A new validator therefore
+cannot ship without a decision about whether authors are told — the "any future validator
+lands here the day it ships" requirement, enforced rather than remembered.
+"""
+
+from __future__ import annotations
+
+# Validators whose rule is stated in the authoring-rules asset. The value is the rule id
+# the asset carries, so the binding is checkable rather than a naming convention.
+AUTHOR_FACING: dict[str, str] = {
+    "validate_unique_expected_artifacts": "one-file-one-owner",
+    "validate_expected_artifact_shapes": "artifacts-are-files",
+    "validate_frozen_artifact_ownership": "no-frozen-claims",
+    "validate_qa_artifact_ownership": "qa-owns-only-tests",
+    "validate_module_existence": "imports-must-exist",
+    "validate_criteria_scope": "regex-only-on-documents",
+    "validate_command_checks": "commands-must-run-here",
+    "validate_against_profile": "roles-must-exist",
+}
+
+# Validators an author is already taught by a different managed asset. Restating them
+# would put the same rule in two places, free to drift; the value names the owning asset
+# so the next reader can find it.
+COVERED_ELSEWHERE: dict[str, str] = {
+    # SIP-0098 §6.3 "bind, don't author" — rendered per-cycle with the actual criterion
+    # ids, which is strictly more useful than a general statement of the rule.
+    "validate_criteria_refs": "request.plan_bind_criteria_appendix",
+}
+
+# Validators with no author-facing rule: nothing the author writes can trip them, or the
+# defect they catch is not expressible in the plan the author is composing.
+NOT_AUTHOR_FACING: dict[str, str] = {}
+
+
+def rule_ids() -> frozenset[str]:
+    """Rule ids the authoring-rules asset must carry."""
+    return frozenset(AUTHOR_FACING.values())
+
+
+def classified_validators() -> frozenset[str]:
+    """Every validator this module has an opinion about."""
+    return frozenset(AUTHOR_FACING) | frozenset(COVERED_ELSEWHERE) | frozenset(NOT_AUTHOR_FACING)

--- a/src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md
+++ b/src/squadops/prompts/request_templates/request.development_propose_plan_tasks.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.development_propose_plan_tasks
-version: "2"
+version: "3"
 required_variables:
   - brief_content
   - planning_content
@@ -15,6 +15,7 @@ optional_variables:
   - bind_criteria_section
   - frozen_surface_section
   - rejection_context_section
+  - authoring_rules_section
 ---
 You are proposing development-domain plan tasks for the upcoming build.
 
@@ -34,7 +35,8 @@ The brief below was authored upstream and is immutable. Your proposal must opera
 
 {{planning_content}}
 
-{{typed_acceptance_vocabulary}}
+{{typed_acceptance_vocabulary}}{{authoring_rules_section}}
+
 ## Your task
 
 Decompose the development work for this build into focused tasks (`task_type: development.develop`) that, together with QA's test proposal and Strategy's guidance, will assemble into a complete implementation plan. Restrict your proposal to dev-domain tasks. Use the typed-acceptance vocabulary above where applicable.

--- a/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
@@ -1,0 +1,51 @@
+---
+template_id: request.plan_authoring_rules_appendix
+version: "1"
+required_variables: []
+---
+## PLAN SHAPE RULES (authoritative — a plan that breaks one is rejected)
+
+These are deterministic system validators, not reviewer preference. A plan violating any
+of them is rejected before it runs, the whole framing is re-rolled, and re-rolls are
+limited. Every rule below is checkable from what you are writing — none of them depend on
+how the build turns out.
+
+**one-file-one-owner** — An artifact path appears in the `expected_artifacts` of exactly
+ONE task. Two tasks naming the same file aliases them onto one file's fate: repair
+scoping and missing-artifact routing both key on this list, so a failing non-producing
+claimant aims its repair at another task's file, and if both produce, ordering silently
+decides whose version ships. A task that only *verifies* a file does not list it.
+
+**artifacts-are-files** — Every `expected_artifacts` entry is a file path, never a
+directory (`backend/tests/` is invalid; `backend/tests/test_runs.py` is fine). Presence is
+checked against emitted file names, so a directory entry can never be satisfied.
+
+**qa-owns-only-tests** — A `qa.test` task's `expected_artifacts` contains only its own
+test files. Never a scaffold file, and never a file another task produces: write
+authorization refuses those at emission, so the task provably cannot produce its own
+declared output.
+
+**no-frozen-claims** — No task of any role declares a scaffold-frozen file as an
+`expected_artifact`. Frozen files are scaffold-owned; an emission touching one is
+discarded, so the claim can never be satisfied.
+
+**imports-must-exist** — An error-severity `import_present` names a module the scaffold
+surface actually provides. Check the package root: if the scaffold's backend lives under
+`backend/`, then `app.routes` and `src.backend.main` do not exist and never will, and a
+check requiring one is unsatisfiable by any correct implementation.
+
+**regex-only-on-documents** — `regex_match` targets documents (`.md`, `.txt`, `.rst`)
+only. A regex against source prescribes another author's stylistic choices — quote style,
+identifier spelling — and rejects correct code. Verify source with the structural checks
+instead.
+
+**commands-must-run-here** — An error-severity `command_exit_zero` runs the tooling the
+check environment actually ships, against a file type that tool accepts. A missing
+executable, or `node --check` pointed at `.jsx`/`.tsx`, fails on every attempt regardless
+of content.
+
+**roles-must-exist** — Every task's `role` is one the squad profile actually staffs. A
+task assigned to an absent role can never be dispatched.
+
+A verification-only task is legitimate and common: declare `expected_artifacts: []` and
+express what it checks through its acceptance criteria.

--- a/src/squadops/prompts/request_templates/request.planning_task_base.md
+++ b/src/squadops/prompts/request_templates/request.planning_task_base.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.planning_task_base
-version: "2"
+version: "3"
 required_variables:
   - prd
   - role
@@ -8,11 +8,13 @@ optional_variables:
   - time_budget_section
   - prior_outputs
   - rejection_context_section
+  - authoring_rules_section
 ---
 ## Product Requirements Document
 
 {{prd}}
 {{time_budget_section}}
 {{prior_outputs}}
+{{authoring_rules_section}}
 {{rejection_context_section}}
 Please provide your {{role}} analysis and deliverables.

--- a/src/squadops/prompts/request_templates/request.qa_propose_plan_tasks.md
+++ b/src/squadops/prompts/request_templates/request.qa_propose_plan_tasks.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.qa_propose_plan_tasks
-version: "2"
+version: "3"
 required_variables:
   - brief_content
   - planning_content
@@ -14,6 +14,7 @@ optional_variables:
   - bind_criteria_section
   - frozen_surface_section
   - rejection_context_section
+  - authoring_rules_section
 ---
 You are proposing QA-domain plan tasks for the upcoming build.
 
@@ -33,7 +34,8 @@ The brief below was authored upstream and is immutable. Your proposal must opera
 
 {{planning_content}}
 
-{{typed_acceptance_vocabulary}}
+{{typed_acceptance_vocabulary}}{{authoring_rules_section}}
+
 ## Your task
 
 Decompose the QA work for this build into focused tasks (`task_type: qa.test`) that verify the brief's `must_cover_requirements`. Where a requirement isn't already covered by acceptance criteria on a development task, propose a qa task that covers it explicitly. Restrict your proposal to qa-domain tasks. Reference development tasks via `depends_on_focus: ["dev:..."]` strings.

--- a/src/squadops/prompts/request_templates/request.strategy_propose_plan_guidance.md
+++ b/src/squadops/prompts/request_templates/request.strategy_propose_plan_guidance.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.strategy_propose_plan_guidance
-version: "2"
+version: "3"
 required_variables:
   - brief_content
   - planning_content
@@ -10,6 +10,7 @@ optional_variables:
   - prd
   - roles_section
   - rejection_context_section
+  - authoring_rules_section
 ---
 You are proposing cross-cutting plan-authoring guidance for the upcoming build.
 
@@ -28,6 +29,8 @@ The brief below was authored upstream and is immutable. Your guidance overlays t
 ## Planning artifacts (upstream framing)
 
 {{planning_content}}
+
+{{authoring_rules_section}}
 
 ## Your task
 

--- a/tests/unit/capabilities/test_propose_plan_tasks.py
+++ b/tests/unit/capabilities/test_propose_plan_tasks.py
@@ -486,9 +486,12 @@ class TestPromptRegistryIntegration:
 
         await handler.handle(ctx, _seeded_inputs())
 
-        ctx.ports.request_renderer.render.assert_called_once()
-        template_id = ctx.ports.request_renderer.render.call_args.args[0]
-        assert template_id == expected_template
+        # #686 renders the plan-shape rules appendix first, so the MAIN template is the
+        # last render — assert on identity rather than call count, which would now only
+        # be counting how many appendices happen to exist.
+        rendered = [c.args[0] for c in ctx.ports.request_renderer.render.call_args_list]
+        assert rendered[-1] == expected_template
+        assert "request.plan_authoring_rules_appendix" in rendered
 
         ctx.ports.prompt_service.assemble.assert_called_once_with(
             role=handler._role,

--- a/tests/unit/capabilities/test_reroll_rejection_context.py
+++ b/tests/unit/capabilities/test_reroll_rejection_context.py
@@ -189,3 +189,84 @@ async def test_real_assets_carry_the_teaching_message_and_the_plan():
     assert "frozen (scaffold-owned)" in section
     assert "focus: Backend store" in section  # the rejected plan body
     assert "revise" in section.lower()
+
+
+# --- #686: the plan-shape rules reach the same four authoring prompts ----------- #
+
+
+@pytest.mark.parametrize(
+    "handler_cls",
+    [
+        DevelopmentProposePlanTasksHandler,
+        QaProposePlanTasksHandler,
+        StrategyProposePlanGuidanceHandler,
+        GovernancePreparePlanAuthoringBriefHandler,
+    ],
+)
+async def test_every_authoring_handler_renders_the_plan_shape_rules(handler_cls):
+    """Unlike the rejection appendix there is no input to key on — these rules hold for
+    every plan on every roll, so a handler that renders them only sometimes would leave
+    the first framing (the one shk-1 lost) exactly as uninformed as before."""
+    renderer = AsyncMock()
+    renderer.render.side_effect = lambda template_id, variables: MagicMock(
+        content=f"RENDERED:{template_id}"
+    )
+
+    out = await handler_cls()._authoring_rules_section(renderer)
+
+    assert out == "RENDERED:request.plan_authoring_rules_appendix"
+    (template_id, variables) = renderer.render.await_args.args
+    assert template_id == "request.plan_authoring_rules_appendix"
+    assert variables == {}  # prose-only asset: no data to inject (#448)
+
+
+async def test_real_asset_states_the_shk1_rule_in_the_rendered_section():
+    """A live render through the real template, so a malformed asset header or a
+    frontmatter typo fails here rather than silently rendering nothing into the prompt
+    that was supposed to carry the teaching."""
+    from adapters.prompts.filesystem_asset_adapter import FilesystemPromptAssetAdapter
+    from squadops.prompts.renderer import RequestTemplateRenderer
+
+    templates_dir = (
+        Path(__file__).resolve().parents[3] / "src" / "squadops" / "prompts" / "request_templates"
+    )
+    renderer = RequestTemplateRenderer(
+        FilesystemPromptAssetAdapter(
+            fragments_path=templates_dir.parent / "fragments",
+            templates_path=templates_dir,
+        )
+    )
+
+    section = await DevelopmentProposePlanTasksHandler()._authoring_rules_section(renderer)
+
+    assert "PLAN SHAPE RULES" in section
+    assert "one-file-one-owner" in section  # the class that cost shk-1 a re-roll
+    assert "expected_artifacts: []" in section  # the legitimate alternative
+    assert "no-frozen-claims" in section  # #658
+    assert "imports-must-exist" in section  # #671
+
+
+@pytest.mark.parametrize(
+    "template_id",
+    [
+        "request.planning_task_base",
+        "request.development_propose_plan_tasks",
+        "request.qa_propose_plan_tasks",
+        "request.strategy_propose_plan_guidance",
+    ],
+)
+def test_every_authoring_template_declares_and_places_the_slot(template_id):
+    """Declaring the variable without placing it, or vice versa, renders nothing into
+    the prompt while every handler-side test still passes — the silent-no-op shape this
+    patch line keeps closing."""
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "squadops"
+        / "prompts"
+        / "request_templates"
+        / f"{template_id}.md"
+    )
+    header, _, body = path.read_text(encoding="utf-8").partition("\n---\n")
+    assert "- authoring_rules_section" in header
+    assert "{{authoring_rules_section}}" in body

--- a/tests/unit/cycles/test_plan_authoring_rules.py
+++ b/tests/unit/cycles/test_plan_authoring_rules.py
@@ -1,0 +1,98 @@
+"""#686 — the plan-shape rules the validators enforce reach the plan authors.
+
+shk-1 (cyc_b03d203df3f2) authored the #673 dual-claim shape on its first framing with
+the contract, the interface manifest and the typed-acceptance vocabulary all present in
+its inputs, because the plan-shape *rules* appeared in no authoring prompt. The gate
+caught it; the teaching arrived a framing re-roll late, and one more authoring defect
+would have exhausted ``framing_max_rerolls``.
+
+These bind three surfaces that must not drift apart: the validator family, the
+classification table, and the managed asset the authors actually read.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from squadops.cycles.implementation_plan import ImplementationPlan
+from squadops.cycles.plan_authoring_rules import (
+    AUTHOR_FACING,
+    COVERED_ELSEWHERE,
+    NOT_AUTHOR_FACING,
+    classified_validators,
+    rule_ids,
+)
+
+pytestmark = [pytest.mark.domain_contracts]
+
+_TEMPLATES = (
+    Path(__file__).resolve().parents[3] / "src" / "squadops" / "prompts" / "request_templates"
+)
+_ASSET = _TEMPLATES / "request.plan_authoring_rules_appendix.md"
+
+
+def _validator_names() -> set[str]:
+    return {n for n in dir(ImplementationPlan) if n.startswith("validate_")}
+
+
+def test_every_validator_is_classified_exactly_once():
+    """The enforcement behind "any future validator lands here the day it ships". A new
+    validator with no entry fails here, so shipping one forces a decision about whether
+    the authors are told — rather than repeating shk-1, where the rule existed and the
+    author never saw it."""
+    validators = _validator_names()
+    assert validators, "the validator family must be discoverable by name"
+
+    unclassified = validators - classified_validators()
+    assert not unclassified, (
+        f"new plan validator(s) {sorted(unclassified)} are unclassified — add each to "
+        "AUTHOR_FACING (and state its rule in the asset), COVERED_ELSEWHERE, or "
+        "NOT_AUTHOR_FACING in squadops.cycles.plan_authoring_rules"
+    )
+    stale = classified_validators() - validators
+    assert not stale, f"classified validator(s) {sorted(stale)} no longer exist"
+
+    tables = [set(AUTHOR_FACING), set(COVERED_ELSEWHERE), set(NOT_AUTHOR_FACING)]
+    for i, a in enumerate(tables):
+        for b in tables[i + 1 :]:
+            assert not (a & b), f"validator classified twice: {sorted(a & b)}"
+
+
+def test_every_author_facing_rule_is_stated_in_the_asset():
+    """A rule id in the table with no prose in the asset is the #686 defect itself —
+    the system knows the rule and the author is not told."""
+    asset = _ASSET.read_text(encoding="utf-8")
+    missing = sorted(rid for rid in rule_ids() if f"**{rid}**" not in asset)
+    assert not missing, (
+        f"rule id(s) {missing} are classified author-facing but absent from the asset"
+    )
+
+
+def test_the_asset_states_no_rule_the_table_does_not_claim():
+    """The reverse drift: prose for a rule no validator enforces teaches authors to obey
+    something the system does not check, which is worse than silence — it spends author
+    attention and cannot be relied on."""
+    import re
+
+    stated = set(re.findall(r"^\*\*([a-z0-9-]+)\*\*", _ASSET.read_text(encoding="utf-8"), re.M))
+    assert stated == rule_ids()
+
+
+def test_covered_elsewhere_names_an_asset_that_exists():
+    """A pointer to a nonexistent asset is an unverifiable excuse for omitting a rule."""
+    for validator, template_id in COVERED_ELSEWHERE.items():
+        assert (_TEMPLATES / f"{template_id}.md").is_file(), (
+            f"{validator} is recorded as covered by {template_id}, which does not exist"
+        )
+
+
+def test_the_asset_teaches_the_shk1_defect_and_its_legitimate_alternative():
+    """The specific shape that cost shk-1 a re-roll: two tasks claiming one file. Stating
+    the ban without the verification-only alternative would push authors toward dropping
+    the verification task instead of declaring an empty artifact list."""
+    asset = _ASSET.read_text(encoding="utf-8")
+    assert "one-file-one-owner" in asset
+    assert "expected_artifacts: []" in asset
+    assert "verif" in asset.lower()

--- a/tests/unit/prompts/test_migration_validation.py
+++ b/tests/unit/prompts/test_migration_validation.py
@@ -427,10 +427,16 @@ class TestTemplateContractCompleteness:
         sorted(TEMPLATES_DIR.glob("*.md")),
         ids=lambda p: p.name,
     )
-    def test_every_template_has_required_variables(self, template_file):
-        """Bug caught: a template without required_variables silently accepts
-        any input — missing variables produce empty sections instead of errors.
-        """
+    def test_every_template_placeholder_is_declared(self, template_file):
+        """Bug caught: an undeclared variable silently accepts any input — a missing
+        value produces an empty section instead of an error.
+
+        Stated against the BODY rather than as "declare at least one variable" (#686):
+        a prose-only asset has no placeholders and therefore nothing to declare, and
+        demanding a variable there would only invite an invented one. Every placeholder
+        that IS used must still be declared, which is the actual contract."""
+        import re
+
         import yaml
 
         content = template_file.read_text()
@@ -438,8 +444,12 @@ class TestTemplateContractCompleteness:
         assert match, f"{template_file.name}: no YAML frontmatter found"
 
         header = yaml.safe_load(match.group(1)) or {}
-        required = header.get("required_variables", [])
-        assert len(required) > 0, (
-            f"{template_file.name}: no required_variables declared — "
-            "contract must specify at least one required variable"
+        declared = set(header.get("required_variables") or []) | set(
+            header.get("optional_variables") or []
+        )
+        used = set(re.findall(r"\{\{(\w+)\}\}", content[match.end() :]))
+        undeclared = sorted(used - declared)
+        assert not undeclared, (
+            f"{template_file.name}: placeholder(s) {undeclared} used but not declared in "
+            "required_variables/optional_variables"
         )


### PR DESCRIPTION
Last fix of the 1.4.2 patch line. Hash-stable: no contract or manifest change. Agent-image surface only (templates + one new asset).

## What shk-1 paid for

Its first framing authored the #673 dual-claim shape with the contract, the interface manifest, and the typed-acceptance vocabulary all present in its inputs — because the plan-shape **rules** appeared in no authoring prompt. #673 caught it at the gate; the teaching arrived one framing re-roll and 45 minutes late. One more authoring defect would have exhausted `framing_max_rerolls` and hard-failed a cycle whose every mechanism worked.

#629's pattern — the system holds the answer and never shows the author — applied to plan authoring.

## The rules

A managed asset, `request.plan_authoring_rules_appendix`, rendered into the four authoring prompts: the brief (which pins the frame the proposers work from) and the three proposers.

**Unconditional**, unlike the sections beside it. There is no input to key on — these rules hold for every plan on every roll — and a section that rendered only sometimes would leave the *first* framing, the one shk-1 lost, exactly as uninformed as before.

Eight rules, each traced to its validator:

| rule id | validator | origin |
|---|---|---|
| `one-file-one-owner` | `validate_unique_expected_artifacts` | #673 |
| `artifacts-are-files` | `validate_expected_artifact_shapes` | fay-9 |
| `qa-owns-only-tests` | `validate_qa_artifact_ownership` | pf-39 |
| `no-frozen-claims` | `validate_frozen_artifact_ownership` | #658 |
| `imports-must-exist` | `validate_module_existence` | #671 |
| `regex-only-on-documents` | `validate_criteria_scope` | #464 |
| `commands-must-run-here` | `validate_command_checks` | #645 |
| `roles-must-exist` | `validate_against_profile` | — |

Each states the rule **and why breaking it is unsatisfiable**, so an author can reason about a case the wording didn't anticipate rather than pattern-match the examples. The dual-claim ban ships with its legitimate alternative (`expected_artifacts: []` plus criteria) — stating the ban alone would push authors to drop verification tasks instead of declaring them artifact-less.

## The part that keeps it true

The issue's real requirement was *"validators and prompts share one source of truth — any future validator lands here the day it ships."* Prose in an asset can't enforce that by itself, so the binding is checked.

`squadops.cycles.plan_authoring_rules` classifies every validator into one of three tables:

- **`AUTHOR_FACING`** → rule id, which must appear in the asset;
- **`COVERED_ELSEWHERE`** → names the asset that already teaches it. `validate_criteria_refs` lives here: the bind appendix teaches "bind, don't author" per-cycle *with the actual criterion ids*, which beats a general restatement and would drift if duplicated;
- **`NOT_AUTHOR_FACING`** → nothing the author writes can trip it.

A test asserts every `ImplementationPlan.validate_*` appears in exactly one table, that every author-facing rule id appears in the asset, and — the reverse direction — that the asset states no rule the table doesn't claim, since prose for an unenforced rule spends author attention on something the system won't check. A new validator now cannot ship without a decision about whether authors are told. Classification is data; prose is the asset (#448).

## One test refined

`test_every_template_has_required_variables` demanded at least one required variable per template. A prose-only asset can't satisfy that without inventing a variable, so I restated it against the body: **every placeholder used must be declared**. That's the bug its own docstring names ("missing variables produce empty sections instead of errors") and is strictly tighter than a count. Verified against all templates before changing it — the only pre-existing mismatch is in the other direction (`role` declared but unused in `request.cycle_repair_task`), which I left alone rather than pull an unrelated fix into this PR.

## Tests

10 new: the three-way binding guard, an unconditional render from all four handlers, a live render through the real template (a frontmatter typo would otherwise render *nothing* into the prompt meant to carry the teaching, with every handler-side mock test still green), and a per-template check that the slot is both declared and placed — declaring without placing is silently inert.

Three existing `test_propose_plan_tasks` assertions moved from `render.assert_called_once()` to asserting the main template is the last render, since counting renders now just counts how many appendices happen to exist.

Regression suite **6070 passed, 1 skipped**.

**Live proof is negative and comes at the deploy window:** shk-1's dual-claim class should not recur in the confirmation cycle, and if framing authors it anyway, the #669 re-roll receipt shows whether the rules section was present in the authoring prompt.

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
