### PR TITLE
refactor(prompts): #452 build-profile narratives externalized byte-identically

### DIFF
--- a/src/squadops/capabilities/handlers/build_profiles.py
+++ b/src/squadops/capabilities/handlers/build_profiles.py
@@ -11,11 +11,37 @@ narrative `system_prompt_template` cannot drift away from what the validator
 will accept. Adding a file to `required_files` automatically adds it to the
 prompt; the file list cannot be edited in the prompt without also editing
 the validator's `required_files`.
+
+#452: the narrative TEXT lives in ``src/squadops/prompts/profile_narratives/``
+(one ``.md`` per profile, loaded once at import) — prompt prose is reviewable
+and editable as prose under the prompts seam, never a Python literal (#448).
+The profile dimension stays deliberate contract data rather than a fragment
+layer; extending the fragment model with a non-role dimension is the deferred
+SIP-sized question. Byte-equivalence with the pre-move literals is pinned by
+test (the #452 hard acceptance gate).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
+
+import squadops.prompts as _prompts_pkg
+
+_NARRATIVES_DIR = Path(_prompts_pkg.__file__).parent / "profile_narratives"
+
+
+def _narrative(profile_name: str) -> str:
+    """Load a profile's system-prompt narrative from its packaged ``.md`` file.
+
+    Files are stored with one trailing newline (editor/git hygiene); exactly
+    one is stripped so a future editor auto-adding the final newline cannot
+    change rendered prompt bytes. A missing file raises at module import —
+    loud and immediate, never a silently-empty narrative in a prompt.
+    """
+    text = (_NARRATIVES_DIR / f"{profile_name}.md").read_text(encoding="utf-8")
+    return text[:-1] if text.endswith("\n") else text
+
 
 # ---------------------------------------------------------------------------
 # QA handoff section name constants (D12 — single source of truth)
@@ -176,15 +202,7 @@ class BuildProfile:
 BUILD_PROFILES: dict[str, BuildProfile] = {
     "python_cli_builder": BuildProfile(
         name="python_cli_builder",
-        system_prompt_template=(
-            "You are a Python application assembler. You receive source code "
-            "that a developer has already written and your job is to package "
-            "it into a deployable artifact.\n\n"
-            "DO NOT rewrite or regenerate the source code — it is already done. "
-            "Your outputs are deployment artifacts only: container packaging, "
-            "an entrypoint that wires to the developer's existing main module, "
-            "and a consolidated dependency manifest derived from the source imports."
-        ),
+        system_prompt_template=_narrative("python_cli_builder"),
         required_files=("Dockerfile", "__main__.py", "requirements.txt", "qa_handoff.md"),
         optional_files=(),
         validation_rules=(
@@ -196,12 +214,7 @@ BUILD_PROFILES: dict[str, BuildProfile] = {
     ),
     "static_web_builder": BuildProfile(
         name="static_web_builder",
-        system_prompt_template=(
-            "You are a static web application builder. Generate a complete, "
-            "browser-openable web application from the implementation plan.\n\n"
-            "All assets must use relative paths (no CDN dependencies). The "
-            "result must open by double-clicking the HTML entry point."
-        ),
+        system_prompt_template=_narrative("static_web_builder"),
         required_files=("index.html", "styles.css", "main.js", "qa_handoff.md"),
         optional_files=("favicon.ico", "manifest.json"),
         validation_rules=(
@@ -213,12 +226,7 @@ BUILD_PROFILES: dict[str, BuildProfile] = {
     ),
     "web_app_builder": BuildProfile(
         name="web_app_builder",
-        system_prompt_template=(
-            "You are a web application builder. Generate a complete, "
-            "runnable Python web application from the implementation plan.\n\n"
-            "Use a lightweight framework (Flask preferred). The application "
-            "must start with a single command."
-        ),
+        system_prompt_template=_narrative("web_app_builder"),
         required_files=("app.py", "index.html", "requirements.txt", "qa_handoff.md"),
         optional_files=("static/styles.css", "static/main.js", "templates/"),
         validation_rules=(
@@ -230,20 +238,7 @@ BUILD_PROFILES: dict[str, BuildProfile] = {
     ),
     "fullstack_fastapi_react": BuildProfile(
         name="fullstack_fastapi_react",
-        system_prompt_template=(
-            "You are assembling a fullstack web application with a FastAPI "
-            "backend and a React (Vite) frontend.\n\n"
-            "The source code from the development step is provided as context. "
-            "Do not regenerate application code — focus on packaging, "
-            "configuration, and operational readiness. The container build "
-            "must be multi-stage: a Python base for the backend, a Node build "
-            "stage for the frontend static assets, and a final stage that "
-            "serves both. Keep the app portable: pass the frontend API base as a "
-            "build arg/env (`VITE_API_BASE`) and the backend CORS origins as a "
-            "runtime env (`CORS_ORIGINS`), document both in `.env.example`, and "
-            "never hardcode `localhost` URLs into the image. The QA handoff "
-            "document must include CORS configuration notes for the backend."
-        ),
+        system_prompt_template=_narrative("fullstack_fastapi_react"),
         required_files=("Dockerfile", "qa_handoff.md"),
         optional_files=("docker-compose.yaml", "start.sh", ".env.example", "nginx.conf"),
         validation_rules=(

--- a/src/squadops/prompts/profile_narratives/fullstack_fastapi_react.md
+++ b/src/squadops/prompts/profile_narratives/fullstack_fastapi_react.md
@@ -1,0 +1,3 @@
+You are assembling a fullstack web application with a FastAPI backend and a React (Vite) frontend.
+
+The source code from the development step is provided as context. Do not regenerate application code — focus on packaging, configuration, and operational readiness. The container build must be multi-stage: a Python base for the backend, a Node build stage for the frontend static assets, and a final stage that serves both. Keep the app portable: pass the frontend API base as a build arg/env (`VITE_API_BASE`) and the backend CORS origins as a runtime env (`CORS_ORIGINS`), document both in `.env.example`, and never hardcode `localhost` URLs into the image. The QA handoff document must include CORS configuration notes for the backend.

--- a/src/squadops/prompts/profile_narratives/python_cli_builder.md
+++ b/src/squadops/prompts/profile_narratives/python_cli_builder.md
@@ -1,0 +1,3 @@
+You are a Python application assembler. You receive source code that a developer has already written and your job is to package it into a deployable artifact.
+
+DO NOT rewrite or regenerate the source code — it is already done. Your outputs are deployment artifacts only: container packaging, an entrypoint that wires to the developer's existing main module, and a consolidated dependency manifest derived from the source imports.

--- a/src/squadops/prompts/profile_narratives/static_web_builder.md
+++ b/src/squadops/prompts/profile_narratives/static_web_builder.md
@@ -1,0 +1,3 @@
+You are a static web application builder. Generate a complete, browser-openable web application from the implementation plan.
+
+All assets must use relative paths (no CDN dependencies). The result must open by double-clicking the HTML entry point.

--- a/src/squadops/prompts/profile_narratives/web_app_builder.md
+++ b/src/squadops/prompts/profile_narratives/web_app_builder.md
@@ -1,0 +1,3 @@
+You are a web application builder. Generate a complete, runnable Python web application from the implementation plan.
+
+Use a lightweight framework (Flask preferred). The application must start with a single command.

--- a/tests/unit/capabilities/test_profile_narratives.py
+++ b/tests/unit/capabilities/test_profile_narratives.py
@@ -1,0 +1,86 @@
+"""#452 hard acceptance gate — profile narratives externalized BYTE-IDENTICALLY.
+
+The pinned hashes below were computed on main (2026-08-06) from the inline
+``system_prompt_template`` literals BEFORE the move to
+``src/squadops/prompts/profile_narratives/``. Per the 1.5 plan's rule for
+#452, this refactor is only safe byte-identical: any drift between the
+externalized files and these hashes is a behavioral change to agent prompts
+dressed as a refactor, and this test is what makes that visible.
+
+If a narrative is ever changed DELIBERATELY, update its hashes here in the
+same PR — the diff then honestly shows "prompt content changed", which is
+the entire point.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from squadops.capabilities.handlers.build_profiles import (
+    BUILD_PROFILES,
+    _narrative,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+# sha256 of each pre-move inline literal (narrative alone).
+_PINNED_NARRATIVE = {
+    "python_cli_builder": "2d7b8b77bcf66751d99eec4baeed9ac044007b4b07dcc7d9fa36b294bee2ad2e",
+    "static_web_builder": "c6582150bb6af350f93ac00e7e8ad028bad8d5935e3ce56f0cc999d84ff652eb",
+    "web_app_builder": "3e11df5924d41749d00fb6b8a22e281eb4e775af206d560a70d144e6a0ec21fe",
+    "fullstack_fastapi_react": "2250e64354f268bdc605e05137a3d61bd7de7e9116c5c1b648a5f8a6444b4639",
+}
+
+# sha256 of each pre-move COMPOSED full_system_prompt — the seam the builder
+# handler actually consumes (narrative + required/optional/qa_handoff blocks),
+# so composition changes cannot hide behind a stable narrative.
+_PINNED_COMPOSED = {
+    "python_cli_builder": "321140533889cb25f8ce0817de680ffce5c2f38412c7464f28c5162ffd0b6cc6",
+    "static_web_builder": "10d0efbc5c8c158529b37e5d1da66a49e9fe3a55de9ed75109f471ed55ec3a1f",
+    "web_app_builder": "b242252619ccc82c6fc081b6d657a41903174274ca387e576e9171cb878a6e1b",
+    "fullstack_fastapi_react": "748c4e740fafe63f39cc94eec91d1e842050dcf5d1e070919e6f0680402b1957",
+}
+
+
+def _sha(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+@pytest.mark.parametrize("profile_name", sorted(BUILD_PROFILES))
+def test_narrative_bytes_match_pre_move_literal(profile_name):
+    assert (
+        _sha(BUILD_PROFILES[profile_name].system_prompt_template)
+        == (_PINNED_NARRATIVE[profile_name])
+    ), f"{profile_name} narrative drifted from the pre-#452 inline literal"
+
+
+@pytest.mark.parametrize("profile_name", sorted(BUILD_PROFILES))
+def test_composed_system_prompt_bytes_unchanged(profile_name):
+    assert (
+        _sha(BUILD_PROFILES[profile_name].full_system_prompt) == (_PINNED_COMPOSED[profile_name])
+    ), f"{profile_name} composed system prompt drifted from the pre-#452 bytes"
+
+
+def test_every_profile_is_pinned():
+    # a new profile must join the byte-equivalence regime, not slip past it
+    assert set(BUILD_PROFILES) == set(_PINNED_NARRATIVE) == set(_PINNED_COMPOSED)
+
+
+def test_loader_strips_exactly_one_trailing_newline(tmp_path, monkeypatch):
+    # D3: files are stored with one trailing newline; an editor auto-adding
+    # it must not change rendered prompt bytes — and real trailing content
+    # (a second newline) is preserved, never blanket-stripped
+    import squadops.capabilities.handlers.build_profiles as bp
+
+    monkeypatch.setattr(bp, "_NARRATIVES_DIR", tmp_path)
+    (tmp_path / "one.md").write_text("narrative text\n")
+    (tmp_path / "two.md").write_text("narrative text\n\n")
+    assert bp._narrative("one") == "narrative text"
+    assert bp._narrative("two") == "narrative text\n"
+
+
+def test_missing_narrative_raises_loudly():
+    with pytest.raises(FileNotFoundError):
+        _narrative("no_such_profile")


### PR DESCRIPTION
Closes #452. Design decision table posted to the issue before code — including a **scope reconciliation you should review** (D1), since it reclassifies two of the disposition's six counted blocks.

## What moved (the live-path payload)

The four `system_prompt_template` literals in `build_profiles.py` — composed into the builder system prompt on **every** builder task via `system_prompt_for_files` — now live as `src/squadops/prompts/profile_narratives/<profile>.md`, loaded once at import. Prompt prose is reviewable and editable as prose under the prompts seam (#448's rule in substance); `BuildProfile` stays a frozen dataclass and the builder handler is untouched. The profile dimension stays deliberate contract data (the issue's own "keep — and say so" arm); extending the fragment model with a non-role dimension remains the deferred SIP-sized question. The files ride into agent images via the existing `COPY src/` path, same as fragments and request templates.

## The hard acceptance gate (plan §F: byte-identical or it didn't happen)

`test_profile_narratives.py` pins the **pre-move sha256 of every narrative AND every composed `full_system_prompt`** (captured from main before the move). Any byte drift fails the suite — a deliberate prompt change must update the pins in the same PR, so it reads as a prompt change, never a refactor. Also pinned: every profile must be in the byte-equivalence regime (a new profile can't slip past it); the loader strips exactly one trailing newline (files stored newline-terminated, so editor hygiene can't move prompt bytes); a missing narrative file raises at import — loud, never a silently-empty prompt.

## Premise delta for your review (documented on the issue)

The disposition counted six blocks. Two — `cycle/builder.py` (1) and `impl/repair_handlers.py` (1) — turn out to sit on the **renderer-absent fallback branch** (SIP-0084 dual-path): their live paths already render the governed assets `request.builder_assemble.build_assemble` and `request.cycle_repair_task`, and the inline text renders only when renderer construction failed in the agent entrypoint (degraded mode). That is the exact class the disposition itself excluded ("fallback-path text for when no renderer is injected, not managed-asset candidates") — the two excluded `"Please provide your {role}..."` lines, just longer. Fallback text for asset-system absence cannot itself live in the asset system, so these stay inline, deliberately. **With that, live-path inline prompt prose in handler source is zero.**

Residue, named: `_plan_authoring_service` typed-acceptance doctrine and capability-dimensioned `test_prompt_supplement`s were outside the disposition's six-block count and stay put; the fragment-dimension design is the deferred SIP-sized item.

## Verification

Byte-equivalence suite (10 tests) + existing build-profile and builder-assemble suites green; full regression: **6405 passed, 1 skipped**. No live render path changed by construction, so no shakedown scenario is added for this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
