### PR TITLE
feat(scaffold): the Next.js + TypeScript stack — stack #2 (#822, Stage 1c)

### DIFF
--- a/src/squadops/capabilities/dev_capabilities.py
+++ b/src/squadops/capabilities/dev_capabilities.py
@@ -334,6 +334,87 @@ DEV_CAPABILITIES: dict[str, DevelopmentCapability] = {
         max_completion_tokens=12000,
         test_timeout_seconds=180,
     ),
+    # #822 stack #2. Bound to the scaffold stack of the same name by
+    # ``ScaffoldStack.dev_capability`` (#832), so the two registries can no longer disagree
+    # about which stack a cycle is building.
+    "nextjs_ts": DevelopmentCapability(
+        name="nextjs_ts",
+        system_prompt_supplement=(
+            "You are generating source code for a Next.js (App Router) application in "
+            "TypeScript. One project at the repository root — there is no separate backend "
+            "or frontend tree.\n"
+            "Emit each file as a fenced code block with the language and path separated by "
+            "a colon. Examples:\n"
+            "```typescript:app/api/runs/route.ts\n"
+            "```tsx:app/runs/page.tsx\n\n"
+            "Paths must be clean relative paths with no colons in the path or spaces."
+        ),
+        file_structure_guidance=(
+            "\n\nGenerate complete, runnable source for a Next.js App Router application in "
+            "TypeScript.\n\n"
+            "### Routing\n"
+            "- Server endpoints are ROUTE HANDLERS at app/api/<path>/route.ts, exporting one "
+            "async function per HTTP method (`export async function GET(request: Request)`).\n"
+            "- Do NOT use server actions for endpoints the design declares: they have no "
+            "stable URL, so nothing can address them over HTTP.\n"
+            "- A path parameter is a DIRECTORY in brackets: `/runs/{run_id}` is "
+            "app/api/runs/[run_id]/route.ts. Read it from the second handler argument, "
+            "`{ params }`.\n"
+            "- Pages are app/<path>/page.tsx with a default-exported component. The URL comes "
+            "from the directory; the filename is always page.tsx.\n\n"
+            "### Conventions\n"
+            "- Server-first. Add `'use client'` only to a component that genuinely needs "
+            "browser interactivity — anything rendered on the client is absent from the "
+            "initial HTML.\n"
+            "- Import through the `@/` alias (`@/lib/store`), not long relative chains.\n"
+            "- Return errors through the scaffold-owned envelope in lib/errors.ts. Never "
+            "invent a second error shape.\n"
+            "- Every declared testid must appear as a `data-testid` attribute on the element "
+            "it names.\n"
+            "- TypeScript is strict and `next build` fails on type errors; it is the only "
+            "static check this stack has.\n\n"
+            "### General\n"
+            "- Forward slashes, no colons, no spaces; paths relative to the project root."
+        ),
+        example_structure=(
+            "package.json\n"
+            "tsconfig.json\n"
+            "app/\n"
+            "  layout.tsx\n"
+            "  page.tsx\n"
+            "  api/\n"
+            "    runs/\n"
+            "      route.ts\n"
+            "lib/\n"
+            "  models.ts\n"
+            "  store.ts"
+        ),
+        expected_extensions=(".ts", ".tsx", ".json", ".css"),
+        test_framework=TEST_FRAMEWORK_VITEST,
+        test_prompt_supplement=(
+            "You are generating vitest test files for a Next.js TypeScript application.\n\n"
+            "Import ONLY packages the shipped package.json declares — a suite that fails to "
+            "load fails the whole tests_pass check (#448).\n"
+            "Consume the scaffold-owned store seam (`reset`, `insert`, `all` from "
+            "@/lib/store) rather than reaching into the app entry.\n"
+            "Place tests in __tests__/ with a .test.ts suffix, e.g. "
+            "__tests__/runs.test.ts.\n\n"
+            "Emit each file as a fenced code block with the language and path separated by a "
+            "colon:\n"
+            "```typescript:__tests__/runs.test.ts\n\n"
+            "Paths must be clean relative paths — no colons, no spaces."
+        ),
+        source_filter=(".ts", ".tsx"),
+        test_file_patterns=("*.test.ts", "*.test.tsx", "*.spec.ts", "*.spec.tsx"),
+        build_support_files=(
+            "package.json",
+            "tsconfig.json",
+            "next.config.mjs",
+            "vitest.config.ts",
+        ),
+        max_completion_tokens=12000,
+        test_timeout_seconds=180,
+    ),
 }
 
 

--- a/src/squadops/capabilities/handlers/probe_runner.py
+++ b/src/squadops/capabilities/handlers/probe_runner.py
@@ -106,6 +106,17 @@ DEFAULT_PROFILE = ExecutionProfile(
 #: stack-specific.
 _PROFILES: dict[str, ExecutionProfile] = {
     "fastapi_uvicorn": DEFAULT_PROFILE,
+    # #822 stack #2, and the first consumer of `prepare_argv` (#827). A Next app cannot run
+    # from source: `next build` compiles it, and only then does `next start` serve. Stack #1
+    # is interpreted, so its profile declares no preparation and the step stays inert for it.
+    "nextjs_next_start": ExecutionProfile(
+        # Install *and* build: `next start` serves `.next/`, which only `next build` produces,
+        # so a prepare step that stopped at install would boot into "no production build
+        # found" and report as a boot failure — the exact conflation #827 separated. `sh -c`
+        # for the two-step, matching the sandbox contract's INSTALL_DEPENDENCIES precedent.
+        prepare_argv=("sh", "-c", "npm ci --no-audit --no-fund && npx next build"),
+        boot_argv=("npx", "next", "start", "--port", "{port}"),
+    ),
 }
 
 

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -33,6 +33,15 @@ from typing import Any
 
 import yaml
 
+# #822: stack #2's expander lives in its own module — a second one inline would push this
+# file past 2000 lines and interleave two stacks' source templates. No cycle: it annotates
+# against ``InterfaceManifest`` under ``TYPE_CHECKING`` and imports nothing here at runtime.
+from squadops.capabilities.stack_nextjs_ts import STACK_NAME as _NEXTJS_TS_NAME
+from squadops.capabilities.stack_nextjs_ts import expand_nextjs_ts as _expand_nextjs_ts
+from squadops.capabilities.stack_nextjs_ts import (
+    fill_slots_nextjs_ts as _fill_slots_nextjs_ts,
+)
+
 # Schema v1 is frozen (SIP-0099 phase 99.1): the shape below is the canonical
 # interface-manifest contract the fullstack_fastapi_react expander was proven against
 # in the Phase-0.5 spike. A manifest declaring any other version/kind is rejected at
@@ -1519,6 +1528,28 @@ _STACKS: dict[str, ScaffoldStack] = {
         criteria_pack="fullstack_fastapi_react",
         probe_profile="fastapi_uvicorn",
         dev_capability="fullstack_fastapi_react",
+    ),
+    # #822 stack #2. Imported below rather than defined here: a second expander inline would
+    # push this module past 2000 lines and interleave two stacks' source templates. Extracting
+    # stack #1 to match is a follow-up refactor, deliberately not bundled — it would move
+    # bytes the reference contract is pinned to.
+    _NEXTJS_TS_NAME: ScaffoldStack(
+        name=_NEXTJS_TS_NAME,
+        expand=_expand_nextjs_ts,
+        fill_slots=_fill_slots_nextjs_ts,
+        # Co-located `__tests__/` beside source, not a directory prefix at the tree root —
+        # one of the three FastAPI-shaped assumptions S2 selected this stack to break.
+        qa_test_namespace=("__tests__/", "app/", "lib/"),
+        # Node module resolution has no import boundary between tests and app, so there is
+        # no equivalent of `backend.main` to forbid. Declared empty as a fact, not an omission.
+        harness_entry_modules=(),
+        # Empty: the typed-check evaluators are Python AST implementations and were never
+        # verified against this stack, so they skip rather than being fed a guess (#503's
+        # conservative default, and #822 bend 6).
+        check_stack="",
+        criteria_pack=_NEXTJS_TS_NAME,
+        probe_profile="nextjs_next_start",
+        dev_capability=_NEXTJS_TS_NAME,
     ),
 }
 

--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -220,7 +220,53 @@ def _fastapi_react_slot_criteria(manifest: InterfaceManifest, path: str) -> dict
     return _routes_criteria(manifest) if path == _ROUTES_PATH else _view_criteria(path)
 
 
+def _nextjs_ts_slot_criteria(manifest: InterfaceManifest, path: str) -> dict[str, Any]:
+    """Stack #2 has two kinds of fill slot — API route handlers and pages (#822).
+
+    **Both get the same criterion, and that is the disclosure, not an oversight.** The nine
+    AST checks parse Python by construction, and ``tsc --noEmit`` is safelisted but not
+    provisionable (``tsc`` lives in ``node_modules/.bin``, never on PATH — #707's
+    "passes the allowlist but cannot run" class). ``next build`` runs tsc itself, so
+    ``frontend_compiles`` *is* the type check here, for server and client files alike.
+
+    Anchored per slot rather than once for the tree even though the build is whole-tree:
+    #641/#648 attach it to the file under evaluation so a failure repairs where the defect
+    lives. Bend 5 records the cost — stack #1 pays 3 builds, stack #2 pays 7.
+
+    Consequence stated plainly: **no criterion here proves the declared endpoints exist in
+    the source.** ``endpoint_defined`` is Python-only, so that claim is carried by the
+    behavioral probes alone — late and functionally, rather than early and structurally.
+    """
+    return {
+        "interface": [],
+        "implementation": [
+            {
+                "check": "frontend_compiles",
+                "id": f"vc-compiles-{_slug(path.rsplit('/', 1)[-1].rsplit('.', 1)[0]) or 'root'}",
+                "file": path,
+                "project_dir": ".",
+                "requires": CAP_NODE,
+            }
+        ],
+    }
+
+
 _CRITERIA_PACKS: dict[str, CriteriaPack] = {
+    "nextjs_ts": CriteriaPack(
+        name="nextjs_ts",
+        slot_criteria=_nextjs_ts_slot_criteria,
+        # `next build` at the project root, not `npm run build` in `frontend/` — the
+        # assumption #828 parameterised, exercised here for the first time.
+        build_criteria=lambda: [
+            {"check": "frontend_build", "id": "vc-frontend-builds", "requires": CAP_NODE},
+        ],
+        # vitest, so the suite check requires node rather than python. Stack #1's pack
+        # emitted CAP_PYTHON unconditionally, which would have demanded a Python toolchain
+        # of a stack that has none.
+        suite_criteria=lambda: [
+            {"check": "tests_pass", "id": "vc-suite-passes", "requires": CAP_NODE},
+        ],
+    ),
     "fullstack_fastapi_react": CriteriaPack(
         name="fullstack_fastapi_react",
         slot_criteria=_fastapi_react_slot_criteria,

--- a/src/squadops/capabilities/stack_nextjs_ts.py
+++ b/src/squadops/capabilities/stack_nextjs_ts.py
@@ -1,0 +1,405 @@
+"""The Next.js + TypeScript walking skeleton — stack #2 (#822, Stage 1c).
+
+Its purpose is not "support another language". It is the **acceptance gate for the Stack
+Blueprint SIP**, which declines its own acceptance until a second real stack exists because
+*"generalising from one instance produces the FastAPI contract with generic field names —
+worse than no contract, because it looks authoritative and the second stack will quietly bend
+itself to fit rather than reveal the mismatch."* Every bend recorded below is S3's evidence.
+
+**Parity of ambition with stack #1, deliberately** (#822 gate decision 1): the same seams —
+models, store, errors, an app entry, a client helper, a test harness, routes and views — no
+more and no fewer, with the same frozen/fill split. Writing a *better* skeleton would make
+VS-vs-V5 uninterpretable, because a yield difference would be ambiguous between "the blueprint
+schema generalises" and "stack #2's skeleton is better".
+
+**Why this is a module and stack #1's expander is not.** Stack #1's lives inline in
+``scaffold.py``. A second one there would push that file past 2000 lines and interleave two
+stacks' source templates. Extracting stack #1 to match is a follow-up refactor, deliberately
+not bundled — it would move bytes the reference contract is pinned to.
+
+### Bend register (S3's exit criterion — zero *unexplained* bends)
+
+1. **The API is many fill slots, not one.** FastAPI holds every endpoint in a single
+   ``backend/routes.py``; Next.js requires one file per path segment, so the reference
+   manifest's 5 endpoints become 4 route files, split by path rather than by choice. The
+   blueprint has never expressed this — ``_ROUTES_PATH`` was singular. **Argued as a genuine
+   cross-stack convention:** an API is a set of addressable operations, and how many files
+   hold them is the stack's business. ``endpoint_owners()`` already returns a dict and
+   survives unchanged, which is evidence the relation was modelled correctly even though the
+   partition was not.
+2. **A third path-parameter convention.** ``{run_id}`` (manifest) · ``:run_id`` (Express) ·
+   ``[run_id]`` (Next.js, as a *directory*). The manifest's form stays canonical and the
+   expander translates declared → placed. #820's trigger 3, as predicted.
+3. **``frontend.routes[].view`` has no natural home.** Next derives the URL from the directory
+   and the file is always ``page.tsx``, so a declared component name cannot be a filename. It
+   becomes the exported component's name instead. Recorded as a strain on the manifest —
+   §5c.3's blueprint-owned-design-artifact territory, routed to 1.7.
+4. **Route handlers, not server actions** (#822 gate decision 2). An idiomatic Next app often
+   uses server actions for mutations; they have no stable path, so probes could not address
+   them. Constrained because the manifest speaks HTTP.
+5. **The per-slot bundler check costs a whole-tree build each.** Stack #1 pays 3, stack #2
+   pays 7. Kept at parity anyway: #641/#648 anchor the check to each slot so a failure repairs
+   *where the defect lives*, and dropping that to save builds would trade repair targeting for
+   wall-clock.
+6. **No static check on the API route slots beyond the build.** The nine AST checks are
+   Python-only by construction, and ``tsc --noEmit`` is safelisted but not provisionable —
+   ``tsc`` lives in ``node_modules/.bin``, not on PATH, so emitting it would produce #707's
+   "passes the allowlist but cannot run" class. ``next build`` type-checks by default, so the
+   bundler check is the type check. Disclosed, not worked around: this is S4's territory.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - annotations only, avoids a scaffold import cycle
+    from squadops.capabilities.scaffold import InterfaceManifest
+
+STACK_NAME = "nextjs_ts"
+
+_TS_TYPES = {
+    "str": "string",
+    "string": "string",
+    "text": "string",
+    "int": "number",
+    "integer": "number",
+    "float": "number",
+    "number": "number",
+    "decimal": "number",
+    "bool": "boolean",
+    "boolean": "boolean",
+    "datetime": "string",
+    "date": "string",
+    "time": "string",
+}
+
+
+def _ts_type(raw: str) -> str:
+    """Manifest field type → TypeScript. Unknown types become ``string`` rather than ``any``:
+    ``any`` would silently disable the type checking that is stack #2's entire hygiene tier."""
+    t = (raw or "").strip().lower()
+    inner = re.fullmatch(r"(?:list|array)\[(.+)\]", t)
+    if inner:
+        return f"{_ts_type(inner.group(1))}[]"
+    return _TS_TYPES.get(t, "string")
+
+
+def _segments(path: str) -> str:
+    """``/runs/{run_id}/join`` → ``runs/[run_id]/join`` (bend 2). Frontend routes arrive in
+    ``:id`` form, so both parameter syntaxes translate to Next's bracket directory."""
+    out = []
+    for seg in path.strip("/").split("/"):
+        if not seg:
+            continue
+        if seg.startswith("{") and seg.endswith("}"):
+            out.append(f"[{seg[1:-1]}]")
+        elif seg.startswith(":"):
+            out.append(f"[{seg[1:]}]")
+        else:
+            out.append(seg)
+    return "/".join(out)
+
+
+def _route_groups(manifest: Any) -> dict[str, list[Any]]:
+    """Endpoints grouped by the file that will own them — **bend 1**.
+
+    Insertion-ordered so the emitted file list is deterministic, which the contract's frozen
+    hashes and the golden benchmark both depend on.
+    """
+    groups: dict[str, list[Any]] = {}
+    for ep in manifest.api.endpoints:
+        path = f"app/api/{_segments(ep.path)}/route.ts".replace("//", "/")
+        groups.setdefault(path, []).append(ep)
+    return groups
+
+
+def _page_path(route: Any) -> str:
+    segs = _segments(getattr(route, "path", "/") or "/")
+    return f"app/{segs}/page.tsx" if segs else "app/page.tsx"
+
+
+# --------------------------------------------------------------------------- #
+# Frozen sources
+# --------------------------------------------------------------------------- #
+
+
+def _package_json(manifest: Any) -> str:
+    return (
+        json.dumps(
+            {
+                "name": str(getattr(manifest, "project_id", "app")).replace("_", "-"),
+                "private": True,
+                "scripts": {
+                    "dev": "next dev",
+                    "build": "next build",
+                    "start": "next start",
+                    "test": "vitest run",
+                },
+                "dependencies": {"next": "14.2.5", "react": "18.3.1", "react-dom": "18.3.1"},
+                "devDependencies": {
+                    "@types/node": "20.14.10",
+                    "@types/react": "18.3.3",
+                    "typescript": "5.5.3",
+                    "vitest": "1.6.0",
+                },
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+_TSCONFIG = """{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": { "@/*": ["./*"] },
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}
+"""
+
+_NEXT_CONFIG = """/** @type {import('next').NextConfig} */
+// Type errors fail the build deliberately: `next build` runs tsc, and it is stack #2's
+// entire hygiene tier — the nine AST checks parse Python only. Disabling this would leave
+// the API route slots with no static coverage at all (#822 bend 6).
+const nextConfig = { typescript: { ignoreBuildErrors: false } }
+export default nextConfig
+"""
+
+_VITEST_CONFIG = """import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: { environment: 'node', include: ['**/__tests__/**/*.test.ts'] },
+})
+"""
+
+_HARNESS_TEST = """// Scaffold-owned harness (SIP-0100). QA suites consume the seams this proves, and must
+// not reach past them into the app entry — the boundary that killed pf-25/26 on stack #1.
+import { describe, it, expect } from 'vitest'
+import { reset, insert, all } from '@/lib/store'
+
+describe('scaffold harness', () => {
+  it('provides an isolated store per test', () => {
+    reset()
+    expect(all('__probe')).toHaveLength(0)
+    insert('__probe', { id: 'x' })
+    expect(all('__probe')).toHaveLength(1)
+    reset()
+    expect(all('__probe')).toHaveLength(0)
+  })
+})
+"""
+
+_STORE = """// In-memory persistence, scaffold-owned and frozen. Module-level state reset per test via
+// `reset()` — the coverage expectation the contract states for every stack.
+const tables: Record<string, Record<string, unknown>[]> = {}
+
+export function reset(): void {
+  for (const key of Object.keys(tables)) delete tables[key]
+}
+
+export function all(table: string): Record<string, unknown>[] {
+  return tables[table] ?? []
+}
+
+export function insert(table: string, row: Record<string, unknown>): Record<string, unknown> {
+  ;(tables[table] ??= []).push(row)
+  return row
+}
+
+export function find(table: string, id: string): Record<string, unknown> | undefined {
+  return (tables[table] ?? []).find((r) => r.id === id)
+}
+
+export function nextId(): string {
+  return Math.random().toString(36).slice(2, 10)
+}
+"""
+
+_API_CLIENT = """// Client fetch helper, scaffold-owned. Views consume this rather than calling fetch
+// directly, so the error envelope is parsed in exactly one place.
+export async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    ...init,
+    headers: { 'content-type': 'application/json', ...(init?.headers ?? {}) },
+  })
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) throw new Error(body?.error?.code ?? `http_${res.status}`)
+  return body as T
+}
+"""
+
+_LAYOUT = """export const metadata = { title: 'app' }
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}
+"""
+
+
+def _models_source(manifest: Any) -> str:
+    lines = [
+        "// Entity types, derived from the interface manifest. Scaffold-owned and frozen:",
+        "// the fill slots import these rather than restating field names (#822).",
+        "",
+    ]
+    for entity in getattr(manifest, "entities", ()) or ():
+        lines.append(f"export interface {entity.name} {{")
+        for field in entity.fields:
+            optional = "" if getattr(field, "required", True) else "?"
+            lines.append(f"  {field.name}{optional}: {_ts_type(getattr(field, 'type', 'str'))}")
+        lines.append("}")
+        lines.append("")
+    for shape in getattr(manifest.api, "request_shapes", ()) or ():
+        lines.append(f"export interface {shape.name} {{")
+        for name in shape.required:
+            lines.append(f"  {name}: string")
+        for name in getattr(shape, "optional", ()) or ():
+            lines.append(f"  {name}?: string")
+        lines.append("}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _errors_source(manifest: Any) -> str:
+    contract = getattr(manifest.api, "error_contract", None)
+    codes = list(getattr(contract, "codes", ()) or ()) if contract else []
+    mapping = ",\n".join(f"  {c.code}: {c.http}" for c in codes)
+    return f"""// Error envelope and code→status map, derived from the manifest's error contract.
+// Frozen: a route that invents its own envelope breaks every probe that asserts on it.
+export const ERROR_STATUS: Record<string, number> = {{
+{mapping}
+}}
+
+export class ApiError extends Error {{
+  constructor(
+    public code: string,
+    public detail: string = '',
+  ) {{
+    super(code)
+  }}
+}}
+
+export function errorResponse(err: unknown): Response {{
+  const code = err instanceof ApiError ? err.code : 'internal_error'
+  const status = ERROR_STATUS[code] ?? 500
+  const detail = err instanceof ApiError ? err.detail : ''
+  return Response.json({{ error: {{ code, detail }} }}, {{ status }})
+}}
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Fill slots — stubs that FAIL, by construction
+# --------------------------------------------------------------------------- #
+
+
+def _route_stub(path: str, endpoints: list[Any]) -> str:
+    """A route file exporting one handler per declared method.
+
+    Stubs throw rather than return: the bare skeleton must fail its probes, or the
+    behavioral gate would measure the scaffold instead of the fill (SIP-0098 §7).
+    """
+    head = [
+        "// FILL SLOT. Implement each exported handler against the declared contract.",
+        "// The scaffold owns the signatures, the error envelope and the store; fill bodies only.",
+        "import { ApiError, errorResponse } from '@/lib/errors'",
+        "import * as store from '@/lib/store'",
+        "",
+        f"// Declared here: {', '.join(f'{e.method} {e.path}' for e in endpoints)}",
+        "",
+    ]
+    body = []
+    for ep in endpoints:
+        status = getattr(ep, "success_status", None) or 200
+        body += [
+            f"export async function {ep.method.upper()}(request: Request) {{",
+            "  try {",
+            f"    // TODO: implement {ep.method} {ep.path} — respond {status}",
+            f"    throw new ApiError('not_implemented', '{ep.method} {ep.path}')",
+            "  } catch (err) {",
+            "    return errorResponse(err)",
+            "  }",
+            "}",
+            "",
+        ]
+    return "\n".join(head + body)
+
+
+def _page_stub(route: Any) -> str:
+    view = getattr(route, "view", None) or "Page"
+    testids = list(getattr(route, "testids", ()) or ())
+    anchors = "\n".join(f"      {{/* required anchor: {t} */}}" for t in testids)
+    return f"""// FILL SLOT. Render this route's view. Every declared testid below must appear as a
+// `data-testid` on the element it names — the QA suite queries them and nothing else.
+'use client'
+
+import {{ api }} from '@/lib/api'
+
+export default function {view}() {{
+  // TODO: implement. Declared anchors: {", ".join(testids) or "none"}
+  return (
+    <main>
+{anchors}
+    </main>
+  )
+}}
+"""
+
+
+# --------------------------------------------------------------------------- #
+# The expander
+# --------------------------------------------------------------------------- #
+
+
+def expand_nextjs_ts(manifest: InterfaceManifest) -> list[dict[str, str]]:
+    """Manifest → the Next.js walking skeleton, frozen files and fill slots together."""
+    files: list[dict[str, str]] = [
+        {"name": "package.json", "content": _package_json(manifest)},
+        {"name": "tsconfig.json", "content": _TSCONFIG},
+        {"name": "next.config.mjs", "content": _NEXT_CONFIG},
+        {"name": "vitest.config.ts", "content": _VITEST_CONFIG},
+        {"name": "lib/models.ts", "content": _models_source(manifest)},
+        {"name": "lib/store.ts", "content": _STORE},
+        {"name": "lib/errors.ts", "content": _errors_source(manifest)},
+        {"name": "lib/api.ts", "content": _API_CLIENT},
+        {"name": "app/layout.tsx", "content": _LAYOUT},
+        {"name": "__tests__/harness.test.ts", "content": _HARNESS_TEST},
+    ]
+    for path, endpoints in _route_groups(manifest).items():
+        files.append({"name": path, "content": _route_stub(path, endpoints)})
+    for route in getattr(manifest.frontend, "routes", ()) or ():
+        files.append({"name": _page_path(route), "content": _page_stub(route)})
+    return files
+
+
+def fill_slots_nextjs_ts(manifest: InterfaceManifest) -> tuple[str, ...]:
+    """The files a dev fills bodies into: every route handler and every page.
+
+    **Bend 1 lives here.** Stack #1 returns one routes file plus its views; this returns *n*
+    route files, because Next derives the URL from the directory and an API with five
+    endpoints across four paths is four files whether or not the blueprint expected it.
+    """
+    routes = tuple(_route_groups(manifest))
+    pages = tuple(
+        dict.fromkeys(_page_path(r) for r in (getattr(manifest.frontend, "routes", ()) or ()))
+    )
+    return routes + pages

--- a/src/squadops/sandbox/environment.py
+++ b/src/squadops/sandbox/environment.py
@@ -123,8 +123,38 @@ FULLSTACK_FASTAPI_REACT = EnvironmentContract(
     install_network="bridge",
 )
 
+# #822 stack #2. Same image family as stack #1 — the sandbox env already carries Node 20 and
+# npm 10 for the frontend build, so no new language runtime enters the pipeline. What differs
+# is every command: one project at the root instead of two trees, and a build step the
+# application itself cannot start without.
+NEXTJS_TS = EnvironmentContract(
+    stack="nextjs_ts",
+    image="squadops-sandbox-env:fastapi-react-1.4-dev",
+    required_tools=(("node", "20"), ("npm", "10")),
+    operation_commands=(
+        (OperationName.INSTALL_DEPENDENCIES, ("npm", "ci", "--no-audit", "--no-fund")),
+        (OperationName.BUILD_FRONTEND, ("npx", "next", "build")),
+        (OperationName.RUN_BACKEND_TESTS, ("npx", "vitest", "run")),
+        (
+            OperationName.START_APPLICATION,
+            (
+                "npx",
+                "next",
+                "start",
+                "--hostname",
+                "0.0.0.0",  # noqa: S104 — inside the container; host publish is loopback-only
+                "--port",
+                "8000",
+            ),
+        ),
+    ),
+    app_port=8000,
+    install_network="bridge",
+)
+
+
 _CONTRACTS: dict[str, EnvironmentContract] = {
-    contract.stack: contract for contract in (FULLSTACK_FASTAPI_REACT,)
+    contract.stack: contract for contract in (FULLSTACK_FASTAPI_REACT, NEXTJS_TS)
 }
 
 

--- a/tests/unit/capabilities/test_dev_capabilities.py
+++ b/tests/unit/capabilities/test_dev_capabilities.py
@@ -209,8 +209,12 @@ class TestTokenBudgetFields:
 
 
 class TestRegistryCompleteness:
-    def test_registry_has_four_capabilities(self):
-        assert len(DEV_CAPABILITIES) == 4
+    # #822: `assert len(DEV_CAPABILITIES) == 4` was removed rather than bumped to 5. A count
+    # names no bug class, breaks on every legitimate addition, and is the shape
+    # docs/TEST_QUALITY_STANDARD.md rules out. What it appeared to protect — that every
+    # registered capability is well formed and reachable — is covered by the tests below, and
+    # the binding that actually matters (every scaffold stack names a capability that exists)
+    # is pinned in tests/unit/cycles/test_stack_dev_capability.py (#832).
 
     def test_all_are_capability_instances(self):
         for name, cap in DEV_CAPABILITIES.items():

--- a/tests/unit/capabilities/test_source_artifact_materialization.py
+++ b/tests/unit/capabilities/test_source_artifact_materialization.py
@@ -80,7 +80,12 @@ def test_frontend_capabilities_declare_build_support():
     assert frontend_caps, "expected at least one vitest/both capability"
     for cap in frontend_caps:
         assert "package.json" in cap.build_support_files, f"{cap.name} missing package.json"
-        assert "index.html" in cap.build_support_files, f"{cap.name} missing index.html"
+        # #822: `index.html` was asserted for every frontend capability. That is VITE's entry
+        # point, not a property of frontends — Next.js generates its HTML and ships no
+        # index.html, so requiring it would force a capability to declare a file its stack
+        # does not have. The real invariant, and the one #290 was about, is package.json:
+        # without it npm cannot resolve anything and vitest silently skips.
+        assert cap.build_support_files, f"{cap.name} declares no build support files"
 
 
 def test_get_capability_default_build_support_empty():

--- a/tests/unit/capabilities/test_stack_nextjs_ts.py
+++ b/tests/unit/capabilities/test_stack_nextjs_ts.py
@@ -1,0 +1,240 @@
+"""Stack #2 — the Next.js + TypeScript skeleton (#822, Stage 1c).
+
+The second real stack the Stack Blueprint SIP's acceptance gate requires. What matters here is
+not that it expands, but *where it disagrees with stack #1* — those disagreements are S3's
+evidence, and a test suite that only proved it works would hide them.
+
+Bug classes guarded:
+
+- **stack #1 moving.** Its contract and manifest hashes are what every bind-mode cycle and the
+  1.4 banked evidence key on; a second registration must be inert for it;
+- **the API collapsing to one fill slot** (bend 1). Next derives the URL from the directory, so
+  five endpoints across four paths are four files. A partition that returned one would put
+  every endpoint in a file that cannot serve them;
+- **path parameters surviving untranslated** (bend 2) — `{run_id}` reaching disk would create a
+  literal `{run_id}` directory that Next never routes;
+- **the skeleton passing its own probes.** A stub that returns success would make the
+  behavioral gate measure the scaffold instead of the fill (SIP-0098 §7);
+- a fill slot that is not expanded, or an expanded file claimed as a slot — the two halves
+  disagreeing is how a plan claims a file that does not exist;
+- **the pack demanding Python of a stack that has none**, which is what stack #1's
+  `tests_pass: CAP_PYTHON` would have done before #818 gave each stack its own pack;
+- the five per-stack registries drifting apart.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from squadops.capabilities import scaffold, scaffold_contract
+from squadops.capabilities.dev_capabilities import DEV_CAPABILITIES, TEST_FRAMEWORK_VITEST
+from squadops.capabilities.handlers import probe_runner as pr
+from squadops.capabilities.scaffold import InterfaceManifest, expand, fill_slot_paths
+from squadops.capabilities.scaffold_contract import emit_contract_dict, emit_contract_yaml
+from squadops.sandbox.environment import get_environment_contract
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_STACK = "nextjs_ts"
+_REFERENCE_SRC = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+).read_text(encoding="utf-8")
+
+
+def _manifest(stack: str = _STACK) -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_REFERENCE_SRC.replace("fullstack_fastapi_react", stack))
+
+
+def _names(manifest: InterfaceManifest) -> list[str]:
+    return [f["name"] for f in expand(manifest)]
+
+
+# --------------------------------------------------------------------------- #
+# Stack #1 is untouched
+# --------------------------------------------------------------------------- #
+
+
+def test_registering_a_second_stack_leaves_the_first_byte_identical():
+    """The release's banked evidence is bound to these two hashes."""
+    reference = _manifest("fullstack_fastapi_react")
+
+    assert reference.content_hash().startswith("bb472e267e53d5ad")
+    assert (
+        hashlib.sha256(emit_contract_yaml(reference).encode())
+        .hexdigest()
+        .startswith("7622f570c949fe95")
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Bend 1 — the API is many fill slots
+# --------------------------------------------------------------------------- #
+
+
+def test_five_endpoints_across_four_paths_become_four_route_files():
+    """The structural disagreement between the two stacks, and the most valuable thing this
+    stack surfaces. Stack #1 holds every endpoint in one `backend/routes.py`."""
+    manifest = _manifest()
+    routes = [p for p in fill_slot_paths(manifest) if p.startswith("app/api/")]
+
+    assert len(manifest.api.endpoints) == 5
+    assert routes == [
+        "app/api/runs/route.ts",
+        "app/api/runs/[run_id]/route.ts",
+        "app/api/runs/[run_id]/join/route.ts",
+        "app/api/runs/[run_id]/leave/route.ts",
+    ]
+
+
+def test_the_two_endpoints_sharing_a_path_share_a_file():
+    """`GET /runs` and `POST /runs` are one file exporting two handlers — the grouping is by
+    path, which is what makes the count four rather than five."""
+    content = next(
+        f["content"] for f in expand(_manifest()) if f["name"] == "app/api/runs/route.ts"
+    )
+
+    assert "export async function GET(" in content
+    assert "export async function POST(" in content
+
+
+def test_the_contract_names_every_route_file_as_a_fill_slot():
+    """A slot the contract does not cover ships unverified; a covered path that is not
+    expanded is a plan claiming a file that does not exist."""
+    manifest = _manifest()
+    contract = emit_contract_dict(manifest)
+
+    assert set(contract["fill_files"]) == set(fill_slot_paths(manifest))
+    assert set(fill_slot_paths(manifest)) <= set(_names(manifest))
+
+
+# --------------------------------------------------------------------------- #
+# Bend 2 — path parameters translate
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("declared", "placed"),
+    [("{run_id}", "[run_id]"), (":id", "[id]")],
+)
+def test_declared_path_parameters_are_placed_as_bracket_directories(declared, placed):
+    """Third convention after `{run_id}` and Express's `:run_id` (#820 trigger 3). An
+    untranslated parameter creates a literal directory Next never routes."""
+    names = " ".join(_names(_manifest()))
+
+    assert placed in names
+    assert declared not in names
+
+
+# --------------------------------------------------------------------------- #
+# The skeleton must fail its own probes
+# --------------------------------------------------------------------------- #
+
+
+def test_every_route_stub_throws_rather_than_returning_success():
+    """SIP-0098 §7: if the bare skeleton answered its probes, the behavioral gate would be
+    measuring the scaffold instead of the fill."""
+    stubs = [
+        f["content"]
+        for f in expand(_manifest())
+        if f["name"].startswith("app/api/") and f["name"].endswith("route.ts")
+    ]
+
+    assert stubs
+    for content in stubs:
+        assert "not_implemented" in content
+        assert "TODO" in content
+
+
+def test_the_declared_testids_reach_the_page_stub_as_required_anchors():
+    """The QA suite queries these and nothing else; a stub that omitted them would leave the
+    dev agent to rediscover them from the manifest it is not given."""
+    page = next(f["content"] for f in expand(_manifest()) if f["name"] == "app/create/page.tsx")
+
+    assert "create-run-form" in page
+
+
+def test_the_frozen_package_declares_the_scripts_the_contract_runs():
+    """`frontend_build` shells `npm run build` and the suite runs vitest; a package.json
+    missing either turns both into environment skips rather than evidence."""
+    pkg = json.loads(next(f["content"] for f in expand(_manifest()) if f["name"] == "package.json"))
+
+    assert pkg["scripts"]["build"] == "next build"
+    assert pkg["scripts"]["start"] == "next start"
+    assert "vitest" in pkg["devDependencies"]
+
+
+# --------------------------------------------------------------------------- #
+# The pack
+# --------------------------------------------------------------------------- #
+
+
+def test_the_pack_requires_node_and_never_python():
+    """Stack #1's pack emitted `tests_pass: CAP_PYTHON` unconditionally. Before #818 gave each
+    stack its own pack, that demanded a Python toolchain of a stack that has none."""
+    contract = emit_contract_dict(_manifest())
+
+    assert contract["capabilities"] == ["node"]
+    assert all(
+        c["requires"] == "node"
+        for c in (*contract["behavioral"]["build"], *contract["behavioral"]["suite"]["checks"])
+    )
+
+
+def test_every_fill_slot_carries_the_build_anchored_to_itself():
+    """#641/#648: the check is attached to the file under evaluation so a failure repairs
+    where the defect lives. Bend 5 records what that costs — seven whole-tree builds."""
+    contract = emit_contract_dict(_manifest())
+
+    for path, spec in contract["fill_files"].items():
+        checks = [c for c in spec["implementation"] if c["check"] == "frontend_compiles"]
+        assert checks, f"{path} has no static check at all"
+        assert checks[0]["file"] == path
+        assert checks[0]["project_dir"] == ".", "Next builds at the root, not in frontend/"
+
+
+def test_the_behavioral_probes_transfer_unchanged():
+    """S2's HTTP-constant containment paying off: probes are manifest-derived, so both stacks
+    get the same five. This is the only tier that proves the endpoints answer."""
+    assert len(emit_contract_dict(_manifest())["behavioral"]["probes"]) == len(
+        emit_contract_dict(_manifest("fullstack_fastapi_react"))["behavioral"]["probes"]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Five registries, one stack
+# --------------------------------------------------------------------------- #
+
+
+def test_the_stack_is_answered_by_every_registry():
+    """Scaffold, criteria pack, probe profile, sandbox environment, dev capability. Forgetting
+    one produces a plausible wrong answer rather than an error — the S1 failure, now guarded
+    across all five."""
+    stack = scaffold._STACKS[_STACK]
+
+    assert stack.criteria_pack in scaffold_contract._CRITERIA_PACKS
+    assert stack.probe_profile in pr._PROFILES
+    assert stack.dev_capability in DEV_CAPABILITIES
+    assert get_environment_contract(_STACK).app_port == 8000
+    assert DEV_CAPABILITIES[stack.dev_capability].test_framework == TEST_FRAMEWORK_VITEST
+
+
+def test_the_probe_profile_builds_before_it_boots():
+    """`next start` serves `.next/`, which only `next build` produces. A profile that stopped
+    at install would boot into "no production build found" and report it as a boot failure —
+    the conflation #827 separated."""
+    profile = pr.profile_for_stack(_STACK)
+
+    assert profile is not None
+    assert "next build" in " ".join(profile.prepare_argv)
+    assert "start" in profile.boot_argv
+
+
+def test_the_typed_check_vocabulary_is_declared_empty_not_guessed():
+    """#503's conservative default. The AST evaluators are Python implementations never
+    verified against this stack, so its checks must skip rather than be fed a guess."""
+    assert scaffold.check_stack_for(_STACK) is None
+    assert scaffold.check_stack_for("fullstack_fastapi_react") == "fastapi"

--- a/tests/unit/capabilities/test_stack_registry.py
+++ b/tests/unit/capabilities/test_stack_registry.py
@@ -162,7 +162,13 @@ def test_the_manifest_hash_every_bound_cycle_keys_on_did_not_move():
 
 def test_the_registry_is_the_single_answer_to_which_stacks_exist():
     """The point of the consolidation. A second declaration elsewhere is how the five facts
-    drifted apart in the first place."""
-    assert set(scaffold._STACKS) == {"fullstack_fastapi_react"}
+    drifted apart in the first place.
+
+    #822: pinned to a single stack until stack #2 registered. The invariant was never the
+    *count* — it is that membership has one source — so it now asserts both known stacks are
+    answered from here and that the accessor still refuses everything else."""
+    assert set(scaffold._STACKS) == {"fullstack_fastapi_react", "nextjs_ts"}
     assert is_scaffoldable_stack("fullstack_fastapi_react")
+    assert is_scaffoldable_stack("nextjs_ts")
     assert not is_scaffoldable_stack("")
+    assert not is_scaffoldable_stack("nextjs")


### PR DESCRIPTION
**Stage 1c.** Expander, criteria pack, probe profile, sandbox environment contract and dev capability — all five per-stack registries. Stack #1 byte-unmoved (`7622f570c949fe95` / `bb472e267e53d5ad`); regression **6890 passed, 1 skipped**.

17 files, 7 fill slots, against stack #1's 19 and 4. **Parity of ambition deliberately** — a better skeleton would make VS-vs-V5 uninterpretable.

## The bend that matters

**The API is many fill slots, not one.** FastAPI holds every endpoint in a single `backend/routes.py`. Next derives the URL from the directory, so the reference manifest's five endpoints become **four route files**:

```
app/api/runs/route.ts                  <- GET /runs + POST /runs
app/api/runs/[run_id]/route.ts
app/api/runs/[run_id]/join/route.ts
app/api/runs/[run_id]/leave/route.ts
```

The blueprint never expressed this — `_ROUTES_PATH` was singular. **Argued as a genuine cross-stack convention rather than a concession:** an API is a set of addressable operations, and how many files hold them is the stack's business. Supporting evidence — `endpoint_owners()` already returned a *dict* and survives unchanged, so the relation was modelled correctly even while the partition was not.

Five more bends are in the module docstring, including two disclosures: the per-slot bundler check costs seven whole-tree builds (kept at parity because #641/#648 anchor blame to the failing file), and **the route slots have no static check beyond the build** — the nine AST checks parse Python by construction, and `tsc --noEmit` is safelisted but *not provisionable* (`tsc` lives in `node_modules/.bin`, never on PATH — #707's "passes the allowlist but cannot run" class). `next build` runs tsc itself, so the bundler check is the type check.

## The two earlier seams pay off

**#827's `prepare_argv`** gets its first consumer: `next start` serves `.next/`, which only `next build` produces. A profile stopping at install would boot into *"no production build found"* and report it as a boot failure — exactly the conflation #827 separated.

**#828's `project_dir`** likewise: the pack emits `"."` because Next builds at the root.

## Three stack-#1-pinned tests updated — flagging for scrutiny

**The 1a sweep covered `src/` and `adapters/` but not `tests/`.** Tests encode stack assumptions too, and three did:

| Test | Change |
|---|---|
| `..._single_answer_to_which_stacks_exist` | asserted the set was exactly one stack. The invariant was never the *count* — it is that membership has one source — so it now asserts both, plus that the accessor still refuses a near-miss |
| `test_frontend_capabilities_declare_build_support` | required `index.html` of every frontend capability. That is **Vite's** entry point, not a property of frontends; Next generates its HTML and ships none, so the assertion would have forced a capability to declare a file its stack does not have. `package.json` — the real #290 invariant — is kept |
| `test_registry_has_four_capabilities` | **removed**, not bumped to 5. A count names no bug class, breaks on every legitimate addition, and is the shape `docs/TEST_QUALITY_STANDARD.md` rules out. What it appeared to protect is covered by its neighbours; the binding that matters is pinned by #832's test |

The removal is the one worth arguing about, so it is called out rather than buried.

## Fifteen new tests

Written against where the two stacks *disagree*, not that this one works — a suite that only proved it works would hide the evidence S3 needs. Includes the four-route-file partition, both parameter translations, the stubs failing their own probes (SIP-0098 §7), the pack requiring node and never python, and all five registries answering for the stack.

## Next

**1c-iv/v** are done as part of this. Remaining in Stage 1: **1d** (bend register — currently in the module docstring; S3 may want it as its own document) and **1e/VS** — a Next.js cycle end to end, which needs a deploy.

Refs #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv