### PR TITLE
fix(planning): plan authoring collapse is a rejection, never a silent static fallback (#424)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2786,6 +2786,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         errors: list[str] = []
         interface_content: str | None = None
         parsed_plan: ImplementationPlan | None = None
+        plan_artifact_seen = False  # #424: exists-but-unreadable ≠ absent
         contract = None  # set in bind mode below; feeds the soft-violation log
         for ref_id in tuple(run.artifact_refs or ()):
             try:
@@ -2796,6 +2797,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             if ref.filename == "implementation_plan.yaml" or (
                 artifact_type == "control_implementation_plan"
             ):
+                plan_artifact_seen = True
                 try:
                     parsed_plan = ImplementationPlan.from_yaml(
                         content_bytes.decode(errors="replace")
@@ -2834,6 +2836,24 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     errors.extend(parsed_plan.validate_build_config(cycle.resolved_config()))
             elif ref.filename == "interface_manifest.yaml" or artifact_type == "interface_manifest":
                 interface_content = content_bytes.decode(errors="replace")
+
+        # #424: this seam's precondition is implementation_plan=true, so a
+        # COMPLETED framing run with no plan artifact at all means plan
+        # authoring collapsed (manifest exhaustion / artifact lost) — the
+        # profile's instrument does not exist, and letting the gate approve
+        # spends a full implementation run to be caught by the SIP-0096
+        # throttle at the very end. Reject here, where a re-roll costs
+        # minutes; generate_task_plan's dispatch net is the raising backstop.
+        # An unreadable plan (parse failure above) still defers — that
+        # artifact exists and the dispatch net gives it a full diagnosis.
+        if not plan_artifact_seen:
+            errors.append(
+                "plan_authoring_collapsed: this framing run produced no "
+                "implementation_plan artifact, but the profile's instrumentation "
+                "contract (typed_acceptance/implementation_plan) lives in the "
+                "authored plan — re-roll framing rather than running "
+                "uninstrumented."
+            )
 
         # SIP-0099 99.2: a framing-emitted interface manifest is validated here — this is
         # its ONLY net (the dispatch-time net in cycles/task_plan.py stays scaffold-free to

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -651,6 +651,7 @@ def generate_task_plan(
     # SIP-0086: replace static build steps with plan-derived steps.
     # Only applies when the step list actually contains build steps.
     has_build_steps = any(s[0] in _BUILD_TASK_TYPES for s in steps)
+    _require_plan_for_instrumented_cycle(plan, has_build_steps, resolved_config)
     if plan is not None and has_build_steps:
         plan = _bind_plan_criteria(plan, contract)
         steps = _replace_build_steps_with_plan(steps, plan, profile, profile_roles, contract)
@@ -878,6 +879,31 @@ def _validate_plan_against_contract(plan: ImplementationPlan, contract: Verifica
     # the gate reviewer (never a rejection — reverted-#552 lesson).
     for warning in plan.lint_prose_contract_conflicts(contract):
         logger.warning("Plan prose/contract conflict: %s", warning)
+
+
+def _require_plan_for_instrumented_cycle(
+    plan: ImplementationPlan | None, has_build_steps: bool, resolved_config: dict
+) -> None:
+    """#424: refuse the static-step fallback when the plan IS the instrument.
+
+    For a profile with ``typed_acceptance``/``implementation_plan``, a missing
+    plan must never degrade to static steps — the run would spend itself with
+    its instrumentation contract silently absent, caught only by the SIP-0096
+    required-check throttle at the very end (cyc_7d2f505e5e8f). Raising here is
+    the dispatch backstop (the #291/#392 precedent, single point with config in
+    hand); the workload-gate net records the graceful rejection first.
+    """
+    if plan is not None or not has_build_steps:
+        return
+    if not (resolved_config.get("implementation_plan") or resolved_config.get("typed_acceptance")):
+        return
+    raise CycleError(
+        "implementation plan required but absent: this cycle's profile sets "
+        "typed_acceptance/implementation_plan, so its instrumentation contract "
+        "lives in the authored plan — plan authoring collapsed (or the plan "
+        "artifact was not forwarded), and falling back to static task steps "
+        "would run the cycle with that contract silently absent."
+    )
 
 
 def _replace_build_steps_with_plan(

--- a/tests/unit/capabilities/test_interface_manifest_framing.py
+++ b/tests/unit/capabilities/test_interface_manifest_framing.py
@@ -105,6 +105,31 @@ def test_validate_unparseable_manifest_is_a_single_error():
 def _executor_for(manifest_yaml: str | None) -> tuple[DispatchedFlowExecutor, Any, Any]:
     stored: dict[str, tuple[Any, bytes]] = {}
     refs: list[str] = []
+    # #424: the seam now rejects a plan-less framing outright
+    # (plan_authoring_collapsed), so these interface-manifest-net tests carry a
+    # minimal valid plan to keep exercising their own net in isolation.
+    plan_ref = MagicMock()
+    plan_ref.filename = "implementation_plan.yaml"
+    plan_ref.artifact_type = "control_implementation_plan"
+    minimal_plan = (
+        "version: 1\n"
+        "project_id: p\n"
+        "cycle_id: c\n"
+        "prd_hash: h\n"
+        "tasks:\n"
+        "  - task_index: 0\n"
+        "    task_type: development.develop\n"
+        "    role: dev\n"
+        '    focus: "Backend"\n'
+        '    description: "Build"\n'
+        "    expected_artifacts:\n"
+        '      - "backend/main.py"\n'
+        "    depends_on: []\n"
+        "summary:\n"
+        "  total_tasks: 1\n"
+    )
+    stored["ref-plan"] = (plan_ref, minimal_plan.encode("utf-8"))
+    refs.append("ref-plan")
     if manifest_yaml is not None:
         ref = MagicMock()
         ref.filename = "interface_manifest.yaml"

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -1205,3 +1205,37 @@ class TestWorkloadGateSeamValidation:
             gated_run, gated_cycle, "progress_plan_review"
         )
         assert any("build_profile" in e for e in errors)
+
+
+class TestWorkloadGatePlanAbsent:
+    """#424: a completed framing with NO plan artifact on an
+    implementation_plan profile = authoring collapsed — reject at the gate
+    (free re-roll), never approve into an uninstrumented implementation run."""
+
+    async def test_absent_plan_rejected(self, executor, mock_vault, cycle, run):
+        import dataclasses
+
+        gated_cycle = dataclasses.replace(cycle, applied_defaults={"implementation_plan": True})
+        bare_run = dataclasses.replace(run, artifact_refs=())
+
+        errors = await executor._reject_invalid_plan_before_workload_gate(
+            bare_run, gated_cycle, "progress_plan_review"
+        )
+        assert any("plan_authoring_collapsed" in e for e in errors)
+
+    async def test_unreadable_plan_still_defers(self, executor, mock_vault, cycle, run):
+        """Exists-but-unparseable keeps today's deferral — the dispatch net
+        gives it a full diagnosis; only true absence is a collapse."""
+        import dataclasses
+
+        gated_cycle = dataclasses.replace(cycle, applied_defaults={"implementation_plan": True})
+        ref = MagicMock()
+        ref.filename = "implementation_plan.yaml"
+        ref.artifact_type = "control_implementation_plan"
+        mock_vault.retrieve.return_value = (ref, b"{{{{not yaml")
+        wired_run = dataclasses.replace(run, artifact_refs=("art_plan",))
+
+        errors = await executor._reject_invalid_plan_before_workload_gate(
+            wired_run, gated_cycle, "progress_plan_review"
+        )
+        assert not any("plan_authoring_collapsed" in e for e in errors)

--- a/tests/unit/cycles/test_task_plan_implementation.py
+++ b/tests/unit/cycles/test_task_plan_implementation.py
@@ -217,3 +217,54 @@ class TestDeterministicTaskIds:
         assert plan[0].task_id.endswith("governance.define_done")
         assert plan[1].task_id.endswith("development.develop")
         assert plan[2].task_id.endswith("qa.test")
+
+
+class TestPlanRequiredNoStaticFallback:
+    """#424: an implementation_plan/typed_acceptance cycle whose plan is absent
+    must refuse dispatch — the static-step fallback ran the whole cycle with
+    the profile's instrumentation contract silently missing (cyc_7d2f505e5e8f:
+    caught only by the required-check throttle after the full run was spent)."""
+
+    @staticmethod
+    def _gated_cycle(impl_cycle, **defaults):
+        import dataclasses
+
+        return dataclasses.replace(impl_cycle, applied_defaults=dict(defaults))
+
+    def test_absent_plan_raises_for_implementation_plan_cycle(self, impl_cycle, impl_run, profile):
+        from squadops.cycles.models import CycleError
+
+        cycle = self._gated_cycle(impl_cycle, implementation_plan=True, build_tasks=True)
+        with pytest.raises(CycleError) as exc_info:
+            generate_task_plan(cycle, impl_run, profile, plan=None)
+        assert "implementation plan required but absent" in str(exc_info.value)
+
+    def test_absent_plan_raises_for_typed_acceptance_cycle(self, impl_cycle, impl_run, profile):
+        from squadops.cycles.models import CycleError
+
+        cycle = self._gated_cycle(impl_cycle, typed_acceptance=True, build_tasks=True)
+        with pytest.raises(CycleError):
+            generate_task_plan(cycle, impl_run, profile, plan=None)
+
+    def test_unflagged_cycle_keeps_static_fallback(self, impl_cycle, impl_run, profile):
+        """Legacy/plan-less profiles (smoke, selftest) still get static steps."""
+        cycle = self._gated_cycle(impl_cycle, build_tasks=True)
+        envelopes = generate_task_plan(cycle, impl_run, profile, plan=None)
+        assert envelopes  # static build steps materialized, no raise
+
+    def test_framing_workload_unaffected(self, impl_cycle, profile):
+        """Framing has no build steps — the guard must not fire there."""
+        from squadops.cycles.models import Run, WorkloadType
+
+        cycle = self._gated_cycle(impl_cycle, implementation_plan=True)
+        framing_run = Run(
+            run_id="run_framing",
+            cycle_id="cyc_impl",
+            run_number=1,
+            status="queued",
+            initiated_by="api",
+            resolved_config_hash="hash",
+            workload_type=WorkloadType.FRAMING,
+        )
+        envelopes = generate_task_plan(cycle, framing_run, profile, plan=None)
+        assert envelopes


### PR DESCRIPTION
1.4.4 fix 5 (plan: `docs/plans/1-4-4-patch-plan.md`). Full rationale in the commit message; highlights:

- **Premise corrections**: the sole-author exhaustion leg already fails loudly (closed since filing); the surviving holes were the silent static fallback in `generate_task_plan` (plan=None → static steps, `task_plan.py:654`) and the workload gate approving a plan-less framing. The issue's `plan_authoring_collapsed` artifact is superseded by the #473 gate-decision recording + #427's persisted failure reason.
- **Gate net**: completed framing + no plan artifact + `implementation_plan` profile → `plan_authoring_collapsed` rejection → free re-roll. Unreadable-but-present still defers to the dispatch net's fuller diagnosis.
- **Dispatch backstop**: `_require_plan_for_instrumented_cycle` raises `CycleError` for instrumented cycles; legacy/plan-less profiles keep static steps (tested both ways, plus framing-workload unaffected).
- Tests: 6 new (dispatch raise ×2, flag-off fallback preserved, framing exempt, gate absent-plan rejection, unreadable-defers); two interface-manifest-net fixtures gained a minimal plan (they modeled plan-less framings incidentally, which is now the rejected shape).
- Full regression: **6213 passed, 1 skipped**.

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv