### PR TITLE
docs(prd): finish the SIP-0098 §6.7 split — group_run PRD v0.5 (#843)

### DIFF
--- a/examples/03_group_run/prd.md
+++ b/examples/03_group_run/prd.md
@@ -1,5 +1,6 @@
 # PRD: group_run (1-Hour Cycle MVP+)
-**Version:** v0.4 (SIP-0098 §6.7 split — product-only content; technical contract externalized)
+**Version:** v0.5 (SIP-0098 §6.7 split, completed — product-only content; technical contract
+externalized. v0.4 declared the stack externalized in §1 and then specified it in §2; #843.)
 **Purpose:** Define a testable full-stack MVP for a 1-hour SquadOps cycle
 **Status:** Draft for cycle planning
 **Timebox Target:** 1-hour autonomous cycle (5-agent squad)
@@ -33,13 +34,13 @@ resolve.
 - view event details and participants
 
 This PRD is intentionally scoped to support a **1-hour autonomous build attempt** by an agent squad.
-The goal is a **coherent, runnable full-stack vertical slice** (FastAPI + React) with validation and basic tests.
+The goal is a **coherent, runnable full-stack vertical slice** with validation and basic tests.
 
 ---
 
 ## 2) Objective (for this cycle)
 
-Deliver a runnable full-stack MVP (FastAPI backend + React frontend) that allows a user to:
+Deliver a runnable full-stack MVP that allows a user to:
 
 1. Create a group run event
 2. View a list of upcoming group runs
@@ -50,7 +51,7 @@ Deliver a runnable full-stack MVP (FastAPI backend + React frontend) that allows
 
 ### Success Definition (Cycle-Level)
 A reviewer can:
-- start backend and frontend locally
+- start the application locally
 - create at least one run from the UI
 - view the run in the list and open the detail page
 - join the run with a participant name
@@ -260,7 +261,7 @@ Routes, view names, and view purposes are owned by `interface_manifest.yaml`
 - No UI component library required
 - No animations
 - No auth/session state
-- Prefer simple `fetch` calls over heavier client abstractions
+- Avoid heavy client-side data-fetching libraries
 
 ---
 


### PR DESCRIPTION
Finishes the SIP-0098 §6.7 split. **Manifest `bb472e267e53d5ad` and contract `7622f570c949fe95` both unmoved; regression 6902 passed.**

## The contradiction

v0.4 declared its own scope in §1:

> Per SIP-0098 §6.7, this PRD carries **product content only**… The technical fill contract lives in `interface_manifest.yaml` — entities, API endpoints…, **stack**, persistence mode…

…and then specified the stack twice, in the goal statement and the objective. **§6.7 moved the endpoints out and left the stack in**, and nobody noticed for two releases because there was only one stack for it to be wrong about.

## What it cost

VS (`cyc_afa934886acd`) framed for **75m33s** designing a FastAPI application on a cycle configured `build_profile=nextjs_ts`. Every stage was obediently following the requirements, and the mention amplified at each hop:

| artifact | FastAPI | Next.js |
|---|---|---|
| PRD v0.4 | 2 | 0 |
| `objective_frame.md` | 2 | 0 |
| `context_research.md` | 3 | 0 |
| `technical_design.md` | **8** | 0 |

## Five sites, not two

| line | change |
|---|---|
| 36 | `(FastAPI + React)` deleted |
| 42 | `(FastAPI backend + React frontend)` deleted |
| **53** | "start **backend and frontend** locally" → "start the application locally" |
| **263** | "Prefer simple `fetch` calls…" → "Avoid heavy client-side data-fetching libraries" |
| 260 | "No UI component library required" — **left**, it reads as a scope constraint |

**Lines 53 and 263 are the ones a framework-name grep misses**, and both are real assumptions rather than naming slips: a Next.js app is one process, not two; and `fetch` is a browser-JS API that a server-rendered stack does not have.

**Kept deliberately:** "full-stack", "backend" and "frontend" where they describe *behavior*. §5.1's *"Backend validates request payload"* is a genuine product requirement — validation must be server-side, not client-only — not a stack choice.

## I had the sequencing wrong

I recorded this as *"after V7, to protect comparability."* **That was wrong, and the correction is why this PR exists now rather than in three weeks:**

- `source_prd` is **excluded from the manifest's hashed projection**
- M0a pins `interface_manifest.yaml` and the contract file — **not the PRD**
- Removing an implementation statement does not change the product content the reference manifest was hand-authored from; entities, endpoints and behaviors are untouched

Verified after the edit: both hashes unmoved. **Nothing is pinned to this document.** Leaving it would have meant every cycle relying on #842's precedence rule to out-argue its own requirements — mitigation standing in for a fix.

The reference manifest keeps citing the path it was authored from. Its provenance is accurate, not stale.

## Owed at V7

The pre-registration must **name the PRD version the window ran**, so a later comparison is not made against rolls that read a different document.

## Follow-up, not in this PR

A `lint_prd_product_only.py` over `examples/*/prd.md` with a framework deny-list — the same declare-and-guard shape as `lint_test_quality.py` and `lint_realm_exports.py`. §6.7 left the stack behind silently once; that lint is the difference between fixing this and fixing it again at stack #3.

Closes #843 · Refs #838, #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
