### PR TITLE
feat(#730): fill_slot_signature — blocking injected check (D1; closes #730, #504)

### DIFF
--- a/docs/architecture/typed-check-menu.md
+++ b/docs/architecture/typed-check-menu.md
@@ -14,6 +14,7 @@ Regenerate: `UPDATE_CHECK_MENU=1 pytest tests/unit/cycles/test_check_governance.
 | `count_at_least` | authored | product | yes | yes | yes | yes | error |
 | `endpoint_defined` | authored | product | yes | yes | yes | yes | error |
 | `field_present` | authored | product | yes | yes | yes | yes | error |
+| `fill_slot_signature` | injected | product | no | yes | yes | yes | error |
 | `frontend_compiles` | authored | product | no | no | yes | no | error |
 | `function_defined` | authored | product | yes | yes | yes | yes | error |
 | `harness_boundary` | authored | suite | yes | yes | yes | yes | error |

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -312,6 +312,11 @@ CHECK_UNDEFINED_NAMES = "undefined_names"
 # tests) — same single-source rule as the two above.
 CHECK_CONTRACT_ASSERTIONS = "contract_assertions_match"
 
+# #730 D1 / #504: the fill-slot signature surface, promoted from report to
+# blocking injected check. Constant beside its CHECK_SPECS key so a rename
+# moves both together.
+CHECK_FILL_SLOT_SIGNATURE = "fill_slot_signature"
+
 # #629 (1.5 A6/D2): the ADVISORY prose-vs-contract identity. Deliberately NOT a
 # ``CHECK_SPECS`` entry — that would make it plan-authorable; it names the
 # warning rows the plan-prose lint emits (``implementation_plan``), keeping its
@@ -599,6 +604,49 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         signature_participation=False,
         outcome_contribution=True,
         replayable=False,
+        blocking_default="error",
+    ),
+    CHECK_FILL_SLOT_SIGNATURE: CheckSpec(
+        name=CHECK_FILL_SLOT_SIGNATURE,
+        applicable_extensions=frozenset({".py"}),
+        required_params=frozenset({"file", "routes"}),
+        param_types={"file": str, "routes": list},
+        supported_stacks=frozenset({"python"}),
+        requires_stack_context=False,
+        path_params=frozenset({"file"}),
+        framework_injected=True,
+        example={
+            "file": "backend/routes.py",
+            "routes": [
+                {
+                    "route": "POST /runs",
+                    "function": "create_run",
+                    "params": ["payload"],
+                    "response_model": "RunEvent",
+                }
+            ],
+        },
+        # #730 D1 / #504: pf-40's lesson made blocking. The stub header says
+        # "scaffold-owned signatures, fill-only bodies"; instruction wasn't
+        # enforcement, and SIP-0100's restore covers only the body-independent
+        # elements. The rest was report-only — drift was free. Now it fails
+        # acceptance with the divergence list as evidence, routing repair at
+        # the producer instead of the framework ever rewriting producer code.
+        notes=(
+            "Injected by the framework on tasks that author .py fill slots: the "
+            "slot's scaffold-owned signature surface — handler name, parameter "
+            "names, response_model — is diffed against the seed's declared "
+            "routes (params carry the declaration; the evaluator needs no "
+            "scaffold access). status_code and the router assignment are "
+            "restored at storage (SIP-0100), not checked here; a dropped route "
+            "is endpoint_defined's job. Never authored."
+        ),
+        failure_ownership=OWNERSHIP_PRODUCT,
+        # Fill slots are dev-lane emissions; qa authors suites, never slots.
+        qa_available=False,
+        signature_participation=True,
+        outcome_contribution=True,
+        replayable=True,
         blocking_default="error",
     ),
     CHECK_CONTRACT_ASSERTIONS: CheckSpec(

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -31,6 +31,7 @@ from typing import Any
 from squadops.cycles.acceptance_check_spec import (
     CHECK_CONTRACT_ASSERTIONS,
     CHECK_ENDPOINT_DEFINED,
+    CHECK_FILL_SLOT_SIGNATURE,
     CHECK_SPECS,
     CHECK_UNDEFINED_NAMES,
     FRONTEND_SUFFIXES,
@@ -468,6 +469,69 @@ def _prefixed_pinned_path(
         if m == method and path != p and path.endswith(p):
             return p
     return None
+
+
+@register_check(CHECK_FILL_SLOT_SIGNATURE)
+class FillSlotSignatureCheck(BaseCheck):
+    """The fill slot's scaffold-owned signature surface, enforced (#730 D1/#504).
+
+    pf-40: the stub header's "scaffold-owned signatures, fill-only bodies" was
+    instruction, not enforcement — the producer dropped response_model and
+    renamed the handler and its params, and only the body-independent elements
+    (status_code, router assignment) could be safely RESTORED at storage.
+    The rest was report-only, so the drift was free. This check makes it cost:
+    any divergence on a reported element fails acceptance with the divergence
+    list as evidence, routing repair at the producer — the framework never
+    rewrites producer code.
+
+    Params are self-contained (the #629 pattern): ``routes`` carries the
+    seed's declared signature surface, so evaluation needs no scaffold access.
+    A dropped route is ``endpoint_defined``'s job; an unparseable emission is
+    the syntax gate's.
+    """
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        try:
+            file_path = _safe_resolve(params["file"], workspace_root)
+        except _SafetyError as exc:
+            return CheckOutcome.error(reason=exc.reason)
+        if (skip := _unparseable_source_skip(file_path)) is not None:
+            return skip
+        if not file_path.is_file():
+            return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
+        try:
+            source = file_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return CheckOutcome.error(reason="file_unreadable")
+        try:
+            ast.parse(source, filename=str(file_path))
+        except SyntaxError:
+            # The syntax gate owns unparseable emissions; reporting it twice
+            # would make one defect look like two.
+            return CheckOutcome.skipped(reason="unsupported_stack_or_syntax")
+
+        declared = params.get("routes")
+        if not isinstance(declared, list) or not declared:
+            # An injected check with no declaration is an injection bug, not
+            # an app gap — never fail the producer for it.
+            return CheckOutcome.error(reason="missing_route_declaration")
+
+        from squadops.cycles.fill_slot_integrity import signature_divergences
+
+        divergences = signature_divergences(declared, source)
+        if divergences:
+            return CheckOutcome.failed(
+                reason="scaffold-owned signature diverged: " + "; ".join(divergences),
+                file=str(params["file"]),
+                divergences=divergences,
+            )
+        return CheckOutcome.passed(file=str(params["file"]))
 
 
 @register_check(CHECK_CONTRACT_ASSERTIONS)

--- a/src/squadops/cycles/fill_slot_integrity.py
+++ b/src/squadops/cycles/fill_slot_integrity.py
@@ -524,3 +524,71 @@ def divergence_summary(divergences: list[DecoratorDivergence]) -> str:
         f"{'restored' if d.restored else 'observed'} {d.method} {d.path}: {d.detail}"
         for d in ordered
     )
+
+
+def declared_route_signatures(seed_source: str) -> list[dict[str, object]]:
+    """The scaffold-owned signature surface of a fill-slot seed (#730 D1/#504).
+
+    Self-contained check params for ``fill_slot_signature``: one dict per
+    seeded route carrying the reported-not-restored elements (handler name,
+    parameter names, ``response_model`` when declared). status_code and the
+    router assignment are absent on purpose — those are RESTORED at storage
+    (SIP-0100) and checking them here would fail emissions the enforcement
+    layer silently fixes. Empty for a seed with no routes (or unparseable —
+    a scaffold that cannot parse its own seed has bigger problems than this
+    check).
+    """
+    out: list[dict[str, object]] = []
+    for route in _routes(seed_source):
+        sig: dict[str, object] = {
+            "route": f"{route.method.upper()} {route.path}",
+            "function": route.func_name,
+            "params": list(route.arg_names),
+        }
+        if route.response_model:
+            sig["response_model"] = route.response_model
+        out.append(sig)
+    return out
+
+
+def signature_divergences(declared: list[dict], emitted_source: str) -> list[str]:
+    """Diff an emission's routes against declared signature params (#730 D1).
+
+    Matching is by normalized ``(method, path)`` — the same ``_route_key`` the
+    restore path uses, so a renamed path *parameter* still matches its scaffold
+    counterpart. A declared route absent from the emission contributes nothing:
+    that is ``endpoint_defined``'s job, and reporting it twice would make one
+    defect look like two. Unparseable emissions return no divergences — the
+    caller owns the skip (the syntax gate reports those).
+    """
+    emitted = {_route_key(r.method, r.path): r for r in _routes(emitted_source)}
+    details: list[str] = []
+    for sig in declared:
+        if not isinstance(sig, dict):
+            continue
+        route_token = str(sig.get("route", ""))
+        method, _, path = route_token.partition(" ")
+        if not method or not path:
+            continue
+        got = emitted.get(_route_key(method, path))
+        if got is None:
+            continue
+        want_model = sig.get("response_model")
+        if want_model and got.response_model != want_model:
+            details.append(
+                f"{route_token}: response_model={want_model} declared by the scaffold, "
+                f"emitted as {got.response_model or 'absent'}"
+            )
+        want_fn = sig.get("function")
+        if want_fn and got.func_name != want_fn:
+            details.append(
+                f"{route_token}: scaffold-owned handler name {want_fn!r} emitted as "
+                f"{got.func_name!r}"
+            )
+        want_params = sig.get("params")
+        if isinstance(want_params, list) and tuple(str(p) for p in want_params) != got.arg_names:
+            details.append(
+                f"{route_token}: scaffold-owned parameters {[str(p) for p in want_params]} "
+                f"emitted as {list(got.arg_names)}"
+            )
+    return details

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -31,7 +31,11 @@ from squadops.capabilities.scaffold import (
     is_qa_test_path_for_stack,
     testid_surface_instructions,
 )
-from squadops.cycles.acceptance_check_spec import CHECK_CONTRACT_ASSERTIONS, is_check_applicable
+from squadops.cycles.acceptance_check_spec import (
+    CHECK_CONTRACT_ASSERTIONS,
+    CHECK_FILL_SLOT_SIGNATURE,
+    is_check_applicable,
+)
 from squadops.cycles.agent_config import resolve_agent_config
 from squadops.cycles.failure_evidence import FailureLocus
 from squadops.cycles.implementation_plan import (
@@ -611,6 +615,50 @@ def _harness_boundary_criteria(
     ]
 
 
+def _fill_slot_signature_criteria(
+    task_type: str,
+    plan_task: Any,
+    interface_manifest: InterfaceManifest | None,
+) -> list[TypedCheck]:
+    """#730 D1 / #504: scaffold-owned ``fill_slot_signature`` checks for a dev task
+    authoring ``.py`` fill slots — the pf-40 report promoted to blocking. Params carry
+    the seed's declared signature surface (handler name, parameter names,
+    response_model), derived from the manifest via the same expander the bound record
+    uses, so the evaluator needs no scaffold access. Empty for manifest-less cycles,
+    non-scaffoldable stacks, non-dev tasks, and tasks that claim no ``.py`` fill slot
+    (the ``.jsx`` slots are #668/D3's territory). status_code and the router
+    assignment stay restore-owned (SIP-0100), deliberately outside this check."""
+    if task_type != "development.develop" or interface_manifest is None:
+        return []
+    from squadops.capabilities.scaffold import expand, fill_slot_paths, is_scaffoldable_stack
+    from squadops.cycles.bound_scaffold_record import _normalize
+    from squadops.cycles.fill_slot_integrity import declared_route_signatures
+
+    if not is_scaffoldable_stack(getattr(interface_manifest, "stack", "")):
+        return []
+    fill = {_normalize(p) for p in fill_slot_paths(interface_manifest)}
+    claimed = [
+        art
+        for art in plan_task.expected_artifacts
+        if art.endswith(".py") and _normalize(art) in fill
+    ]
+    if not claimed:
+        return []
+    seeds = {_normalize(f["name"]): f["content"] for f in expand(interface_manifest)}
+    checks: list[TypedCheck] = []
+    for art in claimed:
+        routes = declared_route_signatures(seeds.get(_normalize(art), ""))
+        if routes:
+            checks.append(
+                TypedCheck(
+                    check=CHECK_FILL_SLOT_SIGNATURE,
+                    params={"file": art, "routes": routes},
+                    id=f"fill-slot-signature:{art}",
+                )
+            )
+    return checks
+
+
 def _bind_plan_criteria(plan, contract):
     """#509: same deterministic binding the plan-validation gate applies —
     dispatch and validation must see one plan. Criterion linkage comes from
@@ -799,6 +847,11 @@ def generate_task_plan(
             # bound qa.test suite files — layer 1's authoring block is guidance,
             # this is the guarantee.
             acceptance.extend(_contract_assertion_criteria(task_type, plan_task, contract))
+            # #730 D1 / #504: scaffold-owned signature enforcement on .py fill
+            # slots — the pf-40 report, promoted to blocking.
+            acceptance.extend(
+                _fill_slot_signature_criteria(task_type, plan_task, interface_manifest)
+            )
             inputs["acceptance_criteria"] = acceptance
 
         _inject_contract_inputs(inputs, contract, task_type, interface_manifest)

--- a/tests/unit/cycles/goldens/plan_context.json
+++ b/tests/unit/cycles/goldens/plan_context.json
@@ -350,7 +350,8 @@
   },
   "01:development.develop": {
    "acceptance_criteria": [
-    "TypedCheck(check='endpoint_defined', params={'methods_paths': ['POST /items'], 'file': 'backend/routes.py'}, severity='error', description='', id='vc-routes-endpoints')"
+    "TypedCheck(check='endpoint_defined', params={'methods_paths': ['POST /items'], 'file': 'backend/routes.py'}, severity='error', description='', id='vc-routes-endpoints')",
+    "TypedCheck(check='fill_slot_signature', params={'file': 'backend/routes.py', 'routes': [{'route': 'GET /runs', 'function': 'get_runs', 'params': [], 'response_model': 'list[RunEvent]'}, {'route': 'POST /runs', 'function': 'post_runs', 'params': ['payload'], 'response_model': 'RunEvent'}, {'route': 'GET /runs/{run_id}', 'function': 'get_runs_run_id', 'params': ['run_id'], 'response_model': 'RunEvent'}, {'route': 'POST /runs/{run_id}/join', 'function': 'post_runs_run_id_join', 'params': ['run_id', 'payload'], 'response_model': 'RunEvent'}, {'route': 'POST /runs/{run_id}/leave', 'function': 'post_runs_run_id_leave', 'params': ['run_id', 'payload'], 'response_model': 'RunEvent'}]}, severity='error', description='', id='fill-slot-signature:backend/routes.py')"
    ],
    "agent_config_overrides": {},
    "agent_model": "m",

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -1533,3 +1533,73 @@ def test_undefined_names_is_framework_injected_and_out_of_the_authoring_vocabula
     assert "undefined_names" not in render_typed_acceptance_vocabulary()
     # Every other check stays advertised — the flag must not hide the vocabulary.
     assert "endpoint_defined" in render_typed_acceptance_vocabulary()
+
+
+# ---------------------------------------------------------------------------
+# fill_slot_signature (#730 D1 / #504)
+# ---------------------------------------------------------------------------
+
+_FILL_SEED_ROUTES = [
+    {
+        "route": "POST /runs",
+        "function": "create_run",
+        "params": ["payload"],
+        "response_model": "RunEvent",
+    }
+]
+
+_COMPLIANT_SLOT = """
+from fastapi import APIRouter
+router = APIRouter()
+
+@router.post("/runs", response_model=RunEvent, status_code=201)
+def create_run(payload):
+    return payload
+"""
+
+
+class TestFillSlotSignature:
+    async def test_divergent_signature_fails_with_the_divergence_list(self, tmp_path):
+        """The pf-40 promotion: drift on a reported element now costs the
+        producer an acceptance failure carrying exactly what to put back —
+        instead of a log line nobody's repair ever read."""
+        (tmp_path / "routes.py").write_text(
+            _COMPLIANT_SLOT.replace("create_run(payload)", "make_run(data)")
+        )
+        result = await get_check("fill_slot_signature").evaluate(
+            {"file": "routes.py", "routes": list(_FILL_SEED_ROUTES)}, tmp_path
+        )
+        assert result.status == "failed"
+        assert "'create_run'" in result.reason and "'make_run'" in result.reason
+        assert len(result.actual["divergences"]) == 2  # handler name + params
+
+    async def test_compliant_slot_passes(self, tmp_path):
+        (tmp_path / "routes.py").write_text(_COMPLIANT_SLOT)
+        result = await get_check("fill_slot_signature").evaluate(
+            {"file": "routes.py", "routes": list(_FILL_SEED_ROUTES)}, tmp_path
+        )
+        assert result.status == "passed"
+
+    async def test_syntax_broken_emission_skips_not_fails(self, tmp_path):
+        # The syntax gate owns unparseable emissions (one defect, one report).
+        (tmp_path / "routes.py").write_text("def broken(:\n")
+        result = await get_check("fill_slot_signature").evaluate(
+            {"file": "routes.py", "routes": list(_FILL_SEED_ROUTES)}, tmp_path
+        )
+        assert result.status == "skipped"
+        assert result.reason == "unsupported_stack_or_syntax"
+
+    async def test_missing_declaration_is_an_injection_bug_not_an_app_gap(self, tmp_path):
+        (tmp_path / "routes.py").write_text(_COMPLIANT_SLOT)
+        result = await get_check("fill_slot_signature").evaluate(
+            {"file": "routes.py", "routes": []}, tmp_path
+        )
+        assert result.status == "error"
+        assert result.reason == "missing_route_declaration"
+
+    async def test_missing_file_fails(self, tmp_path):
+        result = await get_check("fill_slot_signature").evaluate(
+            {"file": "routes.py", "routes": list(_FILL_SEED_ROUTES)}, tmp_path
+        )
+        assert result.status == "failed"
+        assert result.reason == "file_not_found"

--- a/tests/unit/cycles/test_fill_slot_integrity.py
+++ b/tests/unit/cycles/test_fill_slot_integrity.py
@@ -520,3 +520,87 @@ class TestParseBackstop:
         assert len(status_divs) == 1
         assert status_divs[0].restored is False  # the evidence never claims a dead restore
         assert "restore abandoned" in status_divs[0].detail
+
+
+# ---------------------------------------------------------------------------
+# #730 D1 / #504: the reported surface as self-contained check params
+# ---------------------------------------------------------------------------
+
+from squadops.cycles.fill_slot_integrity import (  # noqa: E402
+    declared_route_signatures,
+    signature_divergences,
+)
+
+_SEED = """
+from fastapi import APIRouter
+router = APIRouter(prefix="/api/v1")
+
+@router.post("/runs", response_model=RunEvent, status_code=201)
+def create_run(payload):
+    ...
+
+@router.get("/runs/{run_id}")
+def get_run(run_id):
+    ...
+"""
+
+
+class TestDeclaredRouteSignatures:
+    def test_extracts_the_reported_surface_only(self):
+        """The params must carry exactly the reported-not-restored elements —
+        status_code appearing here would fail emissions the SIP-0100 restore
+        silently fixes (a check fighting its own enforcement layer)."""
+        sigs = declared_route_signatures(_SEED)
+        assert sigs == [
+            {
+                "route": "POST /runs",
+                "function": "create_run",
+                "params": ["payload"],
+                "response_model": "RunEvent",
+            },
+            {"route": "GET /runs/{run_id}", "function": "get_run", "params": ["run_id"]},
+        ]
+
+    def test_routeless_or_unparseable_seed_declares_nothing(self):
+        assert declared_route_signatures("x = 1\n") == []
+        assert declared_route_signatures("def broken(:\n") == []
+
+
+class TestSignatureDivergences:
+    def test_compliant_emission_diverges_nowhere(self):
+        assert signature_divergences(declared_route_signatures(_SEED), _SEED) == []
+
+    def test_each_reported_element_produces_its_divergence(self):
+        """The pf-40 drift classes, now costed: renamed handler, renamed
+        params, dropped response_model — each named individually so the
+        repair evidence says exactly what to put back."""
+        emitted = _SEED.replace("create_run(payload)", "make_run(data)").replace(
+            ", response_model=RunEvent", ""
+        )
+        details = signature_divergences(declared_route_signatures(_SEED), emitted)
+        assert len(details) == 3
+        assert any("response_model=RunEvent" in d and "absent" in d for d in details)
+        assert any("'create_run'" in d and "'make_run'" in d for d in details)
+        assert any("['payload']" in d and "['data']" in d for d in details)
+
+    def test_renamed_path_parameter_still_matches_its_route(self):
+        """The pf-31 rename class: `{run_id}` → `{id}` must still match the
+        scaffold counterpart (normalized key) — and the path-param rename
+        surfaces as a PARAMETER divergence, not a silent non-match."""
+        emitted = _SEED.replace("{run_id}", "{id}").replace("get_run(run_id)", "get_run(id)")
+        details = signature_divergences(declared_route_signatures(_SEED), emitted)
+        assert len(details) == 1
+        assert "['run_id']" in details[0] and "['id']" in details[0]
+
+    def test_dropped_route_is_not_this_checks_failure(self):
+        """A route absent from the emission is endpoint_defined's job —
+        reporting it here would make one defect look like two."""
+        emitted = "\n".join(
+            line for line in _SEED.splitlines() if "get_run" not in line and "{run_id}" not in line
+        )
+        details = signature_divergences(declared_route_signatures(_SEED), emitted)
+        assert details == []
+
+    def test_unparseable_emission_diverges_nowhere(self):
+        # The syntax gate owns broken emissions; the caller owns the skip.
+        assert signature_divergences(declared_route_signatures(_SEED), "def broken(:\n") == []

--- a/tests/unit/cycles/test_task_plan_probe_injection.py
+++ b/tests/unit/cycles/test_task_plan_probe_injection.py
@@ -366,3 +366,115 @@ def test_probe_less_contract_injects_no_endpoint_owners():
     cycle, run, profile = _implementation_setup()
     envs = generate_task_plan(cycle, run, profile, plan=None, contract=_contract(with_probes=False))
     assert all("contract_endpoint_owners" not in e.inputs for e in envs)
+
+
+# ---------------------------------------------------------------------------
+# #730 D1 / #504: fill_slot_signature injection
+# ---------------------------------------------------------------------------
+
+
+def _plan_claiming(artifacts, task_type="development.develop", role="dev"):
+    import yaml as _yaml
+
+    from squadops.cycles.implementation_plan import ImplementationPlan
+
+    return ImplementationPlan.from_yaml(
+        _yaml.safe_dump(
+            {
+                "version": 1,
+                "project_id": "p",
+                "cycle_id": "cy",
+                "prd_hash": "h",
+                "tasks": [
+                    {
+                        "task_index": 0,
+                        "task_type": task_type,
+                        "role": role,
+                        "focus": "f",
+                        "description": "d",
+                        "expected_artifacts": list(artifacts),
+                        "acceptance_criteria": [],
+                        "depends_on": [],
+                        "criteria_refs": [],
+                    }
+                ],
+                "summary": {"total_dev_tasks": 1, "total_qa_tasks": 0, "total_tasks": 1},
+            }
+        )
+    )
+
+
+def _fill_slot_checks(envs, task_type):
+    return [
+        c
+        for e in envs
+        if e.task_type == task_type
+        for c in e.inputs.get("acceptance_criteria", [])
+        if getattr(c, "check", None) == "fill_slot_signature"
+    ]
+
+
+def test_dev_task_claiming_a_py_fill_slot_gets_the_signature_check():
+    """The pf-40 report, promoted: a dev task authoring backend/routes.py must
+    carry the scaffold's declared signature surface as SELF-CONTAINED params —
+    the evaluator has no scaffold access, so a missing injection silently
+    un-enforces the whole class."""
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(
+        cycle,
+        run,
+        profile,
+        plan=_plan_claiming(["backend/routes.py"]),
+        contract=_contract(),
+        interface_manifest=_testid_manifest(),
+    )
+    checks = _fill_slot_checks(envs, "development.develop")
+    assert len(checks) == 1
+    assert checks[0].params["file"] == "backend/routes.py"
+    routes = checks[0].params["routes"]
+    assert routes, "declared route surface must be non-empty for the routes slot"
+    assert all({"route", "function", "params"} <= set(r) for r in routes)
+    assert checks[0].id == "fill-slot-signature:backend/routes.py"
+
+
+def test_no_manifest_injects_nothing():
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(
+        cycle, run, profile, plan=_plan_claiming(["backend/routes.py"]), contract=_contract()
+    )
+    assert _fill_slot_checks(envs, "development.develop") == []
+
+
+def test_non_fill_slot_py_artifact_injects_nothing():
+    """A dev task authoring a NON-slot .py file must not carry the check —
+    there is no scaffold-owned signature to enforce on free files."""
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(
+        cycle,
+        run,
+        profile,
+        plan=_plan_claiming(["backend/services.py"]),
+        contract=_contract(),
+        interface_manifest=_testid_manifest(),
+    )
+    assert _fill_slot_checks(envs, "development.develop") == []
+
+
+def test_jsx_fill_slots_are_out_of_scope():
+    """The .jsx view slots are #668/D3's territory — a .py-scoped check
+    injected on them could only ever skip (the pf-47/pf-49 dead-weight class)."""
+    cycle, run, profile = _implementation_setup()
+    envs = generate_task_plan(
+        cycle,
+        run,
+        profile,
+        plan=_plan_claiming(["frontend/src/views/RunsListView.jsx"]),
+        contract=_contract(),
+        interface_manifest=_testid_manifest(),
+    )
+    assert _fill_slot_checks(envs, "development.develop") == []
+
+
+# A qa.test task claiming a fill slot is unreachable: the qa-artifact-
+# ownership validation net rejects the plan outright (verified while writing
+# these tests) — the dev-only guard has no reachable counterexample to pin.


### PR DESCRIPTION
## #730 D1 — `fill_slot_signature`: the pf-40 report promoted to blocking (closes #730, #504)

Executes the ratified D1 ruling: **restore nothing further — make the report cost.** SIP-0100 restores only the body-independent elements (`status_code`, the router assignment); everything else on the scaffold-owned signature surface was report-only, so pf-40's drift class (dropped `response_model`, renamed handler, renamed params) was free. Now any reported divergence fails acceptance with the divergence list as evidence, routing repair at the producer — the framework still never rewrites producer code.

### The pieces

- **`fill_slot_integrity` public pair** (the reporting logic, reused, not reimplemented): `declared_route_signatures(seed)` extracts the reported-not-restored surface as self-contained check params — `status_code` deliberately absent, so the check never fights its own restore layer (an emission the enforcement silently fixes must not fail acceptance for it). `signature_divergences(declared, emitted)` diffs by the same normalized route key the restore path uses, so the pf-31 path-param rename class still *matches* its scaffold counterpart — and surfaces as a parameter divergence rather than a silent non-match. Dropped routes contribute nothing (that's `endpoint_defined`'s job; one defect, one report).
- **Registry entry + evaluator** (the pairing forced by `assert_registry_complete`): injected, `.py`-scoped, governance per the extension — `product` ownership, `qa_available=False` (fill slots are dev-lane emissions), signature-participating, replayable, blocking `error`. Syntax-broken emissions **skip** (the syntax gate owns them); an empty `routes` declaration is an **injection bug (`error`)**, never an app gap.
- **Plan-time injection** beside the other criteria helpers: per claimed `.py` fill slot on `development.develop`, seeds derived from the manifest via the same expander the bound record uses (one source of truth). The `.jsx` view slots stay out — #668/D3's territory; a `.py`-scoped check there could only ever skip (the pf-47/pf-49 dead-weight class). Repairs inherit the check automatically through `acceptance_criteria` forwarding and `verify_patched_artifacts`.

### Deliberate regens (disclosed per protocol)

- Plan golden: `implementation_bind`'s dev task gains exactly one check carrying the group_run seed's 5-route declared surface.
- `typed-check-menu.md`: one new row (13 evaluable checks).

### Tests

Extraction shape (reported surface only), each divergence class individually named, path-param rename match, dropped-route non-report, unparseable-emission non-report; evaluator fail/pass/skip/error/file-not-found; injection presence + the three absence guards (no manifest, non-slot `.py`, `.jsx` slot). One planned test was dropped as unreachable: a qa task claiming a fill slot is rejected by the qa-artifact-ownership net before injection could ever run — recorded as a comment where the test would have been.

### Verification

Full regression: **6487 passed, 1 skipped** (ruff clean).

### Issue closure

- **Closes #504** — its remaining scope was exactly this promotion (restore-vs-report ruled: nothing further restored).
- **Closes #730** — PR 1 (registry extension, #757) + this D1 entry complete the issue's in-1.5 scope. The two remaining threads have homes: **D3-half-a `testids_present`** stays tracked by #668 (narrowed to the suite half for 1.6; the static-view half is capacity-bound — buildable in 1.5 if capacity allows, on #668); **D4 `package_builds`** is recorded declared-unbuilt in the registry with its named 1.6 trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
