### PR TITLE
fix(plan): the sole author is shown the rules its plan is validated against (#856)

### DIFF
--- a/src/squadops/capabilities/handlers/_plan_authoring.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring.py
@@ -31,6 +31,34 @@ from squadops.llm.models import ChatMessage
 logger = logging.getLogger(__name__)
 
 
+async def authoring_rules_section(renderer: Any) -> str:
+    """The plan-shape rules every deterministic validator enforces (#686), or ``""``.
+
+    Unconditional — unlike the contract surfaces below there is no input to key on, because
+    these rules hold for every plan on every roll.
+
+    **Shared because it had three authors and reached two (#856.)** The proposers render it
+    (`planning/propose.py`) and the brief author renders it (`planning/brief.py`); the
+    sole-author path in `_plan_authoring_service.produce_plan` did not, and that is the path
+    that authors the plan on every CRP except ``validation-multirole``.
+
+    VS roll 5 (`cyc_d430f25fd01d`) is the measurement: a `qa.test` task declared
+    `expected_artifacts: ['__tests__/qa_execution_report.md']` — a report, no test file — and
+    `validate_check_applicability` rejected it. The rule that covers it,
+    ``qa-tests-must-be-discoverable``, states the correct form in its second sentence
+    ("through the acceptance criteria of a verification-only task"). The author never saw it.
+
+    That is the exact failure the asset was written for, quoted from its own docstring:
+    *"shk-1's first framing authored the #673 dual-claim shape with the contract, the manifest
+    and the typed-acceptance vocabulary all present, because the rules themselves appeared in
+    no prompt: the validator knew, the author never did."*
+    """
+    if renderer is None:
+        return ""
+    rendered = await renderer.render("request.plan_authoring_rules_appendix", {})
+    return rendered.content
+
+
 async def contract_surface_sections(renderer: Any, inputs: dict[str, Any]) -> str:
     """The contract surfaces an author needs, rendered, or ``""``.
 

--- a/src/squadops/capabilities/handlers/_plan_authoring_service.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring_service.py
@@ -21,7 +21,10 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any
 
-from squadops.capabilities.handlers._plan_authoring import contract_surface_sections
+from squadops.capabilities.handlers._plan_authoring import (
+    authoring_rules_section,
+    contract_surface_sections,
+)
 from squadops.capabilities.handlers.cycle_tasks import (
     _PRD_COVERAGE_DISCIPLINE_SECTION,
     _rewrite_manifest_identifiers,
@@ -226,6 +229,14 @@ async def produce_plan(
         manifest_prompt = rendered.content
     else:
         manifest_prompt = _build_manifest_user_prompt_inline(template_variables)
+
+    # #856: the plan-shape rules the deterministic validators enforce. Unconditional —
+    # they hold for every plan on every roll. The proposers and the brief author have
+    # rendered these since #686; this path did not, so the author that actually writes the
+    # plan on every CRP but `validation-multirole` was the one never shown them. VS roll 5
+    # authored a qa.test task emitting only a report and was rejected by a rule whose own
+    # text states the correct form. General rules first, then the cycle-specific surfaces.
+    manifest_prompt += await authoring_rules_section(renderer)
 
     # #846: the sole author gets the contract's surfaces, same as a proposer would.
     # This path runs whenever no plan_authoring_contributors are configured — which is

--- a/src/squadops/capabilities/handlers/planning/base.py
+++ b/src/squadops/capabilities/handlers/planning/base.py
@@ -154,8 +154,9 @@ class _PlanningTaskHandler(_CycleTaskHandler):
         is the managed asset; which validators are author-facing is the data table in
         ``squadops.cycles.plan_authoring_rules``, and a test binds the two (#448).
         """
-        rendered = await renderer.render("request.plan_authoring_rules_appendix", {})
-        return rendered.content
+        from squadops.capabilities.handlers._plan_authoring import authoring_rules_section
+
+        return await authoring_rules_section(renderer)
 
     async def _rejection_context_section(self, renderer: Any, inputs: dict[str, Any]) -> str:
         """The prior-rejection appendix on a framing re-roll, or "" (#669).

--- a/tests/unit/capabilities/test_plan_authoring_service.py
+++ b/tests/unit/capabilities/test_plan_authoring_service.py
@@ -346,8 +346,10 @@ async def test_produce_plan_renders_manifest_template(seeded_inputs):
     )
 
     assert artifact is not None
-    ctx.ports.request_renderer.render.assert_called_once()
-    call_args = ctx.ports.request_renderer.render.call_args
+    # #856: two renders now — the manifest template, then the unconditional authoring
+    # rules appendix. The first is the one under test.
+    assert ctx.ports.request_renderer.render.call_count == 2
+    call_args = ctx.ports.request_renderer.render.call_args_list[0]
     assert call_args.args[0] == "request.governance_review_plan_manifest"
 
     variables = call_args.args[1]
@@ -469,7 +471,7 @@ async def test_produce_plan_filters_builder_assemble_by_squad_capability():
         handler_name="test_harness",
         chat_kwargs={},
     )
-    no_builder_render = str(ctx_no_builder.ports.request_renderer.render.call_args)
+    no_builder_render = str(ctx_no_builder.ports.request_renderer.render.call_args_list[0])
     assert "builder.assemble" not in no_builder_render
 
     # #426: the builder role alone no longer suffices — the offer also
@@ -484,7 +486,7 @@ async def test_produce_plan_filters_builder_assemble_by_squad_capability():
         handler_name="test_harness",
         chat_kwargs={},
     )
-    builder_render = str(ctx_builder.ports.request_renderer.render.call_args)
+    builder_render = str(ctx_builder.ports.request_renderer.render.call_args_list[0])
     assert "builder.assemble" in builder_render
 
 
@@ -674,7 +676,11 @@ async def test_author_mode_prompt_is_unchanged_without_a_contract(seeded_inputs)
     )
 
     prompt = _rendered_prompt(ctx)
-    assert prompt == "user prompt (rendered from request.governance_review_plan_manifest)"
+    # #856 made the authoring-rules appendix unconditional, so exact equality with the base
+    # prompt is no longer the right assertion — what this guards is that no CONTRACT
+    # appendix appears when there is no contract.
+    assert "request.plan_bind_criteria_appendix" not in prompt
+    assert "request.plan_frozen_surface_appendix" not in prompt
 
 
 async def test_an_empty_index_is_not_rendered_as_an_empty_section(seeded_inputs):
@@ -698,4 +704,70 @@ async def test_an_empty_index_is_not_rendered_as_an_empty_section(seeded_inputs)
     )
 
     prompt = _rendered_prompt(ctx)
-    assert prompt == "user prompt (rendered from request.governance_review_plan_manifest)"
+    assert "request.plan_bind_criteria_appendix" not in prompt
+    assert "request.plan_frozen_surface_appendix" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# #856 — the sole author is shown the rules its plan is validated against
+# ---------------------------------------------------------------------------
+
+
+async def test_sole_author_prompt_carries_the_plan_authoring_rules(seeded_inputs):
+    """VS roll 5 (`cyc_d430f25fd01d`) was rejected by a rule the author never saw.
+
+    Its `qa.test` task declared `expected_artifacts: ['__tests__/qa_execution_report.md']`
+    — a report, no test file — and `validate_check_applicability` refused it. The rule
+    covering that case, `qa-tests-must-be-discoverable`, states the correct form in its own
+    second sentence. `_authoring_rules_section` was rendered by the proposers and the brief
+    author and by nothing on this path, which is the path that writes the plan on every CRP
+    except `validation-multirole`.
+
+    Asserted on the message the LLM received, not on the render call: the question the
+    failure turned on is whether the rules reached the model, and a call-count assertion
+    passes against a render whose output is dropped.
+    """
+    ctx = _make_context()
+    ctx.ports.request_renderer.render.side_effect = _fake_render
+
+    await produce_plan(
+        ctx,
+        seeded_inputs,
+        planning_content="planning",
+        resolved_config=seeded_inputs["resolved_config"],
+        role="lead",
+        handler_name="test",
+        chat_kwargs={},
+    )
+
+    prompt = _rendered_prompt(ctx)
+    assert "request.plan_authoring_rules_appendix" in prompt, (
+        "the sole author must be shown the plan-shape rules its output is validated "
+        "against — the validator knowing a rule the author never sees is #686's defect"
+    )
+
+
+async def test_the_rules_precede_the_cycle_specific_surfaces(seeded_inputs):
+    """Ordering is deliberate, not incidental: general rules, then this cycle's contract.
+
+    Both are appended to the same prompt, and a reader that meets the fill-slot list before
+    the rule about what a qa task may declare has to hold the specifics without the frame.
+    Pinned so a later append does not silently invert it.
+    """
+    ctx = _make_context()
+    ctx.ports.request_renderer.render.side_effect = _fake_render
+
+    await produce_plan(
+        ctx,
+        {**seeded_inputs, "contract_criteria_index": "- app/api/runs/route.ts: bind vc-runs"},
+        planning_content="planning",
+        resolved_config=seeded_inputs["resolved_config"],
+        role="lead",
+        handler_name="test",
+        chat_kwargs={},
+    )
+
+    prompt = _rendered_prompt(ctx)
+    assert prompt.index("request.plan_authoring_rules_appendix") < prompt.index(
+        "request.plan_bind_criteria_appendix"
+    )


### PR DESCRIPTION
Closes #856.

Roll 5 was rejected at the framing gate on **one** defect: a `qa.test` task declaring only `__tests__/qa_execution_report.md`. The intent was legitimate — run an earlier task's suite, emit a coverage report — and the correct form is `expected_artifacts: []`. The rule that says so, `qa-tests-must-be-discoverable`, states it in its own second sentence.

**The author never saw it.** `_authoring_rules_section` renders that appendix and had exactly two callers — `planning/propose.py` and `planning/brief.py`. `_plan_authoring_service.produce_plan` rendered it nowhere, and that is the path that writes the plan on every CRP except `validation-multirole`.

Verbatim the failure the asset was written for, quoted from its own docstring:

> shk-1's first framing authored the #673 dual-claim shape with the contract, the manifest and the typed-acceptance vocabulary all present, because the rules themselves appeared in no prompt: **the validator knew, the author never did.**

## My miss at #848

#846's Family B found this same path missing the *contract* surfaces, and I fixed those. I went looking at `bind_criteria_index` and never asked what **else** the proposers receive that this path doesn't. So I closed #846 declaring B resolved with half the forwarding gap still open.

## Fifth time, same shape

| | |
|---|---|
| #846 | `governance.merge_plan` absent from `CONTEXT_CONTRACTS` |
| #707 | two command allowlists, each gating what the other also gated |
| #849 | `VerificationContract.lint()` with no production caller |
| #854 | promotion reachable only through the HTTP gate route |
| **this** | authoring rules rendered by two of three authoring paths |

And a limit worth stating plainly: **2a's guard-wiring sweep catches neither #854 nor this one.** Both had production callers — just not on every path. The sweep asks *"does this have a caller"*; the recurring defect is *"does this have all its callers."* That's a narrower check than I claimed when I built it.

## Shape of the fix

`authoring_rules_section` extracted to `handlers/_plan_authoring.py` beside `contract_surface_sections`, called by both the base handler and `produce_plan` — rather than adding a second copy, which is how this class starts. Unconditional in both, since the rules hold for every plan on every roll. Ordered **before** the cycle-specific contract surfaces (general frame, then specifics), pinned by test so a later append can't invert it.

## Tests

Four existing tests updated, **two of them mine from #848**. They asserted the sole-author prompt equals the base string exactly, which an unconditional section correctly breaks. Rewritten to assert what they actually guard — that no *contract* appendix appears when there is no contract — rather than loosened to keep passing.

Regression **6971 passed**. Fix verified by mutation.

Refs #686, #846, #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX