### PR TITLE
fix(observability): #506 in-flight task runs visible — transport owns the task-run lifecycle

### DIFF
--- a/adapters/cycles/task_dispatcher.py
+++ b/adapters/cycles/task_dispatcher.py
@@ -107,8 +107,24 @@ class TaskDispatcher:
         task_run_id = await self._workflow_tracker.create_task_run(
             flow_run_id, envelope.task_id, task_name
         )
-        await self._workflow_tracker.set_task_run_state(task_run_id, "RUNNING", "Running")
+        await self._set_task_run_state(task_run_id, "RUNNING", "Running")
         return task_run_id
+
+    async def _set_task_run_state(
+        self, task_run_id: str | None, state_type: str, state_name: str
+    ) -> None:
+        """Best-effort task-run state transition; a tracker failure never touches dispatch."""
+        if self._workflow_tracker is None or not task_run_id:
+            return
+        try:
+            await self._workflow_tracker.set_task_run_state(task_run_id, state_type, state_name)
+        except Exception:
+            logger.warning(
+                "best-effort set_task_run_state(%s, %s) failed",
+                task_run_id,
+                state_type,
+                exc_info=True,
+            )
 
     async def _task_heartbeat(
         self,
@@ -168,6 +184,12 @@ class TaskDispatcher:
         :class:`WorkflowTrackerPort` is wired, one is created here — supports
         correction/repair paths that don't pre-create the workflow run.
 
+        #506: the task-run lifecycle is transport-owned end to end — every
+        dispatch (re-)enters ``RUNNING`` (a retry re-attempt arrives with a
+        prior attempt's already-terminal id), and the terminal state is set
+        from the result here, never left to an event bridge that may not know
+        the id. All best-effort; tracker failures never touch dispatch.
+
         Enters a ``CorrelationContext`` scope with flow/task run IDs so the
         ``PrefectLogHandler`` scopes handler logs to the right Prefect task
         pane, and spawns a periodic heartbeat coroutine so long-running LLM
@@ -183,6 +205,13 @@ class TaskDispatcher:
 
         if task_run_id is None:
             task_run_id = await self.create_task_run_if_enabled(flow_run_id, envelope)
+        else:
+            # #506: a SUPPLIED id may be a prior attempt's task run, already
+            # terminal (dispatch_with_retry re-dispatches with the same id) —
+            # re-enter RUNNING so the in-flight attempt is visible. For a
+            # freshly-created id this is an idempotent duplicate. Prefect's own
+            # retry model: one task run, state history carries the attempts.
+            await self._set_task_run_state(task_run_id, "RUNNING", "Running")
 
         # SIP-0087 B1: propagate run IDs to the agent over the wire so the
         # agent's PrefectLogHandler can scope handler logs to the right task
@@ -215,9 +244,18 @@ class TaskDispatcher:
                 # Reply wait raised (rare — _publish_and_await usually returns a
                 # FAILED TaskResult): record the task activity as failed.
                 await self._finish_task_activity(activity_id, None)
+                # #506: terminal task-run state is transport-owned (SIP-0097:
+                # per-task observability starts AND finishes here), so every
+                # dispatch path — including retry re-attempts and internally-
+                # created ids — leaves the row consistent with reality.
+                await self._set_task_run_state(task_run_id, "FAILED", "Failed")
                 raise
             else:
                 await self._finish_task_activity(activity_id, result)
+                if result is not None and result.status == "SUCCEEDED":
+                    await self._set_task_run_state(task_run_id, "COMPLETED", "Completed")
+                else:
+                    await self._set_task_run_state(task_run_id, "FAILED", "Failed")
                 return result
             finally:
                 heartbeat.cancel()

--- a/src/squadops/events/bridges/workflow_tracker.py
+++ b/src/squadops/events/bridges/workflow_tracker.py
@@ -1,12 +1,12 @@
 """WorkflowTrackerBridge — translates CycleEvent to WorkflowTrackerPort state transitions.
 
-Maps run lifecycle events to flow-run state changes. As of SIP-0087,
-task-run lifecycle (creation + state transitions) lives in
-``TaskDispatcher.dispatch_task`` where the ``task_run_id`` is
-available for correlation-context scoping and the long-task heartbeat.
-The bridge still forwards terminal task-state transitions when a
-``task_run_id`` is carried in the event context, but it no longer creates
-task runs itself.
+Maps run lifecycle events to flow-run state changes. The ENTIRE task-run
+lifecycle (creation, per-attempt ``RUNNING``, terminal state) lives in
+``TaskDispatcher.dispatch_task`` (#506, completing the SIP-0097 rule that
+per-task observability starts and finishes in the transport) — the bridge
+acting on terminal task events was a second writer of the same state, and
+its event-context ``task_run_id`` was blank on exactly the paths that
+needed it (retry re-attempts, internally-created ids).
 
 The class name is retained for parity with :class:`LangFuseBridge`, but the
 bridge depends on the vendor-neutral :class:`WorkflowTrackerPort` and works
@@ -37,21 +37,12 @@ _RUN_STATE_MAP: dict[str, tuple[str, str]] = {
     EventType.RUN_RESUMED: ("RUNNING", "Running"),
 }
 
-# Task events → Prefect task run state (state_type, state_name)
-_TASK_STATE_MAP: dict[str, tuple[str, str]] = {
-    EventType.TASK_SUCCEEDED: ("COMPLETED", "Completed"),
-    EventType.TASK_FAILED: ("FAILED", "Failed"),
-}
-
 
 class WorkflowTrackerBridge:
     """Subscriber that forwards CycleEvents to a :class:`WorkflowTrackerPort`.
 
-    Handles run-level state transitions and terminal task-state transitions
-    (when the emitter supplies ``task_run_id`` in the event context).
-    Task-run creation + ``RUNNING`` transitions are driven by
-    ``dispatch_task`` so the ``task_run_id`` is known before the handler
-    starts emitting logs.
+    Handles run-level (flow-run) state transitions only. Task-run lifecycle
+    is transport-owned in ``TaskDispatcher.dispatch_task`` (#506).
     """
 
     def __init__(self, workflow_tracker: WorkflowTrackerPort) -> None:
@@ -63,16 +54,6 @@ class WorkflowTrackerBridge:
         if event.event_type in _RUN_STATE_MAP and flow_run_id:
             state_type, state_name = _RUN_STATE_MAP[event.event_type]
             self._schedule(self._tracker.set_flow_run_state(flow_run_id, state_type, state_name))
-            return
-
-        if event.event_type in _TASK_STATE_MAP:
-            task_run_id = event.context.get("task_run_id", "")
-            if task_run_id:
-                state_type, state_name = _TASK_STATE_MAP[event.event_type]
-                self._schedule(
-                    self._tracker.set_task_run_state(task_run_id, state_type, state_name)
-                )
-            return
 
     @staticmethod
     def _schedule(coro) -> None:  # noqa: ANN001

--- a/tests/unit/cycles/test_dispatched_flow_executor_observability.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor_observability.py
@@ -312,20 +312,23 @@ class TestPrefectTaskRuns:
         ):
             await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
 
-        # 5 sequential tasks → 5 create_task_run + 5 set_task_run_state(RUNNING)
+        # 5 sequential tasks → 5 create_task_run; RUNNING is set at creation
+        # AND re-entered per dispatch attempt (#506 — a retry re-attempt
+        # arrives with a prior attempt's already-terminal id, so the transport
+        # always re-enters RUNNING before publish).
         assert mock_prefect.create_task_run.await_count == 5
         running_calls = [
             c for c in mock_prefect.set_task_run_state.await_args_list if c.args[1] == "RUNNING"
         ]
-        assert len(running_calls) == 5
-        # Terminal task states come through PrefectBridge events, not direct
-        # executor calls — the executor only emits RUNNING directly.
+        assert len(running_calls) == 10
+        # #506: terminal task states are transport-owned (dispatch_task sets
+        # them from the result) — the bridge no longer writes task-run state.
         terminal_calls = [
             c
             for c in mock_prefect.set_task_run_state.await_args_list
             if c.args[1] in ("COMPLETED", "FAILED")
         ]
-        assert terminal_calls == []
+        assert len(terminal_calls) == 5
 
     async def test_emits_task_dispatched_events(self, executor, mock_queue, mock_prefect):
         """Executor emits TASK_DISPATCHED for each of the 5 sequential tasks."""

--- a/tests/unit/cycles/test_task_dispatcher.py
+++ b/tests/unit/cycles/test_task_dispatcher.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -222,7 +222,12 @@ class TestDispatchTaskPrefectLifecycle:
         mock_reporter.create_task_run.assert_awaited_once_with(
             "fr_abc", "task_abc", "neo: development.design"
         )
-        mock_reporter.set_task_run_state.assert_awaited_once_with("tr_new", "RUNNING", "Running")
+        # #506: transport-owned lifecycle — RUNNING at creation, terminal from
+        # the result (the bridge no longer writes task-run state).
+        assert mock_reporter.set_task_run_state.await_args_list == [
+            call("tr_new", "RUNNING", "Running"),
+            call("tr_new", "COMPLETED", "Completed"),
+        ]
 
     async def test_no_prefect_calls_when_reporter_missing(self, mock_queue, envelope):
         self._wire_success_reply(mock_queue, envelope.task_id)
@@ -256,7 +261,10 @@ class TestDispatchTaskPrefectLifecycle:
     ):
         # Sequential path pre-creates the task_run (so TASK_DISPATCHED can
         # emit it) and passes task_run_id in. _dispatch_task must not create
-        # a second one.
+        # a second one — but it DOES re-enter RUNNING (#506): the supplied id
+        # may be a prior attempt's already-terminal task run, and the retry
+        # re-attempt was invisible in flight for exactly that reason (the
+        # July-19 develop task heartbeating with no live row).
         self._wire_success_reply(mock_queue, envelope.task_id)
         dispatcher = self._build_dispatcher(mock_queue, mock_reporter)
 
@@ -269,7 +277,45 @@ class TestDispatchTaskPrefectLifecycle:
             )
 
         mock_reporter.create_task_run.assert_not_awaited()
-        mock_reporter.set_task_run_state.assert_not_awaited()
+        assert mock_reporter.set_task_run_state.await_args_list == [
+            call("tr_preallocated", "RUNNING", "Running"),
+            call("tr_preallocated", "COMPLETED", "Completed"),
+        ]
+
+    async def test_failed_result_sets_terminal_failed(self, mock_queue, mock_reporter, envelope):
+        # a FAILED reply must leave the row FAILED — before #506 nothing
+        # transitioned an internally-created task run, so it hung RUNNING
+        mock_queue.reply_router.results[envelope.task_id] = TaskResult(
+            task_id=envelope.task_id, status="FAILED", outputs={}, error="boom"
+        )
+        dispatcher = self._build_dispatcher(mock_queue, mock_reporter)
+
+        with patch(
+            "adapters.cycles.task_dispatcher.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await dispatcher.dispatch_task(envelope, "run_001", flow_run_id="fr_abc")
+
+        assert mock_reporter.set_task_run_state.await_args_list == [
+            call("tr_new", "RUNNING", "Running"),
+            call("tr_new", "FAILED", "Failed"),
+        ]
+
+    async def test_tracker_failure_never_breaks_dispatch(self, mock_queue, mock_reporter, envelope):
+        # best-effort contract: a tracker transport error is logged, never raised
+        mock_reporter.set_task_run_state = AsyncMock(side_effect=RuntimeError("prefect down"))
+        self._wire_success_reply(mock_queue, envelope.task_id)
+        dispatcher = self._build_dispatcher(mock_queue, mock_reporter)
+
+        with patch(
+            "adapters.cycles.task_dispatcher.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            result = await dispatcher.dispatch_task(
+                envelope, "run_001", flow_run_id="fr_abc", task_run_id="tr_x"
+            )
+
+        assert result.status == "SUCCEEDED"
 
     async def test_published_envelope_carries_run_ids(self, mock_queue, mock_reporter, envelope):
         """SIP-0087 B1: dispatched envelope on the wire carries flow_run_id /

--- a/tests/unit/events/bridges/test_workflow_tracker_bridge.py
+++ b/tests/unit/events/bridges/test_workflow_tracker_bridge.py
@@ -1,10 +1,9 @@
 """Tests for WorkflowTrackerBridge subscriber.
 
-As of SIP-0087 the bridge handles only flow-level state transitions and
-terminal task-state transitions — task-run creation + RUNNING is done in
-``TaskDispatcher.dispatch_task``. The bridge therefore expects
-``task_run_id`` to be carried in the event context for TASK_SUCCEEDED /
-TASK_FAILED events.
+As of #506 the bridge handles flow-level state transitions ONLY — the full
+task-run lifecycle (creation, per-attempt RUNNING, terminal state) is
+transport-owned in ``TaskDispatcher.dispatch_task``, so any task event is
+a no-op here.
 """
 
 from datetime import UTC, datetime
@@ -86,9 +85,14 @@ class TestWorkflowTrackerBridgeRunStates:
 
 @pytest.mark.domain_events
 class TestWorkflowTrackerBridgeTaskStates:
-    def test_task_succeeded_sets_completed_using_context_task_run_id(self, bridge, mock_reporter):
+    @pytest.mark.parametrize("event_type", [EventType.TASK_SUCCEEDED, EventType.TASK_FAILED])
+    def test_terminal_task_events_are_noop(self, bridge, mock_reporter, event_type):
+        # #506: the FULL task-run lifecycle is transport-owned in
+        # TaskDispatcher.dispatch_task. A bridge transition here would be a
+        # second writer of the same state — and its context task_run_id was
+        # blank on exactly the paths that needed it (retry re-attempts).
         event = _make_event(
-            event_type=EventType.TASK_SUCCEEDED,
+            event_type=event_type,
             entity_type="task",
             entity_id="task_a",
             context={
@@ -96,34 +100,6 @@ class TestWorkflowTrackerBridgeTaskStates:
                 "run_id": "run_1",
                 "task_run_id": "tr_from_executor",
             },
-        )
-        bridge.on_event(event)
-        mock_reporter.set_task_run_state.assert_called_once_with(
-            "tr_from_executor", "COMPLETED", "Completed"
-        )
-
-    def test_task_failed_sets_failed_using_context_task_run_id(self, bridge, mock_reporter):
-        event = _make_event(
-            event_type=EventType.TASK_FAILED,
-            entity_type="task",
-            entity_id="task_a",
-            context={
-                "cycle_id": "cyc_1",
-                "run_id": "run_1",
-                "task_run_id": "tr_failed",
-            },
-        )
-        bridge.on_event(event)
-        mock_reporter.set_task_run_state.assert_called_once_with("tr_failed", "FAILED", "Failed")
-
-    def test_task_succeeded_without_task_run_id_is_noop(self, bridge, mock_reporter):
-        # Executor didn't create a Prefect task_run (no flow_run_id) — bridge
-        # must not try to transition a missing ID.
-        event = _make_event(
-            event_type=EventType.TASK_SUCCEEDED,
-            entity_type="task",
-            entity_id="task_a",
-            context={"cycle_id": "cyc_1", "run_id": "run_1"},
         )
         bridge.on_event(event)
         mock_reporter.set_task_run_state.assert_not_called()

--- a/tests/unit/events/test_bridge_parity.py
+++ b/tests/unit/events/test_bridge_parity.py
@@ -188,8 +188,13 @@ class TestPrefectParity:
         reporter.create_task_run.assert_not_called()
         reporter.set_task_run_state.assert_not_called()
 
-    def test_task_success_sets_completed_when_task_run_id_in_context(self):
-        """Bridge forwards COMPLETED when executor supplies task_run_id."""
+    def test_terminal_task_events_never_touch_task_run_state(self):
+        """#506: task-run state has exactly ONE writer — TaskDispatcher.dispatch_task.
+
+        Bug caught: someone reintroduces a bridge task-state transition, giving
+        the same row two writers whose ordering with the transport's terminal
+        set is a race (and whose context task_run_id is blank on retry paths).
+        """
         reporter = MagicMock()
         reporter.set_task_run_state = AsyncMock()
         bridge = WorkflowTrackerBridge(reporter)
@@ -201,31 +206,7 @@ class TestPrefectParity:
             "task_run_id": "tr_99",
         }
         bridge.on_event(_event(EventType.TASK_SUCCEEDED, "task", "t_1", context=ctx))
-        reporter.set_task_run_state.assert_called_with("tr_99", "COMPLETED", "Completed")
-
-    def test_task_failure_sets_failed_when_task_run_id_in_context(self):
-        """Bridge forwards FAILED when executor supplies task_run_id."""
-        reporter = MagicMock()
-        reporter.set_task_run_state = AsyncMock()
-        bridge = WorkflowTrackerBridge(reporter)
-
-        ctx = {
-            "cycle_id": "cyc_1",
-            "run_id": "run_1",
-            "flow_run_id": "fr_1",
-            "task_run_id": "tr_99",
-        }
         bridge.on_event(_event(EventType.TASK_FAILED, "task", "t_1", context=ctx))
-        reporter.set_task_run_state.assert_called_with("tr_99", "FAILED", "Failed")
-
-    def test_terminal_event_without_task_run_id_is_dropped(self):
-        """Without task_run_id in context, bridge has nothing to address."""
-        reporter = MagicMock()
-        reporter.set_task_run_state = AsyncMock()
-        bridge = WorkflowTrackerBridge(reporter)
-
-        ctx = {"cycle_id": "cyc_1", "run_id": "run_1", "flow_run_id": "fr_1"}
-        bridge.on_event(_event(EventType.TASK_SUCCEEDED, "task", "t_1", context=ctx))
         reporter.set_task_run_state.assert_not_called()
 
 


### PR DESCRIPTION
Closes #506. Design decision table posted to the issue before code, including a root-cause correction established against the **live Prefect store** rather than the issue's framing.

## The actual mechanism (premise delta)

The issue says "task runs materialize only at completion — create at dispatch"; the disposition guessed the fix "touches the workflow-tracker port and its adapter." Neither held: dispatch-time creation has existed since SIP-0087 (April, deployed during the July-19 observation), and **the port and adapter need no changes**.

Reading the July-19 timeline off the live server's `task_runs/filter` nailed it: `develop[2/7]` failed at 02:12:22 and its task run went terminal FAILED. `dispatch_with_retry`'s `while True` loop then re-dispatched attempts 2 and 3 with the **same task_run_id** — and `dispatch_task` only set RUNNING on ids it created itself, so the already-terminal row never re-entered RUNNING and no new row appeared. The 02:28→02:45 develop task the operator watched heartbeat "with no row" was attempt 3; `_dispatch_protocol_step` steps in the same window (validate_repair, round-2 analyze/decision/repair) all had correct dispatch-time rows. The "retroactive" appearance was the old row's state flipping when the invisible attempt ended. A second, latent hole: an id created *inside* `dispatch_task` never escaped, so `dispatch_with_retry`'s terminal events carried `task_run_id=""`.

## The fix — transport owns the lifecycle end to end

- **`dispatch_task` (re-)enters RUNNING on every dispatch**, including a supplied id — a retry re-attempt arrives with a prior attempt's terminal id and is now visible in flight. Prefect's own retry model: one task run, state history carries the attempts (no row proliferation; SIP-0087 logs/heartbeats keep one pane per task).
- **`dispatch_task` sets the terminal state from the result** (COMPLETED iff SUCCEEDED; FAILED otherwise, including the raise path), placed exactly beside `_start_task_activity`/`_finish_task_activity` — completing SIP-0097's stated rule that per-task observability starts *and finishes* in the transport, and closing the internal-id hole without any port change. Best-effort throughout: a tracker failure logs and never touches dispatch.
- **`WorkflowTrackerBridge` drops its task-state map** — with the transport owning terminal states it was a second writer of the same state (whose context id was blank on exactly the paths that needed it). Flow-run lifecycle stays bridge-owned; the `TASK_*` events keep flowing for other consumers.

Every dispatch seam (sequential, fan-out, correction, pulse-repair) flows through `dispatch_task`, so the consolidation covers all paths at once — the July asymmetry was per-path only because the retry loop was the one seam that skipped the transport's create step.

## Verification

Dispatcher unit tests: supplied id → RUNNING before publish + terminal from result (the invisible-attempt regression test); FAILED reply → terminal FAILED; internally-created id transitions terminally; tracker failure never breaks dispatch; tracker/flow_run_id absent → zero calls. Bridge + parity tests now pin the single-writer rule (a reintroduced bridge transition fails the suite). Executor observability test updated to the new contract (5 creates, 10 RUNNING, 5 terminal). Full regression: **6394 passed, 1 skipped**.

**Live proof rides the Gate-2 exit shakedown**: mid-cycle `POST /api/task_runs/filter` must show the in-flight task RUNNING — the exact query used in this diagnosis, now the reproducible check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
