### PR TITLE
fix(#481): startup sweep surfaces cycles stranded between workloads (closes #481)

### DIFF
--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -382,6 +382,7 @@ async def _init_cycle_subsystem(config, pool) -> None:
         # (#373) blocks recruitment outright, a live activity row (#672) kills
         # that agent's activity tracking.
         from squadops.api.runtime.startup_reaps import (
+            detect_stranded_cycles,
             reap_stranded_activities,
             reap_stranded_leases,
             reap_stranded_modes,
@@ -392,6 +393,9 @@ async def _init_cycle_subsystem(config, pool) -> None:
         await reap_stranded_leases(cycle_registry, _runtime_coordinator, focus_lease_port)
         await reap_stranded_modes(_runtime_coordinator, state_port)
         await reap_stranded_activities(cycle_registry, activity_port)
+        # Read-only, last: a post-crash boot immediately names every cycle
+        # stranded between workloads and its recovery command (#481).
+        await detect_stranded_cycles(cycle_registry, project_registry)
 
         flow_executor = create_flow_executor(
             "dispatched",

--- a/src/squadops/api/runtime/startup_reaps.py
+++ b/src/squadops/api/runtime/startup_reaps.py
@@ -19,6 +19,10 @@ then turn that residue into a hard block on every later run:
 - :func:`reap_stranded_activities` (#672) — an active activity trips
   ``uq_runtime_activities_one_active_per_agent``, so activity tracking goes
   silently dead for that agent.
+- :func:`detect_stranded_cycles` (#481) — the READ-ONLY sweep: a cycle whose
+  ``execute_cycle`` loop died between workloads strands silently (completed
+  run, gate approved or absent, no successor); nothing detected it until an
+  operator noticed the cycle had stopped moving.
 
 Each owns its own best-effort contract: a reap failure is logged and never
 blocks startup, because a runtime-api that will not boot is worse than one that
@@ -36,6 +40,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from squadops.ports.cycles.cycle_registry import CycleRegistryPort
+    from squadops.ports.cycles.project_registry import ProjectRegistryPort
     from squadops.ports.runtime.activity import RuntimeActivityPort
     from squadops.ports.runtime.focus_lease import FocusLeasePort
     from squadops.ports.runtime.state import RuntimeStatePort
@@ -192,4 +197,107 @@ async def reap_stranded_activities(
         return reaped
     except Exception:
         logger.warning("Startup stranded-activity reap failed", exc_info=True)
+        return 0
+
+
+_STRANDED_SWEEP_CYCLES_PER_PROJECT = 200
+
+
+async def detect_stranded_cycles(
+    cycle_registry: CycleRegistryPort,
+    project_registry: ProjectRegistryPort | None,
+) -> int:
+    """Log every cycle stranded between workloads at startup (#481). READ-ONLY.
+
+    Returns how many STRANDED cycles were surfaced; 0 when unwired or the
+    sweep failed. Unlike its three siblings this sweep writes nothing —
+    idempotent by construction across repeated boots, and racing a concurrent
+    operator ``runs retry`` costs at most one stale warning.
+
+    The classification is the domain's (``classify_workload_stranding``,
+    beside the status derivations), fed runs + sequence directly: the
+    sequence-unaware ``derive_cycle_status`` calls the stranded state
+    COMPLETED, so filtering by a status column would miss every stranded
+    cycle. STRANDED gets the actionable warning (the recovery command —
+    #433 resolves the run's workload type positionally, #434 rebuilds
+    forwarding); GATE_PENDING/GATE_REJECTED get visibility logs and must
+    never be auto-acted on.
+    """
+    if project_registry is None:
+        return 0
+    try:
+        from squadops.cycles.lifecycle import WorkloadStranding, classify_workload_stranding
+        from squadops.cycles.models import RunStatus
+
+        stranded_count = 0
+        for project in await project_registry.list_projects():
+            cycles = await cycle_registry.list_cycles(
+                project.project_id, limit=_STRANDED_SWEEP_CYCLES_PER_PROJECT
+            )
+            if len(cycles) >= _STRANDED_SWEEP_CYCLES_PER_PROJECT:
+                logger.warning(
+                    "Stranded-cycle sweep bounded at %d newest cycles for project %s — "
+                    "older stranded cycles would not be surfaced",
+                    _STRANDED_SWEEP_CYCLES_PER_PROJECT,
+                    project.project_id,
+                )
+            for cycle in cycles:
+                sequence = cycle.resolved_config().get("workload_sequence") or []
+                if not sequence:
+                    continue
+                runs = await cycle_registry.list_runs(cycle.cycle_id)
+                verdict = classify_workload_stranding(sequence, runs, cycle.cancelled)
+                if verdict is None:
+                    continue
+                position = len([r for r in runs if r.status != RunStatus.CANCELLED.value]) - 1
+                if verdict is WorkloadStranding.STRANDED:
+                    stranded_count += 1
+                    logger.warning(
+                        "Cycle %s (project %s) is STRANDED between workloads: position "
+                        "%d/%d (%s) completed%s but its execute_cycle loop died before "
+                        "creating the successor. Recover with: squadops runs retry %s %s",
+                        cycle.cycle_id,
+                        project.project_id,
+                        position,
+                        len(sequence),
+                        sequence[position].get("type", "unknown"),
+                        (
+                            " with gate approved"
+                            if sequence[position].get("gate")
+                            else " (ungated boundary)"
+                        ),
+                        project.project_id,
+                        cycle.cycle_id,
+                    )
+                elif verdict is WorkloadStranding.GATE_PENDING:
+                    logger.info(
+                        "Cycle %s (project %s) awaits gate %r on completed position %d/%d — "
+                        "its gate poller died with the process, so approval alone will not "
+                        "resume it: approve, then squadops runs retry %s %s",
+                        cycle.cycle_id,
+                        project.project_id,
+                        sequence[position].get("gate"),
+                        position,
+                        len(sequence),
+                        project.project_id,
+                        cycle.cycle_id,
+                    )
+                elif verdict is WorkloadStranding.GATE_REJECTED:
+                    logger.info(
+                        "Cycle %s (project %s) carries a rejected gate %r at position %d/%d "
+                        "with no supersede/re-roll recorded — the rejection landed as the "
+                        "process died; it resolves FAILED and stays operator-owned",
+                        cycle.cycle_id,
+                        project.project_id,
+                        sequence[position].get("gate"),
+                        position,
+                        len(sequence),
+                    )
+        if stranded_count:
+            logger.warning(
+                "Startup sweep surfaced %d cycle(s) stranded between workloads", stranded_count
+            )
+        return stranded_count
+    except Exception:
+        logger.warning("Startup stranded-cycle detection failed", exc_info=True)
         return 0

--- a/src/squadops/cycles/lifecycle.py
+++ b/src/squadops/cycles/lifecycle.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Sequence
+from enum import Enum
 
 from squadops.cycles.models import (
     CycleStatus,
+    GateDecisionValue,
     IllegalStateTransitionError,
     Run,
     RunStatus,
@@ -163,6 +165,74 @@ def resolve_cycle_status(
         return CycleStatus.ACTIVE
 
     return derived
+
+
+class WorkloadStranding(Enum):
+    """Classification of a cycle stalled between workloads (#481).
+
+    ``STRANDED`` is the only class safe to act on: the sequence owes a
+    successor run, nothing gates it, and only a dead ``execute_cycle`` loop
+    explains its absence. The two gate classes are *visibility* verdicts —
+    an undecided gate is the supported operator path (approve + retry), and a
+    recorded rejection means the supersede/re-roll died with the process;
+    both must never be auto-acted on.
+    """
+
+    STRANDED = "stranded"
+    GATE_PENDING = "gate_pending"
+    GATE_REJECTED = "gate_rejected"
+
+
+def classify_workload_stranding(
+    workload_sequence: Sequence[dict],
+    runs: Sequence[Run],
+    cycle_cancelled: bool,
+) -> WorkloadStranding | None:
+    """Classify a cycle stalled between workloads, or ``None`` (#481).
+
+    Pure function of durable state: the positional run↔workload invariant
+    (#257/D14 — the Nth non-cancelled run occupies sequence position N) plus
+    the latest run's own ``gate_decisions``. A successor's absence is
+    positional: the latest non-cancelled run sitting COMPLETED at a
+    non-final position IS the missing successor.
+
+    ``None`` for everything this predicate does not recognize with high
+    confidence — cancelled cycles, sequence-less (legacy) cycles, exhausted
+    sequences, and any latest-run status other than COMPLETED (a running or
+    failed run has an owner; ``resolve_cycle_status`` rule 3 names the
+    COMPLETED-mid-sequence window this predicate detects).
+    """
+    if cycle_cancelled or not workload_sequence:
+        return None
+
+    non_cancelled = sorted(
+        (r for r in runs if r.status != RunStatus.CANCELLED.value),
+        key=lambda r: r.run_number,
+    )
+    if not non_cancelled or len(non_cancelled) >= len(workload_sequence):
+        return None
+
+    latest = non_cancelled[-1]
+    if latest.status != RunStatus.COMPLETED.value:
+        return None
+
+    gate_name = workload_sequence[len(non_cancelled) - 1].get("gate")
+    if not gate_name:
+        return WorkloadStranding.STRANDED
+
+    decisions = {gd.decision for gd in latest.gate_decisions if gd.gate_name == gate_name}
+    # Mirrors the executor's #466 exhaustive dispatch. Rejection first: if
+    # contradictory decisions somehow coexist, the conservative read wins.
+    if GateDecisionValue.REJECTED in decisions:
+        return WorkloadStranding.GATE_REJECTED
+    if decisions & {GateDecisionValue.APPROVED, GateDecisionValue.APPROVED_WITH_REFINEMENTS}:
+        return WorkloadStranding.STRANDED
+    if not decisions:
+        return WorkloadStranding.GATE_PENDING
+    # RETURNED_FOR_REVISION (a deliberate, recorded stop awaiting a manual
+    # retry — #466) and any unrecognized future value: never treat an
+    # un-approving decision as stranding.
+    return None
 
 
 def _canonical_json(obj: dict) -> str:

--- a/tests/unit/api/test_startup_reaps.py
+++ b/tests/unit/api/test_startup_reaps.py
@@ -24,11 +24,18 @@ from unittest.mock import AsyncMock
 import pytest
 
 from squadops.api.runtime.startup_reaps import (
+    detect_stranded_cycles,
     reap_stranded_activities,
     reap_stranded_leases,
     reap_stranded_modes,
 )
-from squadops.cycles.models import CycleNotFoundError, Run, RunNotFoundError, RunStatus
+from squadops.cycles.models import (
+    CycleNotFoundError,
+    GateDecision,
+    Run,
+    RunNotFoundError,
+    RunStatus,
+)
 from squadops.runtime.models import FocusLease, RuntimeActivity
 
 pytestmark = [pytest.mark.domain_api]
@@ -259,3 +266,114 @@ async def test_activity_reap_failure_never_blocks_startup():
     activity_port.list_active_activities.side_effect = RuntimeError("db down")
 
     assert await reap_stranded_activities(AsyncMock(), activity_port) == 0
+
+
+# =============================================================================
+# detect_stranded_cycles (#481)
+# =============================================================================
+
+
+def _seq_run(run_number: int, status: str, decisions: tuple = ()) -> Run:
+    return Run(
+        run_id=f"run_{run_number:03d}",
+        cycle_id="cyc_stranded",
+        run_number=run_number,
+        status=status,
+        initiated_by="api",
+        resolved_config_hash="h",
+        gate_decisions=decisions,
+    )
+
+
+def _stranded_fixture(decisions: tuple):
+    """A two-workload cycle whose framing run completed at position 0."""
+    sequence = [{"type": "framing", "gate": "plan-review"}, {"type": "implementation"}]
+    cycle = SimpleNamespace(
+        cycle_id="cyc_stranded",
+        cancelled=False,
+        resolved_config=lambda: {"workload_sequence": sequence},
+    )
+    project_registry = AsyncMock()
+    project_registry.list_projects.return_value = [SimpleNamespace(project_id="proj")]
+    cycle_registry = AsyncMock()
+    cycle_registry.list_cycles.return_value = [cycle]
+    cycle_registry.list_runs.return_value = [_seq_run(1, "completed", decisions)]
+    return cycle_registry, project_registry
+
+
+_APPROVAL = (
+    GateDecision(gate_name="plan-review", decision="approved", decided_by="op", decided_at=NOW),
+)
+
+
+class TestDetectStrandedCycles:
+    """Bug classes guarded: the sweep acting on (or miscounting) states the
+    operator owns; a registry failure aborting boot; and the sweep silently
+    doing nothing when unwired."""
+
+    async def test_stranded_cycle_is_counted_and_names_its_recovery(self, caplog):
+        cycle_registry, project_registry = _stranded_fixture(_APPROVAL)
+
+        with caplog.at_level("WARNING"):
+            count = await detect_stranded_cycles(cycle_registry, project_registry)
+
+        assert count == 1
+        stranded_lines = [r.message for r in caplog.records if "STRANDED" in r.message]
+        assert any("squadops runs retry proj cyc_stranded" in m for m in stranded_lines), (
+            "the warning must name the exact recovery command — detection that "
+            "does not say what to do re-creates the manual-inspection incident"
+        )
+
+    async def test_pending_gate_is_visibility_not_count(self, caplog):
+        cycle_registry, project_registry = _stranded_fixture(())
+
+        with caplog.at_level("INFO"):
+            count = await detect_stranded_cycles(cycle_registry, project_registry)
+
+        assert count == 0
+        assert any("awaits gate" in r.message for r in caplog.records), (
+            "an undecided gate whose poller died must still be surfaced — approval "
+            "alone will not resume it"
+        )
+
+    async def test_sweep_is_read_only(self):
+        cycle_registry, project_registry = _stranded_fixture(_APPROVAL)
+
+        await detect_stranded_cycles(cycle_registry, project_registry)
+
+        called = {c[0] for c in cycle_registry.mock_calls}
+        assert called <= {"list_cycles", "list_runs"}, (
+            f"read-only sweep touched mutating registry surface: {called}"
+        )
+
+    async def test_registry_failure_never_blocks_boot(self):
+        project_registry = AsyncMock()
+        project_registry.list_projects.side_effect = RuntimeError("db down")
+
+        assert await detect_stranded_cycles(AsyncMock(), project_registry) == 0
+
+    async def test_unwired_project_registry_is_a_noop(self):
+        assert await detect_stranded_cycles(AsyncMock(), None) == 0
+
+    async def test_terminal_and_sequenceless_cycles_are_silent(self, caplog):
+        sequence = [{"type": "framing", "gate": "plan-review"}, {"type": "implementation"}]
+        exhausted = SimpleNamespace(
+            cycle_id="cyc_done",
+            cancelled=False,
+            resolved_config=lambda: {"workload_sequence": sequence},
+        )
+        legacy = SimpleNamespace(cycle_id="cyc_legacy", cancelled=False, resolved_config=lambda: {})
+        project_registry = AsyncMock()
+        project_registry.list_projects.return_value = [SimpleNamespace(project_id="proj")]
+        cycle_registry = AsyncMock()
+        cycle_registry.list_cycles.return_value = [exhausted, legacy]
+        cycle_registry.list_runs.return_value = [
+            _seq_run(1, "completed", _APPROVAL),
+            _seq_run(2, "completed"),
+        ]
+
+        with caplog.at_level("INFO"):
+            count = await detect_stranded_cycles(cycle_registry, project_registry)
+
+        assert count == 0
+        assert not caplog.records

--- a/tests/unit/cycles/test_lifecycle.py
+++ b/tests/unit/cycles/test_lifecycle.py
@@ -2,6 +2,7 @@
 Tests for SIP-0064 lifecycle state machine, status derivation, and hash computation.
 """
 
+import dataclasses
 from datetime import UTC, datetime
 
 import pytest
@@ -9,6 +10,8 @@ import pytest
 from squadops.cycles.lifecycle import (
     GATE_REJECTED_STATES,
     TERMINAL_STATES,
+    WorkloadStranding,
+    classify_workload_stranding,
     compute_config_hash,
     compute_profile_snapshot_hash,
     derive_cycle_status,
@@ -17,6 +20,7 @@ from squadops.cycles.lifecycle import (
 )
 from squadops.cycles.models import (
     CycleStatus,
+    GateDecision,
     IllegalStateTransitionError,
     Run,
     RunStatus,
@@ -413,3 +417,130 @@ class TestResolveCycleStatus:
         runs = [_make_run(status="running")]
         statuses = ["running", "pending", "pending"]
         assert resolve_cycle_status(runs, False, statuses) == CycleStatus.ACTIVE
+
+
+# =============================================================================
+# classify_workload_stranding tests (#481)
+# =============================================================================
+
+_SEQ_GATED = [
+    {"type": "framing", "gate": "plan-review"},
+    {"type": "implementation", "gate": None},
+    {"type": "wrapup"},
+]
+_SEQ_UNGATED = [{"type": "framing"}, {"type": "implementation"}]
+
+
+def _decided(gate_name: str, decision: str) -> GateDecision:
+    return GateDecision(
+        gate_name=gate_name,
+        decision=decision,
+        decided_by="operator",
+        decided_at=NOW,
+    )
+
+
+def _completed_run(run_number: int = 1, decisions: tuple = ()) -> Run:
+    run = _make_run(run_number=run_number, status="completed")
+    return dataclasses.replace(run, gate_decisions=decisions)
+
+
+class TestClassifyWorkloadStranding:
+    """The stranded window is resolve_cycle_status rule 3's own words —
+    'between gate approval and next-Run creation'. Bug classes guarded: a
+    detector that treats an undecided or revision-returned gate as stranded
+    would aim auto-recovery at states the operator deliberately owns; one
+    keyed on derived status would miss every stranded cycle (derive says
+    COMPLETED there)."""
+
+    def test_approved_gate_with_no_successor_is_stranded(self):
+        runs = [_completed_run(decisions=(_decided("plan-review", "approved"),))]
+        verdict = classify_workload_stranding(_SEQ_GATED, runs, cycle_cancelled=False)
+        assert verdict is WorkloadStranding.STRANDED
+
+    def test_approved_with_refinements_also_strands(self):
+        """The executor advances on APPROVED_WITH_REFINEMENTS too (#466) —
+        so its absence after that decision is the same dead-loop evidence."""
+        runs = [_completed_run(decisions=(_decided("plan-review", "approved_with_refinements"),))]
+        verdict = classify_workload_stranding(_SEQ_GATED, runs, cycle_cancelled=False)
+        assert verdict is WorkloadStranding.STRANDED
+
+    def test_ungated_boundary_with_no_successor_is_stranded(self):
+        runs = [_completed_run()]
+        verdict = classify_workload_stranding(_SEQ_UNGATED, runs, cycle_cancelled=False)
+        assert verdict is WorkloadStranding.STRANDED
+
+    def test_gate_none_entry_is_an_ungated_boundary(self):
+        """A literal ``gate: None`` entry (the #682 waiver-specimen shape)
+        strands like a missing key, not like a pending gate."""
+        runs = [
+            _completed_run(1, decisions=(_decided("plan-review", "approved"),)),
+            _completed_run(2),
+        ]
+        verdict = classify_workload_stranding(_SEQ_GATED, runs, cycle_cancelled=False)
+        assert verdict is WorkloadStranding.STRANDED
+
+    def test_undecided_gate_is_pending_not_stranded(self):
+        runs = [_completed_run()]
+        verdict = classify_workload_stranding(_SEQ_GATED, runs, cycle_cancelled=False)
+        assert verdict is WorkloadStranding.GATE_PENDING
+
+    def test_decision_for_another_gate_does_not_satisfy_this_one(self):
+        runs = [_completed_run(decisions=(_decided("other-gate", "approved"),))]
+        verdict = classify_workload_stranding(_SEQ_GATED, runs, cycle_cancelled=False)
+        assert verdict is WorkloadStranding.GATE_PENDING
+
+    def test_rejected_gate_is_visibility_only(self):
+        runs = [_completed_run(decisions=(_decided("plan-review", "rejected"),))]
+        verdict = classify_workload_stranding(_SEQ_GATED, runs, cycle_cancelled=False)
+        assert verdict is WorkloadStranding.GATE_REJECTED
+
+    def test_contradictory_decisions_read_conservatively(self):
+        runs = [
+            _completed_run(
+                decisions=(
+                    _decided("plan-review", "approved"),
+                    _decided("plan-review", "rejected"),
+                )
+            )
+        ]
+        verdict = classify_workload_stranding(_SEQ_GATED, runs, cycle_cancelled=False)
+        assert verdict is WorkloadStranding.GATE_REJECTED
+
+    def test_returned_for_revision_is_a_deliberate_stop(self):
+        """#466: revision requires manual retry BY DESIGN — classifying it as
+        stranded would aim auto-recovery at an operator-owned state."""
+        runs = [_completed_run(decisions=(_decided("plan-review", "returned_for_revision"),))]
+        assert classify_workload_stranding(_SEQ_GATED, runs, cycle_cancelled=False) is None
+
+    def test_unrecognized_decision_value_is_never_stranding(self):
+        runs = [_completed_run(decisions=(_decided("plan-review", "shipped_it"),))]
+        assert classify_workload_stranding(_SEQ_GATED, runs, cycle_cancelled=False) is None
+
+    @pytest.mark.parametrize("status", ["queued", "running", "paused", "failed"])
+    def test_non_completed_latest_run_is_owned_elsewhere(self, status):
+        runs = [_make_run(status=status)]
+        assert classify_workload_stranding(_SEQ_GATED, runs, cycle_cancelled=False) is None
+
+    def test_exhausted_sequence_is_terminal_not_stranded(self):
+        runs = [_completed_run(1), _completed_run(2)]
+        assert classify_workload_stranding(_SEQ_UNGATED, runs, cycle_cancelled=False) is None
+
+    def test_cancelled_cycle_is_silent(self):
+        runs = [_completed_run(decisions=(_decided("plan-review", "approved"),))]
+        assert classify_workload_stranding(_SEQ_GATED, runs, cycle_cancelled=True) is None
+
+    def test_sequenceless_legacy_cycle_is_silent(self):
+        assert classify_workload_stranding([], [_completed_run()], cycle_cancelled=False) is None
+
+    def test_runless_cycle_is_not_between_workloads(self):
+        assert classify_workload_stranding(_SEQ_GATED, [], cycle_cancelled=False) is None
+
+    def test_cancelled_successor_reopens_the_position(self):
+        """A re-roll that cancelled its replacement's predecessor but died
+        before creating the replacement: the cancelled run holds no position
+        (#257/D14), so the completed run at position 0 is stranded again."""
+        cancelled = _make_run(run_number=2, status="cancelled")
+        runs = [_completed_run(1, decisions=(_decided("plan-review", "approved"),)), cancelled]
+        verdict = classify_workload_stranding(_SEQ_GATED, runs, cycle_cancelled=False)
+        assert verdict is WorkloadStranding.STRANDED


### PR DESCRIPTION
## #481 — startup sweep surfaces cycles stranded between workloads (1.5 Gate-3 B3)

Executes the design table posted on the issue. The attempt-2 incident class (`cyc_9d775e1aebeb`): `execute_cycle` dies between workloads, and the cycle sits silently in the window `resolve_cycle_status` rule 3 names in its own docstring — "between gate approval and next-Run creation" — until a human notices. Recovery has been complete since #433/#434; this adds the missing half, detection.

### The domain predicate (D1/D2)

`classify_workload_stranding(workload_sequence, runs, cycle_cancelled)` in `cycles/lifecycle.py`, beside the status derivations — a pure function of the positional D14 run↔workload invariant plus the latest run's own `gate_decisions`:

- **`STRANDED`** — latest non-cancelled run COMPLETED at a non-final position, boundary approved or ungated, no successor. The only actionable class.
- **`GATE_PENDING`** — no decision recorded: visibility only (the gate *poller* died too, so approval alone won't resume it — the log says approve **then** retry).
- **`GATE_REJECTED`** — rejection recorded but the supersede/re-roll died with the process: visibility only.
- **`None`** — everything else, including two cases the survey settled against the executor's #466 exhaustive dispatch: `APPROVED_WITH_REFINEMENTS` **advances**, so its absence strands (⊂ STRANDED); `RETURNED_FOR_REVISION` is a *deliberate, recorded* stop awaiting manual retry — classifying it stranded would aim recovery at an operator-owned state. Unrecognized future decision values are likewise never stranding. *(One refinement vs the posted table: the table's GATE_PENDING is tightened to strictly "no decision rows" — a revision-returned gate is not "pending".)*

### The sweep (D3/D5/D6)

`detect_stranded_cycles` — 4th sweep in `api/runtime/startup_reaps.py`, wired after the three reaps, same best-effort contract (failure logged, never blocks boot). **READ-ONLY**: idempotent by construction across boots; racing a concurrent operator `runs retry` costs at most one stale warning. Each STRANDED cycle gets one structured warning naming position, workload type, gate state, and the exact recovery command (`squadops runs retry <project> <cycle>`).

Trap the survey confirmed, now load-bearing in both code and tests: the sequence-unaware `derive_cycle_status` calls the stranded state **COMPLETED**, so any status pre-filter at the port would miss every stranded cycle — the sweep classifies runs + sequence directly. Per-project enumeration bound (200 newest, #684 ordering) is logged when hit — no silent caps.

### Escalation ruling (D4 — merging ratifies)

Log-only ships and closes the issue (its own sequencing: "log-only is safe to ship first"). Auto-resume remains a possible follow-up requiring separate owner opt-in — not filed; the classification enum is exactly the seam it would consume.

### Tests

- 16 predicate tests: every classification, the #466 parity cases (refinements-approval strands; revision-return doesn't), contradictory-decision conservatism, the cancelled-successor-reopens-position case, and each silent class.
- 6 sweep tests: counted-and-names-recovery, pending-is-visibility, **read-only assertion on the registry mock**, failure-never-blocks-boot, unwired no-op, terminal/legacy silence.
- Full regression: **6459 passed, 1 skipped** (ruff clean).

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
