### PR TITLE
fix(telemetry): a literal `|` in the email TLD class swallowed the next log field (#573)

### DIFF
--- a/adapters/telemetry/langfuse/redaction.py
+++ b/adapters/telemetry/langfuse/redaction.py
@@ -45,8 +45,13 @@ _PASSWORD_PATTERNS: list[re.Pattern[str]] = [
 
 # PII patterns (strict mode only)
 _PII_PATTERNS: list[re.Pattern[str]] = [
-    # Email addresses
-    re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),
+    # Email addresses. The TLD class is `[A-Za-z]`, NOT `[A-Z|a-z]` (#573): a `|`
+    # inside a character class is a literal pipe, not alternation, so the old
+    # form accepted `|` as a TLD character and ran the match past the address
+    # into the next pipe-delimited field —
+    # `email=a@b.com|status=ok` redacted to `email=[REDACTED-PII]=ok`, destroying
+    # the surrounding context instead of just the address.
+    re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
     # Phone numbers (US/international)
     re.compile(r"\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b"),
     # SSN patterns

--- a/tests/unit/telemetry/test_langfuse_redaction.py
+++ b/tests/unit/telemetry/test_langfuse_redaction.py
@@ -1,12 +1,38 @@
 """Unit tests for redaction strategies (SIP-0061)."""
 
+import re
+
 import pytest
 
 from adapters.telemetry.langfuse.redaction import (
+    _API_KEY_PATTERNS,
+    _PASSWORD_PATTERNS,
+    _PII_PATTERNS,
     StandardRedaction,
     StrictRedaction,
     get_redaction_strategy,
 )
+
+
+class TestPatternHygiene:
+    """#573 asked for a sweep of the sibling patterns for the same typo. This
+    pins the outcome rather than leaving it to the next reader's eyeball."""
+
+    # A `[...]` containing an unescaped `|` — the #573 shape.
+    _CLASS_WITH_PIPE = re.compile(r"\[(?:[^\]\\]|\\.)*\|(?:[^\]\\]|\\.)*\]")
+
+    @pytest.mark.parametrize(
+        "pattern",
+        [*_API_KEY_PATTERNS, *_PASSWORD_PATTERNS, *_PII_PATTERNS],
+        ids=lambda p: p.pattern[:40],
+    )
+    def test_no_literal_pipe_inside_a_character_class(self, pattern):
+        """In a character class `|` is a literal pipe, never alternation. In a
+        scrubber that means the class silently accepts a character it was never
+        meant to, and the match runs past its intended end — which is how the
+        email pattern started swallowing the next pipe-delimited log field.
+        No pattern in this module wants a literal pipe."""
+        assert self._CLASS_WITH_PIPE.search(pattern.pattern) is None
 
 
 class TestStandardRedaction:
@@ -105,6 +131,44 @@ class TestStrictRedaction:
         assert h1 == h2  # Deterministic
         assert h1 != h3  # Different inputs produce different hashes
         assert len(h1) == 16  # Truncated to 16 chars
+
+    def test_email_redaction_stops_at_the_address_in_a_pipe_delimited_line(self):
+        """#573: the TLD class was `[A-Z|a-z]`, and a `|` inside a character
+        class is a *literal pipe*, not alternation. The match therefore ran past
+        the address into the next pipe-delimited field, so a log line lost its
+        surrounding context — `email=…|status=ok` redacted to
+        `email=[REDACTED-PII]=ok`, silently corrupting the record it was meant to
+        make safe. Pipe-delimited fields are everywhere in log output, so this is
+        the shape that actually bit."""
+        r = StrictRedaction()
+
+        result = r.redact("email=alice@example.com|status=ok|retry=3")
+
+        assert result == "email=[REDACTED-PII]|status=ok|retry=3"
+
+    def test_a_pipe_is_not_a_tld_character(self):
+        """The direct statement of the typo: `b.c|m` is not a domain, so the
+        pattern must not treat it as one."""
+        r = StrictRedaction()
+
+        assert r.redact("user@example.c|m") == "user@example.c|m"
+
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "alice@example.com",
+            "Bob.Smith+tag@sub.example.co.uk",
+            "x@y.IO",
+            "user_name%test@mail-server.example.org",
+        ],
+    )
+    def test_real_addresses_still_redact(self, address):
+        """The fix narrows the class, so the guard that matters is that every
+        genuine address still scrubs — both ranges were always covered, and this
+        pins that they stay covered."""
+        r = StrictRedaction()
+
+        assert address not in r.redact(f"Contact {address} for help")
 
 
 class TestGetRedactionStrategy:


### PR DESCRIPTION
Fifth and final fix of the **1.4.3** line.

## Not cosmetic

`[A-Z|a-z]` is "uppercase, a literal pipe, or lowercase" — inside a character class `|` is a literal, never alternation. Both letter ranges were still covered, so every genuine address kept redacting, which is why the issue reads as cosmetic-adjacent.

Measuring it says otherwise. Accepting `|` as a TLD character let the match run **past the address into the next pipe-delimited field**:

```
input : email=alice@example.com|status=ok|retry=3
before: email=[REDACTED-PII]=ok|retry=3          <- ate `|status`, left a corrupted `=ok`
after : email=[REDACTED-PII]|status=ok|retry=3
```

Pipe-delimited fields are everywhere in log output, so in strict mode this quietly destroyed the surrounding context of the very record it was making safe. That is the shape that actually bit — not "the class also matches `|` in a TLD position".

**No leak in either direction.** The only other behavioral delta is that `user@example.c|m` — not a valid address — stops matching, which is over-redaction going away. Verified across a matrix of real and malformed addresses; every genuine form still scrubs.

## The sibling sweep

The issue asked for "a quick eyeball of the sibling patterns for the same class of typo". Rather than eyeball it, I swept the **whole repo** for the shape (`[...]` containing an unescaped `|`, in a line that looks like a regex).

One other hit: `src/squadops/capabilities/handlers/wrapup_tasks.py:64`, `[:=|]`. That literal pipe is **deliberate** — the pattern parses `suggested_owner` out of "markdown tables or YAML-like content", where `|` is the table delimiter. Correct usage; left alone.

## Guard

The sweep result is pinned by a parametrized test over every pattern in the redaction module — API-key, password, and PII lists — asserting none contains a literal pipe inside a character class. Scoped to this module deliberately: a literal pipe is legitimate elsewhere (see `wrapup_tasks`), but in a scrubber it means the class silently accepts a character it was never meant to and the match overruns its intended end.

Confirmed the guard has teeth: it flags the old pattern (`[A-Z|a-z]`) and passes the new one.

## Verification

- New tests: the pipe-delimited log line redacts to exactly the expected string (exact-equality, not a substring check); `user@example.c|m` is left alone; four real address shapes still scrub via parametrize; the pattern-hygiene guard.
- Full regression: **6162 passed, 1 skipped**.
- **Hash-stable**: no contract or manifest surface touched.

## Line status

This closes the 1.4.3 code. All five fixes merged or open: #373+#529 (PR #704), #561 (#705), #498 + both riders (#706), #572 (#708), #573 (this one). Six issues closed, two riders landed, plus #707 filed to 1.5 from the #498 sweep.

Next is the deploy window — rebuild + verify-LOADED on both evaluator surfaces, assert contract v9 / manifest v4 unchanged, the **cancel probe** (#373/#529/#561's only real proof: launch, cancel mid-implementation, assert zero unreleased leases and zero stranded activities with no restart, then relaunch and confirm immediate acquisition), one unfiltered confirmation shakedown, then the 1.4.3 bump and tag.

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
