### PR TITLE
fix(runtime): reap agents stranded in cycle mode with no lease at startup (#710)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -62,7 +62,7 @@ from squadops.events.types import EventType
 from squadops.ports.cycles.flow_execution import FlowExecutionPort
 from squadops.runtime import reasons
 from squadops.runtime.admission import admit_participants, release_participants
-from squadops.runtime.lease_reaper import release_owner_leases
+from squadops.runtime.focus_reaper import release_owner_leases
 from squadops.runtime.recruitment import reserve_buffer_decision
 from squadops.tasks.models import TaskEnvelope, TaskResult, TaskResultStatus
 from squadops.telemetry.context import use_correlation_context

--- a/adapters/persistence/runtime/state_postgres.py
+++ b/adapters/persistence/runtime/state_postgres.py
@@ -43,6 +43,24 @@ class PostgresRuntimeState(RuntimeStatePort):
             )
         return _row_to_state(row) if row else None
 
+    async def list_states(
+        self, *, mode: str | None = None, conn: Any = None
+    ) -> tuple[AgentRuntimeState, ...]:
+        query = (
+            "SELECT agent_id, mode, runtime_status, focus, "
+            "current_runtime_activity_id, interruptibility, "
+            "last_heartbeat_at, current_assignment_ref "
+            "FROM agent_runtime_state"
+        )
+        args: list[Any] = []
+        if mode is not None:
+            query += " WHERE mode = $1"
+            args.append(mode)
+        query += " ORDER BY agent_id"
+        async with acquire(self._pool, conn) as conn:
+            rows = await conn.fetch(query, *args)
+        return tuple(_row_to_state(row) for row in rows)
+
     async def upsert_state(
         self, state: AgentRuntimeState, *, conn: Any = None
     ) -> AgentRuntimeState:

--- a/src/squadops/api/routes/cycles/cancellation.py
+++ b/src/squadops/api/routes/cycles/cancellation.py
@@ -78,7 +78,7 @@ async def release_cancelled_run_leases(cycle_id: str, run_ids: list[str]) -> int
     if coordinator is None or focus_lease is None or not run_ids:
         return 0
     from squadops.runtime import reasons
-    from squadops.runtime.lease_reaper import release_owner_leases
+    from squadops.runtime.focus_reaper import release_owner_leases
 
     released = 0
     for run_id in run_ids:

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -337,10 +337,12 @@ async def _init_cycle_subsystem(config, pool) -> None:
         assignment_port = None
         activity_port = None
         focus_lease_port = None
+        state_port = None
         if pool is not None:
             from adapters.persistence.runtime.activity_postgres import PostgresRuntimeActivity
             from adapters.persistence.runtime.assignments_postgres import PostgresAssignment
             from adapters.persistence.runtime.focus_lease_postgres import PostgresFocusLease
+            from adapters.persistence.runtime.state_postgres import PostgresRuntimeState
             from squadops.api.runtime.deps import set_assignment_port
 
             assignment_port = PostgresAssignment(pool)
@@ -355,6 +357,9 @@ async def _init_cycle_subsystem(config, pool) -> None:
             # `create_runtime_coordinator` builds (same precedent as the
             # assignment/activity adapters, which are also built twice).
             focus_lease_port = PostgresFocusLease(pool)
+            # #710: the mode half of the same residue. Stateless over the pool,
+            # same as the adapters above.
+            state_port = PostgresRuntimeState(pool)
 
         # SIP-0089 §3.5 (#233): the single-writer coordinator (D16), built once
         # here and reused by the duty scheduler (see _init_duty_scheduler) so the
@@ -379,9 +384,13 @@ async def _init_cycle_subsystem(config, pool) -> None:
         from squadops.api.runtime.startup_reaps import (
             reap_stranded_activities,
             reap_stranded_leases,
+            reap_stranded_modes,
         )
 
+        # Lease first: it returns the agents it clears to ambient, so the mode
+        # sweep after it sees only the residue with no lease at all (#710).
         await reap_stranded_leases(cycle_registry, _runtime_coordinator, focus_lease_port)
+        await reap_stranded_modes(_runtime_coordinator, state_port)
         await reap_stranded_activities(cycle_registry, activity_port)
 
         flow_executor = create_flow_executor(

--- a/src/squadops/api/runtime/startup_reaps.py
+++ b/src/squadops/api/runtime/startup_reaps.py
@@ -13,6 +13,9 @@ then turn that residue into a hard block on every later run:
 - :func:`reap_stranded_leases` (#373) — a held cycle lease makes recruitment
   reject with ``focus_lease_conflict``, so the next cycle pauses before
   dispatching a task.
+- :func:`reap_stranded_cycle_modes` (#710) — the inverse residue: `cycle` mode
+  with *no* lease, which the lease sweep structurally cannot see. Recruitment
+  then idempotent-skips forever and focus arbitration is off entirely.
 - :func:`reap_stranded_activities` (#672) — an active activity trips
   ``uq_runtime_activities_one_active_per_agent``, so activity tracking goes
   silently dead for that agent.
@@ -21,7 +24,7 @@ Each owns its own best-effort contract: a reap failure is logged and never
 blocks startup, because a runtime-api that will not boot is worse than one that
 boots with residue.
 
-The domain reapers (``runtime.lease_reaper`` / ``runtime.activity_reaper``) stay
+The domain reapers (``runtime.focus_reaper`` / ``runtime.activity_reaper``) stay
 free of cycle-domain imports (D26); the "is the owner finished?" question is
 answered here, where the registry is already in scope.
 """
@@ -35,6 +38,7 @@ if TYPE_CHECKING:
     from squadops.ports.cycles.cycle_registry import CycleRegistryPort
     from squadops.ports.runtime.activity import RuntimeActivityPort
     from squadops.ports.runtime.focus_lease import FocusLeasePort
+    from squadops.ports.runtime.state import RuntimeStatePort
     from squadops.runtime.coordinator import RuntimeCoordinator
 
 logger = logging.getLogger(__name__)
@@ -70,7 +74,7 @@ async def reap_stranded_leases(
         from squadops.cycles.lifecycle import TERMINAL_STATES
         from squadops.cycles.models import RunNotFoundError, RunStatus
         from squadops.runtime import reasons
-        from squadops.runtime.lease_reaper import reap_stale_leases
+        from squadops.runtime.focus_reaper import reap_stale_leases
 
         async def _owner_cannot_be_executing(run_id: str) -> bool:
             try:
@@ -99,6 +103,39 @@ async def reap_stranded_leases(
         return released
     except Exception:
         logger.warning("Startup stranded-lease reap failed", exc_info=True)
+        return 0
+
+
+async def reap_stranded_modes(
+    coordinator: RuntimeCoordinator | None,
+    state_port: RuntimeStatePort | None,
+) -> int:
+    """Return every agent left in `cycle` mode to `ambient` at startup (#710).
+
+    Returns how many moved; 0 when unwired or the reap failed.
+
+    Runs *after* :func:`reap_stranded_leases`, which already returns the agents
+    it clears — so what remains here is the residue with no lease at all, the
+    state that made focus arbitration silently inert for 64 cycles. Same
+    justification as the other two sweeps: nothing dispatches in a process that
+    has not begun serving, so no agent can legitimately hold cycle focus yet.
+    """
+    if coordinator is None or state_port is None:
+        return 0
+    try:
+        from squadops.runtime.focus_reaper import reap_stranded_cycle_modes
+
+        reaped = await reap_stranded_cycle_modes(coordinator, state_port)
+        if reaped:
+            logger.warning(
+                "Startup reap returned %d agent(s) from a stranded cycle mode to ambient — "
+                "recruitment had been idempotent-skipping them, so no focus lease was being "
+                "acquired at all.",
+                reaped,
+            )
+        return reaped
+    except Exception:
+        logger.warning("Startup stranded-mode reap failed", exc_info=True)
         return 0
 
 

--- a/src/squadops/ports/runtime/focus_lease.py
+++ b/src/squadops/ports/runtime/focus_lease.py
@@ -116,7 +116,7 @@ class FocusLeasePort(ABC):
         for `cycle` leases, an assignment id for `duty` leases. At most one
         active lease exists per agent (§3.2), so the result is bounded by the
         roster size and callers iterate it without pagination. Backs the
-        #373/#529 stranded-lease sweeps (`runtime.lease_reaper`), which need to
+        #373/#529 stranded-lease sweeps (`runtime.focus_reaper`), which need to
         find held leases *by owner* — `get_current_lease` answers only the
         inverse question, and an owner whose agents are unknown (a dead process,
         a cancelled run) cannot ask it.

--- a/src/squadops/ports/runtime/state.py
+++ b/src/squadops/ports/runtime/state.py
@@ -27,6 +27,20 @@ class RuntimeStatePort(ABC):
         """Return the current state for `agent_id`, or `None` if no row exists."""
 
     @abstractmethod
+    async def list_states(
+        self, *, mode: str | None = None, conn: Any = None
+    ) -> tuple[AgentRuntimeState, ...]:
+        """Return every agent's state, oldest agent_id first; `mode` narrows it.
+
+        Bounded by the roster, so callers iterate it without pagination. Backs
+        the #710 stranded-mode sweep, which has to find agents left in `cycle`
+        *by mode* — `get_state` answers only the per-agent question, and an agent
+        stranded by a dead process is one nobody thought to ask about.
+
+        `conn` (§4.5/D25): read on the caller's unit-of-work connection when given.
+        """
+
+    @abstractmethod
     async def upsert_state(
         self, state: AgentRuntimeState, *, conn: Any = None
     ) -> AgentRuntimeState:

--- a/src/squadops/runtime/focus_reaper.py
+++ b/src/squadops/runtime/focus_reaper.py
@@ -1,5 +1,10 @@
 """
-Stranded FocusLease hygiene (#373/#529 — the #672 activity sweeps, applied to leases).
+Stranded focus hygiene (#373/#529/#710 — the #672 activity sweeps, applied to focus).
+
+An agent's focus is **two** coupled facts: the `FocusLease` it holds and the
+`RuntimeMode` that rides with it. They are written atomically (§4.5/D25), and
+either one surviving alone is a stranded state that nothing else reclaims — so
+both are swept here.
 
 `focus_leases` enforces one active lease per agent (§3.2, the partial unique
 index), and #288 makes a same-mode `cycle` request from a *different* owner a
@@ -8,7 +13,7 @@ released. A run that dies, or is cancelled outside the executor's finalize path,
 leaves its cycle leases held — with `expires_at = NULL`, so nothing reclaims
 them — and every later cycle recruiting those agents pauses at admission with
 `focus_lease_conflict` before dispatching a single task. Recovery is manual SQL
-today. Two sweeps close the class, mirroring `activity_reaper`:
+today. Three sweeps close the class, mirroring `activity_reaper`:
 
 - :func:`release_owner_leases` — cancel / run finalize: the owning run is over,
   so any lease still held for it is stranded; release them all. This is the
@@ -17,8 +22,15 @@ today. Two sweeps close the class, mirroring `activity_reaper`:
 - :func:`reap_stale_leases` — sweep every held cycle lease whose owner is
   finished, for callers that cannot enumerate owners (rows stranded by a process
   death that skipped finalize, and historic rows predating the sweep).
+- :func:`reap_stranded_cycle_modes` — the *other* half (#710). A lease sweep
+  iterates held leases, so it cannot see an agent left in `cycle` with **no**
+  lease. That state is silent and self-perpetuating: recruitment takes the #288
+  same-mode branch, finds nothing to conflict with, and `idempotent_skip`s —
+  admitted without acquiring, so finalize releases nothing and the mode stays.
+  Measured on the dev box at the 1.4.3 deploy: 64 cycles over two weeks, one of
+  them a green confirmation roll, none of which acquired a single lease.
 
-Both drive the **coordinator**, not the lease port directly. A stranded lease
+All three drive the **coordinator**, not the lease port directly. A stranded lease
 comes with a stranded ``mode = cycle``: releasing only the lease would leave the
 agent pinned in `cycle`, where the next recruitment takes the #288 same-mode
 path, finds no conflicting lease, and *idempotently skips* — admitted without
@@ -30,15 +42,16 @@ which the null-UoW path can produce when a mode write commits and its release
 then fails — is released through the port afterwards, because the coordinator
 has no transition that expresses that case.
 
-Only `cycle` leases are swept. A `duty` lease's ``owner_ref`` is an assignment
-id, not a run id, so a run-shaped predicate does not apply to it and a live duty
-window must never be reaped by a question about runs.
+Only `cycle` focus is swept, lease and mode alike. A `duty` lease's ``owner_ref``
+is an assignment id rather than a run id, and a `duty` agent may legitimately be
+mid-window with the scheduler about to re-evaluate — so a run-shaped question
+must never reap one.
 
-Both are best-effort and per-row isolated, like ``admission.release_participants``:
+All are best-effort and per-row isolated, like ``admission.release_participants``:
 one bad row never blocks clearing the rest, since a single stranded lease blocks
 all of that agent's future recruitment.
 
-Pure orchestration: depends only on the coordinator, the lease port, and
+Pure orchestration: depends only on the coordinator, the runtime ports, and
 ``runtime.reasons``. Run-status knowledge enters through the ``owner_is_finished``
 predicate the composition root supplies — ``squadops.runtime`` never imports the
 cycles domain (D26 direction).
@@ -49,10 +62,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Final
 
+from squadops.runtime import reasons
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from squadops.ports.runtime.focus_lease import FocusLeasePort
+    from squadops.ports.runtime.state import RuntimeStatePort
     from squadops.runtime.coordinator import RuntimeCoordinator
     from squadops.runtime.models import FocusLease
 
@@ -123,6 +139,56 @@ async def reap_stale_leases(
             continue
         if await _return_to_ambient(coordinator, focus_lease, lease, reason_code):
             reaped += 1
+    return reaped
+
+
+async def reap_stranded_cycle_modes(
+    coordinator: RuntimeCoordinator,
+    state: RuntimeStatePort,
+) -> int:
+    """Return every agent left in `cycle` mode to `ambient`; count those that moved.
+
+    The half a lease sweep structurally cannot reach (#710): with no lease held,
+    :func:`reap_stale_leases` has nothing to iterate, so the mode survives it —
+    and a `cycle` mode with no lease disables focus arbitration outright.
+    Recruitment hits the #288 same-mode branch, finds no conflicting lease, and
+    `idempotent_skip`s: admitted without acquiring, nothing recorded as
+    recruited, so finalize releases nothing and the mode stays. Every step is
+    individually correct and the loop is silent — the same-mode branch emits no
+    event and admission logs nothing on a skip.
+
+    Callers must only invoke this when no cycle can be executing (startup): a
+    live cycle's participants are legitimately in `cycle`, and reaping them
+    mid-run would hand their focus away. `duty` is never touched.
+
+    Per-agent isolated: one failed transition never blocks the rest.
+    """
+    reaped = 0
+    for agent in await state.list_states(mode=_CYCLE_OWNER_TYPE):
+        try:
+            outcome = await coordinator.request_transition(
+                agent.agent_id,
+                "ambient",
+                reasons.MODE_STRANDED_AT_STARTUP,
+                requester_kind="coordinator",
+                owner_ref=reasons.MODE_STRANDED_AT_STARTUP,
+            )
+        except Exception:
+            logger.warning(
+                "best-effort ambient transition for stranded cycle mode failed (agent=%s)",
+                agent.agent_id,
+                exc_info=True,
+            )
+            continue
+        if getattr(outcome, "applied", False):
+            reaped += 1
+            logger.info("returned agent %s from a stranded cycle mode to ambient", agent.agent_id)
+        else:
+            logger.warning(
+                "agent %s stayed in cycle mode (reason=%s)",
+                agent.agent_id,
+                getattr(outcome, "rejected_reason", None),
+            )
     return reaped
 
 

--- a/src/squadops/runtime/reasons.py
+++ b/src/squadops/runtime/reasons.py
@@ -48,11 +48,15 @@ FOCUS_LEASE_QUEUEING_NOT_SUPPORTED: Final[str] = "focus_lease_queueing_not_suppo
 # Stranded-lease hygiene (#373/#529). A cancelled or abnormally-terminated run
 # leaves its cycle leases held with no expiry, and #288 turns that into a hard
 # reject for every later recruitment of those agents. The cancel sweep and the
-# startup reaper (`runtime.lease_reaper`) return the agent to ambient, which
+# startup reaper (`runtime.focus_reaper`) return the agent to ambient, which
 # releases the lease; these are the reasons those transitions carry.
 LEASE_STRANDED_AT_CANCEL: Final[str] = "lease_stranded_at_cancel"
 LEASE_STRANDED_AT_RUN_FINALIZE: Final[str] = "lease_stranded_at_run_finalize"
 LEASE_STRANDED_AT_STARTUP: Final[str] = "lease_stranded_at_startup"
+# #710: the other half — an agent left in `cycle` mode with NO lease. A lease
+# sweep iterates held leases, so it cannot reach this; the mode has to be swept
+# on its own or recruitment silently idempotent-skips forever.
+MODE_STRANDED_AT_STARTUP: Final[str] = "mode_stranded_at_startup"
 
 # Runtime-activity reasons (Phase 4 §4.4/§4.5)
 ACTIVITY_STARTED: Final[str] = "activity_started"

--- a/tests/unit/api/test_startup_reaps.py
+++ b/tests/unit/api/test_startup_reaps.py
@@ -1,6 +1,6 @@
-"""Tests for the composition root's startup hygiene sweeps (#373, #672).
+"""Tests for the composition root's startup hygiene sweeps (#373, #710, #672).
 
-`startup_reaps` owns the two things `main.py` used to inline: the wiring gate
+`startup_reaps` owns the three things `main.py` used to inline: the wiring gate
 and the "is the owner finished?" predicate. Both are where the silent-no-op bugs
 live, so both are tested here rather than through the domain reapers.
 
@@ -23,7 +23,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from squadops.api.runtime.startup_reaps import reap_stranded_activities, reap_stranded_leases
+from squadops.api.runtime.startup_reaps import (
+    reap_stranded_activities,
+    reap_stranded_leases,
+    reap_stranded_modes,
+)
 from squadops.cycles.models import CycleNotFoundError, Run, RunNotFoundError, RunStatus
 from squadops.runtime.models import FocusLease, RuntimeActivity
 
@@ -159,6 +163,40 @@ async def test_lease_reap_failure_never_blocks_startup():
     registry = AsyncMock()
 
     assert await reap_stranded_leases(registry, coordinator, port) == 0
+
+
+# ---------------------------------------------------------------------------
+# reap_stranded_modes (#710)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("coordinator", "state_port"),
+    [(None, AsyncMock()), (AsyncMock(), None), (None, None)],
+    ids=["no-coordinator", "no-state-port", "neither"],
+)
+async def test_mode_reap_is_a_noop_without_wiring(coordinator, state_port):
+    assert await reap_stranded_modes(coordinator, state_port) == 0
+
+
+async def test_mode_reap_asks_only_for_cycle_agents():
+    """Narrowed in SQL, not in Python: `duty` must never be enumerated by a sweep
+    that unconditionally sends everything it finds to ambient."""
+    coordinator = AsyncMock()
+    state_port = AsyncMock()
+    state_port.list_states.return_value = ()
+
+    await reap_stranded_modes(coordinator, state_port)
+
+    state_port.list_states.assert_awaited_once_with(mode="cycle")
+
+
+async def test_mode_reap_failure_never_blocks_startup():
+    coordinator = AsyncMock()
+    state_port = AsyncMock()
+    state_port.list_states.side_effect = RuntimeError("db down")
+
+    assert await reap_stranded_modes(coordinator, state_port) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -956,7 +956,7 @@ class TestRunCompletionActivityWiring:
         """Same silent-no-op class for #373: the composition root builds the
         executor through `create_flow_executor`, so a kwarg the factory drops
         leaves the finalize stranded-lease sweep permanently inert — with every
-        lease_reaper unit test still green."""
+        focus_reaper unit test still green."""
         from unittest.mock import AsyncMock
 
         from adapters.cycles.factory import create_flow_executor

--- a/tests/unit/runtime/test_coordinator.py
+++ b/tests/unit/runtime/test_coordinator.py
@@ -55,6 +55,12 @@ class _FakeStatePort(RuntimeStatePort):
     async def get_state(self, agent_id):
         return self._rows.get(agent_id)
 
+    async def list_states(self, *, mode=None, conn=None):
+        rows = list(self._rows.values())
+        if mode is not None:
+            rows = [r for r in rows if r.mode == mode]
+        return tuple(sorted(rows, key=lambda r: r.agent_id))
+
     async def upsert_state(self, state, *, conn=None):
         self._rows[state.agent_id] = state
         self.upserts.append(state)

--- a/tests/unit/runtime/test_coordinator_with_activity.py
+++ b/tests/unit/runtime/test_coordinator_with_activity.py
@@ -63,6 +63,12 @@ class _FakeStatePort(RuntimeStatePort):
     async def get_state(self, agent_id):
         return self._rows.get(agent_id)
 
+    async def list_states(self, *, mode=None, conn=None):
+        rows = list(self._rows.values())
+        if mode is not None:
+            rows = [r for r in rows if r.mode == mode]
+        return tuple(sorted(rows, key=lambda r: r.agent_id))
+
     async def upsert_state(self, state, *, conn=None):
         self._rows[state.agent_id] = state
         self.upserts.append(state)

--- a/tests/unit/runtime/test_coordinator_with_lease.py
+++ b/tests/unit/runtime/test_coordinator_with_lease.py
@@ -61,6 +61,12 @@ class _FakeStatePort(RuntimeStatePort):
     async def get_state(self, agent_id):
         return self._rows.get(agent_id)
 
+    async def list_states(self, *, mode=None, conn=None):
+        rows = list(self._rows.values())
+        if mode is not None:
+            rows = [r for r in rows if r.mode == mode]
+        return tuple(sorted(rows, key=lambda r: r.agent_id))
+
     async def upsert_state(self, state, *, conn=None):
         if self.fail_upsert:
             raise RuntimeError("simulated mode-write failure")

--- a/tests/unit/runtime/test_focus_reaper.py
+++ b/tests/unit/runtime/test_focus_reaper.py
@@ -1,4 +1,4 @@
-"""Tests for the stranded-lease sweeps (#373/#529 — `runtime.lease_reaper`).
+"""Tests for the stranded-focus sweeps (#373/#529/#710 — `runtime.focus_reaper`).
 
 Bug classes guarded:
 - the startup reaper releasing a lease whose owning run is still live — would
@@ -17,7 +17,10 @@ Bug classes guarded:
 - the cancel sweep reaching beyond its own owner and releasing a concurrent
   run's leases;
 - counting attempted rather than actually-cleared rows, and stealing a slot a
-  new owner re-acquired mid-sweep.
+  new owner re-acquired mid-sweep;
+- the inverse residue (#710): `cycle` mode with NO lease, which a lease sweep
+  structurally cannot see. Left unswept it disables focus arbitration outright
+  and does so silently — measured at 64 cycles over two weeks on the dev box.
 """
 
 from __future__ import annotations
@@ -28,8 +31,13 @@ import pytest
 
 from squadops.ports.runtime.focus_lease import FocusLeasePort
 from squadops.runtime import reasons
-from squadops.runtime.lease_reaper import reap_stale_leases, release_owner_leases
-from squadops.runtime.models import FocusLease
+from squadops.runtime.coordinator import TransitionOutcome
+from squadops.runtime.focus_reaper import (
+    reap_stale_leases,
+    reap_stranded_cycle_modes,
+    release_owner_leases,
+)
+from squadops.runtime.models import AgentRuntimeState, FocusLease
 
 pytestmark = [pytest.mark.domain_runtime]
 
@@ -124,16 +132,60 @@ class _FakeCoordinator:
         if agent_id in self._raises_for:
             raise RuntimeError("coordinator down")
         self.transitions.append((agent_id, target_mode, reason_code))
-        if self._modes.get(agent_id, "cycle") == target_mode:
-            return None  # same-mode idempotent skip: the lease is left held
+        current = self._modes.get(agent_id, "cycle")
+        if current == target_mode:
+            # Same-mode idempotent skip: never reaches lease arbitration, so a
+            # held lease stays held and a stranded mode stays stranded.
+            return TransitionOutcome(
+                applied=False,
+                agent_id=agent_id,
+                from_mode=current,
+                to_mode=target_mode,
+                reason_code=reason_code,
+                idempotent_skip=True,
+            )
         self._modes[agent_id] = target_mode
         held = await self._store.get_current_lease(agent_id)
         if held is not None:
             await self._store.release_lease(held.lease_id, reasons.FOCUS_LEASE_RELEASED)
-        return None
+        return TransitionOutcome(
+            applied=True,
+            agent_id=agent_id,
+            from_mode=current,
+            to_mode=target_mode,
+            reason_code=reason_code,
+        )
 
     def mode_of(self, agent_id: str) -> str:
         return self._modes.get(agent_id, "cycle")
+
+
+class _FakeStates:
+    """Minimal `RuntimeStatePort` listing surface for the mode sweep."""
+
+    def __init__(self, modes: dict[str, str], *, raises: bool = False) -> None:
+        self._modes = modes
+        self._raises = raises
+
+    async def list_states(self, *, mode=None, conn=None):
+        if self._raises:
+            raise RuntimeError("db down")
+        rows = [
+            AgentRuntimeState(
+                agent_id=agent_id,
+                mode=agent_mode,
+                runtime_status="online",
+                focus="",
+                current_runtime_activity_id=None,
+                interruptibility="high",
+                last_heartbeat_at=NOW,
+                current_assignment_ref=None,
+            )
+            for agent_id, agent_mode in sorted(self._modes.items())
+        ]
+        if mode is not None:
+            rows = [r for r in rows if r.mode == mode]
+        return tuple(rows)
 
 
 def _terminal_only(terminal_runs: set[str], *, raises_for: set[str] | None = None):
@@ -390,3 +442,88 @@ async def test_release_owner_leases_on_an_owner_holding_nothing_is_a_noop():
     assert released == 0
     assert coordinator.transitions == []
     assert store.released == []
+
+
+# ---------------------------------------------------------------------------
+# reap_stranded_cycle_modes (#710 — the half a lease sweep cannot reach)
+# ---------------------------------------------------------------------------
+
+
+async def test_stranded_cycle_modes_return_to_ambient():
+    """The measured production state: agents in `cycle` with NO lease. A lease
+    sweep iterates held leases, so it sees nothing and the mode survives —
+    which is why recruitment idempotent-skipped for 64 cycles and focus
+    arbitration was off entirely."""
+    store = _FakeLeaseStore()
+    coordinator = _FakeCoordinator(store, {"max": "cycle", "neo": "cycle", "eve": "ambient"})
+    states = _FakeStates({"max": "cycle", "neo": "cycle", "eve": "ambient"})
+
+    assert (
+        await reap_stale_leases(
+            coordinator,
+            store,
+            owner_is_finished=_terminal_only(set()),
+            reason_code=reasons.LEASE_STRANDED_AT_STARTUP,
+        )
+        == 0
+    )  # the lease sweep is structurally blind to this residue
+
+    reaped = await reap_stranded_cycle_modes(coordinator, states)
+
+    assert reaped == 2
+    assert coordinator.mode_of("max") == "ambient"
+    assert coordinator.mode_of("neo") == "ambient"
+    assert [t[2] for t in coordinator.transitions] == [reasons.MODE_STRANDED_AT_STARTUP] * 2
+
+
+async def test_ambient_and_duty_agents_are_not_touched():
+    """`duty` may legitimately be mid-window with the scheduler about to
+    re-evaluate, and `ambient` is already the target — reaping either would take
+    focus from an agent that holds it for a reason."""
+    store = _FakeLeaseStore()
+    coordinator = _FakeCoordinator(store, {"eve": "ambient", "nat": "duty"})
+    states = _FakeStates({"eve": "ambient", "nat": "duty"})
+
+    reaped = await reap_stranded_cycle_modes(coordinator, states)
+
+    assert reaped == 0
+    assert coordinator.transitions == []
+    assert coordinator.mode_of("nat") == "duty"
+
+
+async def test_a_failed_transition_skips_only_that_agent():
+    store = _FakeLeaseStore()
+    coordinator = _FakeCoordinator(
+        store, {"max": "cycle", "neo": "cycle"}, raises_for=frozenset({"max"})
+    )
+    states = _FakeStates({"max": "cycle", "neo": "cycle"})
+
+    reaped = await reap_stranded_cycle_modes(coordinator, states)
+
+    assert reaped == 1
+    assert coordinator.mode_of("max") == "cycle"  # untouched
+    assert coordinator.mode_of("neo") == "ambient"
+
+
+async def test_a_rejected_transition_is_not_counted():
+    """Counting attempts rather than applied transitions would report the box
+    healed when it was not — the reap total is the operator's only signal."""
+    store = _FakeLeaseStore()
+    # Coordinator believes the agent is already ambient, so its request is a
+    # same-mode idempotent skip: reported, not applied.
+    coordinator = _FakeCoordinator(store, {"max": "ambient"})
+    states = _FakeStates({"max": "cycle"})
+
+    reaped = await reap_stranded_cycle_modes(coordinator, states)
+
+    assert reaped == 0
+    assert coordinator.transitions == [("max", "ambient", reasons.MODE_STRANDED_AT_STARTUP)]
+
+
+async def test_nothing_stranded_is_a_noop():
+    store = _FakeLeaseStore()
+    coordinator = _FakeCoordinator(store, {})
+    states = _FakeStates({"eve": "ambient", "max": "ambient"})
+
+    assert await reap_stranded_cycle_modes(coordinator, states) == 0
+    assert coordinator.transitions == []

--- a/tests/unit/runtime/test_scheduler.py
+++ b/tests/unit/runtime/test_scheduler.py
@@ -104,6 +104,12 @@ class _FakeStatePort(RuntimeStatePort):
     async def get_state(self, agent_id):
         return self._row
 
+    async def list_states(self, *, mode=None, conn=None):
+        rows = list([self._row] if self._row is not None else [])
+        if mode is not None:
+            rows = [r for r in rows if r.mode == mode]
+        return tuple(sorted(rows, key=lambda r: r.agent_id))
+
     async def upsert_state(self, state, *, conn=None):
         self._row = state
         self.upserts.append(state)


### PR DESCRIPTION
Sixth fix of the **1.4.3** line, added after the pre-deploy state capture turned up a blocker for the window's own verification.

## What the box was actually doing

```
 agent_id   |  mode   |          focus_leases where released_at is null: 0
------------+---------+          most recent lease row of any kind: released 2026-07-21
 bob        | cycle   |          cycles created since then: 64
 data       | cycle   |          focus_lease / mode-transition log lines in those cycles: 0
 eve        | cycle   |
 max        | cycle   |
 nat        | cycle   |
 neo        | cycle   |
 comms-agent| ambient |
```

Sixty-four cycles over two weeks — **including shk-3, the green 1.4.2 confirmation roll** — and not one acquired a focus lease. SIP-0089 focus arbitration has been inert, and with it #288's protection against two cycles sharing an agent.

## Why it never surfaced

Every step is individually correct, and the loop is silent:

1. An agent is left in `mode = cycle` with no held lease.
2. Recruitment calls `request_transition(agent, "cycle", …)`. `current == target_mode`, so it takes the #288 same-mode branch (`coordinator.py:235`), reads `get_current_lease` → `None`, finds nothing to conflict with, returns `idempotent_skip`.
3. `admit_participants` treats that as admitted but — correctly — does **not** add the agent to `recruited_agent_ids`.
4. Nothing acquired, so finalize releases nothing and the mode stays `cycle`. Back to 1, forever.

The same-mode branch emits no event; admission logs nothing on a skip. No test could have caught it either — every unit under it behaves correctly in isolation. Same discovery shape as #689's qa-boundary gap on shk-3: found by looking at what actually happened, not by the suite.

## Why it blocks the deploy window

The 1.4.3 **cancel probe** asserts zero unreleased leases after a mid-implementation cancel. On this box that passes trivially, because zero leases are ever acquired. #373/#529/#561 would have shipped reported-verified and actually unverified — precisely the false-green class this release line exists to close.

And the #373 reaper cannot clear it. `reap_stale_leases` iterates **held leases**; with none held it has nothing to iterate and the modes survive. #373's own documented recovery SQL has two statements for exactly this reason — one for `focus_leases`, one for `agent_runtime_state` — and what shipped only performs the second as a side effect of the first.

## The fix

A third startup sweep, on the same justification as the other two: nothing dispatches in a process that has not begun serving, so no agent can legitimately hold cycle focus yet. It runs *after* the lease sweep, so what it sees is the residue with no lease at all.

- `RuntimeStatePort.list_states(mode=…)` — the port exposed only `get_state(agent_id)`, the same gap `list_active_leases` filled for #373. An agent stranded by a dead process is one nobody thought to ask about, so a per-agent read cannot find it. Narrowed in SQL.
- `duty` is never swept — a duty agent may be legitimately mid-window with the scheduler about to re-evaluate, and duty leases key to assignments rather than runs.
- Counts *applied* transitions, not attempts: the reap total is the operator's only signal that the box healed, so a rejected transition must not inflate it.

## Rename

`runtime/lease_reaper.py` → `runtime/focus_reaper.py`. An agent's focus is two coupled facts — the `FocusLease` and the `RuntimeMode` that rides with it, written atomically since #244/D25 — and the module now sweeps both. Naming it for one half is a fair part of why the other half went unnoticed for two weeks. Mechanical: 4 import sites plus the test module.

## Likely origin

Probably historical residue rather than something current code reproduces: since #244/D25 the coordinator writes mode and lease inside one `RuntimeTransactionPort.begin()` in both directions, so `cycle` with no lease should no longer be reachable through the normal path. That is a hypothesis, not a proof — and a state that cannot be *created* is still worth being able to *clear*, especially one this quiet.

## Verification

- 8 new tests. The headline one asserts the lease sweep returns **0** on this exact state before showing the mode sweep clears it — the structural blindness, pinned.
- Also covered: `duty`/`ambient` untouched; per-agent isolation on a failed transition; a rejected transition not counted; `list_states` called with `mode="cycle"` so `duty` is never even enumerated; all three wiring-gate permutations; a port failure never blocking startup.
- Four existing `_FakeStatePort` doubles gained `list_states`, and `_FakeCoordinator` now returns a real `TransitionOutcome` instead of `None` — which makes the existing lease tests more faithful too.
- Full regression: **6172 passed, 1 skipped**.
- **Hash-stable**: no contract or manifest surface touched.

Live proof arrives at the deploy: the first runtime-api boot should log the mode reap clearing 6 agents, after which a launched cycle acquires real leases and the cancel probe becomes meaningful.

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
