### PR TITLE
test(llm): LLM port conformance suite — one contract, adapter-parameterized (SIP Atlas P3)

### DIFF
--- a/tests/unit/llm/conformance.py
+++ b/tests/unit/llm/conformance.py
@@ -1,0 +1,223 @@
+"""Shared machinery for the LLM port conformance suite (SIP-Atlas-Provider-Adapter P3).
+
+Not a test module — imported by ``test_llm_port_conformance.py``.
+
+**What this is.** One behavioral suite that every ``LLMPort`` adapter must pass.
+With a single live provider it *characterizes* the current contract; it becomes a
+conformance suite the moment a second adapter is registered. The 1.5 stabilization
+plan asked for exactly this distinction and was explicit about the trap:
+
+    it must declare semantic capabilities ... as required/optional/extension per
+    provider — **not** enshrine Ollama transport behavior as the contract.
+
+So the assertions live in the shared suite and speak only the *port's* vocabulary.
+Everything provider-shaped — routes, payload keys, streaming framing — is confined
+to an :class:`AdapterCase`'s dialect handler. Adding an adapter is one registry
+entry, never a new test.
+
+**Why the wire is mocked at the transport, not at the adapter.** The neighbouring
+Ollama tests patch ``_get_client``, which is fine for testing *that* adapter and
+useless for a shared suite: it presumes a private method every adapter must happen
+to have. ``httpx.MockTransport`` intercepts one layer lower, so the adapter's real
+URL construction, payload shaping, response parsing, and error mapping all execute.
+That is the code conformance is actually about.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import httpx
+
+from adapters.llm.ollama import OllamaAdapter
+from squadops.ports.llm.provider import LLMPort
+
+# A dialect handler answers a request the way its provider's server would.
+DialectHandler = Callable[[httpx.Request], httpx.Response]
+
+
+@dataclass(frozen=True)
+class AdapterCase:
+    """One provider under conformance test.
+
+    ``build`` returns a fresh adapter; ``ok`` answers requests the way a healthy
+    server of that dialect would. Registering a second provider means adding one
+    of these — no shared assertion changes.
+    """
+
+    name: str
+    build: Callable[[], LLMPort]
+    ok: DialectHandler
+
+    def __str__(self) -> str:  # pytest id
+        return self.name
+
+
+class Wire:
+    """The live backend for a test, swappable mid-test.
+
+    Indirection rather than re-patching, because adapters cache their client:
+    once ``_get_client`` has built one, entering a second ``patch`` block does
+    nothing and a "now the backend fails" assertion silently keeps talking to the
+    healthy transport. Mutation testing caught exactly that — a cache-preservation
+    test that passed against an adapter which emptied its cache on failure.
+
+    One transport for the whole test, dispatching to whatever handler is current,
+    is immune to that regardless of how an adapter manages connections.
+    """
+
+    def __init__(self, handler: DialectHandler) -> None:
+        self._handler = handler
+
+    def set(self, handler: DialectHandler) -> None:
+        """Swap the backend behavior. Takes effect on the next request."""
+        self._handler = handler
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        return self._handler(request)
+
+
+@contextmanager
+def wire(handler: DialectHandler) -> Iterator[Wire]:
+    """Route every ``httpx.AsyncClient`` built inside the block through ``handler``.
+
+    Patching the class rather than the adapter keeps this provider-agnostic: any
+    httpx-based adapter is intercepted without the suite knowing how it stores or
+    creates its client. Yields the :class:`Wire` so a test can change backend
+    behavior part-way through.
+    """
+    live = Wire(handler)
+    real = httpx.AsyncClient
+
+    def factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(live)
+        return real(*args, **kwargs)
+
+    with patch("httpx.AsyncClient", factory):
+        yield live
+
+
+def raises(exc: Exception) -> DialectHandler:
+    """A dialect handler whose transport fails — connect errors, timeouts."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise exc
+
+    return handler
+
+
+def status(code: int, body: dict | None = None) -> DialectHandler:
+    """A dialect handler that answers every route with one status."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(code, json=body if body is not None else {})
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Ollama dialect
+#
+# Everything Ollama-specific in the suite lives here: route paths, payload keys,
+# NDJSON stream framing, nanosecond durations. The shared assertions never see
+# any of it.
+# ---------------------------------------------------------------------------
+
+OLLAMA_MODELS = ["qwen2.5:7b", "llama3.2"]
+OLLAMA_CONTENT = "the assembled answer"
+
+# Split so a streaming assertion proves reassembly rather than a single passthrough.
+# The last part rides the terminal `done` frame, which is how Ollama actually
+# behaves and is load-bearing for the test: with an empty done-frame an adapter
+# that ignores its content passes anyway. Mutation testing found that hole.
+OLLAMA_STREAM_PARTS = ["the ", "assembled "]
+OLLAMA_STREAM_FINAL_PART = "answer"
+
+# 12 tokens over 2s. Chosen so tokens/sec is exactly 6.0 — an adapter that divides
+# by the wrong unit lands orders of magnitude away, not fractionally.
+_EVAL_COUNT = 12
+_EVAL_DURATION_NS = 2_000_000_000
+_PROMPT_EVAL_COUNT = 5
+
+
+def _ollama_usage() -> dict:
+    return {
+        "prompt_eval_count": _PROMPT_EVAL_COUNT,
+        "eval_count": _EVAL_COUNT,
+        "eval_duration": _EVAL_DURATION_NS,
+    }
+
+
+def ollama_ok(request: httpx.Request) -> httpx.Response:
+    """Answer as a healthy Ollama server."""
+    path = request.url.path
+
+    if path == "/api/tags":
+        return httpx.Response(200, json={"models": [{"name": m} for m in OLLAMA_MODELS]})
+
+    if path == "/api/generate":
+        return httpx.Response(
+            200,
+            json={
+                "response": OLLAMA_CONTENT,
+                "model": json.loads(request.content)["model"],
+                **_ollama_usage(),
+            },
+        )
+
+    if path == "/api/chat":
+        streaming = json.loads(request.content).get("stream", False)
+        if not streaming:
+            return httpx.Response(
+                200,
+                json={
+                    "message": {"role": "assistant", "content": OLLAMA_CONTENT},
+                    **_ollama_usage(),
+                },
+            )
+        # NDJSON: content frames, then a terminal `done` frame carrying both the
+        # final content fragment and the usage totals.
+        lines = [
+            json.dumps({"message": {"role": "assistant", "content": part}, "done": False})
+            for part in OLLAMA_STREAM_PARTS
+        ]
+        lines.append(
+            json.dumps(
+                {
+                    "message": {"role": "assistant", "content": OLLAMA_STREAM_FINAL_PART},
+                    "done": True,
+                    **_ollama_usage(),
+                }
+            )
+        )
+        return httpx.Response(200, content=("\n".join(lines) + "\n").encode())
+
+    return httpx.Response(404, json={"error": f"unexpected route {path}"})
+
+
+# ---------------------------------------------------------------------------
+# The registry — one entry per adapter under conformance.
+#
+# Atlas (P4) and vLLM (P6) each land here as one AdapterCase with their own
+# dialect handler. No shared assertion changes.
+# ---------------------------------------------------------------------------
+
+ADAPTER_CASES: list[AdapterCase] = [
+    AdapterCase(
+        name="ollama",
+        build=lambda: OllamaAdapter(default_model="qwen2.5:7b", timeout_seconds=5.0),
+        ok=ollama_ok,
+    ),
+]
+
+# Expected tokens/sec for a case's `ok` handler. Keyed by adapter name because the
+# rate is computed from provider-supplied timings, which are dialect-shaped.
+EXPECTED_TOKENS_PER_SECOND = {"ollama": 6.0}
+EXPECTED_COMPLETION_TOKENS = {"ollama": _EVAL_COUNT}
+EXPECTED_PROMPT_TOKENS = {"ollama": _PROMPT_EVAL_COUNT}
+EXPECTED_MODELS = {"ollama": OLLAMA_MODELS}
+EXPECTED_CONTENT = {"ollama": OLLAMA_CONTENT}

--- a/tests/unit/llm/test_llm_port_conformance.py
+++ b/tests/unit/llm/test_llm_port_conformance.py
@@ -1,0 +1,281 @@
+"""LLM port conformance suite (SIP-Atlas-Provider-Adapter P3).
+
+Every registered adapter runs the same assertions. Shared machinery, the dialect
+handlers, and the registry live in ``conformance.py``; see its docstring for why
+the wire is mocked at the transport rather than at the adapter.
+
+**These tests speak only the port's vocabulary.** No assertion below names a route,
+a payload key, or a streaming format. When Atlas registers (P4), it either satisfies
+these or it is not a conforming adapter — which is the whole point: the contract is
+decided here, once, rather than rediscovered per provider.
+
+Dimensions not yet expressible are deliberately absent rather than stubbed:
+``capabilities()`` honesty and listing-vs-absence need P0/P1's port surface. They
+join this file when that surface lands.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from squadops.llm.exceptions import (
+    LLMConnectionError,
+    LLMModelNotFoundError,
+    LLMTimeoutError,
+)
+from squadops.llm.models import ChatMessage, LLMRequest
+from tests.unit.llm.conformance import (
+    ADAPTER_CASES,
+    EXPECTED_COMPLETION_TOKENS,
+    EXPECTED_CONTENT,
+    EXPECTED_MODELS,
+    EXPECTED_PROMPT_TOKENS,
+    EXPECTED_TOKENS_PER_SECOND,
+    raises,
+    status,
+    wire,
+)
+
+pytestmark = pytest.mark.parametrize("case", ADAPTER_CASES, ids=str)
+
+
+def _messages() -> list[ChatMessage]:
+    return [
+        ChatMessage(role="system", content="be terse"),
+        ChatMessage(role="user", content="the question"),
+    ]
+
+
+class TestGeneration:
+    """The port's two generation entry points return the declared shape."""
+
+    async def test_generate_returns_text_and_echoes_resolved_model(self, case):
+        """A response attributed to the wrong model makes per-model cost and
+        throughput accounting silently wrong — every downstream number is keyed
+        on it."""
+        with wire(case.ok):
+            response = await case.build().generate(LLMRequest(prompt="the question"))
+
+        assert response.text == EXPECTED_CONTENT[case.name]
+        assert response.model == "qwen2.5:7b"
+
+    async def test_chat_returns_assistant_role_and_content(self, case):
+        with wire(case.ok):
+            message = await case.build().chat(_messages())
+
+        assert message.role == "assistant"
+        assert message.content == EXPECTED_CONTENT[case.name]
+
+    async def test_chat_stream_reassembles_to_the_same_content(self, case):
+        """Streaming is a transport detail; callers must not be able to tell.
+        An adapter that drops the first or last frame — an off-by-one in its
+        chunk loop — passes a "yields something" check and fails this one."""
+        chunks: list[str] = []
+        with wire(case.ok):
+            async for chunk in case.build().chat_stream(_messages()):
+                chunks.append(chunk)
+
+        assert len(chunks) > 1, "single chunk cannot demonstrate reassembly"
+        assert "".join(chunks) == EXPECTED_CONTENT[case.name]
+
+    async def test_chat_stream_with_usage_returns_whole_message_not_chunks(self, case):
+        """The streaming-for-liveness path: stream the wire to hold the
+        connection open on long generations, hand back one assembled message."""
+        with wire(case.ok):
+            message = await case.build().chat_stream_with_usage(_messages())
+
+        assert message.role == "assistant"
+        assert message.content == EXPECTED_CONTENT[case.name]
+
+
+class TestUsageAccounting:
+    """Token accounting feeds LangFuse cost tracking and the Atlas A/B. Partial
+    or zero-filled counts are worse than absent ones — they look like data."""
+
+    @pytest.mark.parametrize("via", ["chat", "stream_with_usage"])
+    async def test_counts_are_present_and_internally_consistent(self, case, via):
+        with wire(case.ok):
+            adapter = case.build()
+            message = await (
+                adapter.chat(_messages())
+                if via == "chat"
+                else adapter.chat_stream_with_usage(_messages())
+            )
+
+        assert message.prompt_tokens == EXPECTED_PROMPT_TOKENS[case.name]
+        assert message.completion_tokens == EXPECTED_COMPLETION_TOKENS[case.name]
+        assert message.total_tokens == message.prompt_tokens + message.completion_tokens
+
+    @pytest.mark.parametrize("via", ["chat", "stream_with_usage"])
+    async def test_tokens_per_second_is_a_rate_not_a_count(self, case, via):
+        """Throughput is the Atlas migration's decision number. A unit error in
+        the duration conversion — nanoseconds read as seconds — yields a value
+        off by a factor of 1e9 while still being a plausible-looking float."""
+        with wire(case.ok):
+            adapter = case.build()
+            message = await (
+                adapter.chat(_messages())
+                if via == "chat"
+                else adapter.chat_stream_with_usage(_messages())
+            )
+
+        assert message.tokens_per_second == EXPECTED_TOKENS_PER_SECOND[case.name]
+
+    async def test_generate_reports_the_same_usage_as_chat(self, case):
+        """Two entry points, one accounting contract. An adapter that populates
+        usage on chat and forgets it on generate produces a silently partial
+        cost picture that depends on which handler ran."""
+        with wire(case.ok):
+            response = await case.build().generate(LLMRequest(prompt="the question"))
+
+        assert response.prompt_tokens == EXPECTED_PROMPT_TOKENS[case.name]
+        assert response.completion_tokens == EXPECTED_COMPLETION_TOKENS[case.name]
+        assert response.total_tokens == response.prompt_tokens + response.completion_tokens
+
+    async def test_usage_absent_from_the_wire_is_none_never_zero(self, case):
+        """A provider that omits usage must yield None, not 0. Zero is a lie the
+        cost dashboards cannot distinguish from a free call, and it silently
+        drags any average toward zero."""
+        with wire(status(200, {"message": {"role": "assistant", "content": "hi"}})):
+            message = await case.build().chat(_messages())
+
+        assert message.prompt_tokens is None
+        assert message.completion_tokens is None
+        assert message.total_tokens is None
+        assert message.tokens_per_second is None
+
+
+class TestModelListing:
+    """``list_models`` is sync and cached; ``refresh_models`` performs the I/O."""
+
+    async def test_refresh_populates_the_cache_read_by_list_models(self, case):
+        with wire(case.ok):
+            adapter = case.build()
+            assert adapter.list_models() == [], "cache must start empty, not pre-populated"
+            refreshed = await adapter.refresh_models()
+
+        assert refreshed == EXPECTED_MODELS[case.name]
+        assert adapter.list_models() == EXPECTED_MODELS[case.name]
+
+    async def test_list_models_performs_no_network_io(self, case):
+        """The port documents this as a MUST NOT and nothing tested it. A sync
+        method that reaches the network blocks the event loop for every caller on
+        that thread — an outage-shaped bug, not a slow one.
+
+        Enforced by making the transport fatal *while the adapter's client is
+        already live*: any request from here on raises."""
+        with wire(case.ok) as live:
+            adapter = case.build()
+            await adapter.refresh_models()
+
+            live.set(raises(AssertionError("list_models() performed network I/O")))
+            assert adapter.list_models() == EXPECTED_MODELS[case.name]
+
+    async def test_list_models_returns_a_copy(self, case):
+        """Handing out the internal list lets any caller corrupt every other
+        caller's view by mutating it."""
+        with wire(case.ok):
+            adapter = case.build()
+            await adapter.refresh_models()
+
+        adapter.list_models().append("not-a-real-model")
+        assert adapter.list_models() == EXPECTED_MODELS[case.name]
+
+    async def test_refresh_failure_preserves_the_last_known_list(self, case):
+        """A transient backend blip must not empty the cache — a downstream
+        availability preflight would read the emptied list as "no models present"
+        and block a valid cycle on missing evidence."""
+        with wire(case.ok) as live:
+            adapter = case.build()
+            await adapter.refresh_models()
+
+            live.set(raises(httpx.ConnectError("backend down")))
+            assert await adapter.refresh_models() == EXPECTED_MODELS[case.name]
+            assert adapter.list_models() == EXPECTED_MODELS[case.name]
+
+
+class TestErrorTranslation:
+    """Failure-locus classification (#568) reads these types to decide whether a
+    failure is infrastructure or a work-product defect. An adapter that leaks a
+    raw transport exception silently reclassifies an outage as a squad mistake
+    and burns a correction attempt on it."""
+
+    @pytest.mark.parametrize(
+        ("wire_failure", "expected"),
+        [
+            (raises(httpx.ConnectError("refused")), LLMConnectionError),
+            (raises(httpx.ReadTimeout("too slow")), LLMTimeoutError),
+            (status(404, {"error": "model not found"}), LLMModelNotFoundError),
+            (status(500, {"error": "internal"}), LLMConnectionError),
+        ],
+        ids=["connect-refused", "timeout", "unknown-model", "server-error"],
+    )
+    async def test_chat_translates_transport_failures(self, case, wire_failure, expected):
+        with wire(wire_failure), pytest.raises(expected):
+            await case.build().chat(_messages())
+
+    @pytest.mark.parametrize(
+        ("wire_failure", "expected"),
+        [
+            (raises(httpx.ConnectError("refused")), LLMConnectionError),
+            (raises(httpx.ReadTimeout("too slow")), LLMTimeoutError),
+            (status(404, {"error": "model not found"}), LLMModelNotFoundError),
+        ],
+        ids=["connect-refused", "timeout", "unknown-model"],
+    )
+    async def test_generate_translates_transport_failures(self, case, wire_failure, expected):
+        with wire(wire_failure), pytest.raises(expected):
+            await case.build().generate(LLMRequest(prompt="the question"))
+
+    @pytest.mark.parametrize(
+        ("wire_failure", "expected"),
+        [
+            (raises(httpx.ConnectError("refused")), LLMConnectionError),
+            (raises(httpx.ReadTimeout("too slow")), LLMTimeoutError),
+        ],
+        ids=["connect-refused", "timeout"],
+    )
+    async def test_streaming_translates_transport_failures(self, case, wire_failure, expected):
+        """Streaming has its own error path — a failure mid-iteration must
+        surface as the same typed exception, not escape as a raw httpx error
+        from inside the async generator."""
+        with wire(wire_failure), pytest.raises(expected):
+            async for _ in case.build().chat_stream(_messages()):
+                pass
+
+
+class TestHealth:
+    """Health drives operational probes; it reports, it never raises."""
+
+    async def test_health_reports_healthy_against_a_live_backend(self, case):
+        with wire(case.ok):
+            result = await case.build().health()
+
+        assert result["healthy"] is True
+
+    async def test_health_reports_unhealthy_instead_of_raising(self, case):
+        """A probe that raises takes down the caller it was meant to inform."""
+        with wire(raises(httpx.ConnectError("refused"))):
+            result = await case.build().health()
+
+        assert result["healthy"] is False
+
+
+class TestPortSurface:
+    """Contract properties every adapter carries."""
+
+    async def test_default_model_is_the_configured_one(self, case):
+        """Handlers resolve their model as `agent_model or port.default_model`,
+        so a placeholder here silently becomes the model that actually runs."""
+        assert case.build().default_model == "qwen2.5:7b"
+
+    async def test_request_model_overrides_the_adapter_default(self, case):
+        """Per-agent model pinning (squad profiles) rides this override. If it
+        is ignored, every agent quietly runs the adapter default instead."""
+        with wire(case.ok):
+            response = await case.build().generate(
+                LLMRequest(prompt="the question", model="llama3.2")
+            )
+
+        assert response.model == "llama3.2"


### PR DESCRIPTION
Implements **P3** of `sips/proposed/SIP-Atlas-Provider-Adapter.md` (filed in #794).

Test-only. No production file is touched, so this is inert against the 1.6 lane by construction.

## What this is

One behavioral suite every `LLMPort` adapter must pass. With a single live provider it **characterizes** the current contract; it becomes a conformance suite the moment a second adapter registers. The 1.5 stabilization plan asked for exactly this, and was explicit about the trap:

> it must declare semantic capabilities … as required/optional/extension per provider — **not** enshrine Ollama transport behavior as the contract.

So **no assertion names a route, a payload key, or a streaming format.** Everything provider-shaped is confined to an `AdapterCase`'s dialect handler. Atlas (P4) and vLLM (P6) each land as one registry entry — no shared assertion changes.

## Why the wire is mocked at the transport

The neighbouring Ollama tests patch `_get_client`. That's fine for testing *that* adapter and useless for a shared suite: it presumes a private method every adapter must happen to have. `httpx.MockTransport` intercepts a layer lower, so the adapter's real URL construction, payload shaping, response parsing, and error mapping all execute — which is the code conformance is actually about.

## Coverage — 27 tests, 6 dimensions

Generation (incl. stream reassembly) · usage accounting · model listing · error translation · health · port surface.

Assertions nothing covered before:

| Assertion | Bug it catches |
|---|---|
| `list_models()` performs no network I/O | the port documents this as a MUST NOT and nothing tested it — a sync method reaching the network blocks the event loop for every caller on that thread |
| usage absent from the wire is `None`, never `0` | zero is indistinguishable from a free call and silently drags every average toward zero |
| `tokens_per_second` is a rate, not a count | a ns/s unit error yields a value off by 1e9 that still looks like a plausible float |
| refresh failure preserves the last known list | a transient blip would otherwise read downstream as "no models present" and block a valid cycle |
| streaming errors translate to typed exceptions | locus classification (#568) reads these types; a raw httpx error escaping reclassifies an outage as a squad mistake and burns a correction attempt |

## Validated by mutation, not by passing

A new suite that goes green first try is unverified, not good. Eight deliberate defects were injected into `OllamaAdapter`; **each fails the suite**:

`ns→s unit error in t/s` · `404 no longer → ModelNotFound` · `list_models leaks the internal list` · `refresh failure empties the cache` · `zero-filled usage` · `dropped final stream frame` · `ignored request model override` · `untranslated stream errors`

**That pass caught two vacuous tests of my own**, both now fixed:

1. **Adapters cache their httpx client**, so entering a second `patch` block had no effect — "now the backend fails" assertions kept talking to the healthy transport. A cache-preservation test passed against an adapter that emptied its cache on failure. Replaced with one transport dispatching to a swappable handler (`Wire`), immune to how any adapter manages connections.
2. **The streaming fixture's terminal `done` frame carried empty content**, so an adapter ignoring done-frame content passed regardless. The final fragment now rides that frame — which is also how Ollama actually behaves.

## Deliberately absent

`capabilities()` honesty and listing-vs-absence need P0/P1's port surface. They join this file when it lands, rather than being stubbed now.

## Verification

- Regression suite: **6624 passed, 2 skipped**
- `ruff check` / `ruff format`: clean · `lint_test_quality.py`: clean
- `tests/unit/llm/` is already in `REGRESSION_DIRS` — no allowlist change

Refs #313, #301 — neither is closed by this PR; P3 adds no production behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuQJ2ZGMRD9rMfFJCQoofD
