### PR TITLE
fix(runtime): owner-check the lease release on ambient entry (#712)

### DIFF
--- a/src/squadops/api/runtime/startup_reaps.py
+++ b/src/squadops/api/runtime/startup_reaps.py
@@ -85,8 +85,8 @@ async def reap_stranded_leases(
             if RunStatus(owning_run.status) not in TERMINAL_STATES:
                 logger.warning(
                     "Releasing focus lease held by run %s still marked %r — no run "
-                    "can be executing at startup, so its executor died mid-run and "
-                    "the run status is stale.",
+                    "can be executing at startup, so its owning process exited "
+                    "without finalizing it and the run status is stale.",
                     run_id,
                     owning_run.status,
                 )

--- a/src/squadops/runtime/coordinator.py
+++ b/src/squadops/runtime/coordinator.py
@@ -430,6 +430,15 @@ class RuntimeCoordinator:
         Never writes `mode` (lease ≠ mode). All reads/writes run on the caller's
         unit-of-work `conn` (§4.5/D25) so they roll back with the transition on a
         later failure. Resolution by case:
+        - entering ambient with the leaving-mode lease held by a DIFFERENT owner
+          → not ok (#712). Release is owner-checked, symmetric with #288's
+          owner-checked acquire: a cancelled run's finalize fires only at its
+          next dispatch boundary, which can be minutes after the cancel route
+          already released its leases — and a relaunched run may have
+          re-recruited the agent in between. Without this check the stale
+          finalize would flip the agent to ambient and release the NEW run's
+          lease, leaving that run to execute with no focus protection (the #288
+          double-booking hole, reopened silently);
         - entering ambient → no acquire; defer releasing the leaving-mode lease
           to after the mode write;
         - entering cycle/duty with no conflict → acquire (`granted`);
@@ -448,6 +457,14 @@ class RuntimeCoordinator:
         holds_leaving_lease = old_lease is not None and old_lease.owner_type == leaving_owner
 
         if new_owner is None:
+            # (#712) the owner check. Only the lease's owner may release it by
+            # leaving the mode; a mismatched caller is a stale finalize whose
+            # focus was already handed to someone else. No lease means nothing
+            # to protect (the #710 stranded-mode sweep relies on that path).
+            if holds_leaving_lease and old_lease is not None and old_lease.owner_ref != owner_ref:
+                return _LeaseArbitration(
+                    ok=False, rejected_reason=reasons.FOCUS_LEASE_HELD_BY_OTHER_OWNER
+                )
             return _LeaseArbitration(
                 ok=True,
                 release_after_lease_id=(old_lease.lease_id if holds_leaving_lease else None),

--- a/src/squadops/runtime/focus_reaper.py
+++ b/src/squadops/runtime/focus_reaper.py
@@ -78,6 +78,13 @@ logger = logging.getLogger(__name__)
 # assignment window, not a run, and `ambient` holds no lease in v1.1 (§10.4).
 _CYCLE_OWNER_TYPE: Final[str] = "cycle"
 
+# `owner_ref` for the #710 mode sweep's transitions: a stranded mode has no
+# owning run to name, and the field is required. Distinct from any run id, so
+# a reader of the MODE_TRANSITION payload sees the sweep, not a phantom owner.
+# The #712 owner check never consults it on this path — a stranded mode holds
+# no lease, so there is no owner to mismatch.
+STARTUP_REAP_OWNER_REF: Final[str] = "startup_reap"
+
 
 async def release_owner_leases(
     coordinator: RuntimeCoordinator,
@@ -171,7 +178,7 @@ async def reap_stranded_cycle_modes(
                 "ambient",
                 reasons.MODE_STRANDED_AT_STARTUP,
                 requester_kind="coordinator",
-                owner_ref=reasons.MODE_STRANDED_AT_STARTUP,
+                owner_ref=STARTUP_REAP_OWNER_REF,
             )
         except Exception:
             logger.warning(

--- a/src/squadops/runtime/reasons.py
+++ b/src/squadops/runtime/reasons.py
@@ -45,6 +45,11 @@ CURRENT_ACTIVITY_CANNOT_PAUSE: Final[str] = "current_activity_cannot_pause"
 AGENT_RUNTIME_STATUS_UNAVAILABLE: Final[str] = "agent_runtime_status_unavailable"
 # Deferred-queue rejection (§3.0/D20): a request that would have queued in v1.2.
 FOCUS_LEASE_QUEUEING_NOT_SUPPORTED: Final[str] = "focus_lease_queueing_not_supported_in_v1.1"
+# #712: release is owner-checked, symmetric with #288's owner-checked acquire.
+# A caller leaving a focus-bearing mode whose lease is now held by a DIFFERENT
+# owner (a cancelled run's finalize firing after a relaunch re-recruited the
+# agent) no longer owns that focus; the transition is refused with this reason.
+FOCUS_LEASE_HELD_BY_OTHER_OWNER: Final[str] = "focus_lease_held_by_other_owner"
 # Stranded-lease hygiene (#373/#529). A cancelled or abnormally-terminated run
 # leaves its cycle leases held with no expiry, and #288 turns that into a hard
 # reject for every later recruitment of those agents. The cancel sweep and the

--- a/tests/unit/api/test_startup_reaps.py
+++ b/tests/unit/api/test_startup_reaps.py
@@ -144,7 +144,7 @@ async def test_a_non_terminal_owner_is_logged_as_a_dead_executor(caplog):
         await reap_stranded_leases(registry, coordinator, port)
 
     assert "run_1" in caplog.text
-    assert "died mid-run" in caplog.text
+    assert "exited without finalizing" in caplog.text
 
 
 async def test_missing_run_row_still_releases_the_lease():

--- a/tests/unit/runtime/test_coordinator_with_lease.py
+++ b/tests/unit/runtime/test_coordinator_with_lease.py
@@ -294,6 +294,90 @@ async def test_duty_to_ambient_releases_lease_after_mode_write():
     assert events.FOCUS_LEASE_RELEASED in pub.names()
 
 
+async def test_ambient_entry_by_a_non_owner_is_refused_without_touching_focus():
+    """Bug class (#712): release must be owner-checked, symmetric with #288's
+    owner-checked acquire. A cancelled run's finalize fires at its next dispatch
+    boundary — minutes after the cancel route released its leases — and by then
+    a relaunched run may hold the agent. The stale caller must not flip the mode
+    or release the NEW owner's lease."""
+    state = _FakeStatePort(_state(mode="cycle"))
+    pub = _RecordingPublisher()
+    fl = _FakeFocusLease()
+    new_lease = fl.seed("max", "cycle", "run_new")
+    coord = RuntimeCoordinator(state, events_publisher=pub, focus_lease=fl)
+
+    outcome = await coord.request_transition(
+        "max", "ambient", reasons.CYCLE_COMPLETED, requester_kind="external", owner_ref="run_old"
+    )
+
+    assert outcome.applied is False
+    assert outcome.rejected_reason == reasons.FOCUS_LEASE_HELD_BY_OTHER_OWNER
+    assert state.upserts == []  # mode never written
+    held = await fl.get_current_lease("max")
+    assert held is not None and held.lease_id == new_lease.lease_id  # lease intact
+    assert new_lease.lease_id not in fl.released
+    assert events.MODE_TRANSITION not in pub.names()
+    assert pub.reason_for(events.FOCUS_LEASE_REJECTED) == reasons.FOCUS_LEASE_HELD_BY_OTHER_OWNER
+
+
+async def test_stale_cancel_finalize_cannot_strip_a_relaunched_runs_focus():
+    """The full #712 sequence: recruit → cancel-sweep release → relaunch
+    re-recruits → the cancelled run's finalize fires late. The relaunched run
+    must come out still holding both the mode and its lease."""
+    state = _FakeStatePort(_state(mode="ambient"))
+    pub = _RecordingPublisher()
+    fl = _FakeFocusLease()
+    coord = RuntimeCoordinator(state, events_publisher=pub, focus_lease=fl)
+
+    # Old run recruits, then the cancel route returns the agent to ambient.
+    await coord.request_transition(
+        "max", "cycle", reasons.CYCLE_RECRUITED, requester_kind="external", owner_ref="run_old"
+    )
+    await coord.request_transition(
+        "max",
+        "ambient",
+        reasons.LEASE_STRANDED_AT_CANCEL,
+        requester_kind="coordinator",
+        owner_ref="run_old",
+    )
+    # Relaunch: a new run recruits the same agent.
+    await coord.request_transition(
+        "max", "cycle", reasons.CYCLE_RECRUITED, requester_kind="external", owner_ref="run_new"
+    )
+    # The cancelled run's executor finally unwinds and releases its participants.
+    stale = await coord.request_transition(
+        "max", "ambient", reasons.CYCLE_COMPLETED, requester_kind="external", owner_ref="run_old"
+    )
+
+    assert stale.applied is False
+    assert stale.rejected_reason == reasons.FOCUS_LEASE_HELD_BY_OTHER_OWNER
+    assert state.upserts[-1].mode == "cycle"  # the relaunched run keeps the agent
+    held = await fl.get_current_lease("max")
+    assert held is not None and held.owner_ref == "run_new"
+
+
+async def test_ambient_entry_with_no_lease_still_writes_mode():
+    """The #710 stranded-mode sweep path: `cycle` with NO lease must still reach
+    ambient — an owner check that fired with nothing held would re-strand the
+    exact residue the sweep exists to clear."""
+    state = _FakeStatePort(_state(mode="cycle"))
+    pub = _RecordingPublisher()
+    fl = _FakeFocusLease()
+    coord = RuntimeCoordinator(state, events_publisher=pub, focus_lease=fl)
+
+    outcome = await coord.request_transition(
+        "max",
+        "ambient",
+        reasons.MODE_STRANDED_AT_STARTUP,
+        requester_kind="coordinator",
+        owner_ref="startup_reap",
+    )
+
+    assert outcome.applied is True
+    assert state.upserts[-1].mode == "ambient"
+    assert fl.released == []  # nothing held, nothing released
+
+
 # ---------------------------------------------------------------------------
 # lease ≠ mode + rollback (the load-bearing regression)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fix 7 of the **1.4.3** line — the F1 finding from the pre-deploy code review, fixed before the rebuild so the cancel probe proves what it claims to.

## The race

The #529 fix makes cancel→relaunch possible, and thereby exposes a hole underneath it: **the coordinator's ambient-entry path releases whatever leaving-mode lease the agent holds without checking who owns it** (`coordinator.py` `_arbitrate_lease`, ambient branch — `holds_leaving_lease` compares `owner_type` only, never `owner_ref`).

Cancel detection is a dispatch-boundary registry poll (`dispatched_flow_executor.py:3052`), so a cancelled run's executor keeps unwinding until its in-flight task replies — which can be minutes. Sequence:

1. Cancel route releases the run's leases, agents → ambient *(intended)*.
2. Operator relaunches; the new cycle recruits the same agents — new leases, `owner_ref = new_run` *(intended)*.
3. The old executor's in-flight task replies → `_CancellationError` → `finally:` → `release_participants(recruited_agent_ids, owner_ref=old_run)`.
4. The coordinator flips the agent to ambient and **releases the new run's lease**.

The relaunched run then executes with no focus protection — a third cycle can double-book its agents (the #288 hole reopened), the duty scheduler could pull one via a legal `ambient → duty`, and #561's self-heal would let an interloper supersede the live activity. All silent. Pre-1.4.3 the race was unreachable only because cancel never released leases: the deadlock #529 complains about was an accidental guard. The 1.4.3 cancel probe — cancel, relaunch immediately — constructs exactly this window, which is why this ships before the rebuild rather than after.

## The fix

The symmetric half of #288: **acquire is owner-checked, release now is too.** Entering ambient while the leaving-mode lease belongs to a different `owner_ref` is refused with the new typed reason `focus_lease_held_by_other_owner` — no mode write, no release — and surfaces through the existing `FOCUS_LEASE_REJECTED` event, so a stale finalize is *visible* in the event stream instead of silently stealing.

Checked against every ambient-entry call site:

| Caller | owner_ref vs held lease | Result |
|---|---|---|
| Normal run finalize (`release_participants`) | match | proceeds, unchanged |
| Stale cancelled-run finalize | **mismatch** | **refused — the fix** |
| Cancel-route sweep / startup lease reap (`_return_to_ambient`) | passes `lease.owner_ref`, match by construction | proceeds |
| #710 mode sweep | agent holds **no** lease → guard bypassed | proceeds |
| Scheduler duty-close | assignment id the lease was acquired under, match | proceeds |
| Partial-admission rollback | just-recruited, match | proceeds |

## Riders from the same review

- **F2**: the #710 mode sweep passed `reasons.MODE_STRANDED_AT_STARTUP` — a reason-code string — as `owner_ref`. Now a proper `STARTUP_REAP_OWNER_REF` sentinel; owner_ref semantics are load-bearing with this guard in place.
- **F3**: the startup lease reap's log claimed "its executor died mid-run" even for a run that was still `queued`; reworded.

## Verification

- 3 new coordinator tests: the direct refusal (mode unwritten, lease intact, `FOCUS_LEASE_REJECTED` carries the new reason); the **full four-step stale-finalize narrative** ending with the relaunched run still holding both mode and lease; and the #710 no-lease path still transitioning — the guard must not re-strand what the mode sweep exists to clear.
- Existing owner-matched tests (`duty-1`/`duty-1` etc.) pass untouched — the guard is invisible to every legitimate caller.
- Full regression: **6175 passed, 1 skipped**.
- **Hash-stable**: no contract or manifest surface touched; no migrations.

With this merged, the review's findings are all resolved or placed: F1 fixed here, F2/F3 ride along, F4 was a no-op (additive response keys), F5 (plan-doc amendments) rides the bump PR, #707 filed to 1.5. Next: rebuild + deploy, verify-LOADED, seed check, **cancel probe**, shakedown, bump.

Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
