### PR TITLE
fix(dev): the developer is told what the frozen files declare (#861, #858)

### DIFF
--- a/src/squadops/capabilities/context_assembly.py
+++ b/src/squadops/capabilities/context_assembly.py
@@ -45,6 +45,12 @@ SURFACE_TESTID = "testid_surface"
 #: The qa-keyed landing of the SAME testid inventory (#667): identical
 #: deriver, distinct envelope key — each handler reads its own variant.
 SURFACE_DOM_TESTID = "dom_testid_surface"
+#: #861: what each scaffold-frozen file declares. The plan author has had this since pf-42;
+#: the developer that must IMPORT from those files had not, and roll 7 died of it — it wrote
+#: `import { runStore } from '@/lib/store'` against a module exporting
+#: `reset, all, insert, find, nextId`, then repaired to the same invented name because the
+#: repair path was blind identically. A name the author cannot see is a name it will invent.
+SURFACE_FROZEN = "frozen_surface"
 
 
 @dataclass(frozen=True)
@@ -120,7 +126,7 @@ ACCEPTANCE_WORKSPACE_FILTER = ArtifactFilter(
     by_type_fallback=("document",),
 )
 
-_DEV_SURFACES = (SURFACE_ERROR_CONTRACT, SURFACE_MODEL, SURFACE_TESTID)
+_DEV_SURFACES = (SURFACE_ERROR_CONTRACT, SURFACE_MODEL, SURFACE_TESTID, SURFACE_FROZEN)
 
 CONTEXT_CONTRACTS: dict[str, ContextAssemblyContract] = {
     # --- build tasks (D3): curated prompt context + acceptance workspace ----
@@ -341,6 +347,7 @@ def manifest_surface_fragments(
         return {}
     from squadops.capabilities.scaffold import (
         error_seam_instructions,
+        frozen_surface_index_lines,
         model_surface_instructions,
         testid_surface_instructions,
     )
@@ -350,6 +357,7 @@ def manifest_surface_fragments(
         SURFACE_MODEL: model_surface_instructions,
         SURFACE_TESTID: testid_surface_instructions,
         SURFACE_DOM_TESTID: testid_surface_instructions,
+        SURFACE_FROZEN: frozen_surface_index_lines,
     }
     fragments: dict[str, list[str]] = {}
     for surface in contract.manifest_surfaces:

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -788,8 +788,33 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         testid_surface = await self._testid_surface_section(renderer, inputs)
         if testid_surface:
             variables["testid_surface"] = testid_surface
+        # #861: what the frozen files DECLARE, same transport and same reasoning as the
+        # three above. Roll 7 emitted `import { runStore } from '@/lib/store'` against a
+        # module exporting `reset, all, insert, find, nextId`, and the repair invented the
+        # same name again because it was blind identically — so the correction terminated
+        # as plan_defect on a defect no repair could see. The plan author has had this
+        # index since pf-42; the agent that must import from those files had not.
+        frozen_surface = await self._frozen_surface_section(renderer, inputs)
+        if frozen_surface:
+            variables["frozen_surface"] = frozen_surface
         rendered = await renderer.render(
             "request.development_develop_fill_only_appendix", variables
+        )
+        return rendered.content
+
+    async def _frozen_surface_section(self, renderer: Any, inputs: dict | None) -> str:
+        """Render the FROZEN FILES block from executor-threaded lines, or "".
+
+        The lines are manifest-derived data (``scaffold.frozen_surface_index_lines``); all
+        prose lives in the appendix asset (CLAUDE.md #448).
+        """
+        lines = [str(line).strip() for line in ((inputs or {}).get("frozen_surface") or [])]
+        lines = [line for line in lines if line]
+        if not lines:
+            return ""
+        rendered = await renderer.render(
+            "request.development_develop_frozen_surface_appendix",
+            {"frozen_lines": "\n".join(lines)},
         )
         return rendered.content
 

--- a/src/squadops/prompts/request_templates/request.development_author_manifest.md
+++ b/src/squadops/prompts/request_templates/request.development_author_manifest.md
@@ -48,6 +48,7 @@ entities:                          # the data types the app stores and returns
       - { name: id,      type: string,  required: true, generated: true }
       - { name: title,   type: string,  required: true }
       - { name: done,    type: boolean, required: false, default: false }
+      - { name: tags,    type: "list[Tag]", required: false, default: [] }   # QUOTE bracket types
 api:
   base_path: ""                    # "" when the PRD's paths are unprefixed (/items)
   request_shapes:                  # request BODIES — a projection of entity fields
@@ -88,6 +89,11 @@ decisions:                         # judgments the schema cannot express mechani
     unresolved: true
     question: "PRD does not state a page size or whether listing is paginated at all"
 ```
+
+**A type containing brackets must be quoted.** `type: list[Tag]` inside a `{ ... }`
+entry is invalid YAML — the `[` opens a flow sequence and the document fails to parse
+before any gate can read it. Write `type: "list[Tag]"`. This is the single most
+common reason a first manifest attempt is rejected.
 
 The example is illustrative. Replace it with THIS build's real entities, endpoints,
 routes, anchors and decisions, drawn from the PRD and the framing documents above.

--- a/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix.md
@@ -1,12 +1,13 @@
 ---
 template_id: request.development_develop_fill_only_appendix
-version: "4"
+version: "5"
 required_variables:
   - stack
 optional_variables:
   - error_contract
   - model_surface
   - testid_surface
+  - frozen_surface
 ---
 ## Fill-only: a walking skeleton is already in your workspace
 
@@ -37,6 +38,8 @@ the fixed slots** — never to rebuild, rewire, or regenerate the scaffold.
 {{model_surface}}
 
 {{testid_surface}}
+
+{{frozen_surface}}
 
 Filling the fixed slots — rather than regenerating the app — is the whole point: the
 skeleton already builds and boots, so a fill that preserves it stays green, while one

--- a/src/squadops/prompts/request_templates/request.development_develop_frozen_surface_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_frozen_surface_appendix.md
@@ -1,0 +1,24 @@
+---
+template_id: request.development_develop_frozen_surface_appendix
+version: "1"
+required_variables:
+  - frozen_lines
+optional_variables: []
+---
+**FROZEN FILES AND WHAT THEY DECLARE (authoritative — import from these, never rewrite them):**
+{{frozen_lines}}
+
+These files are already in your workspace and the scaffold restores them if you edit
+them, so a change you make here is discarded before anything checks it.
+
+Read the list literally. The names after each path are the **only** names those files
+export. If a module lists `reset, all, insert, find`, then `runStore` does not exist and
+importing it fails the build — no matter how reasonable the name looks. The same holds for
+model fields and error codes: what is listed is what is there.
+
+Import them exactly as the listing shows other scaffold files importing them. Where a path
+alias appears (`@/lib/store`), use that form — a relative path guessed from your own file's
+location is the single most common way this build fails.
+
+If you need something these files do not declare, build it inside your own slot. Do not
+add it to a frozen file.

--- a/tests/unit/capabilities/test_stack_inventory.py
+++ b/tests/unit/capabilities/test_stack_inventory.py
@@ -329,3 +329,56 @@ def test_the_ecmascript_surface_is_empty_for_files_that_declare_nothing():
     """Config and data files must render bare rather than as noise — the bare/described
     split is what the appendix's rule keys on."""
     assert scaffold._ecmascript_surface("// a comment only\nconst private = 1\n") == ""
+
+
+# --------------------------------------------------------------------------- #
+# #861 — the developer receives what the frozen files declare
+# --------------------------------------------------------------------------- #
+
+
+def test_the_developer_is_told_what_the_frozen_files_declare():
+    """Roll 7 died of this. `development.develop` writes `app/api/runs/route.ts`, whose job
+    is calling into the frozen `lib/store.ts`, and emitted
+    `import { runStore } from '@/lib/store'` against a module exporting
+    `reset, all, insert, find, nextId`. The repair invented the same name again, because it
+    was blind identically, so the correction terminated as `plan_defect` on a defect no
+    repair could see.
+
+    The index carrying the answer has existed since pf-42 and reached the plan author only.
+    Asserted on the derived fragment rather than on the registry flag: the question is
+    whether the exports reach the prompt, and a flag can be set while the deriver returns
+    nothing (which is what `.py`-only rendering did to this stack before #851).
+    """
+    from squadops.capabilities.context_assembly import (
+        CONTEXT_CONTRACTS,
+        SURFACE_FROZEN,
+        manifest_surface_fragments,
+    )
+
+    contract = CONTEXT_CONTRACTS["development.develop"]
+    assert SURFACE_FROZEN in contract.manifest_surfaces
+
+    fragments = manifest_surface_fragments(contract, _manifest_for("nextjs_ts"))
+    rendered = "\n".join(fragments.get(SURFACE_FROZEN, []))
+    assert "lib/store.ts" in rendered
+    assert "reset" in rendered and "insert" in rendered, (
+        "the developer must be told which symbols the frozen store exports — this is the "
+        "exact line roll 7 needed and did not have"
+    )
+
+
+@pytest.mark.parametrize("stack", _STACK_NAMES)
+def test_the_frozen_surface_reaches_the_developer_on_every_stack(stack):
+    """Parameterized over the registry: a third stack inherits the wiring or fails here."""
+    from squadops.capabilities.context_assembly import (
+        CONTEXT_CONTRACTS,
+        SURFACE_FROZEN,
+        manifest_surface_fragments,
+    )
+
+    fragments = manifest_surface_fragments(
+        CONTEXT_CONTRACTS["development.develop"], _manifest_for(stack)
+    )
+    assert fragments.get(SURFACE_FROZEN), (
+        f"stack {stack!r} threads no frozen-surface lines to the developer"
+    )

--- a/tests/unit/cycles/goldens/context_assembly.json
+++ b/tests/unit/cycles/goldens/context_assembly.json
@@ -62,6 +62,23 @@
    "on failure raise `ApiError(code, message)` (imported from `.errors`): the FIRST argument is the error-code STRING, the second a human message \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
    "valid error codes (code \u2192 HTTP status, mapped by frozen `errors.py`): `validation_error` \u2192 422, `run_not_found` \u2192 404, `duplicate_participant` \u2192 409, `participant_not_found` \u2192 404"
   ],
+  "frozen_surface": [
+   "- `backend/__init__.py`",
+   "- `backend/main.py` \u2014 functions health; imports `.errors`, `.routes`, `fastapi`, `fastapi.middleware.cors`, `os`",
+   "- `backend/models.py` \u2014 defines Participant(id, name), RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants), RunEventCreate(title, datetime, location, distance, pace_target, route_notes), ParticipantName(name); imports `pydantic`, `typing`",
+   "- `backend/store.py` \u2014 module state participant_store: dict[str, Participant], run_event_store: dict[str, RunEvent]; functions reset; imports `.models`",
+   "- `backend/errors.py` \u2014 defines ApiError; functions register_error_handlers; imports `fastapi`, `fastapi.exceptions`, `fastapi.responses`",
+   "- `backend/requirements.txt`",
+   "- `conftest.py` \u2014 functions client; imports `backend.main`, `fastapi.testclient`, `os`, `pytest`, `sys`",
+   "- `frontend/index.html`",
+   "- `frontend/package.json`",
+   "- `frontend/vite.config.js` \u2014 imports `@vitejs/plugin-react`, `vite`",
+   "- `frontend/src/test-setup.js`",
+   "- `frontend/src/__tests__/harness.test.jsx` \u2014 imports `../App.jsx`, `@testing-library/react`, `react-router-dom`, `vitest`",
+   "- `frontend/src/main.jsx` \u2014 imports `./App.jsx`, `react`, `react-dom/client`, `react-router-dom`",
+   "- `frontend/src/api.js` \u2014 functions apiFetch",
+   "- `frontend/src/App.jsx` \u2014 imports `./views/CreateRunView.jsx`, `./views/RunDetailView.jsx`, `./views/RunsListView.jsx`, `react-router-dom`"
+  ],
   "model_surface": [
    "`backend/models.py` is scaffold-frozen and defines EXACTLY these names: `Participant(id, name)`, `RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants)`, `RunEventCreate(title, datetime, location, distance, pace_target, route_notes)`, `ParticipantName(name)`. Import only from this list \u2014 these are the complete contents of that module",
    "field names are exact \u2014 construct and read models with the fields shown above; a near-miss (`pace` for `pace_target`, `meeting_location` for `location`) raises at request time and every affected endpoint returns HTTP 500",
@@ -100,6 +117,23 @@
   "error_contract": [
    "on failure raise `ApiError(code, message)` (imported from `.errors`): the FIRST argument is the error-code STRING, the second a human message \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
    "valid error codes (code \u2192 HTTP status, mapped by frozen `errors.py`): `validation_error` \u2192 422, `run_not_found` \u2192 404, `duplicate_participant` \u2192 409, `participant_not_found` \u2192 404"
+  ],
+  "frozen_surface": [
+   "- `backend/__init__.py`",
+   "- `backend/main.py` \u2014 functions health; imports `.errors`, `.routes`, `fastapi`, `fastapi.middleware.cors`, `os`",
+   "- `backend/models.py` \u2014 defines Participant(id, name), RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants), RunEventCreate(title, datetime, location, distance, pace_target, route_notes), ParticipantName(name); imports `pydantic`, `typing`",
+   "- `backend/store.py` \u2014 module state participant_store: dict[str, Participant], run_event_store: dict[str, RunEvent]; functions reset; imports `.models`",
+   "- `backend/errors.py` \u2014 defines ApiError; functions register_error_handlers; imports `fastapi`, `fastapi.exceptions`, `fastapi.responses`",
+   "- `backend/requirements.txt`",
+   "- `conftest.py` \u2014 functions client; imports `backend.main`, `fastapi.testclient`, `os`, `pytest`, `sys`",
+   "- `frontend/index.html`",
+   "- `frontend/package.json`",
+   "- `frontend/vite.config.js` \u2014 imports `@vitejs/plugin-react`, `vite`",
+   "- `frontend/src/test-setup.js`",
+   "- `frontend/src/__tests__/harness.test.jsx` \u2014 imports `../App.jsx`, `@testing-library/react`, `react-router-dom`, `vitest`",
+   "- `frontend/src/main.jsx` \u2014 imports `./App.jsx`, `react`, `react-dom/client`, `react-router-dom`",
+   "- `frontend/src/api.js` \u2014 functions apiFetch",
+   "- `frontend/src/App.jsx` \u2014 imports `./views/CreateRunView.jsx`, `./views/RunDetailView.jsx`, `./views/RunsListView.jsx`, `react-router-dom`"
   ],
   "model_surface": [
    "`backend/models.py` is scaffold-frozen and defines EXACTLY these names: `Participant(id, name)`, `RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants)`, `RunEventCreate(title, datetime, location, distance, pace_target, route_notes)`, `ParticipantName(name)`. Import only from this list \u2014 these are the complete contents of that module",

--- a/tests/unit/prompts/test_planning_fragments.py
+++ b/tests/unit/prompts/test_planning_fragments.py
@@ -222,3 +222,33 @@ class TestPlanningFragmentsContent:
         task_type_dir = FRAGMENTS_DIR / "shared" / "task_type"
         md_files = list(task_type_dir.glob("*.md"))
         assert len(md_files) == 22
+
+
+def test_the_manifest_example_shows_a_quoted_collection_type():
+    """#858: two of roll 7's four authoring attempts died on `type: list[X]` unquoted.
+
+    Inside a `{ ... }` flow mapping an unquoted `[` opens a flow sequence and the document
+    fails to parse before any gate reads it. The example taught flow style with three scalar
+    fields and no collection type at all, so the first list an author needed hit the trap —
+    while the reference manifest, which SIP-0103 §4 keeps out of squad inputs, has had the
+    quoted form all along.
+    """
+    from pathlib import Path
+
+    asset = (
+        Path(__file__).resolve().parents[3]
+        / "src/squadops/prompts/request_templates/request.development_author_manifest.md"
+    )
+    text = asset.read_text(encoding="utf-8")
+
+    # Scoped to the fenced example, not the file. The prose below it also contains
+    # `type: "list[Tag]"`, so a file-wide check passes with the example field deleted —
+    # which is exactly what a mutation test caught it doing.
+    example = text.split("```yaml:interface_manifest.yaml", 1)[1].split("```", 1)[0]
+    assert 'type: "list[' in example, (
+        "the EXAMPLE must show a quoted bracket type — an author copies the block, not the "
+        "prose around it"
+    )
+    assert "must be quoted" in text, (
+        "a trailing comment is dropped when an author copies the block — the rule needs prose"
+    )


### PR DESCRIPTION
Closes #861 and #858. Both were measured by VS roll 7 (`cyc_0e301961f099`), and both are the same class: **supply the authoritative fact to the agent that needs it.**

## #861 — the index reached the plan author, not the developer

Roll 7 cleared framing with a clean plan (7/7 fill slots, 7 distinct `criteria_refs`) and failed implementation after 38 minutes as `plan_defect`:

| round | emitted | outcome |
|---|---|---|
| 0 | `import … from '../../lib/store'` | unresolvable relative path |
| 1 | `import { runStore } from '@/lib/store'` | **`runStore` is not exported** — same signature, A4 terminated |

`lib/store.ts` exports `reset, all, insert, find, nextId`.

`development.develop` declared `manifest_surfaces=(error_contract, model_surface, testid_surface)` and no frozen surface. That index rides on `bind_criteria_index`, which it does not declare; its `artifact_filter` threads planning documents and its own prior output, not the scaffold's files; `acceptance_workspace` is explicitly separate from prompt context (#643).

So the line naming those exports reached the plan author and stopped. The repair path was blind identically, which is why round 1 reproduced round 0 instead of converging — **the correction terminated on a defect no repair could see.**

`SURFACE_FROZEN` now rides the same transport #588/pf-45/#659 used to give the developer the error-contract convention, the model field surface and the DOM testid inventory. Each of those exists for this exact reason.

#851 was the prerequisite and is already merged: before it, this index rendered `lib/store.ts` as a bare name with no exports.

## #858 — two of four authoring attempts lost to unquoted `list[X]`

An unquoted `[` inside a `{ … }` flow mapping opens a flow sequence and the document fails to parse before any gate reads it. The example taught flow style with three scalar fields and **no collection type**, so the first list an author needed hit the trap — while the reference manifest, kept out of squad inputs by SIP-0103 §4, has carried the quoted form all along.

The example now shows `type: "list[Tag]"`, and the rule is stated in prose because a trailing comment is dropped when an author copies the block.

## Two weaknesses in my own tests, caught by mutation

- The #858 assertion checked the whole file, and `type: "list[Tag]"` also appears in the prose I added — so **deleting the example still passed**. Now scoped to the fenced block, and it fails under mutation.
- #861's assertion is on the **derived fragment**, not the registry flag. A flag can be set while the deriver returns nothing — precisely what `.py`-only rendering did to this stack before #851.

## Recorded, not fixed here

Threading this index to the developer also hands it **#787**'s defect: the index describes each file's *own* imports, which models the relative form — and round 0's failure was exactly a relative import. On stack #2 that's harmless and helpful (the scaffold uses `@/`, so the index shows the correct reachable form). On stack #1 it would teach `./views/CreateRunView.jsx`. **This raises #787 from latent to live for stack #1**, noted on that issue.

## Verification

- Regression **6984 passed**, 1 skipped.
- Both fixes **mutation-verified** (the #858 one only after its assertion was fixed).
- Context-assembly golden regenerated in the same commit; the delta is exactly the `frozen_surface` key on the two develop scenarios.

Refs #787, #822 (Stage 1e), #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX