### PR TITLE
fix(planning): builder offer and gate net both key off configured build_profile (#426)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1516,7 +1516,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # roll-up reads is emitted at the builder task itself (#399), so an
         # in-loop builder failure is disclosed even though this gate is only
         # reached when every task succeeded.
-        resolved_config = {**cycle.applied_defaults, **cycle.execution_overrides}
+        resolved_config = cycle.resolved_config()
         deficiency = compute_missing_required_files(plan, stored_artifacts, resolved_config)
         if deficiency is not None:
             profile_name, missing = deficiency
@@ -3038,13 +3038,18 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # style-lottery regex costs seconds at the gate, not an hour of
         # correction budget mid-implementation.
         errors += plan.validate_criteria_scope()
+        # #426: same seam again — a builder task without a build_profile is
+        # refused by generate_task_plan anyway, but only after the gate
+        # approved the plan and the implementation run was admitted.
+        errors += plan.validate_build_config(cycle.resolved_config())
         if errors:
             raise _ExecutionError(
                 f"Plan rejected at gate(s) {gate_names}: the materialized implementation "
                 f"plan fails gate validation against squad profile {profile.profile_id!r} — "
                 + "; ".join(errors)
-                + ". Fix the plan: roles must exist in the profile, and regex criteria "
-                "may only target document artifacts."
+                + ". Fix the plan: roles must exist in the profile, regex criteria "
+                "may only target document artifacts, and builder tasks need a "
+                "configured build_profile."
             )
 
     # ------------------------------------------------------------------

--- a/src/squadops/capabilities/handlers/_plan_authoring_service.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring_service.py
@@ -69,17 +69,22 @@ async def produce_plan(
         else ""
     )
 
-    # Only offer task types the squad can actually execute: builder.assemble
-    # needs the builder role, so a builder-less squad must not be offered it
-    # (else the LLM authors a task that aborts at dispatch with
-    # "No handler for capability: builder.assemble").
-    allowed_task_types = sorted(planner_build_task_types(has_builder=has_builder))
+    # Only offer task types the plan can actually execute. builder.assemble
+    # needs BOTH the builder role (else dispatch aborts with "No handler for
+    # capability: builder.assemble") AND a configured build_profile (#426 —
+    # generate_task_plan's #291 guard refuses builder tasks without one, so a
+    # role-only offer invites the author to write a deterministically dead
+    # plan). The guideline/example prompt blocks below key off the same
+    # judgment: dropping the task type while the prose still teaches it would
+    # invite exactly the invalid plan the vocabulary forbids.
+    offer_builder = has_builder and bool(resolved_config.get("build_profile"))
+    allowed_task_types = sorted(planner_build_task_types(offer_builder=offer_builder))
     task_types_section = (
         f"Available task_types (use ONLY these; do NOT invent new ones): "
         f"{', '.join(allowed_task_types)}\n\n"
     )
 
-    if has_builder:
+    if offer_builder:
         builder_guideline = (
             "- Route packaging, entrypoints, requirements.txt/package.json, "
             "Dockerfile/startup scripts, and qa_handoff.md to `builder.assemble` "

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -85,15 +85,18 @@ def _importable_module_surface(paths: frozenset[str] | set[str]) -> frozenset[st
     return frozenset(modules)
 
 
-def planner_build_task_types(*, has_builder: bool) -> set[str]:
-    """Build task types the plan-authoring prompt may offer for a given squad.
+def planner_build_task_types(*, offer_builder: bool) -> set[str]:
+    """Build task types the plan-authoring prompt may offer.
 
-    Returns the full known set when the squad has a builder role; otherwise
-    drops builder-only task types so packaging/scaffolding is routed to a role
-    the squad actually has (e.g. ``development.develop``) instead of producing a
-    ``builder.assemble`` task no agent can handle.
+    ``offer_builder`` is the caller's judgment that a builder task could
+    actually execute — the squad carries the builder role AND the resolved
+    config carries a ``build_profile`` (#426; squad composition alone invited
+    the author to write tasks ``generate_task_plan``'s #291 guard then refused,
+    a deterministically dead plan). When False, builder-only task types are
+    dropped so packaging/scaffolding routes to a role that can run (e.g.
+    ``development.develop``).
     """
-    if has_builder:
+    if offer_builder:
         return set(_KNOWN_BUILD_TASK_TYPES)
     return _KNOWN_BUILD_TASK_TYPES - _BUILDER_ROLE_BUILD_TASK_TYPES
 
@@ -336,6 +339,30 @@ class ImplementationPlan:
             if task.role not in available_roles:
                 errors.append(f"Task {task.task_index}: role '{task.role}' not in profile")
         return errors
+
+    def validate_build_config(self, resolved_config: dict) -> list[str]:
+        """#426: builder tasks require a configured ``build_profile``.
+
+        The dispatch-time #291 guard already refuses such a plan — but only
+        after the gate approved it and a full implementation run was admitted.
+        This is the same rule at the gate seam, where a rejection costs a
+        re-roll instead of a run.
+        """
+        if resolved_config.get("build_profile"):
+            return []
+        offending = [
+            task.task_index
+            for task in self.tasks
+            if task.task_type in _BUILDER_ROLE_BUILD_TASK_TYPES
+        ]
+        if not offending:
+            return []
+        return [
+            f"Task(s) {', '.join(str(i) for i in offending)}: builder task authored but no "
+            "build_profile is configured — the plan cannot execute (a builder must not "
+            "assemble for an assumed stack). Set build_profile in the cycle request "
+            "profile, or author without builder tasks"
+        ]
 
     def _regex_on_source_criteria(self):
         """Yield ``(task, criterion, target)`` for every ``regex_match`` criterion

--- a/src/squadops/cycles/models.py
+++ b/src/squadops/cycles/models.py
@@ -316,6 +316,16 @@ class Cycle:
     # regardless of run state.
     cancelled: bool = False
 
+    def resolved_config(self) -> dict:
+        """The cycle's effective execution config: overrides win over defaults.
+
+        The single definition of the merge (#426): plan generation, the plan
+        authoring prompt, and the gate-time validation net must all answer
+        "what is configured?" from the same dict, or they drift into offering
+        work one of them will refuse.
+        """
+        return {**self.applied_defaults, **self.execution_overrides}
+
 
 @dataclass(frozen=True)
 class Run:

--- a/src/squadops/cycles/plan_authoring_rules.py
+++ b/src/squadops/cycles/plan_authoring_rules.py
@@ -45,7 +45,16 @@ COVERED_ELSEWHERE: dict[str, str] = {
 
 # Validators with no author-facing rule: nothing the author writes can trip them, or the
 # defect they catch is not expressible in the plan the author is composing.
-NOT_AUTHOR_FACING: dict[str, str] = {}
+NOT_AUTHOR_FACING: dict[str, str] = {
+    # #426: enforced upstream of authoring — when no build_profile is configured, the
+    # offer drops builder task types from the vocabulary AND the builder guideline/example
+    # prose, so a compliant author cannot trip this. The gate check is the net for an
+    # author that broke the use-ONLY-these vocabulary rule, which the task-types section
+    # already teaches inline. Restating "builder needs build_profile" to an author who
+    # was never offered builder tasks would be noise about an unavailable option.
+    "validate_build_config": "enforced-by-offer (#426): unconfigured squads are never "
+    "offered builder task types; the inline task-types vocabulary is the teaching",
+}
 
 
 def rule_ids() -> frozenset[str]:

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -634,7 +634,7 @@ def generate_task_plan(
     # SIP-0093 PR 93.3: framing workload threads plan_authoring_contributors
     # through resolved_config so the proposer steps are added/skipped per
     # cycle config. Other workload types ignore the extra argument.
-    resolved_config = {**cycle.applied_defaults, **cycle.execution_overrides}
+    resolved_config = cycle.resolved_config()
     # #669: a framing re-roll forwards the prior rejection on the §6.6 overrides
     # rail. It is authoring CONTEXT, not config — lift it out so resolved_config
     # stays config-shaped on every envelope, then inject it onto the

--- a/tests/unit/capabilities/test_plan_authoring_service.py
+++ b/tests/unit/capabilities/test_plan_authoring_service.py
@@ -472,12 +472,14 @@ async def test_produce_plan_filters_builder_assemble_by_squad_capability():
     no_builder_render = str(ctx_no_builder.ports.request_renderer.render.call_args)
     assert "builder.assemble" not in no_builder_render
 
+    # #426: the builder role alone no longer suffices — the offer also
+    # requires a configured build_profile (see the offer tests below).
     ctx_builder = _make_context()
     await produce_plan(
         ctx_builder,
         {**base, "profile_roles": ["lead", "dev", "builder", "qa"]},
         planning_content="## Plan",
-        resolved_config=base["resolved_config"],
+        resolved_config={**base["resolved_config"], "build_profile": "python_cli_builder"},
         role="lead",
         handler_name="test_harness",
         chat_kwargs={},
@@ -539,3 +541,44 @@ def test_validate_manifest_candidate_accepts_safelisted_command():
     manifest, error_msg = _validate_manifest_candidate(yaml_content, 1, 15, ["dev"])
     assert error_msg is None
     assert manifest is not None
+
+
+# ---------------------------------------------------------------------------
+# #426 — the builder offer keys off config, not squad composition alone
+# ---------------------------------------------------------------------------
+
+
+async def _render_vars_for(profile_roles, resolved_config):
+    ctx = _make_context()
+    await produce_plan(
+        ctx,
+        {"prd": "Build it", "profile_roles": profile_roles, "resolved_config": resolved_config},
+        planning_content="## Plan",
+        resolved_config=resolved_config,
+        role="lead",
+        handler_name="test_harness",
+        chat_kwargs={},
+    )
+    call = ctx.ports.request_renderer.render.call_args_list[0]
+    return call.args[1]
+
+
+async def test_builder_squad_without_build_profile_is_not_offered_builder_tasks():
+    """#426: lite/full squads on a profile with no build_profile authored
+    builder.assemble plans that generate_task_plan then refused — a
+    deterministically dead plan, knowable at framing time. The offer (task
+    vocabulary AND the guideline/example prose) must key off config too."""
+    variables = await _render_vars_for(
+        ["lead", "dev", "qa", "builder"], {"implementation_plan": True}
+    )
+    assert "builder.assemble" not in variables["task_types_section"]
+    assert variables["builder_guideline"] == ""
+
+
+async def test_builder_squad_with_build_profile_is_offered_builder_tasks():
+    variables = await _render_vars_for(
+        ["lead", "dev", "qa", "builder"],
+        {"implementation_plan": True, "build_profile": "fullstack_fastapi_react"},
+    )
+    assert "builder.assemble" in variables["task_types_section"]
+    assert "builder.assemble" in variables["builder_guideline"]

--- a/tests/unit/capabilities/test_planning_handlers.py
+++ b/tests/unit/capabilities/test_planning_handlers.py
@@ -1143,9 +1143,14 @@ class TestProduceManifestRetry:
         assert ctx.ports.llm.chat_stream_with_usage.await_count == 1
 
     async def test_builder_guidance_added_when_builder_role_present(self):
-        """When profile includes builder, prompt directs Max to use builder.assemble."""
+        """When profile includes builder AND build_profile is configured (#426),
+        prompt directs Max to use builder.assemble."""
         ctx = _make_context(_VALID_MANIFEST_YAML)
-        await self._call_produce(ctx, profile_roles=["dev", "qa", "lead", "builder"])
+        await self._call_produce(
+            ctx,
+            profile_roles=["dev", "qa", "lead", "builder"],
+            resolved_config={"build_profile": "python_cli_builder"},
+        )
 
         user_prompt = ctx.ports.llm.chat_stream_with_usage.await_args_list[0].args[0][1].content
         assert "`builder.assemble`" in user_prompt

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -970,3 +970,87 @@ class TestRunCompletionActivityWiring:
         )
 
         assert executor._focus_lease_port is focus_lease_port
+
+
+# ---------------------------------------------------------------------------
+# #426 — gate-time build-config net
+# ---------------------------------------------------------------------------
+
+
+class TestGateRejectsBuilderPlanWithoutBuildProfile:
+    """#426: a builder-task plan on a config with no build_profile used to
+    pass the gate and die 8ms into the implementation run at the #291 guard.
+    The gate net must reject it where a re-roll is cheap — and must read the
+    SAME merged config generate_task_plan reads, or the two nets disagree."""
+
+    _BUILDER_PLAN_YAML = (
+        "version: 1\n"
+        "project_id: hello_squad\n"
+        "cycle_id: cyc_001\n"
+        "prd_hash: abc\n"
+        "tasks:\n"
+        "  - task_index: 0\n"
+        "    task_type: builder.assemble\n"
+        "    role: builder\n"
+        '    focus: "Package"\n'
+        '    description: "Assemble"\n'
+        "    expected_artifacts:\n"
+        '      - "qa_handoff.md"\n'
+        "    depends_on: []\n"
+        "summary:\n"
+        "  total_tasks: 1\n"
+    )
+
+    @staticmethod
+    def _stored_plan_artifacts():
+        ref = MagicMock()
+        ref.filename = "implementation_plan.yaml"
+        ref.artifact_type = "control_implementation_plan"
+        return [("art_plan", ref)]
+
+    @staticmethod
+    def _profile_with_builder():
+        agent = MagicMock()
+        agent.role = "builder"
+        agent.enabled = True
+        profile = MagicMock()
+        profile.profile_id = "full"
+        profile.agents = [agent]
+        return profile
+
+    async def test_rejected_when_no_build_profile_configured(self, executor, mock_vault, cycle):
+        import dataclasses
+
+        from adapters.cycles.execution_errors import _ExecutionError
+
+        gated_cycle = dataclasses.replace(cycle, applied_defaults={"implementation_plan": True})
+        mock_vault.retrieve.return_value = ("ref", self._BUILDER_PLAN_YAML.encode())
+
+        with pytest.raises(_ExecutionError) as exc_info:
+            await executor._reject_unsatisfiable_plan_at_gate(
+                self._stored_plan_artifacts(),
+                self._profile_with_builder(),
+                ["progress_plan_review"],
+                gated_cycle,
+            )
+        assert "build_profile" in str(exc_info.value)
+
+    async def test_build_profile_via_execution_overrides_passes(self, executor, mock_vault, cycle):
+        """The gate must read the merged config — a build_profile arriving via
+        execution_overrides is configured, and rejecting it would kill valid
+        cycles (the #426 disease with the polarity flipped)."""
+        import dataclasses
+
+        gated_cycle = dataclasses.replace(
+            cycle,
+            applied_defaults={"implementation_plan": True},
+            execution_overrides={"build_profile": "python_cli_builder"},
+        )
+        mock_vault.retrieve.return_value = ("ref", self._BUILDER_PLAN_YAML.encode())
+
+        await executor._reject_unsatisfiable_plan_at_gate(
+            self._stored_plan_artifacts(),
+            self._profile_with_builder(),
+            ["progress_plan_review"],
+            gated_cycle,
+        )

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -550,14 +550,14 @@ class TestPlannerBuildTaskTypes:
     """
 
     def test_builder_squad_gets_full_known_set(self):
-        assert planner_build_task_types(has_builder=True) == {
+        assert planner_build_task_types(offer_builder=True) == {
             "development.develop",
             "qa.test",
             "builder.assemble",
         }
 
     def test_builderless_squad_drops_builder_assemble_but_keeps_build_path(self):
-        offered = planner_build_task_types(has_builder=False)
+        offered = planner_build_task_types(offer_builder=False)
         # The offending capability is gone...
         assert "builder.assemble" not in offered
         # ...but the dev/qa build path remains, so builder-less squads still build.
@@ -566,10 +566,10 @@ class TestPlannerBuildTaskTypes:
     def test_result_is_a_fresh_set_callers_cannot_corrupt_constants(self):
         """Returning the module constant itself would let one caller's mutation
         leak into the next cycle's offered task types."""
-        result = planner_build_task_types(has_builder=True)
+        result = planner_build_task_types(offer_builder=True)
         result.add("bogus.capability")
-        assert "bogus.capability" not in planner_build_task_types(has_builder=True)
-        assert "bogus.capability" not in planner_build_task_types(has_builder=False)
+        assert "bogus.capability" not in planner_build_task_types(offer_builder=True)
+        assert "bogus.capability" not in planner_build_task_types(offer_builder=False)
 
 
 # ---------------------------------------------------------------------------
@@ -1283,3 +1283,53 @@ class TestValidateExpectedArtifactShapes:
             expected="[]",
         )
         assert empty.validate_expected_artifact_shapes() == []
+
+
+class TestValidateBuildConfig:
+    """#426: builder tasks without a configured build_profile die at
+    generate_task_plan's #291 guard — but only after the gate approved the
+    plan and a full run was admitted. This rule rejects them at the gate."""
+
+    BUILDER_MANIFEST_YAML = """\
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+
+tasks:
+  - task_index: 0
+    task_type: development.develop
+    role: dev
+    focus: "Backend"
+    description: "Create backend"
+    expected_artifacts:
+      - "backend/main.py"
+    depends_on: []
+
+  - task_index: 1
+    task_type: builder.assemble
+    role: builder
+    focus: "Package"
+    description: "Assemble packaging"
+    expected_artifacts:
+      - "qa_handoff.md"
+    depends_on: [0]
+
+summary:
+  total_tasks: 2
+"""
+
+    def test_builder_task_without_build_profile_rejected(self):
+        plan = ImplementationPlan.from_yaml(self.BUILDER_MANIFEST_YAML)
+        errors = plan.validate_build_config({"implementation_plan": True})
+        assert len(errors) == 1
+        assert "Task(s) 1" in errors[0]
+        assert "build_profile" in errors[0]
+
+    def test_builder_task_with_build_profile_passes(self):
+        plan = ImplementationPlan.from_yaml(self.BUILDER_MANIFEST_YAML)
+        assert plan.validate_build_config({"build_profile": "python_cli_builder"}) == []
+
+    def test_builderless_plan_needs_no_build_profile(self):
+        plan = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
+        assert plan.validate_build_config({}) == []

--- a/tests/unit/cycles/test_models.py
+++ b/tests/unit/cycles/test_models.py
@@ -196,6 +196,19 @@ class TestCycle:
         with pytest.raises(dataclasses.FrozenInstanceError):
             sample_cycle.cycle_id = "changed"
 
+    def test_resolved_config_overrides_win(self, sample_cycle):
+        """#426: the single merge definition — an override must beat the
+        default, or the gate net and generate_task_plan would disagree about
+        what is configured."""
+        cycle = dataclasses.replace(
+            sample_cycle,
+            applied_defaults={"build_profile": "default_profile", "typed_acceptance": True},
+            execution_overrides={"build_profile": "override_profile"},
+        )
+        resolved = cycle.resolved_config()
+        assert resolved["build_profile"] == "override_profile"
+        assert resolved["typed_acceptance"] is True
+
 
 class TestRun:
     def test_defaults(self):


### PR DESCRIPTION
1.4.4 fix 2 (plan: `docs/plans/1-4-4-patch-plan.md`). Closes the mismatched-sources-of-truth defect where a builder-carrying squad on a profile without `build_profile` authored plans that passed the gate and died at implementation start (`cyc_23c6d9a7363a`: 8ms failure after a full framing).

## What

Three layers, one source of truth:

- **`Cycle.resolved_config()`** — the single definition of the `{**applied_defaults, **execution_overrides}` merge. `generate_task_plan`, the build-completeness check, and the new gate net all read it; two of those previously open-coded the merge, which is exactly how offer-vs-guard drift happens.
- **The offer keys off config**: `produce_plan` computes `offer_builder = has_builder AND build_profile`, and the *entire* builder prompt bundle keys off it — the task-type vocabulary and the guideline/example prose together (dropping only the vocabulary would leave prose teaching a forbidden task type). `planner_build_task_types`'s kwarg renamed `has_builder` → `offer_builder` to say what it now means.
- **The gate net**: `ImplementationPlan.validate_build_config(resolved_config)` rides the existing #295/#464 fail-fast seam in `_reject_unsatisfiable_plan_at_gate` — a builder task without a configured `build_profile` is rejected at the gate (minutes) instead of at dispatch (a full admitted run).

The #686 classification test forced the author-teaching decision on the spot: `validate_build_config` is recorded **NOT_AUTHOR_FACING** with the reasoning — the offer removes the option upstream, so the inline "use ONLY these task types" vocabulary is the teaching; restating the rule to authors who can't be offered builder tasks would be noise.

**Recorded no-change decision** (per the merged plan): the `validation` request profile does not gain a `build_profile` — it measures plan/validation machinery, not assembly.

## Verification

- New tests: the offer pair (builder squad without `build_profile` → no `builder.assemble` in vocabulary and empty guideline; with it → both present), `validate_build_config` (builder task + no profile → named rejection; with profile → clean; builderless plan → clean), `Cycle.resolved_config` override-wins, and the executor gate-net pair — including the polarity guard: a `build_profile` arriving via `execution_overrides` must pass, or the net kills valid cycles.
- Two pre-existing tests updated where the old role-only premise was the very behavior removed.
- Full regression: **6195 passed, 1 skipped** (was 6187).
- Live-proof lands in the deploy window's gate-rejection replay (per the plan).

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
