### PR TITLE
fix(contract): the rejects-blank expectation is the pack's call (#874)

### DIFF
--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -63,7 +63,8 @@ class CriteriaPack:
     Deliberately NOT covering the manifest-derived tiers. Probes, coverage expectations,
     the frozen-file hashing, and ``skeleton.expander`` are language-agnostic already, which
     is why this seam is small — and is S2's HTTP-constant containment argument paying off
-    exactly where it was meant to.
+    exactly where it was meant to. (#874 carved out one probe fact: the blank-rejection
+    status is framework-dependent, so it lives here — see ``blank_rejection_status``.)
     """
 
     name: str
@@ -73,6 +74,16 @@ class CriteriaPack:
     build_criteria: Callable[[], list[dict[str, Any]]]
     #: ``behavioral.suite.checks`` — what proves its test suite ran.
     suite_criteria: Callable[[], list[dict[str, Any]]]
+    #: #874: what the rejects-blank probe expects. An ``int`` is a framework-FIXED status
+    #: (stack #1: pydantic rejects blank required fields with its native 422 *before* any
+    #: app code runs, so the manifest's declared mapping is unenforceable for this probe).
+    #: ``None`` means the stack's frozen error seam owns validation status, so the
+    #: expectation derives from ``error_contract.codes[validation_error].http`` — roll 13
+    #: (cyc_732b773cf323) authored that mapping as 400, the hardcoded 422 contradicted the
+    #: seam in the same derived YAML, and the probe was unwinnable by construction. When
+    #: deriving and the mapping is absent, the probe is omitted: an expectation the seam
+    #: cannot deliver is the same defect with extra steps.
+    blank_rejection_status: int | None = None
 
 
 def emit_contract_dict(manifest: InterfaceManifest) -> dict[str, Any]:
@@ -207,7 +218,7 @@ def _behavioral(manifest: InterfaceManifest, pack: CriteriaPack) -> dict[str, An
             "checks": pack.suite_criteria(),
             "coverage_expectations": _coverage_expectations(manifest),
         },
-        "probes": _probes(manifest),
+        "probes": _probes(manifest, pack),
     }
 
 
@@ -284,6 +295,9 @@ _CRITERIA_PACKS: dict[str, CriteriaPack] = {
         suite_criteria=lambda: [
             {"check": "tests_pass", "id": "vc-suite-passes", "requires": CAP_NODE},
         ],
+        # #874: no framework preempts the frozen error seam — route handlers shape every
+        # status — so the rejects-blank expectation derives from the authored mapping.
+        blank_rejection_status=None,
     ),
     "fullstack_fastapi_react": CriteriaPack(
         name="fullstack_fastapi_react",
@@ -294,6 +308,9 @@ _CRITERIA_PACKS: dict[str, CriteriaPack] = {
         suite_criteria=lambda: [
             {"check": "tests_pass", "id": "vc-suite-passes", "requires": CAP_PYTHON},
         ],
+        # #874: pydantic 422s a blank required field before any stub or fill body runs;
+        # the declared error-contract mapping cannot change what the framework emits.
+        blank_rejection_status=422,
     ),
 }
 
@@ -366,7 +383,7 @@ def _probe_sample_value(field_name: str, field_type: str) -> Any:
     return "sample"
 
 
-def _probes(manifest: InterfaceManifest) -> list[dict[str, Any]]:
+def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, Any]]:
     """POST-create probes plus their sequenced child-action probes (#651, v8).
 
     fay-3 shipped a broken join as "functional": v7 probed create + blank
@@ -417,27 +434,44 @@ def _probes(manifest: InterfaceManifest) -> list[dict[str, Any]]:
         probes.append(create_probe)
         # #593: the blank-input rejection probe. pf-38 volunteered blank-field
         # guards and pf-39 didn't — both green, because nothing required OR
-        # tested the behavior. The scaffold model now owns the constraint
-        # (NonBlankStr on required request fields), so this probe is a
-        # scaffold-owned regression guard: pydantic rejects the blank body
-        # before any stub or fill body runs, hence guards="scaffold" (passes
-        # on the bare skeleton by design — the frontend_build class, not the
-        # tests_pass class). Emitted only alongside an error contract, whose
-        # frozen handler shapes the 422 validation_error envelope.
+        # tested the behavior. The scaffold owns the constraint (stack #1:
+        # NonBlankStr on required request fields; stack #2: the frozen route
+        # stub's required-field guard), so this probe is a scaffold-owned
+        # regression guard, hence guards="scaffold" (passes on the bare
+        # skeleton by design — the frontend_build class, not the tests_pass
+        # class). Emitted only alongside an error contract.
+        #
+        # #874: the expected status is the pack's call, pf-39's lesson applied
+        # to the rejection side (that comment above records the SUCCESS status
+        # being un-hardcoded; this one stayed hardcoded 422 and roll 13's
+        # authored `validation_error: 400` derived a contract that contradicted
+        # its own frozen seam — unwinnable by construction, masked before by
+        # every author happening to declare 422). A framework-fixed status
+        # (pydantic's 422) stays fixed; a seam-owned stack derives from the
+        # authored mapping, and an unmapped code omits the probe.
         if shape and shape.required and manifest.api.error_contract:
-            probes.append(
-                {
-                    "id": f"vc-probe-{_slug(ep.path) or 'root'}-rejects-blank",
-                    "subject": "backend",
-                    "request": {
-                        "method": ep.method,
-                        "path": ep.path,
-                        "json": dict.fromkeys(shape.required, ""),
-                    },
-                    "expect": {"status": 422, "error_code": "validation_error"},
-                    "guards": "scaffold",
-                }
+            expected_rejection = (
+                pack.blank_rejection_status
+                if pack.blank_rejection_status is not None
+                else error_http.get("validation_error")
             )
+            if expected_rejection is not None:
+                probes.append(
+                    {
+                        "id": f"vc-probe-{_slug(ep.path) or 'root'}-rejects-blank",
+                        "subject": "backend",
+                        "request": {
+                            "method": ep.method,
+                            "path": ep.path,
+                            "json": dict.fromkeys(shape.required, ""),
+                        },
+                        "expect": {
+                            "status": expected_rejection,
+                            "error_code": "validation_error",
+                        },
+                        "guards": "scaffold",
+                    }
+                )
 
         # #651 (v8): sequenced child-action probes. A child is a POST under
         # this create's path with exactly one path parameter

--- a/tests/unit/capabilities/test_contract_emitter_stack_seam.py
+++ b/tests/unit/capabilities/test_contract_emitter_stack_seam.py
@@ -335,3 +335,81 @@ def test_next_js_ids_name_the_directory_that_distinguishes_the_slot():
     assert "vc-compiles-app-api-runs-run-id-join-route" in ids
     assert "vc-compiles-app-api-runs-run-id-leave-route" in ids
     assert len({i for i in ids if i.endswith("-route")}) == 4
+
+
+# --------------------------------------------------------------------------- #
+# #874 — the rejects-blank expectation is the pack's call
+# --------------------------------------------------------------------------- #
+
+
+def _remap_validation(manifest: InterfaceManifest, http: int | None) -> InterfaceManifest:
+    """The manifest with validation_error remapped to *http* (None = removed)."""
+    import dataclasses
+
+    ec = manifest.api.error_contract
+    assert ec is not None
+    codes = tuple(
+        dataclasses.replace(code, http=http) if code.code == "validation_error" else code
+        for code in ec.codes
+        if not (code.code == "validation_error" and http is None)
+    )
+    return dataclasses.replace(
+        manifest,
+        api=dataclasses.replace(manifest.api, error_contract=dataclasses.replace(ec, codes=codes)),
+    )
+
+
+def _rejection_expects(contract: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        probe["expect"]
+        for probe in contract["behavioral"]["probes"]
+        if probe["id"].endswith("rejects-blank")
+    ]
+
+
+def test_a_seam_owned_stack_derives_the_rejection_status_from_the_authored_mapping():
+    """Roll 13 (cyc_732b773cf323): the author mapped validation_error to 400, the frozen
+    seam therefore returns 400, and the hardcoded-422 probe made the contract contradict
+    itself in one YAML — unwinnable by construction, one correction burned before triage.
+    On a stack whose frozen error seam owns validation status, the probe must expect what
+    the seam will deliver."""
+    from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+    manifest = _remap_validation(manifest_for_stack("nextjs_ts"), 400)
+    expects = _rejection_expects(emit_contract_dict(manifest))
+    assert expects and all(e["status"] == 400 for e in expects)
+
+
+def test_a_framework_fixed_stack_keeps_422_whatever_the_author_declares():
+    """The inverse trap: pydantic rejects a blank required field with its native 422
+    before any app code runs, so on stack #1 deriving from a 400 mapping would emit a
+    probe no correct app can pass — the same defect, mirrored."""
+    manifest = _remap_validation(_manifest(), 400)
+    expects = _rejection_expects(emit_contract_dict(manifest))
+    assert expects and all(e["status"] == 422 for e in expects)
+
+
+def test_an_unmapped_validation_error_omits_the_probe_on_a_seam_owned_stack():
+    """An expectation the seam cannot deliver is the same defect with extra steps: the
+    frozen handler resolves an unmapped code to 500, so any declared status loses."""
+    from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+    manifest = _remap_validation(manifest_for_stack("nextjs_ts"), None)
+    assert _rejection_expects(emit_contract_dict(manifest)) == []
+
+
+def test_the_probe_and_the_coverage_expectation_cannot_disagree_on_a_seam_owned_stack():
+    """The self-consistency roll 13 lacked: the same derived YAML said
+    'validation_error -> HTTP 400' in coverage_expectations and 'status: 422' in the
+    probe. Whatever the author maps, both lines must say the same number."""
+    import re
+
+    from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+    for http in (400, 422):
+        contract = emit_contract_dict(_remap_validation(manifest_for_stack("nextjs_ts"), http))
+        expects = _rejection_expects(contract)
+        coverage = "\n".join(contract["behavioral"]["suite"]["coverage_expectations"])
+        stated = re.search(r"validation_error -> HTTP (\d+)", coverage)
+        assert stated is not None
+        assert expects and all(e["status"] == int(stated.group(1)) for e in expects)


### PR DESCRIPTION
Roll 13 (`cyc_732b773cf323`) authored `validation_error: { http: 400 }` — a legitimate choice — and the deriver emitted a contract that contradicts itself in one YAML: the frozen seam and coverage expectations say 400, the `rejects-blank` probe says 422 (**hardcoded**, on the stack-1 assumption that pydantic rejects blank fields before app code runs). The probe was unwinnable by construction, and the run burned a correction round on it before triage. Every prior authored roll masked this by happening to declare 422.

## The fix

pf-39's lesson applied to the rejection side (the comment block directly above the hardcode records the *success* status being un-hardcoded the same way): the expected status is a **per-stack fact on the CriteriaPack** (#818's seam):

- `fullstack_fastapi_react`: `blank_rejection_status=422` — framework-fixed; pydantic preempts the seam, the authored mapping is unenforceable for this probe (deriving here would create the mirrored defect).
- `nextjs_ts`: `blank_rejection_status=None` — derive from `error_contract.codes[validation_error].http`; an unmapped code **omits the probe** (the frozen handler resolves unmapped codes to 500, so any declared expectation loses).

## Verification

- Reference (stack-1) contract byte-identical — the M0a guard's subject unmoved; stack-2 fixture (which maps 422) also derives identically, so no hash pins move anywhere.
- New tests pin all four faces: seam-owned derives the authored 400 (the roll-13 shape), framework-fixed ignores a declared 400, unmapped omits, and **probe-vs-coverage-expectation self-consistency** (the exact disagreement roll 13 shipped — an #820-flavored assertion, live early).
- Three mutations each killed: regress to hardcoded 422; make stack #1 derive; fall back to 422 when unmapped.
- 4489 capabilities+cycles tests pass; regression 7050 passed with the same 2 pre-existing `TestCommandExitZero` environmental failures main shows in this shell.

Closes #874. Refs #820, #593, #651, #875.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX