### PR TITLE
feat(cycles): a cycle declares its stack once, not twice (#832)

### DIFF
--- a/src/squadops/api/routes/cycles/cycles.py
+++ b/src/squadops/api/routes/cycles/cycles.py
@@ -40,6 +40,7 @@ from squadops.cycles.preflight import (
     model_availability_decision,
     required_check_tooling_decision,
     required_roles_decision,
+    stack_dev_capability_decision,
 )
 
 logger = logging.getLogger(__name__)
@@ -130,6 +131,11 @@ async def _run_create_preflight(profile: SquadProfile, config: dict) -> tuple[Fi
         # construction — the sole-author path never receives the criteria index,
         # so every framing attempt is rejected. Fail in seconds, not per re-roll.
         bind_mode_authoring_decision(config),
+        # #832: build_profile and dev_capability both name the stack. Disagreement expands
+        # one stack's skeleton while prompting the dev agent for another's files — every
+        # emission outside the fill slots, surfacing as "the plan claims nothing" a full
+        # framing workload later.
+        stack_dev_capability_decision(config),
         model_availability_decision(profile, await _pulled_model_names()),
         # SIP-0096 §6.5: a required check whose tooling is knowably absent is a
         # create-time reject, never a mid-run blocked_unverified surprise.

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -28,6 +28,7 @@ from squadops.capabilities.handlers.cycle.validation import (
     _detect_stubs,
     _estimate_min_artifacts,
 )
+from squadops.capabilities.scaffold import resolve_dev_capability
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +270,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         strategy: str | None = None,
     ) -> str:
         """Build prompt with PRD + plan artifacts for code generation."""
-        capability = get_capability(self._resolved_config.get("dev_capability", "python_cli"))
+        capability = get_capability(resolve_dev_capability(self._resolved_config) or "python_cli")
 
         parts = [f"## Product Requirements Document\n\n{prd}"]
 
@@ -423,7 +424,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
             rendered = None
             try:
                 capability = get_capability(
-                    self._resolved_config.get("dev_capability", "python_cli")
+                    resolve_dev_capability(self._resolved_config) or "python_cli"
                 )
             except ValueError as exc:
                 return self._fail_result(start_time, inputs, str(exc))
@@ -433,7 +434,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
             # Resolve capability (fail fast on unknown dev_capability)
             try:
                 capability = get_capability(
-                    self._resolved_config.get("dev_capability", "python_cli")
+                    resolve_dev_capability(self._resolved_config) or "python_cli"
                 )
             except ValueError as exc:
                 return self._fail_result(start_time, inputs, str(exc))

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -34,6 +34,7 @@ from squadops.capabilities.handlers.cycle.validation import (
     _detect_stubs,
     _is_test_file,
 )
+from squadops.capabilities.scaffold import resolve_dev_capability
 
 logger = logging.getLogger(__name__)
 
@@ -186,7 +187,7 @@ class QATestHandler(_CycleTaskHandler):
         the frontend build check (#290) + vitest skip on "no package.json" (#296).
         """
         capability = get_capability(
-            inputs.get("resolved_config", {}).get("dev_capability", "python_cli")
+            resolve_dev_capability(inputs.get("resolved_config")) or "python_cli"
         )
         contents = inputs.get("artifact_contents", {})
         support = set(getattr(capability, "build_support_files", ()))
@@ -649,7 +650,7 @@ class QATestHandler(_CycleTaskHandler):
         prd = inputs.get("prd", "")
         prior_outputs = inputs.get("prior_outputs")
         resolved_config = inputs.get("resolved_config", {})
-        capability_name = resolved_config.get("dev_capability", "python_cli")
+        capability_name = resolve_dev_capability(resolved_config) or "python_cli"
 
         # Resolve capability (fail fast on unknown dev_capability)
         try:

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -1489,6 +1489,20 @@ class ScaffoldStack:
     #: not one fact duplicated — the interpreter is context-specific, only the launcher and
     #: entry point are stack-specific.
     probe_profile: str = ""
+    #: #832: the ``DEV_CAPABILITIES`` entry this stack requires — the prompt text,
+    #: ``expected_extensions``, ``source_filter`` and ``test_framework`` a dev agent is given.
+    #: A *name*, like the two fields above, so the capability vocabulary stays in its layer.
+    #:
+    #: Exists because a cycle declared its stack **twice**: ``build_profile`` selecting this
+    #: registry and ``dev_capability`` selecting that one, the same literal on adjacent CRP
+    #: lines, bound by convention alone. Nothing stopped a cycle from expanding one stack's
+    #: skeleton while instructing the dev agent to write another stack's files — every
+    #: emission landing outside the fill slots, surfacing only as a plan that claims nothing.
+    #:
+    #: Not a collapse of the two registries: ``python_cli``, ``python_api`` and ``react_app``
+    #: are free-form capabilities for cycles with no scaffold stack at all. Not every dev
+    #: capability is a stack; every stack needs one.
+    dev_capability: str = ""
 
 
 _STACKS: dict[str, ScaffoldStack] = {
@@ -1504,6 +1518,7 @@ _STACKS: dict[str, ScaffoldStack] = {
         # without minting a fourth stack vocabulary to express it.
         criteria_pack="fullstack_fastapi_react",
         probe_profile="fastapi_uvicorn",
+        dev_capability="fullstack_fastapi_react",
     ),
 }
 
@@ -1549,6 +1564,37 @@ def probe_profile_for(stack: str) -> str:
     """
     known = _STACKS.get(stack)
     return known.probe_profile if known else ""
+
+
+def dev_capability_for(stack: str) -> str:
+    """The ``DEV_CAPABILITIES`` entry ``stack`` requires, or ``""`` (#832)."""
+    known = _STACKS.get(stack)
+    return known.dev_capability if known else ""
+
+
+def resolve_dev_capability(resolved_config: Mapping[str, Any] | None) -> str | None:
+    """The dev capability a cycle actually runs, or ``None`` if its config contradicts itself.
+
+    One rule (#832): **the stack declares it; the config may restate it but not contradict
+    it.** A ``build_profile`` naming a scaffoldable stack is the authority, so an absent
+    ``dev_capability`` is derived rather than defaulted to ``python_cli`` — which is how a
+    fullstack cycle could otherwise be handed CLI prompts.
+
+    ``None`` means *contradiction*, and is deliberately distinguished from ``""``: the caller
+    is preflight, which must reject rather than silently pick a side. Overriding an explicit
+    config value would hide the drift instead of ending it.
+
+    A cycle with no scaffoldable ``build_profile`` is a free-form generation cycle
+    (``python_cli``, ``react_app``); its ``dev_capability`` is returned untouched.
+    """
+    config = resolved_config or {}
+    declared = str(config.get("dev_capability") or "")
+    required = dev_capability_for(str(config.get("build_profile") or ""))
+    if not required:
+        return declared
+    if declared and declared != required:
+        return None
+    return required
 
 
 def scaffold_stack_for(resolved_config: Mapping[str, Any] | None) -> str:

--- a/src/squadops/cycles/preflight.py
+++ b/src/squadops/cycles/preflight.py
@@ -208,6 +208,53 @@ def bind_mode_authoring_decision(config: Mapping[str, Any]) -> PreflightDecision
     )
 
 
+def stack_dev_capability_decision(config: Mapping[str, Any]) -> PreflightDecision:
+    """Block a cycle whose two stack declarations contradict each other (#832).
+
+    A cycle names its stack twice: ``build_profile`` selects the expander, fill slots,
+    criteria pack and probe profile; ``dev_capability`` selects the dev agent's prompt text,
+    ``expected_extensions``, ``source_filter`` and ``test_framework``. The CRP sets both to
+    the same literal on adjacent lines, and until this check nothing verified that.
+
+    The failure it prevents is not a crash. The skeleton expands for one stack while the dev
+    agent is instructed to write another's files, so every emission lands outside the fill
+    slots and the cycle surfaces as *"the plan claims no slots"* — a symptom several layers
+    from its cause, after a full framing workload has been spent.
+
+    Blocks rather than warns, per this module's rule: both inputs are present in the resolved
+    config at create time, and the outcome is deterministic rather than probable. Blocks
+    rather than silently deriving, because overriding an explicit config value hides the drift
+    instead of ending it — the operator should fix the profile.
+    """
+    from squadops.capabilities.scaffold import dev_capability_for, resolve_dev_capability
+
+    if resolve_dev_capability(config) is not None:
+        return PreflightDecision()
+
+    build_profile = str(config.get("build_profile") or "")
+    required = dev_capability_for(build_profile)
+    declared = str(config.get("dev_capability") or "")
+    return PreflightDecision(
+        blocking=(
+            Finding(
+                code="stack_dev_capability_mismatch",
+                severity="block",
+                message=(
+                    f"this cycle declares its stack twice and the two disagree: "
+                    f"`build_profile` is `{build_profile}`, whose scaffold requires "
+                    f"dev capability `{required}`, but `dev_capability` is `{declared}`. "
+                    "The skeleton would expand for one stack while the dev agent is "
+                    "instructed to write the other's files, so every emission would land "
+                    "outside the fill slots and the plan would claim nothing. Set "
+                    f"`dev_capability: {required}` in the request profile or "
+                    "`execution_overrides`, or omit it — a scaffoldable `build_profile` "
+                    "derives it."
+                ),
+            ),
+        )
+    )
+
+
 def _canonical_model(name: str) -> str:
     """Ollama canonical model tag: a tagless reference defaults to ``:latest``.
 

--- a/tests/unit/cycles/test_stack_dev_capability.py
+++ b/tests/unit/cycles/test_stack_dev_capability.py
@@ -1,0 +1,153 @@
+"""A cycle declares its stack once, not twice (#832).
+
+`build_profile` selects the expander, fill slots, criteria pack and probe profile.
+`dev_capability` selects the dev agent's prompt text, `expected_extensions`, `source_filter`
+and `test_framework`. The CRP set both to the same literal on adjacent lines, bound by
+convention alone — nothing in code verified they agreed.
+
+The failure that prevents is not a crash. The skeleton expands for one stack while the dev
+agent is instructed to write another's files, so every emission lands **outside the fill
+slots** and the cycle surfaces as "the plan claims no slots" — a symptom several layers from
+its cause, a full framing workload after the mistake.
+
+Bug classes guarded:
+
+- **the two declarations disagreeing silently**, which is the defect;
+- **a fullstack cycle falling back to `python_cli`** because `dev_capability` was merely
+  absent — the pre-#832 default at five call sites, which would hand a scaffolded fullstack
+  cycle CLI prompts;
+- the fix reaching into free-form cycles. `python_cli`, `python_api` and `react_app` have no
+  scaffold stack, and blocking or rewriting them would break a working configuration — the
+  #762 lesson that a net which false-positives is worse than the gap it closes;
+- **contradiction being silently resolved** rather than rejected. Picking a side hides the
+  drift instead of ending it, and the operator never learns the profile is wrong;
+- a stack registered without a capability, or naming one that does not exist — the same
+  registry drift the other per-stack seams are pinned against.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities import scaffold
+from squadops.capabilities.dev_capabilities import DEV_CAPABILITIES
+from squadops.capabilities.scaffold import (
+    ScaffoldStack,
+    dev_capability_for,
+    resolve_dev_capability,
+)
+from squadops.cycles.preflight import stack_dev_capability_decision
+
+pytestmark = [pytest.mark.domain_contracts]
+
+_STACK = "fullstack_fastapi_react"
+
+
+# --------------------------------------------------------------------------- #
+# Resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_a_scaffoldable_build_profile_derives_the_capability():
+    """The pre-#832 default at five call sites was `python_cli`. A fullstack cycle that
+    simply omitted `dev_capability` would have been handed CLI prompts — an omission, not a
+    contradiction, and therefore invisible to any equality check."""
+    assert resolve_dev_capability({"build_profile": _STACK}) == _STACK
+
+
+def test_agreement_is_accepted_unchanged():
+    assert resolve_dev_capability({"build_profile": _STACK, "dev_capability": _STACK}) == _STACK
+
+
+def test_contradiction_resolves_to_none_rather_than_a_winner():
+    """`None` is deliberately distinct from `""`: the caller is preflight, which must reject.
+    Silently preferring either side would hide the drift instead of ending it."""
+    assert resolve_dev_capability({"build_profile": _STACK, "dev_capability": "react_app"}) is None
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({"dev_capability": "python_cli"}, "python_cli"),
+        ({"dev_capability": "react_app"}, "react_app"),
+        ({"build_profile": "not_a_registered_stack", "dev_capability": "python_cli"}, "python_cli"),
+        ({}, ""),
+        (None, ""),
+    ],
+)
+def test_a_cycle_with_no_scaffoldable_stack_is_untouched(config, expected):
+    """Free-form generation cycles have no expander to disagree with. A net that
+    false-positives on a working configuration is worse than the gap it closes (#762)."""
+    assert resolve_dev_capability(config) == expected
+
+
+# --------------------------------------------------------------------------- #
+# The create-time block
+# --------------------------------------------------------------------------- #
+
+
+def test_a_contradicting_cycle_is_rejected_at_create():
+    """Deterministic downstream failure, both inputs knowable at create — this module's
+    block-vs-warn rule. Warning would spend a framing workload to reach a certain failure."""
+    decision = stack_dev_capability_decision(
+        {"build_profile": _STACK, "dev_capability": "react_app"}
+    )
+
+    assert decision.rejected
+    assert decision.blocking[0].code == "stack_dev_capability_mismatch"
+
+
+def test_the_rejection_names_both_values_and_the_fix():
+    """A block that says only "mismatch" sends the operator into two registries to work out
+    which value is wrong."""
+    message = (
+        stack_dev_capability_decision({"build_profile": _STACK, "dev_capability": "react_app"})
+        .blocking[0]
+        .message
+    )
+
+    assert _STACK in message and "react_app" in message
+    assert "omit it" in message
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"build_profile": _STACK, "dev_capability": _STACK},
+        {"build_profile": _STACK},
+        {"dev_capability": "python_cli"},
+        {},
+    ],
+)
+def test_valid_configurations_are_not_blocked(config):
+    assert not stack_dev_capability_decision(config).rejected
+
+
+# --------------------------------------------------------------------------- #
+# Registry binding
+# --------------------------------------------------------------------------- #
+
+
+def test_every_registered_stack_names_a_capability_that_exists():
+    """Fifth per-stack registry, same binding as the other four: forgetting must be an error
+    rather than the plausible wrong answer S1 was written to eliminate."""
+    for name, stack in scaffold._STACKS.items():
+        assert stack.dev_capability, f"stack {name!r} declares no dev_capability"
+        assert stack.dev_capability in DEV_CAPABILITIES, (
+            f"stack {name!r} names dev_capability {stack.dev_capability!r}, which is not registered"
+        )
+
+
+def test_a_second_stack_does_not_inherit_the_first_stacks_capability(monkeypatch):
+    """The inheritance trap S1 removed from `fill_slot_paths`, checked one registry over."""
+    monkeypatch.setitem(
+        scaffold._STACKS,
+        "node_ts",
+        ScaffoldStack(name="node_ts", expand=lambda m: [], fill_slots=lambda m: ()),
+    )
+
+    assert dev_capability_for("node_ts") == ""
+    assert dev_capability_for(_STACK) == _STACK
+    assert resolve_dev_capability({"build_profile": "node_ts", "dev_capability": "python_cli"}) == (
+        "python_cli"
+    ), "an undeclaring stack must not silently claim the config's value is wrong"


### PR DESCRIPTION
**Stage 1b, step b1** — the first class-(b) item from the 1a sweep, and the only one carrying a design fork. Regression **6868 passed, 1 skipped**.

## The defect

A cycle named its stack in two config keys, indexing two registries, set to the same literal on adjacent CRP lines and bound by convention alone:

```yaml
  dev_capability: fullstack_fastapi_react   # -> DEV_CAPABILITIES
  build_profile:  fullstack_fastapi_react   # -> _STACKS
```

Nothing verified they agreed. The failure is not a crash: **the skeleton expands for one stack while the dev agent is instructed to write another's files**, so every emission lands outside the fill slots and the cycle surfaces as *"the plan claims no slots"* — a symptom several layers from its cause, a full framing workload after the mistake.

Fifth per-stack registry, after `_STACKS`, `_CRITERIA_PACKS`, `_PROFILES` and the sandbox's `_CONTRACTS`.

## Not a collapse — one rule instead

`python_cli`, `python_api` and `react_app` are free-form capabilities for cycles with **no** scaffold stack, so the two registries are not the same set. Not every dev capability is a stack; every stack needs one.

**The stack declares it; the config may restate it but not contradict it.**

| Config | Behavior |
|---|---|
| scaffoldable `build_profile`, `dev_capability` absent | **derived** |
| …agreeing | proceed |
| …**contradicting** | **blocked at create** |
| no scaffoldable `build_profile` | untouched |

**Blocked rather than derived-over**, per #762's precedent: both inputs are knowable at create, the downstream failure is deterministic rather than probable, and silently overriding an explicit config value hides the drift instead of ending it. `resolve_dev_capability` returns `None` for contradiction — deliberately distinct from `""` — so the caller must decide rather than quietly pick a side.

## A second defect the sweep exposed

**Five call sites defaulted an absent `dev_capability` to `"python_cli"`.** A scaffolded fullstack cycle that merely *omitted* the key was handed CLI prompts — an omission rather than a contradiction, so no equality check would ever have caught it. All five now resolve through the stack.

That one was not in the issue; it surfaced while wiring the resolver.

## Tests

Sixteen. The resolution truth table, the create-time block, the message naming both values and the fix, free-form cycles left untouched (a net that false-positives on a working configuration is worse than the gap it closes — #762), and the registry binding that keeps the fifth registry from drifting like the other four.

Closes #832 · Refs #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv