### PR TITLE
fix(cycles): an answered design question reaches the author as a revision (#811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,12 @@ a system-owned block recording mode, cycle, task, attempt count and the *classif
 for each revision, excluded from the manifest's canonical projection so recording how a
 design was written can never move the hash its contract binds.
 **#811** closes the revision loop: a design question the gate asks can now be *answered* —
-`RETURNED_FOR_REVISION` re-executes framing with the reviewer's notes and the prior manifest
-as authoring context, bounded by `manifest_max_attempts`, instead of stopping the sequence
-for a manual retry run.
+`RETURNED_FOR_REVISION` re-executes framing with the notes and the prior manifest as
+authoring context, bounded by `manifest_max_attempts`, instead of stopping the sequence for a
+manual retry run. It **restores the prefix the note does not invalidate** via SIP-0101's
+checkpoint translation — enabled by framing task ids becoming deterministic in the same
+change — and re-runs from the technical design, so the design answers the note rather than
+describing an interface the revised manifest no longer has.
 **B1 (#809)** closes the one item whose omission would have been permanent: rejections are
 now classified at the moment they happen — plan-validation by producing validator, authoring
 by M6 class — so the pre-memory recurrence baseline Cross-Cycle Memory will be measured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ shown; a design that asks nothing records a distinguishable system approval and 
 a system-owned block recording mode, cycle, task, attempt count and the *classified* reason
 for each revision, excluded from the manifest's canonical projection so recording how a
 design was written can never move the hash its contract binds.
+**#811** closes the revision loop: a design question the gate asks can now be *answered* —
+`RETURNED_FOR_REVISION` re-executes framing with the reviewer's notes and the prior manifest
+as authoring context, bounded by `manifest_max_attempts`, instead of stopping the sequence
+for a manual retry run.
 **B1 (#809)** closes the one item whose omission would have been permanent: rejections are
 now classified at the moment they happen — plan-validation by producing validator, authoring
 by M6 class — so the pre-memory recurrence baseline Cross-Cycle Memory will be measured

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -826,6 +826,9 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         forwarding_overrides = {
                             **(forwarding_overrides or {}),
                             "framing_rejection_context": revision_context,
+                            # #811: the superseded run whose completed prefix the revision
+                            # restores instead of re-earning.
+                            "framing_revision_source": run.run_id,
                         }
                         revision_run = await self._create_next_workload_run(
                             cycle,
@@ -1340,6 +1343,11 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # SOURCE run's boundary checkpoint instead (translated into this
             # run's task-id namespace); None for normal cycles.
             checkpoint = await self._resolve_replay_checkpoint(cycle, run_id)
+        if checkpoint is None:
+            # #811: an operator-requested revision restores the framing prefix its note
+            # does not invalidate. Distinct from replay above: replay fails closed, a
+            # revision degrades to the full re-run it used to do.
+            checkpoint = await self._resolve_revision_checkpoint(cycle, run_id)
         if checkpoint:
             await self._restore_checkpoint_state(
                 checkpoint,
@@ -2301,6 +2309,84 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             return translate_checkpoint_for_replay(source_cp, run_id)
         except ValueError as e:
             raise _ExecutionError(str(e)) from e
+
+    async def _resolve_revision_checkpoint(self, cycle: Cycle, run_id: str) -> RunCheckpoint | None:
+        """#811: the framing prefix an operator-requested revision does not need to redo.
+
+        A revision changes the design, so everything from the technical design onward is
+        stale and re-runs. Everything *before* it — the context research and the objective
+        frame — is upstream of the design and unaffected by a note about it, so the
+        superseded run's boundary checkpoint is restored instead of re-earned.
+
+        This is SIP-0101's replay mechanism pointed at a different source. It only became
+        possible when framing task ids turned deterministic in the same change:
+        ``translate_checkpoint_for_replay`` rebinds a run prefix and raises on anything else,
+        so ``uuid4().hex`` framing ids could never be translated onto a new run.
+
+        **Degrades, never fails closed.** Replay fails closed because a replay that silently
+        executed the full plan would claim a saved prefix it did not earn. A revision claims
+        nothing — the full re-execution is simply the slower correct answer, and it is what
+        this did before the optimisation existed. So an unresolvable boundary logs and
+        returns ``None``.
+        """
+        from squadops.cycles.manifest_authoring import REVISION_RESTART_TASK_TYPE
+        from squadops.cycles.replay import translate_checkpoint_for_replay
+
+        source_run_id = (cycle.execution_overrides or {}).get("framing_revision_source")
+        if not source_run_id:
+            return None
+
+        try:
+            checkpoints = await self._cycle_registry.list_checkpoints(source_run_id)
+        except Exception:
+            logger.warning(
+                "Revision run %s could not read checkpoints from %s; re-running the whole "
+                "framing workload instead",
+                run_id,
+                source_run_id,
+                exc_info=True,
+            )
+            return None
+
+        # The latest boundary that has NOT yet done the work a revision invalidates.
+        usable = [
+            c
+            for c in checkpoints
+            if not any(tid.endswith(REVISION_RESTART_TASK_TYPE) for tid in c.completed_task_ids)
+        ]
+        if not usable:
+            logger.info(
+                "Revision run %s found no checkpoint before %s on %s (pruned, or the source "
+                "predates deterministic framing ids); re-running the whole framing workload",
+                run_id,
+                REVISION_RESTART_TASK_TYPE,
+                source_run_id,
+            )
+            return None
+
+        boundary = max(usable, key=lambda c: c.checkpoint_index)
+        try:
+            translated = translate_checkpoint_for_replay(boundary, run_id)
+        except ValueError as exc:
+            logger.info(
+                "Revision run %s could not translate boundary %d from %s (%s); re-running "
+                "the whole framing workload",
+                run_id,
+                boundary.checkpoint_index,
+                source_run_id,
+                exc,
+            )
+            return None
+
+        logger.info(
+            "Revision run %s restores %d task(s) from %s boundary %d — re-running from %s",
+            run_id,
+            len(translated.completed_task_ids),
+            source_run_id,
+            boundary.checkpoint_index,
+            REVISION_RESTART_TASK_TYPE,
+        )
+        return translated
 
     async def _restore_checkpoint_state(
         self,

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -600,6 +600,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # (default) is byte-identical to the old `for` loop.
         framing_rerolls = 0
         max_framing_rerolls = cycle.resolved_config().get("framing_max_rerolls", 0)
+        # #811: operator-requested revisions are counted SEPARATELY from system re-rolls and
+        # bounded by ``manifest_max_attempts`` (§5c.6), not ``framing_max_rerolls``. The
+        # latter defaults to 0 and the validated profiles do not set it, so sharing it would
+        # ship this switched off — and it conflates a stochastic framing fault the system
+        # retries with a deliberate instruction from a human.
+        framing_revisions = 0
+        max_framing_revisions = int(cycle.resolved_config().get("manifest_max_attempts", 2))
         i = start_index
         while i < len(workload_sequence):
             workload_entry = workload_sequence[i]
@@ -786,18 +793,80 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     break  # Run stays COMPLETED; rejection in gate_decisions
 
                 if decision.decision == GateDecisionValue.RETURNED_FOR_REVISION:
-                    # #466: revision is NOT an approval — do not advance the
-                    # sequence with the un-revised plan (the 3.10 false-approve).
-                    # Parity with the mid-run gate path: revision requires
-                    # manual retry-run creation; the decision + notes stay in
-                    # gate_decisions for whoever creates it.
+                    # #466: revision is NOT an approval — the sequence must never advance
+                    # with the un-revised plan (the 3.10 false-approve). #811 makes the
+                    # revision actually happen instead of stopping: without it the gate could
+                    # ask a design question and then do nothing with the answer, which is the
+                    # rubber stamp it replaced wearing a better costume.
+                    #
+                    # Deliberately the SAME path a system rejection takes (#522/#669), driven
+                    # by a different trigger — a second re-execution loop beside a proven one
+                    # is how they drift.
+                    if (
+                        workload_entry.get("type") == "framing"
+                        and framing_revisions < max_framing_revisions
+                    ):
+                        framing_revisions += 1
+                        # Cancel FIRST: the positional run↔workload invariant (#257/D14) is
+                        # exactly one non-cancelled run per position, and the superseded run
+                        # still occupies this one.
+                        await self._cycle_registry.cancel_run(current_run_id)
+                        revision_context: dict[str, Any] = {
+                            "rejection_reasons": [
+                                decision.notes.strip()
+                                or "The reviewer returned this design for revision."
+                            ]
+                        }
+                        # §5c.6's "revise, don't re-roll": without the prior manifest the new
+                        # framing re-authors from scratch with a hint attached, which is the
+                        # fay-6 new-dice failure in disguise.
+                        prior_manifest = await self._run_manifest_content(run, cycle)
+                        if prior_manifest:
+                            revision_context["prior_manifest_yaml"] = prior_manifest
+                        forwarding_overrides = {
+                            **(forwarding_overrides or {}),
+                            "framing_rejection_context": revision_context,
+                        }
+                        revision_run = await self._create_next_workload_run(
+                            cycle,
+                            run,
+                            workload_entry,
+                            config_hash=run.resolved_config_hash,
+                        )
+                        current_run_id = revision_run.run_id
+                        self._cycle_event_bus.emit(
+                            EventType.WORKLOAD_ADVANCED,
+                            entity_type="workload",
+                            entity_id=current_run_id,
+                            context={"cycle_id": cycle_id, "run_id": current_run_id},
+                            payload={
+                                "workload_type": "framing",
+                                "reason": "framing_revision_on_operator_request",
+                                "revision": framing_revisions,
+                            },
+                        )
+                        logger.info(
+                            "Gate %r returned_for_revision on run %s: revising (%d/%d) in "
+                            "new framing run %s with the reviewer's notes as authoring "
+                            "context",
+                            gate_name,
+                            run.run_id,
+                            framing_revisions,
+                            max_framing_revisions,
+                            current_run_id,
+                        )
+                        continue  # same index — re-execute framing, revised
                     logger.info(
-                        "Gate %r returned_for_revision on run %s: stopping the "
-                        "workload sequence; revision requires manual retry-run "
-                        "creation (automatic retry-in-same-phase is not "
-                        "implemented in this version)",
+                        "Gate %r returned_for_revision on run %s: stopping the workload "
+                        "sequence — %s",
                         gate_name,
                         current_run_id,
+                        (
+                            f"the revision budget is spent ({framing_revisions}/"
+                            f"{max_framing_revisions})"
+                            if workload_entry.get("type") == "framing"
+                            else "only a framing workload can be revised"
+                        ),
                     )
                     break
 
@@ -1799,8 +1868,20 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         first guard exists to forbid. The question is a property of the design, not of who
         supplied it.
         """
-        from squadops.cycles.contract_derivation import load_seeded_manifest_content
         from squadops.cycles.manifest_authoring import open_questions
+
+        content = await self._run_manifest_content(run, cycle)
+        return None if content is None else open_questions(content)
+
+    async def _run_manifest_content(self, run: Any, cycle: Any) -> str | None:
+        """The interface manifest governing this run, from either rail, or ``None``.
+
+        One lookup, two readers (#807's question-gate and #811's revision context). Both
+        rails are read — the manifest this run authored lives on the run's own refs, an
+        operator-seeded one on the cycle's ``plan_artifact_refs`` — because behavior keyed on
+        *who supplied the design* is the authoring-mode branch Guard 1a forbids.
+        """
+        from squadops.cycles.contract_derivation import load_seeded_manifest_content
 
         # The completed run the caller already fetched — re-reading it here would add a
         # registry round-trip per gate for a value the loop is holding.
@@ -1810,12 +1891,11 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             except Exception:
                 continue
             if is_interface_manifest(ref):
-                return open_questions(content_bytes.decode(errors="replace"))
+                return content_bytes.decode(errors="replace")
 
-        seeded = await load_seeded_manifest_content(
+        return await load_seeded_manifest_content(
             self._artifact_vault, cycle.execution_overrides.get("plan_artifact_refs")
         )
-        return None if seeded is None else open_questions(seeded)
 
     async def _approve_gate_without_questions(
         self, run_id: str, cycle_id: str, gate_name: str

--- a/src/squadops/capabilities/context_assembly.py
+++ b/src/squadops/capabilities/context_assembly.py
@@ -178,6 +178,10 @@ CONTEXT_CONTRACTS: dict[str, ContextAssemblyContract] = {
         artifact_landing=LANDING_PRIOR_OUTPUTS,
         plan_rejection_context=True,
     ),
+    # #811: the technical design answers an operator's revision request too. A note about
+    # the interface is a note about the design, and a revision that changed only the manifest
+    # would leave `technical_design.md` describing an interface that no longer exists.
+    "development.design_plan": ContextAssemblyContract(plan_rejection_context=True),
     # SIP-0103 §5c.1 (#791): the manifest author's input contract, as data. The PRD and
     # the blueprint's vocabulary arrive on the envelope; what lands here is the cycle's
     # OWN framing — strategy's frame (which §5a has constraining scope from above) and

--- a/src/squadops/capabilities/handlers/planning/framing.py
+++ b/src/squadops/capabilities/handlers/planning/framing.py
@@ -6,10 +6,8 @@ specializations of the shared base; all behavior lives there.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any
 
-if TYPE_CHECKING:
-    pass
 from squadops.capabilities.handlers.planning.base import _PlanningTaskHandler
 
 # ---------------------------------------------------------------------------
@@ -42,6 +40,24 @@ class DevelopmentDesignPlanHandler(_PlanningTaskHandler):
     _capability_id = "development.design_plan"
     _role = "dev"
     _artifact_name = "technical_design.md"
+
+    async def _rejection_context_section(self, renderer: Any, inputs: dict[str, Any]) -> str:
+        """The revision request, or "" (#811).
+
+        Overrides the planning base, which renders the *plan* re-roll appendix — a rejected
+        `implementation_plan.yaml` this stage did not write, under rules about task shape that
+        say nothing about a technical design. Same #669 rail, a document-appropriate asset.
+        """
+        reasons = [
+            str(r).strip() for r in (inputs.get("rejection_reasons") or []) if str(r).strip()
+        ]
+        if not reasons:
+            return ""
+        rendered = await renderer.render(
+            "request.design_revision_request_appendix",
+            {"reviewer_notes": "\n".join(f"- {r}" for r in reasons)},
+        )
+        return rendered.content
 
 
 class QADefineTestStrategyHandler(_PlanningTaskHandler):

--- a/src/squadops/capabilities/handlers/planning/manifest.py
+++ b/src/squadops/capabilities/handlers/planning/manifest.py
@@ -83,7 +83,7 @@ class DevelopmentAuthorManifestHandler(_PlanningTaskHandler):
         variables["authoring_rules_section"] = (
             await renderer.render("request.manifest_authoring_rules_appendix", {})
         ).content
-        rejection_section = await self._rejection_context_section(renderer, inputs)
+        rejection_section = await self._revision_context_section(renderer, inputs)
         if rejection_section:
             variables["rejection_context_section"] = rejection_section
 
@@ -146,6 +146,32 @@ class DevelopmentAuthorManifestHandler(_PlanningTaskHandler):
             )
 
         return self._success(start_time, inputs, content, outcome, assembled, rendered)
+
+    async def _revision_context_section(self, renderer: Any, inputs: dict[str, Any]) -> str:
+        """The revision appendix on a re-roll or an operator-requested revision, or "".
+
+        Overrides the planning base's version, which renders the *plan* re-roll appendix —
+        wrong for a manifest author, and it would show them a rejected plan they did not
+        write. Same #669 rail, a document-appropriate asset.
+
+        The prior manifest is what makes this a revision rather than a re-roll (§5c.6,
+        #811): shown the design being revised, the author changes what was asked about;
+        shown only a note, it re-derives everything and the reviewer reads a new design.
+        """
+        reasons = [
+            str(r).strip() for r in (inputs.get("rejection_reasons") or []) if str(r).strip()
+        ]
+        if not reasons:
+            return ""
+        variables: dict[str, str] = {"reviewer_notes": "\n".join(f"- {r}" for r in reasons)}
+        prior = str(inputs.get("prior_manifest_yaml") or "").strip()
+        if prior:
+            variables["prior_manifest"] = (
+                "\n### The design you are revising\n\n"
+                f"```yaml:interface_manifest.yaml\n{prior}\n```\n"
+            )
+        rendered = await renderer.render("request.manifest_revision_request_appendix", variables)
+        return rendered.content
 
     # -- results ------------------------------------------------------------------
 

--- a/src/squadops/cycles/manifest_authoring.py
+++ b/src/squadops/cycles/manifest_authoring.py
@@ -73,6 +73,17 @@ AUTHORING_INPUT_CONTRACT: frozenset[str] = frozenset(
 INPUT_CONTRACT_EXTENSION_POINTS: tuple[str, ...] = ("cross_cycle_recall",)
 
 
+#: Where an operator-requested revision re-enters the framing sequence (#811).
+#:
+#: NOT the authoring stage itself. A reviewer's note is a change to the *design*, so the
+#: technical design must answer it too — restarting at the manifest alone would leave
+#: `technical_design.md` describing an interface the revised manifest no longer has, and the
+#: next reader could not tell which one the squad meant.
+#:
+#: Everything before this point is restored from the superseded run's checkpoint: research and
+#: the objective frame are upstream of the design and unaffected by a note about it.
+REVISION_RESTART_TASK_TYPE = "development.design_plan"
+
 #: Recorded as ``GateDecision.decided_by`` when the design asked nothing and the gate passed
 #: itself. Distinct from a human's approval on purpose: the argument for question-gating is
 #: that a rubber stamp cannot be told from a considered decision, and an unrecorded machine

--- a/src/squadops/cycles/manifest_authoring.py
+++ b/src/squadops/cycles/manifest_authoring.py
@@ -58,6 +58,9 @@ AUTHORING_INPUT_CONTRACT: frozenset[str] = frozenset(
         # #669 in-cycle rejection context — the revise-don't-re-dice rail.
         "rejection_reasons",
         "rejected_plan_yaml",
+        # #811: the design an operator returned for revision. In-cycle by definition — it
+        # is this cycle's own prior output, not an external input.
+        "prior_manifest_yaml",
         # Dispatch mechanics, not design inputs: model selection and chat kwargs.
         "agent_model",
         "agent_config_overrides",

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -772,8 +772,16 @@ def generate_task_plan(
 
     # RC-1 (SIP-0079): Deterministic task IDs for implementation runs.
     # RC-2 (SIP-0086): Manifest-derived IDs use -m{index}- namespace.
-    use_deterministic_ids = (
-        run.workload_type is not None and run.workload_type == WorkloadType.IMPLEMENTATION
+    # #811: FRAMING joins IMPLEMENTATION here. Replay's checkpoint translation rebinds the
+    # run prefix of a deterministic id (``task-{run}-{index}-{type}``) and *raises* on
+    # anything else, so a framing run whose ids were ``uuid4().hex`` could never be replayed
+    # or resumed onto a new run — which is what made an operator-requested manifest revision
+    # cost a full 58-minute re-execution. Ids stay unique within a run and now carry their
+    # position and type, which is also what makes a checkpoint boundary selectable by task
+    # type rather than by guesswork.
+    use_deterministic_ids = run.workload_type in (
+        WorkloadType.IMPLEMENTATION,
+        WorkloadType.FRAMING,
     )
 
     envelopes: list[TaskEnvelope] = []

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -502,6 +502,12 @@ def _inject_rejection_context(
     plan_yaml = str(rejection_context.get("rejected_plan_yaml") or "")
     if plan_yaml.strip():
         inputs["rejected_plan_yaml"] = plan_yaml
+    # #811: an operator-requested revision carries the design being revised. Without it a
+    # revision run re-authors from scratch with a note attached — the fay-6 new-dice failure
+    # in disguise, and the thing §5c.6's "revise, don't re-roll" exists to forbid.
+    manifest_yaml = str(rejection_context.get("prior_manifest_yaml") or "")
+    if manifest_yaml.strip():
+        inputs["prior_manifest_yaml"] = manifest_yaml
 
 
 def inject_contract_inputs(

--- a/src/squadops/prompts/request_templates/request.design_revision_request_appendix.md
+++ b/src/squadops/prompts/request_templates/request.design_revision_request_appendix.md
@@ -1,0 +1,28 @@
+---
+template_id: request.design_revision_request_appendix
+version: "1"
+required_variables:
+  - reviewer_notes
+---
+## THIS CYCLE'S PREVIOUS FRAMING WAS RETURNED — respond to it
+
+An earlier attempt at this cycle's framing was sent back, either by a reviewer reading the
+proposed interface or by a deterministic gate rejecting the plan built from it. You are
+producing the technical design again so that it **answers what came back**, not so that you
+can design the application from scratch.
+
+### What was returned
+
+{{reviewer_notes}}
+
+### How to respond
+
+- **Address it directly in the design.** The interface manifest is being revised against the
+  same notes; if your design and that manifest disagree, the next reader cannot tell which
+  one the squad meant.
+- **Keep everything that was not raised.** Re-deriving the rest replaces decisions that were
+  accepted with different ones, for no gain.
+- **If a note answers a question the design left open,** record the answer as settled and say
+  where it came from, so the reasoning survives past this cycle.
+- **If you think it is wrong,** say so explicitly and explain why. A design that quietly
+  complies while believing otherwise is worse than a disagreement on the record.

--- a/src/squadops/prompts/request_templates/request.manifest_revision_request_appendix.md
+++ b/src/squadops/prompts/request_templates/request.manifest_revision_request_appendix.md
@@ -6,25 +6,25 @@ required_variables:
 optional_variables:
   - prior_manifest
 ---
-## REVISION REQUESTED — a reviewer returned your previous design
+## YOUR PREVIOUS DESIGN WAS RETURNED — revise it
 
-This is not a fresh start. A human read the interface manifest below, did not reject it,
-and asked for a specific change. Your job is to **revise that document**, not to design the
-application again.
+This is not a fresh start. The manifest below came back — either from a reviewer who read it
+and asked for a change, or from a deterministic gate that rejected the plan built on it.
+Your job is to **revise that document**, not to design the application again.
 
-### What the reviewer said
+### What came back
 
 {{reviewer_notes}}
 {{prior_manifest}}
 
 ### How to revise
 
-- **Change what was asked about, and leave the rest alone.** Everything the reviewer did not
-  raise was acceptable; re-deriving it risks replacing correct decisions with different ones
-  and makes the reviewer read the whole design a second time.
-- **If the note answers a question you declared `unresolved`,** resolve that decision: replace
-  it with a `choice` and a `warrant` citing the reviewer's answer as its source. That is what
-  the question was for.
+- **Change what was raised, and leave the rest alone.** Everything not mentioned was
+  acceptable; re-deriving it risks replacing correct decisions with different ones and makes
+  the next reader check the whole design again.
+- **If a note answers a question you declared `unresolved`,** resolve that decision: replace
+  it with a `choice` and a `warrant` naming where the answer came from. That is what the
+  question was for.
 - **If you disagree,** say so in the decision's `warrant` rather than silently complying or
   silently ignoring. A design record that hides a disagreement is worse than either.
 - Re-emit the **complete** `interface_manifest.yaml`. The gates run again on the whole

--- a/src/squadops/prompts/request_templates/request.manifest_revision_request_appendix.md
+++ b/src/squadops/prompts/request_templates/request.manifest_revision_request_appendix.md
@@ -1,0 +1,31 @@
+---
+template_id: request.manifest_revision_request_appendix
+version: "1"
+required_variables:
+  - reviewer_notes
+optional_variables:
+  - prior_manifest
+---
+## REVISION REQUESTED — a reviewer returned your previous design
+
+This is not a fresh start. A human read the interface manifest below, did not reject it,
+and asked for a specific change. Your job is to **revise that document**, not to design the
+application again.
+
+### What the reviewer said
+
+{{reviewer_notes}}
+{{prior_manifest}}
+
+### How to revise
+
+- **Change what was asked about, and leave the rest alone.** Everything the reviewer did not
+  raise was acceptable; re-deriving it risks replacing correct decisions with different ones
+  and makes the reviewer read the whole design a second time.
+- **If the note answers a question you declared `unresolved`,** resolve that decision: replace
+  it with a `choice` and a `warrant` citing the reviewer's answer as its source. That is what
+  the question was for.
+- **If you disagree,** say so in the decision's `warrant` rather than silently complying or
+  silently ignoring. A design record that hides a disagreement is worse than either.
+- Re-emit the **complete** `interface_manifest.yaml`. The gates run again on the whole
+  document, so a partial emission fails on everything you left out.

--- a/tests/unit/capabilities/test_manifest_authoring_stage.py
+++ b/tests/unit/capabilities/test_manifest_authoring_stage.py
@@ -325,4 +325,6 @@ async def test_rejection_context_is_inside_the_contract_and_actually_reaches_the
     )
 
     rendered = [c.args[0] for c in ctx.ports.request_renderer.render.call_args_list]
-    assert "request.plan_reroll_rejection_appendix" in rendered
+    # A manifest author gets a manifest-shaped appendix, not the plan re-roll one — that
+    # asset shows a rejected PLAN, which this author did not write (#811).
+    assert "request.manifest_revision_request_appendix" in rendered

--- a/tests/unit/capabilities/test_manifest_revision.py
+++ b/tests/unit/capabilities/test_manifest_revision.py
@@ -16,7 +16,15 @@ Bug classes guarded:
   write, describing rules that do not apply to them;
 - the revision context escaping the declared input contract, which would make it
   contamination rather than capability;
-- a first-roll authoring run rendering a revision appendix it has no reason to see.
+- a first-roll authoring run rendering a revision appendix it has no reason to see;
+- **the revision re-earning a framing prefix its note did not invalidate** — 58 minutes to
+  change one document, when research and the objective frame are upstream of the design and
+  unaffected by a note about it;
+- the technical design NOT answering the note, which would leave `technical_design.md`
+  describing an interface the revised manifest no longer has;
+- a revision failing closed when its boundary is unresolvable. Replay fails closed because it
+  would otherwise claim a saved prefix it never earned; a revision claims nothing, so the
+  full re-run is simply the slower correct answer.
 """
 
 from __future__ import annotations
@@ -156,3 +164,185 @@ def test_a_task_type_outside_the_registry_gets_no_revision_context():
     )
 
     assert inputs == {}
+
+
+# --------------------------------------------------------------------------- #
+# The replay half: restore the prefix a revision does not invalidate
+# --------------------------------------------------------------------------- #
+
+
+def _checkpoint(index: int, task_ids: tuple[str, ...]) -> Any:
+    from datetime import UTC, datetime
+
+    from squadops.cycles.checkpoint import RunCheckpoint
+
+    return RunCheckpoint(
+        run_id="run_source0001",
+        checkpoint_index=index,
+        completed_task_ids=task_ids,
+        prior_outputs={"data": {"summary": "research"}},
+        artifact_refs=(),
+        plan_delta_refs=(),
+        created_at=datetime(2026, 8, 9, tzinfo=UTC),
+    )
+
+
+def _executor_with_checkpoints(checkpoints: list[Any]) -> Any:
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+    executor = DispatchedFlowExecutor(artifact_vault=AsyncMock())
+    executor._cycle_registry = AsyncMock()
+    executor._cycle_registry.list_checkpoints.return_value = checkpoints
+    return executor
+
+
+def _cycle(**overrides: Any) -> Any:
+    cycle = MagicMock()
+    cycle.execution_overrides = dict(overrides)
+    return cycle
+
+
+async def test_the_revision_restores_the_prefix_before_the_design():
+    """Research and the objective frame are upstream of the design, so a note about the
+    design cannot invalidate them. Re-earning them costs ~20 of the 58 minutes for nothing."""
+    executor = _executor_with_checkpoints(
+        [
+            _checkpoint(0, ("task-run_source00-000-data.research_context",)),
+            _checkpoint(
+                1,
+                (
+                    "task-run_source00-000-data.research_context",
+                    "task-run_source00-001-strategy.frame_objective",
+                ),
+            ),
+        ]
+    )
+
+    restored = await executor._resolve_revision_checkpoint(
+        _cycle(framing_revision_source="run_source0001"), "run_target0002"
+    )
+
+    assert restored is not None
+    assert len(restored.completed_task_ids) == 2
+    assert all(t.startswith("task-run_target00-") for t in restored.completed_task_ids), (
+        "ids must be rebound into the target run's namespace or suppression matches nothing"
+    )
+
+
+async def test_a_checkpoint_that_already_did_the_design_is_not_restorable():
+    """The design must re-run — it is the first thing a revision invalidates. Restoring past
+    it would skip the stage that answers the note."""
+    executor = _executor_with_checkpoints(
+        [
+            _checkpoint(0, ("task-run_source00-000-data.research_context",)),
+            _checkpoint(
+                2,
+                (
+                    "task-run_source00-000-data.research_context",
+                    "task-run_source00-002-development.design_plan",
+                ),
+            ),
+        ]
+    )
+
+    restored = await executor._resolve_revision_checkpoint(
+        _cycle(framing_revision_source="run_source0001"), "run_target0002"
+    )
+
+    assert restored is not None
+    assert restored.checkpoint_index == 0, "the latest boundary BEFORE the design, not after"
+
+
+@pytest.mark.parametrize(
+    ("checkpoints", "why"),
+    [
+        ([], "no checkpoints survived pruning"),
+        (
+            [_checkpoint(0, ("opaque-uuid4-id-from-before-deterministic-framing-ids",))],
+            "a source run predating deterministic framing ids cannot be translated",
+        ),
+    ],
+)
+async def test_an_unresolvable_boundary_degrades_instead_of_failing(checkpoints, why):
+    """Replay fails closed because a replay that ran the full plan would claim a prefix it
+    never earned. A revision claims nothing — the full re-run is the slower correct answer,
+    and it is exactly what this did before the optimisation existed."""
+    executor = _executor_with_checkpoints(checkpoints)
+
+    restored = await executor._resolve_revision_checkpoint(
+        _cycle(framing_revision_source="run_source0001"), "run_target0002"
+    )
+
+    assert restored is None, why
+
+
+async def test_a_normal_run_resolves_no_revision_checkpoint():
+    """Every framing run passes through this seam; only a revision names a source."""
+    executor = _executor_with_checkpoints([_checkpoint(0, ("task-run_source00-000-x",))])
+
+    assert await executor._resolve_revision_checkpoint(_cycle(), "run_target0002") is None
+
+
+async def test_framing_task_ids_are_deterministic_so_a_checkpoint_can_translate():
+    """The enabling change. `translate_checkpoint_for_replay` rebinds a run prefix and RAISES
+    on anything else, so framing's old `uuid4().hex` ids could never be replayed onto a new
+    run — which is what made a revision cost a full re-execution."""
+    from datetime import UTC, datetime
+
+    from squadops.cycles.models import (
+        AgentProfileEntry,
+        Cycle,
+        Run,
+        SquadProfile,
+        TaskFlowPolicy,
+    )
+    from squadops.cycles.task_plan import generate_task_plan
+
+    now = datetime(2026, 8, 9, tzinfo=UTC)
+    profile = SquadProfile(
+        profile_id="full",
+        name="f",
+        description="d",
+        version=1,
+        agents=tuple(
+            AgentProfileEntry(agent_id=a, role=r, model="m", enabled=True)
+            for a, r in (
+                ("nat", "strat"),
+                ("neo", "dev"),
+                ("eve", "qa"),
+                ("d", "data"),
+                ("max", "lead"),
+            )
+        ),
+        created_at=now,
+    )
+    cycle = Cycle(
+        cycle_id="cyc_1",
+        project_id="p",
+        created_at=now,
+        created_by="s",
+        prd_ref="prd",
+        squad_profile_id="full",
+        squad_profile_snapshot_ref="sha256:a",
+        task_flow_policy=TaskFlowPolicy(mode="sequential"),
+        build_strategy="fresh",
+        applied_defaults={},
+        execution_overrides={},
+    )
+    run = Run(
+        run_id="run_abcdef123456",
+        cycle_id="cyc_1",
+        run_number=1,
+        status="queued",
+        initiated_by="api",
+        resolved_config_hash="h",
+        workload_type="framing",
+    )
+
+    envelopes = generate_task_plan(cycle, run, profile)
+
+    assert envelopes, "framing must produce a plan"
+    for env in envelopes:
+        assert env.task_id.startswith("task-run_abcdef12-"), env.task_id
+        assert env.task_id.endswith(env.task_type), env.task_id
+    assert len({e.task_id for e in envelopes}) == len(envelopes), "ids stay unique within a run"

--- a/tests/unit/capabilities/test_manifest_revision.py
+++ b/tests/unit/capabilities/test_manifest_revision.py
@@ -1,0 +1,158 @@
+"""An answered question reaches the author as a revision (#811).
+
+The gate could ask and could not be answered: `RETURNED_FOR_REVISION` stopped the sequence
+and revision needed a manual retry run. A system that asks a question and cannot act on the
+reply is the rubber stamp M4 replaced, wearing a better costume.
+
+Bug classes guarded:
+
+- the reviewer's notes never reaching the author, leaving a revision run that re-authors
+  blind — the fay-6 new-dice failure with an audit trail;
+- **the prior manifest not reaching the author**, which is the same failure one level
+  subtler: given only a note, the author re-derives the whole design, so decisions the
+  reviewer accepted come back different and they must read it all again (§5c.6's
+  "revise, don't re-roll");
+- a manifest author being shown the *plan* re-roll appendix — a rejected plan they did not
+  write, describing rules that do not apply to them;
+- the revision context escaping the declared input contract, which would make it
+  contamination rather than capability;
+- a first-roll authoring run rendering a revision appendix it has no reason to see.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities.handlers.planning import DevelopmentAuthorManifestHandler
+from squadops.cycles.manifest_authoring import AUTHORING_INPUT_CONTRACT
+from squadops.cycles.task_plan import inject_contract_inputs  # noqa: F401  (import guard)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_MANIFEST = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "authored_v4"
+    / "interface_manifest_roll2.yaml"
+).read_text(encoding="utf-8")
+
+
+def _renderer() -> Any:
+    renderer = AsyncMock()
+
+    async def _render(template_id: str, variables: dict[str, Any]):
+        rendered = MagicMock()
+        rendered.content = f"[{template_id}] {variables}"
+        rendered.template_id = template_id
+        rendered.template_version = "1"
+        rendered.render_hash = "cafe"
+        return rendered
+
+    renderer.render.side_effect = _render
+    return renderer
+
+
+async def _section(inputs: dict[str, Any]) -> tuple[str, Any]:
+    handler = DevelopmentAuthorManifestHandler()
+    renderer = _renderer()
+    section = await handler._revision_context_section(renderer, inputs)
+    return section, renderer
+
+
+async def test_the_reviewers_notes_reach_the_author():
+    section, renderer = await _section(
+        {"rejection_reasons": ["drop the pagination assumption and ask instead"]}
+    )
+
+    assert "drop the pagination assumption" in section
+    template_ids = [c.args[0] for c in renderer.render.call_args_list]
+    assert template_ids == ["request.manifest_revision_request_appendix"]
+
+
+async def test_the_design_being_revised_is_shown_to_the_author():
+    """The difference between a revision and a re-roll. Without the prior manifest the
+    author re-derives everything, so decisions the reviewer accepted come back changed."""
+    section, renderer = await _section(
+        {"rejection_reasons": ["resolve the expansion question"], "prior_manifest_yaml": _MANIFEST}
+    )
+
+    variables = renderer.render.call_args_list[0].args[1]
+    assert "prior_manifest" in variables
+    assert "kind: interface_manifest" in variables["prior_manifest"]
+    assert "expansion-gating" in variables["prior_manifest"], (
+        "the author must see the unresolved decision the reviewer is answering"
+    )
+
+
+async def test_notes_without_a_prior_manifest_still_revise():
+    """A seeded cycle, or a manifest that failed to load, still gets the reviewer's words —
+    degraded, not silent."""
+    section, renderer = await _section({"rejection_reasons": ["narrow the scope"]})
+
+    assert "prior_manifest" not in renderer.render.call_args_list[0].args[1]
+    assert "narrow the scope" in section
+
+
+async def test_a_first_roll_renders_no_revision_appendix():
+    """Nothing was returned, so there is nothing to revise — a first-roll prompt must be
+    byte-identical to one from before this existed."""
+    section, renderer = await _section({})
+
+    assert section == ""
+    renderer.render.assert_not_awaited()
+
+
+async def test_the_manifest_author_never_sees_the_plan_reroll_appendix():
+    """The inherited planning-base version renders `request.plan_reroll_rejection_appendix`,
+    which shows a rejected *plan* — a document this author did not write, under rules that do
+    not apply to it."""
+    _, renderer = await _section({"rejection_reasons": ["revise"]})
+
+    assert "request.plan_reroll_rejection_appendix" not in [
+        c.args[0] for c in renderer.render.call_args_list
+    ]
+
+
+def test_the_revision_context_is_inside_the_declared_input_contract():
+    """§5c.1: an undeclared input is contamination by definition. The prior manifest is
+    in-cycle — this cycle's own prior output — so it belongs in the contract, declared."""
+    assert "prior_manifest_yaml" in AUTHORING_INPUT_CONTRACT
+    assert "rejection_reasons" in AUTHORING_INPUT_CONTRACT
+
+
+def test_the_injector_threads_the_prior_manifest_onto_the_envelope():
+    """The executor puts it on the forwarding rail; the composer has to carry it to the
+    authoring task or the appendix renders without it."""
+    from squadops.capabilities.context_assembly import get_context_contract
+    from squadops.cycles.task_plan import _inject_rejection_context
+
+    assert get_context_contract("development.author_manifest").plan_rejection_context
+
+    inputs: dict[str, Any] = {}
+    _inject_rejection_context(
+        inputs,
+        {"rejection_reasons": ["revise"], "prior_manifest_yaml": _MANIFEST},
+        "development.author_manifest",
+    )
+
+    assert inputs["rejection_reasons"] == ["revise"]
+    assert inputs["prior_manifest_yaml"] == _MANIFEST
+
+
+def test_a_task_type_outside_the_registry_gets_no_revision_context():
+    """Who receives rejection context is the registry's declaration (#663 S3), not the
+    injector's opinion — the merger is deliberately excluded."""
+    from squadops.cycles.task_plan import _inject_rejection_context
+
+    inputs: dict[str, Any] = {}
+    _inject_rejection_context(
+        inputs,
+        {"rejection_reasons": ["revise"], "prior_manifest_yaml": _MANIFEST},
+        "governance.merge_plan",
+    )
+
+    assert inputs == {}

--- a/tests/unit/cycles/goldens/plan_context.json
+++ b/tests/unit/cycles/goldens/plan_context.json
@@ -58,6 +58,11 @@
     "qa",
     "strat"
    ],
+   "rejected_plan_yaml": "version: 1\ntasks: []\n",
+   "rejection_reasons": [
+    "plan_task 2 claims frozen file backend/app.py",
+    "qa.test task binds no runnable suite artifact"
+   ],
    "resolved_config": {
     "contract_ref": "art_c",
     "plan_authoring_contributors": [

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -565,46 +565,87 @@ class TestInterWorkloadGates:
         executor.execute_run.assert_awaited_once()
         mock_registry.create_run.assert_not_called()
 
-    async def test_returned_for_revision_stops_orchestration(
+    async def test_returned_for_revision_revises_framing_and_never_advances(
         self, executor, mock_registry, mock_event_bus
     ):
-        """#466, the 3.10 false-approve: returned_for_revision advanced the
-        sequence and spawned implementation with the un-revised plan. Revision
-        is not an approval — no next workload Run may be created."""
+        """#466's guard, preserved through #811's change of mechanism.
+
+        The defect #466 fixed was the 3.10 false-approve: revision advanced the sequence
+        and spawned implementation with the un-revised plan. That must still be
+        impossible. What changed is what happens *instead* — #811 re-executes framing
+        with the reviewer's notes rather than stopping, so the assertion moves from "no
+        run is created" to "the run created is a FRAMING revision, never implementation".
+        """
         cycle = _make_cycle(
             workload_sequence=[
                 {"type": "framing", "gate": "progress_plan_review"},
                 {"type": "implementation"},
-            ]
+            ],
+            applied_defaults_extra={"manifest_max_attempts": 1},
         )
         mock_registry.get_cycle.return_value = cycle
 
-        run1 = _make_run("run_001", 1, "completed", "framing")
-        run1_with_revision = _make_run(
-            "run_001",
-            1,
-            "completed",
-            "framing",
-            gate_decisions=(
-                _gate_decision(
-                    "progress_plan_review",
-                    GateDecisionValue.RETURNED_FOR_REVISION,
-                    notes="remove three style regexes",
-                ),
-            ),
+        revision = _gate_decision(
+            "progress_plan_review",
+            GateDecisionValue.RETURNED_FOR_REVISION,
+            notes="drop the pagination assumption and ask instead",
         )
+        run1 = _make_run("run_001", 1, "completed", "framing", gate_decisions=(revision,))
+        run2 = _make_run("run_002", 2, "completed", "framing", gate_decisions=(revision,))
 
-        mock_registry.get_run.side_effect = [
-            run1,  # status check after execute_run
-            run1,  # _is_cancelled in _poll (not cancelled)
-            run1_with_revision,  # _poll finds the revision decision
-        ]
+        async def _get_run(run_id):
+            return run1 if run_id == "run_001" else run2
+
+        mock_registry.get_run.side_effect = _get_run
+        mock_registry.list_runs.return_value = [run1]
+        mock_registry.create_run.side_effect = lambda r: r
 
         with patch.object(asyncio, "sleep", new_callable=AsyncMock):
             await executor.execute_cycle("cyc_001", "run_001")
 
-        executor.execute_run.assert_awaited_once()
-        mock_registry.create_run.assert_not_called()
+        created = [c.args[0] for c in mock_registry.create_run.await_args_list]
+        assert len(created) == 1, "budget is 1, so exactly one revision may be created"
+        assert created[0].workload_type == "framing"
+        assert not [r for r in created if r.workload_type == "implementation"], (
+            "revision is not an approval — implementation must never start on the un-revised design"
+        )
+        # The superseded run is cancelled, or two non-cancelled runs occupy one
+        # workload position (#257/D14).
+        mock_registry.cancel_run.assert_awaited_once_with("run_001")
+
+    async def test_revision_stops_once_its_budget_is_spent(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        """An unbounded revision loop would let a reviewer who keeps returning the design
+        spin framing forever. The second request, with a budget of 1 already spent, stops
+        the sequence instead of creating a third run."""
+        cycle = _make_cycle(
+            workload_sequence=[
+                {"type": "framing", "gate": "progress_plan_review"},
+                {"type": "implementation"},
+            ],
+            applied_defaults_extra={"manifest_max_attempts": 1},
+        )
+        mock_registry.get_cycle.return_value = cycle
+
+        revision = _gate_decision(
+            "progress_plan_review", GateDecisionValue.RETURNED_FOR_REVISION, notes="again"
+        )
+        run1 = _make_run("run_001", 1, "completed", "framing", gate_decisions=(revision,))
+        # The revision run's id is generated, so match on anything-but-the-first.
+        run2 = _make_run("run_002", 2, "completed", "framing", gate_decisions=(revision,))
+
+        async def _get_run(run_id):
+            return run1 if run_id == "run_001" else run2
+
+        mock_registry.get_run.side_effect = _get_run
+        mock_registry.list_runs.return_value = [run1]
+        mock_registry.create_run.side_effect = lambda r: r
+
+        with patch.object(asyncio, "sleep", new_callable=AsyncMock):
+            await executor.execute_cycle("cyc_001", "run_001")
+
+        assert mock_registry.create_run.await_count == 1, "the budget bounds the loop"
 
     async def test_unrecognized_decision_never_advances(
         self, executor, mock_registry, mock_event_bus

--- a/tests/unit/events/test_event_emission.py
+++ b/tests/unit/events/test_event_emission.py
@@ -335,9 +335,10 @@ class TestEmitCallSitePayloadFields:
         assert with_payload >= 35
 
     def test_total_emit_call_count(self) -> None:
-        """Sanity check: 21 executor + 9 correction-runner +
-        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 47 total
-        emit calls (#807 added M4's question-gate GATE_DECIDED emit for a
+        """Sanity check: 22 executor + 9 correction-runner +
+        8 pulse-boundary-runner + 2 task-dispatcher + 7 route = 48 total
+        emit calls (#811 added the operator-revision WORKLOAD_ADVANCED emit,
+        47 -> 48; #807 added M4's question-gate GATE_DECIDED emit for a
         design that declares no open question, 46 → 47;
         #473 added the pre-gate rejection's GATE_DECIDED emit;
         #522 added the framing re-roll's WORKLOAD_ADVANCED emit; SIP-0100 3.3
@@ -357,4 +358,4 @@ class TestEmitCallSitePayloadFields:
         total = 0
         for path in _ALL_EMISSION_FILES:
             total += len(self._extract_emit_calls(path))
-        assert total == 47
+        assert total == 48


### PR DESCRIPTION
The gate could ask and could not be answered. `RETURNED_FOR_REVISION` stopped the workload sequence and revision required a manual retry run — so at V5 a human could be asked *"the PRD does not define the expansion checkpoint — which is it?"* and their answer would go nowhere. A system that asks a question it cannot act on is the rubber stamp M4 replaced, wearing a better costume.

## The revision replays the prefix it does not invalidate

The first cut of this re-executed the **whole** framing workload — 58 minutes to change one document — and I wrongly recorded that as an architectural limitation. It wasn't. SIP-0101 Slice 3 already restores a source run's boundary checkpoint into a new run's namespace and suppresses those dispatches.

**One thing genuinely blocked it:** `translate_checkpoint_for_replay` rebinds a deterministic id's run prefix and **raises** on anything else — and framing task ids were `uuid4().hex`, so no framing checkpoint could ever be translated onto a new run. Framing now joins implementation in the deterministic namespace (`task-{run}-{index}-{type}`). Ids stay unique within a run and now carry position and type, which is also what lets a boundary be selected by task type rather than by guesswork. **Zero test churn** from the change.

## Where a revision restarts, and why it isn't the manifest

`development.design_plan`, not `development.author_manifest`.

A reviewer's note is a change to the **design**. Restarting at the manifest alone would leave `technical_design.md` describing an interface the revised manifest no longer has, and no later reader could tell which one the squad meant. So the design stage now receives the revision context too and answers the note; research and the objective frame are upstream of the design, unaffected by a note about it, and restore from the checkpoint.

## Degrades, never fails closed

Replay fails closed because a replay that silently ran the full plan would claim a saved prefix it never earned. **A revision claims nothing** — the full re-execution is simply the slower correct answer, and it is exactly what this did before the optimisation. An unresolvable boundary (pruned checkpoints, or a source run predating deterministic ids) logs and re-runs everything.

## Budget: `manifest_max_attempts`, counted separately

Not `framing_max_rerolls` — it **defaults to 0** and the validated profiles don't set it, so sharing it would have shipped the feature switched off, and it conflates a stochastic fault the system retries with a deliberate human instruction. `manifest_max_attempts` is what §5c.6 specifies and is already CRP-allow-listed.

## Revise, don't re-roll

The context carries the notes **and the prior manifest**. Given only a note the author re-derives everything, so decisions that were accepted come back changed — the fay-6 new-dice failure one level subtler.

## Two defects the guards caught mid-build

- **The golden context guard** flagged that `development.design_plan` now receives rejection context, and told me to regenerate in the same PR so it reads as a behaviour change. Done, in the same commit.
- Regenerating exposed a wording defect I'd introduced: **both revision appendices also render on *system* re-rolls**, where nobody human returned anything. Neither may say "a reviewer asked". Both now name what came back without asserting who sent it.
- A test also caught me mis-writing the deterministic id format (`run_id[:12]`) in a fixture.

## Two guard families pointed back at their intent

- `test_returned_for_revision_stops_orchestration` guarded #466's false-approve as *"no run may be created"*. Post-#811 a run **is** created — a framing revision. Rewritten to assert what it always meant: framing, never implementation. Flipping it to match new behaviour would have quietly retired the #466 guard.
- Emit-site count 47 → 48.

## Verification

14 tests in the new file plus a rewritten guard and a budget-bound test. Full regression green: 7,147 unit / 6,761 regression / 22 architecture.

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
