### PR TITLE
feat(api): a gate decision records who made it (#812)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ manual retry run. It **restores the prefix the note does not invalidate** via SI
 checkpoint translation — enabled by framing task ids becoming deterministic in the same
 change — and re-runs from the technical design, so the design answers the note rather than
 describing an interface the revised manifest no longer has.
+**#812** makes a gate decision say who made it. `decided_by` was a hardcoded `"system"` with
+a TODO beside it, so all 140 human approvals in the project's history carried the word that
+means *no human was involved* — in the same namespace the machine paths use. It now composes
+`{actor}:{principal}` from the request identity, and an agent can declare itself
+(`--as-agent`) since a token cannot tell.
 **B1 (#809)** closes the one item whose omission would have been permanent: rejections are
 now classified at the moment they happen — plan-validation by producing validator, authoring
 by M6 class — so the pre-memory recurrence baseline Cross-Cycle Memory will be measured

--- a/src/squadops/api/routes/cycles/dtos.py
+++ b/src/squadops/api/routes/cycles/dtos.py
@@ -61,6 +61,10 @@ class GateDecisionRequest(BaseModel):
         "rejected",
     ]
     notes: str | None = None
+    #: #812: who is deciding, when the token cannot say. An agent authenticating as a
+    #: person is invisible to the token, so declaring is the only way the record can be
+    #: true. Omitted → the identity's own type is used; never inferred from behavior.
+    decided_by_kind: Literal["human", "agent"] | None = None
     waived_checks: list[str] = Field(default_factory=list)
     waiver_reason: str | None = None
 

--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends, Request
 
 from squadops.api.middleware.auth import require_scopes
 from squadops.api.routes.cycles.dtos import (
@@ -17,6 +17,7 @@ from squadops.api.routes.cycles.dtos import (
 from squadops.api.routes.cycles.errors import handle_cycle_error
 from squadops.api.routes.cycles.mapping import compute_workload_progress, run_to_response
 from squadops.auth.models import Scope
+from squadops.cycles.gate_attribution import compose_decided_by
 from squadops.cycles.lifecycle import (
     TERMINAL_STATES,
     compute_config_hash,
@@ -220,6 +221,7 @@ async def gate_decision(
     run_id: str,
     gate_name: str,
     body: GateDecisionRequest,
+    request: Request,
 ):
     from squadops.api.runtime.deps import get_cycle_registry
 
@@ -242,10 +244,15 @@ async def gate_decision(
             if waiver_error is not None:
                 raise ValidationError(waiver_error)
 
+        # #812: was a hardcoded "system" with a TODO beside it, so every human approval
+        # carried the word that means "no human was involved" — the same namespace the
+        # machine paths use. The identity was available the whole time.
         decision = GateDecision(
             gate_name=gate_name,
             decision=body.decision,
-            decided_by="system",  # TODO: extract from auth context
+            decided_by=compose_decided_by(
+                getattr(request.state, "identity", None), body.decided_by_kind
+            ),
             decided_at=datetime.now(UTC),
             notes=body.notes,
             waived_checks=tuple(body.waived_checks),

--- a/src/squadops/cli/commands/runs.py
+++ b/src/squadops/cli/commands/runs.py
@@ -218,6 +218,13 @@ def gate_decision(
     waiver_reason: str | None = typer.Option(
         None, "--waiver-reason", help="Reason for the waiver (required with --waive)"
     ),
+    as_agent: bool = typer.Option(
+        False,
+        "--as-agent",
+        help="Record this decision as made by an autonomous agent, not a person (#812). "
+        "An agent using a human's credentials is invisible to the token, so declaring is "
+        "the only way the record can be true.",
+    ),
 ):
     """Record a gate decision.
 
@@ -252,6 +259,10 @@ def gate_decision(
         decision = "returned_for_revision"
 
     body = {"decision": decision}
+    # #812: only sent when declared. Omitted → the API uses the token's own identity type,
+    # which is the truthful default for a person and the known gap for an undeclared agent.
+    if as_agent:
+        body["decided_by_kind"] = "agent"
     if notes:
         body["notes"] = notes
     if waive:

--- a/src/squadops/cycles/gate_attribution.py
+++ b/src/squadops/cycles/gate_attribution.py
@@ -1,0 +1,78 @@
+"""Who decided a gate, in a vocabulary that can tell them apart (#812).
+
+Every API-made gate decision recorded the literal string ``decided_by="system"`` — a
+hardcoded value with a ``TODO: extract from auth context`` beside it. So all 140 human
+approvals in the project's history carry the same word the machine paths use as their
+prefix (``system:plan_validation``, ``system:no_open_questions``). The word that means *no
+human was involved* was exactly the word every human decision carried.
+
+That matters beyond tidiness, because two consumers read this as evidence:
+
+- **the authored-mode window** — a banked number describing "squad-authored design with
+  human adjudication" means something different from one describing "…with an LLM
+  adjudicating its own squad's questions", and the record has to be able to say which;
+- **Cross-Cycle Memory (1.8)** — gate and revision history is its seed corpus, and a corpus
+  that files agent answers under a human's name teaches the wrong thing about who resolves
+  what.
+
+**The honest limit, stated rather than glossed:** an agent acting on a human's token is
+undetectable — the token says what it says. This offers a way to *declare* it and records the
+declaration faithfully. An undeclared agent decision still records as the token's type. That
+is a policy problem, not a mechanism problem; what changes here is that being honest becomes
+possible, which it was not.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: An identified person decided it.
+ACTOR_HUMAN = "human"
+#: An autonomous agent decided it, acting on some principal's credentials. Declared by the
+#: caller — never inferred, because it cannot be.
+ACTOR_AGENT = "agent"
+#: A non-human principal (a service account) decided it.
+ACTOR_SERVICE = "service"
+#: The machine decided it with no principal involved: plan validation, or M4's
+#: no-open-questions pass-through. Pre-existing and unchanged.
+ACTOR_SYSTEM = "system"
+
+#: What a caller may declare. ``service`` and ``system`` are not declarable — the first comes
+#: from the token, the second only from code paths inside the executor.
+DECLARABLE_ACTORS: frozenset[str] = frozenset({ACTOR_HUMAN, ACTOR_AGENT})
+
+#: Recorded when there is no identity at all (auth disabled in a local deployment). Names
+#: what is actually known — that something unauthenticated decided it — rather than
+#: promoting it to a person.
+UNATTRIBUTED = "unattributed"
+
+
+def compose_decided_by(identity: Any, declared_actor: str | None = None) -> str:
+    """``{actor}:{principal}`` for a gate decision, or ``unattributed``.
+
+    ``declared_actor`` wins over the identity's own type, and is the whole point: an agent
+    authenticating as a person is invisible to the token, so the only way the record can be
+    true is for the caller to say so. It is validated by the caller against
+    :data:`DECLARABLE_ACTORS`; anything else falls back to the identity.
+
+    Nothing is inferred from usage patterns or timing — a guess that is usually right would
+    make the field unreliable in exactly the cases anyone would want to check it.
+    """
+    principal = getattr(identity, "user_id", None) or getattr(identity, "display_name", None)
+    if not principal:
+        return UNATTRIBUTED
+    actor = declared_actor if declared_actor in DECLARABLE_ACTORS else None
+    if actor is None:
+        actor = getattr(identity, "identity_type", None) or ACTOR_HUMAN
+    return f"{actor}:{principal}"
+
+
+def is_machine_decision(decided_by: str) -> bool:
+    """True when no principal was involved — the executor decided it.
+
+    Reads the prefix rather than matching whole values, so a new ``system:*`` mechanism is
+    covered the day it ships. Deliberately excludes the bare legacy ``"system"``: those are
+    the 140 historical rows a human actually made, and calling them machine decisions would
+    launder the very confusion this module exists to end.
+    """
+    return decided_by.startswith(f"{ACTOR_SYSTEM}:")

--- a/tests/unit/cycles/test_gate_attribution.py
+++ b/tests/unit/cycles/test_gate_attribution.py
@@ -1,0 +1,119 @@
+"""Who decided a gate, in a vocabulary that can tell them apart (#812).
+
+Every API-made gate decision recorded the literal `"system"` — a hardcoded value with a
+`TODO: extract from auth context` beside it. So all 140 human approvals in the project's
+history carry the word that means *no human was involved*, in the same namespace the machine
+paths use (`system:plan_validation`, `system:no_open_questions`).
+
+Bug classes guarded:
+
+- **an agent's decision recorded as a person's**, which is the reason this exists: the
+  authored-mode window has to be able to state whether its questions were adjudicated by a
+  human or an LLM, and 1.8's memory seeds itself from this history;
+- the reverse — a person's decision demoted to a machine's — which would launder a real
+  approval into something nobody has to answer for;
+- **inferring the actor** from timing, notes, or usage. A guess that is usually right makes
+  the field unreliable in exactly the cases anyone would check it;
+- a caller declaring an actor class that is not theirs to declare (`system`, `service`);
+- attribution silently promoting an unauthenticated caller to a person when auth is off;
+- the machine-decision predicate matching the bare legacy `"system"`, which would relabel
+  140 real human approvals as machine ones.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from squadops.cycles.gate_attribution import (
+    ACTOR_AGENT,
+    ACTOR_HUMAN,
+    ACTOR_SERVICE,
+    DECLARABLE_ACTORS,
+    UNATTRIBUTED,
+    compose_decided_by,
+    is_machine_decision,
+)
+from squadops.cycles.manifest_authoring import GATE_DECIDED_BY_NO_QUESTIONS
+
+pytestmark = [pytest.mark.domain_contracts]
+
+
+@dataclass(frozen=True)
+class _Identity:
+    user_id: str = "squadops-admin"
+    display_name: str = "Admin"
+    identity_type: str = ACTOR_HUMAN
+
+
+def test_a_person_is_recorded_as_a_person():
+    assert compose_decided_by(_Identity()) == "human:squadops-admin"
+
+
+def test_an_agent_declaring_itself_is_not_filed_as_the_human_it_authenticated_as():
+    """The case that motivated this. An agent answered V5's two design questions on a human
+    account; the record said a person did. Declaring is the only mechanism available —
+    the token cannot tell."""
+    assert compose_decided_by(_Identity(), ACTOR_AGENT) == "agent:squadops-admin"
+
+
+def test_a_service_account_keeps_its_own_type():
+    assert (
+        compose_decided_by(_Identity(user_id="squadops-agent", identity_type=ACTOR_SERVICE))
+        == "service:squadops-agent"
+    )
+
+
+@pytest.mark.parametrize("declared", ["system", "service", "robot", "", None])
+def test_an_undeclarable_actor_falls_back_to_the_identity(declared):
+    """`system` is the executor's alone and `service` comes from the token. A caller that
+    could claim either could dress an agent's decision as a machine's — which is the same
+    laundering from the other direction."""
+    assert compose_decided_by(_Identity(), declared) == "human:squadops-admin"
+    assert declared not in DECLARABLE_ACTORS or declared in ("human", "agent")
+
+
+def test_no_identity_is_recorded_as_unattributed_not_as_a_person():
+    """Auth can be off in a local deployment. Naming what is known — that something
+    unauthenticated decided it — beats promoting it to a human."""
+    assert compose_decided_by(None) == UNATTRIBUTED
+    assert compose_decided_by(_Identity(user_id="", display_name="")) == UNATTRIBUTED
+
+
+def test_display_name_is_the_fallback_principal():
+    """A token with no user_id still identifies someone; losing that to `unattributed`
+    would discard real attribution."""
+    assert compose_decided_by(_Identity(user_id="", display_name="Jane")) == "human:Jane"
+
+
+# --------------------------------------------------------------------------- #
+# Telling machine decisions apart
+# --------------------------------------------------------------------------- #
+
+
+def test_machine_decisions_are_recognised_by_prefix_so_new_ones_are_covered():
+    assert is_machine_decision("system:plan_validation")
+    assert is_machine_decision(GATE_DECIDED_BY_NO_QUESTIONS)
+    assert is_machine_decision("system:some_future_mechanism")
+
+
+@pytest.mark.parametrize(
+    "value", ["human:squadops-admin", "agent:squadops-admin", "service:x", UNATTRIBUTED]
+)
+def test_principal_decisions_are_not_machine_decisions(value):
+    assert not is_machine_decision(value)
+
+
+def test_the_legacy_bare_system_is_not_treated_as_a_machine_decision():
+    """The 140 historical rows saying `"system"` are decisions people actually made — the
+    field simply could not say so. Matching them as machine decisions would launder exactly
+    the confusion this module ends, and it would do it retroactively."""
+    assert not is_machine_decision("system")
+
+
+def test_the_machine_and_declared_vocabularies_cannot_collide():
+    """A declarable actor that shared the machine prefix would make the two indistinguishable
+    again the moment someone declared it."""
+    for actor in DECLARABLE_ACTORS:
+        assert not is_machine_decision(f"{actor}:someone")


### PR DESCRIPTION
## The issue's premise was wrong, and the reality was worse

I filed this saying `decided_by` "is derived from the authenticated principal." It wasn't derived from anything — `runs.py:248` was the hardcoded literal `"system"` with a `TODO: extract from auth context` beside it. Measured:

```
system                 | approved              | 140
system:plan_validation | rejected              |  34
system                 | rejected              |   4
system                 | returned_for_revision |   1
```

**All 140 human approvals in this project's history carry the word that means "no human was involved"** — in the same namespace the machine paths use for `system:plan_validation` and `system:no_open_questions`. Not indistinguishable by convention: colliding in vocabulary.

## The fix

`decided_by` now composes `{actor}:{principal}` from the request identity, using the `IdentityType` vocabulary that already existed (`human` / `service`) rather than inventing one. Machine paths keep `system:*` unchanged.

**An agent can declare itself** — `decided_by_kind` on the API, `--as-agent` on the CLI. An agent authenticating as a person is invisible to the token, so declaring is the only mechanism available. **Declared, never inferred:** a guess from timing or note style would be usually right, which is exactly what would make the field unreliable in the cases anyone would actually check it.

Only `human` and `agent` are declarable. `service` comes from the token and `system` belongs to the executor — a caller who could claim either could dress an agent's decision as a machine's, which is the same laundering from the other direction.

No identity at all records `unattributed` rather than being promoted to a person. Auth can be off in a local deployment, and naming what is known beats inventing what is not.

## The legacy rows are left alone, deliberately

`is_machine_decision()` reads the `system:` prefix so a future mechanism is covered the day it ships — and deliberately does **not** match the bare legacy `"system"`. Those 140 rows are decisions people actually made; the field simply couldn't say so. Matching them as machine decisions would launder retroactively the precise confusion this ends.

## Why it's load-bearing, not cosmetic

- **The authored-mode window (V7)** must be able to state whether its design questions were adjudicated by a human or an agent. A banked number describing "squad-authored design with human adjudication" means something different from one describing "…with an LLM adjudicating its own squad's questions".
- **1.8's Cross-Cycle Memory** seeds itself from gate and revision history. A corpus filing agent answers under a human's name teaches the wrong thing about who resolves what.

## Honest limit

An **undeclared** agent still records as the token's type. The system cannot detect an agent, only offer a way to declare one and record it faithfully. That's a policy problem, not a mechanism problem — what changes here is that being honest becomes *possible*, which it was not. Recorded on the issue.

## Verification

17 new tests. Full regression green: 7,164 unit / 6,778 regression / 449 API+CLI.

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv