### PR TITLE
feat(probes): the probe runner boots the stack the cycle actually builds (#822)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -265,6 +265,7 @@ class QATestHandler(_CycleTaskHandler):
             return
 
         from squadops.capabilities.handlers.probe_runner import probe_check_rows, run_probes
+        from squadops.capabilities.scaffold import scaffold_stack_for
         from squadops.cycles.patch_verification import materialize_artifacts
         from squadops.cycles.verification_contract import Probe
 
@@ -295,7 +296,11 @@ class QATestHandler(_CycleTaskHandler):
         with tempfile.TemporaryDirectory(prefix="qa_probes_") as tmp:
             workspace = Path(tmp)
             materialize_artifacts(artifacts, workspace)
-            outcomes = await asyncio.to_thread(run_probes, workspace, probes)
+            # #822: boot the stack this cycle actually builds. Before this, `run_probes`
+            # took the FastAPI profile as a default argument and nothing overrode it, so
+            # every stack was booted with `uvicorn backend.main:app`.
+            stack = scaffold_stack_for(inputs.get("resolved_config"))
+            outcomes = await asyncio.to_thread(run_probes, workspace, probes, stack=stack)
 
         vr = outputs.setdefault("validation_result", {})
         vr.setdefault("checks", []).extend(probe_check_rows(outcomes))

--- a/src/squadops/capabilities/handlers/probe_runner.py
+++ b/src/squadops/capabilities/handlers/probe_runner.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import contextlib
 import dataclasses
+import logging
 import os
 import socket
 import subprocess
@@ -44,6 +45,8 @@ from squadops.cycles.verification_contract import (
     resolve_probe_path,
 )
 from squadops.cycles.verification_integrity import ResultStatus
+
+logger = logging.getLogger(__name__)
 
 # The one subject the default profile knows how to boot: a FastAPI backend. A probe whose
 # subject the active profile cannot boot is reported skipped (not-executed), never a false pass.
@@ -82,6 +85,32 @@ DEFAULT_PROFILE = ExecutionProfile(
     ),
 )
 
+#: #822: per-stack boot, keyed by the ``probe_profile`` name a ``ScaffoldStack`` declares.
+#: Registered here rather than derived from the sandbox ``EnvironmentContract``: that contract's
+#: ``START_APPLICATION`` argv runs inside the sandbox container against ``.sandbox-venv``, while
+#: this boots in the qa container against a fresh temp dir on ``sys.executable``. Two execution
+#: contexts, so the interpreter is context-specific and only the launcher and entry point are
+#: stack-specific.
+_PROFILES: dict[str, ExecutionProfile] = {
+    "fastapi_uvicorn": DEFAULT_PROFILE,
+}
+
+
+def profile_for_stack(stack: str) -> ExecutionProfile | None:
+    """The boot profile ``stack`` declares, or ``None`` if it declares none (#822).
+
+    ``None`` is the signal to report the backend probes not-executed rather than to boot
+    something else: before this, ``run_probes`` took ``DEFAULT_PROFILE`` as a default argument
+    and no caller overrode it, so **every stack was booted as FastAPI**. That is loud rather
+    than silent — a Node app does not start under ``uvicorn backend.main:app``, so the probes
+    skip and SIP-0096 declines to credit them — but "boot the wrong thing and let it fail" is
+    a diagnosis the reader has to reconstruct, and a declared refusal is one they are handed.
+    """
+    from squadops.capabilities.scaffold import probe_profile_for
+
+    name = probe_profile_for(stack)
+    return _PROFILES.get(name) if name else None
+
 
 @dataclass(frozen=True)
 class ProbeOutcome:
@@ -106,7 +135,8 @@ def run_probes(
     workspace: Path,
     probes: tuple[Probe, ...] | list[Probe],
     *,
-    profile: ExecutionProfile = DEFAULT_PROFILE,
+    profile: ExecutionProfile | None = None,
+    stack: str = "",
 ) -> list[ProbeOutcome]:
     """Boot the subject once, run every probe against it, tear it down.
 
@@ -115,6 +145,17 @@ def run_probes(
     ready, every backend probe is ``skipped`` with a boot reason — a boot failure is a
     not-executed result, not a probe failure. Returns one ``ProbeOutcome`` per probe, in
     contract order.
+
+    **How the subject gets booted (#822).** An explicit ``profile`` wins (the test seam); else
+    ``stack``'s declared profile; else ``DEFAULT_PROFILE``, which is today's behavior for every
+    caller that cannot name a stack and keeps this change inert for them.
+
+    A *registered* stack declaring no profile is the one case that reports not-executed instead
+    of booting something: it means a stack was added without saying how to start it, and the
+    completeness test in ``test_stack_seams`` is what makes that a build-time error rather than
+    a runtime surprise. **This does not raise**, unlike the emitter's refusal in #818, because
+    the caller's contract forbids it — ``qa_test`` treats probes as additive evidence that
+    "surfaces at the run verdict/rollup, not as a task failure here."
     """
     backend = [p for p in probes if p.subject == SUBJECT_BACKEND]
     other = [p for p in probes if p.subject != SUBJECT_BACKEND]
@@ -123,8 +164,25 @@ def run_probes(
         for p in other
     }
 
+    resolved = profile
+    if resolved is None:
+        resolved = profile_for_stack(stack) if stack else DEFAULT_PROFILE
+    if resolved is None:
+        logger.warning(
+            "probe_boot_profile_missing stack=%s — stack declares no probe_profile, so its "
+            "backend probes report not-executed rather than booting another stack's app",
+            stack,
+        )
+        outcomes.update(
+            {
+                p.id: ProbeOutcome(p.id, "skipped", f"stack {stack!r} declares no probe profile")
+                for p in backend
+            }
+        )
+        backend = []
+
     if backend:
-        outcomes.update({o.id: o for o in _run_backend_probes(workspace, backend, profile)})
+        outcomes.update({o.id: o for o in _run_backend_probes(workspace, backend, resolved)})
 
     # preserve contract order
     return [outcomes[p.id] for p in probes]

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -1477,6 +1477,18 @@ class ScaffoldStack:
     #: that every gate accepted. Visible-and-unverified has a safe default; silently-wrong
     #: does not.
     criteria_pack: str = ""
+    #: #822: the probe-boot profile ``handlers.probe_runner`` uses to stand this stack's app
+    #: up for behavioral probes — the launcher and entry point (``uvicorn backend.main:app``
+    #: vs ``node dist/server.js``) and the readiness path. A *name*, like ``criteria_pack``,
+    #: so the boot vocabulary stays in the runner layer.
+    #:
+    #: **Not derived from the sandbox ``EnvironmentContract``**, which also carries a
+    #: ``START_APPLICATION`` command: that argv runs *inside the sandbox container*, where
+    #: ``INSTALL_DEPENDENCIES`` built ``.sandbox-venv``. Probes run in the qa container
+    #: against a fresh temp dir with no venv, on ``sys.executable``. Two execution contexts,
+    #: not one fact duplicated — the interpreter is context-specific, only the launcher and
+    #: entry point are stack-specific.
+    probe_profile: str = ""
 
 
 _STACKS: dict[str, ScaffoldStack] = {
@@ -1491,6 +1503,7 @@ _STACKS: dict[str, ScaffoldStack] = {
         # later stack can share one (a FastAPI+Vue stack wants these same backend criteria)
         # without minting a fourth stack vocabulary to express it.
         criteria_pack="fullstack_fastapi_react",
+        probe_profile="fastapi_uvicorn",
     ),
 }
 
@@ -1525,3 +1538,28 @@ def criteria_pack_for(stack: str) -> str:
     """
     known = _STACKS.get(stack)
     return known.criteria_pack if known else ""
+
+
+def probe_profile_for(stack: str) -> str:
+    """The probe-boot profile ``stack`` declares, or ``""`` (#822).
+
+    Total, like :func:`criteria_pack_for`: what to *do* about an undeclared profile belongs
+    to the probe runner, whose caller treats probes as additive evidence that may report
+    not-executed but must never raise.
+    """
+    known = _STACKS.get(stack)
+    return known.probe_profile if known else ""
+
+
+def scaffold_stack_for(resolved_config: Mapping[str, Any] | None) -> str:
+    """The scaffold stack a cycle's config names, or ``""`` (#822).
+
+    Sibling of ``cycles.acceptance_evaluation.resolve_check_stack``, and deliberately not the
+    same function: that one maps ``build_profile`` through to the *evaluator* vocabulary
+    (``"fastapi"``), while boot profiles are keyed on the scaffold stack itself
+    (``"fullstack_fastapi_react"``). Collapsing them would reintroduce the vocabulary
+    confusion S3 still owes a reconciliation for.
+    """
+    config = resolved_config or {}
+    profile = config.get("build_profile")
+    return str(profile) if profile and str(profile) in _STACKS else ""

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -1448,8 +1448,9 @@ class TestQAContractProbeEmission:
     def _fake_run_probes(self, captured):
         from squadops.capabilities.handlers.probe_runner import ProbeOutcome
 
-        def fake(workspace, probes):
+        def fake(workspace, probes, *, stack=""):
             captured["probe_ids"] = [p.id for p in probes]
+            captured["stack"] = stack
             captured["files"] = sorted(
                 str(p.relative_to(workspace)) for p in workspace.rglob("*") if p.is_file()
             )
@@ -1459,6 +1460,33 @@ class TestQAContractProbeEmission:
             ]
 
         return fake
+
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
+    async def test_the_handler_names_the_stack_it_is_probing(
+        self, _mock_run, mock_context, qa_inputs, monkeypatch
+    ):
+        """#822 end to end. The runner can only boot the right app if the handler tells it
+        which stack this cycle builds; before this, nothing did, and every stack was booted
+        with `uvicorn backend.main:app`."""
+        mock_context.ports.llm.chat_stream_with_usage = AsyncMock(
+            return_value=ChatMessage(role="assistant", content=LLM_TEST_FILE_RESPONSE),
+        )
+        captured = {}
+        monkeypatch.setattr(
+            "squadops.capabilities.handlers.probe_runner.run_probes",
+            self._fake_run_probes(captured),
+        )
+
+        await QATestHandler().handle(
+            mock_context,
+            {
+                **qa_inputs,
+                "contract_probes": self._PROBES,
+                "resolved_config": {"build_profile": "fullstack_fastapi_react"},
+            },
+        )
+
+        assert captured["stack"] == "fullstack_fastapi_react"
 
     @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
     async def test_generate_path_appends_probe_rows(
@@ -1479,6 +1507,10 @@ class TestQAContractProbeEmission:
         # source workspace (the same artifacts the suite validated).
         assert captured["probe_ids"] == ["vc-probe-create", "vc-probe-dup"]
         assert captured["files"] == ["src/main.py", "src/utils.py"]
+        # #822: the handler names the stack it is probing. Empty here because this
+        # fixture declares no build_profile — which is the fallback path, and the
+        # runner keeps booting the historical FastAPI profile for it.
+        assert captured["stack"] == ""
         # Exact evidence rows: per-probe check rows, criterion-ID-stamped, with the
         # status key normalize_task_checks requires to carry criterion_id through.
         rows = result.outputs["validation_result"]["checks"]
@@ -1915,7 +1947,7 @@ class TestRetestProbesPatchedTree:
     ):
         captured = {}
 
-        def fake_run_probes(workspace, probes):
+        def fake_run_probes(workspace, probes, *, stack=""):
             from squadops.capabilities.handlers.probe_runner import ProbeOutcome
 
             captured["probe_ids"] = [p.id for p in probes]

--- a/tests/unit/capabilities/test_probe_boot_seam.py
+++ b/tests/unit/capabilities/test_probe_boot_seam.py
@@ -1,0 +1,224 @@
+"""Which app the probe runner boots is the stack's declaration (#822).
+
+`run_probes` took `profile: ExecutionProfile = DEFAULT_PROFILE` as a default argument and
+**no caller overrode it**, so every stack was booted with `python -m uvicorn
+backend.main:app`. The second stack this release adds is Node/TypeScript.
+
+This is loud rather than silent — a Node app does not start under uvicorn, so boot fails and
+`ProbeOutcome.skipped` means not-executed, which SIP-0096 declines to credit — and that is
+why it is scope rather than the emergency #818 was. But "boot the wrong thing and read the
+failure" is a diagnosis someone has to reconstruct, and a declared refusal is one they are
+handed.
+
+Deliberately **not** derived from the sandbox `EnvironmentContract`, which also carries a
+`START_APPLICATION` command: that argv runs inside the sandbox container against
+`.sandbox-venv`, while probes run in the qa container against a fresh temp dir on
+`sys.executable`. Two execution contexts, so the interpreter is context-specific and only
+the launcher and entry point are stack-specific.
+
+Bug classes guarded:
+
+- **a second stack's probes booting the first stack's app** — the defect;
+- the fix changing behavior for callers that cannot name a stack, which is every caller that
+  exists today: this must be inert for them or it is a regression in banked evidence;
+- the resolution reaching for the *evaluator* stack vocabulary (`"fastapi"`) instead of the
+  scaffold one (`"fullstack_fastapi_react"`) — two names, and S3 still owes the
+  reconciliation;
+- a config naming an unknown build profile resolving to something rather than nothing;
+- **the refusal escalating to an exception.** `qa_test` states probes are "additive evidence
+  only … a failed probe surfaces at the run verdict/rollup, not as a task failure here", so
+  raising here would convert missing evidence into a dead task;
+- a stack registered in one seam and forgotten in another — the S1 failure recurring across
+  registries instead of within one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from squadops.capabilities import scaffold
+from squadops.capabilities.handlers import probe_runner as pr
+from squadops.capabilities.handlers.probe_runner import (
+    DEFAULT_PROFILE,
+    ExecutionProfile,
+    ProbeOutcome,
+    profile_for_stack,
+    run_probes,
+)
+from squadops.capabilities.scaffold import ScaffoldStack, scaffold_stack_for
+from squadops.cycles.verification_contract import Probe
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+def _probe(pid: str = "vc-probe-runs") -> Probe:
+    return Probe.from_dict(
+        {"id": pid, "subject": "backend", "request": {"method": "GET", "path": "/runs"}}
+    )
+
+
+def _register(monkeypatch, *, probe_profile: str) -> None:
+    monkeypatch.setitem(
+        scaffold._STACKS,
+        "node_ts",
+        ScaffoldStack(
+            name="node_ts",
+            expand=lambda m: [],
+            fill_slots=lambda m: ("src/routes.ts",),
+            criteria_pack="node_ts",
+            probe_profile=probe_profile,
+        ),
+    )
+
+
+def _capture_boot(monkeypatch) -> list[ExecutionProfile]:
+    """Intercept the boot so resolution can be asserted without standing a server up."""
+    seen: list[ExecutionProfile] = []
+
+    def _fake(workspace, probes, profile):
+        seen.append(profile)
+        return [ProbeOutcome(p.id, "passed") for p in probes]
+
+    monkeypatch.setattr(pr, "_run_backend_probes", _fake)
+    return seen
+
+
+# --------------------------------------------------------------------------- #
+# The defect
+# --------------------------------------------------------------------------- #
+
+
+def test_a_stack_with_no_probe_profile_reports_not_executed_instead_of_booting_fastapi(
+    monkeypatch, tmp_path: Path
+):
+    """The bug. Before this, `node_ts` probes ran `uvicorn backend.main:app` — against a
+    workspace with no Python app in it — and the boot failure was the only clue."""
+    _register(monkeypatch, probe_profile="")
+    seen = _capture_boot(monkeypatch)
+
+    outcomes = run_probes(tmp_path, [_probe()], stack="node_ts")
+
+    assert [(o.id, o.status) for o in outcomes] == [("vc-probe-runs", "skipped")]
+    assert "declares no probe profile" in (outcomes[0].reason or "")
+    assert seen == [], "nothing may be booted for a stack that has not said how"
+
+
+def test_the_refusal_does_not_raise(monkeypatch, tmp_path: Path):
+    """`qa_test` treats probes as additive evidence that "surfaces at the run verdict/rollup,
+    not as a task failure here". Raising would turn missing evidence into a dead QA task —
+    which is why this refuses differently from the emitter's in #818."""
+    _register(monkeypatch, probe_profile="")
+
+    outcomes = run_probes(tmp_path, [_probe()], stack="node_ts")
+
+    assert len(outcomes) == 1
+
+
+def test_a_stack_boots_with_its_own_launcher(monkeypatch, tmp_path: Path):
+    """The point of the seam: the launcher and entry point are the stack's, not FastAPI's."""
+    _register(monkeypatch, probe_profile="node_server")
+    monkeypatch.setitem(
+        pr._PROFILES,
+        "node_server",
+        ExecutionProfile(boot_argv=("node", "dist/server.js", "--port", "{port}")),
+    )
+    seen = _capture_boot(monkeypatch)
+
+    outcomes = run_probes(tmp_path, [_probe()], stack="node_ts")
+
+    assert seen[0].boot_argv == ("node", "dist/server.js", "--port", "{port}")
+    assert "uvicorn" not in " ".join(seen[0].boot_argv)
+    assert [o.status for o in outcomes] == ["passed"]
+
+
+# --------------------------------------------------------------------------- #
+# Inertness for everything that exists today
+# --------------------------------------------------------------------------- #
+
+
+def test_a_caller_that_names_no_stack_keeps_the_historical_profile(monkeypatch, tmp_path: Path):
+    """Every caller before this change passed no stack. If that path stopped booting, the
+    behavioral half of every contract would quietly stop being evidence."""
+    seen = _capture_boot(monkeypatch)
+
+    run_probes(tmp_path, [_probe()])
+
+    assert seen == [DEFAULT_PROFILE]
+
+
+def test_an_explicit_profile_still_wins(monkeypatch, tmp_path: Path):
+    """The existing test seam — `test_probe_runner` passes fast-fail and crashing profiles
+    to exercise boot handling, and must keep working."""
+    _register(monkeypatch, probe_profile="node_server")
+    explicit = ExecutionProfile(boot_argv=("true",))
+    seen = _capture_boot(monkeypatch)
+
+    run_probes(tmp_path, [_probe()], profile=explicit, stack="node_ts")
+
+    assert seen == [explicit]
+
+
+def test_the_reference_stack_still_boots_uvicorn():
+    """Named rather than assumed: `fullstack_fastapi_react` must keep resolving to the
+    interpreter-relative uvicorn boot the qa container's installed packages support."""
+    profile = profile_for_stack("fullstack_fastapi_react")
+
+    assert profile is not None
+    assert "uvicorn" in profile.boot_argv
+    assert "backend.main:app" in profile.boot_argv
+    assert profile.boot_argv[0].endswith("python") or "python" in profile.boot_argv[0]
+
+
+# --------------------------------------------------------------------------- #
+# Resolving the stack from config
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({"build_profile": "fullstack_fastapi_react"}, "fullstack_fastapi_react"),
+        ({"build_profile": "not_a_stack"}, ""),
+        ({"build_profile": ""}, ""),
+        ({}, ""),
+        (None, ""),
+    ],
+)
+def test_the_scaffold_stack_is_resolved_from_build_profile(config, expected):
+    """An unknown profile must resolve to nothing, so the caller falls back to the historical
+    default rather than skipping — a config typo should not silently delete probe evidence."""
+    assert scaffold_stack_for(config) == expected
+
+
+def test_the_scaffold_vocabulary_is_not_the_evaluator_vocabulary():
+    """`resolve_check_stack` answers `"fastapi"`; boot profiles are keyed on the scaffold
+    stack. Collapsing the two would key a lookup on a name the registry does not hold —
+    the drift S3 still owes a reconciliation for."""
+    from squadops.cycles.acceptance_evaluation import resolve_check_stack
+
+    config = {"build_profile": "fullstack_fastapi_react"}
+
+    assert resolve_check_stack(config) == "fastapi"
+    assert scaffold_stack_for(config) == "fullstack_fastapi_react"
+    assert profile_for_stack("fastapi") is None
+
+
+# --------------------------------------------------------------------------- #
+# The seams cannot drift apart
+# --------------------------------------------------------------------------- #
+
+
+def test_every_registered_stack_can_be_built_verified_and_booted():
+    """S1's real lesson was not "one registry" — it was that forgetting must be an error
+    rather than a plausible wrong answer. A stack now appears in three, so this is where
+    forgetting any one of them fails, at build time rather than mid-cycle."""
+    from squadops.sandbox.environment import get_environment_contract
+
+    for name, stack in scaffold._STACKS.items():
+        assert stack.probe_profile, f"stack {name!r} declares no probe_profile"
+        assert stack.probe_profile in pr._PROFILES, (
+            f"stack {name!r} names probe profile {stack.probe_profile!r}, which is not registered"
+        )
+        get_environment_contract(name)  # raises if the stack has no environment contract


### PR DESCRIPTION
First of two PRs on #822. The boot seam, landing alone so that a probe failure when the Node stack arrives is unambiguous between "the parameterization broke FastAPI" and "the new stack doesn't boot."

## The defect

`run_probes` took `profile: ExecutionProfile = DEFAULT_PROFILE` as a **default argument**, and no caller overrode it. Every stack was booted with `python -m uvicorn backend.main:app`.

This is loud rather than silent — a Node app doesn't start under uvicorn, boot fails, and `ProbeOutcome.skipped` means not-executed, which SIP-0096 declines to credit. That's why it's scope and #818 was the emergency. But *"boot the wrong thing and read the failure"* is a diagnosis someone has to reconstruct; a declared refusal is one they're handed.

## This corrects the design gate

The gate on #822 said to derive the profile from the sandbox `EnvironmentContract`'s `START_APPLICATION`. **Verified before building, and it doesn't work:**

```
EnvironmentContract.START_APPLICATION:
    (".sandbox-venv/bin/python", "-m", "uvicorn", "backend.main:app", "--host", "0.0.0.0",   "--port", "8000")
probe_runner.DEFAULT_PROFILE:
    (sys.executable,             "-m", "uvicorn", "backend.main:app", "--host", "127.0.0.1", "--port", "{port}")
```

That argv runs **inside the sandbox container**, against the `.sandbox-venv` its `INSTALL_DEPENDENCIES` step builds. `run_probes` is called from `handlers/cycle/qa_test.py` **in the qa container**, against a fresh `TemporaryDirectory` where no venv exists — hence `sys.executable`. Two execution contexts, not one fact duplicated: the **interpreter is context-specific**, only the launcher and entry point are stack-specific.

The gate flagged host/port and missed the interpreter, which is the disqualifying half. Correction was posted on #822 before this was written.

## The shape

`ScaffoldStack.probe_profile` names a profile registered in `probe_runner` — a name, not a callable, so the boot vocabulary stays in the runner layer. Exactly `criteria_pack` from #818.

| Case | Behavior |
|---|---|
| explicit `profile` | use it (preserves the existing test seam) |
| stack declares one | use it |
| **registered stack declaring none** | report not-executed, logged |
| no stack resolvable | **`DEFAULT_PROFILE`** — today's behavior, byte-identical |

That last row is the important one: a config typo must fall back, never silently delete probe evidence.

**The refusal does not raise**, unlike #818's. `qa_test` states probes are *"additive evidence only … a failed probe surfaces at the run verdict/rollup, not as a task failure here"* — raising would convert missing evidence into a dead QA task. Forgetting is caught at **build time** instead, by a completeness test across all three per-stack registries. S1's real lesson was that forgetting must be an error, not that there must be one registry.

`scaffold_stack_for()` resolves `build_profile` to the **scaffold** stack name, deliberately not reusing `resolve_check_stack`, which maps to the **evaluator** vocabulary (`"fastapi"`). Two names, and S3 still owes the reconciliation — collapsing them here would key a lookup on a name the registry doesn't hold.

## Proof

| | |
|---|---|
| Reference contract `7622f570c949fe95` | ✅ unmoved |
| Manifest `bb472e267e53d5ad` | ✅ unmoved |
| Full regression | ✅ **6812 passed, 1 skipped** |

Four existing test doubles in `test_build_handlers.py` didn't accept the new kwarg. **Tightened rather than made permissive** — they capture the stack instead of swallowing `**kwargs`, and a new test proves the handler threads it end to end. A double that absorbs unknown arguments would have hidden exactly the wiring regression this PR exists to prevent.

Eleven new tests in `test_probe_boot_seam.py`, including the inertness guard for every caller that exists today — if that path stopped booting, the behavioral half of every contract would quietly stop being evidence.

## Next

The Node/TypeScript stack itself: expander, criteria pack, environment contract, bend register. Then **VS**, which gates S3.

Refs #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
