### PR TITLE
fix(preflight): reject bind mode with no plan_authoring_contributors at create (#762)

### DIFF
--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -35,6 +35,7 @@ from squadops.cycles.models import (
 from squadops.cycles.preflight import (
     Finding,
     PreflightDecision,
+    bind_mode_authoring_decision,
     combine,
     model_availability_decision,
     required_check_tooling_decision,
@@ -125,6 +126,10 @@ async def _run_create_preflight(profile: SquadProfile, config: dict) -> tuple[Fi
     """
     decision = combine(
         required_roles_decision(profile, config),
+        # #762: bind mode with no plan_authoring_contributors is unwinnable by
+        # construction — the sole-author path never receives the criteria index,
+        # so every framing attempt is rejected. Fail in seconds, not per re-roll.
+        bind_mode_authoring_decision(config),
         model_availability_decision(profile, await _pulled_model_names()),
         # SIP-0096 §6.5: a required check whose tooling is knowably absent is a
         # create-time reject, never a mid-run blocked_unverified surprise.

--- a/src/squadops/cycles/models.py
+++ b/src/squadops/cycles/models.py
@@ -210,6 +210,13 @@ WORKLOAD_REQUIRED_ROLES: dict[str, frozenset[str]] = {
     WorkloadType.IMPLEMENTATION: frozenset(),
 }
 
+# Roles that may appear in ``plan_authoring_contributors`` (SIP-0093 Rev 1). Homed
+# here for the same reason as WORKLOAD_REQUIRED_ROLES above: two readers key off it —
+# dispatch-time sequence construction (task_plan.build_planning_steps) and the
+# create-time preflight (cycles.preflight.bind_mode_authoring_decision, #762) — and a
+# duplicated literal is how those two drift.
+VALID_PLAN_AUTHORING_CONTRIBUTORS = frozenset({"development", "qa", "strategy"})
+
 
 # =============================================================================
 # Validation helpers

--- a/src/squadops/cycles/preflight.py
+++ b/src/squadops/cycles/preflight.py
@@ -32,7 +32,12 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from squadops.cycles.check_registry import get_framework_check
-from squadops.cycles.models import REQUIRED_PLAN_ROLES, WORKLOAD_REQUIRED_ROLES
+from squadops.cycles.models import (
+    REQUIRED_PLAN_ROLES,
+    VALID_PLAN_AUTHORING_CONTRIBUTORS,
+    WORKLOAD_REQUIRED_ROLES,
+    WorkloadType,
+)
 
 if TYPE_CHECKING:
     from squadops.cycles.models import SquadProfile
@@ -131,6 +136,76 @@ def _required_roles_by_workload(config: Mapping[str, Any]) -> dict[str, frozense
     if config.get("plan_tasks", True):
         return {"plan_tasks": REQUIRED_PLAN_ROLES}
     return {}
+
+
+def _authors_a_plan(config: Mapping[str, Any]) -> bool:
+    """True iff this cycle's requested workloads will actually author a plan.
+
+    Mirrors :func:`_required_roles_by_workload`'s reading of the same surface,
+    including its legacy fallback, so the two never disagree about whether
+    planning happens.
+    """
+    sequence = config.get("workload_sequence") or []
+    if sequence:
+        return any(
+            (entry.get("type") if isinstance(entry, Mapping) else None) == WorkloadType.FRAMING
+            for entry in sequence
+        )
+    return bool(config.get("plan_tasks", True))
+
+
+def bind_mode_authoring_decision(config: Mapping[str, Any]) -> PreflightDecision:
+    """Block a bind-mode cycle whose framing cannot produce a bindable plan (#762).
+
+    In bind mode (``contract_ref`` present) the plan is validated to *bind* the
+    contract's criteria by id. Only the proposer task types carry the criteria
+    index — ``bind_criteria_index`` is set on ``development.propose_plan_tasks`` and
+    ``qa.propose_plan_tasks`` in ``capabilities.context_assembly``, and
+    ``governance.merge_plan`` is deliberately excluded there. So with no
+    ``plan_authoring_contributors`` there are no proposers, *nothing* in the framing
+    workload ever receives the index, and every plan the sole-author merger can
+    produce (frozen-surface claims, zero ``criteria_refs``) is rejected by bind-mode
+    validation. The configuration is unwinnable by construction, and it costs a full
+    framing workload per attempt to discover — shk-6 rolls 1-3 burned three.
+
+    **Scoped to configurations that actually author a plan.** An implementation-only
+    bind-mode cycle is legitimate and used: the SIP-0101 replay demonstration
+    (``cyc_cfe6962e8fc8``) skipped framing via a ``workload_sequence`` override to
+    resume from a checkpoint. Blocking on ``contract_ref`` alone would have rejected
+    it, and a net that false-positives on a working configuration is worse than the
+    gap it closes.
+
+    Blocks rather than warns: every input is present in the resolved config at create
+    time (knowable, per this module's block-vs-warn rule), and the downstream
+    rejection is deterministic rather than probable — warning would spend a framing
+    workload to reach a certain failure.
+    """
+    if not config.get("contract_ref"):
+        return PreflightDecision()
+    if config.get("plan_authoring_contributors"):
+        return PreflightDecision()
+    if not _authors_a_plan(config):
+        return PreflightDecision()
+
+    roles = ", ".join(f"`{r}`" for r in sorted(VALID_PLAN_AUTHORING_CONTRIBUTORS))
+    return PreflightDecision(
+        blocking=(
+            Finding(
+                code="bind_mode_without_authoring_contributors",
+                severity="block",
+                message=(
+                    "this cycle is in bind mode (`contract_ref` is set) but "
+                    "`plan_authoring_contributors` is empty, so plan authoring would run "
+                    "sole-author — a path that never receives the contract's criteria "
+                    "index and therefore cannot produce a plan that binds it. Every "
+                    "framing attempt would be rejected. Set "
+                    f"`plan_authoring_contributors` (any of {roles}) in the request "
+                    "profile or `execution_overrides`, or drop `contract_ref` to run in "
+                    "author mode."
+                ),
+            ),
+        )
+    )
 
 
 def _canonical_model(name: str) -> str:

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -45,6 +45,7 @@ from squadops.cycles.implementation_plan import (
 )
 from squadops.cycles.models import (
     REQUIRED_PLAN_ROLES,
+    VALID_PLAN_AUTHORING_CONTRIBUTORS,
     WORKLOAD_REQUIRED_ROLES,
     Cycle,
     CycleError,
@@ -109,12 +110,10 @@ _PLAN_AUTHORING_PROPOSER_STEPS: dict[str, tuple[str, str]] = {
     "strategy": ("strategy.propose_plan_guidance", role_to_id("strategy")),
 }
 
+
 # Rev 1 contributor vocabulary. ``build`` is reserved for Rev 2 (SIP-0093
 # §5.12 — builder-role proposer). Reject early so a typo or premature
 # config doesn't silently drop a proposer.
-_VALID_PLAN_AUTHORING_CONTRIBUTORS = frozenset({"development", "qa", "strategy"})
-
-
 def build_planning_steps(
     plan_authoring_contributors: list[str] | None,
 ) -> list[tuple[str, str]]:
@@ -134,17 +133,17 @@ def build_planning_steps(
 
     Raises:
         CycleError: if any contributor in the list isn't in
-            ``_VALID_PLAN_AUTHORING_CONTRIBUTORS``. Rejecting at sequence-
+            ``VALID_PLAN_AUTHORING_CONTRIBUTORS``. Rejecting at sequence-
             build time fails the cycle early rather than running a partial
             pipeline that drops the misconfigured proposer.
     """
     contributors = list(plan_authoring_contributors or [])
-    unknown = set(contributors) - _VALID_PLAN_AUTHORING_CONTRIBUTORS
+    unknown = set(contributors) - VALID_PLAN_AUTHORING_CONTRIBUTORS
     if unknown:
         raise CycleError(
             "plan_authoring_contributors contains unsupported roles: "
             f"{sorted(unknown)}. Rev 1 supports "
-            f"{sorted(_VALID_PLAN_AUTHORING_CONTRIBUTORS)}."
+            f"{sorted(VALID_PLAN_AUTHORING_CONTRIBUTORS)}."
         )
 
     steps: list[tuple[str, str]] = [

--- a/tests/unit/cycles/test_preflight.py
+++ b/tests/unit/cycles/test_preflight.py
@@ -21,10 +21,15 @@ from datetime import UTC, datetime
 
 import pytest
 
-from squadops.cycles.models import AgentProfileEntry, SquadProfile
+from squadops.cycles.models import (
+    VALID_PLAN_AUTHORING_CONTRIBUTORS,
+    AgentProfileEntry,
+    SquadProfile,
+)
 from squadops.cycles.preflight import (
     Finding,
     PreflightDecision,
+    bind_mode_authoring_decision,
     combine,
     model_availability_decision,
     required_check_tooling_decision,
@@ -294,3 +299,115 @@ def test_tooling_free_required_checks_never_block():
 def test_empty_required_checks_is_empty_decision():
     decision = required_check_tooling_decision([], available_tooling=None)
     assert decision.blocking == () and decision.warnings == ()
+
+
+# ---------------------------------------------------------------------------
+# #762 — bind mode with no plan_authoring_contributors is unwinnable
+#
+# Bug classes guarded: (a) the doomed configuration reaching dispatch at all —
+# shk-6 rolls 1-3 each burned a full framing workload to reach a deterministic
+# rejection; (b) the net over-reaching onto configurations that DO work, in
+# particular the implementation-only bind-mode shape the SIP-0101 replay
+# demonstration uses; (c) the net missing the legacy no-workload_sequence path,
+# which is exactly how the two config readings drift apart; (d) rejection text
+# that names the fault but not the remedy, reproducing the diagnosis cost the
+# check exists to remove.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "config", "blocks"),
+    [
+        (
+            "bind + framing + no contributors — the shk-6 rolls 1-3 shape",
+            {
+                "contract_ref": "art_4f368ea08799",
+                "workload_sequence": [{"type": "framing"}, {"type": "implementation"}],
+            },
+            True,
+        ),
+        (
+            "bind + framing + contributors — the shk-6 roll-4+ / shk-7 green shape",
+            {
+                "contract_ref": "art_4f368ea08799",
+                "workload_sequence": [{"type": "framing"}, {"type": "implementation"}],
+                "plan_authoring_contributors": ["development", "qa", "strategy"],
+            },
+            False,
+        ),
+        (
+            "bind + implementation-only — the SIP-0101 replay shape, must not block",
+            {
+                "contract_ref": "art_4f368ea08799",
+                "workload_sequence": [{"type": "implementation"}],
+            },
+            False,
+        ),
+        (
+            "author mode sole-author — the common case, no contract to bind",
+            {"workload_sequence": [{"type": "framing"}]},
+            False,
+        ),
+        (
+            "legacy path: bind, no workload_sequence, plan_tasks defaults true",
+            {"contract_ref": "art_4f368ea08799"},
+            True,
+        ),
+        (
+            "legacy path: bind with plan_tasks disabled — nothing authors a plan",
+            {"contract_ref": "art_4f368ea08799", "plan_tasks": False},
+            False,
+        ),
+        (
+            "bind + framing + explicitly empty contributors list",
+            {
+                "contract_ref": "art_4f368ea08799",
+                "workload_sequence": [{"type": "framing"}],
+                "plan_authoring_contributors": [],
+            },
+            True,
+        ),
+    ],
+)
+def test_bind_mode_authoring_truth_table(label, config, blocks):
+    decision = bind_mode_authoring_decision(config)
+    assert decision.rejected is blocks, label
+    assert decision.warnings == ()
+
+
+def test_bind_mode_rejection_names_the_remedy_not_just_the_fault():
+    """A message that says only 'invalid config' rebuilds the cost this check removes."""
+    decision = bind_mode_authoring_decision(
+        {"contract_ref": "art_4f368ea08799", "workload_sequence": [{"type": "framing"}]}
+    )
+    (finding,) = decision.blocking
+    assert finding.code == "bind_mode_without_authoring_contributors"
+    assert finding.severity == "block"
+    # names why it is bind mode, what is missing, every valid role, and both exits
+    assert "contract_ref" in finding.message
+    assert "plan_authoring_contributors" in finding.message
+    for role in VALID_PLAN_AUTHORING_CONTRIBUTORS:
+        assert f"`{role}`" in finding.message
+    assert "execution_overrides" in finding.message
+    assert "author mode" in finding.message
+
+
+def test_contributors_vocabulary_is_single_sourced_with_dispatch():
+    """The preflight and dispatch-time sequence builder must not drift.
+
+    A duplicated literal here is how a role accepted at create time becomes a
+    CycleError at dispatch (or vice versa).
+    """
+    from squadops.cycles import task_plan
+
+    assert task_plan.VALID_PLAN_AUTHORING_CONTRIBUTORS is VALID_PLAN_AUTHORING_CONTRIBUTORS
+
+
+def test_bind_mode_check_is_composed_into_the_create_preflight():
+    """An uncomposed check is a check that never runs — the inert-capability class."""
+    import inspect
+
+    from squadops.api.routes.cycles import cycles as cycles_route
+
+    source = inspect.getsource(cycles_route._run_create_preflight)
+    assert "bind_mode_authoring_decision(config)" in source


### PR DESCRIPTION
First item of the v1.6 queue front. Design gate (D1–D6) posted to the issue before any code.

Closes #762

## The premise, re-verified against `main` rather than taken from the shakedown write-up

- `bind_criteria_index=True` is set on **exactly two** contracts in `capabilities/context_assembly.py`: `development.propose_plan_tasks` and `qa.propose_plan_tasks`. `governance.merge_plan` is **deliberately** excluded, and the registry says why.
- `build_planning_steps()` adds proposer steps only for roles in `plan_authoring_contributors`; an empty list yields *no proposers* and the merger runs sole-author.
- So nothing in framing ever receives the criteria index → no `criteria_refs` can be authored → bind-mode validation rejects, deterministically, after a full framing workload is spent. shk-6 rolls 1–3 burned three.

## The check

Blocks iff **all three** hold on the resolved config (#724's single merge, which is what dispatch honors):

1. `contract_ref` present → bind mode;
2. a planning workload will actually run;
3. `plan_authoring_contributors` empty or absent.

**Condition 2 is load-bearing, not defensive.** An implementation-only bind-mode cycle is legitimate and *used* — the SIP-0101 replay demonstration (`cyc_cfe6962e8fc8`) skipped framing via a `workload_sequence` override to resume from a checkpoint. Blocking on `contract_ref` alone would have rejected it. `_authors_a_plan()` mirrors `_required_roles_by_workload()`'s reading of the same surface, legacy `plan_tasks` fallback included, so the two can't disagree about whether planning happens.

| Configuration | Result |
|---|---|
| bind + framing + no contributors — **the shk-6 rolls 1–3 shape** | **block** |
| bind + framing + contributors — the shk-7 green shape | allow |
| bind + implementation-only — **the replay shape** | allow |
| author mode, sole-author — the common case | allow |
| legacy: bind, no `workload_sequence`, `plan_tasks` default | **block** |
| legacy: bind + `plan_tasks: false` | allow |
| bind + framing + explicitly empty list | **block** |

**Blocks rather than warns**, per the module's own rule: every input is knowable in the resolved config at create time, and the downstream rejection is deterministic — a warning would spend a framing workload to reach a certain failure.

## The message names the remedy

Why it's bind mode, what's missing, every valid role, and both exits (add contributors, or drop `contract_ref` for author mode). A message that says only "invalid configuration" rebuilds the diagnosis cost this check removes — pinned by a test.

## Rode along: one vocabulary, not two literals

`VALID_PLAN_AUTHORING_CONTRIBUTORS` moves from a private constant in `task_plan` to `cycles/models.py`, beside `WORKLOAD_REQUIRED_ROLES` — whose comment already states exactly this pattern: one source of truth shared by dispatch-time step resolution and the create-time preflight, "so the two never drift." A duplicated literal is how a role accepted at create becomes a `CycleError` at dispatch. An identity test pins it.

## Deliberately *not* changed

**`validated-fullstack.yaml`.** The shakedown write-up reads as "the CRP lacks `plan_authoring_contributors`," which invites adding it there. That would be wrong: bind mode comes from `execution_overrides.contract_ref` at launch, **not** from the CRP, so `validated-fullstack` is a perfectly valid *author-mode* profile whose users would silently inherit three extra proposer tasks and their cost.

**Option 2** (thread the criteria index into the sole-author merge path) is foreclosed with a named trigger — `merge_plan`'s exclusion is a documented choice, so reversing it is a design change, not a bug fix. No configuration wants sole-author bind mode today.

## Tests

Seven-case truth table (including both false-positive shapes that must **not** block and both legacy paths), remedy-content assertions, the single-sourcing identity, and a composition test — because an uncomposed check is one that never runs.

**Regression: 6497 passed, 1 skipped.**