### PR TITLE
refactor(#663): S2 — correction-path context through the context-assembly registry

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -39,6 +39,11 @@ from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
 from adapters.cycles.execution_errors import _ExecutionError
+from squadops.capabilities.context_assembly import (
+    REPAIR_CONTEXT_CONTRACT,
+    manifest_surface_fragments,
+    retest_forwarded_inputs,
+)
 from squadops.cycles.agent_config import resolve_agent_config
 from squadops.cycles.checkpoint import RunCheckpoint
 from squadops.cycles.correction_signature import (
@@ -1137,10 +1142,13 @@ class CorrectionRunner:
         # the SUBJECT and would point a test re-author at app source files).
         repair_artifacts: list[dict[str, Any]] = []
         if correction_path == "patch":
-            from squadops.capabilities.scaffold import testid_surface_instructions
-
             failed_inputs = envelope.inputs or {}
-            testid_lines = testid_surface_instructions(interface_manifest)
+            # #667/#663 S2: the anchor surface rides every repair envelope,
+            # re-derived from the manifest under both key variants — the
+            # declaration lives with the registry (REPAIR_CONTEXT_CONTRACT).
+            repair_surfaces = manifest_surface_fragments(
+                REPAIR_CONTEXT_CONTRACT, interface_manifest
+            )
             (
                 failure_locus,
                 repair_expected_artifacts,
@@ -1184,17 +1192,11 @@ class CorrectionRunner:
                     "expected_artifacts": repair_expected_artifacts,
                     "acceptance_criteria": failed_inputs.get("acceptance_criteria", []),
                 }
-                # #667: the anchor surface must survive the correction loop —
-                # fay-14's first fill complied with the manifest convention and
-                # every repair regenerated the view blind, stripping the anchors.
-                # Re-derived from the manifest (same deriver as initial dispatch)
-                # rather than copied from the failed envelope: the dev repair
-                # chain is routinely reached from a failed qa.test task (SUBJECT
-                # locus), whose envelope carries only the qa-keyed variant. Both
-                # keys ride every repair envelope; each handler reads its own.
-                if testid_lines:
-                    repair_inputs["testid_surface"] = testid_lines
-                    repair_inputs["dom_testid_surface"] = testid_lines
+                # #667: fay-14's first fill complied with the manifest
+                # convention and every repair regenerated the view blind,
+                # stripping the anchors — hence the registry-declared
+                # re-derivation above (presence-keyed: no manifest, no keys).
+                repair_inputs.update(repair_surfaces)
 
                 repair_envelope = TaskEnvelope(
                     task_id=repair_task_id,
@@ -1331,35 +1333,20 @@ class CorrectionRunner:
             return None
 
         resolved = resolve_agent_config("qa", profile)
+        # #663 S2: which failed-envelope context survives into the retest is a
+        # registry-owned declaration — the workspace/contract identity
+        # unconditionally, plus RETEST_PRESENCE_KEYS presence-keyed (#639
+        # probes: stale probe evidence for a tree the repair changed; #643
+        # acceptance workspace: the scaffold siblings exactly like the original
+        # dispatch; #667 anchor surface: the fay-6 new-dice re-author works
+        # blind to the DOM contract without it).
         retest_inputs: dict[str, Any] = {
             "prd": cycle.prd_ref,
-            "resolved_config": failed_inputs.get("resolved_config", {}),
-            "artifact_contents": failed_inputs.get("artifact_contents", {}),
             "retest_files": retest_files,
             "agent_model": resolved.model,
             "agent_config_overrides": resolved.config_overrides,
-            "subtask_focus": failed_inputs.get("subtask_focus"),
-            "expected_artifacts": failed_inputs.get("expected_artifacts", []),
-            "acceptance_criteria": failed_inputs.get("acceptance_criteria", []),
+            **retest_forwarded_inputs(failed_inputs),
         }
-        # #639: probes ride the retest or the final verdict carries stale
-        # probe evidence for a tree the repair changed. Presence-keyed, like
-        # the bind-mode injection (probe-less contracts thread no key).
-        if failed_inputs.get("contract_probes"):
-            retest_inputs["contract_probes"] = failed_inputs["contract_probes"]
-        # #643: same presence-keyed threading for the typed-acceptance
-        # workspace — the retest's evaluation needs the scaffold siblings
-        # exactly like the original dispatch did.
-        if failed_inputs.get("acceptance_workspace_files"):
-            retest_inputs["acceptance_workspace_files"] = failed_inputs[
-                "acceptance_workspace_files"
-            ]
-        # #667: the retest re-dispatches qa.test, which re-authors the suite
-        # from scratch (the fay-6 new-dice path) — without the anchor surface
-        # the retest author works blind to the DOM contract the original
-        # dispatch carried. Presence-keyed like the probes above.
-        if failed_inputs.get("dom_testid_surface"):
-            retest_inputs["dom_testid_surface"] = failed_inputs["dom_testid_surface"]
 
         retest_envelope = TaskEnvelope(
             task_id=f"retest-{run_id[:12]}-{correction_attempts:02d}-{envelope.task_type}",

--- a/src/squadops/capabilities/context_assembly.py
+++ b/src/squadops/capabilities/context_assembly.py
@@ -24,6 +24,7 @@ attribute-homed contracts would drag handler imports into runtime-api.)
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -41,6 +42,9 @@ LANDING_PRIOR_OUTPUTS = "prior_outputs"  # envelope-local ``prior_outputs["artif
 SURFACE_ERROR_CONTRACT = "error_contract"
 SURFACE_MODEL = "model_surface"
 SURFACE_TESTID = "testid_surface"
+#: The qa-keyed landing of the SAME testid inventory (#667): identical
+#: deriver, distinct envelope key — each handler reads its own variant.
+SURFACE_DOM_TESTID = "dom_testid_surface"
 
 
 @dataclass(frozen=True)
@@ -187,6 +191,51 @@ CONTEXT_CONTRACTS: dict[str, ContextAssemblyContract] = {
 }
 
 
+#: #667: the repair envelope's own context declaration (S2) — the anchor
+#: surface must survive the correction loop, RE-DERIVED from the manifest
+#: (same deriver as initial dispatch), never copied from the failed envelope:
+#: the dev repair chain is routinely reached from a failed qa.test task
+#: (SUBJECT locus), whose envelope carries only the qa-keyed variant. Both
+#: key variants ride every repair envelope; each handler reads its own.
+REPAIR_CONTEXT_CONTRACT = ContextAssemblyContract(
+    manifest_surfaces=(SURFACE_TESTID, SURFACE_DOM_TESTID),
+)
+
+#: Presence-keyed retest forwarding (S2): failed-envelope inputs a retest
+#: re-dispatch copies ONLY when present — probe-less contracts thread no key
+#: (#639), the typed-acceptance workspace forwards exactly when the original
+#: dispatch carried it (#643), and the retest's from-scratch suite re-author
+#: needs the DOM anchor surface the original dispatch carried (#667). A key
+#: silently forwarded as empty would flip the handlers' presence-gated
+#: sections.
+RETEST_PRESENCE_KEYS: tuple[str, ...] = (
+    "contract_probes",
+    "acceptance_workspace_files",
+    SURFACE_DOM_TESTID,
+)
+
+
+def retest_forwarded_inputs(failed_inputs: Mapping[str, Any]) -> dict[str, Any]:
+    """The failed task's context a retest re-dispatch carries forward (#456).
+
+    Unconditional keys are the failed task's workspace and contract identity —
+    the retest must evaluate the same tree against the same contract (missing
+    workspace defaults to empty; the runner skips the doomed dispatch before
+    composing). ``RETEST_PRESENCE_KEYS`` forward presence-keyed.
+    """
+    forwarded: dict[str, Any] = {
+        "resolved_config": failed_inputs.get("resolved_config", {}),
+        "artifact_contents": failed_inputs.get("artifact_contents", {}),
+        "subtask_focus": failed_inputs.get("subtask_focus"),
+        "expected_artifacts": failed_inputs.get("expected_artifacts", []),
+        "acceptance_criteria": failed_inputs.get("acceptance_criteria", []),
+    }
+    for key in RETEST_PRESENCE_KEYS:
+        if failed_inputs.get(key):
+            forwarded[key] = failed_inputs[key]
+    return forwarded
+
+
 def get_context_contract(task_type: str) -> ContextAssemblyContract:
     """The task type's declared contract; the empty contract for undeclared
     types (base enrichment only — chain context and artifact refs)."""
@@ -234,6 +283,7 @@ def manifest_surface_fragments(
         SURFACE_ERROR_CONTRACT: error_seam_instructions,
         SURFACE_MODEL: model_surface_instructions,
         SURFACE_TESTID: testid_surface_instructions,
+        SURFACE_DOM_TESTID: testid_surface_instructions,
     }
     fragments: dict[str, list[str]] = {}
     for surface in contract.manifest_surfaces:

--- a/tests/unit/cycles/goldens/correction_context.json
+++ b/tests/unit/cycles/goldens/correction_context.json
@@ -1,0 +1,351 @@
+{
+ "repair_dev_no_manifest": {
+  "repair_steps": [
+   {
+    "inputs": {
+     "acceptance_criteria": [
+      {
+       "check": "endpoint_defined",
+       "params": {
+        "method": "GET",
+        "path": "/api/runs"
+       }
+      }
+     ],
+     "agent_config_overrides": {},
+     "agent_model": null,
+     "artifact_refs": [
+      "art_routes",
+      "delta_000000000000"
+     ],
+     "correction_decision": {
+      "affected_task_types": [
+       "development.develop"
+      ],
+      "correction_path": "patch",
+      "decision_rationale": "patch the failing artifact",
+      "structural_plan_change_candidate": "none"
+     },
+     "expected_artifacts": [
+      "backend/routes.py",
+      "backend/models.py"
+     ],
+     "failed_task_type": "development.develop",
+     "failure_analysis": {
+      "analysis_summary": "the emitted routes module fails its endpoint check",
+      "classification": "work_product"
+     },
+     "failure_evidence": {
+      "contract_expectations": [
+       "`` must define exactly these routes (method, absolute path, and path-parameter names are all literal): "
+      ],
+      "error": "validation failed",
+      "failed_task_id": "task-development.develop",
+      "failed_task_type": "development.develop",
+      "failure_category": "executed_and_failed",
+      "outcome_class": "SEMANTIC_FAILURE",
+      "preliminary_failure_classification": "work_product",
+      "prior_plan_deltas_count": 0,
+      "rejected_artifacts": [
+       {
+        "content_snippet": "def broken(): ...",
+        "name": "backend/routes.py",
+        "size": 17,
+        "type": "source"
+       }
+      ],
+      "validation_result": {
+       "checks": [
+        {
+         "check": "endpoint_defined",
+         "detail": "GET /api/runs missing",
+         "passed": false
+        }
+       ],
+       "missing_components": [],
+       "passed": false,
+       "summary": "1/2 checks passed"
+      }
+     },
+     "prd": "PRD-CONTENT",
+     "prior_outputs": {
+      "dev": {
+       "summary": "[dev] built"
+      }
+     },
+     "resolved_config": {
+      "build_profile": "fastapi_react_vite"
+     },
+     "subtask_description": "Create endpoints",
+     "subtask_focus": "Backend API"
+    },
+    "task_type": "development.correction_repair"
+   }
+  ]
+ },
+ "repair_dev_with_manifest": {
+  "repair_steps": [
+   {
+    "inputs": {
+     "acceptance_criteria": [
+      {
+       "check": "endpoint_defined",
+       "params": {
+        "method": "GET",
+        "path": "/api/runs"
+       }
+      }
+     ],
+     "agent_config_overrides": {},
+     "agent_model": null,
+     "artifact_refs": [
+      "art_routes",
+      "delta_000000000000"
+     ],
+     "correction_decision": {
+      "affected_task_types": [
+       "development.develop"
+      ],
+      "correction_path": "patch",
+      "decision_rationale": "patch the failing artifact",
+      "structural_plan_change_candidate": "none"
+     },
+     "dom_testid_surface": [
+      "`RunsListView` (route `/`): root container `runs-list`; anchors: `runs-list`, `run-item`, `run-participant-count`, `empty-state`, `create-run-link`",
+      "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",
+      "`RunDetailView` (route `/runs/:id`): root container `run-detail`; anchors: `run-detail`, `participant-list`, `participant-item`, `join-form`, `join-name-input`, `join-submit`, `leave-form`, `leave-name-input`, `leave-submit`, `action-error`, `not-found`"
+     ],
+     "expected_artifacts": [
+      "backend/routes.py",
+      "backend/models.py"
+     ],
+     "failed_task_type": "development.develop",
+     "failure_analysis": {
+      "analysis_summary": "the emitted routes module fails its endpoint check",
+      "classification": "work_product"
+     },
+     "failure_evidence": {
+      "contract_expectations": [
+       "`` must define exactly these routes (method, absolute path, and path-parameter names are all literal): "
+      ],
+      "error": "validation failed",
+      "error_contract": [
+       "on failure raise `ApiError(code, message)` (imported from `.errors`): the FIRST argument is the error-code STRING, the second a human message \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
+       "valid error codes (code \u2192 HTTP status, mapped by frozen `errors.py`): `validation_error` \u2192 422, `run_not_found` \u2192 404, `duplicate_participant` \u2192 409, `participant_not_found` \u2192 404"
+      ],
+      "failed_task_id": "task-development.develop",
+      "failed_task_type": "development.develop",
+      "failure_category": "executed_and_failed",
+      "model_surface": [
+       "`backend/models.py` is scaffold-frozen and defines EXACTLY these names: `Participant(id, name)`, `RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants)`, `RunEventCreate(title, datetime, location, distance, pace_target, route_notes)`, `ParticipantName(name)`. Import only from this list \u2014 these are the complete contents of that module",
+       "field names are exact \u2014 construct and read models with the fields shown above; a near-miss (`pace` for `pace_target`, `meeting_location` for `location`) raises at request time and every affected endpoint returns HTTP 500",
+       "do NOT invent model names or aliases (`Run`, `RunCreate`, `RunResponse`, `RunJoin` and similar do not exist); an import of a name absent from the list above fails at load, the app never starts, and the patch is rejected",
+       "`models.py` is frozen \u2014 if a name you want is missing, use the declared names and shape the response in the fill slot; do not edit or re-emit the model module",
+       "`backend/store.py` is scaffold-frozen and already defines the in-memory stores: `participant_store`, `run_event_store` (plus `reset()` for test isolation). Import them (`from .store import ...`); do NOT declare your own store dicts \u2014 a shadow store is invisible to `reset()`, so state leaks between tests and the suite fails on isolation"
+      ],
+      "outcome_class": "SEMANTIC_FAILURE",
+      "preliminary_failure_classification": "work_product",
+      "prior_plan_deltas_count": 0,
+      "rejected_artifacts": [
+       {
+        "content_snippet": "def broken(): ...",
+        "name": "backend/routes.py",
+        "size": 17,
+        "type": "source"
+       }
+      ],
+      "scaffold_enforcement": [
+       "restore: backend/app.py is scaffold-owned"
+      ],
+      "validation_result": {
+       "checks": [
+        {
+         "check": "endpoint_defined",
+         "detail": "GET /api/runs missing",
+         "passed": false
+        }
+       ],
+       "missing_components": [],
+       "passed": false,
+       "summary": "1/2 checks passed"
+      }
+     },
+     "prd": "PRD-CONTENT",
+     "prior_outputs": {
+      "dev": {
+       "summary": "[dev] built"
+      }
+     },
+     "resolved_config": {
+      "build_profile": "fastapi_react_vite"
+     },
+     "subtask_description": "Create endpoints",
+     "subtask_focus": "Backend API",
+     "testid_surface": [
+      "`RunsListView` (route `/`): root container `runs-list`; anchors: `runs-list`, `run-item`, `run-participant-count`, `empty-state`, `create-run-link`",
+      "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",
+      "`RunDetailView` (route `/runs/:id`): root container `run-detail`; anchors: `run-detail`, `participant-list`, `participant-item`, `join-form`, `join-name-input`, `join-submit`, `leave-form`, `leave-name-input`, `leave-submit`, `action-error`, `not-found`"
+     ]
+    },
+    "task_type": "development.correction_repair"
+   }
+  ]
+ },
+ "repair_qa_own_artifact": {
+  "repair_steps": [
+   {
+    "inputs": {
+     "acceptance_criteria": [
+      {
+       "check": "expected_artifacts",
+       "params": {}
+      }
+     ],
+     "agent_config_overrides": {},
+     "agent_model": null,
+     "artifact_refs": [
+      "art_routes",
+      "delta_000000000000"
+     ],
+     "correction_decision": {
+      "affected_task_types": [
+       "development.develop"
+      ],
+      "correction_path": "patch",
+      "decision_rationale": "patch the failing artifact",
+      "structural_plan_change_candidate": "none"
+     },
+     "dom_testid_surface": [
+      "`RunsListView` (route `/`): root container `runs-list`; anchors: `runs-list`, `run-item`, `run-participant-count`, `empty-state`, `create-run-link`",
+      "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",
+      "`RunDetailView` (route `/runs/:id`): root container `run-detail`; anchors: `run-detail`, `participant-list`, `participant-item`, `join-form`, `join-name-input`, `join-submit`, `leave-form`, `leave-name-input`, `leave-submit`, `action-error`, `not-found`"
+     ],
+     "expected_artifacts": [
+      "tests/test_api.py"
+     ],
+     "failed_task_type": "qa.test",
+     "failure_analysis": {
+      "analysis_summary": "the emitted routes module fails its endpoint check",
+      "classification": "work_product"
+     },
+     "failure_evidence": {
+      "contract_expectations": [
+       "expected_artifacts"
+      ],
+      "emission_failure": {
+       "raw_response_chars": 812,
+       "reason": "zero_extraction"
+      },
+      "error": "no artifacts extracted",
+      "error_contract": [
+       "on failure raise `ApiError(code, message)` (imported from `.errors`): the FIRST argument is the error-code STRING, the second a human message \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
+       "valid error codes (code \u2192 HTTP status, mapped by frozen `errors.py`): `validation_error` \u2192 422, `run_not_found` \u2192 404, `duplicate_participant` \u2192 409, `participant_not_found` \u2192 404"
+      ],
+      "failed_task_id": "task-qa.test",
+      "failed_task_type": "qa.test",
+      "failure_category": "emission_absent",
+      "model_surface": [
+       "`backend/models.py` is scaffold-frozen and defines EXACTLY these names: `Participant(id, name)`, `RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants)`, `RunEventCreate(title, datetime, location, distance, pace_target, route_notes)`, `ParticipantName(name)`. Import only from this list \u2014 these are the complete contents of that module",
+       "field names are exact \u2014 construct and read models with the fields shown above; a near-miss (`pace` for `pace_target`, `meeting_location` for `location`) raises at request time and every affected endpoint returns HTTP 500",
+       "do NOT invent model names or aliases (`Run`, `RunCreate`, `RunResponse`, `RunJoin` and similar do not exist); an import of a name absent from the list above fails at load, the app never starts, and the patch is rejected",
+       "`models.py` is frozen \u2014 if a name you want is missing, use the declared names and shape the response in the fill slot; do not edit or re-emit the model module",
+       "`backend/store.py` is scaffold-frozen and already defines the in-memory stores: `participant_store`, `run_event_store` (plus `reset()` for test isolation). Import them (`from .store import ...`); do NOT declare your own store dicts \u2014 a shadow store is invisible to `reset()`, so state leaks between tests and the suite fails on isolation"
+      ],
+      "outcome_class": "SEMANTIC_FAILURE",
+      "preliminary_failure_classification": "",
+      "prior_plan_deltas_count": 0,
+      "rejected_artifacts": [],
+      "validation_result": {
+       "checks": [],
+       "missing_components": [],
+       "passed": false,
+       "summary": "no artifacts"
+      }
+     },
+     "prd": "PRD-CONTENT",
+     "prior_outputs": {
+      "dev": {
+       "summary": "[dev] built"
+      }
+     },
+     "resolved_config": {
+      "build_profile": "fastapi_react_vite"
+     },
+     "subtask_description": "Write tests",
+     "subtask_focus": "API tests",
+     "testid_surface": [
+      "`RunsListView` (route `/`): root container `runs-list`; anchors: `runs-list`, `run-item`, `run-participant-count`, `empty-state`, `create-run-link`",
+      "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",
+      "`RunDetailView` (route `/runs/:id`): root container `run-detail`; anchors: `run-detail`, `participant-list`, `participant-item`, `join-form`, `join-name-input`, `join-submit`, `leave-form`, `leave-name-input`, `leave-submit`, `action-error`, `not-found`"
+     ]
+    },
+    "task_type": "qa.test_repair"
+   }
+  ]
+ },
+ "retest_full": {
+  "retest_inputs": {
+   "acceptance_criteria": [
+    {
+     "check": "expected_artifacts",
+     "params": {}
+    }
+   ],
+   "acceptance_workspace_files": {
+    "backend/models.py": "x",
+    "backend/routes.py": "def ok(): ..."
+   },
+   "agent_config_overrides": {},
+   "agent_model": null,
+   "artifact_contents": {
+    "backend/routes.py": "def ok(): ..."
+   },
+   "contract_probes": [
+    {
+     "expect_status": 200,
+     "probe": "GET /api/runs"
+    }
+   ],
+   "dom_testid_surface": [
+    "run-list",
+    "run-form-submit"
+   ],
+   "expected_artifacts": [
+    "tests/test_api.py"
+   ],
+   "prd": "PRD-CONTENT",
+   "resolved_config": {
+    "build_profile": "fastapi_react_vite"
+   },
+   "retest_files": [
+    {
+     "content": "def test_runs(): pass",
+     "filename": "tests/test_api.py"
+    }
+   ],
+   "subtask_focus": "API tests"
+  }
+ },
+ "retest_minimal": {
+  "retest_inputs": {
+   "acceptance_criteria": [],
+   "agent_config_overrides": {},
+   "agent_model": null,
+   "artifact_contents": {
+    "backend/routes.py": "def ok(): ..."
+   },
+   "expected_artifacts": [
+    "tests/test_api.py"
+   ],
+   "prd": "PRD-CONTENT",
+   "resolved_config": {},
+   "retest_files": [
+    {
+     "content": "def test_runs(): pass",
+     "filename": "tests/test_api.py"
+    }
+   ],
+   "subtask_focus": null
+  }
+ }
+}

--- a/tests/unit/cycles/test_context_assembly.py
+++ b/tests/unit/cycles/test_context_assembly.py
@@ -90,3 +90,68 @@ def test_rc3_default_filter_lane_is_build_landing_only():
     assert ca.dispatch_artifact_filter_spec("qa.test") == ca.ACCEPTANCE_WORKSPACE_FILTER.to_spec()
     assert ca.dispatch_artifact_filter_spec("qa.propose_plan_tasks") is None  # planning landing
     assert ca.dispatch_artifact_filter_spec("strategy.frame_objective") is None  # undeclared
+
+
+def test_repair_contract_threads_the_same_anchor_inventory_under_both_keys():
+    """S2/#667: both testid key variants on a repair envelope must carry the
+    SAME derivation. Bug caught: mapping SURFACE_DOM_TESTID to a different
+    deriver would hand the dev and qa repair handlers divergent anchor
+    surfaces — repairs and retests would then disagree on the DOM contract."""
+    from pathlib import Path
+
+    from squadops.capabilities.scaffold import InterfaceManifest, testid_surface_instructions
+
+    manifest_path = (
+        Path(__file__).resolve().parents[3]
+        / "examples"
+        / "03_group_run"
+        / "interface_manifest.yaml"
+    )
+    manifest = InterfaceManifest.from_yaml(manifest_path.read_text(encoding="utf-8"))
+    expected_lines = testid_surface_instructions(manifest)
+    assert expected_lines, "group_run manifest lost its testid inventory — scenario broken"
+
+    fragments = ca.manifest_surface_fragments(ca.REPAIR_CONTEXT_CONTRACT, manifest)
+
+    assert fragments == {
+        ca.SURFACE_TESTID: expected_lines,
+        ca.SURFACE_DOM_TESTID: expected_lines,
+    }
+    # No manifest → no keys (the presence-gated shape repairs rely on).
+    assert ca.manifest_surface_fragments(ca.REPAIR_CONTEXT_CONTRACT, None) == {}
+
+
+def test_retest_forwarding_is_presence_keyed():
+    """S2: a presence key absent (or empty) on the failed envelope must stay
+    absent on the retest. Bug caught: forwarding an empty value would flip the
+    qa handler's presence-gated sections (probe execution, workspace
+    evaluation, anchor instructions) from 'not applicable' to 'applicable with
+    nothing in it'."""
+    failed = {
+        "resolved_config": {"build_profile": "p"},
+        "artifact_contents": {"a.py": "x"},
+        "subtask_focus": "focus",
+        "expected_artifacts": ["t.py"],
+        "acceptance_criteria": [{"check": "c"}],
+        "contract_probes": [{"probe": "GET /x"}],
+        "acceptance_workspace_files": {},  # present but EMPTY → not forwarded
+        # dom_testid_surface entirely absent
+    }
+
+    forwarded = ca.retest_forwarded_inputs(failed)
+
+    assert forwarded["contract_probes"] == [{"probe": "GET /x"}]
+    assert "acceptance_workspace_files" not in forwarded
+    assert "dom_testid_surface" not in forwarded
+    assert forwarded["resolved_config"] == {"build_profile": "p"}
+    assert forwarded["artifact_contents"] == {"a.py": "x"}
+
+    # Unconditional keys default rather than disappear on a bare envelope.
+    bare = ca.retest_forwarded_inputs({})
+    assert bare == {
+        "resolved_config": {},
+        "artifact_contents": {},
+        "subtask_focus": None,
+        "expected_artifacts": [],
+        "acceptance_criteria": [],
+    }

--- a/tests/unit/cycles/test_correction_context_golden.py
+++ b/tests/unit/cycles/test_correction_context_golden.py
@@ -1,0 +1,323 @@
+"""#663 S2 golden harness — correction-path envelope equivalence.
+
+Pins the EXACT repair-envelope and retest-envelope inputs the correction
+protocol produces, as canonical JSON goldens captured BEFORE the S2
+extraction (correction-path context declarations move beside the
+context-assembly registry). Same contract as
+``test_context_assembly_golden.py``: every #663 slice keeps these
+byte-identical — a deliberate context change must regenerate the golden in
+the same PR and read as a behavior change, never a silent refactor side
+effect.
+
+The capture seam is ``_dispatch_protocol_step`` (mocked): envelopes arrive
+there with final inputs, un-enriched — exactly the composition S2 relocates.
+
+Regenerate: UPDATE_CONTEXT_GOLDENS=1 pytest tests/unit/cycles/test_correction_context_golden.py
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from adapters.cycles.correction_runner import CorrectionRunner
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.tasks.models import TaskEnvelope, TaskResult
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+_GOLDEN_PATH = Path(__file__).parent / "goldens" / "correction_context.json"
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+
+_CYCLE = SimpleNamespace(
+    cycle_id="cyc_golden",
+    project_id="proj",
+    prd_ref="PRD-CONTENT",
+    resolved_config=lambda: {},
+)
+
+_RUN_ID = "run_abcdef123456"
+
+# Deterministic protocol-step results keyed by task type: the analyzer and
+# the governance decision drive the protocol to the patch path; repair and
+# retest steps return empty artifact sets (their outputs are not under test —
+# their INPUTS are).
+_STEP_OUTPUTS: dict[str, dict] = {
+    "data.analyze_failure": {
+        "classification": "work_product",
+        "analysis_summary": "the emitted routes module fails its endpoint check",
+    },
+    "governance.correction_decision": {
+        "correction_path": "patch",
+        "decision_rationale": "patch the failing artifact",
+        "affected_task_types": ["development.develop"],
+        "structural_plan_change_candidate": "none",
+    },
+}
+
+
+def _failed_envelope(task_type: str, inputs: dict, role: str) -> TaskEnvelope:
+    return TaskEnvelope(
+        task_id=f"task-{task_type}",
+        agent_id="agent",
+        cycle_id="cyc_golden",
+        pulse_id="p1",
+        project_id="proj",
+        task_type=task_type,
+        correlation_id="corr",
+        causation_id="cause",
+        trace_id="trace",
+        span_id="span",
+        inputs=dict(inputs),
+        metadata={"role": role},
+    )
+
+
+_DEV_FAILED_INPUTS = {
+    "prd": "PRD-CONTENT",
+    "resolved_config": {"build_profile": "fastapi_react_vite"},
+    "subtask_focus": "Backend API",
+    "subtask_description": "Create endpoints",
+    "expected_artifacts": ["backend/routes.py"],
+    "implementation_artifacts": ["backend/routes.py", "backend/models.py"],
+    "acceptance_criteria": [
+        {"check": "endpoint_defined", "params": {"method": "GET", "path": "/api/runs"}}
+    ],
+    "artifact_contents": {"backend/models.py": "class Run: ..."},
+}
+
+_DEV_FAILED_RESULT = TaskResult(
+    task_id="task-development.develop",
+    status="FAILED",
+    outputs={
+        "outcome_class": "SEMANTIC_FAILURE",
+        "failure_classification": "work_product",
+        "validation_result": {
+            "passed": False,
+            "summary": "1/2 checks passed",
+            "missing_components": [],
+            "checks": [
+                {"check": "endpoint_defined", "passed": False, "detail": "GET /api/runs missing"}
+            ],
+        },
+        "artifacts": [
+            {"name": "backend/routes.py", "type": "source", "content": "def broken(): ..."}
+        ],
+    },
+    error="validation failed",
+)
+
+_QA_FAILED_INPUTS = {
+    "prd": "PRD-CONTENT",
+    "resolved_config": {"build_profile": "fastapi_react_vite"},
+    "subtask_focus": "API tests",
+    "subtask_description": "Write tests",
+    "expected_artifacts": ["tests/test_api.py"],
+    "acceptance_criteria": [{"check": "expected_artifacts", "params": {}}],
+    "artifact_contents": {"backend/routes.py": "def ok(): ..."},
+    "acceptance_workspace_files": {"backend/routes.py": "def ok(): ...", "backend/models.py": "x"},
+    "contract_probes": [{"probe": "GET /api/runs", "expect_status": 200}],
+    "dom_testid_surface": ["run-list", "run-form-submit"],
+}
+
+# Zero-extraction marker → OWN_ARTIFACT locus → qa re-produces its own suite.
+_QA_FAILED_RESULT = TaskResult(
+    task_id="task-qa.test",
+    status="FAILED",
+    outputs={
+        "outcome_class": "SEMANTIC_FAILURE",
+        "emission_failure": {"reason": "zero_extraction", "raw_response_chars": 812},
+        "validation_result": {"passed": False, "summary": "no artifacts", "checks": []},
+        "artifacts": [],
+    },
+    error="no artifacts extracted",
+)
+
+
+@pytest.fixture(scope="module")
+def manifest() -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    """A CorrectionRunner with the dispatch seam mocked to capture envelope
+    inputs (deep-copied at capture — ``prior_outputs`` mutates between steps)
+    and uuids pinned so the plan-delta artifact id in ``artifact_refs`` is
+    stable."""
+    runner = CorrectionRunner(
+        cycle_registry=AsyncMock(),
+        artifact_vault=AsyncMock(),
+        event_bus=MagicMock(),
+        task_dispatcher=AsyncMock(),
+        store_artifact=AsyncMock(),
+    )
+    captured: list[tuple[str, str, dict]] = []
+
+    async def _capture_dispatch(step_envelope, *args, **kwargs):
+        captured.append(
+            (step_envelope.task_id, step_envelope.task_type, copy.deepcopy(step_envelope.inputs))
+        )
+        outputs = _STEP_OUTPUTS.get(step_envelope.task_type, {"artifacts": []})
+        return TaskResult(task_id=step_envelope.task_id, status="SUCCEEDED", outputs=dict(outputs))
+
+    monkeypatch.setattr(runner, "_dispatch_protocol_step", _capture_dispatch)
+
+    counter = iter(range(10_000))
+    monkeypatch.setattr("uuid.uuid4", lambda: SimpleNamespace(hex=f"{next(counter):032d}"))
+    return runner, captured
+
+
+async def _run_repair_scenario(
+    harness, manifest_obj, *, envelope, result, scaffold_enforcement_carry=None
+):
+    runner, captured = harness
+    await runner.run_correction_protocol(
+        run_id=_RUN_ID,
+        cycle=_CYCLE,
+        envelope=envelope,
+        result=result,
+        correction_attempts=0,
+        prior_outputs={"dev": {"summary": "[dev] built"}},
+        all_artifact_refs=["art_routes"],
+        stored_artifacts=[],
+        completed_task_ids=["task-development.develop"],
+        plan_delta_refs=[],
+        profile=None,
+        flow_run_id=None,
+        interface_manifest=manifest_obj,
+        artifact_contents=None,
+        scaffold_enforcement_carry=scaffold_enforcement_carry,
+        budget_guard=None,
+        signature_state=None,
+    )
+    return {
+        "repair_steps": [
+            {"task_type": task_type, "inputs": inputs}
+            for task_id, task_type, inputs in captured
+            if task_id.startswith("repair-")
+        ]
+    }
+
+
+async def _run_retest_scenario(harness, *, failed_inputs, patched_artifacts):
+    runner, captured = harness
+    result = await runner.reexecute_repaired_suite(
+        run_id=_RUN_ID,
+        cycle=_CYCLE,
+        envelope=_failed_envelope("qa.test", failed_inputs, "qa"),
+        patched_artifacts=patched_artifacts,
+        correction_attempts=1,
+        prior_outputs={},
+        all_artifact_refs=[],
+        stored_artifacts=[],
+        completed_task_ids=[],
+        plan_delta_refs=[],
+        profile=None,
+    )
+    assert result is not None, "retest unexpectedly skipped — scenario broken"
+    retests = [inputs for task_id, _, inputs in captured if task_id.startswith("retest-")]
+    assert len(retests) == 1
+    return {"retest_inputs": retests[0]}
+
+
+_PATCHED = [
+    {"name": "tests/test_api.py", "type": "source", "content": "def test_runs(): pass"},
+    # *about*-the-run artifact: excluded from the re-executed workspace (#456)
+    {"name": "report.md", "type": "test_report", "content": "1 failed"},
+]
+
+
+async def _scenario_repair_dev_with_manifest(harness, manifest_obj):
+    """Dev-locus repair with a manifest: testid anchors ride both key
+    variants; error-contract/model-surface evidence derives from the manifest;
+    prior enforcement instructions carry."""
+    return await _run_repair_scenario(
+        harness,
+        manifest_obj,
+        envelope=_failed_envelope("development.develop", _DEV_FAILED_INPUTS, "dev"),
+        result=_DEV_FAILED_RESULT,
+        scaffold_enforcement_carry=["restore: backend/app.py is scaffold-owned"],
+    )
+
+
+async def _scenario_repair_dev_no_manifest(harness, manifest_obj):
+    """No manifest → no testid keys, no manifest-derived evidence — the
+    presence-gated shape."""
+    return await _run_repair_scenario(
+        harness,
+        None,
+        envelope=_failed_envelope("development.develop", _DEV_FAILED_INPUTS, "dev"),
+        result=_DEV_FAILED_RESULT,
+    )
+
+
+async def _scenario_repair_qa_own_artifact(harness, manifest_obj):
+    """Zero-extraction qa.test failure → OWN_ARTIFACT locus: qa re-produces
+    its own suite; the repair target is the failed task's own contract."""
+    return await _run_repair_scenario(
+        harness,
+        manifest_obj,
+        envelope=_failed_envelope("qa.test", _QA_FAILED_INPUTS, "qa"),
+        result=_QA_FAILED_RESULT,
+    )
+
+
+async def _scenario_retest_full(harness, manifest_obj):
+    """Every presence-keyed forwarding input set: probes (#639), acceptance
+    workspace (#643), DOM anchor surface (#667) all survive into the retest."""
+    return await _run_retest_scenario(
+        harness, failed_inputs=_QA_FAILED_INPUTS, patched_artifacts=_PATCHED
+    )
+
+
+async def _scenario_retest_minimal(harness, manifest_obj):
+    """Presence keys absent on the failed envelope → absent on the retest."""
+    minimal = {
+        "artifact_contents": {"backend/routes.py": "def ok(): ..."},
+        "expected_artifacts": ["tests/test_api.py"],
+    }
+    return await _run_retest_scenario(harness, failed_inputs=minimal, patched_artifacts=_PATCHED)
+
+
+_SCENARIOS = {
+    "repair_dev_with_manifest": _scenario_repair_dev_with_manifest,
+    "repair_dev_no_manifest": _scenario_repair_dev_no_manifest,
+    "repair_qa_own_artifact": _scenario_repair_qa_own_artifact,
+    "retest_full": _scenario_retest_full,
+    "retest_minimal": _scenario_retest_minimal,
+}
+
+
+def _canonical(obj) -> str:
+    return json.dumps(obj, sort_keys=True, indent=1, default=str)
+
+
+@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
+async def test_correction_context_matches_golden(harness, manifest, scenario):
+    value = await _SCENARIOS[scenario](harness, manifest)
+    rendered = _canonical(value)
+
+    goldens = json.loads(_GOLDEN_PATH.read_text()) if _GOLDEN_PATH.exists() else {}
+    if os.environ.get("UPDATE_CONTEXT_GOLDENS"):
+        goldens[scenario] = json.loads(rendered)
+        _GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _GOLDEN_PATH.write_text(json.dumps(goldens, sort_keys=True, indent=1) + "\n")
+        return
+
+    assert scenario in goldens, (
+        f"no golden for {scenario!r} — run UPDATE_CONTEXT_GOLDENS=1 pytest {__file__}"
+    )
+    assert rendered == _canonical(goldens[scenario]), (
+        f"correction-path inputs for {scenario!r} drifted from the pre-S2 golden — if this "
+        "context change is DELIBERATE, regenerate the golden in the same PR so it "
+        "reads as a behavior change, never a silent refactor side effect"
+    )


### PR DESCRIPTION
## #663 S2 — correction-path context through the registry

Second of the three slices from the design table on #663 (D3). S1 moved every dispatch-time context opinion into `squadops/capabilities/context_assembly.py`; this slice moves the **correction-path** declarations beside it, so after S2 both dispatch and correction read one registry (exit criterion 1).

### Golden-first, same as S1

Commit 1 lands `tests/unit/cycles/test_correction_context_golden.py` + goldens **captured on pre-S2 code**: the exact repair-envelope and retest-envelope inputs at the un-enriched dispatch seam (`_dispatch_protocol_step`, mocked; uuids pinned so the plan-delta id in `artifact_refs` is stable). Five scenarios:

- `repair_dev_with_manifest` — dev-locus repair: testid anchors under both key variants, manifest-derived evidence, enforcement carry
- `repair_dev_no_manifest` — the presence-gated shape (no testid keys, no manifest evidence)
- `repair_qa_own_artifact` — zero-extraction qa.test → OWN_ARTIFACT locus → `qa.test_repair` re-produces its own contract
- `retest_full` — all three presence-keyed forwarding sets survive (#639 probes, #643 workspace, #667 anchor surface); `test_report`-typed artifact excluded from `retest_files` (#456)
- `retest_minimal` — presence keys absent on the failed envelope → absent on the retest

Commit 2 is the refactor; **all goldens (S1's 11 + these 5) hold byte-identical through it.**

### What moved

| Was (inline in `correction_runner`) | Now (registry-owned) |
|---|---|
| `testid_surface_instructions` imported ad hoc; both keys hand-threaded onto repair envelopes (#667) | `REPAIR_CONTEXT_CONTRACT` — composed by the same `manifest_surface_fragments` composer dispatch uses; `SURFACE_DOM_TESTID` joins the vocabulary (same deriver as `SURFACE_TESTID`, distinct landing key — each handler reads its own) |
| Hand-built retest dict + three copy-pasted presence-keyed `if` blocks | `retest_forwarded_inputs()` + `RETEST_PRESENCE_KEYS` — unconditional workspace/contract identity + the presence-keyed set, one declaration |

**RC3 re-resolution needed no change**: since S1 it already reads the registry default lane (`dispatch_artifact_filter_spec`) — pinned by `test_rc3_default_filter_lane_is_build_landing_only`.

New registry tests: both testid variants must carry the *same* derivation (divergent anchor surfaces between dev and qa repair handlers is the bug); presence-keyed forwarding must not forward empty values (would flip the qa handler's presence-gated sections).

### Considered and excluded (scope per D3/D6)

`_inject_deterministic_evidence`'s `error_contract`/`model_surface` derivations stay in the runner: they travel the **failure-evidence channel** (failure_evidence → authoritative prompt block), not envelope context assembly — they are evidence about a failure, not a forwarding table. The design table scopes S2 to the forwarding tables; folding the evidence channel into a context registry would conflate the two transports.

### Verification

- 5 correction goldens + 11 S1 goldens byte-identical through the refactor
- `tests/unit/cycles/` domain: 2515 passed
- Full regression: **6429 passed, 1 skipped** (ruff clean)

Part of #663 (slice 2 of 3 — S3 closes it: task_plan sibling + D5 gate-seam ownership tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
