### PR TITLE
fix(plan-validation): reject qa.test tasks whose artifacts cannot satisfy required tests_pass (#715)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2823,6 +2823,15 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     # emission) — provable plan-wide right here, and a system
                     # rejection re-rolls framing for free (#522).
                     errors.extend(parsed_plan.validate_unique_expected_artifacts())
+                    # #715: a qa.test task whose declared artifacts can never
+                    # satisfy required tests_pass fails on any content — shk-4
+                    # burned three correction rounds on one. #426: builder
+                    # tasks without a configured build_profile die at the #291
+                    # dispatch guard — this seam (the one multi-workload
+                    # cycles actually traverse) rejects both for a free
+                    # framing re-roll.
+                    errors.extend(parsed_plan.validate_check_applicability(cycle.resolved_config()))
+                    errors.extend(parsed_plan.validate_build_config(cycle.resolved_config()))
             elif ref.filename == "interface_manifest.yaml" or artifact_type == "interface_manifest":
                 interface_content = content_bytes.decode(errors="replace")
 
@@ -3042,6 +3051,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # refused by generate_task_plan anyway, but only after the gate
         # approved the plan and the implementation run was admitted.
         errors += plan.validate_build_config(cycle.resolved_config())
+        # #715: qa.test artifacts that required tests_pass can never judge.
+        errors += plan.validate_check_applicability(cycle.resolved_config())
         if errors:
             raise _ExecutionError(
                 f"Plan rejected at gate(s) {gate_names}: the materialized implementation "

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -85,6 +85,12 @@ def _importable_module_surface(paths: frozenset[str] | set[str]) -> frozenset[st
     return frozenset(modules)
 
 
+def _pytest_discoverable(path: str) -> bool:
+    """True when pytest's default discovery would collect this file (#715)."""
+    name = PurePosixPath(path).name
+    return name.endswith(".py") and (name.startswith("test_") or name.endswith("_test.py"))
+
+
 def planner_build_task_types(*, offer_builder: bool) -> set[str]:
     """Build task types the plan-authoring prompt may offer.
 
@@ -338,6 +344,43 @@ class ImplementationPlan:
         for task in self.tasks:
             if task.role not in available_roles:
                 errors.append(f"Task {task.task_index}: role '{task.role}' not in profile")
+        return errors
+
+    def validate_check_applicability(self, resolved_config: dict) -> list[str]:
+        """#715: a ``qa.test`` task's declared artifacts must be able to satisfy the
+        required check that judges them.
+
+        ``tests_pass`` judges a qa task's emission by pytest discovery, so a task
+        declaring only non-discoverable artifacts (shk-4's ``test_integration.js``)
+        fails on **any possible content** — the declared shape, not the work, is the
+        failure. The correction loop cannot fix a shape the plan forbids changing:
+        shk-4 burned three rounds and ~2h before escaping via a placebo ``.js`` stub
+        plus an undeclared ``.py`` twin, with the planned coverage silently narrowed
+        under a green verdict. Statically visible right here, at authoring time.
+
+        Verification-only tasks (``expected_artifacts: []``) are exempt — they emit
+        nothing for pytest to judge. Only applies when ``tests_pass`` is actually
+        required by the resolved config.
+
+        Returns:
+            List of validation error strings (empty = valid).
+        """
+        if "tests_pass" not in (resolved_config.get("required_checks") or ()):
+            return []
+        errors: list[str] = []
+        for task in self.tasks:
+            if task.task_type != "qa.test" or not task.expected_artifacts:
+                continue
+            if any(_pytest_discoverable(path) for path in task.expected_artifacts):
+                continue
+            errors.append(
+                f"Task {task.task_index} ({task.focus}): qa.test declares "
+                f"{task.expected_artifacts} but no pytest-discoverable file "
+                "(test_*.py / *_test.py) — the required tests_pass check judges this "
+                "task's emission by pytest discovery, so it fails for any possible "
+                "content. Include a test_*.py among the expected artifacts, or make "
+                "this a verification-only task (expected_artifacts: [])"
+            )
         return errors
 
     def validate_build_config(self, resolved_config: dict) -> list[str]:

--- a/src/squadops/cycles/plan_authoring_rules.py
+++ b/src/squadops/cycles/plan_authoring_rules.py
@@ -32,6 +32,7 @@ AUTHOR_FACING: dict[str, str] = {
     "validate_criteria_scope": "regex-only-on-documents",
     "validate_command_checks": "commands-must-run-here",
     "validate_against_profile": "roles-must-exist",
+    "validate_check_applicability": "qa-tests-pytest-discoverable",
 }
 
 # Validators an author is already taught by a different managed asset. Restating them

--- a/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.plan_authoring_rules_appendix
-version: "1"
+version: "2"
 required_variables: []
 ---
 ## PLAN SHAPE RULES (authoritative — a plan that breaks one is rejected)
@@ -46,6 +46,14 @@ of content.
 
 **roles-must-exist** — Every task's `role` is one the squad profile actually staffs. A
 task assigned to an absent role can never be dispatched.
+
+**qa-tests-pytest-discoverable** — When the `tests_pass` check is required, every
+`qa.test` task that declares expected artifacts includes at least one pytest-discoverable
+file (`test_*.py` or `*_test.py`). The suite check judges a qa task's emission by pytest
+discovery, so a task declaring only a script pytest cannot collect (e.g. a `.js` smoke
+runner) fails on any possible content — the declared shape, not the work, is the failure.
+Express non-pytest verification through a pytest wrapper, or through the acceptance
+criteria of a verification-only task.
 
 A verification-only task is legitimate and common: declare `expected_artifacts: []` and
 express what it checks through its acceptance criteria.

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -1054,3 +1054,154 @@ class TestGateRejectsBuilderPlanWithoutBuildProfile:
             ["progress_plan_review"],
             gated_cycle,
         )
+
+
+class TestMidRunGateRejectsUnwinnableQaTask:
+    """#715 on the mid-run gate seam — parity with the workload seam."""
+
+    _QA_JS_PLAN_YAML = (
+        TestGateRejectsBuilderPlanWithoutBuildProfile._BUILDER_PLAN_YAML.replace(
+            "builder.assemble", "qa.test"
+        )
+        .replace("role: builder", "role: qa")
+        .replace("qa_handoff.md", "backend/tests/test_e2e.js")
+    )
+
+    async def test_rejected_when_tests_pass_required(self, executor, mock_vault, cycle):
+        import dataclasses
+
+        from adapters.cycles.execution_errors import _ExecutionError
+
+        gated_cycle = dataclasses.replace(
+            cycle,
+            applied_defaults={"implementation_plan": True, "required_checks": ["tests_pass"]},
+        )
+        mock_vault.retrieve.return_value = ("ref", self._QA_JS_PLAN_YAML.encode())
+
+        agent = MagicMock()
+        agent.role = "qa"
+        agent.enabled = True
+        profile = MagicMock()
+        profile.profile_id = "full"
+        profile.agents = [agent]
+
+        with pytest.raises(_ExecutionError) as exc_info:
+            await executor._reject_unsatisfiable_plan_at_gate(
+                TestGateRejectsBuilderPlanWithoutBuildProfile._stored_plan_artifacts(),
+                profile,
+                ["progress_plan_review"],
+                gated_cycle,
+            )
+        assert "pytest-discoverable" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# #715 + #426 — the workload-gate seam (the path multi-workload cycles traverse)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkloadGateSeamValidation:
+    """#715/#426 wiring at `_reject_invalid_plan_before_workload_gate` — the
+    seam multi-workload cycles actually traverse (the mid-run gate never fires
+    there, per its own docstring). Errors are RETURNED for a system-REJECTED
+    gate decision and a free framing re-roll, never raised."""
+
+    _QA_JS_PLAN_YAML = (
+        "version: 1\n"
+        "project_id: group_run\n"
+        "cycle_id: cyc_001\n"
+        "prd_hash: abc\n"
+        "tasks:\n"
+        "  - task_index: 0\n"
+        "    task_type: qa.test\n"
+        "    role: qa\n"
+        '    focus: "Integration smoke"\n'
+        '    description: "Node smoke script"\n'
+        "    expected_artifacts:\n"
+        '      - "backend/tests/test_integration.js"\n'
+        "    depends_on: []\n"
+        "summary:\n"
+        "  total_tasks: 1\n"
+    )
+
+    _BUILDER_PLAN_YAML = (
+        "version: 1\n"
+        "project_id: group_run\n"
+        "cycle_id: cyc_001\n"
+        "prd_hash: abc\n"
+        "tasks:\n"
+        "  - task_index: 0\n"
+        "    task_type: builder.assemble\n"
+        "    role: builder\n"
+        '    focus: "Package"\n'
+        '    description: "Assemble"\n'
+        "    expected_artifacts:\n"
+        '      - "qa_handoff.md"\n'
+        "    depends_on: []\n"
+        "summary:\n"
+        "  total_tasks: 1\n"
+    )
+
+    @staticmethod
+    def _wire(mock_vault, run, plan_yaml):
+        import dataclasses
+
+        ref = MagicMock()
+        ref.filename = "implementation_plan.yaml"
+        ref.artifact_type = "control_implementation_plan"
+        mock_vault.retrieve.return_value = (ref, plan_yaml.encode())
+        return dataclasses.replace(run, artifact_refs=("art_plan",))
+
+    async def test_unwinnable_qa_task_rejected_at_workload_gate(
+        self, executor, mock_vault, cycle, run
+    ):
+        """The shk-4 shape: required tests_pass + a .js-only qa task must come
+        back as a validation error (→ free re-roll), reading required_checks
+        from the merged cycle config."""
+        import dataclasses
+
+        gated_cycle = dataclasses.replace(
+            cycle,
+            applied_defaults={"implementation_plan": True, "required_checks": ["tests_pass"]},
+        )
+        gated_run = self._wire(mock_vault, run, self._QA_JS_PLAN_YAML)
+
+        errors = await executor._reject_invalid_plan_before_workload_gate(
+            gated_run, gated_cycle, "progress_plan_review"
+        )
+        assert any("pytest-discoverable" in e for e in errors)
+
+    async def test_qa_js_plan_passes_when_tests_pass_not_required(
+        self, executor, mock_vault, cycle, run
+    ):
+        """Polarity guard: without required tests_pass the same plan is legal —
+        flagging it would reject valid author-mode cycles."""
+        import dataclasses
+
+        gated_cycle = dataclasses.replace(
+            cycle,
+            applied_defaults={"implementation_plan": True},
+        )
+        gated_run = self._wire(mock_vault, run, self._QA_JS_PLAN_YAML)
+
+        errors = await executor._reject_invalid_plan_before_workload_gate(
+            gated_run, gated_cycle, "progress_plan_review"
+        )
+        assert errors == []
+
+    async def test_builder_without_build_profile_rejected_at_workload_gate(
+        self, executor, mock_vault, cycle, run
+    ):
+        """#426 gap closure: the original net landed only on the mid-run gate
+        seam, which multi-workload cycles never traverse — the exact repro
+        shape (framing run, then gate, then implementation run) was still
+        reaching the #291 dispatch guard."""
+        import dataclasses
+
+        gated_cycle = dataclasses.replace(cycle, applied_defaults={"implementation_plan": True})
+        gated_run = self._wire(mock_vault, run, self._BUILDER_PLAN_YAML)
+
+        errors = await executor._reject_invalid_plan_before_workload_gate(
+            gated_run, gated_cycle, "progress_plan_review"
+        )
+        assert any("build_profile" in e for e in errors)

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -1333,3 +1333,76 @@ summary:
     def test_builderless_plan_needs_no_build_profile(self):
         plan = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
         assert plan.validate_build_config({}) == []
+
+
+class TestValidateCheckApplicability:
+    """#715: a qa.test task whose declared artifacts pytest cannot discover
+    fails required tests_pass on any possible content (shk-4: three correction
+    rounds, a placebo .js stub, and silently narrowed coverage — for a defect
+    visible at authoring time)."""
+
+    _CONFIG = {"required_checks": ["tests_pass", "frontend_build"]}
+
+    @staticmethod
+    def _plan_with_qa_artifacts(artifacts_yaml: str) -> ImplementationPlan:
+        return ImplementationPlan.from_yaml(
+            "version: 1\n"
+            "project_id: group_run\n"
+            "cycle_id: cyc_test\n"
+            "prd_hash: abc123\n"
+            "tasks:\n"
+            "  - task_index: 0\n"
+            "    task_type: qa.test\n"
+            "    role: qa\n"
+            '    focus: "Integration smoke"\n'
+            '    description: "Verify the stack"\n'
+            f"    expected_artifacts:{artifacts_yaml}\n"
+            "    depends_on: []\n"
+            "summary:\n"
+            "  total_tasks: 1\n"
+        )
+
+    def test_js_only_qa_task_rejected(self):
+        """The shk-4 task-6 shape must be caught at authoring."""
+        plan = self._plan_with_qa_artifacts('\n      - "backend/tests/test_integration.js"')
+        errors = plan.validate_check_applicability(self._CONFIG)
+        assert len(errors) == 1
+        assert "pytest-discoverable" in errors[0]
+        assert "test_integration.js" in errors[0]
+
+    def test_not_required_means_no_rule(self):
+        plan = self._plan_with_qa_artifacts('\n      - "backend/tests/test_integration.js"')
+        assert plan.validate_check_applicability({"required_checks": ["frontend_build"]}) == []
+        assert plan.validate_check_applicability({}) == []
+
+    @pytest.mark.parametrize(
+        "artifacts_yaml",
+        [
+            '\n      - "backend/tests/test_api.py"',
+            '\n      - "backend/tests/api_test.py"',
+            # Mixed declaration — the shape shk-4's repair invented off-plan,
+            # legal to declare up front: the .py twin satisfies discovery.
+            '\n      - "backend/tests/test_integration.js"\n      - "backend/tests/test_integration.py"',
+        ],
+    )
+    def test_discoverable_artifact_satisfies(self, artifacts_yaml):
+        plan = self._plan_with_qa_artifacts(artifacts_yaml)
+        assert plan.validate_check_applicability(self._CONFIG) == []
+
+    def test_verification_only_task_exempt(self):
+        plan = self._plan_with_qa_artifacts(" []")
+        assert plan.validate_check_applicability(self._CONFIG) == []
+
+    def test_dev_tasks_not_subject(self):
+        """tests_pass judges qa emissions; a dev task shipping a .js view is fine."""
+        plan = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
+        assert plan.validate_check_applicability(self._CONFIG) == []
+
+    def test_lookalike_names_are_not_discoverable(self):
+        """conftest.py and tests.py match neither pytest default pattern — a
+        qa task declaring only those has the same unwinnable shape."""
+        plan = self._plan_with_qa_artifacts(
+            '\n      - "backend/tests/conftest.py"\n      - "backend/tests/tests.py"'
+        )
+        errors = plan.validate_check_applicability(self._CONFIG)
+        assert len(errors) == 1


### PR DESCRIPTION
1.4.4 fix 3 (plan: `docs/plans/1-4-4-patch-plan.md`). The unwinnable-plan class from the 1.4.3 deploy window, caught where it's statically visible: authoring time.

## What

- **`ImplementationPlan.validate_check_applicability(resolved_config)`**: when `tests_pass` is in the config's `required_checks`, every `qa.test` task that declares expected artifacts must include at least one pytest-discoverable file (`test_*.py` / `*_test.py`). Verification-only tasks (`expected_artifacts: []`) are exempt; the rule is inert when `tests_pass` isn't required (author-mode cycles keep full freedom).
- **Wired at both gate seams**: the workload-sequence seam (errors returned → system-REJECTED gate decision → free framing re-roll with #669 revision context) and the mid-run gate seam (parity).
- **The author is taught the rule, not just rejected** (#686 discipline): classified AUTHOR_FACING as `qa-tests-pytest-discoverable`, with the rule prose added to `request.plan_authoring_rules_appendix` (bumped to v2) — the shape, not the work, is the failure, and the appendix now says so with the fix (a pytest wrapper, or a verification-only task).

## Also: closes a #718 seam gap found while wiring

The executor has two gate seams, and multi-workload cycles traverse **only** `_reject_invalid_plan_before_workload_gate` (its own docstring: the mid-run seam "never fires here"). #718's `validate_build_config` net landed only on the mid-run seam — so the exact #426 repro shape (framing run → gate → implementation run) still fell through to the #291 dispatch guard. No regression (the dispatch guard always backstopped it), but the gate net wasn't doing its job on the path that mattered. Both the #426 and #715 nets now run on both seams, with a regression test pinning the workload-seam wiring for each.

## Verification

- Validator units: the shk-4 `.js`-only shape rejected with a teaching message; not-required → inert (polarity guard); `test_*.py` / `*_test.py` / mixed `.js`+`.py` all pass (the mixed shape is shk-4's off-plan escape, now legal to declare up front); verification-only exempt; dev tasks not subject; `conftest.py`/`tests.py` lookalikes correctly non-discoverable.
- Seam tests: workload seam returns the #715 error and the #426 error (gap closure), passes the polarity case; mid-run seam raises with the same named finding.
- Full regression: **6207 passed, 1 skipped** (was 6195).
- Live-proof lands in the deploy window's gate-rejection replay of the stored shk-4 plan (per the plan doc).

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
