### PR TITLE
fix(memory): LanceDB search prefilters in-query and scores with an explicit cosine metric (#571)

### DIFF
--- a/adapters/memory/lancedb.py
+++ b/adapters/memory/lancedb.py
@@ -126,26 +126,33 @@ class LanceDBAdapter(MemoryPort):
             # Generate query embedding via port
             query_embedding = await self._embeddings.embed(query.text)
 
-            # Search
-            results = self._table.search(query_embedding).limit(query.limit).to_list()
+            # #571: filters are pushed into the query with prefilter=True —
+            # filtering in Python AFTER .limit(N) returned the N nearest rows
+            # across ALL namespaces and then discarded the mismatches, so a
+            # query could return far fewer than `limit` (including zero) while
+            # plenty of in-namespace matches sat just past the first N. The
+            # metric is selected explicitly: the default is L2, and the
+            # `1.0 - _distance` score transform is only valid for cosine.
+            search = self._table.search(query_embedding).metric("cosine")
+            predicates = []
+            if query.namespace:
+                ns = str(query.namespace).replace("'", "''")
+                predicates.append(f"namespace = '{ns}'")
+            for tag in query.tags or ():
+                t = str(tag).replace("'", "''")
+                predicates.append(f"array_has(tags, '{t}')")
+            if predicates:
+                search = search.where(" AND ".join(predicates), prefilter=True)
+            results = search.limit(query.limit).to_list()
 
             # Convert to MemoryResult
             memory_results = []
             for row in results:
-                # Filter by threshold
-                score = 1.0 - row.get("_distance", 0.0)  # LanceDB uses distance
+                # Threshold stays a post-filter: it is a quality floor on the
+                # (now valid) cosine score, not a row-identity predicate.
+                score = 1.0 - row.get("_distance", 0.0)
                 if score < query.threshold:
                     continue
-
-                # Filter by namespace if specified
-                if query.namespace and row.get("namespace") != query.namespace:
-                    continue
-
-                # Filter by tags if specified
-                if query.tags:
-                    row_tags = set(row.get("tags", []))
-                    if not all(t in row_tags for t in query.tags):
-                        continue
 
                 entry = MemoryEntry(
                     content=row.get("content", ""),

--- a/tests/unit/memory/test_lancedb_query_semantics.py
+++ b/tests/unit/memory/test_lancedb_query_semantics.py
@@ -1,0 +1,128 @@
+"""#571 — LanceDB query semantics against a REAL store (no mocks).
+
+The two defects were invisible to mock-based tests by construction: post-limit
+filtering starves results only when a real ANN query returns real neighbors,
+and the L2-vs-cosine mismatch only shows in real ``_distance`` values. These
+tests run against an actual LanceDB table in tmp_path with deterministic
+vectors, so they fail on the pre-#571 adapter and on any regression to either
+behavior.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from squadops.memory.models import MemoryEntry, MemoryQuery
+from squadops.ports.embeddings.provider import EmbeddingsPort
+
+pytestmark = [pytest.mark.domain_memory]
+
+_DIM = 4
+
+
+class VectorMapEmbeddings(EmbeddingsPort):
+    """Deterministic text→vector map so distances are designed, not learned."""
+
+    def __init__(self, mapping: dict[str, list[float]]):
+        self._mapping = mapping
+
+    async def embed(self, text: str) -> list[float]:
+        return list(self._mapping[text])
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return [await self.embed(t) for t in texts]
+
+    def dimensions(self) -> int:
+        return _DIM
+
+    async def health(self) -> dict:
+        return {"healthy": True}
+
+
+def _unit(theta: float) -> list[float]:
+    """A unit vector at angle theta in the first two dims."""
+    return [math.cos(theta), math.sin(theta), 0.0, 0.0]
+
+
+def _adapter(tmp_path, mapping):
+    from adapters.memory.lancedb import LanceDBAdapter
+
+    return LanceDBAdapter(db_path=str(tmp_path / "db"), embeddings=VectorMapEmbeddings(mapping))
+
+
+async def test_namespace_prefilter_defeats_limit_starvation(tmp_path):
+    """The #571 headline: N out-of-namespace rows sit NEARER the query than
+    every in-namespace row. Post-limit filtering returns ZERO results here;
+    the prefiltered query must return the in-namespace matches."""
+    mapping = {"query": _unit(0.0)}
+    for i in range(5):
+        mapping[f"noise-{i}"] = _unit(0.01 * (i + 1))  # nearest 5: wrong namespace
+    for i in range(3):
+        mapping[f"role-{i}"] = _unit(0.3 + 0.01 * i)  # farther, right namespace
+
+    adapter = _adapter(tmp_path, mapping)
+    for i in range(5):
+        await adapter.store(MemoryEntry(content=f"noise-{i}", namespace="cycle"))
+    for i in range(3):
+        await adapter.store(MemoryEntry(content=f"role-{i}", namespace="role"))
+
+    results = await adapter.search(
+        MemoryQuery(text="query", limit=3, threshold=0.0, namespace="role")
+    )
+
+    assert len(results) == 3
+    assert {r.entry.content for r in results} == {"role-0", "role-1", "role-2"}
+
+
+async def test_tag_prefilter_defeats_limit_starvation(tmp_path):
+    mapping = {"query": _unit(0.0)}
+    for i in range(4):
+        mapping[f"untagged-{i}"] = _unit(0.01 * (i + 1))
+    mapping["tagged"] = _unit(0.4)
+
+    adapter = _adapter(tmp_path, mapping)
+    for i in range(4):
+        await adapter.store(MemoryEntry(content=f"untagged-{i}", namespace="role"))
+    await adapter.store(MemoryEntry(content="tagged", namespace="role", tags=("lesson",)))
+
+    results = await adapter.search(
+        MemoryQuery(text="query", limit=2, threshold=0.0, namespace="role", tags=("lesson",))
+    )
+
+    assert [r.entry.content for r in results] == ["tagged"]
+
+
+async def test_score_is_cosine_not_l2(tmp_path):
+    """A vector pointing the SAME direction at a different magnitude has
+    cosine distance ~0 (score ~1.0). Under the default L2 metric its distance
+    would be large and the score meaningless — this pins the explicit metric."""
+    mapping = {
+        "query": [1.0, 0.0, 0.0, 0.0],
+        "same-direction-scaled": [10.0, 0.0, 0.0, 0.0],
+    }
+    adapter = _adapter(tmp_path, mapping)
+    await adapter.store(MemoryEntry(content="same-direction-scaled", namespace="role"))
+
+    results = await adapter.search(MemoryQuery(text="query", limit=1, threshold=0.0))
+
+    assert len(results) == 1
+    assert results[0].score == pytest.approx(1.0, abs=1e-5)
+
+
+async def test_threshold_remains_a_quality_floor(tmp_path):
+    """An orthogonal vector (cosine score ~0) must drop below a 0.5 threshold —
+    the post-filter that legitimately returns fewer than limit."""
+    mapping = {
+        "query": [1.0, 0.0, 0.0, 0.0],
+        "aligned": [1.0, 0.1, 0.0, 0.0],
+        "orthogonal": [0.0, 0.0, 1.0, 0.0],
+    }
+    adapter = _adapter(tmp_path, mapping)
+    await adapter.store(MemoryEntry(content="aligned", namespace="role"))
+    await adapter.store(MemoryEntry(content="orthogonal", namespace="role"))
+
+    results = await adapter.search(MemoryQuery(text="query", limit=5, threshold=0.5))
+
+    assert [r.entry.content for r in results] == ["aligned"]


### PR DESCRIPTION
1.4.4 fix 7 of 7 (plan: `docs/plans/1-4-4-patch-plan.md`). Mechanism in the commit message.

- Prefiltered `.where(namespace = ... AND array_has(tags, ...), prefilter=True)` + explicit `.metric("cosine")`; threshold deliberately stays a post-filter (quality floor on the now-valid score).
- Tests against a **real** LanceDB store with deterministic vectors — the starvation repro (nearest-N all wrong-namespace → old code returns zero, fixed code returns the matches), the tag variant, the scaled-same-direction cosine pin, and the threshold floor. **Revert-checked**: 3 of 4 fail on the pre-fix adapter.
- Dev venv runs lancedb 0.29.2; agent images pin 0.8.2 — the API surface used (`metric`, `prefilter`, `array_has`) exists in both, and tonight's integration deploy window includes an in-container recall smoke against the pinned version.
- Full regression: **6207 passed, 1 skipped** (the regression gate excludes the memory domain; the 4 new domain_memory tests run standalone — 4 passed, revert-checked).

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
