### PR TITLE
feat(wrapup): #683 — wrap-up consumes CycleOutcome (SIP-0096 §10/§14)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1291,6 +1291,14 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 stored_artifacts,
             )
 
+        # #683 (SIP-0096 §14): wrap-up tasks consume the CycleOutcome — inject
+        # the structured evidence ONCE per wrap-up run into prior_outputs, so
+        # every wrap-up prompt shows the basis (summary) and the closeout
+        # handler enforces the ceiling (raw dict). Data only; best-effort — a
+        # failed derivation is disclosed by absence and the handler fails
+        # closed to an inconclusive ceiling.
+        await self._inject_wrapup_evidence(plan, cycle, prior_outputs)
+
         # Seed from prior plan artifacts for build-only runs (§2.3)
         if seed_artifact_refs:
             await self._seed_prior_artifacts(
@@ -1826,6 +1834,39 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             )
 
         return False
+
+    _WRAPUP_TASK_TYPES: frozenset[str] = frozenset(
+        {
+            "data.gather_evidence",
+            "qa.assess_outcomes",
+            "data.classify_unresolved",
+            "governance.closeout_decision",
+            "governance.publish_handoff",
+        }
+    )
+
+    async def _inject_wrapup_evidence(
+        self, plan: list[TaskEnvelope], cycle: Cycle, prior_outputs: dict[str, Any]
+    ) -> None:
+        """#683: thread the cycle's CycleOutcome into wrap-up task inputs."""
+        if not any(e.task_type in self._WRAPUP_TASK_TYPES for e in plan):
+            return
+        try:
+            from squadops.cycles.cycle_outcome import resolve_cycle_outcome
+            from squadops.cycles.wrapup_models import verification_evidence_summary
+
+            outcome = await resolve_cycle_outcome(self._cycle_registry, cycle.cycle_id)
+            outcome_dict = outcome.to_dict()
+            prior_outputs["verification_evidence"] = {
+                "summary": verification_evidence_summary(outcome_dict),
+                "outcome": outcome_dict,
+            }
+        except Exception:
+            logger.warning(
+                "wrapup verification-evidence injection failed for %s",
+                cycle.cycle_id,
+                exc_info=True,
+            )
 
     async def _enrich_envelope(
         self,

--- a/src/squadops/capabilities/handlers/wrapup_tasks.py
+++ b/src/squadops/capabilities/handlers/wrapup_tasks.py
@@ -14,6 +14,7 @@ Part of SIP-0080.
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from typing import TYPE_CHECKING, Any
@@ -24,9 +25,11 @@ from squadops.capabilities.handlers.base import HandlerResult
 from squadops.capabilities.handlers.planning_tasks import _PlanningTaskHandler
 from squadops.cycles.wrapup_models import (
     ALLOWED_SUGGESTED_OWNERS,
+    CONFIDENCE_RANK,
     CloseoutRecommendation,
     ConfidenceClassification,
     NextCycleRecommendation,
+    confidence_ceiling,
 )
 
 if TYPE_CHECKING:
@@ -221,7 +224,53 @@ class GovernanceCloseoutDecisionHandler(_PlanningTaskHandler):
                 ),
             )
 
+        # #683 (SIP-0096 §6.6(4)/§14): the structured CycleOutcome is the
+        # confidence ceiling — wrap-up prose can never claim above it. The
+        # claimed value survives as disclosure; the enforced value is the
+        # record. Absent outcome (legacy dispatch, replay without threading)
+        # fails closed to the inconclusive ceiling — never a prose free pass.
+        outcome = ((inputs.get("prior_outputs") or {}).get("verification_evidence") or {}).get(
+            "outcome"
+        )
+        ceiling, basis = confidence_ceiling(outcome)
+        claimed = fm["confidence"]
+        if CONFIDENCE_RANK[claimed] > CONFIDENCE_RANK[ceiling]:
+            enforced_content = _clamp_frontmatter_confidence(content, claimed, ceiling, basis)
+            result.outputs["artifacts"][0]["content"] = enforced_content
+            result.outputs["confidence"] = ceiling
+            result.outputs["confidence_claimed"] = claimed
+            result.outputs["confidence_basis"] = basis
+            logger.warning("closeout confidence clamped %s -> %s (%s)", claimed, ceiling, basis)
+        else:
+            result.outputs["confidence"] = claimed
+            result.outputs["confidence_basis"] = basis
+
         return result
+
+
+def _clamp_frontmatter_confidence(content: str, claimed: str, ceiling: str, basis: str) -> str:
+    """Rewrite the frontmatter confidence to the ceiling, with disclosure.
+
+    Never silent: the claimed value and the deterministic basis ride beside the
+    enforced value, so the artifact reads as an enforcement, not an opinion.
+    """
+    replaced = re.sub(
+        r"^(confidence:\s*).*$",
+        lambda m: f"{m.group(1)}{ceiling}",
+        content,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    disclosure = (
+        f"confidence_claimed: {claimed}\n"
+        f"confidence_enforced_by: cycle_outcome\n"
+        f"confidence_basis: {json.dumps(basis)}\n"
+    )
+    # insert before the closing frontmatter fence (the second ---)
+    parts = replaced.split("---", 2)
+    if len(parts) >= 3:
+        return f"{parts[0]}---{parts[1]}{disclosure}---{parts[2]}"
+    return replaced
 
 
 class GovernancePublishHandoffHandler(_PlanningTaskHandler):

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -366,6 +366,30 @@ class CycleOutcome:
         """
         return tuple(u.check_id for u in self.unverified if u.required)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Wire shape for consumers outside this process (#683: wrap-up task
+        inputs travel the A2A envelope; the confidence ceiling is derived from
+        this dict on the agent side)."""
+        return {
+            "verdict": self.verdict.value,
+            "verified": list(self.verified),
+            "failed": list(self.failed),
+            "unverified": [
+                {"check_id": u.check_id, "reason": u.reason, "required": u.required}
+                for u in self.unverified
+            ],
+            "required_unmet": list(self.required_unmet),
+            "run_count": self.run_count,
+            "inert": list(self.inert),
+            "waived": [
+                {"check_id": w.check_id, "reason": w.reason, "waived_by": w.waived_by}
+                for w in self.waived
+            ],
+            "criteria_verified": list(self.criteria_verified),
+            "criteria_total": list(self.criteria_total),
+            "replay": self.replay.to_dict() if self.replay else None,
+        }
+
 
 def classify(result: CheckResult) -> EvidenceFamily:
     """Map one result to its evidence family — the integrity rule (SIP-0096 §6.1).

--- a/src/squadops/cycles/wrapup_models.py
+++ b/src/squadops/cycles/wrapup_models.py
@@ -6,6 +6,8 @@ unresolved issue taxonomy, and next-cycle recommendations.
 
 from __future__ import annotations
 
+from squadops.cycles.verification_integrity import RunVerdict
+
 
 class ConfidenceClassification:
     """Confidence classification for wrap-up closeout decisions.
@@ -86,3 +88,95 @@ ALLOWED_SUGGESTED_OWNERS = frozenset(
         "operator",
     }
 )
+
+
+# --------------------------------------------------------------------------- #
+# #683 (SIP-0096 §10/§14): the CycleOutcome-derived confidence ceiling
+# --------------------------------------------------------------------------- #
+
+# Rank order for ceiling enforcement — a claimed confidence above the ceiling
+# is clamped, never honored (§6.6(4): wrap-up prose cannot override the
+# structured verdict).
+CONFIDENCE_RANK: dict[str, int] = {
+    ConfidenceClassification.VERIFIED_COMPLETE: 5,
+    ConfidenceClassification.COMPLETE_WITH_CAVEATS: 4,
+    ConfidenceClassification.PARTIAL_COMPLETION: 3,
+    ConfidenceClassification.NOT_SUFFICIENTLY_VERIFIED: 2,
+    ConfidenceClassification.INCONCLUSIVE: 1,
+    ConfidenceClassification.FAILED: 0,
+}
+
+
+def confidence_ceiling(outcome: dict | None) -> tuple[str, str]:
+    """The maximum honest confidence for a cycle's evidence, with its basis.
+
+    Deterministic over the ``CycleOutcome.to_dict()`` wire shape (#683):
+
+    - no outcome / zero runs → ``inconclusive`` (fail-closed: absent evidence
+      can never support a stronger claim — "on every path", incl. replay and
+      legacy dispatches that never threaded the outcome)
+    - ``rejected`` → ``partial_completion`` (executed checks failed)
+    - ``blocked_unverified`` fully waived → ``complete_with_caveats`` (the
+      §6.5 operator accept-with-waiver IS the caveat)
+    - ``blocked_unverified`` otherwise → ``not_sufficiently_verified``
+    - ``accepted`` with unverified disclosures → ``complete_with_caveats``
+    - ``accepted``, everything verified → ``verified_complete``
+    """
+    if not isinstance(outcome, dict) or not outcome:
+        return ConfidenceClassification.INCONCLUSIVE, "verification outcome unavailable"
+    if int(outcome.get("run_count", 0)) == 0:
+        return ConfidenceClassification.INCONCLUSIVE, "no run evidence recorded"
+    verdict = str(outcome.get("verdict", ""))
+    if verdict == RunVerdict.REJECTED.value:
+        failed = outcome.get("failed") or []
+        return (
+            ConfidenceClassification.PARTIAL_COMPLETION,
+            f"verdict rejected — executed checks failed: {', '.join(map(str, failed)) or '?'}",
+        )
+    if verdict == RunVerdict.BLOCKED_UNVERIFIED.value:
+        required_unmet = set(map(str, outcome.get("required_unmet") or []))
+        waived_ids = {str(w.get("check_id")) for w in outcome.get("waived") or []}
+        if required_unmet and required_unmet <= waived_ids:
+            return (
+                ConfidenceClassification.COMPLETE_WITH_CAVEATS,
+                "blocked_unverified fully waived by operator gate decision (§6.5)",
+            )
+        unmet = ", ".join(sorted(required_unmet - waived_ids)) or "?"
+        return (
+            ConfidenceClassification.NOT_SUFFICIENTLY_VERIFIED,
+            f"required checks unverified and unwaived: {unmet}",
+        )
+    if verdict == RunVerdict.ACCEPTED.value:
+        unverified = outcome.get("unverified") or []
+        if unverified:
+            return (
+                ConfidenceClassification.COMPLETE_WITH_CAVEATS,
+                f"accepted with {len(unverified)} unverified check(s) disclosed",
+            )
+        return ConfidenceClassification.VERIFIED_COMPLETE, "accepted; all recorded checks verified"
+    return ConfidenceClassification.INCONCLUSIVE, f"unrecognized verdict {verdict!r}"
+
+
+def verification_evidence_summary(outcome: dict) -> str:
+    """Deterministic evidence lines for the wrap-up prompts (data, not prose).
+
+    Rides ``prior_outputs`` into every wrap-up task's prompt so the squad reads
+    the same structured basis the closeout handler enforces — the #686 lesson:
+    state the rule to the author, don't only spring it at validation.
+    """
+    ceiling, basis = confidence_ceiling(outcome)
+    lines = [
+        f"verdict: {outcome.get('verdict', 'unknown')}",
+        f"runs: {outcome.get('run_count', 0)}",
+        f"verified: {len(outcome.get('verified') or [])}",
+        f"failed: {', '.join(map(str, outcome.get('failed') or [])) or 'none'}",
+        f"unverified: {len(outcome.get('unverified') or [])}"
+        + (
+            " (" + ", ".join(str(u.get("check_id")) for u in outcome.get("unverified") or []) + ")"
+            if outcome.get("unverified")
+            else ""
+        ),
+        f"waived: {', '.join(str(w.get('check_id')) for w in outcome.get('waived') or []) or 'none'}",
+        f"maximum honest confidence: {ceiling} — {basis}",
+    ]
+    return "\n".join(lines)

--- a/tests/unit/capabilities/handlers/test_wrapup_tasks.py
+++ b/tests/unit/capabilities/handlers/test_wrapup_tasks.py
@@ -476,3 +476,77 @@ class TestParseFrontmatter:
         fm, err = _parse_frontmatter("---\n[broken\n---\nBody")
         assert fm is None
         assert "invalid YAML" in err
+
+
+# ---------------------------------------------------------------------------
+# #683: the closeout confidence ceiling (SIP-0096 §6.6(4)/§14)
+# ---------------------------------------------------------------------------
+
+
+def _inputs_with_outcome(outcome: dict | None) -> dict:
+    inputs = dict(VALID_INPUTS)
+    if outcome is not None:
+        inputs["prior_outputs"] = {"verification_evidence": {"outcome": outcome}}
+    return inputs
+
+
+_REJECTED_OUTCOME = {
+    "verdict": "rejected",
+    "verified": [],
+    "failed": ["tests_pass"],
+    "unverified": [],
+    "required_unmet": [],
+    "run_count": 1,
+    "waived": [],
+}
+
+_ACCEPTED_OUTCOME = {
+    "verdict": "accepted",
+    "verified": ["tests_pass"],
+    "failed": [],
+    "unverified": [],
+    "required_unmet": [],
+    "run_count": 1,
+    "waived": [],
+}
+
+
+class TestCloseoutConfidenceCeiling:
+    async def test_overclaim_is_clamped_with_disclosure(self):
+        # verified_complete claimed against a rejected cycle: the §6.6(4)
+        # narrative-override prohibition made mechanical
+        content = "---\nconfidence: verified_complete\nreadiness_recommendation: proceed\n---\nBody"
+        ctx = _make_context(content)
+        h = GovernanceCloseoutDecisionHandler()
+        result = await h.handle(ctx, _inputs_with_outcome(_REJECTED_OUTCOME))
+
+        assert result.success is True
+        assert result.outputs["confidence"] == "partial_completion"
+        assert result.outputs["confidence_claimed"] == "verified_complete"
+        enforced = result.outputs["artifacts"][0]["content"]
+        assert "confidence: partial_completion" in enforced
+        assert "confidence_claimed: verified_complete" in enforced
+        assert "confidence_enforced_by: cycle_outcome" in enforced
+
+    async def test_claim_within_ceiling_is_untouched(self):
+        content = (
+            "---\nconfidence: complete_with_caveats\nreadiness_recommendation: proceed\n---\nBody"
+        )
+        ctx = _make_context(content)
+        h = GovernanceCloseoutDecisionHandler()
+        result = await h.handle(ctx, _inputs_with_outcome(_ACCEPTED_OUTCOME))
+
+        assert result.success is True
+        assert result.outputs["confidence"] == "complete_with_caveats"
+        assert "confidence_claimed" not in result.outputs
+        assert "confidence_claimed" not in result.outputs["artifacts"][0]["content"]
+
+    async def test_absent_outcome_fails_closed(self):
+        # legacy dispatch / replay without threading: prose never stands alone
+        content = "---\nconfidence: verified_complete\nreadiness_recommendation: proceed\n---\nBody"
+        ctx = _make_context(content)
+        h = GovernanceCloseoutDecisionHandler()
+        result = await h.handle(ctx, _inputs_with_outcome(None))
+
+        assert result.outputs["confidence"] == "inconclusive"
+        assert "unavailable" in result.outputs["confidence_basis"]

--- a/tests/unit/cycles/test_confidence_ceiling.py
+++ b/tests/unit/cycles/test_confidence_ceiling.py
@@ -1,0 +1,183 @@
+"""#683 (SIP-0096 §10/§14) — the CycleOutcome-derived confidence ceiling.
+
+The normative claim under test: wrap-up prose can never claim above what the
+structured evidence supports (§6.6(4)), on EVERY path — including the
+no-outcome path, which fails closed to inconclusive rather than falling back
+to prose.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.wrapup_models import (
+    CONFIDENCE_RANK,
+    ConfidenceClassification,
+    confidence_ceiling,
+    verification_evidence_summary,
+)
+
+pytestmark = [pytest.mark.domain_cycles]
+
+
+def _outcome(verdict="accepted", **kw) -> dict:
+    base = {
+        "verdict": verdict,
+        "verified": ["tests_pass"],
+        "failed": [],
+        "unverified": [],
+        "required_unmet": [],
+        "run_count": 2,
+        "waived": [],
+    }
+    base.update(kw)
+    return base
+
+
+class TestConfidenceCeiling:
+    def test_accepted_all_verified_is_verified_complete(self):
+        ceiling, _ = confidence_ceiling(_outcome())
+        assert ceiling == ConfidenceClassification.VERIFIED_COMPLETE
+
+    def test_accepted_with_disclosures_caps_at_caveats(self):
+        ceiling, basis = confidence_ceiling(
+            _outcome(
+                unverified=[
+                    {"check_id": "frontend_build", "reason": "missing_tooling", "required": False}
+                ]
+            )
+        )
+        assert ceiling == ConfidenceClassification.COMPLETE_WITH_CAVEATS
+        assert "unverified" in basis
+
+    def test_rejected_caps_at_partial_completion(self):
+        ceiling, basis = confidence_ceiling(_outcome("rejected", failed=["tests_pass"]))
+        assert ceiling == ConfidenceClassification.PARTIAL_COMPLETION
+        assert "tests_pass" in basis
+
+    def test_blocked_unwaived_caps_at_not_sufficiently_verified(self):
+        ceiling, basis = confidence_ceiling(
+            _outcome(
+                "blocked_unverified",
+                required_unmet=["tests_pass"],
+                unverified=[
+                    {"check_id": "tests_pass", "reason": "missing_tooling", "required": True}
+                ],
+            )
+        )
+        assert ceiling == ConfidenceClassification.NOT_SUFFICIENTLY_VERIFIED
+        assert "tests_pass" in basis
+
+    def test_blocked_fully_waived_allows_caveats(self):
+        # §6.5: an operator accept-with-waiver IS the caveat
+        ceiling, basis = confidence_ceiling(
+            _outcome(
+                "blocked_unverified",
+                required_unmet=["tests_pass"],
+                waived=[{"check_id": "tests_pass", "reason": "node absent", "waived_by": "op"}],
+            )
+        )
+        assert ceiling == ConfidenceClassification.COMPLETE_WITH_CAVEATS
+        assert "waived" in basis
+
+    def test_absent_outcome_fails_closed_to_inconclusive(self):
+        # "on every path": a wrap-up that never received the outcome cannot
+        # let prose stand — inconclusive is the honest maximum
+        for missing in (None, {}):
+            ceiling, basis = confidence_ceiling(missing)
+            assert ceiling == ConfidenceClassification.INCONCLUSIVE
+            assert "unavailable" in basis
+
+    def test_zero_runs_is_inconclusive(self):
+        ceiling, _ = confidence_ceiling(_outcome(run_count=0))
+        assert ceiling == ConfidenceClassification.INCONCLUSIVE
+
+    def test_rank_covers_every_classification(self):
+        # a new classification without a rank would crash enforcement
+        from squadops.cycles.wrapup_models import ConfidenceClassification as C
+
+        values = {
+            getattr(C, name)
+            for name in dir(C)
+            if not name.startswith("_") and isinstance(getattr(C, name), str)
+        }
+        assert set(CONFIDENCE_RANK) == values
+
+
+class TestEvidenceSummary:
+    def test_summary_states_the_ceiling(self):
+        text = verification_evidence_summary(_outcome("rejected", failed=["tests_pass"]))
+        assert "maximum honest confidence: partial_completion" in text
+        assert "verdict: rejected" in text
+
+
+class TestExecutorWrapupInjection:
+    """#683 threading: a wrap-up run's prior_outputs carry the structured
+    evidence; non-wrap-up runs are untouched; derivation failure never kills
+    the run (absence fails closed at the handler)."""
+
+    @staticmethod
+    def _envelope(task_type: str):
+        from unittest.mock import MagicMock
+
+        e = MagicMock()
+        e.task_type = task_type
+        return e
+
+    @staticmethod
+    def _executor_with(outcome_summaries):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+        registry = AsyncMock()
+        registry.list_run_verification_summaries.return_value = outcome_summaries
+        cycle = MagicMock()
+        cycle.execution_overrides = {}
+        registry.get_cycle.return_value = cycle
+        registry.list_runs.return_value = []
+        return DispatchedFlowExecutor(cycle_registry=registry)
+
+    async def test_wrapup_plan_gets_evidence(self):
+        from unittest.mock import MagicMock
+
+        executor = self._executor_with([])
+        prior: dict = {}
+        cycle = MagicMock()
+        cycle.cycle_id = "cyc_1"
+        cycle.execution_overrides = {}
+
+        await executor._inject_wrapup_evidence(
+            [self._envelope("governance.closeout_decision")], cycle, prior
+        )
+
+        evidence = prior["verification_evidence"]
+        assert "maximum honest confidence" in evidence["summary"]
+        assert evidence["outcome"]["run_count"] == 0
+
+    async def test_non_wrapup_plan_untouched(self):
+        from unittest.mock import MagicMock
+
+        executor = self._executor_with([])
+        prior: dict = {}
+        await executor._inject_wrapup_evidence(
+            [self._envelope("development.develop")], MagicMock(), prior
+        )
+        assert prior == {}
+
+    async def test_derivation_failure_never_raises(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+        registry = AsyncMock()
+        registry.list_run_verification_summaries.side_effect = RuntimeError("db down")
+        executor = DispatchedFlowExecutor(cycle_registry=registry)
+        prior: dict = {}
+        cycle = MagicMock()
+        cycle.cycle_id = "cyc_1"
+
+        await executor._inject_wrapup_evidence(
+            [self._envelope("qa.assess_outcomes")], cycle, prior
+        )  # no raise; handler fails closed on absence
+        assert "verification_evidence" not in prior


### PR DESCRIPTION
## What

Second of the SIP-0096 completion trio: **`ConfidenceClassification` stops being LLM-prose-derived**. The audit's finding — `CycleOutcome` had one consumer repo-wide and `wrapup_tasks.py` never read it — is closed on both ends:

- **Threading**: the executor injects the cycle's `CycleOutcome` once per wrap-up run into `prior_outputs.verification_evidence` (new `CycleOutcome.to_dict()`): deterministic summary lines ride **every** wrap-up prompt (the #686 lesson — show the author the basis, don't only spring it at validation), and the raw dict carries enforcement. Zero template changes.
- **Enforcement**: the closeout handler derives the **deterministic confidence ceiling** (`confidence_ceiling` in `wrapup_models`, beside the vocabulary): accepted/all-verified → `verified_complete`; accepted with disclosures → `complete_with_caveats`; rejected → `partial_completion`; `blocked_unverified` **fully waived** → `complete_with_caveats` (the §6.5 waiver IS the caveat — #682 integration); blocked otherwise → `not_sufficiently_verified`; zero runs or absent outcome → `inconclusive`. An over-claim is **clamped with full disclosure** — frontmatter rewritten to the enforced value plus `confidence_claimed`/`confidence_enforced_by`/`confidence_basis`; outputs mirror. §6.6(4)'s narrative-override prohibition, made mechanical.
- **Every path**: an absent outcome (legacy dispatch, replay without threading, injection failure) fails **closed** to the inconclusive ceiling — prose never stands alone.

## Verification

Regression **6340 passed** (the enum-shadow guard caught three verdict literals — now `RunVerdict`). New: ceiling map (8 cases incl. the §6.5 fully-waived path and a rank-coverage drift guard), closeout clamp/untouched/fail-closed, executor injection triad. Live: the wrap-up profile's closeout on the Gate-2 shakedown shows the evidence block in prompt provenance and an honest confidence.

Next in the trio: #684 (§9 inert-check detection) — then SIP-0096 promotion before the RC.

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv