### PR TITLE
fix(contract): criterion ids identify a slot, and a malformed contract is refused (#849)

### DIFF
--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -236,13 +236,31 @@ def _nextjs_ts_slot_criteria(manifest: InterfaceManifest, path: str) -> dict[str
     Consequence stated plainly: **no criterion here proves the declared endpoints exist in
     the source.** ``endpoint_defined`` is Python-only, so that claim is carried by the
     behavioral probes alone — late and functionally, rather than early and structurally.
+
+    **The criterion id is derived from the whole slot path, not the basename (#849).** It was
+    the basename, copied from ``_view_criteria``, and on this stack that produced *colliding
+    ids*: App Router fixes the filename and puts identity in the directory, so all four route
+    files slugged to ``route`` and all three pages to ``page`` — nine criteria, four distinct
+    ids. ``VerificationContract.criterion_index()`` is keyed on id and documents itself as
+    last-writer-wins, so five of seven fill slots resolved to no criterion while a plan that
+    bound all seven refs read as fully covered and every gate passed. Measured on
+    ``cyc_7899ed1feae5``. Not a coverage gap — #818's "incorrect contract that is believed",
+    one layer down, and the same FastAPI-shaped assumption as ``_ROUTES_PATH``: that a
+    filename identifies a file.
+
+    ``_view_criteria`` still slugs the basename and is deliberately left alone. Stack #1's
+    views are emitted into one flat directory, so its basenames are unique *by construction of
+    its own expander* rather than by luck — and changing it would move the contract hash
+    ``7622f570c949fe95`` that #777's guard and every bind-mode cycle are pinned to. The
+    general protection against a future stack repeating this is the id linter, now wired at
+    derivation, not a second hand-audit of the emitters.
     """
     return {
         "interface": [],
         "implementation": [
             {
                 "check": "frontend_compiles",
-                "id": f"vc-compiles-{_slug(path.rsplit('/', 1)[-1].rsplit('.', 1)[0]) or 'root'}",
+                "id": f"vc-compiles-{_slug(path.rsplit('.', 1)[0]) or 'root'}",
                 "file": path,
                 "project_dir": ".",
                 "requires": CAP_NODE,

--- a/src/squadops/cycles/manifest_gates.py
+++ b/src/squadops/cycles/manifest_gates.py
@@ -235,14 +235,28 @@ def _expander_findings(manifest) -> list[WinnabilityFinding]:
 
 
 def _contract_findings(manifest) -> list[WinnabilityFinding]:
-    """The derived contract must exist and must be satisfiable by construction.
+    """The derived contract must exist, be structurally valid, and be satisfiable.
 
-    Two distinct failures: derivation refusing outright, and derivation producing a
-    check that can never execute. The second is the #671 class one level up — a check
-    that skips at every evaluation forever is dead weight the plan still has to carry.
+    Three distinct failures: derivation refusing outright, derivation producing a contract
+    that fails its own linter, and derivation producing a check that can never execute. The
+    third is the #671 class one level up — a check that skips at every evaluation forever is
+    dead weight the plan still has to carry.
+
+    **The linter call is #849, and its absence is the more interesting half of that bug.**
+    ``VerificationContract.lint()`` has existed throughout, and ``_lint_ids`` detects the
+    duplicate-id defect precisely — but repo-wide its only callers were
+    ``scripts/dev/contract_gate.py`` and unit tests. Both run against the *reference FastAPI
+    manifest*, whose criterion ids cannot collide, so the guard was exercised only by the one
+    input incapable of failing it and was absent from every path that derives a contract at
+    cycle time. Stack #2's contract reached a live run malformed.
+
+    Linting here rather than at the storage seam is deliberate: this is the gate that already
+    answers "is this manifest winnable", a malformed contract is exactly a way for it not to
+    be, and a rejection here re-rolls framing for free (#522) instead of failing mid-run.
     """
     from squadops.capabilities.scaffold_contract import emit_contract_dict
     from squadops.cycles.acceptance_check_spec import CHECK_SPECS, is_check_applicable
+    from squadops.cycles.verification_contract import VerificationContract
 
     try:
         contract = emit_contract_dict(manifest)
@@ -252,6 +266,30 @@ def _contract_findings(manifest) -> list[WinnabilityFinding]:
                 PROOF_CONTRACT_DERIVES,
                 f"no verification contract could be derived from this manifest ({exc}), "
                 f"so nothing downstream could state what 'done' means.",
+            )
+        ]
+
+    # Structural validity, before anything reads the contract's contents. A contract whose
+    # own linter rejects it is not a contract the rest of this function can reason about —
+    # duplicate ids in particular make `criterion_index()` silently lossy, so the
+    # per-check findings below would be computed over criteria no ref can ever resolve to.
+    try:
+        lint_errors = VerificationContract.from_dict(contract).lint()
+    except Exception as exc:  # noqa: BLE001 - a contract that will not even load is a finding
+        return [
+            WinnabilityFinding(
+                PROOF_CONTRACT_DERIVES,
+                f"the contract derived from this manifest could not be loaded ({exc}).",
+            )
+        ]
+    if lint_errors:
+        return [
+            WinnabilityFinding(
+                PROOF_CONTRACT_DERIVES,
+                f"the contract derived from this manifest is structurally invalid: "
+                f"{'; '.join(lint_errors)}. Downstream binding resolves criteria by id and "
+                f"would silently drop what it cannot address, so the plan would read as "
+                f"fully covered while part of the surface went unverified.",
             )
         ]
 

--- a/src/squadops/prompts/request_templates/request.plan_frozen_surface_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_frozen_surface_appendix.md
@@ -28,6 +28,13 @@ restored, and the check fails identically until the correction budget is gone. P
 validation now runs these checks against the real skeleton before dispatch and rejects
 the plan if one cannot pass — so a guess here costs the whole framing, not just the task.
 
+**A file listed below with no declarations after its name may not be checked at all.**
+The listing states what a frozen file declares only for languages this system can read
+today; for the rest it can state that the file exists and nothing more. That is a limit of
+the tooling, not evidence that the file is empty — so for those entries you have no line
+proving anything passes, and the rule above applies with no exception available. Write your
+check against a fill slot instead, or verify the behavior through the suite.
+
 **What the frozen files actually declare:**
 
 {{frozen_surface_index}}

--- a/tests/unit/capabilities/test_contract_emitter_stack_seam.py
+++ b/tests/unit/capabilities/test_contract_emitter_stack_seam.py
@@ -273,3 +273,70 @@ def test_every_registered_stack_declares_a_pack_that_exists():
         assert stack.criteria_pack in scaffold_contract._CRITERIA_PACKS, (
             f"stack {name!r} names pack {stack.criteria_pack!r}, which is not registered"
         )
+
+
+# --------------------------------------------------------------------------- #
+# #849 — criterion ids must identify a slot, not a filename
+# --------------------------------------------------------------------------- #
+
+
+def _contract_for(stack: str):
+    """The reference manifest's contract, re-stacked. One manifest, two emitters."""
+    import pathlib
+
+    import yaml
+
+    from squadops.capabilities.scaffold import InterfaceManifest
+    from squadops.cycles.verification_contract import VerificationContract
+
+    raw = yaml.safe_load(pathlib.Path("examples/03_group_run/interface_manifest.yaml").read_text())
+    raw["stack"] = stack
+    manifest = InterfaceManifest.from_yaml(yaml.safe_dump(raw, sort_keys=False))
+    return VerificationContract.from_dict(scaffold_contract.emit_contract_dict(manifest))
+
+
+@pytest.mark.parametrize("stack", sorted(scaffold._STACKS))
+def test_every_stack_emits_unique_criterion_ids(stack):
+    """The defect that shipped a malformed contract into `cyc_7899ed1feae5`.
+
+    `nextjs_ts` slugged the BASENAME, and App Router fixes the filename — every route file
+    is `route.ts`, every page `page.tsx` — so four route criteria and three page criteria
+    collapsed onto two ids. `criterion_index()` is keyed on id and is last-writer-wins, so
+    five of seven fill slots resolved to no criterion at all while a plan binding all seven
+    refs read as fully covered.
+
+    Parameterized over the registry rather than written against one stack: the assumption
+    "a filename identifies a file" is FastAPI-shaped, and the next stack gets to break it
+    too. Stack #1 passes by construction (its views share one flat directory), which is
+    exactly why a stack-specific test would have proved nothing.
+    """
+    ids = [i for i in _contract_for(stack).criterion_ids() if i]
+    dupes = sorted({i for i in ids if ids.count(i) > 1})
+    assert not dupes, (
+        f"stack {stack!r} emits duplicate criterion id(s) {dupes} — criterion_index() is "
+        f"keyed on id and last-writer-wins, so every slot but one silently loses its criteria"
+    )
+
+
+@pytest.mark.parametrize("stack", sorted(scaffold._STACKS))
+def test_every_stack_emits_a_contract_that_passes_its_own_linter(stack):
+    """The generalization of the test above, and the one that would have caught it first.
+
+    `lint()` already checked id uniqueness; nothing outside CI and unit tests ever ran it,
+    and CI runs it only against the reference FastAPI manifest, which cannot collide. This
+    puts every registered stack through the linter, so a new stack's structural defects are
+    a test failure rather than a live-run discovery.
+    """
+    assert _contract_for(stack).lint() == []
+
+
+def test_next_js_ids_name_the_directory_that_distinguishes_the_slot():
+    """Uniqueness alone is satisfiable by a counter (`vc-compiles-1`), which would be stable
+    only until a slot is added in the middle. The id has to carry the path that makes the
+    slot distinct, so a diff of two contracts stays readable and a criterion id in evidence
+    still says which file it judged."""
+    ids = {i for i in _contract_for("nextjs_ts").criterion_ids() if i.startswith("vc-compiles-")}
+    assert "vc-compiles-app-api-runs-route" in ids
+    assert "vc-compiles-app-api-runs-run-id-join-route" in ids
+    assert "vc-compiles-app-api-runs-run-id-leave-route" in ids
+    assert len({i for i in ids if i.endswith("-route")}) == 4

--- a/tests/unit/cycles/test_manifest_gates.py
+++ b/tests/unit/cycles/test_manifest_gates.py
@@ -20,6 +20,7 @@ import pytest
 import yaml
 
 from squadops.cycles.manifest_gates import (
+    PROOF_CONTRACT_DERIVES,
     PROOF_EXPANDS,
     PROOF_PARSES,
     PROOF_STATUS_DECLARED,
@@ -269,3 +270,76 @@ def test_manifest_without_source_prd_is_rejected():
     findings = assess_schema(_as_yaml(data))
 
     assert PROOF_SOURCE_PRD in _proofs(findings)
+
+
+# --------------------------------------------------------------------------- #
+# #849 — a contract that fails its own linter never reaches a run
+# --------------------------------------------------------------------------- #
+
+
+def test_a_structurally_invalid_contract_is_a_winnability_finding(monkeypatch):
+    """`VerificationContract.lint()` existed throughout and had no production caller.
+
+    Its only callers were `scripts/dev/contract_gate.py` and unit tests, both running
+    against the reference FastAPI manifest — whose criterion ids cannot collide. So the
+    guard was exercised solely by the one input incapable of failing it, and stack #2's
+    contract reached a live run with nine criteria under four ids.
+
+    The pack is monkeypatched to re-create the defect rather than reverting the emitter
+    fix, so this stays a test of the GATE. Otherwise it would silently become a duplicate
+    of the emitter's own uniqueness test and stop covering the wiring, which is the half
+    that was actually missing.
+    """
+    from squadops.capabilities import scaffold_contract
+
+    real = scaffold_contract.emit_contract_dict
+
+    def colliding(manifest):
+        contract = real(manifest)
+        for sections in (contract.get("fill_files") or {}).values():
+            for entry in sections.get("implementation") or []:
+                entry["id"] = "vc-same"
+        return contract
+
+    monkeypatch.setattr(scaffold_contract, "emit_contract_dict", colliding)
+
+    findings = assess_winnability(_REFERENCE.read_text(encoding="utf-8"))
+
+    assert PROOF_CONTRACT_DERIVES in _proofs(findings)
+    detail = next(f.detail for f in findings if f.proof == PROOF_CONTRACT_DERIVES)
+    assert "duplicate criterion id" in detail
+    assert "'vc-same'" in detail or "vc-same" in detail
+
+
+def test_the_rejection_says_why_a_duplicate_id_matters(monkeypatch):
+    """ "Structurally invalid" is not actionable on its own.
+
+    A duplicate id does not fail loudly — `criterion_index()` drops the losers and the plan
+    still reads as fully bound. The message has to name that, or the next reader files it as
+    cosmetic and waives it.
+    """
+    from squadops.capabilities import scaffold_contract
+
+    real = scaffold_contract.emit_contract_dict
+
+    def colliding(manifest):
+        contract = real(manifest)
+        for sections in (contract.get("fill_files") or {}).values():
+            for entry in sections.get("implementation") or []:
+                entry["id"] = "vc-same"
+        return contract
+
+    monkeypatch.setattr(scaffold_contract, "emit_contract_dict", colliding)
+
+    detail = next(
+        f.detail
+        for f in assess_winnability(_REFERENCE.read_text(encoding="utf-8"))
+        if f.proof == PROOF_CONTRACT_DERIVES
+    )
+    assert "silently" in detail and "unverified" in detail
+
+
+def test_the_reference_contract_still_passes_the_new_lint_gate():
+    """Polarity guard. A lint step wired into the winnability gate can reject manifests that
+    were previously fine, and the reference pair is what every other pin rests on."""
+    assert assess_winnability(_REFERENCE.read_text(encoding="utf-8")) == ()


### PR DESCRIPTION
Closes #849 — all three findings.

## A · Criterion ids now identify a slot, not a filename

The `nextjs_ts` pack slugged the **basename**. App Router fixes the filename and puts identity in the directory, so `cyc_7899ed1feae5`'s contract came out as **nine criteria under four ids**:

```
vc-compiles-route   x4   (app/api/runs/route.ts, .../[run_id]/route.ts, .../join, .../leave)
vc-compiles-page    x3   (app/page.tsx, app/runs/new/page.tsx, app/runs/[run_id]/page.tsx)
```

`criterion_index()` is keyed on id and documents itself as last-writer-wins, so **five of seven fill slots resolved to no criterion at all** — while the plan, which bound all seven refs correctly, read as fully covered and passed every gate.

That is #818's class verbatim (*"an incorrect contract that is believed"*), one layer down, and the same FastAPI-shaped assumption as `_ROUTES_PATH`: that a filename identifies a file. Mine, from #822.

**`_view_criteria` is deliberately untouched.** Stack #1's views land in one flat directory, so its basenames are unique *by construction of its own expander* rather than by luck — and changing it would move `7622f570c949fe95`, the hash #777's guard and every bind-mode cycle are pinned to.

## B · The linter that catches this had no production caller

`lint()._lint_ids` detects duplicate ids precisely and has existed throughout. Its only callers, repo-wide, were `scripts/dev/contract_gate.py` and unit tests — **both running against the reference FastAPI manifest, whose ids cannot collide.** The guard was exercised solely by the one input incapable of failing it, and was absent from every path that derives a contract at cycle time.

`_contract_findings` now lints before reading the contract's contents, and returns alone on failure: a contract whose own linter rejects it is not something the per-check findings below it can reason about — duplicate ids in particular make `criterion_index()` lossy, so those findings would be computed over criteria no ref can resolve to.

Linting at the winnability gate rather than at storage is deliberate. This is the gate that already answers *"is this manifest winnable"*, a malformed contract is exactly a way for it not to be, and a rejection here re-rolls framing for free (#522) instead of failing mid-run.

## C · A frozen file with no declarations may not be checked

**I mis-diagnosed this initially and corrected it before building.** The appendix already says *"do not write typed checks against a frozen file unless the line below proves it passes"* — the rule was never missing.

The real gap is one layer down: `frozen_surface_index_lines` renders declarations for `.py` only, so on stack #2 all ten frozen files are bare names and the rule's escape hatch has **no line to reason from**. Roll 3's single rejection was an author guessing into that vacuum.

The appendix now states that an entry with no declarations may not be checked at all. Teaching the index to read TypeScript is S4's territory (typed checks off hardcoded `.py`) and is recorded there rather than built here under deadline.

## Test shape

Both new suites are **parameterized over `_STACKS`**, not written against `nextjs_ts`. The assumption "a filename identifies a file" is FastAPI-shaped and the next stack gets to break it too — and stack #1 passes by construction, which is exactly why a stack-specific test would have proved nothing.

The gate test **monkeypatches the pack to re-create the defect** rather than reverting the emitter fix. Otherwise it would silently degrade into a duplicate of the emitter's uniqueness test and stop covering the wiring — the half that was actually missing.

There is also a third assertion beyond uniqueness: ids must name the *directory that distinguishes the slot*. Uniqueness alone is satisfiable by a counter (`vc-compiles-1`), which is stable only until a slot is inserted in the middle, and would make a criterion id in evidence say nothing about which file it judged.

## Verification

- Regression **6946 passed**, 1 skipped.
- Stack #1 contract `7622f570c949fe95` and manifest `bb472e267e53d5ad` **unmoved**.
- Both stacks now emit **14 criteria / 14 distinct ids** and lint clean.
- **Mutation-verified both ways**: reverting the emitter fix fails 3 tests; unwiring the lint fails the 2 gate tests.
- Stack #2's contract hash moves, which is the point.

## Note on how this was found

Roll 3 found this by failing on an unrelated criterion. Had that regex not been authored, the cycle would have passed into implementation with **most of its verification contract silently unenforced** — a green run over an unverified surface. The rejection that looked like the problem was the only thing that stopped a worse one.

Every defect these three rolls surfaced was statically decidable; none needed a cycle to discover. That is the argument for the mechanical stack inventory recorded on #849 rather than another re-roll, and it is what comes next.

Closes #849
Refs #822, #818, #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX
