### PR TITLE
feat(cycles): authoring failure taxonomy — one classification, three consumers (#785, M6)

### DIFF
--- a/src/squadops/cycles/authoring_failure.py
+++ b/src/squadops/cycles/authoring_failure.py
@@ -1,0 +1,191 @@
+"""Why did this manifest fail — and whose problem is it? (#785, M6)
+
+One classification, three consumers: M5's provenance records *why* each revision
+happened, B1's baseline counts *which classes recur*, and the authored-mode measurement
+window needs *which subsystem* a failure is attributable to. Built three times, those
+become three vocabularies that must later be reconciled — the exact problem the post-1.5
+reconciliation names as intention 2.
+
+It exists before the first authored manifest is rejected, because **a rejection recorded
+without a class is data that cannot be recovered later**. Without it the window's output
+collapses into one "manifest rejected" bucket, which cannot say whether authored mode is
+limited by the author, the schema, the blueprint, or the deriver — the entire question
+the release is asking.
+
+Keyed alongside the vocabulary that already exists (``FailureEvidenceCategory``,
+``OWNERSHIP_*``, locus classification) rather than as a parallel set: this adds the
+*authoring* dimension those lack, and borrows their ownership semantics rather than
+inventing a second answer to "whose problem is it?".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from squadops.cycles.acceptance_check_spec import (
+    OWNERSHIP_CONTRACT,
+    OWNERSHIP_INFRASTRUCTURE,
+    OWNERSHIP_PLAN,
+)
+from squadops.cycles.manifest_gates import (
+    PROOF_CHECKS_LIVE,
+    PROOF_CONTRACT_DERIVES,
+    PROOF_DECISION_RECORD,
+    PROOF_EXPANDS,
+    PROOF_LINT,
+    PROOF_PARSES,
+    PROOF_PROVENANCE,
+    PROOF_STATUS_DECLARED,
+    PROOF_TESTID_COVERAGE,
+    WinnabilityFinding,
+    assess_schema,
+    assess_winnability,
+)
+
+#: The manifest is wrong; schema, blueprint and deriver are all fine. Retrying the
+#: authoring stage with rejection context is the right response.
+AUTHORING_DEFECT = "authoring_defect"
+
+#: The manifest could not express something the design needs. Fixing it means changing
+#: the schema, which is a blueprint-version change (SIP-0103 §5c.4) — never silent drift.
+SCHEMA_GAP = "schema_gap"
+
+#: The stack's closed vocabulary cannot express the design. Adjudicated by the blueprint
+#: admission rule (S5: a new field must be demonstrated on ≥2 stacks).
+BLUEPRINT_LIMITATION = "blueprint_limitation"
+
+#: Authoring was sound; the deriver mishandled it. The fix is in M0's code, never in the
+#: manifest — asking an author to work around a broken deriver teaches them a superstition.
+DERIVATION_DEFECT = "derivation_defect"
+
+#: The PRD does not determine the answer. Handled by ``decisions[]`` with
+#: ``unresolved: true`` and the human review gate — NOT by asking the author to guess.
+PRD_INSUFFICIENCY = "prd_insufficiency"
+
+#: Ownership, borrowed from the check registry's vocabulary rather than restated. The
+#: author owns their own document; a schema or blueprint gap is a contract-level
+#: concern; a deriver defect is ours, in the same sense infrastructure failures are.
+CLASS_OWNERSHIP: dict[str, str] = {
+    AUTHORING_DEFECT: OWNERSHIP_PLAN,
+    SCHEMA_GAP: OWNERSHIP_CONTRACT,
+    BLUEPRINT_LIMITATION: OWNERSHIP_CONTRACT,
+    DERIVATION_DEFECT: OWNERSHIP_INFRASTRUCTURE,
+    PRD_INSUFFICIENCY: OWNERSHIP_PLAN,
+}
+
+# How each gate proof classifies at a SINGLE occurrence.
+#
+# Read the conservative entries with the recurrence rule in mind (see
+# `classify_finding`): `expands` and `checks_live` are ambiguous in one sighting and
+# resolve only across cycles.
+_PROOF_CLASS: dict[str, str] = {
+    PROOF_PARSES: AUTHORING_DEFECT,
+    PROOF_LINT: AUTHORING_DEFECT,
+    PROOF_PROVENANCE: AUTHORING_DEFECT,
+    PROOF_DECISION_RECORD: AUTHORING_DEFECT,
+    PROOF_TESTID_COVERAGE: AUTHORING_DEFECT,
+    PROOF_STATUS_DECLARED: AUTHORING_DEFECT,
+    PROOF_EXPANDS: AUTHORING_DEFECT,
+    # Derivation succeeded structurally but produced something unusable, on a manifest
+    # that already passed lint and expansion. That is the deriver's problem by
+    # elimination, not the author's.
+    PROOF_CONTRACT_DERIVES: DERIVATION_DEFECT,
+    PROOF_CHECKS_LIVE: DERIVATION_DEFECT,
+}
+
+
+@dataclass(frozen=True)
+class ClassifiedFinding:
+    """A gate finding with its authoring class and the owner who can act on it."""
+
+    proof: str
+    detail: str
+    failure_class: str
+    ownership: str
+
+
+@dataclass(frozen=True)
+class AuthoringOutcome:
+    """What a manifest's gates say, classified for the three downstream consumers."""
+
+    findings: tuple[ClassifiedFinding, ...] = ()
+    #: Declared open questions. NOT failures — see :func:`assess_authoring_outcome`.
+    open_questions: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def rejected(self) -> bool:
+        """True when a gate found something that must be fixed before proceeding."""
+        return bool(self.findings)
+
+    def class_counts(self) -> dict[str, int]:
+        """Occurrences per class — the shape B1's baseline accumulates across cycles."""
+        counts: dict[str, int] = {}
+        for f in self.findings:
+            counts[f.failure_class] = counts.get(f.failure_class, 0) + 1
+        if self.open_questions:
+            counts[PRD_INSUFFICIENCY] = len(self.open_questions)
+        return counts
+
+
+def classify_finding(finding: WinnabilityFinding) -> ClassifiedFinding:
+    """Classify one gate finding, conservatively.
+
+    **Some classes are recurrence-determined, and single-occurrence precision here would
+    be faked.** "The expander refused this design" is genuinely ambiguous between *the
+    author asked for something outside the vocabulary* (``AUTHORING_DEFECT``) and *the
+    vocabulary should support it* (``BLUEPRINT_LIMITATION``); nothing available at the
+    gate distinguishes them.
+
+    So a single occurrence takes the conservative class — the author's — and
+    **recurrence is what promotes it**. That promotion is measured across cycles by B1's
+    baseline, not inside one assessment, which is precisely why B1 records recurrence
+    rather than only totals. Same ratchet as M2's judgment surface: a class that keeps
+    reappearing is evidence of a gap rather than a run of bad luck.
+
+    Unknown proofs classify as ``AUTHORING_DEFECT`` rather than raising: an unclassified
+    finding is the undifferentiated bucket this module exists to prevent, and losing the
+    finding entirely would be worse than filing it conservatively.
+    """
+    failure_class = _PROOF_CLASS.get(finding.proof, AUTHORING_DEFECT)
+    return ClassifiedFinding(
+        proof=finding.proof,
+        detail=finding.detail,
+        failure_class=failure_class,
+        ownership=CLASS_OWNERSHIP[failure_class],
+    )
+
+
+def assess_authoring_outcome(manifest_content: str) -> AuthoringOutcome:
+    """Run both gates and classify everything they say about this manifest.
+
+    Also reads the manifest's **declared uncertainty**. An ``unresolved`` decision
+    *passes* the schema gate by design — stating an open question is correct behavior,
+    not a defect — so a classifier that looked only at findings would report zero PRD
+    insufficiency on a manifest whose author explicitly said the requirements were
+    ambiguous. Those are recorded as ``open_questions`` and counted under
+    ``PRD_INSUFFICIENCY`` without rejecting the manifest.
+
+    That distinction is the point of the class: a PRD that under-specifies must not look
+    identical to a squad that cannot design, because the remedies are opposite — one
+    needs a better PRD, the other a better author.
+    """
+    findings = tuple(
+        classify_finding(f)
+        for f in (*assess_schema(manifest_content), *assess_winnability(manifest_content))
+    )
+    return AuthoringOutcome(findings=findings, open_questions=_open_questions(manifest_content))
+
+
+def _open_questions(manifest_content: str) -> tuple[str, ...]:
+    """Questions the author declined to answer, in their own words.
+
+    An unparseable manifest has no readable decisions; the parse failure is already a
+    finding, so this stays silent rather than adding a second complaint about it.
+    """
+    from squadops.capabilities.scaffold import InterfaceManifest
+
+    try:
+        manifest = InterfaceManifest.from_yaml(manifest_content)
+    except Exception:  # noqa: BLE001 - the parse failure is reported as a finding
+        return ()
+    return tuple(d.question for d in manifest.decisions if d.unresolved and d.question.strip())

--- a/tests/unit/cycles/test_authoring_failure.py
+++ b/tests/unit/cycles/test_authoring_failure.py
@@ -1,0 +1,168 @@
+"""The authoring failure taxonomy (#785, M6).
+
+Bug classes guarded:
+
+- a gate proof with **no** authoring class — the undifferentiated "manifest rejected"
+  bucket this module exists to prevent, and the failure mode that would make the
+  authored-mode window's numbers unactionable;
+- a new proof added later without a class, which is how that bucket comes back;
+- `prd_insufficiency` never being reported, because an unresolved decision *passes* both
+  gates and a findings-only classifier would see nothing — leaving a PRD that
+  under-specifies indistinguishable from a squad that cannot design;
+- an open question being treated as a rejection, which would punish an author for
+  correctly declaring ambiguity;
+- ownership drifting from the vocabulary the check registry already uses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from squadops.cycles import manifest_gates
+from squadops.cycles.authoring_failure import (
+    AUTHORING_DEFECT,
+    CLASS_OWNERSHIP,
+    DERIVATION_DEFECT,
+    PRD_INSUFFICIENCY,
+    AuthoringOutcome,
+    ClassifiedFinding,
+    assess_authoring_outcome,
+    classify_finding,
+)
+from squadops.cycles.manifest_gates import WinnabilityFinding
+
+_REFERENCE = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+
+
+def _reference_dict() -> dict:
+    return yaml.safe_load(_REFERENCE.read_text(encoding="utf-8"))
+
+
+def _as_yaml(data: dict) -> str:
+    return yaml.dump(data, sort_keys=False)
+
+
+def test_every_gate_proof_has_a_class():
+    """The drift guard: a proof added to the gates without a class here silently
+    re-creates the bucket. Enumerated from the gate module so it cannot be forgotten.
+    """
+    proofs = {
+        value
+        for name, value in vars(manifest_gates).items()
+        if name.startswith("PROOF_") and isinstance(value, str)
+    }
+    assert proofs, "no proofs discovered — the enumeration itself broke"
+
+    for proof in proofs:
+        classified = classify_finding(WinnabilityFinding(proof, "detail"))
+        assert classified.failure_class in CLASS_OWNERSHIP, f"{proof} has no authoring class"
+
+
+def test_unknown_proof_is_filed_conservatively_rather_than_lost():
+    """Losing a finding is worse than filing it under the author's column."""
+    classified = classify_finding(WinnabilityFinding("a_proof_from_the_future", "detail"))
+
+    assert classified.failure_class == AUTHORING_DEFECT
+
+
+def test_derivation_failures_are_ours_not_the_authors():
+    """Asking an author to work around a broken deriver teaches a superstition."""
+    for proof in (manifest_gates.PROOF_CONTRACT_DERIVES, manifest_gates.PROOF_CHECKS_LIVE):
+        classified = classify_finding(WinnabilityFinding(proof, "detail"))
+        assert classified.failure_class == DERIVATION_DEFECT
+        assert classified.ownership == "infrastructure"
+
+
+def test_clean_manifest_reports_nothing():
+    outcome = assess_authoring_outcome(_REFERENCE.read_text(encoding="utf-8"))
+
+    assert outcome.rejected is False
+    assert outcome.class_counts() == {}
+
+
+def test_open_questions_are_counted_without_rejecting():
+    """The distinction the class exists for.
+
+    Declaring ambiguity is correct behavior, so the manifest passes — but the ambiguity
+    must still be *counted*, or a PRD that under-specifies looks exactly like a squad
+    that cannot design, and the two have opposite remedies.
+    """
+    data = _reference_dict()
+    data["decisions"].append(
+        {"id": "pagination", "unresolved": True, "question": "page size for GET /runs?"}
+    )
+
+    outcome = assess_authoring_outcome(_as_yaml(data))
+
+    assert outcome.rejected is False
+    assert outcome.open_questions == ("page size for GET /runs?",)
+    assert outcome.class_counts() == {PRD_INSUFFICIENCY: 1}
+
+
+def test_authoring_defect_is_attributed_to_the_author():
+    """#772's shape, classified: the manifest is wrong and the author can fix it."""
+    data = _reference_dict()
+    for ep in data["api"]["endpoints"]:
+        if ep["method"] == "POST" and "{" not in ep["path"]:
+            ep.pop("success_status", None)
+
+    outcome = assess_authoring_outcome(_as_yaml(data))
+
+    assert outcome.rejected is True
+    assert outcome.class_counts() == {AUTHORING_DEFECT: 1}
+    assert outcome.findings[0].ownership == "plan"
+
+
+def test_findings_and_open_questions_are_counted_together():
+    """B1 accumulates this shape across cycles; both dimensions must survive."""
+    data = _reference_dict()
+    data["frontend"]["routes"][0].pop("testids", None)
+    data["decisions"].append({"id": "q", "unresolved": True, "question": "unknown thing?"})
+
+    counts = assess_authoring_outcome(_as_yaml(data)).class_counts()
+
+    assert counts[AUTHORING_DEFECT] >= 1
+    assert counts[PRD_INSUFFICIENCY] == 1
+
+
+def test_unparseable_manifest_does_not_double_report():
+    """The parse failure is already a finding; adding 'and it has no decisions' would
+    misdirect the fix."""
+    outcome = assess_authoring_outcome("not: [valid\n yaml")
+
+    assert outcome.rejected is True
+    assert outcome.open_questions == ()
+
+
+@pytest.mark.parametrize("failure_class", sorted(CLASS_OWNERSHIP))
+def test_every_class_names_an_owner_from_the_shared_vocabulary(failure_class):
+    """Ownership is borrowed from the check registry, not restated — two answers to
+    'whose problem is it?' is the drift this codebase keeps paying for."""
+    from squadops.cycles import acceptance_check_spec as spec
+
+    known = {
+        value
+        for name, value in vars(spec).items()
+        if name.startswith("OWNERSHIP_") and isinstance(value, str)
+    }
+    assert CLASS_OWNERSHIP[failure_class] in known
+
+
+def test_outcome_is_empty_by_default():
+    """A default-constructed outcome must read as 'nothing wrong', not as unknown."""
+    assert AuthoringOutcome().rejected is False
+    assert AuthoringOutcome().class_counts() == {}
+
+
+def test_classified_finding_preserves_the_operator_facing_detail():
+    """The class is for machines; the detail is what a person acts on. Losing it would
+    trade a readable rejection for a label."""
+    classified = classify_finding(WinnabilityFinding("lint", "declare at least one endpoint"))
+
+    assert isinstance(classified, ClassifiedFinding)
+    assert classified.detail == "declare at least one endpoint"


### PR DESCRIPTION
Fifth code item of the v1.6 M lane, and the last before M1. Design gate posted to the issue before code.

Closes #785

## One record, not three

M5's revision reason, B1's baseline, and the window's attribution were three asks for the same thing. Built separately they become three vocabularies to reconcile later — the problem the post-1.5 reconciliation names as intention 2. Built once, **before the first authored manifest is rejected**, because a rejection recorded without a class is data that cannot be recovered afterwards.

| Class | Who fixes it |
|---|---|
| `authoring_defect` | the author — retry with rejection context |
| `schema_gap` | schema change ⇒ blueprint version |
| `blueprint_limitation` | blueprint governance (S5's ≥2-stack rule) |
| `derivation_defect` | M0's code, never the manifest |
| `prd_insufficiency` | `decisions[]`, `unresolved: true`, the human gate |

Ownership is **borrowed** from the check registry's `OWNERSHIP_*` constants rather than restated — two answers to "whose problem is it?" is the drift this codebase keeps paying for. A test pins that every class names an owner from that shared set.

## Two positions that shaped it

**`prd_insufficiency` is not a gate failure.** An unresolved decision *passes* the M2 schema gate by design — declaring an open question is correct behavior. So the assessment reads the manifest's **declared uncertainty**, not only its rejections; a findings-only classifier would report zero PRD insufficiency on a manifest whose author explicitly said the requirements were ambiguous. Open questions are counted **without rejecting**.

That's the whole point of the class: a PRD that under-specifies must not look identical to a squad that cannot design, because the remedies are opposite.

**Some classes are recurrence-determined, and single-occurrence precision would be faked.** "The expander refused this design" is genuinely ambiguous between *the author asked for something outside the vocabulary* and *the vocabulary should grow*; nothing at the gate separates them. So a single occurrence takes the conservative class and **recurrence promotes it** — measured across cycles by B1, which is exactly why B1 records recurrence rather than only totals. Documented where the classifier lives, so a later reader can't mistake a conservative class for a confident one.

**Derivation failures classify to us, not the author.** A manifest that already passed lint and expansion but produces an unusable contract is the deriver's problem by elimination — and asking an author to work around a broken deriver teaches a superstition.

## Tests worth noting

Every gate proof is **enumerated from the gate module** and must have a class, so a proof added later without one fails the suite rather than silently re-creating the bucket. An unknown proof is filed conservatively rather than lost — losing a finding is worse than filing it under the author's column.

**Regression: 6552 passed, 1 skipped.**

## What's next

**M1** — the authoring stage. Everything since the queue front has been building the things that make M1's failures readable; this was the last of them. Per the verification cadence, M1 is followed by **V4**: the first authored cycles, unscored, where the thing to watch is not the pass rate but whether this taxonomy can name which subsystem to blame.