### PR TITLE
feat(cycles): schema gate — provenance and the decisions[] judgment record (#783, M2)

### DIFF
--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -127,6 +127,30 @@ class Frontend:
 
 
 @dataclass(frozen=True)
+class Decision:
+    """One design judgment the schema cannot express mechanically (SIP-0103 §5c.4).
+
+    Pagination behavior, authorization boundaries, idempotency, caching — decisions a
+    designer must make and the manifest's structural fields cannot hold. Recording them
+    with a PRD ``warrant`` makes the judgment explicit, reviewable at the human gate,
+    and auditable afterwards.
+
+    ``unresolved`` marks a question the author declines to answer (§5c.10): a PRD that
+    does not determine something should surface as a stated question rather than a
+    silent default. An unresolved entry carries its ``question`` instead of a
+    ``choice``.
+
+    Deliberately NOT part of the structural projection — see ``_canonical``.
+    """
+
+    id: str
+    choice: str = ""
+    warrant: str = ""
+    unresolved: bool = False
+    question: str = ""
+
+
+@dataclass(frozen=True)
 class InterfaceManifest:
     """The typed interface contract framing emits and the expander consumes."""
 
@@ -140,6 +164,10 @@ class InterfaceManifest:
     api: Api = field(default_factory=Api)
     frontend: Frontend = field(default_factory=Frontend)
     persistence: str = "in_memory"
+    #: Design judgments and open questions (SIP-0103 §5c.4/§5c.10). Provenance, not
+    #: structure: excluded from ``_canonical`` so revising an explanation never moves
+    #: the hash the verification contract is bound to.
+    decisions: tuple[Decision, ...] = ()
 
     @classmethod
     def from_yaml(cls, content: str) -> InterfaceManifest:
@@ -181,6 +209,17 @@ class InterfaceManifest:
             api=api,
             frontend=frontend,
             persistence=str(data.get("persistence", "in_memory")),
+            decisions=tuple(
+                Decision(
+                    id=str(d.get("id", "")),
+                    choice=str(d.get("choice", "")),
+                    warrant=str(d.get("warrant", "")),
+                    unresolved=bool(d.get("unresolved", False)),
+                    question=str(d.get("question", "")),
+                )
+                for d in (data.get("decisions") or [])
+                if isinstance(d, dict)
+            ),
         )
 
     def _canonical(self) -> dict[str, Any]:

--- a/src/squadops/cycles/manifest_gates.py
+++ b/src/squadops/cycles/manifest_gates.py
@@ -1,4 +1,12 @@
-"""Can this interface manifest actually be won? (#781, M3)
+"""The two deterministic gates an authored manifest passes (#781 M3, #783 M2).
+
+Both are pure predicates over a manifest, so they live together and share one finding
+type: :func:`assess_schema` (M2 — is the document well-formed and does it carry its
+provenance?) and :func:`assess_winnability` (M3 — can what it describes actually be
+built and verified?). The authoring loop runs schema first: a document that has not
+declared where its design came from is not worth asking harder questions of.
+
+Can this interface manifest actually be won? (#781, M3)
 
 A manifest that *parses* is not a manifest that can be *satisfied*. It can name a route
 the expander cannot place, promise a view with no DOM anchor to query, or imply a
@@ -30,6 +38,10 @@ PROOF_CONTRACT_DERIVES = "contract_derives"
 PROOF_CHECKS_LIVE = "checks_live"
 PROOF_TESTID_COVERAGE = "testid_coverage"
 PROOF_STATUS_DECLARED = "status_declared"
+
+#: Schema-gate proof classes (M2).
+PROOF_PROVENANCE = "provenance"
+PROOF_DECISION_RECORD = "decision_record"
 
 
 @dataclass(frozen=True)
@@ -70,6 +82,96 @@ def assess_winnability(manifest_content: str) -> tuple[WinnabilityFinding, ...]:
     findings.extend(_testid_findings(manifest))
     findings.extend(_status_findings(manifest))
     return tuple(findings)
+
+
+def assess_schema(manifest_content: str) -> tuple[WinnabilityFinding, ...]:
+    """The M2 schema gate: is this document well-formed and does it cite its origin?
+
+    Distinct from winnability on purpose. This asks whether the manifest is a
+    *legible design document* — it parses, it says which PRD it came from, and every
+    judgment it made is recorded with a warrant. Whether the design can be BUILT is
+    :func:`assess_winnability`, and asking that of a document with no stated provenance
+    wastes the harder analysis.
+
+    Citation is at **decision granularity**, not per entry: ``source_prd`` plus
+    ``decisions[].warrant``. §5b Correction 3 ruled per-entry citation would bloat
+    authoring for little gate value, and the schema has no field for it anyway.
+    """
+    from squadops.capabilities.scaffold import InterfaceManifest
+
+    try:
+        manifest = InterfaceManifest.from_yaml(manifest_content)
+    except Exception as exc:  # noqa: BLE001 - untrusted authored output: one rejection
+        return (
+            WinnabilityFinding(
+                PROOF_PARSES,
+                f"the manifest is not valid YAML or does not match the interface-manifest "
+                f"shape ({exc}). Fix the document structure before anything else can run.",
+            ),
+        )
+
+    findings: list[WinnabilityFinding] = []
+    if not manifest.source_prd.strip():
+        findings.append(
+            WinnabilityFinding(
+                PROOF_PROVENANCE,
+                "`source_prd` is empty — the manifest does not say which requirements "
+                "document it was designed from, so no reviewer can check the design "
+                "against its source. Name the PRD this manifest derives from.",
+            )
+        )
+    findings.extend(_decision_findings(manifest))
+    return tuple(findings)
+
+
+def _decision_findings(manifest) -> list[WinnabilityFinding]:
+    """Every recorded judgment must be attributable, or answerable.
+
+    A resolved decision needs its PRD ``warrant`` — that is the whole point of recording
+    it, and a choice with no citation is indistinguishable from an invention. An
+    unresolved one needs its ``question``, or it defers something without saying what,
+    which is worse than defaulting silently: it looks like diligence.
+    """
+    findings: list[WinnabilityFinding] = []
+    for index, decision in enumerate(manifest.decisions):
+        label = f"`{decision.id}`" if decision.id else f"entry {index}"
+        if not decision.id.strip():
+            findings.append(
+                WinnabilityFinding(
+                    PROOF_DECISION_RECORD,
+                    f"decision {label} has no `id`, so it cannot be referenced in review "
+                    f"or tracked across revisions.",
+                )
+            )
+        if decision.unresolved:
+            if not decision.question.strip():
+                findings.append(
+                    WinnabilityFinding(
+                        PROOF_DECISION_RECORD,
+                        f"decision {label} is marked `unresolved` but states no "
+                        f"`question` — it defers a design choice without saying which "
+                        f"one, which reads as diligence while communicating nothing.",
+                    )
+                )
+        else:
+            if not decision.choice.strip():
+                findings.append(
+                    WinnabilityFinding(
+                        PROOF_DECISION_RECORD,
+                        f"decision {label} records no `choice`. Either state the choice "
+                        f"made, or mark it `unresolved: true` with the question.",
+                    )
+                )
+            if not decision.warrant.strip():
+                findings.append(
+                    WinnabilityFinding(
+                        PROOF_DECISION_RECORD,
+                        f"decision {label} has no `warrant` — a choice with no citation "
+                        f"back to the PRD is indistinguishable from an invention. Cite "
+                        f"the section it follows from.",
+                    )
+                )
+    return findings
 
 
 def _lint_findings(manifest) -> list[WinnabilityFinding]:

--- a/tests/unit/cycles/test_manifest_gates.py
+++ b/tests/unit/cycles/test_manifest_gates.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from squadops.cycles.manifest_winnability import (
+from squadops.cycles.manifest_gates import (
     PROOF_EXPANDS,
     PROOF_PARSES,
     PROOF_STATUS_DECLARED,
@@ -153,3 +153,119 @@ def test_structurally_doomed_manifests_are_rejected(mutation):
     mutation(data)
 
     assert assess_winnability(_as_yaml(data)) != ()
+
+
+# ---------------------------------------------------------------------------
+# M2 — the schema gate: provenance and the decisions[] record (#783)
+#
+# Bug classes guarded: adding `decisions` to the model moving the manifest's
+# structural hash, which would invalidate the contract bound to it and break every
+# bind-mode cycle; a choice recorded with no citation back to the PRD, which is
+# indistinguishable from an invention; an `unresolved` marker that defers a design
+# question without saying which one; and a decision leaking into the derived contract,
+# where it could become something a check depends on.
+# ---------------------------------------------------------------------------
+
+from squadops.capabilities.scaffold import InterfaceManifest  # noqa: E402
+from squadops.cycles.manifest_gates import (  # noqa: E402
+    PROOF_DECISION_RECORD,
+    PROOF_PROVENANCE,
+    assess_schema,
+)
+
+# The manifest hash contract v9 is bound to (`skeleton.interface_manifest_hash`).
+_BOUND_MANIFEST_HASH = "bb472e267e53d5ad29406663b4340de45613dd68fa091fe7f2d06a99b7267530"
+
+
+def test_reference_manifest_passes_the_schema_gate():
+    assert assess_schema(_REFERENCE.read_text(encoding="utf-8")) == ()
+
+
+def test_decisions_do_not_move_the_structural_hash():
+    """The constraint that governs this whole item.
+
+    `_canonical()` is "every field the expander reads, and nothing else" — provenance is
+    excluded so a provenance-only edit cannot invalidate the contract bound to the hash.
+    Decisions are judgment, not structure. If they entered the projection, contract v9's
+    binding would break and every bind-mode cycle with it.
+    """
+    manifest = InterfaceManifest.from_yaml(_REFERENCE.read_text(encoding="utf-8"))
+
+    assert manifest.decisions  # the field is populated, not silently empty
+    assert manifest.content_hash() == _BOUND_MANIFEST_HASH
+
+
+def test_revising_a_decision_never_invalidates_the_contract():
+    """The consequence worth stating: an author may improve an explanation without
+    re-deriving anything, because the design did not change."""
+    data = _reference_dict()
+    data["decisions"][0]["warrant"] = "§9.9 — a completely different citation"
+    data["decisions"].append(
+        {"id": "added-later", "choice": "something", "warrant": "§1.1 — anything"}
+    )
+
+    revised = InterfaceManifest.from_yaml(_as_yaml(data))
+
+    assert revised.content_hash() == _BOUND_MANIFEST_HASH
+
+
+def test_decisions_never_reach_the_derived_contract():
+    """Lifecycle rule 3 holds *by construction*: since decisions are absent from the
+    contract, no derived check can depend on an unresolved one. Pinned rather than
+    re-checked — a detector for an impossible condition is the pattern this repo rejects.
+    """
+    from squadops.capabilities.scaffold_contract import emit_contract_yaml
+
+    data = _reference_dict()
+    data["decisions"].append(
+        {"id": "open-question", "unresolved": True, "question": "should runs expire?"}
+    )
+
+    emitted = emit_contract_yaml(InterfaceManifest.from_yaml(_as_yaml(data)))
+
+    assert "open-question" not in emitted
+    assert "should runs expire" not in emitted
+
+
+def test_unresolved_decision_round_trips_and_is_preserved():
+    """Preserved, never consumed: approval does not silently drop the open question."""
+    data = _reference_dict()
+    data["decisions"].append(
+        {"id": "pagination", "unresolved": True, "question": "page size for GET /runs?"}
+    )
+
+    manifest = InterfaceManifest.from_yaml(_as_yaml(data))
+
+    (open_one,) = [d for d in manifest.decisions if d.unresolved]
+    assert open_one.id == "pagination"
+    assert open_one.question == "page size for GET /runs?"
+    assert assess_schema(_as_yaml(data)) == ()
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected_fragment"),
+    [
+        ({"id": "no-warrant", "choice": "did a thing"}, "warrant"),
+        ({"id": "no-choice", "warrant": "§1.1"}, "choice"),
+        ({"id": "silent-defer", "unresolved": True}, "question"),
+        ({"choice": "x", "warrant": "§1.1"}, "id"),
+    ],
+)
+def test_malformed_decision_records_are_rejected(entry, expected_fragment):
+    data = _reference_dict()
+    data["decisions"].append(entry)
+
+    findings = assess_schema(_as_yaml(data))
+
+    assert PROOF_DECISION_RECORD in _proofs(findings)
+    assert any(expected_fragment in f.detail for f in findings)
+
+
+def test_manifest_without_source_prd_is_rejected():
+    """A design that does not say what it was designed from cannot be reviewed."""
+    data = _reference_dict()
+    data["source_prd"] = ""
+
+    findings = assess_schema(_as_yaml(data))
+
+    assert PROOF_PROVENANCE in _proofs(findings)


### PR DESCRIPTION
Fourth code item of the v1.6 M lane. Design gate posted to the issue before code.

Closes #783

## The premise was worse than the plan assumed

`decisions` is present in the reference manifest — 4 entries, each `id` / `choice` / `warrant` — but was **not parsed into the model at all**. The citation discipline SIP-0103 leans on existed only as YAML nobody read.

Now parsed, with the §5c.10 **`unresolved: true`** form: an author surfaces a design question it declines to answer instead of silently defaulting.

## The constraint that governs the whole item

Decisions stay **out of `_canonical()`**. That projection is *"every field the expander reads to produce the skeleton, and nothing else,"* with provenance excluded precisely so a provenance-only edit cannot move the hash and invalidate the contract bound to it.

Decisions are judgment, not structure. Adding them to the projection would have moved the manifest hash, broken contract v9's binding, invalidated #777's guard, and broken **every bind-mode cycle**.

Pinned two ways: the hash still equals the one contract v9 names (`bb472e26…`), and revising a warrant plus appending a decision leaves it unmoved. **Consequence worth stating:** an author may improve an explanation without re-deriving anything, because the design didn't change.

## Lifecycle rule 3 holds by construction — pinned, not checked

The plan says derivation may not depend on an unresolved decision. Since decisions are absent from both the structural projection *and* the derived contract, **no derived check can depend on one**.

A detector for an impossible condition is the "rejects the guess but never supplies the answer" pattern this repo has ruled against, so the test proves the exclusion rather than re-checking it.

## Schema-gate proofs

| Proof | Rejects |
|---|---|
| `provenance` | empty `source_prd` — a design that doesn't say what it was designed from can't be reviewed |
| `decision_record` | no `id` (can't be referenced across revisions); a `choice` with no `warrant` — **indistinguishable from an invention**; `unresolved` with no `question` — deferring without saying what, which *reads as diligence while communicating nothing* |

Citation stays at **decision granularity** (`source_prd` + `decisions[].warrant`), not per entry — §5b Correction 3 ruled per-entry would bloat authoring for little gate value, and the schema has no field for it.

## Rename

`manifest_winnability.py` → `manifest_gates.py`. It now holds both authoring gates and the name should say so. Done now while the only importer is its own test (no call sites yet, per M3's D5) — the rename gets expensive once the authoring loop wires them.

**Regression: 6537 passed, 1 skipped.**