### PR TITLE
fix(crp): validated-fullstack budget 7200 -> 10800s

### DIFF
--- a/src/squadops/contracts/cycle_request_profiles/profiles/validated-fullstack.yaml
+++ b/src/squadops/contracts/cycle_request_profiles/profiles/validated-fullstack.yaml
@@ -60,6 +60,13 @@ defaults:
     - frontend_build
     - required_files
   # Long-cycle budget for a full instrumented fullstack build.
-  time_budget_seconds: 7200
+  #
+  # 7200 -> 10800 (owner-approved 2026-08-12): an authored-mode design's size is a
+  # per-roll lottery — VS roll 11 (cyc_1ccd1e422e78) authored 8 develop tasks, executed
+  # 33/33 checks green, and died of TIME mid-qa with zero failures standing, so the
+  # budget (not a defect) was the binding constraint. Roll 12 at 10800s ran its full
+  # correction arc to a natural terminal state at 2h05m. V7's window pre-registers its
+  # own budget, so this is roll configuration, not measurement methodology.
+  time_budget_seconds: 10800
   experiment_context: {}
   notes: "#279 — instrumented validation + builder + fullstack_fastapi_react (best-of-both)"


### PR DESCRIPTION
One line + the reason in place. Roll 11 executed 33/33 checks green and died of time mid-qa with an 8-develop-task authored design — the budget was the binding constraint, and design size is a per-roll lottery (5 tasks roll 10, 8 tasks roll 11, same PRD). Roll 12 validated 10800s: full correction arc to a natural terminal state at 2h05m. V7's window pre-registers its own budget, so this changes roll configuration, not measurement methodology. Also removes the need for per-launch typed API-body overrides (`--set` is string-only and the executor compares numerically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX