### PR TITLE
docs(sip): record #571 as a hard prerequisite for Cross-Cycle Memory

### DIFF
--- a/sips/proposed/SIP-Cross-Cycle-Memory.md
+++ b/sips/proposed/SIP-Cross-Cycle-Memory.md
@@ -403,9 +403,22 @@ Per the ratified post-1.4 reshuffle (`docs/plans/post-1-4-roadmap-reconciliation
   *learned-experience* leg of the capability-backed agent equation — **agent = identity
   (SIP-0088/0089) + capability (packs) + memory (this SIP) + policy + evidence
   history** — which is why it precedes the umbrella rather than riding inside it.
+- **Hard prerequisite — #571 (added 2026-08-04, verified against the code):** the
+  SIP-042 LanceDB adapter's recall path has two defects that Phase 1 would build
+  directly on top of. `adapters/memory/lancedb.py:130` applies `.limit()` *before*
+  namespace and tag filtering (done in Python at 138–147), so a query whose nearest
+  neighbours all sit in another namespace returns nothing while matching entries exist
+  — and namespace-scoped recall is exactly what §5's filter chain does. Line 136 scores
+  `1.0 - _distance` against LanceDB's default **L2** metric, which is not a `[0, 1]`
+  similarity, so the confidence threshold in that same chain does not mean what it says.
+  Neither is live today (nothing leverages memory yet), which is why they must be fixed
+  BEFORE this SIP rather than beside it: §9's gate is a *measured recurrence-rate drop*,
+  and a starving recall path would report "memory doesn't help" when the truth is
+  "recall never returned the memory." Fix #571 first; it is small and independent.
 - **Sequencing (readiness, not dates):** implementation can begin once design review
-  accepts; hard dependencies are already shipped (SIP-042 mechanics, the #669 injection
-  seam, `gate_decisions` persistence). SIP-0101's replay harness must be usable before
+  accepts and #571 is fixed; the other hard dependencies are already shipped (SIP-042
+  mechanics, the #669 injection seam, `gate_decisions` persistence). SIP-0101's replay
+  harness must be usable before
   the Phase-1 *measurement* is scored, not before implementation starts. Campaign
   landing in the same release supplies `created_campaign` provenance and the
   within-campaign consumer from day one (§7); nothing in Phase 1 hard-requires it.


### PR DESCRIPTION
Verified `adapters/memory/lancedb.py` today while triaging the backlog. Two defects in the SIP-042 recall path that Cross-Cycle Memory Phase 1 would build directly on top of:

- **line 130** — `.limit(query.limit)` is applied *before* namespace and tag filtering, which happens in Python at 138–147. A query whose nearest neighbours all sit in another namespace returns **zero** results while matching entries exist.
- **line 136** — `score = 1.0 - _distance` against LanceDB's default **L2** metric. That is not a `[0, 1]` similarity; L2 is unbounded above, so scores go negative and `query.threshold` stops meaning what its name says.

Namespace-scoped recall and confidence gating are exactly §5's Phase-1 filter chain, so both defects sit directly under it.

Neither is live today — nothing leverages memory yet — and that is precisely the argument for fixing them *first*. §9's gate is a **measured recurrence-rate drop**. A starving recall path would report "memory doesn't help" when the truth is "recall never returned the memory," and that is an expensive wrong conclusion to bank.

Adds the prerequisite to §12 and amends the sequencing bullet. Docs only; the fix itself is #571, which is small and independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv