### PR TITLE
fix(runtime): self-heal stale activity rows and end them at cancel and startup (#561)

### DIFF
--- a/adapters/cycles/task_dispatcher.py
+++ b/adapters/cycles/task_dispatcher.py
@@ -232,7 +232,9 @@ class TaskDispatcher:
         Best-effort: returns the activity id, or None when disabled/failed — it
         must never raise, so observability can't break dispatch. D9 (one active
         activity per agent) is enforced by the partial unique index; a leftover
-        active row from a prior crashed task makes this conflict, which we swallow.
+        active row from a prior crashed task is superseded by the adapter and the
+        insert retried (#561), so the swallow below no longer hides a permanently
+        dead tracking surface — it catches genuine failures only.
         """
         if self._activity_port is None:
             return None

--- a/adapters/persistence/runtime/activity_postgres.py
+++ b/adapters/persistence/runtime/activity_postgres.py
@@ -5,11 +5,14 @@ registry and the other runtime adapters. All rows hit `runtime_activities`
 (migration `1130_runtime_activities.sql`).
 
 `start_activity` inserts a `running` activity; the §4.2 partial unique index
-enforces the single-active-activity invariant (D9), so a second active start for
-the same agent raises `UniqueViolationError` — the §4.4 instrumentation treats
-activity calls as best-effort and swallows it so observability never breaks a
-real task. `update_state` manages the lifecycle timestamps; the terminal helpers
-are thin wrappers over it (their reason/evidence is event-surfaced, not stored).
+enforces the single-active-activity invariant (D9). A conflicting *stale* row
+(one whose task died without terminalizing it) is superseded and the insert
+retried once — see :meth:`PostgresRuntimeActivity.start_activity`. Without that,
+a single leftover row silently killed activity tracking for that agent forever,
+because the §4.4 instrumentation treats activity calls as best-effort and
+swallows the conflict so observability never breaks a real task (#561).
+`update_state` manages the lifecycle timestamps; the terminal helpers are thin
+wrappers over it (their reason/evidence is event-surfaced, not stored).
 
 JSONB columns (`completion_conditions`/`evidence_requirements`) follow the cycle
 registry convention: `json.dumps` on write, decode on read.
@@ -18,6 +21,7 @@ registry convention: `json.dumps` on write, decode on read.
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -38,6 +42,19 @@ _COLUMNS = (
     "runtime_activity_id, agent_id, mode, activity_type, goal, priority, state, "
     "source_kind, cycle_id, workload_id, task_id, source_ref, can_pause, can_resume, "
     "can_abort, completion_conditions, evidence_requirements, started_at, paused_at, ended_at"
+)
+
+logger = logging.getLogger(__name__)
+
+# Hoisted so the D9 self-heal retry (#561) replays the *same* statement rather
+# than a second copy that could drift from it.
+_INSERT_ACTIVITY = (
+    "INSERT INTO runtime_activities ("
+    "runtime_activity_id, agent_id, mode, activity_type, goal, priority, state, "
+    "source_kind, cycle_id, workload_id, task_id, source_ref, can_pause, can_resume, "
+    "can_abort, completion_conditions, evidence_requirements, started_at"
+    ") VALUES ($1,$2,$3,$4,$5,$6,'running',$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17) "
+    f"RETURNING {_COLUMNS}"
 )
 
 
@@ -66,34 +83,67 @@ class PostgresRuntimeActivity(RuntimeActivityPort):
         completion_conditions: tuple[dict, ...] = (),
         evidence_requirements: tuple[dict, ...] = (),
     ) -> RuntimeActivity:
-        activity_id = uuid.uuid4().hex
+        args = (
+            uuid.uuid4().hex,
+            agent_id,
+            mode,
+            activity_type,
+            goal,
+            priority,
+            source_kind,
+            cycle_id,
+            workload_id,
+            task_id,
+            source_ref,
+            can_pause,
+            can_resume,
+            can_abort,
+            json.dumps(list(completion_conditions)),
+            json.dumps(list(evidence_requirements)),
+            datetime.now(UTC),
+        )
         async with self._pool.acquire() as conn:
-            row = await conn.fetchrow(
-                "INSERT INTO runtime_activities ("
-                "runtime_activity_id, agent_id, mode, activity_type, goal, priority, state, "
-                "source_kind, cycle_id, workload_id, task_id, source_ref, can_pause, can_resume, "
-                "can_abort, completion_conditions, evidence_requirements, started_at"
-                ") VALUES ($1,$2,$3,$4,$5,$6,'running',$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17) "
-                f"RETURNING {_COLUMNS}",
-                activity_id,
-                agent_id,
-                mode,
-                activity_type,
-                goal,
-                priority,
-                source_kind,
-                cycle_id,
-                workload_id,
-                task_id,
-                source_ref,
-                can_pause,
-                can_resume,
-                can_abort,
-                json.dumps(list(completion_conditions)),
-                json.dumps(list(evidence_requirements)),
-                datetime.now(UTC),
-            )
+            try:
+                row = await conn.fetchrow(_INSERT_ACTIVITY, *args)
+            except asyncpg.UniqueViolationError:
+                # D9 self-heal (#561). The agent already holds an active row, and
+                # under D9 it holds at most one — so a *new* dispatch for this
+                # agent is itself the evidence that the old activity is no longer
+                # live: dispatch is sequential within a run, and #288 stops a
+                # second cycle from recruiting an agent another cycle holds.
+                # Supersede it and retry once. Before this, one leftover row from
+                # a crashed task silently ended activity tracking for that agent
+                # until someone ran DELETE by hand — observed dead for ~3 days
+                # across the green-roll arc while every dispatch logged the
+                # swallowed conflict.
+                superseded = await self._supersede_active(conn, agent_id)
+                if superseded is None:
+                    raise  # nothing stale to clear: a real, live conflict
+                logger.warning(
+                    "superseded stale activity %s for agent %s — its task ended "
+                    "without terminalizing the row (activity tracking was dead "
+                    "for this agent until now)",
+                    superseded,
+                    agent_id,
+                )
+                row = await conn.fetchrow(_INSERT_ACTIVITY, *args)
         return _row_to_activity(row)
+
+    @staticmethod
+    async def _supersede_active(conn: asyncpg.Connection, agent_id: str) -> str | None:
+        """Abort the agent's active activity so the slot frees; return its id or None.
+
+        `None` means the row vanished between the failed insert and this update
+        (a concurrent writer terminalized it), in which case the caller retries
+        anyway — the slot is free either way.
+        """
+        return await conn.fetchval(
+            "UPDATE runtime_activities SET state = 'aborted', ended_at = now(), "
+            "updated_at = now() "
+            "WHERE agent_id = $1 AND state IN ('pending', 'running', 'paused') "
+            "RETURNING runtime_activity_id",
+            agent_id,
+        )
 
     async def update_state(
         self, activity_id: str, state: ActivityState, *, conn: Any = None

--- a/src/squadops/api/routes/cycles/cancellation.py
+++ b/src/squadops/api/routes/cycles/cancellation.py
@@ -11,10 +11,14 @@ kinds of live state behind, and each needs an explicit hand-off:
   finalize path, so the cycle leases the run holds are never released. Post-#288
   that is a hard block: the next cycle recruiting any of those agents pauses at
   admission with ``focus_lease_conflict`` and needs manual SQL to clear.
+- **#561 — the cycle's open runtime activities.** Same bypass, same shape: the
+  ``RunCompletion`` sweep never runs, so each recruited agent keeps an active
+  row that trips ``uq_runtime_activities_one_active_per_agent`` on every later
+  dispatch, silently ending that agent's activity tracking.
 
-Both are best-effort and never raise, so the cancel route reports the cycle/run
-as cancelled even if Prefect is unreachable or no lease wiring exists (the
-failure is logged).
+All three are best-effort and never raise, so the cancel route reports the
+cycle/run as cancelled even if Prefect is unreachable or no runtime wiring
+exists (the failure is logged).
 """
 
 from __future__ import annotations
@@ -22,6 +26,7 @@ from __future__ import annotations
 import logging
 
 from squadops.api.runtime.deps import (
+    get_activity_port,
     get_focus_lease_port,
     get_runtime_coordinator,
     get_workflow_tracker,
@@ -93,3 +98,38 @@ async def release_cancelled_run_leases(cycle_id: str, run_ids: list[str]) -> int
             run_ids,
         )
     return released
+
+
+async def abort_cancelled_cycle_activities(cycle_id: str) -> int:
+    """End the cycle's open runtime activities. Returns how many flipped.
+
+    Scoped to the cycle rather than the cancelled run because that is how
+    activities are owned — ``RunCompletion.finalize`` sweeps by ``cycle_id``
+    too, and a cycle runs one workload at a time, so a run-cancel ends the only
+    dispatch loop the cycle has.
+
+    Returns 0 when no activity port is wired (a pool-less deployment records no
+    activities).
+    """
+    activity_port = get_activity_port()
+    if activity_port is None:
+        return 0
+    from squadops.runtime import reasons
+    from squadops.runtime.activity_reaper import abort_cycle_activities
+
+    try:
+        aborted = await abort_cycle_activities(
+            activity_port, cycle_id, reason_code=reasons.ACTIVITY_STRANDED_AT_CANCEL
+        )
+    except Exception:
+        logger.warning(
+            "#561: activity teardown failed for cancelled cycle %s", cycle_id, exc_info=True
+        )
+        return 0
+    if aborted:
+        logger.info(
+            "#561: ended %d open runtime activity row(s) for cancelled cycle %s",
+            aborted,
+            cycle_id,
+        )
+    return aborted

--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -326,6 +326,7 @@ async def cancel_cycle(project_id: str, cycle_id: str):
         # #77: stop the orphaned Prefect flow run(s) for this cycle's runs so
         # workers don't keep executing a logically-cancelled cycle.
         from squadops.api.routes.cycles.cancellation import (
+            abort_cancelled_cycle_activities,
             cancel_orphaned_flow_runs,
             release_cancelled_run_leases,
         )
@@ -353,11 +354,17 @@ async def cancel_cycle(project_id: str, cycle_id: str):
         # run is exactly #373's case and blocks recruitment just as hard.
         leases_released = await release_cancelled_run_leases(cycle_id, run_ids)
 
+        # #561: and end the cycle's open activity rows. One left active trips the
+        # one-active-per-agent index on every later dispatch, silently ending
+        # that agent's activity tracking.
+        activities_ended = await abort_cancelled_cycle_activities(cycle_id)
+
         return {
             "status": "cancelled",
             "cycle_id": cycle_id,
             "prefect_flow_runs_cancelled": cancelled,
             "focus_leases_released": leases_released,
+            "activities_ended": activities_ended,
         }
     except CycleError as e:
         raise handle_cycle_error(e) from e

--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -186,23 +186,26 @@ async def cancel_run(project_id: str, cycle_id: str, run_id: str):
             )
         await registry.cancel_run(run_id)
 
-        # #77: stop the orphaned Prefect flow run for this run.
-        # #529: and release the focus leases it holds — cancellation bypasses the
-        # executor's finalize path, so without this the next cycle recruiting any
-        # of this run's agents deadlocks on focus_lease_conflict.
+        # Cancellation bypasses the executor's finalize path, so everything
+        # finalize would have torn down has to be torn down here: the Prefect
+        # flow run (#77), the focus leases the run holds (#529), and the cycle's
+        # open activity rows (#561).
         from squadops.api.routes.cycles.cancellation import (
+            abort_cancelled_cycle_activities,
             cancel_orphaned_flow_runs,
             release_cancelled_run_leases,
         )
 
         cancelled = await cancel_orphaned_flow_runs(project_id, cycle_id, [run_id])
         leases_released = await release_cancelled_run_leases(cycle_id, [run_id])
+        activities_ended = await abort_cancelled_cycle_activities(cycle_id)
 
         return {
             "status": "cancelled",
             "run_id": run_id,
             "prefect_flow_runs_cancelled": cancelled,
             "focus_leases_released": leases_released,
+            "activities_ended": activities_ended,
         }
     except CycleError as e:
         raise handle_cycle_error(e) from e

--- a/src/squadops/api/runtime/deps.py
+++ b/src/squadops/api/runtime/deps.py
@@ -22,6 +22,7 @@ from squadops.ports.runtime.assignments import AssignmentPort
 
 if TYPE_CHECKING:
     from squadops.api.runtime.health_checker import HealthChecker
+    from squadops.ports.runtime.activity import RuntimeActivityPort
     from squadops.ports.runtime.focus_lease import FocusLeasePort
     from squadops.runtime.coordinator import RuntimeCoordinator
 
@@ -51,11 +52,12 @@ _llm_port: LLMPort | None = None
 # SIP-0089 §2.7: Assignment port for the assignment REST surface
 _assignment_port: AssignmentPort | None = None
 
-# #373/#529: the composition root's single-writer coordinator (D16) and the lease
-# port, shared with the cancel routes so cancellation can release the leases the
-# cancelled run holds. Both stay None without a Postgres pool.
+# #373/#529/#561: the runtime state a cancel has to tear down, since cancellation
+# bypasses the executor's finalize path entirely — the single-writer coordinator
+# (D16) plus the lease and activity ports. All None without a Postgres pool.
 _runtime_coordinator: RuntimeCoordinator | None = None
 _focus_lease_port: FocusLeasePort | None = None
+_activity_port: RuntimeActivityPort | None = None
 
 
 def set_auth_ports(
@@ -282,23 +284,27 @@ def get_assignment_port() -> AssignmentPort:
 
 
 # =============================================================================
-# #373/#529: runtime coordinator + focus-lease port (stranded-lease sweeps)
+# #373/#529/#561: runtime ports the cancel path tears down
 # =============================================================================
 
 
-def set_lease_sweep_ports(
+def set_cancellation_ports(
     coordinator: RuntimeCoordinator | None,
     focus_lease: FocusLeasePort | None,
+    activity: RuntimeActivityPort | None,
 ) -> None:
-    """Register the shared coordinator and lease port for the cancel-time sweep.
+    """Register the runtime ports a cancel has to tear down.
 
-    The coordinator MUST be the composition root's single instance (D16) — the
+    Cancellation never reaches the executor's finalize path, so the leases and
+    activities the cancelled run holds have to be cleared by the route. The
+    coordinator MUST be the composition root's single instance (D16) — the lease
     sweep returns agents to ambient through it, and a second mode-writer would
     race the executor and the duty scheduler.
     """
-    global _runtime_coordinator, _focus_lease_port
+    global _runtime_coordinator, _focus_lease_port, _activity_port
     _runtime_coordinator = coordinator
     _focus_lease_port = focus_lease
+    _activity_port = activity
 
 
 def get_runtime_coordinator() -> RuntimeCoordinator | None:
@@ -313,6 +319,14 @@ def get_focus_lease_port() -> FocusLeasePort | None:
     succeed on a pool-less deployment, where there are no leases to release.
     """
     return _focus_lease_port
+
+
+def get_activity_port() -> RuntimeActivityPort | None:
+    """Return the activity port, or None when no Postgres pool is wired.
+
+    Never raises, for the same reason as :func:`get_focus_lease_port`.
+    """
+    return _activity_port
 
 
 # =============================================================================

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -364,11 +364,12 @@ async def _init_cycle_subsystem(config, pool) -> None:
 
         _runtime_coordinator = create_runtime_coordinator(pool)
 
-        # #373/#529: share the single coordinator + lease port with the cancel
-        # routes, so cancelling a cycle/run releases the leases it holds.
-        from squadops.api.runtime.deps import set_lease_sweep_ports
+        # #373/#529/#561: share the runtime ports with the cancel routes, which
+        # bypass the executor's finalize path and so have to release the leases
+        # and end the activities the cancelled run leaves behind.
+        from squadops.api.runtime.deps import set_cancellation_ports
 
-        set_lease_sweep_ports(_runtime_coordinator, focus_lease_port)
+        set_cancellation_ports(_runtime_coordinator, focus_lease_port, activity_port)
 
         # Startup hygiene: clear runtime state a dead process left active, before
         # anything recruits against it. Each sweep is best-effort and owns its own

--- a/src/squadops/api/runtime/startup_reaps.py
+++ b/src/squadops/api/runtime/startup_reaps.py
@@ -106,11 +106,17 @@ async def reap_stranded_activities(
     cycle_registry: CycleRegistryPort,
     activity_port: RuntimeActivityPort | None,
 ) -> int:
-    """End active activities whose owning cycle is terminal (#672).
+    """End every active runtime activity at startup (#672, #561).
 
-    Returns how many ended; 0 when unwired or the reap failed. Rows stranded by
-    a process death that skipped run finalize — one blocks all of that agent's
-    future activity tracking.
+    Returns how many ended; 0 when unwired or the reap failed.
+
+    Same reasoning as :func:`reap_stranded_leases`, and the same correction: a
+    cycle whose runs were killed mid-flight derives as ACTIVE forever, so gating
+    on a terminal cycle status spared exactly the rows a crash strands — #561's
+    live evidence was four agents with one open row each, two of them dead for
+    three days. Nothing dispatches in a process that has not begun serving, so
+    every active row here is residue. The cycle status is looked up for the
+    *log*, not the decision.
     """
     if activity_port is None:
         return 0
@@ -119,17 +125,31 @@ async def reap_stranded_activities(
         from squadops.cycles.models import CycleNotFoundError, CycleStatus
         from squadops.runtime.activity_reaper import reap_stale_activities
 
-        async def _cycle_is_terminal(cycle_id: str) -> bool:
+        async def _owner_cannot_be_dispatching(cycle_id: str | None) -> bool:
+            if cycle_id is None:
+                # A duty/ambient row has no cycle to consult. Sparing it is what
+                # left #561's residue unreachable by any sweep.
+                logger.warning("Ending stranded activity with no owning cycle")
+                return True
             try:
                 owning_cycle = await cycle_registry.get_cycle(cycle_id)
             except CycleNotFoundError:
-                # No owner on record → definitionally stranded.
+                logger.warning("Ending stranded activity of unknown cycle %s", cycle_id)
                 return True
             runs = await cycle_registry.list_runs(cycle_id)
             derived = derive_cycle_status(runs, cycle_cancelled=owning_cycle.cancelled)
-            return derived in (CycleStatus.COMPLETED, CycleStatus.FAILED, CycleStatus.CANCELLED)
+            if derived not in (CycleStatus.COMPLETED, CycleStatus.FAILED, CycleStatus.CANCELLED):
+                logger.warning(
+                    "Ending stranded activity of cycle %s still deriving as %s — nothing "
+                    "dispatches at startup, so its executor died mid-task.",
+                    cycle_id,
+                    derived.value,
+                )
+            return True
 
-        reaped = await reap_stale_activities(activity_port, cycle_is_terminal=_cycle_is_terminal)
+        reaped = await reap_stale_activities(
+            activity_port, owner_is_finished=_owner_cannot_be_dispatching
+        )
         if reaped:
             logger.info("Startup reap ended %d stranded runtime activity row(s)", reaped)
         return reaped

--- a/src/squadops/ports/runtime/activity.py
+++ b/src/squadops/ports/runtime/activity.py
@@ -52,10 +52,16 @@ class RuntimeActivityPort(ABC):
     ) -> RuntimeActivity:
         """Create a new `running` activity for `agent_id` and return it.
 
-        Mints the id and sets `started_at`. Raises if the agent already holds an
-        active activity (D9 — the partial unique index rejects a second). Source
-        identity is explicit (`cycle_id`/`workload_id`/`task_id`); `source_ref` is
-        opaque and never parsed by core.
+        Mints the id and sets `started_at`. Source identity is explicit
+        (`cycle_id`/`workload_id`/`task_id`); `source_ref` is opaque and never
+        parsed by core.
+
+        D9 keeps one active activity per agent, so an existing active row is
+        **superseded** (aborted) and this start takes the slot: a new start for
+        an agent is itself evidence the previous activity is no longer live, and
+        refusing instead would let one row stranded by a crashed task disable
+        that agent's activity tracking permanently (#561). Implementations raise
+        only when the slot cannot be freed.
         """
 
     @abstractmethod

--- a/src/squadops/runtime/activity_reaper.py
+++ b/src/squadops/runtime/activity_reaper.py
@@ -9,12 +9,13 @@ with no expiry, and every later ``start_activity`` for that agent then trips
 runs proceed while activity tracking goes silently dead and the traceback
 recurs at every dispatch. Two complementary sweeps close the class:
 
-- :func:`abort_cycle_activities` — run finalize: task dispatch for the run is
-  over, so any activity still active for its cycle is stranded; end them all.
-  Called from the ``RunCompletion`` collaborator on every terminal path.
-- :func:`reap_stale_activities` — startup: end active activities whose owning
-  cycle is already terminal (rows stranded by a process death that skipped
-  finalize, and historic rows predating the sweep).
+- :func:`abort_cycle_activities` — run finalize / cancel: task dispatch for the
+  cycle is over, so any activity still active for it is stranded; end them all.
+  Called from the ``RunCompletion`` collaborator on every terminal path and from
+  the cancel routes, which bypass finalize entirely.
+- :func:`reap_stale_activities` — sweep every active activity whose owner is
+  finished (rows stranded by a process death that skipped finalize, and historic
+  rows predating the sweep).
 
 Both are best-effort and per-row isolated, like ``admission.release_participants``:
 one bad row never blocks clearing the rest, and the adapter's active-only
@@ -22,7 +23,7 @@ UPDATE guard makes a concurrent terminalization a harmless no-op (counted only
 when the row actually flipped).
 
 Pure orchestration: depends only on the activity port and ``runtime.reasons``.
-Cycle-status knowledge enters through the ``cycle_is_terminal`` predicate the
+Cycle-status knowledge enters through the ``owner_is_finished`` predicate the
 composition root supplies — ``squadops.runtime`` never imports the cycles
 domain (D26 direction).
 """
@@ -81,24 +82,26 @@ async def abort_cycle_activities(
 async def reap_stale_activities(
     activity_port: RuntimeActivityPort,
     *,
-    cycle_is_terminal: Callable[[str], Awaitable[bool]],
+    owner_is_finished: Callable[[str | None], Awaitable[bool]],
 ) -> int:
-    """Abort active activities whose owning cycle is terminal; return how many flipped.
+    """Abort active activities whose owner is finished; return how many flipped.
 
-    Startup reaper. Activities without a ``cycle_id`` (duty/ambient sources)
-    have no owning cycle to consult and are left alone. A predicate or abort
-    failure skips that row only — the reaper must clear what it can, since one
+    ``owner_is_finished`` decides, and it is asked about **every** active row —
+    including one with no ``cycle_id``, which the caller must answer for rather
+    than this module silently sparing. Skipping those was the #561 residue: a row
+    no predicate is ever asked about is a row nothing can ever clear, and one
     stranded row blocks all of that agent's future activity tracking.
+
+    A predicate or abort failure skips that row only — the reaper must clear
+    what it can.
     """
     reaped = 0
     for activity in await activity_port.list_active_activities():
-        if activity.cycle_id is None:
-            continue
         try:
-            if not await cycle_is_terminal(activity.cycle_id):
+            if not await owner_is_finished(activity.cycle_id):
                 continue
             ended = await activity_port.abort_activity(
-                activity.runtime_activity_id, reasons.ACTIVITY_STRANDED_CYCLE_TERMINAL
+                activity.runtime_activity_id, reasons.ACTIVITY_STRANDED_AT_STARTUP
             )
         except Exception:
             logger.warning(

--- a/src/squadops/runtime/reasons.py
+++ b/src/squadops/runtime/reasons.py
@@ -60,11 +60,12 @@ ACTIVITY_COMPLETED: Final[str] = "activity_completed"
 ACTIVITY_FAILED: Final[str] = "activity_failed"
 # The coordinator aborts an activity orphaned by a mode change (§4.5 thin seam).
 ACTIVITY_PREEMPTED_BY_MODE_CHANGE: Final[str] = "activity_preempted_by_mode_change"
-# Stranded-activity hygiene (#672): an interrupted task leaves its activity
-# active with no owner to terminalize it. The run-finalize sweep and the
+# Stranded-activity hygiene (#672/#561): an interrupted task leaves its activity
+# active with no owner to terminalize it. The run-finalize/cancel sweep and the
 # startup reaper (`runtime.activity_reaper`) abort such rows.
 ACTIVITY_STRANDED_AT_RUN_FINALIZE: Final[str] = "activity_stranded_at_run_finalize"
-ACTIVITY_STRANDED_CYCLE_TERMINAL: Final[str] = "activity_stranded_cycle_terminal"
+ACTIVITY_STRANDED_AT_CANCEL: Final[str] = "activity_stranded_at_cancel"
+ACTIVITY_STRANDED_AT_STARTUP: Final[str] = "activity_stranded_at_startup"
 
 # Ambient irreversibility policy (Phase 4 §4.6 — v1.2 embodiment seam, no v1.1 callers)
 AMBIENT_IRREVERSIBLE_ACTION_FORBIDDEN: Final[str] = "ambient_irreversible_action_forbidden"

--- a/tests/unit/api/test_startup_reaps.py
+++ b/tests/unit/api/test_startup_reaps.py
@@ -183,17 +183,37 @@ async def test_missing_cycle_row_is_treated_as_terminal():
     assert await reap_stranded_activities(registry, activity_port) == 1
 
 
-async def test_activity_of_a_live_cycle_is_spared():
+async def test_an_activity_of_a_still_active_cycle_is_ended_and_logged(caplog):
+    """#561's live evidence: a cycle whose runs were killed derives as ACTIVE
+    forever, so gating on a terminal cycle spared exactly the rows a crash
+    strands — two agents sat dead for three days. Nothing dispatches at startup,
+    so the row is residue whatever the derived status says."""
     activity_port = AsyncMock()
     activity_port.list_active_activities.return_value = (_activity(),)
+    activity_port.abort_activity.return_value = _activity()
     registry = AsyncMock()
     # The predicate reads only `cancelled` off the cycle; the run list carries
     # the rest of the derivation.
     registry.get_cycle.return_value = SimpleNamespace(cancelled=False)
     registry.list_runs.return_value = [_run(RunStatus.RUNNING.value)]
 
-    assert await reap_stranded_activities(registry, activity_port) == 0
-    activity_port.abort_activity.assert_not_awaited()
+    with caplog.at_level("WARNING"):
+        assert await reap_stranded_activities(registry, activity_port) == 1
+
+    assert "cyc_1" in caplog.text
+    assert "died mid-task" in caplog.text
+
+
+async def test_an_activity_with_no_owning_cycle_is_ended():
+    """The residue #672 left unreachable: no cycle to consult meant no sweep
+    could ever clear the row."""
+    activity_port = AsyncMock()
+    activity_port.list_active_activities.return_value = (_activity(cycle_id=None),)
+    activity_port.abort_activity.return_value = _activity(cycle_id=None)
+    registry = AsyncMock()
+
+    assert await reap_stranded_activities(registry, activity_port) == 1
+    registry.get_cycle.assert_not_awaited()  # nothing to ask
 
 
 async def test_activity_reap_failure_never_blocks_startup():

--- a/tests/unit/cycles/test_api_cycles.py
+++ b/tests/unit/cycles/test_api_cycles.py
@@ -3,6 +3,7 @@ Tests for SIP-0064 cycle API routes.
 """
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -365,6 +366,36 @@ class TestCancelCycle:
 
         assert resp.status_code == 200
         assert resp.json()["focus_leases_released"] == 2
+
+    def test_cancel_ends_the_cycles_open_activities(self, client, mock_cycle_registry, monkeypatch):
+        """#561: cancel bypasses `RunCompletion.finalize`, leaving one active row
+        per recruited agent to trip the one-active-per-agent index forever."""
+        import squadops.api.runtime.deps as deps_mod
+        from squadops.runtime import reasons
+
+        mock_cycle_registry.cancel_cycle.return_value = None
+        mock_cycle_registry.list_runs.return_value = []
+        rows = tuple(
+            SimpleNamespace(
+                runtime_activity_id=f"act-{agent}",
+                agent_id=agent,
+                cycle_id="cyc_001",
+                activity_type="development.develop",
+            )
+            for agent in ("eve", "neo")
+        )
+        activity_port = AsyncMock()
+        activity_port.list_active_activities.return_value = rows
+        activity_port.abort_activity.side_effect = list(rows)
+        monkeypatch.setattr(deps_mod, "_activity_port", activity_port)
+
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/cancel")
+
+        assert resp.status_code == 200
+        assert resp.json()["activities_ended"] == 2
+        assert [c.args[1] for c in activity_port.abort_activity.await_args_list] == [
+            reasons.ACTIVITY_STRANDED_AT_CANCEL
+        ] * 2
 
 
 class TestCycleRouteScopeEnforcement:

--- a/tests/unit/cycles/test_api_runs.py
+++ b/tests/unit/cycles/test_api_runs.py
@@ -3,6 +3,7 @@ Tests for SIP-0064 run API routes.
 """
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -19,6 +20,7 @@ from squadops.cycles.models import (
     RunTerminalError,
     TaskFlowPolicy,
 )
+from squadops.runtime import reasons
 from squadops.runtime.models import FocusLease
 
 pytestmark = [pytest.mark.domain_orchestration]
@@ -216,6 +218,45 @@ class TestCancelRun:
 
         assert resp.status_code == 200
         assert resp.json()["focus_leases_released"] == 0
+
+    def test_cancel_ends_the_cycles_open_activities(self, client, monkeypatch):
+        """#561: cancel bypasses `RunCompletion.finalize`, so each recruited
+        agent kept an active row that trips the one-active-per-agent index on
+        every later dispatch — silently ending that agent's activity tracking."""
+        import squadops.api.runtime.deps as deps_mod
+
+        open_row = SimpleNamespace(
+            runtime_activity_id="act-1",
+            agent_id="neo",
+            cycle_id="cyc_001",
+            activity_type="development.develop",
+        )
+        activity_port = AsyncMock()
+        activity_port.list_active_activities.return_value = (open_row,)
+        activity_port.abort_activity.return_value = open_row
+        monkeypatch.setattr(deps_mod, "_activity_port", activity_port)
+
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs/run_001/cancel")
+
+        assert resp.status_code == 200
+        assert resp.json()["activities_ended"] == 1
+        activity_port.list_active_activities.assert_awaited_once_with(cycle_id="cyc_001")
+        activity_port.abort_activity.assert_awaited_once_with(
+            "act-1", reasons.ACTIVITY_STRANDED_AT_CANCEL
+        )
+
+    def test_cancel_survives_an_activity_teardown_failure(self, client, monkeypatch):
+        import squadops.api.runtime.deps as deps_mod
+
+        activity_port = AsyncMock()
+        activity_port.list_active_activities.side_effect = RuntimeError("db down")
+        monkeypatch.setattr(deps_mod, "_activity_port", activity_port)
+
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs/run_001/cancel")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "cancelled"
+        assert resp.json()["activities_ended"] == 0
 
 
 class TestGateDecision:

--- a/tests/unit/runtime/test_activity_reaper.py
+++ b/tests/unit/runtime/test_activity_reaper.py
@@ -100,16 +100,16 @@ class _FakeActivityPort(RuntimeActivityPort):
 
 
 def _terminal_only(terminal_cycles: set[str], *, raises_for: set[str] | None = None):
-    calls: list[str] = []
+    calls: list[str | None] = []
 
-    async def cycle_is_terminal(cycle_id: str) -> bool:
+    async def owner_is_finished(cycle_id: str | None) -> bool:
         calls.append(cycle_id)
         if raises_for and cycle_id in raises_for:
             raise RuntimeError("registry down")
         return cycle_id in terminal_cycles
 
-    cycle_is_terminal.calls = calls  # type: ignore[attr-defined]
-    return cycle_is_terminal
+    owner_is_finished.calls = calls  # type: ignore[attr-defined]
+    return owner_is_finished
 
 
 # ---------------------------------------------------------------------------
@@ -127,23 +127,34 @@ async def test_reap_aborts_terminal_cycle_rows_and_spares_live_ones():
         )
     )
 
-    reaped = await reap_stale_activities(port, cycle_is_terminal=_terminal_only({"cyc-dead"}))
+    reaped = await reap_stale_activities(port, owner_is_finished=_terminal_only({"cyc-dead"}))
 
     assert reaped == 1
-    assert port.aborted == [("act-dead", reasons.ACTIVITY_STRANDED_CYCLE_TERMINAL)]
+    assert port.aborted == [("act-dead", reasons.ACTIVITY_STRANDED_AT_STARTUP)]
 
 
-async def test_reap_leaves_cycle_less_activities_alone():
-    """Bug class: duty/ambient activities have no owning cycle — the cycle rule
-    must not consult the predicate for them, let alone abort them."""
+async def test_reap_asks_the_predicate_about_cycle_less_activities_too():
+    """Bug class (#561): a row skipped *before* the predicate is a row no sweep
+    can ever reach — permanently stranded, and one stranded row blocks all of
+    that agent's future activity tracking. The caller decides whether a
+    cycle-less row is finished; this module must not silently spare it."""
     port = _FakeActivityPort((_activity("act-duty", cycle_id=None),))
     predicate = _terminal_only(set())
 
-    reaped = await reap_stale_activities(port, cycle_is_terminal=predicate)
+    reaped = await reap_stale_activities(port, owner_is_finished=predicate)
 
-    assert reaped == 0
-    assert port.aborted == []
-    assert predicate.calls == []
+    assert reaped == 0  # this predicate answers "not finished"
+    assert predicate.calls == [None]  # but it was ASKED — that is the fix
+
+
+async def test_reap_ends_a_cycle_less_activity_when_the_predicate_says_finished():
+    port = _FakeActivityPort((_activity("act-duty", cycle_id=None),))
+
+    async def _finished(cycle_id: str | None) -> bool:
+        return True
+
+    assert await reap_stale_activities(port, owner_is_finished=_finished) == 1
+    assert port.aborted == [("act-duty", reasons.ACTIVITY_STRANDED_AT_STARTUP)]
 
 
 async def test_reap_survives_predicate_failure_and_clears_the_rest():
@@ -159,11 +170,11 @@ async def test_reap_survives_predicate_failure_and_clears_the_rest():
 
     reaped = await reap_stale_activities(
         port,
-        cycle_is_terminal=_terminal_only({"cyc-dead"}, raises_for={"cyc-unknown"}),
+        owner_is_finished=_terminal_only({"cyc-dead"}, raises_for={"cyc-unknown"}),
     )
 
     assert reaped == 1
-    assert port.aborted == [("act-dead", reasons.ACTIVITY_STRANDED_CYCLE_TERMINAL)]
+    assert port.aborted == [("act-dead", reasons.ACTIVITY_STRANDED_AT_STARTUP)]
 
 
 async def test_reap_survives_abort_failure_and_clears_the_rest():
@@ -175,10 +186,10 @@ async def test_reap_survives_abort_failure_and_clears_the_rest():
         abort_raises_for=frozenset({"act-a"}),
     )
 
-    reaped = await reap_stale_activities(port, cycle_is_terminal=_terminal_only({"cyc-dead"}))
+    reaped = await reap_stale_activities(port, owner_is_finished=_terminal_only({"cyc-dead"}))
 
     assert reaped == 1
-    assert ("act-b", reasons.ACTIVITY_STRANDED_CYCLE_TERMINAL) in port.aborted
+    assert ("act-b", reasons.ACTIVITY_STRANDED_AT_STARTUP) in port.aborted
 
 
 async def test_reap_does_not_count_concurrently_terminalized_rows():
@@ -190,7 +201,7 @@ async def test_reap_does_not_count_concurrently_terminalized_rows():
         abort_gone_for=frozenset({"act-gone"}),
     )
 
-    reaped = await reap_stale_activities(port, cycle_is_terminal=_terminal_only({"cyc-dead"}))
+    reaped = await reap_stale_activities(port, owner_is_finished=_terminal_only({"cyc-dead"}))
 
     assert reaped == 0
 

--- a/tests/unit/runtime/test_runtime_activity.py
+++ b/tests/unit/runtime/test_runtime_activity.py
@@ -20,6 +20,7 @@ import json
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
+import asyncpg
 import pytest
 
 from adapters.persistence.runtime.activity_postgres import PostgresRuntimeActivity
@@ -141,6 +142,71 @@ async def test_start_activity_opens_running_with_started_at_and_minted_id():
     # completion_conditions serialized as JSON text (param order: ...,$15,$16,$17)
     assert json.loads(args[15]) == [{"kind": "tests_pass"}]
     assert isinstance(args[-1], datetime)  # started_at stamped
+
+
+async def _start(adapter, agent_id="max"):
+    return await adapter.start_activity(
+        agent_id,
+        mode="cycle",
+        activity_type="design",
+        goal="build the thing",
+        source_kind="cycle_task",
+        source_ref="task-7",
+        task_id="task-7",
+        cycle_id="cyc-1",
+    )
+
+
+async def test_start_activity_supersedes_a_stale_row_and_retries():
+    """#561: a leftover active row from a crashed task made every later
+    start_activity for that agent raise, and the best-effort dispatcher swallowed
+    it — so activity tracking was silently dead for that agent until someone ran
+    SQL by hand (observed: four agents, two dead for three days). The conflicting
+    row must be superseded and the insert retried."""
+    conn = AsyncMock()
+    conn.fetchrow.side_effect = [asyncpg.UniqueViolationError("D9"), _activity_row()]
+    conn.fetchval.return_value = "act-stale"
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    activity = await _start(adapter)
+
+    assert activity.runtime_activity_id == "act-1"  # the retry's row, not the stale one
+    # The stale row was aborted (not deleted) and scoped to this agent's active row.
+    supersede_query, agent_id = conn.fetchval.await_args.args
+    assert "state = 'aborted'" in supersede_query
+    assert "ended_at = now()" in supersede_query
+    assert "state IN ('pending', 'running', 'paused')" in supersede_query
+    assert agent_id == "max"
+    # Retry replays the same INSERT rather than a divergent second copy.
+    first, second = (call.args[0] for call in conn.fetchrow.await_args_list)
+    assert first == second
+
+
+async def test_start_activity_reraises_when_nothing_stale_can_be_cleared():
+    """Bug class: blanket retry. If the conflicting row vanished or the slot is
+    genuinely contested, `fetchval` returns None and the original violation must
+    surface rather than being retried into a second failure or swallowed."""
+    conn = AsyncMock()
+    conn.fetchrow.side_effect = asyncpg.UniqueViolationError("D9")
+    conn.fetchval.return_value = None
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    with pytest.raises(asyncpg.UniqueViolationError):
+        await _start(adapter)
+
+    assert conn.fetchrow.await_count == 1  # no retry attempted
+
+
+async def test_start_activity_does_not_supersede_when_the_insert_succeeds():
+    """Bug class: an unconditional pre-clear would abort a *live* activity on
+    every dispatch. The supersede path fires only on the D9 violation."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = _activity_row()
+    adapter = PostgresRuntimeActivity(_make_pool(conn))
+
+    await _start(adapter)
+
+    conn.fetchval.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Second fix of the **1.4.3** line. Same character as #373/#529 — *a cycle can neither strand the next one nor fail silently* — one layer down.

## The bug

`runtime_activities` allows one active row per agent (D9, the §4.2 partial unique index). A task that ends without terminalizing its row leaves that row active forever, so **every** later `start_activity` for that agent raises `UniqueViolationError`. The §4.4 instrumentation is best-effort by design, so `task_dispatcher` swallows it — runs proceed, a traceback logs on every dispatch, and the agent's activity tracking is dead until someone runs SQL by hand.

The issue's live evidence is four agents with exactly one open row each — the D9 signature — two of them dead for **three days spanning the entire green-roll measurement arc**. The "best-effort, never break dispatch" guard is correct, and it is exactly what hid that the feature had been off for days.

## The fix — three ways in, closed in the order the row's life runs

**1. Self-heal on conflict** (the issue's headline recommendation). `start_activity` catches `UniqueViolationError` *specifically*, supersedes the conflicting active row, and retries the same INSERT once.

The justification for auto-healing is the issue's own: under D9 an agent holds at most one activity, so a **new dispatch for that agent is itself the evidence** the old one is no longer live. Dispatch is sequential within a run, and #288 stops a second cycle from recruiting an agent another cycle holds. I deliberately did **not** add the age threshold the issue floats as an alternative — it would be a tunable with no principled default, and `feedback_externalize_config_verify_seam` says invent those only when something real needs tuning. When nothing stale can be cleared (`fetchval` returns None) the original violation surfaces rather than retrying into a second failure.

This is the one that matters most: it heals at the moment of the conflict, without waiting for a restart.

**2. Cancel teardown.** Cancellation bypasses `RunCompletion.finalize` — the identical bypass #529 exposed for leases — so both cancel routes now end the cycle's open activities alongside the lease sweep. This is the issue's second acceptance criterion.

**3. Startup.** `reap_stale_activities` gated on a terminal *cycle* status, and **a cycle whose runs were killed derives as ACTIVE forever** — so it spared exactly the rows a crash strands. Same correction as #373's: nothing dispatches in a process that has not begun serving, so every active row at startup is residue. The derived status is now logged instead of gating.

The predicate is also asked about `cycle_id`-less rows now. Skipping them *before* the predicate made them unreachable by any sweep at all — a row nothing can ever ask about is a row nothing can ever clear.

## Correcting the plan's premise

The 1.4.3 plan narrowed #561 to "the residue #672's reaper docstring explicitly leaves alone" — duty/ambient rows with no `cycle_id` — and posed the open design question as *which terminal predicate replaces "owning cycle is terminal"*.

That premise doesn't survive contact with the code. **`task_dispatcher.py:240` is the only `start_activity` caller in the repo, and `TaskEnvelope.cycle_id` is a plain `str`** — so no cycle_id-less row can currently be created. I wrote that narrowing off the reaper's docstring caveat rather than off who actually writes rows.

The rows that actually strand are cycle-owned ones under a cycle that never reaches a terminal status. So the plan's open design question resolves to **no new predicate** — not lease expiry, not a heartbeat-age bound. Both would have been machinery invented for a population that doesn't exist, while missing the one that does.

## Structural note

`deps.set_lease_sweep_ports` becomes `set_cancellation_ports` now that a third port joins it. The seam's concern is "runtime state a cancel has to tear down", not leases specifically; renaming a one-PR-old private seam is cheaper than letting the name go stale.

`RuntimeActivityPort.start_activity`'s contract changed (raise → supersede), so the port docstring changed with it.

## Verification

- **7 new/rewritten tests**; full regression **6115 passed, 1 skipped**.
- Adapter tests cover the supersede path end to end: the stale row is *aborted* (not deleted), scoped to that agent's active row, the retry replays the **same** statement rather than a divergent copy, an unclearable slot re-raises with no retry attempted, and a successful insert never touches the supersede path — that last one guards against a blanket pre-clear aborting a live activity on every dispatch.
- Route tests cover cancel teardown on both routes, plus degradation (a teardown failure must not turn a cancel into a 500) and the pool-less path.
- Reaper tests now assert the predicate is *asked* about cycle-less rows, and the startup test asserts an ACTIVE-deriving cycle's row is ended and logged.
- **Hash-stable**: no contract or manifest surface touched.

The reason-code rename (`activity_stranded_cycle_terminal` → `activity_stranded_at_startup`) needs no data migration — reason codes are event-surfaced, not persisted as a column in v1.1.

Live proof rides the same **cancel probe** as #373/#529 in the deploy window, from the other side: assert zero stranded activities after a mid-implementation cancel with no restart.

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
