### PR TITLE
fix(qa): #670 — qa.test joins the typed-acceptance seam

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -50,9 +50,9 @@ def _framework_injected_criteria(
     """Checks the framework applies to this emission regardless of what was authored (#689).
 
     Today that is ``undefined_names`` on every ``.py`` file emitted by a handler that
-    routes through this seam. That is dev and builder, NOT ``qa.test``, which overrides
-    ``_validate_output`` and never calls here (#670, ruled fork 1 for v1.5 — wiring qa
-    into the seam brings authored checks and framework injections alike). Injection —
+    routes through this seam: dev, builder, and — since #670 (ruled fork 1, landed
+    v1.5) — ``qa.test``, whose override now calls the seam like the others, so
+    authored checks and framework injections alike reach qa emissions. Injection —
     rather than adding the check to the contract's per-slot criteria — is what makes
     it reach a BIND-mode cycle at all: bind mode loads the pinned contract from
     ``contract_ref`` instead of regenerating it, so a criterion added to the expander

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -18,7 +18,7 @@ from squadops.capabilities.handlers.base import (
 )
 from squadops.capabilities.handlers.prompt_guard import _guard_prompt_size
 from squadops.cycles.check_registry import CHECK_FRONTEND_BUILD
-from squadops.cycles.verification_integrity import NotExecutedReason
+from squadops.cycles.verification_integrity import NotExecutedReason, ResultStatus
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
 
@@ -77,14 +77,18 @@ class QATestHandler(_CycleTaskHandler):
         *,
         typed_error_counts: dict[str, int] | None = None,
     ) -> ValidationResult:
-        """Validate QA handler output (SIP-0086 §6.4).
+        """Validate QA handler output (SIP-0086 §6.4; #670 typed acceptance).
 
-        SIP-0092 M1.3: signature is async to match the base class. Typed
-        acceptance evaluation in the QA path is out of scope for M1.3 —
-        the SIP focuses on the dev FC3 site. The ``typed_error_counts``
-        kwarg is accepted for caller compatibility but unused here.
+        #670 (owner-ruled fork 1, 2026-08-04): qa joins the shared
+        typed-acceptance seam, retiring M1.3's dev-only scope note. Authored
+        checks on qa.test tasks — including the SIP-0100 ``harness_boundary``
+        bindings that were render-only until this change — AND framework
+        injections (#689 ``undefined_names`` on ``.py`` emissions) both
+        evaluate here, with the same RC-9 blocking matrix and #423
+        evidence-gap accounting as the dev/builder surfaces.
         """
-        del typed_error_counts  # accepted for caller compat; not used in QA
+        if typed_error_counts is None:
+            typed_error_counts = {}
         checks: list[dict] = []
         missing: list[str] = []
 
@@ -132,8 +136,19 @@ class QATestHandler(_CycleTaskHandler):
             }
         )
 
-        passed = all(c["passed"] for c in checks)
-        passed_count = sum(1 for c in checks if c["passed"])
+        # #670: typed acceptance on the qa surface — same seam as dev/builder.
+        await self._evaluate_typed_acceptance(
+            inputs, artifacts, checks, missing, typed_error_counts
+        )
+
+        # #423 parity with dev: evidence-gap rows are honest non-passes that
+        # must not fail the task (a correction cannot repair an evaluator
+        # limitation) — they block at the SIP-0096 roll-up instead.
+        passed = (
+            all(c.get("passed", True) or c.get("evidence_gap", False) for c in checks)
+            and not missing
+        )
+        passed_count = sum(1 for c in checks if c.get("passed", True))
         coverage = passed_count / len(checks) if checks else 1.0
 
         summary_parts = []
@@ -141,6 +156,16 @@ class QATestHandler(_CycleTaskHandler):
             summary_parts.append(f"Missing: {', '.join(missing)}")
         if stubs:
             summary_parts.append(f"Stub files: {', '.join(stubs)}")
+        # #670 diagnosability parity with dev (pf-33: name what failed)
+        typed_failed = [
+            c
+            for c in checks
+            if c.get("check", "").startswith("acceptance:")
+            and c.get("status") in {ResultStatus.FAILED, ResultStatus.ERROR}
+        ]
+        if typed_failed:
+            total_typed = sum(1 for c in checks if c.get("check", "").startswith("acceptance:"))
+            summary_parts.append(f"Typed checks failed: {len(typed_failed)} of {total_typed}")
 
         return ValidationResult(
             passed=passed,
@@ -774,8 +799,14 @@ class QATestHandler(_CycleTaskHandler):
         evidence_extra: dict[str, Any] = {}
         output_validation_enabled = resolved_config.get("output_validation", False)
 
+        # #670 / RC-9b: shared across self-eval passes so per-criterion
+        # evaluator-error counts accumulate (2-strikes escalation), dev parity
+        typed_error_counts: dict[str, int] = {}
+
         if output_validation_enabled:
-            validation = await self._validate_output(inputs, artifacts)
+            validation = await self._validate_output(
+                inputs, artifacts, typed_error_counts=typed_error_counts
+            )
 
             # Self-evaluation loop
             if not validation.passed:
@@ -815,7 +846,9 @@ class QATestHandler(_CycleTaskHandler):
                         for f in new_extracted
                     ]
                     artifacts = self._merge_artifacts(artifacts, new_artifacts, evidence_extra)
-                    validation = await self._validate_output(inputs, artifacts)
+                    validation = await self._validate_output(
+                        inputs, artifacts, typed_error_counts=typed_error_counts
+                    )
 
                 evidence_extra["self_eval_passes"] = self_eval_count
         else:

--- a/tests/unit/capabilities/handlers/test_qa_typed_acceptance.py
+++ b/tests/unit/capabilities/handlers/test_qa_typed_acceptance.py
@@ -1,0 +1,156 @@
+"""#670 — qa.test joins the typed-acceptance seam (owner-ruled fork 1).
+
+The gap this closes, measured on shk-3: qa task 4 emitted
+``backend/tests/test_runs.py`` with four authored typed checks and produced
+NO typed-check evaluation — the checks were render-only, and the #689
+framework injection never arrived either. These tests are that exhibit
+inverted: authored checks and framework injections must both be load-bearing
+on qa emissions, with dev-parity #423 evidence-gap accounting.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.handlers.cycle.qa_test import QATestHandler
+from squadops.cycles.implementation_plan import TypedCheck
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+# Valid-Python filler so fixtures never trip the #689 injection by accident.
+_VALID_TEST = "import json\n\n\ndef test_shapes():\n    assert json.loads('{}') == {}\n"
+
+# The shk-3 / #689 exhibit class: a call-time NameError the suite would only
+# surface when executed — `respones` is never defined.
+_NAMEERROR_TEST = "import json\n\n\ndef test_runs():\n    assert respones.status_code == 200\n"
+
+# Imports an app entry module directly — the SIP-0100 harness-boundary
+# violation the scaffold-bound check exists to reject.
+_BOUNDARY_VIOLATION_TEST = (
+    "from app.main import app\n\n\ndef test_direct():\n    assert app is not None\n"
+)
+
+
+def _art(name: str, content: str) -> dict:
+    return {"name": name, "content": content, "media_type": "text/x-python", "type": "test"}
+
+
+def _inputs(criteria=(), *, expected=("backend/tests/test_runs.py",)) -> dict:
+    return {
+        "subtask_focus": "QA suite",
+        "expected_artifacts": list(expected),
+        "acceptance_criteria": list(criteria),
+        # the fleet shape: build_profile resolves the check stack (#503)
+        "resolved_config": {"build_profile": "fullstack_fastapi_react"},
+    }
+
+
+class TestAuthoredChecksAreLoadBearing:
+    async def test_authored_check_failure_blocks_validation(self):
+        # render-only no more: an authored error-severity check that fails
+        # must fail qa validation, not decorate it
+        h = QATestHandler()
+        criteria = [
+            TypedCheck(
+                check="function_defined",
+                params={
+                    "file": "backend/tests/test_runs.py",
+                    "name_prefix": "test_",
+                    "min_count": 3,
+                },
+                severity="error",
+                description="suite defines at least three test functions",
+            )
+        ]
+        result = await h._validate_output(
+            _inputs(criteria), [_art("backend/tests/test_runs.py", _VALID_TEST)]
+        )
+        assert result.passed is False
+        row = next(c for c in result.checks if c["check"] == "acceptance:function_defined")
+        assert row["status"] == "failed"
+        assert "Typed checks failed" in result.summary
+
+    async def test_authored_check_pass_keeps_validation_green(self):
+        h = QATestHandler()
+        criteria = [
+            TypedCheck(
+                check="function_defined",
+                params={"file": "backend/tests/test_runs.py", "name_prefix": "test_"},
+                severity="error",
+                description="suite defines test functions",
+            )
+        ]
+        result = await h._validate_output(
+            _inputs(criteria), [_art("backend/tests/test_runs.py", _VALID_TEST)]
+        )
+        assert result.passed is True
+
+    async def test_sip0100_harness_boundary_binding_is_real(self):
+        # the SIP-0100 scaffold binds harness_boundary onto qa.test slots;
+        # until #670 those bound checks evaluated nowhere
+        h = QATestHandler()
+        criteria = [
+            TypedCheck(
+                check="harness_boundary",
+                params={
+                    "file": "backend/tests/test_direct.py",
+                    "entry_modules": ["app.main", "main"],
+                },
+                severity="error",
+                description="suite consumes the scaffold client fixture",
+            )
+        ]
+        result = await h._validate_output(
+            _inputs(criteria, expected=("backend/tests/test_direct.py",)),
+            [_art("backend/tests/test_direct.py", _BOUNDARY_VIOLATION_TEST)],
+        )
+        assert result.passed is False
+        row = next(c for c in result.checks if c["check"] == "acceptance:harness_boundary")
+        assert row["status"] == "failed"
+
+
+class TestFrameworkInjectionReachesQa:
+    async def test_undefined_names_injected_on_py_emission(self):
+        # the shk-3 exhibit inverted: zero authored criteria, yet the .py
+        # emission with a call-time NameError is caught at acceptance
+        h = QATestHandler()
+        result = await h._validate_output(
+            _inputs(), [_art("backend/tests/test_runs.py", _NAMEERROR_TEST)]
+        )
+        row = next((c for c in result.checks if c["check"] == "acceptance:undefined_names"), None)
+        assert row is not None, "framework injection never reached the qa emission"
+        assert row["status"] == "failed"
+        assert result.passed is False
+
+    async def test_no_injection_on_out_of_family_emission(self):
+        # #605 skip property preserved: a .js suite gets no python check
+        h = QATestHandler()
+        result = await h._validate_output(
+            _inputs(expected=("frontend/tests/app.test.js",)),
+            [_art("frontend/tests/app.test.js", "test('x', () => {})")],
+        )
+        assert not any(c["check"] == "acceptance:undefined_names" for c in result.checks)
+        assert result.passed is True
+
+
+class TestEvidenceGapParityWithDev:
+    async def test_evaluator_gap_does_not_fail_the_task(self):
+        # #423 on the qa surface: an authored error check the evaluator cannot
+        # run is an honest non-pass that blocks at the roll-up, not here
+        h = QATestHandler()
+        criteria = [
+            TypedCheck(
+                check="import_present",
+                params={"file": "frontend/tests/app.test.tsx", "module": "vitest"},
+                severity="error",
+                description="suite imports the harness",
+            )
+        ]
+        result = await h._validate_output(
+            _inputs(criteria, expected=("frontend/tests/app.test.tsx",)),
+            [_art("frontend/tests/app.test.tsx", "import {test} from 'vitest'")],
+        )
+        row = next(c for c in result.checks if c["check"] == "acceptance:import_present")
+        assert row["evidence_gap"] is True
+        assert row["passed"] is False
+        assert result.passed is True  # the gap blocks at SIP-0096, not the task


### PR DESCRIPTION
## What

Gate-2 opener of the 1.5 line (plan A1; owner ruling: fork 1, 2026-08-04). `qa.test` calls `_evaluate_typed_acceptance` like dev and builder do — authored typed checks AND framework injections both become load-bearing on qa emissions. The change is one contained seam call plus dev-parity accounting: RC-9 blocking, RC-9b error counts threaded across self-eval passes, #423 evidence-gap handling (gap rows block at the SIP-0096 roll-up, never fail the task), pf-33 failure naming in the summary. The qa `handle()` path already emitted the #114 evaluation artifact — it returned `None` for lack of typed rows and now lights up.

## Design-gate answers (plan A1), verified in code

- **Which injections reach qa?** Applicability-driven on the producer's own emissions (`is_check_applicable` inside `_framework_injected_criteria`) — qa gets exactly the applicable set, no qa-specific filter.
- **Cross-surface duplication?** None by construction: injection is scoped to the task's own artifacts; authored same-identity rows dedup at the SIP-0096 roll-up (`executed_final` last-wins). Source attribution rides the per-task evaluation artifact.
- **`harness_boundary` exemption?** Evaluation-scope only — the check is static AST, no new execution. Its SIP-0100 qa.test bindings were exactly the render-only exhibit this issue measured; #671's *authoring-side* `entry_modules` exemption is untouched.

## The exhibit, inverted

shk-3's qa task 4 emitted `backend/tests/test_runs.py` with four authored checks and produced **no** evaluation. The headline test reproduces that shape with a call-time NameError and zero authored criteria — the framework injection alone now catches it at acceptance.

## Verification

Six new tests (authored block/pass, harness_boundary real, injection arrives, .js uninjected — #605 property, .tsx evidence-gap parity); regression **6281 passed** including the registry-wide #605 skip test and the enum-shadow guard (new comparison uses `ResultStatus`). Evidence-matrix requirement outstanding for the cut: the **silent-on-clean shakedown** (no false reds from newly-real gates) rides the Gate-2 exit shakedown.

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv