### PR TITLE
feat(cycles): the manifest gate stops only when the design asks a question (#807, M4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ step that revises against the gates, replacing the ungated proposer-side emissio
 relocates, and **#796** — the fix V4 roll 1 exposed: an authored manifest now derives and
 pins its contract mid-framing, so the plan authors bind to the design their own squad just
 wrote instead of inventing paths, and every contract-gated net engages. M4 (the human
-manifest gate, narrowed to question-gated review) and **M5 authoring provenance (#803)** —
+manifest gate, narrowed to question-gated review — #807: the gate stops only when the
+design declares an unresolved decision, and the question itself is what the operator is
+shown; a design that asks nothing records a distinguishable system approval and proceeds) and **M5 authoring provenance (#803)** —
 a system-owned block recording mode, cycle, task, attempt count and the *classified* reason
 for each revision, excluded from the manifest's canonical projection so recording how a
 design was written can never move the hash its contract binds.

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -46,9 +46,16 @@ from squadops.cycles.acceptance_evaluation import resolve_check_stack
 from squadops.cycles.agent_config import build_agent_resolver
 from squadops.cycles.build_completeness import compute_missing_required_files
 from squadops.cycles.checkpoint import RunCheckpoint
-from squadops.cycles.contract_derivation import CONTRACT_ARTIFACT_TYPE, SEEDED_MANIFEST_FILENAME
+from squadops.cycles.contract_derivation import (
+    CONTRACT_ARTIFACT_TYPE,
+    SEEDED_MANIFEST_FILENAME,
+    is_interface_manifest,
+)
 from squadops.cycles.frozen_check_validation import frozen_check_violations
-from squadops.cycles.manifest_authoring import MANIFEST_ARTIFACT_TYPE
+from squadops.cycles.manifest_authoring import (
+    GATE_DECIDED_BY_NO_QUESTIONS,
+    MANIFEST_ARTIFACT_TYPE,
+)
 from squadops.cycles.models import (
     ArtifactRef,
     Cycle,
@@ -728,18 +735,46 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         )
                         continue  # same index — re-execute framing
                     break
-                self._cycle_event_bus.emit(
-                    EventType.WORKLOAD_GATE_AWAITING,
-                    entity_type="workload",
-                    entity_id=current_run_id,
-                    context={"cycle_id": cycle_id, "run_id": current_run_id},
-                    payload={"gate_name": gate_name},
-                )
-                decision = await self._poll_inter_workload_gate(
-                    current_run_id,
-                    cycle,
-                    gate_name,
-                )
+                # M4 (#807): the gate stops only when the DESIGN asks a question. A
+                # manifest that declares no unresolved decision has already been approved by
+                # the deterministic gates, and a review that adds nothing is worse than no
+                # review — it manufactures the appearance of one. Keyed on the design, never
+                # on who wrote it (Guard 1a).
+                questions = await self._design_questions_for_gate(run, cycle)
+                if questions is not None and not questions:
+                    # Synthesized, not short-circuited: the decision runs through the SAME
+                    # exhaustive dispatch below that a human's answer does, so a
+                    # pass-through cannot reach a path an approval would not.
+                    decision = await self._approve_gate_without_questions(
+                        current_run_id, cycle_id, gate_name
+                    )
+                else:
+                    self._cycle_event_bus.emit(
+                        EventType.WORKLOAD_GATE_AWAITING,
+                        entity_type="workload",
+                        entity_id=current_run_id,
+                        context={"cycle_id": cycle_id, "run_id": current_run_id},
+                        # The questions ARE the review request (§5c.10): an operator shown
+                        # "approve?" reviews nothing; one shown "the PRD does not define the
+                        # expansion checkpoint — which is it?" answers what only they know.
+                        payload={
+                            "gate_name": gate_name,
+                            "open_questions": list(questions or ()),
+                        },
+                    )
+                    if questions:
+                        logger.info(
+                            "Gate %r on run %s is waiting on %d design question(s): %s",
+                            gate_name,
+                            current_run_id,
+                            len(questions),
+                            "; ".join(questions),
+                        )
+                    decision = await self._poll_inter_workload_gate(
+                        current_run_id,
+                        cycle,
+                        gate_name,
+                    )
 
                 if decision.decision == GateDecisionValue.REJECTED:
                     break  # Run stays COMPLETED; rejection in gate_decisions
@@ -1691,6 +1726,88 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         ``execution_overrides`` — no feature flag (house rule). Absence is
         author mode = today's behavior exactly."""
         return bool(cycle.execution_overrides.get("contract_ref"))
+
+    async def _design_questions_for_gate(self, run: Any, cycle: Any) -> tuple[str, ...] | None:
+        """The design questions this run's manifest declined to answer (#807, M4).
+
+        Three-valued, and the third value is the point:
+
+        - ``None`` — **the cycle has no manifest at all.** A plan-only or non-scaffolded
+          cycle has no design artifact, so its gate is a plan review and keeps today's
+          behavior. Narrowing to design-bearing cycles keeps M4 from silently removing a
+          human checkpoint from cycles it never claimed to be about.
+        - ``()`` — a design that asks nothing. The deterministic gates are its approval.
+        - non-empty — the author declared the PRD does not determine something and refused to
+          guess. That is the one input a human uniquely holds.
+
+        **Both rails are read, and that is Guard 1a.** A manifest this run authored lives on
+        the run's refs; an operator-seeded one lives on the cycle's ``plan_artifact_refs``.
+        Reading only the first would make seeded cycles keep a mandatory review while
+        authored ones lost it — behavior correlated with authoring mode, which the release's
+        first guard exists to forbid. The question is a property of the design, not of who
+        supplied it.
+        """
+        from squadops.cycles.contract_derivation import load_seeded_manifest_content
+        from squadops.cycles.manifest_authoring import open_questions
+
+        # The completed run the caller already fetched — re-reading it here would add a
+        # registry round-trip per gate for a value the loop is holding.
+        for ref_id in tuple(run.artifact_refs or ()):
+            try:
+                ref, content_bytes = await self._artifact_vault.retrieve(ref_id)
+            except Exception:
+                continue
+            if is_interface_manifest(ref):
+                return open_questions(content_bytes.decode(errors="replace"))
+
+        seeded = await load_seeded_manifest_content(
+            self._artifact_vault, cycle.execution_overrides.get("plan_artifact_refs")
+        )
+        return None if seeded is None else open_questions(seeded)
+
+    async def _approve_gate_without_questions(
+        self, run_id: str, cycle_id: str, gate_name: str
+    ) -> GateDecision:
+        """Record the pass-through as a decision and return it.
+
+        **Recorded, not implied.** The argument for question-gating is that a rubber stamp
+        cannot be told from a considered approval; a machine pass-through leaving no row
+        would reproduce exactly that, one level down. ``decided_by`` distinguishes the two
+        for `runs show` and for anyone reading the history later.
+
+        Returned rather than acted on, so the caller runs it through the same exhaustive
+        decision dispatch a human's answer takes — a pass-through cannot reach a path an
+        approval would not.
+        """
+        decision = GateDecision(
+            gate_name=gate_name,
+            decision=GateDecisionValue.APPROVED.value,
+            decided_by=GATE_DECIDED_BY_NO_QUESTIONS,
+            decided_at=datetime.now(UTC),
+            notes=(
+                "The manifest declares no unresolved decision, so the design asked nothing "
+                "a human uniquely answers. Schema and winnability gates are the approval; "
+                "plan validation passed at this gate."
+            ),
+        )
+        await self._cycle_registry.record_gate_decision(run_id, decision)
+        self._cycle_event_bus.emit(
+            EventType.GATE_DECIDED,
+            entity_type="run",
+            entity_id=run_id,
+            context={"cycle_id": cycle_id, "run_id": run_id},
+            payload={
+                "gate_name": gate_name,
+                "decision": GateDecisionValue.APPROVED.value,
+                "decided_by": GATE_DECIDED_BY_NO_QUESTIONS,
+            },
+        )
+        logger.info(
+            "Gate %r on run %s auto-approved: the design declares no open question",
+            gate_name,
+            run_id,
+        )
+        return decision
 
     async def _bind_authored_manifest(
         self,

--- a/src/squadops/cycles/manifest_authoring.py
+++ b/src/squadops/cycles/manifest_authoring.py
@@ -70,6 +70,40 @@ AUTHORING_INPUT_CONTRACT: frozenset[str] = frozenset(
 INPUT_CONTRACT_EXTENSION_POINTS: tuple[str, ...] = ("cross_cycle_recall",)
 
 
+#: Recorded as ``GateDecision.decided_by`` when the design asked nothing and the gate passed
+#: itself. Distinct from a human's approval on purpose: the argument for question-gating is
+#: that a rubber stamp cannot be told from a considered decision, and an unrecorded machine
+#: pass-through would reproduce that defect from the other side.
+GATE_DECIDED_BY_NO_QUESTIONS = "system:no_open_questions"
+
+
+def open_questions(manifest_content: str | None) -> tuple[str, ...]:
+    """The design questions this manifest declined to answer, in the author's own words.
+
+    The M4 firing rule (SIP-0103 §3.4 as narrowed 2026-08-08). An `unresolved: true` decision
+    is the author saying the PRD does not determine something and refusing to guess — the one
+    input a human uniquely holds, and the only thing worth stopping a cycle for.
+
+    **Keyed on the design, never on who wrote it.** Guard 1a forbids branching on authoring
+    mode, and a seeded manifest can carry an open question exactly as an authored one can.
+
+    Unparseable or absent content yields no questions: the gate's own plan-validation net
+    already rejects a manifest that cannot be read, and inventing a second opinion here would
+    stop a cycle for a defect that is already being reported.
+    """
+    if not manifest_content:
+        return ()
+    from squadops.capabilities.scaffold import InterfaceManifest
+
+    try:
+        manifest = InterfaceManifest.from_yaml(manifest_content)
+    except Exception:  # noqa: BLE001 - unreadable manifests are the gate net's to report
+        return ()
+    return tuple(
+        d.question.strip() for d in manifest.decisions if d.unresolved and d.question.strip()
+    )
+
+
 def authors_interface_manifest(resolved_config: Mapping[str, Any] | None) -> bool:
     """True when the squad writes the manifest rather than binding a seeded one.
 

--- a/tests/fixtures/authored_v4/README.md
+++ b/tests/fixtures/authored_v4/README.md
@@ -9,7 +9,13 @@ Captured verbatim from `cyc_9c8c98ea3171` / `run_7115f0f7082d` (group_run, squad
   with the manifest invisible to its authors: **zero of nine expected artifacts land on a
   fill slot**, four claim scaffold-frozen files, five name paths the skeleton does not have.
 
-Kept as a matched pair because the pair is the evidence: a good design and a plan that could
+- `interface_manifest_roll2.yaml` — artifact `art_f3977c787af4`, from `cyc_77cbb5aab7ca`, the
+  roll after #796 landed. Same PRD, independently authored: it binds all four fill slots and
+  **declares one unresolved decision** (`expansion-gating` — the PRD requires expansion after
+  core stability but defines no checkpoint). That open question is the observed case M4's
+  question-gate exists for, so this file is the fixture that must stop a gate.
+
+Roll 1's files are kept as a matched pair because the pair is the evidence: a good design and a plan that could
 not be built from it, which is what #796 fixes. `test_authored_contract_binding.py` replays
 it — deriving the contract from the manifest must make the gate reject this exact plan.
 

--- a/tests/fixtures/authored_v4/interface_manifest_roll2.yaml
+++ b/tests/fixtures/authored_v4/interface_manifest_roll2.yaml
@@ -1,0 +1,70 @@
+version: 1
+kind: interface_manifest
+project_id: group_run
+source_prd: "PRD: group_run (1-Hour Cycle MVP+)"
+stack: fullstack_fastapi_react
+scope: "Core group run event management (create, list, detail, join, leave) with in-memory persistence; explicitly excludes authentication, database migrations, external integrations, real-time sync, and UI polish."
+entities:
+  - name: Run
+    fields:
+      - { name: id, type: string, required: true, generated: true }
+      - { name: title, type: string, required: true }
+      - { name: datetime, type: string, required: true }
+      - { name: location, type: string, required: true }
+      - { name: distance, type: string, required: false }
+      - { name: pace, type: string, required: false }
+      - { name: route_notes, type: string, required: false }
+      - { name: participants, type: "list[string]", required: true, default: [] }
+api:
+  base_path: ""
+  request_shapes:
+    RunCreate:
+      required: [title, datetime, location]
+      optional: [distance, pace, route_notes]
+    ParticipantAction:
+      required: [name]
+  endpoints:
+    - { method: POST, path: /runs, summary: create run event, request: RunCreate, response: Run, success_status: 201, errors: [validation_error] }
+    - { method: GET, path: /runs, summary: list upcoming runs, response: "list[Run]" }
+    - { method: GET, path: "/runs/{run_id}", summary: get run details, response: Run, errors: [run_not_found] }
+    - { method: POST, path: "/runs/{run_id}/join", summary: join run with participant name, request: ParticipantAction, response: Run, success_status: 200, errors: [run_not_found, participant_already_joined, validation_error] }
+    - { method: POST, path: "/runs/{run_id}/leave", summary: leave run by participant name, request: ParticipantAction, response: Run, success_status: 200, errors: [run_not_found, participant_not_found, validation_error] }
+  error_contract:
+    shape: '{"detail": "message"}'
+    codes:
+      validation_error: { http: 422 }
+      run_not_found: { http: 404 }
+      participant_already_joined: { http: 409 }
+      participant_not_found: { http: 404 }
+frontend:
+  framework: react_vite
+  routes:
+    - path: /
+      view: RunListView
+      purpose: display upcoming runs and navigate to create/detail
+      testids: [runs-view, run-list, run-row, run-title, run-datetime, run-location, run-participant-count, create-run-link]
+    - path: /create
+      view: CreateRunView
+      purpose: form to create a new run event
+      testids: [create-run-view, create-run-form, title-input, datetime-input, location-input, distance-input, pace-input, route-notes-input, submit-btn]
+    - path: /runs/:run_id
+      view: RunDetailView
+      purpose: view run details and manage participation (join/leave)
+      testids: [run-detail-view, run-details, participant-list, participant-name, join-form, join-name-input, join-submit, leave-form, leave-name-input, leave-submit]
+persistence: in_memory
+decisions:
+  - id: duplicate-name-comparison
+    choice: case-insensitive comparison
+    warrant: "PRD §5.4 default recommendation: 'case-insensitive uniqueness'"
+  - id: datetime-handling
+    choice: store and return raw string; client sorts lexicographically
+    warrant: "PRD §4.1 Tier 1 allows 'best-effort lexical sort acceptable for MVP'; §5.1 permits 'string input acceptable'"
+  - id: leave-unknown-participant
+    choice: return 404 with participant_not_found error
+    warrant: "Technical design resolves PRD §5.5 ambiguity: 'Return 404 with clear error; clearer for UI error handling'"
+  - id: expansion-gating
+    unresolved: true
+    question: "PRD §4.1 specifies expansion only after core stability, but does not define the exact checkpoint or time threshold for triggering Tier 1 items."
+  - id: id-generation
+    choice: UUID4 strings
+    warrant: "Technical design §2 specifies 'id: str # UUID4'; standard for uncoordinated distributed IDs"

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -1325,6 +1325,24 @@ tasks:
 """
 
 
+def _assert_gate_reached_without_rejection(mock_registry, mock_event_bus) -> None:
+    """The run reached a gate decision, and that decision was not a rejection.
+
+    What the #494/#496/#509 inverse guards are actually about: plan validation must not
+    auto-reject a bound plan. They expressed it as "no decision recorded, and AWAITING was
+    emitted" — both of which M4 (#807) changed without changing what they guard. A design
+    that declares no open question now records a *system approval* and never emits AWAITING,
+    because there is nothing for an operator to be asked. Asserting the decision instead of
+    the wait keeps the guard pointed at the rejection it was written for.
+    """
+    decisions = [call.args[1] for call in mock_registry.record_gate_decision.await_args_list]
+    rejected = [d for d in decisions if d.decision == GateDecisionValue.REJECTED.value]
+    assert not rejected, f"plan validation auto-rejected: {[d.notes for d in rejected]}"
+
+    reached = decisions or EventType.WORKLOAD_GATE_AWAITING in _emit_types(mock_event_bus)
+    assert reached, "the run never reached its gate at all"
+
+
 class TestInterWorkloadGatePlanValidation:
     """#464 at the seam cycles ACTUALLY traverse: multi-workload runs gate
     between workloads on a COMPLETED framing run — the mid-run gate check
@@ -1636,8 +1654,7 @@ class TestInterWorkloadGatePlanValidation:
 
         await executor.execute_cycle("cyc_001", "run_001")
 
-        mock_registry.record_gate_decision.assert_not_awaited()
-        assert EventType.WORKLOAD_GATE_AWAITING in _emit_types(mock_event_bus)
+        _assert_gate_reached_without_rejection(mock_registry, mock_event_bus)
 
     async def test_bind_mode_with_manifest_and_bound_plan_gates_normally(
         self, executor, mock_registry, mock_event_bus
@@ -1719,8 +1736,7 @@ class TestInterWorkloadGatePlanValidation:
 
         await executor.execute_cycle("cyc_001", "run_001")
 
-        mock_registry.record_gate_decision.assert_not_awaited()
-        assert EventType.WORKLOAD_GATE_AWAITING in _emit_types(mock_event_bus)
+        _assert_gate_reached_without_rejection(mock_registry, mock_event_bus)
 
     async def test_bind_mode_with_seeded_manifest_gates_normally(
         self, executor, mock_registry, mock_event_bus
@@ -1808,8 +1824,7 @@ class TestInterWorkloadGatePlanValidation:
 
         await executor.execute_cycle("cyc_001", "run_001")
 
-        mock_registry.record_gate_decision.assert_not_awaited()
-        assert EventType.WORKLOAD_GATE_AWAITING in _emit_types(mock_event_bus)
+        _assert_gate_reached_without_rejection(mock_registry, mock_event_bus)
 
     async def test_document_regex_plan_gates_normally(
         self, executor, mock_registry, mock_event_bus

--- a/tests/unit/cycles/test_manifest_question_gate.py
+++ b/tests/unit/cycles/test_manifest_question_gate.py
@@ -1,0 +1,208 @@
+"""The gate stops only when the design asks a question (#807, M4).
+
+Bug classes guarded:
+
+- **a design that asks nothing still stopping the pipeline** — the defect this item exists
+  for. V4 roll 2's gate was approved with a note repeating what the deterministic gates had
+  already proven, while the manifest's one real question went unasked;
+- the reverse, and worse: a design that *does* declare a question sailing through, which
+  silently converts "the PRD does not determine this" into a guess nobody reviewed;
+- the question not reaching the operator, leaving them a bare "approve?" — which is the
+  rubber stamp with extra steps;
+- a pass-through leaving **no record**, so a later reader cannot tell a design that asked
+  nothing from a human who said yes. That reproduces the original defect from the other side;
+- behavior correlated with **who wrote the manifest** — Guard 1a. Reading only the run's own
+  artifacts would make seeded cycles keep a mandatory review while authored ones lost it;
+- a plan-only cycle losing its gate, which this item never claimed to touch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+from squadops.cycles.manifest_authoring import (
+    GATE_DECIDED_BY_NO_QUESTIONS,
+    MANIFEST_ARTIFACT_TYPE,
+    open_questions,
+)
+from squadops.cycles.models import GateDecisionValue
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+#: V4 roll 2's real manifest — the observed case this item exists for. It declares exactly
+#: one unresolved decision (`expansion-gating`), so it is the fixture that must stop a gate.
+#: Roll 1's manifest, beside it in the same directory, resolves everything and would make
+#: these tests pass while proving nothing.
+_AUTHORED = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "authored_v4"
+    / "interface_manifest_roll2.yaml"
+).read_text(encoding="utf-8")
+_REFERENCE = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+).read_text(encoding="utf-8")
+
+
+def _resolved(manifest_yaml: str) -> str:
+    """The same design with every question answered."""
+    data = yaml.safe_load(manifest_yaml)
+    for d in data.get("decisions", []):
+        if d.pop("unresolved", False):
+            d["choice"] = "resolved for the test"
+            d["warrant"] = "PRD §x"
+            d.pop("question", None)
+    return yaml.dump(data, sort_keys=False)
+
+
+def _executor(run_manifest: str | None = None, seeded_manifest: str | None = None):
+    store: dict[str, tuple[Any, bytes]] = {}
+    run_refs: list[str] = []
+    plan_refs: list[str] = []
+
+    def _ref(artifact_id: str) -> Any:
+        ref = MagicMock()
+        ref.artifact_id = artifact_id
+        ref.filename = "interface_manifest.yaml"
+        ref.artifact_type = MANIFEST_ARTIFACT_TYPE
+        return ref
+
+    if run_manifest is not None:
+        store["art_run"] = (_ref("art_run"), run_manifest.encode())
+        run_refs.append("art_run")
+    if seeded_manifest is not None:
+        store["art_seed"] = (_ref("art_seed"), seeded_manifest.encode())
+        plan_refs.append("art_seed")
+
+    vault = AsyncMock()
+
+    async def _retrieve(artifact_id: str):
+        return store[artifact_id]
+
+    vault.retrieve.side_effect = _retrieve
+    executor = DispatchedFlowExecutor(artifact_vault=vault)
+    executor._cycle_registry = AsyncMock()
+    executor._cycle_event_bus = MagicMock()
+
+    run = MagicMock()
+    run.run_id = "run_1"
+    run.artifact_refs = run_refs
+    cycle = MagicMock()
+    cycle.execution_overrides = {"plan_artifact_refs": plan_refs} if plan_refs else {}
+    return executor, run, cycle
+
+
+# --------------------------------------------------------------------------- #
+# The firing rule
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_design_that_declares_a_question_stops_the_gate():
+    """V4 roll 2's actual manifest. It asked whether Tier-1 expansion has a checkpoint, and
+    nothing stopped to ask anyone — the case that motivated the whole item."""
+    executor, run, cycle = _executor(run_manifest=_AUTHORED)
+
+    questions = await executor._design_questions_for_gate(run, cycle)
+
+    assert len(questions) == 1
+    assert "expansion" in questions[0].lower()
+
+
+def test_the_fixture_is_the_manifest_that_actually_asked_a_question():
+    """Guards the fixture: roll 1's manifest resolves every decision, so pointing these tests
+    at it would make them pass while proving the opposite of what they claim."""
+    assert open_questions(_AUTHORED), "the roll-2 fixture must declare an open question"
+    roll1 = (
+        Path(__file__).resolve().parents[2] / "fixtures" / "authored_v4" / "interface_manifest.yaml"
+    ).read_text(encoding="utf-8")
+    assert open_questions(roll1) == (), "roll 1 resolved everything — that is the contrast"
+
+
+async def test_a_design_that_asks_nothing_does_not_stop_the_gate():
+    executor, run, cycle = _executor(run_manifest=_resolved(_AUTHORED))
+
+    assert await executor._design_questions_for_gate(run, cycle) == ()
+
+
+async def test_a_cycle_with_no_manifest_keeps_todays_behavior():
+    """``None``, not ``()`` — the distinction is load-bearing. A plan-only cycle's gate is a
+    plan review, and M4 never claimed to remove it."""
+    executor, run, cycle = _executor()
+
+    assert await executor._design_questions_for_gate(run, cycle) is None
+
+
+async def test_a_seeded_manifest_is_read_from_the_cycles_own_rail():
+    """Guard 1a. An operator-seeded manifest lives on ``plan_artifact_refs``, not on the
+    run's outputs; reading only the run would leave seeded cycles with a mandatory review and
+    authored ones without — behavior correlated with authoring mode, which is forbidden."""
+    executor, run, cycle = _executor(seeded_manifest=_AUTHORED)
+
+    questions = await executor._design_questions_for_gate(run, cycle)
+
+    assert len(questions) == 1
+
+
+async def test_the_runs_own_manifest_wins_over_a_seeded_one():
+    """A cycle that authored a design is governed by the design it authored."""
+    executor, run, cycle = _executor(run_manifest=_resolved(_AUTHORED), seeded_manifest=_AUTHORED)
+
+    assert await executor._design_questions_for_gate(run, cycle) == ()
+
+
+# --------------------------------------------------------------------------- #
+# The pass-through is recorded
+# --------------------------------------------------------------------------- #
+
+
+async def test_the_pass_through_records_a_decision_a_reader_can_tell_apart():
+    """The argument for question-gating is that a rubber stamp cannot be distinguished from a
+    considered approval. A machine pass-through leaving no row would do exactly that, one
+    level down — so it is recorded, and ``decided_by`` names it."""
+    executor, _, _ = _executor()
+
+    decision = await executor._approve_gate_without_questions(
+        "run_1", "cyc_1", "progress_plan_review"
+    )
+
+    assert decision.decision == GateDecisionValue.APPROVED.value
+    assert decision.decided_by == GATE_DECIDED_BY_NO_QUESTIONS
+    assert decision.notes.strip()
+    executor._cycle_registry.record_gate_decision.assert_awaited_once()
+    recorded = executor._cycle_registry.record_gate_decision.await_args.args[1]
+    assert recorded is decision, "the returned decision must be the one recorded"
+
+
+# --------------------------------------------------------------------------- #
+# The question reader
+# --------------------------------------------------------------------------- #
+
+
+def test_resolved_decisions_are_not_questions():
+    """The reference manifest records four judgments, all answered. Treating a *recorded*
+    decision as an open one would stop every cycle that documented its reasoning — punishing
+    exactly the discipline M2 asks for."""
+    assert open_questions(_REFERENCE) == ()
+
+
+def test_an_unresolved_decision_with_no_question_asks_nothing():
+    """Deferring without saying what was deferred is already a schema-gate finding
+    (`decision_record`). Stopping the pipeline on it too would ask an operator to answer a
+    question nobody stated."""
+    doc = _REFERENCE + "\ndecisions:\n  - id: vague\n    unresolved: true\n"
+
+    assert open_questions(doc) == ()
+
+
+@pytest.mark.parametrize("content", [None, "", "::: not yaml :::"])
+def test_unreadable_content_asks_nothing(content):
+    """The gate's plan-validation net already rejects an unparseable manifest with the
+    deriver's own reason. A second opinion here would stop a cycle for a defect that is
+    already being reported."""
+    assert open_questions(content) == ()

--- a/tests/unit/events/test_event_emission.py
+++ b/tests/unit/events/test_event_emission.py
@@ -335,9 +335,11 @@ class TestEmitCallSitePayloadFields:
         assert with_payload >= 35
 
     def test_total_emit_call_count(self) -> None:
-        """Sanity check: 20 executor + 9 correction-runner +
-        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 46 total
-        emit calls (#473 added the pre-gate rejection's GATE_DECIDED emit;
+        """Sanity check: 21 executor + 9 correction-runner +
+        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 47 total
+        emit calls (#807 added M4's question-gate GATE_DECIDED emit for a
+        design that declares no open question, 46 → 47;
+        #473 added the pre-gate rejection's GATE_DECIDED emit;
         #522 added the framing re-roll's WORKLOAD_ADVANCED emit; SIP-0100 3.3
         added the scaffold-integrity ARTIFACT_OWNERSHIP_ENFORCED emit;
         SIP-0100 3.4b added the correction runner's repair-path
@@ -355,4 +357,4 @@ class TestEmitCallSitePayloadFields:
         total = 0
         for path in _ALL_EMISSION_FILES:
             total += len(self._extract_emit_calls(path))
-        assert total == 46
+        assert total == 47


### PR DESCRIPTION
The build item behind the plan section rewritten in #802 — that PR was docs-only.

A manifest declaring no unresolved decision has already been approved by the deterministic gates, so the cycle proceeds. One that declares a question stops, and **the question is what the operator is shown** rather than a bare "approve?".

## The evidence is also the fixture

V4 roll 2's gate was approved with a note repeating what M2 and M3 had already proven, while the manifest's one real question reached nobody:

> **expansion-gating** — *PRD §4.1 specifies expansion only after core stability, but does not define the exact checkpoint or time threshold for triggering Tier 1 items.*

That manifest is now committed as `interface_manifest_roll2.yaml` and is the fixture that must stop a gate. A guard test asserts it declares a question **and** that roll 1's manifest (already in the fixture directory, all decisions resolved) declares none — otherwise pointing the suite at the wrong file would make it pass while proving the opposite.

That mistake actually happened during the build: I first wired the tests to roll 1's manifest and they failed `assert 0 == 1`. The guard exists because of it.

## Shape

- **Keyed on the design, never on who wrote it.** Both rails are read — a manifest the run authored, and an operator-seeded one on `plan_artifact_refs`. Reading only the first would leave seeded cycles with a mandatory review and authored ones without, which is behavior correlated with authoring mode and exactly what **Guard 1a** forbids.
- **Three-valued on purpose.** No manifest at all returns `None` and keeps today's behavior, because a plan-only cycle's gate is a *plan* review and M4 never claimed to touch it.
- **The pass-through is recorded**, with its own `decided_by`. The argument for question-gating is that a rubber stamp can't be told from a considered approval; a machine pass-through leaving no row would reproduce that defect from the other side.
- **The synthesized decision runs through the same exhaustive dispatch** a human's answer does, so a pass-through cannot reach a path an approval would not. (My first attempt used `continue`, which in that loop means *re-run the same workload* — an infinite loop, caught by the suite timing out.)

## The "unresolved-critical" reading

§5c.10 and the plan both say *unresolved-critical*, but `Decision` is `id / choice / warrant / unresolved / question` — there is no criticality field.

Reading taken: **`unresolved: true` is itself the assertion that it matters.** An author that declines to guess and states the question has already judged it worth surfacing. A criticality field would ask them to grade their own question — the self-assertion problem M5 just removed from provenance — and would be a schema change that should ride the #772/#795 boundary. If authors declare unresolved liberally once it stops the pipeline, that is measurable and criticality can be added with evidence.

## Two guard families pointed back at their intent

- The #494/#496/#509 inverse guards asserted *"no gate decision at all"* when they meant *"plan validation did not auto-reject"*. Rewritten to assert the rejection they were written for, rather than flipped to match new behavior.
- The emit-site count moved 46 → 47.

## Disclosed behavior change

A **seeded** cycle whose manifest declares no open question now auto-approves where it previously waited for a human. The deliverable is unaffected — approval doesn't influence what gets built — and it removes human-latency variance from V8's seeded control re-run. But it is a change to the control configuration, so it is stated here rather than absorbed.

## Verification

12 new tests. Full regression green: 7,107 unit / 6,721 regression. Live at V5, which also needs B1 emitting.

Closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv