### PR TITLE
fix(plan): plan validation knows the stack, and the sole author gets the contract (#846)

### DIFF
--- a/src/squadops/capabilities/context_assembly.py
+++ b/src/squadops/capabilities/context_assembly.py
@@ -157,15 +157,25 @@ CONTEXT_CONTRACTS: dict[str, ContextAssemblyContract] = {
     # --- planning chain (#657): upstream documents on an envelope-local
     # prior_outputs copy; all four authoring types receive a re-roll's
     # rejection context (#669 — fresh dice previously meant zero teaching,
-    # fay-10 re-tripped the same class three times). governance.merge_plan is
-    # DELIBERATELY absent from BOTH: by merge time both proposals collide on
-    # the proposed_plan_tasks.yaml filename, so artifact threading would
+    # fay-10 re-tripped the same class three times). governance.merge_plan takes
+    # NEITHER artifact threading nor rejection context: by merge time both proposals
+    # collide on the proposed_plan_tasks.yaml filename, so artifact threading would
     # silently drop one proposal (the merger consumes brief_outcome/
     # proposal_outcome output keys instead), and its normal merge path is
     # deterministic — no prompt for rejection context to teach.
     # bind_criteria_index (SIP-0098 98.3): dev/qa propose BUILD tasks and so
     # bind covered-file criteria; strategy proposes guidance and the brief
     # author frames — neither is indexed.
+    #
+    # #846: "its normal merge path is deterministic" was true of the merge and hid the
+    # case that matters. When no plan_authoring_contributors are configured the proposers
+    # never run, and merge_plan authors the whole plan itself through an LLM — the
+    # sole-author fallback, which is the DEFAULT for every CRP but validation-multirole.
+    # Reading merge_plan's absence here as "this task type has no prompt" left the one
+    # author that actually reaches implementation as the only one never given the
+    # contract. Measured on cyc_0edb55919384: 0 criteria_refs, 3 frozen files claimed,
+    # 8 invented paths. So it is present now, for the index alone.
+    "governance.merge_plan": ContextAssemblyContract(bind_criteria_index=True),
     "governance.prepare_plan_authoring_brief": ContextAssemblyContract(
         artifact_filter=ArtifactFilter(
             by_producing_task=(

--- a/src/squadops/capabilities/dev_capabilities.py
+++ b/src/squadops/capabilities/dev_capabilities.py
@@ -9,7 +9,9 @@ Mirrors the BuildProfile registry pattern in build_profiles.py.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # Test framework constants (D5)
@@ -437,3 +439,54 @@ def get_capability(name: str) -> DevelopmentCapability:
             f"Unknown development capability {name!r}. Available capabilities: {available}"
         )
     return capability
+
+
+#: What a cycle that names no capability gets: free-form Python generation, the
+#: pre-SIP-0072 behavior. Named because the literal was written out at six call sites
+#: as ``resolve_dev_capability(cfg) or "python_cli"`` (#846).
+DEFAULT_DEV_CAPABILITY = "python_cli"
+
+
+def effective_capability_name(resolved_config: Mapping[str, Any] | None) -> str:
+    """The capability a cycle actually runs under, defaulted.
+
+    ``scaffold.resolve_dev_capability`` answers "what does this config *declare*", and
+    returns ``None`` for a contradiction so preflight can reject rather than silently pick
+    a side. This wraps it with the fallback every consumer applied by hand, so "which
+    capability is in force" has one answer instead of six copies of one expression.
+
+    A contradiction resolves to the default here rather than raising: the callers are
+    validators and prompt builders that must not crash on a config preflight already
+    refuses, and picking the conservative Python capability is what they did before.
+    """
+    from squadops.capabilities.scaffold import resolve_dev_capability
+
+    return resolve_dev_capability(resolved_config) or DEFAULT_DEV_CAPABILITY
+
+
+def matches_test_file_patterns(path: str, patterns: tuple[str, ...]) -> bool:
+    """True when ``path``'s basename matches any of the stack's test-file conventions.
+
+    Basename globbing only — deliberately narrower than
+    ``handlers.cycle.validation._is_test_file``, which additionally treats anything under
+    ``__tests__/`` as a test file. That generosity is right for *excluding* files from a
+    source set, and wrong for asking "will the runner discover this?": ``__tests__/
+    helpers.py`` is not collected by pytest, and counting it would weaken #715's guard for
+    Python stacks. One matcher, two callers, each with its own answer about directories.
+    """
+    from fnmatch import fnmatch
+    from pathlib import PurePosixPath
+
+    name = PurePosixPath(path).name
+    return any(fnmatch(name, pat) for pat in patterns)
+
+
+def test_file_patterns_for(resolved_config: Mapping[str, Any] | None) -> tuple[str, ...]:
+    """The test-file conventions a cycle's stack actually uses (#846).
+
+    ``pytest``'s ``test_*.py``/``*_test.py`` was hardcoded into plan validation, so a
+    correct vitest suite (``__tests__/store.test.ts``) was rejected for containing no
+    pytest-discoverable file — and the remedy the error suggested, "include a test_*.py",
+    would have been wrong. The stack has always declared this; nothing asked it.
+    """
+    return get_capability(effective_capability_name(resolved_config)).test_file_patterns

--- a/src/squadops/capabilities/handlers/_plan_authoring.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring.py
@@ -31,6 +31,50 @@ from squadops.llm.models import ChatMessage
 logger = logging.getLogger(__name__)
 
 
+async def contract_surface_sections(renderer: Any, inputs: dict[str, Any]) -> str:
+    """The contract surfaces an author needs, rendered, or ``""``.
+
+    Two managed assets (#448 — the prose is theirs, only the index data is a variable):
+
+    - ``request.plan_bind_criteria_appendix`` — *bind, don't author* plus the criteria
+      index, so covered-file criteria arrive as ``criteria_refs`` (SIP-0098 98.3);
+    - ``request.plan_frozen_surface_appendix`` — what the scaffold froze, so a check is
+      not written against an invented interior and a frozen file is not claimed as a
+      deliverable (pf-42).
+
+    **Shared because it had two authors and reached one (#846).** Only
+    ``*.propose_plan_tasks`` rendered these. When no ``plan_authoring_contributors`` are
+    configured — every CRP but ``validation-multirole``  — the proposers do not run at all
+    and ``governance.merge_plan`` authors the plan alone through
+    ``_plan_authoring_service.produce_plan``, which had no access to either surface.
+
+    Measured on VS's Next.js re-roll (``cyc_0edb55919384``), whose plan was
+    ``authoring_mode: sole_author`` with every task ``gap_filled``: **0 criteria_refs**
+    (it could not bind an index it never saw), 3 frozen files claimed as deliverables,
+    8 invented paths and 3 fill slots claimed by nothing. The paths it invented were
+    plausible variants of the real ones — ``app/api/runs/[id]/route.ts`` for the slot's
+    ``[run_id]`` — which is what an author with the manifest's endpoints and none of the
+    contract's file list produces.
+
+    Empty when the keys are absent, which is author mode with no derived contract: the
+    prompt stays byte-identical there.
+    """
+    if renderer is None:
+        return ""
+    surfaces = (
+        ("request.plan_bind_criteria_appendix", "criteria_index", "contract_criteria_index"),
+        ("request.plan_frozen_surface_appendix", "frozen_surface_index", "frozen_surface_index"),
+    )
+    sections: list[str] = []
+    for template_id, variable, input_key in surfaces:
+        index = inputs.get(input_key)
+        if not index:
+            continue
+        rendered = await renderer.render(template_id, {variable: index})
+        sections.append(rendered.content)
+    return "".join(sections)
+
+
 async def retry_yaml_call(
     llm: Any,
     chat_kwargs: dict[str, Any],

--- a/src/squadops/capabilities/handlers/_plan_authoring_service.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring_service.py
@@ -21,6 +21,7 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any
 
+from squadops.capabilities.handlers._plan_authoring import contract_surface_sections
 from squadops.capabilities.handlers.cycle_tasks import (
     _PRD_COVERAGE_DISCIPLINE_SECTION,
     _rewrite_manifest_identifiers,
@@ -225,6 +226,14 @@ async def produce_plan(
         manifest_prompt = rendered.content
     else:
         manifest_prompt = _build_manifest_user_prompt_inline(template_variables)
+
+    # #846: the sole author gets the contract's surfaces, same as a proposer would.
+    # This path runs whenever no plan_authoring_contributors are configured — which is
+    # every CRP but one — so until now the plan that reaches implementation was authored
+    # by the one path that had never been told the fill-slot paths, the criteria index,
+    # or which files are frozen. Absent keys render nothing (author mode stays
+    # byte-identical); the prose lives in the two managed assets.
+    manifest_prompt += await contract_surface_sections(renderer, inputs)
 
     assembled = context.ports.prompt_service.assemble(
         role=role,

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -8,7 +8,10 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from squadops.capabilities.dev_capabilities import get_capability
+from squadops.capabilities.dev_capabilities import (
+    effective_capability_name,
+    get_capability,
+)
 from squadops.capabilities.handlers.base import (
     HandlerEvidence,
     HandlerResult,
@@ -28,7 +31,6 @@ from squadops.capabilities.handlers.cycle.validation import (
     _detect_stubs,
     _estimate_min_artifacts,
 )
-from squadops.capabilities.scaffold import resolve_dev_capability
 
 logger = logging.getLogger(__name__)
 
@@ -270,7 +272,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         strategy: str | None = None,
     ) -> str:
         """Build prompt with PRD + plan artifacts for code generation."""
-        capability = get_capability(resolve_dev_capability(self._resolved_config) or "python_cli")
+        capability = get_capability(effective_capability_name(self._resolved_config))
 
         parts = [f"## Product Requirements Document\n\n{prd}"]
 
@@ -423,9 +425,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
             )
             rendered = None
             try:
-                capability = get_capability(
-                    resolve_dev_capability(self._resolved_config) or "python_cli"
-                )
+                capability = get_capability(effective_capability_name(self._resolved_config))
             except ValueError as exc:
                 return self._fail_result(start_time, inputs, str(exc))
         else:
@@ -433,9 +433,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
 
             # Resolve capability (fail fast on unknown dev_capability)
             try:
-                capability = get_capability(
-                    resolve_dev_capability(self._resolved_config) or "python_cli"
-                )
+                capability = get_capability(effective_capability_name(self._resolved_config))
             except ValueError as exc:
                 return self._fail_result(start_time, inputs, str(exc))
 

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -11,7 +11,11 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from squadops.capabilities.dev_capabilities import get_capability
+from squadops.capabilities.dev_capabilities import (
+    DEFAULT_DEV_CAPABILITY,
+    effective_capability_name,
+    get_capability,
+)
 from squadops.capabilities.handlers.base import (
     HandlerEvidence,
     HandlerResult,
@@ -34,7 +38,6 @@ from squadops.capabilities.handlers.cycle.validation import (
     _detect_stubs,
     _is_test_file,
 )
-from squadops.capabilities.scaffold import resolve_dev_capability
 
 logger = logging.getLogger(__name__)
 
@@ -186,9 +189,7 @@ class QATestHandler(_CycleTaskHandler):
         support files the QA build/test workspace can't build the deliverable and
         the frontend build check (#290) + vitest skip on "no package.json" (#296).
         """
-        capability = get_capability(
-            resolve_dev_capability(inputs.get("resolved_config")) or "python_cli"
-        )
+        capability = get_capability(effective_capability_name(inputs.get("resolved_config")))
         contents = inputs.get("artifact_contents", {})
         support = set(getattr(capability, "build_support_files", ()))
         sources = {}
@@ -216,7 +217,7 @@ class QATestHandler(_CycleTaskHandler):
         prior_outputs: dict[str, Any] | None,
         val_plan: str | None = None,
         sources: dict[str, str] | None = None,
-        capability_name: str = "python_cli",
+        capability_name: str = DEFAULT_DEV_CAPABILITY,
     ) -> str:
         """Build prompt with validation plan + source code for test generation."""
         capability = get_capability(capability_name)
@@ -650,7 +651,7 @@ class QATestHandler(_CycleTaskHandler):
         prd = inputs.get("prd", "")
         prior_outputs = inputs.get("prior_outputs")
         resolved_config = inputs.get("resolved_config", {})
-        capability_name = resolve_dev_capability(resolved_config) or "python_cli"
+        capability_name = effective_capability_name(resolved_config)
 
         # Resolve capability (fail fast on unknown dev_capability)
         try:

--- a/src/squadops/capabilities/handlers/cycle/validation.py
+++ b/src/squadops/capabilities/handlers/cycle/validation.py
@@ -325,10 +325,15 @@ def _classify_file(filename: str) -> tuple[str, str]:
 def _is_test_file(path: str, patterns: tuple[str, ...]) -> bool:
     """Check if *path* matches any test file pattern or resides in __tests__/.
 
-    Uses fnmatch for glob-style pattern matching (D4).
-    """
-    from fnmatch import fnmatch
-    from pathlib import PurePosixPath
+    The basename match is ``dev_capabilities.matches_test_file_patterns`` — shared with
+    plan validation (#846) so both read the stack's declared conventions rather than
+    each carrying its own idea of what a test file looks like.
 
-    name = PurePosixPath(path).name
-    return any(fnmatch(name, pat) for pat in patterns) or "/__tests__/" in path
+    The ``__tests__/`` clause stays local and is not shared. Callers here use this to
+    *exclude* files from a source set, where over-matching is the safe direction; plan
+    validation asks the stricter question "will the runner discover this?", and a
+    ``__tests__/helpers.py`` pytest never collects must not count there.
+    """
+    from squadops.capabilities.dev_capabilities import matches_test_file_patterns
+
+    return matches_test_file_patterns(path, patterns) or "/__tests__/" in path

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -93,12 +93,6 @@ def _importable_module_surface(paths: frozenset[str] | set[str]) -> frozenset[st
     return frozenset(modules)
 
 
-def _pytest_discoverable(path: str) -> bool:
-    """True when pytest's default discovery would collect this file (#715)."""
-    name = PurePosixPath(path).name
-    return name.endswith(".py") and (name.startswith("test_") or name.endswith("_test.py"))
-
-
 def planner_build_task_types(*, offer_builder: bool) -> set[str]:
     """Build task types the plan-authoring prompt may offer.
 
@@ -358,16 +352,25 @@ class ImplementationPlan:
         """#715: a ``qa.test`` task's declared artifacts must be able to satisfy the
         required check that judges them.
 
-        ``tests_pass`` judges a qa task's emission by pytest discovery, so a task
-        declaring only non-discoverable artifacts (shk-4's ``test_integration.js``)
-        fails on **any possible content** — the declared shape, not the work, is the
-        failure. The correction loop cannot fix a shape the plan forbids changing:
-        shk-4 burned three rounds and ~2h before escaping via a placebo ``.js`` stub
-        plus an undeclared ``.py`` twin, with the planned coverage silently narrowed
+        ``tests_pass`` judges a qa task's emission by the runner's discovery rules, so a
+        task declaring only undiscoverable artifacts (shk-4's ``test_integration.js`` on a
+        Python stack) fails on **any possible content** — the declared shape, not the
+        work, is the failure. The correction loop cannot fix a shape the plan forbids
+        changing: shk-4 burned three rounds and ~2h before escaping via a placebo ``.js``
+        stub plus an undeclared ``.py`` twin, with the planned coverage silently narrowed
         under a green verdict. Statically visible right here, at authoring time.
 
+        **The discovery rules are the stack's, not pytest's (#846).** This asserted
+        ``test_*.py``/``*_test.py`` unconditionally, so for a vitest stack *every correct
+        qa task failed it* — VS's Next.js re-roll was rejected for declaring
+        ``__tests__/store.test.ts``, and the remedy the message suggested ("include a
+        test_*.py") would have been wrong. The stack has declared its conventions since
+        SIP-0072 (``DevelopmentCapability.test_file_patterns``); nothing asked it. Reached
+        through ``ScaffoldStack.dev_capability`` (#832) — an explicit declared pointer
+        rather than a naming convention, which is the distinction Stage 2a exists to close.
+
         Verification-only tasks (``expected_artifacts: []``) are exempt — they emit
-        nothing for pytest to judge. Only applies when ``tests_pass`` is actually
+        nothing for the runner to judge. Only applies when ``tests_pass`` is actually
         required by the resolved config.
 
         Returns:
@@ -375,19 +378,26 @@ class ImplementationPlan:
         """
         if "tests_pass" not in (resolved_config.get("required_checks") or ()):
             return []
+        from squadops.capabilities.dev_capabilities import (
+            matches_test_file_patterns,
+            test_file_patterns_for,
+        )
+
+        patterns = test_file_patterns_for(resolved_config)
         errors: list[str] = []
         for task in self.tasks:
             if task.task_type != "qa.test" or not task.expected_artifacts:
                 continue
-            if any(_pytest_discoverable(path) for path in task.expected_artifacts):
+            if any(matches_test_file_patterns(p, patterns) for p in task.expected_artifacts):
                 continue
+            shown = " / ".join(patterns)
             errors.append(
                 f"Task {task.task_index} ({task.focus}): qa.test declares "
-                f"{task.expected_artifacts} but no pytest-discoverable file "
-                "(test_*.py / *_test.py) — the required tests_pass check judges this "
-                "task's emission by pytest discovery, so it fails for any possible "
-                "content. Include a test_*.py among the expected artifacts, or make "
-                "this a verification-only task (expected_artifacts: [])"
+                f"{task.expected_artifacts} but no file this stack's test runner "
+                f"discovers ({shown}) — the required tests_pass check judges this task's "
+                f"emission by those conventions, so it fails for any possible content. "
+                f"Name at least one expected artifact matching {shown}, or make this a "
+                f"verification-only task (expected_artifacts: [])"
             )
         return errors
 

--- a/src/squadops/cycles/plan_authoring_rules.py
+++ b/src/squadops/cycles/plan_authoring_rules.py
@@ -32,7 +32,10 @@ AUTHOR_FACING: dict[str, str] = {
     "validate_criteria_scope": "regex-only-on-documents",
     "validate_command_checks": "commands-must-run-here",
     "validate_against_profile": "roles-must-exist",
-    "validate_check_applicability": "qa-tests-pytest-discoverable",
+    # Renamed from "qa-tests-pytest-discoverable" by #846: the rule reads the stack's
+    # declared test conventions, and a rule id naming one stack's runner is how the
+    # validator came to assert pytest's patterns against a vitest suite in the first place.
+    "validate_check_applicability": "qa-tests-must-be-discoverable",
 }
 
 # Validators an author is already taught by a different managed asset. Restating them

--- a/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
@@ -50,13 +50,15 @@ too. TypeScript has no command form at all; the frontend build type-checks it.
 **roles-must-exist** — Every task's `role` is one the squad profile actually staffs. A
 task assigned to an absent role can never be dispatched.
 
-**qa-tests-pytest-discoverable** — When the `tests_pass` check is required, every
-`qa.test` task that declares expected artifacts includes at least one pytest-discoverable
-file (`test_*.py` or `*_test.py`). The suite check judges a qa task's emission by pytest
-discovery, so a task declaring only a script pytest cannot collect (e.g. a `.js` smoke
-runner) fails on any possible content — the declared shape, not the work, is the failure.
-Express non-pytest verification through a pytest wrapper, or through the acceptance
-criteria of a verification-only task.
+**qa-tests-must-be-discoverable** — When the `tests_pass` check is required, every
+`qa.test` task that declares expected artifacts includes at least one file **this stack's
+test runner discovers**. The suite check judges a qa task's emission by that runner's
+conventions, so a task declaring only files it cannot collect fails on any possible
+content — the declared shape, not the work, is the failure. Follow the file-naming
+conventions your stack's guidance states (`test_*.py` / `*_test.py` under pytest,
+`*.test.ts` / `*.spec.ts` and their `.tsx` forms under vitest); a directory named
+`__tests__/` is not itself enough. Express verification that produces no such file
+through the acceptance criteria of a verification-only task instead.
 
 A verification-only task is legitimate and common: declare `expected_artifacts: []` and
 express what it checks through its acceptance criteria.

--- a/tests/unit/capabilities/test_plan_authoring_service.py
+++ b/tests/unit/capabilities/test_plan_authoring_service.py
@@ -582,3 +582,120 @@ async def test_builder_squad_with_build_profile_is_offered_builder_tasks():
     )
     assert "builder.assemble" in variables["task_types_section"]
     assert "builder.assemble" in variables["builder_guideline"]
+
+
+# ---------------------------------------------------------------------------
+# #846 — the sole author receives the contract's surfaces
+#
+# This path authors the plan that reaches implementation whenever no
+# ``plan_authoring_contributors`` are configured, which is the default for every CRP
+# but ``validation-multirole``. Until #846 it was the ONLY authoring path never given
+# the criteria index or the frozen-surface index: the proposers rendered both, and the
+# proposers were not running.
+#
+# Measured on VS's Next.js re-roll (`cyc_0edb55919384`, `authoring_mode: sole_author`,
+# every task `gap_filled`): 0 criteria_refs in the emitted plan, 3 frozen files claimed
+# as deliverables, 8 invented paths, 3 fill slots claimed by no task.
+# ---------------------------------------------------------------------------
+
+
+def _rendered_prompt(ctx) -> str:
+    """The user message the LLM actually saw."""
+    return ctx.ports.llm.chat_stream_with_usage.call_args[0][0][1].content
+
+
+async def _fake_render(template_id, variables):
+    """Render each template distinguishably, so the assertions can tell them apart.
+
+    The shared fixture returns one canned string for every template; the appendices have
+    to be separable from the base prompt or "the index reached the LLM" is unfalsifiable.
+    """
+    out = MagicMock()
+    out.template_id = template_id
+    out.template_version = "1"
+    if template_id == "request.governance_review_plan_manifest":
+        out.content = "user prompt (rendered from request.governance_review_plan_manifest)"
+    else:
+        out.content = "\n\n[{}]\n{}".format(template_id, "\n".join(variables.values()))
+    return out
+
+
+async def test_sole_author_prompt_carries_the_criteria_and_frozen_indexes(seeded_inputs):
+    """Both surfaces reach the LLM, not merely the inputs dict.
+
+    Asserting on the message the model received is the point: the contract was reaching
+    `inject_contract_inputs` correctly all along and stopping one layer short, so a test
+    that checked injection would have passed while the author stayed blind.
+    """
+    ctx = _make_context()
+    seeded_inputs = {
+        **seeded_inputs,
+        "contract_criteria_index": "- app/api/runs/route.ts: bind vc-runs (frontend_compiles)",
+        "frozen_surface_index": "- `lib/store.ts`\n- `package.json`",
+    }
+
+    ctx.ports.request_renderer.render.side_effect = None
+    ctx.ports.request_renderer.render.side_effect = _fake_render
+
+    result = await produce_plan(
+        ctx,
+        seeded_inputs,
+        planning_content="planning",
+        resolved_config=seeded_inputs["resolved_config"],
+        role="lead",
+        handler_name="test",
+        chat_kwargs={},
+    )
+    assert result is not None
+
+    prompt = _rendered_prompt(ctx)
+    assert "app/api/runs/route.ts" in prompt, "the fill-slot criteria index never arrived"
+    assert "lib/store.ts" in prompt, "the frozen-surface index never arrived"
+
+
+async def test_author_mode_prompt_is_unchanged_without_a_contract(seeded_inputs):
+    """No contract, no appendices — author-mode cycles stay byte-identical.
+
+    The polarity guard for the fix above: appending unconditionally would have changed
+    every contract-less cycle's prompt, which is the class of silent behavior change the
+    plan-context golden exists to catch.
+    """
+    ctx = _make_context()
+    ctx.ports.request_renderer.render.side_effect = _fake_render
+
+    await produce_plan(
+        ctx,
+        seeded_inputs,
+        planning_content="planning",
+        resolved_config=seeded_inputs["resolved_config"],
+        role="lead",
+        handler_name="test",
+        chat_kwargs={},
+    )
+
+    prompt = _rendered_prompt(ctx)
+    assert prompt == "user prompt (rendered from request.governance_review_plan_manifest)"
+
+
+async def test_an_empty_index_is_not_rendered_as_an_empty_section(seeded_inputs):
+    """A present-but-empty key must behave like an absent one.
+
+    `frozen_surface_index_lines` returns [] for a stack whose skeleton is all fill slots,
+    and `"\\n".join([])` is `""`. Rendering the appendix's prose over no data would tell
+    an author "these files are frozen:" followed by nothing.
+    """
+    ctx = _make_context()
+    ctx.ports.request_renderer.render.side_effect = _fake_render
+
+    await produce_plan(
+        ctx,
+        {**seeded_inputs, "contract_criteria_index": "", "frozen_surface_index": ""},
+        planning_content="planning",
+        resolved_config=seeded_inputs["resolved_config"],
+        role="lead",
+        handler_name="test",
+        chat_kwargs={},
+    )
+
+    prompt = _rendered_prompt(ctx)
+    assert prompt == "user prompt (rendered from request.governance_review_plan_manifest)"

--- a/tests/unit/cycles/goldens/plan_context.json
+++ b/tests/unit/cycles/goldens/plan_context.json
@@ -217,6 +217,8 @@
    "agent_config_overrides": {},
    "agent_model": "m",
    "config_hash": "confhash",
+   "contract_criteria_index": "- backend/routes.py: bind vc-routes-endpoints (endpoint_defined)",
+   "frozen_surface_index": "- `backend/__init__.py`\n- `backend/main.py` \u2014 functions health; imports `.errors`, `.routes`, `fastapi`, `fastapi.middleware.cors`, `os`\n- `backend/models.py` \u2014 defines Participant(id, name), RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants), RunEventCreate(title, datetime, location, distance, pace_target, route_notes), ParticipantName(name); imports `pydantic`, `typing`\n- `backend/store.py` \u2014 module state participant_store: dict[str, Participant], run_event_store: dict[str, RunEvent]; functions reset; imports `.models`\n- `backend/errors.py` \u2014 defines ApiError; functions register_error_handlers; imports `fastapi`, `fastapi.exceptions`, `fastapi.responses`\n- `backend/requirements.txt`\n- `conftest.py` \u2014 functions client; imports `backend.main`, `fastapi.testclient`, `os`, `pytest`, `sys`\n- `frontend/index.html`\n- `frontend/package.json`\n- `frontend/vite.config.js`\n- `frontend/src/test-setup.js`\n- `frontend/src/__tests__/harness.test.jsx`\n- `frontend/src/main.jsx`\n- `frontend/src/api.js`\n- `frontend/src/App.jsx`",
    "prd": "PRD-CONTENT",
    "profile_roles": [
     "data",

--- a/tests/unit/cycles/test_authored_contract_binding.py
+++ b/tests/unit/cycles/test_authored_contract_binding.py
@@ -242,13 +242,43 @@ async def test_a_run_without_a_derived_contract_is_byte_identical():
 
 
 async def test_injection_follows_the_registry_not_the_task_name():
-    """Who receives what stays the context-assembly registry's declaration — the merger
-    consumes proposer outputs and is deliberately excluded."""
+    """Who receives what stays the context-assembly registry's declaration.
+
+    **This test asserted the opposite until #846, and the assertion was the defect.**
+    It read "the merger consumes proposer outputs and is deliberately excluded", which is
+    true of the merge path and silent about the one that matters: with no
+    ``plan_authoring_contributors`` configured — the default for every CRP but
+    ``validation-multirole`` — the proposers never run and ``governance.merge_plan``
+    authors the entire plan itself through an LLM. So the only author that reaches
+    implementation was the only one never given the contract. Measured on
+    ``cyc_0edb55919384``: 0 criteria_refs, 3 frozen files claimed as deliverables,
+    8 invented fill-slot paths.
+
+    A test that pins an exclusion has to be read as a claim about every path through the
+    excluded task type, not just the one its author had in mind.
+    """
     contract, manifest = _derived()
 
     inputs = await _enriched("governance.merge_plan", contract, manifest)
 
+    assert "backend/routes.py" in inputs["contract_criteria_index"]
+    assert "backend/models.py" in inputs["frozen_surface_index"]
+
+
+async def test_strategy_proposer_is_still_excluded():
+    """The registry's exclusions are not all wrong — this one holds.
+
+    Strategy proposes *guidance*, never build tasks, so it binds no covered-file criteria
+    and a criteria index would be context it cannot act on. Kept as the polarity guard
+    #846 left behind: the fix above widened who receives the contract, and without this
+    "everyone gets everything" would pass the suite.
+    """
+    contract, manifest = _derived()
+
+    inputs = await _enriched("strategy.propose_plan_guidance", contract, manifest)
+
     assert "contract_criteria_index" not in inputs
+    assert "frozen_surface_index" not in inputs
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -1092,7 +1092,7 @@ class TestMidRunGateRejectsUnwinnableQaTask:
                 ["progress_plan_review"],
                 gated_cycle,
             )
-        assert "pytest-discoverable" in str(exc_info.value)
+        assert "test_*.py" in str(exc_info.value)
 
 
 # ---------------------------------------------------------------------------
@@ -1169,7 +1169,7 @@ class TestWorkloadGateSeamValidation:
         errors = await executor._reject_invalid_plan_before_workload_gate(
             gated_run, gated_cycle, "progress_plan_review"
         )
-        assert any("pytest-discoverable" in e for e in errors)
+        assert any("test_*.py" in e for e in errors)
 
     async def test_qa_js_plan_passes_when_tests_pass_not_required(
         self, executor, mock_vault, cycle, run

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -1387,7 +1387,7 @@ class TestValidateCheckApplicability:
         plan = self._plan_with_qa_artifacts('\n      - "backend/tests/test_integration.js"')
         errors = plan.validate_check_applicability(self._CONFIG)
         assert len(errors) == 1
-        assert "pytest-discoverable" in errors[0]
+        assert "test_*.py" in errors[0]
         assert "test_integration.js" in errors[0]
 
     def test_not_required_means_no_rule(self):
@@ -1426,3 +1426,61 @@ class TestValidateCheckApplicability:
         )
         errors = plan.validate_check_applicability(self._CONFIG)
         assert len(errors) == 1
+
+    # -- #846: the rule reads the stack's conventions, not pytest's ------------
+
+    _NEXTJS_CONFIG = {
+        "required_checks": ["tests_pass"],
+        "build_profile": "nextjs_ts",
+    }
+
+    def test_vitest_suite_accepted_on_a_typescript_stack(self):
+        """The exact rejection that cost VS's re-roll (`cyc_0edb55919384`).
+
+        `__tests__/store.test.ts` is what a correct Next.js qa task declares, and vitest
+        discovers it. Judged by pytest's patterns it is unwinnable, so EVERY correct qa
+        task on this stack was rejected — and the message told the author to add a
+        `test_*.py`, which would have been wrong.
+        """
+        plan = self._plan_with_qa_artifacts(
+            '\n      - "__tests__/store.test.ts"\n      - "__tests__/api.test.ts"'
+        )
+        assert plan.validate_check_applicability(self._NEXTJS_CONFIG) == []
+
+    def test_python_suite_rejected_on_a_typescript_stack(self):
+        """The rule has to bite in the new direction too, or it is only half moved.
+
+        A `test_api.py` on a Next.js stack is undiscoverable by vitest for exactly the
+        reason the `.js` file was undiscoverable by pytest. A validator that accepted
+        both would have stopped catching anything.
+        """
+        plan = self._plan_with_qa_artifacts('\n      - "__tests__/test_api.py"')
+        errors = plan.validate_check_applicability(self._NEXTJS_CONFIG)
+        assert len(errors) == 1
+        assert "*.test.ts" in errors[0]
+        assert "test_api.py" in errors[0]
+
+    def test_message_names_the_stacks_own_conventions(self):
+        """The remedy must be actionable on the stack the author is building for.
+
+        The old text hardcoded "include a test_*.py" and would have sent a Next.js
+        author to write a Python file the runner never collects — the correction loop
+        following advice that cannot work.
+        """
+        plan = self._plan_with_qa_artifacts('\n      - "__tests__/helpers.ts"')
+        (error,) = plan.validate_check_applicability(self._NEXTJS_CONFIG)
+        assert "test_*.py" not in error
+        assert "*.test.ts" in error and "*.spec.tsx" in error
+
+    def test_tests_dir_membership_alone_does_not_satisfy(self):
+        """`__tests__/` is not a free pass, even though the sibling matcher in
+        `handlers.cycle.validation` treats it as one.
+
+        That helper is generous on purpose — it EXCLUDES files from a source set. Here
+        the question is "will the runner collect this?", and `__tests__/helpers.py` is
+        collected by neither pytest nor vitest. Sharing the directory clause would have
+        quietly widened #715's guard for every stack.
+        """
+        plan = self._plan_with_qa_artifacts('\n      - "__tests__/helpers.py"')
+        assert len(plan.validate_check_applicability(self._CONFIG)) == 1
+        assert len(plan.validate_check_applicability(self._NEXTJS_CONFIG)) == 1


### PR DESCRIPTION
**Stacked on #847** (`feature/707-one-command-allowlist`) — both touch `implementation_plan.py`. Merge #847 first; this PR's diff against `main` will then be just its own two commits.

Covers #846's **A2** and **Family B**. Family A1 is #847, because it was already specified in #707 with its own acceptance criteria.

---

## A2 — plan validation judged a vitest suite by pytest discovery

`validate_check_applicability` asserted `test_*.py` / `*_test.py` unconditionally. On a vitest stack that rejects **every correct qa task**: VS's re-roll was refused for declaring `__tests__/store.test.ts`, and the remedy the message offered — "include a test_*.py" — would have been wrong.

The stack has declared this since SIP-0072 (`DevelopmentCapability.test_file_patterns`; `nextjs_ts` names the four vitest forms). Nothing asked it. Now reached through `ScaffoldStack.dev_capability` (#832) — an **explicit declared pointer**, not a naming convention, which is the distinction Stage 2a exists to close.

**This was my class-(d) miss in the Stage 1a sweep.** I verified `run_node_tests` discovers `package.json` and concluded the vitest path was fine. That was about *execution*. Plan validation carried its own hardcoded assumption and I never looked at it.

One deliberate non-reuse: the basename matcher is now shared with `handlers.cycle.validation._is_test_file`, but its `/__tests__/` clause is **not**. That generosity is right for *excluding* files from a source set and wrong for "will the runner collect this?" — `__tests__/helpers.py` is collected by neither runner, and sharing the clause would have quietly widened #715's guard for every stack. Pinned by test.

Also collapses `resolve_dev_capability(cfg) or "python_cli"`, written out at six call sites across two handlers. A seventh copy was the wrong way to add the first non-Python stack.

---

## Family B — the answer is neither option the issue offered

#846 framed B as *"a wiring gap (the #796 class, partial) versus an authoring defect"* and correctly marked it unverified. It is neither.

**The proposers never ran.** `merge_decisions.yaml` for `cyc_0edb55919384`:

```yaml
authoring_mode: sole_author
sole_author_reason: no_contributors_configured
proposal_ids: []
canonical_tasks:
- merge_action: gap_filled
  reason: Sole-author fallback via PlanAuthoringService — no proposer contribution available.
  # ...for all 8 tasks
```

`bind_criteria_index` is declared only on `*.propose_plan_tasks`. `governance.merge_plan` had **no entry in `CONTEXT_CONTRACTS` at all**, so `inject_contract_inputs` injected nothing and `produce_plan` built its prompt from the PRD and framing documents alone.

So the one authoring path that reaches implementation **on every CRP except `validation-multirole`** was the only one never given the contract.

### The evidence in the emitted plan is unambiguous

| | |
|---|---|
| `criteria_refs` in `implementation_plan.yaml` | **0** — it could not bind an index it never saw |
| frozen files claimed as deliverables | 3 |
| invented paths | 8 |
| fill slots claimed by no task | 3 |

The invented paths being *plausible variants* — `app/api/runs/[id]/route.ts` for the slot's `[run_id]`, `app/create/page.tsx` for `app/runs/new/page.tsx` — is precisely what an author holding the manifest's endpoint list and none of the contract's file list produces. #846 suspected this and could not confirm it; the zero `criteria_refs` count settles it.

This is **#796's class at a seam #796 did not touch**: #796 fixed *when* the contract exists in authored mode. This fixes *who is told*.

### The fix

Split along the #663 S3 line — the registry declares who receives an input class, the handler owns the mechanics:

- `governance.merge_plan` gains `ContextAssemblyContract(bind_criteria_index=True)`.
- `contract_surface_sections` renders the two **existing** managed assets and is shared with the proposer's two methods. No new prose (#448).

### The test that pinned the defect

`test_injection_follows_the_registry_not_the_task_name` asserted `"contract_criteria_index" not in inputs` for merge_plan, docstringed *"the merger consumes proposer outputs and is deliberately excluded."* True of the merge path, and silent about the sole-author path that actually runs. Inverted here with the reason recorded, plus `test_strategy_proposer_is_still_excluded` as the polarity guard — without it, "everyone gets everything" would pass.

A test pinning an exclusion is a claim about **every** path through that task type, not just the one its author had in mind.

### A premise correction on my own earlier work

At #762 I deliberately did not add contributors to `validated-fullstack.yaml`, reasoning it "would tax author-mode users." The consequence is that author-mode users got the path with **no contract at all** — and #762's preflight block requires `contract_ref`, so authored mode falls through its middle condition by design. Configuring contributors would have masked this rather than fixed it.

---

## Verification

- Regression **6938 passed**, 1 skipped.
- Both fixes verified by **mutation** — removing either makes its test fail on the intended assertion.
- Plan-context golden regenerated **in the same commit** (exactly two keys added to the merge_plan envelope), so the behavior change reads as one rather than as a silent refactor side effect.
- Author-mode polarity guard: with no contract, the sole-author prompt is byte-identical.

## Still open on #846

**B1's remaining question.** With the author now told which files are frozen, is a frozen claim still possible? `validate_frozen_artifact_ownership` exists and is author-facing (`no-frozen-claims`), so the gate should catch what teaching misses — but VS's plan reached the gate *with* frozen claims, and whether that rule fired is worth confirming on the next roll rather than asserting here.

Refs #846, #796, #762, #832, #715, #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX
