### PR TITLE
feat(cycles): derive the verification contract when a cycle seeds a manifest but no contract (#779, M0b)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -3047,17 +3047,16 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         ``_load_interface_manifest_for_run`` reads at the implementation run — so the
         manifest the gate hash-checks against the contract is the same one the
         skeleton will expand from. Unreadable refs are skipped, not fatal: an absent
-        seeded manifest is reported by the caller as the #494/#496 rejection."""
-        for ref_id in cycle.execution_overrides.get("plan_artifact_refs") or []:
-            try:
-                ref, content_bytes = await self._artifact_vault.retrieve(ref_id)
-            except Exception:
-                continue
-            if ref.filename == "interface_manifest.yaml" or (
-                getattr(ref, "artifact_type", None) == "interface_manifest"
-            ):
-                return content_bytes.decode(errors="replace")
-        return None
+        seeded manifest is reported by the caller as the #494/#496 rejection.
+
+        The selection rule itself lives in ``cycles.contract_derivation`` (#779) so the
+        create path, which derives a contract from this same artifact, cannot disagree
+        with the executor about which ref is the manifest."""
+        from squadops.cycles.contract_derivation import load_seeded_manifest_content
+
+        return await load_seeded_manifest_content(
+            self._artifact_vault, cycle.execution_overrides.get("plan_artifact_refs")
+        )
 
     async def _seeded_manifest_for_authoring(self, cycle: Cycle) -> Any:
         """The seeded manifest parsed, for describing the frozen surface to a proposer.

--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -150,6 +150,54 @@ async def _run_create_preflight(profile: SquadProfile, config: dict) -> tuple[Fi
     return decision.warnings
 
 
+async def _seed_derived_contract(body: CycleCreateRequest, project_id: str) -> str | None:
+    """Derive and pin a contract when a manifest is seeded without one (#779, M0b).
+
+    Bind mode is keyed on ``contract_ref``, so a cycle that seeds only a manifest runs
+    UNBOUND today — the operator asked for contract verification by seeding the
+    manifest and would silently get none. The contract is mechanically derivable from
+    that manifest (#777 pins the equality as exact), so derive it here, store it, and
+    let the rest of the pipeline see an ordinary ``contract_ref``.
+
+    Never overrides a supplied ref: an operator who passes one is pinning a SPECIFIC
+    contract — possibly deliberately unlike what today's deriver emits, as when
+    replaying an older run — and replay compatibility keys on ``contract_ref``.
+
+    Returns the new artifact id, or None when nothing was derived. An unusable
+    manifest raises :class:`PreflightRejectedError`: falling through to author mode
+    would hand back a green carrying none of the criteria that were asked for.
+    """
+    from squadops.api.runtime.deps import get_artifact_vault
+    from squadops.cycles.contract_derivation import (
+        ContractDerivationError,
+        derive_and_store_contract,
+        load_seeded_manifest_content,
+    )
+
+    overrides = body.execution_overrides or {}
+    if overrides.get("contract_ref"):
+        return None
+    if not overrides.get("plan_artifact_refs"):
+        # Nothing seeded to derive from. Checked before reaching for the vault so a
+        # cycle that never had a manifest does not depend on vault wiring at all.
+        return None
+
+    vault = get_artifact_vault()
+    manifest_content = await load_seeded_manifest_content(
+        vault, overrides.get("plan_artifact_refs")
+    )
+    if manifest_content is None:
+        return None
+
+    try:
+        return await derive_and_store_contract(vault, project_id, manifest_content)
+    except ContractDerivationError as exc:
+        raise PreflightRejectedError(
+            f"a manifest is seeded in plan_artifact_refs but no verification contract "
+            f"could be derived from it, so the cycle would run unbound: {exc}"
+        ) from exc
+
+
 async def _validate_replay_declaration(
     registry, body: CycleCreateRequest, applied_defaults: dict
 ) -> None:
@@ -264,6 +312,22 @@ async def create_cycle(
         # SIP-0101 Slice 3: replay declaration validated + interim compatibility
         # gate, same fail-fast point (moves into the SIP-0095 preflight in Slice 4).
         await _validate_replay_declaration(get_cycle_registry(), body, applied_defaults)
+
+        # #779 (M0b): a seeded manifest with no contract_ref would run UNBOUND. Derive
+        # the contract it implies and pin it as an artifact, so bind mode engages
+        # exactly as it does for an operator who ingested one by hand. After this the
+        # effective config must be recomputed — the new ref is part of it.
+        derived_ref = await _seed_derived_contract(body, project_id)
+        if derived_ref is not None:
+            body.execution_overrides = {
+                **(body.execution_overrides or {}),
+                "contract_ref": derived_ref,
+            }
+            effective_config = resolve_config(applied_defaults, body.execution_overrides)
+            logger.info(
+                "cycle_create_derived_contract",
+                extra={"project_id": project_id, "contract_ref": derived_ref},
+            )
 
         config_hash = compute_config_hash(applied_defaults, body.execution_overrides)
 

--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -151,7 +151,11 @@ async def _run_create_preflight(profile: SquadProfile, config: dict) -> tuple[Fi
 
 
 async def _seed_derived_contract(body: CycleCreateRequest, project_id: str) -> str | None:
-    """Derive and pin a contract when a manifest is seeded without one (#779, M0b).
+    """Derive a verification contract from a seeded manifest (#779, M0b).
+
+    Fires only when the cycle supplies an interface manifest but **no**
+    ``contract_ref`` — the manifest says what the app's interface is, and the contract
+    is the checklist derived from it.
 
     Bind mode is keyed on ``contract_ref``, so a cycle that seeds only a manifest runs
     UNBOUND today — the operator asked for contract verification by seeding the

--- a/src/squadops/cycles/contract_derivation.py
+++ b/src/squadops/cycles/contract_derivation.py
@@ -1,5 +1,11 @@
 """Derive a verification contract from a seeded interface manifest (#779, M0b).
 
+Two artifacts, and the distinction matters throughout this module: the **interface
+manifest** is the design — endpoints, entities, views — and the **verification
+contract** is the checklist derived from it, naming every criterion the finished app
+must satisfy. A cycle can be given both, or only the manifest. This module handles the
+second case by producing the contract the manifest implies.
+
 Bind mode is keyed on a seeded ``contract_ref``, which is correct for seeded mode and
 impossible for authored mode: a manifest the squad has just written has no
 pre-existing contract to point at. Producing one was three manual steps

--- a/src/squadops/cycles/contract_derivation.py
+++ b/src/squadops/cycles/contract_derivation.py
@@ -1,0 +1,129 @@
+"""Derive a verification contract from a seeded interface manifest (#779, M0b).
+
+Bind mode is keyed on a seeded ``contract_ref``, which is correct for seeded mode and
+impossible for authored mode: a manifest the squad has just written has no
+pre-existing contract to point at. Producing one was three manual steps
+(``contract_gate.py`` → ``artifacts ingest`` → pass the id) for an artifact that is
+**mechanically derivable** from the manifest — an equality #777 pinned as exact.
+
+This module owns that derivation and the seeded-manifest lookup that feeds it, so the
+create path and (later, at M1) the framing→implementation boundary share **one**
+derivation path rather than growing two that drift.
+
+Deriving *and persisting*, never deriving in memory: a contract with no artifact id
+cannot be replayed, audited, or hash-frozen. Seeded mode's guarantee is that the
+contract is a pinned artifact; authored mode gets the same guarantee, not a weaker one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Iterable
+
+    from squadops.ports.cycles.artifact_vault import ArtifactVaultPort
+
+#: The filename an operator-seeded interface manifest carries. Matched alongside the
+#: ``interface_manifest`` artifact type because both rails exist in the wild.
+SEEDED_MANIFEST_FILENAME = "interface_manifest.yaml"
+
+#: Artifact type for a derived contract — deliberately the SAME type the manual
+#: ``artifacts ingest`` path uses, so nothing downstream can tell a derived contract
+#: from an ingested one. Provenance belongs in the artifact record, not in a divergent
+#: type that every consumer would then have to learn about.
+CONTRACT_ARTIFACT_TYPE = "verification_contract"
+CONTRACT_FILENAME = "verification_contract.yaml"
+
+
+class ContractDerivationError(Exception):
+    """The seeded manifest could not produce a contract."""
+
+
+def is_seeded_manifest(ref: Any) -> bool:
+    """True when an artifact ref is an operator-seeded interface manifest.
+
+    One rule, shared by the executor's seeded-manifest lookup and the create path. A
+    second copy of this predicate is how the two ends start disagreeing about which
+    artifact is the manifest.
+    """
+    return ref.filename == SEEDED_MANIFEST_FILENAME or (
+        getattr(ref, "artifact_type", None) == "interface_manifest"
+    )
+
+
+async def load_seeded_manifest_content(
+    vault: ArtifactVaultPort, refs: Iterable[str] | None
+) -> str | None:
+    """Raw content of the seeded interface manifest among ``refs``, or ``None``.
+
+    Unreadable refs are skipped rather than fatal: callers report an absent manifest in
+    their own terms (the create path rejects, the executor records a #494/#496 gate
+    rejection).
+    """
+    for ref_id in refs or []:
+        try:
+            ref, content_bytes = await vault.retrieve(ref_id)
+        except Exception:
+            continue
+        if is_seeded_manifest(ref):
+            return content_bytes.decode(errors="replace")
+    return None
+
+
+def derive_contract_bytes(manifest_content: str) -> bytes:
+    """The verification contract implied by a manifest, as the bytes to store.
+
+    Pure. Raises :class:`ContractDerivationError` with the parse failure named — an
+    unusable manifest must surface as a rejection, never as a silent fall-through to
+    author mode, because an operator who seeded a manifest asked for bind mode and an
+    unbound green would carry none of the criteria they expected.
+    """
+    from squadops.capabilities.scaffold import InterfaceManifest
+    from squadops.capabilities.scaffold_contract import emit_contract_yaml
+
+    try:
+        manifest = InterfaceManifest.from_yaml(manifest_content)
+    except Exception as exc:  # noqa: BLE001 - any parse/shape failure is one rejection
+        raise ContractDerivationError(f"interface manifest did not parse: {exc}") from exc
+
+    try:
+        return emit_contract_yaml(manifest).encode("utf-8")
+    except Exception as exc:  # noqa: BLE001 - expander refusal is a rejection, not a crash
+        raise ContractDerivationError(
+            f"manifest parsed but no contract could be derived from it: {exc}"
+        ) from exc
+
+
+async def derive_and_store_contract(
+    vault: ArtifactVaultPort,
+    project_id: str,
+    manifest_content: str,
+    *,
+    cycle_id: str | None = None,
+) -> str:
+    """Derive the contract, store it as an artifact, return its id.
+
+    The stored artifact records that it was derived rather than ingested, so a later
+    reader can tell where it came from without the type differing.
+    """
+    from squadops.cycles.models import ArtifactRef
+
+    content = derive_contract_bytes(manifest_content)
+    ref = ArtifactRef(
+        artifact_id=f"art_{uuid4().hex[:12]}",
+        project_id=project_id,
+        artifact_type=CONTRACT_ARTIFACT_TYPE,
+        filename=CONTRACT_FILENAME,
+        content_hash=hashlib.sha256(content).hexdigest(),
+        size_bytes=len(content),
+        media_type="application/yaml",
+        created_at=datetime.now(UTC),
+        cycle_id=cycle_id,
+        metadata={"derived_from": "interface_manifest", "derivation": "scaffold_contract"},
+    )
+    stored = await vault.store(ref, content)
+    return stored.artifact_id

--- a/tests/unit/cycles/test_contract_derivation.py
+++ b/tests/unit/cycles/test_contract_derivation.py
@@ -1,0 +1,146 @@
+"""Deriving a verification contract from a seeded manifest (#779, M0b).
+
+Bug classes guarded:
+
+- a seeded manifest with no ``contract_ref`` running **unbound** — the operator asked
+  for contract verification and silently gets a green carrying none of the criteria;
+- a supplied ``contract_ref`` being overridden, which would break replay (compatibility
+  keys on it) and quietly discard a deliberately-pinned contract;
+- an unusable manifest falling through to author mode instead of rejecting;
+- the derived contract diverging from what the expander emits — the equality #777 pins;
+- the seeded-manifest selection rule drifting between the create path and the executor.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.capabilities.scaffold_contract import emit_contract_yaml
+from squadops.cycles.contract_derivation import (
+    CONTRACT_ARTIFACT_TYPE,
+    ContractDerivationError,
+    derive_and_store_contract,
+    derive_contract_bytes,
+    is_seeded_manifest,
+    load_seeded_manifest_content,
+)
+
+_REFERENCE_MANIFEST = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+
+
+class _Ref:
+    def __init__(self, filename: str, artifact_type: str = "document"):
+        self.filename = filename
+        self.artifact_type = artifact_type
+        self.artifact_id = "art_stub"
+
+
+class _Vault:
+    """Minimal vault double: retrieve by id, record what was stored."""
+
+    def __init__(self, items: dict[str, tuple[_Ref, bytes]] | None = None):
+        self._items = items or {}
+        self.stored: list[tuple[object, bytes]] = []
+
+    async def retrieve(self, artifact_id: str):
+        if artifact_id not in self._items:
+            raise KeyError(artifact_id)
+        return self._items[artifact_id]
+
+    async def store(self, ref, content: bytes):
+        self.stored.append((ref, content))
+        return ref
+
+
+def _manifest_text() -> str:
+    return _REFERENCE_MANIFEST.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("filename", "artifact_type", "expected"),
+    [
+        ("interface_manifest.yaml", "document", True),
+        ("anything.yaml", "interface_manifest", True),
+        ("implementation_plan.yaml", "document", False),
+        ("verification_contract.yaml", "verification_contract", False),
+    ],
+)
+def test_seeded_manifest_selection_matches_both_rails(filename, artifact_type, expected):
+    """Both rails exist in the wild; a rule that knows only one silently picks nothing."""
+    assert is_seeded_manifest(_Ref(filename, artifact_type)) is expected
+
+
+async def test_derived_contract_equals_what_the_expander_emits():
+    """The invariant #777 pins, exercised through the derivation entry point."""
+    derived = derive_contract_bytes(_manifest_text())
+
+    expected = emit_contract_yaml(InterfaceManifest.from_yaml(_manifest_text()))
+    assert derived.decode("utf-8") == expected
+
+
+def test_unparseable_manifest_raises_rather_than_returning_nothing():
+    """Falling through would run the cycle unbound while the operator believed
+    otherwise — the failure mode this whole item exists to prevent."""
+    with pytest.raises(ContractDerivationError) as exc:
+        derive_contract_bytes("this: is: not: a: manifest\n\t- broken")
+
+    assert "did not parse" in str(exc.value)
+
+
+def test_manifest_that_parses_but_cannot_expand_still_raises():
+    """A structurally-valid YAML that is not a manifest must not yield a contract."""
+    with pytest.raises(ContractDerivationError):
+        derive_contract_bytes("title: not a manifest\nrandom_key: 3\n")
+
+
+async def test_load_seeded_manifest_finds_it_among_unrelated_refs():
+    vault = _Vault(
+        {
+            "art_plan": (_Ref("implementation_plan.yaml"), b"plan"),
+            "art_manifest": (_Ref("interface_manifest.yaml"), _manifest_text().encode()),
+        }
+    )
+
+    content = await load_seeded_manifest_content(vault, ["art_plan", "art_manifest"])
+
+    assert content == _manifest_text()
+
+
+async def test_unreadable_refs_are_skipped_not_fatal():
+    """A dangling ref alongside a good one must not hide the manifest."""
+    vault = _Vault({"art_manifest": (_Ref("interface_manifest.yaml"), _manifest_text().encode())})
+
+    content = await load_seeded_manifest_content(vault, ["art_missing", "art_manifest"])
+
+    assert content == _manifest_text()
+
+
+async def test_no_manifest_among_refs_returns_none():
+    vault = _Vault({"art_plan": (_Ref("implementation_plan.yaml"), b"plan")})
+
+    assert await load_seeded_manifest_content(vault, ["art_plan"]) is None
+    assert await load_seeded_manifest_content(vault, None) is None
+
+
+async def test_stored_contract_is_indistinguishable_from_an_ingested_one():
+    """Same artifact type as the manual `artifacts ingest` path — a divergent type
+    would make every downstream consumer learn about derivation.
+    """
+    vault = _Vault()
+
+    artifact_id = await derive_and_store_contract(vault, "proj", _manifest_text())
+
+    (ref, content) = vault.stored[0]
+    assert ref.artifact_type == CONTRACT_ARTIFACT_TYPE
+    assert ref.filename == "verification_contract.yaml"
+    assert ref.artifact_id == artifact_id
+    assert ref.project_id == "proj"
+    # provenance is recorded on the record, not in the type
+    assert ref.metadata["derived_from"] == "interface_manifest"
+    assert content == derive_contract_bytes(_manifest_text())
+    assert ref.size_bytes == len(content)


### PR DESCRIPTION
Second code item of the v1.6 M lane, and the first that changes runtime behavior.

Closes #779

## The gap

Bind mode is keyed strictly on a seeded `contract_ref` — correct for seeded mode, impossible for authored mode, where a manifest the squad has just written has no pre-existing contract to point at.

Today an operator runs `contract_gate.py`, then `squadops artifacts ingest --type verification_contract`, then passes the returned id. **Three manual steps** to produce something mechanically derivable from the manifest — an equality #777 just pinned as exact.

## What changes

A cycle that seeds a manifest and **no** `contract_ref` now gets the contract derived, stored as an artifact, and `contract_ref` set to the stored id. After that the pipeline is unchanged: bind mode sees an ordinary ref.

**Derived *and persisted***, not derived in memory at run start — a contract with no artifact id cannot be replayed, audited, or hash-frozen. Seeded mode's guarantee is a pinned artifact; authored mode gets the same one rather than a weaker version.

## Three decisions worth the reading

**Never overrides a supplied `contract_ref`.** An operator who passes one is pinning a *specific* contract — possibly deliberately unlike what today's deriver emits, as when replaying an older run — and replay compatibility keys on `contract_ref` (`REPLAY_COMPATIBILITY_ELEMENTS`). Silently replacing it would break replay.

**An unusable manifest rejects at create; it never falls through to author mode.** Seeding a manifest *is* the request for bind mode, and an unbound green carries none of the criteria that were asked for. Same stance `_load_contract_for_run` already takes toward a broken ref.

**Same artifact type as the manual ingest path.** Nothing downstream can tell a derived contract from an ingested one; provenance lives on the artifact record rather than in a divergent type every consumer would have to learn about.

## Rode along: one selection rule, not two

The seeded-manifest predicate (`filename == interface_manifest.yaml` **or** `artifact_type == interface_manifest`) is hoisted out of the executor into the shared module, and the executor delegates to it. Two copies is how the create path and the executor start disagreeing about which ref is the manifest.

## Scope boundary

M0b covers a manifest that exists **at create time**. Authored mode's manifest is produced by framing, so its derivation happens at the framing→implementation boundary — that belongs with **M1**, which reuses this helper rather than growing a second derivation path.

## Caught in regression rather than shipped

The first version called `get_artifact_vault()` unconditionally, which broke eight create tests that wire no vault. Fixed by checking for `plan_artifact_refs` first, so a cycle with nothing seeded never depends on vault wiring at all.

**Regression: 6517 passed, 1 skipped.**

## What follows

Per the plan's verification cadence this is the item **V2** attaches to: Guard 1b plus a full seeded-mode control cycle, because M0b changes what contract a cycle runs against on the path seeded mode uses too. That needs a deploy, so it's the release's first deploy window.