### PR TITLE
feat(#734): workspace-revision provenance — Slice A (closes #734)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1862,6 +1862,18 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             )
             if workspace_files:
                 extra_inputs["acceptance_workspace_files"] = workspace_files
+            # #734 Slice A: cut a revision from the EXACT post-filter mapping
+            # attached above (never from store state) so every acceptance
+            # verdict names the tree it ran against. An empty context is a
+            # nameable state — evaluation still runs with the task's own
+            # artifacts overlaid, so the id is stamped unconditionally.
+            from squadops.sandbox.models import RevisionOrigin, WorkspaceRevision
+
+            extra_inputs["workspace_revision_id"] = WorkspaceRevision.cut(
+                cycle_id=envelope.cycle_id,
+                origin=RevisionOrigin.ACCEPTANCE_ASSEMBLY,
+                files=workspace_files or {},
+            ).revision_id
 
         return dataclasses.replace(
             envelope,
@@ -2326,6 +2338,10 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             **(prior_validation if isinstance(prior_validation, dict) else {}),
             "passed": True,
             "patch_verified": True,
+            # #734 Slice A: the repair-acceptance verdict names the workspace
+            # tree it verified against (verify_patched_artifacts computes it
+            # from the exact mapping it materialized).
+            "workspace_revision_id": verification.workspace_revision_id,
             "checks": [r.to_check_row() for r in verification.checks] + retest_rows,
         }
         corrected_outputs.pop("outcome_class", None)

--- a/src/squadops/capabilities/context_assembly.py
+++ b/src/squadops/capabilities/context_assembly.py
@@ -242,6 +242,10 @@ REPAIR_CONTEXT_CONTRACT = ContextAssemblyContract(
 RETEST_PRESENCE_KEYS: tuple[str, ...] = (
     "contract_probes",
     "acceptance_workspace_files",
+    # #734 Slice A: the workspace identity travels WITH the forwarded tree,
+    # so retest evidence shows the forwarded id == the failed task's id —
+    # the forwarded-vs-reassembled distinction, visible for the first time.
+    "workspace_revision_id",
     SURFACE_DOM_TESTID,
 )
 

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -121,8 +121,11 @@ class _CycleTaskHandler(CapabilityHandler):
         validation_checks: list[dict],
         task_index: Any,
         task_type: str,
+        workspace_revision_id: str | None = None,
     ) -> dict | None:
-        return _build_typed_check_evaluation_artifact(validation_checks, task_index, task_type)
+        return _build_typed_check_evaluation_artifact(
+            validation_checks, task_index, task_type, workspace_revision_id
+        )
 
     def validate_inputs(
         self,

--- a/src/squadops/capabilities/handlers/cycle/builder.py
+++ b/src/squadops/capabilities/handlers/cycle/builder.py
@@ -438,7 +438,10 @@ class BuilderAssembleHandler(_CycleTaskHandler):
         # Issue #114: per-task typed-check evaluation evidence, same as the
         # dev seam — emitted whenever typed checks ran, both outcomes.
         tce_artifact = self._build_typed_check_evaluation_artifact(
-            validation_checks, inputs.get("subtask_index"), self._capability_id
+            validation_checks,
+            inputs.get("subtask_index"),
+            self._capability_id,
+            inputs.get("workspace_revision_id"),
         )
         if tce_artifact is not None:
             artifacts.append(tce_artifact)

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -639,6 +639,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
                 validation.checks,
                 inputs.get("subtask_index"),
                 self._capability_id,
+                inputs.get("workspace_revision_id"),
             )
             if tce_artifact is not None:
                 artifacts.append(tce_artifact)

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -950,6 +950,7 @@ class QATestHandler(_CycleTaskHandler):
                 validation.checks,
                 inputs.get("subtask_index"),
                 self._capability_id,
+                inputs.get("workspace_revision_id"),
             )
             if tce_artifact is not None:
                 artifacts.append(tce_artifact)

--- a/src/squadops/capabilities/handlers/cycle/validation.py
+++ b/src/squadops/capabilities/handlers/cycle/validation.py
@@ -237,6 +237,7 @@ def _build_typed_check_evaluation_artifact(
     validation_checks: list[dict],
     task_index: Any,
     task_type: str,
+    workspace_revision_id: str | None = None,
 ) -> dict | None:
     """Issue #114: serialize typed-acceptance evaluation rows for the gate evaluator.
 
@@ -260,6 +261,10 @@ def _build_typed_check_evaluation_artifact(
         "task_index": task_index,
         "task_type": task_type,
         "evaluated_at": datetime.now(UTC).isoformat(),
+        # #734 Slice A: the acceptance-workspace assembly these evaluations ran
+        # against, by content-addressed id (the envelope's dispatch-time stamp —
+        # the same mapping this handler materialized as workspace context).
+        "workspace_revision_id": workspace_revision_id,
         "evaluations": typed_rows,
     }
     suffix = f"_task_{task_index}" if task_index is not None else ""

--- a/src/squadops/cycles/patch_verification.py
+++ b/src/squadops/cycles/patch_verification.py
@@ -96,11 +96,17 @@ class PatchCheckRecord:
 
 @dataclass(frozen=True)
 class PatchVerification:
-    """Aggregate verdict over all typed criteria."""
+    """Aggregate verdict over all typed criteria.
+
+    ``workspace_revision_id`` (#734 Slice A): the content-addressed id of the
+    exact workspace mapping the criteria evaluated against — None only on the
+    early returns that never materialized a workspace.
+    """
 
     status: str  # PATCH_PASSED | PATCH_FAILED | PATCH_UNVERIFIABLE
     checks: tuple[PatchCheckRecord, ...] = ()
     reason: str | None = None
+    workspace_revision_id: str | None = None
 
 
 def rebase_artifact_paths(
@@ -310,6 +316,11 @@ async def verify_patched_artifacts(
     records: list[PatchCheckRecord] = []
     blocking_failure = False
     blocking_passed = 0
+    # #734 Slice A: name the exact workspace mapping evaluated below — computed
+    # from the parameter (the post-filter mapping handed in), never store state.
+    from squadops.sandbox.models import compute_revision_id
+
+    revision_id = compute_revision_id(workspace_files or {})
     with tempfile.TemporaryDirectory(prefix="squadops-patch-verify-") as tmpdir:
         workspace_root = Path(tmpdir)
         if workspace_files:
@@ -334,6 +345,7 @@ async def verify_patched_artifacts(
             return PatchVerification(
                 status=PATCH_FAILED,
                 reason=f"unresolved_imports:{summary}",
+                workspace_revision_id=revision_id,
             )
 
         for criterion in typed:
@@ -365,6 +377,7 @@ async def verify_patched_artifacts(
                     status=PATCH_UNVERIFIABLE,
                     checks=tuple(records),
                     reason=f"evaluator_error:{criterion.check}",
+                    workspace_revision_id=revision_id,
                 )
             if outcome.status == "failed":
                 blocking_failure = True
@@ -372,7 +385,9 @@ async def verify_patched_artifacts(
                 blocking_passed += 1
 
     if blocking_failure:
-        return PatchVerification(status=PATCH_FAILED, checks=tuple(records))
+        return PatchVerification(
+            status=PATCH_FAILED, checks=tuple(records), workspace_revision_id=revision_id
+        )
     if blocking_passed == 0:
         # Every blocking criterion was skipped (disabled config, unset stack).
         # Accepting a patch requires positive executed evidence — "nothing
@@ -381,5 +396,8 @@ async def verify_patched_artifacts(
             status=PATCH_UNVERIFIABLE,
             checks=tuple(records),
             reason=REASON_NO_EXECUTED_BLOCKING_CHECKS,
+            workspace_revision_id=revision_id,
         )
-    return PatchVerification(status=PATCH_PASSED, checks=tuple(records))
+    return PatchVerification(
+        status=PATCH_PASSED, checks=tuple(records), workspace_revision_id=revision_id
+    )

--- a/src/squadops/sandbox/models.py
+++ b/src/squadops/sandbox/models.py
@@ -28,8 +28,13 @@ class RevisionOrigin:
     SCAFFOLD_SEED = "scaffold_seed"
     AGENT_PATCH = "agent_patch"
     PROMOTED_OUTPUTS = "promoted_outputs"
+    #: #734 Slice A: the executor's acceptance-workspace assembly (#643) —
+    #: content crossing into a verification substrate, cut at dispatch so
+    #: every acceptance verdict names the tree it ran against. Identity-only
+    #: in 1.5 (nothing reconstructs from it until SIP-0102 steps 3-4).
+    ACCEPTANCE_ASSEMBLY = "acceptance_assembly"
 
-    ALL = frozenset({SCAFFOLD_SEED, AGENT_PATCH, PROMOTED_OUTPUTS})
+    ALL = frozenset({SCAFFOLD_SEED, AGENT_PATCH, PROMOTED_OUTPUTS, ACCEPTANCE_ASSEMBLY})
 
 
 class OperationStatus:

--- a/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
+++ b/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
@@ -631,6 +631,28 @@ class TestTypedCheckEvaluationArtifactBuilder:
         assert payload["evaluations"][0]["status"] == "failed"
         assert payload["evaluations"][0]["check"] == "acceptance:regex_match"
 
+    def test_payload_names_the_workspace_it_evaluated_against(self):
+        """#734 Slice A: the evaluation artifact carries the envelope's
+        dispatch-time workspace identity. Bug caught: a call site dropping the
+        threading — the verdict silently loses which tree it ran against, the
+        exact assumption-hole the slice exists to close."""
+        import json as _json
+
+        rows = [{"check": "acceptance:regex_match", "passed": True}]
+        artifact = DevelopmentDevelopHandler._build_typed_check_evaluation_artifact(
+            rows, task_index=1, task_type="qa.test", workspace_revision_id="b" * 64
+        )
+        payload = _json.loads(artifact["content"])
+        assert payload["workspace_revision_id"] == "b" * 64
+
+        # Envelope without the stamp (pre-#734 forwarded envelopes): explicit
+        # null, never a missing key — consumers distinguish "no identity
+        # recorded" from an older artifact version by presence.
+        legacy = DevelopmentDevelopHandler._build_typed_check_evaluation_artifact(
+            rows, task_index=1, task_type="qa.test"
+        )
+        assert _json.loads(legacy["content"])["workspace_revision_id"] is None
+
     def test_filename_omits_task_suffix_when_index_unknown(self):
         # Legacy flow without subtask_index — artifact still emits, just
         # without the per-task suffix (no second-task collision possible

--- a/tests/unit/cycles/goldens/context_assembly.json
+++ b/tests/unit/cycles/goldens/context_assembly.json
@@ -17,7 +17,8 @@
    "dev": {
     "summary": "[dev] designed"
    }
-  }
+  },
+  "workspace_revision_id": "1abfd337f2fd108568fb52af333c73573de456c7e560520953d5f70ca723b88c"
  },
  "develop_no_manifest": {
   "acceptance_workspace_files": {
@@ -39,7 +40,8 @@
    "dev": {
     "summary": "[dev] designed"
    }
-  }
+  },
+  "workspace_revision_id": "1abfd337f2fd108568fb52af333c73573de456c7e560520953d5f70ca723b88c"
  },
  "develop_with_manifest": {
   "acceptance_workspace_files": {
@@ -77,7 +79,8 @@
    "`RunsListView` (route `/`): root container `runs-list`; anchors: `runs-list`, `run-item`, `run-participant-count`, `empty-state`, `create-run-link`",
    "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",
    "`RunDetailView` (route `/runs/:id`): root container `run-detail`; anchors: `run-detail`, `participant-list`, `participant-item`, `join-form`, `join-name-input`, `join-submit`, `leave-form`, `leave-name-input`, `leave-submit`, `action-error`, `not-found`"
-  ]
+  ],
+  "workspace_revision_id": "1abfd337f2fd108568fb52af333c73573de456c7e560520953d5f70ca723b88c"
  },
  "dispatch_shadows_plan_keys": {
   "acceptance_workspace_files": {
@@ -114,7 +117,8 @@
    "`RunsListView` (route `/`): root container `runs-list`; anchors: `runs-list`, `run-item`, `run-participant-count`, `empty-state`, `create-run-link`",
    "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",
    "`RunDetailView` (route `/runs/:id`): root container `run-detail`; anchors: `run-detail`, `participant-list`, `participant-item`, `join-form`, `join-name-input`, `join-submit`, `leave-form`, `leave-name-input`, `leave-submit`, `action-error`, `not-found`"
-  ]
+  ],
+  "workspace_revision_id": "1abfd337f2fd108568fb52af333c73573de456c7e560520953d5f70ca723b88c"
  },
  "planning_brief_author": {
   "artifact_refs": [],
@@ -196,7 +200,8 @@
    "dev": {
     "summary": "[dev] designed"
    }
-  }
+  },
+  "workspace_revision_id": "1abfd337f2fd108568fb52af333c73573de456c7e560520953d5f70ca723b88c"
  },
  "untabled_base_only": {
   "artifact_refs": [

--- a/tests/unit/cycles/goldens/correction_context.json
+++ b/tests/unit/cycles/goldens/correction_context.json
@@ -323,7 +323,8 @@
      "filename": "tests/test_api.py"
     }
    ],
-   "subtask_focus": "API tests"
+   "subtask_focus": "API tests",
+   "workspace_revision_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   }
  },
  "retest_minimal": {

--- a/tests/unit/cycles/test_context_assembly.py
+++ b/tests/unit/cycles/test_context_assembly.py
@@ -9,6 +9,7 @@ serves build-landing filters only.
 
 from __future__ import annotations
 
+import dataclasses
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
@@ -143,8 +144,14 @@ def test_retest_forwarding_is_presence_keyed():
     assert forwarded["contract_probes"] == [{"probe": "GET /x"}]
     assert "acceptance_workspace_files" not in forwarded
     assert "dom_testid_surface" not in forwarded
+    # #734: pre-stamp envelopes forward no identity — a fabricated id would
+    # claim provenance the failed dispatch never recorded.
+    assert "workspace_revision_id" not in forwarded
     assert forwarded["resolved_config"] == {"build_profile": "p"}
     assert forwarded["artifact_contents"] == {"a.py": "x"}
+
+    stamped = ca.retest_forwarded_inputs({**failed, "workspace_revision_id": "c" * 64})
+    assert stamped["workspace_revision_id"] == "c" * 64
 
     # Unconditional keys default rather than disappear on a bare envelope.
     bare = ca.retest_forwarded_inputs({})
@@ -155,3 +162,75 @@ def test_retest_forwarding_is_presence_keyed():
         "expected_artifacts": [],
         "acceptance_criteria": [],
     }
+
+
+def _source_ref(artifact_id, filename):
+    ref = _ref(artifact_id, filename, "development.develop")
+    return dataclasses.replace(ref, artifact_type="source", metadata=dict(ref.metadata))
+
+
+def _executor_with(reply_router, universe):
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+    by_id = {aid: (ref, body) for aid, ref, body in universe}
+    vault = AsyncMock()
+
+    async def retrieve(art_id):
+        return by_id[art_id]
+
+    vault.retrieve = AsyncMock(side_effect=retrieve)
+    return DispatchedFlowExecutor(
+        cycle_registry=AsyncMock(),
+        artifact_vault=vault,
+        queue=reply_router.bind(AsyncMock()),
+        squad_profile=AsyncMock(),
+        project_registry=AsyncMock(),
+        reply_router=reply_router,
+    )
+
+
+async def _stamped_id(reply_router, universe):
+    executor = _executor_with(reply_router, universe)
+    envelope = TaskEnvelope(
+        task_id="t1",
+        agent_id="a",
+        cycle_id="cyc_734",
+        pulse_id="p",
+        project_id="proj",
+        task_type="development.develop",
+        correlation_id="x",
+        causation_id="x",
+        trace_id="x",
+        span_id="x",
+    )
+    enriched = await executor._enrich_envelope(
+        envelope, {}, [], [(aid, ref) for aid, ref, _ in universe]
+    )
+    return enriched.inputs["workspace_revision_id"]
+
+
+class TestWorkspaceRevisionStamp:
+    """#734 Slice A acceptance criterion 2 at the dispatch surface: the id is
+    content-addressed over the exact post-filter mapping — resolution order
+    must not matter, content must."""
+
+    async def test_permuted_store_order_yields_the_same_id(self, reply_router):
+        a = ("art_a", _source_ref("art_a", "backend/a.py"), b"a-body")
+        b = ("art_b", _source_ref("art_b", "backend/b.py"), b"b-body")
+
+        assert await _stamped_id(reply_router, [a, b]) == await _stamped_id(reply_router, [b, a])
+
+    async def test_content_change_yields_a_new_id(self, reply_router):
+        a = ("art_a", _source_ref("art_a", "backend/a.py"), b"a-body")
+        b1 = ("art_b", _source_ref("art_b", "backend/b.py"), b"b-body")
+        b2 = ("art_b", _source_ref("art_b", "backend/b.py"), b"b-body CHANGED")
+
+        assert await _stamped_id(reply_router, [a, b1]) != await _stamped_id(reply_router, [a, b2])
+
+    async def test_empty_workspace_context_is_still_named(self, reply_router):
+        """Evaluation runs even with no workspace context (the task's own
+        artifacts overlay an empty tree) — the verdict must name that state,
+        not carry null (#734 criterion 1)."""
+        from squadops.sandbox.models import compute_revision_id
+
+        assert await _stamped_id(reply_router, []) == compute_revision_id({})

--- a/tests/unit/cycles/test_correction_context_golden.py
+++ b/tests/unit/cycles/test_correction_context_golden.py
@@ -124,6 +124,9 @@ _QA_FAILED_INPUTS = {
     "acceptance_criteria": [{"check": "expected_artifacts", "params": {}}],
     "artifact_contents": {"backend/routes.py": "def ok(): ..."},
     "acceptance_workspace_files": {"backend/routes.py": "def ok(): ...", "backend/models.py": "x"},
+    # #734: the dispatch-time workspace identity — the retest must forward it
+    # unchanged (forwarded id == failed task's id, visible in evidence).
+    "workspace_revision_id": "a" * 64,
     "contract_probes": [{"probe": "GET /api/runs", "expect_status": 200}],
     "dom_testid_surface": ["run-list", "run-form-submit"],
 }

--- a/tests/unit/cycles/test_patch_verification.py
+++ b/tests/unit/cycles/test_patch_verification.py
@@ -72,6 +72,36 @@ class TestVerifyPatchedArtifacts:
         assert by_name["qa_handoff.md"] == REPAIRED_DOC
         assert set(by_name) == {"qa_handoff.md", "a.txt", "b.txt"}
 
+    async def test_verdict_names_the_exact_workspace_it_evaluated(self):
+        """#734 Slice A: the repair-acceptance verdict is content-addressed to
+        the workspace mapping it materialized — computed from the parameter,
+        never store state (the spike's risk note). Bug caught: hashing
+        upstream state that differs from what the evaluator actually saw."""
+        from squadops.sandbox.models import compute_revision_id
+
+        workspace = {"backend/models.py": "x = 1\n"}
+        result = await verify_patched_artifacts(
+            _heading_criteria(),
+            [{"name": "qa_handoff.md", "content": REPAIRED_DOC}],
+            workspace_files=workspace,
+        )
+        assert result.status == PATCH_PASSED
+        assert result.workspace_revision_id == compute_revision_id(workspace)
+        # The empty context is a nameable state, distinct from None.
+        bare = await verify_patched_artifacts(
+            _heading_criteria(), [{"name": "qa_handoff.md", "content": REPAIRED_DOC}]
+        )
+        assert bare.workspace_revision_id == compute_revision_id({})
+
+    async def test_early_returns_carry_no_workspace_identity(self):
+        """Unparseable/typed-less criteria never materialize a workspace —
+        stamping an id there would claim an evaluation that never ran."""
+        result = await verify_patched_artifacts(
+            ["prose only"], [{"name": "qa_handoff.md", "content": REPAIRED_DOC}]
+        )
+        assert result.status == PATCH_UNVERIFIABLE
+        assert result.workspace_revision_id is None
+
     async def test_unverifiable_when_no_typed_criteria(self):
         """Bug caught: a prose-only contract silently 'passing' with zero
         behavioral evidence — patch acceptance requires executed checks."""


### PR DESCRIPTION
## #734 — workspace-revision provenance, Slice A (1.5 Gate-3 B4)

Executes the ratified Gate-1 spike disposition (`docs/plans/1-5-workspace-revision-spike.md`, PR #733): cut a `WorkspaceRevision` at the three by-value acceptance-workspace surfaces and stamp `workspace_revision_id` into what they emit. **Identity is computed and recorded; nothing reads it yet** — behavior-preserving, and after this PR every acceptance verdict names the tree it ran against (the no-mixed-provenance constraint is satisfied by scope: all three surfaces stamp in one PR).

### The three stamps

| Surface | Stamp |
|---|---|
| **Dispatch assembly** (executor, the #643 site) | Cuts a revision — new additive origin `RevisionOrigin.ACCEPTANCE_ASSEMBLY` — from the **exact post-filter mapping it attaches** (the spike's risk note: never store state) and rides the id beside `acceptance_workspace_files`. Stamps unconditionally on acceptance-workspace contracts: an empty context is a nameable state (evaluation still runs with the task's own artifacts overlaid), which is what makes criterion 1's "non-null everywhere" hold. |
| **Evaluation records** | `typed_check_evaluation` payloads carry the envelope's id (explicit `null` for pre-stamp forwarded envelopes — presence distinguishes "no identity recorded" from an old artifact version); all four handler call sites thread it. `PatchVerification` gains `workspace_revision_id`, computed by `verify_patched_artifacts` from the exact mapping **it** materializes (None only on the early returns that never evaluated); the accept path records it in the durable `validation_result` beside `patch_verified`. |
| **Retest forwarding** | `workspace_revision_id` joins `RETEST_PRESENCE_KEYS` — the retest carries the failed task's id verbatim, making the forwarded-vs-reassembled distinction *visible in evidence* for the first time. Pre-stamp envelopes forward nothing (a fabricated id would claim provenance the failed dispatch never recorded). |

One clarification the survey settled: the id names the workspace **context** assembly — the handler evaluator overlays the task's own artifacts on top, but those are the *candidate under evaluation*, already named by the task's emission. The dispatched mapping is what the id pins, and the envelope's stamp is what the evaluator echoes.

### Acceptance criteria (spike doc)

1. Evaluation + repair-acceptance records carry the id — ✓ (stamped unconditionally at dispatch; patch verification computes its own).
2. Content-addressed — ✓ pinned at the dispatch stamp (permuted store order → same id; content change → new id; empty tree → stable id) and at the patch surface (id == `compute_revision_id` of the exact mapping).
3. Retest forwarded id == failed task's id — ✓ (presence-key test + `retest_full` golden shows verbatim forwarding).
4. Zero evaluation-outcome diffs on a replayed stored cycle — **rides the next deploy window** (Track C replay on the Spark, same as prior slices' live proofs). Static stand-in here: full regression + the golden diff showing the *only* delta is the new key.
5. `RevisionOrigin` gains `acceptance_assembly` additively; sandbox parity guards untouched — ✓ (sandbox suite green unmodified).

### Goldens (deliberate change, disclosed per protocol)

Regenerated in this PR: exactly the **5 acceptance-workspace dispatch scenarios** gain `workspace_revision_id` (identical fixture universe → identical id across all five, itself a determinism demonstration), and `retest_full` gains the forwarded id. Planning, wrap-up, and repair goldens byte-identical.

### Verification

Full regression: **6465 passed, 1 skipped** (ruff clean).

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
