### PR TITLE
feat(build): register nextjs_ts, and stop swallowing a missing build profile (#838)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1764,9 +1764,32 @@ class DispatchedFlowExecutor(FlowExecutionPort):
 
         if not is_scaffoldable_stack(manifest.stack):
             return []
+
+        # #838: a REGISTRATION failure and an EXPANSION failure are different defects with
+        # different diagnoses, and one broad `except` conflated them. `is_scaffoldable_stack`
+        # has already passed, so the stack is in `_STACKS`; if it is absent from
+        # `BUILD_PROFILES` those two registries disagree, and swallowing that produced the
+        # inversion VS found — a *correct* `nextjs_ts` manifest would have been silently
+        # unscaffolded, leaving the wrong manifest as the only one that worked. An
+        # unscaffolded cycle has no contract, no fill slots and no frozen files: it is not a
+        # degraded run, it is a run whose entire verification story is absent. Loud.
         try:
-            files = get_profile(manifest.stack).expand(manifest)
+            profile = get_profile(manifest.stack)
+        except ValueError:
+            logger.error(
+                "stack %s is registered as scaffoldable but has no build profile — the two "
+                "registries disagree, and proceeding would produce an unscaffolded cycle with "
+                "no contract, no fill slots and no frozen files",
+                manifest.stack,
+            )
+            raise
+
+        try:
+            files = profile.expand(manifest)
         except Exception:
+            # An expansion failure on a properly registered stack stays tolerant: the run
+            # proceeds on the non-scaffolded path, which is the pre-SIP-0099 behavior this
+            # helper was written to fall back to.
             logger.warning(
                 "Failed to expand interface manifest (stack=%s); skipping scaffold seed",
                 manifest.stack,

--- a/src/squadops/capabilities/handlers/build_profiles.py
+++ b/src/squadops/capabilities/handlers/build_profiles.py
@@ -43,21 +43,6 @@ def _narrative(profile_name: str) -> str:
     return text[:-1] if text.endswith("\n") else text
 
 
-def narrative_for_stack(stack: str) -> str:
-    """The architecture narrative for a scaffold stack, or ``""`` if it has none (#838).
-
-    Deliberately tolerant where :func:`_narrative` is loud. That one raises at import for a
-    BUILD_PROFILES entry missing its file — a registration error. This answers a different
-    question, asked at prompt-assembly time about a stack that may legitimately not have one
-    yet, and a framing stage must not die because a narrative is absent.
-    """
-    path = _NARRATIVES_DIR / f"{stack}.md"
-    if not path.is_file():
-        return ""
-    text = path.read_text(encoding="utf-8")
-    return text[:-1] if text.endswith("\n") else text
-
-
 # ---------------------------------------------------------------------------
 # QA handoff section name constants (D12 — single source of truth)
 # ---------------------------------------------------------------------------
@@ -260,6 +245,25 @@ BUILD_PROFILES: dict[str, BuildProfile] = {
             "Dockerfile must use multi-stage build",
             "docker-compose.yaml must define backend and frontend services",
             "qa_handoff.md must include startup and test instructions for both stacks",
+        ),
+        artifact_output_mode=ARTIFACT_MODE_MULTI_FILE,
+        qa_handoff_expectations=QA_HANDOFF_REQUIRED_SECTIONS,
+    ),
+    # #838 stack #2. The SIXTH per-stack registry, and the one VS found by its absence:
+    # `_seed_skeleton_artifacts` resolves `get_profile(manifest.stack)`, which raises for an
+    # unregistered name — and the call site swallowed it. A correct `nextjs_ts` manifest would
+    # therefore have produced a silently UNSCAFFOLDED cycle, so the wrong manifest was the
+    # only one that worked.
+    "nextjs_ts": BuildProfile(
+        name="nextjs_ts",
+        system_prompt_template=_narrative("nextjs_ts"),
+        # One project at the root: no docker-compose pairing two services, and the packaging
+        # story is a single container serving `next start`.
+        required_files=("Dockerfile", "qa_handoff.md"),
+        optional_files=(".dockerignore", ".env.example", "start.sh"),
+        validation_rules=(
+            "Dockerfile must build the Next.js app and run `next start`",
+            "qa_handoff.md must include startup and test instructions",
         ),
         artifact_output_mode=ARTIFACT_MODE_MULTI_FILE,
         qa_handoff_expectations=QA_HANDOFF_REQUIRED_SECTIONS,

--- a/src/squadops/capabilities/handlers/planning/base.py
+++ b/src/squadops/capabilities/handlers/planning/base.py
@@ -127,13 +127,13 @@ class _PlanningTaskHandler(_CycleTaskHandler):
         Empty for a cycle with no scaffoldable ``build_profile``: a free-form generation cycle
         has no stack to be decided for it, and asserting one would be a fiction.
         """
-        from squadops.capabilities.handlers.build_profiles import narrative_for_stack
         from squadops.capabilities.scaffold import scaffold_stack_for
+        from squadops.capabilities.stack_narratives import stack_narrative
 
         stack = scaffold_stack_for(inputs.get("resolved_config"))
         if not stack:
             return ""
-        narrative = narrative_for_stack(stack)
+        narrative = stack_narrative(stack)
         if not narrative:
             # A registered stack with no narrative would render a bare heading and teach
             # nothing. Silence beats an authoritative-looking empty section.

--- a/src/squadops/capabilities/stack_narratives.py
+++ b/src/squadops/capabilities/stack_narratives.py
@@ -1,0 +1,42 @@
+"""Architecture narratives — what a stack's code looks like, for the stages that design it.
+
+**Separate from ``prompts/profile_narratives/`` on purpose, and the separation is a bug fix.**
+Those are the *builder's* prompts: they open *"You are assembling…"* and instruct *"do not
+regenerate application code — focus on packaging, configuration, and operational readiness."*
+Correct for Bob, actively wrong for a designer.
+
+#842 pointed framing's target-stack section at that directory, so every framing stage on a
+`fullstack_fastapi_react` cycle was handed the packaging prompt under a heading reading
+"TARGET STACK — decided, not proposed" — telling the stage that authors the technical design
+not to write application code. Two audiences reading one asset, which is the ownership smell
+CLAUDE.md's edit-time rule exists to catch, arriving one release after that rule was written.
+
+So: **``profile_narratives/`` answers "how is this stack packaged"; this answers "how is this
+stack written".** They are both per-stack and they are not the same question — the #92
+invariant makes the difference concrete, since a builder narrative must not enumerate
+filenames while an architecture narrative is largely *about* where things live.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from squadops.prompts import __file__ as _prompts_pkg
+
+_NARRATIVES_DIR = Path(_prompts_pkg).parent / "stack_narratives"
+
+
+def stack_narrative(stack: str) -> str:
+    """How ``stack``'s code is laid out, or ``""`` if it declares no narrative.
+
+    Deliberately tolerant where ``build_profiles._narrative`` is loud. That one raises at
+    import for a registered builder profile missing its file — a registration error, correctly
+    fatal. This is asked at prompt-assembly time about a stack that may legitimately not have
+    one yet, and a framing stage must not die because a narrative is absent. The caller renders
+    nothing rather than an authoritative-looking empty heading.
+    """
+    path = _NARRATIVES_DIR / f"{stack}.md"
+    if not path.is_file():
+        return ""
+    text = path.read_text(encoding="utf-8")
+    return text[:-1] if text.endswith("\n") else text

--- a/src/squadops/prompts/profile_narratives/nextjs_ts.md
+++ b/src/squadops/prompts/profile_narratives/nextjs_ts.md
@@ -1,17 +1,3 @@
-A Next.js application using the App Router, written in TypeScript. **One project at the
-repository root** — there is no separate backend or frontend tree, and no `frontend/`
-directory.
+You are assembling a single-project TypeScript web application built with the Next.js App Router.
 
-- **Server endpoints are route handlers** at `app/api/<path>/route.ts`, exporting one async
-  function per HTTP method (`export async function POST(request: Request)`). Not server
-  actions: an action has no stable URL, so nothing can address it over HTTP.
-- **A path parameter is a directory in brackets** — `/runs/{run_id}` lives at
-  `app/api/runs/[run_id]/route.ts`, and its value arrives in the handler's second argument.
-- **Pages are `app/<path>/page.tsx`** with a default-exported component. The URL comes from the
-  directory; the filename is always `page.tsx`.
-- **Server-first.** `'use client'` belongs only on a component that genuinely needs browser
-  interactivity — anything client-rendered is absent from the initial HTML.
-- **Shared code lives in `lib/`** and is imported through the `@/` alias.
-- **Tests are vitest**, in `__tests__/`, with a `.test.ts` suffix.
-- **`next build` type-checks.** TypeScript is strict and build failures on type errors are
-  deliberate: it is the only static analysis this stack has.
+The source code from the development step is provided as context. Do not regenerate application code — focus on packaging, configuration, and operational readiness. The container build must be multi-stage: a build stage that installs dependencies and produces the production build, and a lean runtime stage that serves it. There is one project at the repository root, so there are no separate backend and frontend services to compose — the image runs a single process. Keep the app portable: pass any API base or external origin as build args or runtime env, document them in the environment example, and never hardcode `localhost` URLs into the image. The runtime stage must copy the build output and the production dependency tree only, not the full workspace. The QA handoff document must include the build command, the start command, and the port the server listens on.

--- a/src/squadops/prompts/stack_narratives/fullstack_fastapi_react.md
+++ b/src/squadops/prompts/stack_narratives/fullstack_fastapi_react.md
@@ -1,0 +1,14 @@
+A Python **FastAPI** backend and a **React** frontend built with Vite, in two trees.
+
+- **Server endpoints live in `backend/routes.py`** — one module holding every route, declared
+  with decorators (`@router.post("/runs")`).
+- **A path parameter is written in braces** — `/runs/{run_id}` — and the same name is used by
+  every endpoint addressing that resource.
+- **Views are `.jsx` components under `frontend/src/views/`**, one file per declared route,
+  wired through the frontend's own router.
+- **Shared server code sits beside the routes** in `backend/` — models, an in-memory store,
+  and the error envelope.
+- **Tests are pytest for the backend** under `backend/tests/`, and vitest for the frontend
+  under `frontend/src/__tests__/`.
+- **The frontend builds with Vite** and reaches the API through a relative base, never a
+  hardcoded host.

--- a/src/squadops/prompts/stack_narratives/nextjs_ts.md
+++ b/src/squadops/prompts/stack_narratives/nextjs_ts.md
@@ -1,0 +1,17 @@
+A Next.js application using the App Router, written in TypeScript. **One project at the
+repository root** — there is no separate backend or frontend tree, and no `frontend/`
+directory.
+
+- **Server endpoints are route handlers** at `app/api/<path>/route.ts`, exporting one async
+  function per HTTP method (`export async function POST(request: Request)`). Not server
+  actions: an action has no stable URL, so nothing can address it over HTTP.
+- **A path parameter is a directory in brackets** — `/runs/{run_id}` lives at
+  `app/api/runs/[run_id]/route.ts`, and its value arrives in the handler's second argument.
+- **Pages are `app/<path>/page.tsx`** with a default-exported component. The URL comes from the
+  directory; the filename is always `page.tsx`.
+- **Server-first.** `'use client'` belongs only on a component that genuinely needs browser
+  interactivity — anything client-rendered is absent from the initial HTML.
+- **Shared code lives in `lib/`** and is imported through the `@/` alias.
+- **Tests are vitest**, in `__tests__/`, with a `.test.ts` suffix.
+- **`next build` type-checks.** TypeScript is strict and build failures on type errors are
+  deliberate: it is the only static analysis this stack has.

--- a/tests/unit/capabilities/test_build_profiles.py
+++ b/tests/unit/capabilities/test_build_profiles.py
@@ -176,9 +176,12 @@ class TestFullstackFastapiReactProfile:
 
 
 class TestBuildProfilesRegistry:
-    def test_registry_has_four_profiles(self):
-        assert len(BUILD_PROFILES) == 4
-
+    # #838: `assert len(BUILD_PROFILES) == 4` removed rather than bumped to 5 — a count
+    # names no bug class, breaks on every legitimate registration, and is the shape
+    # docs/TEST_QUALITY_STANDARD.md rules out. Same removal as the DEV_CAPABILITIES
+    # count in #836. What matters is the BINDING, pinned in
+    # tests/unit/cycles/test_build_profile_registration.py: every scaffoldable stack
+    # has a profile, and its absence raises instead of being swallowed.
     def test_all_profiles_are_build_profile_instances(self):
         for name, profile in BUILD_PROFILES.items():
             assert isinstance(profile, BuildProfile), f"{name} is not a BuildProfile"
@@ -267,8 +270,15 @@ class TestProfileSourceOfTruthInvariants:
         # Forbidden patterns: anything that looks like a file with an
         # extension, or known extension-less structural files.
         forbidden = []
+        # #838: framework names containing a dot are not filenames. The heuristic below
+        # cannot tell `Next.js` from `main.js`, and the existing narratives only escaped it
+        # by naming frameworks that happen to have no dot (FastAPI, React, Vite). Naming the
+        # framework is not what #92 forbids — enumerating the files the validator grades is.
+        product_names = {"Next.js", "Node.js", "Vue.js", "Nuxt.js", "Express.js"}
         # Simple file-with-extension regex (word chars + dot + 2-5 letter ext)
         for match in re.finditer(r"\b[\w./-]+\.[a-zA-Z]{2,5}\b", stripped):
+            if match.group(0) in product_names:
+                continue
             forbidden.append(match.group(0))
         for sentinel in ("Dockerfile", "Makefile"):
             if sentinel in stripped:

--- a/tests/unit/capabilities/test_profile_narratives.py
+++ b/tests/unit/capabilities/test_profile_narratives.py
@@ -31,6 +31,7 @@ _PINNED_NARRATIVE = {
     "static_web_builder": "c6582150bb6af350f93ac00e7e8ad028bad8d5935e3ce56f0cc999d84ff652eb",
     "web_app_builder": "3e11df5924d41749d00fb6b8a22e281eb4e775af206d560a70d144e6a0ec21fe",
     "fullstack_fastapi_react": "2250e64354f268bdc605e05137a3d61bd7de7e9116c5c1b648a5f8a6444b4639",
+    "nextjs_ts": "8a541ffcd4077959770018cfb17eeba5e7ab584fca6ac34061ad4373b7cdf053",
 }
 
 # sha256 of each pre-move COMPOSED full_system_prompt — the seam the builder
@@ -41,6 +42,11 @@ _PINNED_COMPOSED = {
     "static_web_builder": "10d0efbc5c8c158529b37e5d1da66a49e9fe3a55de9ed75109f471ed55ec3a1f",
     "web_app_builder": "b242252619ccc82c6fc081b6d657a41903174274ca387e576e9171cb878a6e1b",
     "fullstack_fastapi_react": "748c4e740fafe63f39cc94eec91d1e842050dcf5d1e070919e6f0680402b1957",
+    # #838: nextjs_ts has NO pre-move inline literal — it was authored for stack #2,
+    # after the #452 externalization. Its pin therefore establishes a baseline rather
+    # than verifying a move, which is the same guarantee going forward: a change to
+    # this prompt shows honestly in the diff instead of arriving as a silent edit.
+    "nextjs_ts": "5d8855d96521e1098b191421f20f43dba9c1f729a05df5b0eb601082336e6dda",
 }
 
 

--- a/tests/unit/capabilities/test_target_stack_section.py
+++ b/tests/unit/capabilities/test_target_stack_section.py
@@ -35,12 +35,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from squadops.capabilities.handlers.build_profiles import narrative_for_stack
 from squadops.capabilities.handlers.planning.framing import (
     DataResearchContextHandler,
     DevelopmentDesignPlanHandler,
     StrategyFrameObjectiveHandler,
 )
+from squadops.capabilities.stack_narratives import stack_narrative
 
 pytestmark = [pytest.mark.domain_capabilities]
 
@@ -107,9 +107,7 @@ async def test_no_section_when_the_cycle_has_no_stack(config):
 async def test_a_registered_stack_with_no_narrative_renders_nothing(monkeypatch):
     """Silence beats an authoritative-looking empty section — a heading with no content reads
     as instruction while teaching nothing."""
-    monkeypatch.setattr(
-        "squadops.capabilities.handlers.build_profiles.narrative_for_stack", lambda s: ""
-    )
+    monkeypatch.setattr("squadops.capabilities.stack_narratives.stack_narrative", lambda s: "")
 
     assert await _section(DevelopmentDesignPlanHandler(), {"build_profile": "nextjs_ts"}) == ""
 
@@ -153,11 +151,11 @@ def test_both_registered_stacks_have_a_narrative():
     from squadops.capabilities.scaffold import _STACKS
 
     for name in _STACKS:
-        assert narrative_for_stack(name), f"stack {name!r} has no profile narrative"
+        assert stack_narrative(name), f"stack {name!r} has no profile narrative"
 
 
 def test_narrative_lookup_is_tolerant_where_registration_is_loud():
     """`_narrative` raises at import for a BUILD_PROFILES entry missing its file — a
     registration error. This answers a different question at prompt-assembly time, about a
     stack that may legitimately not have one, and must not kill a framing stage."""
-    assert narrative_for_stack("definitely_not_a_stack") == ""
+    assert stack_narrative("definitely_not_a_stack") == ""

--- a/tests/unit/cycles/test_build_profile_registration.py
+++ b/tests/unit/cycles/test_build_profile_registration.py
@@ -1,0 +1,124 @@
+"""A registered stack must have a build profile, and its absence must be loud (#838).
+
+VS (`cyc_afa934886acd`) found this by its absence. `_seed_skeleton_artifacts` resolves
+`get_profile(manifest.stack)`, which raises for a name `BUILD_PROFILES` does not hold — and
+the call site wrapped the whole thing in one broad `except Exception` that returned `[]` with
+a warning.
+
+`nextjs_ts` was registered in five per-stack registries and absent from this sixth one. So
+**a correct `nextjs_ts` manifest would have been silently unscaffolded**, and the wrong
+manifest — the one declaring `fullstack_fastapi_react` — was the only one that worked. The
+inversion is the point: the failing path was the correct one.
+
+Bug classes guarded:
+
+- **a registered stack missing its build profile**, which is the two registries disagreeing;
+- **that disagreement being swallowed.** An unscaffolded cycle has no contract, no fill slots
+  and no frozen files — it is not a degraded run, it is a run whose entire verification story
+  is absent, and it would report `completed`;
+- a registration failure and an expansion failure sharing one diagnosis, which is the
+  conflation #827 separated for the probe path;
+- **expansion failures becoming fatal.** The tolerant path predates SIP-0099 and is what a
+  non-scaffolded run falls back to; making it loud would fail cycles that work today.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities import scaffold
+from squadops.capabilities.handlers.build_profiles import BUILD_PROFILES
+from squadops.capabilities.scaffold import InterfaceManifest, ScaffoldStack
+
+pytestmark = [pytest.mark.domain_contracts]
+
+_REFERENCE = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+).read_text(encoding="utf-8")
+
+
+def _manifest(stack: str) -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_REFERENCE.replace("fullstack_fastapi_react", stack))
+
+
+def _executor():
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+    return DispatchedFlowExecutor(artifact_vault=AsyncMock())
+
+
+# --------------------------------------------------------------------------- #
+# The registries must agree
+# --------------------------------------------------------------------------- #
+
+
+def test_every_scaffoldable_stack_has_a_build_profile():
+    """The sixth binding. Five registries agreed about `nextjs_ts` and this one did not, which
+    is precisely how a plausible wrong answer beat the correct one."""
+    for name in scaffold._STACKS:
+        assert name in BUILD_PROFILES, (
+            f"stack {name!r} is registered as scaffoldable but has no build profile — "
+            f"a correct manifest for it would be silently unscaffolded"
+        )
+
+
+def test_every_build_profile_narrative_is_non_empty():
+    """`_narrative` raises at import for a missing file, so this asserts the weaker thing that
+    can still go wrong: a file that exists and says nothing."""
+    for name, profile in BUILD_PROFILES.items():
+        assert profile.system_prompt_template.strip(), f"{name} has an empty narrative"
+
+
+# --------------------------------------------------------------------------- #
+# The absence must be loud
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_registered_stack_with_no_build_profile_raises(monkeypatch, caplog):
+    """The inversion VS found. Swallowing this left the *correct* manifest as the failing one,
+    and an unscaffolded cycle would have gone on to report `completed` with no contract, no
+    fill slots and no frozen files."""
+    monkeypatch.setitem(
+        scaffold._STACKS,
+        "unprofiled_stack",
+        ScaffoldStack(name="unprofiled_stack", expand=lambda m: [], fill_slots=lambda m: ()),
+    )
+
+    with pytest.raises(ValueError, match="Unknown build profile"):
+        await _executor()._seed_skeleton_artifacts(
+            _manifest("unprofiled_stack"), MagicMock(), "run_x"
+        )
+
+    assert any("registries disagree" in r.message for r in caplog.records)
+
+
+async def test_an_unregistered_stack_is_still_skipped_quietly(monkeypatch):
+    """`is_scaffoldable_stack` gates first: a manifest naming a stack this system does not
+    know is not a registration error, and the run proceeds unscaffolded as it always has."""
+    result = await _executor()._seed_skeleton_artifacts(
+        _manifest("some_stack_we_never_registered"), MagicMock(), "run_x"
+    )
+
+    assert result == []
+
+
+async def test_an_expansion_failure_stays_tolerant(monkeypatch):
+    """The distinction that matters: a properly registered stack whose expansion raises falls
+    back to the non-scaffolded path, which is the pre-SIP-0099 behavior. Making this loud too
+    would fail cycles that work today."""
+
+    def _boom(_manifest):
+        raise RuntimeError("expander blew up")
+
+    # BuildProfile is frozen and its expander import is function-local, so the seam is the
+    # scaffold's `expand` itself — resolved fresh on every call.
+    monkeypatch.setattr("squadops.capabilities.scaffold.expand", _boom, raising=True)
+
+    result = await _executor()._seed_skeleton_artifacts(
+        _manifest("fullstack_fastapi_react"), MagicMock(), "run_x"
+    )
+
+    assert result == []


### PR DESCRIPTION
**Stage 1e-i(c)** — the last of #838's three fixes, **plus a live defect I introduced in #842** that this work surfaced. Regression **6933 passed, 1 skipped**.

## The registry gap

`nextjs_ts` was registered in five per-stack registries and absent from `BUILD_PROFILES`, the sixth. `_seed_skeleton_artifacts` resolves `get_profile(manifest.stack)`, which raises for an unregistered name — and the call site wrapped it in one broad `except Exception` returning `[]`.

**So a *correct* `nextjs_ts` manifest would have been silently unscaffolded, leaving the *wrong* manifest as the only one that worked.** The failing path was the correct one.

Registration and expansion are now separate concerns: a registered-but-unprofiled stack **raises**, naming the disagreement; an expansion failure on a properly registered stack **stays tolerant**, because that fallback predates SIP-0099 and making it loud would fail cycles that work today. Same separation #827 made for the probe path, for the same reason — two defects, two diagnoses.

An unscaffolded cycle has no contract, no fill slots and no frozen files. It is not a degraded run; it is a run whose entire verification story is absent, and it would report `completed`.

## A live defect in #842, already merged

**#842 pointed framing's target-stack section at `prompts/profile_narratives/` — which is the *builder's* asset.** Those prompts open *"You are assembling…"* and instruct *"do not regenerate application code — focus on packaging, configuration, and operational readiness."*

So since #842 merged, every framing stage on a `fullstack_fastapi_react` cycle has been handed the packaging prompt under a heading reading **"TARGET STACK — decided, not proposed"** — telling the stage that authors the technical design not to write application code.

Two audiences reading one asset. That is the ownership smell CLAUDE.md's edit-time rule exists to catch, arriving one release after that rule was written, from me.

```
prompts/profile_narratives/  ->  how is this stack PACKAGED   (builder)
prompts/stack_narratives/    ->  how is this stack WRITTEN    (framing)
```

`capabilities/stack_narratives.py` owns the second; `build_profiles` keeps its own loader unchanged. This also required writing the FastAPI **architecture** narrative that never existed — only its packaging one did.

**The #92 invariant makes the split concrete:** a builder narrative must not enumerate filenames, while an architecture narrative is largely *about* where things live. One asset could not have satisfied both, which is why the test caught it.

## Two test changes, flagged rather than buried

**`test_registry_has_four_profiles` removed**, not bumped to 5. A count names no bug class, breaks on every legitimate registration, and is the shape `TEST_QUALITY_STANDARD.md` rules out — same removal as the `DEV_CAPABILITIES` count in #836. The binding that matters is pinned in the new `test_build_profile_registration.py`: every scaffoldable stack has a profile, and its absence raises.

**The #92 filename heuristic now exempts framework product names containing a dot.** It could not tell `Next.js` from `main.js`, and the existing narratives escaped it only by naming frameworks that happen to have no dot (FastAPI, React, Vite). Naming the framework is not what #92 forbids — enumerating the files the validator grades is. This is the change most worth a second opinion, so it is called out.

`nextjs_ts`'s builder narrative joins the #452 byte-pin regime. It has no pre-move literal, so its pin establishes a baseline rather than verifying a move — the same guarantee going forward.

## #838 is now complete

All three fixes landed: the deterministic backstop (#841), the precedence rule (#842), and this. **VS can re-roll** — 1e-ii.

Closes #838 · Refs #822, #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtPXzvgnwxqqwswMcsCTWv
