### PR TITLE
feat(llm): VLLMAdapter — second provider, OpenAI-compatible dialect (SIP Atlas P6)

### DIFF
--- a/adapters/llm/__init__.py
+++ b/adapters/llm/__init__.py
@@ -2,14 +2,17 @@
 
 Provides implementations of LLM ports:
 - OllamaAdapter: Local Ollama LLM server adapter
+- VLLMAdapter: vLLM OpenAI-compatible server adapter
 
 Part of SIP-0.8.7 Infrastructure Ports Migration.
 """
 
 from adapters.llm.factory import create_llm_provider
 from adapters.llm.ollama import OllamaAdapter
+from adapters.llm.vllm import VLLMAdapter
 
 __all__ = [
     "OllamaAdapter",
+    "VLLMAdapter",
     "create_llm_provider",
 ]

--- a/adapters/llm/factory.py
+++ b/adapters/llm/factory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from adapters.llm.ollama import OllamaAdapter
+from adapters.llm.vllm import VLLMAdapter
 from squadops.ports.llm.provider import LLMPort
 
 if TYPE_CHECKING:
@@ -26,7 +27,7 @@ def create_llm_provider(
     """Create an LLM provider.
 
     Args:
-        provider: Provider name ("ollama")
+        provider: Provider name ("ollama" or "vllm")
         secret_manager: Optional secret manager for resolving secret:// refs
         base_url: Base URL for the LLM server (may be secret:// ref)
         default_model: Default model to use
@@ -50,4 +51,15 @@ def create_llm_provider(
             timeout_seconds=timeout_seconds,
         )
 
+    if provider == "vllm":
+        return VLLMAdapter(
+            base_url=base_url,
+            default_model=default_model,
+            timeout_seconds=timeout_seconds,
+            api_key=config.get("api_key"),
+        )
+
+    # No fallback: an unknown provider name must fail loudly at startup rather
+    # than silently running the previous one (the standing no-masking-fallbacks
+    # rule). A typo in configuration is a misconfiguration, not a default.
     raise ValueError(f"Unknown LLM provider: {provider}")

--- a/adapters/llm/vllm.py
+++ b/adapters/llm/vllm.py
@@ -1,0 +1,462 @@
+"""vLLM LLM adapter — OpenAI-compatible HTTP surface.
+
+Second provider adapter, per SIP-Atlas-Provider-Adapter P6. Independent of
+:class:`~adapters.llm.ollama.OllamaAdapter` by design (§3.5a): one adapter per
+provider, no shared dialect base. Sharing a class across providers would put a
+"which provider am I" conditional inside it — the identity-branching #559 bans —
+and any real overlap is better extracted once two implementations exist and the
+overlap is demonstrated rather than assumed.
+
+**Dialect, verified against a live OpenAI-compatible server rather than assumed:**
+
+- ``POST /v1/chat/completions`` — messages in, ``choices[0].message.content`` out.
+- ``POST /v1/completions`` is *not* used; :meth:`generate` is expressed as a
+  single-user-turn chat, because the legacy completions endpoint is deprecated
+  upstream and not universally served.
+- Streaming is SSE: ``data: {json}`` frames, blank-line separated, terminated by
+  ``data: [DONE]``. Content arrives at ``choices[0].delta.content``.
+- ``GET /v1/models`` returns ``{"object": "list", "data": [{"id": ...}]}``. The
+  model *name* is ``id``; there is no size or modification time in this shape, so
+  :class:`ModelInfo` carries ``None`` for both rather than inventing values.
+- Errors are ``{"error": {"message": ..., "type": ...}}`` with 404 for an unknown
+  model.
+
+**No native throughput field.** Unlike Ollama's ``eval_count``/``eval_duration``,
+the OpenAI shape reports token counts and no timings at all. Tokens/sec is
+therefore computed here from measured wall-clock, and is *inclusive* of prefill
+and queueing where Ollama's native number is decode-only. The two are not
+interchangeable, which is exactly why the A/B artifact records wall-clock as the
+decision field and treats rate as a diagnostic (SIP §3.6.1).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+
+from squadops.llm.exceptions import (
+    LLMConnectionError,
+    LLMModelNotFoundError,
+    LLMTimeoutError,
+)
+from squadops.llm.models import ChatMessage, LLMRequest, LLMResponse, ModelInfo
+from squadops.ports.llm.provider import LLMCapability, LLMPort
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL_LIST_TIMEOUT = 10.0
+_SSE_DATA_PREFIX = "data: "
+_SSE_DONE = "[DONE]"
+
+
+def _tokens_per_second(completion_tokens: int | None, elapsed_seconds: float) -> float | None:
+    """Generation rate from measured wall-clock.
+
+    Client-side by necessity: the OpenAI response shape carries no timings. This
+    number therefore includes prefill and any queueing, unlike Ollama's
+    decode-only ``eval_count / eval_duration``. Returned as ``None`` rather than
+    ``0.0`` when it cannot be computed — a zero rate is indistinguishable from a
+    real measurement and would drag any average toward zero.
+    """
+    if not completion_tokens or elapsed_seconds <= 0:
+        return None
+    return round(completion_tokens / elapsed_seconds, 2)
+
+
+def _usage_from(payload: dict[str, Any]) -> tuple[int | None, int | None, int | None]:
+    """(prompt, completion, total) from an OpenAI ``usage`` object.
+
+    All-or-nothing: a provider that omits usage yields three ``None``s, never a
+    partial row. Partial usage is worse than absent — a caller cannot tell which
+    half is real (SIP §3.5).
+    """
+    usage = payload.get("usage") or {}
+    prompt = usage.get("prompt_tokens")
+    completion = usage.get("completion_tokens")
+    total = usage.get("total_tokens")
+    if total is None and (prompt is not None or completion is not None):
+        total = (prompt or 0) + (completion or 0)
+    return prompt, completion, total
+
+
+class VLLMAdapter(LLMPort):
+    """vLLM adapter speaking the OpenAI-compatible HTTP surface.
+
+    Class name is CapWords per the tree's convention — every adapter class is,
+    and ``LangFuseAdapter`` already normalizes a product branded "Langfuse". The
+    provider string is ``"vllm"``, and the project is written "vLLM" in prose.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8000",
+        default_model: str = "",
+        timeout_seconds: float = 180.0,
+        model_list_timeout_seconds: float = _DEFAULT_MODEL_LIST_TIMEOUT,
+        api_key: str | None = None,
+    ):
+        """Initialize the vLLM adapter.
+
+        Args:
+            base_url: server root. ``/v1`` is appended by the request paths, so
+                pass ``http://host:8000``, not ``http://host:8000/v1``.
+            default_model: model used when a request does not name one.
+            timeout_seconds: default request timeout.
+            model_list_timeout_seconds: timeout for the listing/health probe,
+                separate from generation (the #158 rationale).
+            api_key: optional bearer token. Self-hosted vLLM is typically open;
+                resolved config must pass a ``secret://`` ref through
+                ``SecretManager`` at the factory, never a literal.
+        """
+        self._base_url = base_url.rstrip("/")
+        self._default_model = default_model
+        self._timeout = timeout_seconds
+        self._model_list_timeout = model_list_timeout_seconds
+        self._api_key = api_key
+        self._models_cache: list[str] = []
+        self._client: httpx.AsyncClient | None = None
+
+    @property
+    def default_model(self) -> str:
+        return self._default_model
+
+    def capabilities(self) -> dict[str, bool]:
+        """Declare what this adapter does (#572's rule — see the port).
+
+        ``model_management`` is **False**: the OpenAI surface has no pull/delete
+        equivalent, and vLLM serves the weights it was launched with. Callers get
+        an honest 503 rather than a method that silently does nothing.
+
+        ``streaming_usage`` is **True**: the adapter requests
+        ``stream_options.include_usage`` and consumes the terminal usage frame.
+        Verified end to end against a live OpenAI-compatible server, which
+        returns that frame with an empty ``choices`` list.
+
+        This is nonetheless the flag most at risk against a *partial* OpenAI
+        implementation, since a server may accept the option and send nothing.
+        Such a server would report ``None`` counts here — which the conformance
+        suite catches as a declared-True-but-inert capability rather than
+        letting it pass as working.
+        """
+        return {
+            LLMCapability.MODEL_LISTING: True,
+            LLMCapability.MODEL_MANAGEMENT: False,
+            LLMCapability.STREAMING_USAGE: True,
+            LLMCapability.THINKING_TOKENS: False,
+        }
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            headers = {"Authorization": f"Bearer {self._api_key}"} if self._api_key else {}
+            self._client = httpx.AsyncClient(
+                base_url=self._base_url,
+                timeout=httpx.Timeout(self._timeout),
+                headers=headers,
+            )
+        return self._client
+
+    def _payload(
+        self,
+        messages: list[ChatMessage],
+        model: str,
+        max_tokens: int | None,
+        temperature: float | None,
+        *,
+        stream: bool = False,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": m.role, "content": m.content} for m in messages],
+            "stream": stream,
+        }
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if stream:
+            # Without this the stream carries no usage frame at all and token
+            # accounting for streamed calls is simply lost.
+            payload["stream_options"] = {"include_usage": True}
+        return payload
+
+    def _translate(self, exc: Exception, model: str, operation: str) -> Exception:
+        """Map a transport failure onto the port's exception vocabulary.
+
+        Load-bearing rather than cosmetic: failure-locus classification (#568)
+        reads these types to decide whether a failure is infrastructure or a
+        work-product defect. A raw ``httpx`` error escaping here would reclassify
+        an outage as a squad mistake and burn a correction attempt on it.
+        """
+        if isinstance(exc, httpx.TimeoutException):
+            return LLMTimeoutError(f"vLLM {operation} timed out after {self._timeout}s")
+        if isinstance(exc, httpx.ConnectError):
+            return LLMConnectionError(f"Failed to connect to vLLM at {self._base_url}")
+        if isinstance(exc, httpx.HTTPStatusError):
+            if exc.response.status_code == 404:
+                return LLMModelNotFoundError(f"Model '{model}' not found")
+            return LLMConnectionError(f"vLLM {operation} failed: {exc}")
+        return LLMConnectionError(f"vLLM {operation} failed: {exc}")
+
+    async def generate(self, request: LLMRequest) -> LLMResponse:
+        """Generate from a bare prompt.
+
+        Expressed as a single-user-turn chat completion: ``/v1/completions`` is
+        deprecated upstream and not served by every OpenAI-compatible backend,
+        while ``/v1/chat/completions`` is universal.
+        """
+        model = request.model or self._default_model
+        message = await self._chat(
+            [ChatMessage(role="user", content=request.prompt)],
+            model=model,
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+            timeout_seconds=request.timeout_seconds,
+            operation="generate",
+        )
+        return LLMResponse(
+            text=message.content,
+            model=model,
+            prompt_tokens=message.prompt_tokens,
+            completion_tokens=message.completion_tokens,
+            total_tokens=message.total_tokens,
+            tokens_per_second=message.tokens_per_second,
+        )
+
+    async def chat(
+        self,
+        messages: list[ChatMessage],
+        model: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout_seconds: float | None = None,
+    ) -> ChatMessage:
+        return await self._chat(
+            messages,
+            model=model or self._default_model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            timeout_seconds=timeout_seconds,
+            operation="chat",
+        )
+
+    async def _chat(
+        self,
+        messages: list[ChatMessage],
+        *,
+        model: str,
+        max_tokens: int | None,
+        temperature: float | None,
+        timeout_seconds: float | None,
+        operation: str,
+    ) -> ChatMessage:
+        client = await self._get_client()
+        timeout = timeout_seconds or self._timeout
+        started = time.monotonic()
+
+        try:
+            response = await client.post(
+                "/v1/chat/completions",
+                json=self._payload(messages, model, max_tokens, temperature),
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except Exception as e:
+            raise self._translate(e, model, operation) from e
+
+        elapsed = time.monotonic() - started
+        choices = data.get("choices") or [{}]
+        message = choices[0].get("message") or {}
+        prompt_tok, completion_tok, total_tok = _usage_from(data)
+        tps = _tokens_per_second(completion_tok, elapsed)
+
+        logger.info(
+            "LLM %s completed: model=%s, prompt_tokens=%s, completion_tokens=%s, t/s=%.1f",
+            operation,
+            model,
+            prompt_tok,
+            completion_tok,
+            tps or 0.0,
+        )
+
+        return ChatMessage(
+            role=message.get("role", "assistant"),
+            content=message.get("content", "") or "",
+            prompt_tokens=prompt_tok,
+            completion_tokens=completion_tok,
+            total_tokens=total_tok,
+            tokens_per_second=tps,
+        )
+
+    async def _stream_frames(
+        self,
+        messages: list[ChatMessage],
+        model: str,
+        max_tokens: int | None,
+        temperature: float | None,
+        timeout: float,
+        operation: str,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Yield decoded SSE frames, skipping the terminal sentinel.
+
+        SSE, not NDJSON: each frame is ``data: {json}``. A malformed frame is
+        skipped rather than fatal — one unparseable chunk must not discard a
+        generation that is otherwise complete.
+        """
+        client = await self._get_client()
+        try:
+            async with client.stream(
+                "POST",
+                "/v1/chat/completions",
+                json=self._payload(messages, model, max_tokens, temperature, stream=True),
+                timeout=timeout,
+            ) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line or not line.startswith(_SSE_DATA_PREFIX):
+                        continue
+                    body = line[len(_SSE_DATA_PREFIX) :].strip()
+                    if body == _SSE_DONE:
+                        break
+                    try:
+                        yield json.loads(body)
+                    except json.JSONDecodeError:
+                        logger.debug("Skipping malformed vLLM SSE frame")
+        except Exception as e:
+            raise self._translate(e, model, operation) from e
+
+    async def chat_stream(
+        self,
+        messages: list[ChatMessage],
+        model: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout_seconds: float | None = None,
+    ) -> AsyncIterator[str]:
+        """Stream assistant content as plain text chunks."""
+        resolved = model or self._default_model
+        async for frame in self._stream_frames(
+            messages,
+            resolved,
+            max_tokens,
+            temperature,
+            timeout_seconds or self._timeout,
+            "chat_stream",
+        ):
+            for choice in frame.get("choices") or []:
+                content = (choice.get("delta") or {}).get("content")
+                if content:
+                    yield content
+
+    async def chat_stream_with_usage(
+        self,
+        messages: list[ChatMessage],
+        model: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout_seconds: float | None = None,
+    ) -> ChatMessage:
+        """Stream for connection liveness, return one assembled message.
+
+        The final frame carries usage when the server honors
+        ``stream_options.include_usage``. A server that does not send one leaves
+        the counts ``None`` — never zero, which would read as a free call.
+        """
+        resolved = model or self._default_model
+        started = time.monotonic()
+        chunks: list[str] = []
+        usage_frame: dict[str, Any] = {}
+
+        async for frame in self._stream_frames(
+            messages,
+            resolved,
+            max_tokens,
+            temperature,
+            timeout_seconds or self._timeout,
+            "chat_stream_with_usage",
+        ):
+            if frame.get("usage"):
+                usage_frame = frame
+            for choice in frame.get("choices") or []:
+                content = (choice.get("delta") or {}).get("content")
+                if content:
+                    chunks.append(content)
+
+        elapsed = time.monotonic() - started
+        prompt_tok, completion_tok, total_tok = _usage_from(usage_frame)
+        tps = _tokens_per_second(completion_tok, elapsed)
+
+        logger.info(
+            "LLM chat_stream_with_usage completed: model=%s, prompt_tokens=%s, "
+            "completion_tokens=%s, t/s=%.1f",
+            resolved,
+            prompt_tok,
+            completion_tok,
+            tps or 0.0,
+        )
+
+        return ChatMessage(
+            role="assistant",
+            content="".join(chunks),
+            prompt_tokens=prompt_tok,
+            completion_tokens=completion_tok,
+            total_tokens=total_tok,
+            tokens_per_second=tps,
+        )
+
+    def list_models(self) -> list[str]:
+        """Cached model names. Performs no I/O, per the port contract."""
+        return self._models_cache.copy()
+
+    async def refresh_models(self) -> list[str]:
+        """Refresh the name cache, preserving the last known list on failure.
+
+        Emptying the cache on a transient blip would read downstream as *no
+        models present* and block work that should proceed.
+        """
+        try:
+            self._models_cache = [m.name for m in await self.list_available_models()]
+        except Exception:
+            logger.debug("vLLM model refresh failed; keeping the last known list")
+        return self._models_cache.copy()
+
+    async def list_available_models(self) -> list[ModelInfo]:
+        """Models the server can serve.
+
+        ``/v1/models`` carries no size or modification time, so those stay
+        ``None`` rather than being invented — a caller can tell "not reported"
+        from "zero".
+        """
+        client = await self._get_client()
+        try:
+            response = await client.get("/v1/models", timeout=self._model_list_timeout)
+            response.raise_for_status()
+            data = response.json()
+        except Exception as e:
+            raise self._translate(e, self._default_model, "list_available_models") from e
+
+        return [ModelInfo(name=name) for entry in data.get("data", []) if (name := entry.get("id"))]
+
+    async def health(self) -> dict[str, Any]:
+        """Report reachability. Never raises — a probe that raises takes down
+        the caller it was meant to inform."""
+        try:
+            client = await self._get_client()
+            response = await client.get("/v1/models", timeout=self._model_list_timeout)
+            return {
+                "healthy": response.status_code == 200,
+                "base_url": self._base_url,
+                "models_available": len(self._models_cache),
+            }
+        except Exception as e:
+            return {"healthy": False, "base_url": self._base_url, "error": str(e)}
+
+    async def close(self) -> None:
+        if self._client:
+            await self._client.aclose()
+            self._client = None

--- a/sips/proposed/SIP-Atlas-Provider-Adapter.md
+++ b/sips/proposed/SIP-Atlas-Provider-Adapter.md
@@ -442,12 +442,36 @@ that nobody here can tune to flatter the result.
 
 Any of the three is worth knowing before committing to maintain an in-house engine.
 
-**Why it is cheap, and only once P4 exists.** If Atlas and vLLM are both
-OpenAI-compatible, they differ mainly in capability declarations, not transport.
-**That second OpenAI-compatible provider is what justifies extracting a shared
-`OpenAICompatibleAdapter` base** — with only Atlas it would be speculative
-generality, which the standing no-gold-plating rule forbids. With two, the base earns
-itself and vLLM costs roughly a capability table plus a factory branch.
+**One adapter per provider. No shared dialect base — amended 2026-08-08.**
+
+An earlier revision proposed a shared `OpenAICompatibleAdapter` serving both vLLM and
+Atlas, on the theory that a common dialect makes them differ only in capability
+declarations. **That is withdrawn**, for two reasons that only became clear once the
+dialect was examined rather than assumed:
+
+1. **Atlas is already expected to diverge.** §10.2 asks Atlas to emit duration fields the
+   standard OpenAI response shape does not carry (see there for why the A/B needs them).
+   A class shared with vLLM would need Atlas-specific handling inside it on day one —
+   a conditional keyed on which provider you are, which is exactly the identity-branching
+   #559 bans. Separate types *are* the polymorphic answer.
+2. **It inverts the no-gold-plating rule.** Extracting a base on the *expectation* that
+   Atlas matches vLLM builds shared structure on the same §10.2 assumption this SIP
+   otherwise refuses to rely on. Extraction is something done *after* two implementations
+   exist and their overlap is demonstrated — not before, from a guess about one of them.
+
+So: `OllamaAdapter`, `VLLMAdapter`, `AtlasAdapter`, each implementing `LLMPort`
+independently, each declaring its own capabilities, none aware of the others. If real
+overlap appears once two exist, extracting shared helpers then is cheap and evidence-based.
+
+**What makes per-provider adapters affordable is the conformance suite (§3.6).** The usual
+objection is duplicated bug surface — fix a streaming defect in one adapter, forget the
+other. Every adapter runs the *same* assertions, so a defect in any of them fails the same
+test. That is why P3 precedes P4, and why three adapters is a manageable number rather than
+three times the risk.
+
+**Naming:** `VLLMAdapter` in code (every adapter class in the tree is CapWords —
+`LangFuseAdapter` normalizes a product branded "Langfuse"; PEP 8 N801 agrees), `"vllm"` as
+the provider string alongside `"ollama"`, and "vLLM" in prose where the brand belongs.
 
 **Secondary value:** it makes the conformance suite honest. Two adapters can silently
 encode "whatever these two happen to do." A third that the team does not control tests the
@@ -974,7 +998,32 @@ dialect is discovered wrong at integration, which is the most expensive place to
 | 2 | streaming: supported? SSE or NDJSON? | `chat_stream` / `chat_stream_with_usage` |
 | 3 | model-listing endpoint, or none | `model_listing` |
 | 4 | model load/unload management, or none | `model_management` |
-| 5 | usage fields returned, incl. any timing/duration fields | `streaming_usage`, and §3.6.1's `prefill_ms` / `load_ms` / `total_ms` |
+| 5 | usage fields returned, **and specifically whether prefill / load / total durations are emitted** — see below | `streaming_usage`, and §3.6.1's `prefill_ms` / `load_ms` / `total_ms` |
+
+**Item 5 is an ask, not just a question — measured, not assumed.** The standard OpenAI
+response shape carries **no duration fields at all**. Confirmed against this box's Ollama,
+which serves both dialects:
+
+| Field | Ollama native `/api/chat` | the same server's `/v1` shim |
+|---|---|---|
+| token counts | yes | yes |
+| `eval_duration` (decode) | yes | **absent** |
+| `prompt_eval_duration` (prefill) | yes | **absent** |
+| `load_duration` (model residency) | yes | **absent** |
+| `total_duration` | yes | **absent** |
+
+Those four are exactly §3.6.1's `prefill_ms` / `load_ms` / `total_ms`. Two consequences:
+
+1. **Ollama keeps its native adapter.** Moving it onto the OpenAI shape would delete the
+   attribution half of the A/B *on the baseline arm*, and drop `model_management` to False.
+2. **If Atlas ships the plain OpenAI shape, the A/B is asymmetric** — full attribution on
+   the Ollama arm, wall-clock and token counts only on the Atlas arm. `wall_clock_ms`
+   survives (the handler measures it client-side), so a decision is still possible, but
+   "is the win in decode, prefill, or residency?" becomes answerable for one side only.
+
+Atlas is in-house, so this is cheap to fix at the source: **emit the durations.** Recorded
+here as an explicit ask on whoever owns the engine, to be settled before P4 opens rather
+than discovered when the A/B artifact comes back half-populated.
 
 **Failure mode if it is not OpenAI-compatible** — bounded, and worth stating so the
 assumption is not load-bearing beyond its blast radius: the transport layer of

--- a/tests/unit/llm/conformance.py
+++ b/tests/unit/llm/conformance.py
@@ -34,6 +34,7 @@ from unittest.mock import patch
 import httpx
 
 from adapters.llm.ollama import OllamaAdapter
+from adapters.llm.vllm import VLLMAdapter
 from squadops.ports.llm.provider import LLMPort
 
 # A dialect handler answers a request the way its provider's server would.
@@ -54,6 +55,19 @@ class AdapterCase:
     build: Callable[[], LLMPort]
     ok: DialectHandler
     nameless_model: DialectHandler
+
+    # Expectations for this provider's `ok` handler. On the case rather than in
+    # parallel name-keyed dicts: one entry fully describes a provider, so adding
+    # Atlas is one object and no shared assertion learns a new name.
+    default_model: str
+    override_model: str
+    models: list[str]
+    content: str
+    prompt_tokens: int
+    completion_tokens: int
+    # Exact rate when the provider reports timings; None when the adapter derives
+    # it from wall-clock, which is machine-dependent and range-checked instead.
+    tokens_per_second: float | None
 
     def __str__(self) -> str:  # pytest id
         return self.name
@@ -216,6 +230,82 @@ def ollama_nameless_model(request: httpx.Request) -> httpx.Response:
 
 
 # ---------------------------------------------------------------------------
+# vLLM dialect — OpenAI-compatible
+#
+# Shaped from a live OpenAI-compatible server, not from documentation: SSE
+# `data: {json}` frames terminated by `data: [DONE]`, `choices[0].delta.content`
+# while streaming and `choices[0].message.content` when not, `/v1/models`
+# returning entries keyed on `id`, and a 404 with an `{"error": {...}}` body for
+# an unknown model.
+# ---------------------------------------------------------------------------
+
+VLLM_MODELS = ["Qwen/Qwen2.5-7B-Instruct", "meta-llama/Llama-3.2-3B-Instruct"]
+VLLM_CONTENT = "the assembled answer"
+VLLM_STREAM_PARTS = ["the ", "assembled ", "answer"]
+
+# The usage frame rides its own terminal chunk (stream_options.include_usage),
+# separate from the content frames — a real structural difference from Ollama's
+# NDJSON, where usage shares the final content frame.
+_VLLM_PROMPT_TOKENS = 5
+_VLLM_COMPLETION_TOKENS = 12
+
+
+def _vllm_usage() -> dict:
+    return {
+        "prompt_tokens": _VLLM_PROMPT_TOKENS,
+        "completion_tokens": _VLLM_COMPLETION_TOKENS,
+        "total_tokens": _VLLM_PROMPT_TOKENS + _VLLM_COMPLETION_TOKENS,
+    }
+
+
+def _sse(frames: list[dict]) -> bytes:
+    body = "".join(f"data: {json.dumps(f)}\n\n" for f in frames)
+    return (body + "data: [DONE]\n\n").encode()
+
+
+def vllm_ok(request: httpx.Request) -> httpx.Response:
+    """Answer as a healthy vLLM server."""
+    path = request.url.path
+
+    if path == "/v1/models":
+        return httpx.Response(
+            200,
+            json={"object": "list", "data": [{"id": m, "object": "model"} for m in VLLM_MODELS]},
+        )
+
+    if path == "/v1/chat/completions":
+        body = json.loads(request.content)
+        model = body["model"]
+        if not body.get("stream"):
+            return httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-1",
+                    "model": model,
+                    "choices": [
+                        {"index": 0, "message": {"role": "assistant", "content": VLLM_CONTENT}}
+                    ],
+                    "usage": _vllm_usage(),
+                },
+            )
+        frames = [
+            {"choices": [{"index": 0, "delta": {"role": "assistant", "content": part}}]}
+            for part in VLLM_STREAM_PARTS
+        ]
+        frames.append({"choices": [], "usage": _vllm_usage()})
+        return httpx.Response(200, content=_sse(frames))
+
+    return httpx.Response(404, json={"error": {"message": f"unexpected route {path}"}})
+
+
+def vllm_nameless_model(request: httpx.Request) -> httpx.Response:
+    """A listing entry with no usable id."""
+    if request.url.path == "/v1/models":
+        return httpx.Response(200, json={"object": "list", "data": [{"object": "model"}]})
+    return vllm_ok(request)
+
+
+# ---------------------------------------------------------------------------
 # The registry — one entry per adapter under conformance.
 #
 # Atlas (P4) and vLLM (P6) each land here as one AdapterCase with their own
@@ -228,13 +318,32 @@ ADAPTER_CASES: list[AdapterCase] = [
         build=lambda: OllamaAdapter(default_model="qwen2.5:7b", timeout_seconds=5.0),
         ok=ollama_ok,
         nameless_model=ollama_nameless_model,
+        default_model="qwen2.5:7b",
+        override_model="llama3.2",
+        models=OLLAMA_MODELS,
+        content=OLLAMA_CONTENT,
+        prompt_tokens=_PROMPT_EVAL_COUNT,
+        completion_tokens=_EVAL_COUNT,
+        tokens_per_second=6.0,  # exact: derived from reported ns timings
+    ),
+    AdapterCase(
+        name="vllm",
+        build=lambda: VLLMAdapter(
+            base_url="http://localhost:8000",
+            default_model="Qwen/Qwen2.5-7B-Instruct",
+            timeout_seconds=5.0,
+        ),
+        ok=vllm_ok,
+        nameless_model=vllm_nameless_model,
+        default_model="Qwen/Qwen2.5-7B-Instruct",
+        override_model="meta-llama/Llama-3.2-3B-Instruct",
+        models=VLLM_MODELS,
+        content=VLLM_CONTENT,
+        prompt_tokens=_VLLM_PROMPT_TOKENS,
+        completion_tokens=_VLLM_COMPLETION_TOKENS,
+        tokens_per_second=None,  # wall-clock derived; no timing field in the shape
     ),
 ]
 
 # Expected tokens/sec for a case's `ok` handler. Keyed by adapter name because the
 # rate is computed from provider-supplied timings, which are dialect-shaped.
-EXPECTED_TOKENS_PER_SECOND = {"ollama": 6.0}
-EXPECTED_COMPLETION_TOKENS = {"ollama": _EVAL_COUNT}
-EXPECTED_PROMPT_TOKENS = {"ollama": _PROMPT_EVAL_COUNT}
-EXPECTED_MODELS = {"ollama": OLLAMA_MODELS}
-EXPECTED_CONTENT = {"ollama": OLLAMA_CONTENT}

--- a/tests/unit/llm/test_llm_port_conformance.py
+++ b/tests/unit/llm/test_llm_port_conformance.py
@@ -26,17 +26,13 @@ from squadops.llm.exceptions import (
 )
 from squadops.llm.models import ChatMessage, LLMRequest, ModelInfo
 from squadops.ports.llm.provider import LLMCapability
-from tests.unit.llm.conformance import (
-    ADAPTER_CASES,
-    EXPECTED_COMPLETION_TOKENS,
-    EXPECTED_CONTENT,
-    EXPECTED_MODELS,
-    EXPECTED_PROMPT_TOKENS,
-    EXPECTED_TOKENS_PER_SECOND,
-    raises,
-    status,
-    wire,
-)
+from tests.unit.llm.conformance import ADAPTER_CASES, raises, status, wire
+
+# A wall-clock-derived rate is machine-dependent, so it is bounded rather than
+# pinned. The window is wide because the defect it guards against — a duration
+# unit error — lands ~1e9 out, not a few percent.
+MIN_PLAUSIBLE_TPS = 0.01
+MAX_PLAUSIBLE_TPS = 1_000_000.0
 
 pytestmark = pytest.mark.parametrize("case", ADAPTER_CASES, ids=str)
 
@@ -58,15 +54,15 @@ class TestGeneration:
         with wire(case.ok):
             response = await case.build().generate(LLMRequest(prompt="the question"))
 
-        assert response.text == EXPECTED_CONTENT[case.name]
-        assert response.model == "qwen2.5:7b"
+        assert response.text == case.content
+        assert response.model == case.default_model
 
     async def test_chat_returns_assistant_role_and_content(self, case):
         with wire(case.ok):
             message = await case.build().chat(_messages())
 
         assert message.role == "assistant"
-        assert message.content == EXPECTED_CONTENT[case.name]
+        assert message.content == case.content
 
     async def test_chat_stream_reassembles_to_the_same_content(self, case):
         """Streaming is a transport detail; callers must not be able to tell.
@@ -78,7 +74,7 @@ class TestGeneration:
                 chunks.append(chunk)
 
         assert len(chunks) > 1, "single chunk cannot demonstrate reassembly"
-        assert "".join(chunks) == EXPECTED_CONTENT[case.name]
+        assert "".join(chunks) == case.content
 
     async def test_chat_stream_with_usage_returns_whole_message_not_chunks(self, case):
         """The streaming-for-liveness path: stream the wire to hold the
@@ -87,7 +83,7 @@ class TestGeneration:
             message = await case.build().chat_stream_with_usage(_messages())
 
         assert message.role == "assistant"
-        assert message.content == EXPECTED_CONTENT[case.name]
+        assert message.content == case.content
 
 
 class TestUsageAccounting:
@@ -104,8 +100,8 @@ class TestUsageAccounting:
                 else adapter.chat_stream_with_usage(_messages())
             )
 
-        assert message.prompt_tokens == EXPECTED_PROMPT_TOKENS[case.name]
-        assert message.completion_tokens == EXPECTED_COMPLETION_TOKENS[case.name]
+        assert message.prompt_tokens == case.prompt_tokens
+        assert message.completion_tokens == case.completion_tokens
         assert message.total_tokens == message.prompt_tokens + message.completion_tokens
 
     @pytest.mark.parametrize("via", ["chat", "stream_with_usage"])
@@ -121,7 +117,12 @@ class TestUsageAccounting:
                 else adapter.chat_stream_with_usage(_messages())
             )
 
-        assert message.tokens_per_second == EXPECTED_TOKENS_PER_SECOND[case.name]
+        if case.tokens_per_second is not None:
+            assert message.tokens_per_second == case.tokens_per_second
+        else:
+            # No timing field in this dialect — the adapter derives the rate from
+            # wall-clock, so bound it instead of pinning it.
+            assert MIN_PLAUSIBLE_TPS < message.tokens_per_second < MAX_PLAUSIBLE_TPS
 
     async def test_generate_reports_the_same_usage_as_chat(self, case):
         """Two entry points, one accounting contract. An adapter that populates
@@ -130,8 +131,8 @@ class TestUsageAccounting:
         with wire(case.ok):
             response = await case.build().generate(LLMRequest(prompt="the question"))
 
-        assert response.prompt_tokens == EXPECTED_PROMPT_TOKENS[case.name]
-        assert response.completion_tokens == EXPECTED_COMPLETION_TOKENS[case.name]
+        assert response.prompt_tokens == case.prompt_tokens
+        assert response.completion_tokens == case.completion_tokens
         assert response.total_tokens == response.prompt_tokens + response.completion_tokens
 
     async def test_usage_absent_from_the_wire_is_none_never_zero(self, case):
@@ -156,8 +157,8 @@ class TestModelListing:
             assert adapter.list_models() == [], "cache must start empty, not pre-populated"
             refreshed = await adapter.refresh_models()
 
-        assert refreshed == EXPECTED_MODELS[case.name]
-        assert adapter.list_models() == EXPECTED_MODELS[case.name]
+        assert refreshed == case.models
+        assert adapter.list_models() == case.models
 
     async def test_list_models_performs_no_network_io(self, case):
         """The port documents this as a MUST NOT and nothing tested it. A sync
@@ -171,7 +172,7 @@ class TestModelListing:
             await adapter.refresh_models()
 
             live.set(raises(AssertionError("list_models() performed network I/O")))
-            assert adapter.list_models() == EXPECTED_MODELS[case.name]
+            assert adapter.list_models() == case.models
 
     async def test_list_models_returns_a_copy(self, case):
         """Handing out the internal list lets any caller corrupt every other
@@ -181,7 +182,7 @@ class TestModelListing:
             await adapter.refresh_models()
 
         adapter.list_models().append("not-a-real-model")
-        assert adapter.list_models() == EXPECTED_MODELS[case.name]
+        assert adapter.list_models() == case.models
 
     async def test_refresh_failure_preserves_the_last_known_list(self, case):
         """A transient backend blip must not empty the cache — a downstream
@@ -192,8 +193,8 @@ class TestModelListing:
             await adapter.refresh_models()
 
             live.set(raises(httpx.ConnectError("backend down")))
-            assert await adapter.refresh_models() == EXPECTED_MODELS[case.name]
-            assert adapter.list_models() == EXPECTED_MODELS[case.name]
+            assert await adapter.refresh_models() == case.models
+            assert adapter.list_models() == case.models
 
 
 class TestErrorTranslation:
@@ -275,9 +276,7 @@ class TestCapabilityHonesty:
         adapter = case.build()
         with wire(case.ok):
             if adapter.supports(LLMCapability.MODEL_LISTING):
-                assert [m.name for m in await adapter.list_available_models()] == EXPECTED_MODELS[
-                    case.name
-                ]
+                assert [m.name for m in await adapter.list_available_models()] == case.models
             else:
                 with pytest.raises(NotImplementedError):
                     await adapter.list_available_models()
@@ -304,7 +303,7 @@ class TestCapabilityHonesty:
         with wire(case.ok):
             message = await adapter.chat_stream_with_usage(_messages())
 
-        assert message.completion_tokens == EXPECTED_COMPLETION_TOKENS[case.name]
+        assert message.completion_tokens == case.completion_tokens
 
 
 class TestModelInfoShape:
@@ -317,7 +316,7 @@ class TestModelInfoShape:
         with wire(case.ok):
             models = await case.build().list_available_models()
 
-        assert [m.name for m in models] == EXPECTED_MODELS[case.name]
+        assert [m.name for m in models] == case.models
         assert all(isinstance(m, ModelInfo) for m in models)
 
     async def test_unnamed_entries_are_dropped_not_surfaced_as_blanks(self, case):
@@ -358,14 +357,14 @@ class TestPortSurface:
     async def test_default_model_is_the_configured_one(self, case):
         """Handlers resolve their model as `agent_model or port.default_model`,
         so a placeholder here silently becomes the model that actually runs."""
-        assert case.build().default_model == "qwen2.5:7b"
+        assert case.build().default_model == case.default_model
 
     async def test_request_model_overrides_the_adapter_default(self, case):
         """Per-agent model pinning (squad profiles) rides this override. If it
         is ignored, every agent quietly runs the adapter default instead."""
         with wire(case.ok):
             response = await case.build().generate(
-                LLMRequest(prompt="the question", model="llama3.2")
+                LLMRequest(prompt="the question", model=case.override_model)
             )
 
-        assert response.model == "llama3.2"
+        assert response.model == case.override_model

--- a/tests/unit/llm/test_vllm_adapter.py
+++ b/tests/unit/llm/test_vllm_adapter.py
@@ -1,0 +1,184 @@
+"""vLLM dialect specifics (SIP-Atlas-Provider-Adapter P6).
+
+The shared conformance suite owns the *contract* — what every adapter must do.
+This file owns what is true of the **OpenAI-compatible dialect in particular**:
+SSE sentinel handling and partial `usage` objects.
+
+These deliberately do not live in the shared suite. Putting them there would
+force every case to supply a `[DONE]` frame and a total-less usage object, which
+would enshrine vLLM's transport shape as the contract — the mirror image of the
+Ollama-shaped assumptions that adding a second adapter just exposed. The 1.5 plan
+named that trap in one direction; it applies in both.
+
+Found by mutation testing: both behaviors below survived a deliberate defect
+because the shared suite's fixture never exercised them.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from adapters.llm.vllm import VLLMAdapter
+from squadops.llm.models import ChatMessage
+from tests.unit.llm.conformance import wire
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+
+def _adapter() -> VLLMAdapter:
+    return VLLMAdapter(
+        base_url="http://localhost:8000",
+        default_model="Qwen/Qwen2.5-7B-Instruct",
+        timeout_seconds=5.0,
+    )
+
+
+def _messages() -> list[ChatMessage]:
+    return [ChatMessage(role="user", content="the question")]
+
+
+def _sse(*raw_frames: str) -> bytes:
+    return ("".join(f"data: {f}\n\n" for f in raw_frames)).encode()
+
+
+class TestSSESentinel:
+    """`data: [DONE]` terminates the stream."""
+
+    async def test_frames_after_done_are_ignored(self):
+        """A sentinel that does not stop iteration lets post-`[DONE]` output —
+        a keep-alive, a trailing artifact of a proxy — append itself to the
+        assistant's answer, corrupting a work product rather than failing.
+
+        Mutation-verified: disabling the sentinel check passes without this,
+        because malformed-frame skipping happens to absorb the sentinel itself.
+        """
+        body = _sse(
+            json.dumps({"choices": [{"delta": {"content": "real"}}]}),
+            "[DONE]",
+            json.dumps({"choices": [{"delta": {"content": "-LEAKED"}}]}),
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=body)
+
+        with wire(handler):
+            chunks = [c async for c in _adapter().chat_stream(_messages())]
+
+        assert "".join(chunks) == "real"
+
+    async def test_malformed_frame_is_skipped_not_fatal(self):
+        """One unparseable frame must not discard an otherwise complete
+        generation — on a slow box that is minutes of work thrown away."""
+        body = _sse(
+            json.dumps({"choices": [{"delta": {"content": "before "}}]}),
+            "{not json at all",
+            json.dumps({"choices": [{"delta": {"content": "after"}}]}),
+            "[DONE]",
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=body)
+
+        with wire(handler):
+            chunks = [c async for c in _adapter().chat_stream(_messages())]
+
+        assert "".join(chunks) == "before after"
+
+
+class TestPartialUsageObject:
+    """Not every OpenAI-compatible server fills every usage field."""
+
+    async def test_total_is_derived_when_the_server_omits_it(self):
+        """Servers that report prompt and completion but no total are real. The
+        port's consistency contract is `total == prompt + completion`, so the
+        adapter derives it rather than surfacing None and making a caller guess
+        whether usage was reported at all.
+
+        Mutation-verified: removing the derivation passes the shared suite,
+        whose fixture always sends `total_tokens`.
+        """
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "model": "Qwen/Qwen2.5-7B-Instruct",
+                    "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+                    "usage": {"prompt_tokens": 7, "completion_tokens": 3},
+                },
+            )
+
+        with wire(handler):
+            message = await _adapter().chat(_messages())
+
+        assert message.prompt_tokens == 7
+        assert message.completion_tokens == 3
+        assert message.total_tokens == 10
+
+    async def test_absent_usage_object_yields_none_not_zero(self):
+        """A server reporting no usage at all must not read as a free call."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "model": "Qwen/Qwen2.5-7B-Instruct",
+                    "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+                },
+            )
+
+        with wire(handler):
+            message = await _adapter().chat(_messages())
+
+        assert message.prompt_tokens is None
+        assert message.completion_tokens is None
+        assert message.total_tokens is None
+        assert message.tokens_per_second is None
+
+
+class TestStreamingUsageFrame:
+    """`stream_options.include_usage` is requested, and its frame is consumed."""
+
+    async def test_include_usage_is_requested_on_streaming_calls(self):
+        """The option is what makes the terminal usage frame appear at all. An
+        adapter that streams without requesting it loses token accounting for
+        every streamed call — silently, since the content still arrives."""
+        seen: dict = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.update(json.loads(request.content))
+            return httpx.Response(200, content=_sse("[DONE]"))
+
+        with wire(handler):
+            await _adapter().chat_stream_with_usage(_messages())
+
+        assert seen["stream"] is True
+        assert seen["stream_options"] == {"include_usage": True}
+
+    async def test_usage_rides_a_frame_carrying_no_choices(self):
+        """The usage frame arrives with an empty `choices` list, unlike Ollama
+        where usage shares the final content frame. An adapter that only reads
+        usage from content-bearing frames loses it entirely."""
+        body = _sse(
+            json.dumps({"choices": [{"delta": {"content": "answer"}}]}),
+            json.dumps(
+                {
+                    "choices": [],
+                    "usage": {"prompt_tokens": 4, "completion_tokens": 6, "total_tokens": 10},
+                }
+            ),
+            "[DONE]",
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=body)
+
+        with wire(handler):
+            message = await _adapter().chat_stream_with_usage(_messages())
+
+        assert message.content == "answer"
+        assert message.completion_tokens == 6
+        assert message.total_tokens == 10


### PR DESCRIPTION
Implements **P6** of `sips/proposed/SIP-Atlas-Provider-Adapter.md`, plus the two SIP amendments this work produced.

All files cold against the 1.6 line: a new adapter, `factory.py` (0 commits in 5 months), and test files added by this arc.

## The design changed — §3.5a amended

An earlier revision proposed a shared `OpenAICompatibleAdapter` for vLLM and Atlas. **Withdrawn**, for two reasons that only appeared once the dialect was examined rather than assumed:

1. **Atlas is already expected to diverge.** §10.2 asks it to emit duration fields the OpenAI shape lacks — so a shared class would need provider conditionals on day one, which is the identity-branching #559 bans. Separate types *are* the polymorphic answer.
2. **It inverts the no-gold-plating rule.** Extracting a base on the expectation that Atlas matches vLLM builds shared structure on the very §10.2 assumption this SIP otherwise refuses to rely on. Extraction happens *after* two implementations exist and overlap is demonstrated.

So: `OllamaAdapter`, `VLLMAdapter`, `AtlasAdapter` — independent, each declaring its own capabilities. **The conformance suite is what makes that affordable**: one defect, one failing test, every adapter.

## §10.2 upgraded from question to ask — with measurements

Probed the same server serving both dialects:

| Field | Ollama native `/api/chat` | that server's `/v1` shim |
|---|---|---|
| token counts | yes | yes |
| `eval_duration` (decode) | yes | **absent** |
| `prompt_eval_duration` (prefill) | yes | **absent** |
| `load_duration` (residency) | yes | **absent** |
| `total_duration` | yes | **absent** |

Those four are exactly §3.6.1's `prefill_ms` / `load_ms` / `total_ms`. Two consequences now recorded in the SIP: **Ollama keeps its native adapter** (the OpenAI shape would delete the attribution half of the A/B *on the baseline arm* and drop `model_management`), and **if Atlas ships plain OpenAI, the A/B is asymmetric**. Atlas is in-house — so: emit the durations, settled before P4 opens.

## The adapter

Built against a live OpenAI-compatible server, not documentation: SSE `data: {json}` frames terminated by `data: [DONE]`, `delta.content` streaming vs `message.content` not, `/v1/models` keyed on `id`, 404 + `{"error":{...}}` for unknown model. `generate()` is a single-turn chat because `/v1/completions` is deprecated upstream and not universally served.

Declares `model_management: False` (no pull/delete in the shape — callers get an honest 503) and computes tokens/sec from wall-clock, since there is no timing field. **That rate includes prefill where Ollama's is decode-only** — not interchangeable, which is why §3.6.1 makes wall-clock the decision field and rate a diagnostic.

## Adding a second adapter did its job immediately

**Four shared assertions had `qwen2.5:7b` baked in.** The "provider-neutral" suite was secretly Ollama-shaped — precisely the trap the 1.5 plan named. Expectations moved off parallel name-keyed dicts onto `AdapterCase`, so one entry fully describes a provider and Atlas becomes one object rather than five dict edits.

## Mutation-verified

Eight deliberate defects against the new adapter: SSE prefix mishandling · zero-filled usage · dropped 404 translation · wrong `delta` key · over-declared `model_management` · wrong listing field · absent `[DONE]` handling · missing `total` derivation.

**The last two initially survived** — the shared fixture never exercised them. Now covered in `test_vllm_adapter.py`, which holds dialect specifics *deliberately outside* the shared suite: forcing Ollama to fake a `[DONE]` frame would enshrine vLLM's transport as the contract, the mirror image of the mistake just fixed.

## A correction carried into the code

An earlier probe suggested Ollama's `/v1` ignores `stream_options.include_usage`. That was `head -3` SIGPIPE-ing curl and truncating the stream before the usage frame. **It honors it** — the frame arrives with empty `choices`, exactly as the fixture models. Docstrings carrying the wrong claim are corrected.

## Verification

- **Live against a real OpenAI-compatible server:** `prompt=32, completion=6, total=38, t/s=20.66` — internally consistent.
- **Live conformance tier green for both providers**, 14 checks each.
- Unit suite: 130 in `tests/unit/llm/`. Regression: **6696 passed, 2 skipped**. ruff + `lint_test_quality.py` clean.

Nothing selects this adapter: `LLMConfig` still has no `provider` field (that's P2), so the default path is untouched.

Refs #313, #301 — neither closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QuQJ2ZGMRD9rMfFJCQoofD
