### PR TITLE
feat(verification): #684 SIP-0096 §9 inert-check detection — CycleOutcome.inert populated

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,9 @@ SQUADOPS_PROFILE=dev  # Options: dev, local, lab, cloud
 # SQUADOPS__TELEMETRY__OTLP_ENDPOINT=http://localhost:4317
 # SQUADOPS__TELEMETRY__PROMETHEUS_PORT=8888
 
+# Cycle Verification (SIP-0096)
+# SQUADOPS__CYCLES__INERT_CYCLE_THRESHOLD=3   # §9 N: consecutive not-executed cycles before a check is inert
+
 # Agent Lifecycle Configuration
 # SQUADOPS__AGENT__INSTANCES_FILE=agents/instances/instances.yaml
 # SQUADOPS__AGENT__HEARTBEAT_TIMEOUT_WINDOW=90

--- a/adapters/cycles/memory_cycle_registry.py
+++ b/adapters/cycles/memory_cycle_registry.py
@@ -83,6 +83,11 @@ class MemoryCycleRegistry(CycleRegistryPort):
                 if derived != status:
                     continue
             results.append(cycle)
+        # Port ordering contract: newest first, so `limit` pages the most recent
+        # cycles — matching the postgres adapter's ORDER BY created_at DESC
+        # (#684: the inert-detection history walk depends on which window a
+        # bounded read returns).
+        results.sort(key=lambda c: c.created_at, reverse=True)
         return results[offset : offset + limit]
 
     async def cancel_cycle(self, cycle_id: str) -> None:

--- a/src/squadops/api/routes/cycles/dtos.py
+++ b/src/squadops/api/routes/cycles/dtos.py
@@ -207,6 +207,7 @@ class CycleOutcomeDTO(BaseModel):
     unverified: list[UnverifiedCheckDTO] = Field(default_factory=list)
     required_unmet: list[str] = Field(default_factory=list)
     run_count: int = 0
+    inert: list[str] = Field(default_factory=list)  # §9 chronic not-executed (#684)
     waived: list[WaivedCheckDTO] = Field(default_factory=list)  # §6.5 (#682)
     replay: ReplayProvenanceDTO | None = None  # SIP-0101 — present iff replayed
 

--- a/src/squadops/api/routes/cycles/mapping.py
+++ b/src/squadops/api/routes/cycles/mapping.py
@@ -157,6 +157,7 @@ def _cycle_outcome_to_dto(outcome: CycleOutcome) -> CycleOutcomeDTO:
         ],
         required_unmet=list(outcome.required_unmet),
         run_count=outcome.run_count,
+        inert=list(outcome.inert),
         waived=[
             WaivedCheckDTO(check_id=w.check_id, reason=w.reason, waived_by=w.waived_by)
             for w in outcome.waived

--- a/src/squadops/config/schema.py
+++ b/src/squadops/config/schema.py
@@ -468,6 +468,14 @@ class CyclesConfig(BaseModel):
         default="config",
         description="Squad profile provider: 'config' or 'postgres' (SIP-0075)",
     )
+    inert_cycle_threshold: int = Field(
+        default=3,
+        ge=1,
+        description=(
+            "SIP-0096 §9 N: consecutive not-executed cycles before a stable "
+            "framework check is surfaced as inert (#684)"
+        ),
+    )
 
 
 class SchedulerConfig(BaseModel):

--- a/src/squadops/cycles/cycle_outcome.py
+++ b/src/squadops/cycles/cycle_outcome.py
@@ -12,8 +12,15 @@ continuation decision later).
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
+from squadops.cycles.inert_detection import (
+    INERT_CYCLE_THRESHOLD_DEFAULT,
+    INERT_LOOKBACK_CYCLES,
+    cycle_check_state,
+    detect_inert_checks,
+)
 from squadops.cycles.replay import (
     REPLAY_COMPATIBILITY_ELEMENTS,
     parse_replay_declaration,
@@ -26,15 +33,79 @@ from squadops.cycles.verification_integrity import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from squadops.cycles.models import Cycle
+    from squadops.cycles.verification_integrity import RunVerificationSummary
     from squadops.ports.cycles.cycle_registry import CycleRegistryPort
 
+logger = logging.getLogger(__name__)
 
-async def resolve_cycle_outcome(registry: CycleRegistryPort, cycle_id: str) -> CycleOutcome:
+
+def _configured_inert_threshold() -> int:
+    """The §9 N from config, or the SIP default when config isn't loaded.
+
+    ``SQUADOPS__CYCLES__INERT_CYCLE_THRESHOLD`` in deployments; library/test use
+    without a loaded config falls back to the same declared default (a drift
+    test pins the schema default to the constant).
+    """
+    from squadops.config import get_config
+
+    try:
+        return get_config().cycles.inert_cycle_threshold
+    except RuntimeError:
+        return INERT_CYCLE_THRESHOLD_DEFAULT
+
+
+async def _collect_inert(
+    registry: CycleRegistryPort,
+    cycle: Cycle,
+    current_summaries: Sequence[RunVerificationSummary],
+    threshold: int,
+) -> tuple[str, ...]:
+    """Walk the cycle's prior same-project/profile cycles for §9 streaks (#684).
+
+    Series scope is strict: same ``project_id`` + ``squad_profile_id`` +
+    ``request_profile``, created strictly before the perspective cycle — cross-
+    profile history could accrue streaks against checks with different
+    applicability (false inerts). The walk consults at most
+    ``INERT_LOOKBACK_CYCLES`` prior cycles (``list_cycles`` returns newest
+    first — the port's ordering contract); a streak not resolvable within the
+    window is not flagged.
+    """
+    cycles = await registry.list_cycles(cycle.project_id, limit=50)
+    series = [
+        c
+        for c in cycles
+        if c.cycle_id != cycle.cycle_id
+        and c.created_at < cycle.created_at
+        and c.squad_profile_id == cycle.squad_profile_id
+        and c.request_profile == cycle.request_profile
+    ][:INERT_LOOKBACK_CYCLES]
+    states = [cycle_check_state(current_summaries)]
+    for prior in series:
+        states.append(
+            cycle_check_state(await registry.list_run_verification_summaries(prior.cycle_id))
+        )
+    return detect_inert_checks(states, threshold=threshold)
+
+
+async def resolve_cycle_outcome(
+    registry: CycleRegistryPort,
+    cycle_id: str,
+    *,
+    inert_threshold: int | None = None,
+) -> CycleOutcome:
     """Derive a cycle's ``CycleOutcome`` from its persisted per-run summaries (§10).
 
     ``waived`` (#682): populated from the cycle's recorded gate decisions — an
     operator accept-with-waiver sits beside the verdict, never altering it (§6.5).
-    ``inert`` (chronic not-executed, §9) stays empty until #684 wires its source.
+
+    ``inert`` (#684, §9): chronic not-executed streaks derived by walking prior
+    same-project/profile cycles' summaries — disclosure-only enrichment, so a
+    history-read failure logs and yields an empty list, never a failed roll-up;
+    the verdict and the #683 confidence ceiling never depend on it.
+    ``inert_threshold`` overrides the configured N (tests; ``None`` = config).
 
     SIP-0101 Slice 3.4: a replay-mode cycle's outcome carries ``ReplayProvenance``
     derived from the immutable, create-time-validated declaration — same
@@ -62,4 +133,12 @@ async def resolve_cycle_outcome(registry: CycleRegistryPort, cycle_id: str) -> C
         if replay_req is not None
         else None
     )
-    return aggregate_cycle_outcome(summaries, waived=waived, replay=replay)
+    try:
+        threshold = (
+            inert_threshold if inert_threshold is not None else _configured_inert_threshold()
+        )
+        inert = await _collect_inert(registry, cycle, summaries, threshold)
+    except Exception:
+        logger.warning("inert-check detection failed for %s", cycle_id, exc_info=True)
+        inert = ()
+    return aggregate_cycle_outcome(summaries, waived=waived, inert=inert, replay=replay)

--- a/src/squadops/cycles/inert_detection.py
+++ b/src/squadops/cycles/inert_detection.py
@@ -1,0 +1,96 @@
+"""Inert-check detection — chronic not-executed streaks across cycles (SIP-0096 §9, #684).
+
+A check with stable identity that has reported not-executed for N consecutive
+cycles (default 3) in the same project/profile is **inert**: a permanently
+skipping check is indistinguishable from no check. Detection is derived on read
+from the persisted per-run ``RunVerificationSummary`` rows — no counter table,
+no migration; the "counter" is a streak computed by walking the project's
+recent cycles newest→oldest, so reset-on-real-execution falls out of the walk.
+
+Identity domain (§6.3): only ``check_registry``'s stable framework vocabulary
+participates — plan-authored typed checks have per-cycle identity and pulse
+suites are a separate axis whose results do not flow into run summaries today.
+Because these ids are the canonical strings producers emit, a rename is a
+vocabulary change, not a per-run alias — the §9 rename-survival rule holds by
+construction.
+
+Streak semantics (§9): a cycle where the check executed the real subject
+resets the streak; a cycle where it reported not-executed increments it; a
+cycle where it is absent pauses it — the counter "resets only when the check
+evaluates the real subject — not when the check disappears, is renamed, or is
+reclassified optional."
+
+Pure functions over summaries — ``cycle_outcome.resolve_cycle_outcome`` owns
+the registry reads, series scoping, and failure containment.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Sequence
+
+from squadops.cycles.check_registry import framework_check_ids
+from squadops.cycles.verification_integrity import (
+    RunVerificationSummary,
+    aggregate_cycle_outcome,
+)
+
+#: SIP-0096 §9 default N. Config-addressable via
+#: ``SQUADOPS__CYCLES__INERT_CYCLE_THRESHOLD`` (a drift test pins the schema
+#: default to this constant).
+INERT_CYCLE_THRESHOLD_DEFAULT = 3
+
+#: How many prior same-project/profile cycles the walk may consult. A streak
+#: not resolvable within this window is NOT inert — insufficient evidence is
+#: never flagged. Bounds the read cost of the derive-on-read detection.
+INERT_LOOKBACK_CYCLES = 10
+
+
+def cycle_check_state(
+    summaries: Sequence[RunVerificationSummary],
+) -> tuple[frozenset[str], frozenset[str]]:
+    """One cycle's reconciled per-check state: ``(executed_ids, not_executed_ids)``.
+
+    Uses the same reconciliation the roll-up uses (``aggregate_cycle_outcome``:
+    executed evidence in any run supersedes the check's not-executed rows), so
+    detection and disclosure can never disagree about what a cycle proved. A
+    cycle with no summaries yields two empty sets — every check is *absent*
+    there, which pauses streaks without resetting them.
+    """
+    outcome = aggregate_cycle_outcome(summaries)
+    executed = frozenset(outcome.verified) | frozenset(outcome.failed)
+    reported = frozenset(u.check_id for u in outcome.unverified)
+    return executed, reported - executed
+
+
+def detect_inert_checks(
+    cycle_states: Sequence[tuple[Collection[str], Collection[str]]],
+    *,
+    stable_ids: Collection[str] | None = None,
+    threshold: int = INERT_CYCLE_THRESHOLD_DEFAULT,
+) -> tuple[str, ...]:
+    """Stable checks whose not-executed streak has reached ``threshold`` (§9).
+
+    ``cycle_states`` is newest-first — the perspective cycle first, then its
+    prior same-project/profile cycles — each a ``(executed_ids,
+    not_executed_ids)`` pair (see ``cycle_check_state``). The perspective cycle
+    participates like any other: a check it executed is reset (not inert); a
+    check absent now but chronic before stays inert until a real execution.
+
+    Only ``stable_ids`` (default: the ``check_registry`` framework vocabulary)
+    are tracked; everything else is invisible to the walk.
+    """
+    if threshold < 1:
+        raise ValueError(f"threshold must be >= 1, got {threshold}")
+    stable = frozenset(stable_ids if stable_ids is not None else framework_check_ids())
+    inert: set[str] = set()
+    resolved: set[str] = set()  # reset by execution, or already flagged inert
+    streak: dict[str, int] = {}
+    for executed, not_executed in cycle_states:
+        executed_stable = stable.intersection(executed)
+        resolved.update(executed_stable)
+        for cid in stable.intersection(not_executed) - executed_stable - resolved:
+            streak[cid] = streak.get(cid, 0) + 1
+            if streak[cid] >= threshold:
+                inert.add(cid)
+                resolved.add(cid)
+    return tuple(sorted(inert))

--- a/src/squadops/cycles/wrapup_models.py
+++ b/src/squadops/cycles/wrapup_models.py
@@ -177,6 +177,7 @@ def verification_evidence_summary(outcome: dict) -> str:
             else ""
         ),
         f"waived: {', '.join(str(w.get('check_id')) for w in outcome.get('waived') or []) or 'none'}",
+        f"inert: {', '.join(map(str, outcome.get('inert') or [])) or 'none'}",
         f"maximum honest confidence: {ceiling} — {basis}",
     ]
     return "\n".join(lines)

--- a/src/squadops/ports/cycles/cycle_registry.py
+++ b/src/squadops/ports/cycles/cycle_registry.py
@@ -44,7 +44,12 @@ class CycleRegistryPort(ABC):
         limit: int = 50,
         offset: int = 0,
     ) -> list[Cycle]:
-        """List cycles for a project, optionally filtered by status."""
+        """List cycles for a project, optionally filtered by status.
+
+        Ordering contract: newest first by ``created_at`` — ``limit``/``offset``
+        page over that ordering, so a bounded read returns the most recent
+        cycles (#684's inert-detection history walk depends on this).
+        """
 
     @abstractmethod
     async def cancel_cycle(self, cycle_id: str) -> None:

--- a/tests/unit/cycles/test_confidence_ceiling.py
+++ b/tests/unit/cycles/test_confidence_ceiling.py
@@ -110,6 +110,13 @@ class TestEvidenceSummary:
         assert "maximum honest confidence: partial_completion" in text
         assert "verdict: rejected" in text
 
+    def test_summary_discloses_inert_and_tolerates_its_absence(self):
+        # #684: chronic checks reach the wrap-up prompt; a pre-#684 outcome
+        # dict without the key still renders (fail-open to 'none', never a crash)
+        text = verification_evidence_summary(_outcome(inert=["frontend_build"]))
+        assert "inert: frontend_build" in text
+        assert "inert: none" in verification_evidence_summary(_outcome())
+
 
 class TestExecutorWrapupInjection:
     """#683 threading: a wrap-up run's prior_outputs carry the structured

--- a/tests/unit/cycles/test_cycle_registry_contract.py
+++ b/tests/unit/cycles/test_cycle_registry_contract.py
@@ -206,6 +206,24 @@ async def test_list_cycles_with_pagination(registry):
         assert cycle.project_id == "proj_1"
 
 
+async def test_list_cycles_orders_newest_first(registry):
+    """Port ordering contract (#684): newest first, and `limit` pages the most
+    recent cycles — the postgres adapter's ORDER BY created_at DESC. Bug caught:
+    the memory adapter returned insertion order, so a bounded read handed the
+    inert-detection history walk the OLDEST window instead of the newest."""
+    import dataclasses
+    from datetime import timedelta
+
+    for i in range(4):
+        cycle = dataclasses.replace(
+            _make_cycle(cycle_id=f"cyc_{i:03d}"), created_at=NOW + timedelta(hours=i)
+        )
+        await registry.create_cycle(cycle)
+
+    page = await registry.list_cycles("proj_1", limit=2)
+    assert [c.cycle_id for c in page] == ["cyc_003", "cyc_002"]
+
+
 # ---------------------------------------------------------------------------
 # Pulse Verification contract tests (SIP-0070, Phase 1.9)
 # ---------------------------------------------------------------------------

--- a/tests/unit/cycles/test_inert_detection.py
+++ b/tests/unit/cycles/test_inert_detection.py
@@ -1,0 +1,269 @@
+"""#684 (SIP-0096 §9) — inert-check detection: chronic not-executed streaks.
+
+The design-gate bindings these tests enforce: only real-subject execution
+resets a streak (absence pauses — the §9 disappearance/rename rule), only the
+stable framework vocabulary participates, detection is derived on read from
+persisted summaries (the multi-cycle real-store sequence below — the evidence
+matrix's verification row), and a history-read failure yields empty inert,
+never a failed roll-up.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from squadops.cycles.cycle_outcome import resolve_cycle_outcome
+from squadops.cycles.inert_detection import (
+    INERT_CYCLE_THRESHOLD_DEFAULT,
+    cycle_check_state,
+    detect_inert_checks,
+)
+from squadops.cycles.models import Cycle, Run, TaskFlowPolicy
+from squadops.cycles.verification_integrity import (
+    RunVerdict,
+    RunVerificationSummary,
+    UnverifiedCheck,
+)
+
+pytestmark = [pytest.mark.domain_cycles]
+
+
+def _state(executed=(), not_executed=()):
+    return (frozenset(executed), frozenset(not_executed))
+
+
+class TestDetectInertChecks:
+    def test_streak_reaching_threshold_is_inert(self):
+        # newest-first: three consecutive not-executed reports of a stable check
+        states = [_state(not_executed=["tests_pass"])] * 3
+        assert detect_inert_checks(states) == ("tests_pass",)
+
+    def test_below_threshold_not_flagged(self):
+        states = [_state(not_executed=["tests_pass"])] * 2
+        assert detect_inert_checks(states) == ()
+
+    def test_execution_resets_the_streak(self):
+        # an execution between reports ends the streak before it reaches N
+        states = [
+            _state(not_executed=["tests_pass"]),
+            _state(executed=["tests_pass"]),
+            _state(not_executed=["tests_pass"]),
+            _state(not_executed=["tests_pass"]),
+        ]
+        assert detect_inert_checks(states) == ()
+
+    def test_absence_pauses_without_resetting(self):
+        # §9: the counter resets ONLY on real execution — cycles where the
+        # check is absent (disappeared/renamed/reclassified) pause the streak
+        states = [
+            _state(not_executed=["frontend_build"]),
+            _state(),  # check absent — no reset
+            _state(not_executed=["frontend_build"]),
+            _state(),
+            _state(not_executed=["frontend_build"]),
+        ]
+        assert detect_inert_checks(states) == ("frontend_build",)
+
+    def test_current_cycle_execution_wins(self):
+        # chronic history, but the perspective cycle executed the real subject
+        states = [_state(executed=["tests_pass"])] + [_state(not_executed=["tests_pass"])] * 5
+        assert detect_inert_checks(states) == ()
+
+    def test_chronic_check_absent_now_stays_inert(self):
+        # absent in the perspective cycle but chronic before — still inert
+        # until a real execution clears it (absence never resets)
+        states = [_state()] + [_state(not_executed=["required_files"])] * 3
+        assert detect_inert_checks(states) == ("required_files",)
+
+    def test_non_stable_ids_are_invisible(self):
+        # plan-authored typed checks have per-cycle identity (§6.3) — excluded
+        states = [_state(not_executed=["acceptance:api_returns_json"])] * 5
+        assert detect_inert_checks(states) == ()
+
+    def test_threshold_override(self):
+        states = [_state(not_executed=["tests_pass"])] * 2
+        assert detect_inert_checks(states, threshold=2) == ("tests_pass",)
+
+    def test_invalid_threshold_raises(self):
+        with pytest.raises(ValueError):
+            detect_inert_checks([], threshold=0)
+
+
+class TestCycleCheckState:
+    def test_executed_supersedes_not_executed_within_a_cycle(self):
+        # same reconciliation as the roll-up: a framing run's subject_missing
+        # row is superseded by the impl run's real execution (#444)
+        framing = RunVerificationSummary(
+            verdict=RunVerdict.ACCEPTED,
+            verified=(),
+            failed=(),
+            unverified=(UnverifiedCheck("tests_pass", "subject_missing", required=False),),
+            required_unmet=(),
+            executed_count=0,
+            passed_count=0,
+        )
+        impl = RunVerificationSummary(
+            verdict=RunVerdict.ACCEPTED,
+            verified=("tests_pass",),
+            failed=(),
+            unverified=(),
+            required_unmet=(),
+            executed_count=1,
+            passed_count=1,
+        )
+        executed, not_executed = cycle_check_state([framing, impl])
+        assert "tests_pass" in executed
+        assert "tests_pass" not in not_executed
+
+    def test_no_summaries_is_absent_for_everything(self):
+        assert cycle_check_state([]) == (frozenset(), frozenset())
+
+
+# ---------------------------------------------------------------------------
+# Multi-cycle real-store sequence (the evidence matrix's verification row):
+# detection through resolve_cycle_outcome against the memory registry — real
+# persisted summaries across cycles, not mocks.
+# ---------------------------------------------------------------------------
+
+_T0 = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+_POLICY = TaskFlowPolicy(mode="sequential", gates=())
+
+
+def _cycle(i: int, *, squad_profile="full", request_profile="selftest") -> Cycle:
+    return Cycle(
+        cycle_id=f"cyc_{i:03d}",
+        project_id="proj_inert",
+        created_at=_T0 + timedelta(hours=i),
+        created_by="test",
+        prd_ref=None,
+        squad_profile_id=squad_profile,
+        squad_profile_snapshot_ref="sha256:abc",
+        task_flow_policy=_POLICY,
+        build_strategy="fresh",
+        request_profile=request_profile,
+    )
+
+
+def _summary(*, verified=(), not_executed=()) -> RunVerificationSummary:
+    return RunVerificationSummary(
+        verdict=RunVerdict.ACCEPTED,
+        verified=tuple(verified),
+        failed=(),
+        unverified=tuple(
+            UnverifiedCheck(cid, "missing_tooling", required=False) for cid in not_executed
+        ),
+        required_unmet=(),
+        executed_count=len(verified),
+        passed_count=len(verified),
+    )
+
+
+class TestInertRealStoreSequence:
+    @staticmethod
+    async def _add_cycle(registry, i, summary, **cycle_kw):
+        cycle = _cycle(i, **cycle_kw)
+        await registry.create_cycle(cycle)
+        run = Run(
+            run_id=f"run_{i:03d}",
+            cycle_id=cycle.cycle_id,
+            run_number=1,
+            status="queued",
+            initiated_by="test",
+            resolved_config_hash="h",
+        )
+        await registry.create_run(run)
+        await registry.record_run_verification_summary(run.run_id, summary)
+        return cycle
+
+    @pytest.fixture
+    def registry(self):
+        from adapters.cycles.memory_cycle_registry import MemoryCycleRegistry
+
+        return MemoryCycleRegistry()
+
+    async def test_three_chronic_cycles_flag_inert(self, registry):
+        chronic = _summary(verified=["tests_pass"], not_executed=["frontend_build"])
+        for i in range(3):
+            newest = await self._add_cycle(registry, i, chronic)
+
+        outcome = await resolve_cycle_outcome(registry, newest.cycle_id)
+
+        assert outcome.inert == ("frontend_build",)
+        assert "tests_pass" not in outcome.inert  # executes every cycle
+        assert outcome.verdict is RunVerdict.ACCEPTED  # disclosure-only, never gates
+
+    async def test_real_execution_clears_the_flag(self, registry):
+        chronic = _summary(not_executed=["frontend_build"])
+        for i in range(3):
+            await self._add_cycle(registry, i, chronic)
+        newest = await self._add_cycle(registry, 3, _summary(verified=["frontend_build"]))
+
+        outcome = await resolve_cycle_outcome(registry, newest.cycle_id)
+
+        assert outcome.inert == ()
+
+    async def test_other_profile_cycles_are_outside_the_series(self, registry):
+        # two chronic cycles on the perspective profile + interleaved chronic
+        # cycles on ANOTHER profile: the series has only 2 reports → not inert
+        # (cross-profile history must never accrue a streak — applicability differs)
+        chronic = _summary(not_executed=["frontend_build"])
+        await self._add_cycle(registry, 0, chronic)
+        await self._add_cycle(registry, 1, chronic, squad_profile="lite", request_profile=None)
+        await self._add_cycle(registry, 2, chronic, squad_profile="lite", request_profile=None)
+        newest = await self._add_cycle(registry, 3, chronic)
+
+        outcome = await resolve_cycle_outcome(registry, newest.cycle_id)
+
+        assert outcome.inert == ()
+
+    async def test_history_read_failure_yields_empty_inert(self, registry, monkeypatch):
+        newest = await self._add_cycle(registry, 0, _summary(not_executed=["frontend_build"]))
+
+        async def _boom(*a, **kw):
+            raise RuntimeError("history unavailable")
+
+        monkeypatch.setattr(registry, "list_cycles", _boom)
+        outcome = await resolve_cycle_outcome(registry, newest.cycle_id)
+
+        assert outcome.inert == ()  # containment: disclosure-only enrichment
+        assert outcome.verdict is RunVerdict.ACCEPTED  # roll-up itself unharmed
+
+    async def test_threshold_parameter_is_honored(self, registry):
+        chronic = _summary(not_executed=["frontend_build"])
+        for i in range(2):
+            newest = await self._add_cycle(registry, i, chronic)
+
+        strict = await resolve_cycle_outcome(registry, newest.cycle_id, inert_threshold=2)
+        default = await resolve_cycle_outcome(registry, newest.cycle_id)
+
+        assert strict.inert == ("frontend_build",)
+        assert default.inert == ()  # config-default N=3 not yet reached
+
+
+def test_config_default_matches_module_constant():
+    """Drift guard: the SQUADOPS__CYCLES__INERT_CYCLE_THRESHOLD schema default
+    and the module constant are the same declared N — a config edit that
+    diverges them would make deployments and library use disagree silently."""
+    from squadops.config.schema import CyclesConfig
+
+    assert CyclesConfig().inert_cycle_threshold == INERT_CYCLE_THRESHOLD_DEFAULT
+
+
+def test_outcome_dto_carries_inert():
+    """#684 API threading: the roll-up's inert list survives into the DTO."""
+    from squadops.api.routes.cycles.mapping import _cycle_outcome_to_dto
+    from squadops.cycles.verification_integrity import CycleOutcome
+
+    dto = _cycle_outcome_to_dto(
+        CycleOutcome(
+            verdict=RunVerdict.ACCEPTED,
+            verified=("tests_pass",),
+            failed=(),
+            unverified=(),
+            run_count=3,
+            inert=("frontend_build",),
+        )
+    )
+    assert dto.inert == ["frontend_build"]


### PR DESCRIPTION
Closes #684 — the last of the SIP-0096 trio (#682 → #683 → #684). `CycleOutcome.inert` stops being permanently empty.

Design decisions ratified via the decision table posted to #684 before code (D1–D7). The load-bearing one: **detection is derived on read from the persisted per-run `RunVerificationSummary` rows — no counter table, no migration** (the line's policy allows exactly the two landed migrations; a materialized counter would have been a design-review stop). The "counter" is a streak computed by walking the perspective cycle's prior same-project/profile cycles newest→oldest at `resolve_cycle_outcome` time — the same derive-on-read philosophy as the roll-up itself — so reset-on-real-execution falls out of the walk and both existing consumers (API cycle detail, #683 wrap-up evidence injection) get the population for free.

## What landed

- **`src/squadops/cycles/inert_detection.py`** (new, pure): `detect_inert_checks` — per stable check, walking newest→oldest: execution resets, a not-executed report increments, absence **pauses without resetting** (§9: the counter "resets only when the check evaluates the real subject — not when the check disappears, is renamed, or is reclassified optional"); inert iff streak ≥ N. `cycle_check_state` derives one cycle's reconciled `(executed, not_executed)` via `aggregate_cycle_outcome`, so detection and disclosure can never disagree about what a cycle proved.
- **Identity domain** = `check_registry.framework_check_ids()` — the §6.3 single source of truth (its docstring already rules pulse suites a separate axis; typed-acceptance checks have per-cycle identity). Rename survival holds by construction: these ids are the canonical strings producers emit.
- **Series scope**: strict `(project_id, squad_profile_id, request_profile)` equality, cycles created strictly before the perspective cycle, bounded at 10 prior cycles — cross-profile history can't accrue streaks against checks with different applicability, and a streak not resolvable within the window is never guessed inert.
- **N is config-addressable**: `SQUADOPS__CYCLES__INERT_CYCLE_THRESHOLD` (CyclesConfig, default 3, ge=1), drift-tested against the module constant; `resolve_cycle_outcome` takes an explicit `inert_threshold` override for tests.
- **Containment**: disclosure-only enrichment — a history-read failure logs a warning and yields `inert=()`, never a failed roll-up; the verdict and #683 confidence ceiling never depend on it.
- **Threading**: `CycleOutcomeDTO.inert` + mapping; one `inert:` line in the wrap-up `verification_evidence_summary` (tolerates pre-#684 outcome dicts).
- **Premise-delta fix (first commit)**: `list_cycles` had no ordering contract — postgres returns `created_at DESC`, the memory adapter returned insertion order and sliced the *oldest* page under `limit`, so a bounded read handed different windows per adapter. The port docstring now states newest-first, the memory adapter conforms, and a parity test enforces it.

## Verification

- Pure-walk unit tests: threshold/reset/pause semantics, perspective-cycle execution wins, chronic-but-absent-now stays inert, non-stable ids invisible, invalid threshold.
- **Multi-cycle real-store sequence** (the evidence matrix's row for A2 #684, not mocks): through `resolve_cycle_outcome` against the memory registry — three chronic cycles flag inert / a real execution clears it / cross-profile cycles are outside the series / history-read failure contained.
- Full regression: **6360 passed, 1 skipped**.
- Live proof rides the Gate-2 exit confirmation shakedown, per the line's pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
