### PR TITLE
fix(executor): scaffold-seeded artifacts never shadow produced content (#881)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1246,8 +1246,16 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 if art_id not in selected_ids:
                     selected_ids.append(art_id)
 
-        # Resolve content (D3: 512KB limit)
+        # Resolve content (D3: 512KB limit). Per filename, later-in-order wins
+        # (RC3: the latest correction attempt supersedes earlier ones) with ONE
+        # exception (#881): a scaffold-seeded artifact never shadows produced
+        # content. The run's artifact list is a log, not a manifest — a resumed
+        # run's checkpoint can carry a re-seeded stub set AFTER the dev fills,
+        # and stubs throw by design, so order alone would hand every fill slot
+        # back to the skeleton. Frozen files exist only as seeded artifacts and
+        # are unaffected; among seeded versions the latest still wins.
         contents: dict[str, str] = {}
+        seeded_holder: set[str] = set()
         total_bytes = 0
         limit = 512 * 1024
 
@@ -1264,7 +1272,14 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                         task_type,
                     )
                     break
+                is_seeded = bool(ref.metadata.get("scaffold_seeded"))
+                if is_seeded and ref.filename in contents and ref.filename not in seeded_holder:
+                    continue
                 contents[ref.filename] = decoded
+                if is_seeded:
+                    seeded_holder.add(ref.filename)
+                else:
+                    seeded_holder.discard(ref.filename)
             except Exception:
                 logger.warning(
                     "Failed to retrieve artifact %s for build task %s",

--- a/tests/unit/cycles/test_executor_build_wiring.py
+++ b/tests/unit/cycles/test_executor_build_wiring.py
@@ -154,6 +154,78 @@ class TestArtifactContentsPreResolution:
         assert "validation_plan.md" in contents
         assert "src/main.py" in contents
 
+    # ------------------------------------------------------------------
+    # #881 consumer side: a scaffold-seeded stub never shadows produced code
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _source_ref(art_id: str, filename: str, *, seeded: bool = False) -> ArtifactRef:
+        metadata: dict = (
+            {"producing_task_type": "scaffold.expand", "scaffold_seeded": True}
+            if seeded
+            else {"producing_task_type": "development.develop"}
+        )
+        return ArtifactRef(
+            artifact_id=art_id,
+            project_id="test",
+            artifact_type="source",
+            filename=filename,
+            content_hash="abc",
+            size_bytes=100,
+            media_type="text/plain",
+            created_at=NOW,
+            metadata=metadata,
+        )
+
+    async def _resolve(self, executor, entries):
+        stored = [(ref.artifact_id, ref) for ref, _ in entries]
+        executor._artifact_vault.retrieve = AsyncMock(
+            side_effect=[(ref, content) for ref, content in entries]
+        )
+        return await executor._resolve_artifact_contents("qa.test", stored)
+
+    async def test_reseeded_stub_after_fill_loses(self, executor):
+        """The checkpoint-21 shape from roll 14's resume: the re-seeded stub sits
+        AFTER the dev fill in the restored order and previously won last-writer-
+        wins, so the qa workspace materialized a route that throws by design."""
+        fill = self._source_ref("art_fill", "app/api/runs/route.ts")
+        stub = self._source_ref("art_stub", "app/api/runs/route.ts", seeded=True)
+
+        contents = await self._resolve(
+            executor, [(fill, b"export async function POST() {}"), (stub, b"throw stub")]
+        )
+
+        assert contents["app/api/runs/route.ts"] == "export async function POST() {}"
+
+    async def test_produced_after_stub_wins(self, executor):
+        """The normal fresh-run shape: seed first, develop fills later."""
+        stub = self._source_ref("art_stub", "app/api/runs/route.ts", seeded=True)
+        fill = self._source_ref("art_fill", "app/api/runs/route.ts")
+
+        contents = await self._resolve(executor, [(stub, b"throw stub"), (fill, b"filled")])
+
+        assert contents["app/api/runs/route.ts"] == "filled"
+
+    async def test_latest_produced_version_still_wins(self, executor):
+        """RC3: the latest correction attempt supersedes earlier produced
+        versions — the #881 rule must not freeze the first fill."""
+        v1 = self._source_ref("art_v1", "lib/store_use.ts")
+        v2 = self._source_ref("art_v2", "lib/store_use.ts")
+
+        contents = await self._resolve(executor, [(v1, b"attempt 1"), (v2, b"attempt 2")])
+
+        assert contents["lib/store_use.ts"] == "attempt 2"
+
+    async def test_frozen_file_latest_seeded_wins(self, executor):
+        """Frozen files exist ONLY as seeded artifacts — among seeded versions
+        the latest must still win, or a re-seeded frozen fix would be invisible."""
+        s1 = self._source_ref("art_s1", "lib/errors.ts", seeded=True)
+        s2 = self._source_ref("art_s2", "lib/errors.ts", seeded=True)
+
+        contents = await self._resolve(executor, [(s1, b"frozen v1"), (s2, b"frozen v2")])
+
+        assert contents["lib/errors.ts"] == "frozen v2"
+
     async def test_size_limit_stops_resolution(self, executor):
         """If content exceeds 512KB, resolution stops early."""
         big_content = b"x" * (256 * 1024)  # 256KB each, 2 = 512KB


### PR DESCRIPTION
Closes #881 (second half — reopened after PR #882 proved incomplete).

The seeding guard in #882 prevents *new* stub sets, but the poison from the first resume is already baked into the run's checkpoints: `run_02cc78b7acbe` checkpoint 21 carries the dev fill at index 26 and the re-seeded stub at index 68 of 92. `_restore_checkpoint_state` appends in checkpoint order and `_resolve_artifact_contents` was last-writer-wins per filename — so the first post-#882 resume (01:54Z) re-poisoned the workspace with zero new seeding. Verified live before the in-flight attempt even finished.

## Fix

`_resolve_artifact_contents` now applies the same rule `assemble` got in #882 — the invariant lives at the consumer, where #882's own PR body said it belonged ("artifact_refs are a log, not a manifest"):

- a **scaffold-seeded artifact never replaces produced content** for the same filename;
- among produced versions, later-in-order still wins (RC3 latest-correction-attempt semantics preserved);
- among seeded versions, later still wins (frozen files exist only as seeded artifacts, so a re-seeded frozen fix stays visible).

One `continue` plus a holder set; byte-budget accounting unchanged.

## Tests (mutation-verified — rule removed, the checkpoint-21 test fails)

In `TestArtifactContentsPreResolution`:
- `test_reseeded_stub_after_fill_loses` — the exact checkpoint-21 shape (stub after fill → fill wins);
- `test_produced_after_stub_wins` — the normal fresh-run shape unchanged;
- `test_latest_produced_version_still_wins` — RC3 semantics not frozen by the new rule;
- `test_frozen_file_latest_seeded_wins` — seeded-only files still take the latest seed.

Full regression: 7069 passed, 1 skipped.

## Operational context

The 01:54Z resume attempt is burning to FAILED against the still-poisoned workspace (bounded by #435/budget; cancel would forfeit resume eligibility). After this merges + runtime-api rebuild, the next resume restores checkpoint order as before but resolution now picks the fills — the #877 experiment finally gets its clean workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX
