### PR TITLE
docs(plan): amend 1.4.3 — add #561, retitle the #605 rider, declare pyflakes

### DIFF
--- a/docs/plans/1-4-3-patch-plan.md
+++ b/docs/plans/1-4-3-patch-plan.md
@@ -13,16 +13,22 @@ usable without saying so — a run that leaks state the next cycle blocks on, an
 that reports an environment gap as an outcome.
 
 Every item was verified against the code during the 2026-08-04 backlog triage, not read
-off an issue title. Two of the five changed classification on inspection: #605 appears
-already fixed, and #498's fix belongs somewhere other than where the issue first
-proposed.
+off an issue title. Two changed classification on inspection: #605 was already fixed
+(**closed 2026-08-04**, evidence on the issue), and #498's fix belongs somewhere other
+than where the issue first proposed.
+
+**Amended 2026-08-04** after the full-backlog sweep that followed: **#561 joins as fix 2**
+(the sweep narrowed it to a residue that lands in the same module as #373, so it costs one
+PR and closes a third stranding issue in a window already about stranding), and a second
+rider declares a dependency 1.4.2 left load-bearing but undeclared. Five fixes, two
+riders, six issues closed.
 
 **Hash-stable by construction:** no fix touches the verification contract or interface
 manifest. This is a live constraint here, not a formality — see #498, where one of the
 two candidate fix sites *would* have moved the contract hash. Deploy window asserts
 contract v9 `art_4f368ea08799` / manifest v4 `art_8becd104e9fc` unchanged.
 
-## The four fixes (order = build order)
+## The five fixes (order = build order)
 
 ### 1. #373 + #529 — stranded focus leases never self-heal
 The highest-value item on the board and the one whose shape is already proven. #529 is
@@ -47,7 +53,28 @@ this line exists to close). Then the behavioral proof, which is the manual check
 automated: start a cycle, cancel it, assert `focus_leases WHERE released_at IS NULL` = 0
 **without a restart**, and that a fresh cycle acquires leases immediately after.
 
-### 2. #498 — `python` resolves by PATH, so a structural check can report `missing_tooling`
+### 2. #561 — stale activity rows with no owning cycle still never heal
+The residue #672 deliberately left behind, and the sweep narrowed this issue to exactly
+it. `activity_reaper.py`'s docstring is explicit:
+
+> Activities without a ``cycle_id`` (duty/ambient sources) have no owning cycle to
+> consult and are left alone.
+
+So the permanent-breakage claim in #561 still holds for any activity row created in a
+**duty or ambient** posture (SIP-0089). Cycle-owned rows heal; those do not, and one
+stranded row blocks all of that agent's future activity tracking.
+
+Sequenced immediately after #373 on purpose: same module, same startup/finalize seams,
+same reviewer context, and the cancel probe below exercises both. The one design question
+it raises is the terminal predicate — there is no cycle to ask, so it needs a different
+one. Lease expiry and a heartbeat-age bound are the candidates; resolve in the fix PR and
+record the choice there, the way #689's D0/D1 rulings were recorded.
+
+**Verification:** a duty/ambient activity row with no `cycle_id`, stranded active, is
+ended by the startup reap — and a cycle-owned row's behavior is unchanged, so #672's
+guarantee is not widened by accident.
+
+### 3. #498 — `python` resolves by PATH, so a structural check can report `missing_tooling`
 `scaffold_contract.py` emits `vc-*-compiles` as `argv: ["python", "-m", "py_compile", …]`,
 and `acceptance_checks._restricted_env()` inherits `PATH`. Ubuntu ships only
 `/usr/bin/python3`, so on a box without a `python` alias the spawn raises
@@ -69,7 +96,7 @@ the check evaluator fixes the pinned contracts too, and is hash-stable by constr
 flip the issue documents — plus a test that pins the resolution so a later refactor
 can't reintroduce the bare name.
 
-### 3. #572 — the queue advertises a delay capability it cannot honor
+### 4. #572 — the queue advertises a delay capability it cannot honor
 `adapters/comms/rabbitmq.py:175` sets a per-message `expiration` (TTL) with no
 dead-letter exchange declared, so an expired message is discarded rather than routed
 onward. Line 537 nonetheless reports `"delay": True` with the comment *"Supported via
@@ -88,7 +115,7 @@ message outliving its TTL arrives on the dead-letter queue; if the flag is dropp
 test asserts `capabilities()["delay"] is False` and that `publish(..., delay_seconds=N)`
 with a non-zero N raises rather than silently under-delivering.
 
-### 4. #573 — literal `|` inside the redaction email character class
+### 5. #573 — literal `|` inside the redaction email character class
 `adapters/telemetry/langfuse/redaction.py:49` compiles
 `\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b`. `[A-Z|a-z]` is "uppercase, a
 literal pipe, or lowercase".
@@ -104,20 +131,25 @@ inspecting the regex source.
 
 ## Riders (no dedicated PRs)
 
-- **Close #605** — verify-and-close, no code change. The issue reports four AST checks
-  erroring instead of skipping on non-Python files; today every AST-parsing check
-  (`endpoint_defined`, `import_present`, `field_present`, `function_defined`,
-  `harness_boundary`, `module_imports`, `undefined_names`) calls
-  `_unparseable_source_skip` before parsing. The four that do not — `regex_match`,
-  `count_at_least`, `command_exit_zero`, `frontend_compiles` — do not parse Python and
-  never needed it. Close with that evidence, and land a registry-wide test asserting
-  every Python-parsing check skips a non-Python target, so the property is enforced
-  rather than re-verified by hand next time (rides #498's PR — same file).
+- **Pin the #605 property with a test.** The issue itself is **closed** (2026-08-04):
+  every AST-parsing check already calls `_unparseable_source_skip`, and the four that do
+  not — `regex_match`, `count_at_least`, `command_exit_zero`, `frontend_compiles` — never
+  parse Python. What remains is that the property is true by construction and asserted
+  nowhere. Land a registry-wide test ("every Python-parsing check skips a non-Python
+  target") so it cannot regress unnoticed; rides #498's PR, same file.
+- **Declare `pyflakes` in `tests/requirements.txt`.** 1.4.2 added it to
+  `requirements/base.txt` and the three locks, so every container has it — but the test
+  harness gets it only **transitively, through `flake8>=6.0.0`** (`tests/requirements.txt:92`).
+  CI and contributors are fine today for that reason alone. They stop being fine the day
+  anyone retires flake8 — which is a live prospect, since ruff's own config comment in
+  `pyproject.toml` records that its `F` rules *are* pyflakes. #689's `undefined_names`
+  would then return `error: missing_analyzer` across the suite with nothing pointing at
+  why. One line; declares a load-bearing dependency as load-bearing.
 
-## Deploy window (after all four merge)
+## Deploy window (after all five merge)
 
 1. Rebuild all + explicit runtime-api restart + verify-LOADED behaviorally in-container.
-   Surfaces: #373 touches runtime-api (port, reaper, composition root); #498 and #605
+   Surfaces: #373 and #561 touch runtime-api (port, reaper, composition root); #498 and #605
    touch the check evaluator, which runs in **both** the agent images and runtime-api
    (`patch_verification` evaluates criteria too); #572/#573 touch adapters present in
    both. So: rebuild everything, probe both sides.
@@ -125,7 +157,9 @@ inspecting the regex source.
 3. **The cancel probe** — a deliberate cancel, not a green roll: launch a cycle, cancel
    it mid-implementation, assert zero unreleased leases and zero stranded activities
    with no restart, then launch again and confirm immediate lease acquisition. This is
-   #373/#529's live proof and it cannot be obtained from a passing cycle.
+   #373/#529's live proof and it cannot be obtained from a passing cycle. #561's residue
+   rides the same probe from the other side: assert a `cycle_id`-less active row is also
+   ended, which the pre-#561 reaper leaves untouched by design.
 4. **One unfiltered confirmation shakedown** (standard seeded launcher, full, bind mode,
    unscored) — proves #498's evaluator change did not disturb structural criteria on a
    real roll, and that nothing regressed.
@@ -153,7 +187,9 @@ inspecting the regex source.
 | Issue | Fix | Surface | Verification |
 |---|---|---|---|
 | #373 + #529 | focus-lease reaper (mirrors #672) | runtime-api (port, reaper, composition) | cancel probe: 0 unreleased leases, no restart |
+| #561 | reap stale activities with no owning cycle | runtime-api (activity reaper) | cycle_id-less row ends; cycle-owned behavior unchanged |
 | #498 | resolve `python` → `sys.executable` at spawn | check evaluator (agents + runtime-api) | the two named tests pass with `.venv/bin` off PATH |
 | #572 | declare the DLX or drop the `delay` claim | comms adapter | declaration matches implementation |
 | #573 | literal `\|` in the email character class | telemetry redaction | behavioral pattern test |
-| #605 | (rider) close with evidence + pin the property | check registry | registry-wide skip test |
+| #605 | (rider) CLOSED 2026-08-04; pin the property | check registry | registry-wide skip test |
+| — | (rider) declare `pyflakes` in the test harness | `tests/requirements.txt` | suite passes without flake8 installed |


### PR DESCRIPTION
Follow-up to #700 (merged), from the full-backlog sweep that ran after it. Docs only.

## #561 joins as fix 2

Narrowing it during the sweep turned it into a patch item. It is now precisely the residue #672 deliberately left behind — `activity_reaper.py`'s own docstring says activities without a `cycle_id` (duty/ambient postures, SIP-0089) have no owning cycle to consult and are left alone. Cycle-owned rows heal; those don't, and one stranded row blocks all of that agent's future activity tracking.

Sequenced immediately after #373 because it is the same module, the same startup/finalize seams, the same reviewer context, and the same cancel probe. One extra PR closes a third stranding issue in a window already about stranding.

Its one design question — there is no cycle to ask, so it needs a different terminal predicate (lease expiry? heartbeat-age bound?) — is flagged for resolution **in the fix PR**, the way #689's D0/D1 rulings were recorded before building.

## #605 rider retitled

The issue is **closed** (2026-08-04, evidence on the issue): every AST-parsing check already calls `_unparseable_source_skip`, and the four that don't — `regex_match`, `count_at_least`, `command_exit_zero`, `frontend_compiles` — never parse Python. What remains is that the property is true by construction and asserted nowhere, so the rider is now the registry-wide pinning test rather than the close.

## New rider: declare `pyflakes` in `tests/requirements.txt`

1.4.2 added pyflakes to `requirements/base.txt` and the three locks, so every container has it. The **test harness** gets it only transitively, through `flake8>=6.0.0` at `tests/requirements.txt:92`.

CI and contributors are fine today *for that reason alone*. They stop being fine the day anyone retires flake8 — which is a live prospect, since ruff's own config comment in `pyproject.toml` records that its `F` rules **are** pyflakes. #689's `undefined_names` would then return `error: missing_analyzer` across the suite, with nothing pointing at why. One line, declaring a load-bearing dependency as load-bearing.

## Net

Five fixes, two riders, **six issues closed** in one hash-stable window. Character unchanged: everything added is still state that strands, or a dependency that lies about being there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv