### PR TITLE
feat(verification): #682 — the gate-waiver slice (SIP-0096 §6.5/AC#12)

### DIFF
--- a/adapters/cycles/memory_cycle_registry.py
+++ b/adapters/cycles/memory_cycle_registry.py
@@ -236,6 +236,10 @@ class MemoryCycleRegistry(CycleRegistryPort):
             raise RunNotFoundError(f"Run not found: {run_id}")
         self._verification_summaries[run_id] = summary
 
+    async def get_run_verification_summary(self, run_id: str) -> RunVerificationSummary | None:
+        """One run's persisted verification roll-up, or None (#682)."""
+        return self._verification_summaries.get(run_id)
+
     async def list_run_verification_summaries(self, cycle_id: str) -> list[RunVerificationSummary]:
         """Return a cycle's persisted per-run verification summaries, by run_number."""
         runs = sorted(

--- a/adapters/cycles/postgres_cycle_registry.py
+++ b/adapters/cycles/postgres_cycle_registry.py
@@ -179,7 +179,8 @@ class PostgresCycleRegistry(CycleRegistryPort):
             if row is None:
                 raise RunNotFoundError(f"Run not found: {run_id}")
             gate_rows = await conn.fetch(
-                "SELECT gate_name, decision, decided_by, decided_at, notes "
+                "SELECT gate_name, decision, decided_by, decided_at, notes, "
+                "waived_checks, waiver_reason "
                 "FROM cycle_gate_decisions WHERE run_id = $1 ORDER BY id",
                 run_id,
             )
@@ -216,7 +217,8 @@ class PostgresCycleRegistry(CycleRegistryPort):
 
             run_ids = [r["run_id"] for r in run_rows]
             gate_rows = await conn.fetch(
-                "SELECT run_id, gate_name, decision, decided_by, decided_at, notes "
+                "SELECT run_id, gate_name, decision, decided_by, decided_at, notes, "
+                "waived_checks, waiver_reason "
                 "FROM cycle_gate_decisions WHERE run_id = ANY($1) ORDER BY id",
                 run_ids,
             )
@@ -347,14 +349,20 @@ class PostgresCycleRegistry(CycleRegistryPort):
                 try:
                     await conn.execute(
                         "INSERT INTO cycle_gate_decisions "
-                        "(run_id, gate_name, decision, decided_by, decided_at, notes) "
-                        "VALUES ($1, $2, $3, $4, $5, $6)",
+                        "(run_id, gate_name, decision, decided_by, decided_at, notes, "
+                        "waived_checks, waiver_reason) "
+                        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
                         run_id,
                         decision.gate_name,
                         decision.decision,
                         decision.decided_by,
                         decision.decided_at,
                         decision.notes,
+                        # NULL (no waiver) stays distinguishable from a recorded one
+                        json.dumps(list(decision.waived_checks))
+                        if decision.waived_checks
+                        else None,
+                        decision.waiver_reason,
                     )
                 except asyncpg.UniqueViolationError as err:
                     # Safety net: concurrent race between two transactions
@@ -418,6 +426,16 @@ class PostgresCycleRegistry(CycleRegistryPort):
                 summary.verdict.value,
                 json.dumps(_verification_summary_to_dict(summary)),
             )
+
+    async def get_run_verification_summary(self, run_id: str) -> RunVerificationSummary | None:
+        """One run's persisted verification roll-up, or None (#682)."""
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT summary FROM run_verification_summaries WHERE run_id = $1", run_id
+            )
+        if row is None:
+            return None
+        return _verification_summary_from_dict(parse_jsonb(row["summary"]))
 
     async def list_run_verification_summaries(self, cycle_id: str) -> list[RunVerificationSummary]:
         """Return a cycle's persisted per-run verification summaries (SIP-0096 §10)."""
@@ -532,6 +550,10 @@ class PostgresCycleRegistry(CycleRegistryPort):
                 decided_by=g["decided_by"],
                 decided_at=g["decided_at"],
                 notes=g.get("notes"),
+                # #682: absent column (pre-migration reads) and NULL both mean
+                # "no waiver" — the model's empty defaults
+                waived_checks=tuple(parse_jsonb(g.get("waived_checks")) or ()),
+                waiver_reason=g.get("waiver_reason"),
             )
             for g in gate_rows
         )

--- a/infra/migrations/1030_gate_decision_waiver.sql
+++ b/infra/migrations/1030_gate_decision_waiver.sql
@@ -1,0 +1,7 @@
+-- SIP-0096 #682 (1.5 A2): operator gate waiver — accept-with-waiver records the
+-- waived checks and reason ON the gate decision (§6.5/AC#12), above the evidence,
+-- never mutating it. Additive + nullable: NULL (historical rows / no waiver) is
+-- distinguishable from a recorded waiver; old code ignores the columns entirely
+-- (1010-pattern compatibility). Forward-only; downgrade unsupported by policy.
+ALTER TABLE cycle_gate_decisions ADD COLUMN IF NOT EXISTS waived_checks JSONB;
+ALTER TABLE cycle_gate_decisions ADD COLUMN IF NOT EXISTS waiver_reason TEXT;

--- a/src/squadops/api/routes/cycles/dtos.py
+++ b/src/squadops/api/routes/cycles/dtos.py
@@ -48,7 +48,11 @@ class CycleCreateRequest(BaseModel):
 
 
 class GateDecisionRequest(BaseModel):
-    """Gate decision (T4+T13: normalized vocab, typed)."""
+    """Gate decision (T4+T13: normalized vocab, typed).
+
+    ``waived_checks``/``waiver_reason`` (SIP-0096 §6.5, #682): explicit
+    accept-with-waiver — validated against the run's unverified disclosure.
+    """
 
     decision: Literal[
         "approved",
@@ -57,6 +61,8 @@ class GateDecisionRequest(BaseModel):
         "rejected",
     ]
     notes: str | None = None
+    waived_checks: list[str] = Field(default_factory=list)
+    waiver_reason: str | None = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -133,6 +139,8 @@ class GateDecisionResponse(BaseModel):
     decided_by: str
     decided_at: datetime
     notes: str | None = None
+    waived_checks: list[str] = Field(default_factory=list)  # SIP-0096 §6.5 (#682)
+    waiver_reason: str | None = None
 
 
 class RunResponse(BaseModel):
@@ -168,6 +176,14 @@ class UnverifiedCheckDTO(BaseModel):
     required: bool
 
 
+class WaivedCheckDTO(BaseModel):
+    """SIP-0096 §6.5: an operator waiver recorded above the evidence (#682)."""
+
+    check_id: str
+    reason: str
+    waived_by: str | None = None
+
+
 class ReplayProvenanceDTO(BaseModel):
     """SIP-0101 §4.1: the prefix of this outcome was restored from another run's
     checkpoint — inherited evidence, never presentable as earned."""
@@ -191,6 +207,7 @@ class CycleOutcomeDTO(BaseModel):
     unverified: list[UnverifiedCheckDTO] = Field(default_factory=list)
     required_unmet: list[str] = Field(default_factory=list)
     run_count: int = 0
+    waived: list[WaivedCheckDTO] = Field(default_factory=list)  # §6.5 (#682)
     replay: ReplayProvenanceDTO | None = None  # SIP-0101 — present iff replayed
 
 

--- a/src/squadops/api/routes/cycles/mapping.py
+++ b/src/squadops/api/routes/cycles/mapping.py
@@ -17,6 +17,7 @@ from squadops.api.routes.cycles.dtos import (
     SquadProfileResponse,
     TaskFlowPolicyDTO,
     UnverifiedCheckDTO,
+    WaivedCheckDTO,
     WorkloadProgressEntry,
 )
 from squadops.api.runtime.agent_labels import get_role_label
@@ -62,6 +63,8 @@ def run_to_response(run: Run) -> RunResponse:
                 decided_by=gd.decided_by,
                 decided_at=gd.decided_at,
                 notes=gd.notes,
+                waived_checks=list(gd.waived_checks),
+                waiver_reason=gd.waiver_reason,
             )
             for gd in run.gate_decisions
         ],
@@ -154,6 +157,10 @@ def _cycle_outcome_to_dto(outcome: CycleOutcome) -> CycleOutcomeDTO:
         ],
         required_unmet=list(outcome.required_unmet),
         run_count=outcome.run_count,
+        waived=[
+            WaivedCheckDTO(check_id=w.check_id, reason=w.reason, waived_by=w.waived_by)
+            for w in outcome.waived
+        ],
         replay=(
             ReplayProvenanceDTO(
                 source_run_id=outcome.replay.source_run_id,

--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -225,12 +225,31 @@ async def gate_decision(
 
     try:
         registry = get_cycle_registry()
+
+        # SIP-0096 §6.5 (#682): accept-with-waiver is explicit, reasoned, and
+        # validated against the run's own unverified disclosure — a waiver
+        # records above the evidence and can never touch a check that ran.
+        if body.waived_checks or body.waiver_reason:
+            from squadops.cycles.models import validate_waiver_request
+
+            summary = await registry.get_run_verification_summary(run_id)
+            unverified_ids = (
+                {u.check_id for u in summary.unverified} if summary is not None else None
+            )
+            waiver_error = validate_waiver_request(
+                body.decision, body.waived_checks, body.waiver_reason, unverified_ids
+            )
+            if waiver_error is not None:
+                raise ValidationError(waiver_error)
+
         decision = GateDecision(
             gate_name=gate_name,
             decision=body.decision,
             decided_by="system",  # TODO: extract from auth context
             decided_at=datetime.now(UTC),
             notes=body.notes,
+            waived_checks=tuple(body.waived_checks),
+            waiver_reason=body.waiver_reason,
         )
         updated = await registry.record_gate_decision(run_id, decision)
 
@@ -259,6 +278,11 @@ async def gate_decision(
                 "decision": body.decision,
                 "decided_by": decision.decided_by,
                 "notes": body.notes,
+                **(
+                    {"waived_checks": list(decision.waived_checks)}
+                    if decision.waived_checks
+                    else {}
+                ),
             },
         )
 

--- a/src/squadops/cli/commands/runs.py
+++ b/src/squadops/cli/commands/runs.py
@@ -209,12 +209,22 @@ def gate_decision(
         False, "--return-for-revision", help="Return for revision on same workload path"
     ),
     notes: str | None = typer.Option(None, "--notes", help="Decision notes"),
+    waive: list[str] = typer.Option(
+        [],
+        "--waive",
+        help="Waive an unverified check id (repeatable; --approve only, "
+        "requires --waiver-reason). SIP-0096 accept-with-waiver.",
+    ),
+    waiver_reason: str | None = typer.Option(
+        None, "--waiver-reason", help="Reason for the waiver (required with --waive)"
+    ),
 ):
     """Record a gate decision.
 
     Wire mapping: --approve sends "approved", --reject sends "rejected",
     --with-refinements sends "approved_with_refinements",
-    --return-for-revision sends "returned_for_revision".
+    --return-for-revision sends "returned_for_revision". --waive/--waiver-reason
+    ride the approved decision as an explicit accept-with-waiver (§6.5).
     """
     fmt = ctx.obj.get("format", "table") if ctx.obj else "table"
 
@@ -244,6 +254,10 @@ def gate_decision(
     body = {"decision": decision}
     if notes:
         body["notes"] = notes
+    if waive:
+        body["waived_checks"] = list(waive)
+    if waiver_reason:
+        body["waiver_reason"] = waiver_reason
 
     try:
         client = _get_client(ctx)

--- a/src/squadops/cycles/cycle_outcome.py
+++ b/src/squadops/cycles/cycle_outcome.py
@@ -21,6 +21,7 @@ from squadops.cycles.replay import (
 from squadops.cycles.verification_integrity import (
     CycleOutcome,
     ReplayProvenance,
+    WaivedCheck,
     aggregate_cycle_outcome,
 )
 
@@ -31,9 +32,9 @@ if TYPE_CHECKING:
 async def resolve_cycle_outcome(registry: CycleRegistryPort, cycle_id: str) -> CycleOutcome:
     """Derive a cycle's ``CycleOutcome`` from its persisted per-run summaries (§10).
 
-    ``waived`` (operator gate waivers, §6.5) and ``inert`` (chronic not-executed, §9)
-    stay empty until their Phase-3 slices wire them — the roll-up shape carries them,
-    but there is no source yet, so we pass nothing rather than fabricate.
+    ``waived`` (#682): populated from the cycle's recorded gate decisions — an
+    operator accept-with-waiver sits beside the verdict, never altering it (§6.5).
+    ``inert`` (chronic not-executed, §9) stays empty until #684 wires its source.
 
     SIP-0101 Slice 3.4: a replay-mode cycle's outcome carries ``ReplayProvenance``
     derived from the immutable, create-time-validated declaration — same
@@ -42,6 +43,15 @@ async def resolve_cycle_outcome(registry: CycleRegistryPort, cycle_id: str) -> C
     """
     summaries = await registry.list_run_verification_summaries(cycle_id)
     cycle = await registry.get_cycle(cycle_id)
+    # #682: operator gate waivers (§6.5) — collected off the cycle's recorded
+    # gate decisions, one WaivedCheck per waived id, decided_by as provenance.
+    runs = await registry.list_runs(cycle_id)
+    waived = [
+        WaivedCheck(check_id=check_id, reason=gd.waiver_reason or "", waived_by=gd.decided_by)
+        for run in runs
+        for gd in run.gate_decisions
+        for check_id in gd.waived_checks
+    ]
     replay_req = parse_replay_declaration(cycle.execution_overrides or {})
     replay = (
         ReplayProvenance(
@@ -52,4 +62,4 @@ async def resolve_cycle_outcome(registry: CycleRegistryPort, cycle_id: str) -> C
         if replay_req is not None
         else None
     )
-    return aggregate_cycle_outcome(summaries, replay=replay)
+    return aggregate_cycle_outcome(summaries, waived=waived, replay=replay)

--- a/src/squadops/cycles/models.py
+++ b/src/squadops/cycles/models.py
@@ -7,6 +7,7 @@ Gate Decisions, and Artifact Refs. Enums, constants, and exceptions are co-locat
 
 from __future__ import annotations
 
+from collections.abc import Collection, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
@@ -268,13 +269,50 @@ class TaskFlowPolicy:
 
 @dataclass(frozen=True)
 class GateDecision:
-    """Recorded gate decision on a Run. SIP-0064 §8.4."""
+    """Recorded gate decision on a Run. SIP-0064 §8.4.
+
+    ``waived_checks``/``waiver_reason`` (SIP-0096 §6.5, #682): an explicit
+    accept-with-waiver records the waived check ids and reason ON the decision
+    — above the evidence, never mutating it. Empty/None on ordinary decisions
+    and on all pre-#682 historical rows.
+    """
 
     gate_name: str
     decision: str  # GateDecisionValue value
     decided_by: str
     decided_at: datetime
     notes: str | None = None
+    waived_checks: tuple[str, ...] = ()
+    waiver_reason: str | None = None
+
+
+def validate_waiver_request(
+    decision: str,
+    waived_checks: Sequence[str],
+    waiver_reason: str | None,
+    unverified_ids: Collection[str] | None,
+) -> str | None:
+    """Validate an accept-with-waiver request (§6.5/AC#12) — error text or None.
+
+    A waiver is never implicit and never mutates evidence: it requires an
+    explicit approval, a non-empty reason, and check ids that are actually in
+    the run's unverified disclosure (``unverified_ids``; ``None`` means no
+    summary was ever persisted — then there is nothing to waive against).
+    """
+    if not waived_checks:
+        if waiver_reason:
+            return "waiver_reason requires waived_checks — a waiver names its checks"
+        return None
+    if decision != GateDecisionValue.APPROVED.value:
+        return "a waiver is accept-with-waiver: only valid on an 'approved' decision"
+    if not (waiver_reason or "").strip():
+        return "a waiver requires a non-empty reason (§6.5: never implicit)"
+    if unverified_ids is None:
+        return "no verification summary recorded for this run — nothing to waive against"
+    unknown = sorted(set(waived_checks) - set(unverified_ids))
+    if unknown:
+        return "waived checks are not in the run's unverified disclosure: " + ", ".join(unknown)
+    return None
 
 
 @dataclass(frozen=True)

--- a/src/squadops/ports/cycles/cycle_registry.py
+++ b/src/squadops/ports/cycles/cycle_registry.py
@@ -165,6 +165,11 @@ class CycleRegistryPort(ABC):
         """
 
     @abstractmethod
+    async def get_run_verification_summary(self, run_id: str) -> RunVerificationSummary | None:
+        """One run's persisted verification roll-up, or None (#682 waiver validation)."""
+        return None  # default for adapters predating the getter
+
+    @abstractmethod
     async def list_run_verification_summaries(self, cycle_id: str) -> list[RunVerificationSummary]:
         """Return the persisted verification summaries for a cycle's runs (SIP-0096 §10).
 

--- a/tests/unit/cycles/test_gate_waiver.py
+++ b/tests/unit/cycles/test_gate_waiver.py
@@ -1,0 +1,121 @@
+"""SIP-0096 §6.5 / AC#12 (#682) — the operator gate waiver.
+
+The normative claims under test: a waiver is never implicit (explicit approval
++ non-empty reason), it can only name checks the run actually disclosed as
+unverified (it records ABOVE evidence, never touches a check that ran), and
+the roll-up carries it beside an unaltered verdict.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.cycles.models import GateDecision, validate_waiver_request
+from squadops.cycles.verification_integrity import (
+    RunVerdict,
+    UnverifiedCheck,
+    WaivedCheck,
+    aggregate_cycle_outcome,
+)
+
+pytestmark = [pytest.mark.domain_cycles]
+
+
+class TestValidateWaiverRequest:
+    _UNVERIFIED = {"tests_pass", "frontend_build"}
+
+    def test_valid_waiver_passes(self):
+        assert (
+            validate_waiver_request(
+                "approved", ["tests_pass"], "node absent on runner", self._UNVERIFIED
+            )
+            is None
+        )
+
+    def test_no_waiver_fields_is_an_ordinary_decision(self):
+        assert validate_waiver_request("rejected", [], None, None) is None
+
+    def test_waiver_requires_approved_decision(self):
+        err = validate_waiver_request("rejected", ["tests_pass"], "r", self._UNVERIFIED)
+        assert err is not None and "approved" in err
+
+    def test_waiver_requires_a_reason(self):
+        # §6.5: a waiver is never implicit
+        err = validate_waiver_request("approved", ["tests_pass"], "  ", self._UNVERIFIED)
+        assert err is not None and "reason" in err
+
+    def test_reason_without_checks_is_rejected(self):
+        err = validate_waiver_request("approved", [], "why", self._UNVERIFIED)
+        assert err is not None and "waived_checks" in err
+
+    def test_waiving_a_check_that_ran_is_rejected(self):
+        # the evidence-mutation guard: only unverified checks are waivable
+        err = validate_waiver_request(
+            "approved", ["tests_pass", "no_stub_fallback_tests"], "r", self._UNVERIFIED
+        )
+        assert err is not None and "no_stub_fallback_tests" in err
+
+    def test_no_summary_means_nothing_to_waive_against(self):
+        err = validate_waiver_request("approved", ["tests_pass"], "r", None)
+        assert err is not None and "summary" in err
+
+
+class TestGateDecisionCompat:
+    def test_pre_682_construction_still_valid(self):
+        # every existing call site builds decisions without the new fields
+        gd = GateDecision(
+            gate_name="g", decision="approved", decided_by="op", decided_at=datetime.now(UTC)
+        )
+        assert gd.waived_checks == ()
+        assert gd.waiver_reason is None
+
+
+class TestOutcomeCarriesWaivers:
+    def test_waiver_sits_beside_an_unaltered_verdict(self):
+        # §6.5: the verdict is the UN-WAIVED evidence verdict — a waived
+        # blocked_unverified cycle still reads blocked_unverified
+        from squadops.cycles.verification_integrity import RunVerificationSummary
+
+        summary = RunVerificationSummary(
+            verdict=RunVerdict.BLOCKED_UNVERIFIED,
+            verified=(),
+            failed=(),
+            unverified=(UnverifiedCheck("tests_pass", "missing_tooling", required=True),),
+            required_unmet=("tests_pass",),
+            executed_count=0,
+            passed_count=0,
+        )
+        waived = [WaivedCheck("tests_pass", "node absent on runner", waived_by="op")]
+        outcome = aggregate_cycle_outcome([summary], waived=waived)
+        assert outcome.verdict is RunVerdict.BLOCKED_UNVERIFIED  # never altered
+        assert outcome.waived == tuple(waived)  # recorded beside it
+
+    async def test_resolve_cycle_outcome_collects_waivers_from_gate_decisions(self):
+        from squadops.cycles.cycle_outcome import resolve_cycle_outcome
+
+        registry = AsyncMock()
+        registry.list_run_verification_summaries.return_value = []
+        cycle = MagicMock()
+        cycle.execution_overrides = {}
+        registry.get_cycle.return_value = cycle
+        run = MagicMock()
+        run.gate_decisions = [
+            GateDecision(
+                gate_name="progress_review",
+                decision="approved",
+                decided_by="operator",
+                decided_at=datetime.now(UTC),
+                waived_checks=("tests_pass",),
+                waiver_reason="node absent on runner",
+            )
+        ]
+        registry.list_runs.return_value = [run]
+
+        outcome = await resolve_cycle_outcome(registry, "cyc_1")
+
+        assert outcome.waived == (
+            WaivedCheck("tests_pass", "node absent on runner", waived_by="operator"),
+        )

--- a/tests/unit/cycles/test_postgres_cycle_registry.py
+++ b/tests/unit/cycles/test_postgres_cycle_registry.py
@@ -899,3 +899,111 @@ class TestCheckpointRetentionSQL:
         sql = delete_call.args[0]
         assert "DELETE FROM run_checkpoints" in sql
         assert "retained = FALSE" in sql  # retained boundaries never pruned
+
+
+class TestGateWaiverSQL:
+    """#682 — the postgres half: waiver columns persisted and read back;
+    pre-migration rows (absent/NULL columns) assemble to the empty defaults."""
+
+    @pytest.fixture
+    def conn(self):
+        return _make_conn()
+
+    @pytest.fixture
+    def registry(self, conn):
+        from adapters.cycles.postgres_cycle_registry import PostgresCycleRegistry
+
+        return PostgresCycleRegistry(_make_pool(conn))
+
+    async def test_insert_carries_waiver_columns(self, registry, conn):
+        from datetime import UTC, datetime
+
+        from squadops.cycles.models import GateDecision
+
+        conn.fetchrow = AsyncMock(
+            side_effect=[
+                {"status": "paused", "cycle_id": "cyc_1"},  # run row
+                {"task_flow_policy": '{"gates": [{"name": "g1"}]}'},  # policy
+                None,  # no existing decision
+            ]
+        )
+        registry.get_run = AsyncMock()
+
+        await registry.record_gate_decision(
+            "run_1",
+            GateDecision(
+                gate_name="g1",
+                decision="approved",
+                decided_by="op",
+                decided_at=datetime.now(UTC),
+                waived_checks=("tests_pass",),
+                waiver_reason="node absent",
+            ),
+        )
+
+        insert_sql = conn.execute.call_args_list[0].args[0]
+        assert "waived_checks" in insert_sql and "waiver_reason" in insert_sql
+        args = conn.execute.call_args_list[0].args
+        assert '"tests_pass"' in args[7]  # JSON-encoded list
+        assert args[8] == "node absent"
+
+    async def test_no_waiver_persists_null_not_empty_list(self, registry, conn):
+        from datetime import UTC, datetime
+
+        from squadops.cycles.models import GateDecision
+
+        conn.fetchrow = AsyncMock(
+            side_effect=[
+                {"status": "paused", "cycle_id": "cyc_1"},
+                {"task_flow_policy": '{"gates": [{"name": "g1"}]}'},
+                None,
+            ]
+        )
+        registry.get_run = AsyncMock()
+
+        await registry.record_gate_decision(
+            "run_1",
+            GateDecision(
+                gate_name="g1", decision="approved", decided_by="op", decided_at=datetime.now(UTC)
+            ),
+        )
+        assert conn.execute.call_args_list[0].args[7] is None  # NULL, not []
+
+    def test_assemble_maps_waiver_and_tolerates_old_rows(self, registry):
+        from datetime import UTC, datetime
+
+        base_row = {
+            "run_id": "run_1",
+            "cycle_id": "cyc_1",
+            "run_number": 1,
+            "status": "completed",
+            "initiated_by": "api",
+            "resolved_config_hash": "h",
+            "resolved_config_ref": None,
+            "workload_type": None,
+            "started_at": None,
+            "finished_at": None,
+            "artifact_refs": "[]",
+            "failure_reason": None,
+        }
+        new_gate = {
+            "gate_name": "g1",
+            "decision": "approved",
+            "decided_by": "op",
+            "decided_at": datetime.now(UTC),
+            "notes": None,
+            "waived_checks": '["tests_pass"]',
+            "waiver_reason": "node absent",
+        }
+        old_gate = {  # pre-migration read: columns absent entirely
+            "gate_name": "g0",
+            "decision": "approved",
+            "decided_by": "op",
+            "decided_at": datetime.now(UTC),
+            "notes": None,
+        }
+        run = registry._assemble_run(base_row, [new_gate, old_gate])
+        assert run.gate_decisions[0].waived_checks == ("tests_pass",)
+        assert run.gate_decisions[0].waiver_reason == "node absent"
+        assert run.gate_decisions[1].waived_checks == ()
+        assert run.gate_decisions[1].waiver_reason is None


### PR DESCRIPTION
## What

Gate-2 A2, first of the SIP-0096 completion trio: **accept-with-waiver**, end to end. Before this, only the `WaivedCheck` shape existed (the audit's finding) — `CycleOutcome.waived` was permanently empty and a `blocked_unverified` gate had no recorded waiver path.

- **`GateDecision.waived_checks` + `waiver_reason`** (additive defaults; every existing call site unchanged).
- **Migration 1030** — the line's second and final expected migration, under A2's migration gate: additive + nullable (NULL = no waiver, distinguishable from a recorded one), old code ignores the columns, pre-migration rows assemble to empty defaults (tested), forward-only policy in the header. Replay of pre-migration artifacts produces the same roll-up (aggregation is unchanged when no waivers exist).
- **Validation** (`validate_waiver_request`, homed in `models.py` beside `GateDecisionValue` — the enum-shadow guard and the aggregation module's purity guard were mutually exclusive, so the validator lives with the enum): approved-only (accept-with-waiver), non-empty reason (**a waiver is never implicit**), and waived ids ⊆ the run's own unverified disclosure via a new `get_run_verification_summary` port getter — **a waiver can never touch a check that ran**.
- **Roll-up**: `resolve_cycle_outcome` collects waivers off recorded gate decisions into `CycleOutcome.waived`; the verdict remains the **un-waived** evidence verdict, tested (a waived `blocked_unverified` still reads `blocked_unverified`, with the waiver beside it).
- **Surface**: `GATE_DECIDED` payload, response DTOs, and `squadops runs gate --approve --waive <check_id> --waiver-reason "..."`.

## Verification

Regression **6325 passed**. Migration 1030 boot-apply + a live waiver exercise ride the Gate-2 deploy window (the SIP's §15 E2E case: required-check `blocked_unverified` → waiver path recorded).

Next in the trio: #683 (wrap-up consumes `CycleOutcome`) — schema before reader, per the plan's concurrency rule.

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv