### PR TITLE
fix(runs): persist the terminal failure reason on the run row (#427)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -470,7 +470,9 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # former per-class handlers).
             outcome = resolve_terminal_outcome(exc, run_id)
             terminal_status = outcome.terminal_status
-            await self._safe_transition(run_id, outcome.run_status)
+            await self._safe_transition(
+                run_id, outcome.run_status, failure_reason=outcome.failure_reason
+            )
             self._cycle_event_bus.emit(
                 outcome.event_type,
                 entity_type="run",
@@ -3143,10 +3145,14 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             logger.warning("Failed to resolve PRD for project %s", project_id, exc_info=True)
             return None
 
-    async def _safe_transition(self, run_id: str, status: RunStatus) -> None:
+    async def _safe_transition(
+        self, run_id: str, status: RunStatus, *, failure_reason: str | None = None
+    ) -> None:
         """Attempt status transition, logging but not raising on failure."""
         try:
-            await self._cycle_registry.update_run_status(run_id, status)
+            await self._cycle_registry.update_run_status(
+                run_id, status, failure_reason=failure_reason
+            )
         except Exception:
             logger.warning(
                 "Failed to transition run %s to %s",

--- a/adapters/cycles/in_process_flow_executor.py
+++ b/adapters/cycles/in_process_flow_executor.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from adapters.cycles.execution_errors import _CancellationError, _ExecutionError
+from adapters.cycles.run_completion import failure_reason_text
 from squadops.cycles.models import ArtifactRef, Cycle, RunStatus
 from squadops.cycles.task_plan import generate_task_plan
 from squadops.ports.cycles.flow_execution import FlowExecutionPort
@@ -111,11 +112,17 @@ class InProcessFlowExecutor(FlowExecutionPort):
             logger.info("Run %s cancelled", run_id)
 
         except _ExecutionError as exc:
-            await self._safe_transition(run_id, RunStatus.FAILED)
+            await self._safe_transition(
+                run_id,
+                RunStatus.FAILED,
+                failure_reason=failure_reason_text(exc, include_type=False),
+            )
             logger.error("Run %s failed: %s", run_id, exc)
 
         except Exception as exc:
-            await self._safe_transition(run_id, RunStatus.FAILED)
+            await self._safe_transition(
+                run_id, RunStatus.FAILED, failure_reason=failure_reason_text(exc)
+            )
             logger.exception("Run %s failed with unexpected error: %s", run_id, exc)
 
     async def cancel_run(self, run_id: str) -> None:
@@ -321,10 +328,14 @@ class InProcessFlowExecutor(FlowExecutionPort):
             logger.warning("Failed to resolve PRD for project %s", project_id, exc_info=True)
             return None
 
-    async def _safe_transition(self, run_id: str, status: RunStatus) -> None:
+    async def _safe_transition(
+        self, run_id: str, status: RunStatus, *, failure_reason: str | None = None
+    ) -> None:
         """Attempt status transition, logging but not raising on failure."""
         try:
-            await self._cycle_registry.update_run_status(run_id, status)
+            await self._cycle_registry.update_run_status(
+                run_id, status, failure_reason=failure_reason
+            )
         except Exception:
             logger.warning(
                 "Failed to transition run %s to %s",

--- a/adapters/cycles/memory_cycle_registry.py
+++ b/adapters/cycles/memory_cycle_registry.py
@@ -117,12 +117,17 @@ class MemoryCycleRegistry(CycleRegistryPort):
             results = [r for r in results if r.workload_type == workload_type]
         return results[offset : offset + limit]
 
-    async def update_run_status(self, run_id: str, status: RunStatus) -> Run:
+    async def update_run_status(
+        self, run_id: str, status: RunStatus, *, failure_reason: str | None = None
+    ) -> Run:
         if run_id not in self._runs:
             raise RunNotFoundError(f"Run not found: {run_id}")
         data = self._runs[run_id]
         validate_run_transition(RunStatus(data["status"]), status)
         data["status"] = status.value
+        # #427: reason rides the terminal transition; never null out a recorded one.
+        if status in TERMINAL_STATES and failure_reason is not None:
+            data["failure_reason"] = failure_reason
         return self._to_run(data)
 
     async def cancel_run(self, run_id: str) -> None:

--- a/adapters/cycles/postgres_cycle_registry.py
+++ b/adapters/cycles/postgres_cycle_registry.py
@@ -227,7 +227,9 @@ class PostgresCycleRegistry(CycleRegistryPort):
 
         return [self._assemble_run(r, gates_by_run.get(r["run_id"], [])) for r in run_rows]
 
-    async def update_run_status(self, run_id: str, status: RunStatus) -> Run:
+    async def update_run_status(
+        self, run_id: str, status: RunStatus, *, failure_reason: str | None = None
+    ) -> Run:
         async with self._pool.acquire() as conn:
             row = await conn.fetchrow("SELECT status FROM cycle_runs WHERE run_id = $1", run_id)
             if row is None:
@@ -246,12 +248,17 @@ class PostgresCycleRegistry(CycleRegistryPort):
                     run_id,
                 )
             elif status in TERMINAL_STATES:
+                # #427: the reason commits with the terminal status. COALESCE on
+                # the value side so a later reason-less transition attempt never
+                # nulls out a recorded reason.
                 await conn.execute(
                     "UPDATE cycle_runs SET status = $1, "
-                    "finished_at = COALESCE(finished_at, now()) "
+                    "finished_at = COALESCE(finished_at, now()), "
+                    "failure_reason = COALESCE($3, failure_reason) "
                     "WHERE run_id = $2",
                     status.value,
                     run_id,
+                    failure_reason,
                 )
             else:
                 await conn.execute(
@@ -534,6 +541,7 @@ class PostgresCycleRegistry(CycleRegistryPort):
             gate_decisions=gate_decisions,
             artifact_refs=tuple(row["artifact_refs"] or []),
             workload_type=row.get("workload_type"),
+            failure_reason=row.get("failure_reason"),
         )
 
     def _row_to_checkpoint(self, row: asyncpg.Record) -> RunCheckpoint:

--- a/adapters/cycles/run_completion.py
+++ b/adapters/cycles/run_completion.py
@@ -68,6 +68,9 @@ class TerminalOutcome:
     event_payload: dict[str, Any] | None
     log_kind: Literal["info", "error", "exception"]
     log_message: str
+    # #427: persisted on the run row with the terminal transition. Set only by
+    # the FAILED mappings — cancellation and pauses have their own affordances.
+    failure_reason: str | None = None
 
 
 def resolve_terminal_outcome(exc: BaseException, run_id: str) -> TerminalOutcome:
@@ -120,6 +123,7 @@ def resolve_terminal_outcome(exc: BaseException, run_id: str) -> TerminalOutcome
             event_payload={"error": str(exc)},
             log_kind="error",
             log_message=f"Run {run_id} failed: {exc}",
+            failure_reason=failure_reason_text(exc, include_type=False),
         )
     return TerminalOutcome(
         terminal_status="FAILED",
@@ -128,7 +132,29 @@ def resolve_terminal_outcome(exc: BaseException, run_id: str) -> TerminalOutcome
         event_payload={"error": str(exc)},
         log_kind="exception",
         log_message=f"Run {run_id} failed with unexpected error: {exc}",
+        failure_reason=failure_reason_text(exc),
     )
+
+
+# Bound so a pathological exception message cannot bloat the run row; the full
+# text is still in the RUN_FAILED payload and the executor log line.
+_FAILURE_REASON_MAX_CHARS = 2000
+
+
+def failure_reason_text(exc: BaseException, *, include_type: bool = True) -> str:
+    """The persisted reason, bounded (#427).
+
+    ``include_type=False`` for the internal ``_ExecutionError`` wrapper, whose
+    class name is executor plumbing — its message alone is the diagnosis. For
+    unexpected exceptions the type name is the diagnosis (``KeyError: 'x'``).
+    """
+    if include_type:
+        text = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
+    else:
+        text = str(exc) or type(exc).__name__
+    if len(text) > _FAILURE_REASON_MAX_CHARS:
+        text = text[: _FAILURE_REASON_MAX_CHARS - 1] + "…"
+    return text
 
 
 def _stamp_behavioral_criteria(results: Any, contract: Any) -> Any:

--- a/infra/migrations/1010_run_failure_reason.sql
+++ b/infra/migrations/1010_run_failure_reason.sql
@@ -1,0 +1,9 @@
+-- 1010_run_failure_reason.sql
+-- #427 (1.4.4 fix 1): persist the terminal failure reason on the run row.
+-- A failed run's exception was recoverable nowhere — runs show gave a bare
+-- `status: failed` and the report pointed at task artifacts that may not exist
+-- (a pre-dispatch failure produces none). The finalize path already holds the
+-- exception; this column is where it lands. Nullable: only FAILED runs carry
+-- one, and only those failed after this migration.
+
+ALTER TABLE cycle_runs ADD COLUMN IF NOT EXISTS failure_reason TEXT;

--- a/src/squadops/api/routes/cycles/dtos.py
+++ b/src/squadops/api/routes/cycles/dtos.py
@@ -148,6 +148,7 @@ class RunResponse(BaseModel):
     gate_decisions: list[GateDecisionResponse] = Field(default_factory=list)
     artifact_refs: list[str] = Field(default_factory=list)
     workload_type: str | None = None
+    failure_reason: str | None = None
 
 
 class WorkloadProgressEntry(BaseModel):

--- a/src/squadops/api/routes/cycles/mapping.py
+++ b/src/squadops/api/routes/cycles/mapping.py
@@ -66,6 +66,7 @@ def run_to_response(run: Run) -> RunResponse:
         ],
         artifact_refs=list(run.artifact_refs),
         workload_type=run.workload_type,
+        failure_reason=run.failure_reason,
     )
 
 

--- a/src/squadops/cycles/models.py
+++ b/src/squadops/cycles/models.py
@@ -333,6 +333,9 @@ class Run:
     gate_decisions: tuple[GateDecision, ...] = ()
     artifact_refs: tuple[str, ...] = ()
     workload_type: str | None = None
+    # #427: why the run reached FAILED, written once at finalize alongside the
+    # terminal transition. None for non-failed runs and pre-1.4.4 history.
+    failure_reason: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/squadops/cycles/run_report_builder.py
+++ b/src/squadops/cycles/run_report_builder.py
@@ -44,6 +44,11 @@ def _build_report_metadata_lines(
         f"- **Run Number:** {run.run_number}",
         f"- **Status:** {terminal_status}",
     ]
+    # #427: the terminal exception, read off the run row finalize just wrote.
+    # Without it a pre-dispatch failure points readers at task artifacts that
+    # do not exist.
+    if getattr(run, "failure_reason", None):
+        lines.append(f"- **Failure Reason:** {run.failure_reason}")
     if cycle:
         lines.append(f"- **Project ID:** {cycle.project_id}")
         lines.append(f"- **Build Strategy:** {cycle.build_strategy}")

--- a/src/squadops/ports/cycles/cycle_registry.py
+++ b/src/squadops/ports/cycles/cycle_registry.py
@@ -80,8 +80,15 @@ class CycleRegistryPort(ABC):
         """List runs for a cycle, with optional workload_type filter and pagination."""
 
     @abstractmethod
-    async def update_run_status(self, run_id: str, status: RunStatus) -> Run:
+    async def update_run_status(
+        self, run_id: str, status: RunStatus, *, failure_reason: str | None = None
+    ) -> Run:
         """Transition a run to a new status.
+
+        ``failure_reason`` (#427) is persisted with the transition when given —
+        callers pass it on FAILED so the reason and the status commit together.
+        It is stored only on terminal transitions and never overwrites an
+        already-recorded reason with None.
 
         Raises:
             RunNotFoundError: If the run_id is not found.

--- a/tests/unit/api/test_cycle_dto_mapping.py
+++ b/tests/unit/api/test_cycle_dto_mapping.py
@@ -246,3 +246,25 @@ class TestCycleOutcomeInResponse:
         assert resp.cycle_outcome.required_unmet == ["required_files"]  # derived from unverified
         assert resp.cycle_outcome.unverified[0].check_id == "required_files"
         assert resp.cycle_outcome.unverified[0].required is True
+
+
+class TestRunToResponseFailureReason:
+    """#427: the reason must survive the DTO boundary — runs show renders
+    whatever the response carries, so a dropped field re-blinds the CLI."""
+
+    def test_failure_reason_carried(self):
+        import dataclasses
+
+        from squadops.api.routes.cycles.mapping import run_to_response
+
+        run = dataclasses.replace(
+            _make_run(status="failed"),
+            failure_reason="CycleError: build_profile is required",
+        )
+        resp = run_to_response(run)
+        assert resp.failure_reason == "CycleError: build_profile is required"
+
+    def test_absent_reason_serializes_none(self):
+        from squadops.api.routes.cycles.mapping import run_to_response
+
+        assert run_to_response(_make_run()).failure_reason is None

--- a/tests/unit/cycles/test_cycle_registry_contract.py
+++ b/tests/unit/cycles/test_cycle_registry_contract.py
@@ -406,3 +406,41 @@ class TestListRunVerificationSummaries:
 
     async def test_unknown_cycle_returns_empty(self, registry):
         assert await registry.list_run_verification_summaries("nope") == []
+
+
+# ---------------------------------------------------------------------------
+# #427: failure reason rides the terminal transition
+# ---------------------------------------------------------------------------
+
+
+async def test_failed_transition_persists_failure_reason(registry):
+    """The reason written with FAILED must round-trip on get_run — a dropped
+    write or unmapped read column would leave runs show blank again (#427)."""
+    await registry.create_run(_make_run())
+    await registry.update_run_status("run_001", RunStatus.RUNNING)
+
+    updated = await registry.update_run_status(
+        "run_001", RunStatus.FAILED, failure_reason="CycleError: build_profile is required"
+    )
+    assert updated.failure_reason == "CycleError: build_profile is required"
+
+    fetched = await registry.get_run("run_001")
+    assert fetched.failure_reason == "CycleError: build_profile is required"
+    assert fetched.status == RunStatus.FAILED.value
+
+
+async def test_non_terminal_transition_ignores_failure_reason(registry):
+    """A reason passed on a non-terminal transition must not stick — otherwise
+    a retried run would carry a stale reason while still RUNNING."""
+    await registry.create_run(_make_run())
+    updated = await registry.update_run_status(
+        "run_001", RunStatus.RUNNING, failure_reason="should not persist"
+    )
+    assert updated.failure_reason is None
+
+
+async def test_completed_run_has_no_failure_reason(registry):
+    await registry.create_run(_make_run())
+    await registry.update_run_status("run_001", RunStatus.RUNNING)
+    updated = await registry.update_run_status("run_001", RunStatus.COMPLETED)
+    assert updated.failure_reason is None

--- a/tests/unit/cycles/test_flow_executor.py
+++ b/tests/unit/cycles/test_flow_executor.py
@@ -48,7 +48,7 @@ def mock_registry():
         initiated_by="api",
         resolved_config_hash="hash",
     )
-    mock.update_run_status.side_effect = lambda run_id, status: Run(
+    mock.update_run_status.side_effect = lambda run_id, status, **kwargs: Run(
         run_id=run_id,
         cycle_id="cyc_001",
         run_number=1,
@@ -214,6 +214,12 @@ class TestFailFast:
         status_calls = mock_registry.update_run_status.call_args_list
         terminal_statuses = [c.args[1] for c in status_calls]
         assert RunStatus.FAILED in terminal_statuses
+
+        # #427: the FAILED transition carries the diagnosis — without it the
+        # run row is a black box again ("status: failed", reason nowhere).
+        failed_call = next(c for c in status_calls if c.args[1] == RunStatus.FAILED)
+        reason = failed_call.kwargs.get("failure_reason")
+        assert reason is not None and reason.startswith("Task ") and "failed: boom" in reason
 
     async def test_sequential_fail_fast_on_third_task(
         self, executor, mock_orchestrator, mock_registry

--- a/tests/unit/cycles/test_run_completion.py
+++ b/tests/unit/cycles/test_run_completion.py
@@ -745,3 +745,44 @@ class TestStrandedActivitySweep:
         await completion.finalize("cyc_001", "run_001", "COMPLETED", None, None)
 
         completion._cycle_registry.record_run_verification_summary.assert_awaited_once()
+
+
+class TestTerminalOutcomeFailureReason:
+    """#427: the FAILED mappings carry the persisted reason; others do not."""
+
+    def test_execution_error_reason_is_message_without_wrapper_type(self):
+        from adapters.cycles.execution_errors import _ExecutionError
+        from adapters.cycles.run_completion import resolve_terminal_outcome
+
+        outcome = resolve_terminal_outcome(
+            _ExecutionError("Max correction attempts (5) exhausted"), "run_x"
+        )
+        assert outcome.failure_reason == "Max correction attempts (5) exhausted"
+
+    def test_unexpected_error_reason_includes_type(self):
+        from adapters.cycles.run_completion import resolve_terminal_outcome
+
+        outcome = resolve_terminal_outcome(KeyError("build_profile"), "run_x")
+        assert outcome.failure_reason == "KeyError: 'build_profile'"
+
+    def test_cancellation_and_pause_carry_no_reason(self):
+        from adapters.cycles.execution_errors import _CancellationError, _PausedError
+        from adapters.cycles.run_completion import resolve_terminal_outcome
+
+        assert resolve_terminal_outcome(_CancellationError(), "run_x").failure_reason is None
+        assert resolve_terminal_outcome(_PausedError(), "run_x").failure_reason is None
+
+    def test_reason_is_bounded(self):
+        from adapters.cycles.run_completion import (
+            _FAILURE_REASON_MAX_CHARS,
+            failure_reason_text,
+        )
+
+        text = failure_reason_text(RuntimeError("x" * 10_000))
+        assert len(text) == _FAILURE_REASON_MAX_CHARS
+        assert text.endswith("…")
+
+    def test_messageless_exception_falls_back_to_type_name(self):
+        from adapters.cycles.run_completion import failure_reason_text
+
+        assert failure_reason_text(RuntimeError(), include_type=False) == "RuntimeError"

--- a/tests/unit/cycles/test_run_report_builder.py
+++ b/tests/unit/cycles/test_run_report_builder.py
@@ -106,3 +106,36 @@ def test_verification_lines_omit_coverage_when_no_criteria():
     )
     text = "\n".join(_build_verification_lines(summary))
     assert "Contract criteria" not in text
+
+
+class TestFailureReasonLine:
+    """#427: a failed run's report must carry the terminal reason — a
+    pre-dispatch failure has no task artifacts for the reader to check."""
+
+    @staticmethod
+    def _run(reason):
+        from squadops.cycles.models import Run
+
+        return Run(
+            run_id="run_001",
+            cycle_id="cyc_001",
+            run_number=1,
+            status="failed",
+            initiated_by="api",
+            resolved_config_hash="hash",
+            failure_reason=reason,
+        )
+
+    def test_reason_rendered_when_present(self):
+        from squadops.cycles.run_report_builder import build_run_report
+
+        report = build_run_report(
+            "cyc_001", "run_001", self._run("CycleError: build_profile is required"), "FAILED"
+        )
+        assert "- **Failure Reason:** CycleError: build_profile is required" in report
+
+    def test_no_reason_line_when_absent(self):
+        from squadops.cycles.run_report_builder import build_run_report
+
+        report = build_run_report("cyc_001", "run_001", self._run(None), "FAILED")
+        assert "Failure Reason" not in report


### PR DESCRIPTION
1.4.4 fix 1 (plan: `docs/plans/1-4-4-patch-plan.md`). The persistence half of #427 — the logging half shipped earlier (`configure_logging` in the API entrypoint, verified live through the whole 1.4.3 deploy window).

## What

A failed run's terminal exception now lands on the run row, atomically with the FAILED transition, and surfaces everywhere a triager looks:

- **Migration 1010** (the line's only one, per the merged plan's design decision): nullable `failure_reason TEXT` on `cycle_runs`. Additive + idempotent; the exact ALTER and the new terminal UPDATE were validated against live Postgres in a rolled-back transaction (zero residue).
- **`TerminalOutcome.failure_reason`**: the FAILED mappings in `resolve_terminal_outcome` carry it; CANCELLED/PAUSED deliberately do not (they have their own affordances). `_ExecutionError` persists its message alone — the wrapper class name is executor plumbing; unexpected exceptions persist `TypeName: message` (there the type IS the diagnosis). Bounded at 2000 chars.
- **Port**: `update_run_status(..., *, failure_reason=None)` — reason commits with the terminal status in one UPDATE; `COALESCE` on the value side so a reason-less transition never nulls a recorded reason. Postgres + memory registries in parity.
- **Both executors** thread it through `_safe_transition` (dispatched via `TerminalOutcome`, in-process at its two FAILED sites).
- **Surfaces**: `run_report.md` gains a `Failure Reason` metadata line (the report builder reads the run row finalize just wrote); `RunResponse` carries the field, so `runs show` renders it with zero CLI changes (`print_detail` is schema-driven).

## Verification

- 12 new tests: FAILED-mapping reason content (wrapper vs unexpected), no reason on cancel/pause, 2000-char bound, messageless fallback, registry round-trip + non-terminal-ignores-reason + completed-carries-none, report line present/absent, DTO carried/None, and the executor wiring assertion (the FAILED transition call carries the diagnosis).
- Full regression: **6187 passed, 1 skipped** (was 6175).
- Live-proof lands in the deploy window's designed-failure probe (per the plan).

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
