### PR TITLE
fix(nextjs): the route file is derived from the URL it serves (#859)

### DIFF
--- a/docs/plans/stack-2-bend-register.md
+++ b/docs/plans/stack-2-bend-register.md
@@ -28,8 +28,11 @@ here" and "the stack conceded here" demand opposite responses.**
 | 4 | route handlers, not server actions | **bend** | the stack conceded |
 | 5 | seven whole-tree builds per acceptance pass | disclosure | a cost, not a concession |
 | 6 | no static check on route slots | disclosure | a coverage gap, already known |
+| 7 | the API prefix is the manifest's to declare | **bend** | the stack conceded |
 
-**One true bend.** That is the number S3 has to argue, and #4 is argued below.
+**Two true bends.** #4 was the only one until VS roll 6 produced #7 — which is the first bend found
+by *running* the stack rather than by building it, and the only one whose evidence is a manifest
+that cannot be built at all.
 
 ---
 
@@ -157,6 +160,48 @@ bundler check is the type check.**
 source*. `endpoint_defined` is Python-only, so that claim rests on the behavioral probes alone —
 late and functionally, rather than early and structurally. This is S4's territory and was
 disclosed before the stack was built.
+
+---
+
+## 7 — The API prefix is the manifest's to declare, not the expander's to supply · **the second bend**
+
+**What happened.** `_route_groups` built each handler's path as `app/api/{segments(ep.path)}`,
+prefixing unconditionally. VS roll 6's authored manifest declared its endpoints as the URLs Next
+actually serves — `/api/runs` — and got **`app/api/api/runs/route.ts`**, as a fill slot in the
+derived contract rather than as a dev error. That file serves `/api/api/runs` while the
+contract's probes request `/api/runs`, so the application could not answer its own
+verification. Every gate passed it; the correction chain looped until the 7200s budget ended
+the run after 16 tasks.
+
+**The field that forced it.** `api.endpoints[].path`, read as *unprefixed* — true of the
+reference manifest and FastAPI-shaped, where routes mount wherever they are told and stack #1's
+flat `backend/routes.py` makes double-prefixing structurally impossible. On App Router
+`app/api/` **is** the URL prefix, so the stack imposes a segment the manifest may or may not
+repeat, and nothing decided which.
+
+**The resolution, and why it is a bend rather than a schema defect.** `path` now means the same
+thing on every stack — the URL the app serves — and the file is derived from it directly. That
+is the schema doing its job. What the stack concedes is the *converse*: because handlers and
+pages now share one `app/` tree, an API path that collides with a page path is unbuildable, so
+**stack #2 requires its API to be declared under a distinct prefix.** Stack #1 has no such
+requirement; its two halves live in separate trees and cannot interfere.
+
+**The evidence is unusually sharp: the reference manifest fails the new rule.** Its API is
+`/runs` and its page is `/runs/:id`, which under one tree ask Next for two slug names at the
+same dynamic position. So the constraint is not hypothetical — it invalidates the very design
+every other stack test is built from, which is why the test fixtures now express the reference
+*per stack* rather than re-stacking it.
+
+**Argued as a genuine cross-stack convention:** a design declares the URLs it serves, and each
+stack decides where the code for a URL lives. The counter-argument, recorded so the decision is
+real: this stack additionally demands that two *different kinds* of declaration not collide in
+URL space, which is a constraint on the manifest that stack #1 does not impose. A schema that
+says nothing about it leaves stack #2 with a rule enforced only by its expander raising.
+
+**Status: argued, not settled. S3 decides** whether "API and page routes share a routing tree"
+is a blueprint declaration or stays the pack's own business. Today it is the latter — the rule
+lives in `_assert_routing_tree_is_coherent`, and M3's `PROOF_EXPANDS` turns it into a framing
+rejection costing a free re-roll.
 
 ---
 

--- a/docs/plans/stack-blueprint-schema-draft.md
+++ b/docs/plans/stack-blueprint-schema-draft.md
@@ -103,6 +103,24 @@ Regenerate with the extractor in `tests/unit/capabilities/test_stack_inventory.p
 
 ---
 
+## 4b. A per-stack fact this schema does not carry (#859)
+
+**"Do API routes and page routes share a routing tree?"** Stack #1: no — `backend/` and
+`frontend/src/` cannot interfere. Stack #2: yes — both are directories under `app/`, so an API
+path colliding with a page path is unbuildable and the manifest must declare its API under a
+distinct prefix.
+
+Demonstrated on two stacks with opposite values, which is exactly what S5's admission rule asks
+of a candidate field. It is **not** in Tier 1 above: the fix expressed it as *behavior* in the
+pack's own expander (`_assert_routing_tree_is_coherent`, surfaced through M3's `PROOF_EXPANDS`)
+rather than as declared data.
+
+That is a defensible Tier 2 reading — the rule is Next's, and enforcing it needs the stack's
+own knowledge of `route.ts`/`page.tsx` conflicts, not a boolean. But it means a reader of the
+schema cannot tell that stack #2 constrains its author's URL space and stack #1 does not.
+**2c owes this a disposition**: promote it to a declared field, or record it as pack behavior
+with the reason. Left undecided it becomes the thing a third stack discovers by failing.
+
 ## 5. Open questions carried to 2g
 
 1. **Does the blueprint own the packaging set?** `required_files` and `qa_handoff_expectations` are identical across both stacks — weak evidence they are universal rather than blueprint-owned. Tier 3 above takes that reading; a third stack could overturn it.

--- a/src/squadops/capabilities/stack_nextjs_ts.py
+++ b/src/squadops/capabilities/stack_nextjs_ts.py
@@ -82,16 +82,85 @@ def _segments(path: str) -> str:
     return "/".join(out)
 
 
+def _dir_shape(directory: str) -> str:
+    """``app/runs/[run_id]`` → ``app/runs/[]``. Two paths sharing a shape occupy the same
+    position in Next's routing tree, whatever their slug names are called."""
+    return "/".join("[]" if s.startswith("[") else s for s in directory.split("/"))
+
+
+def _assert_routing_tree_is_coherent(routes: dict[str, list[Any]], pages: tuple[str, ...]) -> None:
+    """Refuse a manifest whose API and page paths cannot coexist in one App Router tree (#859).
+
+    **This is the other half of dropping the ``app/api/`` prefix.** That prefix used to keep
+    API handlers and pages in disjoint subtrees, so a collision was structurally impossible
+    and nobody had to think about it. Deriving the file from the declared URL is correct —
+    ``/api/runs`` now yields ``app/api/runs/route.ts``, which serves ``/api/runs`` — but it
+    puts both kinds of file in one tree, where Next has rules we must not silently violate:
+
+    - a directory cannot hold both ``route.ts`` and ``page.tsx``;
+    - two paths cannot use different slug names at the same dynamic position
+      (``app/runs/[run_id]`` beside ``app/runs/[id]``).
+
+    Raising rather than repairing is deliberate. The manifest states what the app serves, and
+    two declarations that cannot both be served is a design defect the author must resolve —
+    silently relocating one would produce an app that answers different URLs than its own
+    contract probes, which is exactly the failure this change exists to end (roll 6 burned a
+    full 7200s budget on it). M3's ``PROOF_EXPANDS`` turns this into a framing rejection, so
+    it costs a free re-roll rather than an implementation run.
+
+    The reference manifest fails this check by design of its own paths — its API is ``/runs``
+    and its page is ``/runs/:id`` — which is why declaring API endpoints under ``/api`` is now
+    a stated requirement of this stack rather than a convention the expander supplied.
+    """
+    route_dirs = {p.rsplit("/", 1)[0]: p for p in routes}
+    page_dirs = {p.rsplit("/", 1)[0]: p for p in pages}
+
+    both = sorted(set(route_dirs) & set(page_dirs))
+    if both:
+        raise ValueError(
+            f"directory {both[0]!r} would hold both a route handler and a page — Next serves "
+            f"one path from one file, so an API endpoint and a frontend route cannot share a "
+            f"path on this stack. Declare the API under a distinct prefix (conventionally "
+            f"`/api/...`) so the two occupy separate directories."
+        )
+
+    by_shape: dict[str, str] = {}
+    for directory in list(route_dirs) + list(page_dirs):
+        shape = _dir_shape(directory)
+        clash = by_shape.setdefault(shape, directory)
+        if clash != directory:
+            raise ValueError(
+                f"{clash!r} and {directory!r} occupy the same position in the routing tree "
+                f"with different parameter names — Next requires one slug name per dynamic "
+                f"segment. Use the same parameter name in both paths, or declare the API "
+                f"under a distinct prefix (conventionally `/api/...`)."
+            )
+
+
 def _route_groups(manifest: Any) -> dict[str, list[Any]]:
     """Endpoints grouped by the file that will own them — **bend 1**.
 
     Insertion-ordered so the emitted file list is deterministic, which the contract's frozen
     hashes and the golden benchmark both depend on.
+
+    **The path is derived from the declared URL, with no ``app/api/`` prefix (#859).** It used
+    to prefix unconditionally, so a manifest declaring the true Next URL — ``/api/runs``, which
+    is what an App Router author writes and what the frontend fetches — produced
+    ``app/api/api/runs/route.ts``. That file serves ``/api/api/runs`` while the contract's
+    probes request ``/api/runs``, so the application could never answer its own verification.
+    Every gate passed it and roll 6's correction chain looped until the time budget ended it.
+
+    ``path`` now means the same thing on every stack: the URL the app serves. Where the file
+    lives is the stack's business, and here it is a direct function of that URL.
     """
     groups: dict[str, list[Any]] = {}
     for ep in manifest.api.endpoints:
-        path = f"app/api/{_segments(ep.path)}/route.ts".replace("//", "/")
+        path = f"app/{_segments(ep.path)}/route.ts".replace("//", "/")
         groups.setdefault(path, []).append(ep)
+    _assert_routing_tree_is_coherent(
+        groups,
+        tuple(_page_path(r) for r in (getattr(manifest.frontend, "routes", ()) or ())),
+    )
     return groups
 
 

--- a/tests/unit/capabilities/_stack_fixtures.py
+++ b/tests/unit/capabilities/_stack_fixtures.py
@@ -1,0 +1,55 @@
+"""One reference design, expressed for whichever stack is under test.
+
+Every stack test derives its manifest from `examples/03_group_run/interface_manifest.yaml`
+by swapping `stack:`. That works only while the *rest* of the document is stack-neutral,
+and #859 found the point where it stops being.
+
+The reference declares its API at `/runs` and a page at `/runs/:id`. On stack #1 those live
+in different trees (`backend/` and `frontend/src/`) and cannot interfere. On App Router both
+are directories under `app/`, so the same two declarations ask Next to serve one path from
+two files — which it refuses, and which `_assert_routing_tree_is_coherent` now refuses at
+framing rather than four hours into a run.
+
+So declaring API endpoints under `/api` is a **requirement of stack #2**, not decoration.
+That is what `manifest_for_stack` applies, and applying it in one place means a third stack
+adds its own clause here rather than each test growing a private workaround.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from squadops.capabilities.scaffold import InterfaceManifest
+
+REFERENCE_PATH = (
+    Path(__file__).resolve().parents[3] / "examples" / "03_group_run" / "interface_manifest.yaml"
+)
+
+#: Stacks whose API handlers and pages share one routing tree, so an API path must be
+#: distinguishable from a page path. Empty prefix = the stack keeps them in separate trees
+#: and the reference's paths work unmodified.
+_API_PREFIX: dict[str, str] = {"nextjs_ts": "/api"}
+
+
+def reference_dict() -> dict[str, Any]:
+    return yaml.safe_load(REFERENCE_PATH.read_text(encoding="utf-8"))
+
+
+def manifest_dict_for_stack(stack: str) -> dict[str, Any]:
+    """The reference design as `stack` requires it to be declared."""
+    raw = reference_dict()
+    raw["stack"] = stack
+    prefix = _API_PREFIX.get(stack, "")
+    if prefix:
+        for ep in raw["api"]["endpoints"]:
+            ep["path"] = prefix + ep["path"]
+    return raw
+
+
+def manifest_for_stack(stack: str) -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(
+        yaml.safe_dump(manifest_dict_for_stack(stack), sort_keys=False)
+    )

--- a/tests/unit/capabilities/test_contract_emitter_stack_seam.py
+++ b/tests/unit/capabilities/test_contract_emitter_stack_seam.py
@@ -282,16 +282,11 @@ def test_every_registered_stack_declares_a_pack_that_exists():
 
 def _contract_for(stack: str):
     """The reference manifest's contract, re-stacked. One manifest, two emitters."""
-    import pathlib
 
-    import yaml
-
-    from squadops.capabilities.scaffold import InterfaceManifest
     from squadops.cycles.verification_contract import VerificationContract
+    from tests.unit.capabilities._stack_fixtures import manifest_for_stack
 
-    raw = yaml.safe_load(pathlib.Path("examples/03_group_run/interface_manifest.yaml").read_text())
-    raw["stack"] = stack
-    manifest = InterfaceManifest.from_yaml(yaml.safe_dump(raw, sort_keys=False))
+    manifest = manifest_for_stack(stack)
     return VerificationContract.from_dict(scaffold_contract.emit_contract_dict(manifest))
 
 

--- a/tests/unit/capabilities/test_stack_inventory.py
+++ b/tests/unit/capabilities/test_stack_inventory.py
@@ -43,7 +43,6 @@ import ast
 import pathlib
 
 import pytest
-import yaml
 
 from squadops.capabilities import dev_capabilities, scaffold, scaffold_contract
 from squadops.capabilities.handlers import build_profiles, probe_runner
@@ -97,10 +96,16 @@ def _registry_key(stack_name: str, field: str | None) -> str:
 
 
 def _manifest_for(stack: str) -> InterfaceManifest:
-    """The reference manifest, re-stacked. One design, every emitter."""
-    raw = yaml.safe_load(_REFERENCE.read_text(encoding="utf-8"))
-    raw["stack"] = stack
-    return InterfaceManifest.from_yaml(yaml.safe_dump(raw, sort_keys=False))
+    """The reference design, expressed as ``stack`` requires it (#859).
+
+    Not a plain re-stack any more. Stack #2 serves API handlers and pages from one routing
+    tree, so its API paths must be distinguishable from its page paths — the reference's
+    `/runs` API beside its `/runs/:id` page is a collision Next refuses. The shared fixture
+    owns that per-stack clause so a third stack adds one there rather than here.
+    """
+    from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+    return manifest_for_stack(stack)
 
 
 def _contract_for(stack: str) -> VerificationContract:

--- a/tests/unit/capabilities/test_stack_nextjs_ts.py
+++ b/tests/unit/capabilities/test_stack_nextjs_ts.py
@@ -46,7 +46,11 @@ _REFERENCE_SRC = (
 
 
 def _manifest(stack: str = _STACK) -> InterfaceManifest:
-    return InterfaceManifest.from_yaml(_REFERENCE_SRC.replace("fullstack_fastapi_react", stack))
+    """The reference design as this stack requires it declared (#859): API under `/api`,
+    because App Router serves route handlers and pages from one tree."""
+    from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+    return manifest_for_stack(stack)
 
 
 def _names(manifest: InterfaceManifest) -> list[str]:
@@ -238,3 +242,73 @@ def test_the_typed_check_vocabulary_is_declared_empty_not_guessed():
     verified against this stack, so its checks must skip rather than be fed a guess."""
     assert scaffold.check_stack_for(_STACK) is None
     assert scaffold.check_stack_for("fullstack_fastapi_react") == "fastapi"
+
+
+# --------------------------------------------------------------------------- #
+# #859 — the file path is derived from the URL, and the tree must be coherent
+# --------------------------------------------------------------------------- #
+
+
+def _with_api_paths(paths: list[str], routes: list[str] | None = None) -> InterfaceManifest:
+    """The reference design with its API paths (and optionally its pages) replaced."""
+    from tests.unit.capabilities._stack_fixtures import manifest_dict_for_stack
+
+    raw = manifest_dict_for_stack(_STACK)
+    raw["api"]["endpoints"] = [
+        {**raw["api"]["endpoints"][i], "path": p} for i, p in enumerate(paths)
+    ]
+    if routes is not None:
+        raw["frontend"]["routes"] = [{**raw["frontend"]["routes"][0], "path": p} for p in routes]
+    import yaml
+
+    return InterfaceManifest.from_yaml(yaml.safe_dump(raw, sort_keys=False))
+
+
+def test_the_route_file_serves_the_url_the_manifest_declared():
+    """Roll 6's defect, stated as the invariant it violated.
+
+    The expander used to prefix `app/api/` unconditionally, so a manifest declaring the true
+    Next URL — `/api/runs`, which is what an App Router author writes and what the frontend
+    fetches — produced `app/api/api/runs/route.ts`. That file serves `/api/api/runs` while
+    the contract's probes request `/api/runs`, so the app could never answer its own
+    verification and the correction chain looped until the 7200s budget ended the run.
+    """
+    slots = fill_slot_paths(_with_api_paths(["/api/runs"]))
+
+    assert "app/api/runs/route.ts" in slots
+    assert not any("api/api" in s for s in slots), (
+        "the declared URL was prefixed twice — the emitted file cannot serve the path the "
+        "contract probes request"
+    )
+
+
+def test_an_unprefixed_api_path_is_placed_where_it_will_actually_serve():
+    """`path` means the served URL on every stack, so `/runs` yields `app/runs/route.ts`.
+
+    The correctness of that placement is the reason the collision guard below has to exist:
+    the prefix is no longer supplied silently, so nothing keeps API files out of the page
+    tree except the manifest's own paths.
+    """
+    slots = fill_slot_paths(_with_api_paths(["/runs"], routes=["/"]))
+
+    assert "app/runs/route.ts" in slots
+
+
+def test_an_api_path_colliding_with_a_page_is_refused():
+    """A directory cannot hold both `route.ts` and `page.tsx`; Next serves one path from one
+    file. Refusing is deliberate — silently relocating one would ship an app answering
+    different URLs than its own contract, which is the failure this change ends."""
+    with pytest.raises(ValueError, match="both a route handler and a page"):
+        fill_slot_paths(_with_api_paths(["/runs"], routes=["/runs"]))
+
+
+def test_two_paths_disagreeing_on_a_slug_name_are_refused():
+    """The reference manifest's own shape: API `/runs/{run_id}` beside page `/runs/:id`.
+
+    Next requires one slug name per dynamic segment, so these cannot coexist — which is why
+    declaring the API under `/api` is now a requirement of this stack rather than a
+    convention the expander supplied. Pinned with the exact pair that would otherwise have
+    shipped, since the reference is the design every other stack test is built from.
+    """
+    with pytest.raises(ValueError, match="same position in the routing tree"):
+        fill_slot_paths(_with_api_paths(["/runs/{run_id}"], routes=["/runs/:id"]))


### PR DESCRIPTION
Closes #859. Roll 6 reached implementation on stack #2 for the first time and burned its full 7200s budget across 16 tasks and three correction rounds, on a defect **the contract itself created**.

## The defect

The manifest declared `/api/runs` — the URL Next actually serves, what an App Router author writes, what the frontend fetches. `_route_groups` prefixed `app/api/` unconditionally:

| | |
|---|---|
| derived fill slot | `app/api/api/runs/route.ts` |
| that file serves | `/api/api/runs` |
| contract probe requests | `/api/runs` |

The app could never answer its own verification. The dev emitted exactly what it was told, three times. Every gate passed it — M3's proofs, the #849 lint, plan validation.

## The fix, in two parts

**1.** `path` means the same thing on every stack — the URL served — and the file derives from it. `/api/runs` → `app/api/runs/route.ts`.

**2.** `_assert_routing_tree_is_coherent`. Dropping the prefix puts handlers and pages in one `app/` tree, where Next refuses a directory holding both `route.ts` and `page.tsx`, and refuses two slug names at the same dynamic position. Without this, part 1 trades a *silent double-prefix* for a *silent collision* — the same defect class facing the other way.

Raising rather than relocating is deliberate: silently moving a file would ship an app answering different URLs than its own contract, which is the failure being fixed. M3's `PROOF_EXPANDS` turns the raise into a framing rejection costing a free re-roll rather than an implementation run.

## The reference manifest fails the new rule

That's the sharpest evidence for it. Its API is `/runs`, its page is `/runs/:id` — under one tree, two slug names at the same position. So declaring the API under a distinct prefix is a **requirement of stack #2**, not decoration.

**17 stack-#2 tests failed on exactly this**, every one of them building its manifest by re-stacking the reference. They now route through a single shared fixture that expresses the reference *per stack*, so a third stack adds its clause in one place rather than each test growing a private workaround.

## Recorded, not acted on

*"Do API and page routes share a routing tree?"* — stack #1 no, stack #2 yes. Demonstrated with opposite values on two stacks, which is exactly what S5's admission rule asks of a candidate blueprint field. This fix expresses it as **pack behavior**, not declared data. Defensible (the rule is Next's and needs the stack's own knowledge), but a schema reader cannot tell that stack #2 constrains its author's URL space and stack #1 doesn't. **2c owes it a disposition** — noted in the 2b draft rather than decided here.

## Verification

- Regression **6975 passed**, 1 skipped.
- Stack #1's contract and manifest pins **unmoved** — M0a byte-equality green. Stack #2's hash moves, which is the point.
- **Both halves mutation-verified**: restoring the prefix fails 1 test; removing the collision guard fails 2.
- Bend register **entry 7** added in this PR per its written-during rule — the first bend found by *running* the stack rather than building it.

Refs #822 (Stage 1e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX