### PR TITLE
fix(executor): never re-seed the walking skeleton on resume (#881)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -420,8 +420,13 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # Data-driven: no manifest -> seed_artifact_refs unchanged = byte-identical to
             # today (the manifest itself is already among plan_artifact_refs; this ADDS the
             # expanded skeleton). Logic lives in helpers (#290 god-file rule).
+            # #881: never on resume. The checkpoint's artifact_refs already carry the
+            # original seed set, and a fresh set stores NEW artifact ids that
+            # _seed_prior_artifacts appends AFTER the restored state — last-writer-wins
+            # per filename then hands every fill slot back to a stub that throws by
+            # design, so the resumed run tests the skeleton instead of the app.
             interface_manifest = await self._load_interface_manifest_for_run(cycle, run)
-            if interface_manifest is not None:
+            if interface_manifest is not None and existing_checkpoint is None:
                 seed_artifact_refs.extend(
                     await self._seed_skeleton_artifacts(interface_manifest, cycle, run_id)
                 )
@@ -2499,8 +2504,16 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         stored_artifacts: list[tuple[str, ArtifactRef]],
         all_artifact_refs: list[str],
     ) -> None:
-        """Load seed artifacts for build-only runs (section 2.3)."""
+        """Load seed artifacts for build-only runs (section 2.3).
+
+        #881: ids already restored from a checkpoint are skipped — plan refs are
+        id-stable across resume, and re-appending them after the restored state
+        would let a seed-era version win last-writer-wins over later produced
+        versions of the same filename.
+        """
         for art_id in seed_artifact_refs:
+            if art_id in all_artifact_refs:
+                continue
             try:
                 ref, _ = await self._artifact_vault.retrieve(art_id)
                 stored_artifacts.append((art_id, ref))

--- a/src/squadops/cli/commands/runs.py
+++ b/src/squadops/cli/commands/runs.py
@@ -359,6 +359,27 @@ def list_checkpoints(
 _BUILD_ARTIFACT_TYPES = {"source", "test", "config"}
 
 
+def _is_scaffold_seeded(meta: dict) -> bool:
+    return bool((meta.get("metadata") or {}).get("scaffold_seeded"))
+
+
+def _prefer_artifact(candidate: dict, incumbent: dict) -> bool:
+    """True when *candidate* should replace *incumbent* for the same filename (#881).
+
+    Produced code beats a scaffold-seeded version regardless of recency — a
+    resumed run can carry re-seeded stubs stored AFTER the dev fills, and
+    write-in-list-order would ship the stub. Among equals, the later
+    ``created_at`` wins (ISO timestamps compare lexicographically).
+    """
+    seeded_candidate, seeded_incumbent = (
+        _is_scaffold_seeded(candidate),
+        _is_scaffold_seeded(incumbent),
+    )
+    if seeded_candidate != seeded_incumbent:
+        return seeded_incumbent
+    return str(candidate.get("created_at") or "") >= str(incumbent.get("created_at") or "")
+
+
 @app.command("assemble")
 def assemble_run(
     ctx: typer.Context,
@@ -407,6 +428,16 @@ def assemble_run(
                 "this run may only contain planning artifacts"
             )
             raise typer.Exit(code=exit_codes.NOT_FOUND)
+
+        # 3b. #881: one artifact per filename — produced code over scaffold stubs,
+        # then latest. A plain write-in-list-order ships whichever version was
+        # stored last, which on a resumed run is the re-seeded stub.
+        by_filename: dict[str, dict] = {}
+        for meta in build_artifacts:
+            incumbent = by_filename.get(meta["filename"])
+            if incumbent is None or _prefer_artifact(meta, incumbent):
+                by_filename[meta["filename"]] = meta
+        build_artifacts = list(by_filename.values())
 
         # 4. Create output directory and download each artifact
         target_dir = out / output_dir_name

--- a/tests/unit/cli/test_commands_runs.py
+++ b/tests/unit/cli/test_commands_runs.py
@@ -210,3 +210,67 @@ class TestRunsCheckpoints:
         )
         assert result.exit_code == 0
         assert "checkpoint_index" in result.output
+
+
+class TestAssembleArtifactPreference:
+    """#881: a resumed run's artifact list carries re-seeded scaffold stubs stored
+    AFTER the dev fills — write-in-list-order would assemble the skeleton, not
+    the app. One artifact per filename: produced code beats scaffold-seeded,
+    then latest created_at."""
+
+    @staticmethod
+    def _meta(art_id, filename, created_at, seeded=False):
+        meta = {
+            "artifact_id": art_id,
+            "filename": filename,
+            "artifact_type": "source",
+            "created_at": created_at,
+        }
+        if seeded:
+            meta["metadata"] = {"scaffold_seeded": True}
+        return meta
+
+    def test_produced_beats_newer_scaffold_stub(self):
+        """The roll-14 resume shape: the re-seeded stub is NEWEST but must lose."""
+        from squadops.cli.commands.runs import _prefer_artifact
+
+        fill = self._meta("art_fill", "app/api/runs/route.ts", "2026-08-12 18:43:01+00:00")
+        reseeded_stub = self._meta(
+            "art_stub2", "app/api/runs/route.ts", "2026-08-13 00:07:25+00:00", seeded=True
+        )
+
+        assert _prefer_artifact(fill, reseeded_stub) is True
+        assert _prefer_artifact(reseeded_stub, fill) is False
+
+    def test_among_produced_versions_latest_wins(self):
+        from squadops.cli.commands.runs import _prefer_artifact
+
+        older = self._meta("art_a", "lib/store.ts", "2026-08-12 18:40:00+00:00")
+        newer = self._meta("art_b", "lib/store.ts", "2026-08-12 19:10:00+00:00")
+
+        assert _prefer_artifact(newer, older) is True
+        assert _prefer_artifact(older, newer) is False
+
+    def test_among_scaffold_versions_latest_wins(self):
+        """Frozen files exist only as scaffold artifacts — the newest seed set
+        must still be assemblable when no produced version exists."""
+        from squadops.cli.commands.runs import _prefer_artifact
+
+        old_seed = self._meta("art_s1", "lib/errors.ts", "2026-08-12 18:34:13+00:00", seeded=True)
+        new_seed = self._meta("art_s2", "lib/errors.ts", "2026-08-13 00:07:25+00:00", seeded=True)
+
+        assert _prefer_artifact(new_seed, old_seed) is True
+
+    def test_missing_metadata_treated_as_produced(self):
+        """Artifacts predating the scaffold_seeded marker (or with metadata absent
+        entirely) must not be mistaken for stubs and shadowed by one."""
+        from squadops.cli.commands.runs import _prefer_artifact
+
+        legacy = {
+            "artifact_id": "art_x",
+            "filename": "main.py",
+            "created_at": "2026-08-12 18:00:00+00:00",
+        }
+        stub = self._meta("art_s", "main.py", "2026-08-13 00:00:00+00:00", seeded=True)
+
+        assert _prefer_artifact(legacy, stub) is True

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -1239,3 +1239,95 @@ class TestWorkloadGatePlanAbsent:
             wired_run, gated_cycle, "progress_plan_review"
         )
         assert not any("plan_authoring_collapsed" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# #881: resume must not re-seed the walking skeleton
+# ---------------------------------------------------------------------------
+
+
+class TestResumeDoesNotReseedSkeleton:
+    """#881: skeleton seeding is a run-START act. On resume, the checkpoint's
+    artifact_refs already carry the original seed set; a fresh set stores NEW
+    artifact ids that are appended AFTER the restored state, and per-filename
+    last-writer-wins then hands every fill slot back to a stub that throws by
+    design — the resumed run tests the skeleton instead of the app (roll 14's
+    resume: probes that passed 38/39 began returning 500 the moment it resumed).
+    """
+
+    @staticmethod
+    def _manifest_bytes() -> bytes:
+        from pathlib import Path
+
+        return (
+            Path(__file__).resolve().parents[3]
+            / "examples"
+            / "03_group_run"
+            / "interface_manifest.yaml"
+        ).read_bytes()
+
+    def _wire(self, mock_registry, mock_vault, mock_queue, cycle, run):
+        import dataclasses
+
+        TestSequentialHappyPath._wire_canned_replies(mock_queue)
+        seeded_cycle = dataclasses.replace(
+            cycle, execution_overrides={"plan_artifact_refs": ["art_iface"]}
+        )
+        mock_registry.get_cycle.return_value = seeded_cycle
+        ref = MagicMock()
+        ref.artifact_id = "art_iface"
+        ref.filename = "interface_manifest.yaml"
+        ref.artifact_type = "interface_manifest"
+        ref.metadata = {}
+        mock_vault.retrieve = AsyncMock(return_value=(ref, self._manifest_bytes()))
+
+    @staticmethod
+    def _seeded_store_calls(mock_vault) -> list:
+        return [
+            call.args[0]
+            for call in mock_vault.store.await_args_list
+            if getattr(call.args[0], "metadata", None)
+            and call.args[0].metadata.get("scaffold_seeded")
+        ]
+
+    async def test_fresh_run_seeds_the_skeleton(
+        self, executor, mock_registry, mock_vault, mock_queue, cycle, run
+    ) -> None:
+        """Guard for the guard: if seeding stopped happening at all, the resume
+        test below would pass vacuously."""
+        self._wire(mock_registry, mock_vault, mock_queue, cycle, run)
+
+        with patch(
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        assert len(self._seeded_store_calls(mock_vault)) > 0
+
+    async def test_resumed_run_does_not_reseed(
+        self, executor, mock_registry, mock_vault, mock_queue, cycle, run
+    ) -> None:
+        from squadops.cycles.checkpoint import RunCheckpoint
+
+        self._wire(mock_registry, mock_vault, mock_queue, cycle, run)
+        mock_registry.get_latest_checkpoint.return_value = RunCheckpoint(
+            run_id="run_001",
+            checkpoint_index=1,
+            completed_task_ids=(),
+            prior_outputs={},
+            artifact_refs=(),
+            plan_delta_refs=(),
+            created_at=NOW,
+        )
+
+        with patch(
+            "adapters.cycles.dispatched_flow_executor.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await executor.execute_run(cycle_id="cyc_001", run_id="run_001")
+
+        assert self._seeded_store_calls(mock_vault) == []
+        # the guard must not break execution — the resumed run still finishes
+        statuses = [c.args[1] for c in mock_registry.update_run_status.call_args_list]
+        assert statuses[-1] == RunStatus.COMPLETED

--- a/tests/unit/cycles/test_executor_interface_manifest.py
+++ b/tests/unit/cycles/test_executor_interface_manifest.py
@@ -149,3 +149,36 @@ class TestSeedSkeletonArtifacts:
 
         assert ids == []
         executor._artifact_vault.store.assert_not_awaited()
+
+
+class TestSeedPriorArtifactsDedupe:
+    """#881: ids already restored from a checkpoint must not be re-appended.
+
+    Plan refs are id-stable across resume; re-appending one after the restored
+    state would put a seed-era version of a filename AFTER later produced
+    versions in ``stored_artifacts``, and ``_resolve_artifact_contents`` is
+    last-writer-wins per filename.
+    """
+
+    async def test_already_restored_id_is_skipped(self):
+        executor = _make_executor()
+        executor._artifact_vault.retrieve.return_value = (_FakePlanRef(), b"content")
+        stored: list = []
+        all_refs = ["art_plan"]  # restored from checkpoint
+
+        await executor._seed_prior_artifacts(["art_plan"], stored, all_refs)
+
+        assert stored == []
+        assert all_refs == ["art_plan"]
+        executor._artifact_vault.retrieve.assert_not_awaited()
+
+    async def test_fresh_id_is_seeded(self):
+        executor = _make_executor()
+        executor._artifact_vault.retrieve.return_value = (_FakePlanRef(), b"content")
+        stored: list = []
+        all_refs: list = []
+
+        await executor._seed_prior_artifacts(["art_plan"], stored, all_refs)
+
+        assert [a for a, _ in stored] == ["art_plan"]
+        assert all_refs == ["art_plan"]


### PR DESCRIPTION
Closes #881.

Resuming a failed run re-ran walking-skeleton seeding, and the fresh stub set shadowed the dev-completed fills in every subsequently materialized workspace — the resumed run tested the skeleton, not the app. Live instance: roll 14's resume (`cyc_25b4a9b0b637/run_02cc78b7acbe`), where probes that passed 38/39 in the original run returned 500 from the moment it resumed, and two correction rounds (~66 min of generation) burned diagnosing an environmental defect as a work-product one.

## Mechanism

Three cooperating pieces, none individually wrong:

1. `execute_run` seeded the skeleton unconditionally — on resume this stored a second full stub set under **new** artifact ids (`scaffold_seeded: True`).
2. `_execute_sequential` restores checkpoint artifacts (old seeds → dev fills → builder) first, then `_seed_prior_artifacts` appends the fresh stubs **after**.
3. `_resolve_artifact_contents` resolves per-filename by last-writer-wins over insertion order — so the fresh stub beat the dev fill for every fill slot. Stubs throw by design, so every route 500s.

## Fix

- **`execute_run`**: skeleton seeding is guarded on *no self-checkpoint* — the restored checkpoint's `artifact_refs` already carry the original seed set. A checkpoint-less resume (failed before any task completed) still seeds; there is nothing to shadow. Replay (SIP-0101) and revision (#811) paths are untouched: they have no self-checkpoint, and their translated/boundary checkpoints carry no implementation fills.
- **`_seed_prior_artifacts`**: ids already restored from the checkpoint are skipped — plan refs are id-stable across resume and were being re-appended after the restored state.
- **`runs assemble`** (second consumer of the same defect): one artifact per filename — produced code beats a scaffold-seeded version regardless of recency, then latest `created_at` wins. Previously it wrote `artifact_refs` in list order with filename overwrite, which on a resumed run ships the stubs.

With the guard in place, tonight's poison artifacts are never referenced again: the next resume restores checkpoint 13 (which predates them) and materializes the dev fills. No vault surgery.

## Tests (each mutation-verified — the fix reverted, the test fails)

- `TestResumeDoesNotReseedSkeleton` — full `execute_run` through the existing harness: a resumed run stores zero `scaffold_seeded` artifacts and still completes; paired with a fresh-run test so the resume assertion can't pass vacuously.
- `TestSeedPriorArtifactsDedupe` — already-restored ids are skipped; fresh ids still seed.
- `TestAssembleArtifactPreference` — the exact roll-14 shape (newer re-seeded stub loses to older produced fill), latest-wins among equals both ways, and legacy artifacts without metadata never mistaken for stubs.

Full regression: 7065 passed, 1 skipped.

## Operational context

Roll 14's resumed run is still burning down its correction chain against the poisoned workspace (bounded by budget, lands FAILED — deliberately not cancelled, since cancel would forfeit resume eligibility and `runs retry` is #880-broken). After this merges + runtime-api rebuild, resuming it again gives the #877 experiment a clean workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX
