### PR TITLE
feat(diagnostics): build the two SIP-0103 §5c.7 signals M4 spent before they existed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,11 +168,20 @@ SIPs govern architectural decisions. Located in `sips/` with lifecycle:
 | 3. Accept | Merge to main | Maintainer | Runs `update_sip_status.py ... accepted`, merges |
 | 4. Branch | Feature branch off main | Implementer | `git checkout -b feature/sip-NNNN-...` from main (which now has the accepted SIP) |
 | 5. Implement | Feature branch | Implementer | Incremental commits per phase |
+| **5a. Amend** | **The diverging PR** | **Implementer** | **Implementation showed the accepted design was wrong, or a decision narrowed it → add an amendment section to the SIP *in the PR that diverges*** |
 | 6. Code review | PR to main | Maintainer + team | Review the implementation |
 | 7. Merge | main | Maintainer | Merge the feature PR |
 | 8. Promote | main | Maintainer | Runs `update_sip_status.py ... implemented` after verification |
 
 Key principle: **acceptance is a design commitment on main, not an implementation artifact.** The feature branch starts from a main that already has the accepted SIP, so the implementer works from an approved spec. This separates "we agree this is the right design" from "the implementation is correct."
+
+**Step 5a is not optional, and it is the step that gets skipped.** Acceptance being a *commitment* is a statement about sequencing — the spec is approved before the branch starts. It is **not** a licence to leave the SIP stale once implementation contradicts it. A SIP whose accepted text no longer describes main is worse than no SIP: it reads as authoritative, and the next implementer builds against a design that was abandoned.
+
+- **Amend in the SIP itself, as a new numbered section** (`## 5d. Post-acceptance amendments`, then `5e`, …). SIP-0103's own `§5a`/`§5b`/`§5c` are exactly this shape — the mechanism already exists and is demonstrated.
+- **A release plan is not an amendment.** Plans are superseded at the cut; the SIP is permanent. Recording a divergence only in `docs/plans/*` means it is gone the moment the release closes — the failure that produced SIP-0103's `§5d` (2026-08-09), where three divergences and four unimplemented dispositions lived only in the 1.6 plan.
+- **A code comment is not an amendment either.** Necessary, not sufficient: a reader of the SIP never sees it.
+- Each amendment names **what changed, the evidence, and who ruled it.** "We decided otherwise" without evidence is how a spec becomes advisory.
+- **A disposition that is deliberately not built is an amendment too** — silence reads as "shipped."
 
 ### Key Implemented SIPs
 

--- a/docs/plans/1-6-0-authorship-plan.md
+++ b/docs/plans/1-6-0-authorship-plan.md
@@ -571,11 +571,29 @@ unobserved. **FAY yield does not cover this**: V4 roll 2 flattened the reference
 `Participant` entity into an untyped list and still went green — a design regression yield is
 structurally blind to.
 
-The answer is **sampling, not gating**, carried by diagnostics §5c.7 already requires:
+The answer is **sampling, not gating**, carried by the four diagnostics §5c.7 requires:
 structural diff against the human reference, revision/attempt counts, the gate-rejection
 taxonomy (M6), and manifest size/surface counts. Those move when design quality moves,
 without anyone reading a manifest. A design gets read when a number looks wrong — an operator
 choice, not a pipeline stall.
+
+> **Correction 2026-08-09 — this paragraph originally read "diagnostics §5c.7 *already
+> requires*", which a reader takes as "already has". Two of the four had never been built.**
+> Revision/attempt counts (M5, #803) and the gate-rejection taxonomy (M6, #785) existed; the
+> structural diff and the size/surface counts did not. So the argument for removing a human
+> gate was half-funded from the moment it was made — the same shape as the seeded control's
+> retirement resting on two unbuilt guards, and the second instance of it in this document.
+>
+> Now built: `cycles/manifest_diagnostics.py` plus `scripts/dev/emit_manifest_diagnostics.py`.
+> **Operator-run, never a pipeline stage** — the reference manifest is excluded from squad
+> inputs (§4/§5c.1), so a diff computed inside a cycle would make it an input; an architecture
+> test pins that nothing under `src/squadops` or `adapters/` can reach the module.
+>
+> It reproduces the case it was built for on the first run: against V4 roll 2 it reports
+> `entities → only in reference: Participant` — the typed entity flattened into an untyped list
+> by a roll that then went green on every probe. It also surfaces `/runs/:run_id` vs the
+> reference's `/runs/:id`, which is #820's deferred naming-prior class showing up as a visible
+> non-gating signal rather than a silence.
 
 **The freeze moment moved, and §5a's wording no longer matches the code.** §5a's third
 containment bound says the manifest hash-freezes and the contract derives *"the instant the

--- a/scripts/dev/emit_manifest_diagnostics.py
+++ b/scripts/dev/emit_manifest_diagnostics.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Emit the authored-mode window's design-quality diagnostics (SIP-0103 §5c.7).
+
+**Operator-run, deliberately.** The reference manifest is excluded from squad inputs (§4,
+§5c.1), so the comparison happens here — after a window, outside any cycle — rather than in a
+pipeline stage that would make the reference an input and contaminate authored mode.
+
+Nothing in 1.6 consumes the output. It exists because M4 removed the mandatory manifest review
+on the argument that design quality moves to *sampling, not gating*, and this is half of what
+that argument spends. FAY is blind to it: V4 roll 2 flattened the reference's typed
+``Participant`` entity into an untyped list and still delivered a working app.
+
+Usage:
+    .venv/bin/python scripts/dev/emit_manifest_diagnostics.py AUTHORED.yaml [AUTHORED.yaml ...] \
+        [--reference examples/03_group_run/interface_manifest.yaml] [--out report.md]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT))
+
+from squadops.capabilities.scaffold import InterfaceManifest  # noqa: E402
+from squadops.cycles.manifest_diagnostics import render, structural_diff  # noqa: E402
+
+_DEFAULT_REFERENCE = REPO_ROOT / "examples" / "03_group_run" / "interface_manifest.yaml"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifests", nargs="+", type=Path, help="authored manifest YAML files")
+    parser.add_argument("--reference", type=Path, default=_DEFAULT_REFERENCE)
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args()
+
+    reference = InterfaceManifest.from_yaml(args.reference.read_text(encoding="utf-8"))
+
+    sections: list[str] = []
+    for path in args.manifests:
+        authored = InterfaceManifest.from_yaml(path.read_text(encoding="utf-8"))
+        sections.append(f"<!-- {path} -->\n" + render(structural_diff(authored, reference)))
+
+    output = "\n---\n\n".join(sections)
+    if args.out:
+        args.out.write_text(output, encoding="utf-8")
+        print(f"wrote {args.out} ({len(args.manifests)} manifest(s))")
+    else:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sips/accepted/SIP-0103-Squad-Authored-Manifest.md
+++ b/sips/accepted/SIP-0103-Squad-Authored-Manifest.md
@@ -361,6 +361,106 @@ not open threads.
     operator mid-authoring stay out of Phase 1 (async human latency inside a task);
     the gate is the clarification point.
 
+## 5d. Post-acceptance amendments (2026-08-09)
+
+Everything above §5d was written **before** acceptance on 2026-08-07. This section records
+what changed after it, and it exists because the changes had been recorded only in
+`docs/plans/1-6-0-authorship-plan.md` — a document superseded at the release cut, after which
+this SIP would have been the sole surviving description of a design it no longer matched.
+SIP-0093's Phase-1 successor and the Cross-Cycle Memory SIP both read this document (§5c.9
+hands the learning channel to the latter explicitly), so a stale §3 is a live defect and not
+an untidiness.
+
+The mechanism is not new: §5a, §5b and §5c are themselves amendment rounds. It simply stopped
+being used at the moment acceptance made it matter. CLAUDE.md's contributor workflow now
+carries step 5a so the next implementer amends in the diverging PR rather than in a plan.
+
+### A. Premises falsified after acceptance
+
+**A1 — §5b Correction 1 is wrong in both halves.** It states *"contract v9 is a hand-authored
+artifact … no `derive_contract(manifest)` exists anywhere in the pipeline."* Measured
+2026-08-07 against the live artifacts: the deriver **does** exist
+(`capabilities/scaffold_contract.py::emit_contract_dict`, shipped as SIP-0098 phase 98.2), and
+`emit_contract_dict(manifest v4 art_8becd104e9fc)` equals contract v9 (`art_4f368ea08799`)
+**exactly** — all six sections, 4 `fill_files`, 5 probes. Contract v9 is a *pinned emission*,
+not a hand-authored artifact.
+
+*Consequence:* the SIP's headline scope addition — "add mechanical contract derivation to
+scope" — was already satisfied before work started. It collapsed to a standing equivalence
+guard (M0a, #777) plus derive-at-seed wiring (M0b, #779). Pinned by
+`tests/unit/capabilities/test_contract_derivation_reference.py`.
+
+**A2 — §5b Correction 1's derivability split is wrong in detail.** It lists as "fully
+derivable" the interface layer, *"`endpoint_defined` **per fill slot** from `api.endpoints`,
+`field_present` from `entities`."* Measured: `endpoint_defined` is emitted **once**, on the
+routes slot only (1 occurrence across 4 `fill_files`), and **`field_present` is not emitted at
+all**. The deriver's entire emitted vocabulary is `command_exit_zero`, `endpoint_defined`,
+`frontend_build`, `frontend_compiles`, `import_present`, `module_imports`, `tests_pass`.
+
+**A3 — §5a's foundation inventory overstates readiness, and this is the costly one.** It
+claims an authored manifest *"propagates into the entire verification stack with **zero new
+plumbing**."* The opposite held: framing→implementation forwarding filtered promoted artifacts
+to `{document, control_implementation_plan}` and **dropped `interface_manifest`**, so an
+authored manifest was stored, gate-validated, promoted, and then silently not carried.
+**Authored mode was dead on arrival** and V4 roll 1 failed on it — the plan hit 0 of 9 fill
+slots. Fixed as #796. The claim was invisible because every cycle since SIP-0099 99.2 ran bind
+mode, where the manifest rides `plan_artifact_refs` from creation (#496).
+
+### B. Design narrowed by owner ruling
+
+**B1 — §3.4's manifest review gate is question-gated, not mandatory.** §3.4 specifies *"a named
+gate between manifest acceptance and implementation: the operator approves the authored design
+the way `progress_plan_review` approves the plan."* **Every authored manifest is no longer
+reviewed.** The gate now stops the cycle **only** when the design declares an
+`unresolved: true` decision — the author saying the PRD does not determine something and
+declining to guess.
+
+*Ruled by:* the owner, 2026-08-08, on V4 evidence. V4 roll 2's framing bundle went through
+`progress_plan_review` and a human approved it; the approval note discussed fill slots and
+criteria counts, facts the deterministic gates had already proven. Meanwhile the manifest
+carried one genuinely unresolved question (`expansion-gating`) and **nothing surfaced it to the
+reviewer.** The design then implemented with 15/15 criteria verified and zero corrections. A
+gate that is rubber-stamped manufactures the appearance of review, and a later reader cannot
+tell a considered approval from a reflex.
+
+*Consistency with this SIP:* §5c.10 already required an unresolved-critical entry to *"land in
+the HITL gate note as a question rather than silently defaulting."* B1 promotes that from a
+passenger on a mandatory review to the trigger itself — a narrowing of §3.4, not a
+contradiction of §5c.10.
+
+*Coded at:* `cycles/manifest_authoring.py::open_questions` (the firing rule),
+`adapters/cycles/dispatched_flow_executor.py` (the gate branch), and
+`GATE_DECIDED_BY_NO_QUESTIONS = "system:no_open_questions"` (the audit trail, kept distinct
+from a human's approval on purpose). The machine pass-through runs through the **same**
+exhaustive dispatch a human's answer does. Keyed on the design, never on who wrote it, so a
+seeded manifest carrying an open question stops the cycle exactly as an authored one does
+(Guard 1a). #807 / PR #808.
+
+### C. Dispositions not implemented
+
+Recorded because silence reads as "shipped."
+
+| § | Disposition | Status |
+|---|---|---|
+| **5c.7** | structural manifest diff vs the reference; manifest size/surface counts | **being built** — see below |
+| 5c.7 | revision/attempt counts; gate-rejection reason taxonomy | built (M5 #803, M6 #785) |
+| **5c.5** | *"after any operator edit at the gate — the edit's own record"* | **not built, and neither is the path.** `Provenance` carries `mode`, `cycle_id`, `task_id`, `attempts`, `revisions`; no operator-edit code path exists anywhere. The immutability rule it states ("an operator edit is a new manifest version with a new hash") therefore describes an act the system cannot currently perform |
+| **5c.3** | manifest is **blueprint-owned** — *"the coupling is to the blueprint contract, not to 'one YAML file'"* | **not built.** One universal `InterfaceManifest` schema is still assumed, and its domain half (`persistence`, `entities`, `api`, `frontend`) is FastAPI+React-shaped. Deferred to **1.7**, deliberately: generalising the schema from one stack would produce the FastAPI manifest with generic field names, the exact failure the Stack Blueprint SIP declines acceptance over. The second stack's bend register is the evidence it should be written from |
+| **3.3** (3rd bullet) | interface self-consistency — the `{id}`/`{run_id}` naming-prior class as an authoring-time check | **not built.** Deferred to 1.7 with named triggers → **#820** |
+
+**On §5c.7 specifically, because a control was removed citing it.** B1's argument for dropping
+the mandatory review was that design quality moves to *sampling, not gating*, carried by four
+diagnostics this SIP "already requires." **Two of the four were never built.** That makes B1's
+justification half-funded, and it is the one item in this section where the delivered system is
+weaker than the ruling authorized. Being built ahead of the pre-registered measurement window,
+which is the one place nothing may be fixed mid-flight.
+
+### D. What this section does not change
+
+The measurement (§4), the input contract (§5c.1), the freeze rule (§5c.8), the stateless-Phase-1
+ruling (§5c.9, extension point declared as `INPUT_CONTRACT_EXTENSION_POINTS`), and the
+`decisions[]` discipline (§5c.4/§5c.10) all stand as accepted and are implemented.
+
 ## 6. Open questions for design review
 
 1. Authoring decomposition: single merger-authored manifest (spike-rider shape) vs the

--- a/src/squadops/cycles/manifest_diagnostics.py
+++ b/src/squadops/cycles/manifest_diagnostics.py
@@ -1,0 +1,233 @@
+"""Non-gating design-quality observables for the authored-mode window (SIP-0103 §5c.7).
+
+**Why this exists, stated plainly:** M4 removed the mandatory human manifest review, and the
+argument for removing it was that design quality moves to *sampling, not gating*, carried by
+four diagnostics §5c.7 requires — structural diff against the human reference, revision and
+attempt counts, the gate-rejection taxonomy, and manifest size/surface counts. Revision counts
+(M5) and the taxonomy (M6) were built. **These two were not**, so the argument for dropping the
+review was half-funded until now. Recorded as SIP-0103 §5d C.
+
+**FAY is structurally blind to what these measure.** V4 roll 2 flattened the reference's typed
+``Participant`` entity into an untyped list and still went green: the app installed, built,
+booted and answered every probe. A yield number cannot see a design regression that the app
+happens to survive, and a multi-roll window with no design instrument reports "it worked" while
+the designs drift.
+
+The sharper risk is that **the squad authors the exam it sits.** The manifest decides the
+contract and the contract decides the checks, so a roll can win by declaring less. Executed
+checks were 29 on V4 roll 2 and 57 on V5 — same PRD. ``surface_counts`` is what makes that
+visible; a floor would be the wrong instrument, since it invites padding in the other direction.
+
+**Contamination discipline (§4, §5c.1).** The reference manifest is excluded from squad inputs.
+Nothing here is wired into a handler, a capability, or the executor, and
+``tests/unit/cycles/test_manifest_diagnostics.py`` pins that: these are read by an operator
+after a window, never by a cycle during one. Non-gating is likewise structural — this module
+returns data and raises nothing that could fail a run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# Surface counts
+# --------------------------------------------------------------------------- #
+
+#: The counted surfaces, in report order. Named rather than derived by introspection so that
+#: adding a manifest field is a deliberate act here — a count that silently appears mid-window
+#: makes two rolls incomparable, which is the one thing a window cannot tolerate.
+SURFACE_KEYS: tuple[str, ...] = (
+    "entities",
+    "entity_fields",
+    "endpoints",
+    "endpoints_declaring_status",
+    "request_shapes",
+    "error_codes",
+    "routes",
+    "testids",
+    "decisions",
+    "unresolved_decisions",
+)
+
+
+def surface_counts(manifest: Any) -> dict[str, int]:
+    """How much interface this manifest declares (§5c.7).
+
+    Every key in :data:`SURFACE_KEYS` is always present, including zeros: an absent key and a
+    zero are different facts, and a window that silently omits one cannot be aggregated.
+    """
+    api = manifest.api
+    frontend = manifest.frontend
+    error_codes = len(api.error_contract.codes) if api.error_contract else 0
+    return {
+        "entities": len(manifest.entities),
+        "entity_fields": sum(len(e.fields) for e in manifest.entities),
+        "endpoints": len(api.endpoints),
+        "endpoints_declaring_status": sum(1 for e in api.endpoints if e.success_status),
+        "request_shapes": len(api.request_shapes),
+        "error_codes": error_codes,
+        "routes": len(frontend.routes),
+        "testids": sum(len(r.testids) for r in frontend.routes),
+        "decisions": len(manifest.decisions),
+        "unresolved_decisions": sum(1 for d in manifest.decisions if d.unresolved),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Structural diff against the reference
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class SurfaceDiff:
+    """One surface's three-way split. ``changed`` is only populated where a shared key can
+    carry differing detail — an endpoint's status, an entity's fields."""
+
+    surface: str
+    only_authored: tuple[str, ...] = ()
+    only_reference: tuple[str, ...] = ()
+    changed: tuple[str, ...] = ()
+
+    @property
+    def identical(self) -> bool:
+        return not (self.only_authored or self.only_reference or self.changed)
+
+
+@dataclass(frozen=True)
+class ManifestDiff:
+    """A structural comparison, deliberately not a score.
+
+    §5c.7 declines "maintainability"/"elegance" metrics because no deterministic
+    representation exists and an LLM-graded score is the evidence laundering A6 forbids. So
+    this reports *what differs* and leaves *whether that is worse* to a reader. Distance from
+    the human design is not error — V4 roll 2 chose 409 for the conflict case where roll 1 chose
+    400, and 409 is the better answer.
+    """
+
+    diffs: tuple[SurfaceDiff, ...] = ()
+    authored_counts: dict[str, int] = field(default_factory=dict)
+    reference_counts: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def identical(self) -> bool:
+        return all(d.identical for d in self.diffs)
+
+    @property
+    def divergent_surfaces(self) -> tuple[str, ...]:
+        return tuple(d.surface for d in self.diffs if not d.identical)
+
+
+def _split(
+    surface: str,
+    authored: dict[str, Any],
+    reference: dict[str, Any],
+) -> SurfaceDiff:
+    a_keys, r_keys = set(authored), set(reference)
+    changed = tuple(
+        sorted(
+            f"{k}: {reference[k]} -> {authored[k]}"
+            for k in a_keys & r_keys
+            if authored[k] != reference[k]
+        )
+    )
+    return SurfaceDiff(
+        surface=surface,
+        only_authored=tuple(sorted(a_keys - r_keys)),
+        only_reference=tuple(sorted(r_keys - a_keys)),
+        changed=changed,
+    )
+
+
+def _endpoint_detail(manifest: Any) -> dict[str, Any]:
+    return {
+        f"{e.method} {e.path}": f"status={e.success_status or '-'} errors={','.join(sorted(e.errors)) or '-'}"
+        for e in manifest.api.endpoints
+    }
+
+
+def _entity_detail(manifest: Any) -> dict[str, Any]:
+    return {e.name: ",".join(sorted(f.name for f in e.fields)) or "-" for e in manifest.entities}
+
+
+def _route_detail(manifest: Any) -> dict[str, Any]:
+    return {
+        r.path: f"view={r.view} testids={','.join(sorted(r.testids)) or '-'}"
+        for r in manifest.frontend.routes
+    }
+
+
+def _error_detail(manifest: Any) -> dict[str, Any]:
+    ec = manifest.api.error_contract
+    return {c.code: f"http={c.http}" for c in (ec.codes if ec else ())}
+
+
+def _shape_detail(manifest: Any) -> dict[str, Any]:
+    return {
+        s.name: f"required={','.join(sorted(s.required)) or '-'}"
+        for s in manifest.api.request_shapes
+    }
+
+
+#: Surface name -> projection. The projections are deliberately *shallow strings*: a nested
+#: structural diff reads as a merge conflict, and the question this answers is "where did the
+#: two designs part company", not "reconcile them".
+_SURFACES: tuple[tuple[str, Any], ...] = (
+    ("endpoints", _endpoint_detail),
+    ("entities", _entity_detail),
+    ("routes", _route_detail),
+    ("error_codes", _error_detail),
+    ("request_shapes", _shape_detail),
+)
+
+
+def structural_diff(authored: Any, reference: Any) -> ManifestDiff:
+    """Compare an authored manifest to the human reference (§5b Q3, §5c.7).
+
+    Mechanical and deterministic — the manifest is a typed canonical surface, so this needs no
+    model and produces the same answer every time. **Non-gating by construction**: it returns a
+    report and has no failure mode.
+    """
+    return ManifestDiff(
+        diffs=tuple(
+            _split(name, project(authored), project(reference)) for name, project in _SURFACES
+        ),
+        authored_counts=surface_counts(authored),
+        reference_counts=surface_counts(reference),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+
+def render(diff: ManifestDiff) -> str:
+    """A operator-readable report. Counts first — they are what a multi-roll window trends."""
+    lines = ["# Manifest diagnostics (SIP-0103 §5c.7 — non-gating)", "", "## Surface counts", ""]
+    lines.append("| surface | authored | reference | delta |")
+    lines.append("|---|---|---|---|")
+    for key in SURFACE_KEYS:
+        a = diff.authored_counts.get(key, 0)
+        r = diff.reference_counts.get(key, 0)
+        lines.append(f"| {key} | {a} | {r} | {a - r:+d} |")
+
+    lines += ["", "## Structural diff vs the human reference", ""]
+    if diff.identical:
+        lines.append("No structural divergence.")
+        return "\n".join(lines) + "\n"
+
+    for d in diff.diffs:
+        if d.identical:
+            continue
+        lines.append(f"### {d.surface}")
+        for label, items in (
+            ("only in authored", d.only_authored),
+            ("only in reference", d.only_reference),
+            ("differing", d.changed),
+        ):
+            if items:
+                lines.append(f"- **{label}:**")
+                lines += [f"  - `{item}`" for item in items]
+        lines.append("")
+    return "\n".join(lines) + "\n"

--- a/tests/unit/cycles/test_manifest_diagnostics.py
+++ b/tests/unit/cycles/test_manifest_diagnostics.py
@@ -1,0 +1,221 @@
+"""The design-quality signal M4 spent before it existed (SIP-0103 §5c.7).
+
+M4 removed the mandatory human manifest review arguing that design quality moves to *sampling,
+not gating*, carried by four diagnostics — structural diff vs the human reference, revision and
+attempt counts, the gate-rejection taxonomy, and manifest size/surface counts. Two were built
+(M5, M6). **These two were not**, so the justification for dropping a human gate was half-funded
+until now (SIP-0103 §5d C).
+
+Bug classes guarded:
+
+- **a design regression that the app survives** — the case that motivated this. V4 roll 2
+  flattened the reference's typed `Participant` entity into an untyped list and still went
+  green: installed, built, booted, answered every probe. FAY is structurally blind to it;
+- **the squad shrinking the exam it sits.** The manifest decides the contract and the contract
+  decides the checks, so a roll can win by declaring less — 29 executed checks on V4 roll 2
+  against 57 on V5, same PRD. A count that only appears when non-zero would hide exactly the
+  roll that declared nothing;
+- the diagnostic reporting noise on an unchanged design, which is how an advisory signal earns
+  being ignored;
+- **the reference manifest reaching the squad.** It is excluded from authoring inputs (§4,
+  §5c.1), so this comparison is operator-run and must stay unreachable from the pipeline;
+- the diagnostic acquiring a failure mode. §5c.7 is explicitly non-gating; a diff that can
+  raise becomes a gate the first time it does;
+- a surface silently entering or leaving the count set mid-window, which makes two rolls
+  incomparable — the one thing a pre-registered window cannot absorb.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.cycles.manifest_diagnostics import (
+    SURFACE_KEYS,
+    render,
+    structural_diff,
+    surface_counts,
+)
+
+pytestmark = [pytest.mark.domain_contracts]
+
+_ROOT = Path(__file__).resolve().parents[3]
+_REFERENCE = InterfaceManifest.from_yaml(
+    (_ROOT / "examples" / "03_group_run" / "interface_manifest.yaml").read_text(encoding="utf-8")
+)
+_AUTHORED = InterfaceManifest.from_yaml(
+    (_ROOT / "tests" / "fixtures" / "authored_v4" / "interface_manifest_roll2.yaml").read_text(
+        encoding="utf-8"
+    )
+)
+
+
+def _surface(diff, name):
+    return next(d for d in diff.diffs if d.surface == name)
+
+
+# --------------------------------------------------------------------------- #
+# The case this exists for
+# --------------------------------------------------------------------------- #
+
+
+def test_the_flattened_entity_that_went_green_is_detected():
+    """V4 roll 2's one real divergence from the human design: the reference models
+    `Participant` as a typed entity; the authored manifest collapsed it into an untyped list.
+    The delivered app installed, built, booted and answered all five probes — so yield saw
+    nothing. This is the instrument that does."""
+    diff = structural_diff(_AUTHORED, _REFERENCE)
+
+    assert "Participant" in _surface(diff, "entities").only_reference
+    assert diff.authored_counts["entities"] < diff.reference_counts["entities"]
+    assert "entities" in diff.divergent_surfaces
+
+
+def test_a_shrinking_declared_surface_is_visible_in_the_counts():
+    """The squad authors the exam it sits: fewer endpoints means fewer derived checks means an
+    easier green. A window with no size instrument cannot tell a strong roll from a small one."""
+    import dataclasses
+
+    from squadops.capabilities.scaffold import Api
+
+    narrowed = dataclasses.replace(
+        _AUTHORED,
+        api=Api(
+            base_path=_AUTHORED.api.base_path,
+            request_shapes=_AUTHORED.api.request_shapes,
+            endpoints=_AUTHORED.api.endpoints[:2],
+            error_contract=_AUTHORED.api.error_contract,
+        ),
+    )
+
+    assert surface_counts(narrowed)["endpoints"] == 2
+    assert surface_counts(_AUTHORED)["endpoints"] == 5
+
+    diff = structural_diff(narrowed, _AUTHORED)
+    assert not diff.identical
+    assert len(_surface(diff, "endpoints").only_reference) == 3, (
+        "the three dropped endpoints must be named, not merely counted"
+    )
+
+
+def test_differing_detail_on_a_shared_key_is_reported_not_dropped():
+    """A set difference alone would call `POST /runs/{run_id}/join` "present in both" while the
+    two designs disagreed on its success status and one of its error codes."""
+    changed = _surface(structural_diff(_AUTHORED, _REFERENCE), "endpoints").changed
+
+    assert any("join" in c for c in changed)
+    assert any("status=" in c for c in changed)
+
+
+# --------------------------------------------------------------------------- #
+# Counts
+# --------------------------------------------------------------------------- #
+
+
+def test_every_surface_is_always_counted_including_zeros():
+    """An absent key and a zero are different facts. A roll that declared no decisions must
+    report `decisions: 0`, not omit the key — otherwise aggregation across a window silently
+    drops the rolls that most need explaining."""
+    bare = InterfaceManifest.from_yaml(
+        "version: 1\nkind: interface_manifest\nproject_id: p\n"
+        "stack: fullstack_fastapi_react\napi:\n  endpoints: []\n"
+    )
+
+    counts = surface_counts(bare)
+
+    assert set(counts) == set(SURFACE_KEYS)
+    assert all(v == 0 for v in counts.values()), counts
+
+
+def test_the_counts_read_the_reference_correctly():
+    """Exact values, not shapes: these are the numbers a window trends, and an off-by-one in
+    the instrument is indistinguishable from drift in the thing measured."""
+    counts = surface_counts(_REFERENCE)
+
+    assert counts["endpoints"] == 5
+    assert counts["endpoints_declaring_status"] == 1  # the #772 sparsity, measured
+    assert counts["entities"] == 2
+    assert counts["decisions"] == 4
+    assert counts["unresolved_decisions"] == 0
+
+
+def test_an_unresolved_decision_is_counted_apart_from_the_rest():
+    """M4's gate fires on unresolved decisions, so the window needs to relate "how often did the
+    gate stop" to "how often did a design decline to guess"."""
+    counts = surface_counts(_AUTHORED)
+
+    assert counts["unresolved_decisions"] == 1
+    assert counts["decisions"] > counts["unresolved_decisions"]
+
+
+# --------------------------------------------------------------------------- #
+# It must not become a gate, and must not reach the squad
+# --------------------------------------------------------------------------- #
+
+
+def test_an_identical_manifest_reports_no_divergence():
+    """Advisory signals that cry wolf get ignored, and this one is the replacement for a human
+    review — it has to be quiet when nothing moved."""
+    diff = structural_diff(_REFERENCE, _REFERENCE)
+
+    assert diff.identical
+    assert diff.divergent_surfaces == ()
+    assert "No structural divergence." in render(diff)
+
+
+def test_an_empty_manifest_diffs_without_raising():
+    """§5c.7 is non-gating, which has to be structural rather than a promise: a diff that can
+    raise becomes a gate the first time it does, inside the window where nothing may be fixed."""
+    bare = InterfaceManifest.from_yaml(
+        "version: 1\nkind: interface_manifest\nproject_id: p\n"
+        "stack: fullstack_fastapi_react\napi:\n  endpoints: []\n"
+    )
+
+    diff = structural_diff(bare, _REFERENCE)
+
+    assert not diff.identical
+    assert render(diff)
+
+
+def test_nothing_in_the_pipeline_can_reach_this_module():
+    """Contamination discipline (§4, §5c.1): the reference manifest is excluded from squad
+    inputs, and this module *reads the reference*. An import from a handler, capability or the
+    executor would make it an input — the diagnostic is operator-run, after a window, never by a
+    cycle during one."""
+    offenders = []
+    for path in (_ROOT / "src" / "squadops").rglob("*.py"):
+        if path.name == "manifest_diagnostics.py":
+            continue
+        if "manifest_diagnostics" in path.read_text(encoding="utf-8"):
+            offenders.append(str(path.relative_to(_ROOT)))
+    for path in (_ROOT / "adapters").rglob("*.py"):
+        if "manifest_diagnostics" in path.read_text(encoding="utf-8"):
+            offenders.append(str(path.relative_to(_ROOT)))
+
+    assert offenders == [], f"diagnostics reachable from the pipeline: {offenders}"
+
+
+def test_the_reference_manifest_is_not_an_authoring_input():
+    """The other half of the same guard, stated where the reference is actually consumed."""
+    from squadops.cycles.manifest_authoring import AUTHORING_INPUT_CONTRACT
+
+    assert not any("reference" in key for key in AUTHORING_INPUT_CONTRACT)
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+
+def test_the_report_leads_with_counts_and_names_the_divergent_surfaces():
+    """Counts first because they are what trends across rolls; the diff is what you read once a
+    count moves. §5c.7 declines a score deliberately — distance from the human design is not
+    error, and roll 2's 409-for-conflict was better than the reference's."""
+    report = render(structural_diff(_AUTHORED, _REFERENCE))
+
+    assert report.index("## Surface counts") < report.index("## Structural diff")
+    assert "| entities | 1 | 2 | -1 |" in report
+    assert "### entities" in report
+    assert "score" not in report.lower()


### PR DESCRIPTION
Second of the two PRs from the SIP-0103 audit. #824 records the divergences; this closes the one gap where the delivered system was **weaker than any decision authorized**.

## The gap

M4 removed the mandatory human manifest review. The justification — mine — was that design quality moves to *sampling, not gating*, carried by the four diagnostics §5c.7 requires:

| diagnostic | status when M4 shipped |
|---|---|
| revision/attempt counts | ✅ M5 (#803) |
| gate-rejection taxonomy | ✅ M6 (#785) |
| **structural diff vs the human reference** | ❌ never built |
| **manifest size/surface counts** | ❌ never built |

So the argument for dropping a human gate was half-funded from the moment it was made. That's the **second instance of one pattern** — the seeded control was retired citing three offline mechanisms, two of which were unbuilt. Both arguments removed a control by naming replacements and not checking that the replacements existed.

## Why these two, and not just "for completeness"

**FAY is structurally blind to what they measure.** V4 roll 2 flattened the reference's typed `Participant` entity into an untyped list and still went green — installed, built, booted, answered all five probes. A yield number cannot see a design regression the app happens to survive.

**The sharper risk is that the squad authors the exam it sits.** The manifest decides the contract and the contract decides the checks, so a roll can win by *declaring less* — 29 executed checks on V4 roll 2 against 57 on V5, same PRD. `surface_counts` is what makes that visible. A floor would be the wrong instrument; it invites padding in the other direction.

## It works on the first run

Against the real V4 roll-2 fixture, unprompted:

```
| entities | 1 | 2 | -1 |
### entities
- only in reference: `Participant`
```

That's the motivating case, caught mechanically. It also surfaces `/runs/:run_id` against the reference's `/runs/:id` — **#820's deferred naming-prior class**, now showing up as a visible non-gating signal rather than a silence. That materially strengthens the deferral: the class isn't unobserved, it's unblocked.

## Three properties enforced structurally, not promised

**Operator-run, never a pipeline stage.** The reference manifest is excluded from squad inputs (§4, §5c.1), so a diff computed inside a cycle would make it an input and contaminate authored mode. An architecture test asserts nothing under `src/squadops/` or `adapters/` can reach the module — the same shape as Guard 1a.

**Non-gating by construction.** The diff returns a report and has no failure mode, pinned by a test. A diagnostic that can raise becomes a gate the first time it does, and it would do so inside the window where nothing may be fixed.

**Not a score.** §5c.7 declines maintainability/elegance metrics because no deterministic representation exists and an LLM-graded score is the evidence laundering A6 forbids. This reports *what* differs and leaves *whether that is worse* to a reader — distance from the human design is not error, and roll 2's 409-for-conflict was better than roll 1's 400.

## Also

Corrects the plan's M4 section, which read *"diagnostics §5c.7 **already requires**"* — which a reader takes as "already has."

Eleven tests, each against a reachable bug: the flattened entity, a shrinking declared surface, differing detail on a shared key being dropped by a naive set diff, zero-vs-absent in the counts, noise on an unchanged design, the contamination reach, and the non-gating property.

**Regression 6823 passed, 1 skipped.**

Sequencing: owed **before V6 and pre-registration**, since this is the instrument the window relies on and V7 is the one place nothing may be fixed mid-flight. Does not block the stack decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
