### PR TITLE
feat(replay): SIP-0101 Slice 1 — replay evidence rails (inert)

### DIFF
--- a/src/squadops/api/routes/cycles/dtos.py
+++ b/src/squadops/api/routes/cycles/dtos.py
@@ -168,6 +168,15 @@ class UnverifiedCheckDTO(BaseModel):
     required: bool
 
 
+class ReplayProvenanceDTO(BaseModel):
+    """SIP-0101 §4.1: the prefix of this outcome was restored from another run's
+    checkpoint — inherited evidence, never presentable as earned."""
+
+    source_run_id: str
+    boundary_index: int
+    compatibility_set: list[str] = Field(default_factory=list)
+
+
 class CycleOutcomeDTO(BaseModel):
     """SIP-0096 §10 per-cycle verification roll-up, derived on read.
 
@@ -182,6 +191,7 @@ class CycleOutcomeDTO(BaseModel):
     unverified: list[UnverifiedCheckDTO] = Field(default_factory=list)
     required_unmet: list[str] = Field(default_factory=list)
     run_count: int = 0
+    replay: ReplayProvenanceDTO | None = None  # SIP-0101 — present iff replayed
 
 
 class CycleResponse(BaseModel):

--- a/src/squadops/api/routes/cycles/mapping.py
+++ b/src/squadops/api/routes/cycles/mapping.py
@@ -12,6 +12,7 @@ from squadops.api.routes.cycles.dtos import (
     GateDecisionResponse,
     GateDTO,
     ProjectResponse,
+    ReplayProvenanceDTO,
     RunResponse,
     SquadProfileResponse,
     TaskFlowPolicyDTO,
@@ -153,6 +154,15 @@ def _cycle_outcome_to_dto(outcome: CycleOutcome) -> CycleOutcomeDTO:
         ],
         required_unmet=list(outcome.required_unmet),
         run_count=outcome.run_count,
+        replay=(
+            ReplayProvenanceDTO(
+                source_run_id=outcome.replay.source_run_id,
+                boundary_index=outcome.replay.boundary_index,
+                compatibility_set=list(outcome.replay.compatibility_set),
+            )
+            if outcome.replay is not None
+            else None
+        ),
     )
 
 

--- a/src/squadops/cli/commands/cycles.py
+++ b/src/squadops/cli/commands/cycles.py
@@ -77,6 +77,21 @@ def _merge_crp_body_fields(body: dict, merged: dict) -> None:
             body[key] = merged[key]
 
 
+def _replay_marker_lines_from_detail(data: dict) -> list[str]:
+    """SIP-0101 §4.1 disclosure lines for a replayed cycle, empty when normal.
+
+    Reads the ``cycle_outcome.replay`` block off the detail response; rendering
+    wording comes from the shared :func:`replay_marker_lines` source so surfaces
+    cannot drift.
+    """
+    replay = ((data.get("cycle_outcome") or {}).get("replay")) or None
+    if not replay:
+        return []
+    from squadops.cycles.replay import ReplayProvenance, replay_marker_lines
+
+    return replay_marker_lines(ReplayProvenance.from_dict(replay))
+
+
 def _parse_set_flags(set_flags: list[str]) -> dict:
     """Parse --set key=value flags into a dict."""
     result = {}
@@ -241,6 +256,10 @@ def show_cycle(
     if fmt == "json":
         print_json(data)
     else:
+        # SIP-0101 §4.1: a replayed cycle is marked before any other detail —
+        # inherited-prefix evidence must be impossible to read as earned.
+        for line in _replay_marker_lines_from_detail(data):
+            typer.secho(line, fg=typer.colors.YELLOW, bold=True)
         # Extract workload_progress for dedicated rendering
         wp = data.pop("workload_progress", [])
         print_detail(data, quiet=quiet)

--- a/src/squadops/cycles/replay.py
+++ b/src/squadops/cycles/replay.py
@@ -1,0 +1,28 @@
+"""Replay evidence rails — rendering surface (SIP-0101 Slice 1).
+
+The ``ReplayProvenance`` record itself lives in ``verification_integrity``
+beside its evidence-disclosure siblings (``UnverifiedCheck``, ``WaivedCheck``)
+so the aggregation module stays import-pure; it is re-exported here as the
+SIP-0101-named import path. This module owns the human-facing wording.
+"""
+
+from __future__ import annotations
+
+from squadops.cycles.verification_integrity import ReplayProvenance
+
+__all__ = ["ReplayProvenance", "replay_marker_lines"]
+
+
+def replay_marker_lines(replay: ReplayProvenance) -> list[str]:
+    """The human-facing replay disclosure, shared by every rendering surface.
+
+    One source for the wording so the report, CLI, and any future surface
+    cannot drift into softer language: evidence at or before the boundary is
+    inherited, not earned.
+    """
+    return [
+        f"⚠ REPLAYED — prefix restored from {replay.source_run_id} "
+        f"at boundary {replay.boundary_index}",
+        "Evidence at or before the boundary is inherited from the source run, "
+        "not earned by this execution.",
+    ]

--- a/src/squadops/cycles/run_report_builder.py
+++ b/src/squadops/cycles/run_report_builder.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from squadops.cycles.models import RunStatus
 from squadops.cycles.pulse_models import PulseDecision
+from squadops.cycles.replay import ReplayProvenance, replay_marker_lines
 from squadops.cycles.verification_integrity import RunVerdict
 
 if TYPE_CHECKING:
@@ -173,9 +174,16 @@ def build_run_report(
     plan: list[TaskEnvelope] | None = None,
     pulse_report_entries: list[dict[str, Any]] | None = None,
     verification_summary: RunVerificationSummary | None = None,
+    replay: ReplayProvenance | None = None,
 ) -> str:
     """Assemble the full run_report.md markdown content (D10)."""
     lines = _build_report_metadata_lines(cycle_id, run_id, run, terminal_status, cycle)
+
+    # SIP-0101 §4.1: a replayed run's report leads with the disclosure — the
+    # marker must be impossible to miss before any inherited evidence is read.
+    if replay is not None:
+        marker, caveat = replay_marker_lines(replay)
+        lines[:0] = [f"## {marker}", caveat, ""]
 
     # Task breakdown
     if plan:

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -34,9 +34,51 @@ where a profile requires them.
 from __future__ import annotations
 
 from collections.abc import Collection, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
+
+
+@dataclass(frozen=True)
+class ReplayProvenance:
+    """Where a replayed run's prefix came from (SIP-0101 §4.1).
+
+    An evidence-disclosure record like its siblings ``UnverifiedCheck`` and
+    ``WaivedCheck``: non-None on ``CycleOutcome.replay`` iff the outcome's
+    prefix was restored from another run's checkpoint — inherited evidence,
+    marked on every rendering surface. Nothing constructs it until the replay
+    mechanism (SIP-0101 Slice 3) ships; the rails land first so an unlabelled
+    replayed run can never exist (§4).
+
+    ``compatibility_set`` records the elements the create-time gate matched
+    between source and target, so the evidence names what "compatible" meant
+    when the replay was admitted.
+    """
+
+    source_run_id: str
+    boundary_index: int
+    compatibility_set: tuple[str, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not self.source_run_id:
+            raise ValueError("source_run_id must be non-empty")
+        if self.boundary_index < 0:
+            raise ValueError("boundary_index must be >= 0")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_run_id": self.source_run_id,
+            "boundary_index": self.boundary_index,
+            "compatibility_set": list(self.compatibility_set),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ReplayProvenance:
+        return cls(
+            source_run_id=str(data["source_run_id"]),
+            boundary_index=int(data["boundary_index"]),
+            compatibility_set=tuple(str(x) for x in data.get("compatibility_set", ())),
+        )
 
 
 class ResultStatus:
@@ -305,6 +347,9 @@ class CycleOutcome:
     # criterion verified in any run is honestly verified, matching verified/failed).
     criteria_verified: tuple[str, ...] = ()
     criteria_total: tuple[str, ...] = ()
+    # SIP-0101 §4.1: non-None iff this outcome's prefix was restored from another
+    # run's checkpoint — inherited evidence, marked on every rendering surface.
+    replay: ReplayProvenance | None = None
 
     @property
     def criteria_coverage(self) -> tuple[int, int]:

--- a/tests/unit/api/test_cycle_dto_mapping.py
+++ b/tests/unit/api/test_cycle_dto_mapping.py
@@ -246,6 +246,34 @@ class TestCycleOutcomeInResponse:
         assert resp.cycle_outcome.required_unmet == ["required_files"]  # derived from unverified
         assert resp.cycle_outcome.unverified[0].check_id == "required_files"
         assert resp.cycle_outcome.unverified[0].required is True
+        # SIP-0101: outcomes built without provenance must serialize replay=None
+        assert resp.cycle_outcome.replay is None
+
+    def test_replay_provenance_survives_the_dto_boundary(self):
+        """SIP-0101 §4.1: a dropped replay field is a replayed cycle the API
+        presents as earned — the exact state the rails exist to make impossible."""
+        from squadops.cycles.replay import ReplayProvenance
+        from squadops.cycles.verification_integrity import CycleOutcome, RunVerdict
+
+        outcome = CycleOutcome(
+            verdict=RunVerdict.ACCEPTED,
+            verified=(),
+            failed=(),
+            unverified=(),
+            run_count=1,
+            replay=ReplayProvenance(
+                source_run_id="run_src",
+                boundary_index=2,
+                compatibility_set=("contract_ref", "prd_ref"),
+            ),
+        )
+
+        resp = cycle_to_response(_make_cycle(), runs=[], cycle_outcome=outcome)
+
+        assert resp.cycle_outcome.replay is not None
+        assert resp.cycle_outcome.replay.source_run_id == "run_src"
+        assert resp.cycle_outcome.replay.boundary_index == 2
+        assert resp.cycle_outcome.replay.compatibility_set == ["contract_ref", "prd_ref"]
 
 
 class TestRunToResponseFailureReason:

--- a/tests/unit/cli/test_cycles_replay_marker.py
+++ b/tests/unit/cli/test_cycles_replay_marker.py
@@ -1,0 +1,47 @@
+"""SIP-0101 Slice 1 — `cycles show` renders the replay disclosure.
+
+The CLI reads the detail response's ``cycle_outcome.replay`` block; a dropped
+or mis-keyed read is a replayed cycle presented as earned on the operator's
+primary surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cli.commands.cycles import _replay_marker_lines_from_detail
+
+pytestmark = [pytest.mark.domain_cli]
+
+
+def test_marker_lines_rendered_from_replay_block():
+    data = {
+        "cycle_id": "cyc_001",
+        "cycle_outcome": {
+            "verdict": "accepted",
+            "replay": {
+                "source_run_id": "run_src",
+                "boundary_index": 3,
+                "compatibility_set": ["contract_ref"],
+            },
+        },
+    }
+    lines = _replay_marker_lines_from_detail(data)
+    assert len(lines) == 2
+    assert "run_src" in lines[0]
+    assert "boundary 3" in lines[0]
+    assert "inherited" in lines[1]
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"cycle_id": "cyc_001"},  # no outcome at all (list/legacy shape)
+        {"cycle_id": "cyc_001", "cycle_outcome": None},
+        {"cycle_id": "cyc_001", "cycle_outcome": {"verdict": "accepted"}},
+        {"cycle_id": "cyc_001", "cycle_outcome": {"verdict": "accepted", "replay": None}},
+    ],
+)
+def test_no_marker_for_normal_cycles(data):
+    # the symmetric §4 half: a normal cycle must never render the disclosure
+    assert _replay_marker_lines_from_detail(data) == []

--- a/tests/unit/cycles/test_replay_provenance.py
+++ b/tests/unit/cycles/test_replay_provenance.py
@@ -1,0 +1,83 @@
+"""SIP-0101 Slice 1 — replay evidence rails.
+
+The rails land before the mechanism exists (plan sequencing rule), so what
+these tests protect is the §4 invariant itself: a replayed outcome can never
+render unmarked, and a normal outcome can never render marked.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.models import Run
+from squadops.cycles.replay import ReplayProvenance, replay_marker_lines
+from squadops.cycles.run_report_builder import build_run_report
+
+pytestmark = [pytest.mark.domain_cycles]
+
+
+def _run() -> Run:
+    return Run(
+        run_id="run_001",
+        cycle_id="cyc_001",
+        run_number=1,
+        status="completed",
+        initiated_by="api",
+        resolved_config_hash="hash",
+    )
+
+
+class TestReplayProvenanceModel:
+    def test_empty_source_run_id_rejected(self):
+        # a provenance record that can't name its source is exactly the
+        # unlabelled-replay state §4 forbids — fail at construction
+        with pytest.raises(ValueError, match="source_run_id"):
+            ReplayProvenance(source_run_id="", boundary_index=2)
+
+    def test_negative_boundary_rejected(self):
+        with pytest.raises(ValueError, match="boundary_index"):
+            ReplayProvenance(source_run_id="run_a", boundary_index=-1)
+
+    def test_dict_roundtrip_preserves_all_fields(self):
+        # persistence/DTO layers serialize this — a dropped or coerced field
+        # is a replay that later renders unmarked
+        original = ReplayProvenance(
+            source_run_id="run_abc",
+            boundary_index=3,
+            compatibility_set=("contract_ref", "prd_ref"),
+        )
+        assert ReplayProvenance.from_dict(original.to_dict()) == original
+
+    def test_from_dict_defaults_missing_compatibility_set(self):
+        p = ReplayProvenance.from_dict({"source_run_id": "run_a", "boundary_index": 0})
+        assert p.compatibility_set == ()
+
+
+class TestReportMarker:
+    def test_replayed_report_leads_with_the_disclosure(self):
+        report = build_run_report(
+            "cyc_001",
+            "run_001",
+            _run(),
+            "COMPLETED",
+            replay=ReplayProvenance(source_run_id="run_src", boundary_index=2),
+        )
+        first_line = report.splitlines()[0]
+        assert "REPLAYED" in first_line
+        assert "run_src" in first_line
+        assert "boundary 2" in first_line
+        assert "inherited from the source run" in report
+
+    def test_normal_report_carries_no_replay_marker(self):
+        # the symmetric half of §4: a normal run must never render as a replay
+        report = build_run_report("cyc_001", "run_001", _run(), "COMPLETED")
+        assert "REPLAYED" not in report
+
+    def test_marker_wording_is_single_sourced(self):
+        # every surface renders through replay_marker_lines — if a surface
+        # re-words the disclosure this fails at the source
+        p = ReplayProvenance(source_run_id="run_src", boundary_index=2)
+        marker, caveat = replay_marker_lines(p)
+        report = build_run_report("cyc_001", "run_001", _run(), "COMPLETED", replay=p)
+        assert marker in report
+        assert caveat in report


### PR DESCRIPTION
## What

Slice 1 of the SIP-0101 minimum path (1.5 Gate-1 Track C; `docs/plans/SIP-0101-cycle-replay-harness-plan.md`): the evidence rails, landed **before** the mechanism per the plan's sequencing rule — nothing sets the attribute yet, so this is inert and independently mergeable, and an unlabelled replayed run can never come to exist.

- `ReplayProvenance` (source_run_id, boundary_index, compatibility_set) — placed in `verification_integrity.py` beside its evidence-disclosure siblings `UnverifiedCheck`/`WaivedCheck`, keeping that module's zero-squadops-imports purity guard intact; `cycles/replay.py` re-exports it (the SIP-named path) and owns the single-sourced disclosure wording.
- `CycleOutcome.replay: ReplayProvenance | None = None` + DTO/mapping threading on the cycle detail GET.
- Run report leads with the disclosure when provenance is passed; `cycles show` renders a yellow banner off the response's replay block.
- Tests cover both §4 halves: a replayed outcome can't render unmarked, a normal outcome can't render marked; DTO boundary survival; wording single-sourced.

Regression: **6235 passed**, quality lint clean.

## Decision needed before Slice 2 (flagging per the plan's own rule)

Slice 2 (boundary retention — checkpoints worth replaying currently get pruned by `max_keep=5` mid-run) carries an **additive `retained` column migration**. The 1.5 plan says "#682 is the line's only expected migration; any second is a design-review stop." This one was in the accepted SIP-0101 plan all along — the 1.5 plan's premise was incomplete, not the migration new. **Recommendation:** accept it (additive, nullable-default-false, same 1010-pattern compatibility; range 1000–1099) and amend the plan line to "two expected migrations (#682, SIP-0101 retention)." Say the word with the merge and Slice 2 proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv