### PR TITLE
feat(correction): view source for repair targeting comes from the contract (#829)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -180,12 +180,13 @@ def _widen_target_for_frontend_build(
     """
     if not _frontend_build_failed(failure_evidence):
         return target
-    frontend_source = [
-        p
-        for p in (failed_inputs.get("implementation_artifacts") or [])
-        if isinstance(p, str) and p.startswith("frontend/")
-    ]
-    return list(dict.fromkeys([*target, *frontend_source]))
+    # #822: which files are views is the CONTRACT's answer, not a directory prefix. This read
+    # `p.startswith("frontend/")` — stack #1's layout stated as a property of views. A stack
+    # that builds at the project root would union nothing, and the fay-8 trap this function
+    # exists to close would reopen intact for it. Same authoring-independent relation
+    # `_probe_owned_slots` uses (#688), one criterion over.
+    view_slots = [p for p in (failed_inputs.get("contract_view_slots") or []) if isinstance(p, str)]
+    return list(dict.fromkeys([*target, *view_slots]))
 
 
 def _failed_probe_ids(failure_evidence: Any) -> list[str]:

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -320,6 +320,12 @@ CHECK_CONTRACT_ASSERTIONS = "contract_assertions_match"
 # moves both together.
 CHECK_FILL_SLOT_SIGNATURE = "fill_slot_signature"
 
+# #822: the per-view bundler check. Named here because `VerificationContract.view_slots`
+# filters on it to identify a stack's view files for repair targeting — the same
+# single-source rule as the constants above, and the same failure mode if it drifts: a
+# literal that stops matching resolves to "this stack has no views" rather than erroring.
+CHECK_FRONTEND_COMPILES = "frontend_compiles"
+
 # #629 (1.5 A6/D2): the ADVISORY prose-vs-contract identity. Deliberately NOT a
 # ``CHECK_SPECS`` entry — that would make it plan-authorable; it names the
 # warning rows the plan-prose lint emits (``implementation_plan``), keeping its

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -568,6 +568,14 @@ def inject_contract_inputs(
             endpoint_owners = contract.endpoint_owners()
             if endpoint_owners:
                 inputs["contract_endpoint_owners"] = endpoint_owners
+        # #822: the view slots, for the same reason and by the same route — a correction born
+        # of a FAILING frontend build must reach the view that broke it. Threaded outside the
+        # probe branch because a stack can have views and no probes; absent when the contract
+        # bundler-checks nothing, which is the same condition under which no frontend_build
+        # row can fail. Data only; no prose (#448).
+        view_slots = contract.view_slots()
+        if view_slots:
+            inputs["contract_view_slots"] = list(view_slots)
         # #629 / pf-54: the contract's pinned statuses (probe expects + the
         # error-code→status map) never reached suite AUTHORING — five authored
         # suite versions asserted 200 where the probe pinned 201, an unwinnable

--- a/src/squadops/cycles/verification_contract.py
+++ b/src/squadops/cycles/verification_contract.py
@@ -488,6 +488,33 @@ class VerificationContract:
                         owners.setdefault(f"{parsed[0]} {parsed[1]}", ff.path)
         return owners
 
+    def view_slots(self) -> tuple[str, ...]:
+        """Fill files whose acceptance runs the bundler — the stack's *view* slots (#822).
+
+        Read off the ``frontend_compiles`` criteria the expander attaches per fill slot, in
+        document order. Same relation ``endpoint_owners`` reads, one criterion over: only the
+        contract joins "the manifest declared these views" to "the blueprint put them here".
+
+        Exists because the repair-target widening for a failing frontend build identified view
+        source as ``path.startswith("frontend/")``. That is stack #1's layout, not a property
+        of views: a stack that builds at the project root would union nothing, and #650's
+        fay-8 trap — five correction rounds polishing a passing backend while the
+        build-breaking view sat outside every target — would return intact for stack #2.
+
+        Empty for a contract with no bundler-checked slot, which is the same condition under
+        which no ``frontend_build`` row can fail, so the caller's behavior is unchanged.
+        """
+        from squadops.cycles.acceptance_check_spec import CHECK_FRONTEND_COMPILES
+
+        return tuple(
+            ff.path
+            for ff in self.fill_files
+            if any(
+                crit.check == CHECK_FRONTEND_COMPILES
+                for crit in (*ff.interface, *ff.implementation)
+            )
+        )
+
     def covered_fill_paths(self) -> frozenset[str]:
         """The set of fill-file paths this contract owns the acceptance of. A plan
         task whose ``expected_artifacts`` names one of these must bind that file's

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -3389,6 +3389,16 @@ class TestFrontendBuildProvenanceTargeting:
             "frontend/src/views/CreateRunView.jsx",
             "frontend/src/views/RunDetailView.jsx",
         ],
+        # #822: which files are views now comes from the contract rather than from a
+        # `frontend/` prefix over implementation_artifacts — a prefix is stack #1's layout,
+        # not a property of views, and a root-built stack would union nothing. These are the
+        # reference contract's actual `view_slots()`, so the assertions below are unchanged
+        # and the fixture is closer to a real qa.test envelope, which carries this key.
+        "contract_view_slots": [
+            "frontend/src/views/RunsListView.jsx",
+            "frontend/src/views/CreateRunView.jsx",
+            "frontend/src/views/RunDetailView.jsx",
+        ],
         "subtask_focus": "Backend API test suite",
         "subtask_description": "pytest suites",
     }

--- a/tests/unit/cycles/test_view_slot_repair_targeting.py
+++ b/tests/unit/cycles/test_view_slot_repair_targeting.py
@@ -1,0 +1,216 @@
+"""Which files are views is the contract's answer, not a directory prefix (#822).
+
+`_widen_target_for_frontend_build` exists because of fay-8 (cyc_7f5f1b8b1790): five correction
+rounds, four identical `frontend_build` failures, every repair emitting backend and test files
+only — RC2's package scoping never reaches `frontend/*`, so the loop polished a passing backend
+while the build-breaking view sat outside every target. #650 closed it by unioning frontend
+source into the repair target.
+
+It identified that source as `path.startswith("frontend/")`. That is stack #1's layout stated as
+a property of views. A stack that builds at the project root unions nothing, and the trap
+reopens intact — in the correction path, where it costs a full round each time rather than one
+check.
+
+The fix is the relation `_probe_owned_slots` already uses (#688), one criterion over: only the
+contract joins "the manifest declared these views" to "the blueprint put them here."
+
+Bug classes guarded:
+
+- **a root-built stack's views never reaching the repair target**, which is fay-8 again for
+  stack #2 and costs correction budget per round;
+- **stack #1's target changing**, which would alter repair behavior on the configuration the
+  release's banked evidence was measured on;
+- the accessor reading a prefix by another name — a view outside `frontend/` must be found
+  *because the contract says it is a view*, not because of where it sits;
+- the value being computed and not carried. #796 was exactly this: an artifact stored,
+  validated, promoted, and silently not forwarded, so the capability was dead while looking
+  built;
+- the widening firing when no frontend build failed, or crashing when the contract carries no
+  views at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from adapters.cycles.correction_runner import _widen_target_for_frontend_build
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.capabilities.scaffold_contract import emit_contract_dict
+from squadops.cycles.verification_contract import VerificationContract
+
+pytestmark = [pytest.mark.domain_contracts]
+
+_REFERENCE = InterfaceManifest.from_yaml(
+    (
+        Path(__file__).resolve().parents[3]
+        / "examples"
+        / "03_group_run"
+        / "interface_manifest.yaml"
+    ).read_text(encoding="utf-8")
+)
+
+
+def _failed_build_evidence() -> dict:
+    return {"validation_result": {"checks": [{"check": "frontend_build", "passed": False}]}}
+
+
+def _contract(fill_files: dict) -> VerificationContract:
+    return VerificationContract.from_dict(
+        {
+            "contract_version": 1,
+            "skeleton": {"expander": "s", "interface_manifest_hash": "h"},
+            "capabilities": [],
+            "frozen": [],
+            "fill_files": fill_files,
+            "behavioral": {
+                "build": [],
+                "suite": {"checks": [], "coverage_expectations": []},
+                "probes": [],
+            },
+        }
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The relation
+# --------------------------------------------------------------------------- #
+
+
+def test_the_reference_contract_names_its_three_views():
+    """Exact values: this is the set the prefix used to produce, so a difference here is a
+    behavior change on the configuration 1.4's evidence was measured against."""
+    contract = VerificationContract.from_dict(emit_contract_dict(_REFERENCE))
+
+    assert contract.view_slots() == (
+        "frontend/src/views/RunsListView.jsx",
+        "frontend/src/views/CreateRunView.jsx",
+        "frontend/src/views/RunDetailView.jsx",
+    )
+
+
+def test_a_view_outside_the_first_stacks_directory_is_still_a_view():
+    """The whole point. `app/runs/page.tsx` is a view because the contract bundler-checks it,
+    not because of where it sits — a prefix rule answers "no views" for this contract."""
+    contract = _contract(
+        {
+            "app/runs/page.tsx": {
+                "interface": [],
+                "implementation": [
+                    {"check": "frontend_compiles", "id": "vc-v", "file": "app/runs/page.tsx"}
+                ],
+            },
+            "app/api/runs/route.ts": {
+                "interface": [
+                    {"check": "endpoint_defined", "id": "vc-r", "methods_paths": ["GET /runs"]}
+                ],
+                "implementation": [],
+            },
+        }
+    )
+
+    assert contract.view_slots() == ("app/runs/page.tsx",)
+    assert not [p for p in contract.view_slots() if p.startswith("frontend/")]
+
+
+def test_a_contract_that_bundler_checks_nothing_has_no_views():
+    """A backend-only stack must yield an empty tuple rather than raising — and it is the same
+    condition under which no `frontend_build` row can fail, so the caller is unaffected."""
+    contract = _contract(
+        {
+            "src/routes.go": {
+                "interface": [],
+                "implementation": [
+                    {"check": "command_exit_zero", "id": "x", "argv": ["go", "build"]}
+                ],
+            }
+        }
+    )
+
+    assert contract.view_slots() == ()
+
+
+# --------------------------------------------------------------------------- #
+# The widening
+# --------------------------------------------------------------------------- #
+
+
+def test_a_root_built_stacks_views_reach_the_repair_target():
+    """fay-8 for stack #2. Under the prefix rule this returned the target unchanged, and the
+    correction loop would repair everything except the file that broke the build."""
+    target = _widen_target_for_frontend_build(
+        ["app/api/runs/route.ts"],
+        _failed_build_evidence(),
+        {
+            "contract_view_slots": ["app/runs/page.tsx"],
+            "implementation_artifacts": ["app/runs/page.tsx"],
+        },
+    )
+
+    assert target == ["app/api/runs/route.ts", "app/runs/page.tsx"]
+
+
+def test_the_first_stacks_widening_is_unchanged():
+    """Same three views the prefix produced, in the same union order."""
+    views = list(VerificationContract.from_dict(emit_contract_dict(_REFERENCE)).view_slots())
+
+    target = _widen_target_for_frontend_build(
+        ["backend/routes.py"], _failed_build_evidence(), {"contract_view_slots": views}
+    )
+
+    assert target == ["backend/routes.py", *views]
+
+
+def test_no_widening_when_the_build_did_not_fail():
+    """The widening is conditional on the evidence, not on the inputs being present."""
+    target = _widen_target_for_frontend_build(
+        ["backend/routes.py"],
+        {"validation_result": {"checks": [{"check": "frontend_build", "passed": True}]}},
+        {"contract_view_slots": ["frontend/src/views/V.jsx"]},
+    )
+
+    assert target == ["backend/routes.py"]
+
+
+@pytest.mark.parametrize("inputs", [{}, {"contract_view_slots": []}, {"contract_view_slots": None}])
+def test_absent_view_slots_leave_the_target_alone(inputs):
+    """Pre-#822 envelopes and contract-less cycles must be byte-identical, never crash."""
+    assert _widen_target_for_frontend_build(["a.py"], _failed_build_evidence(), inputs) == ["a.py"]
+
+
+def test_the_target_does_not_duplicate_a_view_already_in_it():
+    """The union is order-preserving and deduplicated — a duplicated path would be handed to
+    the repair prompt twice."""
+    target = _widen_target_for_frontend_build(
+        ["frontend/src/views/V.jsx"],
+        _failed_build_evidence(),
+        {"contract_view_slots": ["frontend/src/views/V.jsx"]},
+    )
+
+    assert target == ["frontend/src/views/V.jsx"]
+
+
+# --------------------------------------------------------------------------- #
+# The wiring — computed is not carried
+# --------------------------------------------------------------------------- #
+
+
+def test_the_composer_threads_the_view_slots_onto_the_task():
+    """#796's lesson: an artifact was stored, validated, promoted and silently not forwarded,
+    so authored mode was dead while looking built. An accessor nothing carries is the same
+    defect — this asserts the value reaches task inputs, not merely that it can be computed."""
+    from squadops.capabilities.context_assembly import get_context_contract
+    from squadops.cycles.task_plan import inject_contract_inputs
+
+    contract = VerificationContract.from_dict(emit_contract_dict(_REFERENCE))
+    task_type = next(
+        t
+        for t in ("qa.test", "development.implement_task")
+        if get_context_contract(t).bind_behavioral_surface
+    )
+
+    inputs: dict = {}
+    inject_contract_inputs(inputs, contract, task_type, _REFERENCE)
+
+    assert inputs["contract_view_slots"] == list(contract.view_slots())


### PR DESCRIPTION
Third seam PR for stack #2, and the one with the highest cost per occurrence. Contract `7622f570c949fe95` and manifest `bb472e267e53d5ad` unmoved; regression **6852 passed, 1 skipped**.

## The defect

`_widen_target_for_frontend_build` identified view source as `p.startswith("frontend/")` — stack #1's directory layout stated as a property of views. **A root-built stack unions nothing.**

That function exists because of fay-8, recorded in its own docstring: *"five correction rounds, four identical `frontend_build` failures, every repair emitted backend/test files only … the loop polished a passing backend while the build-breaking view sat outside every target."* For a second stack the trap reopens intact — **in the correction path, where it costs a full round each time** rather than a single check.

Third instance of the same assumption: #818 (contract emitter), #828 (`frontend_compiles` project dir), this one.

## The fix, and why not a wider prefix

The precedent is twenty lines up in the same file. `_probe_owned_slots` (#688) resolves repair targets from **contract data**, deliberately: *"This relation is authoring-independent: it comes from the contract."* It was written because prefix and package scoping made reachability depend on where the squad happened to author its suite.

Same relation, one criterion over: a fill slot is a **view** when the contract attaches `frontend_compiles` to it. `VerificationContract.view_slots()` reads it, `inject_contract_inputs` threads it as `contract_view_slots` beside `contract_endpoint_owners`, the widening consumes it.

**Measured against the reference contract, `view_slots()` returns exactly the three files the prefix matched** — so this is a strict generalization, not a behavior change on the configuration the release's evidence was measured on.

**No fallback, and none is needed.** `_frontend_build_failed` requires a `frontend_build` row, which only a contract emits, so a contract-less cycle can never reach the widening and the absent-input path is byte-identical to today. That avoids the legacy/new dual path the repo rules out.

## Two things checked rather than assumed

**Does the input reach the right task?** `qa.test` carries `bind_behavioral_surface` and `frontend_build` runs inside it, so the failing task whose inputs the correction reads does receive `contract_view_slots`. Verified before relying on it.

**Is the value carried, not just computable?** A test asserts it reaches task inputs through `inject_contract_inputs`, because #796 was exactly the other thing — an artifact stored, validated, promoted, and silently not forwarded, so the capability was dead while looking built.

## On the two modified tests

The two #650 tests failed, and that's the right kind of failure — their fixtures predate this input. **Their setup gained `contract_view_slots`; every assertion is unchanged.** The assertions are about behavior (the views reach the target), which is still required; what changed is how the runner learns which files are views. The fixture is now closer to a real `qa.test` envelope, which carries the key.

Flagging it explicitly because "tests changed to make the code pass" deserves scrutiny by default.

## Also

`CHECK_FRONTEND_COMPILES` joins the named-constant block beside `CHECK_ENDPOINT_DEFINED`, for the reason those comments already give: a literal that stops matching after a rename resolves to *"this stack has no views"* rather than erroring.

Closes #829 · Refs #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
