### PR TITLE
fix(cycles): an authored manifest binds its own run (#796)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ seeds a manifest but no contract (#779), M3 winnability gate (#781), M2 schema g
 the `decisions[]` judgment record (#783), M6 authoring failure taxonomy (#785), and **M1
 the authoring stage itself (#791)** — a dedicated `development.author_manifest` framing
 step that revises against the gates, replacing the ungated proposer-side emission it
-relocates. M4 (the human manifest gate) and M5 (provenance) follow.
+relocates, and **#796** — the fix V4 roll 1 exposed: an authored manifest now derives and
+pins its contract mid-framing, so the plan authors bind to the design their own squad just
+wrote instead of inventing paths, and every contract-gated net engages. M4 (the human
+manifest gate) and M5 (provenance) follow.
 Plan: `docs/plans/1-6-0-authorship-plan.md`.
 
 ## [1.5.0] — 2026-08-07

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -46,7 +46,7 @@ from squadops.cycles.acceptance_evaluation import resolve_check_stack
 from squadops.cycles.agent_config import build_agent_resolver
 from squadops.cycles.build_completeness import compute_missing_required_files
 from squadops.cycles.checkpoint import RunCheckpoint
-from squadops.cycles.contract_derivation import SEEDED_MANIFEST_FILENAME
+from squadops.cycles.contract_derivation import CONTRACT_ARTIFACT_TYPE, SEEDED_MANIFEST_FILENAME
 from squadops.cycles.frozen_check_validation import frozen_check_violations
 from squadops.cycles.manifest_authoring import MANIFEST_ARTIFACT_TYPE
 from squadops.cycles.models import (
@@ -67,7 +67,7 @@ from squadops.cycles.patch_verification import (
 )
 from squadops.cycles.run_ledger import RunLedger
 from squadops.cycles.task_outcome import TaskOutcome
-from squadops.cycles.task_plan import generate_task_plan
+from squadops.cycles.task_plan import generate_task_plan, inject_contract_inputs
 from squadops.cycles.verification_normalize import normalize_task_checks
 from squadops.events.types import EventType
 from squadops.ports.cycles.flow_execution import FlowExecutionPort
@@ -975,6 +975,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 overrides["plan_artifact_refs"] = merged
             else:
                 overrides["plan_artifact_refs"] = plan_refs
+            # #796: a contract the framing run derived from its own authored manifest
+            # becomes the next workload's contract_ref, exactly as a seeded one would be.
+            # An operator-supplied ref always wins — the merge rule for every other key.
+            if not overrides.get("contract_ref"):
+                derived = [a for a in promoted if a.artifact_type == CONTRACT_ARTIFACT_TYPE]
+                if derived:
+                    overrides["contract_ref"] = max(derived, key=lambda a: a.created_at).artifact_id
         elif wt == "implementation":
             if "impl_run_id" not in overrides:
                 overrides["impl_run_id"] = completed_run.run_id
@@ -1160,6 +1167,12 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # None for unbound/legacy runs → no enforcement (plan §10).
         bound_record = self._build_bound_record_for_run(interface_manifest, run_id)
 
+        # #796: in authored mode the contract does not exist when the plan is generated —
+        # the squad has not designed anything yet. It comes into being mid-run, the moment
+        # the authoring stage lands a manifest, and every task dispatched after that point
+        # binds to it. Empty for seeded runs, whose contract was pinned at creation.
+        authored: tuple[Any, Any] = (None, None)
+
         # SIP-0079: Checkpoint/resume state tracking
         completed_task_ids: list[str] = []
         plan_delta_refs: list[str] = []
@@ -1271,12 +1284,14 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 continue
 
             # Enrich envelope with chain context and dispatch
+            authored_contract, authored_manifest = authored
             enriched = await self._enrich_envelope(
                 envelope,
                 prior_outputs,
                 all_artifact_refs,
                 stored_artifacts,
-                interface_manifest=interface_manifest,
+                interface_manifest=interface_manifest or authored_manifest,
+                run_derived_contract=authored_contract,
             )
 
             # SIP-0087: executor owns Prefect task-run creation so task_run_id
@@ -1437,6 +1452,10 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 compliance_counter=compliance_counter,
                 retain_checkpoint=self._is_phase_boundary(plan, task_idx),
             )
+
+            # #796: the authoring stage may have just stored a manifest. Derive here — after
+            # collection, before the next dispatch — so the very next task binds.
+            authored = await self._bind_authored_manifest(cycle, run_id, stored_artifacts, authored)
 
             # ----------------------------------------------------------
             # SIP-0070: Pulse boundary evaluation (after task, before gate)
@@ -1673,11 +1692,95 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         author mode = today's behavior exactly."""
         return bool(cycle.execution_overrides.get("contract_ref"))
 
-    async def _load_contract_for_run(self, cycle: Any, run: Any) -> Any:
-        """Load the seeded verification contract for a run (SIP-0098 98.3).
+    async def _bind_authored_manifest(
+        self,
+        cycle: Any,
+        run_id: str,
+        stored_artifacts: list[tuple[str, ArtifactRef]],
+        current: tuple[Any, Any],
+    ) -> tuple[Any, Any]:
+        """Derive and pin the contract the moment this run has authored a manifest (#796).
+
+        The instant the design exists it is fixed, so the cycle stops being author mode and
+        becomes exactly what a seeded cycle is: a manifest, and the contract derived from
+        it. Everything downstream is then the machinery 1.4/1.5 hardened, unchanged —
+        SIP-0103 §3.5's "authored mode is a mode of manifest provenance, not a second
+        pipeline", made true rather than asserted.
+
+        Without it, authored mode ran with every contract-gated net switched off. V4 roll 1
+        measured the cost: the proposers, told nothing about the skeleton their own squad
+        had just designed, put **zero of nine** expected artifacts on a fill slot — four
+        claimed scaffold-frozen files and five named paths the skeleton does not contain.
+
+        Derives ONCE per run. A re-rolled authoring stage produces a new run, so "the design
+        is fixed" needs no mid-run invalidation rule — and a second derivation inside one run
+        would be a moving target, which is the #494 stale-binding class by construction.
+
+        Never raises. A manifest that cannot derive is already a winnability finding, so the
+        gate rejects it with the deriver's own reason (``contract_derives``, attributed to
+        infrastructure by M6) rather than this seam inventing a second verdict.
+        """
+        from squadops.capabilities.scaffold import InterfaceManifest
+        from squadops.cycles.contract_derivation import (
+            derive_and_store_contract,
+            find_interface_manifest,
+        )
+        from squadops.cycles.verification_contract import VerificationContract
+
+        contract, _manifest = current
+        if contract is not None or self._is_bind_mode(cycle):
+            # Already derived, or seeded at creation — the seeded path is untouched.
+            return current
+
+        manifest_id = find_interface_manifest(stored_artifacts)
+        if manifest_id is None:
+            return current
+
+        try:
+            _, manifest_bytes = await self._artifact_vault.retrieve(manifest_id)
+            manifest_content = manifest_bytes.decode(errors="replace")
+            contract_ref = await derive_and_store_contract(
+                self._artifact_vault,
+                cycle.project_id,
+                manifest_content,
+                cycle_id=cycle.cycle_id,
+                run_id=run_id,
+            )
+            _, contract_bytes = await self._artifact_vault.retrieve(contract_ref)
+            derived = VerificationContract.from_yaml(contract_bytes.decode(errors="replace"))
+            manifest = InterfaceManifest.from_yaml(manifest_content)
+            # On the run's own ref list, like any other output: it is then visible in
+            # `artifacts list`, seen by the gate's plan-validation net, promoted with the
+            # rest of the framing output on approval, and forwarded to the implementation
+            # workload. A contract only this loop knew about would bind the plan and then
+            # vanish at the gate.
+            await self._cycle_registry.append_artifact_refs(run_id, (contract_ref,))
+        except Exception:
+            logger.warning(
+                "Could not derive a contract from the manifest authored by run %s; the "
+                "framing gate will reject it with the deriver's own reason",
+                run_id,
+                exc_info=True,
+            )
+            return current
+
+        logger.info(
+            "Derived contract %s from the manifest authored by run %s "
+            "(manifest_hash=%s, %d fill files) — the run binds from here",
+            contract_ref,
+            run_id,
+            manifest.content_hash()[:12],
+            len(derived.fill_files),
+        )
+        return derived, manifest
+
+    async def _load_contract_for_run(self, cycle: Any, run: Any, ref: str | None = None) -> Any:
+        """Load the verification contract governing a run (SIP-0098 98.3).
 
         Reads the ``contract_ref`` artifact id from ``execution_overrides`` (a bare
         id or a single-element list) and parses it into a ``VerificationContract``.
+        ``ref`` overrides that lookup with a contract the run itself derived from an
+        authored manifest (#796) — the same artifact, arriving on a different rail.
         Returns the contract, or ``None`` when no ref is seeded (author mode) or the
         seeded ref is unreadable/unparseable. A seeded-but-broken ref is NOT silently
         treated as author mode — ``_is_bind_mode`` stays true, so the plan-validation
@@ -1685,7 +1788,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         (the stale-binding class, SIP §10)."""
         from squadops.cycles.verification_contract import VerificationContract
 
-        ref = cycle.execution_overrides.get("contract_ref")
+        ref = ref or cycle.execution_overrides.get("contract_ref")
         if not ref:
             return None
         ref_id = ref[0] if isinstance(ref, (list, tuple)) and ref else ref
@@ -1809,6 +1912,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         all_artifact_refs: list[str],
         stored_artifacts: list[tuple[str, ArtifactRef]],
         interface_manifest: Any = None,
+        run_derived_contract: Any = None,
     ) -> TaskEnvelope:
         """Build chain context inputs and return an enriched envelope.
 
@@ -1816,6 +1920,12 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         from the capability-owned ``ContextAssemblyContract``; this method owns
         only the deterministic mechanics — fragment order, the artifact I/O,
         and the merge (dispatch keys shadow plan-time keys of the same name).
+
+        ``run_derived_contract`` is #796's authored-mode path: a seeded contract exists
+        when the plan is generated and its inputs are injected there, but an authored one
+        does not exist yet, so its injection has to happen here — which is exactly what the
+        shadowing rule above was built for. Passed only when the contract was derived during
+        THIS run, so a seeded run is byte-identical.
         """
         contract = get_context_contract(envelope.task_type)
 
@@ -1823,6 +1933,15 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             "prior_outputs": prior_outputs,
             "artifact_refs": list(all_artifact_refs),
         }
+
+        # The same injector the plan-generation path calls, keyed by the same registry —
+        # one implementation of "who receives the contract's surfaces", two moments it can
+        # run. The two are mutually exclusive by construction: plan-time gets the contract
+        # when it is seeded, this gets it when it is authored.
+        if run_derived_contract is not None:
+            inject_contract_inputs(
+                extra_inputs, run_derived_contract, envelope.task_type, interface_manifest
+            )
 
         # Manifest seam surfaces (#588/pf-45/#659): presence-keyed instruction
         # sets (error contract, model surface, testid inventory) for task types
@@ -2873,6 +2992,12 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         interface_content: str | None = None
         parsed_plan: ImplementationPlan | None = None
         plan_artifact_seen = False  # #424: exists-but-unreadable ≠ absent
+        # #796: an authored cycle's contract was derived DURING this run, so it lives on the
+        # run's refs rather than in execution_overrides. Without this the bind-mode nets —
+        # frozen-artifact ownership, qa ownership, module existence, criteria binding — stay
+        # switched off for exactly the plans that need them most (V4 roll 1: four tasks
+        # claimed scaffold-frozen files and nothing caught it).
+        run_contract_ref: str | None = None
         contract = None  # set in bind mode below; feeds the soft-violation log
         for ref_id in tuple(run.artifact_refs or ()):
             try:
@@ -2924,6 +3049,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 ref.filename == SEEDED_MANIFEST_FILENAME or artifact_type == MANIFEST_ARTIFACT_TYPE
             ):
                 interface_content = content_bytes.decode(errors="replace")
+            elif artifact_type == CONTRACT_ARTIFACT_TYPE:
+                run_contract_ref = ref_id
 
         # #424: this seam's precondition is implementation_plan=true, so a
         # COMPLETED framing run with no plan artifact at all means plan
@@ -2958,7 +3085,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # a hard rejection, never a silent fall-through to author mode (§10). Errors join
         # the same returned list → identical system:plan_validation REJECTED recording.
         # Contract absent (author mode) → no-op = today's behavior.
-        if self._is_bind_mode(cycle):
+        if self._is_bind_mode(cycle) or run_contract_ref is not None:
             # #494/#496: the contract binds to a skeleton, so bind mode REQUIRES an
             # interface manifest — without one, no skeleton is expanded at the
             # implementation run and contract checks would measure from-scratch code
@@ -2979,7 +3106,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     "implementation would run unscaffolded while claiming contract "
                     "verification (#494, #496)"
                 )
-            contract = await self._load_contract_for_run(cycle, run)
+            contract = await self._load_contract_for_run(cycle, run, ref=run_contract_ref)
             if contract is None:
                 errors.append(
                     "verification_contract: contract_ref is seeded but the contract is "

--- a/src/squadops/cycles/contract_derivation.py
+++ b/src/squadops/cycles/contract_derivation.py
@@ -33,8 +33,8 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
     from squadops.ports.cycles.artifact_vault import ArtifactVaultPort
 
-#: The filename an operator-seeded interface manifest carries. Matched alongside the
-#: ``interface_manifest`` artifact type because both rails exist in the wild.
+#: The filename an interface manifest carries, whichever rail it arrived on. Matched
+#: alongside the ``interface_manifest`` artifact type because both exist in the wild.
 SEEDED_MANIFEST_FILENAME = "interface_manifest.yaml"
 
 #: Artifact type for a derived contract — deliberately the SAME type the manual
@@ -46,19 +46,40 @@ CONTRACT_FILENAME = "verification_contract.yaml"
 
 
 class ContractDerivationError(Exception):
-    """The seeded manifest could not produce a contract."""
+    """The manifest could not produce a contract."""
 
 
-def is_seeded_manifest(ref: Any) -> bool:
-    """True when an artifact ref is an operator-seeded interface manifest.
+def is_interface_manifest(ref: Any) -> bool:
+    """True when an artifact ref is an interface manifest — **whoever wrote it**.
 
-    One rule, shared by the executor's seeded-manifest lookup and the create path. A
-    second copy of this predicate is how the two ends start disagreeing about which
+    Provenance-neutral by design. It was ``is_seeded_manifest`` until #791 made a
+    squad-authored manifest possible, at which point a name asserting the operator put
+    it there described only half the callers. The predicate never checked provenance and
+    must not start: the create path, the executor's seeded lookup, and #796's
+    authored-manifest lookup all ask the same question — *is this the manifest?*
+
+    One rule, one copy. A second copy is how the ends start disagreeing about which
     artifact is the manifest.
     """
     return ref.filename == SEEDED_MANIFEST_FILENAME or (
         getattr(ref, "artifact_type", None) == "interface_manifest"
     )
+
+
+def find_interface_manifest(stored: Iterable[tuple[str, Any]]) -> str | None:
+    """The artifact id of the interface manifest among ``(artifact_id, ref)`` pairs.
+
+    The in-run counterpart of :func:`load_seeded_manifest_content`, which reads the
+    cycle's seeded rail. This one reads what the current run has produced so far, which
+    is where an authored manifest lives before any promotion or forwarding has happened
+    (#796). Last match wins: a re-rolled authoring stage stores a new manifest, and the
+    later one is the design in force.
+    """
+    found: str | None = None
+    for artifact_id, ref in stored:
+        if is_interface_manifest(ref):
+            found = artifact_id
+    return found
 
 
 async def load_seeded_manifest_content(
@@ -75,7 +96,7 @@ async def load_seeded_manifest_content(
             ref, content_bytes = await vault.retrieve(ref_id)
         except Exception:
             continue
-        if is_seeded_manifest(ref):
+        if is_interface_manifest(ref):
             return content_bytes.decode(errors="replace")
     return None
 
@@ -110,6 +131,7 @@ async def derive_and_store_contract(
     manifest_content: str,
     *,
     cycle_id: str | None = None,
+    run_id: str | None = None,
 ) -> str:
     """Derive the contract, store it as an artifact, return its id.
 
@@ -129,6 +151,10 @@ async def derive_and_store_contract(
         media_type="application/yaml",
         created_at=datetime.now(UTC),
         cycle_id=cycle_id,
+        # #796: an in-run derivation attaches to the run, so the contract is promoted
+        # with the rest of the framing output at gate approval and forwards to the
+        # implementation workload on the rails a seeded contract already uses.
+        run_id=run_id,
         metadata={"derived_from": "interface_manifest", "derivation": "scaffold_contract"},
     )
     stored = await vault.store(ref, content)

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -504,13 +504,19 @@ def _inject_rejection_context(
         inputs["rejected_plan_yaml"] = plan_yaml
 
 
-def _inject_contract_inputs(
+def inject_contract_inputs(
     inputs: dict,
     contract: VerificationContract | None,
     task_type: str,
     interface_manifest: InterfaceManifest | None = None,
 ) -> None:
-    """Bind-mode envelope inputs derived from the seeded contract (SIP-0098).
+    """Bind-mode envelope inputs derived from the contract (SIP-0098).
+
+    Public because it has two callers at two moments (#796): plan generation, when the
+    contract was seeded at cycle creation, and dispatch-time enrichment, when the squad
+    authored the manifest mid-run and the contract could not have existed any earlier. One
+    implementation of "who receives which contract surface" — a second copy is how the two
+    modes would start disagreeing about what an author is told.
 
     98.3 (§6.3): dev/qa proposers receive the criteria index so they *bind*
     (list ``criteria_refs``) rather than author covered-file criteria; only the
@@ -875,7 +881,7 @@ def generate_task_plan(
             )
             inputs["acceptance_criteria"] = acceptance
 
-        _inject_contract_inputs(inputs, contract, task_type, interface_manifest)
+        inject_contract_inputs(inputs, contract, task_type, interface_manifest)
         _inject_rejection_context(inputs, framing_rejection_context, task_type)
 
         envelope = TaskEnvelope(

--- a/tests/fixtures/authored_v4/README.md
+++ b/tests/fixtures/authored_v4/README.md
@@ -1,0 +1,16 @@
+# V4 roll 1 — the first squad-authored manifest, and the plan that went with it
+
+Captured verbatim from `cyc_9c8c98ea3171` / `run_7115f0f7082d` (group_run, squad `full`,
+2026-08-08), the first cycle run in authored mode after #791 landed the authoring stage.
+
+- `interface_manifest.yaml` — artifact `art_c9da5390c7ba`. Authored by dev on attempt 2 of 4
+  (attempt 1 failed the `parses` proof). Passes both gates.
+- `implementation_plan.yaml` — artifact `art_4ca2c9adfb34`. Authored in the same framing run,
+  with the manifest invisible to its authors: **zero of nine expected artifacts land on a
+  fill slot**, four claim scaffold-frozen files, five name paths the skeleton does not have.
+
+Kept as a matched pair because the pair is the evidence: a good design and a plan that could
+not be built from it, which is what #796 fixes. `test_authored_contract_binding.py` replays
+it — deriving the contract from the manifest must make the gate reject this exact plan.
+
+Not a golden. Nothing regenerates these; they are a record of one observed run.

--- a/tests/fixtures/authored_v4/implementation_plan.yaml
+++ b/tests/fixtures/authored_v4/implementation_plan.yaml
@@ -1,0 +1,316 @@
+version: 1
+project_id: group_run
+cycle_id: cyc_9c8c98ea3171
+prd_hash: e464ea4a0931c9107a532ffdb6e6839ea2cf6b40f9cbe5ce166cb578ff4b640e
+tasks:
+- task_index: 0
+  task_type: development.develop
+  role: dev
+  focus: backend pydantic models
+  description: Define Pydantic v2 models for the Run entity and all request/response
+    schemas. Includes RunCreate, RunResponse, RunDetail, JoinRequest, LeaveRequest,
+    and ErrorResponse. Run model carries id (UUID4), title, datetime (ISO8601 string),
+    location, optional distance/pace/notes, and a participants list. All required
+    fields enforced at schema level.
+  expected_artifacts:
+  - backend/models.py
+  acceptance_criteria:
+  - check: field_present
+    file: backend/models.py
+    class_name: RunCreate
+    fields:
+    - title
+    - datetime
+    - location
+  - check: field_present
+    file: backend/models.py
+    class_name: JoinRequest
+    fields:
+    - participant_name
+  - check: field_present
+    file: backend/models.py
+    class_name: LeaveRequest
+    fields:
+    - participant_name
+  - check: field_present
+    file: backend/models.py
+    class_name: RunResponse
+    fields:
+    - id
+    - title
+    - datetime
+    - location
+    - participants
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/models.py
+  depends_on: []
+- task_index: 1
+  task_type: development.develop
+  role: dev
+  focus: backend main entry point
+  description: Create the FastAPI application entry point with in-memory store (dict
+    of runs, nested participant lists), asyncio.Lock for concurrency safety on join/leave
+    mutations, CORS middleware (AllowAllOrigins as dev fallback), and router mounting.
+    Includes a lightweight in-memory store module inline or as a submodule with lock-guarded
+    mutation helpers.
+  expected_artifacts:
+  - backend/main.py
+  acceptance_criteria:
+  - check: import_present
+    file: backend/main.py
+    module: fastapi
+    symbol: FastAPI
+  - check: import_present
+    file: backend/main.py
+    module: asyncio
+  - check: import_present
+    file: backend/main.py
+    module: backend.routes.runs
+  - check: module_imports
+    severity: warning
+    file: backend/main.py
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/main.py
+  depends_on:
+  - 0
+- task_index: 2
+  task_type: development.develop
+  role: dev
+  focus: backend runs crud endpoints
+  description: Implement POST /runs (create with required-field validation → 201 or
+    422), GET /runs (list all runs with participant counts → 200, empty list when
+    none), and GET /runs/{id} (detail with participants → 200 or 404). All routes
+    use the in-memory store. Created runs appear immediately in the list.
+  expected_artifacts:
+  - backend/routes/runs.py
+  acceptance_criteria:
+  - check: endpoint_defined
+    file: backend/routes/runs.py
+    methods_paths:
+    - POST /runs
+    - GET /runs
+    - GET /runs/{id}
+  - check: import_present
+    file: backend/routes/runs.py
+    module: backend.models
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/routes/runs.py
+  depends_on:
+  - 0
+  - 1
+- task_index: 3
+  task_type: development.develop
+  role: dev
+  focus: backend join leave endpoints
+  description: Implement POST /runs/{id}/join (accepts participant_name, rejects empty
+    names with 400, rejects case-insensitive duplicates with 409, returns 404 for
+    missing run) and POST /runs/{id}/leave (removes participant, rejects empty names
+    with 400, returns 404 for missing run or missing participant). Both endpoints
+    use the asyncio.Lock from main.py to prevent race conditions during concurrent
+    mutations. Duplicate check normalizes via lower().strip() but preserves original
+    casing for display.
+  expected_artifacts:
+  - backend/routes/runs.py
+  acceptance_criteria:
+  - check: endpoint_defined
+    file: backend/routes/runs.py
+    methods_paths:
+    - POST /runs/{id}/join
+    - POST /runs/{id}/leave
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/routes/runs.py
+  depends_on:
+  - 0
+  - 1
+  - 2
+- task_index: 4
+  task_type: development.develop
+  role: dev
+  focus: frontend vite react setup
+  description: Scaffold the Vite + React frontend with HashRouter for client-side
+    routing. Configure Vite dev server proxy to forward /api/* to localhost:8000 (backend)
+    to bypass CORS. Set up the app shell with route definitions for /, /new, and /run/:id.
+    Import and render placeholder view components.
+  expected_artifacts:
+  - frontend/src/main.jsx
+  acceptance_criteria:
+  - check: import_present
+    file: frontend/src/main.jsx
+    module: react
+  - check: frontend_compiles
+    severity: warning
+    file: frontend/src/main.jsx
+  depends_on: []
+- task_index: 5
+  task_type: development.develop
+  role: dev
+  focus: frontend runlist view
+  description: Implement the RunList view component at frontend/src/components/RunList.jsx.
+    Fetches GET /runs (proxied via /api/runs), renders each run's title, datetime,
+    location, and participant count. Shows empty-state message when no runs exist.
+    Includes a link/button to navigate to the CreateRun view (/new) and to individual
+    run detail pages.
+  expected_artifacts:
+  - frontend/src/components/RunList.jsx
+  acceptance_criteria:
+  - check: frontend_compiles
+    severity: warning
+    file: frontend/src/components/RunList.jsx
+  depends_on:
+  - 2
+  - 4
+- task_index: 6
+  task_type: development.develop
+  role: dev
+  focus: frontend create run view
+  description: Implement the CreateRun view component at frontend/src/components/CreateRun.jsx.
+    Form with required fields (title, datetime, location) and optional fields (distance,
+    pace, notes). Client-side validation rejects empty required fields before submit.
+    On successful POST /runs, navigates to the run list view. Displays error message
+    on failure.
+  expected_artifacts:
+  - frontend/src/components/CreateRun.jsx
+  acceptance_criteria:
+  - check: frontend_compiles
+    severity: warning
+    file: frontend/src/components/CreateRun.jsx
+  depends_on:
+  - 2
+  - 4
+- task_index: 7
+  task_type: development.develop
+  role: dev
+  focus: frontend run detail view
+  description: Implement the RunDetail view component at frontend/src/components/RunDetail.jsx.
+    Displays run details and participant list. Includes join form (POST /runs/{id}/join
+    with participant_name) and leave form (POST /runs/{id}/leave with participant_name).
+    Shows error messages for duplicate name (409), empty name (400), and missing run/participant
+    (404). Re-fetches run data after mutations to keep state consistent.
+  expected_artifacts:
+  - frontend/src/components/RunDetail.jsx
+  acceptance_criteria:
+  - check: frontend_compiles
+    severity: warning
+    file: frontend/src/components/RunDetail.jsx
+  depends_on:
+  - 2
+  - 3
+  - 4
+- task_index: 8
+  task_type: development.develop
+  role: dev
+  focus: backend pytest suite
+  description: 'Write pytest test suite in backend/tests/test_runs.py using httpx/Starlette
+    TestClient. Covers: happy-path create + list + detail, required-field validation
+    rejection (422), join with valid name, duplicate-name rejection (409/400), case-insensitive
+    duplicate detection (Alice vs alice), empty name rejection, leave valid participant,
+    leave missing participant (404), missing run 404 on all endpoints, and empty-state
+    list returns empty array. Lightweight fixtures only — in-memory store resets per
+    test via fresh app client.'
+  expected_artifacts:
+  - backend/tests/test_runs.py
+  acceptance_criteria:
+  - check: function_defined
+    file: backend/tests/test_runs.py
+    name_prefix: test_
+    min_count: 6
+  - check: import_present
+    file: backend/tests/test_runs.py
+    module: backend.main
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/tests/test_runs.py
+  depends_on:
+  - 2
+  - 3
+- task_index: 9
+  task_type: qa.test
+  role: qa
+  focus: backend test suite verification
+  description: Verify that backend/tests/test_runs.py contains sufficient test functions
+    covering happy paths, required-field validation (422), case-insensitive duplicate
+    rejection (409/400), and 404 handling. Validates file compiles cleanly and imports
+    the FastAPI test client from backend.main.
+  expected_artifacts: []
+  acceptance_criteria:
+  - check: function_defined
+    file: backend/tests/test_runs.py
+    name_prefix: test_
+    min_count: 8
+  - check: import_present
+    file: backend/tests/test_runs.py
+    module: backend.main
+  - check: command_exit_zero
+    argv:
+    - python
+    - -m
+    - py_compile
+    - backend/tests/test_runs.py
+  depends_on:
+  - 8
+- task_index: 10
+  task_type: qa.test
+  role: qa
+  focus: frontend view compilation checks
+  description: Verify that the three required frontend views (RunList, CreateRun,
+    RunDetail) compile successfully without bundler-level errors. Ensures routing,
+    imports, and component structure are sound before manual FE/BE integration smoke
+    testing.
+  expected_artifacts: []
+  acceptance_criteria:
+  - check: frontend_compiles
+    file: frontend/src/components/RunList.jsx
+  - check: frontend_compiles
+    file: frontend/src/components/CreateRun.jsx
+  - check: frontend_compiles
+    file: frontend/src/components/RunDetail.jsx
+  depends_on:
+  - 5
+  - 6
+  - 7
+- task_index: 11
+  task_type: qa.test
+  role: qa
+  focus: qa_handoff documentation validation
+  description: 'Verify that qa_handoff.md contains all mandatory sections required
+    for cycle closure: start/run commands, verification steps, implemented scope,
+    and known limitations. Ensures the handoff artifact meets QA readiness standards.'
+  expected_artifacts: []
+  acceptance_criteria:
+  - check: regex_match
+    file: qa_handoff.md
+    pattern: '## How to (Start|Run|Verify|Test)'
+    count_min: 2
+  - check: regex_match
+    file: qa_handoff.md
+    pattern: '## Implemented Scope'
+    count_min: 1
+  - check: regex_match
+    file: qa_handoff.md
+    pattern: '## Known Limitations'
+    count_min: 1
+  depends_on: []
+summary:
+  total_dev_tasks: 9
+  total_qa_tasks: 3
+  total_tasks: 12
+  estimated_layers: []

--- a/tests/fixtures/authored_v4/interface_manifest.yaml
+++ b/tests/fixtures/authored_v4/interface_manifest.yaml
@@ -1,0 +1,79 @@
+version: 1
+kind: interface_manifest
+project_id: group_run
+source_prd: group_run_prd_v0.4.md
+stack: fullstack_fastapi_react
+scope: Core MVP for group run coordination (create, list, detail, join, leave) with in-memory persistence; excludes auth, persistent DB, external APIs, and Tier 2/3 expansions.
+entities:
+  - name: Run
+    fields:
+      - { name: id, type: string, required: true, generated: true }
+      - { name: title, type: string, required: true }
+      - { name: datetime, type: string, required: true }
+      - { name: location, type: string, required: true }
+      - { name: distance, type: string, required: false }
+      - { name: pace, type: string, required: false }
+      - { name: notes, type: string, required: false }
+      - { name: capacity, type: integer, required: false }
+      - name: participants
+        type: list
+        required: false
+        default: []
+api:
+  base_path: ""
+  request_shapes:
+    RunCreate:
+      required: [title, datetime, location]
+      optional: [distance, pace, notes, capacity]
+    ParticipantJoin:
+      required: [participant_name]
+      optional: []
+    ParticipantLeave:
+      required: [participant_name]
+      optional: []
+  endpoints:
+    - { method: POST, path: /runs, summary: create run, request: RunCreate, response: Run, success_status: 201, errors: [validation_error] }
+    - { method: GET, path: /runs, summary: list runs, response: "list[Run]" }
+    - { method: GET, path: "/runs/{run_id}", summary: run details, response: Run, errors: [run_not_found] }
+    - { method: POST, path: "/runs/{run_id}/join", summary: join run, request: ParticipantJoin, response: Run, errors: [run_not_found, validation_error, participant_already_joined, capacity_reached] }
+    - { method: POST, path: "/runs/{run_id}/leave", summary: leave run, request: ParticipantLeave, response: Run, errors: [run_not_found, validation_error, participant_not_found] }
+  error_contract:
+    shape: '{"detail": "string"}'
+    codes:
+      validation_error: { http: 422 }
+      run_not_found: { http: 404 }
+      participant_already_joined: { http: 400 }
+      participant_not_found: { http: 400 }
+      capacity_reached: { http: 400 }
+frontend:
+  framework: react_vite
+  routes:
+    - path: /
+      view: RunListView
+      purpose: list upcoming runs and link to create
+      testids: [runs-view, run-list, run-row, create-run-link]
+    - path: /new
+      view: CreateRunView
+      purpose: form to create a new run event
+      testids: [create-run-view, create-run-form, create-run-title, create-run-datetime, create-run-location, create-run-submit]
+    - path: /runs/:run_id
+      view: RunDetailView
+      purpose: view details, participants, join/leave forms
+      testids: [run-detail-view, run-title, run-datetime, run-location, participants-list, participant-name, join-run-form, join-run-submit, leave-run-form, leave-run-submit]
+persistence: in_memory
+decisions:
+  - id: participant-uniqueness
+    choice: case-insensitive comparison with original casing preserved for display
+    warrant: "PRD §5.4 / objective_frame.md Key Decisions — prevents 'Alex' vs 'alex' duplicates"
+  - id: leave-behavior
+    choice: return 400 when participant name not found on run
+    warrant: "technical_design.md Unknown Classification — explicit error preferred over silent no-op"
+  - id: datetime-sorting
+    choice: lexicographical sort on frontend, no backend parsing
+    warrant: "PRD §4.1 Expansion Tier 1 — best-effort lexical sort acceptable for MVP"
+  - id: capacity-enforcement
+    choice: capacity is optional; if set, joins are rejected when participant count reaches capacity
+    warrant: "PRD §4.1 Expansion Tier 1 — preferred if time permits"
+  - id: persistence-boundary
+    choice: data is lost on backend restart
+    warrant: "PRD §8 / objective_frame.md — in-memory only for 2-hour cycle, DB deferred"

--- a/tests/unit/capabilities/test_frozen_surface_proposer.py
+++ b/tests/unit/capabilities/test_frozen_surface_proposer.py
@@ -23,7 +23,7 @@ from squadops.capabilities.handlers.planning_tasks import (
 )
 from squadops.capabilities.scaffold import InterfaceManifest
 from squadops.capabilities.scaffold_contract import emit_contract_dict
-from squadops.cycles.task_plan import _inject_contract_inputs
+from squadops.cycles.task_plan import inject_contract_inputs
 from squadops.cycles.verification_contract import VerificationContract
 
 pytestmark = [pytest.mark.domain_capabilities]
@@ -46,7 +46,7 @@ def _contract() -> VerificationContract:
 
 def test_proposer_envelope_carries_the_frozen_surface():
     inputs: dict = {}
-    _inject_contract_inputs(inputs, _contract(), "development.propose_plan_tasks", _manifest())
+    inject_contract_inputs(inputs, _contract(), "development.propose_plan_tasks", _manifest())
 
     index = inputs["frozen_surface_index"]
     assert "RunEvent(id, title, datetime, location" in index
@@ -57,14 +57,14 @@ def test_proposer_envelope_carries_the_frozen_surface():
 def test_build_tasks_do_not_carry_it():
     """Only the proposers author checks; a develop task has no use for the index."""
     inputs: dict = {}
-    _inject_contract_inputs(inputs, _contract(), "development.develop", _manifest())
+    inject_contract_inputs(inputs, _contract(), "development.develop", _manifest())
 
     assert "frozen_surface_index" not in inputs
 
 
 def test_author_mode_injects_nothing():
     inputs: dict = {}
-    _inject_contract_inputs(inputs, None, "development.propose_plan_tasks", _manifest())
+    inject_contract_inputs(inputs, None, "development.propose_plan_tasks", _manifest())
 
     assert inputs == {}
 
@@ -72,7 +72,7 @@ def test_author_mode_injects_nothing():
 def test_bind_mode_without_a_manifest_still_injects_the_criteria_index():
     """The frozen surface is additive — losing it must not cost the bind index."""
     inputs: dict = {}
-    _inject_contract_inputs(inputs, _contract(), "development.propose_plan_tasks", None)
+    inject_contract_inputs(inputs, _contract(), "development.propose_plan_tasks", None)
 
     assert "frozen_surface_index" not in inputs
     assert inputs["contract_criteria_index"]
@@ -137,7 +137,7 @@ async def test_real_asset_renders_the_declarations_into_the_prompt():
     )
 
     inputs: dict = {}
-    _inject_contract_inputs(inputs, _contract(), "development.propose_plan_tasks", _manifest())
+    inject_contract_inputs(inputs, _contract(), "development.propose_plan_tasks", _manifest())
     section = await DevelopmentProposePlanTasksHandler()._frozen_surface_section(renderer, inputs)
 
     # the two facts pf-42 invented

--- a/tests/unit/cycles/test_authored_contract_binding.py
+++ b/tests/unit/cycles/test_authored_contract_binding.py
@@ -1,0 +1,371 @@
+"""An authored manifest binds its own run (#796).
+
+Until this landed, authored mode was a second pipeline: the manifest was written at framing
+step 4 and nothing carried it to the plan authors at steps 6–9, so every contract-gated net
+was switched off for exactly the cycles that needed them. V4 roll 1 measured it — zero of
+nine expected artifacts on a fill slot, four claiming scaffold-frozen files, and the gate
+blind to all of it.
+
+Bug classes guarded:
+
+- the derivation not happening, which is the whole defect;
+- it happening in **seeded** mode, which would re-derive over a pinned contract and move the
+  hash the 1.4/1.5 evidence was measured against — the control must not shift;
+- deriving twice in one run, which is a mid-run moving target (the #494 stale-binding class);
+- a derivation failure escaping as an exception instead of leaving the gate to reject with
+  the deriver's own reason;
+- the contract existing but reaching nobody — bound in the loop and invisible to the gate,
+  or injected into the wrong task types;
+- **the gate not engaging its bind-mode nets on a run-derived contract**, which is what let
+  V4's frozen claims through;
+- the implementation run not inheriting it, which would scaffold and then verify nothing;
+- an operator-supplied contract being overwritten by a derived one.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.cycles.contract_derivation import (
+    CONTRACT_ARTIFACT_TYPE,
+    derive_contract_bytes,
+    find_interface_manifest,
+)
+from squadops.cycles.implementation_plan import ImplementationPlan
+from squadops.cycles.manifest_authoring import MANIFEST_ARTIFACT_TYPE
+from squadops.cycles.verification_contract import VerificationContract
+from squadops.tasks.models import TaskEnvelope
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "authored_v4"
+_MANIFEST = (_FIXTURES / "interface_manifest.yaml").read_text(encoding="utf-8")
+_PLAN = (_FIXTURES / "implementation_plan.yaml").read_text(encoding="utf-8")
+
+
+def _ref(artifact_id: str, filename: str, artifact_type: str) -> Any:
+    ref = MagicMock()
+    ref.artifact_id = artifact_id
+    ref.filename = filename
+    ref.artifact_type = artifact_type
+    ref.created_at = datetime(2026, 8, 8, 12, 0, tzinfo=UTC)
+    return ref
+
+
+def _vault(contents: dict[str, tuple[Any, bytes]]) -> Any:
+    vault = AsyncMock()
+
+    async def _retrieve(artifact_id: str):
+        return contents[artifact_id]
+
+    async def _store(ref, content):
+        contents[ref.artifact_id] = (ref, content)
+        return ref
+
+    vault.retrieve.side_effect = _retrieve
+    vault.store.side_effect = _store
+    return vault
+
+
+def _cycle(**overrides: Any) -> Any:
+    cycle = MagicMock()
+    cycle.cycle_id = "cyc_test"
+    cycle.project_id = "group_run"
+    cycle.execution_overrides = dict(overrides)
+    return cycle
+
+
+def _executor_with_manifest() -> tuple[Any, list[tuple[str, Any]], Any]:
+    manifest_ref = _ref("art_manifest", "interface_manifest.yaml", MANIFEST_ARTIFACT_TYPE)
+    contents = {"art_manifest": (manifest_ref, _MANIFEST.encode())}
+    executor = DispatchedFlowExecutor(artifact_vault=_vault(contents))
+    executor._cycle_registry = AsyncMock()
+    return executor, [("art_manifest", manifest_ref)], contents
+
+
+# --------------------------------------------------------------------------- #
+# Deriving at manifest acceptance
+# --------------------------------------------------------------------------- #
+
+
+async def test_an_authored_manifest_produces_a_contract_bound_to_its_own_hash():
+    executor, stored, _ = _executor_with_manifest()
+
+    contract, manifest = await executor._bind_authored_manifest(
+        _cycle(), "run_1", stored, (None, None)
+    )
+
+    assert contract is not None
+    assert contract.skeleton.interface_manifest_hash == manifest.content_hash()
+    assert len(contract.fill_files) == 4
+    executor._cycle_registry.append_artifact_refs.assert_awaited_once()
+
+
+async def test_the_derived_contract_lands_on_the_runs_own_artifact_refs():
+    """A contract only the dispatch loop knew about would bind the plan and then vanish at
+    the gate, which reads the run's refs."""
+    executor, stored, _ = _executor_with_manifest()
+
+    await executor._bind_authored_manifest(_cycle(), "run_1", stored, (None, None))
+
+    run_id, refs = executor._cycle_registry.append_artifact_refs.await_args.args
+    assert run_id == "run_1"
+    assert len(refs) == 1
+
+
+async def test_a_seeded_cycle_derives_nothing():
+    """The control must not move. Re-deriving over a pinned contract would change the hash
+    every seeded comparison and replay is measured against."""
+    executor, stored, _ = _executor_with_manifest()
+
+    result = await executor._bind_authored_manifest(
+        _cycle(contract_ref="art_seeded"), "run_1", stored, (None, None)
+    )
+
+    assert result == (None, None)
+    executor._cycle_registry.append_artifact_refs.assert_not_awaited()
+
+
+async def test_the_contract_is_derived_once_per_run():
+    """A second derivation mid-run is a moving target — every check, probe and repair after
+    it would measure against a different hash than the ones before (#494)."""
+    executor, stored, _ = _executor_with_manifest()
+
+    first = await executor._bind_authored_manifest(_cycle(), "run_1", stored, (None, None))
+    second = await executor._bind_authored_manifest(_cycle(), "run_1", stored, first)
+
+    assert second is first
+    executor._cycle_registry.append_artifact_refs.assert_awaited_once()
+
+
+async def test_no_manifest_yet_is_not_an_error():
+    """Every task before the authoring stage runs through this seam."""
+    executor, _, _ = _executor_with_manifest()
+
+    assert await executor._bind_authored_manifest(_cycle(), "run_1", [], (None, None)) == (
+        None,
+        None,
+    )
+
+
+async def test_an_underivable_manifest_leaves_the_rejection_to_the_gate():
+    """Raising here would kill the run; the gate rejects with the deriver's own reason,
+    which M6 attributes to infrastructure rather than to the author."""
+    bad = _ref("art_bad", "interface_manifest.yaml", MANIFEST_ARTIFACT_TYPE)
+    executor = DispatchedFlowExecutor(
+        artifact_vault=_vault({"art_bad": (bad, b"::: not yaml :::")})
+    )
+    executor._cycle_registry = AsyncMock()
+
+    result = await executor._bind_authored_manifest(
+        _cycle(), "run_1", [("art_bad", bad)], (None, None)
+    )
+
+    assert result == (None, None)
+
+
+def test_the_latest_manifest_wins():
+    """A re-rolled authoring stage stores a second manifest; the later one is the design in
+    force, and binding the earlier would freeze a design the squad already replaced."""
+    first = _ref("art_1", "interface_manifest.yaml", MANIFEST_ARTIFACT_TYPE)
+    second = _ref("art_2", "interface_manifest.yaml", MANIFEST_ARTIFACT_TYPE)
+
+    assert find_interface_manifest([("art_1", first), ("art_2", second)]) == "art_2"
+
+
+# --------------------------------------------------------------------------- #
+# The contract reaching the plan authors
+# --------------------------------------------------------------------------- #
+
+
+def _envelope(task_type: str) -> TaskEnvelope:
+    return TaskEnvelope(
+        task_id="task-1",
+        agent_id="neo",
+        cycle_id="cyc_test",
+        pulse_id="pulse-1",
+        project_id="group_run",
+        task_type=task_type,
+        correlation_id="corr",
+        causation_id="cause",
+        trace_id="trace",
+        span_id="span",
+        inputs={},
+        metadata={"role": "dev"},
+    )
+
+
+async def _enriched(task_type: str, contract: Any, manifest: Any) -> dict[str, Any]:
+    executor = DispatchedFlowExecutor(artifact_vault=AsyncMock())
+    envelope = _envelope(task_type)
+    enriched = await executor._enrich_envelope(
+        envelope,
+        prior_outputs={},
+        all_artifact_refs=[],
+        stored_artifacts=[],
+        interface_manifest=manifest,
+        run_derived_contract=contract,
+    )
+    return enriched.inputs
+
+
+def _derived() -> tuple[Any, Any]:
+    manifest = InterfaceManifest.from_yaml(_MANIFEST)
+    return VerificationContract.from_yaml(derive_contract_bytes(_MANIFEST).decode()), manifest
+
+
+async def test_the_dev_proposer_is_told_what_the_squad_just_designed():
+    """The V4 defect, at the seam that caused it: the proposer had neither the criteria it
+    should bind nor the frozen files it must not claim, so it invented paths."""
+    contract, manifest = _derived()
+
+    inputs = await _enriched("development.propose_plan_tasks", contract, manifest)
+
+    assert "backend/routes.py" in inputs["contract_criteria_index"]
+    assert "backend/models.py" in inputs["frozen_surface_index"]
+
+
+async def test_a_run_without_a_derived_contract_is_byte_identical():
+    """Seeded runs pass None here — their inputs were injected at plan generation, and a
+    second injection would be the same fact arriving twice."""
+    inputs = await _enriched("development.propose_plan_tasks", None, None)
+
+    assert "contract_criteria_index" not in inputs
+    assert "frozen_surface_index" not in inputs
+
+
+async def test_injection_follows_the_registry_not_the_task_name():
+    """Who receives what stays the context-assembly registry's declaration — the merger
+    consumes proposer outputs and is deliberately excluded."""
+    contract, manifest = _derived()
+
+    inputs = await _enriched("governance.merge_plan", contract, manifest)
+
+    assert "contract_criteria_index" not in inputs
+
+
+# --------------------------------------------------------------------------- #
+# The gate — replaying V4 roll 1
+# --------------------------------------------------------------------------- #
+
+
+def _gate_executor(with_contract: bool) -> tuple[Any, Any, Any]:
+    plan_ref = _ref("art_plan", "implementation_plan.yaml", "control_implementation_plan")
+    manifest_ref = _ref("art_manifest", "interface_manifest.yaml", MANIFEST_ARTIFACT_TYPE)
+    contents = {
+        "art_plan": (plan_ref, _PLAN.encode()),
+        "art_manifest": (manifest_ref, _MANIFEST.encode()),
+    }
+    refs = ["art_plan", "art_manifest"]
+    if with_contract:
+        contract_ref = _ref("art_contract", "verification_contract.yaml", CONTRACT_ARTIFACT_TYPE)
+        contents["art_contract"] = (contract_ref, derive_contract_bytes(_MANIFEST))
+        refs.append("art_contract")
+
+    executor = DispatchedFlowExecutor(artifact_vault=_vault(contents))
+    run = MagicMock()
+    run.run_id = "run_1"
+    run.artifact_refs = refs
+    cycle = _cycle()
+    cycle.applied_defaults = {"implementation_plan": True}
+    cycle.resolved_config.return_value = {"implementation_plan": True}
+    return executor, run, cycle
+
+
+async def test_the_gate_rejects_v4s_plan_once_the_contract_is_derived():
+    """The replay. This exact plan reached a human-review gate unchallenged; with the
+    contract derived from the manifest beside it, the frozen claims and the impossible
+    import are all provable before anything is built."""
+    executor, run, cycle = _gate_executor(with_contract=True)
+
+    errors = await executor._reject_invalid_plan_before_workload_gate(
+        run, cycle, "progress_plan_review"
+    )
+
+    claimed_frozen = [e for e in errors if "which is frozen" in e]
+    assert len(claimed_frozen) == 3, errors
+    assert any("backend/models.py" in e for e in claimed_frozen)
+    assert any("backend/main.py" in e for e in claimed_frozen)
+    assert any("frontend/src/main.jsx" in e for e in claimed_frozen)
+    # The impossible import the plan wrote against its own invented path.
+    assert any("backend.routes.runs" in e for e in errors)
+    # And every criterion aimed at a frozen file, which could never have executed.
+    assert any("can never pass" in e for e in errors)
+
+
+async def test_without_the_derived_contract_the_gate_sees_none_of_it():
+    """The state V4 ran in, pinned so the regression is visible if the wiring is ever cut."""
+    executor, run, cycle = _gate_executor(with_contract=False)
+
+    errors = await executor._reject_invalid_plan_before_workload_gate(
+        run, cycle, "progress_plan_review"
+    )
+
+    assert not [e for e in errors if "which is frozen" in e]
+    assert not [e for e in errors if "backend.routes.runs" in e]
+
+
+def test_the_v4_plan_is_the_fixture_the_bug_report_described():
+    """Guards the fixture itself: if it is ever replaced with a clean plan, the two tests
+    above would pass while proving nothing."""
+    manifest = InterfaceManifest.from_yaml(_MANIFEST)
+    plan = ImplementationPlan.from_yaml(_PLAN)
+    from squadops.capabilities.scaffold import fill_slot_paths
+
+    slots = set(fill_slot_paths(manifest))
+    claimed = {a for t in plan.tasks for a in t.expected_artifacts}
+
+    assert claimed, "the fixture plan claims no artifacts at all"
+    assert not (claimed & slots), "the fixture plan is supposed to hit ZERO fill slots"
+
+
+# --------------------------------------------------------------------------- #
+# Forwarding to the implementation run
+# --------------------------------------------------------------------------- #
+
+
+async def _forwarded(cycle: Any, *promoted: Any) -> dict[str, Any]:
+    vault = AsyncMock()
+    vault.list_artifacts.return_value = list(promoted)
+    executor = DispatchedFlowExecutor(artifact_vault=vault)
+    completed = MagicMock()
+    completed.run_id = "run_framing"
+    completed.workload_type = "framing"
+    return await executor._build_forwarding_overrides(cycle, completed)
+
+
+async def test_the_implementation_run_inherits_the_derived_contract():
+    """Scaffolding without the contract would build the skeleton and verify nothing."""
+    overrides = await _forwarded(
+        _cycle(),
+        _ref("art_plan", "implementation_plan.yaml", "control_implementation_plan"),
+        _ref("art_manifest", "interface_manifest.yaml", MANIFEST_ARTIFACT_TYPE),
+        _ref("art_contract", "verification_contract.yaml", CONTRACT_ARTIFACT_TYPE),
+    )
+
+    assert overrides["contract_ref"] == "art_contract"
+    assert overrides["plan_artifact_refs"] == ["art_plan", "art_manifest"]
+
+
+async def test_an_operator_supplied_contract_is_never_overwritten():
+    """Same precedence every other forwarded key has: the operator's value wins."""
+    overrides = await _forwarded(
+        _cycle(contract_ref="art_operator"),
+        _ref("art_contract", "verification_contract.yaml", CONTRACT_ARTIFACT_TYPE),
+    )
+
+    assert overrides["contract_ref"] == "art_operator"
+
+
+async def test_a_framing_run_that_derived_nothing_forwards_no_contract_ref():
+    """A non-scaffolded cycle must stay exactly as it is."""
+    overrides = await _forwarded(_cycle(), _ref("art_doc", "planning_artifact.md", "document"))
+
+    assert "contract_ref" not in overrides

--- a/tests/unit/cycles/test_contract_derivation.py
+++ b/tests/unit/cycles/test_contract_derivation.py
@@ -24,7 +24,7 @@ from squadops.cycles.contract_derivation import (
     ContractDerivationError,
     derive_and_store_contract,
     derive_contract_bytes,
-    is_seeded_manifest,
+    is_interface_manifest,
     load_seeded_manifest_content,
 )
 
@@ -72,7 +72,7 @@ def _manifest_text() -> str:
 )
 def test_seeded_manifest_selection_matches_both_rails(filename, artifact_type, expected):
     """Both rails exist in the wild; a rule that knows only one silently picks nothing."""
-    assert is_seeded_manifest(_Ref(filename, artifact_type)) is expected
+    assert is_interface_manifest(_Ref(filename, artifact_type)) is expected
 
 
 async def test_derived_contract_equals_what_the_expander_emits():


### PR DESCRIPTION
Derive and pin the verification contract the moment the authoring stage lands a manifest,
mid-framing, so every task dispatched after that point binds to the design the squad just
wrote. Found by **V4 roll 1** — the first cycle ever run in authored mode.

## What V4 measured

The manifest was good: both gates clean, contract derives, 19-file skeleton, 4 fill slots.
The plan authored beside it, in the same framing run:

```
FILL SLOTS : backend/routes.py, frontend/src/views/{CreateRunView,RunDetailView,RunListView}.jsx

task 0  FROZEN     backend/models.py          task 5  INVENTED  frontend/src/components/RunList.jsx
task 1  FROZEN     backend/main.py            task 6  INVENTED  frontend/src/components/CreateRun.jsx
task 2  INVENTED   backend/routes/runs.py     task 7  INVENTED  frontend/src/components/RunDetail.jsx
task 3  INVENTED   backend/routes/runs.py     task 8  INVENTED  backend/tests/test_runs.py
task 4  FROZEN     frontend/src/main.jsx
```

**Zero of nine on a fill slot.** The recorded rejection was #673's dual-claim rule catching
tasks 2 and 3 — the one contract-independent net that happened to fire. Everything else was
invisible, because every contract-gated net keys on `_is_bind_mode`, which an authored cycle
(no seeded `contract_ref`) never satisfies. Authored mode was a second pipeline: one with
frozen-artifact ownership, qa ownership, module existence and criteria binding all switched
off.

## The fix

The manifest is a design artifact; the instant it exists it is fixed. So the cycle stops
being author mode right there and becomes what a seeded cycle already is — a manifest, and
the contract derived from it. Four seams, each on rails that already existed:

1. **Derive at acceptance** (`_bind_authored_manifest`) and append the contract to the run's
   own artifact refs, so it is listed in `artifacts list`, seen by the gate, promoted at
   approval, and forwarded.
2. **Inject at dispatch-time enrichment** — `_enrich_envelope`, the declared single
   composition point (#663), whose "dispatch keys shadow plan-time keys" rule was built for
   exactly this. A seeded contract exists at plan generation and is injected there; an
   authored one cannot exist that early. Same injector, same registry, two moments —
   mutually exclusive by construction.
3. **The gate recognises a run-derived contract**, so its bind-mode nets engage.
4. **Forwarding sets `contract_ref`** for the implementation run; an operator-supplied ref
   always wins, matching every other forwarded key.

This is SIP-0103 §3.5 made true rather than asserted — *"authored mode is a mode of manifest
provenance, not a second pipeline"* — and §5a's third containment bound: at freeze the
manifest hash-freezes and the contract derives, after which determinism is identical to
seeded mode by construction.

**Seeded mode is untouched by construction**, which matters because it is the control: the
derivation no-ops when a `contract_ref` exists, and enrichment injects only when handed a
contract derived during *this* run. Pinned by test.

## Verification

The V4 manifest and its plan are committed as a matched fixture pair (`tests/fixtures/authored_v4/`,
with a README recording their provenance) and the suite **replays the observed failure**:
with the contract derived, the gate rejects that exact plan on three frozen claims plus the
impossible `backend.routes.runs` import — ten errors where author mode raised one.

16 new tests covering derivation (once per run, never in seeded mode, latest manifest wins,
underivable manifests left to the gate), injection (right task types, byte-identical without
a derived contract), the gate replay, and forwarding. Full regression green: 7,000 unit,
6,614 regression.

## Two names corrected in passing

- `is_seeded_manifest` → `is_interface_manifest`. It never checked provenance, and after #791
  half its callers ask about an authored manifest.
- `_inject_contract_inputs` → `inject_contract_inputs`, having gained a second legitimate
  caller; a cross-module import of a private name is the smell that says promote it.

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
