### PR TITLE
feat(llm): declare capabilities on the port; model listing speaks ModelInfo (SIP Atlas P0 + P1 listing)

### DIFF
--- a/adapters/llm/ollama.py
+++ b/adapters/llm/ollama.py
@@ -18,8 +18,8 @@ from squadops.llm.exceptions import (
     LLMModelNotFoundError,
     LLMTimeoutError,
 )
-from squadops.llm.models import ChatMessage, LLMRequest, LLMResponse
-from squadops.ports.llm.provider import LLMPort
+from squadops.llm.models import ChatMessage, LLMRequest, LLMResponse, ModelInfo
+from squadops.ports.llm.provider import LLMCapability, LLMPort
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +74,23 @@ class OllamaAdapter(LLMPort):
     def default_model(self) -> str:
         """Return the default model name."""
         return self._default_model
+
+    def capabilities(self) -> dict[str, bool]:
+        """Declare what this adapter actually does (#572's rule, see the port).
+
+        ``thinking_tokens`` is False deliberately, and it is not a statement
+        about the models: qwen3-family models emit ``message.thinking`` through
+        Ollama by default, but this adapter never sends a ``think`` parameter and
+        reads only ``message.content``. Reasoning tokens are paid for and cannot
+        be separated from content here (#410). Declaring True would tell a caller
+        it could split them.
+        """
+        return {
+            LLMCapability.MODEL_LISTING: True,
+            LLMCapability.MODEL_MANAGEMENT: True,
+            LLMCapability.STREAMING_USAGE: True,
+            LLMCapability.THINKING_TOKENS: False,
+        }
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create async HTTP client."""
@@ -444,14 +461,14 @@ class OllamaAdapter(LLMPort):
                 "error": str(e),
             }
 
-    async def pull_model(self, model_name: str) -> dict[str, Any]:
+    async def pull_model(self, model_name: str) -> None:
         """Pull a model from the Ollama registry.
+
+        Returns None per the port contract: a provider response body handed back
+        through the port would make every caller Ollama-shaped (#313).
 
         Args:
             model_name: Model name to pull (e.g. "qwen2.5:7b")
-
-        Returns:
-            Ollama response dict with pull status
         """
         client = await self._get_client()
         try:
@@ -461,7 +478,6 @@ class OllamaAdapter(LLMPort):
                 timeout=600.0,
             )
             response.raise_for_status()
-            return response.json()
         except httpx.TimeoutException as e:
             raise LLMTimeoutError(f"Model pull timed out for '{model_name}'") from e
         except httpx.ConnectError as e:
@@ -471,14 +487,11 @@ class OllamaAdapter(LLMPort):
                 raise LLMModelNotFoundError(f"Model '{model_name}' not found in registry") from e
             raise LLMConnectionError(f"Ollama pull failed: {e}") from e
 
-    async def delete_model(self, model_name: str) -> dict[str, Any]:
+    async def delete_model(self, model_name: str) -> None:
         """Delete a locally pulled model.
 
         Args:
             model_name: Model name to delete
-
-        Returns:
-            Empty dict on success
         """
         client = await self._get_client()
         try:
@@ -488,7 +501,6 @@ class OllamaAdapter(LLMPort):
                 json={"name": model_name},
             )
             response.raise_for_status()
-            return {}
         except httpx.ConnectError as e:
             raise LLMConnectionError(f"Failed to connect to Ollama at {self._base_url}") from e
         except httpx.HTTPStatusError as e:
@@ -496,20 +508,43 @@ class OllamaAdapter(LLMPort):
                 raise LLMModelNotFoundError(f"Model '{model_name}' not found locally") from e
             raise LLMConnectionError(f"Ollama delete failed: {e}") from e
 
-    async def list_pulled_models(self) -> list[dict[str, Any]]:
-        """List pulled models with full metadata (size, modified_at).
+    async def list_available_models(self) -> list[ModelInfo]:
+        """List pulled models with metadata (#313).
 
-        Returns:
-            List of model dicts from Ollama /api/tags
+        Replaces the former ``list_pulled_models``, whose raw ``/api/tags`` dicts
+        were the coupling: every caller had to know Ollama's payload keys, so
+        reaching for model metadata made the caller Ollama-specific by
+        construction. ``ModelInfo`` is the port's vocabulary; translating to it
+        is this adapter's job.
         """
         client = await self._get_client()
         try:
             response = await client.get("/api/tags", timeout=self._model_list_timeout)
             response.raise_for_status()
             data = response.json()
-            return data.get("models", [])
         except httpx.ConnectError as e:
             raise LLMConnectionError(f"Failed to connect to Ollama at {self._base_url}") from e
+
+        return [
+            ModelInfo(name=name, size_bytes=m.get("size"), modified_at=m.get("modified_at"))
+            for m in data.get("models", [])
+            if (name := m.get("name"))
+        ]
+
+    async def list_pulled_models(self) -> list[dict[str, Any]]:
+        """DEPRECATED (#313) — use :meth:`list_available_models`.
+
+        Kept solely for ``api/routes/cycles/cycles.py``'s model-availability
+        preflight, not migrated here because that file is under active edit by
+        the 1.6 line. **Delete this with that migration.** It exists so the
+        removal cannot land as an AttributeError that the preflight's broad
+        ``except Exception`` swallows into a silent warn-and-allow — a false
+        green rather than a visible break.
+        """
+        return [
+            {"name": m.name, "size": m.size_bytes, "modified_at": m.modified_at}
+            for m in await self.list_available_models()
+        ]
 
     async def close(self) -> None:
         """Close the HTTP client."""

--- a/src/squadops/api/routes/cycles/models.py
+++ b/src/squadops/api/routes/cycles/models.py
@@ -21,6 +21,7 @@ from squadops.api.routes.cycles.dtos import (
     PullStatusResponse,
 )
 from squadops.auth.models import Scope
+from squadops.ports.llm.provider import LLMCapability
 
 logger = logging.getLogger(__name__)
 
@@ -45,9 +46,18 @@ async def list_models():
     return JSONResponse(content=specs, headers=_CACHE_HEADERS)
 
 
-def _get_ollama_adapter():
-    """Get the OllamaAdapter from DI, raising 503 if not configured."""
-    from adapters.llm.ollama import OllamaAdapter
+def _llm_port_supporting(capability: str):
+    """Get the LLM port from DI, requiring a declared capability.
+
+    Asks the port what it can do rather than which adapter class it is. The
+    former ``isinstance(port, OllamaAdapter)`` check made every one of these
+    routes 503 under any other provider — including one that supports the
+    operation perfectly well (#313, #559 applied to adapter identity).
+
+    The 503 stays: it is the honest answer for a provider that genuinely cannot
+    manage models. What changes is that the reason is a declared capability
+    rather than a vendor name.
+    """
     from squadops.api.runtime.deps import get_llm_port
 
     try:
@@ -55,8 +65,11 @@ def _get_ollama_adapter():
     except RuntimeError:
         raise HTTPException(status_code=503, detail="LLM port not configured") from None
 
-    if not isinstance(port, OllamaAdapter):
-        raise HTTPException(status_code=503, detail="Model management requires Ollama adapter")
+    if not port.supports(capability):
+        raise HTTPException(
+            status_code=503,
+            detail=f"The configured LLM provider does not support '{capability}'",
+        )
     return port
 
 
@@ -65,22 +78,22 @@ async def list_pulled_models():
     """List locally pulled models with active profile cross-reference."""
     from squadops.llm.model_registry import MODEL_SPECS
 
-    adapter = _get_ollama_adapter()
+    port = _llm_port_supporting(LLMCapability.MODEL_LISTING)
 
     try:
-        raw_models = await adapter.list_pulled_models()
+        available = await port.list_available_models()
     except Exception as e:
-        raise HTTPException(status_code=503, detail=f"Ollama unreachable: {e}") from e
+        raise HTTPException(status_code=503, detail=f"LLM provider unreachable: {e}") from e
 
     # Cross-reference against active squad profile
     active_agents: dict[str, list[str]] = {}  # model -> [agent_id, ...]
     try:
         from squadops.api.runtime.deps import get_squad_profile_port
 
-        port = get_squad_profile_port()
-        active_id = await port.get_active_profile_id()
+        profile_port = get_squad_profile_port()
+        active_id = await profile_port.get_active_profile_id()
         if active_id:
-            profile = await port.get_profile(active_id)
+            profile = await profile_port.get_profile(active_id)
             for agent in profile.agents:
                 if agent.model:
                     active_agents.setdefault(agent.model, []).append(agent.agent_id)
@@ -88,14 +101,14 @@ async def list_pulled_models():
         logger.debug("Could not resolve active profile for model cross-ref")
 
     results = []
-    for m in raw_models:
-        name = m.get("name", "")
+    for model in available:
+        name = model.name
         spec = MODEL_SPECS.get(name)
         results.append(
             PulledModelResponse(
                 name=name,
-                size_bytes=m.get("size"),
-                modified_at=m.get("modified_at"),
+                size_bytes=model.size_bytes,
+                modified_at=model.modified_at,
                 in_active_profile=name in active_agents,
                 used_by_active_profile=active_agents.get(name, []),
                 registry_spec=(
@@ -121,12 +134,12 @@ async def pull_model(body: PullModelRequest):
         fail_pull_job,
     )
 
-    adapter = _get_ollama_adapter()
+    port = _llm_port_supporting(LLMCapability.MODEL_MANAGEMENT)
     job = create_pull_job(body.name)
 
     async def _do_pull():
         try:
-            await adapter.pull_model(body.name)
+            await port.pull_model(body.name)
             complete_pull_job(job.pull_id)
         except Exception as e:
             fail_pull_job(job.pull_id, str(e))
@@ -162,10 +175,10 @@ async def delete_model(model_name: str):
     """Delete a locally pulled model."""
     from squadops.llm.exceptions import LLMConnectionError, LLMModelNotFoundError
 
-    adapter = _get_ollama_adapter()
+    port = _llm_port_supporting(LLMCapability.MODEL_MANAGEMENT)
 
     try:
-        await adapter.delete_model(model_name)
+        await port.delete_model(model_name)
         return {"status": "deleted", "model_name": model_name}
     except LLMModelNotFoundError as e:
         raise HTTPException(

--- a/src/squadops/llm/models.py
+++ b/src/squadops/llm/models.py
@@ -38,6 +38,21 @@ class LLMResponse:
 
 
 @dataclass(frozen=True)
+class ModelInfo:
+    """A model the provider can serve, with whatever metadata it supplies.
+
+    Returned by ``LLMPort.list_available_models()``. The optional fields are
+    genuinely optional: a provider that cannot report size or modification time
+    leaves them ``None`` rather than fabricating a value, so a caller can tell
+    "not reported" from "zero" (#572's honesty rule applied to metadata).
+    """
+
+    name: str
+    size_bytes: int | None = None
+    modified_at: str | None = None
+
+
+@dataclass(frozen=True)
 class ChatMessage:
     """Chat message for conversational LLM interactions.
 

--- a/src/squadops/ports/llm/provider.py
+++ b/src/squadops/ports/llm/provider.py
@@ -8,13 +8,30 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from typing import Any
 
-from squadops.llm.models import ChatMessage, LLMRequest, LLMResponse
+from squadops.llm.models import ChatMessage, LLMRequest, LLMResponse, ModelInfo
+
+
+class LLMCapability:
+    """Capability names declared by :meth:`LLMPort.capabilities`.
+
+    Constants, not bare strings, so a caller cannot ask about a capability that
+    does not exist by mistyping it (#559's strings-boundary rule).
+    """
+
+    MODEL_LISTING = "model_listing"
+    MODEL_MANAGEMENT = "model_management"
+    STREAMING_USAGE = "streaming_usage"
+    THINKING_TOKENS = "thinking_tokens"
 
 
 class LLMPort(ABC):
     """Port interface for LLM providers.
 
     Adapters must implement generate, chat, list_models, refresh_models, and health.
+
+    Optional surfaces — model listing and model management — are declared through
+    :meth:`capabilities` and default to unsupported, so callers ask the port what
+    it can do rather than inspecting which adapter class they were handed.
     """
 
     @property
@@ -146,3 +163,82 @@ class LLMPort(ABC):
             Health status dictionary with at least {"healthy": bool}
         """
         ...
+
+    # -------------------------------------------------------------------
+    # Optional surfaces — declared, never inferred
+    # -------------------------------------------------------------------
+
+    def capabilities(self) -> dict[str, bool]:
+        """Return which optional surfaces this provider actually supports.
+
+        Every flag is a contract with future callers: it must describe what the
+        provider *does*, not what its backend could be configured to do. A flag
+        that overstates the implementation is worse than a missing feature — the
+        caller builds on it and fails at runtime instead of at the boundary
+        (#572, the same rule the queue port carries).
+
+        Keys are :class:`LLMCapability` constants:
+
+        - ``model_listing``: :meth:`list_available_models` is implemented.
+        - ``model_management``: :meth:`pull_model` / :meth:`delete_model` are
+          implemented. Hosted providers generally cannot manage local weights.
+        - ``streaming_usage``: :meth:`chat_stream_with_usage` reports real token
+          counts rather than falling back to :meth:`chat`.
+        - ``thinking_tokens``: reasoning tokens are reported separately from
+          content. False here does not mean the model does not think — only that
+          this adapter cannot distinguish the two (#410).
+
+        Defaults to all-False: an adapter that declares nothing is treated as
+        supporting nothing. Failing closed keeps a silent omission from
+        presenting as a working feature.
+        """
+        return {
+            LLMCapability.MODEL_LISTING: False,
+            LLMCapability.MODEL_MANAGEMENT: False,
+            LLMCapability.STREAMING_USAGE: False,
+            LLMCapability.THINKING_TOKENS: False,
+        }
+
+    def supports(self, capability: str) -> bool:
+        """Whether ``capability`` is declared. Unknown names are False."""
+        return self.capabilities().get(capability, False)
+
+    async def list_available_models(self) -> list[ModelInfo]:
+        """List models the provider can serve, with metadata where available.
+
+        Distinct from :meth:`refresh_models`, which maintains the name-only cache
+        read by :meth:`list_models`. This is the metadata-bearing listing used by
+        operator surfaces that show size and modification time.
+
+        Raises:
+            NotImplementedError: when ``model_listing`` is not declared. Raising
+                rather than returning ``[]`` keeps "cannot enumerate" distinct
+                from "enumerated nothing" — an empty list would read downstream
+                as *no models present* and block work that should proceed.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support model listing; "
+            f"capabilities()['{LLMCapability.MODEL_LISTING}'] is False."
+        )
+
+    async def pull_model(self, model_name: str) -> None:
+        """Fetch a model into the provider's local store.
+
+        Raises:
+            NotImplementedError: when ``model_management`` is not declared.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support model management; "
+            f"capabilities()['{LLMCapability.MODEL_MANAGEMENT}'] is False."
+        )
+
+    async def delete_model(self, model_name: str) -> None:
+        """Remove a model from the provider's local store.
+
+        Raises:
+            NotImplementedError: when ``model_management`` is not declared.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support model management; "
+            f"capabilities()['{LLMCapability.MODEL_MANAGEMENT}'] is False."
+        )

--- a/tests/unit/api/test_models_api.py
+++ b/tests/unit/api/test_models_api.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from squadops.api.routes.cycles.models import router
 from squadops.cycles.models import AgentProfileEntry, SquadProfile
+from squadops.llm.models import ModelInfo
 
 NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
 
@@ -18,18 +19,36 @@ pytestmark = [pytest.mark.domain_api]
 
 
 @pytest.fixture()
-def mock_ollama():
-    from adapters.llm.ollama import OllamaAdapter
+def mock_llm_port():
+    """A provider declaring the capabilities these routes need.
 
-    mock = AsyncMock(spec=OllamaAdapter)
-    mock.list_pulled_models.return_value = [
-        {"name": "qwen2.5:7b", "size": 4_000_000_000, "modified_at": "2026-01-01T00:00:00Z"},
-        {"name": "llama3.2:latest", "size": 2_000_000_000, "modified_at": "2026-01-02T00:00:00Z"},
+    No longer an ``OllamaAdapter`` and no ``__class__`` fixup: the routes ask the
+    port what it supports instead of what class it is (#313), so any conforming
+    provider drives them.
+    """
+    from squadops.ports.llm.provider import LLMPort
+
+    mock = AsyncMock(spec=LLMPort)
+    mock.supports.return_value = True
+    mock.list_available_models.return_value = [
+        ModelInfo(name="qwen2.5:7b", size_bytes=4_000_000_000, modified_at="2026-01-01T00:00:00Z"),
+        ModelInfo(
+            name="llama3.2:latest", size_bytes=2_000_000_000, modified_at="2026-01-02T00:00:00Z"
+        ),
     ]
-    mock.pull_model.return_value = {"status": "success"}
-    mock.delete_model.return_value = {}
-    # Ensure isinstance check passes
-    mock.__class__ = OllamaAdapter
+    mock.pull_model.return_value = None
+    mock.delete_model.return_value = None
+    return mock
+
+
+@pytest.fixture()
+def incapable_llm_port():
+    """A provider that declares neither listing nor management — a hosted
+    backend serving models it cannot enumerate or pull."""
+    from squadops.ports.llm.provider import LLMPort
+
+    mock = AsyncMock(spec=LLMPort)
+    mock.supports.return_value = False
     return mock
 
 
@@ -48,15 +67,24 @@ def mock_squad_profile():
     return mock
 
 
-@pytest.fixture()
-def client(mock_ollama, mock_squad_profile, monkeypatch):
+def _client_for(port, mock_squad_profile, monkeypatch):
     app = FastAPI()
     app.include_router(router)
     import squadops.api.runtime.deps as deps_mod
 
-    monkeypatch.setattr(deps_mod, "_llm_port", mock_ollama)
+    monkeypatch.setattr(deps_mod, "_llm_port", port)
     monkeypatch.setattr(deps_mod, "_squad_profile", mock_squad_profile)
     return TestClient(app)
+
+
+@pytest.fixture()
+def client(mock_llm_port, mock_squad_profile, monkeypatch):
+    return _client_for(mock_llm_port, mock_squad_profile, monkeypatch)
+
+
+@pytest.fixture()
+def incapable_client(incapable_llm_port, mock_squad_profile, monkeypatch):
+    return _client_for(incapable_llm_port, mock_squad_profile, monkeypatch)
 
 
 class TestListPulledModels:
@@ -78,8 +106,8 @@ class TestListPulledModels:
         assert llama["in_active_profile"] is False
         assert llama["used_by_active_profile"] == []
 
-    def test_ollama_unreachable(self, client, mock_ollama):
-        mock_ollama.list_pulled_models.side_effect = Exception("Connection refused")
+    def test_provider_unreachable(self, client, mock_llm_port):
+        mock_llm_port.list_available_models.side_effect = Exception("Connection refused")
         resp = client.get("/api/v1/models/pulled")
         assert resp.status_code == 503
 
@@ -122,16 +150,47 @@ class TestDeleteModel:
         assert resp.status_code == 200
         assert resp.json()["status"] == "deleted"
 
-    def test_not_found(self, client, mock_ollama):
+    def test_not_found(self, client, mock_llm_port):
         from squadops.llm.exceptions import LLMModelNotFoundError
 
-        mock_ollama.delete_model.side_effect = LLMModelNotFoundError("not found")
+        mock_llm_port.delete_model.side_effect = LLMModelNotFoundError("not found")
         resp = client.delete("/api/v1/models/nonexistent:latest")
         assert resp.status_code == 404
 
-    def test_ollama_unreachable(self, client, mock_ollama):
+    def test_provider_unreachable(self, client, mock_llm_port):
         from squadops.llm.exceptions import LLMConnectionError
 
-        mock_ollama.delete_model.side_effect = LLMConnectionError("refused")
+        mock_llm_port.delete_model.side_effect = LLMConnectionError("refused")
         resp = client.delete("/api/v1/models/qwen2.5:7b")
         assert resp.status_code == 503
+
+
+class TestUndeclaredCapabilityIsRefused:
+    """#313: a provider that cannot manage models gets a 503 naming the missing
+    capability — not a vendor name, and never a silent success.
+
+    The 503 itself is unchanged behavior; what changed is that a provider which
+    *can* do the work is no longer refused for having the wrong class.
+    """
+
+    @pytest.mark.parametrize(
+        ("method", "path"),
+        [
+            ("get", "/api/v1/models/pulled"),
+            ("post", "/api/v1/models/pull"),
+            ("delete", "/api/v1/models/qwen2.5:7b"),
+        ],
+    )
+    def test_routes_503_when_capability_undeclared(self, incapable_client, method, path):
+        kwargs = {"json": {"name": "qwen2.5:7b"}} if method == "post" else {}
+        resp = getattr(incapable_client, method)(path, **kwargs)
+
+        assert resp.status_code == 503
+        assert "does not support" in resp.json()["detail"]
+
+    def test_registry_route_still_works_without_any_provider_capability(self, incapable_client):
+        """The code-defined registry is not a provider surface; it must not be
+        collateral damage of an incapable backend."""
+        resp = incapable_client.get("/api/v1/models")
+        assert resp.status_code == 200
+        assert len(resp.json()) > 0

--- a/tests/unit/llm/conformance.py
+++ b/tests/unit/llm/conformance.py
@@ -45,13 +45,15 @@ class AdapterCase:
     """One provider under conformance test.
 
     ``build`` returns a fresh adapter; ``ok`` answers requests the way a healthy
-    server of that dialect would. Registering a second provider means adding one
-    of these — no shared assertion changes.
+    server of that dialect would; ``nameless_model`` answers a listing request
+    with an entry carrying no usable name. Registering a second provider means
+    adding one of these — no shared assertion changes.
     """
 
     name: str
     build: Callable[[], LLMPort]
     ok: DialectHandler
+    nameless_model: DialectHandler
 
     def __str__(self) -> str:  # pytest id
         return self.name
@@ -159,6 +161,9 @@ def ollama_ok(request: httpx.Request) -> httpx.Response:
     if path == "/api/tags":
         return httpx.Response(200, json={"models": [{"name": m} for m in OLLAMA_MODELS]})
 
+    if path in ("/api/pull", "/api/delete"):
+        return httpx.Response(200, json={"status": "success"})
+
     if path == "/api/generate":
         return httpx.Response(
             200,
@@ -199,6 +204,17 @@ def ollama_ok(request: httpx.Request) -> httpx.Response:
     return httpx.Response(404, json={"error": f"unexpected route {path}"})
 
 
+def ollama_nameless_model(request: httpx.Request) -> httpx.Response:
+    """A listing whose single entry has no usable name.
+
+    Real servers do return junk rows; the port contract is that an unnamed model
+    is dropped rather than surfaced as an empty-named one.
+    """
+    if request.url.path == "/api/tags":
+        return httpx.Response(200, json={"models": [{"size": 42, "modified_at": "2026-01-01"}]})
+    return ollama_ok(request)
+
+
 # ---------------------------------------------------------------------------
 # The registry — one entry per adapter under conformance.
 #
@@ -211,6 +227,7 @@ ADAPTER_CASES: list[AdapterCase] = [
         name="ollama",
         build=lambda: OllamaAdapter(default_model="qwen2.5:7b", timeout_seconds=5.0),
         ok=ollama_ok,
+        nameless_model=ollama_nameless_model,
     ),
 ]
 

--- a/tests/unit/llm/test_llm_port_conformance.py
+++ b/tests/unit/llm/test_llm_port_conformance.py
@@ -24,7 +24,8 @@ from squadops.llm.exceptions import (
     LLMModelNotFoundError,
     LLMTimeoutError,
 )
-from squadops.llm.models import ChatMessage, LLMRequest
+from squadops.llm.models import ChatMessage, LLMRequest, ModelInfo
+from squadops.ports.llm.provider import LLMCapability
 from tests.unit.llm.conformance import (
     ADAPTER_CASES,
     EXPECTED_COMPLETION_TOKENS,
@@ -243,6 +244,95 @@ class TestErrorTranslation:
         with wire(wire_failure), pytest.raises(expected):
             async for _ in case.build().chat_stream(_messages()):
                 pass
+
+
+class TestCapabilityHonesty:
+    """The load-bearing dimension: declarations must match reality.
+
+    Without this, ``capabilities()`` is aspirational — a flag nobody verified,
+    which is strictly worse than no flag at all because callers build on it
+    (#572, the defect this pattern was copied from).
+    """
+
+    async def test_declared_capabilities_are_exactly_the_known_names(self, case):
+        """An adapter inventing or misspelling a key makes `supports()` answer
+        False for a feature it actually has — a silent capability outage."""
+        declared = set(case.build().capabilities())
+        assert declared == {
+            LLMCapability.MODEL_LISTING,
+            LLMCapability.MODEL_MANAGEMENT,
+            LLMCapability.STREAMING_USAGE,
+            LLMCapability.THINKING_TOKENS,
+        }
+
+    async def test_supports_is_false_for_an_undeclared_capability(self, case):
+        assert case.build().supports("no_such_capability") is False
+
+    async def test_model_listing_declaration_matches_behavior(self, case):
+        """Declared True ⇒ it works. Declared False ⇒ it raises rather than
+        returning [], because an empty list reads downstream as *no models
+        present* and would block work that should proceed."""
+        adapter = case.build()
+        with wire(case.ok):
+            if adapter.supports(LLMCapability.MODEL_LISTING):
+                assert [m.name for m in await adapter.list_available_models()] == EXPECTED_MODELS[
+                    case.name
+                ]
+            else:
+                with pytest.raises(NotImplementedError):
+                    await adapter.list_available_models()
+
+    async def test_model_management_declaration_matches_behavior(self, case):
+        adapter = case.build()
+        with wire(case.ok):
+            if adapter.supports(LLMCapability.MODEL_MANAGEMENT):
+                assert await adapter.pull_model("qwen2.5:7b") is None
+                assert await adapter.delete_model("qwen2.5:7b") is None
+            else:
+                with pytest.raises(NotImplementedError):
+                    await adapter.pull_model("qwen2.5:7b")
+                with pytest.raises(NotImplementedError):
+                    await adapter.delete_model("qwen2.5:7b")
+
+    async def test_streaming_usage_declaration_matches_behavior(self, case):
+        """Declared True means real counts, not the port's chat() fallback —
+        which returns a valid message carrying no streaming usage at all."""
+        adapter = case.build()
+        if not adapter.supports(LLMCapability.STREAMING_USAGE):
+            pytest.skip("streaming_usage not declared")
+
+        with wire(case.ok):
+            message = await adapter.chat_stream_with_usage(_messages())
+
+        assert message.completion_tokens == EXPECTED_COMPLETION_TOKENS[case.name]
+
+
+class TestModelInfoShape:
+    """``list_available_models`` speaks the port's vocabulary, not a dialect's."""
+
+    async def test_listing_returns_model_info_with_names_populated(self, case):
+        if not case.build().supports(LLMCapability.MODEL_LISTING):
+            pytest.skip("model_listing not declared")
+
+        with wire(case.ok):
+            models = await case.build().list_available_models()
+
+        assert [m.name for m in models] == EXPECTED_MODELS[case.name]
+        assert all(isinstance(m, ModelInfo) for m in models)
+
+    async def test_unnamed_entries_are_dropped_not_surfaced_as_blanks(self, case):
+        """A nameless model is unusable — surfacing it as `name=""` puts an
+        un-selectable row in the operator's model list and, worse, lets an
+        availability check match the empty string."""
+        if not case.build().supports(LLMCapability.MODEL_LISTING):
+            pytest.skip("model_listing not declared")
+
+        with wire(case.ok) as live:
+            adapter = case.build()
+            live.set(case.nameless_model)
+            models = await adapter.list_available_models()
+
+        assert models == []
 
 
 class TestHealth:

--- a/tests/unit/llm/test_ollama_pull_delete.py
+++ b/tests/unit/llm/test_ollama_pull_delete.py
@@ -37,8 +37,10 @@ class TestPullModel:
         mock_client.post.return_value = _mock_response(200, {"status": "success"})
         adapter._client = mock_client
 
-        result = await adapter.pull_model("qwen2.5:7b")
-        assert result == {"status": "success"}
+        # None, not the provider's response body: a payload returned through the
+        # port would make every caller Ollama-shaped (#313). The wire assertion
+        # below is what this test is actually for.
+        assert await adapter.pull_model("qwen2.5:7b") is None
         mock_client.post.assert_awaited_once_with(
             "/api/pull",
             json={"name": "qwen2.5:7b", "stream": False},
@@ -76,8 +78,8 @@ class TestDeleteModel:
         mock_client.request.return_value = _mock_response(200)
         adapter._client = mock_client
 
-        result = await adapter.delete_model("qwen2.5:7b")
-        assert result == {}
+        # See pull_model: None is the port contract, the wire assertion is the point.
+        assert await adapter.delete_model("qwen2.5:7b") is None
         mock_client.request.assert_awaited_once_with(
             "DELETE",
             "/api/delete",
@@ -102,6 +104,10 @@ class TestDeleteModel:
 
 
 class TestListPulledModels:
+    """The deprecated raw-dict shim (#313). Still covered because
+    ``cycles.py``'s preflight depends on it until that file is migrated —
+    an untested shim is how a silent warn-and-allow gets shipped."""
+
     async def test_returns_models(self, adapter):
         mock_client = AsyncMock()
         models_data = [


### PR DESCRIPTION
Implements **P0** and **P1's on-port listing half** of `sips/proposed/SIP-Atlas-Provider-Adapter.md`.

## Scope was chosen by churn, not by phase boundary

Both phases add to the same two files and converge on the same caller, so splitting them means touching those files twice. Everything here is **cold against the 1.6 line**:

| File | commits/60d | last touched |
|---|---|---|
| `ports/llm/provider.py` | 0 | 4 months |
| `llm/models.py` | 0 | 4 months |
| `adapters/llm/ollama.py` | 1 | 5 weeks |
| `routes/cycles/models.py` | 1 | 6 weeks |

Nothing config-shaped and nothing in the cycle-create path is touched.

## The port says what it can do

- **`LLMCapability` + `capabilities()` / `supports()`.** Defaults to **all-False**, so an adapter declaring nothing supports nothing — a silent omission fails closed instead of presenting as a working feature. Carries #572's doctrine verbatim from the queue port: *a flag that overstates the implementation is worse than a missing feature.*
- **`list_available_models() -> list[ModelInfo]`**, plus `pull_model`/`delete_model` on the port. All default to **raising `NotImplementedError`, never returning `[]`** — "cannot enumerate" must stay distinct from "enumerated nothing", because an empty list reads downstream as *no models present* and would block work that should proceed.
- **`ModelInfo` replaces raw `/api/tags` dicts.** The dict *was* the coupling: callers had to know Ollama's payload keys, so reaching for metadata made them Ollama-specific by construction.
- **`pull_model`/`delete_model` return `None`.** A provider response body handed back through the port is that same leak in another shape; no caller used it.

**`thinking_tokens: False` is honest, not incidental.** qwen3-family models emit `message.thinking` through Ollama by default, but this adapter never sends a `think` parameter and reads only `message.content` — so reasoning tokens are paid for and inseparable here (#410). Declaring True would tell a caller it could split them.

## Routes ask the port, not the class

`/api/v1/models/*` drop `isinstance(port, OllamaAdapter)` for `port.supports(capability)`. **The 503 stays** — it's the honest answer for a provider that genuinely cannot manage models — but a provider that *can* is no longer refused for having the wrong class.

## What is deliberately NOT migrated

`cycles.py`'s model-availability preflight. It has **15 commits in 60 days, last touched 19 hours ago**, and sits in the cycle-create path every 1.6 validation run hits.

It still calls `list_pulled_models`, so that method stays as an **explicitly deprecated shim** delegating to `list_available_models`. Removing it outright would have raised `AttributeError` *inside that preflight's broad `except Exception`*, degrading silently to warn-and-allow — a false green rather than a visible break. The shim's deletion is a named line item of the preflight migration, and it keeps its test coverage until then.

## Verification

**Conformance suite gains two dimensions** — capability honesty and `ModelInfo` shape (34 tests, up from 27). Mutation-verified, since a suite that passes first try is unverified:

| Mutation | Result |
|---|---|
| flip a declared capability to False | **fails** — declared-False but works |
| misspell a capability key | **fails** — key set no longer matches |
| surface blank-named models | **fails** — unnamed entries must be dropped |

**Live against real local Ollama, no mocks:** 7 models translated to `ModelInfo`, deprecated shim agrees with its source, `refresh_models` agrees with `list_available_models`, health up.

**Existing tests updated, not deleted.** `pull`/`delete` now assert the port contract (`is None`) while keeping their exact-wire assertions; the models API fixture drops its `__class__` isinstance fixup for a capability-declaring `LLMPort`. New coverage for the surface this creates: every management route 503s **naming the missing capability** when undeclared, and the code-defined registry route survives an incapable backend.

Regression suite: **6656 passed, 2 skipped**. ruff + `lint_test_quality.py` clean.

## Not deployed

The local stack is running v1.3.1 and I did not rebuild `runtime-api` — that restarts a service you've had up 11 days, and it's your call. The adapter half is live-verified above; a rebuild is the remaining step if you want the route half exercised end to end before merge.

Refs #313, #301 — neither closed. #313 needs the doctor half; #301 keeps its queue half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuQJ2ZGMRD9rMfFJCQoofD
