### PR TITLE
fix(correction): #687 — thread the app traceback into failure_evidence

### DIFF
--- a/src/squadops/capabilities/handlers/probe_runner.py
+++ b/src/squadops/capabilities/handlers/probe_runner.py
@@ -25,6 +25,7 @@ qa.test handler wraps it in a thread.
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import os
 import socket
 import subprocess
@@ -42,6 +43,7 @@ from squadops.cycles.verification_contract import (
     capture_probe_values,
     resolve_probe_path,
 )
+from squadops.cycles.verification_integrity import ResultStatus
 
 # The one subject the default profile knows how to boot: a FastAPI backend. A probe whose
 # subject the active profile cannot boot is reported skipped (not-executed), never a false pass.
@@ -85,11 +87,19 @@ DEFAULT_PROFILE = ExecutionProfile(
 class ProbeOutcome:
     """The result of one probe. ``status`` is a ``ResultStatus`` literal (passed/failed/
     skipped) so it flows straight through ``normalize_task_checks``; ``skipped`` means
-    not-executed (boot failed / subject unbootable), never a silent pass."""
+    not-executed (boot failed / subject unbootable), never a silent pass.
+
+    ``app_traceback`` (#687): the subject's own stack trace for THIS probe's
+    failure, read from the stderr spool delta the request produced — the fact
+    the analyzer used to guess at (shk-2: two of five correction attempts
+    burned repairing guessed causes while the NameError sat in the spool).
+    Bounded to the last traceback block; ``None`` when the failure produced
+    none (assertion mismatches on healthy responses don't traceback)."""
 
     id: str
     status: str  # "passed" | "failed" | "skipped"
     reason: str | None = None
+    app_traceback: str | None = None
 
 
 def run_probes(
@@ -129,10 +139,21 @@ def probe_check_rows(outcomes: list[ProbeOutcome]) -> list[dict[str, Any]]:
     carries ``criterion_id`` on the status-bearing branch — so a probe row always traces back
     to its contract criterion in the rollup.
     """
-    return [
-        {"check": o.id, "status": o.status, "reason": o.reason, "criterion_id": o.id}
-        for o in outcomes
-    ]
+    rows: list[dict[str, Any]] = []
+    for o in outcomes:
+        row: dict[str, Any] = {
+            "check": o.id,
+            "status": o.status,
+            "reason": o.reason,
+            "criterion_id": o.id,
+        }
+        # #687: the app-side stack trace rides the evidence row so
+        # build_failure_evidence (and through it data.analyze_failure) reads
+        # the actual cause instead of inferring plausible classes.
+        if o.app_traceback:
+            row["app_traceback"] = o.app_traceback
+        rows.append(row)
+    return rows
 
 
 # --------------------------------------------------------------------------- #
@@ -161,7 +182,19 @@ def _run_backend_probes(
         # #651: sequenced probes share a capture context in contract order —
         # a create's captured id resolves the {run_id} in join/leave paths.
         context: dict[str, str] = {}
-        return [_run_one(base, p, profile, context) for p in probes]
+        results: list[ProbeOutcome] = []
+        for p in probes:
+            # #687: bracket each probe with the spool position so a failed
+            # probe's app-side stderr (uvicorn writes the exception traceback
+            # synchronously with the 500) is attributable to THAT probe.
+            spool_start = _spool_size(stderr_spool)
+            outcome = _run_one(base, p, profile, context)
+            if outcome.status == ResultStatus.FAILED:
+                tb = _read_failure_traceback(stderr_spool, spool_start)
+                if tb:
+                    outcome = dataclasses.replace(outcome, app_traceback=tb)
+            results.append(outcome)
+        return results
     finally:
         _terminate(proc)
         with contextlib.suppress(Exception):
@@ -213,6 +246,65 @@ def _boot_failure_reason(
     if tail:
         reason += f": {tail}"
     return reason
+
+
+def _spool_size(stderr_spool: Any) -> int:
+    """Current end position of the spool (the child appends behind us)."""
+    try:
+        stderr_spool.seek(0, os.SEEK_END)
+        return int(stderr_spool.tell())
+    except Exception:
+        return 0
+
+
+def _read_spool_from(stderr_spool: Any, start: int) -> str:
+    """Best-effort read of everything the subject wrote after ``start``."""
+    try:
+        stderr_spool.seek(start)
+        return stderr_spool.read().decode("utf-8", "replace")
+    except Exception:
+        return ""
+
+
+# Bounded per the issue: the last traceback only, never raw log dumps.
+_TRACEBACK_MAX_CHARS = 2000
+_TRACEBACK_MARKER = "Traceback (most recent call last):"
+
+# The subject's logger flushes the exception traceback asynchronously — the
+# 500 response lands ~50ms before the stderr write (measured). A short grace
+# poll on FAILED probes only; a failure with no traceback (assertion mismatch
+# on a healthy response) pays the full window once, bounded and rare.
+_TRACEBACK_GRACE_S = 0.5
+_TRACEBACK_POLL_S = 0.05
+
+
+def _read_failure_traceback(stderr_spool: Any, start: int) -> str | None:
+    """The failed probe's traceback from its spool delta, with a grace poll."""
+    deadline = time.monotonic() + _TRACEBACK_GRACE_S
+    while True:
+        tb = _extract_last_traceback(_read_spool_from(stderr_spool, start))
+        if tb is not None or time.monotonic() >= deadline:
+            return tb
+        time.sleep(_TRACEBACK_POLL_S)
+
+
+def _extract_last_traceback(text: str) -> str | None:
+    """The last complete traceback block in ``text``, newlines preserved.
+
+    Newlines are kept (unlike the boot-reason tail) because the analyzer
+    reads this as structured evidence — a collapsed one-liner loses the
+    frame that names the defect's file and line.
+    """
+    idx = text.rfind(_TRACEBACK_MARKER)
+    if idx == -1:
+        return None
+    block = text[idx:].strip()
+    if len(block) > _TRACEBACK_MAX_CHARS:
+        # Trim from the FRONT: the exception line and the deepest (app) frame
+        # sit at the tail — a head-kept cap would keep middleware frames and
+        # drop the one line that names the defect.
+        block = "…" + block[-(_TRACEBACK_MAX_CHARS - 1) :]
+    return block
 
 
 def _stderr_tail(stderr_spool: Any, limit: int = 500) -> str:

--- a/src/squadops/cycles/failure_evidence.py
+++ b/src/squadops/cycles/failure_evidence.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from squadops.cycles.verification_integrity import ResultStatus
+
 if TYPE_CHECKING:
     from squadops.tasks.models import TaskEnvelope, TaskResult
 
@@ -72,7 +74,87 @@ def build_failure_evidence(
     emission_failure = result_outputs.get("emission_failure")
     if isinstance(emission_failure, dict):
         evidence["emission_failure"] = emission_failure
+    # #687: hoist app-side tracebacks off the probe rows to the evidence top
+    # level — the analyzer's prompt renders the evidence dict, and the stack
+    # trace is THE diagnosis for a behavioral failure (shk-2: two attempts
+    # burned on guessed causes while the NameError sat unread).
+    app_tracebacks = [
+        {"check": row.get("check", ""), "traceback": row["app_traceback"]}
+        for row in (validation_result.get("checks") or [])
+        if isinstance(row, dict) and row.get("app_traceback")
+    ]
+    if app_tracebacks:
+        evidence["app_tracebacks"] = app_tracebacks[:_MAX_APP_TRACEBACKS]
+    evidence["failure_category"] = derive_failure_category(evidence)
     return evidence
+
+
+# Bounded: distinct failing probes usually share one root cause; three
+# tracebacks names it without turning the evidence into a log dump.
+_MAX_APP_TRACEBACKS = 3
+
+
+class FailureEvidenceCategory:
+    """What kind of fact the failure evidence carries (1.5 A3 taxonomy).
+
+    The shared vocabulary of the #687+#431 pair — deterministic, derived from
+    machine signals already in the evidence, never from prose. The analyzer,
+    the locus classifier, and (via evidence persistence) replay all read the
+    same answer to "what actually failed here?", so an infrastructure failure
+    can never masquerade as a work-product failure just because the diagnostic
+    inputs sat downstream of the infrastructure that failed.
+
+    Constants-class pattern (``TaskOutcome``). Categories with no detectable
+    signal yet are declared, not guessed: ``EXTRACTION_LOSS`` gains its signal
+    with #431's emission stats; ``VERIFICATION_INFRA_FAILURE`` with the
+    runner-side reasons already in evidence rows.
+    """
+
+    # The app/product executed its checks and failed them — the ordinary case.
+    EXECUTED_AND_FAILED = "executed_and_failed"
+    # The app executed and errored — an app_traceback names the cause (#687).
+    APP_ERROR = "app_error"
+    # The emission was extracted but materially truncated (#431 gap rule).
+    EXTRACTION_LOSS = "extraction_loss"
+    # Zero extraction — no artifact was ever produced (#566 marker).
+    EMISSION_ABSENT = "emission_absent"
+    # The subject never booted; behavioral checks never ran.
+    SANDBOX_PREEXEC_FAILURE = "sandbox_preexec_failure"
+    # The verification machinery itself failed (runner/env), not the product.
+    VERIFICATION_INFRA_FAILURE = "verification_infra_failure"
+    # Nothing machine-readable survived to classify from.
+    EVIDENCE_UNAVAILABLE = "evidence_unavailable"
+
+
+def derive_failure_category(evidence: dict[str, Any]) -> str:
+    """Deterministic category from the evidence's machine signals (A3).
+
+    Precedence is the diagnosis-integrity order: infrastructure/emission facts
+    first (they invalidate downstream product signals — the #431 lesson),
+    then the app's own error, then ordinary check failures.
+    """
+    if isinstance(evidence.get("emission_failure"), dict):
+        return FailureEvidenceCategory.EMISSION_ABSENT
+    if evidence.get("extraction_loss") is True:
+        return FailureEvidenceCategory.EXTRACTION_LOSS
+    checks = (evidence.get("validation_result") or {}).get("checks") or []
+    rows = [r for r in checks if isinstance(r, dict)]
+    if evidence.get("app_tracebacks"):
+        return FailureEvidenceCategory.APP_ERROR
+    skipped_boot = [
+        r
+        for r in rows
+        if r.get("status") == ResultStatus.SKIPPED
+        and "subject did not boot" in str(r.get("reason", ""))
+    ]
+    if skipped_boot:
+        return FailureEvidenceCategory.SANDBOX_PREEXEC_FAILURE
+    if any(
+        r.get("passed") is False or r.get("status") in (ResultStatus.FAILED, ResultStatus.ERROR)
+        for r in rows
+    ):
+        return FailureEvidenceCategory.EXECUTED_AND_FAILED
+    return FailureEvidenceCategory.EVIDENCE_UNAVAILABLE
 
 
 class FailureLocus:

--- a/tests/unit/capabilities/test_probe_runner.py
+++ b/tests/unit/capabilities/test_probe_runner.py
@@ -393,3 +393,67 @@ def test_capture_key_missing_from_response_fails(monkeypatch):
     assert out.status == "failed"
     assert "capture key 'id' missing" in out.reason
     assert context == {}
+
+
+# --------------------------------------------------------------------------- #
+# #687 — app traceback capture on failed probes
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_last_traceback_takes_the_last_block():
+    text = (
+        "INFO: startup\n"
+        "Traceback (most recent call last):\n  File 'a.py'\nValueError: first\n"
+        "INFO: request\n"
+        "Traceback (most recent call last):\n  File 'b.py'\nNameError: name 'respones' is not defined\n"
+    )
+    tb = pr._extract_last_traceback(text)
+    assert tb is not None
+    assert tb.startswith("Traceback (most recent call last):")
+    assert "respones" in tb
+    assert "ValueError" not in tb  # earlier block never shadows the relevant one
+
+
+def test_extract_last_traceback_bounded_and_none_cases():
+    assert pr._extract_last_traceback("INFO: all quiet") is None
+    long = "Traceback (most recent call last):\n" + ("x" * 5000)
+    tb = pr._extract_last_traceback(long)
+    assert tb is not None and len(tb) <= pr._TRACEBACK_MAX_CHARS
+
+
+def test_probe_check_rows_carry_traceback_only_when_present():
+    rows = pr.probe_check_rows(
+        [
+            pr.ProbeOutcome("a", "failed", "status 500 != 200", app_traceback="Traceback ..."),
+            pr.ProbeOutcome("b", "passed", None),
+        ]
+    )
+    assert rows[0]["app_traceback"] == "Traceback ..."
+    assert "app_traceback" not in rows[1]  # a healthy row never grows the key
+
+
+@pytest.mark.slow
+def test_failed_probe_captures_the_apps_own_traceback(tmp_path):
+    # the shk-2 exhibit, live: a request-time NameError 500s the probe and the
+    # captured evidence must carry the app's actual stack trace — the fact the
+    # analyzer previously guessed at
+    (tmp_path / "backend").mkdir()
+    (tmp_path / "backend" / "__init__.py").write_text("")
+    (tmp_path / "backend" / "main.py").write_text(
+        "from fastapi import FastAPI\n"
+        "app = FastAPI()\n"
+        "@app.get('/boom')\n"
+        "def boom():\n"
+        "    return respones\n"  # NameError at request time
+    )
+    probe = Probe(
+        id="vc-probe-boom",
+        subject="backend",
+        request={"method": "GET", "path": "/boom"},
+        expect={"status": 200},
+    )
+    outcomes = run_probes(tmp_path, [probe])
+    assert outcomes[0].status == "failed"
+    assert outcomes[0].app_traceback is not None
+    assert "NameError" in outcomes[0].app_traceback
+    assert "respones" in outcomes[0].app_traceback

--- a/tests/unit/cycles/test_failure_evidence.py
+++ b/tests/unit/cycles/test_failure_evidence.py
@@ -499,3 +499,99 @@ class TestRunnerAwareLocus:
             "suite_broken": None,
         }
         assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.SUBJECT
+
+
+class TestAppTracebackHoist:
+    """#687: the app-side stack trace must reach the analyzer as structured
+    evidence — shk-2 burned two of five correction attempts on guessed causes
+    while the NameError traceback sat unread in the sandbox spool."""
+
+    def _envelope(self) -> TaskEnvelope:
+        return TaskEnvelope(
+            task_id="t-7",
+            agent_id="eve",
+            cycle_id="cyc_x",
+            pulse_id="pulse",
+            project_id="proj",
+            task_type="qa.test",
+            correlation_id="corr",
+            causation_id=None,
+            trace_id="trace",
+            span_id="span",
+            inputs={},
+            metadata={},
+        )
+
+    def _result_with_checks(self, checks: list[dict]) -> TaskResult:
+        return TaskResult(
+            task_id="t-7",
+            status="FAILED",
+            outputs={"validation_result": {"passed": False, "checks": checks}},
+            error="probe failure",
+        )
+
+    def test_tracebacks_hoisted_to_top_level(self):
+        tb = "Traceback (most recent call last):\n  ...\nNameError: name 'respones' is not defined"
+        checks = [
+            {"check": "vc-probe-runs", "status": "failed", "app_traceback": tb},
+            {"check": "vc-probe-health", "status": "passed"},
+        ]
+        evidence = build_failure_evidence(
+            self._envelope(), self._result_with_checks(checks), prior_plan_deltas_count=0
+        )
+        assert evidence["app_tracebacks"] == [{"check": "vc-probe-runs", "traceback": tb}]
+        assert evidence["failure_category"] == "app_error"
+
+    def test_traceback_count_bounded(self):
+        checks = [
+            {"check": f"vc-{i}", "status": "failed", "app_traceback": f"Traceback {i}"}
+            for i in range(5)
+        ]
+        evidence = build_failure_evidence(
+            self._envelope(), self._result_with_checks(checks), prior_plan_deltas_count=0
+        )
+        assert len(evidence["app_tracebacks"]) == 3  # bounded, never a log dump
+
+    def test_no_tracebacks_no_key(self):
+        checks = [{"check": "vc-probe-runs", "status": "failed", "reason": "status 404 != 200"}]
+        evidence = build_failure_evidence(
+            self._envelope(), self._result_with_checks(checks), prior_plan_deltas_count=0
+        )
+        assert "app_tracebacks" not in evidence
+        assert evidence["failure_category"] == "executed_and_failed"
+
+
+class TestDeriveFailureCategory:
+    """A3 taxonomy precedence: infrastructure/emission facts invalidate
+    downstream product signals — the #431 lesson made deterministic."""
+
+    def test_emission_absent_wins_over_everything(self):
+        from squadops.cycles.failure_evidence import derive_failure_category
+
+        evidence = {
+            "emission_failure": {"kind": "no_fenced_blocks"},
+            "app_tracebacks": [{"check": "x", "traceback": "Traceback ..."}],
+            "validation_result": {"checks": [{"check": "c", "passed": False}]},
+        }
+        assert derive_failure_category(evidence) == "emission_absent"
+
+    def test_boot_failure_is_sandbox_preexec(self):
+        from squadops.cycles.failure_evidence import derive_failure_category
+
+        evidence = {
+            "validation_result": {
+                "checks": [
+                    {
+                        "check": "vc-probe-runs",
+                        "status": "skipped",
+                        "reason": "subject did not boot (exited 1): ModuleNotFoundError",
+                    }
+                ]
+            }
+        }
+        assert derive_failure_category(evidence) == "sandbox_preexec_failure"
+
+    def test_empty_evidence_is_unavailable(self):
+        from squadops.cycles.failure_evidence import derive_failure_category
+
+        assert derive_failure_category({}) == "evidence_unavailable"


### PR DESCRIPTION
## What

First half of the Gate-2 #687+#431 pair (plan A3): **the analyzer stops guessing at behavioral 500s** — the app's own stack trace reaches `failure_evidence` as structured data.

- Probe runner: each probe is bracketed with its stderr-spool position; a FAILED probe reads its own delta with a short grace poll (measured: uvicorn flushes the traceback ~50ms *after* the 500 response) and carries the **last traceback block, tail-kept** under a 2000-char bound — the live test caught that a head-kept cap preserved anyio middleware frames and dropped the one line naming the defect.
- `build_failure_evidence` hoists tracebacks top-level (bounded 3) beside the rows, so `data.analyze_failure`'s evidence leads with the actual cause.
- **The A3 shared taxonomy lands here**: `FailureEvidenceCategory` (seven categories) + `derive_failure_category` stamped on every payload, with diagnosis-integrity precedence — infrastructure/emission facts invalidate downstream product signals (the #431 lesson made deterministic). `EXTRACTION_LOSS` is declared with its signal arriving in the #431 half, next PR.

## The exhibit, live

shk-2 (`cyc_88162ecfd895`): `NameError: name 'RunEvent'` at request time → 500 → two of five correction attempts burned on guessed causes while the traceback sat in the sandbox spool. The headline test reproduces the shape end-to-end — a NameError route under real uvicorn — and asserts the captured evidence names the undefined symbol.

## Verification

Regression **6291 passed** (enum-shadow guard caught three raw literals in my first pass — now `ResultStatus`). Replay preservation (A3 criterion): evidence is persisted data on analysis inputs/artifacts, so stored-artifact replays carry the category and tracebacks by construction.

Next: the #431 half — per-attempt emission stats + the extraction-loss gap rule feeding `EXTRACTION_LOSS` and the locus classifier.

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv