### PR TITLE
fix(executor): time budget gates correction-chain dispatch, not just the main task loop (#511)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -678,8 +678,13 @@ class CorrectionRunner:
         plan_delta_refs: list[str],
         bound_record: Any = None,
         enforcement_carry: list[str] | None = None,
+        budget_guard: Callable[[], None] | None = None,
     ) -> TaskResult:
         """Dispatch one correction/repair step and handle its outcome.
+
+        ``budget_guard`` (#511) fires FIRST — this is the correction lanes'
+        single dispatch boundary, so raising here is what "the budget gates
+        every dispatch decision" means for analyze/decision/repair/retest.
 
         The shared per-step sequence both protocol loops used verbatim:
         create the Prefect task_run (SIP-0087 B2), emit TASK_DISPATCHED,
@@ -698,6 +703,8 @@ class CorrectionRunner:
         authoritative instruction to ``enforcement_carry`` for the next
         attempt's evidence (restore+signal).
         """
+        if budget_guard is not None:
+            budget_guard()
         task_run_id = await self._task_dispatcher.create_task_run_if_enabled(
             flow_run_id, step_envelope
         )
@@ -782,8 +789,14 @@ class CorrectionRunner:
         interface_manifest: Any = None,
         artifact_contents: dict[str, str] | None = None,
         scaffold_enforcement_carry: list[str] | None = None,
+        budget_guard: Callable[[], None] | None = None,
     ) -> CorrectionProtocolResult:
         """Run the correction protocol: analyze → decide → act.
+
+        ``budget_guard`` (#511) raises at the dispatch choke point when the
+        run's time budget is spent — correction chains previously bypassed
+        the budget entirely and could overrun the run's contract
+        indefinitely.
 
         Returns the correction_path chosen by the governance handler plus,
         on the patch path, the repair steps' emitted artifacts (#389).
@@ -888,6 +901,7 @@ class CorrectionRunner:
                 stored_artifacts=stored_artifacts,
                 completed_task_ids=completed_task_ids,
                 plan_delta_refs=plan_delta_refs,
+                budget_guard=budget_guard,
             )
 
             # Collect correction task outputs into the right named bucket so
@@ -1093,6 +1107,7 @@ class CorrectionRunner:
                     # enforcement as regular storage (restore + carry signal).
                     bound_record=bound_record,
                     enforcement_carry=scaffold_enforcement_carry,
+                    budget_guard=budget_guard,
                 )
 
                 # Collect repair outputs under the role key, matching the
@@ -1153,6 +1168,7 @@ class CorrectionRunner:
         plan_delta_refs: list[str],
         profile: Any = None,
         flow_run_id: str | None = None,
+        budget_guard: Callable[[], None] | None = None,
     ) -> TaskResult | None:
         """Re-execute a repaired qa.test suite in the QA agent's environment (#456).
 
@@ -1249,4 +1265,5 @@ class CorrectionRunner:
             stored_artifacts=stored_artifacts,
             completed_task_ids=completed_task_ids,
             plan_delta_refs=plan_delta_refs,
+            budget_guard=budget_guard,
         )

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -17,6 +17,7 @@ import dataclasses
 import logging
 import os
 import time
+from collections.abc import Callable
 from datetime import UTC, datetime
 from hashlib import sha256
 from typing import TYPE_CHECKING, Any
@@ -1248,6 +1249,22 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         time_budget = cycle.applied_defaults.get("time_budget_seconds")
         run_start_time = time.monotonic()
 
+        # #511: the budget gates EVERY dispatch lane. The main task loop checks
+        # it in _check_task_preconditions, but correction-chain dispatches
+        # (analyze / decision / repair / retest) previously bypassed it — a run
+        # in late-stage correction churn could overrun its contract
+        # indefinitely (run_57807c247bb4: a whole chain dispatched after the
+        # 7200s mark; shk-4: round 2 ran 39 minutes past a 3h budget). This
+        # guard is handed to the CorrectionRunner and raised at its single
+        # dispatch choke point. In-flight work still completes — the semantic
+        # is "no NEW dispatch past expiry", identical to the main loop's.
+        def _budget_guard() -> None:
+            if time_budget is not None and (time.monotonic() - run_start_time) >= time_budget:
+                raise _ExecutionError(
+                    f"Time budget exhausted ({time_budget}s) at correction-chain dispatch "
+                    f"after {len(completed_task_ids)} tasks"
+                )
+
         # SIP-0079: Resume from checkpoint — restore prior state
         checkpoint = await self._cycle_registry.get_latest_checkpoint(run_id)
         if checkpoint:
@@ -1370,6 +1387,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     flow_run_id=flow_run_id,
                     patched_result_holder=_holder,
                     interface_manifest=interface_manifest,
+                    budget_guard=_budget_guard,
                 )
                 if action in ("continue", "accept_patch"):
                     # #379: this attempt failed — re-dispatched ("continue") or
@@ -1975,8 +1993,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         patched_result_holder: dict[str, Any] | None = None,
         enriched_envelope: TaskEnvelope | None = None,
         interface_manifest: Any = None,
+        budget_guard: Callable[[], None] | None = None,
     ) -> str:
         """Route a failed task outcome. Returns an action string.
+
+        ``budget_guard`` (#511) raises when the run's time budget is spent; it
+        is forwarded to every correction-chain dispatch so no lane can start
+        new work past expiry.
 
         ``enriched_envelope`` is the dispatch-time envelope carrying the
         materialized workspace (``artifact_contents``) — the base ``envelope``
@@ -2069,6 +2092,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             profile=profile,
             flow_run_id=flow_run_id,
             interface_manifest=interface_manifest,
+            budget_guard=budget_guard,
             # 3.4b: run-lived restore+signal carry (created beside correction_counter).
             scaffold_enforcement_carry=scaffold_enforcement_carry,
             # RC3 (pf-23): re-resolve the workspace from the LIVE stored_artifacts
@@ -2122,6 +2146,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 plan_delta_refs=plan_delta_refs,
                 profile=profile,
                 flow_run_id=flow_run_id,
+                budget_guard=budget_guard,
             )
             return action
         elif correction_path == "continue":
@@ -2148,6 +2173,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         profile: Any = None,
         flow_run_id: str | None = None,
         enriched_envelope: TaskEnvelope | None = None,
+        budget_guard: Callable[[], None] | None = None,
     ) -> str:
         """Behaviorally verify a patch (#389); return "accept_patch" or "continue".
 
@@ -2263,6 +2289,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 plan_delta_refs=plan_delta_refs if plan_delta_refs is not None else [],
                 profile=profile,
                 flow_run_id=flow_run_id,
+                budget_guard=budget_guard,
             )
             retest_outputs = (retest_result.outputs or {}) if retest_result else {}
             fresh_test_result = retest_outputs.get("test_result")

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -3467,3 +3467,115 @@ class TestFrontendBuildProvenanceTargeting:
         }
         artifacts, _, _ = _resolve_repair_target(evidence, dict(self._FAY8_INPUTS))
         assert not any(a.startswith("frontend/") for a in artifacts)
+
+
+# ---------------------------------------------------------------------------
+# #511 — the budget gates correction-chain dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetGatesCorrectionDispatch:
+    """#511: a run past its time budget must not START correction work.
+    run_57807c247bb4 dispatched a whole repair chain after the 7200s mark;
+    shk-4's round 2 was admitted 2min before expiry and ran 39min past.
+    The guard fires at the runner's single dispatch choke point, BEFORE
+    any transport work."""
+
+    @staticmethod
+    def _bare_runner():
+        from adapters.cycles.correction_runner import CorrectionRunner
+
+        dispatcher = AsyncMock()
+        runner = CorrectionRunner(
+            cycle_registry=AsyncMock(),
+            artifact_vault=AsyncMock(),
+            event_bus=MagicMock(),
+            task_dispatcher=dispatcher,
+            store_artifact=AsyncMock(),
+        )
+        return runner, dispatcher
+
+    @staticmethod
+    def _envelope():
+        from squadops.tasks.models import TaskEnvelope
+
+        return TaskEnvelope(
+            task_id="task-1",
+            agent_id="neo",
+            cycle_id="cyc_001",
+            pulse_id="p1",
+            project_id="proj",
+            task_type="development.develop",
+            correlation_id="c1",
+            causation_id="c1",
+            trace_id="t1",
+            span_id="s1",
+            inputs={},
+            metadata={"role": "dev"},
+        )
+
+    async def test_expired_budget_blocks_correction_before_any_dispatch(self, cycle):
+        from adapters.cycles.execution_errors import _ExecutionError
+        from squadops.tasks.models import TaskResult
+
+        runner, dispatcher = self._bare_runner()
+
+        def expired_guard() -> None:
+            raise _ExecutionError("Time budget exhausted (10s) at correction-chain dispatch")
+
+        with pytest.raises(_ExecutionError, match="Time budget exhausted"):
+            await runner.run_correction_protocol(
+                run_id="run_001",
+                cycle=cycle,
+                envelope=self._envelope(),
+                result=TaskResult(task_id="task-1", status="FAILED", error="boom"),
+                correction_attempts=0,
+                prior_outputs={},
+                all_artifact_refs=[],
+                stored_artifacts=[],
+                completed_task_ids=[],
+                plan_delta_refs=[],
+                budget_guard=expired_guard,
+            )
+        # The guard must fire BEFORE any transport work — no task_run, no dispatch.
+        dispatcher.create_task_run_if_enabled.assert_not_awaited()
+        dispatcher.dispatch_task.assert_not_awaited()
+
+    async def test_unexpired_guard_lets_the_chain_dispatch(self, cycle):
+        """Polarity: a live guard that does not raise must not block the chain."""
+        from squadops.tasks.models import TaskResult
+
+        runner, dispatcher = self._bare_runner()
+        dispatcher.create_task_run_if_enabled.return_value = None
+        dispatcher.dispatch_task.return_value = TaskResult(
+            task_id="corr-1",
+            status="SUCCEEDED",
+            outputs={"classification": "execution", "analysis_summary": "ok", "role": "data"},
+        )
+
+        calls = {"n": 0}
+
+        def live_guard() -> None:
+            calls["n"] += 1
+
+        # The decision step reply lacks a correction_path → protocol raises its
+        # own error AFTER dispatching both chain steps; what this test pins is
+        # that the guard was consulted per dispatch and dispatch happened.
+        try:
+            await runner.run_correction_protocol(
+                run_id="run_001",
+                cycle=cycle,
+                envelope=self._envelope(),
+                result=TaskResult(task_id="task-1", status="FAILED", error="boom"),
+                correction_attempts=0,
+                prior_outputs={},
+                all_artifact_refs=[],
+                stored_artifacts=[],
+                completed_task_ids=[],
+                plan_delta_refs=[],
+                budget_guard=live_guard,
+            )
+        except Exception:
+            pass
+        assert dispatcher.dispatch_task.await_count >= 1
+        assert calls["n"] >= dispatcher.dispatch_task.await_count


### PR DESCRIPTION
1.4.4 fix 6 (plan: `docs/plans/1-4-4-patch-plan.md`). Full mechanism in the commit message.

- One per-run `budget_guard` closure (same clock + budget source as the main loop's check), threaded to the CorrectionRunner's single dispatch choke point — covering analyze/decision/repair/retest in one place, firing **before** any transport work.
- Semantic unchanged and now uniform across lanes: in-flight work completes; no *new* dispatch starts past expiry. With #427 the exhaustion reason persists on the run row.
- Tests: expired guard blocks the chain before any dispatch (no task_run, no publish); polarity — a live guard doesn't block and is consulted per dispatch. The live wiring proof is tonight's tiny-budget designed-failure probe in the 1.4.4 integration deploy window (per the plan).
- Full regression: **6209 passed, 1 skipped**.

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv