### PR TITLE
feat(gates): a manifest must be for the stack the cycle is building (#838)

### DIFF
--- a/src/squadops/capabilities/handlers/planning/manifest.py
+++ b/src/squadops/capabilities/handlers/planning/manifest.py
@@ -100,7 +100,9 @@ class DevelopmentAuthorManifestHandler(_PlanningTaskHandler):
                     f"No `{SEEDED_MANIFEST_FILENAME}` block was found in your response. "
                     f"Emit exactly one fenced block whose header carries that filename."
                 )
-            outcome = assess_authoring_outcome(yaml_or_none)
+            # #838: the gate compares the declared stack to the one this cycle is
+            # configured for. `stack` is already resolved above for the prompt.
+            outcome = assess_authoring_outcome(yaml_or_none, stack)
             outcomes.append(outcome)
             if not outcome.rejected:
                 return yaml_or_none, None

--- a/src/squadops/cycles/authoring_failure.py
+++ b/src/squadops/cycles/authoring_failure.py
@@ -35,6 +35,7 @@ from squadops.cycles.manifest_gates import (
     PROOF_LINT,
     PROOF_PARSES,
     PROOF_SOURCE_PRD,
+    PROOF_STACK_MATCHES_CONFIG,
     PROOF_STATUS_DECLARED,
     PROOF_TESTID_COVERAGE,
     WinnabilityFinding,
@@ -86,6 +87,13 @@ _PROOF_CLASS: dict[str, str] = {
     PROOF_TESTID_COVERAGE: AUTHORING_DEFECT,
     PROOF_STATUS_DECLARED: AUTHORING_DEFECT,
     PROOF_EXPANDS: AUTHORING_DEFECT,
+    # #838: the author wrote another stack's name. Classified as an authoring defect
+    # because a retry with the rejection in hand is the right response -- but VS showed
+    # the cause upstream: the design stage is never told the stack, so the author
+    # inherited the wrong architecture from a technical design that named it eight
+    # times. If this class RECURS once that plumbing lands, it is a blueprint_limitation
+    # instead, and B1's recurrence data is what tells the two apart.
+    PROOF_STACK_MATCHES_CONFIG: AUTHORING_DEFECT,
     # Derivation succeeded structurally but produced something unusable, on a manifest
     # that already passed lint and expansion. That is the deriver's problem by
     # elimination, not the author's.
@@ -155,7 +163,7 @@ def classify_finding(finding: WinnabilityFinding) -> ClassifiedFinding:
     )
 
 
-def assess_authoring_outcome(manifest_content: str) -> AuthoringOutcome:
+def assess_authoring_outcome(manifest_content: str, expected_stack: str = "") -> AuthoringOutcome:
     """Run both gates and classify everything they say about this manifest.
 
     Also reads the manifest's **declared uncertainty**. An ``unresolved`` decision
@@ -178,7 +186,10 @@ def assess_authoring_outcome(manifest_content: str) -> AuthoringOutcome:
         # parsed manifest, so the parse failure returns alone.
         return AuthoringOutcome(findings=tuple(classify_finding(f) for f in schema))
 
-    findings = tuple(classify_finding(f) for f in (*schema, *assess_winnability(manifest_content)))
+    findings = tuple(
+        classify_finding(f)
+        for f in (*schema, *assess_winnability(manifest_content, expected_stack))
+    )
     return AuthoringOutcome(findings=findings, open_questions=_open_questions(manifest_content))
 
 

--- a/src/squadops/cycles/manifest_authoring_rules.py
+++ b/src/squadops/cycles/manifest_authoring_rules.py
@@ -30,6 +30,7 @@ from squadops.cycles.manifest_gates import (
     PROOF_LINT,
     PROOF_PARSES,
     PROOF_SOURCE_PRD,
+    PROOF_STACK_MATCHES_CONFIG,
     PROOF_STATUS_DECLARED,
     PROOF_TESTID_COVERAGE,
 )
@@ -46,6 +47,12 @@ AUTHOR_FACING: dict[str, tuple[str, ...]] = {
     PROOF_STATUS_DECLARED: ("declare-the-success-status",),
     PROOF_SOURCE_PRD: ("name-the-source-prd",),
     PROOF_DECISION_RECORD: ("record-judgments-with-warrants",),
+    # #838: AUTHOR_FACING rather than COVERED_ELSEWHERE, though the authoring request's
+    # schema block does render `stack: {{stack}}`. VS falsified the idea that rendering
+    # it is teaching it: the author saw that line and wrote another stack's name anyway,
+    # having inherited it from a technical design that named the other one eight times.
+    # Filing it as already-covered would assert a teaching that has been measured failing.
+    PROOF_STACK_MATCHES_CONFIG: ("use-the-stack-you-were-given",),
 }
 
 # Proofs an author is already taught by a different managed asset. Restating them would put

--- a/src/squadops/cycles/manifest_gates.py
+++ b/src/squadops/cycles/manifest_gates.py
@@ -38,6 +38,10 @@ PROOF_CONTRACT_DERIVES = "contract_derives"
 PROOF_CHECKS_LIVE = "checks_live"
 PROOF_TESTID_COVERAGE = "testid_coverage"
 PROOF_STATUS_DECLARED = "status_declared"
+#: #838: the manifest declares its own stack, and until VS nothing compared that to the
+#: stack the CYCLE was configured for. A manifest for another stack is unwinnable in the
+#: most literal sense — the expander builds a different application.
+PROOF_STACK_MATCHES_CONFIG = "stack_matches_config"
 
 #: Schema-gate proof classes (M2). ``PROOF_SOURCE_PRD`` was ``PROOF_PROVENANCE`` until #803
 #: gave the manifest an actual ``provenance`` block — one word for "where the design came
@@ -55,7 +59,9 @@ class WinnabilityFinding:
     detail: str
 
 
-def assess_winnability(manifest_content: str) -> tuple[WinnabilityFinding, ...]:
+def assess_winnability(
+    manifest_content: str, expected_stack: str = ""
+) -> tuple[WinnabilityFinding, ...]:
     """Every closed-surface proof this manifest fails, in order.
 
     All proofs run; findings accumulate. Short-circuiting on the first failure would
@@ -64,6 +70,10 @@ def assess_winnability(manifest_content: str) -> tuple[WinnabilityFinding, ...]:
 
     A parse failure is the one exception — nothing downstream can run without a parsed
     manifest, so it returns alone.
+
+    ``expected_stack`` is the cycle's configured ``build_profile``. Empty skips the check —
+    a seeded cycle and the gate's own adversarial fixtures have no cycle config to compare
+    against, and inventing a mismatch for them would reject manifests that are correct.
     """
     from squadops.capabilities.scaffold import InterfaceManifest
 
@@ -77,6 +87,15 @@ def assess_winnability(manifest_content: str) -> tuple[WinnabilityFinding, ...]:
                 f"shape ({exc}). Fix the document structure before the other checks can run.",
             ),
         )
+
+    # #838: a wrong stack returns ALONE, like a parse failure and for the same reason —
+    # it invalidates the frame every other proof reasons in. The remaining proofs would run
+    # happily against the wrong application and report real-looking findings about testids
+    # and statuses for a design that is about to be replaced wholesale. Telling an author to
+    # fix a testid in a manifest whose stack is wrong is worse than telling them nothing.
+    stack_findings = _stack_findings(manifest, expected_stack)
+    if stack_findings:
+        return tuple(stack_findings)
 
     findings: list[WinnabilityFinding] = []
     findings.extend(_lint_findings(manifest))
@@ -259,6 +278,34 @@ def _contract_findings(manifest) -> list[WinnabilityFinding]:
                         )
                     )
     return findings
+
+
+def _stack_findings(manifest, expected_stack: str) -> list[WinnabilityFinding]:
+    """The manifest must be for the stack this cycle is building (#838).
+
+    Found by VS: `cyc_afa934886acd` was configured `build_profile=nextjs_ts`, the manifest
+    declared `fullstack_fastapi_react`, and **every component behaved correctly while building
+    the wrong application for 75 minutes**. `lint()` accepts any *registered* stack — is it
+    known, never is it the one asked for — so nothing downstream had a reason to object.
+
+    The author is told the target (the authoring template renders it), but it lost to a
+    technical design that named the other stack eight times; the design stage is not told the
+    stack at all. That plumbing is a separate fix. This proof is the deterministic backstop
+    that holds regardless of what any model writes, and it turns a 75-minute discovery into a
+    seconds-long one.
+    """
+    declared = str(getattr(manifest, "stack", "") or "")
+    if not expected_stack or declared == expected_stack:
+        return []
+    return [
+        WinnabilityFinding(
+            PROOF_STACK_MATCHES_CONFIG,
+            f"this manifest declares `stack: {declared}` but the cycle is configured to build "
+            f"`{expected_stack}`. The expander would produce a different application than the "
+            f"one requested — every file, every fill slot, and every derived check would be "
+            f"for the wrong stack. Declare `stack: {expected_stack}`.",
+        )
+    ]
 
 
 def _testid_findings(manifest) -> list[WinnabilityFinding]:

--- a/src/squadops/prompts/request_templates/request.manifest_authoring_rules_appendix.md
+++ b/src/squadops/prompts/request_templates/request.manifest_authoring_rules_appendix.md
@@ -10,6 +10,15 @@ checkable from the document you are writing — none depend on how the build tur
 manifest that breaks one is rejected before any code is written, and the rejection is
 returned to you with the specific defect.
 
+**use-the-stack-you-were-given** — The `stack:` field carries exactly the value the
+request gave you, and nothing else. It is not a design choice: it names the scaffold that
+will expand your manifest, and it has already been decided by the cycle. Declaring a
+different one produces a working manifest for an application nobody asked for — the expander
+builds that other stack's files, the plan claims them correctly, and the mismatch surfaces
+hours later as an unrelated failure. If the technical design you were given describes a
+different architecture than the stack you were given, **the stack wins** and the design is
+the thing that was wrong.
+
 **nothing-undeclared** — Every name the manifest uses is declared inside it. An endpoint's
 `request` names a declared `request_shapes` entry or entity; an endpoint's `response` names
 a declared entity (write `list[Entity]` for a collection, unquoted); every frontend route

--- a/tests/unit/cycles/test_stack_matches_config.py
+++ b/tests/unit/cycles/test_stack_matches_config.py
@@ -1,0 +1,147 @@
+"""The manifest must be for the stack the cycle is building (#838).
+
+Found by VS (#822 Stage 1e), `cyc_afa934886acd`: configured `build_profile=nextjs_ts`, the
+authored manifest declared `fullstack_fastapi_react`, and **every component behaved correctly
+while building the wrong application for 75 minutes**. `lint()` accepts any *registered*
+stack — is it known, never is it the one asked for — so nothing downstream had a reason to
+object, and the rejection that eventually fired was incidental (a frozen-file claim) rather
+than the real problem.
+
+The author *is* told the target, but it lost to a technical design that named the other stack
+eight times, produced by a stage that is never told the stack at all. That plumbing is a
+separate fix in the same chain. This proof is the deterministic backstop that holds regardless
+of what any model writes.
+
+Bug classes guarded:
+
+- **a manifest for another stack passing every gate**, which is the defect;
+- **the check firing where there is no cycle config to compare against** — seeded cycles and
+  the gate's own adversarial fixtures — which would reject correct manifests and is the #762
+  lesson that a net false-positiving on a working configuration is worse than the gap it
+  closes;
+- **accumulating findings across a stack mismatch.** The other proofs run happily against the
+  wrong application, so an author would be told to fix a testid in a design about to be
+  replaced wholesale;
+- a rejection that names the problem without naming either value or the fix;
+- **the proof escaping M6's taxonomy**, which would put a rejection in the baseline with no
+  class — data lost at exactly the moment B1 is collecting it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from squadops.cycles.authoring_failure import AUTHORING_DEFECT, assess_authoring_outcome
+from squadops.cycles.manifest_gates import (
+    PROOF_STACK_MATCHES_CONFIG,
+    PROOF_TESTID_COVERAGE,
+    assess_winnability,
+)
+
+pytestmark = [pytest.mark.domain_contracts]
+
+_REFERENCE = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+).read_text(encoding="utf-8")
+
+
+def _manifest(stack: str = "fullstack_fastapi_react") -> str:
+    return _REFERENCE.replace("fullstack_fastapi_react", stack)
+
+
+# --------------------------------------------------------------------------- #
+# The defect
+# --------------------------------------------------------------------------- #
+
+
+def test_the_vs_case_is_rejected():
+    """`cyc_afa934886acd` exactly: a FastAPI manifest on a Next.js cycle."""
+    findings = assess_winnability(_manifest("fullstack_fastapi_react"), "nextjs_ts")
+
+    assert [f.proof for f in findings] == [PROOF_STACK_MATCHES_CONFIG]
+
+
+def test_the_rejection_names_both_stacks_and_the_fix():
+    """A rejection reading only "stack mismatch" sends the author to guess which of two
+    values is wrong — and the author cannot see the cycle's config at all."""
+    detail = assess_winnability(_manifest(), "nextjs_ts")[0].detail
+
+    assert "fullstack_fastapi_react" in detail
+    assert "nextjs_ts" in detail
+    assert "stack: nextjs_ts" in detail, "the corrective action must be literal"
+
+
+@pytest.mark.parametrize("stack", ["fullstack_fastapi_react", "nextjs_ts"])
+def test_a_matching_stack_raises_no_stack_finding(stack):
+    """The check must be silent on every correct cycle, on both real stacks."""
+    findings = assess_winnability(_manifest(stack), stack)
+
+    assert PROOF_STACK_MATCHES_CONFIG not in [f.proof for f in findings]
+
+
+# --------------------------------------------------------------------------- #
+# It must not fire where there is nothing to compare
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("expected", ["", None])
+def test_no_configured_stack_means_no_comparison(expected):
+    """Seeded cycles and the gate's own adversarial fixtures have no cycle config. Inventing
+    a mismatch for them would reject manifests that are correct (#762's lesson)."""
+    findings = assess_winnability(_manifest(), expected or "")
+
+    assert PROOF_STACK_MATCHES_CONFIG not in [f.proof for f in findings]
+
+
+def test_the_reference_manifest_still_passes_every_gate_unconfigured():
+    """The pair the release's evidence is bound to must be unaffected."""
+    assert assess_winnability(_REFERENCE) == ()
+
+
+# --------------------------------------------------------------------------- #
+# It returns alone
+# --------------------------------------------------------------------------- #
+
+
+def test_a_stack_mismatch_suppresses_the_other_findings():
+    """The other proofs run happily against the wrong application. Reporting them would tell
+    an author to fix a testid in a design that is about to be replaced wholesale — the same
+    reason a parse failure returns alone."""
+    broken = _manifest("nextjs_ts").replace("testids:", "removed_testids:")
+
+    # the mutation alone is a real testid failure...
+    assert PROOF_TESTID_COVERAGE in [f.proof for f in assess_winnability(broken, "nextjs_ts")]
+    # ...but a wrong stack hides it, deliberately
+    findings = assess_winnability(broken, "fullstack_fastapi_react")
+    assert [f.proof for f in findings] == [PROOF_STACK_MATCHES_CONFIG]
+
+
+def test_an_unparseable_manifest_still_reports_the_parse_failure_first():
+    """Adding a proof ahead of lint must not displace the parse exception — a document that
+    did not parse has no `stack` to compare."""
+    findings = assess_winnability("not: [valid", "nextjs_ts")
+
+    assert [f.proof for f in findings] == ["parses"]
+
+
+# --------------------------------------------------------------------------- #
+# M6 classifies it
+# --------------------------------------------------------------------------- #
+
+
+def test_the_rejection_is_classified_rather_than_uncounted():
+    """A rejection with no class is data lost at the moment B1 is collecting it — and the
+    taxonomy's drift guard requires every `PROOF_*` to have one."""
+    outcome = assess_authoring_outcome(_manifest(), "nextjs_ts")
+
+    assert outcome.rejected
+    classes = {f.failure_class for f in outcome.findings}
+    assert classes == {AUTHORING_DEFECT}
+
+
+def test_the_outcome_assessor_defaults_to_no_comparison():
+    """Its other callers — B1's replay over stored manifests, the gate's own tests — pass no
+    cycle config and must keep working unchanged."""
+    assert not assess_authoring_outcome(_REFERENCE).rejected


### PR DESCRIPTION
**Stage 1e-i(a)** — the first of #838's three fixes. Taken first because it is the cheapest, independently valuable, and it turns a 75-minute discovery into a seconds-long one for every re-roll the other two fixes will themselves need. Regression **6902 passed, 1 skipped**.

## The defect

VS (`cyc_afa934886acd`) was configured `build_profile=nextjs_ts`, the authored manifest declared `fullstack_fastapi_react`, and **every component behaved correctly while building the wrong application for 75 minutes.**

`lint()` accepts any *registered* stack — *is it known*, never *is it the one asked for* — so nothing downstream had a reason to object. The rejection that eventually fired was incidental (a frozen-file claim), not the real problem.

## The proof

Compares the declared stack to the cycle's `build_profile`, threaded from the handler where it is already resolved for the prompt. **Empty skips the comparison** — seeded cycles and the gate's own adversarial fixtures have no cycle config, and inventing a mismatch for them would reject correct manifests (#762's lesson that a net which false-positives is worse than the gap it closes).

**It returns alone**, like a parse failure and for the same reason: a wrong stack invalidates the frame every other proof reasons in. The remaining proofs run happily against the wrong application and produce real-looking findings about testids and statuses — for a design about to be replaced wholesale. Telling an author to fix a testid in a manifest whose stack is wrong is worse than telling them nothing.

## Two drift guards required feeding, which is the #686 pattern working

**M6's `_PROOF_CLASS`** → `AUTHORING_DEFECT`, with a condition recorded in the code: **if this class recurs once the design-stage plumbing lands, it is a `blueprint_limitation` instead** — and B1's recurrence data is exactly what tells the two apart. That is the taxonomy's own "single occurrence takes the conservative class, recurrence promotes it" rule applied at the moment it matters.

**`manifest_authoring_rules`** → `AUTHOR_FACING`, with a new taught rule `use-the-stack-you-were-given` in the managed asset (#448).

**Filed `AUTHOR_FACING` rather than `COVERED_ELSEWHERE` deliberately.** The authoring request's schema block *does* render `stack: {{stack}}`, so "already taught" was available and would have been less work. **VS falsified it** — the author saw that line and wrote another stack's name anyway, having inherited it from a technical design naming the other one eight times. Classifying it as covered would assert a teaching that has been measured failing.

The rule's last sentence is the one that matters: *if the technical design you were given describes a different architecture than the stack you were given, the stack wins and the design is the thing that was wrong.*

## What this does not fix

**The cause is still upstream.** The design stage is never told the stack — that is 1e-i(b) — and `BUILD_PROFILES` has no `nextjs_ts` entry, with an `except Exception` that would swallow its absence — 1e-i(c). This proof is the deterministic backstop that holds regardless of what any model writes; it is not the plumbing.

Refs #838, #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv