### PR TITLE
feat(probes): a stack that cannot run from source builds before it boots (#822)

### DIFF
--- a/src/squadops/capabilities/handlers/probe_runner.py
+++ b/src/squadops/capabilities/handlers/probe_runner.py
@@ -68,6 +68,19 @@ class ExecutionProfile:
     startup_timeout_s: float = 25.0
     request_timeout_s: float = 10.0
     poll_interval_s: float = 0.1
+    #: #822: a one-time command run in the workspace *before* boot, for stacks whose subject
+    #: cannot run from source. Empty means none — which is every stack that exists today, so
+    #: this is inert until one declares it.
+    #:
+    #: **Why this is not just a longer boot timeout.** Compiling and starting are different
+    #: failures with different diagnoses: "the app is slow to start" and "the app does not
+    #: build" would otherwise arrive as the same `subject did not boot` reason, and the
+    #: build's own output — the only thing that explains it — is on a process that already
+    #: exited. Separating them keeps `_boot_failure_reason` meaning what it says.
+    prepare_argv: tuple[str, ...] = ()
+    #: Generous on purpose: a cold `npm ci` plus a production build is minutes, and this
+    #: bound exists to stop a hang, not to police build speed. Boot keeps its 25s.
+    prepare_timeout_s: float = 600.0
 
 
 # The default profile: boot the FastAPI backend with uvicorn on an allocated port, using the
@@ -222,6 +235,12 @@ def probe_check_rows(outcomes: list[ProbeOutcome]) -> list[dict[str, Any]]:
 def _run_backend_probes(
     workspace: Path, probes: list[Probe], profile: ExecutionProfile
 ) -> list[ProbeOutcome]:
+    # #822: stacks whose subject cannot run from source build first. Inert for every stack
+    # that declares no prepare_argv, which is all of them today.
+    prepare_failure = _prepare(workspace, profile)
+    if prepare_failure is not None:
+        return [ProbeOutcome(p.id, "skipped", prepare_failure) for p in probes]
+
     port = _free_port(profile.host)
     try:
         proc, stderr_spool = _boot(workspace, profile, port)
@@ -265,6 +284,56 @@ def _free_port(host: str) -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind((host, 0))
         return int(s.getsockname()[1])
+
+
+#: The prefix every preparation failure carries, so a reader (and the failure analyzer) can
+#: tell "it would not build" from "it would not start" without parsing the rest.
+PREPARE_FAILURE_PREFIX = "subject preparation failed"
+
+
+def _prepare(workspace: Path, profile: ExecutionProfile) -> str | None:
+    """Run the stack's one-time build, or ``None`` if it declares none (#822).
+
+    Returns a **reason string on failure** rather than raising: a subject that cannot be built
+    is not-executed, exactly as a subject that cannot boot is — never a probe failure and never
+    a crashed task. The caller turns it into ``skipped`` outcomes.
+
+    Output is captured and tailed for the same reason boot stderr is (#512): a build failure
+    disclosed as "preparation failed" and nothing else is undiagnosable, and unlike a boot
+    failure there is no surviving process to interrogate afterwards — if the output is not
+    captured here it does not exist anywhere.
+    """
+    if not profile.prepare_argv:
+        return None
+    try:
+        completed = subprocess.run(  # noqa: S603 — fixed profile argv, workspace-scoped
+            list(profile.prepare_argv),
+            cwd=str(workspace),
+            capture_output=True,
+            timeout=profile.prepare_timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        return (
+            f"{PREPARE_FAILURE_PREFIX} (no exit within {profile.prepare_timeout_s}s): "
+            f"{' '.join(profile.prepare_argv)}"
+        )
+    except OSError as exc:
+        # The build tool is not on PATH, or the workspace is gone. Same class as a boot
+        # launch failure, reported at the stage that actually hit it.
+        return f"{PREPARE_FAILURE_PREFIX} (could not launch): {exc}"
+    if completed.returncode == 0:
+        return None
+    tail = _output_tail(completed.stderr) or _output_tail(completed.stdout)
+    reason = f"{PREPARE_FAILURE_PREFIX} (exited {completed.returncode})"
+    return f"{reason}: {tail}" if tail else reason
+
+
+def _output_tail(raw: bytes | None, limit: int = 500) -> str:
+    """Whitespace-collapsed tail of captured build output. Bounded like ``_stderr_tail``:
+    a build's full log would swamp the evidence row it has to ride on."""
+    if not raw:
+        return ""
+    return " ".join(raw.decode("utf-8", "replace").split())[-limit:]
 
 
 def _boot(workspace: Path, profile: ExecutionProfile, port: int) -> tuple[subprocess.Popen, Any]:

--- a/tests/unit/capabilities/test_probe_prepare_step.py
+++ b/tests/unit/capabilities/test_probe_prepare_step.py
@@ -1,0 +1,218 @@
+"""Stacks whose subject cannot run from source build before they boot (#822).
+
+Every stack that exists today is interpreted: `uvicorn backend.main:app` runs the materialized
+workspace directly, and there is **no build step anywhere in the probe path** — `frontend_build`
+is a separate acceptance check, and probes boot the backend on its own. Stack #2 (Next.js +
+TypeScript) breaks that: `next build` must run before `next start`.
+
+**Why not simply a longer boot timeout.** `startup_timeout_s` is 25s and a cold `npm ci` plus a
+production build is minutes, so the naive fix is to raise it. That conflates two failures with
+two different diagnoses — "the app is slow to start" and "the app does not build" would both
+arrive as `subject did not boot`, and the build's own output, the only thing that explains the
+second, belongs to a process that already exited.
+
+Bug classes guarded:
+
+- **a build failure reported as a boot failure**, which sends the reader (and #687's failure
+  analyzer) looking at a running subject for a defect that killed a compiler;
+- **a build failure with no output**, which is undiagnosable — and worse than the boot case,
+  because there is no surviving process to interrogate afterwards;
+- the preparation step **raising** instead of reporting not-executed: probes are additive
+  evidence that "surfaces at the run verdict/rollup, not as a task failure here";
+- a hanging build with no bound, which would park a QA task indefinitely;
+- **the change being anything but inert for every stack that exists today.** A regression here
+  silently deletes the behavioral half of every contract's evidence;
+- the subject booting anyway after its build failed, which would probe a stale or absent
+  artifact and report whatever it found as truth.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from squadops.capabilities.handlers import probe_runner as pr
+from squadops.capabilities.handlers.probe_runner import (
+    DEFAULT_PROFILE,
+    PREPARE_FAILURE_PREFIX,
+    ExecutionProfile,
+    run_probes,
+)
+from squadops.cycles.verification_contract import Probe
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+def _probe(pid: str = "vc-probe-runs") -> Probe:
+    return Probe.from_dict(
+        {"id": pid, "subject": "backend", "request": {"method": "GET", "path": "/runs"}}
+    )
+
+
+def _profile(argv: tuple[str, ...], **kw) -> ExecutionProfile:
+    """A profile whose boot would succeed instantly if it were ever reached — so any skip in
+    these tests is attributable to preparation, never to the boot that follows it."""
+    return ExecutionProfile(boot_argv=(sys.executable, "-c", "pass"), prepare_argv=argv, **kw)
+
+
+def _no_boot(monkeypatch) -> list:
+    """Record whether boot was attempted. A failed build must not be followed by a boot."""
+    attempts: list = []
+
+    def _fake(workspace, profile, port):
+        attempts.append(profile)
+        raise OSError("boot must not be reached")
+
+    monkeypatch.setattr(pr, "_boot", _fake)
+    return attempts
+
+
+# --------------------------------------------------------------------------- #
+# Inertness — the property that matters most
+# --------------------------------------------------------------------------- #
+
+
+def test_a_profile_declaring_no_preparation_runs_nothing_extra(monkeypatch, tmp_path: Path):
+    """Every stack today is interpreted, so this path must be byte-identical for them. If
+    preparation ran — or even shelled out to a no-op — the behavioral half of every contract's
+    evidence would be paying for a step none of it needs."""
+    calls: list = []
+    monkeypatch.setattr(pr.subprocess, "run", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(pr, "_boot", lambda *a: (_ for _ in ()).throw(OSError("stop here")))
+
+    outcomes = run_probes(tmp_path, [_probe()], profile=DEFAULT_PROFILE)
+
+    assert calls == [], "no subprocess may run for a stack that declares no prepare_argv"
+    assert outcomes[0].status == "skipped"
+    assert PREPARE_FAILURE_PREFIX not in (outcomes[0].reason or "")
+
+
+def test_the_shipped_profile_declares_no_preparation():
+    """FastAPI runs from source. Naming this pins the inertness above to the real default
+    rather than to a fixture that happens to share its shape."""
+    assert DEFAULT_PROFILE.prepare_argv == ()
+
+
+# --------------------------------------------------------------------------- #
+# Failure is not-executed, and says which stage
+# --------------------------------------------------------------------------- #
+
+
+def test_a_failed_build_skips_the_probes_and_names_the_stage(monkeypatch, tmp_path: Path):
+    """The headline. A non-zero build is not-executed evidence, and the reason has to say
+    *build*, or a reader debugs a subject that was never started."""
+    attempts = _no_boot(monkeypatch)
+
+    outcomes = run_probes(
+        tmp_path,
+        [_probe(), _probe("vc-probe-create")],
+        profile=_profile((sys.executable, "-c", "import sys; sys.exit(3)")),
+    )
+
+    assert [o.status for o in outcomes] == ["skipped", "skipped"]
+    assert all(PREPARE_FAILURE_PREFIX in (o.reason or "") for o in outcomes)
+    assert "exited 3" in (outcomes[0].reason or "")
+    assert attempts == [], "a subject whose build failed must not be booted"
+
+
+def test_the_builds_own_output_reaches_the_reason(monkeypatch, tmp_path: Path):
+    """Worse than the boot case, which at least leaves a process to inspect: if the compiler's
+    message is not captured here it exists nowhere. `next build` prints the offending file and
+    the type error, and that is the whole diagnosis."""
+    _no_boot(monkeypatch)
+    script = "import sys; sys.stderr.write('Type error in app/api/runs/route.ts:12'); sys.exit(1)"
+
+    outcome = run_probes(tmp_path, [_probe()], profile=_profile((sys.executable, "-c", script)))[0]
+
+    assert "app/api/runs/route.ts:12" in (outcome.reason or "")
+
+
+def test_stdout_is_read_when_the_tool_writes_there_instead(monkeypatch, tmp_path: Path):
+    """Build tools disagree about which stream carries diagnostics — `tsc` writes to stdout.
+    Reading only stderr would silently drop the message for exactly the toolchain this exists
+    to support."""
+    _no_boot(monkeypatch)
+    script = "import sys; sys.stdout.write('TS2345: Argument of type string'); sys.exit(2)"
+
+    outcome = run_probes(tmp_path, [_probe()], profile=_profile((sys.executable, "-c", script)))[0]
+
+    assert "TS2345" in (outcome.reason or "")
+
+
+def test_a_hanging_build_is_bounded_and_says_so(monkeypatch, tmp_path: Path):
+    """An unbounded build parks the QA task forever. The timeout reason must be distinguishable
+    from a non-zero exit — "it never finished" and "it failed" are different defects."""
+    _no_boot(monkeypatch)
+
+    outcome = run_probes(
+        tmp_path,
+        [_probe()],
+        profile=_profile(
+            (sys.executable, "-c", "import time; time.sleep(30)"), prepare_timeout_s=0.5
+        ),
+    )[0]
+
+    assert outcome.status == "skipped"
+    assert "no exit within 0.5s" in (outcome.reason or "")
+    assert "exited" not in (outcome.reason or "")
+
+
+def test_a_missing_build_tool_is_reported_not_raised(monkeypatch, tmp_path: Path):
+    """`npm` absent from the image is an environment gap, and the repo's standing rule is that
+    those skip rather than fail (#462). Raising here would convert a missing tool into a dead
+    QA task, which `qa_test` explicitly forbids: probes are additive evidence."""
+    _no_boot(monkeypatch)
+
+    outcome = run_probes(
+        tmp_path, [_probe()], profile=_profile(("definitely-not-a-real-build-tool",))
+    )[0]
+
+    assert outcome.status == "skipped"
+    assert "could not launch" in (outcome.reason or "")
+
+
+# --------------------------------------------------------------------------- #
+# The stage boundary
+# --------------------------------------------------------------------------- #
+
+
+def test_a_build_failure_does_not_read_as_a_boot_failure(monkeypatch, tmp_path: Path):
+    """The reason this is a separate stage rather than a longer `startup_timeout_s`. #687's
+    analyzer keys on these strings, and pointing it at a subject that never started is how
+    #788 happened — a repair chasing a cause that was never there."""
+    _no_boot(monkeypatch)
+
+    outcome = run_probes(
+        tmp_path, [_probe()], profile=_profile((sys.executable, "-c", "import sys; sys.exit(1)"))
+    )[0]
+
+    assert "subject did not boot" not in (outcome.reason or "")
+    assert PREPARE_FAILURE_PREFIX in (outcome.reason or "")
+
+
+def test_a_successful_build_proceeds_to_boot(monkeypatch, tmp_path: Path):
+    """The happy path has to actually continue. A preparation step that swallowed control
+    would make every compiled stack silently unprobeable — the #818 shape, one stage over."""
+    attempts = _no_boot(monkeypatch)
+
+    outcome = run_probes(tmp_path, [_probe()], profile=_profile((sys.executable, "-c", "pass")))[0]
+
+    assert len(attempts) == 1, "boot must be attempted after a clean build"
+    assert outcome.status == "skipped"
+    assert PREPARE_FAILURE_PREFIX not in (outcome.reason or "")
+
+
+def test_preparation_runs_in_the_workspace(monkeypatch, tmp_path: Path):
+    """`next build` reads `package.json` and writes `.next/` relative to cwd. Running it
+    anywhere but the materialized workspace builds the wrong tree — or nothing."""
+    _no_boot(monkeypatch)
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    script = "import pathlib,sys; sys.exit(0 if pathlib.Path('package.json').exists() else 9)"
+
+    outcome = run_probes(tmp_path, [_probe()], profile=_profile((sys.executable, "-c", script)))[0]
+
+    assert PREPARE_FAILURE_PREFIX not in (outcome.reason or ""), (
+        "the build ran outside the workspace — package.json was not visible to it"
+    )


### PR DESCRIPTION
First of the seam PRs for stack #2, landing alone so that a probe failure when Next.js arrives is unambiguous between "the parameterization broke FastAPI" and "the new stack doesn't build."

## The gap

Every stack today is **interpreted**. `uvicorn backend.main:app` runs the materialized workspace directly, and there is **no build step anywhere in the probe path** — `frontend_build` is a separate acceptance check, and probes boot the backend on their own. Next.js requires `next build` before `next start`.

## Why this isn't just a longer boot timeout

`startup_timeout_s = 25.0`, and a cold `npm ci` plus a production build is minutes. Raising the boot timeout is the obvious fix and it's wrong: it conflates two failures with two different diagnoses. *"The app is slow to start"* and *"the app does not build"* would both arrive as `subject did not boot`.

That matters concretely — **#687's failure analyzer keys on these reason strings**, and pointing it at a subject that never started is how **#788** happened: a repair chasing a cause that was never there.

So preparation is its own stage with its own bound and its own reason prefix.

## Shape

`ExecutionProfile` gains `prepare_argv` and `prepare_timeout_s`, run once in the workspace before boot.

**Inert until a stack declares it** — empty is the default and that's every stack today. Pinned two ways: a test asserting **no subprocess runs at all** for a profile without it, and a test naming `DEFAULT_PROFILE` directly rather than a look-alike fixture. That property is the one that matters most here; a regression would silently delete the behavioral half of every contract's evidence.

**Failure is not-executed, never raised.** A subject that cannot be built is `skipped` exactly as one that cannot boot is, because `qa_test` states probes are *"additive evidence only … not a task failure here."* Three modes reported distinctly:

| mode | reason |
|---|---|
| non-zero exit | `subject preparation failed (exited N): <output tail>` |
| never finished | `subject preparation failed (no exit within Ns)` |
| tool absent | `subject preparation failed (could not launch)` — the #462 missing-tooling class |

**Output is captured and tailed** for the reason boot stderr is (#512), and the case is stronger here: a boot failure leaves a process to interrogate; a build failure leaves nothing. If the compiler's message isn't captured at that moment it exists nowhere. Both streams are read — `tsc` writes diagnostics to stdout while most tools use stderr, and reading only stderr would drop the message for exactly the toolchain this exists to support.

**A failed build does not proceed to boot.** Otherwise probes would run against a stale or absent artifact and report whatever they found as truth.

## Proof

Ten tests, each against a reachable bug: the inertness guard, a build failure misreported as a boot failure, output reaching the reason from either stream, the unbounded hang, the missing tool, the happy path actually continuing to boot (a preparation step that swallowed control would make every compiled stack silently unprobeable — the #818 shape one stage over), and the build running in the workspace rather than wherever the runner happens to be.

**Regression 6833 passed, 1 skipped.**

## Next

`frontend_build`'s hardcoded `workspace_root / "frontend"` (design gate decision 6), then the stack itself, then VS.

Refs #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
