### PR TITLE
fix(maintainer): derive SIP frontmatter from the body instead of failing (#770)

### DIFF
--- a/scripts/maintainer/update_sip_status.py
+++ b/scripts/maintainer/update_sip_status.py
@@ -149,6 +149,23 @@ _BODY_STATUS_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+# The OTHER declaration shape drafts actually use: a "## Status" heading with the
+# value on a following line ("## Status\nDraft (proposed)"). #253 closed the
+# inline form; this is the same bug class one form down — SIP-0103 had exactly
+# this shape, so its body would have kept saying "Draft" while the frontmatter and
+# registry said "accepted" (#770).
+#
+# Deliberately conservative: the value line must BEGIN with a status keyword,
+# optionally emphasised ("**Proposed** (draft, ...)" is how one real draft writes
+# it). A heading followed by prose ("## Status\n\nSome explanation") still matches
+# nothing, so the caller still warns rather than rewriting arbitrary text. The
+# emphasis is captured into `heading` so a rewrite preserves it.
+_BODY_STATUS_HEADING_RE = re.compile(
+    r"^(?P<heading>#{1,6}[ \t]+[^\n]*Status[^\n]*\n(?:[ \t]*\n)*\*{0,2})"
+    r"(?P<word>" + "|".join(_STATUS_WORDS) + r")",
+    re.IGNORECASE | re.MULTILINE,
+)
+
 
 def update_sip_body_status(file_path: Path, new_status: str) -> bool:
     """Rewrite the human-readable body ``**Status:**`` line to match new_status.
@@ -177,6 +194,11 @@ def update_sip_body_status(file_path: Path, new_status: str) -> bool:
     canonical = new_status.capitalize()
     new_body, count = _BODY_STATUS_RE.subn(lambda m: m.group("prefix") + canonical, body, count=1)
     if count == 0:
+        # Fall back to the heading form ("## Status" + value on a following line).
+        new_body, count = _BODY_STATUS_HEADING_RE.subn(
+            lambda m: m.group("heading") + canonical, body, count=1
+        )
+    if count == 0:
         return False
 
     try:
@@ -203,6 +225,126 @@ def normalize_filename(sip_number: int, title: str) -> str:
     clean_title = "-".join(words)
 
     return f"SIP-{sip_number:04d}-{clean_title}.md"
+
+
+# --- Frontmatter derivation (#770) ------------------------------------------
+#
+# Most drafts in sips/proposed/ are hand-authored prose with no YAML frontmatter
+# (12 of 13 at the time this landed), so promotion used to die on
+# "Could not extract metadata" at the worst possible moment — mid-promotion, at
+# the opening step of a release line.
+#
+# The fix reads what the author ALREADY WROTE rather than asking them to retype
+# it as YAML. Nothing here invents a value: every field is lifted from the body,
+# and the only hard failure is a status that cannot be read at all.
+
+_H1_RE = re.compile(r"^#[ \t]+(?P<title>[^\n]+)", re.MULTILINE)
+# "# SIP-0103: Foo" / "# SIP-0XXX: Foo" / "# SIP: Foo" / "# IDEA — Foo"
+_H1_PREFIX_RE = re.compile(r"^(?:SIP|IDEA)(?:-[0-9X]{4})?[ \t]*[:\u2014-][ \t]*", re.IGNORECASE)
+_BODY_AUTHOR_RE = re.compile(
+    r"^[ \t]{0,3}\*{0,2}[ \t]*Authors?[ \t]*\*{0,2}[ \t]*:[ \t]*\*{0,2}[ \t]*(?P<author>[^\n*]+)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_BODY_CREATED_RE = re.compile(
+    r"^[ \t]{0,3}\*{0,2}[ \t]*Created(?:_at)?[ \t]*\*{0,2}[ \t]*:[ \t]*\*{0,2}[ \t]*"
+    r"(?P<created>\d{4}-\d{2}-\d{2})",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _derive_title(body: str) -> str | None:
+    """Title from the H1, with the SIP/IDEA number prefix stripped."""
+    m = _H1_RE.search(body)
+    if not m:
+        return None
+    return _H1_PREFIX_RE.sub("", m.group("title").strip()).strip() or None
+
+
+def _derive_status(body: str) -> str | None:
+    """Status keyword from either body declaration shape, parenthetical dropped.
+
+    ``**Status:** Proposed (stub)`` and ``## Status\nDraft (proposed)`` both
+    yield the bare keyword, lowercased, so it matches the registry vocabulary.
+    """
+    for pattern in (_BODY_STATUS_RE, _BODY_STATUS_HEADING_RE):
+        m = pattern.search(body)
+        if m:
+            word = m.group("word").lower()
+            # "draft" is the drafting synonym for proposed; the registry has no
+            # such state, so normalize rather than emit an invalid transition.
+            return "proposed" if word == "draft" else word
+    return None
+
+
+def derive_frontmatter_from_body(file_path: Path) -> tuple[dict[str, Any] | None, str]:
+    """Synthesize frontmatter for a draft that has none, reading only its body.
+
+    Returns ``(metadata, detail)``. ``metadata`` is None when ``status`` cannot be
+    read — the one field with no sane fallback, since promoting from an unknown
+    state would be a guess about intent. ``detail`` explains what was derived, or
+    what to add, so the caller can print something actionable either way.
+    """
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except Exception as e:  # pragma: no cover - unreadable file
+        return None, f"could not read {file_path}: {e}"
+
+    status = _derive_status(content)
+    if not status:
+        return None, (
+            "no status declaration found in the body. Add either "
+            "`**Status:** Proposed` or a `## Status` heading followed by "
+            "`Proposed`, then re-run."
+        )
+
+    derived: dict[str, Any] = {"status": status}
+    title = _derive_title(content)
+    if title:
+        derived["title"] = title
+    author = _BODY_AUTHOR_RE.search(content)
+    if author:
+        derived["author"] = author.group("author").strip()
+    created = _BODY_CREATED_RE.search(content)
+    if created:
+        derived["created_at"] = f"{created.group('created')}T00:00:00Z"
+
+    detail = ", ".join(f"{k}={v!r}" for k, v in derived.items())
+    return derived, detail
+
+
+def write_frontmatter(file_path: Path, metadata: dict[str, Any]) -> bool:
+    """Prepend a YAML frontmatter block to a file that has none."""
+    try:
+        content = file_path.read_text(encoding="utf-8")
+        if re.match(r"^---\s*\n", content):
+            return True  # already has one; nothing to do
+        block = yaml.dump(metadata, default_flow_style=False, sort_keys=False, allow_unicode=True)
+        file_path.write_text(f"---\n{block}---\n{content}", encoding="utf-8")
+        return True
+    except Exception as e:
+        print(f"Error: could not write frontmatter to {file_path}: {e}")
+        return False
+
+
+def ensure_frontmatter(file_path: Path) -> dict[str, Any] | None:
+    """Existing frontmatter, or derive-and-stamp one from the body (#770).
+
+    Called on the promotion path so a hand-authored draft is promotable without
+    the maintainer first hand-writing bookkeeping the document already implies.
+    """
+    metadata = extract_metadata_from_file(file_path)
+    if metadata:
+        return metadata
+
+    derived, detail = derive_frontmatter_from_body(file_path)
+    if derived is None:
+        print(f"Error: {file_path} has no YAML frontmatter and {detail}")
+        return None
+
+    if not write_frontmatter(file_path, derived):
+        return None
+    print(f"  Derived frontmatter from the body ({detail})")
+    return derived
 
 
 def validate_transition(current_status: str, new_status: str) -> tuple[bool, str]:
@@ -303,7 +445,10 @@ def find_duplicate_sip_files(
             # Extract metadata from file
             metadata = extract_metadata_from_file(sip_file)
             if not metadata:
-                # Skip files without metadata
+                # #770: a file we cannot read is a file we cannot check. Say so —
+                # a silent skip makes the duplicate net look complete when it has
+                # a blind spot exactly the size of the un-frontmattered drafts.
+                print(f"   ⚠ skipping {sip_file.name}: no YAML frontmatter to compare")
                 continue
 
             file_sip_number = metadata.get("sip_number")
@@ -423,10 +568,10 @@ def update_sip_status(sip_file: Path, new_status: str) -> bool:
         print("Set SQUADOPS_MAINTAINER=1 to proceed.")
         return False
 
-    # Extract metadata
-    metadata = extract_metadata_from_file(sip_file)
+    # Extract metadata — deriving and stamping one from the body when the draft
+    # has none (#770), so a hand-authored SIP is promotable as written.
+    metadata = ensure_frontmatter(sip_file)
     if not metadata:
-        print(f"Error: Could not extract metadata from {sip_file}")
         return False
 
     current_status = metadata.get("status")

--- a/sips/proposed/SIP-API-Contract-Hardening.md
+++ b/sips/proposed/SIP-API-Contract-Hardening.md
@@ -1,3 +1,9 @@
+---
+status: proposed
+title: API Contract Hardening
+author: SquadOps Architecture
+created_at: '2026-02-28T00:00:00Z'
+---
 # SIP-0XXX: API Contract Hardening
 
 **Status:** Proposed

--- a/sips/proposed/SIP-Cross-Cycle-Memory.md
+++ b/sips/proposed/SIP-Cross-Cycle-Memory.md
@@ -1,3 +1,9 @@
+---
+status: proposed
+title: Cross-Cycle Memory
+author: Jason Ladd
+created_at: '2026-08-03T00:00:00Z'
+---
 # SIP: Cross-Cycle Memory
 
 ## Status

--- a/sips/proposed/SIP-Cycle-Evaluation-Scorecard.md
+++ b/sips/proposed/SIP-Cycle-Evaluation-Scorecard.md
@@ -1,3 +1,9 @@
+---
+status: proposed
+title: Cycle Evaluation Scorecard
+author: SquadOps Architecture
+created_at: '2026-02-28T00:00:00Z'
+---
 # SIP-0XXX: Cycle Evaluation Scorecard
 
 **Status:** Proposed

--- a/sips/proposed/SIP-Cycle-Request-Profile-Naming-Taxonomy.md
+++ b/sips/proposed/SIP-Cycle-Request-Profile-Naming-Taxonomy.md
@@ -1,3 +1,9 @@
+---
+status: proposed
+title: Cycle Request-Profile Naming Taxonomy
+author: SquadOps Architecture (Spark lane)
+created_at: '2026-07-01T00:00:00Z'
+---
 # SIP-0XXX: Cycle Request-Profile Naming Taxonomy
 
 **Status:** Proposed

--- a/sips/proposed/SIP-LLM-Emission-Contracts.md
+++ b/sips/proposed/SIP-LLM-Emission-Contracts.md
@@ -1,3 +1,10 @@
+---
+status: proposed
+title: LLM Emission Contracts — Typed Response Handling with Provider-Agnostic Structured
+  Output
+author: SquadOps Architecture
+created_at: '2026-07-25T00:00:00Z'
+---
 # SIP-0XXX: LLM Emission Contracts — Typed Response Handling with Provider-Agnostic Structured Output
 
 **Status:** Proposed

--- a/sips/proposed/SIP-Planning-Sequence-Strategy-First.md
+++ b/sips/proposed/SIP-Planning-Sequence-Strategy-First.md
@@ -1,3 +1,9 @@
+---
+status: proposed
+title: Planning Sequence — Strategy Before Research
+author: SquadOps Architecture
+created_at: '2026-04-19T00:00:00Z'
+---
 # SIP-0XXX: Planning Sequence — Strategy Before Research
 
 **Status:** Proposed (stub)

--- a/sips/proposed/SIP-Post-Retest-Governance-Acceptance-Review.md
+++ b/sips/proposed/SIP-Post-Retest-Governance-Acceptance-Review.md
@@ -1,3 +1,7 @@
+---
+status: proposed
+title: Post-Retest Governance Acceptance Review
+---
 # SIP: Post-Retest Governance Acceptance Review
 
 ## Status

--- a/sips/proposed/SIP-Skill-Layer-For-Capabilities.md
+++ b/sips/proposed/SIP-Skill-Layer-For-Capabilities.md
@@ -1,3 +1,9 @@
+---
+status: proposed
+title: Skill Layer for Capabilities (Capability → Skill → Tool)
+author: SquadOps Team
+created_at: '2026-07-11T00:00:00Z'
+---
 # SIP: Skill Layer for Capabilities (Capability → Skill → Tool)
 
 **Status**: Proposed (concept reservation — no implementation planned)

--- a/sips/proposed/SIP-Stack-Blueprint-Contract.md
+++ b/sips/proposed/SIP-Stack-Blueprint-Contract.md
@@ -1,3 +1,7 @@
+---
+status: proposed
+title: Stack Blueprint Contract
+---
 # SIP: Stack Blueprint Contract
 
 ## Status

--- a/sips/proposed/SIP-Version-Bump-Hardening.md
+++ b/sips/proposed/SIP-Version-Bump-Hardening.md
@@ -1,3 +1,10 @@
+---
+status: proposed
+title: Version Bump Hardening — Single-Sourced Strings, Guardrails, and Automated
+  Changelog
+author: SquadOps Architecture
+created_at: '2026-04-19T00:00:00Z'
+---
 # SIP-0XXX: Version Bump Hardening — Single-Sourced Strings, Guardrails, and Automated Changelog
 
 **Status:** Proposed

--- a/sips/proposed/SIP-intelligent-delegation-protocols.md
+++ b/sips/proposed/SIP-intelligent-delegation-protocols.md
@@ -1,3 +1,7 @@
+---
+status: proposed
+title: Intelligent Delegation Protocols for SquadOps
+---
 # SIP-0XXX: Intelligent Delegation Protocols for SquadOps
 
 ## Status

--- a/tests/unit/maintainer/test_update_sip_status.py
+++ b/tests/unit/maintainer/test_update_sip_status.py
@@ -42,6 +42,13 @@ def _write(tmp_path: Path, body: str) -> Path:
     return f
 
 
+def _write_bare(tmp_path: Path, body: str) -> Path:
+    """A hand-authored draft: body only, no frontmatter block (#770)."""
+    f = tmp_path / "SIP-Hand-Authored.md"
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
 def test_rewrites_canonical_body_line_without_touching_frontmatter(tmp_path):
     """The reported bug: accepted→implemented must flip the body line. The
     frontmatter ``status: accepted`` must be left exactly as-is (it's handled
@@ -134,3 +141,135 @@ def test_frontmatter_status_is_never_rewritten_as_body(tmp_path):
 
     assert update_sip_body_status(f, "implemented") is False
     assert f.read_text(encoding="utf-8") == before
+
+
+# ---------------------------------------------------------------------------
+# #770 — frontmatter derivation for hand-authored drafts
+#
+# Bug classes guarded: promotion dying on "Could not extract metadata" for a
+# draft whose body already states everything the frontmatter needs (12 of 13
+# proposed SIPs at the time this landed); a deriver that INVENTS a status rather
+# than failing when none is declared; the heading-form status declaration being
+# left stale after promotion (the #253 class, one form down — SIP-0103 had this
+# exact shape); and a rewrite that eats the emphasis around an emphasised value.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_title", "expected_status"),
+    [
+        # the three real H1 shapes in sips/proposed/
+        (
+            "# SIP-0XXX: API Contract Hardening\n\n**Status:** Proposed\n",
+            "API Contract Hardening",
+            "proposed",
+        ),
+        (
+            "# SIP: Stack Blueprint Contract\n\n## Status\nDraft (proposed)\n",
+            "Stack Blueprint Contract",
+            "proposed",
+        ),
+        (
+            "# SIP-0103: Squad-Authored Manifest\n\n**Status:** Accepted\n",
+            "Squad-Authored Manifest",
+            "accepted",
+        ),
+        # emphasised value under a heading — the shape that failed the first
+        # implementation and was only caught by running over the real corpus
+        (
+            "# SIP: Post-Retest Review\n\n## Status\n\n**Proposed** (draft, 2026-08-07).\n",
+            "Post-Retest Review",
+            "proposed",
+        ),
+        # parenthetical annotations must not leak into the keyword
+        (
+            "# SIP-0XXX: Planning Sequence\n\n**Status:** Proposed (stub)\n",
+            "Planning Sequence",
+            "proposed",
+        ),
+        (
+            "# SIP: Skill Layer\n\n**Status**: Proposed (concept reservation)\n",
+            "Skill Layer",
+            "proposed",
+        ),
+    ],
+)
+def test_derives_title_and_status_from_real_body_shapes(
+    tmp_path, body, expected_title, expected_status
+):
+    f = _write_bare(tmp_path, body)
+    derived, _detail = update_sip_status.derive_frontmatter_from_body(f)
+    assert derived["title"] == expected_title
+    assert derived["status"] == expected_status
+
+
+def test_derives_author_and_created_when_the_body_states_them(tmp_path):
+    f = _write(
+        tmp_path,
+        "# SIP: Cross-Cycle Memory\n\n## Status\nDraft (proposed)\n\n"
+        "**Author:** Jason Ladd\n**Created:** 2026-08-03\n",
+    )
+    derived, _ = update_sip_status.derive_frontmatter_from_body(f)
+    assert derived["author"] == "Jason Ladd"
+    assert derived["created_at"] == "2026-08-03T00:00:00Z"
+
+
+def test_missing_author_and_created_are_omitted_not_invented(tmp_path):
+    """The promotion path already defaults these; a guessed value is worse than
+    an absent one because it looks authoritative."""
+    f = _write_bare(tmp_path, "# SIP: Bare\n\n**Status:** Proposed\n")
+    derived, _ = update_sip_status.derive_frontmatter_from_body(f)
+    assert "author" not in derived
+    assert "created_at" not in derived
+
+
+def test_underivable_status_fails_with_an_actionable_message(tmp_path):
+    """The one field with no sane fallback: promoting from an unknown state
+    would be a guess about intent."""
+    f = _write_bare(tmp_path, "# SIP: No Status Here\n\nJust prose about a design.\n")
+    derived, detail = update_sip_status.derive_frontmatter_from_body(f)
+    assert derived is None
+    assert "**Status:**" in detail and "## Status" in detail
+
+
+def test_ensure_frontmatter_stamps_a_parsable_block(tmp_path):
+    """End-to-end: a draft that previously died at 'Could not extract metadata'
+    now round-trips through the real extractor."""
+    f = _write_bare(tmp_path, "# SIP: Stack Blueprint Contract\n\n## Status\nDraft (proposed)\n")
+    assert update_sip_status.extract_metadata_from_file(f) is None
+
+    meta = update_sip_status.ensure_frontmatter(f)
+    assert meta["status"] == "proposed"
+
+    reparsed = update_sip_status.extract_metadata_from_file(f)
+    assert reparsed["status"] == "proposed"
+    assert reparsed["title"] == "Stack Blueprint Contract"
+    assert f.read_text(encoding="utf-8").startswith("---\n")
+
+
+def test_ensure_frontmatter_leaves_an_existing_block_alone(tmp_path):
+    """Derivation must never overwrite what a maintainer hand-wrote."""
+    f = _write(tmp_path, "# SIP: Already Stamped\n\n**Status:** Proposed\n")
+    before = f.read_text(encoding="utf-8")
+
+    meta = update_sip_status.ensure_frontmatter(f)
+
+    assert meta["title"] == "Demo"  # from the frontmatter, not the H1
+    assert meta["sip_number"] == 89
+    assert f.read_text(encoding="utf-8") == before
+
+
+def test_heading_form_body_status_is_rewritten_on_promotion(tmp_path):
+    """The #253 class one form down: SIP-0103 declared status as a '## Status'
+    heading, so its body would have kept saying Draft while the frontmatter and
+    registry said accepted.
+    """
+    f = _write(tmp_path, "# SIP: Demo\n\n## Status\nProposed\n\nBody text.\n")
+    assert update_sip_body_status(f, "accepted") is True
+    assert "## Status\nAccepted\n" in f.read_text(encoding="utf-8")
+
+
+def test_heading_form_rewrite_preserves_emphasis_and_annotation(tmp_path):
+    f = _write(tmp_path, "# SIP: Demo\n\n## Status\n\n**Proposed** (draft, 2026-08-07).\n")
+    assert update_sip_body_status(f, "accepted") is True
+    assert "**Accepted** (draft, 2026-08-07)." in f.read_text(encoding="utf-8")


### PR DESCRIPTION
Last item of the v1.6 queue front. Design gate (D1–D6) posted to the issue before code.

Closes #770

## Two findings from re-verifying the premise

1. **`status` is the only genuinely required field.** Downstream, the promotion path uses `title`/`sip_uid`/`author`/`created_at` — and all four already fall back (`"Untitled"`, `None`, `"Unknown"`, `now()`). Only the missing *block* was fatal, not the missing fields.
2. **The duplicate scan silently skipped frontmatter-less files** (`if not metadata: continue`), so those same 12 drafts were invisible to duplicate detection — a quieter second consequence the issue didn't name. It now warns: a file we cannot read is a file we cannot check, and a silent skip makes the net look complete when it has a blind spot exactly the size of the un-frontmattered drafts.

## The fix reads what the author already wrote

Title from the H1 (`SIP-0XXX:` / `SIP:` / `IDEA —` prefixes stripped), status from either declaration shape with the parenthetical dropped (`Proposed (stub)` → `proposed`, `Draft` → `proposed`), author and `created_at` from the body when stated and **omitted when not** — a guessed value is worse than an absent one because it looks authoritative.

**Rejected as the primary fix:** a better error message that still requires a four-line paste. It would fail 11 more times by construction.

## Also closes the #253 class, one form down

`_BODY_STATUS_RE` matched `**Status:** X` but not a `## Status` heading with the value on a following line — the shape **SIP-0103 had**, so its body would have kept saying `Draft (proposed)` while frontmatter and registry said `accepted`. I hand-fixed that during the acceptance; nothing stopped it recurring.

The new pattern is deliberately conservative: the value line must **begin** with a status keyword, optionally emphasised. The existing prose-after-heading no-op test still returns `False` and stands unchanged as the guard.

## The backfill is the test corpus

The same deriver ran once over the 11 `SIP-*.md` drafts. That reuse is the point, and it earned its keep immediately: the emphasised-value shape `**Proposed** (draft, 2026-08-07)` **failed the first implementation** and would never have been caught by a fixture written to match my own regex.

The `IDEA-` file is excluded (D6) — it isn't a SIP, and an `IDEA-` file in `sips/proposed/` is a naming/placement question rather than something to quietly stamp frontmatter onto. Raised separately, not moved here.

## Tests

Derivation across all three real H1 shapes and both status shapes including both parenthetical forms; author/created omitted rather than invented; underivable status fails with an actionable message; end-to-end `ensure_frontmatter` round-trip through the real extractor; existing frontmatter never overwritten; both heading-form rewrites (plain and emphasis-preserving).

**Regression: 6501 passed, 1 skipped.**

## One note on how this was verified

Smoke-testing the promotion path, I ran the real script against `SIP-Stack-Blueprint-Contract.md` and it promoted it to SIP-0104 — the one SIP we deliberately decided *not* to accept until a second stack exists. Fully reverted (registry back to `last_assigned: 103`, no 0104 entry, file back in `sips/proposed/` with its backfilled frontmatter, verified clean). Re-smoked against a throwaway fixture in a temp directory instead. Worth knowing that this script does the whole promotion in one shot with no dry-run flag — arguably a follow-up.