### PR TITLE
feat(framing): the configured stack outranks whatever the PRD says (#838)

### DIFF
--- a/src/squadops/capabilities/handlers/build_profiles.py
+++ b/src/squadops/capabilities/handlers/build_profiles.py
@@ -43,6 +43,21 @@ def _narrative(profile_name: str) -> str:
     return text[:-1] if text.endswith("\n") else text
 
 
+def narrative_for_stack(stack: str) -> str:
+    """The architecture narrative for a scaffold stack, or ``""`` if it has none (#838).
+
+    Deliberately tolerant where :func:`_narrative` is loud. That one raises at import for a
+    BUILD_PROFILES entry missing its file — a registration error. This answers a different
+    question, asked at prompt-assembly time about a stack that may legitimately not have one
+    yet, and a framing stage must not die because a narrative is absent.
+    """
+    path = _NARRATIVES_DIR / f"{stack}.md"
+    if not path.is_file():
+        return ""
+    text = path.read_text(encoding="utf-8")
+    return text[:-1] if text.endswith("\n") else text
+
+
 # ---------------------------------------------------------------------------
 # QA handoff section name constants (D12 — single source of truth)
 # ---------------------------------------------------------------------------

--- a/src/squadops/capabilities/handlers/planning/base.py
+++ b/src/squadops/capabilities/handlers/planning/base.py
@@ -108,6 +108,41 @@ class _PlanningTaskHandler(_CycleTaskHandler):
             variables["time_budget_section"] = budget_section
         return variables
 
+    async def _target_stack_section(self, renderer: Any, inputs: dict[str, Any]) -> str:
+        """The stack this cycle builds, stated as a decision (#838).
+
+        VS (`cyc_afa934886acd`) framed for 75 minutes and designed the wrong application.
+        Nothing had misbehaved: the group_run PRD names its stack in prose — *"a coherent,
+        runnable full-stack vertical slice (FastAPI + React)"* — the research stage summarised
+        it, the design stage designed it, and the manifest author inherited it. **Every stage
+        was obediently following the requirements**, which disagreed with the cycle's
+        configuration and won because they were the louder input.
+
+        So this is not "tell the design stage the stack"; it is *"the stack the cycle
+        configures outranks anything the PRD says about architecture"* — a precedence rule,
+        stated once, on the shared base so every framing stage inherits it rather than the
+        design stage alone. Research frames the design stage's inputs, and objective framing
+        frames both.
+
+        Empty for a cycle with no scaffoldable ``build_profile``: a free-form generation cycle
+        has no stack to be decided for it, and asserting one would be a fiction.
+        """
+        from squadops.capabilities.handlers.build_profiles import narrative_for_stack
+        from squadops.capabilities.scaffold import scaffold_stack_for
+
+        stack = scaffold_stack_for(inputs.get("resolved_config"))
+        if not stack:
+            return ""
+        narrative = narrative_for_stack(stack)
+        if not narrative:
+            # A registered stack with no narrative would render a bare heading and teach
+            # nothing. Silence beats an authoritative-looking empty section.
+            return ""
+        rendered = await renderer.render(
+            "request.target_stack_section", {"stack": stack, "stack_narrative": narrative}
+        )
+        return rendered.content
+
     async def _authoring_rules_section(self, renderer: Any) -> str:
         """The plan-shape rules every deterministic validator enforces (#686).
 
@@ -183,6 +218,13 @@ class _PlanningTaskHandler(_CycleTaskHandler):
         renderer = getattr(context.ports, "request_renderer", None)
         if renderer is not None:
             variables = self._build_render_variables(prd, prior_outputs, inputs)
+            # #838: attached here rather than in `_build_render_variables` because rendering
+            # the section is itself async. Every framing stage inherits it — research frames
+            # the design stage's inputs and objective framing frames both, so telling only
+            # the design stage would leave the contamination path open one step upstream.
+            stack_section = await self._target_stack_section(renderer, inputs)
+            if stack_section:
+                variables["target_stack_section"] = stack_section
             rendered = await renderer.render(self._request_template_id, variables)
             user_prompt = rendered.content
         else:

--- a/src/squadops/prompts/profile_narratives/nextjs_ts.md
+++ b/src/squadops/prompts/profile_narratives/nextjs_ts.md
@@ -1,0 +1,17 @@
+A Next.js application using the App Router, written in TypeScript. **One project at the
+repository root** — there is no separate backend or frontend tree, and no `frontend/`
+directory.
+
+- **Server endpoints are route handlers** at `app/api/<path>/route.ts`, exporting one async
+  function per HTTP method (`export async function POST(request: Request)`). Not server
+  actions: an action has no stable URL, so nothing can address it over HTTP.
+- **A path parameter is a directory in brackets** — `/runs/{run_id}` lives at
+  `app/api/runs/[run_id]/route.ts`, and its value arrives in the handler's second argument.
+- **Pages are `app/<path>/page.tsx`** with a default-exported component. The URL comes from the
+  directory; the filename is always `page.tsx`.
+- **Server-first.** `'use client'` belongs only on a component that genuinely needs browser
+  interactivity — anything client-rendered is absent from the initial HTML.
+- **Shared code lives in `lib/`** and is imported through the `@/` alias.
+- **Tests are vitest**, in `__tests__/`, with a `.test.ts` suffix.
+- **`next build` type-checks.** TypeScript is strict and build failures on type errors are
+  deliberate: it is the only static analysis this stack has.

--- a/src/squadops/prompts/request_templates/request.planning_task_base.md
+++ b/src/squadops/prompts/request_templates/request.planning_task_base.md
@@ -5,6 +5,7 @@ required_variables:
   - prd
   - role
 optional_variables:
+  - target_stack_section
   - time_budget_section
   - prior_outputs
   - rejection_context_section
@@ -13,6 +14,7 @@ optional_variables:
 ## Product Requirements Document
 
 {{prd}}
+{{target_stack_section}}
 {{time_budget_section}}
 {{prior_outputs}}
 {{authoring_rules_section}}

--- a/src/squadops/prompts/request_templates/request.target_stack_section.md
+++ b/src/squadops/prompts/request_templates/request.target_stack_section.md
@@ -1,0 +1,23 @@
+---
+template_id: request.target_stack_section
+version: "1"
+required_variables:
+  - stack
+  - stack_narrative
+---
+## TARGET STACK — decided, not proposed
+
+This cycle builds **`{{stack}}`**. That is a platform decision already made by the cycle's
+configuration; it is not yours to choose, revisit, or improve on.
+
+{{stack_narrative}}
+
+**If the requirements document names a different stack, the stack above wins and the PRD is
+the thing that is out of date.** A PRD often states the architecture that existed when it was
+written. Designing for what it names instead of what this cycle configures produces a design
+nobody can build: the scaffold expands `{{stack}}`, every file lands somewhere your design did
+not anticipate, and the mismatch surfaces hours later as an unrelated failure.
+
+Design *within* this stack. Its conventions — where routes live, how views are addressed, what
+a test file is — are inputs to your design, not details to be settled later by whoever
+implements it.

--- a/tests/unit/capabilities/test_target_stack_section.py
+++ b/tests/unit/capabilities/test_target_stack_section.py
@@ -1,0 +1,163 @@
+"""Every framing stage is told which stack the cycle builds, and that it outranks the PRD (#838).
+
+VS (`cyc_afa934886acd`) framed for 75 minutes and designed the wrong application. **Nothing
+had misbehaved.** The group_run PRD names its stack in prose — *"a coherent, runnable
+full-stack vertical slice (FastAPI + React)"*, twice — the research stage summarised it
+(fastapi 3, react 4, next 0), the design stage designed it, and the manifest author inherited
+it through `prior_outputs`, a declared input. Every stage obediently followed the requirements,
+which disagreed with the cycle's configuration and won for being the louder input.
+
+So the fix is not "tell the design stage the stack". It is a **precedence rule** — the stack
+the cycle configures outranks anything the PRD says about architecture — stated on the shared
+planning base so every framing stage inherits it. Telling only the design stage would leave
+the contamination path open one step upstream, in research.
+
+Bug classes guarded:
+
+- **the precedence going unstated**, leaving a PRD that names a stack to win by volume;
+- **only the design stage being told.** Research frames the design stage's inputs and
+  objective framing frames both, so a fix applied to one stage is reopened by the one before
+  it;
+- **the section rendering for a cycle that has no stack.** Free-form generation cycles
+  (`python_cli`, `react_app`) have no stack decided for them, and asserting one is a fiction —
+  the #762 lesson that a false-positiving net is worse than the gap it closes;
+- **a registered stack with no narrative rendering an authoritative-looking empty heading**,
+  which teaches nothing while looking like instruction;
+- the section landing *before* the PRD, where a precedence rule reads as preamble rather than
+  as the thing that overrides what follows;
+- prose drifting into Python (#448) — the rule and the narrative are managed assets.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities.handlers.build_profiles import narrative_for_stack
+from squadops.capabilities.handlers.planning.framing import (
+    DataResearchContextHandler,
+    DevelopmentDesignPlanHandler,
+    StrategyFrameObjectiveHandler,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+def _renderer() -> Any:
+    renderer = AsyncMock()
+
+    async def _render(template_id: str, variables: dict[str, Any]):
+        rendered = MagicMock()
+        rendered.content = f"[{template_id}] {variables}"
+        return rendered
+
+    renderer.render.side_effect = _render
+    return renderer
+
+
+async def _section(handler, config: dict | None) -> str:
+    return await handler._target_stack_section(_renderer(), {"resolved_config": config})
+
+
+# --------------------------------------------------------------------------- #
+# Every framing stage, not just the design one
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "handler_cls",
+    [DataResearchContextHandler, StrategyFrameObjectiveHandler, DevelopmentDesignPlanHandler],
+)
+async def test_every_framing_stage_is_told_the_stack(handler_cls):
+    """Research summarised the PRD's FastAPI mention before the design stage ever ran. A fix
+    applied only to `development.design_plan` is reopened by the stage before it."""
+    section = await _section(handler_cls(), {"build_profile": "nextjs_ts"})
+
+    assert "request.target_stack_section" in section
+    assert "nextjs_ts" in section
+
+
+async def test_the_narrative_travels_with_the_stack_name():
+    """A stack name alone teaches nothing — `nextjs_ts` does not tell a designer that route
+    handlers live at `app/api/<path>/route.ts`."""
+    section = await _section(DevelopmentDesignPlanHandler(), {"build_profile": "nextjs_ts"})
+
+    assert "route.ts" in section
+    assert "page.tsx" in section
+
+
+# --------------------------------------------------------------------------- #
+# It must not fire where no stack was decided
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "config",
+    [None, {}, {"dev_capability": "python_cli"}, {"build_profile": "not_a_registered_stack"}],
+)
+async def test_no_section_when_the_cycle_has_no_stack(config):
+    """A free-form generation cycle has no stack decided for it. Asserting one would be a
+    fiction, and a net that false-positives on a working configuration is worse than the gap
+    it closes (#762)."""
+    assert await _section(DevelopmentDesignPlanHandler(), config) == ""
+
+
+async def test_a_registered_stack_with_no_narrative_renders_nothing(monkeypatch):
+    """Silence beats an authoritative-looking empty section — a heading with no content reads
+    as instruction while teaching nothing."""
+    monkeypatch.setattr(
+        "squadops.capabilities.handlers.build_profiles.narrative_for_stack", lambda s: ""
+    )
+
+    assert await _section(DevelopmentDesignPlanHandler(), {"build_profile": "nextjs_ts"}) == ""
+
+
+# --------------------------------------------------------------------------- #
+# The precedence rule itself
+# --------------------------------------------------------------------------- #
+
+
+def test_the_asset_states_that_the_stack_outranks_the_prd():
+    """The whole point. Without this sentence the section is a hint that a PRD naming a
+    different stack twice will out-argue."""
+    from pathlib import Path
+
+    asset = (
+        Path(__file__).resolve().parents[3]
+        / "src/squadops/prompts/request_templates/request.target_stack_section.md"
+    ).read_text(encoding="utf-8")
+
+    assert "wins" in asset and "PRD" in asset
+    assert "{{stack}}" in asset and "{{stack_narrative}}" in asset
+
+
+def test_the_section_is_placed_after_the_prd_it_overrides():
+    """A precedence rule read before the thing it overrides is preamble. The template must
+    render the PRD first, then the stack that outranks it."""
+    from pathlib import Path
+
+    template = (
+        Path(__file__).resolve().parents[3]
+        / "src/squadops/prompts/request_templates/request.planning_task_base.md"
+    ).read_text(encoding="utf-8")
+
+    assert template.index("{{prd}}") < template.index("{{target_stack_section}}")
+    assert "target_stack_section" in template.split("---")[1], "must be a declared variable"
+
+
+def test_both_registered_stacks_have_a_narrative():
+    """A stack whose narrative is missing silently loses its section — the failure is a
+    quieter design, not an error, so it is pinned here."""
+    from squadops.capabilities.scaffold import _STACKS
+
+    for name in _STACKS:
+        assert narrative_for_stack(name), f"stack {name!r} has no profile narrative"
+
+
+def test_narrative_lookup_is_tolerant_where_registration_is_loud():
+    """`_narrative` raises at import for a BUILD_PROFILES entry missing its file — a
+    registration error. This answers a different question at prompt-assembly time, about a
+    stack that may legitimately not have one, and must not kill a framing stage."""
+    assert narrative_for_stack("definitely_not_a_stack") == ""


### PR DESCRIPTION
**Stage 1e-i(b)** — and the premise changed on investigation. Regression **6920 passed, 1 skipped**.

## What #838 said, and what is actually true

The issue said *"the design stage is never told the stack, so it designed FastAPI from the only architecture prose that exists."* Reading further:

**The group_run PRD names its stack in prose, twice.**

```
line 36: "a coherent, runnable full-stack vertical slice (FastAPI + React)"
line 42: "Deliver a runnable full-stack MVP (FastAPI backend + React frontend)"
```

Research summarised it (fastapi 3, react 4, **next 0**), the design stage designed it, and the manifest author inherited it through `prior_outputs` — a *declared* input. **The design stage was not uninformed. Every stage was obediently following the requirements**, which disagreed with the cycle's configuration and won for being the louder input.

That is the same defect class yet again: another unbound declaration of the stack, this time in the benchmark's own requirements.

## So the fix is a precedence rule, not plumbing

**The stack the cycle configures outranks anything the PRD says about architecture** — stated on the shared planning base so **all four** framing stages inherit it.

Telling only `development.design_plan` would have left the contamination path open one step upstream, in research, which is where the FastAPI mention was first summarised. That is the difference between fixing the stage that failed and fixing the stage that fed it.

**Rendered after the PRD** in the template: a precedence rule read *before* the thing it overrides is preamble.

Prose lives in managed assets (#448) — `request.target_stack_section` carries the rule, `profile_narratives/nextjs_ts.md` the architecture.

## One deliberate asymmetry

`narrative_for_stack()` is **tolerant** where `_narrative()` is **loud**. The existing one raises at import for a `BUILD_PROFILES` entry missing its file — a registration error, correctly fatal. This answers a different question, at prompt-assembly time, about a stack that may legitimately not have a narrative yet — and a framing stage must not die because one is absent. It returns the empty string, and the section renders nothing rather than an authoritative-looking empty heading.

## Tests

Thirteen, including the one that matters most: **every framing stage** gets the section, not just the design one — parametrized across `DataResearchContextHandler`, `StrategyFrameObjectiveHandler` and `DevelopmentDesignPlanHandler`. Plus silence for free-form cycles, silence for a registered stack with no narrative, and the template ordering assertion.

## What this does not do — and the decision it raises

**It does not touch the PRD.** Removing the stack from the requirements would be the *cleaner* fix — architecture is the squad's job, which is SIP-0103's whole claim — but the PRD is the benchmark's fixed input, and **changing it would invalidate V4/V5 comparability for V7.** Raised separately rather than decided here.

Refs #838, #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
