### PR TITLE
fix(checks): one command allowlist, measured against the images (#707)

### DIFF
--- a/docs/architecture/typed-check-menu.md
+++ b/docs/architecture/typed-check-menu.md
@@ -23,9 +23,31 @@ Regenerate: `UPDATE_CHECK_MENU=1 pytest tests/unit/cycles/test_check_governance.
 | `regex_match` | authored | product | yes | yes | yes | yes | error |
 | `undefined_names` | injected | product | yes | yes | yes | yes | error |
 
-Caveat — `command_exit_zero` ownership is per-command in truth and
-untrustworthy until #707's allowlist inventory + precedence ruling
-(recorded in the registry beside the entry).
+`command_exit_zero` ownership is per-command in truth. The forms it may take
+are inventoried below — this replaces the standing caveat that called the
+surface untrustworthy pending #707's allowlist inventory.
+
+## Authorable `command_exit_zero` forms
+
+One list, not two (#707): a form is authorable exactly when the tool it needs is
+provisioned, and `acceptance_check_spec` refuses to import if that stops being true.
+Entries are measured in the agent images, never assumed.
+
+| form | tool needed |
+|---|---|
+| `python -m py_compile <file>` | `python` |
+| `node --check <file>` | `node` |
+| `pyflakes <file>` | `pyflakes` |
+
+### Languages no form reaches
+
+Declared, not omitted — a list that simply fails to mention a language reads as
+complete. What carries the claim instead is named, because an empty command
+surface is only acceptable while something else verifies the code.
+
+| language | why no form | verified instead by |
+|---|---|---|
+| TypeScript (.ts/.tsx) | no TypeScript checker is provisionable — tsc lives in the app's own node_modules/.bin and never on PATH, and `node --check` refuses both extensions before parsing (ERR_UNKNOWN_FILE_EXTENSION, node v20.19.2, measured 2026-08-10) | frontend_compiles / frontend_build — `next build` runs tsc itself and next.config.mjs declines to ignore type errors, so the bundler check IS the type check (#822 bend register entry 6) |
 
 ## Declared-unbuilt (visible, not evaluable, not authorable)
 

--- a/docs/plans/stack-2-bend-register.md
+++ b/docs/plans/stack-2-bend-register.md
@@ -125,13 +125,33 @@ targeting for wall-clock, and repair targeting is what #650 and #688 were both w
 
 ## 6 — No static check on the API route slots beyond the build · *disclosure*
 
-The nine AST checks parse Python by construction (`ast.parse`). `tsc --noEmit` **is** on the
-`command_exit_zero` safelist but is **not provisionable** — `tsc` lives in `node_modules/.bin`,
+The nine AST checks parse Python by construction (`ast.parse`). `tsc --noEmit` **was** on the
+`command_exit_zero` safelist and was **not provisionable** — `tsc` lives in `node_modules/.bin`,
 never on `PATH` — so emitting it would produce #707's *"passes the allowlist but cannot run"*
 class: a check that is always `skipped`.
 
 `next build` runs tsc itself and `next.config.mjs` declines to ignore type errors, so **the
 bundler check is the type check.**
+
+> **Amended 2026-08-10 (#707, prompted by #846).** The emitter reached this conclusion; the
+> *safelist* never did, and the gap between them was not free. VS's re-roll
+> (`cyc_0edb55919384`) lost a framing run because the squad reached for `tsc --noEmit`
+> **exactly as the safelist advertised it** and plan validation refused it. The safelist now
+> declares the tool each form needs and refuses to import unless the images provide it, so
+> the four unrunnable forms (`tsc`, `ruff`, `eslint`, `python -m mypy`) are gone.
+>
+> **A second, unrecorded hole surfaced in the same measurement:** `node --check` refuses `.ts`
+> with `ERR_UNKNOWN_FILE_EXTENSION` just as it does `.tsx` (node v20.19.2, squadops-eve), but
+> `_NODE_UNPARSEABLE_SUFFIXES` listed only `.jsx`/`.tsx`. After the prune that was the *one*
+> form a TypeScript author could still reach, and it fails on correct code. Now covered.
+>
+> **The disclosure is therefore stronger, not weaker: stack #2 has no authorable
+> `command_exit_zero` form at all.** That is declared in code
+> (`LANGUAGES_WITHOUT_COMMAND_FORM`) and rendered into `docs/architecture/typed-check-menu.md`
+> rather than left as a list that happens not to mention TypeScript — the Stack Blueprint
+> SIP's own argument against `analysable_suffix`, which failed because the frontend "was not
+> modeled as a second language without checkers; it was silently absent, and absence demands
+> no handling." A shorter safelist with nothing said about TypeScript would have repeated it.
 
 **What remains genuinely uncovered:** no criterion proves the declared endpoints *exist in the
 source*. `endpoint_defined` is Python-only, so that claim rests on the behavioral probes alone —

--- a/src/squadops/capabilities/handlers/_plan_authoring_service.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring_service.py
@@ -26,6 +26,7 @@ from squadops.capabilities.handlers.cycle_tasks import (
     _rewrite_manifest_identifiers,
 )
 from squadops.capabilities.handlers.fenced_parser import extract_fenced_files
+from squadops.cycles.acceptance_check_spec import command_safelist_names
 from squadops.cycles.implementation_plan import (
     ImplementationPlan,
     planner_build_task_types,
@@ -170,10 +171,14 @@ async def produce_plan(
         "```\n\n"
         "**Safety rules for `command_exit_zero`:**\n"
         '- `argv` MUST be a YAML list, not a string. `"ruff check src/"` is rejected.\n'
-        "- Only safelisted argv shapes run: `python -m py_compile <file>`, `python -m mypy <args>`, "
-        "`node --check <file>`, `ruff check <args>`, `tsc --noEmit`, `eslint <args>`, `pyflakes <file>`. "
-        "Anything else (notably `python -c`, `python -m pip`, shell strings) errors at evaluation time — "
-        "treat the safelist as the universe.\n"
+        # #707: rendered from COMMAND_SAFELIST, never restated. This block used to
+        # hand-copy seven forms, four of which no image could run — the drift that
+        # cost #846's re-roll its framing run. Prose stays; the vocabulary is sourced.
+        "- Only safelisted argv shapes run: "
+        + ", ".join(f"`{name}`" for name in command_safelist_names())
+        + ". Anything else (notably `python -c`, `python -m pip`, shell strings) is rejected at "
+        "plan validation — treat the safelist as the universe. There is no form for TypeScript; "
+        "`next build` type-checks it via the required frontend build.\n"
         "- Per-command timeout is bounded; do not author long-running builds as acceptance checks.\n\n"
         "**Check-selection hierarchy — behavioral > structural > textual:**\n"
         "- Prefer checks that execute or parse code (`command_exit_zero`, `endpoint_defined`, "

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -184,26 +184,81 @@ def is_check_applicable(check_name: str, file_path: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Command safelist (RC-10a) — single source for the ``command_exit_zero``
+# Command safelist (RC-10a) — the single source for the ``command_exit_zero``
 # argv contract. Consumed by the runtime evaluator (``acceptance_checks.py``),
-# the authoring-time lint (``implementation_plan.py``, #422), and the proposer
-# vocabulary below, so the three surfaces cannot drift.
+# the authoring-time lint (``implementation_plan.py``, #422), the plan-validation
+# net (``validate_command_checks``), and the proposer vocabulary, so no surface
+# can hold a private opinion about what a plan may ask for.
+#
+# **#707: it used to be two sources, and they disagreed in both directions.**
+# ``implementation_plan`` carried ``_CHECK_ENV_EXECUTABLES`` — the tools the check
+# environment provides — and of eleven plausible forms, nine were rejected by exactly
+# one of the two gates. The two rejection messages recommended *disjoint* sets, so an
+# author who followed one was refused by the other. #846 is the bill: VS's Next.js
+# re-roll lost a 75-minute framing run because the squad reached for the obvious
+# TypeScript check, ``tsc --noEmit``, exactly as this list advertised it, and plan
+# validation refused it.
+#
+# The reconciliation is structural, not a one-time resync. Each form declares the
+# ``tool`` it needs; ``CHECK_ENV_TOOLS`` declares what the images provide; and
+# ``_assert_safelist_is_runnable`` (below) refuses to import a self-contradictory
+# vocabulary. The old executable-name gate is gone — asking the safelist is strictly
+# stronger, since it also catches ``python -c`` and other argv that shares a
+# provisioned argv[0] with a legitimate form.
+#
+# Entries are MEASURED, not intended. Every form below was run in both agent
+# containers (squadops-eve, squadops-neo, 2026-08-10). What the measurement removed:
+#
+#   ``ruff check <args...>``  — absent from both images. ``pyflakes`` is the one
+#                               Python linter actually installed (requirements/
+#                               base.txt, for the ``undefined_names`` evaluator) and
+#                               was the one form the old env gate refused.
+#   ``python -m mypy <args>`` — mypy is in no requirements file, so the module import
+#                               fails. argv[0] is ``python``, which is why an
+#                               executable-name gate could never have caught it and
+#                               why this list now keys on the tool a form NEEDS.
+#   ``tsc --noEmit``          — never on PATH; TypeScript lives in the app's own
+#                               ``node_modules/.bin``. ``scaffold_contract``'s
+#                               ``_nextjs_ts_slot_criteria`` had already reached this
+#                               conclusion for stack #2's criteria pack (#822) —
+#                               ``next build`` runs tsc, so ``frontend_compiles`` IS
+#                               the type check. The safelist never got the memo.
+#   ``eslint <args...>``      — present (Debian's npm pulls in v6.4.0) but unusable:
+#                               with no eslint config in the tree it exits 2 before
+#                               reading a line of source, which is #645's "fails on
+#                               any content, correct or not" class.
+#
+# Adding a form back is a measurement, not a preference: run it in the agent image
+# against a representative tree, then declare its tool here.
 # ---------------------------------------------------------------------------
+
+#: The tools the check environment provides, measured in both agent images
+#: (squadops-eve, squadops-neo, 2026-08-10). Not a policy preference — a fact about
+#: the images, and the reason it lives beside the safelist rather than in the
+#: validator is #707: two modules cannot hold one fact without eventually disagreeing
+#: about it.
+#:
+#: ``pytest``/``npm``/``npx`` are provisioned but reach no safelisted form. They stay
+#: because this set describes the environment, not the vocabulary; the subset rule
+#: runs one way only. (``pytest`` is also qa-only — absent from the dev image — so a
+#: form needing it would want a per-role declaration this set does not carry.)
+CHECK_ENV_TOOLS: frozenset[str] = frozenset(
+    {"python", "python3", "pytest", "node", "npm", "npx", "pyflakes"}
+)
 
 
 @dataclass(frozen=True)
 class CommandPattern:
+    """One authorable ``command_exit_zero`` argv form.
+
+    ``tool`` is the executable the form needs present, which is NOT always ``argv[0]``
+    — ``python -m mypy`` needs mypy, not python. Declaring it per form is what makes
+    "authorable" and "runnable" the same question (#707).
+    """
+
     name: str
     matcher: Callable[[list[str]], bool]
-
-
-def _exact(*expected: str) -> Callable[[list[str]], bool]:
-    expected_list = list(expected)
-
-    def matcher(argv: list[str]) -> bool:
-        return list(argv) == expected_list
-
-    return matcher
+    tool: str
 
 
 def _exact_then_one_path(*prefix: str) -> Callable[[list[str]], bool]:
@@ -215,34 +270,39 @@ def _exact_then_one_path(*prefix: str) -> Callable[[list[str]], bool]:
     return matcher
 
 
-def _prefix_with_args(*prefix: str) -> Callable[[list[str]], bool]:
-    prefix_list = list(prefix)
-
-    def matcher(argv: list[str]) -> bool:
-        return len(argv) > len(prefix_list) and list(argv[: len(prefix_list)]) == prefix_list
-
-    return matcher
-
-
-def _argv0_with_args(name: str) -> Callable[[list[str]], bool]:
-    def matcher(argv: list[str]) -> bool:
-        return len(argv) >= 1 and argv[0] == name
-
-    return matcher
-
-
 # Order matters only for human readability; the matcher is `any(...)`.
 COMMAND_SAFELIST: tuple[CommandPattern, ...] = (
     CommandPattern(
-        "python -m py_compile <file>", _exact_then_one_path("python", "-m", "py_compile")
+        "python -m py_compile <file>",
+        _exact_then_one_path("python", "-m", "py_compile"),
+        tool="python",
     ),
-    CommandPattern("python -m mypy <args...>", _prefix_with_args("python", "-m", "mypy")),
-    CommandPattern("node --check <file>", _exact_then_one_path("node", "--check")),
-    CommandPattern("ruff check <args...>", _prefix_with_args("ruff", "check")),
-    CommandPattern("tsc --noEmit", _exact("tsc", "--noEmit")),
-    CommandPattern("eslint <args...>", _argv0_with_args("eslint")),
-    CommandPattern("pyflakes <file>", _exact_then_one_path("pyflakes")),
+    CommandPattern("node --check <file>", _exact_then_one_path("node", "--check"), tool="node"),
+    CommandPattern("pyflakes <file>", _exact_then_one_path("pyflakes"), tool="pyflakes"),
 )
+
+
+def _assert_safelist_is_runnable() -> None:
+    """Refuse to import a vocabulary that advertises what the environment cannot run.
+
+    #707's acceptance is *"the set of authorable command forms equals the set of
+    runnable command forms"*, and the way that was violated for eight months was a
+    second list drifting quietly. A test would catch the drift; raising here means the
+    contradictory state cannot exist at all — the #845 precedent, where a missing build
+    profile stopped being swallowed. The condition is static module content, so this can
+    only fire on an edit to this file, never on runtime data.
+    """
+    missing = sorted({pat.tool for pat in COMMAND_SAFELIST} - CHECK_ENV_TOOLS)
+    if missing:
+        raise RuntimeError(
+            f"command safelist advertises {missing}, which CHECK_ENV_TOOLS does not "
+            f"provide — an authored check using it can never execute, so it fails "
+            f"identically on every correction attempt (#707). Either provision the tool "
+            f"in agents/instances/<role>/ and declare it, or drop the form."
+        )
+
+
+_assert_safelist_is_runnable()
 
 
 def argv_matches_safelist(argv: list[str]) -> bool:
@@ -750,6 +810,52 @@ DECLARED_UNBUILT_CHECKS: tuple[DeclaredUnbuiltCheck, ...] = (
 )
 
 
+@dataclass(frozen=True)
+class LanguageWithoutCommandForm:
+    """A source language no safelisted ``command_exit_zero`` form can reach (#707).
+
+    The same honesty pattern as ``DeclaredUnbuiltCheck``, applied one level down — to a
+    check that *exists* but has no authorable form for some of the code it is offered
+    against. It is declared rather than merely absent because of the argument the Stack
+    Blueprint SIP makes against its own ``analysable_suffix`` sketch: that field encoded
+    *a limitation of the tooling as a property of the domain*, and the frontend "was not
+    modeled as a second language without checkers; it was silently absent, and absence
+    demands no handling." **A partial model is worse than none: it implies the rest does
+    not exist.** A shorter safelist with nothing said about TypeScript would repeat that
+    exactly — the reader infers the list is complete rather than that a language fell off it.
+
+    ``verified_by`` is the load-bearing field. An empty command surface is only acceptable
+    while something else carries the claim, and naming that something is what forces the
+    "then what verifies this language?" question the SIP asks downstream consumers to
+    answer explicitly.
+    """
+
+    language: str
+    reason: str
+    verified_by: str
+
+
+#: Languages the command safelist cannot reach. Rendered into the generated check menu,
+#: so the gap is visible where the vocabulary is documented rather than inferred from a
+#: list that happens not to mention it.
+LANGUAGES_WITHOUT_COMMAND_FORM: tuple[LanguageWithoutCommandForm, ...] = (
+    LanguageWithoutCommandForm(
+        language="TypeScript (.ts/.tsx)",
+        reason=(
+            "no TypeScript checker is provisionable — tsc lives in the app's own "
+            "node_modules/.bin and never on PATH, and `node --check` refuses both "
+            "extensions before parsing (ERR_UNKNOWN_FILE_EXTENSION, node v20.19.2, "
+            "measured 2026-08-10)"
+        ),
+        verified_by=(
+            "frontend_compiles / frontend_build — `next build` runs tsc itself and "
+            "next.config.mjs declines to ignore type errors, so the bundler check IS "
+            "the type check (#822 bend register entry 6)"
+        ),
+    ),
+)
+
+
 def reserved_keys_for(check_name: str) -> frozenset[str]:
     """Return the keys reserved for the wrapper (not part of params).
 
@@ -889,9 +995,35 @@ def render_check_governance_menu() -> str:
         )
     lines += [
         "",
-        "Caveat — `command_exit_zero` ownership is per-command in truth and",
-        "untrustworthy until #707's allowlist inventory + precedence ruling",
-        "(recorded in the registry beside the entry).",
+        "`command_exit_zero` ownership is per-command in truth. The forms it may take",
+        "are inventoried below — this replaces the standing caveat that called the",
+        "surface untrustworthy pending #707's allowlist inventory.",
+        "",
+        "## Authorable `command_exit_zero` forms",
+        "",
+        "One list, not two (#707): a form is authorable exactly when the tool it needs is",
+        "provisioned, and `acceptance_check_spec` refuses to import if that stops being true.",
+        "Entries are measured in the agent images, never assumed.",
+        "",
+        "| form | tool needed |",
+        "|---|---|",
+    ]
+    for pat in COMMAND_SAFELIST:
+        lines.append(f"| `{pat.name}` | `{pat.tool}` |")
+    lines += [
+        "",
+        "### Languages no form reaches",
+        "",
+        "Declared, not omitted — a list that simply fails to mention a language reads as",
+        "complete. What carries the claim instead is named, because an empty command",
+        "surface is only acceptable while something else verifies the code.",
+        "",
+        "| language | why no form | verified instead by |",
+        "|---|---|---|",
+    ]
+    for gap in LANGUAGES_WITHOUT_COMMAND_FORM:
+        lines.append(f"| {gap.language} | {gap.reason} | {gap.verified_by} |")
+    lines += [
         "",
         "## Declared-unbuilt (visible, not evaluable, not authorable)",
         "",

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -51,18 +51,24 @@ _KNOWN_BUILD_TASK_TYPES = {
 # regardless of the authoring squad.
 _BUILDER_ROLE_BUILD_TASK_TYPES = {"builder.assemble"}
 
-# #645: the executable surface of the environment typed checks run in (the QA
-# agent image). A command check whose argv[0] is not here can never execute
-# where checks execute — it fails identically on every correction attempt
-# (fay-2's plan wanted `tsc`; two later plans reached for it again). This
-# mirrors the image's installed tooling, not a policy preference; extend it
-# when the image gains a tool.
-_CHECK_ENV_EXECUTABLES = frozenset({"python", "python3", "pytest", "node", "npm", "npx"})
+# #645 lived here as `_CHECK_ENV_EXECUTABLES`, a second opinion about what a command
+# check may ask for. #707 deleted it rather than resynchronising it: the safelist in
+# `acceptance_check_spec` now declares the tool each form needs and refuses to import
+# unless the environment provides it, so "is this tool present" and "is this argv
+# permitted" are one question with one answer. Asking the safelist is also strictly
+# stronger than the old test, which passed `["python", "-c", "1"]` on argv[0] alone and
+# left the refusal to evaluation time, an hour of correction budget later.
 
-# #645: node refuses these extensions outright (ERR_UNKNOWN_FILE_EXTENSION,
-# exit 1 before parsing) — `node --check view.jsx` fails on ANY content,
-# correct or not (fay-2's killer; verified in the QA container).
-_NODE_UNPARSEABLE_SUFFIXES = (".jsx", ".tsx")
+# #645: node refuses these extensions outright (ERR_UNKNOWN_FILE_EXTENSION, exit 1
+# before parsing) — `node --check view.jsx` fails on ANY content, correct or not
+# (fay-2's killer; verified in the QA container).
+#
+# `.ts` added by #707. It was missing, and the omission was invisible while the tree
+# held one Python stack: `node --check route.ts` exits 1 on node v20.19.2 exactly as
+# `.tsx` does (measured in squadops-eve, 2026-08-10). With stack #2 in the tree this is
+# the one form a TypeScript author could still reach, so the hole sat directly under
+# #846's Family A — a correct plan rejected, or worse, admitted and unwinnable.
+_NODE_UNPARSEABLE_SUFFIXES = (".jsx", ".tsx", ".ts")
 
 
 def _importable_module_surface(paths: frozenset[str] | set[str]) -> frozenset[str]:
@@ -465,11 +471,17 @@ class ImplementationPlan:
         Two deterministic classes from the FAY measurement window, both provable
         at authoring time without running anything:
 
-        - an executable the check environment does not ship (fay-2's ``tsc``) —
-          the spawn fails on every attempt until the correction budget is spent;
-        - ``node`` pointed at a ``.jsx``/``.tsx`` file — node refuses the
+        - a form the check environment cannot run (fay-2's ``tsc``) — the spawn fails
+          on every attempt until the correction budget is spent;
+        - ``node`` pointed at a ``.jsx``/``.tsx``/``.ts`` file — node refuses the
           extension before parsing (``ERR_UNKNOWN_FILE_EXTENSION``), so the check
           fails on ANY content, correct or not.
+
+        #707 replaced the first test's private executable list with the safelist itself.
+        That is not a simplification for its own sake: the two lists recommended disjoint
+        sets in their rejection messages, so an author who took one gate's advice was
+        refused by the other. It is also stricter — an argv sharing a provisioned argv[0]
+        with a legitimate form (``python -c``) used to pass here and fail at evaluation.
 
         Only ``severity=error`` rejects (RC-9: a warning cannot block a build, so
         a doomed warning check costs nothing — fay-6 and fay-8 both carried one
@@ -485,24 +497,24 @@ class ImplementationPlan:
                 argv = criterion.params.get("argv") or []
                 if not argv or not all(isinstance(a, str) for a in argv):
                     continue
-                executable = argv[0]
-                if executable not in _CHECK_ENV_EXECUTABLES:
+                if not argv_matches_safelist(argv):
                     errors.append(
-                        f"Task {task.task_index} ({task.focus}): command_exit_zero invokes "
-                        f"{executable!r}, which the check environment does not provide — "
-                        f"the check can never execute, so no repair can fix it and the "
-                        f"task fails identically on every correction attempt. Use one of "
-                        f"{sorted(_CHECK_ENV_EXECUTABLES)} or a named check"
+                        f"Task {task.task_index} ({task.focus}): command_exit_zero argv "
+                        f"{argv} is not a form the check environment can run — the check "
+                        f"can never execute, so no repair can fix it and the task fails "
+                        f"identically on every correction attempt. Use one of: "
+                        f"{'; '.join(command_safelist_names())} — or a named check"
                     )
-                elif executable == "node" and any(
+                elif argv[0] == "node" and any(
                     arg.endswith(_NODE_UNPARSEABLE_SUFFIXES) for arg in argv[1:]
                 ):
                     errors.append(
                         f"Task {task.task_index} ({task.focus}): command_exit_zero runs "
-                        f"node against a .jsx/.tsx file — node refuses the extension "
+                        f"node against a .jsx/.tsx/.ts file — node refuses the extension "
                         f"before parsing (ERR_UNKNOWN_FILE_EXTENSION), so this fails on "
-                        f"any content, correct or not. JSX compilation is verified by "
-                        f"the frontend build; drop the check or target plain .js"
+                        f"any content, correct or not. TypeScript and JSX are compiled by "
+                        f"the frontend build, which type-checks them; drop the check or "
+                        f"target plain .js"
                     )
         return errors
 

--- a/src/squadops/prompts/fragments/manifest.yaml
+++ b/src/squadops/prompts/fragments/manifest.yaml
@@ -102,13 +102,13 @@ fragments:
   layer: task_type
   roles:
   - dev
-  sha256: b16024fca4cef072b9ca712f8874e4d8bd7ab92d2b160cc68a5b4d28269e642a
+  sha256: 010cc182e800f2957bc539f93f7e0fc5d9dd1e90987a52b42e56dd31524ec3ab
 - fragment_id: task_type.qa.propose_plan_tasks
   path: shared/task_type/task_type.qa.propose_plan_tasks.md
   layer: task_type
   roles:
   - qa
-  sha256: 564c58fb8f7882f4af9c48e275a34bafa6ae863ae7bfbc89935525bc761366bc
+  sha256: f445b6c5dc78c180b921a2e6a0d47e899533deea334f311383ea0b58a220c180
 - fragment_id: task_type.strategy.propose_plan_guidance
   path: shared/task_type/task_type.strategy.propose_plan_guidance.md
   layer: task_type
@@ -193,4 +193,4 @@ fragments:
   roles:
   - data
   sha256: fd44a28f65e449c6320b5ee5f1d8121013a03c7baa757965334c4e19c7904779
-manifest_hash: d46aec070f542e23ab194772a1a49b3512fea4d87ddb96cf7b4b6e912ff15311
+manifest_hash: 4c0dac2b7214d21e533163e63ff00291b714ae066ef771bdbdf450825946dd34

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.development.propose_plan_tasks.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.development.propose_plan_tasks.md
@@ -73,11 +73,14 @@ informational only. The user prompt lists the vocabulary with examples
   implementation is free to make differently, and plan validation
   REJECTS it. Verify source files with the AST/behavioral checks below.
 - `endpoint_defined` for HTTP route presence
-- `command_exit_zero` for static checkers (argv-only safelist). The command
-  runs in the container of the role that executes the task — only author
-  commands whose binary exists there. Dev-role containers carry the Python
-  toolchain ONLY (`python`, `ruff`); `node`/`npm` exist only in the QA
-  container. A missing binary is skipped, not failed — it verifies nothing.
+- `command_exit_zero` for static checkers. These three forms are the whole
+  universe, and each is provisioned in every role container: `python -m
+  py_compile <file>`, `node --check <file>`, `pyflakes <file>`. Any other
+  command is REJECTED at plan validation, not skipped at runtime — a command
+  the environment cannot run fails identically on every correction attempt, so
+  it is refused before it can spend the budget. **TypeScript has no form
+  here** — `node --check` rejects `.ts`/`.tsx` before parsing them. Do not
+  reach for another tool to cover it; the frontend build type-checks it.
 - `count_at_least` for glob match counts
 
 ### Output shape

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.qa.propose_plan_tasks.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.qa.propose_plan_tasks.md
@@ -74,11 +74,14 @@ Prefer **typed checks** for qa assertions:
   by plan validation, failing the whole plan. Test-file behavior is
   verified by executing the suite, not by pattern-matching it.
 - `count_at_least` for test-file/spec-file counts via glob
-- `command_exit_zero` for invoking a test runner (argv-only safelist:
-  `python -m py_compile`, `ruff check`, `tsc --noEmit`, etc.). The command
-  runs in the container of the role that executes the task — only author
-  commands whose binary exists there. Node tooling (`node`, `npm`, `npx`)
-  exists only in the QA container; dev-role tasks get Python tooling only.
+- `command_exit_zero` for static checkers. These three forms are the whole
+  universe — there is no "etc.": `python -m py_compile <file>`, `node --check
+  <file>`, `pyflakes <file>`. Any other command is REJECTED at plan
+  validation, because a command the environment cannot run fails identically
+  on every correction attempt. Do NOT reach for the test runner here; the
+  suite is executed by the required `tests_pass` check. **TypeScript has no
+  form here** — `node --check` rejects `.ts`/`.tsx` before parsing them. Do
+  not substitute another tool; the frontend build type-checks it.
 - `import_present` to verify a test file imports the production module
   it should be exercising
 

--- a/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
@@ -39,10 +39,13 @@ only. A regex against source prescribes another author's stylistic choices — q
 identifier spelling — and rejects correct code. Verify source with the structural checks
 instead.
 
-**commands-must-run-here** — An error-severity `command_exit_zero` runs the tooling the
-check environment actually ships, against a file type that tool accepts. A missing
-executable, or `node --check` pointed at `.jsx`/`.tsx`, fails on every attempt regardless
-of content.
+**commands-must-run-here** — An error-severity `command_exit_zero` uses one of the
+safelisted forms, against a file type that tool accepts. The safelist is the entire
+universe of runnable commands — every form on it is provisioned in every role container,
+and anything outside it is rejected here rather than left to fail on every correction
+attempt. `node --check` pointed at `.ts`/`.tsx`/`.jsx` is rejected for the same reason:
+node refuses those extensions before it parses a line, so the check fails on correct code
+too. TypeScript has no command form at all; the frontend build type-checks it.
 
 **roles-must-exist** — Every task's `role` is one the squad profile actually staffs. A
 task assigned to an absent role can never be dispatched.

--- a/tests/unit/cycles/test_acceptance_checks.py
+++ b/tests/unit/cycles/test_acceptance_checks.py
@@ -805,11 +805,11 @@ class TestCommandExitZero:
 
         monkeypatch.setattr("asyncio.create_subprocess_exec", fake_create_subprocess_exec)
         result = await get_check("command_exit_zero").evaluate(
-            {"argv": ["tsc", "--noEmit"], "timeout_s": 9999},
+            {"argv": ["pyflakes", "app.py"], "timeout_s": 9999},
             tmp_path,
         )
         assert result.status == "passed"
-        assert captured["argv"] == ["tsc", "--noEmit"]
+        assert captured["argv"] == ["pyflakes", "app.py"]
 
 
 # ---------------------------------------------------------------------------
@@ -822,13 +822,7 @@ class TestCommandExitZero:
     [
         # Allowed shapes
         (["python", "-m", "py_compile", "backend/main.py"], True),
-        (["python", "-m", "mypy", "src/"], True),
-        (["python", "-m", "mypy", "--strict", "src/"], True),
         (["node", "--check", "app.js"], True),
-        (["ruff", "check", "src/"], True),
-        (["ruff", "check", "src/", "--select", "E"], True),
-        (["tsc", "--noEmit"], True),
-        (["eslint", "src/"], True),
         (["pyflakes", "main.py"], True),
         # Rejected shapes
         (["python", "-c", "print(1)"], False),
@@ -840,6 +834,14 @@ class TestCommandExitZero:
         (["pyflakes", "a.py", "b.py"], False),  # exact-then-ONE-path
         (["bash", "-c", "echo hi"], False),
         (["sh", "echo hi"], False),
+        # #707: forms this list advertised while no agent image could run them.
+        # Measured absent (ruff, tsc) or present-but-unusable (eslint v6.4.0 exits 2
+        # with no config); `python -m mypy` cleared BOTH old gates and then failed at
+        # evaluation with "No module named mypy" — the case an argv[0] check is blind to.
+        (["python", "-m", "mypy", "src/"], False),
+        (["ruff", "check", "src/"], False),
+        (["tsc", "--noEmit"], False),
+        (["eslint", "src/"], False),
     ],
 )
 def test_argv_matches_safelist(argv, expected):

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -6,7 +6,11 @@ from dataclasses import dataclass
 
 import pytest
 
-from squadops.cycles.acceptance_check_spec import CHECK_SPECS
+from squadops.cycles.acceptance_check_spec import (
+    CHECK_SPECS,
+    COMMAND_SAFELIST,
+    argv_matches_safelist,
+)
 from squadops.cycles.implementation_plan import (
     ImplementationPlan,
     TypedCheck,
@@ -601,6 +605,18 @@ summary:
 """
 
 
+#: One concrete, authorable argv per entry in ``COMMAND_SAFELIST``. Kept beside the
+#: safelist's own test so the pairing is visible; the count is asserted below (#707).
+_SAFELISTED_FORM_CASES = [
+    (
+        '["python", "-m", "py_compile", "backend/main.py"]',
+        ["python", "-m", "py_compile", "backend/main.py"],
+    ),
+    ('["node", "--check", "app.js"]', ["node", "--check", "app.js"]),
+    ('["pyflakes", "main.py"]', ["pyflakes", "main.py"]),
+]
+
+
 class TestCommandSafelistLint:
     """Authoring-boundary rejection of commands the evaluator can never run.
 
@@ -634,21 +650,7 @@ class TestCommandSafelistLint:
                 _plan_yaml_with_command('["npm", "test"]'), enforce_command_safelist=True
             )
 
-    @pytest.mark.parametrize(
-        "argv,parsed_argv",
-        [
-            (
-                '["python", "-m", "py_compile", "backend/main.py"]',
-                ["python", "-m", "py_compile", "backend/main.py"],
-            ),
-            ('["python", "-m", "mypy", "src/"]', ["python", "-m", "mypy", "src/"]),
-            ('["node", "--check", "app.js"]', ["node", "--check", "app.js"]),
-            ('["ruff", "check", "."]', ["ruff", "check", "."]),
-            ('["tsc", "--noEmit"]', ["tsc", "--noEmit"]),
-            ('["eslint", "src/"]', ["eslint", "src/"]),
-            ('["pyflakes", "main.py"]', ["pyflakes", "main.py"]),
-        ],
-    )
+    @pytest.mark.parametrize("argv,parsed_argv", _SAFELISTED_FORM_CASES)
     def test_authoring_accepts_every_safelisted_form(self, argv, parsed_argv):
         plan = ImplementationPlan.from_yaml(
             _plan_yaml_with_command(argv), enforce_command_safelist=True
@@ -656,6 +658,24 @@ class TestCommandSafelistLint:
         criterion = plan.tasks[0].acceptance_criteria[0]
         assert isinstance(criterion, TypedCheck)
         assert criterion.params["argv"] == parsed_argv
+
+    def test_every_safelisted_form_has_an_authoring_case(self):
+        """#707's drift guard, pointed at the fixtures rather than the code.
+
+        The case list is hand-written by necessity — each case needs a concrete argv its
+        pattern accepts, which cannot be derived from a matcher function. That is how the
+        old seven-form list stayed green for eight months while four of its forms could
+        not run anywhere: the fixtures agreed with the safelist, and neither agreed with
+        the images. Asserting the count means a form added without a case fails here
+        instead of shipping untested, and each fixture is confirmed against the live
+        matcher rather than assumed.
+        """
+        assert len(_SAFELISTED_FORM_CASES) == len(COMMAND_SAFELIST), (
+            f"{len(COMMAND_SAFELIST)} safelisted forms but {len(_SAFELISTED_FORM_CASES)} "
+            f"authoring cases — add a case for the new form (or drop the stale one)"
+        )
+        for _, parsed_argv in _SAFELISTED_FORM_CASES:
+            assert argv_matches_safelist(parsed_argv), f"fixture {parsed_argv} is not safelisted"
 
     def test_default_parse_accepts_non_safelisted_command(self):
         """Dispatch-time re-parse must stay permissive: flipping the default

--- a/tests/unit/cycles/test_plan_authoring_rules.py
+++ b/tests/unit/cycles/test_plan_authoring_rules.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import pytest
 
+from squadops.cycles.acceptance_check_spec import COMMAND_SAFELIST
 from squadops.cycles.implementation_plan import ImplementationPlan
 from squadops.cycles.plan_authoring_rules import (
     AUTHOR_FACING,
@@ -27,9 +28,9 @@ from squadops.cycles.plan_authoring_rules import (
 
 pytestmark = [pytest.mark.domain_contracts]
 
-_TEMPLATES = (
-    Path(__file__).resolve().parents[3] / "src" / "squadops" / "prompts" / "request_templates"
-)
+_PROMPTS = Path(__file__).resolve().parents[3] / "src" / "squadops" / "prompts"
+_TEMPLATES = _PROMPTS / "request_templates"
+_FRAGMENTS = _PROMPTS / "fragments" / "shared" / "task_type"
 _ASSET = _TEMPLATES / "request.plan_authoring_rules_appendix.md"
 
 
@@ -96,3 +97,41 @@ def test_the_asset_teaches_the_shk1_defect_and_its_legitimate_alternative():
     assert "one-file-one-owner" in asset
     assert "expected_artifacts: []" in asset
     assert "verif" in asset.lower()
+
+
+#: Assets that name concrete `command_exit_zero` forms to an author. Prose, so they must
+#: restate rather than render — which is precisely how they drifted (#707).
+_COMMAND_FORM_ASSETS = (
+    _FRAGMENTS / "task_type.development.propose_plan_tasks.md",
+    _FRAGMENTS / "task_type.qa.propose_plan_tasks.md",
+)
+
+
+@pytest.mark.parametrize("asset", _COMMAND_FORM_ASSETS, ids=lambda p: p.name)
+def test_proposer_assets_name_only_runnable_command_forms(asset):
+    """#707/#846: the authoring prompts advertised commands no image could run.
+
+    This is the defect that cost VS's Next.js re-roll a 75-minute framing run — the qa
+    fragment offered ``tsc --noEmit`` and ``ruff check``, the squad took the offer, and
+    plan validation rejected the result. These fragments are prose and cannot render from
+    ``COMMAND_SAFELIST``, so the binding has to be a test.
+
+    Asserted in both directions. Naming a retired tool is the trap that fired; failing to
+    name a live form is the quieter half — an author who is never shown a form does not
+    author it, and the check goes unused rather than wrong.
+    """
+    text = asset.read_text(encoding="utf-8")
+    live_tools = {pat.tool for pat in COMMAND_SAFELIST}
+
+    for tool in ("ruff", "tsc", "eslint", "mypy"):
+        assert tool not in live_tools, "update this list — the tool is safelisted again"
+        assert tool not in text, (
+            f"{asset.name} still offers `{tool}`, which no agent image can run. An author "
+            f"who takes the offer is rejected at plan validation (#707)"
+        )
+
+    for tool in sorted(live_tools):
+        assert tool in text, (
+            f"{asset.name} never mentions `{tool}`, a form the author may legitimately "
+            f"use — an unadvertised check is an unused one"
+        )


### PR DESCRIPTION
## What this fixes

Two allowlists gated `command_exit_zero` and **disagreed in both directions** — #707's own measurement, re-confirmed on `main`. #846's Family A is the bill coming due: VS's Next.js re-roll (`cyc_0edb55919384`) lost a 75-minute framing run because the squad reached for `tsc --noEmit` **exactly as the safelist advertised it**, and plan validation refused it.

## Measured, not inferred

I ran the tools in both agent containers (`squadops-eve`, `squadops-neo`, 2026-08-10) rather than reading requirements files:

| form | eve (qa) | neo (dev) | old safelist | old env gate | verdict |
|---|---|---|---|---|---|
| `python -m py_compile` | ✓ | ✓ | ✓ | ✓ | **kept** |
| `node --check` | ✓ | ✓ | ✓ | ✓ | **kept** |
| `pyflakes <file>` | ✓ | ✓ | ✓ | ✗ | **kept** — the one Python linter installed was the one refused |
| `ruff check` | MISSING | MISSING | ✓ | ✗ | dropped |
| `tsc --noEmit` | MISSING | MISSING | ✓ | ✗ | dropped |
| `python -m mypy` | MISSING | MISSING | ✓ | **✓** | dropped |
| `eslint <args>` | v6.4.0 | v6.4.0 | ✓ | ✗ | dropped — present but exits 2 with no config before reading a line (#645's fails-on-any-content class) |

`python -m mypy` is the instructive one: it **cleared both gates** and then failed at evaluation with `No module named mypy`. `argv[0]` is `python`, so an executable-name gate is structurally blind to it — which is why forms now declare the tool they *need*, not the binary they start with.

## The fix is structural, not a resync

- `CommandPattern` gains `tool` — what the form actually needs.
- `CHECK_ENV_TOOLS` declares what the images provide, **beside** the safelist. Two modules cannot hold one fact without eventually disagreeing about it.
- `_assert_safelist_is_runnable()` **refuses to import** a self-contradictory vocabulary. A test catches drift; raising means the contradictory state cannot exist (the #845 precedent). Static module content only — it can fire on an edit to that file, never on runtime data. Verified by mutation.
- `_CHECK_ENV_EXECUTABLES` **deleted** rather than resynchronised. Asking the safelist is strictly stronger: the old test passed `["python", "-c", "1"]` on `argv[0]` alone and left the refusal to evaluation, an hour of correction budget later.

This satisfies #707's acceptance: *one structure answers "may a plan author this command", with no second list to keep in sync*, and a parity test derived from the structures.

## A second hole, found by the same measurement

`node --check` refuses `.ts` with `ERR_UNKNOWN_FILE_EXTENSION` exactly as it does `.tsx` (node v20.19.2), but `_NODE_UNPARSEABLE_SUFFIXES` listed only `.jsx`/`.tsx`. Invisible while the tree held one Python stack. After the prune it was **the one form a TypeScript author could still reach**, and it fails on correct code.

## So stack #2 has no command form — and that is declared, not omitted

The Stack Blueprint SIP argues against its own `analysable_suffix` sketch on exactly this ground: the frontend *"was not modeled as a second language without checkers; it was silently absent, and absence demands no handling… A partial model is worse than none: it implies the rest does not exist."*

A shorter safelist with nothing said about TypeScript repeats that. So `LANGUAGES_WITHOUT_COMMAND_FORM` declares the gap with its reason, and `verified_by` is the load-bearing field — an empty command surface is only acceptable while something else carries the claim, and `next build` does. It renders into the generated `docs/architecture/typed-check-menu.md`, replacing the standing caveat that called this surface *"untrustworthy until #707's allowlist inventory"*.

This does **not** mint per-stack vocabulary: it lives in `acceptance_check_spec` beside `DECLARED_UNBUILT_CHECKS`, not on `ScaffoldStack`. Stage 2a/2b owns the schema question and this deliberately does not prejudge it.

## Three prompt surfaces restated the safelist by hand, and all three had drifted

The dev fragment also told authors that dev containers carry `ruff` and that node exists only in QA — **both false** (neither image has ruff; both have node/npm).

- The Python-hosted block now renders from `command_safelist_names()`.
- The two fragments are prose and cannot render, so a test binds them **in both directions**: naming a retired tool is the trap that fired; failing to name a live form is the quieter half, since an unadvertised check is an unused one.

That test caught this PR's own first draft, which named `tsc` in order to *warn* about it. Naming a forbidden command in a prompt is how it gets emitted, so the fragments now state only the positive.

## Bend register

Entry 6 amended in this PR per its own written-during rule. Its stated fact ("`tsc --noEmit` **is** on the safelist but is not provisionable") stops being true here. The disclosure comes out **stronger**, not weaker.

## Verification

- Regression **6930 passed**, 1 skipped.
- Reference contract `7622f570c949fe95` and manifest `bb472e267e53d5ad` **unmoved** (M0a's pins).
- Import tripwire verified by mutation — adding a `tsc` form raises at import.
- Fragment manifest hashes regenerated via `scripts/dev/regen_fragment_manifest.py --write`.

## Scope note

Deliberately **not** here: #846's Family A2 (plan validation judging a vitest suite by pytest discovery) and Family B. Those follow in a stacked PR off this branch. #846 filed both families together; they split cleanly because this half was already specified in #707 with its own acceptance criteria, and burying it would have hidden that the reconciliation was diagnosed long before it was paid for.

Closes #707
Refs #846, #822, #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX
