### PR TITLE
fix(config): #724 resolved_config sweep — effective-config reads through the #426 single merge

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -1030,7 +1030,7 @@ class CorrectionRunner:
         resolution = resolve_correction_path(
             decision_outputs.get("correction_path", "abort"),
             failure_evidence,
-            cycle.applied_defaults,
+            cycle.resolved_config(),
             # pf-45: the rewind anchor keys on the analyzer's classification — a
             # work_product rewind dies as a run failure with the repair budget unspent,
             # so the guard substitutes the patch the classification says is possible.

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -358,8 +358,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 recruited_agent_ids = admission.recruited_agent_ids
 
             # Build-only validation (D6): require plan_artifact_refs
-            include_plan = bool(cycle.applied_defaults.get("plan_tasks", True))
-            include_build = bool(cycle.applied_defaults.get("build_tasks"))
+            include_plan = bool(cycle.resolved_config().get("plan_tasks", True))
+            include_build = bool(cycle.resolved_config().get("build_tasks"))
             seed_artifact_refs: list[str] = []
             if include_build and not include_plan:
                 # Legacy build-only run: plan_artifact_refs are mandatory
@@ -546,7 +546,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         workload gates are interpreted here, not in the polling helper.
         """
         cycle = await self._cycle_registry.get_cycle(cycle_id)
-        workload_sequence = cycle.applied_defaults.get("workload_sequence", [])
+        workload_sequence = cycle.resolved_config().get("workload_sequence", [])
 
         # Single-workload fast path (D7)
         if len(workload_sequence) <= 1:
@@ -576,7 +576,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # re-roll path `continue`s without the tail `i += 1`. Zero re-rolls
         # (default) is byte-identical to the old `for` loop.
         framing_rerolls = 0
-        max_framing_rerolls = cycle.applied_defaults.get("framing_max_rerolls", 0)
+        max_framing_rerolls = cycle.resolved_config().get("framing_max_rerolls", 0)
         i = start_index
         while i < len(workload_sequence):
             workload_entry = workload_sequence[i]
@@ -1250,7 +1250,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         task_attempt_counts: dict[str, int] = {}
 
         # SIP-0079: Time budget enforcement (RC-8)
-        time_budget = cycle.applied_defaults.get("time_budget_seconds")
+        time_budget = cycle.resolved_config().get("time_budget_seconds")
         run_start_time = time.monotonic()
 
         # #511: the budget gates EVERY dispatch lane. The main task loop checks
@@ -1586,7 +1586,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         from squadops.cycles.implementation_plan import ImplementationPlan
 
         # Only load the plan when implementation_plan is enabled in resolved config
-        if not cycle.applied_defaults.get("implementation_plan", False):
+        if not cycle.resolved_config().get("implementation_plan", False):
             return None
 
         # Search forwarded planning artifacts for the plan
@@ -2126,7 +2126,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # D5 fallback table: classify unclassified failures
         if outcome is None:
             task_attempt_counts[envelope.task_id] = task_attempt_counts.get(envelope.task_id, 0) + 1
-            max_retries = cycle.applied_defaults.get("max_task_retries", 2)
+            max_retries = cycle.resolved_config().get("max_task_retries", 2)
             if task_attempt_counts[envelope.task_id] >= max_retries:
                 outcome = TaskOutcome.SEMANTIC_FAILURE
             else:
@@ -2166,7 +2166,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             )
 
         # Trigger correction protocol
-        max_corrections = cycle.applied_defaults.get("max_correction_attempts", 2)
+        max_corrections = cycle.resolved_config().get("max_correction_attempts", 2)
 
         if correction_counter["n"] >= max_corrections:
             raise _ExecutionError(f"Max correction attempts ({max_corrections}) exhausted")
@@ -2518,7 +2518,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         if unauthorized == 0:
             return
         compliance_counter["n"] += unauthorized
-        bound = cycle.applied_defaults.get("contract_compliance_attempts", 3)
+        bound = cycle.resolved_config().get("contract_compliance_attempts", 3)
         if compliance_counter["n"] > bound:
             raise _ExecutionError(
                 f"Contract-compliance budget ({bound}) exceeded: {compliance_counter['n']} "
@@ -2921,7 +2921,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         plans defer to that same net — this check only ever adds an earlier
         rejection, never a pass.
         """
-        if not cycle.applied_defaults.get("implementation_plan", False):
+        if not cycle.resolved_config().get("implementation_plan", False):
             return []
 
         from squadops.cycles.implementation_plan import ImplementationPlan
@@ -3179,7 +3179,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         An absent or unreadable plan defers to the dispatch-time net —
         this check only ever *adds* an earlier rejection, never a pass.
         """
-        if not cycle.applied_defaults.get("implementation_plan", False):
+        if not cycle.resolved_config().get("implementation_plan", False):
             return
 
         from squadops.cycles.implementation_plan import ImplementationPlan

--- a/adapters/cycles/pulse_boundary_runner.py
+++ b/adapters/cycles/pulse_boundary_runner.py
@@ -99,8 +99,8 @@ class PulseBoundaryRunner:
         Returns a dict with keys: milestone_bindings, cadence_suites,
         has_pulse_checks, cadence, engine.
         """
-        raw_pulse_checks = cycle.applied_defaults.get("pulse_checks", [])
-        raw_cadence = cycle.applied_defaults.get("cadence_policy", {})
+        raw_pulse_checks = cycle.resolved_config().get("pulse_checks", [])
+        raw_cadence = cycle.resolved_config().get("cadence_policy", {})
 
         pulse_checks = parse_pulse_checks(raw_pulse_checks) if raw_pulse_checks else ()
         cadence = (
@@ -199,7 +199,7 @@ class PulseBoundaryRunner:
             run_id=run_id,
         )
 
-        max_repair_attempts = cycle.applied_defaults.get(
+        max_repair_attempts = cycle.resolved_config().get(
             "max_repair_attempts",
             2,
         )

--- a/adapters/cycles/run_completion.py
+++ b/adapters/cycles/run_completion.py
@@ -301,11 +301,13 @@ class RunCompletion:
     ) -> RunVerificationSummary:
         """Run the SIP-0096 aggregation over the ledger against the cycle's required set.
 
-        Requiredness comes only from the cycle's ``applied_defaults['required_checks']``
-        (an explicit profile declaration, §6.3 / AC#5) — never inferred. Both the
-        results and the required list default to empty, so a pre-SIP-0096 cycle or
-        a Phase-1 (throttle-off) cycle that *completes* aggregates to an honest
-        `accepted`.
+        Requiredness comes only from the cycle's explicit ``required_checks``
+        declaration, read through the #426 single merge (``resolved_config()``,
+        #724) — never inferred (§6.3 / AC#5). An ``execution_overrides``
+        declaration is an explicit, recorded create-time operator decision and
+        wins over the profile default. Both the results and the required list
+        default to empty, so a pre-SIP-0096 cycle or a Phase-1 (throttle-off)
+        cycle that *completes* aggregates to an honest `accepted`.
 
         ``terminal_status`` supplies the run-level context the pure verdict cannot
         see: only a ``COMPLETED`` run is eligible for `accepted` (#388). A run that
@@ -316,7 +318,7 @@ class RunCompletion:
         """
         required_check_ids: tuple[str, ...] = ()
         if cycle is not None:
-            declared = cycle.applied_defaults.get("required_checks")
+            declared = cycle.resolved_config().get("required_checks")
             if declared:
                 required_check_ids = tuple(declared)
         results = ledger.check_results if ledger else ()

--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -30,6 +30,7 @@ from squadops.cycles.models import (
     RunStatus,
     SquadProfile,
     TaskFlowPolicy,
+    resolve_config,
 )
 from squadops.cycles.preflight import (
     Finding,
@@ -109,23 +110,26 @@ async def _sandbox_preflight_decision() -> PreflightDecision:
     )
 
 
-async def _run_create_preflight(
-    profile: SquadProfile, applied_defaults: dict
-) -> tuple[Finding, ...]:
+async def _run_create_preflight(profile: SquadProfile, config: dict) -> tuple[Finding, ...]:
     """SIP-0095 create-time preflight: fail fast BEFORE persist/dispatch.
 
     Blocks (HTTP 422) when the squad can't satisfy the requested workloads' required
     roles or names a model definitively not pulled; an unreachable backend warns and
     allows. Returns the non-blocking warnings so the route can surface them on the
     response (Phase 4); raises on a blocking finding.
+
+    ``config`` is the EFFECTIVE config (the #426 single merge, #724): dispatch
+    honors ``execution_overrides``, so preflight must validate the same merged
+    view — evaluating ``applied_defaults`` alone would approve a shape dispatch
+    never runs (or reject one it would).
     """
     decision = combine(
-        required_roles_decision(profile, applied_defaults),
+        required_roles_decision(profile, config),
         model_availability_decision(profile, await _pulled_model_names()),
         # SIP-0096 §6.5: a required check whose tooling is knowably absent is a
         # create-time reject, never a mid-run blocked_unverified surprise.
         required_check_tooling_decision(
-            applied_defaults.get("required_checks") or (),
+            config.get("required_checks") or (),
             resolve_provisioned_tooling(),
         ),
         # SIP-0102 102.2c: a skewed/unprovisioned sandbox environment is a
@@ -184,8 +188,9 @@ async def _validate_replay_declaration(
         )
 
     # Target resolved config mirrors Cycle.resolved_config() for the cycle
-    # about to be built (#426 seam — never applied_defaults alone).
-    target_resolved = {**applied_defaults, **(body.execution_overrides or {})}
+    # about to be built (#426 seam — never applied_defaults alone). #724: the
+    # hoisted single merge definition, not an inline duplicate of it.
+    target_resolved = resolve_config(applied_defaults, body.execution_overrides or {})
     source_resolved = source_cycle.resolved_config()
     errors = check_replay_compatibility(
         {
@@ -244,9 +249,12 @@ async def create_cycle(
 
         # SIP-0065 D2: use client-supplied applied_defaults (CRP defaults from CLI)
         applied_defaults = body.applied_defaults
+        # #724: the effective config the runtime will read (#426 single merge) —
+        # preflight and position-0 workload resolution must see what dispatch sees.
+        effective_config = resolve_config(applied_defaults, body.execution_overrides or {})
 
         # SIP-0095: create-time preflight — fail fast (422) before persist/dispatch.
-        preflight_warnings = await _run_create_preflight(profile, applied_defaults)
+        preflight_warnings = await _run_create_preflight(profile, effective_config)
 
         # SIP-0101 Slice 3: replay declaration validated + interim compatibility
         # gate, same fail-fast point (moves into the SIP-0095 preflight in Slice 4).
@@ -272,8 +280,9 @@ async def create_cycle(
             notes=body.notes,
         )
 
-        # Resolve workload_type from workload_sequence (fixes #26)
-        ws = applied_defaults.get("workload_sequence", [])
+        # Resolve workload_type from workload_sequence (fixes #26; #724: the
+        # effective sequence, so an overridden sequence types run 1 correctly)
+        ws = effective_config.get("workload_sequence", [])
         workload_type = ws[0]["type"] if ws else None
 
         run = Run(

--- a/src/squadops/api/routes/cycles/mapping.py
+++ b/src/squadops/api/routes/cycles/mapping.py
@@ -177,7 +177,7 @@ def _cycle_outcome_to_dto(outcome: CycleOutcome) -> CycleOutcomeDTO:
 def cycle_to_response(
     cycle: Cycle, runs: list[Run], cycle_outcome: CycleOutcome | None = None
 ) -> CycleResponse:
-    ws = cycle.applied_defaults.get("workload_sequence", [])
+    ws = cycle.resolved_config().get("workload_sequence", [])
     progress = compute_workload_progress(ws, runs)
     workload_statuses = [e.status for e in progress] if progress else None
     status = resolve_cycle_status(

--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -54,7 +54,7 @@ def _resolve_retry_workload_type(cycle: Cycle, existing_runs: list[Run]) -> str 
     To re-attempt a failed workload at the same position, cancel the failed
     run first (or pass ``workload_type`` explicitly).
     """
-    workload_sequence = cycle.applied_defaults.get("workload_sequence", [])
+    workload_sequence = cycle.resolved_config().get("workload_sequence", [])
     if not workload_sequence:
         return None
     non_cancelled = [r for r in existing_runs if r.status != RunStatus.CANCELLED.value]
@@ -331,7 +331,7 @@ async def resume_run(
         # 4. Parent cycle must not be terminal
         cycle = await registry.get_cycle(cycle_id)  # validates cycle exists
         runs = await registry.list_runs(cycle_id)
-        ws = cycle.applied_defaults.get("workload_sequence", [])
+        ws = cycle.resolved_config().get("workload_sequence", [])
         progress = compute_workload_progress(ws, runs)
         workload_statuses = [e.status for e in progress] if progress else None
         cycle_status = resolve_cycle_status(runs, False, workload_statuses=workload_statuses)

--- a/src/squadops/cycles/correction_policy.py
+++ b/src/squadops/cycles/correction_policy.py
@@ -84,7 +84,7 @@ def _executed_failed_required(
 def resolve_correction_path(
     decision_path: str,
     failure_evidence: dict[str, Any],
-    applied_defaults: dict[str, Any],
+    resolved_config: dict[str, Any],
     *,
     classification: str = "",
 ) -> CorrectionPathResolution:
@@ -94,7 +94,8 @@ def resolve_correction_path(
         decision_path: ``correction_path`` from the governance decision handler.
         failure_evidence: the payload handed to ``data.analyze_failure``
             (``build_failure_evidence`` shape).
-        applied_defaults: the cycle's resolved defaults (``required_checks``).
+        resolved_config: the cycle's effective config via the #426 single
+            merge (``Cycle.resolved_config()``, #724) — ``required_checks``.
         classification: the analyzer's failure classification. Only consulted for
             the rewind anchor; "" (older callers, missing analysis) never fires it.
 
@@ -113,7 +114,7 @@ def resolve_correction_path(
             )
         return CorrectionPathResolution(path=decision_path)
 
-    required = frozenset(applied_defaults.get("required_checks") or [])
+    required = frozenset(resolved_config.get("required_checks") or [])
     if not required:
         return CorrectionPathResolution(path=decision_path)
 

--- a/src/squadops/cycles/models.py
+++ b/src/squadops/cycles/models.py
@@ -233,6 +233,17 @@ def validate_workload_type(value: str | None) -> str | None:
     return trimmed
 
 
+def resolve_config(applied_defaults: dict, execution_overrides: dict) -> dict:
+    """The #426 single merge definition: overrides win over defaults.
+
+    Module-level so pre-persist surfaces (the create route's preflight, which
+    runs before a ``Cycle`` exists) evaluate the SAME effective config the
+    runtime reads via ``Cycle.resolved_config()`` (#724 — two readers keying
+    off different sources of truth is exactly the class this kills).
+    """
+    return {**applied_defaults, **execution_overrides}
+
+
 # =============================================================================
 # Frozen dataclasses — SIP-0064 §8
 # =============================================================================
@@ -362,7 +373,7 @@ class Cycle:
         "what is configured?" from the same dict, or they drift into offering
         work one of them will refuse.
         """
-        return {**self.applied_defaults, **self.execution_overrides}
+        return resolve_config(self.applied_defaults, self.execution_overrides)
 
 
 @dataclass(frozen=True)

--- a/src/squadops/cycles/preflight.py
+++ b/src/squadops/cycles/preflight.py
@@ -78,22 +78,23 @@ def combine(*decisions: PreflightDecision) -> PreflightDecision:
     )
 
 
-def required_roles_decision(
-    profile: SquadProfile, applied_defaults: Mapping[str, Any]
-) -> PreflightDecision:
+def required_roles_decision(profile: SquadProfile, config: Mapping[str, Any]) -> PreflightDecision:
     """Block when the squad can't satisfy the roles the requested workloads statically require.
 
-    Reads the same inputs dispatch uses — ``applied_defaults["workload_sequence"]``
-    (a list of ``{"type": ...}`` entries) or, when absent, the legacy
-    ``plan_tasks`` / ``build_tasks`` flags — and the same
-    :data:`WORKLOAD_REQUIRED_ROLES` map, so create-time and dispatch never drift.
+    Reads the same inputs dispatch uses — the EFFECTIVE config's
+    ``workload_sequence`` (a list of ``{"type": ...}`` entries) or, when
+    absent, the legacy ``plan_tasks`` / ``build_tasks`` flags — and the same
+    :data:`WORKLOAD_REQUIRED_ROLES` map, so create-time and dispatch never
+    drift. ``config`` is the #426 single merge (``models.resolve_config``,
+    #724): dispatch honors ``execution_overrides``, so preflight must
+    evaluate the same merged view or the two diverge.
     Emits one ``block`` finding per (workload, missing-role). Never warns (role
     satisfiability is always verifiable from the profile).
     """
     profile_roles = frozenset(a.role for a in profile.agents if a.enabled)
     provided = ", ".join(f"`{r}`" for r in sorted(profile_roles)) or "(none)"
     findings: list[Finding] = []
-    for label, required in _required_roles_by_workload(applied_defaults).items():
+    for label, required in _required_roles_by_workload(config).items():
         for role in sorted(required - profile_roles):
             findings.append(
                 Finding(
@@ -109,7 +110,7 @@ def required_roles_decision(
     return PreflightDecision(blocking=tuple(findings))
 
 
-def _required_roles_by_workload(applied_defaults: Mapping[str, Any]) -> dict[str, frozenset[str]]:
+def _required_roles_by_workload(config: Mapping[str, Any]) -> dict[str, frozenset[str]]:
     """Map each requested workload label → its required role set (create-time static).
 
     Workloads/toggles with no static requirement (``implementation``,
@@ -117,7 +118,7 @@ def _required_roles_by_workload(applied_defaults: Mapping[str, Any]) -> dict[str
     fallback, not a block (SIP §6.1). Unknown workload types are ignored here (the
     executor rejects them at dispatch).
     """
-    sequence = applied_defaults.get("workload_sequence") or []
+    sequence = config.get("workload_sequence") or []
     if sequence:
         result: dict[str, frozenset[str]] = {}
         for entry in sequence:
@@ -127,7 +128,7 @@ def _required_roles_by_workload(applied_defaults: Mapping[str, Any]) -> dict[str
                 result[wtype] = roles
         return result
     # Legacy path: plan_tasks (default true) requires the plan roles; build_tasks requires none.
-    if applied_defaults.get("plan_tasks", True):
+    if config.get("plan_tasks", True):
         return {"plan_tasks": REQUIRED_PLAN_ROLES}
     return {}
 
@@ -218,7 +219,8 @@ def required_check_tooling_decision(
       subset. Checks with no external tooling (the test spine, pure-Python diffs)
       never block.
 
-    ``required_check_ids`` come from ``applied_defaults['required_checks']``; every
+    ``required_check_ids`` come from the effective config's ``required_checks``
+    (the #426 single merge, #724); every
     id is a registered framework check (unknown ids are rejected at CRP load, #395),
     so an unregistered id here simply contributes no tooling requirement.
     """

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -405,8 +405,8 @@ def _resolve_legacy_steps(
     cycle: Cycle, profile: SquadProfile, profile_roles: set[str]
 ) -> tuple[list, bool]:
     """Select task steps from legacy plan_tasks/build_tasks flags."""
-    include_plan = bool(cycle.applied_defaults.get("plan_tasks", True))
-    include_build = bool(cycle.applied_defaults.get("build_tasks"))
+    include_plan = bool(cycle.resolved_config().get("plan_tasks", True))
+    include_build = bool(cycle.resolved_config().get("build_tasks"))
     builder_used = include_build and _has_builder_role(profile)
 
     steps: list = []

--- a/tests/unit/api/test_cycle_dto_mapping.py
+++ b/tests/unit/api/test_cycle_dto_mapping.py
@@ -120,6 +120,28 @@ def _make_run(
 class TestCycleToResponseStatus:
     """SIP-0083 D5: cycle_to_response uses resolve_cycle_status, not derive."""
 
+    def test_overridden_workload_sequence_drives_progress(self):
+        """#724 (the #426 mismatched-sources class): a workload_sequence set via
+        execution_overrides must drive progress/status exactly as dispatch sees
+        it — before the sweep this read applied_defaults directly, so the view
+        and the executor could disagree about which workloads exist."""
+        import dataclasses
+
+        cycle = dataclasses.replace(
+            _make_cycle(workload_sequence=[{"type": "framing"}]),
+            execution_overrides={
+                "workload_sequence": [{"type": "framing"}, {"type": "implementation"}]
+            },
+        )
+        runs = [_make_run("run_001", 1, "completed", "framing")]
+
+        resp = cycle_to_response(cycle, runs)
+
+        # two workloads in the effective sequence → cycle still active
+        assert resp.status == "active"
+        assert len(resp.workload_progress) == 2
+        assert resp.workload_progress[1].status == "pending"
+
     def test_completed_run_with_pending_workloads_shows_active(self):
         """Bug that motivated SIP-0083 D5: derive returns COMPLETED but
         pending workloads remain — resolve_cycle_status returns ACTIVE."""

--- a/tests/unit/cycles/test_config_read_guard.py
+++ b/tests/unit/cycles/test_config_read_guard.py
@@ -1,0 +1,48 @@
+"""#724 class-closing guard — no direct ``applied_defaults`` config reads.
+
+The #426/#724 defect class: a runtime surface reads ``applied_defaults``
+directly while dispatch honors ``execution_overrides`` via the single merge
+(``Cycle.resolved_config()`` / ``models.resolve_config``), so an operator's
+override is silently ignored by exactly one reader (the 1.4.4 exhibit:
+``time_budget_seconds`` set via overrides, run used the profile default).
+
+This guard closes the CLASS, not the instance: any ``applied_defaults.get(``
+or ``applied_defaults[`` read in ``src/`` or ``adapters/`` outside the merge
+definition itself fails here. Attribute-level passes (DTO provenance
+exposure, config hashing, registry persistence, the SIP-0083 forwarding-
+overrides machinery) are legitimately about the *parts* rather than the
+effective config and are out of this guard's (textual) scope — the design
+table on #724 enumerates them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.domain_cycles]
+
+_REPO = Path(__file__).resolve().parents[3]
+_SCAN_ROOTS = (_REPO / "src" / "squadops", _REPO / "adapters")
+_READ_PATTERN = re.compile(r"applied_defaults(?:\.get\(|\[)")
+
+# The single merge definition is the ONE place allowed to read the dict.
+_ALLOWED = {_REPO / "src" / "squadops" / "cycles" / "models.py"}
+
+
+def test_no_direct_applied_defaults_reads_outside_the_merge():
+    offenders: list[str] = []
+    for root in _SCAN_ROOTS:
+        for path in root.rglob("*.py"):
+            if path in _ALLOWED:
+                continue
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if _READ_PATTERN.search(line) and not line.lstrip().startswith("#"):
+                    offenders.append(f"{path.relative_to(_REPO)}:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "Direct applied_defaults read(s) found — route effective-config reads "
+        "through cycle.resolved_config() / models.resolve_config (#724, #426):\n"
+        + "\n".join(offenders)
+    )

--- a/tests/unit/cycles/test_models.py
+++ b/tests/unit/cycles/test_models.py
@@ -209,6 +209,21 @@ class TestCycle:
         assert resolved["build_profile"] == "override_profile"
         assert resolved["typed_acceptance"] is True
 
+    def test_module_level_merge_is_the_same_definition(self, sample_cycle):
+        """#724: pre-persist surfaces (create-route preflight) merge via
+        ``models.resolve_config`` — it must agree with ``Cycle.resolved_config``
+        exactly, or create-time validates a config dispatch never runs."""
+        from squadops.cycles.models import resolve_config
+
+        defaults = {"time_budget_seconds": 3600, "plan_tasks": True}
+        overrides = {"time_budget_seconds": 300}
+        cycle = dataclasses.replace(
+            sample_cycle, applied_defaults=defaults, execution_overrides=overrides
+        )
+        assert resolve_config(defaults, overrides) == cycle.resolved_config()
+        assert resolve_config(defaults, overrides)["time_budget_seconds"] == 300
+        assert resolve_config(defaults, {}) == defaults  # absent overrides = identity
+
 
 class TestRun:
     def test_defaults(self):

--- a/tests/unit/cycles/test_sip0100_compliance_budget.py
+++ b/tests/unit/cycles/test_sip0100_compliance_budget.py
@@ -32,7 +32,10 @@ def _ev(code: str) -> ScaffoldIntegrityEvidence:
 
 
 def _cycle(bound: int = 3) -> SimpleNamespace:
-    return SimpleNamespace(applied_defaults={"contract_compliance_attempts": bound})
+    # #724: the executor reads the bound through resolved_config() (the #426
+    # single merge), so the stub carries the same seam a real Cycle has
+    defaults = {"contract_compliance_attempts": bound}
+    return SimpleNamespace(applied_defaults=defaults, resolved_config=lambda: dict(defaults))
 
 
 def _env() -> SimpleNamespace:
@@ -96,6 +99,8 @@ def test_bound_is_configurable_zero_terminates_on_first():
 def test_default_bound_applies_when_unset():
     """Absent the key, the default (3) is used — a fourth cross-slot write terminates."""
     counter = {"n": 3}
-    cycle = SimpleNamespace(applied_defaults={})  # no contract_compliance_attempts
+    cycle = SimpleNamespace(
+        applied_defaults={}, resolved_config=dict
+    )  # no contract_compliance_attempts
     with pytest.raises(_ExecutionError):
         _call([_ev(_UNAUTH)], counter, cycle)


### PR DESCRIPTION
Closes #724 — the last Gate-2 code item before the SIP-0096 promotion PR. Design decision table posted to the issue before code.

## The class, closed

The exhibit: `execute_run` read `time_budget_seconds` from `applied_defaults` directly, so a budget set via `execution_overrides` was silently ignored — the #426 mismatched-sources class (two config readers keying off different sources of truth). The sweep found ~20 direct reads across seven surfaces; every **effective-config** read now routes through the #426 single merge:

- **Executor**: time budget (the exhibit), `workload_sequence` dispatch, plan/build toggles, framing rerolls, the three `implementation_plan` gate-seam preconditions, `max_task_retries`, `max_correction_attempts`, `contract_compliance_attempts`.
- **Pulse runner**: `pulse_checks`, `cadence_policy`, pulse repair attempts. **task_plan**: plan/build toggles. **run_completion**: `required_checks` aggregation requiredness. **correction_policy**: caller now passes `cycle.resolved_config()` (param renamed to match).
- **The four API `workload_sequence` readers** (create-route position-0 run typing, run-create next-workload resolution, resume validation, `cycle_to_response` progress/status) — the operator's view and dispatch can no longer disagree about which workloads exist.
- **Create-time preflight evaluates the merged config** (required roles + required-check tooling): the merge is hoisted to `models.resolve_config()` with `Cycle.resolved_config()` delegating — one definition, two entry shapes — and the replay-validation helper's inline duplicate merge now calls it too.

**Provenance/mechanics reads stay by design**, enumerated in the design table: DTO exposure of both dicts, `compute_config_hash` (hashes the parts), registry persistence, `parse_replay_declaration` (maintainer-only, overrides-scoped deliberately), and the SIP-0083 forwarding-overrides machinery.

## Class closure, not instance closure

`test_config_read_guard.py` fails on any `applied_defaults.get(`/`applied_defaults[` read in `src/`+`adapters/` outside the merge definition — the class cannot silently reopen (same standing-guard pattern as the enum-shadow and purity tests).

## Policy consequence, stated

`required_checks`, `workload_sequence`, `implementation_plan`, and budgets become `execution_overrides`-addressable at create time — an explicit, recorded, preflight-validated operator decision (symmetric with choosing a different profile), distinct from the post-hoc #682 waiver flow. Practical delta for existing cycles: zero (their overrides don't carry these keys). No migration, no API-shape change.

## Verification

Merge-semantics test (module function ≡ method, overrides win, absent-overrides identity); `cycle_to_response` with an overridden sequence proves override-wins at a consumer seam; the guard is the standing net. One pre-existing test fixture (`test_sip0100_compliance_budget`) gained the `resolved_config` seam its `SimpleNamespace` cycle stub lacked. Full regression: **6408 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
