### PR TITLE
fix(runtime): reclaim stranded focus leases at cancel, finalize, and startup (#373, #529)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -60,7 +60,9 @@ from squadops.cycles.task_plan import generate_task_plan
 from squadops.cycles.verification_normalize import normalize_task_checks
 from squadops.events.types import EventType
 from squadops.ports.cycles.flow_execution import FlowExecutionPort
+from squadops.runtime import reasons
 from squadops.runtime.admission import admit_participants, release_participants
+from squadops.runtime.lease_reaper import release_owner_leases
 from squadops.runtime.recruitment import reserve_buffer_decision
 from squadops.tasks.models import TaskEnvelope, TaskResult, TaskResultStatus
 from squadops.telemetry.context import use_correlation_context
@@ -78,6 +80,7 @@ if TYPE_CHECKING:
     from squadops.ports.events.cycle_event_bus import CycleEventBusPort
     from squadops.ports.runtime.activity import RuntimeActivityPort
     from squadops.ports.runtime.assignments import AssignmentPort
+    from squadops.ports.runtime.focus_lease import FocusLeasePort
     from squadops.ports.telemetry.llm_observability import LLMObservabilityPort
     from squadops.runtime.coordinator import RuntimeCoordinator
 
@@ -109,6 +112,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         assignment_port: AssignmentPort | None = None,
         activity_port: RuntimeActivityPort | None = None,
         coordinator: RuntimeCoordinator | None = None,
+        focus_lease_port: FocusLeasePort | None = None,
         run_completion: RunCompletion | None = None,
         correction_runner: CorrectionRunner | None = None,
         pulse_boundary_runner: PulseBoundaryRunner | None = None,
@@ -139,6 +143,12 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # falls back to §2.5-only — a cycle never hard-fails for missing runtime
         # infra.
         self._coordinator = coordinator
+        # #373: opt-in FocusLeasePort for the finalize-time stranded-lease sweep.
+        # `release_participants` below clears the leases *this call* recorded;
+        # this clears the ones the *run* holds — the difference is a recruitment
+        # replay (#288 idempotent-skip, e.g. a resumed run), whose leases are
+        # owned by this run but were never returned in `recruited_agent_ids`.
+        self._focus_lease_port = focus_lease_port
         self._cancelled: set[str] = set()
         # SIP-0097 §6.4: run-completion collaborator (terminal path). Plain
         # injected collaborator with a default composed from this executor's
@@ -483,6 +493,22 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # raise. Empty (and skipped) when the run recruited no one.
             if self._coordinator is not None and recruited_agent_ids:
                 await release_participants(self._coordinator, recruited_agent_ids, owner_ref=run_id)
+            # #373: then sweep anything still held under this run's owner_ref.
+            # `recruited_agent_ids` records only the agents *this* admission call
+            # transitioned; a recruitment replay (#288 idempotent-skip on a
+            # resumed run) leaves leases owned by this run that the release above
+            # cannot see. Best-effort — a sweep failure must not mask the run's
+            # own outcome.
+            if self._coordinator is not None and self._focus_lease_port is not None:
+                try:
+                    await release_owner_leases(
+                        self._coordinator,
+                        self._focus_lease_port,
+                        run_id,
+                        reason_code=reasons.LEASE_STRANDED_AT_RUN_FINALIZE,
+                    )
+                except Exception:
+                    logger.warning("Stranded-lease sweep failed for run %s", run_id, exc_info=True)
             await self._run_completion.finalize(
                 cycle_id,
                 run_id,

--- a/adapters/cycles/factory.py
+++ b/adapters/cycles/factory.py
@@ -120,5 +120,6 @@ def create_flow_executor(
             assignment_port=kwargs.get("assignment_port"),
             activity_port=kwargs.get("activity_port"),
             coordinator=kwargs.get("coordinator"),
+            focus_lease_port=kwargs.get("focus_lease_port"),
         )
     raise ValueError(f"Unknown flow executor provider: {provider}")

--- a/adapters/persistence/runtime/focus_lease_postgres.py
+++ b/adapters/persistence/runtime/focus_lease_postgres.py
@@ -145,6 +145,19 @@ class PostgresFocusLease(FocusLeasePort):
         async with acquire(self._pool, conn) as conn:
             return await self._current_lease(conn, agent_id)
 
+    async def list_active_leases(
+        self, *, owner_ref: str | None = None, conn: Any = None
+    ) -> tuple[FocusLease, ...]:
+        query = f"SELECT {_COLUMNS} FROM focus_leases WHERE released_at IS NULL"
+        args: list[Any] = []
+        if owner_ref is not None:
+            query += " AND owner_ref = $1"
+            args.append(owner_ref)
+        query += " ORDER BY acquired_at"
+        async with acquire(self._pool, conn) as conn:
+            rows = await conn.fetch(query, *args)
+        return tuple(_row_to_lease(row) for row in rows)
+
     async def _mark_released(self, lease_id: str, *, conn: Any = None) -> None:
         """Free the active-lease slot. Shared by release (cooperative) and revoke
         (non-cooperative) — the storage effect is identical in v1.1; the audit

--- a/src/squadops/api/routes/cycles/cancellation.py
+++ b/src/squadops/api/routes/cycles/cancellation.py
@@ -1,21 +1,31 @@
-"""#77: propagate a cycle/run cancellation to Prefect.
+"""Propagate a cycle/run cancellation beyond the registry (#77, #529).
 
-Cancelling a cycle/run flips registry status, but without this the corresponding
-Prefect flow run keeps executing (orphaned GPU/LLM work). We reconstruct the
-flow-run name(s) for the cancelled run(s) — via the same ``flow_run_name`` the
-executor wrote — find the still-running flow run(s) in Prefect, and transition
-them to CANCELLED so workers stop.
+Flipping registry status is the source of truth, but a cancelled run leaves two
+kinds of live state behind, and each needs an explicit hand-off:
 
-Best-effort: registry cancellation is the source of truth; this never raises, so
-the cancel route always reports the cycle/run as cancelled even if Prefect is
-unreachable (the failure is logged).
+- **#77 — the Prefect flow run.** Without this it keeps executing (orphaned
+  GPU/LLM work). We reconstruct the flow-run name(s) for the cancelled run(s)
+  via the same ``flow_run_name`` the executor wrote, find the still-running flow
+  run(s), and transition them to CANCELLED so workers stop.
+- **#529 — the run's focus leases.** Cancellation bypasses the executor's
+  finalize path, so the cycle leases the run holds are never released. Post-#288
+  that is a hard block: the next cycle recruiting any of those agents pauses at
+  admission with ``focus_lease_conflict`` and needs manual SQL to clear.
+
+Both are best-effort and never raise, so the cancel route reports the cycle/run
+as cancelled even if Prefect is unreachable or no lease wiring exists (the
+failure is logged).
 """
 
 from __future__ import annotations
 
 import logging
 
-from squadops.api.runtime.deps import get_workflow_tracker
+from squadops.api.runtime.deps import (
+    get_focus_lease_port,
+    get_runtime_coordinator,
+    get_workflow_tracker,
+)
 from squadops.cycles.naming import flow_run_name
 
 logger = logging.getLogger(__name__)
@@ -45,3 +55,41 @@ async def cancel_orphaned_flow_runs(project_id: str, cycle_id: str, run_ids: lis
             "#77: Prefect cancel propagation failed for cycle %s", cycle_id, exc_info=True
         )
         return 0
+
+
+async def release_cancelled_run_leases(cycle_id: str, run_ids: list[str]) -> int:
+    """Release the focus leases held by the cancelled run(s). Returns how many cleared.
+
+    Each run's leases are keyed by ``owner_ref = run_id`` (the executor's
+    recruitment call), so the sweep needs nothing but the ids the route already
+    has — which is the point: the agents a dead or cancelled run recruited are
+    exactly what a caller *cannot* enumerate.
+
+    Returns 0 when no coordinator/lease port is wired (a pool-less deployment
+    has no leases to release).
+    """
+    coordinator = get_runtime_coordinator()
+    focus_lease = get_focus_lease_port()
+    if coordinator is None or focus_lease is None or not run_ids:
+        return 0
+    from squadops.runtime import reasons
+    from squadops.runtime.lease_reaper import release_owner_leases
+
+    released = 0
+    for run_id in run_ids:
+        try:
+            released += await release_owner_leases(
+                coordinator, focus_lease, run_id, reason_code=reasons.LEASE_STRANDED_AT_CANCEL
+            )
+        except Exception:
+            logger.warning(
+                "#529: focus-lease release failed for cancelled run %s", run_id, exc_info=True
+            )
+    if released:
+        logger.info(
+            "#529: released %d stranded focus lease(s) for cancelled cycle %s (runs=%s)",
+            released,
+            cycle_id,
+            run_ids,
+        )
+    return released

--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -19,7 +19,7 @@ from squadops.api.routes.cycles.mapping import cycle_to_response
 from squadops.auth.models import Scope
 from squadops.cycles.check_tooling import resolve_provisioned_tooling
 from squadops.cycles.cycle_outcome import resolve_cycle_outcome
-from squadops.cycles.lifecycle import compute_config_hash
+from squadops.cycles.lifecycle import TERMINAL_STATES, compute_config_hash
 from squadops.cycles.models import (
     Cycle,
     CycleError,
@@ -27,6 +27,7 @@ from squadops.cycles.models import (
     Gate,
     PreflightRejectedError,
     Run,
+    RunStatus,
     SquadProfile,
     TaskFlowPolicy,
 )
@@ -324,15 +325,39 @@ async def cancel_cycle(project_id: str, cycle_id: str):
 
         # #77: stop the orphaned Prefect flow run(s) for this cycle's runs so
         # workers don't keep executing a logically-cancelled cycle.
-        from squadops.api.routes.cycles.cancellation import cancel_orphaned_flow_runs
+        from squadops.api.routes.cycles.cancellation import (
+            cancel_orphaned_flow_runs,
+            release_cancelled_run_leases,
+        )
 
-        run_ids = [run.run_id for run in await registry.list_runs(cycle_id)]
+        runs = await registry.list_runs(cycle_id)
+        run_ids = [run.run_id for run in runs]
         cancelled = await cancel_orphaned_flow_runs(project_id, cycle_id, run_ids)
+
+        # #529: `cancel_cycle` writes only the cycle's `cancelled` flag, so an
+        # in-flight run stays `running` forever — a stale status, and one that
+        # makes the run look live to the startup lease reaper. Transition them
+        # here, per-run isolated so one failure never blocks the rest.
+        for run in runs:
+            if RunStatus(run.status) in TERMINAL_STATES:
+                continue
+            try:
+                await registry.cancel_run(run.run_id)
+            except Exception:
+                logger.warning(
+                    "cancel_cycle: run %s could not be cancelled", run.run_id, exc_info=True
+                )
+
+        # #529: release the focus leases those runs hold. Swept across every run,
+        # not just the in-flight ones — a lease stranded under an already-terminal
+        # run is exactly #373's case and blocks recruitment just as hard.
+        leases_released = await release_cancelled_run_leases(cycle_id, run_ids)
 
         return {
             "status": "cancelled",
             "cycle_id": cycle_id,
             "prefect_flow_runs_cancelled": cancelled,
+            "focus_leases_released": leases_released,
         }
     except CycleError as e:
         raise handle_cycle_error(e) from e

--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -187,14 +187,22 @@ async def cancel_run(project_id: str, cycle_id: str, run_id: str):
         await registry.cancel_run(run_id)
 
         # #77: stop the orphaned Prefect flow run for this run.
-        from squadops.api.routes.cycles.cancellation import cancel_orphaned_flow_runs
+        # #529: and release the focus leases it holds — cancellation bypasses the
+        # executor's finalize path, so without this the next cycle recruiting any
+        # of this run's agents deadlocks on focus_lease_conflict.
+        from squadops.api.routes.cycles.cancellation import (
+            cancel_orphaned_flow_runs,
+            release_cancelled_run_leases,
+        )
 
         cancelled = await cancel_orphaned_flow_runs(project_id, cycle_id, [run_id])
+        leases_released = await release_cancelled_run_leases(cycle_id, [run_id])
 
         return {
             "status": "cancelled",
             "run_id": run_id,
             "prefect_flow_runs_cancelled": cancelled,
+            "focus_leases_released": leases_released,
         }
     except CycleError as e:
         raise handle_cycle_error(e) from e

--- a/src/squadops/api/runtime/deps.py
+++ b/src/squadops/api/runtime/deps.py
@@ -22,6 +22,8 @@ from squadops.ports.runtime.assignments import AssignmentPort
 
 if TYPE_CHECKING:
     from squadops.api.runtime.health_checker import HealthChecker
+    from squadops.ports.runtime.focus_lease import FocusLeasePort
+    from squadops.runtime.coordinator import RuntimeCoordinator
 
 # Global adapter instances (initialized at startup)
 _auth_port: AuthPort | None = None
@@ -48,6 +50,12 @@ _llm_port: LLMPort | None = None
 
 # SIP-0089 §2.7: Assignment port for the assignment REST surface
 _assignment_port: AssignmentPort | None = None
+
+# #373/#529: the composition root's single-writer coordinator (D16) and the lease
+# port, shared with the cancel routes so cancellation can release the leases the
+# cancelled run holds. Both stay None without a Postgres pool.
+_runtime_coordinator: RuntimeCoordinator | None = None
+_focus_lease_port: FocusLeasePort | None = None
 
 
 def set_auth_ports(
@@ -271,6 +279,40 @@ def get_assignment_port() -> AssignmentPort:
     if _assignment_port is None:
         raise RuntimeError("AssignmentPort not configured")
     return _assignment_port
+
+
+# =============================================================================
+# #373/#529: runtime coordinator + focus-lease port (stranded-lease sweeps)
+# =============================================================================
+
+
+def set_lease_sweep_ports(
+    coordinator: RuntimeCoordinator | None,
+    focus_lease: FocusLeasePort | None,
+) -> None:
+    """Register the shared coordinator and lease port for the cancel-time sweep.
+
+    The coordinator MUST be the composition root's single instance (D16) — the
+    sweep returns agents to ambient through it, and a second mode-writer would
+    race the executor and the duty scheduler.
+    """
+    global _runtime_coordinator, _focus_lease_port
+    _runtime_coordinator = coordinator
+    _focus_lease_port = focus_lease
+
+
+def get_runtime_coordinator() -> RuntimeCoordinator | None:
+    """Return the shared coordinator, or None when no Postgres pool is wired."""
+    return _runtime_coordinator
+
+
+def get_focus_lease_port() -> FocusLeasePort | None:
+    """Return the focus-lease port, or None when no Postgres pool is wired.
+
+    Unlike :func:`get_assignment_port` this never raises: cancellation must
+    succeed on a pool-less deployment, where there are no leases to release.
+    """
+    return _focus_lease_port
 
 
 # =============================================================================

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -336,9 +336,11 @@ async def _init_cycle_subsystem(config, pool) -> None:
         # Without a pool the guard stays unwired and recruitment is never gated.
         assignment_port = None
         activity_port = None
+        focus_lease_port = None
         if pool is not None:
             from adapters.persistence.runtime.activity_postgres import PostgresRuntimeActivity
             from adapters.persistence.runtime.assignments_postgres import PostgresAssignment
+            from adapters.persistence.runtime.focus_lease_postgres import PostgresFocusLease
             from squadops.api.runtime.deps import set_assignment_port
 
             assignment_port = PostgresAssignment(pool)
@@ -348,6 +350,11 @@ async def _init_cycle_subsystem(config, pool) -> None:
             # runtime-api process owns the asyncpg pool, so RuntimeActivity is
             # written here (not in agents) as each task is dispatched/replied.
             activity_port = PostgresRuntimeActivity(pool)
+            # #373/#529: the lease port for the stranded-lease sweeps. Stateless
+            # over the pool, so this instance is interchangeable with the one
+            # `create_runtime_coordinator` builds (same precedent as the
+            # assignment/activity adapters, which are also built twice).
+            focus_lease_port = PostgresFocusLease(pool)
 
         # SIP-0089 §3.5 (#233): the single-writer coordinator (D16), built once
         # here and reused by the duty scheduler (see _init_duty_scheduler) so the
@@ -357,37 +364,24 @@ async def _init_cycle_subsystem(config, pool) -> None:
 
         _runtime_coordinator = create_runtime_coordinator(pool)
 
-        # #672: startup reap — end active activities whose owning cycle is
-        # already terminal (rows stranded by a process death that skipped run
-        # finalize). One stranded row blocks all of that agent's future
-        # activity tracking. Best-effort: a reap failure never blocks startup.
-        if activity_port is not None:
-            try:
-                from squadops.cycles.lifecycle import derive_cycle_status
-                from squadops.cycles.models import CycleNotFoundError, CycleStatus
-                from squadops.runtime.activity_reaper import reap_stale_activities
+        # #373/#529: share the single coordinator + lease port with the cancel
+        # routes, so cancelling a cycle/run releases the leases it holds.
+        from squadops.api.runtime.deps import set_lease_sweep_ports
 
-                async def _cycle_is_terminal(cid: str) -> bool:
-                    try:
-                        owning_cycle = await cycle_registry.get_cycle(cid)
-                    except CycleNotFoundError:
-                        # No owner on record → definitionally stranded.
-                        return True
-                    runs = await cycle_registry.list_runs(cid)
-                    derived = derive_cycle_status(runs, cycle_cancelled=owning_cycle.cancelled)
-                    return derived in (
-                        CycleStatus.COMPLETED,
-                        CycleStatus.FAILED,
-                        CycleStatus.CANCELLED,
-                    )
+        set_lease_sweep_ports(_runtime_coordinator, focus_lease_port)
 
-                reaped = await reap_stale_activities(
-                    activity_port, cycle_is_terminal=_cycle_is_terminal
-                )
-                if reaped:
-                    logger.info("Startup reap ended %d stranded runtime activity row(s)", reaped)
-            except Exception:
-                logger.warning("Startup stranded-activity reap failed", exc_info=True)
+        # Startup hygiene: clear runtime state a dead process left active, before
+        # anything recruits against it. Each sweep is best-effort and owns its own
+        # wiring gate + terminal predicate (see `startup_reaps`); a held lease
+        # (#373) blocks recruitment outright, a live activity row (#672) kills
+        # that agent's activity tracking.
+        from squadops.api.runtime.startup_reaps import (
+            reap_stranded_activities,
+            reap_stranded_leases,
+        )
+
+        await reap_stranded_leases(cycle_registry, _runtime_coordinator, focus_lease_port)
+        await reap_stranded_activities(cycle_registry, activity_port)
 
         flow_executor = create_flow_executor(
             "dispatched",
@@ -404,6 +398,7 @@ async def _init_cycle_subsystem(config, pool) -> None:
             assignment_port=assignment_port,
             activity_port=activity_port,
             coordinator=_runtime_coordinator,
+            focus_lease_port=focus_lease_port,
         )
 
         set_cycle_ports(

--- a/src/squadops/api/runtime/startup_reaps.py
+++ b/src/squadops/api/runtime/startup_reaps.py
@@ -1,0 +1,138 @@
+"""Startup hygiene sweeps for state a dead process left active (#373, #672).
+
+Composition-root helper, kept out of ``main.py`` for the same reason
+``scheduler_bootstrap`` is: the wiring gate and the terminal predicate are then
+unit-testable without standing up FastAPI, and the composition root keeps one
+generic call per sweep instead of an inline block per issue.
+
+Both sweeps close the same class of bug — an interrupted run leaves a row
+*active* with no owner left to terminalize it, and the uniqueness rules that
+make the runtime correct (§3.2 one lease per agent, §4.2 one activity per agent)
+then turn that residue into a hard block on every later run:
+
+- :func:`reap_stranded_leases` (#373) — a held cycle lease makes recruitment
+  reject with ``focus_lease_conflict``, so the next cycle pauses before
+  dispatching a task.
+- :func:`reap_stranded_activities` (#672) — an active activity trips
+  ``uq_runtime_activities_one_active_per_agent``, so activity tracking goes
+  silently dead for that agent.
+
+Each owns its own best-effort contract: a reap failure is logged and never
+blocks startup, because a runtime-api that will not boot is worse than one that
+boots with residue.
+
+The domain reapers (``runtime.lease_reaper`` / ``runtime.activity_reaper``) stay
+free of cycle-domain imports (D26); the "is the owner finished?" question is
+answered here, where the registry is already in scope.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from squadops.ports.cycles.cycle_registry import CycleRegistryPort
+    from squadops.ports.runtime.activity import RuntimeActivityPort
+    from squadops.ports.runtime.focus_lease import FocusLeasePort
+    from squadops.runtime.coordinator import RuntimeCoordinator
+
+logger = logging.getLogger(__name__)
+
+
+async def reap_stranded_leases(
+    cycle_registry: CycleRegistryPort,
+    coordinator: RuntimeCoordinator | None,
+    focus_lease_port: FocusLeasePort | None,
+) -> int:
+    """Release every held cycle focus lease at startup (#373).
+
+    Returns how many cleared; 0 when the sweep is unwired (no Postgres pool) or
+    the reap failed.
+
+    **Every** held lease is orphaned here, not just the terminal-owned ones. Runs
+    execute in this process (the executor dispatches from inside runtime-api), so
+    a process that has not begun serving owns no in-flight run — and the
+    deployment is single-instance by construction, the same constraint the
+    coordinator's single-writer rule already depends on (see
+    ``scheduler_bootstrap``). Sparing a lease whose run still reads ``running``
+    would miss #373's own evidence: a SIGKILL leaves the run row non-terminal
+    forever, so the leases under it would never clear and the manual-SQL recovery
+    would stay mandatory for exactly the case the issue was filed about.
+
+    The run lookup therefore informs the *log*, not the decision — a lease under
+    a non-terminal run says the previous process died mid-run, which is worth
+    stating out loud. #373's complaint was that this failed silently.
+    """
+    if coordinator is None or focus_lease_port is None:
+        return 0
+    try:
+        from squadops.cycles.lifecycle import TERMINAL_STATES
+        from squadops.cycles.models import RunNotFoundError, RunStatus
+        from squadops.runtime import reasons
+        from squadops.runtime.lease_reaper import reap_stale_leases
+
+        async def _owner_cannot_be_executing(run_id: str) -> bool:
+            try:
+                owning_run = await cycle_registry.get_run(run_id)
+            except RunNotFoundError:
+                logger.warning("Releasing focus lease held by unknown run %s", run_id)
+                return True
+            if RunStatus(owning_run.status) not in TERMINAL_STATES:
+                logger.warning(
+                    "Releasing focus lease held by run %s still marked %r — no run "
+                    "can be executing at startup, so its executor died mid-run and "
+                    "the run status is stale.",
+                    run_id,
+                    owning_run.status,
+                )
+            return True
+
+        released = await reap_stale_leases(
+            coordinator,
+            focus_lease_port,
+            owner_is_finished=_owner_cannot_be_executing,
+            reason_code=reasons.LEASE_STRANDED_AT_STARTUP,
+        )
+        if released:
+            logger.info("Startup reap released %d stranded focus lease(s)", released)
+        return released
+    except Exception:
+        logger.warning("Startup stranded-lease reap failed", exc_info=True)
+        return 0
+
+
+async def reap_stranded_activities(
+    cycle_registry: CycleRegistryPort,
+    activity_port: RuntimeActivityPort | None,
+) -> int:
+    """End active activities whose owning cycle is terminal (#672).
+
+    Returns how many ended; 0 when unwired or the reap failed. Rows stranded by
+    a process death that skipped run finalize — one blocks all of that agent's
+    future activity tracking.
+    """
+    if activity_port is None:
+        return 0
+    try:
+        from squadops.cycles.lifecycle import derive_cycle_status
+        from squadops.cycles.models import CycleNotFoundError, CycleStatus
+        from squadops.runtime.activity_reaper import reap_stale_activities
+
+        async def _cycle_is_terminal(cycle_id: str) -> bool:
+            try:
+                owning_cycle = await cycle_registry.get_cycle(cycle_id)
+            except CycleNotFoundError:
+                # No owner on record → definitionally stranded.
+                return True
+            runs = await cycle_registry.list_runs(cycle_id)
+            derived = derive_cycle_status(runs, cycle_cancelled=owning_cycle.cancelled)
+            return derived in (CycleStatus.COMPLETED, CycleStatus.FAILED, CycleStatus.CANCELLED)
+
+        reaped = await reap_stale_activities(activity_port, cycle_is_terminal=_cycle_is_terminal)
+        if reaped:
+            logger.info("Startup reap ended %d stranded runtime activity row(s)", reaped)
+        return reaped
+    except Exception:
+        logger.warning("Startup stranded-activity reap failed", exc_info=True)
+        return 0

--- a/src/squadops/ports/runtime/focus_lease.py
+++ b/src/squadops/ports/runtime/focus_lease.py
@@ -105,3 +105,21 @@ class FocusLeasePort(ABC):
         `conn` (§4.5/D25): read on the caller's unit-of-work connection when given,
         so the coordinator sees a consistent snapshot within its transaction.
         """
+
+    @abstractmethod
+    async def list_active_leases(
+        self, *, owner_ref: str | None = None, conn: Any = None
+    ) -> tuple[FocusLease, ...]:
+        """Return every un-released lease, oldest first.
+
+        `owner_ref` narrows the result to the leases one owner holds — a run id
+        for `cycle` leases, an assignment id for `duty` leases. At most one
+        active lease exists per agent (§3.2), so the result is bounded by the
+        roster size and callers iterate it without pagination. Backs the
+        #373/#529 stranded-lease sweeps (`runtime.lease_reaper`), which need to
+        find held leases *by owner* — `get_current_lease` answers only the
+        inverse question, and an owner whose agents are unknown (a dead process,
+        a cancelled run) cannot ask it.
+
+        `conn` (§4.5/D25): read on the caller's unit-of-work connection when given.
+        """

--- a/src/squadops/runtime/lease_reaper.py
+++ b/src/squadops/runtime/lease_reaper.py
@@ -1,0 +1,186 @@
+"""
+Stranded FocusLease hygiene (#373/#529 — the #672 activity sweeps, applied to leases).
+
+`focus_leases` enforces one active lease per agent (§3.2, the partial unique
+index), and #288 makes a same-mode `cycle` request from a *different* owner a
+hard reject. Those two are correct together only while every lease is eventually
+released. A run that dies, or is cancelled outside the executor's finalize path,
+leaves its cycle leases held — with `expires_at = NULL`, so nothing reclaims
+them — and every later cycle recruiting those agents pauses at admission with
+`focus_lease_conflict` before dispatching a single task. Recovery is manual SQL
+today. Two sweeps close the class, mirroring `activity_reaper`:
+
+- :func:`release_owner_leases` — cancel / run finalize: the owning run is over,
+  so any lease still held for it is stranded; release them all. This is the
+  sweep the executor's ``recruited_agent_ids`` release cannot be: it clears
+  leases the run *holds*, not just the ones one call *recorded*.
+- :func:`reap_stale_leases` — sweep every held cycle lease whose owner is
+  finished, for callers that cannot enumerate owners (rows stranded by a process
+  death that skipped finalize, and historic rows predating the sweep).
+
+Both drive the **coordinator**, not the lease port directly. A stranded lease
+comes with a stranded ``mode = cycle``: releasing only the lease would leave the
+agent pinned in `cycle`, where the next recruitment takes the #288 same-mode
+path, finds no conflicting lease, and *idempotently skips* — admitted without
+ever acquiring, so finalize releases nothing and the agent is lost mid-run to
+the next owner. ``request_transition(…, "ambient")`` writes the mode and
+releases the lease in one unit of work (§4.5/D25) and emits the canonical
+events. A lease the transition did not clear — the agent was already `ambient`,
+which the null-UoW path can produce when a mode write commits and its release
+then fails — is released through the port afterwards, because the coordinator
+has no transition that expresses that case.
+
+Only `cycle` leases are swept. A `duty` lease's ``owner_ref`` is an assignment
+id, not a run id, so a run-shaped predicate does not apply to it and a live duty
+window must never be reaped by a question about runs.
+
+Both are best-effort and per-row isolated, like ``admission.release_participants``:
+one bad row never blocks clearing the rest, since a single stranded lease blocks
+all of that agent's future recruitment.
+
+Pure orchestration: depends only on the coordinator, the lease port, and
+``runtime.reasons``. Run-status knowledge enters through the ``owner_is_finished``
+predicate the composition root supplies — ``squadops.runtime`` never imports the
+cycles domain (D26 direction).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from squadops.ports.runtime.focus_lease import FocusLeasePort
+    from squadops.runtime.coordinator import RuntimeCoordinator
+    from squadops.runtime.models import FocusLease
+
+logger = logging.getLogger(__name__)
+
+# The only owner type these sweeps clear. A `duty` lease is owned by an
+# assignment window, not a run, and `ambient` holds no lease in v1.1 (§10.4).
+_CYCLE_OWNER_TYPE: Final[str] = "cycle"
+
+
+async def release_owner_leases(
+    coordinator: RuntimeCoordinator,
+    focus_lease: FocusLeasePort,
+    owner_ref: str,
+    *,
+    reason_code: str,
+) -> int:
+    """Release every active cycle lease held for ``owner_ref``; return how many cleared.
+
+    Cancel / run-finalize sweep: the owning run has no dispatch loop left to
+    release what it took, so anything still held under its id is stranded.
+    ``reason_code`` is explicit — the two call sites are different situations
+    (`LEASE_STRANDED_AT_CANCEL` vs `LEASE_STRANDED_AT_RUN_FINALIZE`) and the
+    reason is what an operator reads back off the transition.
+    """
+    released = 0
+    for lease in await focus_lease.list_active_leases(owner_ref=owner_ref):
+        if lease.owner_type != _CYCLE_OWNER_TYPE:
+            continue
+        if await _return_to_ambient(coordinator, focus_lease, lease, reason_code):
+            released += 1
+    return released
+
+
+async def reap_stale_leases(
+    coordinator: RuntimeCoordinator,
+    focus_lease: FocusLeasePort,
+    *,
+    owner_is_finished: Callable[[str], Awaitable[bool]],
+    reason_code: str,
+) -> int:
+    """Release every held cycle lease whose owner is finished; return how many cleared.
+
+    ``owner_is_finished`` decides — this module deliberately does not equate
+    "finished" with a terminal run status, because a run whose process was
+    killed keeps a non-terminal status forever (#373). The caller knows what
+    liveness means in its context; see ``api.runtime.startup_reaps``.
+
+    Non-cycle leases are left alone (their ``owner_ref`` is not a run). A
+    predicate or release failure skips that row only — the reaper must clear
+    what it can.
+    """
+    reaped = 0
+    for lease in await focus_lease.list_active_leases():
+        if lease.owner_type != _CYCLE_OWNER_TYPE:
+            continue
+        try:
+            if not await owner_is_finished(lease.owner_ref):
+                continue
+        except Exception:
+            logger.warning(
+                "liveness check for stranded lease %s (agent=%s, owner_ref=%s) failed",
+                lease.lease_id,
+                lease.agent_id,
+                lease.owner_ref,
+                exc_info=True,
+            )
+            continue
+        if await _return_to_ambient(coordinator, focus_lease, lease, reason_code):
+            reaped += 1
+    return reaped
+
+
+async def _return_to_ambient(
+    coordinator: RuntimeCoordinator,
+    focus_lease: FocusLeasePort,
+    lease: FocusLease,
+    reason_code: str,
+) -> bool:
+    """Return one agent to ambient and clear ``lease``; True iff the lease is gone.
+
+    The coordinator transition is the primary path — it writes ``mode`` and
+    releases the lease atomically (§4.5/D25). The port release that follows is
+    the residue handler, not a second path: it fires only when the agent was
+    already `ambient`, where ``request_transition`` is a same-mode idempotent
+    skip that never reaches lease arbitration and so leaves the lease held.
+
+    A *different* lease occupying the agent's slot afterwards means ours was
+    released and someone re-acquired; that counts as cleared and is left alone.
+    """
+    try:
+        await coordinator.request_transition(
+            lease.agent_id,
+            "ambient",
+            reason_code,
+            requester_kind="coordinator",
+            owner_ref=lease.owner_ref,
+        )
+    except Exception:
+        logger.warning(
+            "best-effort ambient transition for stranded lease %s (agent=%s) failed",
+            lease.lease_id,
+            lease.agent_id,
+            exc_info=True,
+        )
+
+    try:
+        current = await focus_lease.get_current_lease(lease.agent_id)
+        if current is not None and current.lease_id == lease.lease_id:
+            await focus_lease.release_lease(lease.lease_id, reason_code)
+            current = await focus_lease.get_current_lease(lease.agent_id)
+        cleared = current is None or current.lease_id != lease.lease_id
+    except Exception:
+        logger.warning(
+            "best-effort release of stranded lease %s (agent=%s, owner_ref=%s) failed",
+            lease.lease_id,
+            lease.agent_id,
+            lease.owner_ref,
+            exc_info=True,
+        )
+        return False
+
+    if cleared:
+        logger.info(
+            "released stranded focus lease %s (agent=%s, owner_ref=%s, reason=%s)",
+            lease.lease_id,
+            lease.agent_id,
+            lease.owner_ref,
+            reason_code,
+        )
+    return cleared

--- a/src/squadops/runtime/reasons.py
+++ b/src/squadops/runtime/reasons.py
@@ -45,6 +45,14 @@ CURRENT_ACTIVITY_CANNOT_PAUSE: Final[str] = "current_activity_cannot_pause"
 AGENT_RUNTIME_STATUS_UNAVAILABLE: Final[str] = "agent_runtime_status_unavailable"
 # Deferred-queue rejection (§3.0/D20): a request that would have queued in v1.2.
 FOCUS_LEASE_QUEUEING_NOT_SUPPORTED: Final[str] = "focus_lease_queueing_not_supported_in_v1.1"
+# Stranded-lease hygiene (#373/#529). A cancelled or abnormally-terminated run
+# leaves its cycle leases held with no expiry, and #288 turns that into a hard
+# reject for every later recruitment of those agents. The cancel sweep and the
+# startup reaper (`runtime.lease_reaper`) return the agent to ambient, which
+# releases the lease; these are the reasons those transitions carry.
+LEASE_STRANDED_AT_CANCEL: Final[str] = "lease_stranded_at_cancel"
+LEASE_STRANDED_AT_RUN_FINALIZE: Final[str] = "lease_stranded_at_run_finalize"
+LEASE_STRANDED_AT_STARTUP: Final[str] = "lease_stranded_at_startup"
 
 # Runtime-activity reasons (Phase 4 §4.4/§4.5)
 ACTIVITY_STARTED: Final[str] = "activity_started"

--- a/tests/unit/api/test_startup_reaps.py
+++ b/tests/unit/api/test_startup_reaps.py
@@ -1,0 +1,203 @@
+"""Tests for the composition root's startup hygiene sweeps (#373, #672).
+
+`startup_reaps` owns the two things `main.py` used to inline: the wiring gate
+and the "is the owner finished?" predicate. Both are where the silent-no-op bugs
+live, so both are tested here rather than through the domain reapers.
+
+Bug classes guarded:
+- a pool-less deployment raising (or the reap running against None ports) at
+  startup — runtime-api that will not boot is worse than one that boots with
+  residue;
+- the run-terminal predicate answering "terminal" for a *live* run, which would
+  release the focus leases of an executing cycle;
+- a missing owner row read as live, so the rows most certainly stranded (their
+  run/cycle is gone) are the only ones never reaped;
+- a registry failure propagating out and aborting startup.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from squadops.api.runtime.startup_reaps import reap_stranded_activities, reap_stranded_leases
+from squadops.cycles.models import CycleNotFoundError, Run, RunNotFoundError, RunStatus
+from squadops.runtime.models import FocusLease, RuntimeActivity
+
+pytestmark = [pytest.mark.domain_api]
+
+NOW = datetime(2026, 8, 4, tzinfo=UTC)
+
+
+def _lease(agent_id="max", owner_ref="run_1") -> FocusLease:
+    return FocusLease(
+        lease_id="lease-1",
+        agent_id=agent_id,
+        owner_type="cycle",
+        owner_ref=owner_ref,
+        acquired_at=NOW,
+        expires_at=None,
+        renewal_policy="ttl",
+        interruptibility="high",
+        recall_policy="graceful",
+        released_at=None,
+        idempotency_key=f"cycle:{owner_ref}:{agent_id}",
+    )
+
+
+def _activity(cycle_id="cyc_1") -> RuntimeActivity:
+    return RuntimeActivity(
+        runtime_activity_id="act-1",
+        agent_id="max",
+        mode="cycle",
+        activity_type="development.develop",
+        goal="Fill the slot",
+        priority=0,
+        state="running",
+        source_kind="cycle_task",
+        source_ref="t1",
+        cycle_id=cycle_id,
+        workload_id=None,
+        task_id="t1",
+        can_pause=False,
+        can_resume=False,
+        can_abort=True,
+    )
+
+
+def _run(status: str) -> Run:
+    return Run(
+        run_id="run_1",
+        cycle_id="cyc_1",
+        run_number=1,
+        status=status,
+        initiated_by="api",
+        resolved_config_hash="x",
+    )
+
+
+def _lease_ports(*, cleared: bool):
+    """A lease port holding one lease; `cleared` decides what the re-read sees."""
+    port = AsyncMock()
+    port.list_active_leases.return_value = (_lease(),)
+    port.get_current_lease.return_value = None if cleared else _lease()
+    return port, AsyncMock()
+
+
+# ---------------------------------------------------------------------------
+# reap_stranded_leases (#373)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("coordinator", "focus_lease"),
+    [(None, AsyncMock()), (AsyncMock(), None), (None, None)],
+    ids=["no-coordinator", "no-lease-port", "neither"],
+)
+async def test_lease_reap_is_a_noop_without_wiring(coordinator, focus_lease):
+    registry = AsyncMock()
+
+    assert await reap_stranded_leases(registry, coordinator, focus_lease) == 0
+    registry.get_run.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        RunStatus.RUNNING.value,
+        RunStatus.QUEUED.value,
+        RunStatus.PAUSED.value,
+        RunStatus.COMPLETED.value,
+        RunStatus.FAILED.value,
+        RunStatus.CANCELLED.value,
+    ],
+)
+async def test_every_held_lease_is_released_whatever_the_run_status(status):
+    """#373's own evidence is a lease under a run still marked `running`: a
+    SIGKILL leaves that status forever. Sparing non-terminal owners would leave
+    exactly the reported case needing manual SQL — and nothing can be executing
+    in a process that has not started serving yet."""
+    port, coordinator = _lease_ports(cleared=True)
+    registry = AsyncMock()
+    registry.get_run.return_value = _run(status)
+
+    assert await reap_stranded_leases(registry, coordinator, port) == 1
+    assert coordinator.request_transition.await_count == 1
+
+
+async def test_a_non_terminal_owner_is_logged_as_a_dead_executor(caplog):
+    """The silent-hang complaint in #373: releasing a lease under a `running` run
+    means the previous process died mid-run, and an operator has to be able to
+    see that rather than infer it."""
+    port, coordinator = _lease_ports(cleared=True)
+    registry = AsyncMock()
+    registry.get_run.return_value = _run(RunStatus.RUNNING.value)
+
+    with caplog.at_level("WARNING"):
+        await reap_stranded_leases(registry, coordinator, port)
+
+    assert "run_1" in caplog.text
+    assert "died mid-run" in caplog.text
+
+
+async def test_missing_run_row_still_releases_the_lease():
+    """A lease whose owning run is gone is the most certainly stranded row there
+    is — a lookup failure must not exempt it."""
+    port, coordinator = _lease_ports(cleared=True)
+    registry = AsyncMock()
+    registry.get_run.side_effect = RunNotFoundError("gone")
+
+    assert await reap_stranded_leases(registry, coordinator, port) == 1
+
+
+async def test_lease_reap_failure_never_blocks_startup():
+    port, coordinator = _lease_ports(cleared=True)
+    port.list_active_leases.side_effect = RuntimeError("db down")
+    registry = AsyncMock()
+
+    assert await reap_stranded_leases(registry, coordinator, port) == 0
+
+
+# ---------------------------------------------------------------------------
+# reap_stranded_activities (#672 — relocated from main.py, behavior unchanged)
+# ---------------------------------------------------------------------------
+
+
+async def test_activity_reap_is_a_noop_without_a_port():
+    registry = AsyncMock()
+
+    assert await reap_stranded_activities(registry, None) == 0
+    registry.get_cycle.assert_not_awaited()
+
+
+async def test_missing_cycle_row_is_treated_as_terminal():
+    activity_port = AsyncMock()
+    activity_port.list_active_activities.return_value = (_activity(),)
+    activity_port.abort_activity.return_value = _activity()
+    registry = AsyncMock()
+    registry.get_cycle.side_effect = CycleNotFoundError("gone")
+
+    assert await reap_stranded_activities(registry, activity_port) == 1
+
+
+async def test_activity_of_a_live_cycle_is_spared():
+    activity_port = AsyncMock()
+    activity_port.list_active_activities.return_value = (_activity(),)
+    registry = AsyncMock()
+    # The predicate reads only `cancelled` off the cycle; the run list carries
+    # the rest of the derivation.
+    registry.get_cycle.return_value = SimpleNamespace(cancelled=False)
+    registry.list_runs.return_value = [_run(RunStatus.RUNNING.value)]
+
+    assert await reap_stranded_activities(registry, activity_port) == 0
+    activity_port.abort_activity.assert_not_awaited()
+
+
+async def test_activity_reap_failure_never_blocks_startup():
+    activity_port = AsyncMock()
+    activity_port.list_active_activities.side_effect = RuntimeError("db down")
+
+    assert await reap_stranded_activities(AsyncMock(), activity_port) == 0

--- a/tests/unit/cycles/test_api_cycles.py
+++ b/tests/unit/cycles/test_api_cycles.py
@@ -281,6 +281,91 @@ class TestCancelCycle:
         assert resp.json()["status"] == "cancelled"
         assert resp.json()["prefect_flow_runs_cancelled"] == 0
 
+    def test_cancel_transitions_the_in_flight_run(self, client, mock_cycle_registry):
+        """#529: `cancel_cycle` writes only the cycle's `cancelled` flag, so an
+        in-flight run stayed `running` forever — a stale status that also makes
+        the run look live to the startup lease reaper."""
+        from squadops.cycles.models import Run
+
+        mock_cycle_registry.cancel_cycle.return_value = None
+        mock_cycle_registry.list_runs.return_value = [
+            Run(
+                run_id="run_001",
+                cycle_id="cyc_001",
+                run_number=1,
+                status="running",
+                initiated_by="api",
+                resolved_config_hash="x",
+            ),
+            Run(
+                run_id="run_000",
+                cycle_id="cyc_001",
+                run_number=0,
+                status="completed",
+                initiated_by="api",
+                resolved_config_hash="x",
+            ),
+        ]
+
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/cancel")
+
+        assert resp.status_code == 200
+        # Only the non-terminal run is transitioned — cancelling a finished run
+        # would rewrite what happened (the #522 edge is for the orchestrator).
+        mock_cycle_registry.cancel_run.assert_awaited_once_with("run_001")
+
+    def test_cancel_releases_leases_across_every_run(
+        self, client, mock_cycle_registry, monkeypatch
+    ):
+        """#373/#529: a lease stranded under an *already-terminal* run blocks
+        recruitment just as hard as one under the run being cancelled, so the
+        sweep covers the cycle's whole run list."""
+        import squadops.api.runtime.deps as deps_mod
+        from squadops.cycles.models import Run
+        from squadops.runtime.models import FocusLease
+
+        mock_cycle_registry.cancel_cycle.return_value = None
+        mock_cycle_registry.list_runs.return_value = [
+            Run(
+                run_id=rid,
+                cycle_id="cyc_001",
+                run_number=n,
+                status=status,
+                initiated_by="api",
+                resolved_config_hash="x",
+            )
+            for n, (rid, status) in enumerate([("run_000", "failed"), ("run_001", "running")])
+        ]
+
+        def _lease(agent_id, owner_ref):
+            return FocusLease(
+                lease_id=f"lease-{agent_id}",
+                agent_id=agent_id,
+                owner_type="cycle",
+                owner_ref=owner_ref,
+                acquired_at=datetime(2026, 8, 4, tzinfo=UTC),
+                expires_at=None,
+                renewal_policy="ttl",
+                interruptibility="high",
+                recall_policy="graceful",
+                released_at=None,
+                idempotency_key=f"cycle:{owner_ref}:{agent_id}",
+            )
+
+        by_owner = {"run_000": (_lease("nat", "run_000"),), "run_001": (_lease("max", "run_001"),)}
+        lease_port = AsyncMock()
+        lease_port.list_active_leases.side_effect = lambda *, owner_ref=None, conn=None: by_owner[
+            owner_ref
+        ]
+        lease_port.get_current_lease.return_value = None
+        monkeypatch.setattr(deps_mod, "_focus_lease_port", lease_port)
+        monkeypatch.setattr(deps_mod, "_runtime_coordinator", AsyncMock())
+
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/cancel")
+
+        assert resp.status_code == 200
+        assert resp.json()["focus_leases_released"] == 2
+
 
 class TestCycleRouteScopeEnforcement:
     """#150: with auth enabled, cycle routes enforce cycles:read/write.

--- a/tests/unit/cycles/test_api_runs.py
+++ b/tests/unit/cycles/test_api_runs.py
@@ -19,6 +19,7 @@ from squadops.cycles.models import (
     RunTerminalError,
     TaskFlowPolicy,
 )
+from squadops.runtime.models import FocusLease
 
 pytestmark = [pytest.mark.domain_orchestration]
 
@@ -44,6 +45,22 @@ _RUN = Run(
     initiated_by="api",
     resolved_config_hash="hash123",
 )
+
+
+def _focus_lease(agent_id: str, owner_ref: str) -> FocusLease:
+    return FocusLease(
+        lease_id=f"lease-{agent_id}",
+        agent_id=agent_id,
+        owner_type="cycle",
+        owner_ref=owner_ref,
+        acquired_at=NOW,
+        expires_at=None,
+        renewal_policy="ttl",
+        interruptibility="high",
+        recall_policy="graceful",
+        released_at=None,
+        idempotency_key=f"cycle:{owner_ref}:{agent_id}",
+    )
 
 
 @pytest.fixture
@@ -147,6 +164,58 @@ class TestCancelRun:
         fake_tracker.set_flow_run_state.assert_awaited_once_with(
             "flowrun-abc", "CANCELLED", "Cancelled"
         )
+
+    def test_cancel_releases_the_runs_focus_leases(self, client, monkeypatch):
+        """#529: cancellation bypasses the executor's finalize path, so without
+        this sweep the run's cycle leases stay held and the next cycle recruiting
+        any of those agents deadlocks on focus_lease_conflict."""
+        import squadops.api.runtime.deps as deps_mod
+
+        held = _focus_lease("data", "run_001")
+        lease_port = AsyncMock()
+        lease_port.list_active_leases.return_value = (held,)
+        lease_port.get_current_lease.return_value = None  # the transition cleared it
+        coordinator = AsyncMock()
+        monkeypatch.setattr(deps_mod, "_focus_lease_port", lease_port)
+        monkeypatch.setattr(deps_mod, "_runtime_coordinator", coordinator)
+
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs/run_001/cancel")
+
+        assert resp.status_code == 200
+        assert resp.json()["focus_leases_released"] == 1
+        # Scoped to the cancelled run's own leases, and the agent goes back to
+        # ambient — releasing the lease alone would leave it pinned in `cycle`.
+        lease_port.list_active_leases.assert_awaited_once_with(owner_ref="run_001")
+        agent_id, target_mode = coordinator.request_transition.await_args.args[:2]
+        assert (agent_id, target_mode) == ("data", "ambient")
+
+    def test_cancel_survives_a_lease_sweep_failure(self, client, monkeypatch):
+        """Registry cancellation is the source of truth (the #77 contract): a
+        lease-release failure must not turn a cancel into a 500."""
+        import squadops.api.runtime.deps as deps_mod
+
+        lease_port = AsyncMock()
+        lease_port.list_active_leases.side_effect = RuntimeError("db down")
+        monkeypatch.setattr(deps_mod, "_focus_lease_port", lease_port)
+        monkeypatch.setattr(deps_mod, "_runtime_coordinator", AsyncMock())
+
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs/run_001/cancel")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "cancelled"
+        assert resp.json()["focus_leases_released"] == 0
+
+    def test_cancel_without_lease_wiring_still_succeeds(self, client, monkeypatch):
+        """A pool-less deployment has no leases to release; cancel must not 500."""
+        import squadops.api.runtime.deps as deps_mod
+
+        monkeypatch.setattr(deps_mod, "_focus_lease_port", None)
+        monkeypatch.setattr(deps_mod, "_runtime_coordinator", None)
+
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs/run_001/cancel")
+
+        assert resp.status_code == 200
+        assert resp.json()["focus_leases_released"] == 0
 
 
 class TestGateDecision:

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -951,3 +951,22 @@ class TestRunCompletionActivityWiring:
         )
 
         assert executor._run_completion._activity_port is activity_port
+
+    async def test_factory_forwards_the_focus_lease_port(self, mock_registry, mock_vault):
+        """Same silent-no-op class for #373: the composition root builds the
+        executor through `create_flow_executor`, so a kwarg the factory drops
+        leaves the finalize stranded-lease sweep permanently inert — with every
+        lease_reaper unit test still green."""
+        from unittest.mock import AsyncMock
+
+        from adapters.cycles.factory import create_flow_executor
+
+        focus_lease_port = AsyncMock()
+        executor = create_flow_executor(
+            "dispatched",
+            cycle_registry=mock_registry,
+            artifact_vault=mock_vault,
+            focus_lease_port=focus_lease_port,
+        )
+
+        assert executor._focus_lease_port is focus_lease_port

--- a/tests/unit/runtime/test_coordinator_with_lease.py
+++ b/tests/unit/runtime/test_coordinator_with_lease.py
@@ -162,6 +162,12 @@ class _FakeFocusLease(FocusLeasePort):
     async def get_current_lease(self, agent_id, *, conn=None):
         return self._active.get(agent_id)
 
+    async def list_active_leases(self, *, owner_ref=None, conn=None):
+        leases = sorted(self._active.values(), key=lambda lease: lease.lease_id)
+        if owner_ref is not None:
+            leases = [lease for lease in leases if lease.owner_ref == owner_ref]
+        return tuple(leases)
+
     def _drop(self, lease_id):
         for aid, lease in list(self._active.items()):
             if lease.lease_id == lease_id:

--- a/tests/unit/runtime/test_focus_lease.py
+++ b/tests/unit/runtime/test_focus_lease.py
@@ -326,3 +326,48 @@ async def test_get_current_lease_maps_row_to_dataclass():
     )
     # current-lease lookup must filter to the active row.
     assert "released_at IS NULL" in conn.fetchrow.await_args.args[0]
+
+
+# ---------------------------------------------------------------------------
+# list_active_leases — the #373/#529 sweep read
+# ---------------------------------------------------------------------------
+
+
+async def test_list_active_leases_filters_to_unreleased_rows():
+    """Bug class: a listing that ignores `released_at` feeds the reaper rows that
+    are already released, which then 'clears' healthy agents and inflates the
+    reap count with phantom work."""
+    conn = AsyncMock()
+    conn.fetch.return_value = [_lease_row(), _lease_row(lease_id="lease-2", agent_id="neo")]
+    adapter = PostgresFocusLease(_make_pool(conn))
+
+    leases = await adapter.list_active_leases()
+
+    assert [lease.lease_id for lease in leases] == ["lease-1", "lease-2"]
+    query, *args = conn.fetch.await_args.args
+    assert "released_at IS NULL" in query
+    assert args == []  # unfiltered: no owner_ref bind
+
+
+async def test_list_active_leases_narrows_by_owner_ref_in_sql():
+    """Bug class: the cancel sweep must not fetch every agent's lease and filter
+    in Python — the narrowing is what keeps one run's cancel from touching a
+    concurrent run's leases if the filter is ever dropped."""
+    conn = AsyncMock()
+    conn.fetch.return_value = [_lease_row(owner_ref="run_7")]
+    adapter = PostgresFocusLease(_make_pool(conn))
+
+    leases = await adapter.list_active_leases(owner_ref="run_7")
+
+    assert [lease.owner_ref for lease in leases] == ["run_7"]
+    query, *args = conn.fetch.await_args.args
+    assert "owner_ref = $1" in query
+    assert args == ["run_7"]
+
+
+async def test_list_active_leases_returns_empty_tuple_when_nothing_is_held():
+    conn = AsyncMock()
+    conn.fetch.return_value = []
+    adapter = PostgresFocusLease(_make_pool(conn))
+
+    assert await adapter.list_active_leases(owner_ref="run_gone") == ()

--- a/tests/unit/runtime/test_lease_reaper.py
+++ b/tests/unit/runtime/test_lease_reaper.py
@@ -1,0 +1,392 @@
+"""Tests for the stranded-lease sweeps (#373/#529 — `runtime.lease_reaper`).
+
+Bug classes guarded:
+- the startup reaper releasing a lease whose owning run is still live — would
+  yank focus out from under an executing cycle;
+- `duty` leases swept by a run-shaped predicate: their ``owner_ref`` is an
+  assignment id, so "no such run" would read as terminal and kill a live duty
+  window;
+- releasing the lease without returning the agent to `ambient` — the agent stays
+  pinned in `cycle`, where the next recruitment takes the #288 same-mode path,
+  finds no conflicting lease, and *idempotently skips*: admitted without
+  acquiring, then lost mid-run when the real owner finalizes;
+- the residue case the coordinator cannot express (agent already `ambient`, lease
+  still held) leaving the lease held forever — the exact shape #373 observed;
+- one bad row (predicate, transition, or release failure) aborting the sweep, so
+  the remaining stranded leases never clear;
+- the cancel sweep reaching beyond its own owner and releasing a concurrent
+  run's leases;
+- counting attempted rather than actually-cleared rows, and stealing a slot a
+  new owner re-acquired mid-sweep.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from squadops.ports.runtime.focus_lease import FocusLeasePort
+from squadops.runtime import reasons
+from squadops.runtime.lease_reaper import reap_stale_leases, release_owner_leases
+from squadops.runtime.models import FocusLease
+
+pytestmark = [pytest.mark.domain_runtime]
+
+NOW = datetime(2026, 8, 4, tzinfo=UTC)
+
+
+def _lease(lease_id="lease-1", agent_id="max", owner_ref="run_1", owner_type="cycle") -> FocusLease:
+    return FocusLease(
+        lease_id=lease_id,
+        agent_id=agent_id,
+        owner_type=owner_type,  # type: ignore[arg-type]
+        owner_ref=owner_ref,
+        acquired_at=NOW,
+        expires_at=None,
+        renewal_policy="ttl",
+        interruptibility="high",
+        recall_policy="graceful",
+        released_at=None,
+        idempotency_key=f"{owner_type}:{owner_ref}:{agent_id}",
+    )
+
+
+class _FakeLeaseStore(FocusLeasePort):
+    """In-memory lease store keyed by agent (the §3.2 one-active-per-agent rule)."""
+
+    def __init__(
+        self,
+        leases: tuple[FocusLease, ...] = (),
+        *,
+        release_raises_for: frozenset[str] = frozenset(),
+    ) -> None:
+        self._active: dict[str, FocusLease] = {lease.agent_id: lease for lease in leases}
+        self._release_raises_for = release_raises_for
+        self.released: list[tuple[str, str]] = []
+        self.list_calls: list[str | None] = []
+
+    async def request_lease(self, agent_id, owner_type, owner_ref, idempotency_key, **kwargs):
+        raise NotImplementedError  # unused here
+
+    async def renew_lease(self, lease_id, *, expires_at=None):
+        raise NotImplementedError  # unused here
+
+    async def release_lease(self, lease_id, reason_code, *, conn=None):
+        if lease_id in self._release_raises_for:
+            raise RuntimeError("db down")
+        self.released.append((lease_id, reason_code))
+        for agent_id, lease in list(self._active.items()):
+            if lease.lease_id == lease_id:
+                del self._active[agent_id]
+
+    async def revoke_lease(self, lease_id, reason_code, *, conn=None):
+        await self.release_lease(lease_id, reason_code)
+
+    async def get_current_lease(self, agent_id, *, conn=None):
+        return self._active.get(agent_id)
+
+    async def list_active_leases(self, *, owner_ref=None, conn=None):
+        self.list_calls.append(owner_ref)
+        leases = sorted(self._active.values(), key=lambda lease: lease.lease_id)
+        if owner_ref is not None:
+            leases = [lease for lease in leases if lease.owner_ref == owner_ref]
+        return tuple(leases)
+
+    def replace_slot(self, agent_id: str, lease: FocusLease) -> None:
+        """Simulate a concurrent owner re-acquiring the agent's slot."""
+        self._active[agent_id] = lease
+
+
+class _FakeCoordinator:
+    """Coordinator stand-in with the real ambient-transition semantics.
+
+    Leaving `cycle` writes ambient and releases the leaving-mode lease (§3.4);
+    an agent already `ambient` is a same-mode idempotent skip that never reaches
+    lease arbitration — the case that leaves the residue.
+    """
+
+    def __init__(
+        self,
+        store: _FakeLeaseStore,
+        modes: dict[str, str] | None = None,
+        *,
+        raises_for: frozenset[str] = frozenset(),
+    ) -> None:
+        self._store = store
+        self._modes = modes if modes is not None else {}
+        self._raises_for = raises_for
+        self.transitions: list[tuple[str, str, str]] = []
+
+    async def request_transition(
+        self, agent_id, target_mode, reason_code, *, requester_kind, owner_ref, **kwargs
+    ):
+        if agent_id in self._raises_for:
+            raise RuntimeError("coordinator down")
+        self.transitions.append((agent_id, target_mode, reason_code))
+        if self._modes.get(agent_id, "cycle") == target_mode:
+            return None  # same-mode idempotent skip: the lease is left held
+        self._modes[agent_id] = target_mode
+        held = await self._store.get_current_lease(agent_id)
+        if held is not None:
+            await self._store.release_lease(held.lease_id, reasons.FOCUS_LEASE_RELEASED)
+        return None
+
+    def mode_of(self, agent_id: str) -> str:
+        return self._modes.get(agent_id, "cycle")
+
+
+def _terminal_only(terminal_runs: set[str], *, raises_for: set[str] | None = None):
+    async def owner_is_finished(run_id: str) -> bool:
+        if raises_for and run_id in raises_for:
+            raise RuntimeError("registry down")
+        return run_id in terminal_runs
+
+    return owner_is_finished
+
+
+# ---------------------------------------------------------------------------
+# reap_stale_leases (startup)
+# ---------------------------------------------------------------------------
+
+
+async def test_reap_clears_terminal_run_leases_and_spares_live_ones():
+    store = _FakeLeaseStore(
+        (
+            _lease("lease-dead", agent_id="max", owner_ref="run_dead"),
+            _lease("lease-live", agent_id="neo", owner_ref="run_live"),
+        )
+    )
+    coordinator = _FakeCoordinator(store)
+
+    reaped = await reap_stale_leases(
+        coordinator,
+        store,
+        owner_is_finished=_terminal_only({"run_dead"}),
+        reason_code=reasons.LEASE_STRANDED_AT_STARTUP,
+    )
+
+    assert reaped == 1
+    assert await store.get_current_lease("max") is None
+    live = await store.get_current_lease("neo")
+    assert live is not None and live.lease_id == "lease-live"
+    assert coordinator.transitions == [("max", "ambient", reasons.LEASE_STRANDED_AT_STARTUP)]
+
+
+async def test_reap_never_touches_duty_leases():
+    """A duty lease's owner_ref is an assignment id, not a run id — a run-shaped
+    predicate would answer "no such run → terminal" and revoke a live window."""
+    store = _FakeLeaseStore(
+        (_lease("lease-duty", agent_id="eve", owner_ref="asn_7", owner_type="duty"),)
+    )
+    coordinator = _FakeCoordinator(store)
+    predicate_calls: list[str] = []
+
+    async def owner_is_finished(owner_ref: str) -> bool:
+        predicate_calls.append(owner_ref)
+        return True
+
+    reaped = await reap_stale_leases(
+        coordinator,
+        store,
+        owner_is_finished=owner_is_finished,
+        reason_code=reasons.LEASE_STRANDED_AT_STARTUP,
+    )
+
+    assert reaped == 0
+    assert predicate_calls == []  # skipped before the predicate is even asked
+    assert (await store.get_current_lease("eve")).lease_id == "lease-duty"
+    assert coordinator.transitions == []
+
+
+async def test_reap_returns_the_agent_to_ambient():
+    """Releasing the lease alone leaves mode=cycle, where the next recruitment
+    #288-idempotently skips and free-rides instead of acquiring."""
+    store = _FakeLeaseStore((_lease("lease-1", agent_id="max", owner_ref="run_dead"),))
+    coordinator = _FakeCoordinator(store, {"max": "cycle"})
+
+    await reap_stale_leases(
+        coordinator,
+        store,
+        owner_is_finished=_terminal_only({"run_dead"}),
+        reason_code=reasons.LEASE_STRANDED_AT_STARTUP,
+    )
+
+    assert coordinator.mode_of("max") == "ambient"
+
+
+async def test_lease_left_held_by_the_transition_is_released_directly():
+    """#373's observed residue: the mode write committed and the release did not,
+    so the agent is already `ambient` — a same-mode skip that never reaches lease
+    arbitration. Nothing but a direct release can clear it."""
+    store = _FakeLeaseStore((_lease("lease-orphan", agent_id="max", owner_ref="run_dead"),))
+    coordinator = _FakeCoordinator(store, {"max": "ambient"})
+
+    reaped = await reap_stale_leases(
+        coordinator,
+        store,
+        owner_is_finished=_terminal_only({"run_dead"}),
+        reason_code=reasons.LEASE_STRANDED_AT_STARTUP,
+    )
+
+    assert reaped == 1
+    assert store.released == [("lease-orphan", reasons.LEASE_STRANDED_AT_STARTUP)]
+    assert await store.get_current_lease("max") is None
+
+
+async def test_predicate_failure_skips_only_that_row():
+    store = _FakeLeaseStore(
+        (
+            _lease("lease-a", agent_id="max", owner_ref="run_boom"),
+            _lease("lease-b", agent_id="neo", owner_ref="run_dead"),
+        )
+    )
+    coordinator = _FakeCoordinator(store)
+
+    reaped = await reap_stale_leases(
+        coordinator,
+        store,
+        owner_is_finished=_terminal_only({"run_dead"}, raises_for={"run_boom"}),
+        reason_code=reasons.LEASE_STRANDED_AT_STARTUP,
+    )
+
+    assert reaped == 1
+    assert (await store.get_current_lease("max")).lease_id == "lease-a"  # untouched
+    assert await store.get_current_lease("neo") is None
+
+
+async def test_transition_failure_still_releases_the_lease():
+    """A coordinator error must not leave the lease held — the whole point of the
+    sweep is that a blocked slot is worse than a stale mode."""
+    store = _FakeLeaseStore((_lease("lease-1", agent_id="max", owner_ref="run_dead"),))
+    coordinator = _FakeCoordinator(store, raises_for=frozenset({"max"}))
+
+    reaped = await reap_stale_leases(
+        coordinator,
+        store,
+        owner_is_finished=_terminal_only({"run_dead"}),
+        reason_code=reasons.LEASE_STRANDED_AT_STARTUP,
+    )
+
+    assert reaped == 1
+    assert store.released == [("lease-1", reasons.LEASE_STRANDED_AT_STARTUP)]
+
+
+async def test_release_failure_is_not_counted_and_does_not_stop_the_sweep():
+    store = _FakeLeaseStore(
+        (
+            _lease("lease-stuck", agent_id="max", owner_ref="run_dead"),
+            _lease("lease-ok", agent_id="neo", owner_ref="run_dead"),
+        ),
+        release_raises_for=frozenset({"lease-stuck"}),
+    )
+    coordinator = _FakeCoordinator(store, {"max": "ambient", "neo": "ambient"})
+
+    reaped = await reap_stale_leases(
+        coordinator,
+        store,
+        owner_is_finished=_terminal_only({"run_dead"}),
+        reason_code=reasons.LEASE_STRANDED_AT_STARTUP,
+    )
+
+    assert reaped == 1  # only the row that actually cleared
+    assert (await store.get_current_lease("max")).lease_id == "lease-stuck"
+    assert await store.get_current_lease("neo") is None
+
+
+async def test_a_reacquired_slot_counts_as_cleared_and_is_left_alone():
+    """Our lease was released and a new owner took the slot mid-sweep. Releasing
+    *that* lease would strand the run that just recruited."""
+    store = _FakeLeaseStore((_lease("lease-old", agent_id="max", owner_ref="run_dead"),))
+    coordinator = _FakeCoordinator(store, {"max": "ambient"})
+    successor = _lease("lease-new", agent_id="max", owner_ref="run_new")
+
+    async def owner_is_finished(run_id: str) -> bool:
+        store.replace_slot("max", successor)  # a concurrent recruit wins the slot
+        return True
+
+    reaped = await reap_stale_leases(
+        coordinator,
+        store,
+        owner_is_finished=owner_is_finished,
+        reason_code=reasons.LEASE_STRANDED_AT_STARTUP,
+    )
+
+    assert reaped == 1
+    assert store.released == []  # nothing released — the old lease was already gone
+    assert (await store.get_current_lease("max")).lease_id == "lease-new"
+
+
+# ---------------------------------------------------------------------------
+# release_owner_leases (cancel / run finalize)
+# ---------------------------------------------------------------------------
+
+
+async def test_release_owner_leases_clears_only_the_named_owner():
+    """Cancelling one run must not take down a concurrent run's leases."""
+    store = _FakeLeaseStore(
+        (
+            _lease("lease-mine", agent_id="max", owner_ref="run_cancelled"),
+            _lease("lease-theirs", agent_id="neo", owner_ref="run_other"),
+        )
+    )
+    coordinator = _FakeCoordinator(store)
+
+    released = await release_owner_leases(
+        coordinator, store, "run_cancelled", reason_code=reasons.LEASE_STRANDED_AT_CANCEL
+    )
+
+    assert released == 1
+    assert store.list_calls == ["run_cancelled"]  # narrowed at the query, not in Python
+    assert await store.get_current_lease("max") is None
+    assert (await store.get_current_lease("neo")).lease_id == "lease-theirs"
+    assert coordinator.transitions == [("max", "ambient", reasons.LEASE_STRANDED_AT_CANCEL)]
+
+
+async def test_release_owner_leases_clears_every_agent_the_run_holds():
+    """#529's shape: a cancelled run holds one lease per recruited agent, and a
+    single leftover blocks the next cycle just as hard as five."""
+    store = _FakeLeaseStore(
+        tuple(
+            _lease(f"lease-{agent}", agent_id=agent, owner_ref="run_cancelled")
+            for agent in ("data", "eve", "max", "nat", "neo")
+        )
+    )
+    coordinator = _FakeCoordinator(store)
+
+    released = await release_owner_leases(
+        coordinator, store, "run_cancelled", reason_code=reasons.LEASE_STRANDED_AT_CANCEL
+    )
+
+    assert released == 5
+    assert await store.list_active_leases() == ()
+
+
+async def test_release_owner_leases_ignores_a_duty_lease_sharing_the_owner_ref():
+    store = _FakeLeaseStore(
+        (
+            _lease("lease-cycle", agent_id="max", owner_ref="run_1"),
+            _lease("lease-duty", agent_id="neo", owner_ref="run_1", owner_type="duty"),
+        )
+    )
+    coordinator = _FakeCoordinator(store)
+
+    released = await release_owner_leases(
+        coordinator, store, "run_1", reason_code=reasons.LEASE_STRANDED_AT_CANCEL
+    )
+
+    assert released == 1
+    assert (await store.get_current_lease("neo")).lease_id == "lease-duty"
+
+
+async def test_release_owner_leases_on_an_owner_holding_nothing_is_a_noop():
+    store = _FakeLeaseStore((_lease("lease-1", agent_id="max", owner_ref="run_other"),))
+    coordinator = _FakeCoordinator(store)
+
+    released = await release_owner_leases(
+        coordinator, store, "run_gone", reason_code=reasons.LEASE_STRANDED_AT_RUN_FINALIZE
+    )
+
+    assert released == 0
+    assert coordinator.transitions == []
+    assert store.released == []


### PR DESCRIPTION
First fix of the **1.4.3** line (`docs/plans/1-4-3-patch-plan.md`) — *a cycle can neither strand the next one nor fail silently.*

## The bug

A cycle FocusLease is created with `expires_at = NULL` and released only by the executor's finalize path. Anything that skips that path leaves the lease held forever, and post-#288 (which correctly hard-rejects a same-mode `cycle` request from a different owner) that is a permanent block: every later cycle recruiting those agents pauses at admission with `focus_lease_conflict` before dispatching a single task. Recovery was raw SQL — the pre-launch `select count(*) from focus_leases where released_at is null` check is in my own runbook.

Two skip paths, one class:
- **#529** — cancellation. `cancel_run` writes `cycle_runs.status`; `cancel_cycle` writes only the cycle's `cancelled` flag. Neither touches leases, and neither goes through the executor's finalize.
- **#373** — process death. Nothing ever reclaims a lease whose owner died.

We shipped this reaper's analogue in 1.4.1 and never built the original. `activity_reaper.py`'s first line says so: *"Stranded RuntimeActivity hygiene (#672 — the FocusLease #373 class, applied to activities)"*. This mirrors it.

## The fix

**`FocusLeasePort.list_active_leases(owner_ref=...)`** — the sweep read, narrowed in SQL. The agents a dead or cancelled run recruited are exactly what a caller cannot enumerate; `get_current_lease` only answers the inverse question. Backed by the existing `WHERE released_at IS NULL` partial index, so no migration.

**`runtime.lease_reaper`** — `release_owner_leases` (by owner) and `reap_stale_leases` (predicate-driven), mirroring `activity_reaper`'s two-sweep shape, both best-effort and per-row isolated.

Both drive the **coordinator**, not the lease port. This is the load-bearing decision: a stranded lease comes with a stranded `mode = cycle`. Releasing only the lease leaves the agent pinned in `cycle`, where the next recruitment hits the #288 same-mode path, finds no conflicting lease, and *idempotently skips* — admitted without ever acquiring, so finalize releases nothing and the agent is lost mid-run to the next owner. `request_transition(…, "ambient")` writes the mode and releases the lease in one unit of work and emits the canonical events. A lease the transition cannot clear — agent already `ambient`, which the null-UoW path produces when a mode write commits and its release then fails — is released through the port afterwards.

**Four call sites:**

| Site | Sweep |
|---|---|
| `runs/{id}/cancel` | by `owner_ref = run_id` |
| `cycles/{id}/cancel` | every run in the cycle — a lease under an *already-terminal* run is #373's case and blocks just as hard |
| executor `finally` | by `owner_ref = run_id`, after `release_participants` |
| runtime-api startup | every held cycle lease |

`cancel_cycle` also transitions its non-terminal runs now — #529's second half, and without it those runs read `running` forever.

The executor sweep is not redundant with `release_participants`: that clears the agents *one admission call recorded*, and a recruitment replay (#288 idempotent-skip on a resumed run) holds leases under the run that were never returned in `recruited_agent_ids`.

## Two judgment calls worth review

**1. Startup releases every held cycle lease, not just terminal-owned ones.** Runs execute in-process (the executor dispatches from inside runtime-api), so a process that has not begun serving owns no in-flight run — the same single-instance constraint the coordinator's single-writer rule already depends on. Gating on a terminal run status would have missed #373's *own evidence*: a SIGKILL leaves the run row `running` forever, so the leases under it would never clear and manual SQL would stay mandatory for exactly the reported case. The run status is looked up for the **log**, not the decision — a lease under a non-terminal run gets a WARNING naming the run, because "no error logged, so it looks like a silent hang" was the complaint. If runtime-api is ever scaled past one instance this needs leader election, which `scheduler_bootstrap` already documents as a precondition for the coordinator itself.

**2. Only `cycle` leases are swept.** A `duty` lease's `owner_ref` is an assignment id, not a run id, so a run-shaped predicate would answer "no such run → orphaned" and revoke a live duty window. Filtered before the predicate is even asked.

## Deliberately not done

#373 lists four candidate fixes. Two are in; two are not:
- **A non-null `expires_at` on `ttl` leases** — a TTL introduces a new failure mode (a long cycle whose lease expires mid-run). Reaping on owner-liveness is strictly safer and covers the same ground.
- **A CLI/doctor affordance to list and release leases** — the ask behind it was "recovery shouldn't be raw SQL". Self-healing removes the need for recovery at all. Say the word if you still want the operator surface and I'll file it.

## Structural note

Both startup reaps moved out of `main.py` into `api.runtime.startup_reaps` — `_init_cycle_subsystem` was already at the complexity ceiling and adding the lease block tripped it (C901 17 > 12). Same rationale as `scheduler_bootstrap`: the wiring gate and the terminal predicate become unit-testable without standing up FastAPI. The #672 activity reap is behavior-identical, just relocated.

## Verification

- **58 new tests**; full regression **6107 passed, 1 skipped**.
- Reaper unit tests cover: live-owner leases spared, duty leases never touched, agent returned to ambient (not lease-only), the already-ambient residue case, per-row isolation on predicate/transition/release failure, owner narrowing, and a slot re-acquired mid-sweep counting as cleared without stealing the successor's lease.
- Route tests reproduce #529 directly, plus best-effort degradation (lease-sweep failure must not turn a cancel into a 500) and the pool-less path.
- A factory-forwarding test for the same silent-no-op class #672's PR guarded — a dropped kwarg would leave the finalize sweep permanently inert with every `lease_reaper` unit test still green.
- **Hash-stable**: no contract or manifest surface touched; contract v9 `art_4f368ea08799` / manifest v4 `art_8becd104e9fc` do not move.

The live proof is the **cancel probe** in the 1.4.3 deploy window — launch, cancel mid-implementation, assert zero unreleased leases with no restart, relaunch and confirm immediate acquisition. #373/#529's proof cannot come from a passing cycle.

Closes #373
Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
