### PR TITLE
refactor(task_plan): injection asks the check what it can parse (#833)

### DIFF
--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -320,6 +320,12 @@ CHECK_CONTRACT_ASSERTIONS = "contract_assertions_match"
 # moves both together.
 CHECK_FILL_SLOT_SIGNATURE = "fill_slot_signature"
 
+# SIP-0100 / #833: the QA harness-boundary check. Named here because `task_plan` filters its
+# injection on the check's own applicability — the same single-source rule as the constants
+# above, and it earns one for the same reason they do: a literal in an injection filter
+# silently injects nothing after a rename.
+CHECK_HARNESS_BOUNDARY = "harness_boundary"
+
 # #822: the per-view bundler check. Named here because `VerificationContract.view_slots`
 # filters on it to identify a stack's view files for repair targeting — the same
 # single-source rule as the constants above, and the same failure mode if it drifts: a

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -34,6 +34,7 @@ from squadops.capabilities.scaffold import (
 from squadops.cycles.acceptance_check_spec import (
     CHECK_CONTRACT_ASSERTIONS,
     CHECK_FILL_SLOT_SIGNATURE,
+    CHECK_HARNESS_BOUNDARY,
     is_check_applicable,
 )
 from squadops.cycles.agent_config import resolve_agent_config
@@ -626,7 +627,12 @@ def _contract_assertion_criteria(
             id=f"contract-assertions:{art}",
         )
         for art in plan_task.expected_artifacts
-        if art.endswith(".py") and is_qa_test_path_for_stack(art, stack)
+        # #833: ask the check whether it can parse this artifact rather than asserting
+        # `.py`. Same boundary, single-sourced at the seam `manifest_gates` and the
+        # dispatch-time strip already use — and it adapts on its own if a non-Python
+        # implementation of the check ever lands.
+        if is_check_applicable(CHECK_CONTRACT_ASSERTIONS, art)
+        and is_qa_test_path_for_stack(art, stack)
     ]
 
 
@@ -652,7 +658,8 @@ def _harness_boundary_criteria(
             id=f"scaffold-harness:{art}",
         )
         for art in plan_task.expected_artifacts
-        if art.endswith(".py") and is_qa_test_path_for_stack(art, stack)
+        if is_check_applicable(CHECK_HARNESS_BOUNDARY, art)
+        and is_qa_test_path_for_stack(art, stack)
     ]
 
 
@@ -681,7 +688,7 @@ def _fill_slot_signature_criteria(
     claimed = [
         art
         for art in plan_task.expected_artifacts
-        if art.endswith(".py") and _normalize(art) in fill
+        if is_check_applicable(CHECK_FILL_SLOT_SIGNATURE, art) and _normalize(art) in fill
     ]
     if not claimed:
         return []

--- a/tests/unit/cycles/test_injection_follows_check_applicability.py
+++ b/tests/unit/cycles/test_injection_follows_check_applicability.py
@@ -1,0 +1,86 @@
+"""Injection asks the check whether it can parse the artifact (#833).
+
+Three sites in `task_plan` filtered on `art.endswith(".py")` before injecting a framework
+check. The literal was **correct** — every check being injected declares
+`applicable_extensions={".py"}` — but it stated the boundary a second time, in a place that
+cannot notice when the first one moves.
+
+Recorded because #833 was filed on the opposite premise, that these were stack #1 layout
+hardwiring undoing a stack-aware seam. They are not: `is_qa_test_path_for_stack` answers
+"is this a QA test path for this stack" and the suffix answered "can the check parse it".
+Both are needed. What was wrong was restating the second one by hand.
+
+Bug classes guarded:
+
+- **the injection filter drifting from the check's declared applicability** — the whole point.
+  If a check gains a `.ts` implementation, injection must follow without anyone remembering
+  this file exists;
+- injecting a check that cannot run, which `manifest_gates` `PROOF_CHECKS_LIVE` would then
+  reject as unwinnable — the manifest gate and this filter must agree, and now they read the
+  same source;
+- **stack #1's plan changing.** These checks are the enforcement surface the release's banked
+  evidence was measured through; the swap must be behavior-identical for `.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.acceptance_check_spec import (
+    CHECK_CONTRACT_ASSERTIONS,
+    CHECK_FILL_SLOT_SIGNATURE,
+    CHECK_HARNESS_BOUNDARY,
+    CHECK_SPECS,
+    is_check_applicable,
+)
+
+pytestmark = [pytest.mark.domain_contracts]
+
+_INJECTED = (CHECK_CONTRACT_ASSERTIONS, CHECK_FILL_SLOT_SIGNATURE, CHECK_HARNESS_BOUNDARY)
+
+
+@pytest.mark.parametrize("check", _INJECTED)
+def test_todays_boundary_is_unchanged_for_python(check):
+    """Behavior-identical for stack #1: every injected check still accepts `.py` and still
+    refuses the suffixes a Python parser cannot read."""
+    assert is_check_applicable(check, "backend/tests/test_runs.py")
+    assert not is_check_applicable(check, "app/api/runs/route.ts")
+    assert not is_check_applicable(check, "frontend/src/views/V.jsx")
+
+
+@pytest.mark.parametrize("check", _INJECTED)
+def test_injection_follows_the_check_when_its_applicability_moves(check, monkeypatch):
+    """The reason for the change. A hand-written `.py` cannot notice that the check learned
+    to parse something else; this reads the declaration, so a future TypeScript implementation
+    is picked up by the injection sites without touching them."""
+    import dataclasses
+
+    spec = CHECK_SPECS[check]
+    monkeypatch.setitem(
+        CHECK_SPECS,
+        check,
+        dataclasses.replace(spec, applicable_extensions=frozenset({".py", ".ts"})),
+    )
+
+    assert is_check_applicable(check, "app/api/runs/route.ts")
+
+
+def test_every_injected_check_is_named_by_a_constant():
+    """A literal in an injection filter silently injects nothing after a rename — the reason
+    the constant block gives for the four names that preceded these."""
+    assert {CHECK_CONTRACT_ASSERTIONS, CHECK_FILL_SLOT_SIGNATURE, CHECK_HARNESS_BOUNDARY} <= set(
+        CHECK_SPECS
+    )
+
+
+def test_the_injection_sites_no_longer_restate_the_suffix():
+    """The drift this closes is textual: a second statement of the boundary in a file that
+    cannot see the first. Asserted against the source so a reintroduction is caught."""
+    from pathlib import Path
+
+    source = (
+        Path(__file__).resolve().parents[3] / "src" / "squadops" / "cycles" / "task_plan.py"
+    ).read_text(encoding="utf-8")
+
+    assert 'endswith(".py") and is_qa_test_path_for_stack' not in source
+    assert 'endswith(".py") and _normalize(art) in fill' not in source


### PR DESCRIPTION
**Stage 1b, steps b2–b4** — delivered far smaller than filed, because the issue's premise was wrong. Regression **6876 passed, 1 skipped**; behavior-identical for stack #1.

## The correction

**Filed as:** stack #1 layout hardwiring — a stack-aware seam ANDed with a literal that undoes it, needing a `source_suffixes` field on `ScaffoldStack`.

**Actually:** the Python-*analysis* boundary, and correct at all six sites.

| Site | What `.py` gates | Verdict |
|---|---|---|
| `task_plan.py:629, 655, 684` | injecting three checks that each declare `applicable_extensions={".py"}` | correct, wrongly expressed |
| `interface_conformance.py:121, 201` | `_model_classes` / `_route_decorators`, both `ast.parse` | correct by construction |
| `scaffold_enforcement.py:236` | restoring `status_code` into a Python decorator; docstring already says *"a non-Python or unparseable artifact passes through untouched"* | correct and documented |

`is_qa_test_path_for_stack` answers *"is this a QA test path for this stack"*; the suffix answered *"can the check parse it"*. Both are needed and neither undoes the other. **Stack #2 loses nothing that was not already disclosed** — the AST tier does not cover TypeScript, which is the S4 disclosure already in the plan.

**So no `source_suffixes` field.** It would have been invented to parameterize something that does not vary by stack — exactly what S5's admission rule exists to prevent.

## What was actually owed

The three `task_plan` sites restated the boundary by hand, in a place that cannot notice when the check's own declaration moves. They now call **`is_check_applicable`** — the same seam `manifest_gates` `PROOF_CHECKS_LIVE` and the dispatch-time strip already use — so the manifest gate and the injection filter read one source, and a future TypeScript implementation of any of those checks is picked up without touching these sites.

`CHECK_HARNESS_BOUNDARY` joins the named-constant block by the criterion those comments already state.

## A method defect in the 1a sweep, recorded on the issue

The sweep classified by **grep hit with one line of context** rather than by reading the enclosing function — the same proximity-for-scope failure as the #822 design gate naming the wrong evaluator.

**Consequence: the class (a)/(c)/(d) calls from Stage 1a carry the same risk and are provisional.** One of the four class-(b) items dissolved on contact; the others were confirmed by implementation. Stage 1c should re-read rather than trust the classification.

Closes #833 · Refs #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv