### PR TITLE
feat(checks): the buildable project directory is a stack fact, not "frontend/" (#822)

### DIFF
--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -574,10 +574,10 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         name="frontend_compiles",
         applicable_extensions=frozenset({".js", ".jsx", ".ts", ".tsx"}),
         required_params=frozenset({"file"}),
-        optional_params=frozenset({"timeout_s"}),
-        param_types={"file": str, "timeout_s": int},
+        optional_params=frozenset({"timeout_s", "project_dir"}),
+        param_types={"file": str, "timeout_s": int, "project_dir": str},
         requires_stack_context=False,
-        path_params=frozenset({"file"}),
+        path_params=frozenset({"file", "project_dir"}),
         example={"file": "frontend/src/views/RunsListView.jsx"},
         # #648: fay-4 and fay-8 both shipped a view with a rollup bind-time
         # error (an undefined identifier) — invisible to every static check
@@ -587,11 +587,13 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         # workspace's full tree (#643).
         notes=(
             "Runs the actual frontend build (npm install + npm run build) in "
-            "the workspace's frontend/ tree and anchors blame to `file`. "
+            "the buildable project directory and anchors blame to `file`. "
             "Catches bundler-level errors (undefined identifiers, broken "
-            "imports) that no static check or `node --check` can see. Missing "
-            "npm or a workspace without frontend/package.json skips "
-            "(missing_tooling), it does not fail."
+            "imports) that no static check or `node --check` can see. "
+            "`project_dir` is the workspace-relative directory holding "
+            "package.json, defaulting to `frontend/` — a stack that builds at "
+            "the root declares `.` (#822). Missing npm or a directory without "
+            "package.json skips (missing_tooling), it does not fail."
         ),
         failure_ownership=OWNERSHIP_PRODUCT,
         qa_available=False,

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -1273,7 +1273,17 @@ class FrontendCompilesCheck(BaseCheck):
         if not file_path.is_file():
             return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
 
-        frontend_dir = workspace_root / "frontend"
+        # #822: which directory holds the buildable project is a STACK fact, not a property
+        # of frontends. `fullstack_fastapi_react` builds in `frontend/`; a Next.js app builds
+        # at the root. Hardcoding it meant a second stack's every view check reported
+        # `no_frontend_tree` — not-executed for the whole stack, which SIP-0096 declines to
+        # credit but which also silently removes the only bundler-level coverage those views
+        # have. The default preserves stack #1 byte-for-byte: its criteria pack emits no
+        # `project_dir`, so its contract is unchanged.
+        try:
+            frontend_dir = _safe_resolve(str(params.get("project_dir", "frontend")), workspace_root)
+        except _SafetyError as exc:
+            return CheckOutcome.error(reason=exc.reason)
         if not (frontend_dir / "package.json").is_file():
             return CheckOutcome.skipped(reason="no_frontend_tree")
         if shutil.which("npm") is None:

--- a/tests/unit/cycles/test_frontend_project_dir.py
+++ b/tests/unit/cycles/test_frontend_project_dir.py
@@ -1,0 +1,128 @@
+"""Which directory holds the buildable project is a stack fact (#822).
+
+`FrontendCompilesCheck` resolved `workspace_root / "frontend"` unconditionally. That is a
+property of `fullstack_fastapi_react`, not of frontends: a Next.js app builds at the project
+root. For a second stack, every view's bundler check would have reported `no_frontend_tree`.
+
+SIP-0096 declines to credit a skip, so this is visible rather than a false green — but the
+consequence is still severe, because `frontend_compiles` is the *only* bundler-level coverage a
+view has, and stack #2 has no AST tier at all (the nine `ast.parse` checks are Python-only). The
+whole static surface of stack #2's views would have been empty, reported as not-executed.
+
+Bug classes guarded:
+
+- **a second stack's views skipping the only check that can see their defects** — fay-4 and
+  fay-8 each shipped a view with a rollup bind-time error invisible to every static check and to
+  `node --check`, which is why #648 built this;
+- the fix moving the reference contract. Stack #1's criteria pack emits no `project_dir`, so its
+  contract must be byte-identical — this is the release's banked evidence;
+- a project directory escaping the workspace, which a bare `workspace_root / value` join would
+  have permitted the moment the value stopped being a literal;
+- the parameter being added speculatively. S5's admission rule wants a field demonstrated on two
+  stacks; `frontend/` vs `.` is the demonstration, and the build *command* is deliberately not
+  parameterized because both stacks run `npm run build`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from squadops.cycles.acceptance_check_spec import CHECK_SPECS
+from squadops.cycles.acceptance_checks import _CHECK_IMPLS
+
+pytestmark = [pytest.mark.domain_contracts]
+
+
+def _tree(root: Path, project_dir: str, view: str) -> Path:
+    """A workspace whose buildable project sits at ``project_dir``."""
+    proj = root / project_dir if project_dir != "." else root
+    proj.mkdir(parents=True, exist_ok=True)
+    (proj / "package.json").write_text(json.dumps({"name": "app"}), encoding="utf-8")
+    view_path = root / view
+    view_path.parent.mkdir(parents=True, exist_ok=True)
+    view_path.write_text("export default function V() { return null }\n", encoding="utf-8")
+    return root
+
+
+async def _evaluate(root: Path, params: dict) -> object:
+    check = _CHECK_IMPLS["frontend_compiles"]()
+    return await check.evaluate(params, root)
+
+
+async def test_a_root_built_project_is_found_when_declared(tmp_path: Path, monkeypatch):
+    """The Next.js shape. Without `project_dir` this reported `no_frontend_tree` and the view
+    went unchecked; `npm` is stubbed absent so the assertion is about *discovery*, not about
+    standing a real bundler up in a unit test."""
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    _tree(tmp_path, ".", "app/runs/page.tsx")
+
+    outcome = await _evaluate(tmp_path, {"file": "app/runs/page.tsx", "project_dir": "."})
+
+    assert outcome.status == "skipped"
+    assert outcome.reason == "missing_tooling", (
+        "the project was found; the only thing missing is npm"
+    )
+
+
+async def test_the_default_is_still_the_first_stacks_layout(tmp_path: Path, monkeypatch):
+    """Stack #1 emits no `project_dir`. If the default moved, every existing cycle's view
+    checks would start reporting `no_frontend_tree`."""
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    _tree(tmp_path, "frontend", "frontend/src/views/RunsListView.jsx")
+
+    outcome = await _evaluate(tmp_path, {"file": "frontend/src/views/RunsListView.jsx"})
+
+    assert outcome.reason == "missing_tooling"
+
+
+async def test_a_root_built_project_without_the_param_is_not_found(tmp_path: Path):
+    """The defect, reproduced. This is what stack #2 would have gotten for every view."""
+    _tree(tmp_path, ".", "app/runs/page.tsx")
+
+    outcome = await _evaluate(tmp_path, {"file": "app/runs/page.tsx"})
+
+    assert outcome.status == "skipped"
+    assert outcome.reason == "no_frontend_tree"
+
+
+@pytest.mark.parametrize("escape", ["../outside", "/etc", "frontend/../../.."])
+async def test_a_project_dir_cannot_escape_the_workspace(tmp_path: Path, escape: str):
+    """`project_dir` is now attacker-adjacent in a way a literal never was: it arrives from a
+    contract. A bare join would resolve outside the workspace and run `npm install` there."""
+    _tree(tmp_path, "frontend", "frontend/src/views/V.jsx")
+
+    outcome = await _evaluate(tmp_path, {"file": "frontend/src/views/V.jsx", "project_dir": escape})
+
+    assert outcome.status == "error"
+
+
+def test_the_parameter_is_declared_so_authoring_time_validation_covers_it():
+    """`path_params` drives the pre-eval traversal rejection in `implementation_plan`, and
+    `param_types` drives type checking. An undeclared param would be accepted by the parser and
+    then be unvalidated at both layers."""
+    spec = CHECK_SPECS["frontend_compiles"]
+
+    assert "project_dir" in spec.optional_params
+    assert "project_dir" in spec.path_params
+    assert spec.param_types["project_dir"] is str
+    assert "project_dir" not in spec.required_params, (
+        "requiring it would move stack #1's contract, which the release's evidence is bound to"
+    )
+
+
+def test_the_build_command_is_deliberately_not_parameterized():
+    """S5's admission rule: a field must be demonstrated on two stacks. `frontend/` vs `.` is
+    demonstrated; both stacks run `npm run build`, so a `build_argv` parameter would be a
+    one-stack guess wearing a general name — the exact decay the rule exists to prevent."""
+    spec = CHECK_SPECS["frontend_compiles"]
+
+    assert not {"build_argv", "install_argv", "package_manager"} & (
+        spec.optional_params | spec.required_params
+    )


### PR DESCRIPTION
Second seam PR for stack #2, landing alone. Reference contract `7622f570c949fe95` and manifest `bb472e267e53d5ad` **unmoved**; regression **6841 passed, 1 skipped**.

## Premise correction — the design gate named the wrong evaluator

Gate decision 6 said *"`frontend_build` hardcodes `workspace_root / "frontend"`."* **It doesn't.** Verified before implementing:

- `run_frontend_build` takes `target_dir` as a parameter, the vitest dispatch already passes `None` (whole tree), and `_find_package_json_dir` *discovers* the package.json location rather than assuming it (#303).
- The hardcoded path is in **`FrontendCompilesCheck`** — the per-view bundler check — at `acceptance_checks.py`.

So the behavioral build check was already stack-tolerant and the per-view one was not. This PR fixes the one that's actually broken.

## Why it matters more than a skip usually would

For a second stack, every view's `frontend_compiles` reported `no_frontend_tree`. SIP-0096 declines to credit a skip, so this is visible rather than a false green — but the consequence is still severe:

`frontend_compiles` is the **only** bundler-level coverage a view has. #648 built it because fay-4 and fay-8 each shipped a view with a rollup bind-time error *invisible to every static check and to `node --check`*, first surfacing at final verification where no correction budget could reach it. And stack #2 has **no AST tier at all** — the nine `ast.parse` checks are Python-only.

So stack #2's views would have shipped with an entirely empty static surface, every check reporting not-executed.

## The change

`frontend_compiles` gains an optional `project_dir`, defaulting to `"frontend"`. Stack #1's criteria pack emits nothing new, so its contract is byte-identical — which is the release's banked evidence and the reason the parameter is optional rather than required.

Declared in **`path_params`** as well as `optional_params`/`param_types`, so it inherits the authoring-time traversal rejection in `implementation_plan` and the pre-eval `_safe_resolve`. That's not decoration: the value now arrives from a contract rather than being a literal, and a bare `workspace_root / value` join would happily resolve outside the workspace and run `npm install` there. Verified `"."` resolves to the root and passes the lint, while `../outside`, `/etc` and `frontend/../../..` are rejected at both layers.

## What is deliberately *not* parameterized

The build **command**. S5's admission rule wants a field demonstrated on two stacks before admission: `frontend/` vs `.` is demonstrated; both stacks run `npm run build`. A `build_argv` or `package_manager` parameter would be a one-stack guess wearing a general name — the exact decay that rule exists to prevent. Pinned by a test so a future PR has to argue rather than drift.

## Tests

Eight, each against a reachable bug: the root-built project found when declared, the default still resolving stack #1's layout, **the defect reproduced** (root-built project without the param → `no_frontend_tree`), three traversal escapes, the declaration wiring that makes both validation layers cover it, and the not-parameterized guard.

## Next

The stack itself — expander, criteria pack, probe profile, environment contract, completeness test, bend register. Then **VS**, which gates S3.

Refs #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
