### PR TITLE
fix(verification): split skipped typed checks into benign vs evidence-gap — gaps never read passed (#423)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -15,7 +15,11 @@ from squadops.capabilities.handlers.base import (
     HandlerEvidence,
     HandlerResult,
 )
-from squadops.cycles.acceptance_check_spec import CHECK_UNDEFINED_NAMES, is_check_applicable
+from squadops.cycles.acceptance_check_spec import (
+    CHECK_UNDEFINED_NAMES,
+    CONFIG_OFF_SKIP_REASONS,
+    is_check_applicable,
+)
 from squadops.cycles.acceptance_checks import CheckOutcome
 from squadops.cycles.acceptance_evaluation import (
     evaluate_criterion,
@@ -24,6 +28,7 @@ from squadops.cycles.acceptance_evaluation import (
 )
 from squadops.cycles.implementation_plan import TypedCheck
 from squadops.cycles.patch_verification import materialize_artifacts
+from squadops.cycles.verification_integrity import ResultStatus
 from squadops.llm.exceptions import LLMError
 from squadops.llm.model_registry import get_model_spec
 from squadops.llm.models import ChatMessage
@@ -406,7 +411,8 @@ class _CycleTaskHandler(CapabilityHandler):
                 }
             )
 
-        typed_criteria = list(split.typed) + _framework_injected_criteria(artifacts, split.typed)
+        authored_criteria = list(split.typed)
+        typed_criteria = authored_criteria + _framework_injected_criteria(artifacts, split.typed)
         if not typed_criteria:
             return
 
@@ -441,6 +447,26 @@ class _CycleTaskHandler(CapabilityHandler):
                     typed_acceptance_enabled=typed_acceptance_enabled,
                     command_acceptance_enabled=command_acceptance_enabled,
                 )
+                # #423: an *authored* error-severity check that the evaluator
+                # skipped for any reason other than deliberate config-off is an
+                # evidence gap — the author asked for enforcement on a concrete
+                # target and the evaluator declared it cannot deliver
+                # (unsupported extension/stack, missing tooling). Distinct from
+                # the benign classes: config-off skips, and framework-injected
+                # checks (which target only files in their own family, #605).
+                # A gap must never read `passed: true` — that is the false
+                # green #423 measured (7 of 14 evaluations skipped-yet-passed,
+                # the whole frontend contract surface unenforced) — but it also
+                # must not mission a correction: no code repair can close an
+                # evaluator limitation. It surfaces as unverified at the
+                # SIP-0096 roll-up instead (see verification_normalize /
+                # aggregate_verification).
+                evidence_gap = (
+                    outcome.status == ResultStatus.SKIPPED
+                    and check_index < len(authored_criteria)
+                    and criterion.severity == "error"
+                    and outcome.reason not in CONFIG_OFF_SKIP_REASONS
+                )
                 check_record = {
                     "check": f"acceptance:{criterion.check}",
                     "severity": criterion.severity,
@@ -450,11 +476,14 @@ class _CycleTaskHandler(CapabilityHandler):
                     "actual": outcome.actual,
                     "reason": outcome.reason,
                     # `passed` flag for compatibility with the legacy
-                    # all-checks-pass aggregator: only severity=error AND
-                    # blocking status counts as not-passed.
+                    # all-checks-pass aggregator: severity=error AND blocking
+                    # status, or an evidence-gap skip (#423), counts as
+                    # not-passed.
                     "passed": not (
                         criterion.severity == "error" and outcome.status in {"failed", "error"}
-                    ),
+                    )
+                    and not evidence_gap,
+                    "evidence_gap": evidence_gap,
                     # Issue #114: identity fields for downstream trigger
                     # composition and per-cycle evaluation persistence.
                     # task_index is None for tasks not driven by an

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -129,7 +129,14 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
             inputs, artifacts, checks, missing, typed_error_counts
         )
 
-        passed = all(c.get("passed", True) for c in checks) and not missing
+        # #423: evidence-gap rows (authored check the evaluator could not run)
+        # are honest non-passes but must not fail the task — a correction
+        # cannot repair an evaluator limitation. They block at the SIP-0096
+        # roll-up (unverified; required when contract-bound), not here.
+        passed = (
+            all(c.get("passed", True) or c.get("evidence_gap", False) for c in checks)
+            and not missing
+        )
         passed_count = sum(1 for c in checks if c.get("passed", True))
         coverage = passed_count / len(checks) if checks else 1.0
 

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -187,6 +187,21 @@ def argv_matches_safelist(argv: list[str]) -> bool:
     return any(pat.matcher(argv) for pat in COMMAND_SAFELIST)
 
 
+# #423: skip reasons that mean "enforcement is deliberately off by config" —
+# the benign skip class. Every OTHER skip on an *authored* error-severity check
+# is an evidence gap: the author asked for enforcement on a concrete target and
+# the evaluator could not deliver it. That deliberately includes
+# ``frontend_acceptance_checks_disabled`` — despite the name there is no such
+# config flag; it marks the not-yet-implemented JS/TS analyzer, and an authored
+# AST check on a ``.tsx`` file was exactly #423's measured exhibit (7 of 14
+# evaluations skipped-yet-passed, the frontend contract surface unenforced).
+CONFIG_OFF_SKIP_REASONS: frozenset[str] = frozenset(
+    {
+        "typed_acceptance_disabled",
+        "command_acceptance_checks_disabled",
+    }
+)
+
 # #464: regex_match may only target document artifacts. Regexes against
 # source files prescribe another roll's stylistic choices (quote style,
 # identifier names) and have twice produced criteria unwinnable by correct

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -110,6 +110,12 @@ class NotExecutedReason(StrEnum):
     TIMEOUT_BEFORE_EXECUTION = "timeout_before_execution"
 
 
+# #423: disclosure prefix for evidence-gap unverified rows — the producer's raw
+# skip reason rides behind it (``evaluator_gap:unsupported_file_extension``),
+# so an operator reads both the class and the diagnosis off one string.
+EVALUATOR_GAP_PREFIX = "evaluator_gap:"
+
+
 # Fallback reason for a producer that emits a not-executed result WITHOUT the
 # mandatory §7 reason. We disclose the gap honestly rather than mask it as a
 # specific diagnosis (the "no fallback that masks a missing data source" rule).
@@ -163,6 +169,13 @@ class CheckResult:
     # (§6.3); ``None`` in author mode / for framework-spine checks. The coverage
     # accounting that consumes it (n-of-m criteria executed-and-passed) lands in 98.4.
     criterion_id: str | None = None
+    # #423: an authored error-severity check the evaluator skipped for a reason
+    # other than deliberate config-off — the author asked for enforcement the
+    # evaluator cannot deliver. Disclosed with an ``evaluator_gap:`` reason
+    # prefix, and REQUIRED-level unverified when contract-bound
+    # (``criterion_id`` set), so a contract criterion can never be silently
+    # unenforceable. False for benign skips and all executed results.
+    evidence_gap: bool = False
     # The producing subject's identity (§6.3) — the plan-task id that emitted this
     # result. DISTINCT from ``provenance.subject_ref`` (the *thing* under test — a
     # file-set hash/artifact/endpoint, which legitimately *differs* between a failed
@@ -465,11 +478,21 @@ def aggregate_verification(
                 )
             )
         else:  # NOT_EXECUTED — non-creditable, always disclosed
+            # #423: an evidence gap is disclosed under its own prefix, and a
+            # CONTRACT-BOUND gap is required-level — a criterion the evaluator
+            # cannot enforce must block acceptance (blocked_unverified), never
+            # ride to green as a free pass. Unbound gaps stay advisory
+            # (disclosed, non-blocking) per the RC-9 decision in the 1.4.4 plan.
             unverified.append(
                 UnverifiedCheck(
                     check_id=r.check_id,
-                    reason=_not_executed_reason(r),
-                    required=r.check_id in required,
+                    reason=(
+                        f"{EVALUATOR_GAP_PREFIX}{r.reason or UNSPECIFIED_REASON}"
+                        if r.evidence_gap
+                        else _not_executed_reason(r)
+                    ),
+                    required=(r.check_id in required)
+                    or (r.evidence_gap and r.criterion_id is not None),
                 )
             )
         if r.criterion_id:

--- a/src/squadops/cycles/verification_normalize.py
+++ b/src/squadops/cycles/verification_normalize.py
@@ -94,6 +94,10 @@ def normalize_task_checks(
                     status=str(row.get("status") or ""),
                     reason=_str_or_none(row.get("reason")),
                     criterion_id=_str_or_none(row.get("criterion_id")),
+                    # #423: authored-check-the-evaluator-could-not-run marker,
+                    # stamped by the typed-acceptance seam; drives the
+                    # evaluator_gap disclosure and contract-bound requiredness.
+                    evidence_gap=bool(row.get("evidence_gap", False)),
                 )
             )
         else:

--- a/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
+++ b/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
@@ -888,3 +888,70 @@ class TestFrameworkInjectedUndefinedNames:
         assert len(rows) == 1
         assert rows[0]["severity"] == "warning"  # the author's choice survives
         assert result.passed is True  # warning does not block (RC-9)
+
+
+# ---------------------------------------------------------------------------
+# #423 — skip-cause accounting: evidence gaps vs benign skips
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceGapAccounting:
+    """#423: an authored error-severity check the evaluator cannot run must
+    never read `passed: true` (cyc_bc325a67417d: 7 of 14 evaluations
+    skipped-yet-passed — the whole frontend contract surface unenforced) —
+    but it must not mission a correction either: no code repair closes an
+    evaluator limitation. It blocks at the SIP-0096 roll-up instead."""
+
+    async def test_authored_check_on_unparseable_target_is_evidence_gap(self):
+        """The #423 exhibit: import_present authored at a .tsx file."""
+        h = DevelopmentDevelopHandler()
+        criterion = TypedCheck(
+            check="import_present",
+            params={"file": "frontend/src/App.tsx", "imports": ["react"]},
+            severity="error",
+        )
+        result = await h._validate_output(
+            _inputs([criterion], expected=("frontend/src/App.tsx",)),
+            [_art("frontend/src/App.tsx", "import React from 'react'\n")],
+        )
+        row = next(c for c in result.checks if c.get("check") == "acceptance:import_present")
+        assert row["status"] == "skipped"
+        assert row["passed"] is False
+        assert row["evidence_gap"] is True
+        # No correction mission and no task failure — the gap blocks at the
+        # roll-up, not here.
+        assert result.passed is True
+        assert not any("acceptance:" in m for m in result.missing_components)
+
+    async def test_warning_severity_skip_is_not_a_gap(self):
+        h = DevelopmentDevelopHandler()
+        criterion = TypedCheck(
+            check="import_present",
+            params={"file": "frontend/src/App.tsx", "imports": ["react"]},
+            severity="warning",
+        )
+        result = await h._validate_output(
+            _inputs([criterion], expected=("frontend/src/App.tsx",)),
+            [_art("frontend/src/App.tsx", "import React from 'react'\n")],
+        )
+        row = next(c for c in result.checks if c.get("check") == "acceptance:import_present")
+        assert row["evidence_gap"] is False
+        assert row["passed"] is True
+
+    async def test_config_off_skip_is_benign(self):
+        """Deliberately disabled enforcement is not an evidence gap."""
+        h = DevelopmentDevelopHandler()
+        criterion = TypedCheck(
+            check="import_present",
+            params={"file": "main.py", "imports": ["os"]},
+            severity="error",
+        )
+        result = await h._validate_output(
+            _inputs([criterion], config={"typed_acceptance": False}),
+            [_art("main.py", "import os\n")],
+        )
+        row = next(c for c in result.checks if c.get("check") == "acceptance:import_present")
+        assert row["status"] == "skipped"
+        assert row["reason"] == "typed_acceptance_disabled"
+        assert row["evidence_gap"] is False
+        assert row["passed"] is True

--- a/tests/unit/cycles/test_verification_integrity.py
+++ b/tests/unit/cycles/test_verification_integrity.py
@@ -695,3 +695,66 @@ def test_bound_contract_with_zero_evidence_reports_zero_of_m():
     assert s.criteria_verified == ()
     assert s.criteria_total == ("vc-a", "vc-b")
     assert s.criteria_coverage == (0, 2)
+
+
+# ---------------------------------------------------------------------------
+# #423 — evidence-gap accounting at the choke point
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceGapAggregation:
+    """#423: an authored check the evaluator could not run is disclosed under
+    the evaluator_gap prefix; contract-bound gaps are required-level (a
+    criterion that cannot be enforced must never ride to accepted)."""
+
+    def test_contract_bound_gap_blocks_acceptance(self):
+        summary = aggregate_verification(
+            [
+                _passed("acceptance:endpoint_defined", criterion_id="vc-routes-endpoints"),
+                CheckResult(
+                    check_id="acceptance:import_present",
+                    status=ResultStatus.SKIPPED,
+                    reason="unsupported_file_extension",
+                    evidence_gap=True,
+                    criterion_id="vc-view-imports",
+                ),
+            ]
+        )
+        assert summary.verdict == RunVerdict.BLOCKED_UNVERIFIED
+        gap = next(u for u in summary.unverified if u.check_id == "acceptance:import_present")
+        assert gap.required is True
+        assert gap.reason == "evaluator_gap:unsupported_file_extension"
+        assert "acceptance:import_present" in summary.required_unmet
+
+    def test_unbound_gap_is_advisory(self):
+        """Author-mode gap (no criterion_id): disclosed, never blocking."""
+        summary = aggregate_verification(
+            [
+                _passed("tests_pass"),
+                CheckResult(
+                    check_id="acceptance:import_present",
+                    status=ResultStatus.SKIPPED,
+                    reason="frontend_acceptance_checks_disabled",
+                    evidence_gap=True,
+                ),
+            ],
+            required_check_ids=["tests_pass"],
+        )
+        assert summary.verdict == RunVerdict.ACCEPTED
+        gap = next(u for u in summary.unverified if u.check_id == "acceptance:import_present")
+        assert gap.required is False
+        assert gap.reason == "evaluator_gap:frontend_acceptance_checks_disabled"
+
+    def test_benign_skip_keeps_raw_reason_and_stays_advisory(self):
+        """A non-gap skip (config-off, injected family) is unchanged by #423."""
+        summary = aggregate_verification(
+            [
+                _passed("tests_pass"),
+                _skipped("acceptance:import_present", reason="typed_acceptance_disabled"),
+            ],
+            required_check_ids=["tests_pass"],
+        )
+        assert summary.verdict == RunVerdict.ACCEPTED
+        row = next(u for u in summary.unverified if u.check_id == "acceptance:import_present")
+        assert row.required is False
+        assert row.reason == "typed_acceptance_disabled"

--- a/tests/unit/cycles/test_verification_normalize.py
+++ b/tests/unit/cycles/test_verification_normalize.py
@@ -365,3 +365,34 @@ def test_failed_reason_flows_through_aggregation_to_failed_detail():
     detail = summary.failed_detail[0]
     assert detail.check_id == CHECK_TESTS_PASS
     assert detail.reason == "exit_code 5: no tests collected"
+
+
+def test_typed_row_threads_evidence_gap():
+    """#423: the seam's gap marker must survive normalization — dropped here,
+    a contract-bound unenforceable criterion silently reverts to advisory."""
+    from squadops.cycles.verification_normalize import normalize_task_checks
+
+    rows = normalize_task_checks(
+        {
+            "validation_result": {
+                "checks": [
+                    {
+                        "check": "acceptance:import_present",
+                        "status": "skipped",
+                        "reason": "unsupported_file_extension",
+                        "evidence_gap": True,
+                        "criterion_id": "vc-x",
+                    },
+                    {
+                        "check": "acceptance:endpoint_defined",
+                        "status": "passed",
+                    },
+                ]
+            }
+        },
+        subject="task-1",
+    )
+    gap_row = next(r for r in rows if r.check_id == "acceptance:import_present")
+    assert gap_row.evidence_gap is True
+    plain_row = next(r for r in rows if r.check_id == "acceptance:endpoint_defined")
+    assert plain_row.evidence_gap is False


### PR DESCRIPTION
1.4.4 fix 4 (plan: `docs/plans/1-4-4-patch-plan.md`). The false-green half of the verification-integrity family: every skipped typed check read `passed: true` regardless of cause (`handlers/cycle/base.py:455`).

## What

Skip causes now split into two accounting classes:

- **Benign** — config-off (`typed_acceptance_disabled`, `command_acceptance_checks_disabled`: the only two reasons an actual config flag produces) and framework-injected checks. Behavior unchanged.
- **Evidence gap** — an *authored* error-severity check the evaluator could not run. The row reads `passed: false` + `evidence_gap: true`; the SIP-0096 roll-up discloses it as unverified with an `evaluator_gap:<reason>` prefix; and when **contract-bound** (`criterion_id` set) it is required-level unverified → verdict `blocked_unverified` — a contract criterion can never again be silently unenforceable. Unbound gaps stay advisory (author-mode plans keep their freedom). This implements the RC-9 decision ratified at the plan review.

Two deliberate design points:

1. **A gap never fails the task or missions a correction** — no code repair closes an evaluator limitation; blocking happens at the roll-up. (The develop handler's all-passed rule excludes gap rows; builder blocks only via `missing`, untouched.)
2. **`frontend_acceptance_checks_disabled` is classified as a gap, not config-off** — despite the name there is no such config flag; it marks the unimplemented JS/TS analyzer, and an authored AST check on `.tsx` was exactly #423's measured exhibit (7 of 14 evaluations skipped-yet-passed). The classification comment documents the naming trap.

**Premise correction found while building** (the aggregation is healthier than the issue's era): since SIP-0096 landed, skipped typed rows already reach `cycle_outcome.unverified` non-creditably — the surviving false greens were the per-task `passed` flag (feeding the task-acceptance rule and the #114 gate-evaluator artifacts) and the missing required-escalation for contract-bound gaps. Both closed here. The #422 polarity note is reconciled as a side effect: unsupported command → executed error; unsupported extension → unverified; neither silently passes.

## Guardrails honored

- The **#605 registry-wide skip property is untouched** — evaluator outcomes don't change, only their accounting (the suite's own test proves it).
- §6.6.3 "never dropped": benign skips remain *disclosed* in unverified (required=False) — the plan's "out of the roll-up" is implemented as never-required, not undisclosed.
- The architecture guard caught my `== "skipped"` literal; it now compares `ResultStatus.SKIPPED`.

## Verification

New tests: the `.tsx` exhibit (gap row honest, task still green, no correction mission), warning-severity and config-off polarity guards, normalizer threading, and the three aggregation cases (contract-bound gap → `blocked_unverified` with prefixed reason; unbound gap → advisory; benign skip → byte-identical behavior). Full regression: **6214 passed, 1 skipped** (was 6207).

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
