### PR TITLE
fix(telemetry): tokens_per_second reaches LangFuse — replace the hand-copied redaction rebuild

### DIFF
--- a/adapters/telemetry/langfuse/adapter.py
+++ b/adapters/telemetry/langfuse/adapter.py
@@ -15,7 +15,7 @@ import queue
 import random
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Any
 
@@ -185,18 +185,17 @@ class LangFuseAdapter(LLMObservabilityPort):
             if random.randint(1, 100) > self._config.sample_rate_percent:
                 return  # Sampled out — silently dropped
 
-        # Redact prompt/response text before buffering
-        redacted_record = GenerationRecord(
-            generation_id=record.generation_id,
-            model=record.model,
+        # Redact prompt/response text before buffering.
+        #
+        # `replace` rather than a field-by-field rebuild (#793): the rebuild copied
+        # ten of eleven fields and silently dropped `tokens_per_second`, which
+        # defaults to None — so LangFuse reported null throughput for every
+        # generation from SIP-0061 until the fix. Copy-everything-redact-two states
+        # the actual intent and cannot drift when a field is added.
+        redacted_record = replace(
+            record,
             prompt_text=self._redaction.redact(record.prompt_text),
             response_text=self._redaction.redact(record.response_text),
-            prompt_tokens=record.prompt_tokens,
-            completion_tokens=record.completion_tokens,
-            total_tokens=record.total_tokens,
-            latency_ms=record.latency_ms,
-            prompt_name=record.prompt_name,
-            prompt_version=record.prompt_version,
         )
         self._enqueue(
             _BufferEntry(
@@ -207,15 +206,10 @@ class LangFuseAdapter(LLMObservabilityPort):
         )
 
     def record_event(self, ctx: CorrelationContext, event: StructuredEvent) -> None:
-        # Redact event message before buffering
-        redacted_event = StructuredEvent(
-            name=event.name,
-            message=self._redaction.redact(event.message),
-            level=event.level,
-            attributes=event.attributes,
-            timestamp=event.timestamp,
-            span_id=event.span_id,
-        )
+        # Redact event message before buffering. `replace` for the same reason as
+        # record_generation (#793) — complete today only because no field has been
+        # added since it was written.
+        redacted_event = replace(event, message=self._redaction.redact(event.message))
         self._enqueue(_BufferEntry(event_type=_EventType.EVENT, ctx=ctx, payload=redacted_event))
 
     def flush(self) -> None:

--- a/tests/unit/telemetry/test_langfuse_adapter.py
+++ b/tests/unit/telemetry/test_langfuse_adapter.py
@@ -8,9 +8,11 @@ Uses a fake langfuse module injection so the SDK is not required.
 
 from __future__ import annotations
 
+import dataclasses
 import sys
 import time
 import types
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -266,6 +268,106 @@ class TestPayloadShapes:
         adapter.record_event(ctx, StructuredEvent(name="task.started", message="go"))
         entry = adapter._buffer.get_nowait()
         assert entry.payload.name == "task.started"
+
+
+class TestRedactionPreservesEveryOtherField:
+    """#793: redaction rebuilt each record field-by-field and dropped
+    ``tokens_per_second`` — one of eleven. It defaults to None, so the omission
+    raised nothing and LangFuse reported null throughput for every generation
+    from SIP-0061 until the fix.
+
+    These tests pin both halves: the value that was lost, and the class of loss.
+    """
+
+    def test_tokens_per_second_survives_redaction(self, adapter):
+        """The exact #793 defect. A populated throughput must reach the buffer."""
+        adapter.record_generation(_make_ctx(), _make_record(tokens_per_second=10.6), _make_layers())
+        assert adapter._buffer.get_nowait().payload[0].tokens_per_second == 10.6
+
+    def test_every_generation_field_but_the_redacted_pair_is_carried_through(self, adapter):
+        """The drift guard, and the reason this is `replace` rather than one more
+        keyword: a field added to GenerationRecord tomorrow is carried without
+        touching this adapter. Every field gets a distinct non-default value, so a
+        silently-dropped one shows up as None rather than coinciding with a default.
+        """
+        record = GenerationRecord(
+            generation_id="gen-793",
+            model="qwen3.6:27b",
+            prompt_text="prompt with no secrets",
+            response_text="response with no secrets",
+            prompt_tokens=1234,
+            completion_tokens=4866,
+            total_tokens=6100,
+            latency_ms=459_100.0,
+            tokens_per_second=10.6,
+            prompt_name="request.development_develop",
+            prompt_version=7,
+        )
+        adapter.record_generation(_make_ctx(), record, _make_layers())
+        buffered = adapter._buffer.get_nowait().payload[0]
+
+        redacted = {"prompt_text", "response_text"}
+        for field in dataclasses.fields(GenerationRecord):
+            if field.name in redacted:
+                continue
+            assert getattr(buffered, field.name) == getattr(record, field.name), (
+                f"{field.name} was dropped or altered by the redaction copy"
+            )
+
+    def test_every_event_field_but_the_message_is_carried_through(self, adapter):
+        """``record_event`` had the same hand-copy shape and was complete only
+        because no field had been added to StructuredEvent since it was written.
+        """
+        event = StructuredEvent(
+            name="task.failed",
+            message="message with no secrets",
+            level="error",
+            attributes=(("attempt", 3),),
+            timestamp=datetime(2026, 8, 8, 12, 0, 0, tzinfo=UTC),
+            span_id="span-793",
+        )
+        adapter.record_event(_make_ctx(), event)
+        buffered = adapter._buffer.get_nowait().payload
+
+        for field in dataclasses.fields(StructuredEvent):
+            if field.name == "message":
+                continue
+            assert getattr(buffered, field.name) == getattr(event, field.name), (
+                f"{field.name} was dropped or altered by the redaction copy"
+            )
+
+    def test_redaction_still_happens(self, adapter):
+        """`replace` copies everything — including, if misapplied, the raw text.
+        Guards the fix against trading a dropped field for a leaked secret.
+        """
+        adapter.record_generation(
+            _make_ctx(),
+            _make_record(
+                prompt_text="Use Bearer abc123456789012345678901 token",
+                response_text="key is sk-secret1234567890123456",
+            ),
+            _make_layers(),
+        )
+        buffered = adapter._buffer.get_nowait().payload[0]
+        assert "abc123456789012345678901" not in buffered.prompt_text
+        assert "sk-secret1234567890123456" not in buffered.response_text
+
+    def test_tokens_per_second_reaches_the_langfuse_generation_call(self, adapter):
+        """The second hop. Surviving redaction is necessary but not sufficient —
+        the value has to land in the payload actually handed to the SDK, which is
+        where a reader would look for it in the LangFuse UI.
+        """
+        ctx = _make_ctx()
+        parent = MagicMock()
+        adapter._span_state[f"task:{adapter._resolve_trace_key(ctx)}:{ctx.task_id}"] = parent
+
+        adapter.record_generation(
+            ctx, _make_record(tokens_per_second=10.6, completion_tokens=4866), _make_layers()
+        )
+        adapter._handle_generation(adapter._buffer.get_nowait())
+
+        metadata = parent.generation.call_args.kwargs["metadata"]
+        assert metadata["tokens_per_second"] == 10.6
 
 
 class TestConcurrentTaskSpans:


### PR DESCRIPTION
## The defect

`LangFuseAdapter.record_generation` rebuilt `GenerationRecord` field-by-field to apply redaction, and copied **ten of eleven** fields — omitting `tokens_per_second`. It defaults to `None`, so the omission raised nothing. **LangFuse has reported null throughput for every generation since SIP-0061.**

```python
# before — ten of eleven
redacted_record = GenerationRecord(
    generation_id=record.generation_id,
    ...
    latency_ms=record.latency_ms,
    #  tokens_per_second=record.tokens_per_second,   <-- never written
    prompt_name=record.prompt_name,
    prompt_version=record.prompt_version,
)

# after
redacted_record = replace(
    record,
    prompt_text=self._redaction.redact(record.prompt_text),
    response_text=self._redaction.redact(record.response_text),
)
```

## Why it stayed invisible

1. The field is optional — had it been required this would have raised on the first call.
2. **`latency_ms` sits directly above it in the same constructor and *is* copied**, so LangFuse timing data looked healthy, which made the whole telemetry path look healthy.
3. The handler logs throughput on a **separate code path** (`capabilities/handlers/cycle/base.py:702`), so the number stayed visible in the Prefect UI and the gap never presented as missing data.

## Why `replace()` rather than adding the keyword

`GenerationRecord` is `@dataclass(frozen=True)`, and `dataclasses.replace()` is the pattern CLAUDE.md already names for this repo. *Copy-everything-redact-two* states the actual intent, and a field added tomorrow is carried without touching this adapter.

Adding `tokens_per_second=` would have fixed today's symptom and left the trap armed for field twelve. The same change is applied to `record_event`/`StructuredEvent` — complete today only because no field has been added to it since it was written.

## Tests — verified against the unfixed adapter

Five added. Stashing the fix and re-running gives **3 failures with the right messages** (`assert None == 10.6`, `tokens_per_second was dropped or altered by the redaction copy`). The 2 that pass guard regressions the *fix itself* could introduce, so passing both before and after is correct.

| Test | Bug it catches |
|---|---|
| `test_tokens_per_second_survives_redaction` | the exact defect |
| `test_every_generation_field_but_the_redacted_pair_is_carried_through` | field twelve added and dropped — each field gets a distinct non-default value so a drop reads as `None` rather than coinciding with a default |
| `test_every_event_field_but_the_message_is_carried_through` | the same latent shape in `record_event` |
| `test_redaction_still_happens` | trading a dropped field for a leaked secret |
| `test_tokens_per_second_reaches_the_langfuse_generation_call` | the second hop — surviving redaction but not landing in the payload handed to the SDK |

## Out of scope, per the issue

Sending real `start_time`/`end_time` so LangFuse can derive latency natively (it currently receives a single point-in-time observation created on the flush thread), and a durable per-generation throughput record — `tokens_per_second` is persisted nowhere. Both are worth doing; neither is needed to restore the metadata field.

## Verification

- Regression suite: **6602 passed, 2 skipped**
- `ruff check` / `ruff format`: clean
- Behavior change is confined to telemetry metadata — no domain, contract, or wire-format surface is touched.

Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuQJ2ZGMRD9rMfFJCQoofD
