### PR TITLE
feat(cycles): winnability gate — prove a manifest can be won before spending on it (#781, M3)

### DIFF
--- a/src/squadops/cycles/manifest_winnability.py
+++ b/src/squadops/cycles/manifest_winnability.py
@@ -1,0 +1,208 @@
+"""Can this interface manifest actually be won? (#781, M3)
+
+A manifest that *parses* is not a manifest that can be *satisfied*. It can name a route
+the expander cannot place, promise a view with no DOM anchor to query, or imply a
+contract holding a check that is dead on arrival — and each of those costs a full
+implementation workload to discover.
+
+This module answers the question deterministically, before anything downstream spends
+on it. **Closed-surface proofs only** (SIP-0103 §5b Q2): every finding is mechanical
+and reproducible. Whether the design actually *satisfies the PRD* is judgment, and it
+stays with the ``decisions[].warrant`` discipline and the human review gate.
+
+Pure by construction — manifest text in, findings out. No vault, no cycle, no deploy —
+so the gate is provable against adversarial manifests long before an authoring stage
+exists to produce one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: Stable finding classes. Typed rather than free text so M6's authoring failure
+#: taxonomy can attribute a rejection without parsing prose — the "one vocabulary, not
+#: three" intention from the post-1.5 reconciliation, applied before there is anything
+#: to reconcile.
+PROOF_PARSES = "parses"
+PROOF_LINT = "lint"
+PROOF_EXPANDS = "expands"
+PROOF_CONTRACT_DERIVES = "contract_derives"
+PROOF_CHECKS_LIVE = "checks_live"
+PROOF_TESTID_COVERAGE = "testid_coverage"
+PROOF_STATUS_DECLARED = "status_declared"
+
+
+@dataclass(frozen=True)
+class WinnabilityFinding:
+    """One reason a manifest could not be won, and what to do about it."""
+
+    proof: str
+    detail: str
+
+
+def assess_winnability(manifest_content: str) -> tuple[WinnabilityFinding, ...]:
+    """Every closed-surface proof this manifest fails, in order.
+
+    All proofs run; findings accumulate. Short-circuiting on the first failure would
+    make an author fix one problem per revision and burn ``manifest_max_attempts`` on a
+    manifest that had three.
+
+    A parse failure is the one exception — nothing downstream can run without a parsed
+    manifest, so it returns alone.
+    """
+    from squadops.capabilities.scaffold import InterfaceManifest
+
+    try:
+        manifest = InterfaceManifest.from_yaml(manifest_content)
+    except Exception as exc:  # noqa: BLE001 - untrusted authored output: one rejection
+        return (
+            WinnabilityFinding(
+                PROOF_PARSES,
+                f"the manifest is not valid YAML or does not match the interface-manifest "
+                f"shape ({exc}). Fix the document structure before the other checks can run.",
+            ),
+        )
+
+    findings: list[WinnabilityFinding] = []
+    findings.extend(_lint_findings(manifest))
+    findings.extend(_expander_findings(manifest))
+    findings.extend(_contract_findings(manifest))
+    findings.extend(_testid_findings(manifest))
+    findings.extend(_status_findings(manifest))
+    return tuple(findings)
+
+
+def _lint_findings(manifest) -> list[WinnabilityFinding]:
+    """The SIP-0099 net: parses-but-unexpandable classes the linter already names."""
+    return [WinnabilityFinding(PROOF_LINT, e) for e in manifest.lint()]
+
+
+def _expander_findings(manifest) -> list[WinnabilityFinding]:
+    """The skeleton this manifest implies must be expressible, with slots to fill.
+
+    A manifest that expands to zero fill slots describes an application nobody can be
+    asked to build: every file would be frozen, so the squad has nothing to write and
+    the cycle would 'succeed' having produced nothing (the pf-26 wrong-root class, one
+    level up from where it was found).
+    """
+    from squadops.capabilities.scaffold import expand, fill_slot_paths
+
+    try:
+        expand(manifest)
+    except Exception as exc:  # noqa: BLE001 - expander refusal is a finding, not a crash
+        return [
+            WinnabilityFinding(
+                PROOF_EXPANDS,
+                f"the expander cannot build a skeleton from this manifest ({exc}). Check "
+                f"that routes and endpoints use paths the stack's scaffold roots allow.",
+            )
+        ]
+
+    if not fill_slot_paths(manifest):
+        return [
+            WinnabilityFinding(
+                PROOF_EXPANDS,
+                "this manifest expands to a skeleton with no fill slots — every file "
+                "would be frozen, leaving the squad nothing to implement. Declare at "
+                "least one endpoint or route that requires authored code.",
+            )
+        ]
+    return []
+
+
+def _contract_findings(manifest) -> list[WinnabilityFinding]:
+    """The derived contract must exist and must be satisfiable by construction.
+
+    Two distinct failures: derivation refusing outright, and derivation producing a
+    check that can never execute. The second is the #671 class one level up — a check
+    that skips at every evaluation forever is dead weight the plan still has to carry.
+    """
+    from squadops.capabilities.scaffold_contract import emit_contract_dict
+    from squadops.cycles.acceptance_check_spec import CHECK_SPECS, is_check_applicable
+
+    try:
+        contract = emit_contract_dict(manifest)
+    except Exception as exc:  # noqa: BLE001 - derivation refusal is a finding
+        return [
+            WinnabilityFinding(
+                PROOF_CONTRACT_DERIVES,
+                f"no verification contract could be derived from this manifest ({exc}), "
+                f"so nothing downstream could state what 'done' means.",
+            )
+        ]
+
+    findings: list[WinnabilityFinding] = []
+    for slot_path, sections in (contract.get("fill_files") or {}).items():
+        for section in ("interface", "implementation"):
+            for entry in sections.get(section) or []:
+                name = entry.get("check")
+                if name not in CHECK_SPECS:
+                    findings.append(
+                        WinnabilityFinding(
+                            PROOF_CHECKS_LIVE,
+                            f"the contract this manifest implies uses check `{name}` on "
+                            f"`{slot_path}`, which is not a registered check.",
+                        )
+                    )
+                elif not is_check_applicable(name, str(entry.get("file") or slot_path)):
+                    findings.append(
+                        WinnabilityFinding(
+                            PROOF_CHECKS_LIVE,
+                            f"check `{name}` can never evaluate `{slot_path}` — it would "
+                            f"skip at every evaluation, so the slot would ship unverified "
+                            f"while appearing covered.",
+                        )
+                    )
+    return findings
+
+
+def _testid_findings(manifest) -> list[WinnabilityFinding]:
+    """Every route needs at least one DOM anchor, or its view cannot be tested.
+
+    A view with no declared testid gives qa nothing stable to query, so any test
+    written against it is guessing at markup the dev was free to change.
+    """
+    missing = [r.path for r in manifest.frontend.routes if not r.testids]
+    if not missing:
+        return []
+    return [
+        WinnabilityFinding(
+            PROOF_TESTID_COVERAGE,
+            f"route(s) {', '.join(f'`{p}`' for p in missing)} declare no `testids`, so "
+            f"qa has no stable anchor to query and any test written against them guesses "
+            f"at markup. Declare at least one testid per route.",
+        )
+    ]
+
+
+def _status_findings(manifest) -> list[WinnabilityFinding]:
+    """A collection POST must declare its success status, or the contract is unwinnable.
+
+    Measured, not assumed (#772). The contract deriver expects ``success_status or 201``
+    for a collection POST, while the scaffold omits ``status_code=`` when it is
+    undeclared — so FastAPI returns 200 and the probe asserts 201 against a correctly
+    implemented app. The field's own docstring records this costing a roll at pf-39:
+    green depended on the dev agent volunteering ``status_code=201``, "and that single
+    token was the whole difference."
+
+    Deliberately narrow. Child-action POSTs default to 200 on *both* sides and agree;
+    GETs derive no status probe at all. Requiring the field everywhere would reject the
+    reference manifest — which declares it on 1 of 5 endpoints — and a rule that rejects
+    the artifact the 1.4 evidence was measured against is the wrong rule.
+    """
+    missing = [
+        ep.path
+        for ep in manifest.api.endpoints
+        if ep.method == "POST" and "{" not in ep.path and ep.success_status is None
+    ]
+    if not missing:
+        return []
+    return [
+        WinnabilityFinding(
+            PROOF_STATUS_DECLARED,
+            f"endpoint(s) POST {', '.join(f'`{p}`' for p in missing)} do not declare "
+            f"`success_status`. The derived contract would assert 201 while the scaffold "
+            f"emits a route returning 200, so the probe fails against a correct "
+            f"implementation. Declare the status the endpoint returns on success.",
+        )
+    ]

--- a/tests/unit/cycles/test_manifest_winnability.py
+++ b/tests/unit/cycles/test_manifest_winnability.py
@@ -1,0 +1,155 @@
+"""The winnability gate: can this manifest be won? (#781, M3)
+
+Bug classes guarded:
+
+- a gate that rejects the **known-good** manifest — worse than no gate, because it
+  blocks the one design proven to work;
+- a proof that fires on the wrong manifest, so a rejection points at the wrong fix;
+- #772's shape — a collection POST with no ``success_status`` — reaching a cycle, where
+  the derived contract asserts 201 against a scaffold emitting 200 and the probe fails
+  on correct code (this cost a roll at pf-39 before the field existed);
+- short-circuiting, which would make an author fix one defect per revision and exhaust
+  ``manifest_max_attempts`` on a manifest that had several.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from squadops.cycles.manifest_winnability import (
+    PROOF_EXPANDS,
+    PROOF_PARSES,
+    PROOF_STATUS_DECLARED,
+    PROOF_TESTID_COVERAGE,
+    assess_winnability,
+)
+
+_REFERENCE = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+
+
+def _reference_dict() -> dict:
+    return yaml.safe_load(_REFERENCE.read_text(encoding="utf-8"))
+
+
+def _as_yaml(data: dict) -> str:
+    return yaml.dump(data, sort_keys=False)
+
+
+def _proofs(findings) -> set[str]:
+    return {f.proof for f in findings}
+
+
+def test_the_reference_manifest_is_winnable():
+    """A gate that rejects the design the 1.4 evidence was measured against is wrong
+    about the rule, not about the manifest."""
+    assert assess_winnability(_REFERENCE.read_text(encoding="utf-8")) == ()
+
+
+def test_unparseable_manifest_reports_only_the_parse_failure():
+    """Nothing downstream can run without a parsed manifest, so piling on findings
+    derived from a half-read document would misdirect the fix."""
+    findings = assess_winnability("this: [is not: valid\n  yaml at all")
+
+    assert _proofs(findings) == {PROOF_PARSES}
+
+
+def test_collection_post_without_success_status_is_unwinnable():
+    """#772's designed-failure probe.
+
+    The deriver expects ``success_status or 201`` for a collection POST while the
+    scaffold omits ``status_code=`` when undeclared, so FastAPI returns 200 — the
+    contract asserts 201 against a correct implementation.
+    """
+    data = _reference_dict()
+    for ep in data["api"]["endpoints"]:
+        if ep["method"] == "POST" and "{" not in ep["path"]:
+            ep.pop("success_status", None)
+
+    findings = assess_winnability(_as_yaml(data))
+
+    assert PROOF_STATUS_DECLARED in _proofs(findings)
+    detail = next(f.detail for f in findings if f.proof == PROOF_STATUS_DECLARED)
+    assert "201" in detail and "200" in detail  # names both sides of the disagreement
+    assert "success_status" in detail  # names the fix
+
+
+def test_child_post_without_success_status_is_fine():
+    """Deliberately narrow: child actions default to 200 on BOTH sides and agree.
+
+    Requiring the field everywhere would reject the reference manifest, which declares
+    it on 1 of 5 endpoints.
+    """
+    data = _reference_dict()
+    for ep in data["api"]["endpoints"]:
+        if "{" in ep["path"]:
+            ep.pop("success_status", None)
+
+    assert PROOF_STATUS_DECLARED not in _proofs(assess_winnability(_as_yaml(data)))
+
+
+def test_get_without_success_status_is_fine():
+    """GETs derive no status probe, so there is nothing to disagree about."""
+    data = _reference_dict()
+    for ep in data["api"]["endpoints"]:
+        if ep["method"] == "GET":
+            ep.pop("success_status", None)
+
+    assert PROOF_STATUS_DECLARED not in _proofs(assess_winnability(_as_yaml(data)))
+
+
+def test_route_without_testids_is_unwinnable():
+    """A view with no declared anchor leaves qa guessing at markup the dev may change."""
+    data = _reference_dict()
+    data["frontend"]["routes"][0].pop("testids", None)
+    dropped = data["frontend"]["routes"][0]["path"]
+
+    findings = assess_winnability(_as_yaml(data))
+
+    assert PROOF_TESTID_COVERAGE in _proofs(findings)
+    assert dropped in next(f.detail for f in findings if f.proof == PROOF_TESTID_COVERAGE)
+
+
+def test_manifest_with_no_endpoints_or_routes_has_nothing_to_implement():
+    """Every file frozen means the cycle would 'succeed' having produced nothing."""
+    data = _reference_dict()
+    data["api"]["endpoints"] = []
+    data["frontend"]["routes"] = []
+
+    findings = assess_winnability(_as_yaml(data))
+
+    assert findings  # rejected on some proof
+    assert PROOF_EXPANDS in _proofs(findings) or "lint" in _proofs(findings)
+
+
+def test_all_proofs_run_so_one_revision_can_fix_everything():
+    """No short-circuit: an author who sees one defect per attempt burns the revision
+    budget on a manifest that had two."""
+    data = _reference_dict()
+    for ep in data["api"]["endpoints"]:
+        if ep["method"] == "POST" and "{" not in ep["path"]:
+            ep.pop("success_status", None)
+    data["frontend"]["routes"][0].pop("testids", None)
+
+    proofs = _proofs(assess_winnability(_as_yaml(data)))
+
+    assert {PROOF_STATUS_DECLARED, PROOF_TESTID_COVERAGE} <= proofs
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        pytest.param(lambda d: d["api"].__setitem__("endpoints", []), id="no-endpoints"),
+        pytest.param(lambda d: d.__setitem__("stack", "not_a_real_stack"), id="unknown-stack"),
+    ],
+)
+def test_structurally_doomed_manifests_are_rejected(mutation):
+    """The classes the SIP-0099 linter already names, reached through this gate."""
+    data = _reference_dict()
+    mutation(data)
+
+    assert assess_winnability(_as_yaml(data)) != ()


### PR DESCRIPTION
Third code item of the v1.6 M lane. Design gate (D1–D5) posted to the issue before code.

Closes #781

## What it does

A manifest that *parses* is not a manifest that can be *satisfied*. Six closed-surface proofs, all deterministic:

| Proof | Catches |
|---|---|
| `parses` | malformed document (returns alone — nothing else can run) |
| `lint` | the SIP-0099 parses-but-unexpandable classes |
| `expands` | expander refusal, or a skeleton with **no fill slots** — every file frozen, so the cycle "succeeds" having produced nothing |
| `contract_derives` | no contract derivable, so nothing could state what done means |
| `checks_live` | a derived check that would skip at every evaluation forever — the slot ships unverified while appearing covered |
| `testid_coverage` | a route with no DOM anchor, leaving qa guessing at markup |
| `status_declared` | #772 — see below |

Whether the design actually *satisfies the PRD* is judgment; that stays with `decisions[].warrant` and the human gate.

## The status proof is narrower than the plan's shorthand — deliberately

The plan says "per-endpoint `success_status`." Implemented literally, **that rejects the reference manifest**, which declares it on 1 of 5 endpoints. A rule that rejects the artifact the 1.4 evidence was measured against is the wrong rule, not a wrong manifest.

Measuring the actual defect gives the exact rule:

- **collection POST** (`POST`, no `{` in path) → deriver expects `success_status or 201`, scaffold omits `status_code=` so FastAPI returns **200** → unwinnable;
- **child POST** → deriver expects `or 200`, scaffold default is also 200 → agree, harmless;
- **GET** → no status probe derived at all.

One rule, aimed at the one real failure. The reference manifest passes it; #772's shape fails it — the pair a gate needs. Both non-failing shapes are tested too, so the narrowness reads as intended rather than as an oversight.

**This delivers #772's protection without waiting on the manifest v5 schema change.** That change still deletes the defaulting entirely (fix-by-deletion); this stops the class reaching a cycle in the meantime.

## The history was already in the code

`success_status`'s own docstring documents this costing a roll at **pf-39**: the expander emitted a bare `@router.post` while the derived probe pinned 201, so *"green then depended on the dev agent volunteering `status_code=201`: pf-38 did, pf-39 did not, and that single token was the whole difference."*

The field was added as the fix. Leaving it **optional** left the trap open. This gate closes it.

## Other decisions

**Pure function, no I/O** — provable against adversarial manifests long before an authoring stage exists to produce one.

**All proofs run; findings accumulate.** Short-circuiting would make an author fix one defect per revision and exhaust `manifest_max_attempts` on a manifest that had three.

**Findings are typed, not free text**, so M6's failure taxonomy can attribute a rejection without parsing prose — the "one vocabulary, not three" intention applied before there's anything to reconcile.

**No call-site wiring (D5).** The gate is built and proven; wiring it into the authoring loop is M1's job, where the thing it gates first exists. Both in one PR would leave neither independently reviewable.

**Regression: 6527 passed, 1 skipped.**