### PR TITLE
fix(correction): file-owned patch gate + rejected-repair evidence carry (#870)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -368,6 +368,7 @@ def _inject_deterministic_evidence(
     artifact_contents: dict[str, str] | None,
     scaffold_enforcement_carry: list[str] | None,
     bound_record: Any = None,
+    repair_rejections: list[str] | None = None,
 ) -> None:
     """Deterministic authoritative-evidence injection for the correction chain.
 
@@ -380,6 +381,8 @@ def _inject_deterministic_evidence(
       cannot drift, and reporting that it does aims repairs at bytes the producer
       may not write; shk-2 lost three attempts to exactly that).
     - ``scaffold_enforcement`` (3.4b): prior attempts' frozen-emission instructions.
+    - ``prior_repair_rejections`` (#870): what happened to this task's previous
+      repair — patch-verification's named failed checks or the retest verdict.
     - ``contract_expectations`` (pf-31 Fix A): the failed task's typed criteria
       as exact expectation lines.
     - ``error_contract`` (pf-34): the ApiError raise convention + code→status
@@ -419,6 +422,12 @@ def _inject_deterministic_evidence(
 
     if scaffold_enforcement_carry:
         failure_evidence["scaffold_enforcement"] = list(scaffold_enforcement_carry)
+
+    # #870: the fate of this task's previous repair(s) — same transport as
+    # scaffold_enforcement, same reason: the loop must be TOLD an attempt was
+    # rejected (and by which named evidence) rather than silently re-deriving.
+    if repair_rejections:
+        failure_evidence["prior_repair_rejections"] = list(repair_rejections)
 
     expectations = expectation_lines((envelope.inputs or {}).get("acceptance_criteria"))
     if expectations:
@@ -895,6 +904,7 @@ class CorrectionRunner:
         scaffold_enforcement_carry: list[str] | None = None,
         budget_guard: Callable[[], None] | None = None,
         signature_state: dict[str, Any] | None = None,
+        repair_rejections: list[str] | None = None,
     ) -> CorrectionProtocolResult:
         """Run the correction protocol: analyze → decide → act.
 
@@ -918,6 +928,14 @@ class CorrectionRunner:
         (3.4b restore+signal): instructions from prior attempts' frozen-path
         restores are injected into this attempt's ``failure_evidence``, and
         this attempt's restores append new instructions for the next.
+
+        ``repair_rejections`` (#870) is this task's slice of the executor-owned
+        rejected-repair record: what happened to the PREVIOUS attempt's repair
+        (patch verification named checks, or the behavioral retest verdict).
+        Injected as an authoritative evidence block so analysis and the next
+        repair reason about the rejection instead of re-deriving the failure
+        blind — roll 12's non-compiling repair was rejected honestly and
+        nothing downstream was ever told why.
         """
         from uuid import uuid4
 
@@ -952,6 +970,7 @@ class CorrectionRunner:
             artifact_contents=artifact_contents,
             scaffold_enforcement_carry=scaffold_enforcement_carry,
             bound_record=bound_record,
+            repair_rejections=repair_rejections,
         )
 
         # Issue #95: capture each correction step's outputs in its own variable

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -110,6 +110,25 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+#: #870: per-entry and per-task bounds on the rejected-repair record — evidence for a
+#: prompt block, not a transcript. Three entries covers every correction attempt any
+#: profile currently budgets; 500 chars keeps a verbose check reason from bloating it.
+_REPAIR_REJECTION_ENTRY_LIMIT = 3
+_REPAIR_REJECTION_CHAR_LIMIT = 500
+
+
+def _record_repair_rejection(carry: dict[str, list[str]] | None, task_id: str, entry: str) -> None:
+    """Append a rejected-repair fact to the run-lived carry (#870), bounded.
+
+    ``None`` carry (legacy call paths, tests) is a no-op — recording evidence is
+    additive and must never fail the acceptance path it documents.
+    """
+    if carry is None:
+        return
+    entries = carry.setdefault(task_id, [])
+    entries.append(entry[:_REPAIR_REJECTION_CHAR_LIMIT])
+    del entries[:-_REPAIR_REJECTION_ENTRY_LIMIT]
+
 
 class DispatchedFlowExecutor(FlowExecutionPort):
     """Flow executor that dispatches tasks to agent containers via RabbitMQ.
@@ -1307,6 +1326,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # failure_evidence surfaces them so the loop is TOLD the edit was rejected
         # instead of silently fighting the restore.
         scaffold_enforcement_carry: list[str] = []
+        # #870: run-lived rejected-repair record, keyed by failed task id. A repair
+        # that patch verification or the behavioral retest rejects was previously
+        # discarded with only "patch_retest status=FAILED" in the log — the next
+        # correction round re-analyzed the task blind to WHY the last repair was
+        # rejected (roll 12: a non-compiling repair, and nothing downstream was ever
+        # told it didn't compile). Same transport as scaffold_enforcement_carry.
+        repair_rejection_carry: dict[str, list[str]] = {}
         # SIP-0100 3.4a: run-level contract-compliance counter, SEPARATE from the convergence
         # counter (D6) — cross-lane (unauthorized-slot) emissions don't fail a task on their own,
         # so this bounded budget is the only thing that stops a producer chronically writing
@@ -1480,6 +1506,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                     patched_result_holder=_holder,
                     interface_manifest=interface_manifest,
                     budget_guard=_budget_guard,
+                    repair_rejection_carry=repair_rejection_carry,
                 )
                 if action in ("continue", "accept_patch"):
                     # #379: this attempt failed — re-dispatched ("continue") or
@@ -2507,6 +2534,7 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         enriched_envelope: TaskEnvelope | None = None,
         interface_manifest: Any = None,
         budget_guard: Callable[[], None] | None = None,
+        repair_rejection_carry: dict[str, list[str]] | None = None,
     ) -> str:
         """Route a failed task outcome. Returns an action string.
 
@@ -2609,6 +2637,9 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             signature_state=correction_signature_state,
             # 3.4b: run-lived restore+signal carry (created beside correction_counter).
             scaffold_enforcement_carry=scaffold_enforcement_carry,
+            # #870: what happened to this task's PREVIOUS repair, so analysis and the
+            # next repair are told instead of re-deriving the failure blind.
+            repair_rejections=(repair_rejection_carry or {}).get(envelope.task_id),
             # RC3 (pf-23): re-resolve the workspace from the LIVE stored_artifacts
             # instead of the enriched envelope's copy captured once at the original
             # dispatch. stored_artifacts accumulates each attempt's repair outputs
@@ -2661,6 +2692,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 profile=profile,
                 flow_run_id=flow_run_id,
                 budget_guard=budget_guard,
+                interface_manifest=interface_manifest,
+                repair_rejection_carry=repair_rejection_carry,
             )
             return action
         elif correction_path == "continue":
@@ -2688,6 +2721,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         flow_run_id: str | None = None,
         enriched_envelope: TaskEnvelope | None = None,
         budget_guard: Callable[[], None] | None = None,
+        interface_manifest: Any = None,
+        repair_rejection_carry: dict[str, list[str]] | None = None,
     ) -> str:
         """Behaviorally verify a patch (#389); return "accept_patch" or "continue".
 
@@ -2725,6 +2760,29 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         workspace_files = ((enriched_envelope or envelope).inputs or {}).get(
             "acceptance_workspace_files"
         ) or {}
+        # #870: the criteria OWNED by the files the repair rewrote, derived from the
+        # canonical contract emission (M0a: emission equals the pinned artifact).
+        # Presence-keyed on the manifest like every other manifest surface; a
+        # derivation failure disables the gate rather than the verification.
+        file_owned: list[Any] = []
+        if interface_manifest is not None:
+            try:
+                from squadops.capabilities.scaffold_contract import emit_contract_dict
+                from squadops.cycles.implementation_plan import resolve_criteria_for_files
+                from squadops.cycles.verification_contract import VerificationContract
+
+                file_owned = resolve_criteria_for_files(
+                    VerificationContract.from_dict(emit_contract_dict(interface_manifest)),
+                    [a.get("name") for a in patched_artifacts if isinstance(a, dict)],
+                )
+            except Exception as exc:
+                logger.warning("patch file-owned gate unavailable: %s", exc)
+        if file_owned:
+            logger.info(
+                "patch file-owned gate: %d criteria own the repaired files (task=%s)",
+                len(file_owned),
+                envelope.task_id,
+            )
         verification = await verify_patched_artifacts(
             criteria,
             patched_artifacts,
@@ -2732,14 +2790,18 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             stack=resolve_check_stack(resolved_config),
             typed_acceptance_enabled=resolved_config.get("typed_acceptance", True),
             command_acceptance_enabled=resolved_config.get("command_acceptance_checks", True),
+            file_owned_criteria=file_owned,
         )
         # pf-33: name the failed checks — "status=failed reason= checks=7" forced
         # a by-hand artifact replay to learn WHICH check rejected the patch.
-        failed_checks = [
-            str(c.get("check", "?"))
-            for c in verification.checks
-            if isinstance(c, dict) and c.get("passed") is False
+        # (#870: the rows are PatchCheckRecord dataclasses; the original dict-shaped
+        # comprehension matched nothing and logged "failed=-" on every rejection.)
+        failed_records = [
+            record
+            for record in verification.checks
+            if record.severity == "error" and record.status in ("failed", "error")
         ]
+        failed_checks = [record.check for record in failed_records]
         logger.info(
             "patch_verification task=%s task_type=%s status=%s reason=%s checks=%d failed=%s",
             envelope.task_id,
@@ -2771,6 +2833,18 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 verification.reason,
             )
         if verification.status != PATCH_PASSED and not retest_decides:
+            # #870: tell the next round WHY this repair was rejected — the named
+            # failed checks with reasons, not just a status in the log.
+            failed_detail = "; ".join(
+                f"{record.check}: {record.reason or 'failed'}" for record in failed_records
+            )
+            _record_repair_rejection(
+                repair_rejection_carry,
+                envelope.task_id,
+                f"correction attempt {correction_attempts}: repair REJECTED by patch "
+                f"verification ({verification.reason or 'failed checks'})"
+                + (f" — {failed_detail}" if failed_detail else ""),
+            )
             return "continue"
 
         corrected_outputs = dict(result.outputs or {})
@@ -2813,13 +2887,41 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 and isinstance(fresh_test_result, dict)
                 and fresh_test_result.get("tests_passed") is True
             )
+            # #870: the retest's own verdict text — previously only a bare
+            # status; roll 12's non-compiling repair died as "status=FAILED
+            # passed=False" and nothing downstream ever learned it didn't build.
+            retest_validation_rows = (retest_outputs.get("validation_result") or {}).get(
+                "checks"
+            ) or []
+            failing_rows = "; ".join(
+                f"{row.get('check', '?')}: {row.get('reason') or 'failed'}"
+                for row in retest_validation_rows
+                if isinstance(row, dict) and row.get("passed") is False
+            )
+            retest_reason = str(
+                (retest_outputs.get("validation_result") or {}).get("summary")
+                or (fresh_test_result or {}).get("summary")
+                or (retest_result.error if retest_result else "")
+                or ""
+            )
+            if failing_rows:
+                retest_reason = (
+                    f"{retest_reason} [{failing_rows}]" if retest_reason else failing_rows
+                )
             logger.info(
-                "patch_retest task=%s status=%s passed=%s",
+                "patch_retest task=%s status=%s passed=%s reason=%s",
                 envelope.task_id,
                 retest_result.status if retest_result else "not_dispatched",
                 retest_passed,
+                retest_reason or "-",
             )
             if not retest_passed:
+                _record_repair_rejection(
+                    repair_rejection_carry,
+                    envelope.task_id,
+                    f"correction attempt {correction_attempts}: repaired suite retest "
+                    f"FAILED — {retest_reason or 'no verdict detail'}",
+                )
                 return "continue"
             corrected_outputs["test_result"] = fresh_test_result
             retest_validation = retest_outputs.get("validation_result")

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -96,6 +96,11 @@ _AUTHORITATIVE_EVIDENCE_BLOCKS: tuple[tuple[str, str], ...] = (
     ("scaffold_enforcement", "FROZEN OWNERSHIP"),
     ("error_contract", "ERROR CONTRACT"),
     ("model_surface", "MODEL SURFACE"),
+    # #870: the fate of this task's previous repair — the rejection's named
+    # evidence (failed checks / retest verdict), so a re-repair addresses what
+    # was actually rejected instead of re-rolling blind (roll 12: a repair that
+    # fixed the diagnosed axis and stopped compiling; the next round never knew).
+    ("prior_repair_rejections", "PRIOR REPAIR REJECTED"),
 )
 
 

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import dataclasses
 import hashlib
 import json
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
@@ -1057,6 +1058,25 @@ def resolve_contract_refs(
             params.setdefault("file", owning_path)
         checks.append(TypedCheck(check=criterion.check, params=params, id=criterion.id))
     return checks
+
+
+def resolve_criteria_for_files(
+    contract: VerificationContract, filenames: Iterable[str]
+) -> list[TypedCheck]:
+    """The contract criteria OWNED by a set of files, as executable ``TypedCheck``s (#870).
+
+    Patch verification judges a repair against the *failed task's* criteria; a repair
+    that rewrites files the failed task does not own is judged against nothing — roll 12's
+    dev repair for a qa.test failure re-emitted four routes that no longer compiled and
+    patch verification was structurally silent. This selects every criterion whose owning
+    ``fill_files`` path is among *filenames*, so a repair can be gated by the criteria that
+    governed those files' original authoring. Refs are sorted for determinism; the ref →
+    ``TypedCheck`` materialization is ``resolve_contract_refs`` unchanged.
+    """
+    names = {name for name in filenames if isinstance(name, str)}
+    index = contract.criterion_index()
+    refs = sorted(ref for ref, (_criterion, owning_path) in index.items() if owning_path in names)
+    return resolve_contract_refs(refs, contract)
 
 
 def _check_dependency_dag(tasks: list[PlanTask]) -> None:

--- a/src/squadops/cycles/patch_verification.py
+++ b/src/squadops/cycles/patch_verification.py
@@ -285,6 +285,108 @@ def _coerce_typed_criteria(criteria: list[Any]) -> list[TypedCheck] | None:
     return list(split.typed)
 
 
+def _dedupe_file_owned(
+    file_owned_criteria: list[TypedCheck] | None, typed: list[TypedCheck]
+) -> list[TypedCheck]:
+    """Drop file-owned criteria the failed task already carries (by contract id).
+
+    A dev-task repair's task criteria ARE its file's criteria — without this the
+    same check evaluates and reports twice on every dev patch.
+    """
+    task_criterion_ids = {check.id for check in typed if check.id}
+    return [
+        check
+        for check in (file_owned_criteria or [])
+        if not (check.id and check.id in task_criterion_ids)
+    ]
+
+
+async def _evaluate_file_owned_gate(
+    gate: list[TypedCheck],
+    workspace_root: Path,
+    *,
+    stack: str | None,
+    typed_acceptance_enabled: bool,
+    command_acceptance_enabled: bool,
+) -> tuple[list[PatchCheckRecord], bool]:
+    """Evaluate the #870 file-owned criteria; returns (records, any executed blocking failure).
+
+    Monotone by design (see ``verify_patched_artifacts``): only ``severity=error``
+    + ``status=failed`` counts as a gate failure — evaluator errors and skips are
+    recorded and change nothing, because this environment may lack the stack's
+    toolchain and the behavioral retest still covers those checks where it runs.
+    """
+    records: list[PatchCheckRecord] = []
+    failed = False
+    for criterion in gate:
+        outcome = await evaluate_criterion(
+            criterion,
+            workspace_root,
+            stack=stack,
+            typed_acceptance_enabled=typed_acceptance_enabled,
+            command_acceptance_enabled=command_acceptance_enabled,
+        )
+        records.append(
+            PatchCheckRecord(
+                check=criterion.check,
+                severity=criterion.severity,
+                status=outcome.status,
+                description=criterion.description or "file-owned criterion (#870)",
+                reason=outcome.reason,
+                actual=outcome.actual,
+            )
+        )
+        if criterion.severity == "error" and outcome.status == "failed":
+            failed = True
+    return records, failed
+
+
+async def _evaluate_task_criteria(
+    typed: list[TypedCheck],
+    workspace_root: Path,
+    records: list[PatchCheckRecord],
+    *,
+    stack: str | None,
+    typed_acceptance_enabled: bool,
+    command_acceptance_enabled: bool,
+) -> tuple[bool, int, str | None]:
+    """Evaluate the failed task's own criteria, appending rows to *records*.
+
+    Returns ``(blocking_failure, blocking_passed, evaluator_error_check)`` for the
+    RC-9 verdict logic in ``verify_patched_artifacts``; a non-None third element
+    aborts evaluation (evaluator broke — the whole verification is untrustworthy).
+    """
+    blocking_failure = False
+    blocking_passed = 0
+    for criterion in typed:
+        outcome = await evaluate_criterion(
+            criterion,
+            workspace_root,
+            stack=stack,
+            typed_acceptance_enabled=typed_acceptance_enabled,
+            command_acceptance_enabled=command_acceptance_enabled,
+        )
+        records.append(
+            PatchCheckRecord(
+                check=criterion.check,
+                severity=criterion.severity,
+                status=outcome.status,
+                description=criterion.description or "",
+                reason=outcome.reason,
+                actual=outcome.actual,
+            )
+        )
+        if criterion.severity != "error":
+            continue
+        if outcome.status == "error":
+            return blocking_failure, blocking_passed, criterion.check
+        if outcome.status == "failed":
+            blocking_failure = True
+        elif outcome.status == "passed":
+            blocking_passed += 1
+    return blocking_failure, blocking_passed, None
+
+
 async def verify_patched_artifacts(
     criteria: list[Any],
     artifacts: list[dict[str, Any]],
@@ -293,6 +395,7 @@ async def verify_patched_artifacts(
     stack: str | None = None,
     typed_acceptance_enabled: bool = True,
     command_acceptance_enabled: bool = True,
+    file_owned_criteria: list[TypedCheck] | None = None,
 ) -> PatchVerification:
     """Re-run the failed task's typed acceptance criteria against *artifacts*.
 
@@ -306,16 +409,26 @@ async def verify_patched_artifacts(
     verification substrate only — never part of what an accepted patch stores.
     Runtime-level checks (module_imports, the #591 import pre-gate) are
     meaningless without the scaffold siblings the patched file imports.
+
+    ``file_owned_criteria`` (#870) are the contract criteria owned by the files
+    the repair rewrote (``resolve_criteria_for_files``) — a repair for a
+    qa.test failure is otherwise judged against nothing structural at all
+    (roll 12: four re-emitted routes that no longer compiled sailed to the
+    retest). The gate is deliberately MONOTONE: an executed blocking failure
+    rejects the patch; an evaluator error or skip changes nothing (this
+    environment may lack the stack's toolchain — runtime-api has no node, so
+    stack #2's compile checks cannot execute here today; the behavioral retest
+    remains the compile gate in the qa environment). Gate rows never count as
+    positive acceptance evidence — compiling is necessary, not sufficient.
     """
     typed = _coerce_typed_criteria(criteria)
     if typed is None:
         return PatchVerification(status=PATCH_UNVERIFIABLE, reason="unparseable_criteria")
-    if not typed:
+    gate = _dedupe_file_owned(file_owned_criteria, typed)
+    if not typed and not gate:
         return PatchVerification(status=PATCH_UNVERIFIABLE, reason=REASON_NO_TYPED_CRITERIA)
 
     records: list[PatchCheckRecord] = []
-    blocking_failure = False
-    blocking_passed = 0
     # #734 Slice A: name the exact workspace mapping evaluated below — computed
     # from the parameter (the post-filter mapping handed in), never store state.
     from squadops.sandbox.models import compute_revision_id
@@ -348,41 +461,53 @@ async def verify_patched_artifacts(
                 workspace_revision_id=revision_id,
             )
 
-        for criterion in typed:
-            outcome = await evaluate_criterion(
-                criterion,
-                workspace_root,
-                stack=stack,
-                typed_acceptance_enabled=typed_acceptance_enabled,
-                command_acceptance_enabled=command_acceptance_enabled,
+        # #870 file-owned gate, BEFORE the task-criteria loop: an executed blocking
+        # failure rejects the patch outright; anything else (pass / skip / evaluator
+        # error) falls through to the existing logic unchanged, and gate rows never
+        # feed ``blocking_passed`` — rejection power only, per the docstring.
+        gate_records, gate_failed = await _evaluate_file_owned_gate(
+            gate,
+            workspace_root,
+            stack=stack,
+            typed_acceptance_enabled=typed_acceptance_enabled,
+            command_acceptance_enabled=command_acceptance_enabled,
+        )
+        records.extend(gate_records)
+        if gate_failed:
+            return PatchVerification(
+                status=PATCH_FAILED,
+                checks=tuple(records),
+                reason="file_owned_criteria",
+                workspace_revision_id=revision_id,
+            )
+        if not typed:
+            # The gate could not reject and the failed task itself has no typed
+            # criteria — same structurally-unevaluable verdict as before the gate
+            # existed, so the behavioral retest still decides (pf-47/pf-49).
+            return PatchVerification(
+                status=PATCH_UNVERIFIABLE,
+                checks=tuple(records),
+                reason=REASON_NO_TYPED_CRITERIA,
+                workspace_revision_id=revision_id,
             )
 
-            records.append(
-                PatchCheckRecord(
-                    check=criterion.check,
-                    severity=criterion.severity,
-                    status=outcome.status,
-                    description=criterion.description or "",
-                    reason=outcome.reason,
-                    actual=outcome.actual,
-                )
+        blocking_failure, blocking_passed, evaluator_error = await _evaluate_task_criteria(
+            typed,
+            workspace_root,
+            records,
+            stack=stack,
+            typed_acceptance_enabled=typed_acceptance_enabled,
+            command_acceptance_enabled=command_acceptance_enabled,
+        )
+        if evaluator_error is not None:
+            # Evaluator couldn't run in this environment — the whole
+            # verification is untrustworthy, not just this row.
+            return PatchVerification(
+                status=PATCH_UNVERIFIABLE,
+                checks=tuple(records),
+                reason=f"evaluator_error:{evaluator_error}",
+                workspace_revision_id=revision_id,
             )
-
-            if criterion.severity != "error":
-                continue
-            if outcome.status == "error":
-                # Evaluator couldn't run in this environment — the whole
-                # verification is untrustworthy, not just this row.
-                return PatchVerification(
-                    status=PATCH_UNVERIFIABLE,
-                    checks=tuple(records),
-                    reason=f"evaluator_error:{criterion.check}",
-                    workspace_revision_id=revision_id,
-                )
-            if outcome.status == "failed":
-                blocking_failure = True
-            elif outcome.status == "passed":
-                blocking_passed += 1
 
     if blocking_failure:
         return PatchVerification(

--- a/tests/unit/capabilities/test_repair_handlers.py
+++ b/tests/unit/capabilities/test_repair_handlers.py
@@ -244,3 +244,29 @@ class TestModelSurfaceReachesTheRepairPrompt:
 
         assert evidence.get("model_surface"), "model_surface must be injected for a bound run"
         assert "RunEvent" in " ".join(evidence["model_surface"])
+
+
+class TestPriorRepairRejectionReachesThePrompt:
+    """#870: the rejected-repair record renders as an authoritative block."""
+
+    def test_rejection_entries_render_into_the_failure_summary(self):
+        """Bug caught: evidence threaded to the envelope but rendered by nothing
+        (#849's declared-read-by-nothing shape) — the repair agent still re-rolls
+        blind while the carry claims otherwise."""
+        from squadops.capabilities.handlers.impl.repair_handlers import _format_failure_summary
+
+        evidence = {
+            "error": "tests failed",
+            "prior_repair_rejections": [
+                "correction attempt 2: repaired suite retest FAILED — frontend build "
+                "failed (exit 1)"
+            ],
+        }
+        rendered = _format_failure_summary(evidence, None)
+        assert "PRIOR REPAIR REJECTED" in rendered
+        assert "frontend build failed (exit 1)" in rendered
+
+    def test_absent_rejections_render_no_block(self):
+        from squadops.capabilities.handlers.impl.repair_handlers import _format_failure_summary
+
+        assert "PRIOR REPAIR REJECTED" not in _format_failure_summary({"error": "x"}, None)

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -3735,3 +3735,90 @@ class TestProgressAwareTermination:
                 completed_task_ids=[],
                 plan_delta_refs=[],
             )  # no raise
+
+
+class TestRepairRejectionEvidence(TestCorrectionRunnerStandalone):
+    """#870: the executor's rejected-repair record reaches this attempt's evidence."""
+
+    async def test_prior_rejections_reach_failure_evidence(self, cycle):
+        """Bug caught: a rejected repair leaving no trace — roll 12's follow-up
+        round re-analyzed the task blind to the fact (and the named reason) that
+        the previous repair had been rejected as non-compiling."""
+        captured: list = []
+
+        def responder(envelope):
+            if envelope.task_type == "data.analyze_failure":
+                captured.append(envelope)
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "continue",
+                        "decision_rationale": "keep going",
+                        "affected_task_types": [],
+                    },
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, _vault, _bus = self._make_runner(responder)
+        rejections = [
+            "correction attempt 2: repaired suite retest FAILED — Repaired suite "
+            "still fails (exit 1) [frontend_build: frontend build failed (exit 1)]"
+        ]
+
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=self._failed_envelope(),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="bad"),
+            correction_attempts=3,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+            repair_rejections=rejections,
+        )
+
+        assert len(captured) == 1
+        evidence = captured[0].inputs["failure_evidence"]
+        assert evidence["prior_repair_rejections"] == rejections
+
+    async def test_no_rejections_add_no_key(self, cycle):
+        """Bug caught: an empty block rendering a bare authoritative header on
+        every first-time correction."""
+        captured: list = []
+
+        def responder(envelope):
+            if envelope.task_type == "data.analyze_failure":
+                captured.append(envelope)
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "continue",
+                        "decision_rationale": "keep going",
+                        "affected_task_types": [],
+                    },
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, _vault, _bus = self._make_runner(responder)
+
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=self._failed_envelope(),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="bad"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+        assert len(captured) == 1
+        assert "prior_repair_rejections" not in captured[0].inputs["failure_evidence"]

--- a/tests/unit/cycles/test_criteria_ref_binding.py
+++ b/tests/unit/cycles/test_criteria_ref_binding.py
@@ -468,3 +468,46 @@ def test_author_mode_and_missing_qa_are_no_ops():
     assert "acceptance_criteria" not in dev.inputs
     _attach_unbound_contract_criteria([dev], None, _contract())  # no qa.test envelope
     assert "acceptance_criteria" not in dev.inputs
+
+
+# --------------------------------------------------------------------------- #
+# #870 — resolve_criteria_for_files: the criteria a set of files OWNS
+# --------------------------------------------------------------------------- #
+
+
+def test_criteria_for_files_selects_exactly_the_owning_files_checks():
+    """Bug caught: a repair judged only by the failed task's criteria — roll 12's
+    dev repair for a qa.test failure rewrote routes no criterion ever re-checked."""
+    from squadops.cycles.implementation_plan import resolve_criteria_for_files
+
+    checks = resolve_criteria_for_files(_contract(), ["backend/routes.py"])
+    assert {c.id for c in checks} == {
+        "vc-routes-endpoints",
+        "vc-routes-apierror",
+        "vc-routes-compiles",
+    }
+    # File-param checks carry their owning file so evaluation targets the right
+    # path (command checks name their target inside argv instead).
+    file_params = {c.id: c.params.get("file") for c in checks if "file" in c.params}
+    assert file_params == {
+        "vc-routes-endpoints": "backend/routes.py",
+        "vc-routes-apierror": "backend/routes.py",
+    }
+
+
+def test_criteria_for_files_ignores_files_the_contract_does_not_own():
+    """Bug caught: net-new or doc files dragging in someone else's criteria —
+    a repair emitting qa_handoff.md must not be judged by the routes' checks."""
+    from squadops.cycles.implementation_plan import resolve_criteria_for_files
+
+    assert resolve_criteria_for_files(_contract(), ["qa_handoff.md", "README.md"]) == []
+
+
+def test_criteria_for_files_never_selects_behavioral_checks():
+    """Bug caught: a file-less behavioral check (frontend_build) materialized as a
+    typed gate row — those run through the qa/build handlers, not typed acceptance."""
+    from squadops.cycles.implementation_plan import resolve_criteria_for_files
+
+    all_files = ["backend/routes.py", "frontend/src/views/ItemView.jsx"]
+    checks = resolve_criteria_for_files(_contract(), all_files)
+    assert "vc-frontend-builds" not in {c.id for c in checks}

--- a/tests/unit/cycles/test_outcome_routing.py
+++ b/tests/unit/cycles/test_outcome_routing.py
@@ -1075,3 +1075,219 @@ class TestAcceptPatchStructurallyUnevaluable:
         )
         assert action == "continue"
         executor._correction_runner.reexecute_repaired_suite.assert_not_awaited()
+
+
+class TestRepairRejectionCarry:
+    """#870: a rejected repair's WHY must survive into the next correction round.
+
+    Roll 12 (cyc_e4b2444fa300): the retest honestly rejected a non-compiling
+    repair, the entire record was "patch_retest status=FAILED passed=False", and
+    the follow-up attempt re-derived the failure blind. These tests pin that
+    every rejection path writes its named evidence to the run-lived carry.
+    """
+
+    def _failed_builder_result(self):
+        return TaskResult(
+            task_id="task_5",
+            status="FAILED",
+            outputs={
+                "artifacts": [
+                    {"name": "qa_handoff.md", "content": "# QA Handoff\n## How to Run\n"}
+                ],
+                "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
+            },
+            error="acceptance failed",
+        )
+
+    def _builder_envelope(self):
+        from squadops.cycles.implementation_plan import TypedCheck
+        from squadops.tasks.models import TaskEnvelope
+
+        return TaskEnvelope(
+            task_id="task_5",
+            agent_id="bob",
+            cycle_id="cyc_001",
+            pulse_id="p",
+            project_id="hello_squad",
+            task_type="builder.assemble",
+            correlation_id="corr",
+            causation_id=None,
+            trace_id="t",
+            span_id="s",
+            inputs={
+                "resolved_config": {},
+                "acceptance_criteria": [
+                    TypedCheck(
+                        check="regex_match",
+                        params={"file": "qa_handoff.md", "pattern": "## How to Test"},
+                        severity="error",
+                        description="Contains How to Test section",
+                    )
+                ],
+            },
+            metadata={"role": "builder"},
+        )
+
+    async def test_rejected_patch_names_its_failed_checks_in_the_carry(self, executor):
+        """Bug caught: a patch-verification rejection recorded as nothing at all —
+        the next round's analysis never told which named check rejected it."""
+        carry: dict = {}
+        action = await executor._try_accept_patch(
+            self._builder_envelope(),
+            self._failed_builder_result(),
+            [{"name": "qa_handoff.md", "content": "# QA Handoff\nstill missing\n"}],
+            {},
+            repair_rejection_carry=carry,
+        )
+        assert action == "continue"
+        (entry,) = carry["task_5"]
+        assert "REJECTED by patch verification" in entry
+        assert "regex_match" in entry
+
+    async def test_accepted_patch_records_nothing(self, executor):
+        """Bug caught: acceptance polluting the carry — a later unrelated failure
+        of the same task would then render a stale 'rejected' block."""
+        carry: dict = {}
+        action = await executor._try_accept_patch(
+            self._builder_envelope(),
+            self._failed_builder_result(),
+            [{"name": "qa_handoff.md", "content": "# QA Handoff\n## How to Test\nok\n"}],
+            {},
+            repair_rejection_carry=carry,
+        )
+        assert action == "accept_patch"
+        assert carry == {}
+
+    async def test_failed_retest_verdict_lands_in_the_carry(self, executor, cycle):
+        """Bug caught: the roll-12 record itself — retest FAILED with the verdict
+        text and failing rows discarded on the spot."""
+        import dataclasses as _dc
+
+        from squadops.cycles.implementation_plan import TypedCheck
+
+        envelope = self._builder_envelope()
+        envelope = _dc.replace(
+            envelope,
+            task_id="task_9",
+            task_type="qa.test",
+            inputs={
+                "resolved_config": {},
+                "artifact_contents": {"src/main.py": "def main():\n    pass\n"},
+                "acceptance_criteria": [
+                    TypedCheck(
+                        check="regex_match",
+                        params={"file": "tests/test_api.py", "pattern": "def test_"},
+                        severity="error",
+                        description="Suite defines tests",
+                    )
+                ],
+            },
+        )
+        failed = TaskResult(
+            task_id="task_9",
+            status="FAILED",
+            outputs={
+                "artifacts": [
+                    {
+                        "name": "tests/test_api.py",
+                        "content": "def test_x():\n    assert 0\n",
+                        "type": "test",
+                    }
+                ],
+                "test_result": {"executed": True, "exit_code": 1, "tests_passed": False},
+                "validation_result": {"passed": False, "checks": []},
+                "outcome_class": TaskOutcome.SEMANTIC_FAILURE,
+            },
+            error="tests failed",
+        )
+        executor._correction_runner.reexecute_repaired_suite = AsyncMock(
+            return_value=TaskResult(
+                task_id="retest",
+                status="FAILED",
+                outputs={
+                    "test_result": {"executed": True, "exit_code": 1, "tests_passed": False},
+                    "validation_result": {
+                        "passed": False,
+                        "summary": "Repaired suite still fails (exit 1)",
+                        "checks": [
+                            {
+                                "check": "frontend_build",
+                                "passed": False,
+                                "reason": "frontend build failed (exit 1)",
+                            }
+                        ],
+                    },
+                },
+                error="still failing",
+            )
+        )
+        carry: dict = {}
+        action = await executor._try_accept_patch(
+            envelope,
+            failed,
+            [{"name": "tests/test_api.py", "content": "def test_x():\n    assert 1\n"}],
+            {},
+            run_id="run_001",
+            cycle=cycle,
+            correction_attempts=2,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+            repair_rejection_carry=carry,
+        )
+        assert action == "continue"
+        (entry,) = carry["task_9"]
+        assert "retest FAILED" in entry
+        assert "Repaired suite still fails (exit 1)" in entry
+        assert "frontend build failed (exit 1)" in entry
+
+    async def test_file_owned_gate_fires_through_the_executor_wiring(self, executor):
+        """Bug caught: the gate existing in patch_verification but the executor
+        never deriving file-owned criteria from the manifest — declared, read by
+        nothing (the #849 class)."""
+        import dataclasses as _dc
+        from pathlib import Path
+
+        from squadops.capabilities.scaffold import InterfaceManifest
+
+        manifest = InterfaceManifest.from_yaml(
+            (
+                Path(__file__).resolve().parents[3]
+                / "examples"
+                / "03_group_run"
+                / "interface_manifest.yaml"
+            ).read_text(encoding="utf-8")
+        )
+        envelope = self._builder_envelope()
+        envelope = _dc.replace(
+            envelope,
+            inputs={"resolved_config": {}, "acceptance_criteria": ["prose only"]},
+        )
+        carry: dict = {}
+        action = await executor._try_accept_patch(
+            envelope,
+            self._failed_builder_result(),
+            [{"name": "backend/routes.py", "content": "x = 1\n"}],
+            {},
+            interface_manifest=manifest,
+            repair_rejection_carry=carry,
+        )
+        assert action == "continue"
+        (entry,) = carry["task_5"]
+        assert "file_owned_criteria" in entry
+
+    def test_the_carry_is_bounded(self):
+        """Bug caught: an unbounded carry growing into the prompt budget."""
+        from adapters.cycles.dispatched_flow_executor import _record_repair_rejection
+
+        carry: dict = {}
+        for n in range(5):
+            _record_repair_rejection(carry, "task_x", f"rejection {n}: " + "y" * 600)
+        entries = carry["task_x"]
+        assert len(entries) == 3
+        assert entries[0].startswith("rejection 2")
+        assert all(len(e) <= 500 for e in entries)
+        # None carry (legacy call paths) is a no-op, never an error.
+        _record_repair_rejection(None, "task_x", "entry")

--- a/tests/unit/cycles/test_patch_verification.py
+++ b/tests/unit/cycles/test_patch_verification.py
@@ -393,3 +393,105 @@ class TestWorkspaceFiles:
             },
         )
         assert result.status == PATCH_PASSED
+
+
+def _fill_slot_criterion(pattern: str = "def register") -> TypedCheck:
+    return TypedCheck(
+        check="regex_match",
+        params={"file": "backend/routes.py", "pattern": pattern},
+        severity="error",
+        description="file-owned: routes defines its registration entrypoint",
+        id="vc-routes-entrypoint",
+    )
+
+
+class TestFileOwnedGate:
+    """#870: a repair is gated by the criteria that OWN the files it rewrote.
+
+    Roll 12 (cyc_e4b2444fa300): a dev repair for a qa.test failure re-emitted four
+    routes that no longer compiled. qa.test has no typed criteria, so patch
+    verification was structurally silent and the broken tree sailed into the
+    behavioral retest. The files' own contract criteria — which gated their
+    original authoring — were never consulted.
+    """
+
+    async def test_gate_rejects_a_repair_that_fails_its_files_own_criteria(self):
+        """Bug caught: the roll-12 shape — no task criteria at all, and a repair
+        that violates the rewritten file's own contract reaches the retest."""
+        result = await verify_patched_artifacts(
+            ["prose only"],
+            [{"name": "backend/routes.py", "content": "x = 1\n"}],
+            file_owned_criteria=[_fill_slot_criterion()],
+        )
+        assert result.status == PATCH_FAILED
+        assert result.reason == "file_owned_criteria"
+        assert [r.status for r in result.checks] == ["failed"]
+
+    async def test_gate_pass_still_leaves_the_retest_to_decide(self):
+        """Bug caught: a compiling repair auto-accepted on gate evidence alone —
+        compiling is necessary, never sufficient; with no task criteria the
+        structurally-unevaluable verdict must survive so the retest decides."""
+        result = await verify_patched_artifacts(
+            ["prose only"],
+            [{"name": "backend/routes.py", "content": "def register():\n    pass\n"}],
+            file_owned_criteria=[_fill_slot_criterion()],
+        )
+        assert result.status == PATCH_UNVERIFIABLE
+        assert result.reason == "no_typed_criteria"
+        # The gate's executed evidence still rides on the verdict.
+        assert [r.status for r in result.checks] == ["passed"]
+
+    async def test_an_unevaluable_gate_row_changes_nothing(self):
+        """Bug caught: a gate row this environment cannot execute (stack #2's
+        compile checks — runtime-api has no node) flipping the verdict and
+        severing the retest path. The gate is monotone: only executed failures
+        reject."""
+        skipped_gate = TypedCheck(
+            check="command_exit_zero",
+            params={"argv": ["true"]},
+            severity="error",
+            description="file-owned: needs a toolchain this environment may lack",
+            id="vc-routes-compiles",
+        )
+        result = await verify_patched_artifacts(
+            ["prose only"],
+            [{"name": "backend/routes.py", "content": "x = 1\n"}],
+            file_owned_criteria=[skipped_gate],
+            command_acceptance_enabled=False,
+        )
+        assert result.status == PATCH_UNVERIFIABLE
+        assert result.reason == "no_typed_criteria"
+
+    async def test_gate_dedupes_criteria_the_task_already_carries(self):
+        """Bug caught: a dev-task repair (whose task criteria ARE its file's
+        criteria) evaluating and reporting every check twice."""
+        shared = _fill_slot_criterion()
+        result = await verify_patched_artifacts(
+            [shared],
+            [{"name": "backend/routes.py", "content": "def register():\n    pass\n"}],
+            file_owned_criteria=[shared],
+        )
+        assert result.status == PATCH_PASSED
+        assert len(result.checks) == 1
+
+    async def test_gate_failure_is_named_beside_the_task_criteria(self):
+        """Bug caught: a repair that satisfies the failed task's own criteria but
+        breaks the rewritten file's contract being accepted — the roll-12 shape
+        one level up, where task criteria exist and pass."""
+        result = await verify_patched_artifacts(
+            [
+                TypedCheck(
+                    check="regex_match",
+                    params={"file": "qa_handoff.md", "pattern": "## How to Test"},
+                    severity="error",
+                    description="Contains How to Test section",
+                )
+            ],
+            [
+                {"name": "qa_handoff.md", "content": "# QA Handoff\n## How to Test\n"},
+                {"name": "backend/routes.py", "content": "x = 1\n"},
+            ],
+            file_owned_criteria=[_fill_slot_criterion()],
+        )
+        assert result.status == PATCH_FAILED
+        assert result.reason == "file_owned_criteria"


### PR DESCRIPTION
Both halves come from the #864 investigation of roll 12 (`cyc_e4b2444fa300`). **One claim in the issue as filed was wrong and is corrected below.**

## 1. File-owned patch gate

Patch verification judged a repair only against the *failed task's* typed criteria. A qa.test failure has none, so roll 12's dev repair — which rewrote four routes that no longer compiled — was judged against nothing structural and sailed into the behavioral retest.

`verify_patched_artifacts` now accepts `file_owned_criteria`: the contract criteria owned by the files the repair actually rewrote, selected by the new `resolve_criteria_for_files` (criterion index → `resolve_contract_refs`, the same seams bind-mode dispatch uses). An **executed blocking failure rejects the patch before the retest**, with named checks.

**The gate is monotone by design**: evaluator errors and skips are recorded and change nothing. This matters because the executor may lack the stack's toolchain — runtime-api has no node, so stack #2's compile checks cannot execute there today, and a non-monotone gate would have severed the retest path (the pf-47/pf-49 deadlock) for exactly the repairs that need it. On stack #1 the gate bites today (verified: `import_present` rejects a garbage `backend/routes.py` through the full executor wiring); on stack #2 it lights up the day the executor gains node. The behavioral retest remains the compile gate in the qa environment — it is what correctly caught roll 12's repair, in 25 seconds.

## 2. Rejected-repair evidence carry

A rejected repair left no trace but `patch_retest status=FAILED passed=False`. The next correction round re-analyzed the task blind to WHY the previous repair was rejected. Now every rejection path (patch verification's named failed checks; the retest's verdict text + failing rows) appends to a run-lived carry (`_record_repair_rejection`, bounded 3×500 chars), which `_inject_deterministic_evidence` renders as a **PRIOR REPAIR REJECTED** authoritative block — the exact transport `scaffold_enforcement` already uses.

Drive-by fix in the same evidence surface: the pf-33 failed-checks log comprehension matched dict rows against what are actually `PatchCheckRecord` dataclasses, so every rejection logged `failed=-`. It now names the checks as intended.

## Correction to the issue

The issue claimed a failed repair "poisons the re-dispatched attempt via latest-wins." **That was wrong**: `_enrich_envelope` already excludes repair-candidate artifacts on fresh dispatches (pf-31 Fix E), and roll 12's attempt 2 demonstrably saw the accepted pre-repair tree (its "16 source file(s)" count matches exactly). No rollback mechanism is needed; none is built here. Attempt 2 failed honestly against the still-defective accepted tree.

## Verification

- 2843 cycles+repair-handler tests pass; regression 7043 passed (+31 new) with the same 2 pre-existing `TestCommandExitZero` environmental failures main shows under the regression script.
- Five mutations each killed by ≥1 test: executor wiring deleted (gate derivation), monotone violated (skips treated as failures), retest rejection not recorded, evidence injection dropped, prompt block dropped.
- Live probe: reference-manifest contract resolves 4 file-owned criteria for `backend/routes.py`; garbage content → `PATCH_FAILED reason=file_owned_criteria` end-to-end through `_try_accept_patch`.

Closes #870. Refs #864, #456, #389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX