### PR TITLE
refactor(#663): S3 — plan-time context through the registry + gate-seam ownership (closes #663)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2826,6 +2826,18 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         dispatch-time net in ``generate_task_plan``. Absent or unreadable
         plans defer to that same net — this check only ever adds an earlier
         rejection, never a pass.
+
+        OWNERSHIP (#663 D5): this seam and ``_reject_unsatisfiable_plan_at_gate``
+        are deliberately SEPARATE nets with different error channels — they are
+        plan VALIDATION, not context assembly, and merging them would conflate
+        #473's returns-vs-raises semantics. This one owns the inter-workload
+        promotion decision: errors return, the caller records a system REJECTED
+        gate decision, and the framing re-rolls for free. The other owns in-run
+        dispatch admission and raises. A new plan-validation rule must pick its
+        net by WHERE the reject must land (recorded re-roll vs run failure) —
+        landing a rule on only one seam when both apply is the #718/#719 scar.
+        Both call sites are pinned by
+        ``tests/unit/cycles/test_plan_gate_seams.py``.
         """
         if not cycle.resolved_config().get("implementation_plan", False):
             return []
@@ -2905,9 +2917,9 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             )
 
         # SIP-0099 99.2: a framing-emitted interface manifest is validated here — this is
-        # its ONLY net (the dispatch-time net in cycles/task_plan.py stays scaffold-free to
-        # preserve the cycles→capabilities layering). Errors join the same returned list,
-        # so they flow into the identical system:plan_validation REJECTED recording.
+        # its ONLY net; generate_task_plan's dispatch-time net validates the PLAN, never
+        # the manifest. Errors join the same returned list, so they flow into the
+        # identical system:plan_validation REJECTED recording.
         # Absent manifest → no-op = today's behavior (byte-identical for plan-only cycles).
         if interface_content is not None:
             errors.extend(self._validate_interface_manifest(interface_content))
@@ -3084,6 +3096,19 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         across the ``progress_plan_review`` / ``plan-review`` naming variants.
         An absent or unreadable plan defers to the dispatch-time net —
         this check only ever *adds* an earlier rejection, never a pass.
+
+        OWNERSHIP (#663 D5): this seam and
+        ``_reject_invalid_plan_before_workload_gate`` are deliberately SEPARATE
+        nets with different error channels — they are plan VALIDATION, not
+        context assembly, and merging them would conflate #473's
+        returns-vs-raises semantics. This one owns in-run dispatch admission:
+        errors RAISE ``_ExecutionError`` and the run fails at the gate. The
+        other owns the inter-workload promotion decision (returns errors for a
+        recorded system REJECTED + free framing re-roll — the path
+        multi-workload cycles actually traverse). A new plan-validation rule
+        must pick its net by WHERE the reject must land — landing a rule on
+        only one seam when both apply is the #718/#719 scar. Both call sites
+        are pinned by ``tests/unit/cycles/test_plan_gate_seams.py``.
         """
         if not cycle.resolved_config().get("implementation_plan", False):
             return

--- a/src/squadops/capabilities/context_assembly.py
+++ b/src/squadops/capabilities/context_assembly.py
@@ -70,8 +70,9 @@ class ArtifactFilter:
 
 @dataclass(frozen=True)
 class ContextAssemblyContract:
-    """One task type's dispatch-time context declaration.
+    """One task type's context declaration — dispatch-time and plan-time.
 
+    Dispatch-time (composed by the executor's ``_enrich_envelope``):
     ``artifact_filter``/``artifact_landing``: which stored artifacts the task
     sees and where they land. ``acceptance_workspace``: thread the full
     accepted tree for typed-acceptance evaluation (#643 — rides separately
@@ -79,6 +80,18 @@ class ContextAssemblyContract:
     seam-instruction sets to thread, presence-keyed (#588/pf-45/#659).
     ``wrapup_evidence``: the run-level CycleOutcome injection applies when any
     planned task carries this flag (#683).
+
+    Plan-time (composed by ``generate_task_plan``, S3 — the flags name WHO
+    receives an input class; the derivation mechanics stay with the plan
+    composer): ``plan_rejection_context``: a #522 framing re-roll threads the
+    prior framing's rejection reasons onto this task (#669).
+    ``bind_criteria_index``: in bind mode this proposer receives the
+    contract's criteria index + the frozen-surface index, so it binds
+    covered-file criteria instead of authoring them (SIP-0098 98.3 / pf-42).
+    ``bind_behavioral_surface``: in bind mode this task receives the
+    contract's behavioral surface — serialized probes (98.5), the
+    endpoint→fill-slot ownership map (#688), pinned-status expectation lines
+    (#629/pf-54), and the DOM anchor inventory (#659) — all presence-keyed.
     """
 
     artifact_filter: ArtifactFilter | None = None
@@ -86,6 +99,9 @@ class ContextAssemblyContract:
     acceptance_workspace: bool = False
     manifest_surfaces: tuple[str, ...] = ()
     wrapup_evidence: bool = False
+    plan_rejection_context: bool = False
+    bind_criteria_index: bool = False
+    bind_behavioral_surface: bool = False
 
 
 _EMPTY_CONTRACT = ContextAssemblyContract()
@@ -131,16 +147,25 @@ CONTEXT_CONTRACTS: dict[str, ContextAssemblyContract] = {
         ),
         acceptance_workspace=True,
     ),
-    # qa.test's prompt context IS the full accepted tree (#644).
+    # qa.test's prompt context IS the full accepted tree (#644); in bind mode
+    # it additionally carries the contract's behavioral surface at PLAN time.
     "qa.test": ContextAssemblyContract(
         artifact_filter=ACCEPTANCE_WORKSPACE_FILTER,
         acceptance_workspace=True,
+        bind_behavioral_surface=True,
     ),
     # --- planning chain (#657): upstream documents on an envelope-local
-    # prior_outputs copy. governance.merge_plan is DELIBERATELY absent: by
-    # merge time both proposals collide on the proposed_plan_tasks.yaml
-    # filename, so threading there would silently drop one proposal — the
-    # merger consumes brief_outcome/proposal_outcome output keys instead.
+    # prior_outputs copy; all four authoring types receive a re-roll's
+    # rejection context (#669 — fresh dice previously meant zero teaching,
+    # fay-10 re-tripped the same class three times). governance.merge_plan is
+    # DELIBERATELY absent from BOTH: by merge time both proposals collide on
+    # the proposed_plan_tasks.yaml filename, so artifact threading would
+    # silently drop one proposal (the merger consumes brief_outcome/
+    # proposal_outcome output keys instead), and its normal merge path is
+    # deterministic — no prompt for rejection context to teach.
+    # bind_criteria_index (SIP-0098 98.3): dev/qa propose BUILD tasks and so
+    # bind covered-file criteria; strategy proposes guidance and the brief
+    # author frames — neither is indexed.
     "governance.prepare_plan_authoring_brief": ContextAssemblyContract(
         artifact_filter=ArtifactFilter(
             by_producing_task=(
@@ -151,6 +176,7 @@ CONTEXT_CONTRACTS: dict[str, ContextAssemblyContract] = {
             ),
         ),
         artifact_landing=LANDING_PRIOR_OUTPUTS,
+        plan_rejection_context=True,
     ),
     "development.propose_plan_tasks": ContextAssemblyContract(
         artifact_filter=ArtifactFilter(
@@ -160,6 +186,8 @@ CONTEXT_CONTRACTS: dict[str, ContextAssemblyContract] = {
             ),
         ),
         artifact_landing=LANDING_PRIOR_OUTPUTS,
+        plan_rejection_context=True,
+        bind_criteria_index=True,
     ),
     "qa.propose_plan_tasks": ContextAssemblyContract(
         artifact_filter=ArtifactFilter(
@@ -171,6 +199,8 @@ CONTEXT_CONTRACTS: dict[str, ContextAssemblyContract] = {
             ),
         ),
         artifact_landing=LANDING_PRIOR_OUTPUTS,
+        plan_rejection_context=True,
+        bind_criteria_index=True,
     ),
     "strategy.propose_plan_guidance": ContextAssemblyContract(
         artifact_filter=ArtifactFilter(
@@ -180,6 +210,7 @@ CONTEXT_CONTRACTS: dict[str, ContextAssemblyContract] = {
             ),
         ),
         artifact_landing=LANDING_PRIOR_OUTPUTS,
+        plan_rejection_context=True,
     ),
     # --- wrap-up pipeline (#683): the run-level verification_evidence
     # injection fires when any planned task carries the flag.

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -19,6 +19,7 @@ from collections import Counter
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from squadops.capabilities.context_assembly import get_context_contract
 from squadops.capabilities.handlers.build_profiles import (
     ROUTING_BUILDER_PRESENT,
     ROUTING_FALLBACK_NO_BUILDER,
@@ -108,13 +109,6 @@ _PLAN_AUTHORING_PROPOSER_STEPS: dict[str, tuple[str, str]] = {
 # §5.12 — builder-role proposer). Reject early so a typo or premature
 # config doesn't silently drop a proposer.
 _VALID_PLAN_AUTHORING_CONTRIBUTORS = frozenset({"development", "qa", "strategy"})
-
-# SIP-0098 98.3: proposer task types that receive the contract criteria index in
-# bind mode. dev/qa propose build tasks and so bind covered-file criteria; strategy
-# proposes guidance (no build tasks), so it is not indexed.
-_BIND_INDEX_PROPOSER_TASK_TYPES = frozenset(
-    {"development.propose_plan_tasks", "qa.propose_plan_tasks"}
-)
 
 
 def build_planning_steps(
@@ -454,19 +448,6 @@ def _applicable_acceptance(plan_task: Any) -> list:
     return acceptance
 
 
-# #669: the plan-authoring tasks that receive the prior framing's rejection
-# context on a re-roll — the same four the #657 planning-artifact filter feeds.
-# The merger is excluded: its normal merge path is deterministic (no prompt).
-_PLAN_AUTHORING_CONTEXT_TASK_TYPES = frozenset(
-    {
-        "governance.prepare_plan_authoring_brief",
-        "development.propose_plan_tasks",
-        "qa.propose_plan_tasks",
-        "strategy.propose_plan_guidance",
-    }
-)
-
-
 def _inject_rejection_context(
     inputs: dict[str, Any], rejection_context: Any, task_type: str
 ) -> None:
@@ -478,10 +459,14 @@ def _inject_rejection_context(
     (fay-10 tripped the same ownership class on all three framings). Data-only
     keys; the authoring handlers render them through a managed appendix asset
     (CLAUDE.md #448). Non-re-roll runs carry no context and get no keys.
+
+    #663 S3: WHO receives the context is the registry's declaration
+    (``plan_rejection_context`` — the four authoring types, merger excluded);
+    this composer owns only the derivation and injection mechanics.
     """
     if not isinstance(rejection_context, dict):
         return
-    if task_type not in _PLAN_AUTHORING_CONTEXT_TASK_TYPES:
+    if not get_context_contract(task_type).plan_rejection_context:
         return
     reasons = [
         str(r).strip() for r in (rejection_context.get("rejection_reasons") or []) if str(r).strip()
@@ -517,10 +502,15 @@ def _inject_contract_inputs(
 
     Author mode (``contract is None``) injects nothing — contract-less cycles
     stay byte-identical.
+
+    #663 S3: WHO receives each bind-mode input class is the registry's
+    declaration (``bind_criteria_index`` / ``bind_behavioral_surface``); this
+    composer owns only the contract/manifest derivation mechanics.
     """
     if contract is None:
         return
-    if task_type in _BIND_INDEX_PROPOSER_TASK_TYPES:
+    task_contract = get_context_contract(task_type)
+    if task_contract.bind_criteria_index:
         inputs["contract_criteria_index"] = "\n".join(contract.criteria_index_lines())
         # pf-42: the criteria index covers the fill slots only — four files of
         # seventeen. The rest are frozen, and the proposer was never told they exist,
@@ -530,7 +520,7 @@ def _inject_contract_inputs(
         frozen_index = frozen_surface_index_lines(interface_manifest)
         if frozen_index:
             inputs["frozen_surface_index"] = "\n".join(frozen_index)
-    if task_type == "qa.test":
+    if task_contract.bind_behavioral_surface:
         if contract.behavioral.probes:
             inputs["contract_probes"] = [p.to_dict() for p in contract.behavioral.probes]
             # #688: the endpoint→fill-slot ownership map, so a correction born of a

--- a/tests/unit/cycles/goldens/plan_context.json
+++ b/tests/unit/cycles/goldens/plan_context.json
@@ -1,0 +1,458 @@
+{
+ "framing_bind_with_rejection": {
+  "00:data.research_context": {
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "plan_authoring_contributors": [
+     "development",
+     "qa",
+     "strategy"
+    ]
+   },
+   "role_index": 1,
+   "role_total": 1
+  },
+  "01:strategy.frame_objective": {
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "plan_authoring_contributors": [
+     "development",
+     "qa",
+     "strategy"
+    ]
+   },
+   "role_index": 1,
+   "role_total": 2
+  },
+  "02:development.design_plan": {
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "plan_authoring_contributors": [
+     "development",
+     "qa",
+     "strategy"
+    ]
+   },
+   "role_index": 1,
+   "role_total": 2
+  },
+  "03:qa.define_test_strategy": {
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "plan_authoring_contributors": [
+     "development",
+     "qa",
+     "strategy"
+    ]
+   },
+   "role_index": 1,
+   "role_total": 2
+  },
+  "04:governance.prepare_plan_authoring_brief": {
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "rejected_plan_yaml": "version: 1\ntasks: []\n",
+   "rejection_reasons": [
+    "plan_task 2 claims frozen file backend/app.py",
+    "qa.test task binds no runnable suite artifact"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "plan_authoring_contributors": [
+     "development",
+     "qa",
+     "strategy"
+    ]
+   },
+   "role_index": 1,
+   "role_total": 3
+  },
+  "05:development.propose_plan_tasks": {
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "contract_criteria_index": "- backend/routes.py: bind vc-routes-endpoints (endpoint_defined)",
+   "frozen_surface_index": "- `backend/__init__.py`\n- `backend/main.py` \u2014 functions health; imports `.errors`, `.routes`, `fastapi`, `fastapi.middleware.cors`, `os`\n- `backend/models.py` \u2014 defines Participant(id, name), RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants), RunEventCreate(title, datetime, location, distance, pace_target, route_notes), ParticipantName(name); imports `pydantic`, `typing`\n- `backend/store.py` \u2014 module state participant_store: dict[str, Participant], run_event_store: dict[str, RunEvent]; functions reset; imports `.models`\n- `backend/errors.py` \u2014 defines ApiError; functions register_error_handlers; imports `fastapi`, `fastapi.exceptions`, `fastapi.responses`\n- `backend/requirements.txt`\n- `conftest.py` \u2014 functions client; imports `backend.main`, `fastapi.testclient`, `os`, `pytest`, `sys`\n- `frontend/index.html`\n- `frontend/package.json`\n- `frontend/vite.config.js`\n- `frontend/src/test-setup.js`\n- `frontend/src/__tests__/harness.test.jsx`\n- `frontend/src/main.jsx`\n- `frontend/src/api.js`\n- `frontend/src/App.jsx`",
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "rejected_plan_yaml": "version: 1\ntasks: []\n",
+   "rejection_reasons": [
+    "plan_task 2 claims frozen file backend/app.py",
+    "qa.test task binds no runnable suite artifact"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "plan_authoring_contributors": [
+     "development",
+     "qa",
+     "strategy"
+    ]
+   },
+   "role_index": 2,
+   "role_total": 2
+  },
+  "06:qa.propose_plan_tasks": {
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "contract_criteria_index": "- backend/routes.py: bind vc-routes-endpoints (endpoint_defined)",
+   "frozen_surface_index": "- `backend/__init__.py`\n- `backend/main.py` \u2014 functions health; imports `.errors`, `.routes`, `fastapi`, `fastapi.middleware.cors`, `os`\n- `backend/models.py` \u2014 defines Participant(id, name), RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants), RunEventCreate(title, datetime, location, distance, pace_target, route_notes), ParticipantName(name); imports `pydantic`, `typing`\n- `backend/store.py` \u2014 module state participant_store: dict[str, Participant], run_event_store: dict[str, RunEvent]; functions reset; imports `.models`\n- `backend/errors.py` \u2014 defines ApiError; functions register_error_handlers; imports `fastapi`, `fastapi.exceptions`, `fastapi.responses`\n- `backend/requirements.txt`\n- `conftest.py` \u2014 functions client; imports `backend.main`, `fastapi.testclient`, `os`, `pytest`, `sys`\n- `frontend/index.html`\n- `frontend/package.json`\n- `frontend/vite.config.js`\n- `frontend/src/test-setup.js`\n- `frontend/src/__tests__/harness.test.jsx`\n- `frontend/src/main.jsx`\n- `frontend/src/api.js`\n- `frontend/src/App.jsx`",
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "rejected_plan_yaml": "version: 1\ntasks: []\n",
+   "rejection_reasons": [
+    "plan_task 2 claims frozen file backend/app.py",
+    "qa.test task binds no runnable suite artifact"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "plan_authoring_contributors": [
+     "development",
+     "qa",
+     "strategy"
+    ]
+   },
+   "role_index": 2,
+   "role_total": 2
+  },
+  "07:strategy.propose_plan_guidance": {
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "rejected_plan_yaml": "version: 1\ntasks: []\n",
+   "rejection_reasons": [
+    "plan_task 2 claims frozen file backend/app.py",
+    "qa.test task binds no runnable suite artifact"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "plan_authoring_contributors": [
+     "development",
+     "qa",
+     "strategy"
+    ]
+   },
+   "role_index": 2,
+   "role_total": 2
+  },
+  "08:governance.merge_plan": {
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "plan_authoring_contributors": [
+     "development",
+     "qa",
+     "strategy"
+    ]
+   },
+   "role_index": 2,
+   "role_total": 3
+  },
+  "09:governance.review_plan": {
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "plan_authoring_contributors": [
+     "development",
+     "qa",
+     "strategy"
+    ]
+   },
+   "role_index": 3,
+   "role_total": 3
+  }
+ },
+ "implementation_author": {
+  "00:governance.define_done": {
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "resolved_config": {
+    "implementation_plan": true
+   },
+   "role_index": 1,
+   "role_total": 1
+  },
+  "01:development.develop": {
+   "acceptance_criteria": [],
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "expected_artifacts": [
+    "backend/routes.py"
+   ],
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "resolved_config": {
+    "implementation_plan": true
+   },
+   "role_index": 1,
+   "role_total": 1,
+   "subtask_description": "implement the routes fill slot",
+   "subtask_focus": "routes",
+   "subtask_index": 0
+  },
+  "02:qa.test": {
+   "acceptance_criteria": [],
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "expected_artifacts": [
+    "backend/tests/test_items.py"
+   ],
+   "implementation_artifacts": [
+    "backend/routes.py"
+   ],
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "resolved_config": {
+    "implementation_plan": true
+   },
+   "role_index": 1,
+   "role_total": 1,
+   "subtask_description": "author the API suite",
+   "subtask_focus": "suite",
+   "subtask_index": 1
+  }
+ },
+ "implementation_bind": {
+  "00:governance.define_done": {
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "implementation_plan": true
+   },
+   "role_index": 1,
+   "role_total": 1
+  },
+  "01:development.develop": {
+   "acceptance_criteria": [
+    "TypedCheck(check='endpoint_defined', params={'methods_paths': ['POST /items'], 'file': 'backend/routes.py'}, severity='error', description='', id='vc-routes-endpoints')"
+   ],
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "config_hash": "confhash",
+   "expected_artifacts": [
+    "backend/routes.py"
+   ],
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "implementation_plan": true
+   },
+   "role_index": 1,
+   "role_total": 1,
+   "subtask_description": "implement the routes fill slot",
+   "subtask_focus": "routes",
+   "subtask_index": 0
+  },
+  "02:qa.test": {
+   "acceptance_criteria": [
+    "TypedCheck(check='harness_boundary', params={'file': 'backend/tests/test_items.py', 'entry_modules': ['backend.main', 'app.main', 'main']}, severity='error', description='', id='scaffold-harness:backend/tests/test_items.py')",
+    "TypedCheck(check='contract_assertions_match', params={'file': 'backend/tests/test_items.py', 'endpoints': ['POST /items 201', 'POST /items 409'], 'allowed_error_statuses': [409]}, severity='error', description='', id='contract-assertions:backend/tests/test_items.py')"
+   ],
+   "agent_config_overrides": {},
+   "agent_model": "m",
+   "api_behavior_contract": [
+    "POST /items \u2192 HTTP 201",
+    "POST /items (rejection case) \u2192 HTTP 409 (error_code: duplicate_item)"
+   ],
+   "config_hash": "confhash",
+   "contract_endpoint_owners": {
+    "POST /items": "backend/routes.py"
+   },
+   "contract_probes": [
+    {
+     "expect": {
+      "json_has": [
+       "id"
+      ],
+      "status": 201
+     },
+     "id": "vc-probe-create",
+     "request": {
+      "json": {
+       "title": "x"
+      },
+      "method": "POST",
+      "path": "/items"
+     },
+     "subject": "backend"
+    },
+    {
+     "expect": {
+      "error_code": "duplicate_item",
+      "status": 409
+     },
+     "id": "vc-probe-dup",
+     "request": {
+      "json": {
+       "title": "x"
+      },
+      "method": "POST",
+      "path": "/items"
+     },
+     "subject": "backend"
+    }
+   ],
+   "dom_testid_surface": [
+    "`RunsListView` (route `/`): root container `runs-list`; anchors: `runs-list`, `run-item`, `run-participant-count`, `empty-state`, `create-run-link`",
+    "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",
+    "`RunDetailView` (route `/runs/:id`): root container `run-detail`; anchors: `run-detail`, `participant-list`, `participant-item`, `join-form`, `join-name-input`, `join-submit`, `leave-form`, `leave-name-input`, `leave-submit`, `action-error`, `not-found`"
+   ],
+   "expected_artifacts": [
+    "backend/tests/test_items.py"
+   ],
+   "implementation_artifacts": [
+    "backend/routes.py"
+   ],
+   "prd": "PRD-CONTENT",
+   "profile_roles": [
+    "data",
+    "dev",
+    "lead",
+    "qa",
+    "strat"
+   ],
+   "resolved_config": {
+    "contract_ref": "art_c",
+    "implementation_plan": true
+   },
+   "role_index": 1,
+   "role_total": 1,
+   "subtask_description": "author the API suite",
+   "subtask_focus": "suite",
+   "subtask_index": 1
+  }
+ }
+}

--- a/tests/unit/cycles/test_plan_context_golden.py
+++ b/tests/unit/cycles/test_plan_context_golden.py
@@ -1,0 +1,266 @@
+"""#663 S3 golden harness — plan-time envelope equivalence.
+
+Pins the EXACT envelope inputs ``generate_task_plan`` produces for the
+framing and implementation sequences, as canonical JSON goldens captured
+BEFORE the S3 extraction (the plan-time membership tables —
+which task types receive bind-mode contract inputs and re-roll rejection
+context — move onto the context-assembly registry's contracts). Same
+contract as the S1/S2 harnesses: every #663 slice keeps these
+byte-identical — a deliberate context change must regenerate the golden in
+the same PR and read as a behavior change, never a silent refactor side
+effect.
+
+Envelope inputs only (lineage uuids are envelope fields, outside the
+capture); ``TypedCheck`` instances render via their deterministic dataclass
+repr (``default=str``).
+
+Regenerate: UPDATE_CONTEXT_GOLDENS=1 pytest tests/unit/cycles/test_plan_context_golden.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.cycles.implementation_plan import ImplementationPlan
+from squadops.cycles.models import (
+    AgentProfileEntry,
+    Cycle,
+    Run,
+    SquadProfile,
+    TaskFlowPolicy,
+    WorkloadType,
+)
+from squadops.cycles.task_plan import generate_task_plan
+from squadops.cycles.verification_contract import VerificationContract
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_GOLDEN_PATH = Path(__file__).parent / "goldens" / "plan_context.json"
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+_NOW = datetime(2026, 7, 18, tzinfo=UTC)
+
+_CONTRACT = VerificationContract.from_dict(
+    {
+        "contract_version": 1,
+        "skeleton": {
+            "expander": "fullstack_fastapi_react",
+            "interface_manifest_hash": "a" * 64,
+        },
+        "capabilities": ["python"],
+        "frozen": [],
+        "fill_files": {
+            "backend/routes.py": {
+                "interface": [
+                    {
+                        "check": "endpoint_defined",
+                        "id": "vc-routes-endpoints",
+                        "methods_paths": ["POST /items"],
+                    }
+                ],
+                "implementation": [],
+            }
+        },
+        "behavioral": {
+            "build": [],
+            "suite": {"checks": [], "coverage_expectations": []},
+            "probes": [
+                {
+                    "id": "vc-probe-create",
+                    "subject": "backend",
+                    "request": {"method": "POST", "path": "/items", "json": {"title": "x"}},
+                    "expect": {"status": 201, "json_has": ["id"]},
+                },
+                {
+                    "id": "vc-probe-dup",
+                    "subject": "backend",
+                    "request": {"method": "POST", "path": "/items", "json": {"title": "x"}},
+                    "expect": {"status": 409, "error_code": "duplicate_item"},
+                },
+            ],
+        },
+    }
+)
+
+_REJECTION_CONTEXT = {
+    "rejection_reasons": [
+        "plan_task 2 claims frozen file backend/app.py",
+        "qa.test task binds no runnable suite artifact",
+    ],
+    "rejected_plan_yaml": "version: 1\ntasks: []\n",
+}
+
+_PLAN = ImplementationPlan.from_yaml(
+    yaml.safe_dump(
+        {
+            "version": 1,
+            "project_id": "p",
+            "cycle_id": "cyc_golden",
+            "prd_hash": "h",
+            "tasks": [
+                {
+                    "task_index": 0,
+                    "task_type": "development.develop",
+                    "role": "dev",
+                    "focus": "routes",
+                    "description": "implement the routes fill slot",
+                    "expected_artifacts": ["backend/routes.py"],
+                    "acceptance_criteria": [],
+                    "depends_on": [],
+                    "criteria_refs": [],
+                },
+                {
+                    "task_index": 1,
+                    "task_type": "qa.test",
+                    "role": "qa",
+                    "focus": "suite",
+                    "description": "author the API suite",
+                    "expected_artifacts": ["backend/tests/test_items.py"],
+                    "acceptance_criteria": [],
+                    "depends_on": [0],
+                    "criteria_refs": [],
+                },
+            ],
+            "summary": {"total_dev_tasks": 1, "total_qa_tasks": 1, "total_tasks": 2},
+        }
+    )
+)
+
+
+def _cycle(applied_defaults: dict, execution_overrides: dict) -> Cycle:
+    return Cycle(
+        cycle_id="cyc_golden",
+        project_id="proj",
+        created_at=_NOW,
+        created_by="s",
+        prd_ref="PRD-CONTENT",
+        squad_profile_id="full",
+        squad_profile_snapshot_ref="sha",
+        task_flow_policy=TaskFlowPolicy(mode="sequential"),
+        build_strategy="fresh",
+        applied_defaults=applied_defaults,
+        execution_overrides=execution_overrides,
+        expected_artifact_types=["source"],
+    )
+
+
+def _run(workload_type: str) -> Run:
+    return Run(
+        run_id="run_abcdef123456",
+        cycle_id="cyc_golden",
+        run_number=1,
+        status="running",
+        initiated_by="api",
+        resolved_config_hash="confhash",
+        workload_type=workload_type,
+    )
+
+
+_PROFILE = SquadProfile(
+    profile_id="full",
+    name="F",
+    description="d",
+    version=1,
+    agents=[
+        AgentProfileEntry(agent_id="max", role="lead", model="m", enabled=True),
+        AgentProfileEntry(agent_id="neo", role="dev", model="m", enabled=True),
+        AgentProfileEntry(agent_id="nat", role="strat", model="m", enabled=True),
+        AgentProfileEntry(agent_id="eve", role="qa", model="m", enabled=True),
+        AgentProfileEntry(agent_id="data", role="data", model="m", enabled=True),
+    ],
+    created_at=_NOW,
+)
+
+
+@pytest.fixture(scope="module")
+def manifest() -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _scenario_framing_bind_with_rejection(manifest_obj):
+    """A #522 framing re-roll in bind mode: proposers get the criteria/frozen
+    indexes (98.3/pf-42), all four authoring types get the prior rejection
+    (#669), the merger and sign-off get neither."""
+    cycle = _cycle(
+        {"plan_authoring_contributors": ["development", "qa", "strategy"]},
+        {"contract_ref": "art_c", "framing_rejection_context": dict(_REJECTION_CONTEXT)},
+    )
+    return generate_task_plan(
+        cycle,
+        _run(WorkloadType.FRAMING),
+        _PROFILE,
+        plan=None,
+        contract=_CONTRACT,
+        interface_manifest=manifest_obj,
+    )
+
+
+def _scenario_implementation_bind(manifest_obj):
+    """Bind-mode implementation: qa.test carries the contract's behavioral
+    surface (probes #98.5, endpoint owners #688, pinned statuses #629, DOM
+    anchors #659); dev carries contract-resolved criteria."""
+    cycle = _cycle({"implementation_plan": True}, {"contract_ref": "art_c"})
+    return generate_task_plan(
+        cycle,
+        _run(WorkloadType.IMPLEMENTATION),
+        _PROFILE,
+        plan=_PLAN,
+        contract=_CONTRACT,
+        interface_manifest=manifest_obj,
+    )
+
+
+def _scenario_implementation_author(manifest_obj):
+    """Author mode (no contract): no bind keys anywhere — the SIP-0098 §6.6
+    byte-identical guarantee for contract-less cycles."""
+    cycle = _cycle({"implementation_plan": True}, {})
+    return generate_task_plan(
+        cycle,
+        _run(WorkloadType.IMPLEMENTATION),
+        _PROFILE,
+        plan=_PLAN,
+        contract=None,
+        interface_manifest=None,
+    )
+
+
+_SCENARIOS = {
+    "framing_bind_with_rejection": _scenario_framing_bind_with_rejection,
+    "implementation_bind": _scenario_implementation_bind,
+    "implementation_author": _scenario_implementation_author,
+}
+
+
+def _canonical(obj) -> str:
+    return json.dumps(obj, sort_keys=True, indent=1, default=str)
+
+
+@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
+def test_plan_envelope_inputs_match_golden(manifest, scenario):
+    envelopes = _SCENARIOS[scenario](manifest)
+    value = {f"{i:02d}:{env.task_type}": env.inputs for i, env in enumerate(envelopes)}
+    rendered = _canonical(value)
+
+    goldens = json.loads(_GOLDEN_PATH.read_text()) if _GOLDEN_PATH.exists() else {}
+    if os.environ.get("UPDATE_CONTEXT_GOLDENS"):
+        goldens[scenario] = json.loads(rendered)
+        _GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _GOLDEN_PATH.write_text(json.dumps(goldens, sort_keys=True, indent=1) + "\n")
+        return
+
+    assert scenario in goldens, (
+        f"no golden for {scenario!r} — run UPDATE_CONTEXT_GOLDENS=1 pytest {__file__}"
+    )
+    assert rendered == _canonical(goldens[scenario]), (
+        f"plan-time envelope inputs for {scenario!r} drifted from the pre-S3 golden — if "
+        "this context change is DELIBERATE, regenerate the golden in the same PR so it "
+        "reads as a behavior change, never a silent refactor side effect"
+    )

--- a/tests/unit/cycles/test_plan_gate_seams.py
+++ b/tests/unit/cycles/test_plan_gate_seams.py
@@ -1,0 +1,94 @@
+"""#663 D5 — the two plan-gate seams stay separate AND both stay wired.
+
+``_reject_invalid_plan_before_workload_gate`` (returns errors → recorded
+system REJECTED + free framing re-roll; the inter-workload promotion net) and
+``_reject_unsatisfiable_plan_at_gate`` (raises; the in-run dispatch-admission
+net) carry deliberately different error-channel semantics (#473). The
+#718/#719 scar: a plan-validation fix landed on one seam while the other
+silently kept the old behavior. These tests mechanize the ownership
+documentation so it cannot rot silently.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+_EXECUTOR_PATH = (
+    Path(__file__).resolve().parents[3] / "adapters" / "cycles" / "dispatched_flow_executor.py"
+)
+
+_PROMOTION_SEAM = "_reject_invalid_plan_before_workload_gate"
+_DISPATCH_SEAM = "_reject_unsatisfiable_plan_at_gate"
+
+
+def _method_calls(tree: ast.AST, method_name: str) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == method_name
+    ]
+
+
+def test_both_plan_gate_seams_are_defined_and_called():
+    """Bug caught: a refactor merges the seams (or drops one call site) and a
+    whole gate path loses its validation net — the promotion path would admit
+    an unvalidatable plan to a full implementation run, or the dispatch path
+    would lose its fail-fast."""
+    tree = ast.parse(_EXECUTOR_PATH.read_text(encoding="utf-8"))
+
+    defined = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef)
+    }
+    assert _PROMOTION_SEAM in defined, f"{_PROMOTION_SEAM} was removed — see its D5 ownership note"
+    assert _DISPATCH_SEAM in defined, f"{_DISPATCH_SEAM} was removed — see its D5 ownership note"
+
+    assert _method_calls(tree, _PROMOTION_SEAM), (
+        f"no call site for {_PROMOTION_SEAM} — the inter-workload promotion path "
+        "(the one multi-workload cycles actually traverse) lost its plan-validation net"
+    )
+    assert _method_calls(tree, _DISPATCH_SEAM), (
+        f"no call site for {_DISPATCH_SEAM} — the in-run dispatch path lost its "
+        "fail-fast plan-validation net"
+    )
+
+
+def test_seam_error_channels_stay_distinct():
+    """Bug caught: someone 'harmonizes' the seams' error handling — the
+    promotion seam starting to raise would kill the orchestrator where a
+    recorded system rejection + re-roll was owed (the 3.13 stall class);
+    the dispatch seam starting to return would silently drop its errors
+    (no caller consumes a return value there)."""
+    tree = ast.parse(_EXECUTOR_PATH.read_text(encoding="utf-8"))
+    methods = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef)
+        and node.name in (_PROMOTION_SEAM, _DISPATCH_SEAM)
+    }
+
+    promotion_returns = [
+        node
+        for node in ast.walk(methods[_PROMOTION_SEAM])
+        if isinstance(node, ast.Return) and node.value is not None
+    ]
+    assert promotion_returns, (
+        f"{_PROMOTION_SEAM} no longer returns its errors — #473 requires the "
+        "returned-list channel so the caller records a system REJECTED decision"
+    )
+
+    dispatch_raises = [
+        node for node in ast.walk(methods[_DISPATCH_SEAM]) if isinstance(node, ast.Raise)
+    ]
+    assert dispatch_raises, (
+        f"{_DISPATCH_SEAM} no longer raises — the in-run net's rejection channel "
+        "is the raise; a returned value would be silently discarded at its call site"
+    )


### PR DESCRIPTION
## #663 S3 — plan-time sibling + gate-seam ownership (closes the slice plan)

Final slice of the design table on #663. After S3, every per-task-type context opinion — dispatch-time (S1), correction-path (S2), and plan-time (S3) — lives on one `ContextAssemblyContract` registry, and the two plan-gate seams have their separate ownership in writing **and** under test.

### Golden-first, same as S1/S2

Commit 1 lands `test_plan_context_golden.py` + goldens **captured pre-S3**: the exact envelope inputs `generate_task_plan` produces for three scenarios — `framing_bind_with_rejection` (the full 10-step framing sequence on a #522 re-roll in bind mode), `implementation_bind`, and `implementation_author`. The goldens pin the membership matrix being relocated: proposers get the criteria/frozen indexes, all four authoring types get rejection context, **the merger and sign-off get neither**, qa.test carries the contract's behavioral surface, author mode injects nothing.

Commit 2 is the refactor; **all 19 goldens (S1's 11 + S2's 5 + these 3) hold byte-identical through it.**

### What moved

| Was (inline in `task_plan`) | Now (registry-declared) |
|---|---|
| `_BIND_INDEX_PROPOSER_TASK_TYPES` frozenset (SIP-0098 98.3) | `bind_criteria_index` on the two proposers' contracts |
| `task_type == "qa.test"` literal gating probes/#688 owners/#629 pins/#659 anchors | `bind_behavioral_surface` on qa.test's contract |
| `_PLAN_AUTHORING_CONTEXT_TASK_TYPES` frozenset (#669) | `plan_rejection_context` on the four authoring contracts |

The injectors (`_inject_contract_inputs`, `_inject_rejection_context`) stay in `task_plan` as the plan-time composer — they keep only the contract/manifest **derivation mechanics**; WHO receives each input class is the registry's declaration. The merger's double exclusion (no artifact threading — filename collision would drop a proposal; no rejection context — its merge path is deterministic, no prompt) is now documented once, in the registry.

**Stays per D6**: `_contract_assertion_criteria` / `_harness_boundary_criteria` remain in `task_plan` — they ride the acceptance-criteria channel, not context inputs.

### D5 — gate seams: separate ownership, in writing, under test

- Both `_reject_invalid_plan_before_workload_gate` (returns errors → recorded system REJECTED + free framing re-roll; the promotion net) and `_reject_unsatisfiable_plan_at_gate` (raises; the dispatch-admission net) get OWNERSHIP docstrings stating the returns-vs-raises split (#473) and the rule for placing new validation rules.
- New `test_plan_gate_seams.py` (AST-based): fails if either seam's **definition or call site** is dropped, and fails if the error channels are "harmonized" (promotion seam must return, dispatch seam must raise) — the #718/#719 scar mechanized.
- Rode along: the executor's stale "task_plan stays scaffold-free" comment is corrected (bind-mode injections import `capabilities.scaffold` directly; the survey caught it, D6 committed the fix).

### Exit criteria (the plan's responsibility tests)

1. **Executor constructs no capability-specific context** — dispatch (S1), RC3/correction (S2), and plan-time membership (S3) all read the registry. ✓
2. **New enrichment without executor edit** — `test_new_enrichment_is_a_registry_edit_only` (S1). ✓
3. **Both gate seams documented separate + tested** — D5 above. ✓

### Verification

- 19 goldens byte-identical through the refactor
- Full regression: **6434 passed, 1 skipped** (ruff clean)

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
