### PR TITLE
fix(checks): resolve a bare `python` at spawn instead of through PATH (#498)

### DIFF
--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -159,6 +159,38 @@ def _restricted_env() -> dict[str, str]:
     return {k: v for k, v in os.environ.items() if k in keep}
 
 
+# Bare interpreter names a contract may emit for `command_exit_zero`.
+_BARE_INTERPRETERS = frozenset({"python", "python3"})
+
+
+def _resolve_interpreter(argv: list[str]) -> list[str]:
+    """Substitute the running interpreter for a bare python name in ``argv[0]``.
+
+    #498: ``command_exit_zero`` argv is authored (or scaffold-emitted) as a
+    *name*, and resolving that name through the inherited ``PATH`` at spawn made
+    the outcome depend on an environment detail. Ubuntu ships only
+    ``/usr/bin/python3`` — there is no ``python`` — so ``python -m py_compile``
+    raised ``FileNotFoundError`` and the check degraded to
+    ``skipped(missing_tooling)``. A structural criterion that silently stops
+    executing on a host detail is exactly what the bare-skeleton gate exists to
+    rule out (SIP-0098 §7).
+
+    The evaluator *is* a Python process, so ``sys.executable`` is by definition a
+    working interpreter — which makes ``_CHECK_ENV_EXECUTABLES``' claim that the
+    check environment provides ``python``/``python3`` true by construction
+    instead of by image accident. It also fixes contracts already seeded with the
+    bare name (v9 among them), which emitting ``python3`` could not do — and that
+    would have moved the contract hash besides.
+
+    Runs strictly *after* the safelist gate: the safelist governs what a contract
+    may ask for (a name), and resolution is a spawn detail. Reversing the order
+    would force every safelist pattern to know about absolute interpreter paths.
+    """
+    if not argv or argv[0] not in _BARE_INTERPRETERS or not sys.executable:
+        return argv
+    return [sys.executable, *argv[1:]]
+
+
 # ---------------------------------------------------------------------------
 # Base + registry
 # ---------------------------------------------------------------------------
@@ -833,10 +865,14 @@ class CommandExitZeroCheck(BaseCheck):
             if not cwd_path.is_dir():
                 return CheckOutcome.error(reason="cwd_not_a_directory")
 
+        # #498: spawn the running interpreter rather than whatever `python` the
+        # inherited PATH happens to resolve to. `argv` stays the authored form so
+        # evidence reads back as the contract wrote it, not as an absolute path.
+        spawn_argv = _resolve_interpreter(argv)
         env = _restricted_env()
         try:
             proc = await asyncio.create_subprocess_exec(
-                *argv,
+                *spawn_argv,
                 cwd=str(cwd_path),
                 env=env,
                 stdout=asyncio.subprocess.PIPE,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -90,6 +90,12 @@ memory-profiler>=0.61.0
 # Code quality
 ruff>=0.1.0
 flake8>=6.0.0
+# Load-bearing, not a lint tool here: the `undefined_names` check (#689) runs
+# pyflakes in-process, so without it the whole typed-acceptance suite reports
+# `error: missing_analyzer`. The harness has only ever had it transitively via
+# flake8 above — which is a live risk, since ruff's F rules ARE pyflakes and
+# retiring flake8 is on the table. Runtime images pin it in requirements/base.txt.
+pyflakes>=3.4.0
 black>=23.0.0
 isort>=5.12.0
 mypy>=1.5.0

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -17,6 +17,7 @@ import pytest
 from squadops.cycles.acceptance_check_spec import CHECK_SPECS, argv_matches_safelist
 from squadops.cycles.acceptance_checks import (
     _CHECK_IMPLS,
+    _resolve_interpreter,
     _safe_resolve,
     assert_registry_complete,
     get_check,
@@ -45,6 +46,34 @@ class TestRegistryInvariants:
         for name in CHECK_SPECS:
             evaluator = get_check(name)
             assert evaluator.spec is CHECK_SPECS[name]
+
+    @pytest.mark.parametrize(
+        "check_name",
+        sorted(n for n, s in CHECK_SPECS.items() if s.applicable_extensions == frozenset({".py"})),
+    )
+    @pytest.mark.parametrize("target", ["view.jsx", "notes.md"])
+    async def test_python_parsing_checks_skip_a_non_python_target(
+        self, check_name, target, tmp_path
+    ):
+        """#605, pinned registry-wide rather than per-check.
+
+        A Python-parsing check handed a non-Python file must *skip*. If it lets
+        `ast.parse` raise, the check reports `error`, `patch_verification` maps
+        that to `evaluator_error:<check>`, and the patch lands UNVERIFIABLE —
+        neither accepted nor rejected. pf-41 lost a roll to exactly that (a
+        `function_defined` aimed at a `.jsx`), and pf-40 is the control: same bad
+        repairs, but verification returned a verdict and rejected them.
+
+        The property held by construction and was asserted nowhere. Derived from
+        `applicable_extensions` so a Python check added later inherits the test
+        instead of quietly opting out of it.
+        """
+        (tmp_path / target).write_text("const App = () => <div/>;\n")
+        params = dict(CHECK_SPECS[check_name].example) | {"file": target}
+
+        result = await get_check(check_name).evaluate(params, tmp_path, stack="fastapi")
+
+        assert result.status == "skipped", f"{check_name} -> {result.status} ({result.reason})"
 
 
 # ---------------------------------------------------------------------------
@@ -608,14 +637,14 @@ class TestCommandExitZero:
         return tmp_path
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX subprocess assumed")
-    async def test_compile_ok_passed(self, py_workspace):
+    async def test_absolute_interpreter_path_is_not_in_the_safelist(self, py_workspace):
+        # The safelist patterns match the *authored name*, so a contract may not
+        # smuggle in an arbitrary interpreter path. (#498 resolves the name to
+        # sys.executable at spawn, strictly after this gate.)
         result = await get_check("command_exit_zero").evaluate(
             {"argv": [sys.executable, "-m", "py_compile", "ok.py"]},
             py_workspace,
         )
-        # argv[0] is sys.executable (typically /path/to/python); pattern wants
-        # literal "python", so the safelist should reject this. We assert the
-        # safelist behavior, not the run-result, to keep the test hermetic.
         assert result.status == "error"
         assert result.reason == "command_not_in_safelist"
 
@@ -642,6 +671,82 @@ class TestCommandExitZero:
         )
         assert result.status == "error"
         assert result.reason == "command_must_be_argv"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX subprocess assumed")
+    async def test_bare_python_runs_with_no_python_on_path(self, py_workspace, monkeypatch):
+        """#498 verbatim: Ubuntu ships only /usr/bin/python3, so a bare `python`
+        raised FileNotFoundError and `vc-*-compiles` degraded to
+        skipped(missing_tooling) — a structural criterion silently not executing
+        on a host detail, which is exactly what the bare-skeleton gate exists to
+        rule out."""
+        monkeypatch.setenv("PATH", "/nonexistent")
+
+        result = await get_check("command_exit_zero").evaluate(
+            {"argv": ["python", "-m", "py_compile", "ok.py"]},
+            py_workspace,
+        )
+
+        assert result.status == "passed"
+
+    @pytest.mark.parametrize(
+        ("argv", "rewritten"),
+        [
+            (["python", "-m", "py_compile", "x.py"], True),
+            # Not authorable today (no python3 safelist pattern), so this is the
+            # only place the branch is reachable — kept because a later safelist
+            # entry would otherwise silently reintroduce the PATH dependency.
+            (["python3", "-m", "py_compile", "x.py"], True),
+            (["node", "--check", "x.js"], False),
+            (["pyflakes", "x.py"], False),
+            ([], False),
+        ],
+    )
+    def test_only_bare_python_names_are_rewritten(self, argv, rewritten):
+        resolved = _resolve_interpreter(argv)
+
+        assert resolved == ([sys.executable, *argv[1:]] if rewritten else argv)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX subprocess assumed")
+    async def test_resolved_interpreter_still_catches_bad_code(self, py_workspace, monkeypatch):
+        """Guard against resolving the check into a no-op: it must still fail on
+        code that does not compile, not just stop skipping."""
+        monkeypatch.setenv("PATH", "/nonexistent")
+
+        result = await get_check("command_exit_zero").evaluate(
+            {"argv": ["python", "-m", "py_compile", "broken.py"]},
+            py_workspace,
+        )
+
+        assert result.status == "failed"
+
+    async def test_a_non_interpreter_command_is_left_alone(self, tmp_path, monkeypatch):
+        """Only bare python names are rewritten. A genuinely missing tool must
+        still report the #462 environment gap under its *authored* name — an
+        absolute path in the evidence can't be matched back to the contract."""
+        monkeypatch.setenv("PATH", "/nonexistent")
+        (tmp_path / "x.js").write_text("const a = 1;\n")
+
+        result = await get_check("command_exit_zero").evaluate(
+            {"argv": ["node", "--check", "x.js"]},
+            tmp_path,
+        )
+
+        assert result.status == "skipped"
+        assert result.reason == "missing_tooling"
+        assert result.actual["command"] == "node"
+
+    async def test_resolution_never_precedes_the_safelist(self, py_workspace):
+        """Ordering pin. The safelist gates the name a contract may ask for; if
+        resolution ran first, argv[0] would already be an absolute path and no
+        pattern would match — so either everything errors, or the gate has to be
+        loosened to accept arbitrary interpreter paths."""
+        result = await get_check("command_exit_zero").evaluate(
+            {"argv": ["python", "-c", "import os; os.system('id')"]},
+            py_workspace,
+        )
+
+        assert result.status == "error"
+        assert result.reason == "command_not_in_safelist"
 
     async def test_safelist_run_passes(self, tmp_path):
         # Use /bin/true via a synthetic safelist entry — actually, the simpler


### PR DESCRIPTION
Third fix of the **1.4.3** line, plus both of the line's riders.

## The bug, reproduced

`scaffold_contract` emits `vc-*-compiles` as `argv: ["python", "-m", "py_compile", …]`, and `_restricted_env()` inherits `PATH`. Ubuntu ships only `/usr/bin/python3` — there is no `python` — so the spawn raises `FileNotFoundError` and the check degrades to `skipped (missing_tooling)`.

On this box, before the change:

```
$ env PATH=/usr/bin:/bin .venv/bin/python -m pytest tests/unit/cycles/test_verification_contract_runner.py
FAILED test_every_structural_criterion_passes_on_bare_skeleton - AssertionError: vc-routes-compiles -> skipped (missing_tooling)
FAILED test_structural_criteria_still_pass_with_reference_fill  - AssertionError: assert 'skipped' == 'passed'
2 failed, 4 passed
```

After: **6 passed**. CI only ever passed because `setup-python` happens to leave a `python` shim on `PATH`.

The tests are the visible symptom; the shipped consequence is that whether `vc-*-compiles` executes or silently skips in a live cycle depends on the evaluating container having a `python` alias. Today's agent images do, so it is latent — but "structural criteria always execute" is the premise the bare-skeleton CI gate encodes (SIP-0098 §7), and a criterion that can quietly become `skipped` on an env detail is not that.

## Fixed in the evaluator, not the emission

Per the ruling recorded in `docs/plans/1-4-3-patch-plan.md` before any code. The issue offers both sites; the emission is the wrong one on a patch line:

- Emitting `python3` **moves the contract hash** — inadmissible here, and this window must not re-seed.
- It also would not help any **already-seeded** contract, v9 included, which keeps the bare name forever.

Resolving `python` → `sys.executable` at spawn fixes the pinned contracts too and is hash-stable by construction. `module_imports` (#628) already spawns `sys.executable`, so this conforms to the pattern rather than inventing one — and it makes `_CHECK_ENV_EXECUTABLES`' claim that the check environment provides `python` true *by construction* instead of by image accident.

**Ordering is load-bearing:** resolution runs strictly *after* the safelist gate. The safelist governs the name a contract may ask for; resolution is a spawn detail. Reversing it would mean `argv[0]` is already an absolute path when the patterns run, so either everything errors or the gate has to be loosened to accept arbitrary interpreter paths. There is a test pinning that order. `argv` also stays the authored form in evidence, so a genuine `missing_tooling` skip still reports `node`, not a path no reader can match back to the contract.

## Riders

**1. Pin the #605 property registry-wide.** Every Python-parsing check must *skip* a non-Python target rather than error — an `error` becomes `evaluator_error:<check>` and the patch lands UNVERIFIABLE, neither accepted nor rejected. pf-41 lost a roll to exactly that; pf-40 is the control (same bad repairs, but verification returned a verdict and rejected them).

#605 itself was already fixed — the property held by construction and was asserted **nowhere**. The test derives its parametrization from each spec's `applicable_extensions`, so it currently covers 7 checks × 2 non-Python targets, and a Python check added later inherits it instead of quietly opting out.

**2. Declare `pyflakes` in `tests/requirements.txt`.** 1.4.2 pinned it in `requirements/base.txt` and the three locks, so every container has it — but the harness got it only **transitively, via `flake8>=6.0.0`**. Ruff's own config comment records that its `F` rules *are* pyflakes, so retiring flake8 is a live prospect; the day that happens, every `undefined_names` check returns `error: missing_analyzer` with nothing pointing at why.

## Not fixed here — worth a look

While tracing the safelist I found `_CHECK_ENV_EXECUTABLES` (plan validation, #645) and `COMMAND_SAFELIST` (authoring lint + runtime gate) are two overlapping allowlists that **disagree in both directions**:

- `python3`, `pytest`, `npm`, `npx` are advertised by the validator's error message but have no safelist pattern, so a plan taking that advice is rejected by the very next gate.
- `ruff`, `tsc`, `eslint` are safelisted but absent from `_CHECK_ENV_EXECUTABLES`, so a plan authoring `ruff check x.py` is rejected as "the check environment does not provide ruff".

Neither is reachable as a live failure today (the two gates agree on the intersection actually in use, `python` and `node`), and reconciling them changes what plans may author — out of scope for a patch line. Flagging rather than filing.

## Verification

- The issue's exact repro now passes: **6 passed** with `.venv/bin` off `PATH`.
- Whole `tests/unit/cycles/` + `tests/unit/capabilities/` in that same env: **3757 passed, 2 skipped**.
- Full regression: **6138 passed, 1 skipped**.
- New tests: bare `python` runs with nothing on `PATH`; a real compile failure still **fails** (guards against resolving the check into a no-op); non-interpreter argv untouched and reported under its authored name; safelist-before-resolution ordering; and the resolver's rewrite/no-rewrite matrix — including `python3`, which is not authorable today and is covered so a later safelist entry can't silently reintroduce the PATH dependency.
- **Hash-stable**: no contract or manifest surface touched.

Also renamed `test_compile_ok_passed`, which asserted a safelist rejection and had nothing to do with a passing compile.

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
