### PR TITLE
fix(correction): #431 — the extraction-loss signal (completes the A3 pair)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -26,6 +26,7 @@ from squadops.cycles.acceptance_evaluation import (
     resolve_check_stack,
     split_acceptance_criteria,
 )
+from squadops.cycles.emission_integrity import emission_stats
 from squadops.cycles.implementation_plan import TypedCheck
 from squadops.cycles.patch_verification import materialize_artifacts
 from squadops.cycles.verification_integrity import ResultStatus
@@ -723,10 +724,15 @@ class _CycleTaskHandler(CapabilityHandler):
             provenance["request_render_hash"] = rendered.render_hash
             provenance["prompt_environment"] = "production"
 
+        artifacts = self._build_artifacts_from_content(content)
         outputs = {
             "summary": f"[{self._role}] {prd_summary}",
             "role": self._role,
-            "artifacts": self._build_artifacts_from_content(content),
+            "artifacts": artifacts,
+            # #431: generated-vs-stored accounting — repair emissions route
+            # through this base handle, and the repair path is where the
+            # production exhibit burned its budget regenerating into a loss
+            "emission_stats": emission_stats(len(content), artifacts),
             "prompt_provenance": provenance,
         }
 

--- a/src/squadops/capabilities/handlers/cycle/builder.py
+++ b/src/squadops/capabilities/handlers/cycle/builder.py
@@ -282,6 +282,7 @@ class BuilderAssembleHandler(_CycleTaskHandler):
         )
         from squadops.capabilities.handlers.fenced_parser import extract_fenced_files
         from squadops.cycles.check_registry import CHECK_REQUIRED_FILES
+        from squadops.cycles.emission_integrity import emission_stats
 
         start_time = time.perf_counter()
 
@@ -479,6 +480,8 @@ class BuilderAssembleHandler(_CycleTaskHandler):
             "summary": f"[builder] Assembled {len(artifacts)} deployment artifact(s)",
             "role": self._role,
             "artifacts": artifacts,
+            # #431: generated-vs-stored accounting for extraction-loss diagnosis
+            "emission_stats": emission_stats(len(content), artifacts),
             # #399/#419: per-task required_files + typed-acceptance evidence
             # for the SIP-0096 roll-up (all passed — validation succeeded).
             "validation_result": {"checks": validation_checks},

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -684,6 +684,13 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         if "validation_result" in evidence_extra:
             outputs["validation_result"] = evidence_extra["validation_result"]
 
+        # #431: generated-vs-stored accounting (primary response; a self-eval
+        # merge changes artifacts, and the stats stay honest against the
+        # response that produced the bulk of them)
+        from squadops.cycles.emission_integrity import emission_stats
+
+        outputs["emission_stats"] = emission_stats(len(content), artifacts)
+
         duration_ms = (time.perf_counter() - start_time) * 1000
         evidence = HandlerEvidence.create(
             handler_name=self._handler_name,

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -18,6 +18,7 @@ from squadops.capabilities.handlers.base import (
 )
 from squadops.capabilities.handlers.prompt_guard import _guard_prompt_size
 from squadops.cycles.check_registry import CHECK_FRONTEND_BUILD
+from squadops.cycles.emission_integrity import emission_stats as _emission_stats
 from squadops.cycles.verification_integrity import NotExecutedReason, ResultStatus
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
@@ -974,6 +975,8 @@ class QATestHandler(_CycleTaskHandler):
             "summary": f"[qa] Generated {len(artifacts) - 1} test file(s){test_suffix}",
             "role": self._role,
             "artifacts": artifacts,
+            # #431: generated-vs-stored accounting for extraction-loss diagnosis
+            "emission_stats": _emission_stats(len(content), artifacts),
             "test_result": {
                 "executed": test_result.executed,
                 "exit_code": test_result.exit_code,

--- a/src/squadops/cycles/emission_integrity.py
+++ b/src/squadops/cycles/emission_integrity.py
@@ -95,6 +95,53 @@ def no_fenced_blocks_failure(
     }
 
 
+EMISSION_STATS_KEY = "emission_stats"
+
+# The #431 gap rule: extraction loss is *suspected* when a substantial response
+# retained almost nothing through extraction. Both bounds are deliberate:
+# responses under the floor legitimately extract small (a one-line config fix
+# wrapped in prose), and healthy responses retain well above the ceiling —
+# prose around fences typically leaves 40–80% retention, while the production
+# exhibit (cyc_8830cfc78a1e: ~7k generated tokens → ~800 stored bytes) sat
+# near 3%. The flag is a DIAGNOSIS input, never a gate: it tells the analyzer
+# the evidence itself is suspect, so a parser loss is not diagnosed as a
+# work-product failure and repaired by regenerating into the same loss.
+_EXTRACTION_LOSS_MIN_RESPONSE_CHARS = 2000
+_EXTRACTION_LOSS_MAX_RETENTION = 0.15
+
+
+def emission_stats(response_chars: int, artifacts: list[Any]) -> dict[str, Any]:
+    """Per-attempt generated-vs-stored accounting (#431).
+
+    Recorded on every build/repair emission — success and failure alike — so a
+    failed attempt's evidence can compare what the model produced against what
+    survived extraction. ``extracted_chars`` counts artifact content only
+    (the stored work product), never metadata.
+    """
+    extracted = sum(
+        len(a.get("content", ""))
+        for a in artifacts
+        if isinstance(a, dict) and isinstance(a.get("content"), str)
+    )
+    return {
+        "response_chars": int(response_chars),
+        "extracted_chars": extracted,
+        "artifact_count": sum(1 for a in artifacts if isinstance(a, dict)),
+    }
+
+
+def extraction_loss_suspected(stats: dict[str, Any]) -> bool:
+    """The #431 gap rule over an ``emission_stats`` record."""
+    try:
+        response_chars = int(stats.get("response_chars", 0))
+        extracted_chars = int(stats.get("extracted_chars", 0))
+    except (TypeError, ValueError):
+        return False
+    if response_chars < _EXTRACTION_LOSS_MIN_RESPONSE_CHARS:
+        return False
+    return extracted_chars < response_chars * _EXTRACTION_LOSS_MAX_RETENTION
+
+
 def emission_retry_reason_line(marker: dict[str, Any]) -> str:
     """One factual sentence describing the marker, for the retry-feedback
     template's ``reason_line`` variable (same deterministic-instruction genre

--- a/src/squadops/cycles/failure_evidence.py
+++ b/src/squadops/cycles/failure_evidence.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from squadops.cycles.emission_integrity import extraction_loss_suspected
 from squadops.cycles.verification_integrity import ResultStatus
 
 if TYPE_CHECKING:
@@ -74,6 +75,15 @@ def build_failure_evidence(
     emission_failure = result_outputs.get("emission_failure")
     if isinstance(emission_failure, dict):
         evidence["emission_failure"] = emission_failure
+    # #431: generated-vs-stored accounting + the gap rule. The flag is the
+    # machine fact that the diagnostic inputs themselves are suspect — a
+    # partial extraction loss must never be diagnosed as a work-product
+    # failure from the fraction that survived.
+    emission_stats = result_outputs.get("emission_stats")
+    if isinstance(emission_stats, dict):
+        evidence["emission_stats"] = emission_stats
+        if extraction_loss_suspected(emission_stats):
+            evidence["extraction_loss"] = True
     # #687: hoist app-side tracebacks off the probe rows to the evidence top
     # level — the analyzer's prompt renders the evidence dict, and the stack
     # trace is THE diagnosis for a behavioral failure (shk-2: two attempts
@@ -200,6 +210,14 @@ def classify_failure_locus(failure_evidence: Any) -> str:
     if isinstance(failure_evidence.get("emission_failure"), dict):
         return FailureLocus.OWN_ARTIFACT
 
+    # #431: partial extraction loss — the emission never arrived whole, so the
+    # defect belongs to the producing task's own re-emission (with #528's
+    # parser fixes, a re-emit can succeed), NEVER to behavioral repair of the
+    # subject: repairing app source against evidence derived from a truncated
+    # artifact is exactly the budget burn this flag exists to stop.
+    if failure_evidence.get("extraction_loss") is True:
+        return FailureLocus.OWN_ARTIFACT
+
     validation_result = failure_evidence.get("validation_result") or {}
     checks = validation_result.get("checks") or []
     for row in checks:
@@ -210,33 +228,43 @@ def classify_failure_locus(failure_evidence: Any) -> str:
             # The task's own named output files are missing from its emission.
             return FailureLocus.OWN_ARTIFACT
         if check == "tests_pass" and row.get("passed") is False:
-            # #626: prefer the runner's OWN suite-health verdict (test_runner
-            # owns test-framework knowledge; vitest cannot express suite-broken
-            # through exit codes, so pytest exit semantics misrouted every
-            # frontend suite defect to the dev chain — pf-53). Absent/None
-            # falls back to the legacy pytest exit-code table.
-            #
-            # #665: the verdict is read BEFORE the executed guard. A suite that
-            # never ran because it does not exist (zero collectable files) is
-            # the producing role's own artifact, but the old executed gate
-            # skipped every own-artifact signal for exactly that case — fay-13's
-            # missing suite (executed:false, exit -1) fell to UNKNOWN and five
-            # dev-chain repairs churned on files only the qa role could author.
-            suite_broken = row.get("suite_broken")
-            if suite_broken is True:
-                return FailureLocus.OWN_ARTIFACT
-            if not row.get("executed"):
-                # Every other never-executed case (env/runner errors, timeouts,
-                # legacy rows with no verdict) stays ambiguous → dev chain.
-                continue
-            if suite_broken is False:
-                return FailureLocus.SUBJECT
-            exit_code = row.get("exit_code")
-            if exit_code in _SUITE_DEFECT_EXIT_CODES:
-                return FailureLocus.OWN_ARTIFACT
-            if exit_code == 1:
-                return FailureLocus.SUBJECT
+            locus = _locus_from_tests_pass_row(row)
+            if locus is not None:
+                return locus
     return FailureLocus.UNKNOWN
+
+
+def _locus_from_tests_pass_row(row: dict[str, Any]) -> str | None:
+    """Locus signal from a failed ``tests_pass`` row, or None (keep scanning).
+
+    #626: prefer the runner's OWN suite-health verdict (test_runner owns
+    test-framework knowledge; vitest cannot express suite-broken through exit
+    codes, so pytest exit semantics misrouted every frontend suite defect to
+    the dev chain — pf-53). Absent/None falls back to the legacy pytest
+    exit-code table.
+
+    #665: the verdict is read BEFORE the executed guard. A suite that never
+    ran because it does not exist (zero collectable files) is the producing
+    role's own artifact, but the old executed gate skipped every own-artifact
+    signal for exactly that case — fay-13's missing suite (executed:false,
+    exit -1) fell to UNKNOWN and five dev-chain repairs churned on files only
+    the qa role could author.
+    """
+    suite_broken = row.get("suite_broken")
+    if suite_broken is True:
+        return FailureLocus.OWN_ARTIFACT
+    if not row.get("executed"):
+        # Every other never-executed case (env/runner errors, timeouts,
+        # legacy rows with no verdict) stays ambiguous → dev chain.
+        return None
+    if suite_broken is False:
+        return FailureLocus.SUBJECT
+    exit_code = row.get("exit_code")
+    if exit_code in _SUITE_DEFECT_EXIT_CODES:
+        return FailureLocus.OWN_ARTIFACT
+    if exit_code == 1:
+        return FailureLocus.SUBJECT
+    return None
 
 
 def compose_failure_trigger(

--- a/tests/unit/cycles/test_emission_integrity.py
+++ b/tests/unit/cycles/test_emission_integrity.py
@@ -265,3 +265,34 @@ class TestUnresolvedImports:
         )
 
         assert unresolved_imports(tmp_path) == []
+
+
+class TestEmissionStats:
+    """#431 accounting: what the model produced vs what survived extraction."""
+
+    def test_counts_content_chars_only(self):
+        from squadops.cycles.emission_integrity import emission_stats
+
+        arts = [
+            {"name": "a.py", "content": "x" * 100, "type": "code"},
+            {"name": "b.md", "content": "y" * 50, "type": "document"},
+            {"name": "meta", "content": None},  # non-string content never counts
+            "not-a-dict",
+        ]
+        stats = emission_stats(4000, arts)
+        assert stats == {"response_chars": 4000, "extracted_chars": 150, "artifact_count": 3}
+
+    def test_gap_rule_boundaries(self):
+        from squadops.cycles.emission_integrity import extraction_loss_suspected
+
+        # the production exhibit shape: ~3% retention on a large response
+        assert extraction_loss_suspected({"response_chars": 28000, "extracted_chars": 800})
+        # healthy prose-around-fences retention
+        assert not extraction_loss_suspected({"response_chars": 28000, "extracted_chars": 21000})
+        # floor: small responses legitimately extract small
+        assert not extraction_loss_suspected({"response_chars": 1999, "extracted_chars": 0})
+        # exactly at the ratio is NOT loss (strict less-than)
+        assert not extraction_loss_suspected({"response_chars": 10000, "extracted_chars": 1500})
+        # malformed stats never crash the evidence path
+        assert not extraction_loss_suspected({"response_chars": "x"})
+        assert not extraction_loss_suspected({})

--- a/tests/unit/cycles/test_failure_evidence.py
+++ b/tests/unit/cycles/test_failure_evidence.py
@@ -595,3 +595,71 @@ class TestDeriveFailureCategory:
         from squadops.cycles.failure_evidence import derive_failure_category
 
         assert derive_failure_category({}) == "evidence_unavailable"
+
+
+class TestExtractionLossSignal:
+    """#431: a partial extraction loss must be diagnosable as an
+    infrastructure fact — cyc_8830cfc78a1e burned three repair attempts
+    regenerating ~7k-token documents into an ~800-byte parser loss that
+    failure analysis called 'work_product'."""
+
+    def _envelope(self) -> TaskEnvelope:
+        return TaskEnvelope(
+            task_id="t-7",
+            agent_id="bob",
+            cycle_id="cyc_x",
+            pulse_id="pulse",
+            project_id="proj",
+            task_type="builder.assemble",
+            correlation_id="corr",
+            causation_id=None,
+            trace_id="trace",
+            span_id="span",
+            inputs={},
+            metadata={},
+        )
+
+    def _result(self, stats: dict) -> TaskResult:
+        return TaskResult(
+            task_id="t-7",
+            status="FAILED",
+            outputs={
+                "emission_stats": stats,
+                "validation_result": {
+                    "passed": False,
+                    "checks": [{"check": "expected_artifacts", "passed": False}],
+                },
+            },
+            error="validation failed",
+        )
+
+    def test_gap_sets_flag_category_and_own_artifact_locus(self):
+        # the production shape: ~28k generated chars, ~800 stored
+        stats = {"response_chars": 28000, "extracted_chars": 800, "artifact_count": 1}
+        evidence = build_failure_evidence(
+            self._envelope(), self._result(stats), prior_plan_deltas_count=0
+        )
+        assert evidence["emission_stats"] == stats
+        assert evidence["extraction_loss"] is True
+        assert evidence["failure_category"] == "extraction_loss"
+        # never behavioral repair: the emission never arrived whole
+        assert classify_failure_locus(evidence) == FailureLocus.OWN_ARTIFACT
+
+    def test_healthy_retention_stays_product_diagnosis(self):
+        stats = {"response_chars": 28000, "extracted_chars": 21000, "artifact_count": 4}
+        evidence = build_failure_evidence(
+            self._envelope(), self._result(stats), prior_plan_deltas_count=0
+        )
+        assert "extraction_loss" not in evidence
+        assert evidence["failure_category"] == "executed_and_failed"
+        # expected_artifacts failed → own-artifact via the existing check rule,
+        # NOT via the loss flag — the two signals stay independent
+        assert classify_failure_locus(evidence) == FailureLocus.OWN_ARTIFACT
+
+    def test_small_responses_never_trip_the_rule(self):
+        # a one-line config fix wrapped in prose legitimately extracts small
+        stats = {"response_chars": 600, "extracted_chars": 40, "artifact_count": 1}
+        evidence = build_failure_evidence(
+            self._envelope(), self._result(stats), prior_plan_deltas_count=0
+        )
+        assert "extraction_loss" not in evidence


### PR DESCRIPTION
## What

The second half of the Gate-2 #687+#431 pair (plan A3): **partial extraction loss becomes a machine fact** instead of masquerading as a work-product failure.

- `emission_stats` (generated vs stored chars, per attempt) recorded at all four producer seams: dev, qa, builder, and the shared base `handle()` the **repair path** routes through — the exhibit's own burn site (cyc_8830cfc78a1e: three repairs regenerated ~7k-token documents into an ~800-byte parser loss that failure analysis called `work_product`).
- The **gap rule** (floor 2,000 response chars; retention < 15% — both bounds justified in the module docstring; the exhibit sat at ~3%, healthy prose-around-fences responses at 40–80%) sets `evidence.extraction_loss`.
- `derive_failure_category` → **`EXTRACTION_LOSS`** (the category #687 declared; its signal arrives here), with infra-first precedence intact.
- `classify_failure_locus` → **`OWN_ARTIFACT`**: re-emit by the producing role, never behavioral repair — satisfying the A3 criterion *an extraction failure never enters behavioral repair*. Partial loss is now distinguishable from #566's zero-extraction marker (the two coexist at different precedence).

Mechanical: the `tests_pass` locus logic hoisted verbatim into `_locus_from_tests_pass_row` (C901; existing locus tests prove behavior preserved).

## Pair completion

With #739 merged and this PR, the A3 shared criteria are all live: traceback reaches the analyzer structured (#739), extraction loss never enters behavioral repair (here), infra facts take precedence over product diagnosis (taxonomy), replay preserves category (evidence is persisted data), authored-vs-framework rows remain distinguishable by identity. **#557's named trigger fires on merge** — its post-retest governance review becomes a SIP candidate (proposal-before-code per its own ruling; not cut-gating for 1.5).

## Verification

Regression **6296 passed**. Scope note: stats reflect the primary response per attempt (self-eval merges change artifacts; the diagnosis case is primary-response loss — recorded as a bounded-scope decision).

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv