### PR TITLE
refactor(scaffold): one registration per stack, not five scattered facts (S1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ means *no human was involved* — in the same namespace the machine paths use. I
 now classified at the moment they happen — plan-validation by producing validator, authoring
 by M6 class — so the pre-memory recurrence baseline Cross-Cycle Memory will be measured
 against is capturable. Read by nothing in 1.6, deliberately.
+**Track S opens with S1**: the five per-stack facts — expander, fill slots, QA namespace,
+harness boundary, check-stack vocabulary — collapse from four module-level dicts plus one
+inline answer into a single `ScaffoldStack` registration. Pure refactor; the reference
+manifest and contract hashes are unmoved. It removes a silent-omission trap: `fill_slot_paths`
+guarded on whether a stack was *registered* and then returned FastAPI's slot map to whoever
+asked, so a second stack would have inherited `backend/routes.py` with nothing objecting.
 Plan: `docs/plans/1-6-0-authorship-plan.md`.
 
 ## [1.5.0] — 2026-08-07

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import json
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -362,9 +363,9 @@ class InterfaceManifest:
         errors: list[str] = []
         if not self.project_id:
             errors.append("project_id is required")
-        if self.stack not in _EXPANDERS:
+        if self.stack not in _STACKS:
             errors.append(
-                f"stack {self.stack!r} has no scaffold expander (known: {sorted(_EXPANDERS)})"
+                f"stack {self.stack!r} has no scaffold expander (known: {sorted(_STACKS)})"
             )
         if not self.api.endpoints:
             errors.append("api.endpoints is empty — declare at least one endpoint to scaffold")
@@ -503,12 +504,7 @@ def expand(manifest: InterfaceManifest) -> list[dict[str, str]]:
     Returns a list of ``{"name": <workspace-relative path>, "content": <str>}`` —
     the shape ``patch_verification.materialize_artifacts`` writes to disk.
     """
-    expander = _EXPANDERS.get(manifest.stack)
-    if expander is None:
-        raise ValueError(
-            f"no scaffold expander for stack {manifest.stack!r}; available: {sorted(_EXPANDERS)}"
-        )
-    return expander(manifest)
+    return _stack(manifest.stack).expand(manifest)
 
 
 def materialize(manifest: InterfaceManifest, dest: Path) -> int:
@@ -540,15 +536,12 @@ def fill_slot_paths(manifest: InterfaceManifest) -> tuple[str, ...]:
     SIP-0098 verification contract pins those by hash and hangs per-file criteria only
     on these slots. Same stack dispatch as ``expand``; raises for an unknown stack.
 
-    (fullstack_fastapi_react: the route bodies + one component per declared route. As
-    more stacks land in 99.4 they carry their own slot map alongside their expander.)
+    Each stack answers this for itself (#S1). It used to be answered inline behind a guard
+    that only checked whether the stack was *registered*, so a second stack would silently
+    have inherited ``backend/routes.py`` and ``.jsx`` view paths — a wrong answer that
+    nothing would have objected to, because the guard it passed asks a different question.
     """
-    if manifest.stack not in _EXPANDERS:
-        raise ValueError(
-            f"no scaffold expander for stack {manifest.stack!r}; available: {sorted(_EXPANDERS)}"
-        )
-    views = tuple(f"frontend/src/views/{r.view}.jsx" for r in manifest.frontend.routes)
-    return ("backend/routes.py", *dict.fromkeys(views))
+    return _stack(manifest.stack).fill_slots(manifest)
 
 
 def error_seam_instructions(manifest: InterfaceManifest | None) -> list[str]:
@@ -789,35 +782,13 @@ def frozen_surface_index_lines(manifest: InterfaceManifest | None) -> list[str]:
     return lines
 
 
-# SIP-0100 D1 (bounded-hybrid QA test ownership): the scaffold owns the *namespace* — the
-# deterministic directory prefixes a bound plan may declare concrete QA test files within — while
-# the plan declares the concrete paths. A QA producer may write only inside this surface; a QA
-# file at an undeclared path outside it is an unauthorized write (Phase 2). Per-stack, like the
-# slot map (99.4 stacks carry their own).
-_QA_TEST_NAMESPACES: dict[str, tuple[str, ...]] = {
-    "fullstack_fastapi_react": ("backend/tests/", "frontend/src/tests/"),
-}
-
-# SIP-0100 harness boundary: the app entry modules a QA test must NOT import — it must consume
-# the scaffold-owned `client` fixture instead. Per stack, like the namespace. The scaffold roots
-# the app at `backend.main` (main.py); `app.main`/`main` are the recurring wrong guesses that
-# killed pf-25/26. The `harness_boundary` acceptance check is authored with this list.
-_HARNESS_ENTRY_MODULES: dict[str, tuple[str, ...]] = {
-    "fullstack_fastapi_react": ("backend.main", "app.main", "main"),
-}
-
-
 def qa_test_namespace(manifest: InterfaceManifest) -> tuple[str, ...]:
     """Workspace-relative directory prefixes that own QA test files for ``manifest.stack``.
 
     Deterministic for a given stack (no dependence on the manifest contents), so plan
     validation and Phase-2 write authorization derive the same surface. Raises for an unknown
     stack (parity with ``expand`` / ``fill_slot_paths``)."""
-    if manifest.stack not in _EXPANDERS:
-        raise ValueError(
-            f"no scaffold expander for stack {manifest.stack!r}; available: {sorted(_EXPANDERS)}"
-        )
-    return _QA_TEST_NAMESPACES.get(manifest.stack, ())
+    return _stack(manifest.stack).qa_test_namespace
 
 
 def is_qa_test_path_for_stack(path: str, stack: str) -> bool:
@@ -828,7 +799,8 @@ def is_qa_test_path_for_stack(path: str, stack: str) -> bool:
     (tolerant: unknown stack → no namespace) so bind-mode dispatch, which has the stack from the
     contract, can use it without a manifest."""
     norm = str(path).strip().lstrip("./").replace("//", "/")
-    return any(norm.startswith(ns) for ns in _QA_TEST_NAMESPACES.get(stack, ()))
+    known = _STACKS.get(stack)
+    return bool(known) and any(norm.startswith(ns) for ns in known.qa_test_namespace)
 
 
 def is_qa_test_path(path: str, manifest: InterfaceManifest) -> bool:
@@ -841,7 +813,8 @@ def harness_entry_modules(stack: str) -> tuple[str, ...]:
 
     Empty for a stack without a declared boundary — dispatch then binds no ``harness_boundary``
     check (author-mode / non-scaffolded parity)."""
-    return _HARNESS_ENTRY_MODULES.get(stack, ())
+    known = _STACKS.get(stack)
+    return known.harness_entry_modules if known else ()
 
 
 def is_scaffoldable_stack(stack: str) -> bool:
@@ -850,7 +823,7 @@ def is_scaffoldable_stack(stack: str) -> bool:
     (``cycles.manifest_authoring.authors_interface_manifest``): only scaffoldable cycles
     dispatch an authoring stage, so a non-scaffoldable stack never produces a manifest
     describing a skeleton nothing can build."""
-    return bool(stack) and stack in _EXPANDERS
+    return bool(stack) and stack in _STACKS
 
 
 # ------------------------------------------------- fullstack_fastapi_react templates
@@ -1451,6 +1424,73 @@ def _expand_fullstack_fastapi_react(manifest: InterfaceManifest) -> list[dict[st
     return files
 
 
-_EXPANDERS = {
-    "fullstack_fastapi_react": _expand_fullstack_fastapi_react,
+def _fill_slots_fullstack_fastapi_react(manifest: InterfaceManifest) -> tuple[str, ...]:
+    """The route bodies, plus one component per declared route."""
+    views = tuple(f"frontend/src/views/{r.view}.jsx" for r in manifest.frontend.routes)
+    return ("backend/routes.py", *dict.fromkeys(views))
+
+
+@dataclass(frozen=True)
+class ScaffoldStack:
+    """Everything the scaffold knows about one stack, in one place (#S1).
+
+    These five facts were four module-level dicts and one function with the answer written
+    inline. Spread out, each new stack had to remember to appear in five places, and
+    forgetting produced a *plausible* wrong answer rather than an error — ``fill_slot_paths``
+    guarded on whether a stack was registered and then returned FastAPI's slot map to
+    whoever asked, so a second stack would have inherited ``backend/routes.py`` silently.
+
+    Deliberately **today's fields and nothing more**. Naming it ``ScaffoldStack`` rather than
+    a blueprint is also deliberate: the Stack Blueprint SIP is not accepted, its schema is
+    meant to be written against two real stacks, and a consolidation that quietly minted its
+    vocabulary would prejudge exactly the question that SIP exists to answer.
+    """
+
+    name: str
+    #: Manifest → the walking skeleton, as ``{"name", "content"}`` files.
+    expand: Callable[[InterfaceManifest], list[dict[str, str]]]
+    #: Manifest → the files a dev fills bodies into. Everything else ``expand`` emits is
+    #: frozen; the verification contract pins those by hash and hangs criteria only on these.
+    fill_slots: Callable[[InterfaceManifest], tuple[str, ...]]
+    #: SIP-0100 D1: workspace-relative directory prefixes that own QA test files. A QA file
+    #: outside this surface is an unauthorized write.
+    qa_test_namespace: tuple[str, ...] = ()
+    #: SIP-0100 harness boundary: app entry modules a QA test must NOT import — it consumes
+    #: the scaffold-owned ``client`` fixture instead. ``app.main``/``main`` are the recurring
+    #: wrong guesses that killed pf-25/26.
+    harness_entry_modules: tuple[str, ...] = ()
+    #: #503: the stack name the typed-check evaluators are keyed on, which is the CHECK
+    #: implementation's vocabulary rather than the scaffold's — "fastapi", not the profile
+    #: name. Empty means the checks skip, which is the conservative default #503 chose.
+    check_stack: str = ""
+
+
+_STACKS: dict[str, ScaffoldStack] = {
+    "fullstack_fastapi_react": ScaffoldStack(
+        name="fullstack_fastapi_react",
+        expand=_expand_fullstack_fastapi_react,
+        fill_slots=_fill_slots_fullstack_fastapi_react,
+        qa_test_namespace=("backend/tests/", "frontend/src/tests/"),
+        harness_entry_modules=("backend.main", "app.main", "main"),
+        check_stack="fastapi",
+    ),
 }
+
+
+def _stack(stack: str) -> ScaffoldStack:
+    """The registered stack, or the same refusal every accessor used to raise separately."""
+    known = _STACKS.get(stack)
+    if known is None:
+        raise ValueError(f"no scaffold expander for stack {stack!r}; available: {sorted(_STACKS)}")
+    return known
+
+
+def check_stack_for(stack: str) -> str | None:
+    """The typed-check evaluator vocabulary for ``stack``, or ``None`` (#503).
+
+    Lives here so "which stacks does this system know?" has one answer. The mapping is
+    conservative by design: an unmapped stack yields ``None`` and its checks skip, rather
+    than being fed a guess the evaluators were never verified against.
+    """
+    known = _STACKS.get(stack)
+    return (known.check_stack or None) if known else None

--- a/src/squadops/cycles/acceptance_evaluation.py
+++ b/src/squadops/cycles/acceptance_evaluation.py
@@ -54,24 +54,28 @@ _SERIALIZED_ROW_KEYS = frozenset({"check", "params", "severity", "description", 
 # skipped in every live cycle — while CI passed them via an explicit stack.
 # Conservative mapping: only profiles deliberately verified against the check
 # implementations; unmapped profiles keep today's skip behavior.
-_BUILD_PROFILE_CHECK_STACKS: dict[str, str] = {
-    "fullstack_fastapi_react": "fastapi",
-}
+# #S1: sourced from the scaffold's stack registry rather than declared a second time here —
+# "which stacks does this system know?" now has one answer. The lookup is still keyed on the
+# BUILD PROFILE, which today is the same string as the stack name; a stack whose profile is
+# named differently is exactly the assumption stack #2 will test, and it will fail visibly
+# (checks skip) rather than silently mapping to the wrong evaluator vocabulary.
 
 
 def resolve_check_stack(resolved_config: Mapping[str, Any]) -> str | None:
     """The stack passed to typed-check evaluators, derived in ONE place (#503).
 
     An explicit ``stack`` key wins (operator override / future configs); else the
-    ``build_profile`` maps through ``_BUILD_PROFILE_CHECK_STACKS``; else ``None``
+    ``build_profile`` maps through the scaffold's stack registry; else ``None``
     (checks skip with ``unsupported_stack_or_syntax``, today's behavior).
     """
+    from squadops.capabilities.scaffold import check_stack_for
+
     explicit = resolved_config.get("stack")
     if explicit:
         return str(explicit)
     profile = resolved_config.get("build_profile")
     if profile:
-        return _BUILD_PROFILE_CHECK_STACKS.get(str(profile))
+        return check_stack_for(str(profile))
     return None
 
 

--- a/tests/unit/capabilities/test_stack_registry.py
+++ b/tests/unit/capabilities/test_stack_registry.py
@@ -1,0 +1,168 @@
+"""Everything the scaffold knows about a stack, in one place (S1).
+
+Five facts — the expander, the fill slots, the QA namespace, the harness boundary and the
+check-stack vocabulary — were four module-level dicts and one function with the answer
+written inline. Spread out, a new stack had to remember to appear in five places, and
+forgetting produced a **plausible wrong answer** rather than an error.
+
+Bug classes guarded:
+
+- **a second stack silently inheriting the first's fill slots** — the trap this consolidation
+  removes. `fill_slot_paths` guarded on whether a stack was *registered* and then returned
+  `backend/routes.py` and `.jsx` view paths to whoever asked, so a Node/TS stack would have
+  been handed FastAPI's answer with nothing objecting. The guard it passed asks a different
+  question than the one being answered;
+- a half-declared stack: registered as expandable while answering some other fact with a
+  silent empty default, which reads as "this stack has no QA namespace" rather than "nobody
+  filled it in";
+- the refusal drifting between accessors, so an unknown stack raises in one place and returns
+  `()` in another;
+- the consolidation changing what the reference stack answers — this is a pure refactor, and
+  the manifest and contract hashes are what every bound cycle and the golden benchmark key on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from squadops.capabilities import scaffold
+from squadops.capabilities.scaffold import (
+    InterfaceManifest,
+    ScaffoldStack,
+    check_stack_for,
+    expand,
+    fill_slot_paths,
+    harness_entry_modules,
+    is_qa_test_path_for_stack,
+    is_scaffoldable_stack,
+    qa_test_namespace,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_REFERENCE = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+).read_text(encoding="utf-8")
+
+
+def _manifest(stack: str = "fullstack_fastapi_react") -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_REFERENCE.replace("fullstack_fastapi_react", stack))
+
+
+# --------------------------------------------------------------------------- #
+# The trap
+# --------------------------------------------------------------------------- #
+
+
+def test_a_second_stack_does_not_inherit_the_first_stacks_fill_slots(monkeypatch):
+    """The bug S1 exists to remove, reproduced against a second registered stack.
+
+    Before this, `fill_slot_paths` checked only that the stack was *registered* and then
+    returned FastAPI's slot map unconditionally — so a Node/TS stack would have been told to
+    fill `backend/routes.py` and `.jsx` views, and every downstream consumer (the contract's
+    covered files, frozen-ownership validation, fill-slot signature checks) would have agreed
+    with it.
+    """
+    other = ScaffoldStack(
+        name="node_ts",
+        expand=lambda m: [{"name": "src/routes.ts", "content": ""}],
+        fill_slots=lambda m: ("src/routes.ts",),
+        qa_test_namespace=("src/__tests__/",),
+        harness_entry_modules=("src/server",),
+        check_stack="node",
+    )
+    monkeypatch.setitem(scaffold._STACKS, "node_ts", other)
+
+    assert fill_slot_paths(_manifest("node_ts")) == ("src/routes.ts",)
+    assert "backend/routes.py" not in fill_slot_paths(_manifest("node_ts"))
+    # and the original is untouched
+    assert "backend/routes.py" in fill_slot_paths(_manifest())
+
+
+def test_every_per_stack_fact_answers_from_the_same_registration(monkeypatch):
+    """One registration, five answers. Previously a stack could be registered as expandable
+    and still answer `()` for its QA namespace — indistinguishable from "declared as empty"."""
+    other = ScaffoldStack(
+        name="node_ts",
+        expand=lambda m: [],
+        fill_slots=lambda m: ("src/routes.ts",),
+        qa_test_namespace=("src/__tests__/",),
+        harness_entry_modules=("src/server",),
+        check_stack="node",
+    )
+    monkeypatch.setitem(scaffold._STACKS, "node_ts", other)
+
+    assert is_scaffoldable_stack("node_ts")
+    assert qa_test_namespace(_manifest("node_ts")) == ("src/__tests__/",)
+    assert harness_entry_modules("node_ts") == ("src/server",)
+    assert check_stack_for("node_ts") == "node"
+    assert is_qa_test_path_for_stack("src/__tests__/routes.test.ts", "node_ts")
+    assert not is_qa_test_path_for_stack("backend/tests/test_x.py", "node_ts")
+
+
+# --------------------------------------------------------------------------- #
+# The refusal is uniform
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("accessor", [expand, fill_slot_paths, qa_test_namespace])
+def test_an_unregistered_stack_is_refused_identically_everywhere(accessor):
+    """Divergent refusals are how a caller learns to trust one accessor and not another."""
+    with pytest.raises(ValueError, match="no scaffold expander for stack"):
+        accessor(_manifest("nothing_registered"))
+
+
+@pytest.mark.parametrize(
+    ("fn", "expected"),
+    [(harness_entry_modules, ()), (check_stack_for, None)],
+)
+def test_the_tolerant_accessors_stay_tolerant(fn, expected):
+    """These two are read where no manifest exists (bind-mode dispatch, check-stack
+    resolution) and have always degraded rather than raised. #503 chose skip-on-unknown
+    deliberately: feeding an evaluator a guessed stack is worse than not running it."""
+    assert fn("nothing_registered") == expected
+
+
+def test_an_unknown_stack_owns_no_qa_namespace():
+    assert not is_qa_test_path_for_stack("backend/tests/test_x.py", "nothing_registered")
+
+
+# --------------------------------------------------------------------------- #
+# The refactor changed nothing
+# --------------------------------------------------------------------------- #
+
+
+def test_the_reference_stack_still_answers_exactly_what_it_did():
+    manifest = _manifest()
+
+    assert len(expand(manifest)) == 19
+    assert fill_slot_paths(manifest) == (
+        "backend/routes.py",
+        "frontend/src/views/RunsListView.jsx",
+        "frontend/src/views/CreateRunView.jsx",
+        "frontend/src/views/RunDetailView.jsx",
+    )
+    assert qa_test_namespace(manifest) == ("backend/tests/", "frontend/src/tests/")
+    assert harness_entry_modules("fullstack_fastapi_react") == (
+        "backend.main",
+        "app.main",
+        "main",
+    )
+    assert check_stack_for("fullstack_fastapi_react") == "fastapi"
+
+
+def test_the_manifest_hash_every_bound_cycle_keys_on_did_not_move():
+    """S1's exact test. The contract binds this value, M0a pins it literally, and the golden
+    benchmark is measured against it — a consolidation that moved it would be a silent
+    re-basing of every comparison in the project."""
+    assert _manifest().content_hash().startswith("bb472e267e53d5ad")
+
+
+def test_the_registry_is_the_single_answer_to_which_stacks_exist():
+    """The point of the consolidation. A second declaration elsewhere is how the five facts
+    drifted apart in the first place."""
+    assert set(scaffold._STACKS) == {"fullstack_fastapi_react"}
+    assert is_scaffoldable_stack("fullstack_fastapi_react")
+    assert not is_scaffoldable_stack("")


### PR DESCRIPTION
Opens **Track S**. "A stack" was an identifier indexing four module-level dicts plus one function with the answer written inline, so a new stack had to remember to appear in five places — and forgetting produced a **plausible wrong answer** rather than an error.

## The trap, concretely

```python
def fill_slot_paths(manifest):
    if manifest.stack not in _EXPANDERS:      # is it registered?
        raise ValueError(...)
    views = tuple(f"frontend/src/views/{r.view}.jsx" for r in manifest.frontend.routes)
    return ("backend/routes.py", *dict.fromkeys(views))   # ...FastAPI's answer, always
```

A registered Node/TS stack would have been told to fill `backend/routes.py` and `.jsx` views — and every downstream consumer would have agreed with it: the contract's covered files, frozen-artifact ownership, `fill_slot_signature`. **The guard it passed asks a different question than the one being answered.**

## What changed

One `ScaffoldStack` per stack now carries all five facts — `expand`, `fill_slots`, `qa_test_namespace`, `harness_entry_modules`, `check_stack`. `acceptance_evaluation`'s `_BUILD_PROFILE_CHECK_STACKS` is sourced from it rather than declaring the known-stack set a second time, so *"which stacks does this system know?"* has one answer.

**Named `ScaffoldStack`, not `StackBlueprint`, carrying today's fields only.** The Stack Blueprint SIP is deliberately unaccepted until two real stacks exist — its own acceptance gate says generalising from one instance "produces the FastAPI contract with generic field names, worse than no contract". A consolidation that quietly minted that vocabulary would prejudge the question the SIP exists to answer against evidence.

## The plan's exact test, verified

| | result |
|---|---|
| `expand()` output | unchanged, 19 files |
| manifest `content_hash` | **`bb472e267e53d5ad`** — unmoved |
| derived contract sha256 | **`7622f570c949fe95`** — unmoved |
| M0a reference guard | green |
| contract lint gate | green |
| regression | 6,789 |

## The headline test

`test_a_second_stack_does_not_inherit_the_first_stacks_fill_slots` registers a second stack and asserts it gets **its own** slots. That's the bug this removes — and nothing could have caught it while only one stack existed, which is precisely why S1 comes before building the Node stack rather than after.

Also guarded: a half-declared stack (registered as expandable while silently answering `()` elsewhere), and the refusal drifting between accessors so an unknown stack raises in one place and returns `()` in another.

## Verification

11 new tests. Full regression green: 7,175 unit / 6,789 regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv