### PR TITLE
fix(telemetry): only attempt Langfuse prompt linkage when assets come from Langfuse (#766)

### DIFF
--- a/adapters/telemetry/factory.py
+++ b/adapters/telemetry/factory.py
@@ -135,6 +135,7 @@ def create_llm_observability_provider(
     provider: str = "langfuse",
     config: LangFuseConfig | None = None,
     secret_manager: SecretManager | None = None,
+    prompt_asset_provider: str = "filesystem",
 ) -> LLMObservabilityPort:
     """Create LLM observability provider (SIP-0061).
 
@@ -146,6 +147,10 @@ def create_llm_observability_provider(
         provider: Provider name (currently only "langfuse")
         config: LangFuseConfig from AppConfig
         secret_manager: For resolving secret:// references in config
+        prompt_asset_provider: ``PromptsConfig.asset_source_provider`` (SIP-0084).
+            Threaded through so the adapter is told where prompt assets come from
+            instead of reading config itself or carrying a duplicate setting (#766);
+            prompt→generation linkage is only attempted when it is ``langfuse``.
 
     Returns:
         LLMObservabilityPort implementation
@@ -158,7 +163,7 @@ def create_llm_observability_provider(
             from adapters.telemetry.langfuse.adapter import LangFuseAdapter
 
             resolved_config = _resolve_secrets(config, secret_manager)
-            return LangFuseAdapter(resolved_config)
+            return LangFuseAdapter(resolved_config, prompt_asset_provider)
         except ImportError:
             logger.warning(
                 "langfuse SDK not installed; falling back to NoOp adapter. "

--- a/adapters/telemetry/langfuse/adapter.py
+++ b/adapters/telemetry/langfuse/adapter.py
@@ -76,7 +76,16 @@ class LangFuseAdapter(LLMObservabilityPort):
     handles all flushing to LangFuse.
     """
 
-    def __init__(self, config: LangFuseConfig) -> None:
+    def __init__(self, config: LangFuseConfig, prompt_asset_provider: str = "filesystem") -> None:
+        """
+        Args:
+            config: resolved LangFuse observability configuration.
+            prompt_asset_provider: the value of ``PromptsConfig.asset_source_provider``
+                (SIP-0084), passed in at the composition root. The adapter is *told*
+                where prompt assets come from rather than reading config itself, so the
+                fact lives in exactly one place (#766). Defaults to ``filesystem`` to
+                match the schema default — the real-world path, not the convenient one.
+        """
         # Lazy-import the SDK — fails here if not installed
         try:
             from langfuse import Langfuse  # noqa: F401
@@ -96,6 +105,25 @@ class LangFuseAdapter(LLMObservabilityPort):
         self._shutdown = threading.Event()
         self._flush_requested = threading.Event()
         self._last_overflow_warning = 0.0  # Protected by _lock
+
+        self._prompt_linkage_enabled = prompt_asset_provider == "langfuse"
+        if not self._prompt_linkage_enabled:
+            # #766: declared, not silently absent. Prompt→generation linkage cannot
+            # work when assets come from anywhere but Langfuse's own prompt registry
+            # — the version namespaces are independent — so state the gap once at
+            # construction rather than emitting a vendor ERROR per generation or,
+            # worse, leaving the feature quietly inert.
+            logger.info(
+                "langfuse_prompt_linkage_disabled",
+                extra={
+                    "prompt_asset_provider": prompt_asset_provider,
+                    "detail": (
+                        "generations will not be linked to prompt versions: prompt "
+                        "assets are sourced from "
+                        f"'{prompt_asset_provider}', not Langfuse's prompt registry"
+                    ),
+                },
+            )
 
         # Redaction applied before enqueue
         self._redaction = get_redaction_strategy(config.redaction_mode)
@@ -461,7 +489,16 @@ class LangFuseAdapter(LLMObservabilityPort):
 
         Returns the prompt object on success, None on any failure (best-effort).
         Called from the background flush thread — must not raise.
+
+        Skipped entirely unless prompt assets are sourced from Langfuse (#766). Under
+        any other provider the name/version pair addresses a registry that has never
+        seen this prompt, so the call cannot succeed for any asset at any version —
+        it only produces a vendor-logged ERROR per generation. A 404 under the
+        ``langfuse`` provider is a different thing: legitimate, informative, and still
+        caught below.
         """
+        if not self._prompt_linkage_enabled:
+            return None
         try:
             kwargs: dict[str, Any] = {"name": prompt_name}
             if prompt_version is not None:

--- a/src/squadops/agents/entrypoint.py
+++ b/src/squadops/agents/entrypoint.py
@@ -411,7 +411,10 @@ class AgentRunner:
         metrics, events = create_telemetry_provider(telemetry_backend)
 
         # Create LLM observability (SIP-0061)
-        llm_observability = create_llm_observability_provider(config=config.langfuse)
+        llm_observability = create_llm_observability_provider(
+            config=config.langfuse,
+            prompt_asset_provider=config.prompts.asset_source_provider,
+        )
 
         # Create filesystem adapter
         filesystem = LocalFileSystemAdapter()

--- a/src/squadops/api/runtime/main.py
+++ b/src/squadops/api/runtime/main.py
@@ -300,7 +300,10 @@ async def _init_cycle_subsystem(config, pool) -> None:
         from adapters.telemetry.factory import create_llm_observability_provider
 
         queue_adapter = RabbitMQAdapter(url=RABBITMQ_URL)
-        llm_obs = create_llm_observability_provider(config=config.langfuse)
+        llm_obs = create_llm_observability_provider(
+            config=config.langfuse,
+            prompt_asset_provider=config.prompts.asset_source_provider,
+        )
 
         # SIP-0094: per-agent reply-queue router. Holds one long-lived
         # subscription per agent (opened lazily on first dispatch) and resolves

--- a/tests/unit/telemetry/test_langfuse_adapter.py
+++ b/tests/unit/telemetry/test_langfuse_adapter.py
@@ -75,8 +75,12 @@ def _inject_fake_langfuse():
     return fake, mock_client
 
 
-def _create_adapter(config=None):
-    """Create a LangFuseAdapter with injected fake SDK."""
+def _create_adapter(config=None, prompt_asset_provider="filesystem"):
+    """Create a LangFuseAdapter with injected fake SDK.
+
+    ``prompt_asset_provider`` defaults to ``filesystem`` to match PromptsConfig's
+    default — the deployed path (#766), not the convenient one.
+    """
     fake_mod, mock_client = _inject_fake_langfuse()
     old = sys.modules.get("langfuse")
     sys.modules["langfuse"] = fake_mod
@@ -85,7 +89,11 @@ def _create_adapter(config=None):
     try:
         from adapters.telemetry.langfuse.adapter import LangFuseAdapter
 
-        return LangFuseAdapter(config or _make_config()), mock_client, old
+        return (
+            LangFuseAdapter(config or _make_config(), prompt_asset_provider),
+            mock_client,
+            old,
+        )
     except Exception:
         # Restore on failure
         if old is None:
@@ -376,8 +384,12 @@ class TestPromptToGenerationLinkage:
     def test_generation_with_prompt_name_resolves_and_links(self):
         """Bug caught: generation() called without prompt kwarg — Langfuse UI
         never shows prompts as 'used in a generation'.
+
+        Provider made explicit by #766: linkage is only attempted when prompt assets
+        come from Langfuse's own registry. The assertion is unchanged — this still
+        guards "does linkage fire when it should".
         """
-        a, mock_client, old = _create_adapter()
+        a, mock_client, old = _create_adapter(prompt_asset_provider="langfuse")
         try:
             fake_prompt_obj = MagicMock()
             mock_client.get_prompt.return_value = fake_prompt_obj
@@ -427,8 +439,14 @@ class TestPromptToGenerationLinkage:
     def test_prompt_resolution_failure_still_records_generation(self):
         """Bug caught: if get_prompt raises (e.g. prompt not in Langfuse),
         the generation must still be recorded without the prompt link.
+
+        Provider made explicit by #766: a 404 under the ``langfuse`` provider is a
+        legitimate, informative failure — the prompt genuinely is not registered at
+        that version — and this guards that it degrades rather than losing the
+        observation. The filesystem case is a different thing entirely (the call is
+        never made) and is covered by TestPromptLinkageProviderAwareness.
         """
-        a, mock_client, old = _create_adapter()
+        a, mock_client, old = _create_adapter(prompt_asset_provider="langfuse")
         try:
             mock_client.get_prompt.side_effect = Exception("not found")
 
@@ -448,3 +466,93 @@ class TestPromptToGenerationLinkage:
             assert "prompt" not in task_span.generation.call_args[1]
         finally:
             _cleanup_adapter(a, old)
+
+
+class TestPromptLinkageProviderAwareness:
+    """#766: the prompt lookup is skipped when it cannot possibly succeed.
+
+    Bug classes guarded: (a) calling Langfuse's prompt registry with a *filesystem*
+    asset's version — a cross-registry lookup that 404s for every asset at every
+    version and emits a vendor-logged ERROR per generation; (b) losing the
+    generation observation itself while skipping the linkage; (c) the skip being
+    silent, which leaves an inert capability looking like a working one.
+    """
+
+    def test_filesystem_provider_never_calls_the_prompt_registry(self):
+        """The regression that would reintroduce one vendor ERROR per generation.
+
+        prompt_name AND prompt_version are both present — the exact shape that
+        produced `Prompt not found: 'request.planning_task_base' with version 3`
+        on every authoring agent during shk-7.
+        """
+        a, mock_client, old = _create_adapter(prompt_asset_provider="filesystem")
+        try:
+            ctx = _make_ctx()
+            from adapters.telemetry.langfuse.adapter import _BufferEntry, _EventType
+
+            a._process_entry(_BufferEntry(_EventType.START_CYCLE, ctx, None))
+            a._process_entry(_BufferEntry(_EventType.START_TASK, ctx, None))
+
+            record = _make_record(prompt_name="request.planning_task_base", prompt_version=3)
+            a._process_entry(_BufferEntry(_EventType.GENERATION, ctx, (record, _make_layers())))
+
+            mock_client.get_prompt.assert_not_called()
+        finally:
+            _cleanup_adapter(a, old)
+
+    def test_skipping_linkage_never_costs_the_generation(self):
+        """Observability must degrade, not disappear: the generation is still
+        recorded, just without a prompt kwarg.
+        """
+        a, mock_client, old = _create_adapter(prompt_asset_provider="filesystem")
+        try:
+            ctx = _make_ctx()
+            from adapters.telemetry.langfuse.adapter import _BufferEntry, _EventType
+
+            a._process_entry(_BufferEntry(_EventType.START_CYCLE, ctx, None))
+            a._process_entry(_BufferEntry(_EventType.START_TASK, ctx, None))
+
+            record = _make_record(prompt_name="request.planning_task_base", prompt_version=3)
+            a._process_entry(_BufferEntry(_EventType.GENERATION, ctx, (record, _make_layers())))
+
+            tk = ctx.trace_id or ctx.cycle_id
+            task_span = a._span_state[f"task:{tk}:{ctx.task_id}"]
+            task_span.generation.assert_called_once()
+            assert "prompt" not in task_span.generation.call_args[1]
+            # the observation itself is intact
+            assert task_span.generation.call_args[1]["model"] == record.model
+        finally:
+            _cleanup_adapter(a, old)
+
+    def test_disabled_linkage_is_declared_once_at_construction(self, caplog):
+        """A silent skip leaves an inert capability indistinguishable from a working
+        one. Declared once — not per generation, which would trade an ERROR per
+        cycle for an INFO per cycle and fix nothing.
+        """
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="adapters.telemetry.langfuse.adapter"):
+            a, _mock_client, old = _create_adapter(prompt_asset_provider="filesystem")
+            try:
+                disclosures = [
+                    r for r in caplog.records if r.msg == "langfuse_prompt_linkage_disabled"
+                ]
+                assert len(disclosures) == 1
+                assert disclosures[0].prompt_asset_provider == "filesystem"
+            finally:
+                _cleanup_adapter(a, old)
+
+    def test_langfuse_provider_stays_silent_about_disablement(self):
+        """No disclosure when linkage is actually enabled."""
+        import logging
+
+        from _pytest.logging import LogCaptureHandler, catching_logs
+
+        with catching_logs(LogCaptureHandler(), level=logging.INFO) as handler:
+            a, _mock_client, old = _create_adapter(prompt_asset_provider="langfuse")
+            try:
+                assert not [
+                    r for r in handler.records if r.msg == "langfuse_prompt_linkage_disabled"
+                ]
+            finally:
+                _cleanup_adapter(a, old)


### PR DESCRIPTION
Second item of the v1.6 queue front. Design gate (D1–D6) posted to the issue before code.

Closes #766

## What was happening

`_handle_generation` passed the **filesystem** asset's front-matter version into **Langfuse's** prompt registry — two registries with independent version namespaces. Under `SQUADOPS__PROMPTS__ASSET_SOURCE_PROVIDER=filesystem` (the schema default *and* the deployed value) the lookup cannot succeed for any asset at any version, so it produced a vendor-logged `ERROR` per agent per cycle while the linkage it exists to create was never established.

## Two defects, kept separate

**The noise** is fixed by not making a call that cannot succeed. The `ERROR` originates in the Langfuse SDK's own logger *before* our `except` sees anything — catching harder or downgrading our own log would not have touched it. **Muting the vendor logger is explicitly not the fix**: that hides the inert-capability defect behind the noise defect.

**The inert capability is not built here — it is declared.** One `INFO` line at construction stating linkage is disabled and why. This is the `DECLARED_UNBUILT_CHECKS` pattern (#730/D4) one level down: a gap that is named is governable, a gap that is silent is a false capability. The trigger for actually building linkage (publishing filesystem assets into Langfuse's registry) is recorded on the issue — the concrete candidate is v1.8's scorecard wanting per-prompt-version attribution.

## Ownership

The adapter is **told** the provider at the composition root; it does not read config itself and does not carry a copy of the setting. `PromptsConfig.asset_source_provider` (SIP-0084) owns that fact and keeps owning it. Both construction sites (`api/runtime/main.py`, `agents/entrypoint.py`) already held the full `AppConfig`.

**Rejected:** a field on `LangFuseConfig` — that's observability config, not prompt-source config, and the same fact living in two config surfaces is exactly the drift class.

## The gate is "can this ever succeed", not "did it error"

A 404 under the `langfuse` provider is legitimate and informative — the prompt genuinely isn't registered at that version — so the existing best-effort catch is untouched.

## Tests

- filesystem path makes **zero** `get_prompt` calls with `prompt_name` *and* `prompt_version` both present — the exact shape that produced `Prompt not found: 'request.planning_task_base' with version 3` on every authoring agent during shk-7;
- the generation is **still recorded** without a `prompt` kwarg, so skipping linkage never costs an observation;
- the disclosure fires **once at construction**, not per generation — otherwise we'd trade an ERROR per cycle for an INFO per cycle and fix nothing;
- no disclosure when linkage is enabled.

**Two existing tests now declare `prompt_asset_provider="langfuse"`.** That is not test-weakening — both assert behavior that only applies where resolution is *attempted* (does linkage fire when it should; does a resolution failure still record the generation), and their assertions are unchanged. The harness default is `filesystem`, matching `PromptsConfig` — the deployed path, not the convenient one.

**Regression: 6501 passed, 1 skipped.**