### PR TITLE
fix(comms): report the delay and priority capabilities the queue actually has (#572)

### DIFF
--- a/adapters/comms/rabbitmq.py
+++ b/adapters/comms/rabbitmq.py
@@ -155,24 +155,32 @@ class RabbitMQAdapter(QueuePort):
         Args:
             queue_name: Name of the queue
             payload: Message payload (must be ACI TaskEnvelope JSON)
-            delay_seconds: Optional delay before message becomes available (None = immediate)
+            delay_seconds: Optional delay before message becomes available.
+                Only ``None``/``0`` (immediate) is supported — see Raises.
 
         Raises:
             QueueError: If publishing fails
+            NotImplementedError: If a non-zero ``delay_seconds`` is requested.
+                This adapter cannot delay delivery (#572), and the previous
+                behavior — a per-message TTL with no dead-letter exchange —
+                made the broker *discard* the message when the TTL expired.
+                Failing loudly beats losing the message: a caller that wanted
+                a delay has to know it did not get one.
         """
+        if delay_seconds is not None and delay_seconds > 0:
+            raise NotImplementedError(
+                f"Delayed delivery is not supported by this queue provider "
+                f"(delay_seconds={delay_seconds}); capabilities()['delay'] is False. "
+                f"Delivering it immediately would be wrong and setting a TTL would "
+                f"drop it — declare a dead-letter exchange or adopt "
+                f"rabbitmq-delayed-message-exchange before relying on this."
+            )
+
         # Build the message once; only the transport send is retried. A bad
         # payload fails here, before the loop, so it is never retried.
         message_properties: dict[str, Any] = {
             "delivery_mode": aio_pika.DeliveryMode.PERSISTENT,
         }
-
-        # Handle delay using TTL and Dead Letter Exchange
-        # Note: For production, consider using rabbitmq-delayed-message-exchange plugin
-        if delay_seconds is not None and delay_seconds > 0:
-            # Use TTL with DLX for delayed delivery
-            # This is a simplified approach; full implementation would use delayed exchange plugin
-            # aio_pika expects expiration as int (milliseconds) or timedelta
-            message_properties["expiration"] = delay_seconds * 1000  # TTL in milliseconds
 
         message = Message(
             body=payload.encode("utf-8"),
@@ -476,10 +484,16 @@ class RabbitMQAdapter(QueuePort):
 
         Args:
             message: QueueMessage to retry
-            delay_seconds: Delay before message becomes available again
+            delay_seconds: Delay before message becomes available again. Only
+                ``0`` (immediate) is supported — see Raises.
 
         Raises:
             QueueError: If retry fails
+            NotImplementedError: If a non-zero ``delay_seconds`` is requested
+                (#572). Propagated from :meth:`publish`, and deliberately not
+                softened into an immediate retry: a backoff that silently
+                becomes a hot loop is how a retry storm starts. The original
+                message is left unacked, so it is not lost.
         """
         try:
             # Republish the message with delay
@@ -490,6 +504,12 @@ class RabbitMQAdapter(QueuePort):
 
             logger.debug(f"Retried message {message.message_id} with {delay_seconds}s delay")
 
+        except NotImplementedError:
+            # A capability gap, not a transport failure. Laundering it into a
+            # QueueError would hand it to callers that treat QueueError as
+            # transient and retry — the unsupported delay would then be
+            # attempted forever instead of surfacing once.
+            raise
         except Exception as e:
             logger.error(f"Failed to retry message {message.message_id}: {e}")
             raise QueueError(f"Failed to retry message: {e}") from e
@@ -532,13 +552,28 @@ class RabbitMQAdapter(QueuePort):
         """
         Return the capabilities supported by this queue provider.
 
+        Each flag is a contract with future callers, so it reports what this
+        adapter *does*, not what RabbitMQ *could* do with configuration this
+        adapter never applies (#572).
+
         Returns:
             Dictionary with capability flags
         """
         return {
-            "delay": True,  # Supported via TTL+DLX (or delayed exchange plugin)
+            # #572: delayed delivery needs a wait queue with
+            # `x-dead-letter-exchange` pointing back at the work exchange, or the
+            # rabbitmq-delayed-message-exchange plugin. Neither is declared, and
+            # the TTL-only version this replaced made the broker *discard* the
+            # message at expiry rather than deliver it late. `publish` now raises
+            # on a non-zero delay instead.
+            "delay": False,
             "fifo": False,  # RabbitMQ does not guarantee FIFO ordering
-            "priority": True,  # Supported via priority queues
+            # #572 (same class, found alongside): priority needs `x-max-priority`
+            # on the queue declaration and a `priority` property per message.
+            # `_get_queue` declares neither and `publish` sets neither, so the
+            # broker ignores priority entirely — a caller ordering work by it
+            # would get plain FIFO-ish delivery and never know.
+            "priority": False,
         }
 
     async def close(self) -> None:

--- a/adapters/noop/ports.py
+++ b/adapters/noop/ports.py
@@ -191,7 +191,13 @@ class NoOpQueuePort(QueuePort):
     async def publish(
         self, queue_name: str, payload: str, delay_seconds: int | None = None
     ) -> None:
-        pass
+        # #572: refuse a delay no provider can honor, so this stub cannot make a
+        # caller believe delayed delivery works.
+        if delay_seconds is not None and delay_seconds > 0:
+            raise NotImplementedError(
+                f"Delayed delivery is not supported (delay_seconds={delay_seconds}); "
+                f"capabilities()['delay'] is False."
+            )
 
     async def consume(self, queue_name: str, max_messages: int = 1) -> list[QueueMessage]:
         return []
@@ -200,13 +206,15 @@ class NoOpQueuePort(QueuePort):
         pass
 
     async def retry(self, message: QueueMessage, delay_seconds: int) -> None:
-        pass
+        await self.publish("", "", delay_seconds=delay_seconds)
 
     async def health(self) -> dict[str, Any]:
         return {"status": "healthy", "provider": "noop"}
 
     def capabilities(self) -> dict[str, bool]:
-        return {"delay": True, "fifo": True, "priority": True}
+        # #572: delay/priority describe operations no shipped provider performs.
+        # `fifo` gates no operation, so it stays as-is.
+        return {"delay": False, "fifo": True, "priority": False}
 
 
 # ---------------------------------------------------------------------------

--- a/src/squadops/ports/comms/noop.py
+++ b/src/squadops/ports/comms/noop.py
@@ -37,8 +37,19 @@ class NoOpQueuePort(QueuePort):
         Args:
             queue_name: Name of the queue
             payload: Message payload
-            delay_seconds: Optional delay (ignored in no-op)
+            delay_seconds: Optional delay. Rejected when non-zero, matching the
+                shipped providers (#572) — a null object that accepts an
+                operation every real provider refuses makes a test exercise the
+                branch production never takes.
+
+        Raises:
+            NotImplementedError: If a non-zero ``delay_seconds`` is requested.
         """
+        if delay_seconds is not None and delay_seconds > 0:
+            raise NotImplementedError(
+                f"Delayed delivery is not supported (delay_seconds={delay_seconds}); "
+                f"capabilities()['delay'] is False."
+            )
         logger.debug(
             "NoOp publish",
             extra={
@@ -97,13 +108,19 @@ class NoOpQueuePort(QueuePort):
         }
 
     def capabilities(self) -> dict[str, bool]:
-        """Return capabilities (all enabled in no-op mode).
+        """Return capabilities, matching what the shipped providers actually do.
+
+        A null object may deliver nothing, but its *flags* are still read by
+        callers deciding which branch to take. Advertising delay/priority here
+        while every real provider reports False (#572) would route tests down a
+        path production never takes. ``fifo`` stays True: it gates no operation,
+        so nothing can be built on it.
 
         Returns:
             Capabilities dictionary
         """
         return {
-            "delay": True,
+            "delay": False,
             "fifo": True,
-            "priority": True,
+            "priority": False,
         }

--- a/src/squadops/ports/comms/queue.py
+++ b/src/squadops/ports/comms/queue.py
@@ -81,10 +81,16 @@ class QueuePort(ABC):
         Args:
             queue_name: Name of the queue
             payload: Message payload (must be ACI TaskEnvelope JSON)
-            delay_seconds: Optional delay before message becomes available (None = immediate)
+            delay_seconds: Optional delay before message becomes available
+                (None = immediate). A provider that does not advertise
+                ``capabilities()["delay"]`` must reject a non-zero value rather
+                than deliver immediately or drop the message (#572).
 
         Raises:
             QueueError: If publishing fails
+            NotImplementedError: If a non-zero ``delay_seconds`` is requested of
+                a provider whose ``capabilities()["delay"]`` is False. No shipped
+                provider supports delay today.
         """
         pass
 
@@ -287,6 +293,11 @@ class QueuePort(ABC):
     def capabilities(self) -> dict[str, bool]:
         """
         Return the capabilities supported by this queue provider.
+
+        Every flag is a contract with future callers: it must describe what the
+        provider *does*, not what its transport could be configured to do. A
+        flag that overstates the implementation is worse than a missing feature
+        — the caller builds on it and loses messages silently (#572).
 
         Returns:
             Dictionary with capability flags:

--- a/tests/integration/adapters/test_rabbitmq_adapter.py
+++ b/tests/integration/adapters/test_rabbitmq_adapter.py
@@ -180,9 +180,9 @@ class TestRabbitMQAdapter:
         assert "delay" in caps
         assert "fifo" in caps
         assert "priority" in caps
-        assert caps["delay"] is True
+        assert caps["delay"] is False  # #572: no DLX declared
         assert caps["fifo"] is False  # RabbitMQ doesn't guarantee FIFO
-        assert caps["priority"] is True
+        assert caps["priority"] is False  # #572: no x-max-priority declared
 
     @pytest.mark.asyncio
     async def test_retry_message(self, rabbitmq_adapter, sample_task_envelope_json, clean_rabbitmq):
@@ -197,12 +197,30 @@ class TestRabbitMQAdapter:
         assert len(messages) == 1
         message = messages[0]
 
-        # Retry message with delay
-        await rabbitmq_adapter.retry(message, delay_seconds=1)
+        # Retry immediately. #572: a non-zero delay is refused, because the
+        # adapter declares no dead-letter exchange and a TTL alone would make the
+        # broker discard the message at expiry instead of delivering it late.
+        await rabbitmq_adapter.retry(message, delay_seconds=0)
 
-        # Verify original message was acked (retry should ack the original)
-        # The retried message should be republished, so we can consume it again
-        # Note: With delay, we may need to wait, but for testing we verify retry succeeded
+        # The retried message was republished and the original acked.
+        redelivered = await rabbitmq_adapter.consume(queue_name, max_messages=1)
+        assert len(redelivered) == 1
+        assert redelivered[0].payload == sample_task_envelope_json
+
+    @pytest.mark.asyncio
+    async def test_retry_with_a_delay_is_refused(
+        self, rabbitmq_adapter, sample_task_envelope_json, clean_rabbitmq
+    ):
+        """#572 against a live broker: the refusal must reach the caller intact,
+        not be laundered into the transient-looking QueueError that `retry` wraps
+        transport failures in — and the original must stay unacked."""
+        queue_name = "test_queue_retry_delay"
+        await rabbitmq_adapter.publish(queue_name, sample_task_envelope_json)
+        messages = await rabbitmq_adapter.consume(queue_name, max_messages=1)
+        assert len(messages) == 1
+
+        with pytest.raises(NotImplementedError):
+            await rabbitmq_adapter.retry(messages[0], delay_seconds=5)
 
     @pytest.mark.asyncio
     async def test_multiple_messages(

--- a/tests/unit/comms/test_rabbitmq_adapter.py
+++ b/tests/unit/comms/test_rabbitmq_adapter.py
@@ -15,6 +15,7 @@ import pytest
 
 import adapters.comms.rabbitmq as rabbitmq_mod
 from adapters.comms.rabbitmq import QueueError, RabbitMQAdapter
+from squadops.comms.queue_message import QueueMessage
 from squadops.ports.comms.queue import REPLY_QUEUE_DECLARE_ARGS
 
 pytestmark = [pytest.mark.unit]
@@ -295,6 +296,81 @@ class TestPublishRetry:
 
         ch.default_exchange.publish.assert_awaited_once()
         adapter.invalidate_queue.assert_not_awaited()
+
+
+class TestDelayCapabilityHonesty:
+    """#572: the adapter set a per-message TTL with no dead-letter exchange
+    declared, so a "delayed" message was *discarded* at expiry rather than
+    delivered late — while ``capabilities()['delay']`` advertised True. A caller
+    trusting that flag lost messages with no error anywhere."""
+
+    @pytest.mark.parametrize("flag", ["delay", "priority"])
+    def test_unimplemented_capabilities_report_false(self, flag) -> None:
+        """Each flag is a contract with future callers. `delay` needs a wait
+        queue with `x-dead-letter-exchange`; `priority` needs `x-max-priority` on
+        the declaration plus a per-message property. Neither is declared
+        anywhere, so neither may claim True."""
+        adapter = _make_adapter_with_channel(MagicMock())
+
+        assert adapter.capabilities()[flag] is False
+
+    @pytest.mark.parametrize("delay", [1, 30, 3600])
+    async def test_non_zero_delay_raises_instead_of_dropping(self, delay) -> None:
+        """The message must not reach the broker at all. Publishing it with a TTL
+        loses it silently; publishing it without one delivers immediately, which
+        is not what the caller asked for. Refusing is the only honest option."""
+        adapter, ch, _ = TestPublishRetry._publish_adapter([None])
+
+        with pytest.raises(NotImplementedError, match="Delayed delivery is not supported"):
+            await adapter.publish("work", "{}", delay_seconds=delay)
+
+        ch.default_exchange.publish.assert_not_awaited()
+
+    @pytest.mark.parametrize("delay", [None, 0])
+    async def test_immediate_publish_is_unaffected(self, delay) -> None:
+        """The only live caller (`aci_executor` retry) passes 0, so the immediate
+        path must keep working exactly as before."""
+        adapter, ch, _ = TestPublishRetry._publish_adapter([None])
+
+        await adapter.publish("work", "{}", delay_seconds=delay)
+
+        ch.default_exchange.publish.assert_awaited_once()
+
+    async def test_retry_does_not_launder_the_refusal_into_a_queue_error(self) -> None:
+        """`retry` wraps failures as QueueError, which callers treat as transient
+        and retry. A capability gap is permanent — laundering it would retry an
+        impossible delay forever instead of surfacing once."""
+        adapter, ch, _ = TestPublishRetry._publish_adapter([None])
+        adapter.ack = AsyncMock()
+        message = QueueMessage(
+            message_id="m1",
+            queue_name="work",
+            payload="{}",
+            receipt_handle="1",
+            attributes={},
+        )
+
+        with pytest.raises(NotImplementedError):
+            await adapter.retry(message, delay_seconds=5)
+
+        # The original is left unacked, so the broker still owns it.
+        adapter.ack.assert_not_awaited()
+
+    async def test_retry_without_delay_still_republishes_and_acks(self) -> None:
+        adapter, ch, _ = TestPublishRetry._publish_adapter([None])
+        adapter.ack = AsyncMock()
+        message = QueueMessage(
+            message_id="m1",
+            queue_name="work",
+            payload="{}",
+            receipt_handle="1",
+            attributes={},
+        )
+
+        await adapter.retry(message, delay_seconds=0)
+
+        ch.default_exchange.publish.assert_awaited_once()
+        adapter.ack.assert_awaited_once()
 
 
 class _FakeIncoming:


### PR DESCRIPTION
Fourth fix of the **1.4.3** line.

## The bug

`publish()` set a per-message `expiration` (TTL) with **no dead-letter exchange declared anywhere** — no `x-dead-letter-exchange` or `x-dead-letter-routing-key` on any queue. In RabbitMQ semantics an expired message is *discarded*, not delivered later. So a "delayed" message was silently dropped, while `capabilities()["delay"]` reported `True` with the comment *"Supported via TTL+DLX"*.

**Nothing is being dropped today.** `delay_seconds` has exactly one live caller — `adapters/capabilities/aci_executor.py:162` — and it passes `0`. The defect is the *declaration*: a capability flag is a contract with future callers, and this one promised a feature that loses messages.

## The fix

Took the issue's **option 3** — delete the TTL path, report the truth — per the 1.4.3 plan's stated preference for the honest declaration. There is no delayed-delivery consumer to serve, and wiring a real wait-queue + DLX (option 1) or adopting `rabbitmq-delayed-message-exchange` (option 2) is building a feature nothing asks for, on a patch line.

A non-zero `delay_seconds` now raises `NotImplementedError`. Both alternatives are wrong: delivering immediately is not what the caller asked for, and setting a TTL loses the message. Refusing is the only honest option, and it is loud.

**One detail worth review:** `retry()` wraps failures in `QueueError`, and its `except Exception` would have caught the refusal and laundered it into one. Callers treat `QueueError` as transient and retry — so an impossible delay would be attempted forever instead of surfacing once. There is now an explicit `except NotImplementedError: raise` ahead of the general handler, and a test pinning it. The original message is left unacked, so the broker still owns it.

## `priority` is the same lie, one line down

Found while verifying the change rather than from the issue. `"priority": True` claims support that needs `x-max-priority` on the queue declaration plus a `priority` property per message — `_get_queue` declares neither and `publish` sets neither, so the broker ignores priority entirely. A caller ordering work by it would get plain delivery and never know.

Fixing `delay` and leaving `priority` would be precisely the half-state the issue says not to keep, so both now report `False`.

## Both NoOps

There are **two** `NoOpQueuePort` classes — `adapters/noop/ports.py:188` says in its own docstring that it "replicates existing pattern from ports/comms/noop.py". Both advertised `delay`/`priority` as `True`.

Aligned both, because a null object advertising an operation every real provider refuses sends a test down the branch production never takes — a future caller writing `if queue.capabilities()["delay"]: … else: …` would have had its tests exercise the wrong half. They also now refuse a non-zero delay, so the port contract holds for every implementation rather than just the real one.

`fifo` is deliberately left as-is (NoOp `True`, RabbitMQ `False`). It gates no operation, so nothing can be built on it — unlike delay, which is a parameter you can pass.

The duplicated null object is a separate smell; not touched here.

## Verification

- **Against the live broker**: 11 integration tests pass, including a new one asserting the refusal reaches the caller intact rather than as a `QueueError`, and the existing retry test upgraded from "we verify retry succeeded" (which asserted nothing) to actually consuming the republished message back.
- Unit: capabilities parity for both flags; a non-zero delay never reaches the transport (`default_exchange.publish` not awaited); `None`/`0` unaffected, since that is the one live caller's path; retry's refusal not laundered and the original left unacked; retry at `delay_seconds=0` still republishes and acks.
- Full regression: **6147 passed, 1 skipped**.
- **Hash-stable**: no contract or manifest surface touched.

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
