### PR TITLE
feat(scaffold): the contract emitter refuses a stack it has no criteria for (#818)

### DIFF
--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -1463,6 +1463,20 @@ class ScaffoldStack:
     #: implementation's vocabulary rather than the scaffold's — "fastapi", not the profile
     #: name. Empty means the checks skip, which is the conservative default #503 chose.
     check_stack: str = ""
+    #: #818: the verification-criteria pack ``scaffold_contract`` emits for this stack —
+    #: which kinds of fill slot it has, what evidence proves each kind, and what proves the
+    #: deliverable builds and its suite ran. A *name*, not a callable, so the check
+    #: vocabulary stays in the emitter layer; same indirection as ``check_stack``.
+    #:
+    #: **The default is deliberately asymmetric with ``check_stack``.** An unset
+    #: ``check_stack`` means the typed checks *skip*, and a skip is safe because
+    #: ``CheckOutcome.skipped`` is not executed-and-passed under SIP-0096 — it surfaces as
+    #: unverified. An unset ``criteria_pack`` means the emitter **refuses**, because the
+    #: failure it prevents is not a missing check but a *wrong* contract: before #818 a
+    #: stack with no pack fell through to the FastAPI view branch and derived a contract
+    #: that every gate accepted. Visible-and-unverified has a safe default; silently-wrong
+    #: does not.
+    criteria_pack: str = ""
 
 
 _STACKS: dict[str, ScaffoldStack] = {
@@ -1473,6 +1487,10 @@ _STACKS: dict[str, ScaffoldStack] = {
         qa_test_namespace=("backend/tests/", "frontend/src/tests/"),
         harness_entry_modules=("backend.main", "app.main", "main"),
         check_stack="fastapi",
+        # Today a pack is named for the stack that needs it; the indirection exists so a
+        # later stack can share one (a FastAPI+Vue stack wants these same backend criteria)
+        # without minting a fourth stack vocabulary to express it.
+        criteria_pack="fullstack_fastapi_react",
     ),
 }
 
@@ -1494,3 +1512,16 @@ def check_stack_for(stack: str) -> str | None:
     """
     known = _STACKS.get(stack)
     return (known.check_stack or None) if known else None
+
+
+def criteria_pack_for(stack: str) -> str:
+    """The verification-criteria pack ``stack`` declares, or ``""`` (#818).
+
+    Companion to :func:`check_stack_for`, and the same reason for existing: the stack
+    registry is the one place that answers "what does this stack use". Returning the empty
+    string for an unknown or undeclaring stack keeps this accessor total; the *refusal*
+    belongs to the emitter, which is the layer that knows a missing pack means it cannot
+    produce a correct contract.
+    """
+    known = _STACKS.get(stack)
+    return known.criteria_pack if known else ""

--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -23,17 +23,56 @@ from __future__ import annotations
 
 import hashlib
 import re
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 import yaml
 
-from squadops.capabilities.scaffold import InterfaceManifest, expand, fill_slot_paths
+from squadops.capabilities.scaffold import (
+    InterfaceManifest,
+    criteria_pack_for,
+    expand,
+    fill_slot_paths,
+)
 
 CONTRACT_VERSION = 1
 CAP_PYTHON = "python"
 CAP_NODE = "node"
 
 _ROUTES_PATH = "backend/routes.py"
+
+
+@dataclass(frozen=True)
+class CriteriaPack:
+    """What proves a filled slot of each kind correct, for one stack (#818).
+
+    Before this, the emitter was FastAPI end to end with no registration point:
+    ``_ROUTES_PATH`` was hardcoded and the slot partition was a single inline
+    conditional. A second stack's fill slots are ``.ts``, so nothing matched, and **every
+    slot — including the API routes file — fell through to the view branch**.
+    ``endpoint_defined`` was never emitted, so the guards that refuse to credit a check
+    which cannot run (``manifest_gates`` ``PROOF_CHECKS_LIVE``, and the dispatch-time strip
+    in ``task_plan``) had nothing to catch: the contract was not *incomplete*, it was
+    *wrong*, and every gate accepted it.
+
+    ``slot_criteria`` therefore owns **the partition as well as the criteria** — "what
+    kinds of fill slot does this stack have, and how do I tell them apart" is the
+    stack-specific claim that inline conditional was making silently.
+
+    Deliberately NOT covering the manifest-derived tiers. Probes, coverage expectations,
+    the frozen-file hashing, and ``skeleton.expander`` are language-agnostic already, which
+    is why this seam is small — and is S2's HTTP-constant containment argument paying off
+    exactly where it was meant to.
+    """
+
+    name: str
+    #: ``(manifest, fill_slot_path) -> {"interface": [...], "implementation": [...]}``.
+    slot_criteria: Callable[[InterfaceManifest, str], dict[str, Any]]
+    #: ``behavioral.build`` — what proves the deliverable builds.
+    build_criteria: Callable[[], list[dict[str, Any]]]
+    #: ``behavioral.suite.checks`` — what proves its test suite ran.
+    suite_criteria: Callable[[], list[dict[str, Any]]]
 
 
 def emit_contract_dict(manifest: InterfaceManifest) -> dict[str, Any]:
@@ -43,6 +82,7 @@ def emit_contract_dict(manifest: InterfaceManifest) -> dict[str, Any]:
     the same ``content_hash``), so the frozen hash the yield baseline measures against
     is reproducible.
     """
+    pack = _pack_for(manifest.stack)
     files = {f["name"]: f["content"] for f in expand(manifest)}
     fill = fill_slot_paths(manifest)
     fill_set = set(fill)
@@ -53,13 +93,9 @@ def emit_contract_dict(manifest: InterfaceManifest) -> dict[str, Any]:
         if name not in fill_set
     ]
 
-    fill_files: dict[str, Any] = {}
-    for path in fill:
-        fill_files[path] = (
-            _routes_criteria(manifest) if path == _ROUTES_PATH else _view_criteria(path)
-        )
+    fill_files: dict[str, Any] = {path: pack.slot_criteria(manifest, path) for path in fill}
 
-    behavioral = _behavioral(manifest)
+    behavioral = _behavioral(manifest, pack)
 
     contract = {
         "contract_version": CONTRACT_VERSION,
@@ -163,19 +199,67 @@ def _view_criteria(path: str) -> dict[str, Any]:
     }
 
 
-def _behavioral(manifest: InterfaceManifest) -> dict[str, Any]:
+def _behavioral(manifest: InterfaceManifest, pack: CriteriaPack) -> dict[str, Any]:
+    """Build and suite come from the pack; coverage and probes are manifest-derived."""
     return {
-        "build": [
-            {"check": "frontend_build", "id": "vc-frontend-builds", "requires": CAP_NODE},
-        ],
+        "build": pack.build_criteria(),
         "suite": {
-            "checks": [
-                {"check": "tests_pass", "id": "vc-suite-passes", "requires": CAP_PYTHON},
-            ],
+            "checks": pack.suite_criteria(),
             "coverage_expectations": _coverage_expectations(manifest),
         },
         "probes": _probes(manifest),
     }
+
+
+def _fastapi_react_slot_criteria(manifest: InterfaceManifest, path: str) -> dict[str, Any]:
+    """This stack has two kinds of fill slot: one designated routes file, and views.
+
+    The partition was previously an inline conditional in ``emit_contract_dict``, which
+    made it look like a property of contracts rather than a claim about *this* stack.
+    """
+    return _routes_criteria(manifest) if path == _ROUTES_PATH else _view_criteria(path)
+
+
+_CRITERIA_PACKS: dict[str, CriteriaPack] = {
+    "fullstack_fastapi_react": CriteriaPack(
+        name="fullstack_fastapi_react",
+        slot_criteria=_fastapi_react_slot_criteria,
+        build_criteria=lambda: [
+            {"check": "frontend_build", "id": "vc-frontend-builds", "requires": CAP_NODE},
+        ],
+        suite_criteria=lambda: [
+            {"check": "tests_pass", "id": "vc-suite-passes", "requires": CAP_PYTHON},
+        ],
+    ),
+}
+
+
+def _pack_for(stack: str) -> CriteriaPack:
+    """The stack's criteria pack, or a refusal (#818).
+
+    Refusal rather than a fallback, and this is the whole point of the issue: the previous
+    behavior *was* the fallback — an unregistered stack's slots quietly took the FastAPI
+    view branch and produced a contract that asserted the wrong things and was believed.
+    Emission is deterministic and offline, so raising here lands before a cycle spends
+    anything, and it is the same refusal ``scaffold._stack`` already raises for a stack
+    with no expander.
+    """
+    name = criteria_pack_for(stack)
+    if not name:
+        raise ValueError(
+            f"stack {stack!r} declares no criteria_pack, so no verification contract can be "
+            f"derived for it. Register one in scaffold_contract._CRITERIA_PACKS and name it "
+            f"on the stack's ScaffoldStack — do not let it inherit another stack's criteria "
+            f"(#818: that produced a contract asserting the wrong things, which every gate "
+            f"accepted)."
+        )
+    pack = _CRITERIA_PACKS.get(name)
+    if pack is None:
+        raise ValueError(
+            f"stack {stack!r} names criteria_pack {name!r}, which is not registered "
+            f"(known: {sorted(_CRITERIA_PACKS)})."
+        )
+    return pack
 
 
 def _coverage_expectations(manifest: InterfaceManifest) -> list[str]:
@@ -357,5 +441,10 @@ def _required_capabilities(fill_files: dict[str, Any], behavioral: dict[str, Any
     for crit in behavioral.get("suite", {}).get("checks", []):
         if crit.get("requires"):
             found.add(crit["requires"])
-    # Stable order: python before node.
-    return [c for c in (CAP_PYTHON, CAP_NODE) if c in found]
+    # Stable order: the known capabilities first, in their historical order, then anything
+    # else sorted. #818: this used to be `[c for c in (CAP_PYTHON, CAP_NODE) if c in found]`,
+    # a closed two-element universe that silently DROPPED a third — so a pack declaring
+    # `requires: "go"` would under-declare its capabilities, in a field whose whole claim is
+    # that it is "declared from what the criteria actually require, so the two can't drift".
+    known = [c for c in (CAP_PYTHON, CAP_NODE) if c in found]
+    return known + sorted(found - set(known))

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -69,11 +69,15 @@ class CheckSpec:
         param_types: Map of param key → expected Python type (or tuple of
             types). The parser does an ``isinstance`` check; mismatches →
             ValueError.
-        supported_stacks: Frozen set of stack identifiers (e.g., ``fastapi``,
-            ``python``) on which the M1.2 evaluator can act. Empty set means
-            stack-agnostic. The parser does NOT enforce stack compatibility —
-            stack-unsupported but well-formed checks are valid plans (RC-11)
-            that the evaluator returns ``skipped`` for at runtime (RC-12).
+        (``supported_stacks`` was removed by #818: declared on 11 specs and read
+            by nothing, repo-wide. It was also a *third* stack vocabulary, and an
+            internally inconsistent one — ``{"fastapi"}`` named a framework,
+            ``{"python"}`` a language, ``{"python", "javascript", "typescript"}``
+            languages. What it appeared to do is done by ``applicable_extensions``,
+            which is read at two live call sites, plus each evaluator's own stack
+            branch. Deleted rather than wired: wiring an unvalidated vocabulary
+            would have minted the stack-blueprint schema by accident, which is
+            exactly what S1 declined to do when it named its type ``ScaffoldStack``.)
         requires_stack_context: When true, the M1.2 evaluator needs declared
             stack context (from ``HandlerContext``) to evaluate. When false,
             language-level cues (file extension) are sufficient. Per RC-12a,
@@ -138,7 +142,6 @@ class CheckSpec:
     required_params: frozenset[str]
     optional_params: frozenset[str] = frozenset()
     param_types: dict[str, type | tuple[type, ...]] = field(default_factory=dict)
-    supported_stacks: frozenset[str] = frozenset()
     requires_stack_context: bool = False
     path_params: frozenset[str] = frozenset()
     example: dict[str, object] = field(default_factory=dict)
@@ -407,7 +410,6 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         applicable_extensions=frozenset({".py"}),
         required_params=frozenset({"file", "methods_paths"}),
         param_types={"file": str, "methods_paths": list},
-        supported_stacks=frozenset({"fastapi"}),
         requires_stack_context=True,
         path_params=frozenset({"file"}),
         example={"file": "app/main.py", "methods_paths": ["GET /runs", "POST /runs"]},
@@ -424,7 +426,6 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         required_params=frozenset({"file", "module"}),
         optional_params=frozenset({"symbol"}),
         param_types={"file": str, "module": str, "symbol": str},
-        supported_stacks=frozenset({"python", "javascript", "typescript"}),
         requires_stack_context=False,
         path_params=frozenset({"file"}),
         example={"file": "app/main.py", "module": "app.models", "symbol": "RunEvent"},
@@ -440,7 +441,6 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         applicable_extensions=frozenset({".py"}),
         required_params=frozenset({"file", "class_name", "fields"}),
         param_types={"file": str, "class_name": str, "fields": list},
-        supported_stacks=frozenset({"python"}),
         requires_stack_context=True,
         path_params=frozenset({"file"}),
         example={"file": "app/models.py", "class_name": "RunEvent", "fields": ["id", "title"]},
@@ -457,7 +457,6 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         required_params=frozenset({"file", "name_prefix"}),
         optional_params=frozenset({"min_count"}),
         param_types={"file": str, "name_prefix": str, "min_count": int},
-        supported_stacks=frozenset({"python"}),
         requires_stack_context=True,
         path_params=frozenset({"file"}),
         example={"file": "backend/tests/test_runs.py", "name_prefix": "test_", "min_count": 3},
@@ -483,7 +482,6 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         required_params=frozenset({"file", "entry_modules"}),
         optional_params=frozenset({"client_ctor"}),
         param_types={"file": str, "entry_modules": list, "client_ctor": str},
-        supported_stacks=frozenset({"python"}),
         requires_stack_context=True,
         path_params=frozenset({"file"}),
         example={
@@ -511,7 +509,6 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         required_params=frozenset({"file", "pattern"}),
         optional_params=frozenset({"count_min"}),
         param_types={"file": str, "pattern": str, "count_min": int},
-        supported_stacks=frozenset(),
         requires_stack_context=False,
         path_params=frozenset({"file"}),
         # pattern carries a backslash escape on purpose: the rendered example
@@ -536,7 +533,6 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         name="count_at_least",
         required_params=frozenset({"glob", "min_count"}),
         param_types={"glob": str, "min_count": int},
-        supported_stacks=frozenset(),
         requires_stack_context=False,
         path_params=frozenset({"glob"}),
         example={"glob": "tests/test_*.py", "min_count": 3},
@@ -552,7 +548,6 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         required_params=frozenset({"argv"}),
         optional_params=frozenset({"cwd", "timeout_s"}),
         param_types={"argv": list, "cwd": str, "timeout_s": int},
-        supported_stacks=frozenset(),
         requires_stack_context=False,
         # argv elements are not single paths; the RC-10a safelist above
         # validates argv shapes pattern-by-pattern. cwd is path-checked at
@@ -581,7 +576,6 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         required_params=frozenset({"file"}),
         optional_params=frozenset({"timeout_s"}),
         param_types={"file": str, "timeout_s": int},
-        supported_stacks=frozenset(),
         requires_stack_context=False,
         path_params=frozenset({"file"}),
         example={"file": "frontend/src/views/RunsListView.jsx"},
@@ -611,7 +605,6 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         applicable_extensions=frozenset({".py"}),
         required_params=frozenset({"file", "routes"}),
         param_types={"file": str, "routes": list},
-        supported_stacks=frozenset({"python"}),
         requires_stack_context=False,
         path_params=frozenset({"file"}),
         framework_injected=True,
@@ -655,7 +648,6 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         required_params=frozenset({"file", "endpoints"}),
         optional_params=frozenset({"allowed_error_statuses"}),
         param_types={"file": str, "endpoints": list, "allowed_error_statuses": list},
-        supported_stacks=frozenset({"python"}),
         requires_stack_context=False,
         path_params=frozenset({"file"}),
         framework_injected=True,
@@ -689,7 +681,6 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         required_params=frozenset({"file"}),
         optional_params=frozenset({"timeout_s"}),
         param_types={"file": str, "timeout_s": int},
-        supported_stacks=frozenset({"python"}),
         requires_stack_context=False,
         path_params=frozenset({"file"}),
         example={"file": "backend/routes.py"},

--- a/tests/unit/capabilities/test_contract_emitter_stack_seam.py
+++ b/tests/unit/capabilities/test_contract_emitter_stack_seam.py
@@ -1,0 +1,275 @@
+"""The contract emitter learns which stack it is emitting for (#818).
+
+S1 consolidated the five per-stack *scaffold* facts. The contract **emitter** was out of
+scope and is the larger half: `_ROUTES_PATH = "backend/routes.py"` was hardcoded and the
+slot partition was one inline conditional — `_routes_criteria if path == _ROUTES_PATH else
+_view_criteria`. A second stack's fill slots are `.ts`, so nothing matched and **every slot,
+including the API routes file, derived view criteria**.
+
+That is worse than a coverage gap, which is what the 1.6 plan's S4 section predicted before
+anyone read this file. `endpoint_defined` — the check that proves the declared endpoints
+exist — was never *emitted*, so the two guards that refuse to credit a check which cannot
+run had nothing to catch: `manifest_gates` `PROOF_CHECKS_LIVE` saw no inapplicable check,
+and `task_plan`'s dispatch-time strip had nothing to strip. The contract was not incomplete,
+it was **wrong, and every gate accepted it**.
+
+Bug classes guarded:
+
+- **a second stack's routes file being checked as a frontend view** — the defect itself,
+  and the reason a refusal beats a fallback;
+- a stack with no criteria pack silently inheriting another stack's, which is the same
+  failure S1 removed from `fill_slot_paths` arriving one layer up;
+- the refusal being skipped because a *pack name* was registered that no pack answers to —
+  a typo would otherwise resolve to `None` and crash somewhere less informative;
+- **the capability list silently dropping a capability it was told about**, in a field whose
+  stated claim is that it is derived from the criteria "so the two can't drift";
+- the parameterization moving the reference contract, which every bind-mode cycle and the
+  golden benchmark key on. (Byte equality itself is pinned by
+  `test_contract_derivation_reference.py`; what is asserted here is that a *second* stack
+  cannot perturb the first.)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from squadops.capabilities import scaffold, scaffold_contract
+from squadops.capabilities.scaffold import InterfaceManifest, ScaffoldStack
+from squadops.capabilities.scaffold_contract import CriteriaPack, emit_contract_dict
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_REFERENCE = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+).read_text(encoding="utf-8")
+
+
+def _manifest(stack: str = "fullstack_fastapi_react") -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_REFERENCE.replace("fullstack_fastapi_react", stack))
+
+
+def _register_stack(monkeypatch: Any, *, criteria_pack: str) -> None:
+    """A Node/TS-shaped second stack: one `.ts` routes slot and one `.tsx` view."""
+    monkeypatch.setitem(
+        scaffold._STACKS,
+        "node_ts",
+        ScaffoldStack(
+            name="node_ts",
+            expand=lambda m: [
+                {"name": "src/routes.ts", "content": "// routes"},
+                {"name": "src/views/RunsList.tsx", "content": "// view"},
+                {"name": "package.json", "content": "{}"},
+            ],
+            fill_slots=lambda m: ("src/routes.ts", "src/views/RunsList.tsx"),
+            check_stack="node",
+            criteria_pack=criteria_pack,
+        ),
+    )
+
+
+def _checks(contract: dict[str, Any], slot: str) -> set[str]:
+    spec = contract["fill_files"][slot]
+    return {c["check"] for cls in ("interface", "implementation") for c in spec.get(cls, [])}
+
+
+# --------------------------------------------------------------------------- #
+# The refusal
+# --------------------------------------------------------------------------- #
+
+
+def test_a_stack_with_no_criteria_pack_is_refused_not_given_the_first_stacks_criteria(
+    monkeypatch,
+):
+    """The defect. Before #818 this returned a contract in which `src/routes.ts` carried a
+    single `frontend_compiles` bundler check and `endpoint_defined` was absent entirely —
+    and nothing objected, because nothing was inapplicable."""
+    _register_stack(monkeypatch, criteria_pack="")
+
+    with pytest.raises(ValueError, match="declares no criteria_pack"):
+        emit_contract_dict(_manifest("node_ts"))
+
+
+def test_a_pack_name_nothing_answers_to_is_refused_too(monkeypatch):
+    """The typo case. Declaring a pack that is not registered must fail here, naming the
+    known packs, rather than resolving to `None` and failing somewhere less informative."""
+    _register_stack(monkeypatch, criteria_pack="node_ts_typo")
+
+    with pytest.raises(ValueError, match="not registered"):
+        emit_contract_dict(_manifest("node_ts"))
+
+
+def test_the_refusal_names_what_to_do_about_it(monkeypatch):
+    """A refusal that does not say where to register the pack sends the reader into the
+    emitter to work it out — and the tempting local fix is a fallback, which is the bug."""
+    _register_stack(monkeypatch, criteria_pack="")
+
+    with pytest.raises(ValueError) as exc:
+        emit_contract_dict(_manifest("node_ts"))
+
+    assert "_CRITERIA_PACKS" in str(exc.value)
+    assert "ScaffoldStack" in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# A second stack with its own pack
+# --------------------------------------------------------------------------- #
+
+
+def _register_node_pack(monkeypatch) -> None:
+    monkeypatch.setitem(
+        scaffold_contract._CRITERIA_PACKS,
+        "node_ts",
+        CriteriaPack(
+            name="node_ts",
+            slot_criteria=lambda m, path: (
+                {
+                    "interface": [
+                        {
+                            "check": "endpoint_defined",
+                            "id": "vc-routes-endpoints",
+                            "methods_paths": [f"{e.method} {e.path}" for e in m.api.endpoints],
+                        }
+                    ],
+                    "implementation": [
+                        {
+                            "check": "command_exit_zero",
+                            "id": "vc-routes-typechecks",
+                            "argv": ["npx", "tsc", "--noEmit"],
+                            "requires": "node",
+                        }
+                    ],
+                }
+                if path.endswith("routes.ts")
+                else {
+                    "interface": [],
+                    "implementation": [
+                        {"check": "frontend_compiles", "id": "vc-view", "file": path}
+                    ],
+                }
+            ),
+            build_criteria=lambda: [
+                {"check": "frontend_build", "id": "vc-frontend-builds", "requires": "node"}
+            ],
+            suite_criteria=lambda: [
+                {"check": "tests_pass", "id": "vc-suite-passes", "requires": "node"}
+            ],
+        ),
+    )
+
+
+def test_the_second_stacks_routes_file_is_not_checked_as_a_view(monkeypatch):
+    """The partition belongs to the pack. Under the hardcoded `path == "backend/routes.py"`
+    conditional, `src/routes.ts` took the else-branch and got the frontend bundler."""
+    _register_stack(monkeypatch, criteria_pack="node_ts")
+    _register_node_pack(monkeypatch)
+
+    contract = emit_contract_dict(_manifest("node_ts"))
+
+    assert _checks(contract, "src/routes.ts") == {"endpoint_defined", "command_exit_zero"}
+    assert "frontend_compiles" not in _checks(contract, "src/routes.ts")
+    assert _checks(contract, "src/views/RunsList.tsx") == {"frontend_compiles"}
+
+
+def test_the_second_stack_does_not_inherit_the_first_stacks_toolchain(monkeypatch):
+    """`tests_pass` used to be emitted with `requires: CAP_PYTHON` unconditionally, which
+    demanded a Python capability of a stack that has none."""
+    _register_stack(monkeypatch, criteria_pack="node_ts")
+    _register_node_pack(monkeypatch)
+
+    contract = emit_contract_dict(_manifest("node_ts"))
+
+    assert contract["capabilities"] == ["node"]
+    assert [c["requires"] for c in contract["behavioral"]["suite"]["checks"]] == ["node"]
+
+
+def test_registering_a_second_stack_does_not_perturb_the_first(monkeypatch):
+    """The reference contract is what every bind-mode cycle and the golden benchmark key
+    on; a second registration must be inert for the first."""
+    _register_stack(monkeypatch, criteria_pack="node_ts")
+    _register_node_pack(monkeypatch)
+
+    reference = emit_contract_dict(_manifest())
+
+    assert reference["skeleton"]["interface_manifest_hash"].startswith("bb472e267e53d5ad")
+    assert _checks(reference, "backend/routes.py") == {
+        "endpoint_defined",
+        "import_present",
+        "command_exit_zero",
+        "module_imports",
+    }
+    assert reference["capabilities"] == ["python", "node"]
+
+
+# --------------------------------------------------------------------------- #
+# The capability list
+# --------------------------------------------------------------------------- #
+
+
+def test_a_capability_outside_the_known_two_is_declared_not_dropped(monkeypatch):
+    """`_required_capabilities` was `[c for c in (CAP_PYTHON, CAP_NODE) if c in found]` — a
+    closed universe that silently discarded a third. The field's own comment claims it is
+    "declared from what the criteria actually require, so the two can't drift"; for a Go or
+    Rust pack it drifted, in the direction of under-declaring what the sandbox must provide."""
+    _register_stack(monkeypatch, criteria_pack="go_pack")
+    monkeypatch.setitem(
+        scaffold_contract._CRITERIA_PACKS,
+        "go_pack",
+        CriteriaPack(
+            name="go_pack",
+            slot_criteria=lambda m, path: {
+                "interface": [],
+                "implementation": [
+                    {"check": "command_exit_zero", "id": "vc-build", "requires": "go"}
+                ],
+            },
+            build_criteria=lambda: [],
+            suite_criteria=lambda: [{"check": "tests_pass", "id": "vc-suite", "requires": "go"}],
+        ),
+    )
+
+    contract = emit_contract_dict(_manifest("node_ts"))
+
+    assert contract["capabilities"] == ["go"]
+
+
+def test_the_historical_capability_order_is_preserved(monkeypatch):
+    """python-before-node is serialized into the pinned reference contract, so a sort that
+    reordered them would move a hash that 1.4's banked evidence was measured against."""
+    _register_stack(monkeypatch, criteria_pack="mixed")
+    monkeypatch.setitem(
+        scaffold_contract._CRITERIA_PACKS,
+        "mixed",
+        CriteriaPack(
+            name="mixed",
+            slot_criteria=lambda m, path: {
+                "interface": [],
+                "implementation": [
+                    {"check": "command_exit_zero", "id": "vc-a", "requires": "node"}
+                ],
+            },
+            build_criteria=lambda: [{"check": "frontend_build", "id": "vc-b", "requires": "rust"}],
+            suite_criteria=lambda: [{"check": "tests_pass", "id": "vc-c", "requires": "python"}],
+        ),
+    )
+
+    contract = emit_contract_dict(_manifest("node_ts"))
+
+    assert contract["capabilities"] == ["python", "node", "rust"]
+
+
+# --------------------------------------------------------------------------- #
+# The registries cannot drift apart
+# --------------------------------------------------------------------------- #
+
+
+def test_every_registered_stack_declares_a_pack_that_exists():
+    """Two registries means two places to forget. This is the binding that makes forgetting
+    an error rather than the plausible wrong answer S1 was written to eliminate."""
+    for name, stack in scaffold._STACKS.items():
+        assert stack.criteria_pack, f"stack {name!r} declares no criteria_pack"
+        assert stack.criteria_pack in scaffold_contract._CRITERIA_PACKS, (
+            f"stack {name!r} names pack {stack.criteria_pack!r}, which is not registered"
+        )


### PR DESCRIPTION
Implements the design gate posted on #818, all three calls as ruled.

## The defect, demonstrated

The pre-change dispatch (`_routes_criteria if path == _ROUTES_PATH else _view_criteria`, with `_ROUTES_PATH = "backend/routes.py"` hardcoded) applied to a Node/TS-shaped slot:

```
src/routes.ts     -> ['frontend_compiles']
backend/routes.py -> ['command_exit_zero', 'endpoint_defined', 'import_present', 'module_imports']
```

A second stack's slots are `.ts`, so nothing matched `_ROUTES_PATH` and **every slot — including the API routes file — fell to the view branch.** The API routes file was handed to the frontend bundler.

**Why no guard caught it.** `endpoint_defined` was never *emitted*, so the two mechanisms that refuse to credit a check which cannot run had nothing to work with: `manifest_gates.py` `PROOF_CHECKS_LIVE` saw no inapplicable check, and `task_plan.py`'s dispatch-time strip had nothing to strip. The contract was not incomplete, it was **wrong, and every gate accepted it** — which is worse than the "narrower enforced surface" the plan's S4 section predicted before anyone opened this file.

## What changed

`CriteriaPack` owns **the partition as well as the criteria**. "What kinds of fill slot does this stack have, and how do I tell them apart" was the stack-specific claim that inline conditional was making silently, and it is the part that breaks first for a second stack.

`ScaffoldStack` gains `criteria_pack: str` — a *name*, not a callable, so the check vocabulary stays in the emitter layer. Same indirection S1 established with `check_stack`, and no new stack vocabulary: today a pack is named for the stack that needs it, and the indirection exists so a later FastAPI+Vue stack can share these backend criteria without minting one.

**The default is deliberately asymmetric with `check_stack`, and that asymmetry is the point.** An unset `check_stack` means the typed checks *skip* — safe, because `CheckOutcome.skipped` is not executed-and-passed under SIP-0096, so it surfaces as unverified. An unset `criteria_pack` **refuses**, because the failure it prevents is not a missing check but a wrong contract. Visible-and-unverified has a safe default; silently-wrong does not.

**Untouched, which is why the seam is small:** probes, coverage expectations, frozen-file hashing and `skeleton.expander` are manifest-derived already. That is S2's HTTP-constant containment argument paying off exactly where it was meant to.

## Two sub-findings, both fixed

**`_required_capabilities` had a closed universe.** It returned `[c for c in (CAP_PYTHON, CAP_NODE) if c in found]`, silently dropping a third — in a field documented as "declared from what the criteria actually require, so the two can't drift." A Go or Rust pack would have under-declared what the sandbox must provide. Known capabilities keep their historical order (python before node, which is serialized into the pinned reference contract), then anything else sorted.

**`CheckSpec.supported_stacks` is deleted.** Declared on 11 specs, read by nothing repo-wide, and a *third* stack vocabulary that was internally inconsistent — `{"fastapi"}` a framework, `{"python"}` a language, `{"python","javascript","typescript"}` languages. What it appeared to do is done by `applicable_extensions`, which is read at two live call sites, plus each evaluator's own stack branch.

Deleted rather than wired, deliberately: it is the seam someone would reach for to fix this issue, and wiring an unvalidated vocabulary would mint the stack-blueprint schema by accident — which is exactly what S1 declined to do when it named its type `ScaffoldStack`. This is S3's falsification pass applied early, and it takes the vocabulary count from three to two.

## Proof

| Exit criterion | Result |
|---|---|
| Reference contract byte-identical | ✅ verified against a captured baseline |
| Contract hash `7622f570c949fe95` | ✅ unmoved |
| Manifest hash `bb472e267e53d5ad` | ✅ unmoved |
| M0a equivalence guard | ✅ green |
| A stack with no pack raises | ✅ `test_a_stack_with_no_criteria_pack_is_refused_not_given_the_first_stacks_criteria` |
| `supported_stacks` deleted with the argument recorded | ✅ |
| Full regression | ✅ **6798 passed, 1 skipped** |

Nine new tests in `test_contract_emitter_stack_seam.py`, each written against a bug that was reachable: the routes file taking view criteria, a pack name nothing answers to, a refusal that does not say where to register the pack, a second stack inheriting the first's toolchain (`tests_pass` demanded `CAP_PYTHON` unconditionally), a second registration perturbing the reference, the dropped third capability, and a binding test so that two registries cannot drift apart — which is the failure mode S1 removed one layer down.

## Not in scope

The Node/TypeScript stack itself, which is the next item and the first thing that will actually exercise this seam. Kept separate deliberately: landing them together would make a moved contract hash ambiguous between "the refactor changed something" and "the new stack revealed something," and the byte-equivalence proof above is only meaningful because nothing else moved.

Also unresolved by design, for S3: whether a pack should be **data rather than callables**. Callables are what exists and prove no behavior change here; data would make S3's falsification pass mechanical instead of manual. Recorded on the issue as an owner fork.

Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
