### PR TITLE
feat(cycles): the pre-memory rejection baseline (#809, B1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ shown; a design that asks nothing records a distinguishable system approval and 
 a system-owned block recording mode, cycle, task, attempt count and the *classified* reason
 for each revision, excluded from the manifest's canonical projection so recording how a
 design was written can never move the hash its contract binds.
+**B1 (#809)** closes the one item whose omission would have been permanent: rejections are
+now classified at the moment they happen — plan-validation by producing validator, authoring
+by M6 class — so the pre-memory recurrence baseline Cross-Cycle Memory will be measured
+against is capturable. Read by nothing in 1.6, deliberately.
 Plan: `docs/plans/1-6-0-authorship-plan.md`.
 
 ## [1.5.0] — 2026-08-07

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import json
 import logging
 import os
 import time
@@ -71,6 +72,11 @@ from squadops.cycles.patch_verification import (
     STRUCTURALLY_UNEVALUABLE_REASONS,
     overlay_artifacts,
     verify_patched_artifacts,
+)
+from squadops.cycles.rejection_baseline import (
+    REJECTION_ARTIFACT_TYPE,
+    REJECTION_FILENAME,
+    RejectionClassifier,
 )
 from squadops.cycles.run_ledger import RunLedger
 from squadops.cycles.task_outcome import TaskOutcome
@@ -1727,6 +1733,52 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         author mode = today's behavior exactly."""
         return bool(cycle.execution_overrides.get("contract_ref"))
 
+    async def _store_rejection_record(
+        self,
+        run: Any,
+        cycle: Any,
+        gate_name: str,
+        classifier: Any,
+        errors: list[str],
+    ) -> None:
+        """Persist which classes rejected this plan (#809, B1).
+
+        Written at the moment of rejection because that is the only moment the producing
+        validator is known without parsing prose back out of a joined error string. Nothing
+        in 1.6 reads it — the pre-memory baseline is unrecoverable once Cross-Cycle Memory
+        exists, so it is captured now and aggregated whenever the window is scored.
+
+        Never raises. A baseline is a record, not a gate: losing one cycle's bookkeeping is a
+        gap in a dataset, while failing the rejection path would turn it into a lost cycle.
+        """
+        payload = classifier.record(gate_name, errors)
+        if not payload:
+            return
+        content = json.dumps(payload, indent=2).encode("utf-8")
+        try:
+            await self._artifact_vault.store(
+                ArtifactRef(
+                    artifact_id=f"art_{uuid4().hex[:12]}",
+                    project_id=cycle.project_id,
+                    artifact_type=REJECTION_ARTIFACT_TYPE,
+                    filename=REJECTION_FILENAME,
+                    content_hash=sha256(content).hexdigest(),
+                    size_bytes=len(content),
+                    media_type="application/json",
+                    created_at=datetime.now(UTC),
+                    cycle_id=cycle.cycle_id,
+                    run_id=run.run_id,
+                ),
+                content,
+            )
+        except Exception:
+            logger.warning(
+                "Could not store the rejection record for run %s; the baseline loses this "
+                "cycle's plan-validation classes",
+                run.run_id,
+                exc_info=True,
+            )
+
     async def _design_questions_for_gate(self, run: Any, cycle: Any) -> tuple[str, ...] | None:
         """The design questions this run's manifest declined to answer (#807, M4).
 
@@ -3115,6 +3167,10 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # switched off for exactly the plans that need them most (V4 roll 1: four tasks
         # claimed scaffold-frozen files and nothing caught it).
         run_contract_ref: str | None = None
+        # B1 (#809): which validator rejected, recorded where it is known. The gate calls its
+        # validators one at a time, so no signature changes and no prose to parse back — the
+        # names are the same vocabulary the authoring-rules asset teaches.
+        classifier = RejectionClassifier()
         contract = None  # set in bind mode below; feeds the soft-violation log
         for ref_id in tuple(run.artifact_refs or ()):
             try:
@@ -3139,20 +3195,38 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         exc_info=True,
                     )
                 else:
-                    errors.extend(parsed_plan.validate_criteria_scope())
+                    errors.extend(
+                        classifier.collect(
+                            "validate_criteria_scope", parsed_plan.validate_criteria_scope()
+                        )
+                    )
                     # #645: contract-independent winnability nets — an
                     # unexecutable command check or a directory-shaped
                     # expected artifact dooms the roll deterministically;
                     # both are provable here in microseconds, and a system
                     # rejection re-rolls framing for free where a human
                     # rejection would end the cycle (#522).
-                    errors.extend(parsed_plan.validate_command_checks())
-                    errors.extend(parsed_plan.validate_expected_artifact_shapes())
+                    errors.extend(
+                        classifier.collect(
+                            "validate_command_checks", parsed_plan.validate_command_checks()
+                        )
+                    )
+                    errors.extend(
+                        classifier.collect(
+                            "validate_expected_artifact_shapes",
+                            parsed_plan.validate_expected_artifact_shapes(),
+                        )
+                    )
                     # #673: a dual-claimed expected artifact aliases two tasks
                     # onto one file's fate (repair mis-scoping, last-wins
                     # emission) — provable plan-wide right here, and a system
                     # rejection re-rolls framing for free (#522).
-                    errors.extend(parsed_plan.validate_unique_expected_artifacts())
+                    errors.extend(
+                        classifier.collect(
+                            "validate_unique_expected_artifacts",
+                            parsed_plan.validate_unique_expected_artifacts(),
+                        )
+                    )
                     # #715: a qa.test task whose declared artifacts can never
                     # satisfy required tests_pass fails on any content — shk-4
                     # burned three correction rounds on one. #426: builder
@@ -3160,8 +3234,18 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     # dispatch guard — this seam (the one multi-workload
                     # cycles actually traverse) rejects both for a free
                     # framing re-roll.
-                    errors.extend(parsed_plan.validate_check_applicability(cycle.resolved_config()))
-                    errors.extend(parsed_plan.validate_build_config(cycle.resolved_config()))
+                    errors.extend(
+                        classifier.collect(
+                            "validate_check_applicability",
+                            parsed_plan.validate_check_applicability(cycle.resolved_config()),
+                        )
+                    )
+                    errors.extend(
+                        classifier.collect(
+                            "validate_build_config",
+                            parsed_plan.validate_build_config(cycle.resolved_config()),
+                        )
+                    )
             elif (
                 ref.filename == SEEDED_MANIFEST_FILENAME or artifact_type == MANIFEST_ARTIFACT_TYPE
             ):
@@ -3293,6 +3377,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     len(soft),
                     "; ".join(soft),
                 )
+        await self._store_rejection_record(run, cycle, gate_name, classifier, errors)
         return errors
 
     async def _load_seeded_manifest_content(self, cycle: Cycle) -> str | None:

--- a/scripts/dev/emit_rejection_baseline.py
+++ b/scripts/dev/emit_rejection_baseline.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Emit the pre-memory rejection baseline for one or more cycles (#809, B1).
+
+Reads only durable, already-stored facts — rejection records, the manifest's authoring
+provenance, and the cycle's framing run count — so a baseline can be produced at any time,
+including retrospectively over cycles that ran before this script existed. **Nothing in 1.6
+consumes the output.** It exists because the pre-memory picture becomes unrecoverable the
+moment Cross-Cycle Memory is live, and this is the cheap moment to capture it.
+
+Usage:
+    .venv/bin/python scripts/dev/emit_rejection_baseline.py CYCLE_ID [CYCLE_ID ...] \
+        [--project group_run] [--out baseline.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from adapters.cycles.filesystem_artifact_vault import FileSystemArtifactVault  # noqa: E402
+from squadops.capabilities.scaffold import InterfaceManifest  # noqa: E402
+from squadops.cycles.contract_derivation import is_interface_manifest  # noqa: E402
+from squadops.cycles.rejection_baseline import (  # noqa: E402
+    REJECTION_ARTIFACT_TYPE,
+    build_baseline,
+    render,
+)
+
+
+async def _cycle_baseline(vault, cycle_id: str):
+    """One cycle's baseline, assembled from what the vault already holds."""
+    import json
+
+    artifacts = await vault.list_artifacts(cycle_id=cycle_id)
+
+    rejection_records = []
+    provenance = None
+    run_ids = set()
+    for ref in artifacts:
+        if ref.run_id:
+            run_ids.add(ref.run_id)
+        try:
+            _, content = await vault.retrieve(ref.artifact_id)
+        except Exception:
+            continue
+        if ref.artifact_type == REJECTION_ARTIFACT_TYPE:
+            try:
+                rejection_records.append(json.loads(content.decode()))
+            except Exception:
+                continue
+        elif is_interface_manifest(ref) and provenance is None:
+            try:
+                manifest = InterfaceManifest.from_yaml(content.decode(errors="replace"))
+            except Exception:
+                continue
+            if manifest.provenance is not None:
+                provenance = {
+                    "attempts": manifest.provenance.attempts,
+                    "revisions": [
+                        {"attempt": r.attempt, "classes": r.classes}
+                        for r in manifest.provenance.revisions
+                    ],
+                }
+
+    # Framing re-rolls: the sequence creates one extra framing run per re-roll, so counting
+    # the runs that produced a manifest or a rejection is the record. Conservative floor of 1
+    # — a cycle always had at least one framing run to reject anything at all.
+    return build_baseline(
+        cycle_id,
+        rejection_records=rejection_records,
+        manifest_provenance=provenance,
+        framing_run_count=max(1, len(run_ids)),
+    )
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("cycle_ids", nargs="+")
+    parser.add_argument("--project", default="group_run")
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args()
+
+    vault = FileSystemArtifactVault(base_dir=str(REPO_ROOT / "data" / "artifacts"))
+    baselines = [await _cycle_baseline(vault, c) for c in args.cycle_ids]
+    output = render(baselines)
+
+    if args.out:
+        args.out.write_text(output, encoding="utf-8")
+        print(f"wrote {args.out} ({len(baselines)} cycle(s))")
+    else:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/squadops/cycles/rejection_baseline.py
+++ b/src/squadops/cycles/rejection_baseline.py
@@ -1,0 +1,173 @@
+"""The pre-memory rejection baseline (#809, B1).
+
+Cross-Cycle Memory's value claim is that recurrence of the same mistake falls. Testing that
+needs a picture of how often each class of mistake happens **before memory exists** — and the
+moment memory is live, the pre-memory picture is gone. Nothing in 1.6 reads what this module
+records; that is deliberate. It is written now because it cannot be written later.
+
+**What is impossible afterwards is the data, not the report.** So the work here is making the
+inputs durable and classified at the moment they occur; the aggregation is arithmetic that can
+run at any time, including retrospectively over cycles already completed. Three of the four
+inputs already existed when this landed:
+
+===========================  ====================================================
+ authoring failure classes    M5's manifest ``provenance.revisions[].classes``
+ attempts consumed            M5's ``provenance.attempts``
+ framing re-rolls consumed    one framing run per re-roll — count them
+ plan-validation classes      **this module** — nothing recorded them before
+===========================  ====================================================
+
+The fourth is the gap this closes. A rejected plan recorded *what* went wrong as a joined
+error string and never *which class*, and re-parsing prose at window time is the failure mode
+the plan warns against ("one vocabulary, not a free-text field that each reader parses
+differently"), not the fix.
+
+Two dimensions, because memory can improve either: **recurrence** (how often a class occurs)
+and **time-to-resolution** (attempts and re-rolls burned before it cleared). A memory
+implementation that halves recovery cost without changing recurrence is a real win that a
+recurrence-only baseline would score as zero.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+#: Artifact type for a recorded rejection. Its own type rather than a ``document`` so the
+#: deriver can select it without reading content, and so it never lands in the plan-artifact
+#: forwarding set (which keys on type).
+REJECTION_ARTIFACT_TYPE = "rejection_record"
+REJECTION_FILENAME = "rejection_record.json"
+
+
+@dataclass
+class RejectionClassifier:
+    """Accumulates which validator rejected a plan, at the moment it does.
+
+    The gate calls its validators one at a time, so the producing validator is known exactly
+    where the errors are collected — no validator signature changes, no error tagging, and no
+    prose to parse back. The names are ``ImplementationPlan.validate_*``, which is the same
+    vocabulary ``plan_authoring_rules`` keys on and therefore the same one the authoring-rules
+    asset teaches. A baseline that spoke different names than the authors are taught would
+    make "did teaching this rule reduce it?" unanswerable.
+    """
+
+    classes: dict[str, int] = field(default_factory=dict)
+
+    def collect(self, validator: str, errors: list[str]) -> list[str]:
+        """Record ``errors`` under ``validator`` and return them unchanged.
+
+        Pass-through by design: it wraps an existing ``errors.extend(...)`` without changing
+        what is collected or the order it is collected in, so a classification bug can never
+        alter which plans are rejected.
+        """
+        if errors:
+            self.classes[validator] = self.classes.get(validator, 0) + len(errors)
+        return errors
+
+    def record(self, gate_name: str, errors: list[str]) -> dict[str, Any]:
+        """The artifact payload for a rejection, or ``{}`` when nothing was rejected."""
+        if not errors:
+            return {}
+        return {
+            "gate": gate_name,
+            "classes": dict(sorted(self.classes.items())),
+            "errors": list(errors),
+        }
+
+
+@dataclass(frozen=True)
+class ClassBaseline:
+    """One rejection class, and what it cost before it cleared."""
+
+    rejection_class: str
+    occurrences: int
+    #: Authoring attempts consumed in the cycle. Whole-cycle rather than per-class: the
+    #: authoring loop revises against every finding at once, so attributing an attempt to one
+    #: class among several would be an invention.
+    attempts: int
+    #: Framing re-rolls consumed in the cycle, on the same whole-cycle basis.
+    rerolls: int
+
+
+@dataclass(frozen=True)
+class CycleBaseline:
+    """A cycle's rejection classes across both dimensions."""
+
+    cycle_id: str
+    classes: tuple[ClassBaseline, ...] = ()
+    attempts: int = 0
+    rerolls: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cycle_id": self.cycle_id,
+            "attempts": self.attempts,
+            "rerolls": self.rerolls,
+            "classes": [
+                {
+                    "class": c.rejection_class,
+                    "occurrences": c.occurrences,
+                    "attempts": c.attempts,
+                    "rerolls": c.rerolls,
+                }
+                for c in self.classes
+            ],
+        }
+
+
+def build_baseline(
+    cycle_id: str,
+    *,
+    rejection_records: list[dict[str, Any]],
+    manifest_provenance: dict[str, Any] | None,
+    framing_run_count: int,
+) -> CycleBaseline:
+    """Assemble one cycle's baseline from durable inputs.
+
+    Pure arithmetic over stored facts — no vault, no registry, no cycle state. That is what
+    makes the baseline reconstructible later: the caller supplies what it read, and this
+    decides nothing it cannot see.
+
+    ``framing_run_count`` yields re-rolls as ``count - 1``: the sequence creates exactly one
+    additional framing run per re-roll, so the runs *are* the record and nothing extra had to
+    be persisted to count them.
+    """
+    counts: dict[str, int] = {}
+    for record in rejection_records:
+        for name, n in (record.get("classes") or {}).items():
+            counts[str(name)] = counts.get(str(name), 0) + int(n)
+
+    provenance = manifest_provenance or {}
+    for revision in provenance.get("revisions") or []:
+        for name, n in (revision.get("classes") or {}).items():
+            counts[str(name)] = counts.get(str(name), 0) + int(n)
+
+    attempts = int(provenance.get("attempts", 0) or 0)
+    rerolls = max(0, framing_run_count - 1)
+    return CycleBaseline(
+        cycle_id=cycle_id,
+        attempts=attempts,
+        rerolls=rerolls,
+        classes=tuple(
+            ClassBaseline(rejection_class=name, occurrences=n, attempts=attempts, rerolls=rerolls)
+            for name, n in sorted(counts.items())
+        ),
+    )
+
+
+def render(baselines: list[CycleBaseline]) -> str:
+    """The baseline as JSON — the shape 1.8 reads, and nothing in 1.6 does."""
+    return json.dumps(
+        {
+            "schema": 1,
+            "purpose": (
+                "pre-memory rejection-class baseline (#809, B1) — recurrence and "
+                "time-to-resolution per cycle, captured before Cross-Cycle Memory exists"
+            ),
+            "cycles": [b.to_dict() for b in baselines],
+        },
+        indent=2,
+        sort_keys=False,
+    )

--- a/tests/unit/cycles/test_rejection_baseline.py
+++ b/tests/unit/cycles/test_rejection_baseline.py
@@ -1,0 +1,223 @@
+"""The pre-memory rejection baseline (#809, B1).
+
+The only item in 1.6 whose omission is permanent: once Cross-Cycle Memory exists, the
+pre-memory recurrence picture cannot be reconstructed, and memory's whole value claim becomes
+unmeasurable.
+
+Bug classes guarded:
+
+- **a rejection recorded without its class** — the defect this closes. A joined error string
+  says what went wrong and not which kind of thing went wrong, and re-parsing prose at window
+  time is the failure mode the plan names, not the fix;
+- classification changing what gets rejected. A baseline is bookkeeping; if a counting bug
+  could alter which plans pass, the instrument would be changing the experiment;
+- recording a "rejection" when nothing was rejected, which inflates a baseline that is read
+  as evidence;
+- losing the second dimension. Memory can reduce how often a mistake happens *or* how
+  expensively it is recovered from; a recurrence-only baseline scores the second as zero;
+- a bookkeeping failure taking down the rejection path with it — a gap in a dataset is
+  survivable, a lost cycle is not;
+- the two vocabularies drifting: the baseline must speak the same validator names the
+  authoring-rules asset teaches, or "did teaching this rule reduce it?" is unanswerable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from squadops.cycles.implementation_plan import ImplementationPlan
+from squadops.cycles.plan_authoring_rules import classified_validators
+from squadops.cycles.rejection_baseline import (
+    RejectionClassifier,
+    build_baseline,
+    render,
+)
+
+pytestmark = [pytest.mark.domain_contracts]
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "authored_v4"
+
+
+# --------------------------------------------------------------------------- #
+# Classifying at the point of rejection
+# --------------------------------------------------------------------------- #
+
+
+def test_collect_records_the_class_and_returns_the_errors_untouched():
+    """Pass-through by design: it wraps an existing ``errors.extend(...)``, so a
+    classification bug cannot change which plans are rejected."""
+    classifier = RejectionClassifier()
+    errors = ["a", "b"]
+
+    returned = classifier.collect("validate_unique_expected_artifacts", errors)
+
+    assert returned == errors
+    assert classifier.classes == {"validate_unique_expected_artifacts": 2}
+
+
+def test_a_validator_that_found_nothing_is_not_a_class():
+    """Recording a clean validator would report rejections that never happened in a dataset
+    read as evidence."""
+    classifier = RejectionClassifier()
+
+    classifier.collect("validate_command_checks", [])
+
+    assert classifier.classes == {}
+    assert classifier.record("progress_plan_review", []) == {}
+
+
+def test_repeat_findings_from_one_validator_accumulate():
+    classifier = RejectionClassifier()
+
+    classifier.collect("validate_module_existence", ["x"])
+    classifier.collect("validate_module_existence", ["y", "z"])
+
+    assert classifier.classes == {"validate_module_existence": 3}
+
+
+def test_the_record_carries_classes_and_the_prose_it_replaces():
+    """Both, not either: the classes are what the baseline counts, and the errors stay so a
+    human reading one record can still see what actually happened."""
+    classifier = RejectionClassifier()
+    classifier.collect("validate_criteria_scope", ["regex on source"])
+
+    record = classifier.record("progress_plan_review", ["regex on source"])
+
+    assert record["gate"] == "progress_plan_review"
+    assert record["classes"] == {"validate_criteria_scope": 1}
+    assert record["errors"] == ["regex on source"]
+
+
+def test_the_baselines_vocabulary_is_the_one_authors_are_taught():
+    """The names must be the `validate_*` family `plan_authoring_rules` classifies. A baseline
+    speaking different names could not answer "did teaching this rule reduce it?" — which is
+    the only question it exists to support."""
+    known = classified_validators()
+    assert known, "the validator classification must be discoverable"
+
+    for name in ("validate_unique_expected_artifacts", "validate_module_existence"):
+        assert name in known
+        assert name in {n for n in dir(ImplementationPlan) if n.startswith("validate_")}
+
+
+# --------------------------------------------------------------------------- #
+# Assembling the baseline
+# --------------------------------------------------------------------------- #
+
+
+def test_a_cycle_with_no_rejections_has_an_empty_baseline():
+    baseline = build_baseline(
+        "cyc_clean", rejection_records=[], manifest_provenance=None, framing_run_count=1
+    )
+
+    assert baseline.classes == ()
+    assert baseline.rerolls == 0
+
+
+def test_both_dimensions_are_recorded():
+    """Recurrence AND time-to-resolution. Memory that halves recovery cost without changing
+    recurrence is a real win a recurrence-only baseline would score as zero."""
+    baseline = build_baseline(
+        "cyc_1",
+        rejection_records=[{"classes": {"validate_unique_expected_artifacts": 1}}],
+        manifest_provenance={"attempts": 2, "revisions": [{"classes": {"authoring_defect": 1}}]},
+        framing_run_count=3,
+    )
+
+    assert baseline.attempts == 2
+    assert baseline.rerolls == 2
+    assert {c.rejection_class: c.occurrences for c in baseline.classes} == {
+        "validate_unique_expected_artifacts": 1,
+        "authoring_defect": 1,
+    }
+
+
+def test_plan_and_authoring_classes_share_one_baseline():
+    """The plan asks for both families. Kept in one record because a reader asking "what did
+    this cycle get wrong?" should not have to know which subsystem rejected it."""
+    baseline = build_baseline(
+        "cyc_2",
+        rejection_records=[
+            {"classes": {"validate_module_existence": 2}},
+            {"classes": {"validate_module_existence": 1, "validate_build_config": 1}},
+        ],
+        manifest_provenance={"attempts": 1, "revisions": []},
+        framing_run_count=1,
+    )
+
+    counts = {c.rejection_class: c.occurrences for c in baseline.classes}
+    assert counts == {"validate_module_existence": 3, "validate_build_config": 1}
+
+
+@pytest.mark.parametrize(("runs", "expected"), [(1, 0), (2, 1), (4, 3), (0, 0)])
+def test_rerolls_come_from_the_run_count_not_a_counter(runs, expected):
+    """The sequence creates one extra framing run per re-roll, so the runs ARE the record —
+    nothing extra had to be persisted, and it works retrospectively on cycles that ran before
+    this existed."""
+    baseline = build_baseline(
+        "cyc_3", rejection_records=[], manifest_provenance=None, framing_run_count=runs
+    )
+
+    assert baseline.rerolls == expected
+
+
+def test_malformed_inputs_do_not_break_the_assembly():
+    """A record is not a contract. Partial bookkeeping must still yield a usable row."""
+    baseline = build_baseline(
+        "cyc_4",
+        rejection_records=[{}, {"classes": None}],
+        manifest_provenance={"revisions": [{}]},
+        framing_run_count=1,
+    )
+
+    assert baseline.classes == ()
+    assert baseline.attempts == 0
+
+
+# --------------------------------------------------------------------------- #
+# Replay over the V4 evidence
+# --------------------------------------------------------------------------- #
+
+
+def test_v4_roll_1s_known_rejection_reproduces_its_class():
+    """Roll 1 died on #673's dual claim — two tasks declaring `backend/routes/runs.py`. Run
+    the real plan through the real validator and assert the baseline names that class, so the
+    end-to-end shape is proven on observed data rather than a hand-made record."""
+    plan = ImplementationPlan.from_yaml(
+        (_FIXTURES / "implementation_plan.yaml").read_text(encoding="utf-8")
+    )
+    classifier = RejectionClassifier()
+    errors = classifier.collect(
+        "validate_unique_expected_artifacts", plan.validate_unique_expected_artifacts()
+    )
+
+    assert errors, "roll 1's plan is supposed to trip the dual-claim rule"
+    baseline = build_baseline(
+        "cyc_9c8c98ea3171",
+        rejection_records=[classifier.record("progress_plan_review", errors)],
+        manifest_provenance=None,
+        framing_run_count=1,
+    )
+
+    assert [c.rejection_class for c in baseline.classes] == ["validate_unique_expected_artifacts"]
+
+
+def test_render_is_json_a_later_reader_can_consume():
+    """1.8 reads this; 1.6 reads nothing. It has to be self-describing to someone who was not
+    here when it was written."""
+    payload = json.loads(
+        render(
+            [
+                build_baseline(
+                    "cyc_x", rejection_records=[], manifest_provenance=None, framing_run_count=1
+                )
+            ]
+        )
+    )
+
+    assert payload["schema"] == 1
+    assert "pre-memory" in payload["purpose"]
+    assert payload["cycles"][0]["cycle_id"] == "cyc_x"


### PR DESCRIPTION
The one item in 1.6 whose omission would be **permanent**. Cross-Cycle Memory's value claim is that recurrence of the same mistake falls; testing that needs a picture of how often each class occurs *before* memory exists, and the moment memory is live that picture is unrecoverable.

## Measuring first made this much smaller

Three of B1's four inputs were already durable — two of them because M5 and M6 landed ahead of it:

| input | durable before this PR? |
|---|---|
| authoring failure classes | ✅ M5's `provenance.revisions[].classes` |
| attempts consumed | ✅ `provenance.attempts` |
| framing re-rolls consumed | ✅ derivable — one framing run per re-roll |
| **plan-validation classes** | ❌ **nothing recorded them** |

So the work is the fourth. A rejected plan recorded *what* went wrong as a joined error string and never *which class* — and re-parsing that prose at window time is the failure mode the plan warns against ("one vocabulary, not a free-text field that each reader parses differently"), not the fix.

## Shape

- **Classified at the point of rejection.** The gate calls its validators one at a time, so the producing validator is known exactly where the errors are collected — no validator signature changes, no error tagging, no prose to parse back.
- **The instrument cannot alter the experiment.** `collect()` is a pass-through around the existing `errors.extend(...)`, returning its input unchanged, so a counting bug cannot change which plans get rejected. Asserted directly.
- **The vocabulary is the one authors are taught** — `ImplementationPlan.validate_*`, which `plan_authoring_rules` keys on and the authoring-rules asset is bound to. A baseline speaking different names could not answer *"did teaching this rule reduce it?"*, which is the only question it exists to support.
- **A `rejection_record` artifact, not a schema change.** Durable, typed, attached to the run that was rejected, no migration. A jsonb column on `cycle_gate_decisions` would be a second answer to where run facts live.
- **Never raises.** A baseline is a record, not a gate: losing one cycle's bookkeeping is a gap in a dataset; failing the rejection path would turn it into a lost cycle.
- **Both dimensions**, per the plan — recurrence, and time-to-resolution from attempts + re-rolls. Memory that halves recovery cost without changing recurrence is a real win a recurrence-only baseline would score as zero.

## The aggregation is a script, deliberately

What is impossible afterwards is the **data**, not the report. With the inputs structured and durable, the baseline can be produced at any time — including retrospectively over cycles already run, which means V4 rolls 1 and 2 are already partly covered. `scripts/dev/emit_rejection_baseline.py` reads only stored facts.

**Read by nothing in 1.6**, exactly as the plan specifies.

## Verification

15 new tests, including a **replay over the V4 fixtures**: roll 1's real plan through the real validator reproduces its known dual-claim class end to end, so the shape is proven on observed data rather than a hand-made record.

Full regression green: 7,122 unit / 6,736 regression / 22 architecture.

Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv