### PR TITLE
feat(replay): SIP-0101 Slice 3 — the replay mechanism (closes the Gate-1 minimum path)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1265,8 +1265,15 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     f"after {len(completed_task_ids)} tasks"
                 )
 
-        # SIP-0079: Resume from checkpoint — restore prior state
+        # SIP-0079: Resume from checkpoint — restore prior state. Self-resume
+        # wins over replay: a replayed run that checkpointed and crashed resumes
+        # its OWN progress (which already contains the translated prefix).
         checkpoint = await self._cycle_registry.get_latest_checkpoint(run_id)
+        if checkpoint is None:
+            # SIP-0101 Slice 3: a replay-mode cycle's matching run restores the
+            # SOURCE run's boundary checkpoint instead (translated into this
+            # run's task-id namespace); None for normal cycles.
+            checkpoint = await self._resolve_replay_checkpoint(cycle, run_id)
         if checkpoint:
             await self._restore_checkpoint_state(
                 checkpoint,
@@ -1911,6 +1918,48 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 **extra_inputs,
             },
         )
+
+    async def _resolve_replay_checkpoint(self, cycle: Cycle, run_id: str) -> RunCheckpoint | None:
+        """SIP-0101 Slice 3.2/3.3: the source boundary checkpoint for a replay run.
+
+        ``None`` unless the cycle declares replay AND this run's workload matches
+        the source run's (other runs in a replay cycle's sequence execute
+        normally). Fails closed — a declared boundary that cannot be resolved or
+        translated raises ``_ExecutionError`` rather than silently executing the
+        full plan as if earned.
+        """
+        from squadops.cycles.replay import (
+            parse_replay_declaration,
+            translate_checkpoint_for_replay,
+        )
+
+        try:
+            replay_req = parse_replay_declaration(cycle.execution_overrides or {})
+        except ValueError as e:
+            # Validated at create — reaching here means the declaration mutated
+            # or predates validation; never guess.
+            raise _ExecutionError(f"replay declaration invalid at execution: {e}") from e
+        if replay_req is None:
+            return None
+
+        source_run = await self._cycle_registry.get_run(replay_req.source_run_id)
+        run = await self._cycle_registry.get_run(run_id)
+        if run.workload_type != source_run.workload_type:
+            return None
+
+        source_cps = await self._cycle_registry.list_checkpoints(replay_req.source_run_id)
+        source_cp = next(
+            (c for c in source_cps if c.checkpoint_index == replay_req.boundary_index), None
+        )
+        if source_cp is None:
+            raise _ExecutionError(
+                f"replay boundary {replay_req.boundary_index} not found on "
+                f"{replay_req.source_run_id} — pruned since create-time validation?"
+            )
+        try:
+            return translate_checkpoint_for_replay(source_cp, run_id)
+        except ValueError as e:
+            raise _ExecutionError(str(e)) from e
 
     async def _restore_checkpoint_state(
         self,

--- a/adapters/cycles/run_completion.py
+++ b/adapters/cycles/run_completion.py
@@ -343,6 +343,38 @@ class RunCompletion:
         )
         return summary
 
+    async def _replay_provenance_for_report(self, cycle: Cycle | None, run) -> Any:
+        """SIP-0101 Slice 3.4: provenance for the report marker, else ``None``.
+
+        Marked when the cycle declares replay and this run's workload matches the
+        source's — including a run that *failed* mid-replay, which is correct: its
+        prefix evidence is still inherited. Best-effort like the report itself;
+        never raises.
+        """
+        from squadops.cycles.replay import (
+            REPLAY_COMPATIBILITY_ELEMENTS,
+            parse_replay_declaration,
+        )
+        from squadops.cycles.verification_integrity import ReplayProvenance
+
+        try:
+            if cycle is None:
+                return None
+            replay_req = parse_replay_declaration(cycle.execution_overrides or {})
+            if replay_req is None:
+                return None
+            source_run = await self._cycle_registry.get_run(replay_req.source_run_id)
+            if run.workload_type != source_run.workload_type:
+                return None
+            return ReplayProvenance(
+                source_run_id=replay_req.source_run_id,
+                boundary_index=replay_req.boundary_index,
+                compatibility_set=REPLAY_COMPATIBILITY_ELEMENTS,
+            )
+        except Exception:
+            logger.warning("replay provenance resolution failed for report", exc_info=True)
+            return None
+
     async def generate_run_report(
         self,
         cycle_id: str,
@@ -370,6 +402,7 @@ class RunCompletion:
             plan=plan,
             pulse_report_entries=list(ledger.pulse_entries) if ledger else None,
             verification_summary=verification_summary,
+            replay=await self._replay_provenance_for_report(cycle, run),
         )
         content_bytes = content.encode("utf-8")
 

--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -141,6 +141,68 @@ async def _run_create_preflight(
     return decision.warnings
 
 
+async def _validate_replay_declaration(
+    registry, body: CycleCreateRequest, applied_defaults: dict
+) -> None:
+    """SIP-0101 Slice 3.1/3.5 — create-time replay validation + interim gate.
+
+    Rejects (as a preflight rejection, the create path's 422 shape) unless the
+    declaration is well-formed, the source run and boundary checkpoint exist,
+    and source/target agree on every ``REPLAY_COMPATIBILITY_ELEMENTS`` entry —
+    strict equality, more conservative than §3.5's eventual per-boundary sets,
+    so Slice 4 relaxes an existing guard rather than adding a missing one. The
+    refusal names the failing element. Maintainer-only surface (the declaration
+    rides ``execution_overrides``); no-op for normal cycles.
+    """
+    from squadops.cycles.models import RunNotFoundError
+    from squadops.cycles.replay import (
+        check_replay_compatibility,
+        parse_replay_declaration,
+    )
+
+    try:
+        replay_req = parse_replay_declaration(body.execution_overrides or {})
+    except ValueError as e:
+        raise PreflightRejectedError(f"replay_declaration_invalid: {e}") from e
+    if replay_req is None:
+        return
+
+    try:
+        source_run = await registry.get_run(replay_req.source_run_id)
+    except RunNotFoundError as e:
+        raise PreflightRejectedError(
+            f"replay_source_missing: run {replay_req.source_run_id} not found"
+        ) from e
+    source_cycle = await registry.get_cycle(source_run.cycle_id)
+
+    checkpoints = await registry.list_checkpoints(replay_req.source_run_id)
+    if replay_req.boundary_index not in {c.checkpoint_index for c in checkpoints}:
+        raise PreflightRejectedError(
+            f"replay_boundary_missing: run {replay_req.source_run_id} has no "
+            f"checkpoint at boundary {replay_req.boundary_index} (pruned, or never "
+            "written — only Slice-2+ runs retain their phase boundaries)"
+        )
+
+    # Target resolved config mirrors Cycle.resolved_config() for the cycle
+    # about to be built (#426 seam — never applied_defaults alone).
+    target_resolved = {**applied_defaults, **(body.execution_overrides or {})}
+    source_resolved = source_cycle.resolved_config()
+    errors = check_replay_compatibility(
+        {
+            "prd_ref": source_cycle.prd_ref,
+            "build_profile": source_resolved.get("build_profile"),
+            "contract_ref": source_resolved.get("contract_ref"),
+        },
+        {
+            "prd_ref": body.prd_ref,
+            "build_profile": target_resolved.get("build_profile"),
+            "contract_ref": target_resolved.get("contract_ref"),
+        },
+    )
+    if errors:
+        raise PreflightRejectedError("; ".join(errors))
+
+
 @router.post("", dependencies=[Depends(require_scopes(Scope.CYCLES_WRITE))])
 async def create_cycle(
     project_id: str, body: CycleCreateRequest, background_tasks: BackgroundTasks
@@ -185,6 +247,10 @@ async def create_cycle(
 
         # SIP-0095: create-time preflight — fail fast (422) before persist/dispatch.
         preflight_warnings = await _run_create_preflight(profile, applied_defaults)
+
+        # SIP-0101 Slice 3: replay declaration validated + interim compatibility
+        # gate, same fail-fast point (moves into the SIP-0095 preflight in Slice 4).
+        await _validate_replay_declaration(get_cycle_registry(), body, applied_defaults)
 
         config_hash = compute_config_hash(applied_defaults, body.execution_overrides)
 

--- a/src/squadops/cycles/cycle_outcome.py
+++ b/src/squadops/cycles/cycle_outcome.py
@@ -14,7 +14,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from squadops.cycles.verification_integrity import CycleOutcome, aggregate_cycle_outcome
+from squadops.cycles.replay import (
+    REPLAY_COMPATIBILITY_ELEMENTS,
+    parse_replay_declaration,
+)
+from squadops.cycles.verification_integrity import (
+    CycleOutcome,
+    ReplayProvenance,
+    aggregate_cycle_outcome,
+)
 
 if TYPE_CHECKING:
     from squadops.ports.cycles.cycle_registry import CycleRegistryPort
@@ -26,6 +34,22 @@ async def resolve_cycle_outcome(registry: CycleRegistryPort, cycle_id: str) -> C
     ``waived`` (operator gate waivers, §6.5) and ``inert`` (chronic not-executed, §9)
     stay empty until their Phase-3 slices wire them — the roll-up shape carries them,
     but there is no source yet, so we pass nothing rather than fabricate.
+
+    SIP-0101 Slice 3.4: a replay-mode cycle's outcome carries ``ReplayProvenance``
+    derived from the immutable, create-time-validated declaration — same
+    derive-on-read philosophy as the rest of this module, so a replayed outcome
+    can never render unmarked regardless of which consumer asks.
     """
     summaries = await registry.list_run_verification_summaries(cycle_id)
-    return aggregate_cycle_outcome(summaries)
+    cycle = await registry.get_cycle(cycle_id)
+    replay_req = parse_replay_declaration(cycle.execution_overrides or {})
+    replay = (
+        ReplayProvenance(
+            source_run_id=replay_req.source_run_id,
+            boundary_index=replay_req.boundary_index,
+            compatibility_set=REPLAY_COMPATIBILITY_ELEMENTS,
+        )
+        if replay_req is not None
+        else None
+    )
+    return aggregate_cycle_outcome(summaries, replay=replay)

--- a/src/squadops/cycles/replay.py
+++ b/src/squadops/cycles/replay.py
@@ -8,9 +8,23 @@ SIP-0101-named import path. This module owns the human-facing wording.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from squadops.cycles.checkpoint import RunCheckpoint
 from squadops.cycles.verification_integrity import ReplayProvenance
 
-__all__ = ["ReplayProvenance", "replay_marker_lines"]
+__all__ = [
+    "EXECUTION_MODE_REPLAY",
+    "REPLAY_COMPATIBILITY_ELEMENTS",
+    "ReplayProvenance",
+    "ReplayRequest",
+    "check_replay_compatibility",
+    "parse_replay_declaration",
+    "replay_marker_lines",
+    "translate_checkpoint_for_replay",
+]
 
 
 def replay_marker_lines(replay: ReplayProvenance) -> list[str]:
@@ -26,3 +40,106 @@ def replay_marker_lines(replay: ReplayProvenance) -> list[str]:
         "Evidence at or before the boundary is inherited from the source run, "
         "not earned by this execution.",
     ]
+
+
+# --------------------------------------------------------------------------- #
+# Slice 3 — the mechanism (SIP-0101 §3): declaration, compatibility, translation
+# --------------------------------------------------------------------------- #
+
+EXECUTION_MODE_REPLAY = "replay"
+
+# Interim create-time compatibility gate (Slice 3.5): strict equality over these
+# elements between source cycle and target request. Deliberately MORE conservative
+# than §3.5's eventual per-boundary sets — Slice 4 relaxes an existing guard.
+# ``plan_artifact_refs`` equality is guaranteed by construction: the replayed
+# prefix restores the source checkpoint's own artifact refs.
+REPLAY_COMPATIBILITY_ELEMENTS = ("prd_ref", "build_profile", "contract_ref")
+
+
+@dataclass(frozen=True)
+class ReplayRequest:
+    """A parsed, well-formed replay declaration off ``execution_overrides``."""
+
+    source_run_id: str
+    boundary_index: int
+
+    def __post_init__(self) -> None:
+        if not self.source_run_id:
+            raise ValueError("replay.source_run_id must be non-empty")
+        if self.boundary_index < 0:
+            raise ValueError("replay.boundary_index must be >= 0")
+
+
+def parse_replay_declaration(execution_overrides: Mapping[str, Any]) -> ReplayRequest | None:
+    """Parse the maintainer-only replay declaration; ``None`` for normal cycles.
+
+    The declaration is two keys in ``execution_overrides`` (no new API surface —
+    the SIP-0101 harness entry point, classified maintainer-only):
+
+        execution_mode: replay
+        replay: {source_run_id: run_..., boundary_index: N}
+
+    Raises ``ValueError`` on any malformed shape — a half-declared replay must
+    never execute as a normal run (or vice versa).
+    """
+    mode = execution_overrides.get("execution_mode")
+    block = execution_overrides.get("replay")
+    if mode is None and block is None:
+        return None
+    if mode != EXECUTION_MODE_REPLAY:
+        raise ValueError(f"replay block requires execution_mode: {EXECUTION_MODE_REPLAY!r}")
+    if not isinstance(block, Mapping):
+        raise ValueError("execution_mode: replay requires a replay: {...} block")
+    try:
+        return ReplayRequest(
+            source_run_id=str(block["source_run_id"]),
+            boundary_index=int(block["boundary_index"]),
+        )
+    except (KeyError, TypeError) as e:
+        raise ValueError(f"malformed replay block: {e!r}") from e
+
+
+def check_replay_compatibility(source: Mapping[str, Any], target: Mapping[str, Any]) -> list[str]:
+    """Strict-equality interim gate (Slice 3.5): mismatches name the failing element."""
+    errors = []
+    for element in REPLAY_COMPATIBILITY_ELEMENTS:
+        if source.get(element) != target.get(element):
+            errors.append(
+                f"replay_incompatible: {element} differs "
+                f"(source={source.get(element)!r}, target={target.get(element)!r})"
+            )
+    return errors
+
+
+def translate_checkpoint_for_replay(checkpoint: RunCheckpoint, target_run_id: str) -> RunCheckpoint:
+    """Rebind a source run's boundary checkpoint into the target run's namespace.
+
+    Task ids embed the producing run (``task-{run_id[:12]}-m{index}-{type}``,
+    SIP-0086 RC-2), so the source's ``completed_task_ids`` can never match the
+    target plan's ids for dispatch suppression — the premise correction to the
+    SIP plan's 3.3. Only the run prefix rebinds; the deterministic suffix
+    (task index + type) is untouched, so suppression matches exactly the same
+    plan positions the source completed. Everything else — prior_outputs
+    (role-keyed), artifact refs (globally addressed), plan-delta refs — is
+    carried verbatim; a source id that does not carry the expected prefix
+    fails closed (the determinism contract, never a guess).
+    """
+    source_prefix = f"task-{checkpoint.run_id[:12]}-"
+    target_prefix = f"task-{target_run_id[:12]}-"
+    translated = []
+    for task_id in checkpoint.completed_task_ids:
+        if not task_id.startswith(source_prefix):
+            raise ValueError(
+                f"replay checkpoint task id {task_id!r} is not in the source run's "
+                f"deterministic namespace ({source_prefix!r}*) — cannot translate"
+            )
+        translated.append(target_prefix + task_id[len(source_prefix) :])
+    return RunCheckpoint(
+        run_id=target_run_id,
+        checkpoint_index=checkpoint.checkpoint_index,
+        completed_task_ids=tuple(translated),
+        prior_outputs=checkpoint.prior_outputs,
+        artifact_refs=checkpoint.artifact_refs,
+        plan_delta_refs=checkpoint.plan_delta_refs,
+        created_at=checkpoint.created_at,
+    )

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -607,6 +607,7 @@ def aggregate_cycle_outcome(
     *,
     waived: Collection[WaivedCheck] = (),
     inert: Collection[str] = (),
+    replay: ReplayProvenance | None = None,
 ) -> CycleOutcome:
     """Pure cycle-level roll-up over per-run summaries (SIP-0096 §10).
 
@@ -712,4 +713,5 @@ def aggregate_cycle_outcome(
         waived=tuple(waived),
         criteria_verified=cycle_criteria_verified,
         criteria_total=cycle_criteria_total,
+        replay=replay,
     )

--- a/tests/unit/api/test_create_replay_validation.py
+++ b/tests/unit/api/test_create_replay_validation.py
@@ -1,0 +1,105 @@
+"""SIP-0101 Slice 3.1/3.5 — create-time replay validation + interim gate.
+
+A replay admitted against a missing run, a pruned boundary, or a divergent
+contract/prd/profile would restore a prefix that never matches what the target
+executes — the gate must refuse at create, naming the failing element.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.api.routes.cycles.cycles import _validate_replay_declaration
+from squadops.cycles.checkpoint import RunCheckpoint
+from squadops.cycles.models import PreflightRejectedError, RunNotFoundError
+
+pytestmark = [pytest.mark.domain_api]
+
+_APPLIED = {"build_profile": "fullstack_fastapi_react"}
+
+
+def _body(overrides: dict, prd_ref: str = "prd_1") -> SimpleNamespace:
+    return SimpleNamespace(execution_overrides=overrides, prd_ref=prd_ref)
+
+
+def _decl(source: str = "run_src", boundary: int = 2) -> dict:
+    return {
+        "execution_mode": "replay",
+        "replay": {"source_run_id": source, "boundary_index": boundary},
+    }
+
+
+def _registry(
+    *,
+    source_prd: str = "prd_1",
+    source_config: dict | None = None,
+    checkpoint_indexes: tuple[int, ...] = (1, 2),
+) -> AsyncMock:
+    registry = AsyncMock()
+    registry.get_run.return_value = SimpleNamespace(run_id="run_src", cycle_id="cyc_src")
+    source_cycle = MagicMock()
+    source_cycle.prd_ref = source_prd
+    source_cycle.resolved_config.return_value = source_config or dict(_APPLIED)
+    registry.get_cycle.return_value = source_cycle
+    registry.list_checkpoints.return_value = [
+        RunCheckpoint(
+            run_id="run_src",
+            checkpoint_index=i,
+            completed_task_ids=(),
+            prior_outputs={},
+            artifact_refs=(),
+            plan_delta_refs=(),
+            created_at=datetime.now(UTC),
+        )
+        for i in checkpoint_indexes
+    ]
+    return registry
+
+
+async def test_normal_cycle_touches_nothing():
+    registry = AsyncMock()
+    await _validate_replay_declaration(registry, _body({}), _APPLIED)
+    registry.get_run.assert_not_awaited()
+
+
+async def test_malformed_declaration_rejected():
+    with pytest.raises(PreflightRejectedError, match="replay_declaration_invalid"):
+        await _validate_replay_declaration(
+            AsyncMock(), _body({"execution_mode": "replay"}), _APPLIED
+        )
+
+
+async def test_missing_source_run_rejected():
+    registry = AsyncMock()
+    registry.get_run.side_effect = RunNotFoundError("nope")
+    with pytest.raises(PreflightRejectedError, match="replay_source_missing"):
+        await _validate_replay_declaration(registry, _body(_decl()), _APPLIED)
+
+
+async def test_missing_boundary_rejected_by_index():
+    registry = _registry(checkpoint_indexes=(1,))  # boundary 2 pruned/never written
+    with pytest.raises(PreflightRejectedError, match="replay_boundary_missing"):
+        await _validate_replay_declaration(registry, _body(_decl(boundary=2)), _APPLIED)
+
+
+async def test_contract_mismatch_rejected_naming_the_element():
+    registry = _registry(source_config={**_APPLIED, "contract_ref": "art_c9"})
+    # target declares no contract_ref → author-mode target vs bind-mode source
+    with pytest.raises(PreflightRejectedError, match="contract_ref"):
+        await _validate_replay_declaration(registry, _body(_decl()), _APPLIED)
+
+
+async def test_prd_mismatch_rejected_naming_the_element():
+    registry = _registry(source_prd="prd_other")
+    with pytest.raises(PreflightRejectedError, match="prd_ref"):
+        await _validate_replay_declaration(registry, _body(_decl()), _APPLIED)
+
+
+async def test_compatible_replay_admitted():
+    registry = _registry(source_config={**_APPLIED, "contract_ref": "art_c9"})
+    overrides = {**_decl(), "contract_ref": "art_c9"}
+    await _validate_replay_declaration(registry, _body(overrides), _APPLIED)  # no raise

--- a/tests/unit/cycles/test_cycle_outcome.py
+++ b/tests/unit/cycles/test_cycle_outcome.py
@@ -29,8 +29,19 @@ def _run_summary(verdict, *, verified=(), failed=()) -> RunVerificationSummary:
     )
 
 
+def _normal_cycle():
+    # a real Cycle always carries a dict here; a bare AsyncMock's truthy
+    # attribute would read as a malformed replay declaration (SIP-0101)
+    from unittest.mock import MagicMock
+
+    cycle = MagicMock()
+    cycle.execution_overrides = {}
+    return cycle
+
+
 async def test_rolls_up_persisted_summaries_worst_verdict_wins():
     registry = AsyncMock()
+    registry.get_cycle.return_value = _normal_cycle()
     registry.list_run_verification_summaries = AsyncMock(
         return_value=[
             _run_summary(RunVerdict.ACCEPTED, verified=["tests_pass"]),
@@ -49,6 +60,7 @@ async def test_rolls_up_persisted_summaries_worst_verdict_wins():
 
 async def test_empty_cycle_rolls_up_to_accepted():
     registry = AsyncMock()
+    registry.get_cycle.return_value = _normal_cycle()
     registry.list_run_verification_summaries = AsyncMock(return_value=[])
 
     outcome = await resolve_cycle_outcome(registry, "cyc_x")

--- a/tests/unit/cycles/test_replay_mechanism.py
+++ b/tests/unit/cycles/test_replay_mechanism.py
@@ -1,0 +1,232 @@
+"""SIP-0101 Slice 3 — the replay mechanism.
+
+Declaration parsing, the interim strict-equality compatibility gate, checkpoint
+translation into the target run's task-id namespace (the premise correction to
+the SIP plan's 3.3 — ids embed the producing run, so cross-run suppression
+requires rebinding), executor resolution, and outcome/report provenance.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor, _ExecutionError
+from squadops.cycles.checkpoint import RunCheckpoint
+from squadops.cycles.models import Run
+from squadops.cycles.replay import (
+    REPLAY_COMPATIBILITY_ELEMENTS,
+    check_replay_compatibility,
+    parse_replay_declaration,
+    translate_checkpoint_for_replay,
+)
+from squadops.cycles.verification_integrity import (
+    ReplayProvenance,
+    RunVerdict,
+    aggregate_cycle_outcome,
+)
+
+pytestmark = [pytest.mark.domain_cycles]
+
+_DECL = {"execution_mode": "replay", "replay": {"source_run_id": "run_src", "boundary_index": 2}}
+
+
+def _source_checkpoint() -> RunCheckpoint:
+    return RunCheckpoint(
+        run_id="run_aaaabbbbcccc",
+        checkpoint_index=2,
+        completed_task_ids=(
+            "task-run_aaaabbbb-m000-development.develop",
+            "task-run_aaaabbbb-m001-builder.assemble",
+        ),
+        prior_outputs={"dev": {"summary": "done"}},
+        artifact_refs=("art_1", "art_2"),
+        plan_delta_refs=("delta_1",),
+        created_at=datetime.now(UTC),
+    )
+
+
+class TestParseDeclaration:
+    def test_absent_means_normal_cycle(self):
+        assert parse_replay_declaration({}) is None
+        assert parse_replay_declaration({"time_budget_seconds": 60}) is None
+
+    def test_valid_declaration_parses(self):
+        req = parse_replay_declaration(_DECL)
+        assert req is not None
+        assert req.source_run_id == "run_src"
+        assert req.boundary_index == 2
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"execution_mode": "replay"},  # mode without block
+            {"replay": {"source_run_id": "run_src", "boundary_index": 2}},  # block, no mode
+            {"execution_mode": "resume", "replay": {}},  # unknown mode
+            {"execution_mode": "replay", "replay": {"source_run_id": "run_src"}},  # no boundary
+            {"execution_mode": "replay", "replay": "run_src@2"},  # non-mapping block
+        ],
+    )
+    def test_half_declared_replay_is_rejected(self, overrides):
+        # a half-declared replay must never execute as a normal run (or vice versa)
+        with pytest.raises(ValueError):
+            parse_replay_declaration(overrides)
+
+
+class TestCompatibilityGate:
+    _SOURCE = {"prd_ref": "prd_1", "build_profile": "fullstack", "contract_ref": "art_c9"}
+
+    def test_identical_elements_pass(self):
+        assert check_replay_compatibility(self._SOURCE, dict(self._SOURCE)) == []
+
+    @pytest.mark.parametrize("element", REPLAY_COMPATIBILITY_ELEMENTS)
+    def test_each_mismatch_is_named(self, element):
+        # the refusal must name the failing element (SIP plan Slice 3 test spec)
+        target = dict(self._SOURCE)
+        target[element] = "different"
+        errors = check_replay_compatibility(self._SOURCE, target)
+        assert len(errors) == 1
+        assert element in errors[0]
+
+    def test_absent_vs_present_is_a_mismatch(self):
+        # author-mode source (no contract_ref) vs bind-mode target must refuse
+        target = dict(self._SOURCE)
+        source = dict(self._SOURCE)
+        source["contract_ref"] = None
+        errors = check_replay_compatibility(source, target)
+        assert any("contract_ref" in e for e in errors)
+
+
+class TestCheckpointTranslation:
+    def test_task_ids_rebound_to_target_namespace(self):
+        translated = translate_checkpoint_for_replay(_source_checkpoint(), "run_ddddeeeeffff")
+        assert translated.completed_task_ids == (
+            "task-run_ddddeeee-m000-development.develop",
+            "task-run_ddddeeee-m001-builder.assemble",
+        )
+        assert translated.run_id == "run_ddddeeeeffff"
+
+    def test_everything_else_carried_verbatim(self):
+        # the SIP §3.4 determinism contract: restored state byte-equal to the
+        # source's state at the boundary (only the id namespace rebinds)
+        src = _source_checkpoint()
+        translated = translate_checkpoint_for_replay(src, "run_ddddeeeeffff")
+        assert translated.checkpoint_index == src.checkpoint_index
+        assert translated.prior_outputs == src.prior_outputs
+        assert translated.artifact_refs == src.artifact_refs
+        assert translated.plan_delta_refs == src.plan_delta_refs
+        assert translated.created_at == src.created_at
+
+    def test_foreign_task_id_fails_closed(self):
+        # an id outside the source's deterministic namespace cannot be
+        # translated — guessing would suppress the wrong task
+        src = _source_checkpoint()
+        import dataclasses
+
+        broken = dataclasses.replace(
+            src, completed_task_ids=src.completed_task_ids + ("adhoc-uuid-task",)
+        )
+        with pytest.raises(ValueError, match="cannot translate"):
+            translate_checkpoint_for_replay(broken, "run_ddddeeeeffff")
+
+
+class TestOutcomeCarriesProvenance:
+    def test_aggregate_threads_replay(self):
+        p = ReplayProvenance("run_src", 2, REPLAY_COMPATIBILITY_ELEMENTS)
+        outcome = aggregate_cycle_outcome([], replay=p)
+        assert outcome.replay == p
+        assert outcome.verdict is RunVerdict.ACCEPTED  # empty-evidence default unchanged
+
+    async def test_resolve_cycle_outcome_derives_provenance_from_declaration(self):
+        from squadops.cycles.cycle_outcome import resolve_cycle_outcome
+
+        registry = AsyncMock()
+        registry.list_run_verification_summaries.return_value = []
+        cycle = MagicMock()
+        cycle.execution_overrides = dict(_DECL)
+        registry.get_cycle.return_value = cycle
+
+        outcome = await resolve_cycle_outcome(registry, "cyc_1")
+
+        assert outcome.replay is not None
+        assert outcome.replay.source_run_id == "run_src"
+        assert outcome.replay.boundary_index == 2
+        assert outcome.replay.compatibility_set == REPLAY_COMPATIBILITY_ELEMENTS
+
+    async def test_resolve_cycle_outcome_normal_cycle_unmarked(self):
+        from squadops.cycles.cycle_outcome import resolve_cycle_outcome
+
+        registry = AsyncMock()
+        registry.list_run_verification_summaries.return_value = []
+        cycle = MagicMock()
+        cycle.execution_overrides = {}
+        registry.get_cycle.return_value = cycle
+
+        outcome = await resolve_cycle_outcome(registry, "cyc_1")
+        assert outcome.replay is None
+
+
+def _run(run_id: str, workload: str) -> Run:
+    return Run(
+        run_id=run_id,
+        cycle_id="cyc_1",
+        run_number=1,
+        status="queued",
+        initiated_by="api",
+        resolved_config_hash="h",
+        workload_type=workload,
+    )
+
+
+class TestExecutorReplayResolution:
+    def _executor(self, registry) -> DispatchedFlowExecutor:
+        return DispatchedFlowExecutor(cycle_registry=registry)
+
+    def _cycle(self, overrides) -> MagicMock:
+        cycle = MagicMock()
+        cycle.execution_overrides = overrides
+        return cycle
+
+    async def test_normal_cycle_resolves_none(self):
+        registry = AsyncMock()
+        executor = self._executor(registry)
+        assert await executor._resolve_replay_checkpoint(self._cycle({}), "run_t") is None
+        registry.get_run.assert_not_awaited()
+
+    async def test_workload_mismatch_resolves_none(self):
+        # replay targets the run matching the source's workload; a framing run
+        # in the same cycle executes normally
+        registry = AsyncMock()
+        registry.get_run.side_effect = lambda rid: _run(
+            rid, "implementation" if rid == "run_src" else "framing"
+        )
+        executor = self._executor(registry)
+        result = await executor._resolve_replay_checkpoint(self._cycle(dict(_DECL)), "run_t")
+        assert result is None
+
+    async def test_missing_boundary_fails_closed(self):
+        registry = AsyncMock()
+        registry.get_run.side_effect = lambda rid: _run(rid, "implementation")
+        registry.list_checkpoints.return_value = []  # pruned or never written
+        executor = self._executor(registry)
+        with pytest.raises(_ExecutionError, match="boundary 2 not found"):
+            await executor._resolve_replay_checkpoint(self._cycle(dict(_DECL)), "run_t")
+
+    async def test_matching_run_gets_translated_checkpoint(self):
+        registry = AsyncMock()
+        registry.get_run.side_effect = lambda rid: _run(rid, "implementation")
+        src = _source_checkpoint()
+        registry.list_checkpoints.return_value = [src]
+        decl = {
+            "execution_mode": "replay",
+            "replay": {"source_run_id": src.run_id, "boundary_index": 2},
+        }
+        executor = self._executor(registry)
+
+        result = await executor._resolve_replay_checkpoint(self._cycle(decl), "run_ddddeeeeffff")
+
+        assert result is not None
+        assert result.run_id == "run_ddddeeeeffff"
+        assert all(t.startswith("task-run_ddddeeee-") for t in result.completed_task_ids)


### PR DESCRIPTION
## What

Slice 3 of the SIP-0101 minimum path (1.5 Gate-1 Track C) — the mechanism itself, landing on rails that already exist (#735) and boundaries that already survive (#736):

- **Declaration (3.1):** `execution_mode: replay` + `replay: {source_run_id, boundary_index}` in `execution_overrides` — the maintainer-only harness entry point, zero new API fields; validated and immutable at create; half-declared shapes rejected.
- **Interim gate (3.5):** create-time strict equality over `prd_ref` / `build_profile` / `contract_ref` (resolved via the #426 `resolved_config` seam), source-run and boundary-checkpoint existence — refusal names the failing element, as a preflight rejection (moves into the SIP-0095 preflight in Slice 4).
- **Restore (3.2/3.3):** the workload-matching run restores the source's boundary checkpoint through the existing `_restore_checkpoint_state`; self-resume wins over replay; missing boundary fails closed.
- **Provenance (3.4):** `CycleOutcome.replay` derived on read from the declaration — the Slice-1 markers now light up on the API, `cycles show`, and the run report (best-effort resolver in `run_completion`).

## Premise correction (recorded in code + tests)

The SIP plan's 3.3 assumed the source checkpoint feeds `_restore_checkpoint_state` unchanged. **Task ids embed the producing run** (`task-{run_id[:12]}-m{index}-{type}`, SIP-0086 RC-2), so cross-run dispatch suppression would silently match nothing. `translate_checkpoint_for_replay` rebinds only the run prefix (deterministic suffix untouched — same plan positions suppress), carries everything else verbatim (the §3.4 determinism contract), and fails closed on ids outside the deterministic namespace.

## Verification

29 new tests (parse / gate / translation / outcome / executor / route validation); regression **6275 passed**. Two pre-existing `test_cycle_outcome` fixtures gained `execution_overrides = {}` (the known MagicMock-truthy-get gotcha). **The live end-to-end proof** — replay a stored run's prefix and reach the phase under study in minutes — is the Gate-1 exit demonstration at the line's first deploy window, per the plan's "Done when"; it needs a deployed image with migration 1020 and a post-Slice-2 source run.

Merging this closes the SIP-0101 minimum path — the last Gate-1 deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv