### PR TITLE
fix(gates): an approved gate promotes, however it was approved (#854)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1954,6 +1954,16 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             ),
         )
         await self._cycle_registry.record_gate_decision(run_id, decision)
+        # #854: an approval promotes the run's artifacts, and that is a consequence of the
+        # gate being APPROVED rather than of how it was approved. It lived only in the HTTP
+        # gate route, so this path — the one M4 added — recorded an approval and forwarded
+        # nothing. VS roll 4 is the first cycle to take it: framing passed, the plan
+        # validated, the gate approved, and the implementation run then refused because
+        # `plan_artifact_refs` was never written (#424 correctly declining to build with
+        # its instrumentation contract absent).
+        from squadops.cycles.gate_promotion import promote_run_artifacts
+
+        await promote_run_artifacts(self._artifact_vault, run_id)
         self._cycle_event_bus.emit(
             EventType.GATE_DECIDED,
             entity_type="run",

--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -409,14 +409,14 @@ async def list_checkpoints(project_id: str, cycle_id: str, run_id: str):
 
 
 async def _promote_run_artifacts(run_id: str) -> None:
-    """Promote all `working` artifacts produced by a run.
+    """Promote the run's artifacts on gate approval (SIP-0086).
 
-    Called from gate_decision() on approval. Idempotent: already-promoted
-    artifacts are skipped by the vault. Errors are logged but do not fail
-    the gate decision — the decision is the source of truth; promotion is
-    a downstream effect that can be retried.
+    Thin delegate: the operation moved to ``cycles.gate_promotion`` at #854 because it was
+    reachable only through this route, and the executor's question-gate auto-approval
+    (#807) is a second approval path that never arrives here.
     """
     from squadops.api.runtime.deps import get_artifact_vault
+    from squadops.cycles.gate_promotion import promote_run_artifacts
 
     try:
         vault = get_artifact_vault()
@@ -424,16 +424,4 @@ async def _promote_run_artifacts(run_id: str) -> None:
         logger.warning("artifact_vault unavailable; skipping promotion for run %s", run_id)
         return
 
-    try:
-        artifacts = await vault.list_artifacts(run_id=run_id)
-    except Exception:
-        logger.exception("failed to list artifacts for run %s during promotion", run_id)
-        return
-
-    for art in artifacts:
-        if art.promotion_status == "promoted":
-            continue
-        try:
-            await vault.promote_artifact(art.artifact_id)
-        except Exception:
-            logger.exception("failed to promote artifact %s for run %s", art.artifact_id, run_id)
+    await promote_run_artifacts(vault, run_id)

--- a/src/squadops/cycles/gate_promotion.py
+++ b/src/squadops/cycles/gate_promotion.py
@@ -1,0 +1,69 @@
+"""What an approved gate does to the run's artifacts (SIP-0086).
+
+Approving a gate promotes every artifact the run produced from ``working`` to
+``promoted``, which is how the next workload finds them: promotion is what puts the
+plan's ref into ``plan_artifact_refs``, and without it an implementation run is admitted
+with no plan and refuses (#424).
+
+**This module exists because that was wired to one of the two approval paths.**
+``_promote_run_artifacts`` lived in ``api/routes/cycles/runs.py`` and ran only when a gate
+was decided over HTTP — a human running ``squadops runs gate --approve``, or an agent
+answering a question. M4's question gate (#807) added a second path: when the manifest
+declares no unresolved decision, the executor approves the gate itself and never touches
+the route. VS roll 4 (``cyc_c82a401a21f8``) is the first cycle in the repo's history to
+take it — one ``system:no_open_questions`` row against 37 ``system:plan_validation``
+rejections — and its framing passed, its plan validated, its gate approved, and its
+implementation run then failed with the plan sitting promoted-never in the framing run's
+artifacts.
+
+So promotion is a consequence of *the gate being approved*, not of *how it was approved*,
+and it belongs where both callers can reach it rather than in the transport layer of one.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from squadops.ports.cycles.artifact_vault import ArtifactVaultPort
+
+logger = logging.getLogger(__name__)
+
+
+async def promote_run_artifacts(vault: ArtifactVaultPort | None, run_id: str) -> int:
+    """Promote every ``working`` artifact this run produced. Returns the count promoted.
+
+    Idempotent — already-promoted artifacts are skipped, so a retried or duplicated
+    approval costs nothing.
+
+    **Failures are logged, never raised.** The gate decision is the source of truth and is
+    already recorded by the time this runs; making promotion able to fail the decision
+    would mean an approval could be lost to a transient vault error. A promotion that did
+    not happen surfaces downstream as the #424 refusal, which is loud and correct.
+
+    A ``None`` vault is tolerated for the same reason: test contexts that never wired one
+    should not have their gate decisions fail.
+    """
+    if vault is None:
+        logger.warning("no artifact vault; skipping promotion for run %s", run_id)
+        return 0
+
+    try:
+        artifacts = await vault.list_artifacts(run_id=run_id)
+    except Exception:
+        logger.exception("failed to list artifacts for run %s during promotion", run_id)
+        return 0
+
+    promoted = 0
+    for art in artifacts:
+        if art.promotion_status == "promoted":
+            continue
+        try:
+            await vault.promote_artifact(art.artifact_id)
+            promoted += 1
+        except Exception:
+            logger.exception("failed to promote artifact %s for run %s", art.artifact_id, run_id)
+
+    logger.info("Promoted %d artifact(s) for run %s on gate approval", promoted, run_id)
+    return promoted

--- a/tests/unit/cycles/test_manifest_question_gate.py
+++ b/tests/unit/cycles/test_manifest_question_gate.py
@@ -19,6 +19,7 @@ Bug classes guarded:
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -206,3 +207,64 @@ def test_unreadable_content_asks_nothing(content):
     deriver's own reason. A second opinion here would stop a cycle for a defect that is
     already being reported."""
     assert open_questions(content) == ()
+
+
+async def test_the_pass_through_promotes_the_runs_artifacts(monkeypatch):
+    """#854: an approval promotes, and this path recorded an approval that promoted nothing.
+
+    The chain, measured on VS roll 4 (`cyc_c82a401a21f8`): the gate approved, all eleven
+    framing artifacts stayed at `promotion_status="working"`, the next-workload override
+    builder reads `list_artifacts(promotion_status="promoted")` and got an empty list, so
+    `plan_artifact_refs` was never written, `_load_plan_for_run` returned None, and #424
+    refused to run implementation with its instrumentation contract absent.
+
+    Every link behaved correctly. Only the first one never fired — promotion lived solely in
+    the HTTP gate route, and M4's question gate (#807) approves inside the executor. Roll 4
+    is the first cycle in the repo's history to take that path: one `no_open_questions` row
+    against 37 `plan_validation` rejections.
+
+    Asserted on the vault rather than on a call count, because "did we promote" is the
+    question the failure turned on — a mock assertion would pass against a call that
+    promoted nothing.
+    """
+    executor, _, _ = _executor()
+
+    promoted: list[str] = []
+    working = [
+        SimpleNamespace(artifact_id="art_plan", promotion_status="working"),
+        SimpleNamespace(artifact_id="art_manifest", promotion_status="working"),
+        SimpleNamespace(artifact_id="art_done", promotion_status="promoted"),
+    ]
+    executor._artifact_vault = SimpleNamespace(
+        list_artifacts=AsyncMock(return_value=working),
+        promote_artifact=AsyncMock(side_effect=lambda aid: promoted.append(aid)),
+    )
+
+    await executor._approve_gate_without_questions("run_1", "cyc_1", "progress_plan_review")
+
+    assert promoted == ["art_plan", "art_manifest"], (
+        "the approval must promote the run's working artifacts — without this the next "
+        "workload's plan_artifact_refs is built from an empty promoted set"
+    )
+
+
+async def test_a_vault_failure_does_not_lose_the_approval():
+    """The decision is the source of truth and is already recorded when promotion runs.
+
+    Letting a transient vault error propagate would turn a recorded approval into a failed
+    gate — trading a loud downstream refusal (#424, which is exactly how this bug surfaced)
+    for a lost decision. A promotion that did not happen is recoverable; an approval that
+    did not stick is not.
+    """
+    executor, _, _ = _executor()
+    executor._artifact_vault = SimpleNamespace(
+        list_artifacts=AsyncMock(side_effect=RuntimeError("vault down")),
+        promote_artifact=AsyncMock(),
+    )
+
+    decision = await executor._approve_gate_without_questions(
+        "run_1", "cyc_1", "progress_plan_review"
+    )
+
+    assert decision.decision == GateDecisionValue.APPROVED.value
+    executor._cycle_registry.record_gate_decision.assert_awaited_once()


### PR DESCRIPTION
Closes #854. Roll 4's framing passed the gate — first time in four rolls — and implementation refused to start reporting the plan absent. **The plan was not absent.** It was authored, validated, stored, and never handed forward.

## The chain, measured on `cyc_c82a401a21f8`

| step | what happened |
|---|---|
| gate approved by `system:no_open_questions` | M4's question gate (#807) approves **inside the executor** |
| `_promote_run_artifacts` | one call site — the HTTP gate route — which that path never reaches |
| framing artifacts | all eleven still `promotion_status="working"` on disk |
| `_build_next_workload_overrides` | reads **promoted only**, got an empty list, never wrote `plan_artifact_refs` |
| `_load_plan_for_run` | reads that key exclusively → `None` |
| #424 | refused to build with its instrumentation contract silently absent |

**Every link behaved correctly. Only the first never fired.** #424's refusal is the system working — it's why this surfaced as a clean failure instead of a build running with no verification contract.

## Why it took four rolls to see

`system:no_open_questions` has **one row in the entire database**, recorded today, against 37 `system:plan_validation` rejections. Every gate before this was decided over HTTP — a human running `squadops runs gate --approve`, or an agent answering. V5's question gate fired *with* questions, so it took the HTTP path too. M4 shipped the auto-approval on 2026-08-09 without the promotion, and roll 4 is the first cycle to take it.

## Fix

Promotion becomes a consequence of *the gate being approved*, not of *how it was approved* — extracted to `cycles/gate_promotion.py`, called by both the route and the executor.

Failures stay logged-not-raised. The decision is already recorded by the time promotion runs, so letting a transient vault error propagate would trade a loud downstream refusal for a lost approval — the wrong direction, given the loud refusal is exactly what made this findable.

## Test shape

Asserts **on the vault**, not on a call count. "Did we promote" is the question the failure turned on, and a mock assertion would pass against a call that promoted nothing. Plus a polarity guard that a vault failure doesn't lose the approval.

## The pattern, fourth time in this line

- `governance.merge_plan` absent from `CONTEXT_CONTRACTS` → default authoring path never got the contract (#846)
- two command allowlists each gating a question the other also answered (#707)
- `VerificationContract.lint()` with no production caller (#849)
- promotion reachable only through the HTTP route (this)

None was a missing feature. Each was correct code whose wiring was never checked against every path through it. 2a's guard-wiring sweep catches the *call-site-count* version of this; it would not have caught this one, because promotion had a caller — just not on both paths.

Regression **6969 passed**. Fix verified by mutation.

Refs #807, #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX