### PR TITLE
fix(stack2): the harness can execute the idiom the stack teaches

### DIFF
--- a/src/squadops/capabilities/handlers/probe_runner.py
+++ b/src/squadops/capabilities/handlers/probe_runner.py
@@ -114,7 +114,14 @@ _PROFILES: dict[str, ExecutionProfile] = {
         # so a prepare step that stopped at install would boot into "no production build
         # found" and report as a boot failure — the exact conflation #827 separated. `sh -c`
         # for the two-step, matching the sandbox contract's INSTALL_DEPENDENCIES precedent.
-        prepare_argv=("sh", "-c", "npm ci --no-audit --no-fund && npx next build"),
+        #
+        # `npm install`, NOT `npm ci` (roll 10, cyc_43a216d43e1e): the scaffold emits no
+        # `package-lock.json` — an offline-deterministic expansion cannot produce one — and
+        # `npm ci` EUSAGE-refuses without a lockfile, so every probe on this stack reported
+        # "subject preparation failed" with npm's usage text as the tail. Install is also
+        # what every other surface runs (the frontend build check and the vitest runner),
+        # so preparation cannot succeed or fail differently from the checks beside it.
+        prepare_argv=("sh", "-c", "npm install --no-audit --no-fund && npx next build"),
         boot_argv=("npx", "next", "start", "--port", "{port}"),
     ),
 }

--- a/src/squadops/capabilities/stack_nextjs_ts.py
+++ b/src/squadops/capabilities/stack_nextjs_ts.py
@@ -229,9 +229,19 @@ const nextConfig = { typescript: { ignoreBuildErrors: false } }
 export default nextConfig
 """
 
-_VITEST_CONFIG = """import { defineConfig } from 'vitest/config'
+_VITEST_CONFIG = """// The `@` alias is declared twice by necessity: tsconfig.json `paths` covers `tsc` and
+// `next build`, but vitest resolves through vite, which does not read tsconfig paths —
+// without this block every suite importing app code the way this stack teaches it
+// (`@/lib/store`) fails collection with "Failed to load url", including the scaffold's
+// own harness test. The two declarations must agree; a test pins them together.
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
+  resolve: { alias: { '@': root } },
   test: { environment: 'node', include: ['**/__tests__/**/*.test.ts'] },
 })
 """

--- a/tests/unit/capabilities/test_stack_nextjs_ts.py
+++ b/tests/unit/capabilities/test_stack_nextjs_ts.py
@@ -237,6 +237,40 @@ def test_the_probe_profile_builds_before_it_boots():
     assert "start" in profile.boot_argv
 
 
+def test_the_probe_prepare_installs_without_a_lockfile():
+    """Roll 10 (cyc_43a216d43e1e): the scaffold emits no `package-lock.json` — an
+    offline-deterministic expansion cannot produce one — and `npm ci` EUSAGE-refuses
+    without a lockfile, so every probe reported "subject preparation failed" and 4 of 11
+    contract criteria went unverified. Two facts pinned together: as long as the expansion
+    carries no lockfile, preparation must not use the lockfile-only installer."""
+    names = _names(_manifest())
+    profile = pr.profile_for_stack(_STACK)
+    prepare = " ".join(profile.prepare_argv)
+
+    assert not any(n.endswith(("package-lock.json", "npm-shrinkwrap.json")) for n in names)
+    assert "npm ci" not in prepare
+    assert "npm install" in prepare
+
+
+def test_vitest_resolves_the_alias_the_stack_teaches():
+    """Roll 10 (cyc_43a216d43e1e): every frozen file imports via `@/` and tsconfig declares
+    the alias, but vitest resolves through vite, which does not read tsconfig paths — so the
+    scaffold's own harness test failed collection ("Failed to load url @/lib/store") and
+    `tests_pass` was unwinnable by construction. Three facts must agree, pinned from the
+    EXPANDED files so a template edit cannot silently split them: tsconfig declares `@/*`,
+    vitest.config declares the resolve alias, and the harness test uses the taught form."""
+    files = {f["name"]: f["content"] for f in expand(_manifest())}
+
+    tsconfig = json.loads(files["tsconfig.json"])
+    assert "@/*" in tsconfig["compilerOptions"]["paths"]
+
+    vitest_cfg = files["vitest.config.ts"]
+    assert "resolve" in vitest_cfg and "alias" in vitest_cfg
+    assert "'@': root" in vitest_cfg
+
+    assert "from '@/lib/store'" in files["__tests__/harness.test.ts"]
+
+
 def test_the_typed_check_vocabulary_is_declared_empty_not_guessed():
     """#503's conservative default. The AST evaluators are Python implementations never
     verified against this stack, so its checks must skip rather than be fed a guess."""


### PR DESCRIPTION
## Roll 10's two blockers (cyc_43a216d43e1e), both #818's class in the stack's own wiring

An incorrect contract that is believed — this time in the harness: the stack teaches the `@/` import form and requires `npm ci`-style preparation, and neither could ever succeed on the tree it emits.

### 1. vitest cannot resolve the alias the stack teaches
tsconfig `paths` covers `tsc`/`next build`; vitest resolves through vite, which does not read tsconfig paths. The emitted `vitest.config.ts` declared no `resolve.alias`, so **every** suite importing app code the taught way failed collection — including the scaffold's own frozen harness test. `tests_pass` was unwinnable by construction; no gate executes vitest, so nine rolls never saw it (roll 9's phantom-package import failed resolution first and masked it).

**Reproduced before fixing** (exact scaffold shapes, vitest 1.6.0): `Failed to load url @/lib/store`. Re-run with the alias: 1 passed.

### 2. Probe preparation used the lockfile-only installer against a lockfile-less tree
The expansion emits no `package-lock.json` (offline-deterministic — it cannot), and `npm ci` EUSAGE-refuses without one. Every probe reported "subject preparation failed" with npm's usage text; 4 of 11 contract criteria unverified. `npm install` matches the frontend build check and the vitest runner, so preparation now cannot succeed or fail differently from the checks beside it.

### Pins
- `test_vitest_resolves_the_alias_the_stack_teaches` — tsconfig, vitest config, and the harness test's import form must agree, asserted from the **expanded** files.
- `test_the_probe_prepare_installs_without_a_lockfile` — a lockfile-less expansion forbids `npm ci` in `prepare_argv`.

Both mutation-verified. Regression **7014 passed / 0 failed**.

Roll 10 context: develop recovered from its one type-error correction, builder passed all five plan-authored checks first try (#866's surfaces working), qa was the only failing surface and both causes are these. Full post-mortem in the morning report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX