### PR TITLE
refactor(#663): S1 — dispatch-time context assembly to the capability-owned registry

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -34,6 +34,14 @@ from adapters.cycles.pulse_boundary_runner import PulseBoundaryRunner
 from adapters.cycles.run_completion import RunCompletion, resolve_terminal_outcome
 from adapters.cycles.task_dispatcher import TaskDispatcher
 from adapters.cycles.task_naming import build_task_name
+from squadops.capabilities.context_assembly import (
+    ACCEPTANCE_WORKSPACE_FILTER,
+    LANDING_PRIOR_OUTPUTS,
+    dispatch_artifact_filter_spec,
+    get_context_contract,
+    manifest_surface_fragments,
+    wrapup_evidence_applies,
+)
 from squadops.cycles.acceptance_evaluation import resolve_check_stack
 from squadops.cycles.agent_config import build_agent_resolver
 from squadops.cycles.build_completeness import compute_missing_required_files
@@ -1014,92 +1022,12 @@ class DispatchedFlowExecutor(FlowExecutionPort):
     # Build task artifact filter (D3, §2.2)
     # ------------------------------------------------------------------
 
-    # Task types that author into the scaffold's fill slots and therefore need the
-    # manifest-derived error seam in their prompt (#588). A table, not a literal
-    # test at the branch — the repair path's equivalent lives in CorrectionRunner's
-    # failure_evidence assembly.
-    _ERROR_SEAM_TASK_TYPES: frozenset[str] = frozenset({"development.develop"})
-
-    # #643: the full accepted source/config tree — scaffold included via
-    # by_type (#443). Threaded to every build task as
-    # ``acceptance_workspace_files``: module_imports is runtime-level, so the
-    # typed-acceptance workspace must hold every sibling a fill file imports —
-    # exactly what the per-task prompt filters below deliberately omit
-    # (prompt diet). fay-1: dev's module_imports evaluated in a
-    # routes.py-only workspace and false-failed every attempt.
-    _ACCEPTANCE_WORKSPACE_FILTER: dict[str, list[str]] = {
-        "by_producing_task": ["qa.validate", "builder.assemble", "development.develop"],
-        "by_type": ["source", "config"],
-        "by_type_fallback": ["document"],
-    }
-
-    # #657: planning-chain context threading (the RC-22 pre-resolution the
-    # proposer handlers were written against). The executor's role-keyed
-    # ``prior_outputs`` strips artifact content, so the brief author and the
-    # plan-task proposers rendered "(brief not yet provided)" and PRD-prefix
-    # stubs while their templates instructed them to operate on the brief and
-    # gap-catch against Development's proposal. Contents resolve into an
-    # ENVELOPE-LOCAL ``prior_outputs["artifact_contents"]`` copy — never the
-    # loop-level dict, which is checkpointed per task (RC-4) and must stay lean.
-    # The merger is deliberately absent: it consumes ``brief_outcome`` /
-    # ``proposal_outcome`` output keys, and by merge time the two proposals
-    # collide on the ``proposed_plan_tasks.yaml`` filename.
-    _PLANNING_ARTIFACT_FILTER: dict[str, dict[str, list[str]]] = {
-        "governance.prepare_plan_authoring_brief": {
-            "by_producing_task": [
-                "data.research_context",
-                "strategy.frame_objective",
-                "development.design_plan",
-                "qa.define_test_strategy",
-            ],
-        },
-        "development.propose_plan_tasks": {
-            "by_producing_task": [
-                "governance.prepare_plan_authoring_brief",
-                "development.design_plan",
-            ],
-        },
-        "qa.propose_plan_tasks": {
-            "by_producing_task": [
-                "governance.prepare_plan_authoring_brief",
-                "development.design_plan",
-                "qa.define_test_strategy",
-                "development.propose_plan_tasks",
-            ],
-        },
-        "strategy.propose_plan_guidance": {
-            "by_producing_task": [
-                "governance.prepare_plan_authoring_brief",
-                "strategy.frame_objective",
-            ],
-        },
-    }
-
-    # Maps build task_type → which prior artifacts to inject.
-    # by_producing_task: match on producing_task_type metadata
-    # by_type / by_type_fallback: match on artifact_type for artifacts without provenance
-    _BUILD_ARTIFACT_FILTER: dict[str, dict[str, list[str]]] = {
-        "development.develop": {
-            # SIP-0086: include prior development.develop for manifest-driven
-            # subtask chaining (dev→dev artifact accumulation)
-            "by_producing_task": [
-                "strategy.analyze_prd",
-                "development.design",
-                "development.develop",
-            ],
-            "by_type_fallback": ["document"],
-        },
-        "builder.assemble": {
-            "by_producing_task": ["development.develop"],
-            "by_type": ["source", "config"],
-            # #443: provenance-less documents are the seeded scaffold (frozen
-            # fill-contract files) — without them assembly packages a partial app.
-            "by_type_fallback": ["document"],
-        },
-        # SIP-0086/#443: QA verification needs the whole accepted tree —
-        # the same selection the acceptance workspace uses (single-sourced).
-        "qa.test": _ACCEPTANCE_WORKSPACE_FILTER,
-    }
+    # #663: per-task-type context opinions (artifact selection, seam surfaces,
+    # workspace composition, wrap-up evidence flags) live in the capability-
+    # owned registry — squadops.capabilities.context_assembly. The executor
+    # keeps the composition MECHANICS (the I/O and the merge point) with zero
+    # task-type opinions of its own; adding a per-task input is a registry
+    # edit beside the capability code, never an executor diff.
 
     async def _resolve_artifact_contents(
         self,
@@ -1124,12 +1052,14 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 the pf-31 endpoint_defined final-verification regression.
             filter_spec: explicit selection override (#643 — the acceptance
                 workspace uses the full-tree spec regardless of task type).
-                Defaults to the task type's prompt-context filter.
+                Defaults to the task type's registry-declared build-lane filter
+                (#663) — the same default the correction loop's RC3
+                re-resolution relies on.
 
         Returns:
             Dict of filename → content string. Empty if task_type not a build task.
         """
-        filter_spec = filter_spec or self._BUILD_ARTIFACT_FILTER.get(task_type)
+        filter_spec = filter_spec or dispatch_artifact_filter_spec(task_type)
         if not filter_spec:
             return {}
 
@@ -1835,21 +1765,16 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
         return False
 
-    _WRAPUP_TASK_TYPES: frozenset[str] = frozenset(
-        {
-            "data.gather_evidence",
-            "qa.assess_outcomes",
-            "data.classify_unresolved",
-            "governance.closeout_decision",
-            "governance.publish_handoff",
-        }
-    )
-
     async def _inject_wrapup_evidence(
         self, plan: list[TaskEnvelope], cycle: Cycle, prior_outputs: dict[str, Any]
     ) -> None:
-        """#683: thread the cycle's CycleOutcome into wrap-up task inputs."""
-        if not any(e.task_type in self._WRAPUP_TASK_TYPES for e in plan):
+        """#683: thread the cycle's CycleOutcome into wrap-up task inputs.
+
+        Which task types constitute the wrap-up pipeline is a registry
+        declaration (#663 — ``wrapup_evidence`` on the context contract); the
+        run-level injection mechanics stay here.
+        """
+        if not wrapup_evidence_applies(e.task_type for e in plan):
             return
         try:
             from squadops.cycles.cycle_outcome import resolve_cycle_outcome
@@ -1876,74 +1801,55 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         stored_artifacts: list[tuple[str, ArtifactRef]],
         interface_manifest: Any = None,
     ) -> TaskEnvelope:
-        """Build chain context inputs and return an enriched envelope."""
+        """Build chain context inputs and return an enriched envelope.
+
+        #663: the SINGLE composition point. Every per-task-type opinion comes
+        from the capability-owned ``ContextAssemblyContract``; this method owns
+        only the deterministic mechanics — fragment order, the artifact I/O,
+        and the merge (dispatch keys shadow plan-time keys of the same name).
+        """
+        contract = get_context_contract(envelope.task_type)
 
         extra_inputs: dict[str, Any] = {
             "prior_outputs": prior_outputs,
             "artifact_refs": list(all_artifact_refs),
         }
 
-        # #588: the manifest-derived error-seam lines the correction path has
-        # carried since pf-34, threaded to the INITIAL author too. The raise
-        # convention lives in the fill-slot stub's docstring, which the first
-        # fill overwrites — so without this the author guesses the signature,
-        # every error path TypeErrors into a 500, and the run pays a correction
-        # to learn what the scaffold already knew. Data only; the block's prose
-        # lives in a managed prompt asset.
-        if envelope.task_type in self._ERROR_SEAM_TASK_TYPES:
-            from squadops.capabilities.scaffold import (
-                error_seam_instructions,
-                model_surface_instructions,
-                testid_surface_instructions,
-            )
+        # Manifest seam surfaces (#588/pf-45/#659): presence-keyed instruction
+        # sets (error contract, model surface, testid inventory) for task types
+        # that author into scaffold fill slots. Data only; prose lives in
+        # managed prompt assets.
+        extra_inputs.update(manifest_surface_fragments(contract, interface_manifest))
 
-            error_lines = error_seam_instructions(interface_manifest)
-            if error_lines:
-                extra_inputs["error_contract"] = error_lines
-            # pf-45: the model surface, to the INITIAL author on the same transport.
-            # Repairs have carried it since #604; the first fill never did, so the dev
-            # guessed a field name (`pace` for `pace_target`) and every POST /runs
-            # raised into a 500 — a correction spent learning what the scaffold already
-            # knew. Field-level since pf-45 for the same reason.
-            surface_lines = model_surface_instructions(interface_manifest)
-            if surface_lines:
-                extra_inputs["model_surface"] = surface_lines
-            # #659: the DOM anchor inventory, same transport — dev is told the
-            # manifest-pinned testids to attach/preserve so the qa suite (which
-            # receives the same inventory) has a stable surface to query.
-            testid_lines = testid_surface_instructions(interface_manifest)
-            if testid_lines:
-                extra_inputs["testid_surface"] = testid_lines
+        if contract.artifact_filter is not None:
+            if contract.artifact_landing == LANDING_PRIOR_OUTPUTS:
+                # #657: planning-chain tasks get upstream documents on an
+                # ENVELOPE-LOCAL prior_outputs copy — the loop-level dict is
+                # checkpointed per task (RC-4) and must stay lean.
+                planning_contents = await self._resolve_artifact_contents(
+                    envelope.task_type,
+                    stored_artifacts,
+                    filter_spec=contract.artifact_filter.to_spec(),
+                )
+                if planning_contents:
+                    extra_inputs["prior_outputs"] = {
+                        **prior_outputs,
+                        "artifact_contents": planning_contents,
+                    }
+            else:
+                # Build tasks (D3). Fresh dispatches see the ACCEPTED state only
+                # (pf-31 Fix E): rejected repair candidates stay out; the
+                # correction loop's own RC3 re-resolution keeps them.
+                artifact_contents = await self._resolve_artifact_contents(
+                    envelope.task_type,
+                    stored_artifacts,
+                    include_repair_candidates=False,
+                    filter_spec=contract.artifact_filter.to_spec(),
+                )
+                if artifact_contents:
+                    extra_inputs["artifact_contents"] = artifact_contents
 
-        # #657: planning-chain tasks get the upstream framing documents the
-        # RC-22 contract promised them, on an envelope-local prior_outputs
-        # copy (checkpoints keep the lean role-keyed dict). Filename keys
-        # last-win in storage order, so a proposer retry's failure artifact
-        # cannot shadow a successful peer document.
-        if envelope.task_type in self._PLANNING_ARTIFACT_FILTER:
-            planning_contents = await self._resolve_artifact_contents(
-                envelope.task_type,
-                stored_artifacts,
-                filter_spec=self._PLANNING_ARTIFACT_FILTER[envelope.task_type],
-            )
-            if planning_contents:
-                extra_inputs["prior_outputs"] = {
-                    **prior_outputs,
-                    "artifact_contents": planning_contents,
-                }
-
-        # Pre-resolve artifact contents for build tasks (D3). Fresh dispatches
-        # see the ACCEPTED state only (pf-31 Fix E): rejected repair candidates
-        # stay out of task workspaces; the correction loop's own re-resolution
-        # keeps them for RC3.
-        if envelope.task_type in self._BUILD_ARTIFACT_FILTER:
-            artifact_contents = await self._resolve_artifact_contents(
-                envelope.task_type,
-                stored_artifacts,
-                include_repair_candidates=False,
-            )
-            if artifact_contents:
-                extra_inputs["artifact_contents"] = artifact_contents
+        if contract.acceptance_workspace:
             # #643: the typed-acceptance workspace rides separately from the
             # curated prompt context — evaluation needs the full accepted tree
             # (scaffold siblings included) or runtime-level checks false-fail
@@ -1952,7 +1858,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 envelope.task_type,
                 stored_artifacts,
                 include_repair_candidates=False,
-                filter_spec=self._ACCEPTANCE_WORKSPACE_FILTER,
+                filter_spec=ACCEPTANCE_WORKSPACE_FILTER.to_spec(),
             )
             if workspace_files:
                 extra_inputs["acceptance_workspace_files"] = workspace_files

--- a/src/squadops/capabilities/context_assembly.py
+++ b/src/squadops/capabilities/context_assembly.py
@@ -1,0 +1,243 @@
+"""Per-task-type context-assembly contracts (#663, 1.5 B1).
+
+The capability-owned answer to "what does a task type's envelope contain?" —
+previously four private tables and three branches inside
+``DispatchedFlowExecutor._enrich_envelope`` (the accretion pattern: every
+per-task-input fix grew the executor). Each task type declares ONE frozen
+``ContextAssemblyContract`` here; the executor keeps a single, readable
+composition point that reads the contract and performs the I/O, with zero
+task-type opinions of its own.
+
+Design boundary (plan B1, decided before code): contracts are **declarative
+data, not enricher callables** — there is no pipeline of arbitrary functions
+to sequence and no shared-dict mutation, so the composition stays singular
+and deterministic by construction. Adding a new task type's use of existing
+context kinds (or changing a filter) is a registry-entry edit beside the
+capability code; a genuinely NEW context kind is a composer change, which is
+correct — it is a new composition rule, not a new opinion.
+
+Pure module: no I/O, no executor imports, importable from both the runtime
+executor and agent-side capability code. (Contracts don't live on handler
+classes because handlers are agent-side and the executor is runtime-side —
+attribute-homed contracts would drag handler imports into runtime-api.)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Fragment vocabulary
+# ---------------------------------------------------------------------------
+
+#: Where a resolved artifact-contents mapping lands on the envelope.
+LANDING_INPUTS = "inputs"  # top-level ``inputs["artifact_contents"]`` (build tasks, D3)
+LANDING_PRIOR_OUTPUTS = "prior_outputs"  # envelope-local ``prior_outputs["artifact_contents"]``
+#   copy (#657 planning chain — the loop-level dict stays lean for checkpoints, RC-4)
+
+#: Manifest-derived seam surfaces a task type may request (#588 / pf-45 / #659).
+#: Constant == the envelope inputs key it lands under.
+SURFACE_ERROR_CONTRACT = "error_contract"
+SURFACE_MODEL = "model_surface"
+SURFACE_TESTID = "testid_surface"
+
+
+@dataclass(frozen=True)
+class ArtifactFilter:
+    """A stored-artifact selection spec (the shape ``_resolve_artifact_contents``
+    consumes): pick by producing task type, by artifact type, with a fallback
+    type-set applied only when the primary axes select nothing."""
+
+    by_producing_task: tuple[str, ...] = ()
+    by_type: tuple[str, ...] = ()
+    by_type_fallback: tuple[str, ...] = ()
+
+    def to_spec(self) -> dict[str, list[str]]:
+        spec: dict[str, list[str]] = {}
+        if self.by_producing_task:
+            spec["by_producing_task"] = list(self.by_producing_task)
+        if self.by_type:
+            spec["by_type"] = list(self.by_type)
+        if self.by_type_fallback:
+            spec["by_type_fallback"] = list(self.by_type_fallback)
+        return spec
+
+
+@dataclass(frozen=True)
+class ContextAssemblyContract:
+    """One task type's dispatch-time context declaration.
+
+    ``artifact_filter``/``artifact_landing``: which stored artifacts the task
+    sees and where they land. ``acceptance_workspace``: thread the full
+    accepted tree for typed-acceptance evaluation (#643 — rides separately
+    from the curated prompt context). ``manifest_surfaces``: which scaffold
+    seam-instruction sets to thread, presence-keyed (#588/pf-45/#659).
+    ``wrapup_evidence``: the run-level CycleOutcome injection applies when any
+    planned task carries this flag (#683).
+    """
+
+    artifact_filter: ArtifactFilter | None = None
+    artifact_landing: str = LANDING_INPUTS
+    acceptance_workspace: bool = False
+    manifest_surfaces: tuple[str, ...] = ()
+    wrapup_evidence: bool = False
+
+
+_EMPTY_CONTRACT = ContextAssemblyContract()
+
+
+# ---------------------------------------------------------------------------
+# The registry
+# ---------------------------------------------------------------------------
+
+#: #643/#644: acceptance/patch-verification workspace composition — the full
+#: accepted tree (scaffold siblings included), single-sourced with qa.test's
+#: prompt context (qa evaluates the same tree it reads).
+ACCEPTANCE_WORKSPACE_FILTER = ArtifactFilter(
+    by_producing_task=("qa.validate", "builder.assemble", "development.develop"),
+    by_type=("source", "config"),
+    by_type_fallback=("document",),
+)
+
+_DEV_SURFACES = (SURFACE_ERROR_CONTRACT, SURFACE_MODEL, SURFACE_TESTID)
+
+CONTEXT_CONTRACTS: dict[str, ContextAssemblyContract] = {
+    # --- build tasks (D3): curated prompt context + acceptance workspace ----
+    "development.develop": ContextAssemblyContract(
+        artifact_filter=ArtifactFilter(
+            by_producing_task=(
+                "strategy.analyze_prd",
+                "development.design",
+                "development.develop",
+            ),
+            by_type_fallback=("document",),
+        ),
+        acceptance_workspace=True,
+        # #588/pf-45/#659: the error-contract raise convention, the model
+        # field surface, and the DOM testid inventory — to the INITIAL author
+        # on the same transport repairs have always used.
+        manifest_surfaces=_DEV_SURFACES,
+    ),
+    "builder.assemble": ContextAssemblyContract(
+        artifact_filter=ArtifactFilter(
+            by_producing_task=("development.develop",),
+            by_type=("source", "config"),
+            by_type_fallback=("document",),
+        ),
+        acceptance_workspace=True,
+    ),
+    # qa.test's prompt context IS the full accepted tree (#644).
+    "qa.test": ContextAssemblyContract(
+        artifact_filter=ACCEPTANCE_WORKSPACE_FILTER,
+        acceptance_workspace=True,
+    ),
+    # --- planning chain (#657): upstream documents on an envelope-local
+    # prior_outputs copy. governance.merge_plan is DELIBERATELY absent: by
+    # merge time both proposals collide on the proposed_plan_tasks.yaml
+    # filename, so threading there would silently drop one proposal — the
+    # merger consumes brief_outcome/proposal_outcome output keys instead.
+    "governance.prepare_plan_authoring_brief": ContextAssemblyContract(
+        artifact_filter=ArtifactFilter(
+            by_producing_task=(
+                "data.research_context",
+                "strategy.frame_objective",
+                "development.design_plan",
+                "qa.define_test_strategy",
+            ),
+        ),
+        artifact_landing=LANDING_PRIOR_OUTPUTS,
+    ),
+    "development.propose_plan_tasks": ContextAssemblyContract(
+        artifact_filter=ArtifactFilter(
+            by_producing_task=(
+                "governance.prepare_plan_authoring_brief",
+                "development.design_plan",
+            ),
+        ),
+        artifact_landing=LANDING_PRIOR_OUTPUTS,
+    ),
+    "qa.propose_plan_tasks": ContextAssemblyContract(
+        artifact_filter=ArtifactFilter(
+            by_producing_task=(
+                "governance.prepare_plan_authoring_brief",
+                "development.design_plan",
+                "qa.define_test_strategy",
+                "development.propose_plan_tasks",
+            ),
+        ),
+        artifact_landing=LANDING_PRIOR_OUTPUTS,
+    ),
+    "strategy.propose_plan_guidance": ContextAssemblyContract(
+        artifact_filter=ArtifactFilter(
+            by_producing_task=(
+                "governance.prepare_plan_authoring_brief",
+                "strategy.frame_objective",
+            ),
+        ),
+        artifact_landing=LANDING_PRIOR_OUTPUTS,
+    ),
+    # --- wrap-up pipeline (#683): the run-level verification_evidence
+    # injection fires when any planned task carries the flag.
+    "data.gather_evidence": ContextAssemblyContract(wrapup_evidence=True),
+    "qa.assess_outcomes": ContextAssemblyContract(wrapup_evidence=True),
+    "data.classify_unresolved": ContextAssemblyContract(wrapup_evidence=True),
+    "governance.closeout_decision": ContextAssemblyContract(wrapup_evidence=True),
+    "governance.publish_handoff": ContextAssemblyContract(wrapup_evidence=True),
+}
+
+
+def get_context_contract(task_type: str) -> ContextAssemblyContract:
+    """The task type's declared contract; the empty contract for undeclared
+    types (base enrichment only — chain context and artifact refs)."""
+    return CONTEXT_CONTRACTS.get(task_type, _EMPTY_CONTRACT)
+
+
+def dispatch_artifact_filter_spec(task_type: str) -> dict[str, list[str]] | None:
+    """The build-lane (INPUTS-landing) filter spec for ``task_type``, or None.
+
+    The default the executor's artifact resolution applies when no explicit
+    spec is passed — including the correction loop's RC3 re-resolution, which
+    must select the same universe dispatch selected (plus repair candidates).
+    Planning filters are excluded: their PRIOR_OUTPUTS landing is a different
+    transport and RC3 never applies to them.
+    """
+    contract = get_context_contract(task_type)
+    if contract.artifact_filter is None or contract.artifact_landing != LANDING_INPUTS:
+        return None
+    return contract.artifact_filter.to_spec()
+
+
+def wrapup_evidence_applies(plan_task_types: Any) -> bool:
+    """True when any planned task type declares the wrap-up evidence flag (#683)."""
+    return any(get_context_contract(t).wrapup_evidence for t in plan_task_types)
+
+
+def manifest_surface_fragments(
+    contract: ContextAssemblyContract, interface_manifest: Any
+) -> dict[str, list[str]]:
+    """The presence-keyed manifest seam fragments the contract requests.
+
+    Pure derivation from the manifest; an empty instruction set contributes no
+    key (the handlers' sections are presence-gated). Scaffold import is lazy —
+    the module stays light for callers that never thread surfaces.
+    """
+    if not contract.manifest_surfaces:
+        return {}
+    from squadops.capabilities.scaffold import (
+        error_seam_instructions,
+        model_surface_instructions,
+        testid_surface_instructions,
+    )
+
+    derivations = {
+        SURFACE_ERROR_CONTRACT: error_seam_instructions,
+        SURFACE_MODEL: model_surface_instructions,
+        SURFACE_TESTID: testid_surface_instructions,
+    }
+    fragments: dict[str, list[str]] = {}
+    for surface in contract.manifest_surfaces:
+        lines = derivations[surface](interface_manifest)
+        if lines:
+            fragments[surface] = lines
+    return fragments

--- a/tests/unit/cycles/goldens/context_assembly.json
+++ b/tests/unit/cycles/goldens/context_assembly.json
@@ -1,0 +1,211 @@
+{
+ "builder_assemble": {
+  "acceptance_workspace_files": {
+   ".env.example": "body of .env.example",
+   "backend/routes.py": "body of backend/routes.py",
+   "validation_report.md": "body of validation_report.md"
+  },
+  "artifact_contents": {
+   ".env.example": "body of .env.example",
+   "backend/routes.py": "body of backend/routes.py"
+  },
+  "artifact_refs": [
+   "art_routes",
+   "art_config"
+  ],
+  "prior_outputs": {
+   "dev": {
+    "summary": "[dev] designed"
+   }
+  }
+ },
+ "develop_no_manifest": {
+  "acceptance_workspace_files": {
+   ".env.example": "body of .env.example",
+   "backend/routes.py": "body of backend/routes.py",
+   "validation_report.md": "body of validation_report.md"
+  },
+  "artifact_contents": {
+   ".env.example": "body of .env.example",
+   "backend/routes.py": "body of backend/routes.py",
+   "requirements.md": "body of requirements.md"
+  },
+  "artifact_refs": [
+   "art_routes",
+   "art_config"
+  ],
+  "prd": "PRD",
+  "prior_outputs": {
+   "dev": {
+    "summary": "[dev] designed"
+   }
+  }
+ },
+ "develop_with_manifest": {
+  "acceptance_workspace_files": {
+   ".env.example": "body of .env.example",
+   "backend/routes.py": "body of backend/routes.py",
+   "validation_report.md": "body of validation_report.md"
+  },
+  "artifact_contents": {
+   ".env.example": "body of .env.example",
+   "backend/routes.py": "body of backend/routes.py",
+   "requirements.md": "body of requirements.md"
+  },
+  "artifact_refs": [
+   "art_routes",
+   "art_config"
+  ],
+  "error_contract": [
+   "on failure raise `ApiError(code, message)` (imported from `.errors`): the FIRST argument is the error-code STRING, the second a human message \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
+   "valid error codes (code \u2192 HTTP status, mapped by frozen `errors.py`): `validation_error` \u2192 422, `run_not_found` \u2192 404, `duplicate_participant` \u2192 409, `participant_not_found` \u2192 404"
+  ],
+  "model_surface": [
+   "`backend/models.py` is scaffold-frozen and defines EXACTLY these names: `Participant(id, name)`, `RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants)`, `RunEventCreate(title, datetime, location, distance, pace_target, route_notes)`, `ParticipantName(name)`. Import only from this list \u2014 these are the complete contents of that module",
+   "field names are exact \u2014 construct and read models with the fields shown above; a near-miss (`pace` for `pace_target`, `meeting_location` for `location`) raises at request time and every affected endpoint returns HTTP 500",
+   "do NOT invent model names or aliases (`Run`, `RunCreate`, `RunResponse`, `RunJoin` and similar do not exist); an import of a name absent from the list above fails at load, the app never starts, and the patch is rejected",
+   "`models.py` is frozen \u2014 if a name you want is missing, use the declared names and shape the response in the fill slot; do not edit or re-emit the model module",
+   "`backend/store.py` is scaffold-frozen and already defines the in-memory stores: `participant_store`, `run_event_store` (plus `reset()` for test isolation). Import them (`from .store import ...`); do NOT declare your own store dicts \u2014 a shadow store is invisible to `reset()`, so state leaks between tests and the suite fails on isolation"
+  ],
+  "prd": "PRD",
+  "prior_outputs": {
+   "dev": {
+    "summary": "[dev] designed"
+   }
+  },
+  "testid_surface": [
+   "`RunsListView` (route `/`): root container `runs-list`; anchors: `runs-list`, `run-item`, `run-participant-count`, `empty-state`, `create-run-link`",
+   "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",
+   "`RunDetailView` (route `/runs/:id`): root container `run-detail`; anchors: `run-detail`, `participant-list`, `participant-item`, `join-form`, `join-name-input`, `join-submit`, `leave-form`, `leave-name-input`, `leave-submit`, `action-error`, `not-found`"
+  ]
+ },
+ "dispatch_shadows_plan_keys": {
+  "acceptance_workspace_files": {
+   ".env.example": "body of .env.example",
+   "backend/routes.py": "body of backend/routes.py",
+   "validation_report.md": "body of validation_report.md"
+  },
+  "artifact_contents": {
+   ".env.example": "body of .env.example",
+   "backend/routes.py": "body of backend/routes.py",
+   "requirements.md": "body of requirements.md"
+  },
+  "artifact_refs": [
+   "art_routes",
+   "art_config"
+  ],
+  "error_contract": [
+   "on failure raise `ApiError(code, message)` (imported from `.errors`): the FIRST argument is the error-code STRING, the second a human message \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
+   "valid error codes (code \u2192 HTTP status, mapped by frozen `errors.py`): `validation_error` \u2192 422, `run_not_found` \u2192 404, `duplicate_participant` \u2192 409, `participant_not_found` \u2192 404"
+  ],
+  "model_surface": [
+   "`backend/models.py` is scaffold-frozen and defines EXACTLY these names: `Participant(id, name)`, `RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants)`, `RunEventCreate(title, datetime, location, distance, pace_target, route_notes)`, `ParticipantName(name)`. Import only from this list \u2014 these are the complete contents of that module",
+   "field names are exact \u2014 construct and read models with the fields shown above; a near-miss (`pace` for `pace_target`, `meeting_location` for `location`) raises at request time and every affected endpoint returns HTTP 500",
+   "do NOT invent model names or aliases (`Run`, `RunCreate`, `RunResponse`, `RunJoin` and similar do not exist); an import of a name absent from the list above fails at load, the app never starts, and the patch is rejected",
+   "`models.py` is frozen \u2014 if a name you want is missing, use the declared names and shape the response in the fill slot; do not edit or re-emit the model module",
+   "`backend/store.py` is scaffold-frozen and already defines the in-memory stores: `participant_store`, `run_event_store` (plus `reset()` for test isolation). Import them (`from .store import ...`); do NOT declare your own store dicts \u2014 a shadow store is invisible to `reset()`, so state leaks between tests and the suite fails on isolation"
+  ],
+  "prior_outputs": {
+   "dev": {
+    "summary": "[dev] designed"
+   }
+  },
+  "testid_surface": [
+   "`RunsListView` (route `/`): root container `runs-list`; anchors: `runs-list`, `run-item`, `run-participant-count`, `empty-state`, `create-run-link`",
+   "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",
+   "`RunDetailView` (route `/runs/:id`): root container `run-detail`; anchors: `run-detail`, `participant-list`, `participant-item`, `join-form`, `join-name-input`, `join-submit`, `leave-form`, `leave-name-input`, `leave-submit`, `action-error`, `not-found`"
+  ]
+ },
+ "planning_brief_author": {
+  "artifact_refs": [],
+  "prior_outputs": {
+   "artifact_contents": {
+    "context_research.md": "body of context_research.md",
+    "objective_frame.md": "body of objective_frame.md",
+    "technical_design.md": "body of technical_design.md",
+    "test_strategy.md": "body of test_strategy.md"
+   },
+   "dev": {
+    "summary": "[dev] designed"
+   }
+  }
+ },
+ "planning_dev_proposer": {
+  "artifact_refs": [],
+  "prior_outputs": {
+   "artifact_contents": {
+    "plan_authoring_brief.yaml": "body of plan_authoring_brief.yaml",
+    "technical_design.md": "body of technical_design.md"
+   },
+   "dev": {
+    "summary": "[dev] designed"
+   }
+  }
+ },
+ "planning_merger_excluded": {
+  "artifact_refs": [],
+  "prior_outputs": {
+   "dev": {
+    "summary": "[dev] designed"
+   }
+  }
+ },
+ "planning_qa_proposer": {
+  "artifact_refs": [],
+  "prior_outputs": {
+   "artifact_contents": {
+    "plan_authoring_brief.yaml": "body of plan_authoring_brief.yaml",
+    "proposed_plan_tasks.yaml": "body of proposed_plan_tasks.yaml",
+    "technical_design.md": "body of technical_design.md",
+    "test_strategy.md": "body of test_strategy.md"
+   },
+   "dev": {
+    "summary": "[dev] designed"
+   }
+  }
+ },
+ "planning_strat_guidance": {
+  "artifact_refs": [],
+  "prior_outputs": {
+   "artifact_contents": {
+    "objective_frame.md": "body of objective_frame.md",
+    "plan_authoring_brief.yaml": "body of plan_authoring_brief.yaml"
+   },
+   "dev": {
+    "summary": "[dev] designed"
+   }
+  }
+ },
+ "qa_test": {
+  "acceptance_workspace_files": {
+   ".env.example": "body of .env.example",
+   "backend/routes.py": "body of backend/routes.py",
+   "validation_report.md": "body of validation_report.md"
+  },
+  "artifact_contents": {
+   ".env.example": "body of .env.example",
+   "backend/routes.py": "body of backend/routes.py",
+   "validation_report.md": "body of validation_report.md"
+  },
+  "artifact_refs": [
+   "art_routes",
+   "art_config"
+  ],
+  "prd": "PRD",
+  "prior_outputs": {
+   "dev": {
+    "summary": "[dev] designed"
+   }
+  }
+ },
+ "untabled_base_only": {
+  "artifact_refs": [
+   "art_frame"
+  ],
+  "prior_outputs": {
+   "dev": {
+    "summary": "[dev] designed"
+   }
+  }
+ }
+}

--- a/tests/unit/cycles/test_context_assembly.py
+++ b/tests/unit/cycles/test_context_assembly.py
@@ -1,0 +1,92 @@
+"""#663 registry behavior — the B1 exit criteria, mechanized.
+
+The byte-level equivalence of the extraction lives in
+``test_context_assembly_golden.py``; these tests pin the registry's load-
+bearing behaviors: a new capability enrichment is a REGISTRY edit (the
+executor threads it with zero changes), and the RC3 default filter lane
+serves build-landing filters only.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from squadops.capabilities import context_assembly as ca
+from squadops.cycles.models import ArtifactRef
+from squadops.tasks.models import TaskEnvelope
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+
+def _ref(artifact_id, filename, producing_task_type):
+    return ArtifactRef(
+        artifact_id=artifact_id,
+        project_id="test",
+        artifact_type="document",
+        filename=filename,
+        content_hash="abc",
+        size_bytes=10,
+        media_type="text/markdown",
+        created_at=NOW,
+        metadata={"task_id": "t", "role": "dev", "producing_task_type": producing_task_type},
+    )
+
+
+async def test_new_enrichment_is_a_registry_edit_only(reply_router, monkeypatch):
+    """B1 exit criterion 2: adding a capability's context declaration must not
+    touch the executor. Bug caught: someone reintroduces a task-type branch in
+    ``_enrich_envelope``, and new declarations silently need executor edits
+    again (the accretion pattern #663 exists to end)."""
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+    monkeypatch.setitem(
+        ca.CONTEXT_CONTRACTS,
+        "future.capability",
+        ca.ContextAssemblyContract(
+            artifact_filter=ca.ArtifactFilter(by_producing_task=("data.research_context",)),
+        ),
+    )
+
+    stored_ref = _ref("art_1", "context_research.md", "data.research_context")
+    vault = AsyncMock()
+    vault.retrieve = AsyncMock(return_value=(stored_ref, b"research body"))
+    executor = DispatchedFlowExecutor(
+        cycle_registry=AsyncMock(),
+        artifact_vault=vault,
+        queue=reply_router.bind(AsyncMock()),
+        squad_profile=AsyncMock(),
+        project_registry=AsyncMock(),
+        reply_router=reply_router,
+    )
+    envelope = TaskEnvelope(
+        task_id="t1",
+        agent_id="a",
+        cycle_id="c",
+        pulse_id="p",
+        project_id="proj",
+        task_type="future.capability",
+        correlation_id="x",
+        causation_id="x",
+        trace_id="x",
+        span_id="x",
+    )
+
+    enriched = await executor._enrich_envelope(envelope, {}, [], [("art_1", stored_ref)])
+
+    assert enriched.inputs["artifact_contents"] == {"context_research.md": "research body"}
+
+
+def test_rc3_default_filter_lane_is_build_landing_only():
+    """The RC3 re-resolution default must select the same universe dispatch
+    selected. Bug caught: a planning filter (PRIOR_OUTPUTS landing) leaking
+    into the default lane would change correction-loop drift evidence for
+    planning task types from empty to populated."""
+    assert ca.dispatch_artifact_filter_spec("development.develop") is not None
+    assert ca.dispatch_artifact_filter_spec("qa.test") == ca.ACCEPTANCE_WORKSPACE_FILTER.to_spec()
+    assert ca.dispatch_artifact_filter_spec("qa.propose_plan_tasks") is None  # planning landing
+    assert ca.dispatch_artifact_filter_spec("strategy.frame_objective") is None  # undeclared

--- a/tests/unit/cycles/test_context_assembly_golden.py
+++ b/tests/unit/cycles/test_context_assembly_golden.py
@@ -1,0 +1,200 @@
+"""#663 golden envelope-equivalence harness (the B1 acceptance gate).
+
+Pins the EXACT enriched-envelope inputs the dispatch path produces for every
+task-type class, as canonical JSON goldens captured BEFORE the context-assembly
+extraction. Every #663 slice must keep these byte-identical — a deliberate
+context change must regenerate the golden in the same PR and read as a
+behavior change, never ride silently inside a refactor (the plan's replay-
+equivalence rule; the #452 pinned-hash pattern scaled up).
+
+Regenerate: UPDATE_CONTEXT_GOLDENS=1 pytest tests/unit/cycles/test_context_assembly_golden.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.cycles.models import ArtifactRef
+from squadops.tasks.models import TaskEnvelope
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+_GOLDEN_PATH = Path(__file__).parent / "goldens" / "context_assembly.json"
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+
+def _ref(artifact_id, filename, artifact_type="document", producing_task_type=""):
+    metadata = {"task_id": "task_1", "role": "dev"}
+    if producing_task_type:
+        metadata["producing_task_type"] = producing_task_type
+    return ArtifactRef(
+        artifact_id=artifact_id,
+        project_id="test",
+        artifact_type=artifact_type,
+        filename=filename,
+        content_hash="abc",
+        size_bytes=100,
+        media_type="text/markdown",
+        created_at=NOW,
+        metadata=metadata,
+    )
+
+
+# One stored-artifact universe covering every filter's selection axes: framing
+# documents (planning filters), dev source/config emissions (build + workspace
+# filters), a qa validation report, and an out-of-map artifact that no filter
+# may select.
+_STORED = [
+    _ref("art_research", "context_research.md", producing_task_type="data.research_context"),
+    _ref("art_frame", "objective_frame.md", producing_task_type="strategy.frame_objective"),
+    _ref("art_design", "technical_design.md", producing_task_type="development.design_plan"),
+    _ref("art_strategy", "test_strategy.md", producing_task_type="qa.define_test_strategy"),
+    _ref(
+        "art_brief",
+        "plan_authoring_brief.yaml",
+        producing_task_type="governance.prepare_plan_authoring_brief",
+    ),
+    _ref(
+        "art_dev_prop",
+        "proposed_plan_tasks.yaml",
+        producing_task_type="development.propose_plan_tasks",
+    ),
+    _ref("art_analyze", "requirements.md", producing_task_type="strategy.analyze_prd"),
+    _ref(
+        "art_routes",
+        "backend/routes.py",
+        artifact_type="source",
+        producing_task_type="development.develop",
+    ),
+    _ref(
+        "art_config",
+        ".env.example",
+        artifact_type="config",
+        producing_task_type="development.develop",
+    ),
+    _ref(
+        "art_qa_report",
+        "validation_report.md",
+        producing_task_type="qa.validate",
+    ),
+    _ref("art_outside", "unrelated_notes.md", producing_task_type="comms.broadcast"),
+]
+_STORED_PAIRS = [(r.artifact_id, r) for r in _STORED]
+
+
+def _envelope(task_type: str, inputs: dict | None = None) -> TaskEnvelope:
+    return TaskEnvelope(
+        task_id=f"task-{task_type}",
+        agent_id="agent",
+        cycle_id="cyc_golden",
+        pulse_id="p1",
+        project_id="proj",
+        task_type=task_type,
+        correlation_id="corr",
+        causation_id="cause",
+        trace_id="trace",
+        span_id="span",
+        inputs=dict(inputs or {}),
+        metadata={"role": "dev"},
+    )
+
+
+@pytest.fixture
+def executor(reply_router):
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+    vault = AsyncMock()
+    by_id = {aid: (ref, f"body of {ref.filename}".encode()) for aid, ref in _STORED_PAIRS}
+
+    async def retrieve(art_id):
+        return by_id[art_id]
+
+    vault.retrieve = AsyncMock(side_effect=retrieve)
+    ex = DispatchedFlowExecutor(
+        cycle_registry=AsyncMock(),
+        artifact_vault=vault,
+        queue=reply_router.bind(AsyncMock()),
+        squad_profile=AsyncMock(),
+        project_registry=AsyncMock(),
+        reply_router=reply_router,
+    )
+    return ex
+
+
+@pytest.fixture(scope="module")
+def manifest() -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+_PRIOR = {"dev": {"summary": "[dev] designed"}}
+_REFS = ["art_routes", "art_config"]
+
+# scenario name → (task_type, prior_outputs, artifact_refs, use_manifest, envelope_inputs)
+_SCENARIOS: dict[str, tuple[str, dict, list, bool, dict]] = {
+    "develop_with_manifest": ("development.develop", _PRIOR, _REFS, True, {"prd": "PRD"}),
+    "develop_no_manifest": ("development.develop", _PRIOR, _REFS, False, {"prd": "PRD"}),
+    "builder_assemble": ("builder.assemble", _PRIOR, _REFS, False, {}),
+    "qa_test": ("qa.test", _PRIOR, _REFS, True, {"prd": "PRD"}),
+    "planning_brief_author": ("governance.prepare_plan_authoring_brief", _PRIOR, [], False, {}),
+    "planning_dev_proposer": ("development.propose_plan_tasks", _PRIOR, [], False, {}),
+    "planning_qa_proposer": ("qa.propose_plan_tasks", _PRIOR, [], False, {}),
+    "planning_strat_guidance": ("strategy.propose_plan_guidance", _PRIOR, [], False, {}),
+    "planning_merger_excluded": ("governance.merge_plan", _PRIOR, [], False, {}),
+    "untabled_base_only": ("data.research_context", _PRIOR, ["art_frame"], False, {}),
+    # dispatch keys shadow plan-time keys of the same name (merge semantics)
+    "dispatch_shadows_plan_keys": (
+        "development.develop",
+        _PRIOR,
+        _REFS,
+        True,
+        {"prior_outputs": {"stale": True}, "artifact_refs": ["stale"]},
+    ),
+}
+
+
+async def _run_scenario(executor, manifest, name):
+    task_type, prior, refs, use_manifest, env_inputs = _SCENARIOS[name]
+    enriched = await executor._enrich_envelope(
+        _envelope(task_type, env_inputs),
+        dict(prior),
+        list(refs),
+        _STORED_PAIRS,
+        interface_manifest=manifest if use_manifest else None,
+    )
+    return enriched.inputs
+
+
+def _canonical(obj) -> str:
+    return json.dumps(obj, sort_keys=True, indent=1, default=str)
+
+
+@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
+async def test_enriched_inputs_match_golden(executor, manifest, scenario):
+    inputs = await _run_scenario(executor, manifest, scenario)
+    rendered = _canonical(inputs)
+
+    goldens = json.loads(_GOLDEN_PATH.read_text()) if _GOLDEN_PATH.exists() else {}
+    if os.environ.get("UPDATE_CONTEXT_GOLDENS"):
+        goldens[scenario] = json.loads(rendered)
+        _GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _GOLDEN_PATH.write_text(json.dumps(goldens, sort_keys=True, indent=1) + "\n")
+        return
+
+    assert scenario in goldens, (
+        f"no golden for {scenario!r} — run UPDATE_CONTEXT_GOLDENS=1 pytest {__file__}"
+    )
+    assert rendered == _canonical(goldens[scenario]), (
+        f"enriched inputs for {scenario!r} drifted from the pre-#663 golden — if this "
+        "context change is DELIBERATE, regenerate the golden in the same PR so it "
+        "reads as a behavior change, never a silent refactor side effect"
+    )

--- a/tests/unit/cycles/test_executor_build_wiring.py
+++ b/tests/unit/cycles/test_executor_build_wiring.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from squadops.capabilities.context_assembly import ACCEPTANCE_WORKSPACE_FILTER
 from squadops.cycles.models import (
     ArtifactRef,
     Cycle,
@@ -262,7 +263,7 @@ class TestAcceptanceWorkspaceResolution:
         workspace = await executor._resolve_artifact_contents(
             "development.develop",
             stored,
-            filter_spec=executor._ACCEPTANCE_WORKSPACE_FILTER,
+            filter_spec=ACCEPTANCE_WORKSPACE_FILTER.to_spec(),
         )
         assert workspace["backend/errors.py"] == "class ApiError(Exception):\n    pass\n"
 
@@ -290,7 +291,7 @@ class TestAcceptanceWorkspaceResolution:
             "development.develop",
             stored,
             include_repair_candidates=False,
-            filter_spec=executor._ACCEPTANCE_WORKSPACE_FILTER,
+            filter_spec=ACCEPTANCE_WORKSPACE_FILTER.to_spec(),
         )
         assert "backend/errors.py" in workspace
         assert "backend/routes.py" not in workspace

--- a/tests/unit/cycles/test_executor_plan_loading.py
+++ b/tests/unit/cycles/test_executor_plan_loading.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+from squadops.capabilities.context_assembly import get_context_contract
 
 # ---------------------------------------------------------------------------
 # Lightweight fakes
@@ -192,31 +193,31 @@ class TestLoadManifestForRun:
 
 
 # ---------------------------------------------------------------------------
-# Phase 3c: Artifact chaining — dev→dev via _BUILD_ARTIFACT_FILTER
+# Phase 3c: Artifact chaining — dev→dev via the context-assembly registry (#663)
 # ---------------------------------------------------------------------------
 
 
 class TestBuildArtifactFilterChaining:
     def test_dev_develop_filter_includes_prior_dev_develop(self):
         """development.develop must see artifacts from prior development.develop tasks."""
-        filt = DispatchedFlowExecutor._BUILD_ARTIFACT_FILTER["development.develop"]
-        assert "development.develop" in filt["by_producing_task"]
+        filt = get_context_contract("development.develop").artifact_filter
+        assert "development.develop" in filt.by_producing_task
 
     def test_dev_develop_filter_includes_planning_artifacts(self):
         """development.develop must also see strategy and design artifacts."""
-        filt = DispatchedFlowExecutor._BUILD_ARTIFACT_FILTER["development.develop"]
-        assert "strategy.analyze_prd" in filt["by_producing_task"]
-        assert "development.design" in filt["by_producing_task"]
+        filt = get_context_contract("development.develop").artifact_filter
+        assert "strategy.analyze_prd" in filt.by_producing_task
+        assert "development.design" in filt.by_producing_task
 
     def test_qa_test_filter_includes_dev_develop(self):
         """qa.test must see artifacts from development.develop subtasks."""
-        filt = DispatchedFlowExecutor._BUILD_ARTIFACT_FILTER["qa.test"]
-        assert "development.develop" in filt["by_producing_task"]
+        filt = get_context_contract("qa.test").artifact_filter
+        assert "development.develop" in filt.by_producing_task
 
     def test_builder_assemble_unchanged(self):
         """builder.assemble filter should still work as before."""
-        filt = DispatchedFlowExecutor._BUILD_ARTIFACT_FILTER["builder.assemble"]
-        assert "development.develop" in filt["by_producing_task"]
+        filt = get_context_contract("builder.assemble").artifact_filter
+        assert "development.develop" in filt.by_producing_task
 
 
 class TestResolveArtifactContentsChaining:


### PR DESCRIPTION
Slice 1 of #663 (of 3, per the design table on the issue — do not auto-close). Executes the plan's B1 boundary: **contracts as declarative data, one composition point, golden-proven byte-identical.**

## What moved

The five executor task-opinion tables and the three per-task-type branches in `_enrich_envelope` → `src/squadops/capabilities/context_assembly.py`: a frozen `ContextAssemblyContract` per task type (artifact filter + landing mode, acceptance-workspace flag, manifest seam surfaces, wrap-up evidence flag). `_enrich_envelope` keeps only mechanics — fragment order, artifact I/O, merge semantics — with zero task-type opinions; the RC3 default filter lane and the wrap-up gating read the registry.

## The acceptance gate (committed FIRST, refactor second)

`test_context_assembly_golden.py`: 11 scenarios spanning every dispatch-time class (dev with/without manifest incl. all three seam keys, builder, qa.test workspace, four planning types + merger exclusion, untabled base, dispatch-shadows-plan merge semantics), snapshotted from the PRE-refactor path as canonical JSON. **All 11 byte-identical through the extraction.** Any future deliberate context change must regenerate goldens in the same PR — it reads as a behavior change, never a silent refactor side effect.

## Exit criteria progress

- (2) new enrichment without executor edit: **mechanized** — `test_new_enrichment_is_a_registry_edit_only` threads a synthetic contract through the untouched executor.
- (1) executor constructs no capability-specific context: dispatch-time done; correction-path (RC3/retest/repair threading) is **S2**.
- (3) both plan-gate seams: ownership-in-writing + both-seam tests ride **S3** with the task_plan sibling migration.

Executor: 3341 → 3252 lines (secondary metric). Full regression: **6422 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv