### PR TITLE
docs(plan): record what S3's schema will not have validated

### DIFF
--- a/docs/plans/1-6-0-authorship-plan.md
+++ b/docs/plans/1-6-0-authorship-plan.md
@@ -613,6 +613,39 @@ proof is the inverse of the failure mode the SIP itself names:
    blueprint is either a genuine optional capability (**declared as such, with the reason**)
    or a FastAPI assumption wearing a general name. The schema must say which.
 
+#### What S3 will NOT have validated — disclose at promotion, do not imply generality
+
+Two gaps, both structural consequences of choices already made. Recording them here so the
+promotion states them, rather than having a later reader infer a generality the schema does
+not have.
+
+**1. Criteria-family variation is untested by construction.** The SIP records that the
+contract emitter's criteria families are **pack-parameterized, not universal**: a
+server-rendered stack has no frontend build, so `vc-frontend-builds` is meaningless for LAMP
+while HTTP probes and suite checks transfer untouched. A blueprint must therefore declare
+*which criteria families the emission gate may draw from*.
+
+**Stack #2 cannot surface this.** Node/TS was chosen to break three FastAPI-shaped
+assumptions while **holding HTTP constant** (S2's containment argument, which still stands) —
+and it also has a frontend build. So both stacks agree on precisely the axis the criteria
+family question turns on. S3's schema will be written against two stacks that cannot
+disagree about it.
+
+Consequence: either the schema declares a criteria-family field it has **not** falsified
+(and says so, per the falsification pass above, which would otherwise delete it as
+decorative), or it omits the field and the first server-rendered pack is a schema change.
+Both are acceptable; silently shipping the first while implying the second is not. The
+honest resolution is a **declared, deliberately un-falsified field with the reason recorded**
+— the `DECLARED_UNBUILT_CHECKS` pattern applied to a schema.
+
+**2. The two stack vocabularies are still two.** The SIP names them: the manifest says
+`fullstack_fastapi_react`, the acceptance checks branch on `stack != "fastapi"`, and
+`resolve_check_stack()` bridges them. **S1 removed the duplicate declaration, not the drift**
+— the mapping is now sourced from the one stack registry, so there is a single answer to
+"which stacks exist", but a stack still has two names and S3 still owes the reconciliation
+the SIP asks for. Recorded because "S1 consolidated the per-stack facts" could otherwise be
+read as having closed this, and it did not.
+
 Together these convert "works for two stacks" from a judgment call into a reviewable
 artifact — which is the same move #730 made for typed checks, where declaration is required
 and drift is guarded.


### PR DESCRIPTION
Two gaps written into S3 so promotion **discloses** them, rather than a later reader inferring a generality the schema doesn't have. Both are structural consequences of choices already made — neither is a reason to change anything.

## 1. Criteria-family variation is untested by construction

The Stack Blueprint SIP records that the contract emitter's criteria families are **pack-parameterized, not universal**: a server-rendered stack has no frontend build, so `vc-frontend-builds` is meaningless for LAMP while HTTP probes and suite checks transfer untouched. A blueprint must therefore declare *which criteria families the emission gate may draw from*.

**Stack #2 cannot surface this.** Node/TS was chosen to break three FastAPI-shaped assumptions while **holding HTTP constant** — S2's containment argument, which still stands — and it *also* has a frontend build. So both stacks agree on precisely the axis the criteria-family question turns on. S3's schema will be written against two stacks that cannot disagree about it.

That collides with S3's own falsification pass, which deletes any field whose removal breaks nothing as decorative. So the resolution has to be explicit: either a **declared, deliberately un-falsified field with the reason recorded** (the `DECLARED_UNBUILT_CHECKS` pattern applied to a schema), or omit it and accept that the first server-rendered pack is a schema change. Both are fine. Shipping the first while implying the second is not.

## 2. The two stack vocabularies are still two

The SIP names them: the manifest says `fullstack_fastapi_react`, the acceptance checks branch on `stack != "fastapi"`, and `resolve_check_stack()` bridges them.

**S1 removed the duplicate declaration, not the drift.** The mapping is now sourced from the one stack registry, so there's a single answer to "which stacks exist" — but a stack still has two names, and S3 still owes the reconciliation the SIP asks for.

Recorded because *"S1 consolidated the per-stack facts"* could easily be read as having closed this. It did not, and I'd rather say so now than have S3 discover it.

## Context

This came out of checking whether the Stack Blueprint SIP needs accepting before the Node stack is built. It does not — its own acceptance gate **is** the existence of a second real stack, and its own sequencing is exactly Track S: consolidate now with no SIP (S1, merged), promote and write the schema against two stacks when #2 is scoped (S3), migrate typed checks after (S4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv