### PR TITLE
feat(replay): SIP-0101 Slice 2 — boundary retention (migration 1020)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -552,6 +552,9 @@ class CorrectionRunner:
             plan_delta_refs=tuple(plan_delta_refs),
             created_at=datetime.now(UTC),
         )
+        # SIP-0101 Slice 2: correction-chain checkpoints are iteration state, not
+        # replay boundaries — deliberately unretained (retain defaults False) so a
+        # correction storm cannot pin unbounded rows past the prune window.
         await self._cycle_registry.save_checkpoint(new_checkpoint)
         self._event_bus.emit(
             EventType.CHECKPOINT_CREATED,

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1461,7 +1461,9 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # Reset consecutive failures on success
             consecutive_failures = 0
 
-            # Collect artifacts + checkpoint after successful task
+            # Collect artifacts + checkpoint after successful task; a checkpoint
+            # that closes a role phase is a replay boundary and survives pruning
+            # (SIP-0101 Slice 2)
             await self._collect_artifacts_and_checkpoint(
                 result=result,
                 envelope=envelope,
@@ -1474,6 +1476,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 plan_delta_refs=plan_delta_refs,
                 bound_record=bound_record,
                 compliance_counter=compliance_counter,
+                retain_checkpoint=self._is_phase_boundary(plan, task_idx),
             )
 
             # ----------------------------------------------------------
@@ -2427,6 +2430,21 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 f"{FailureClassification.CONTRACT_COMPLIANCE}"
             )
 
+    @staticmethod
+    def _is_phase_boundary(plan: list[TaskEnvelope], task_idx: int) -> bool:
+        """True when the task at ``task_idx`` closes a role phase (SIP-0101 Slice 2).
+
+        The last task of the plan, or a task whose successor runs under a
+        different role, ends a phase — its checkpoint is the boundary a replay
+        would restore from, and gets ``retain=True`` so ``max_keep`` pruning
+        cannot destroy it mid-run.
+        """
+        if task_idx + 1 >= len(plan):
+            return True
+        current_role = plan[task_idx].metadata.get("role")
+        next_role = plan[task_idx + 1].metadata.get("role")
+        return current_role != next_role
+
     async def _collect_artifacts_and_checkpoint(
         self,
         result: TaskResult,
@@ -2440,6 +2458,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         plan_delta_refs: list[str],
         bound_record: Any = None,
         compliance_counter: dict[str, int] | None = None,
+        retain_checkpoint: bool = False,
     ) -> None:
         """Collect artifacts from a successful task and save a checkpoint."""
         # Collect artifacts (with producing_task_type metadata)
@@ -2491,7 +2510,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             plan_delta_refs=tuple(plan_delta_refs),
             created_at=datetime.now(UTC),
         )
-        await self._cycle_registry.save_checkpoint(new_checkpoint)
+        await self._cycle_registry.save_checkpoint(new_checkpoint, retain=retain_checkpoint)
         self._cycle_event_bus.emit(
             EventType.CHECKPOINT_CREATED,
             entity_type="run",

--- a/adapters/cycles/memory_cycle_registry.py
+++ b/adapters/cycles/memory_cycle_registry.py
@@ -43,6 +43,9 @@ class MemoryCycleRegistry(CycleRegistryPort):
         self._pulse_verifications: dict[str, list[dict]] = {}
         self._verification_summaries: dict[str, RunVerificationSummary] = {}
         self._checkpoints: dict[str, list[RunCheckpoint]] = {}
+        # SIP-0101 Slice 2: (run_id, checkpoint_index) pairs excluded from pruning
+        # (the model stays retention-agnostic; postgres carries this as a column)
+        self._retained_checkpoints: set[tuple[str, int]] = set()
 
     # --- Cycle CRUD ---
 
@@ -288,15 +291,28 @@ class MemoryCycleRegistry(CycleRegistryPort):
 
     # --- Checkpoint (SIP-0079) ---
 
-    async def save_checkpoint(self, checkpoint: RunCheckpoint, max_keep: int = 5) -> None:
+    async def save_checkpoint(
+        self, checkpoint: RunCheckpoint, max_keep: int = 5, retain: bool = False
+    ) -> None:
         """Persist a run checkpoint, pruning older checkpoints beyond max_keep."""
         run_id = checkpoint.run_id
         if run_id not in self._checkpoints:
             self._checkpoints[run_id] = []
         self._checkpoints[run_id].append(checkpoint)
-        # Prune: keep only the latest max_keep
-        if len(self._checkpoints[run_id]) > max_keep:
-            self._checkpoints[run_id] = self._checkpoints[run_id][-max_keep:]
+        if retain:
+            self._retained_checkpoints.add((run_id, checkpoint.checkpoint_index))
+        # Prune, postgres-parity (SIP-0101 Slice 2): the survival window is the
+        # latest max_keep of ALL rows; retained boundary checkpoints are never
+        # pruned even when they fall outside it.
+        rows = self._checkpoints[run_id]
+        if len(rows) > max_keep:
+            window = {c.checkpoint_index for c in rows[-max_keep:]}
+            self._checkpoints[run_id] = [
+                c
+                for c in rows
+                if c.checkpoint_index in window
+                or (run_id, c.checkpoint_index) in self._retained_checkpoints
+            ]
 
     async def get_latest_checkpoint(self, run_id: str) -> RunCheckpoint | None:
         """Return the latest checkpoint for a run, or None."""

--- a/adapters/cycles/postgres_cycle_registry.py
+++ b/adapters/cycles/postgres_cycle_registry.py
@@ -432,15 +432,17 @@ class PostgresCycleRegistry(CycleRegistryPort):
 
     # --- Checkpoint (SIP-0079) ---
 
-    async def save_checkpoint(self, checkpoint: RunCheckpoint, max_keep: int = 5) -> None:
+    async def save_checkpoint(
+        self, checkpoint: RunCheckpoint, max_keep: int = 5, retain: bool = False
+    ) -> None:
         """Persist a run checkpoint, pruning older checkpoints beyond max_keep."""
         async with self._pool.acquire() as conn:
             async with conn.transaction():
                 await conn.execute(
                     "INSERT INTO run_checkpoints "
                     "(run_id, checkpoint_index, completed_task_ids, prior_outputs, "
-                    "artifact_refs, plan_delta_refs, created_at) "
-                    "VALUES ($1, $2, $3, $4, $5, $6, $7)",
+                    "artifact_refs, plan_delta_refs, created_at, retained) "
+                    "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
                     checkpoint.run_id,
                     checkpoint.checkpoint_index,
                     json.dumps(list(checkpoint.completed_task_ids)),
@@ -448,10 +450,15 @@ class PostgresCycleRegistry(CycleRegistryPort):
                     json.dumps(list(checkpoint.artifact_refs)),
                     json.dumps(list(checkpoint.plan_delta_refs)),
                     checkpoint.created_at,
+                    retain,
                 )
-                # Prune: keep only the latest max_keep checkpoints
+                # Prune: keep only the latest max_keep checkpoints. SIP-0101
+                # Slice 2: retained boundary checkpoints are never pruned —
+                # unretained pruning is unchanged (window still counted over
+                # ALL rows, so retention widens survival, never narrows it).
                 await conn.execute(
                     "DELETE FROM run_checkpoints WHERE run_id = $1 "
+                    "AND retained = FALSE "
                     "AND checkpoint_index NOT IN ("
                     "  SELECT checkpoint_index FROM run_checkpoints "
                     "  WHERE run_id = $1 ORDER BY checkpoint_index DESC LIMIT $2"

--- a/docs/plans/1-5-0-stabilization-plan.md
+++ b/docs/plans/1-5-0-stabilization-plan.md
@@ -132,13 +132,13 @@ shk-3's exhibit inverted; #605's registry-wide skip property untouched.
 ### A2. SIP-0096 completion — #682 → #683 → #684, then promotion **before the release candidate**
 
 - **#682** gate-waiver slice (§6.5/AC#12): `GateDecision` fields + migration + API +
-  roll-up `waived` population. **This is the line's only expected migration and
-  defines its migration gate:** additive and nullable; historical rows remain
-  interpretable (field-absent distinguishable from `waived=false`); old code reads new
-  rows and new code reads old rows (the 1010/`COALESCE` pattern); forward-only, with
-  the no-downgrade policy stated in the migration header; replay of pre-migration
-  artifacts produces the same roll-up. Range 1000–1099 (Spark-owned). Any *second*
-  migration appearing anywhere in the line is a design-review stop.
+  roll-up `waived` population. **Defines the line's migration gate:** additive and
+  nullable; historical rows remain interpretable (field-absent distinguishable from
+  `waived=false`); old code reads new rows and new code reads old rows (the
+  1010/`COALESCE` pattern); forward-only, with the no-downgrade policy stated in the
+  migration header; replay of pre-migration artifacts produces the same roll-up.
+  Range 1000–1099 (Spark-owned). The line expects **two** migrations (see
+  Migrations below); any further one is a design-review stop.
 - **#683** wrap-up consumes `CycleOutcome` (§10/§14): `ConfidenceClassification` gets
   its structured basis on **every** path — including fallback and replay paths, not
   just the happy path; `wrapup_tasks.py` stops deriving confidence from LLM prose.
@@ -436,9 +436,12 @@ File-ownership pinning applies where surfaces are hot: executor/handlers/framing
 (#663, #331, #567, A4) sit on M-lane-owned files; test-runner/build-check/agent-image/
 deploy-infra (#637, #581, Track C's container pieces) on S-lane files.
 
-**Migrations:** #682 carries the line's only expected migration (Spark range
-1000–1099) and defines the migration gate (A2). Any surprise second migration is a
-design-review stop, not a rider.
+**Migrations:** the line expects exactly **two**, both in the Spark range 1000–1099
+and both bound by A2's migration gate: #682's gate-waiver fields, and SIP-0101
+Slice 2's `retained` column (1020 — in the accepted SIP-0101 plan all along; the
+"only #682" premise here was incomplete, owner-accepted as a scope correction
+2026-08-05 at the #735 review). Any further migration is a design-review stop, not
+a rider.
 
 ## Verification discipline
 

--- a/infra/migrations/1020_run_checkpoints_retained.sql
+++ b/infra/migrations/1020_run_checkpoints_retained.sql
@@ -1,0 +1,4 @@
+-- SIP-0101 Slice 2: workload-boundary checkpoints survive the max_keep prune.
+-- Additive + default-false: pre-migration rows read as unretained (prunable),
+-- old code ignores the column entirely (1010-pattern compatibility). Forward-only.
+ALTER TABLE run_checkpoints ADD COLUMN IF NOT EXISTS retained BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/squadops/ports/cycles/cycle_registry.py
+++ b/src/squadops/ports/cycles/cycle_registry.py
@@ -177,8 +177,16 @@ class CycleRegistryPort(ABC):
     # --- Checkpoint (SIP-0079) ---
 
     @abstractmethod
-    async def save_checkpoint(self, checkpoint: RunCheckpoint, max_keep: int = 5) -> None:
-        """Persist a run checkpoint, pruning older checkpoints beyond max_keep."""
+    async def save_checkpoint(
+        self, checkpoint: RunCheckpoint, max_keep: int = 5, retain: bool = False
+    ) -> None:
+        """Persist a run checkpoint, pruning older checkpoints beyond max_keep.
+
+        ``retain=True`` marks a workload-boundary checkpoint (SIP-0101 Slice 2):
+        it is excluded from pruning permanently, so the boundaries a replay
+        would restore from survive runs longer than ``max_keep`` tasks.
+        Unretained pruning behavior is unchanged.
+        """
 
     @abstractmethod
     async def get_latest_checkpoint(self, run_id: str) -> RunCheckpoint | None:

--- a/tests/unit/cycles/test_checkpoint_retention.py
+++ b/tests/unit/cycles/test_checkpoint_retention.py
@@ -1,0 +1,99 @@
+"""SIP-0101 Slice 2 — boundary retention.
+
+The defect this closes: ``max_keep=5`` pruning deletes a long run's
+post-framing/post-dev boundaries *before the run finishes* — exactly the
+checkpoints a replay would restore from. Retained boundary checkpoints must
+survive pruning; unretained pruning must be byte-identical to before.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+from adapters.cycles.memory_cycle_registry import MemoryCycleRegistry
+from squadops.cycles.checkpoint import RunCheckpoint
+from squadops.tasks.models import TaskEnvelope
+
+pytestmark = [pytest.mark.domain_cycles]
+
+
+def _checkpoint(index: int) -> RunCheckpoint:
+    return RunCheckpoint(
+        run_id="run_1",
+        checkpoint_index=index,
+        completed_task_ids=tuple(f"t{i}" for i in range(1, index + 1)),
+        prior_outputs={},
+        artifact_refs=(),
+        plan_delta_refs=(),
+        created_at=datetime.now(UTC),
+    )
+
+
+def _envelope(role: str) -> TaskEnvelope:
+    return TaskEnvelope(
+        task_id="t1",
+        agent_id="a1",
+        cycle_id="c1",
+        pulse_id="p1",
+        project_id="pr1",
+        task_type="development.develop",
+        correlation_id="x",
+        causation_id="y",
+        trace_id="z",
+        span_id="s",
+        metadata={"role": role},
+    )
+
+
+class TestMemoryRegistryRetention:
+    async def test_retained_boundary_survives_max_keep_overflow(self):
+        """The Slice 2 headline: a boundary marked at index 1 must still exist
+        after six more saves push it far outside the prune window."""
+        reg = MemoryCycleRegistry()
+        await reg.save_checkpoint(_checkpoint(1), max_keep=5, retain=True)
+        for i in range(2, 9):
+            await reg.save_checkpoint(_checkpoint(i), max_keep=5)
+
+        indices = [c.checkpoint_index for c in await reg.list_checkpoints("run_1")]
+        assert 1 in indices  # the retained boundary survived
+        assert indices == [1, 4, 5, 6, 7, 8]  # plus the normal latest-5 window
+
+    async def test_unretained_pruning_unchanged(self):
+        """No retention in play → exactly the pre-Slice-2 latest-5 behavior."""
+        reg = MemoryCycleRegistry()
+        for i in range(1, 9):
+            await reg.save_checkpoint(_checkpoint(i), max_keep=5)
+
+        indices = [c.checkpoint_index for c in await reg.list_checkpoints("run_1")]
+        assert indices == [4, 5, 6, 7, 8]
+
+    async def test_get_latest_ignores_retention(self):
+        """Latest means latest — an old retained boundary must never shadow
+        the current resume point."""
+        reg = MemoryCycleRegistry()
+        await reg.save_checkpoint(_checkpoint(1), max_keep=5, retain=True)
+        for i in range(2, 8):
+            await reg.save_checkpoint(_checkpoint(i), max_keep=5)
+
+        latest = await reg.get_latest_checkpoint("run_1")
+        assert latest is not None
+        assert latest.checkpoint_index == 7
+
+
+class TestPhaseBoundaryPredicate:
+    def test_last_task_is_a_boundary(self):
+        plan = [_envelope("dev"), _envelope("dev")]
+        assert DispatchedFlowExecutor._is_phase_boundary(plan, 1) is True
+
+    def test_role_transition_is_a_boundary(self):
+        # dev → qa: the post-dev checkpoint is what a QA-phase replay restores
+        plan = [_envelope("dev"), _envelope("dev"), _envelope("qa")]
+        assert DispatchedFlowExecutor._is_phase_boundary(plan, 1) is True
+
+    def test_mid_phase_task_is_not_a_boundary(self):
+        # dev → dev: pruning this one costs nothing a replay wants
+        plan = [_envelope("dev"), _envelope("dev"), _envelope("qa")]
+        assert DispatchedFlowExecutor._is_phase_boundary(plan, 0) is False

--- a/tests/unit/cycles/test_executor_checkpoint.py
+++ b/tests/unit/cycles/test_executor_checkpoint.py
@@ -810,3 +810,36 @@ class TestVerificationEvidenceRecording:
         assert mock_registry.update_run_status.call_args_list[-1].args[1] == RunStatus.COMPLETED
         assert "Verdict: **accepted**" in report
         assert "Failed: tests_pass" not in report
+
+
+class TestBoundaryRetentionThreading:
+    """SIP-0101 Slice 2: the executor marks phase-boundary checkpoints retained.
+
+    Bug caught: retention machinery exists in the registry but the executor
+    never passes the flag — every boundary still gets pruned and replay has
+    nothing to restore from.
+    """
+
+    async def test_every_save_carries_the_retain_kwarg(
+        self, executor, mock_registry, mock_queue
+    ) -> None:
+        with patch(
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
+
+        calls = mock_registry.save_checkpoint.call_args_list
+        assert calls, "no checkpoints saved"
+        assert all("retain" in c.kwargs for c in calls)
+
+    async def test_final_checkpoint_is_retained(self, executor, mock_registry, mock_queue) -> None:
+        # the last task always closes a phase — its checkpoint is the terminal
+        # replay boundary and must survive pruning
+        with patch(
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_impl", run_id="run_impl")
+
+        assert mock_registry.save_checkpoint.call_args_list[-1].kwargs["retain"] is True

--- a/tests/unit/cycles/test_postgres_cycle_registry.py
+++ b/tests/unit/cycles/test_postgres_cycle_registry.py
@@ -843,3 +843,59 @@ class TestVerificationSummarySerializationFidelity:
         assert rebuilt.failed == ("vc-probe-runs",)
         assert rebuilt.failed_detail == ()
         assert rebuilt.criteria_coverage == (0, 0)
+
+
+class TestCheckpointRetentionSQL:
+    """SIP-0101 Slice 2 — the postgres half of boundary retention.
+
+    SQL-pattern assertions per this file's charter: the INSERT must persist the
+    retain flag and the prune DELETE must exclude retained rows, or a long run
+    destroys its replay boundaries mid-flight exactly as before the fix.
+    """
+
+    @pytest.fixture
+    def conn(self):
+        return _make_conn()
+
+    @pytest.fixture
+    def registry(self, conn):
+        from adapters.cycles.postgres_cycle_registry import PostgresCycleRegistry
+
+        return PostgresCycleRegistry(_make_pool(conn))
+
+    @staticmethod
+    def _checkpoint():
+        from datetime import UTC, datetime
+
+        from squadops.cycles.checkpoint import RunCheckpoint
+
+        return RunCheckpoint(
+            run_id="run_1",
+            checkpoint_index=3,
+            completed_task_ids=("t1", "t2", "t3"),
+            prior_outputs={},
+            artifact_refs=(),
+            plan_delta_refs=(),
+            created_at=datetime.now(UTC),
+        )
+
+    async def test_insert_persists_retain_flag(self, registry, conn):
+        await registry.save_checkpoint(self._checkpoint(), retain=True)
+
+        insert_call = conn.execute.call_args_list[0]
+        assert "retained" in insert_call.args[0]
+        assert insert_call.args[-1] is True  # the retain bind param
+
+    async def test_insert_defaults_unretained(self, registry, conn):
+        await registry.save_checkpoint(self._checkpoint())
+
+        insert_call = conn.execute.call_args_list[0]
+        assert insert_call.args[-1] is False
+
+    async def test_prune_excludes_retained_rows(self, registry, conn):
+        await registry.save_checkpoint(self._checkpoint())
+
+        delete_call = conn.execute.call_args_list[1]
+        sql = delete_call.args[0]
+        assert "DELETE FROM run_checkpoints" in sql
+        assert "retained = FALSE" in sql  # retained boundaries never pruned


### PR DESCRIPTION
## What

Slice 2 of the SIP-0101 minimum path (1.5 Gate-1 Track C): **workload-boundary checkpoints survive pruning**. Today `max_keep=5` deletes a long run's post-framing/post-dev boundaries before the run finishes — the exact state a replay restores from.

- **Migration 1020** (`retained BOOLEAN NOT NULL DEFAULT FALSE`) — additive, 1010-pattern compatibility, forward-only; the second of the line's two owner-accepted migrations (plan amended in this PR per the #735 ruling).
- Port: `save_checkpoint(..., retain: bool = False)`; postgres prune `DELETE` excludes retained rows; memory adapter parity (same all-rows survival window, so retention widens survival, never narrows it).
- Executor: `_is_phase_boundary` (last task or role transition) marks the checkpoint retained at the #643 collect-and-checkpoint site.
- **Premise delta vs the SIP plan's task 2.4** ("mark at the two write sites"): the correction-runner site checkpoints correction-chain *iteration state*, not replay boundaries — it stays deliberately unretained (commented in place) so a correction storm can't pin unbounded rows past the prune window.

## Tests

Retained-survives-overflow + unretained-pruning-unchanged + latest-ignores-retention (real memory store); boundary predicate (last task / role transition / mid-phase); postgres INSERT+DELETE SQL patterns; executor threads `retain` on every save with the final checkpoint retained. Regression **6246 passed**.

Next: Slice 3 (execution_mode + checkpoint-sourced restore + strict-equality compatibility gate) — closes Gate 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv