### PR TITLE
feat(verification): #629 contract-expectation enforcement, split by determinism (A6/D2)

### DIFF
--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -247,6 +247,18 @@ CHECK_ENDPOINT_DEFINED = "endpoint_defined"
 # above — a literal there would silently inject nothing after a rename.
 CHECK_UNDEFINED_NAMES = "undefined_names"
 
+# #629 (1.5 A6/D2): the blocking suite-vs-contract check. Multi-reader constant
+# (injection in task_plan, locus routing in failure_evidence, the evaluator,
+# tests) — same single-source rule as the two above.
+CHECK_CONTRACT_ASSERTIONS = "contract_assertions_match"
+
+# #629 (1.5 A6/D2): the ADVISORY prose-vs-contract identity. Deliberately NOT a
+# ``CHECK_SPECS`` entry — that would make it plan-authorable; it names the
+# warning rows the plan-prose lint emits (``implementation_plan``), keeping its
+# lower evidence quality from laundering into the blocking check above. The
+# full governance-registry entry rides #730's attribute backfill.
+PLAN_PROSE_CONTRACT_DIVERGENCE = "plan_prose_contract_divergence"
+
 
 # The `"METHOD /path"` endpoint-token grammar. `endpoint_defined.methods_paths`
 # is authored in it and the evaluator matches route decorators against it; #688
@@ -279,6 +291,26 @@ def parse_method_path(token: str) -> tuple[str, str] | None:
     if method.lower() not in HTTP_METHODS:
         return None
     return method, path
+
+
+def parse_method_path_status(token: str) -> tuple[str, str, int] | None:
+    """Parse a ``"METHOD /path STATUS"`` token (#629's pinned-status grammar).
+
+    The three-field extension of ``parse_method_path`` — the wire shape the
+    ``contract_assertions_match`` injection uses for its ``endpoints`` param,
+    one token per (endpoint, pinned status). Same tolerance rule: ``None`` for
+    anything malformed, so a bad entry is inert instead of fatal.
+    """
+    parts = token.strip().rsplit(maxsplit=1)
+    if len(parts) != 2 or not parts[1].isdigit():
+        return None
+    method_path = parse_method_path(parts[0])
+    if method_path is None:
+        return None
+    status = int(parts[1])
+    if not 100 <= status <= 599:
+        return None
+    return method_path[0], method_path[1], status
 
 
 # Rev 1 vocabulary. Each entry's evaluator implementation lands in M1.2;
@@ -443,6 +475,34 @@ CHECK_SPECS: dict[str, CheckSpec] = {
             "imports) that no static check or `node --check` can see. Missing "
             "npm or a workspace without frontend/package.json skips "
             "(missing_tooling), it does not fail."
+        ),
+    ),
+    CHECK_CONTRACT_ASSERTIONS: CheckSpec(
+        name=CHECK_CONTRACT_ASSERTIONS,
+        applicable_extensions=frozenset({".py"}),
+        required_params=frozenset({"file", "endpoints"}),
+        optional_params=frozenset({"allowed_error_statuses"}),
+        param_types={"file": str, "endpoints": list, "allowed_error_statuses": list},
+        supported_stacks=frozenset({"python"}),
+        requires_stack_context=False,
+        path_params=frozenset({"file"}),
+        framework_injected=True,
+        example={
+            "file": "backend/tests/test_runs.py",
+            "endpoints": ["POST /runs 201", "POST /runs 422"],
+            "allowed_error_statuses": [404, 409, 422],
+        },
+        # #629 / pf-54: five authored suite versions asserted 200-on-create
+        # against a contract-pinned 201 — an unwinnable correction loop no
+        # source repair could satisfy. The authoring injection (layer 1) is
+        # guidance; this is the guarantee, injected by task_plan onto bound
+        # qa.test tasks per expected suite file, never authored.
+        notes=(
+            "Injected by the framework on bind-mode qa.test tasks: asserted "
+            "status codes in the suite are diffed against the contract's pinned "
+            "endpoint statuses (`endpoints` tokens, `METHOD /path STATUS`); a "
+            "pinned path requested through an undeclared prefix is also a "
+            "violation. Never authored."
         ),
     ),
     "module_imports": CheckSpec(

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any
 
 from squadops.cycles.acceptance_check_spec import (
+    CHECK_CONTRACT_ASSERTIONS,
     CHECK_ENDPOINT_DEFINED,
     CHECK_SPECS,
     CHECK_UNDEFINED_NAMES,
@@ -38,6 +39,7 @@ from squadops.cycles.acceptance_check_spec import (
     argv_matches_safelist,
     normalize_route,
     parse_method_path,
+    parse_method_path_status,
 )
 
 logger = logging.getLogger(__name__)
@@ -375,6 +377,180 @@ class UndefinedNamesCheck(BaseCheck):
                 reason=f"undefined name(s): {names}",
                 file=str(params["file"]),
                 undefined=undefined,
+            )
+        return CheckOutcome.passed(file=str(params["file"]))
+
+
+def _client_http_call(expr: ast.expr) -> tuple[str, str] | None:
+    """``(METHOD, path)`` when ``expr`` is a client-style HTTP call with a string-
+    literal path — ``client.post("/runs", ...)``, any receiver, ``await`` unwrapped —
+    else ``None``. Style-immune by construction: the receiver is whatever name the
+    suite uses (``harness_boundary`` guarantees it is the scaffold client)."""
+    if isinstance(expr, ast.Await):
+        expr = expr.value
+    if not (isinstance(expr, ast.Call) and isinstance(expr.func, ast.Attribute)):
+        return None
+    if expr.func.attr.lower() not in HTTP_METHODS or not expr.args:
+        return None
+    arg0 = expr.args[0]
+    if isinstance(arg0, ast.Constant) and isinstance(arg0.value, str):
+        return expr.func.attr.upper(), arg0.value
+    return None
+
+
+def _assert_status_triples(
+    node: ast.Assert, bindings: list[tuple[str, int, tuple[str, str]]]
+) -> list[tuple[str, str, int, int]]:
+    """``(METHOD, path, asserted_status, lineno)`` rows an assert deterministically
+    pins: ``assert <resp>.status_code == <int>`` (either operand order, ``Eq`` only),
+    where ``<resp>`` is a name bound from a client call earlier in the function or
+    the client call itself. Anything else is unextractable — out of scope (#629:
+    deterministic where assertions are extractable, never a guess)."""
+    test = node.test
+    if not (
+        isinstance(test, ast.Compare) and len(test.ops) == 1 and isinstance(test.ops[0], ast.Eq)
+    ):
+        return []
+    left, right = test.left, test.comparators[0]
+    if isinstance(right, ast.Constant) and isinstance(right.value, int):
+        attr, status = left, right.value
+    elif isinstance(left, ast.Constant) and isinstance(left.value, int):
+        attr, status = right, left.value
+    else:
+        return []
+    if not (isinstance(attr, ast.Attribute) and attr.attr == "status_code"):
+        return []
+    base = attr.value
+    call = _client_http_call(base)
+    if call is None and isinstance(base, ast.Name):
+        # latest binding of this name before the assert (source order, not walk order)
+        prior = [b for name, line, b in bindings if name == base.id and line < node.lineno]
+        call = prior[-1] if prior else None
+    if call is None:
+        return []
+    return [(call[0], call[1], status, node.lineno)]
+
+
+def _extract_status_assertions(tree: ast.AST) -> list[tuple[str, str, int, int]]:
+    """Every deterministically-extractable ``(METHOD, path, status, lineno)`` a
+    suite asserts, per function (response bindings do not leak across tests)."""
+    out: list[tuple[str, str, int, int]] = []
+    for func in (
+        n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef | ast.AsyncFunctionDef)
+    ):
+        bindings: list[tuple[str, int, tuple[str, str]]] = []
+        nodes = sorted(
+            (n for n in ast.walk(func) if isinstance(n, ast.Assign | ast.Assert)),
+            key=lambda n: n.lineno,
+        )
+        for node in nodes:
+            if isinstance(node, ast.Assign):
+                if len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+                    call = _client_http_call(node.value)
+                    if call is not None:
+                        bindings.append((node.targets[0].id, node.lineno, call))
+            else:
+                out.extend(_assert_status_triples(node, bindings))
+    return out
+
+
+def _prefixed_pinned_path(
+    method: str, path: str, pinned: dict[tuple[str, str], set[int]]
+) -> str | None:
+    """The pinned path ``path`` reaches through an undeclared prefix, or ``None``.
+
+    pf-54: three of five suite versions prefixed every call with ``/api`` — the
+    proxy-owned prefix that must not appear in backend paths — making the status
+    rule blind (no pinned match) while every call deterministically 404s against
+    the harness client. A request path that is NOT itself pinned but ends with a
+    pinned path at a segment boundary (``/api`` + ``/runs``) is that violation."""
+    for (m, p), _statuses in pinned.items():
+        if m == method and path != p and path.endswith(p):
+            return p
+    return None
+
+
+@register_check(CHECK_CONTRACT_ASSERTIONS)
+class ContractAssertionsMatchCheck(BaseCheck):
+    """Suite status assertions diffed against the contract's pinned statuses (#629, 1.5 A6/D2).
+
+    pf-54: the contract pinned ``POST /runs → 201``; all five authored suite versions
+    asserted 200-on-create, and five dev-chain repairs of a contract-correct app were
+    honestly rejected against a suite the contract says is wrong — the full correction
+    budget burned on an unwinnable objective. Layer 1 (#629's authoring injection)
+    states the pins to the author; this check is the guarantee.
+
+    A violation requires an exact pinned ``(METHOD, path)`` whose asserted status is
+    outside pinned ∪ allowed-error — asserting 422 after a blank-input POST is
+    contract-correct, never flagged — or a pinned path requested through an
+    undeclared prefix. Unextractable assertions and non-contract paths are out of
+    scope by design: a false positive in a BLOCKING check recreates the unwinnable
+    loop this kills.
+    """
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        try:
+            file_path = _safe_resolve(params["file"], workspace_root)
+        except _SafetyError as exc:
+            return CheckOutcome.error(reason=exc.reason)
+        if (skip := _unparseable_source_skip(file_path)) is not None:
+            return skip
+        if not file_path.is_file():
+            return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
+        try:
+            source = file_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return CheckOutcome.error(reason="file_unreadable")
+        try:
+            tree = ast.parse(source, filename=str(file_path))
+        except SyntaxError:
+            # The syntax gate owns unparseable emissions (#605 sibling semantics).
+            return CheckOutcome.skipped(reason="unsupported_stack_or_syntax")
+
+        pinned: dict[tuple[str, str], set[int]] = {}
+        for token in params.get("endpoints") or []:
+            parsed = parse_method_path_status(str(token))
+            if parsed is not None:
+                pinned.setdefault((parsed[0], parsed[1]), set()).add(parsed[2])
+        if not pinned:
+            # The injection only fires with pinned endpoints in hand — an empty
+            # or unparseable param set is an evaluator-contract bug (RC-9a).
+            return CheckOutcome.error(reason="invalid_endpoints_param")
+        allowed_errors = {
+            int(s) for s in params.get("allowed_error_statuses") or [] if str(s).isdigit()
+        }
+
+        violations: list[str] = []
+        for method, raw_path, status, lineno in _extract_status_assertions(tree):
+            path = normalize_route(raw_path)
+            statuses = pinned.get((method, path))
+            if statuses is not None:
+                if status not in statuses | allowed_errors:
+                    violations.append(
+                        f"line {lineno}: {method} {path} asserts {status}; "
+                        f"contract pins {sorted(statuses | allowed_errors)}"
+                    )
+            else:
+                hit = _prefixed_pinned_path(method, path, pinned)
+                if hit is not None:
+                    violations.append(
+                        f"line {lineno}: {method} {path} requests pinned path "
+                        f"{hit} through an undeclared prefix"
+                    )
+        if violations:
+            shown = violations[:5]
+            if len(violations) > len(shown):
+                shown.append(f"+{len(violations) - len(shown)} more")
+            return CheckOutcome.failed(
+                reason="; ".join(shown),
+                file=str(params["file"]),
+                violations=len(violations),
             )
         return CheckOutcome.passed(file=str(params["file"]))
 

--- a/src/squadops/cycles/failure_evidence.py
+++ b/src/squadops/cycles/failure_evidence.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from squadops.cycles.acceptance_check_spec import CHECK_CONTRACT_ASSERTIONS
 from squadops.cycles.emission_integrity import extraction_loss_suspected
 from squadops.cycles.verification_integrity import ResultStatus
 
@@ -219,15 +220,25 @@ def classify_failure_locus(failure_evidence: Any) -> str:
         return FailureLocus.OWN_ARTIFACT
 
     validation_result = failure_evidence.get("validation_result") or {}
-    checks = validation_result.get("checks") or []
+    checks = [row for row in validation_result.get("checks") or [] if isinstance(row, dict)]
+    # Own-artifact signals scan FIRST, regardless of row order (#629 D4): when the
+    # suite both contradicts the contract AND fails, repairing the app against a
+    # contract-contradicting suite is exactly the pf-54 budget burn — the
+    # tests_pass row must not route to the dev chain before these are consulted.
     for row in checks:
-        if not isinstance(row, dict):
-            continue
         check = row.get("check")
         if check == "expected_artifacts" and row.get("passed") is False:
             # The task's own named output files are missing from its emission.
             return FailureLocus.OWN_ARTIFACT
-        if check == "tests_pass" and row.get("passed") is False:
+        # #629: the frozen contract says the suite's own assertions are wrong
+        # (status pinned by a probe, asserted differently — or a pinned path
+        # requested through an undeclared prefix). Safe from the test-gaming
+        # guard: the signal comes from the contract, not from the app failing
+        # the suite — for qa.test, OWN_ARTIFACT = eve re-authors the suite.
+        if check == f"acceptance:{CHECK_CONTRACT_ASSERTIONS}" and row.get("passed") is False:
+            return FailureLocus.OWN_ARTIFACT
+    for row in checks:
+        if row.get("check") == "tests_pass" and row.get("passed") is False:
             locus = _locus_from_tests_pass_row(row)
             if locus is not None:
                 return locus

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -27,8 +27,10 @@ import yaml
 from squadops.cycles.acceptance_check_spec import (
     ALLOWED_SEVERITIES,
     CHECK_SPECS,
+    PLAN_PROSE_CONTRACT_DIVERGENCE,
     argv_matches_safelist,
     command_safelist_names,
+    normalize_route,
     reserved_keys_for,
 )
 
@@ -585,7 +587,9 @@ class ImplementationPlan:
 
         from squadops.cycles.task_plan import resolve_contract_refs
 
-        warnings: list[str] = []
+        # #629 (A6/D2): the ADVISORY status-code rule — its own identity so its
+        # evidence quality never launders into the blocking suite check.
+        warnings: list[str] = _prose_status_divergence_warnings(self.tasks, contract)
         for task in self.tasks:
             if not task.criteria_refs:
                 continue
@@ -936,6 +940,66 @@ class ImplementationPlan:
                 _serialize_acceptance_criterion(c) for c in task.acceptance_criteria
             ]
         return result
+
+
+_PROSE_METHOD_PATH_RE = r"\b(GET|POST|PUT|PATCH|DELETE)\s+(/\S+)"
+
+
+def _prose_status_divergence_warnings(
+    tasks: list[PlanTask], contract: VerificationContract
+) -> list[str]:
+    """#629 (1.5 A6/D2) — ``plan_prose_contract_divergence``: the ADVISORY half.
+
+    **Comparable prose** (A6's precondition for the rule existing at all, stated
+    here): a ``METHOD /path`` token followed on the same line — before any next
+    endpoint token — by an explicit 3-digit HTTP status. **The bound contract is
+    the authoritative artifact.** Prose short of that shape is not comparable
+    and is never flagged; the flag is a warning row on the existing
+    never-rejects channel (the reverted-#552 rule bars hard gates on prose).
+    Promotion to blocking requires a later registry change with proof of a
+    deterministic representation (the D2 ruling) — until then this identity's
+    lower evidence quality stays out of the blocking suite check.
+
+    Same {param}-name-insensitive path normalization as the pf-31 rules: pf-54's
+    plan prose said "returns 200" beside endpoints whose probes pinned 201.
+    """
+    import re as _re
+
+    pinned = contract.pinned_endpoint_statuses()
+    if not pinned:
+        return []
+    allowed = set(contract.allowed_error_statuses())
+    norm_pinned: dict[tuple[str, str], set[int]] = {}
+    for (method, path), statuses in pinned.items():
+        key = (method, _re.sub(r"\{\w+\}", "{}", path))
+        norm_pinned.setdefault(key, set()).update(statuses)
+
+    warnings: list[str] = []
+    for task in tasks:
+        prose = "\n".join([task.description, *[str(c) for c in task.acceptance_criteria]])
+        for line in prose.splitlines():
+            matches = list(_re.finditer(_PROSE_METHOD_PATH_RE, line))
+            for i, m in enumerate(matches):
+                method, raw_path = m.group(1).upper(), m.group(2).rstrip(".,;:)")
+                norm = _re.sub(r"\{\w+\}", "{}", normalize_route(raw_path))
+                statuses = norm_pinned.get((method, norm))
+                if not statuses:
+                    continue
+                # the status must belong to THIS token: same line, before the
+                # next endpoint token — a neighbour's status is not comparable
+                tail_end = matches[i + 1].start() if i + 1 < len(matches) else len(line)
+                status_match = _re.search(r"\b([1-5]\d{2})\b", line[m.end() : tail_end])
+                if status_match is None:
+                    continue
+                status = int(status_match.group(1))
+                if status not in statuses | allowed:
+                    warnings.append(
+                        f"{PLAN_PROSE_CONTRACT_DIVERGENCE}: Task {task.task_index} "
+                        f"({task.focus}): prose says {method} {raw_path} → {status} but "
+                        f"the contract pins {sorted(statuses | allowed)} — the contract "
+                        f"is authoritative (#629)"
+                    )
+    return warnings
 
 
 def resolve_contract_refs(

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -30,7 +30,7 @@ from squadops.capabilities.scaffold import (
     is_qa_test_path_for_stack,
     testid_surface_instructions,
 )
-from squadops.cycles.acceptance_check_spec import is_check_applicable
+from squadops.cycles.acceptance_check_spec import CHECK_CONTRACT_ASSERTIONS, is_check_applicable
 from squadops.cycles.agent_config import resolve_agent_config
 from squadops.cycles.failure_evidence import FailureLocus
 from squadops.cycles.implementation_plan import (
@@ -559,6 +559,42 @@ def _inject_contract_inputs(
             inputs["dom_testid_surface"] = testid_lines
 
 
+def _contract_assertion_criteria(
+    task_type: str, plan_task: Any, contract: VerificationContract | None
+) -> list[TypedCheck]:
+    """#629 (1.5 A6/D2): contract-owned ``contract_assertions_match`` checks for a bound
+    qa.test task — one per expected ``.py`` suite file in the stack's QA namespace, params
+    carrying the contract's pinned statuses as self-contained data (``METHOD /path STATUS``
+    tokens + the suite-wide allowed error statuses), so the evaluator needs no contract
+    access. pf-54: five authored suite versions asserted 200 where the probe pinned 201 —
+    the authoring injection (layer 1) states the pins; this check enforces them. Empty in
+    author mode, non-qa tasks, and probe-less contracts (byte-identical plans there)."""
+    if task_type != "qa.test" or contract is None:
+        return []
+    pinned = contract.pinned_endpoint_statuses()
+    if not pinned:
+        return []
+    endpoints = [
+        f"{method} {path} {status}"
+        for (method, path), statuses in sorted(pinned.items())
+        for status in statuses
+    ]
+    params: dict[str, Any] = {"endpoints": endpoints}
+    error_statuses = contract.allowed_error_statuses()
+    if error_statuses:
+        params["allowed_error_statuses"] = list(error_statuses)
+    stack = contract.skeleton.expander
+    return [
+        TypedCheck(
+            check=CHECK_CONTRACT_ASSERTIONS,
+            params={"file": art, **params},
+            id=f"contract-assertions:{art}",
+        )
+        for art in plan_task.expected_artifacts
+        if art.endswith(".py") and is_qa_test_path_for_stack(art, stack)
+    ]
+
+
 def _harness_boundary_criteria(
     task_type: str, plan_task: Any, contract: VerificationContract | None
 ) -> list[TypedCheck]:
@@ -769,6 +805,10 @@ def generate_task_plan(
                 acceptance.extend(resolve_contract_refs(plan_task.criteria_refs, contract))
             # SIP-0100 1.1: bind scaffold-owned harness_boundary checks onto bound qa.test slots.
             acceptance.extend(_harness_boundary_criteria(task_type, plan_task, contract))
+            # #629 (A6/D2): bind contract-owned assertion-vs-contract checks onto
+            # bound qa.test suite files — layer 1's authoring block is guidance,
+            # this is the guarantee.
+            acceptance.extend(_contract_assertion_criteria(task_type, plan_task, contract))
             inputs["acceptance_criteria"] = acceptance
 
         _inject_contract_inputs(inputs, contract, task_type, interface_manifest)

--- a/src/squadops/cycles/verification_contract.py
+++ b/src/squadops/cycles/verification_contract.py
@@ -560,6 +560,41 @@ class VerificationContract:
         lines.extend(str(exp) for exp in self.behavioral.suite.coverage_expectations)
         return lines
 
+    def pinned_endpoint_statuses(self) -> dict[tuple[str, str], tuple[int, ...]]:
+        """Per-endpoint pinned statuses from probes (#629): ``(METHOD, /path) →
+        sorted statuses``. A rejection-case probe unions into the same
+        endpoint's set — ``POST /runs`` pinned by a create probe (201) and a
+        blank-input probe (422) yields ``{201, 422}``, so a suite asserting
+        either is contract-correct. Three readers: the
+        ``contract_assertions_match`` injection params, the plan-prose status
+        lint, and tests — one derivation so they cannot drift."""
+        from squadops.cycles.acceptance_check_spec import normalize_route
+
+        pinned: dict[tuple[str, str], set[int]] = {}
+        for probe in self.behavioral.probes:
+            method = str(probe.request.get("method", "")).upper()
+            path = normalize_route(str(probe.request.get("path", "")))
+            status = probe.expect.get("status")
+            if not (method and path) or not isinstance(status, int):
+                continue
+            pinned.setdefault((method, path), set()).add(status)
+        return {key: tuple(sorted(statuses)) for key, statuses in pinned.items()}
+
+    def allowed_error_statuses(self) -> tuple[int, ...]:
+        """Suite-wide allowed error statuses (#629): every 4xx/5xx a probe pins
+        plus every 4xx/5xx named in ``coverage_expectations`` (the error-code→
+        status map is authored prose — statuses are extracted, codes ignored).
+        A suite asserting one of these anywhere is exercising a contract-known
+        error path, never a divergence."""
+        statuses: set[int] = set()
+        for probe in self.behavioral.probes:
+            status = probe.expect.get("status")
+            if isinstance(status, int) and status >= 400:
+                statuses.add(status)
+        for exp in self.behavioral.suite.coverage_expectations:
+            statuses.update(int(m) for m in re.findall(r"\b([45]\d{2})\b", str(exp)))
+        return tuple(sorted(statuses))
+
     # --- linting ---------------------------------------------------------- #
 
     def lint(self) -> list[str]:

--- a/tests/unit/cycles/test_contract_assertion_enforcement.py
+++ b/tests/unit/cycles/test_contract_assertion_enforcement.py
@@ -1,0 +1,323 @@
+"""#629 (1.5 A6/D2) — contract-assertion enforcement: the blocking, deterministic half.
+
+pf-54 is the exhibit these tests pin: the contract pinned ``POST /runs → 201``
+(create probe) and 422 (blank-input probe); all five authored suite versions
+asserted 200-on-create — five dev-chain repairs of a contract-correct app were
+honestly rejected against a suite the contract says is wrong. The design bound
+is zero false positives: a rejection-case assertion is contract-correct, and
+anything unextractable or off-contract is out of scope, never a guess.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.acceptance_check_spec import (
+    CHECK_CONTRACT_ASSERTIONS,
+    parse_method_path_status,
+)
+from squadops.cycles.acceptance_checks import get_check
+from squadops.cycles.failure_evidence import FailureLocus, classify_failure_locus
+from squadops.cycles.implementation_plan import PlanTask
+from squadops.cycles.task_plan import _contract_assertion_criteria
+from squadops.cycles.verification_contract import VerificationContract
+
+pytestmark = [pytest.mark.domain_contracts]
+
+
+class TestPinnedStatusGrammar:
+    @pytest.mark.parametrize(
+        ("token", "expected"),
+        [
+            ("POST /runs 201", ("POST", "/runs", 201)),
+            ("get /runs/ 200", ("GET", "/runs", 200)),  # normalized, not dropped
+            ("POST /runs", None),  # two fields is the OTHER grammar
+            ("TELEPORT /runs 200", None),
+            ("POST /runs 99", None),  # not an HTTP status
+            ("POST /runs abc", None),
+            ("", None),
+        ],
+    )
+    def test_parse(self, token, expected):
+        # malformed tokens must be inert, not fatal — same tolerance rule as
+        # parse_method_path (a bad entry disables itself, not the check)
+        assert parse_method_path_status(token) == expected
+
+
+_PARAMS = {
+    "file": "backend/tests/test_runs.py",
+    "endpoints": ["POST /runs 201", "POST /runs 422", "GET /runs 200"],
+    "allowed_error_statuses": [404, 409, 422],
+}
+
+
+async def _evaluate(tmp_path, source: str, params: dict | None = None):
+    suite = tmp_path / "backend" / "tests"
+    suite.mkdir(parents=True)
+    (suite / "test_runs.py").write_text(source)
+    return await get_check(CHECK_CONTRACT_ASSERTIONS).evaluate(
+        dict(params or _PARAMS), tmp_path, stack="fastapi"
+    )
+
+
+class TestEvaluator:
+    async def test_pf54_exhibit_wrong_create_status_fails(self, tmp_path):
+        # the canonical true positive: 200 asserted where the probe pins 201
+        outcome = await _evaluate(
+            tmp_path,
+            "def test_create_run(client):\n"
+            '    resp = client.post("/runs", json={"title": "x"})\n'
+            "    assert resp.status_code == 200\n",
+        )
+        assert outcome.status == "failed"
+        assert "POST /runs asserts 200" in outcome.reason
+        assert "201" in outcome.reason
+
+    async def test_rejection_assertion_is_contract_correct(self, tmp_path):
+        # 422 on blank input is PINNED (rejection probe) — flagging it would
+        # recreate the unwinnable loop; the per-endpoint union prevents that
+        outcome = await _evaluate(
+            tmp_path,
+            "def test_blank_input(client):\n"
+            '    resp = client.post("/runs", json={})\n'
+            "    assert resp.status_code == 422\n",
+        )
+        assert outcome.status == "passed"
+
+    async def test_allowed_error_status_anywhere_is_silent(self, tmp_path):
+        # 404 comes from the suite-wide error map, not this endpoint's probes
+        outcome = await _evaluate(
+            tmp_path,
+            "def test_missing(client):\n"
+            '    resp = client.get("/runs")\n'
+            "    assert resp.status_code == 404\n",
+        )
+        assert outcome.status == "passed"
+
+    async def test_api_prefixed_pinned_path_fails(self, tmp_path):
+        # pf-54: 3 of 5 versions prefixed every call with /api — no pinned
+        # match, so the status rule alone is blind while every call 404s
+        outcome = await _evaluate(
+            tmp_path,
+            "def test_create_run(client):\n"
+            '    resp = client.post("/api/runs", json={"title": "x"})\n'
+            "    assert resp.status_code == 201\n",
+        )
+        assert outcome.status == "failed"
+        assert "undeclared prefix" in outcome.reason
+
+    async def test_direct_call_and_reversed_operands_extract(self, tmp_path):
+        outcome = await _evaluate(
+            tmp_path,
+            'def test_list(client):\n    assert 500 == client.get("/runs").status_code\n',
+        )
+        assert outcome.status == "failed"
+        assert "GET /runs asserts 500" in outcome.reason
+
+    async def test_await_form_extracts(self, tmp_path):
+        outcome = await _evaluate(
+            tmp_path,
+            "async def test_create(client):\n"
+            '    resp = await client.post("/runs")\n'
+            "    assert resp.status_code == 200\n",
+        )
+        assert outcome.status == "failed"
+
+    async def test_rebinding_uses_the_latest_call(self, tmp_path):
+        # resp is rebound between asserts — each assert reads its own binding
+        outcome = await _evaluate(
+            tmp_path,
+            "def test_flow(client):\n"
+            '    resp = client.post("/runs", json={})\n'
+            "    assert resp.status_code == 201\n"
+            '    resp = client.get("/runs")\n'
+            "    assert resp.status_code == 500\n",
+        )
+        assert outcome.status == "failed"
+        assert "GET /runs asserts 500" in outcome.reason
+        assert "POST" not in outcome.reason
+
+    async def test_non_contract_paths_and_unextractable_are_out_of_scope(self, tmp_path):
+        # off-contract endpoint, variable status, membership test: none is a
+        # deterministic contradiction — never a guess (the zero-false-positive bound)
+        outcome = await _evaluate(
+            tmp_path,
+            "def test_misc(client):\n"
+            '    assert client.get("/health").status_code == 200\n'
+            "    expected = 200\n"
+            '    resp = client.post("/runs", json={})\n'
+            "    assert resp.status_code == expected\n"
+            "    assert resp.status_code in (201, 422)\n",
+        )
+        assert outcome.status == "passed"
+
+    async def test_syntax_error_skips(self, tmp_path):
+        # the syntax gate owns unparseable emissions (#605 sibling semantics)
+        outcome = await _evaluate(tmp_path, "def broken(:\n")
+        assert outcome.status == "skipped"
+        assert outcome.reason == "unsupported_stack_or_syntax"
+
+    async def test_empty_endpoints_param_is_an_evaluator_error(self, tmp_path):
+        # injection only fires with pins in hand — an empty set is a contract
+        # bug between injector and evaluator (RC-9a), not a pass and not a skip
+        outcome = await _evaluate(
+            tmp_path,
+            "def test_x(client):\n    assert client.get('/runs').status_code == 200\n",
+            params={"file": "backend/tests/test_runs.py", "endpoints": ["garbage"]},
+        )
+        assert outcome.status == "error"
+        assert outcome.reason == "invalid_endpoints_param"
+
+
+def _bound_contract(probes: list[dict] | None = None, coverage: list[str] | None = None):
+    return VerificationContract.from_dict(
+        {
+            "contract_version": 1,
+            "skeleton": {
+                "expander": "fullstack_fastapi_react",
+                "interface_manifest_hash": "a" * 64,
+            },
+            "capabilities": ["python"],
+            "frozen": [{"path": "backend/errors.py", "sha256": "b" * 64}],
+            "fill_files": {
+                "backend/routes.py": {
+                    "interface": [
+                        {
+                            "check": "endpoint_defined",
+                            "id": "vc-routes-endpoints",
+                            "methods_paths": ["POST /runs", "GET /runs"],
+                        }
+                    ],
+                    "implementation": [],
+                }
+            },
+            "behavioral": {
+                "probes": (
+                    probes
+                    if probes is not None
+                    else [
+                        {
+                            "id": "p-create",
+                            "subject": "backend",
+                            "request": {"method": "POST", "path": "/runs"},
+                            "expect": {"status": 201},
+                        },
+                        {
+                            "id": "p-blank",
+                            "subject": "backend",
+                            "request": {"method": "POST", "path": "/runs"},
+                            "expect": {"status": 422, "error_code": "validation_error"},
+                        },
+                        {
+                            "id": "p-missing",
+                            "subject": "backend",
+                            "request": {"method": "GET", "path": "/runs/missing"},
+                            "expect": {"status": 404},
+                        },
+                    ]
+                ),
+                "suite": {
+                    "checks": [],
+                    "coverage_expectations": (
+                        coverage if coverage is not None else ["duplicate_participant → 409"]
+                    ),
+                },
+            },
+        }
+    )
+
+
+def _qa_task(artifacts: list[str]) -> PlanTask:
+    return PlanTask(
+        task_index=2,
+        task_type="qa.test",
+        role="qa",
+        focus="behavioral suite",
+        description="author the suite",
+        expected_artifacts=artifacts,
+    )
+
+
+class TestDerivation:
+    def test_pinned_statuses_union_per_endpoint(self):
+        # create (201) + blank-input rejection (422) probes pin the SAME
+        # endpoint: both statuses are contract-correct for POST /runs
+        pinned = _bound_contract().pinned_endpoint_statuses()
+        assert pinned[("POST", "/runs")] == (201, 422)
+        assert pinned[("GET", "/runs/missing")] == (404,)
+
+    def test_allowed_error_statuses_from_probes_and_coverage(self):
+        # 4xx probe statuses + statuses named in coverage_expectations prose
+        assert _bound_contract().allowed_error_statuses() == (404, 409, 422)
+
+    def test_probeless_contract_derives_nothing(self):
+        contract = _bound_contract(probes=[], coverage=[])
+        assert contract.pinned_endpoint_statuses() == {}
+        assert contract.allowed_error_statuses() == ()
+
+
+class TestInjection:
+    def test_bound_qa_task_gets_one_row_per_suite_file(self):
+        rows = _contract_assertion_criteria(
+            "qa.test",
+            _qa_task(["backend/tests/test_runs.py", "backend/tests/test_events.py", "notes.md"]),
+            _bound_contract(),
+        )
+        assert [r.params["file"] for r in rows] == [
+            "backend/tests/test_runs.py",
+            "backend/tests/test_events.py",
+        ]
+        for row in rows:
+            assert row.check == CHECK_CONTRACT_ASSERTIONS
+            assert row.id == f"contract-assertions:{row.params['file']}"
+            assert "POST /runs 201" in row.params["endpoints"]
+            assert "POST /runs 422" in row.params["endpoints"]
+            assert row.params["allowed_error_statuses"] == [404, 409, 422]
+
+    def test_author_mode_non_qa_and_probeless_inject_nothing(self):
+        task = _qa_task(["backend/tests/test_runs.py"])
+        assert _contract_assertion_criteria("qa.test", task, None) == []
+        assert _contract_assertion_criteria("development.develop", task, _bound_contract()) == []
+        assert _contract_assertion_criteria("qa.test", task, _bound_contract(probes=[])) == []
+
+
+class TestLocusRouting:
+    def test_failed_contract_row_routes_own_artifact(self):
+        # the frozen contract says the suite is wrong — eve re-authors the
+        # suite; the app is never the repair target for this signal
+        evidence = {
+            "validation_result": {
+                "passed": False,
+                "checks": [{"check": f"acceptance:{CHECK_CONTRACT_ASSERTIONS}", "passed": False}],
+            }
+        }
+        assert classify_failure_locus(evidence) == FailureLocus.OWN_ARTIFACT
+
+    def test_precedence_over_tests_pass_regardless_of_row_order(self):
+        # when the suite both contradicts the contract AND fails, repairing the
+        # app against a contract-contradicting suite is the pf-54 budget burn —
+        # the earlier tests_pass row must not win by position
+        evidence = {
+            "validation_result": {
+                "passed": False,
+                "checks": [
+                    {
+                        "check": "tests_pass",
+                        "passed": False,
+                        "executed": True,
+                        "suite_broken": False,  # would route SUBJECT on its own
+                    },
+                    {"check": f"acceptance:{CHECK_CONTRACT_ASSERTIONS}", "passed": False},
+                ],
+            }
+        }
+        assert classify_failure_locus(evidence) == FailureLocus.OWN_ARTIFACT
+
+    def test_passing_contract_row_is_no_signal(self):
+        evidence = {
+            "validation_result": {
+                "passed": False,
+                "checks": [{"check": f"acceptance:{CHECK_CONTRACT_ASSERTIONS}", "passed": True}],
+            }
+        }
+        assert classify_failure_locus(evidence) == FailureLocus.UNKNOWN

--- a/tests/unit/cycles/test_contract_expectations.py
+++ b/tests/unit/cycles/test_contract_expectations.py
@@ -246,3 +246,77 @@ class TestProseContractConflictLint:
             summary=PlanSummary(total_dev_tasks=1, total_qa_tasks=0, total_tasks=1),
         )
         assert plan.lint_prose_contract_conflicts(_contract()) == []
+
+
+def _contract_with_probes() -> VerificationContract:
+    """The _contract() shape plus pinned behavior: POST /runs → 201 (create) and
+    422 (blank-input rejection), plus a 409 in coverage_expectations."""
+    from dataclasses import replace
+
+    from squadops.cycles.verification_contract import Behavioral, Probe, Suite
+
+    return replace(
+        _contract(),
+        behavioral=Behavioral(
+            probes=(
+                Probe(
+                    id="p-create",
+                    subject="backend",
+                    request={"method": "POST", "path": "/runs"},
+                    expect={"status": 201},
+                ),
+                Probe(
+                    id="p-blank",
+                    subject="backend",
+                    request={"method": "POST", "path": "/runs"},
+                    expect={"status": 422, "error_code": "validation_error"},
+                ),
+            ),
+            suite=Suite(coverage_expectations=("duplicate_participant → 409",)),
+        ),
+    )
+
+
+class TestProseStatusDivergence:
+    """#629 (1.5 A6/D2) — plan_prose_contract_divergence, the ADVISORY half.
+
+    Comparable prose = a METHOD /path token followed on the same line (before
+    any next endpoint token) by an explicit 3-digit status; the contract is
+    authoritative. The identity stays separate from the blocking suite check
+    so its lower evidence quality never launders into it.
+    """
+
+    def test_divergent_status_warns_under_its_own_identity(self):
+        # the pf-54 prose shape: "returns 200" beside an endpoint pinned 201
+        plan = _plan("Implement POST /runs — returns 200 with the created run.", [])
+        warnings = plan.lint_prose_contract_conflicts(_contract_with_probes())
+        assert any(
+            "plan_prose_contract_divergence" in w and "200" in w and "201" in w for w in warnings
+        )
+
+    @pytest.mark.parametrize(
+        "prose",
+        [
+            "Implement POST /runs → 201 with the created run.",  # pinned
+            "POST /runs returns 422 on blank input.",  # rejection pin
+            "POST /runs yields 409 for duplicates.",  # coverage_expectations
+            "Implement POST /runs to create a run.",  # no status — not comparable
+            "GET /unpinned → 200 somewhere else.",  # endpoint not pinned
+        ],
+    )
+    def test_contract_correct_or_incomparable_prose_is_silent(self, prose):
+        plan = _plan(prose, [])
+        warnings = plan.lint_prose_contract_conflicts(_contract_with_probes())
+        assert not any("plan_prose_contract_divergence" in w for w in warnings)
+
+    def test_neighbouring_endpoint_status_is_not_comparable(self):
+        # the status after the NEXT endpoint token belongs to that token — a
+        # missing status must not borrow the neighbour's and false-flag
+        plan = _plan("Wire POST /runs and GET /health → 200 for monitoring.", [])
+        warnings = plan.lint_prose_contract_conflicts(_contract_with_probes())
+        assert not any("plan_prose_contract_divergence" in w for w in warnings)
+
+    def test_probeless_contract_is_silent(self):
+        plan = _plan("Implement POST /runs — returns 200.", [])
+        warnings = plan.lint_prose_contract_conflicts(_contract())
+        assert not any("plan_prose_contract_divergence" in w for w in warnings)


### PR DESCRIPTION
Closes #629 — the enforcement half (layer 2), executing the ratified D2 ruling (governance design, PR #729) and plan A6: **two identities, split by determinism**. Design decision table posted to #629 before code. Layer 1 (authoring injection) had already shipped; this is the backstop for when statement is not enough — pf-54's suite asserted 200-on-create against a pinned 201 **five times**, and five dev-chain repairs of a contract-correct app burned the full correction budget against a suite the contract says is wrong.

## The blocking half — `contract_assertions_match`

- **Injection** (`task_plan.py`, beside `_harness_boundary_criteria` — the exact precedent): bind-mode qa.test tasks get one row per expected `.py` suite file in the stack's QA namespace, `id=contract-assertions:<file>`. Params are self-contained (`METHOD /path STATUS` tokens + suite-wide allowed error statuses), so the evaluator needs no contract access. Author mode / non-qa / probe-less contracts inject nothing — byte-identical plans there.
- **Derivation** (`VerificationContract`, beside `behavior_expectation_lines()`): `pinned_endpoint_statuses()` — a rejection-case probe unions into the same endpoint's set (`POST /runs → {201, 422}`), so asserting 422 after a blank-input POST is contract-correct, never flagged; `allowed_error_statuses()` — every 4xx/5xx a probe pins plus statuses named in `coverage_expectations`. One derivation, three readers.
- **Evaluator** (`acceptance_checks.py`): AST-extracts `(method, path, asserted_status)` triples — assigned-response and direct-call forms, `await` unwrapped, either operand order, `Eq` only, latest binding before the assert by source position. A violation requires an exact pinned `(METHOD, path)` asserted outside pinned ∪ allowed-error, **or the prefix rule**: a non-pinned request path that reaches a pinned path through an undeclared prefix (`/api/runs` vs pinned `/runs` — 3 of pf-54's 5 versions, invisible to the status rule alone while every call 404s against the harness client). Unextractable assertions and off-contract paths are out of scope by design — **zero false positives is the bound**, because a false positive in a blocking check recreates the unwinnable loop this kills. Syntax errors skip (`unsupported_stack_or_syntax`, #605 sibling semantics); the #605 registry-wide skip property covers the new check automatically.
- **Repair routing** (`failure_evidence.py`): a failed row → `FailureLocus.OWN_ARTIFACT` (eve re-authors the suite), with **precedence over the `tests_pass` scan regardless of row order** — when the suite both contradicts the contract and fails, the app must not be the repair target. Safe from the test-gaming guard: the signal comes from the frozen contract, not from the app failing the suite.

## The advisory half — `plan_prose_contract_divergence`

The status-code rule the pf-31 prose lint never had (#590, folded into this issue): **comparable prose** = a `METHOD /path` token followed on the same line — before any next endpoint token — by an explicit 3-digit status; **the contract is authoritative**. Warning rows only on the existing never-rejects channel (the reverted-#552 rule bars hard gates on prose), carrying their own identity so their evidence quality never launders into the blocking check. Promotion to blocking requires a later registry change with proof of deterministic representation, per the ruling.

## Scope notes

- #730 (CheckSpec governance-attribute extension) is untouched: both identities land against today's registry-of-record; `failure_ownership=suite` and the advisory marking ride #730's backfill.
- `plan_prose_contract_divergence` is deliberately NOT a `CHECK_SPECS` entry — that would make it plan-authorable.

## Verification

Evidence-matrix row A6 ("deterministic-side exhibit; prose side ships advisory"): the pf-54 exhibit as tests — wrong create status fails naming the exact row; the rejection assertion passes; the `/api`-prefixed variant fails via the prefix rule; direct-call/reversed/await/rebinding forms extract; off-contract and unextractable assertions never flag; locus routes at the suite with precedence; the prose side proves warning-not-rejection with contract-correct and incomparable prose silent. Full regression: **6395 passed, 1 skipped**. Live proof rides the Gate-2 exit confirmation shakedown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
