### PR TITLE
fix(correction): repair routing honors ownership facts before heuristics (#884)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -476,6 +476,55 @@ def _locus_and_repair_target(
     return (failure_locus, expected, focus, description)
 
 
+def _apply_ownership_veto(
+    target: list[str],
+    failed_task_type: str,
+    step_role: str,
+    failed_own_artifacts: list[str],
+) -> list[str]:
+    """#884: a repair step may not receive another role's artifacts.
+
+    ``_resolve_repair_target`` unions the failed task's own artifacts into
+    every target (the pf-21 lesson: the failing artifact can carry its own
+    bug) — but when the repair chain runs under a DIFFERENT role than the one
+    that produced those artifacts, handing them over invites a guidance-less
+    cross-role rewrite: roll 14's resume #3/#4 (#884) had the dev chain
+    rewrite the qa suite into a live-fetch version, and its page rewrites
+    shipped a compile break that blocked the verdict. Ownership comes from
+    the own-artifact repair table (``own_artifact_role``); task types without
+    an entry are already repaired by their own role and pass through
+    untouched. If the veto empties the target, the locus classifier missed an
+    own-artifact case — logged as such, and the repair proceeds empty rather
+    than handing the artifacts across the boundary.
+    """
+    from squadops.cycles.task_plan import own_artifact_role
+
+    owner = own_artifact_role(failed_task_type)
+    if owner is None or step_role == owner:
+        return target
+    own = {str(a) for a in failed_own_artifacts if a}
+    if not own:
+        return target
+    stripped = [t for t in target if t not in own]
+    if len(stripped) != len(target):
+        removed = [t for t in target if t in own]
+        logger.info(
+            "correction_repair_target: ownership veto (#884) — %s-owned %s removed "
+            "from %s-role repair target",
+            owner,
+            ", ".join(removed),
+            step_role,
+        )
+        if not stripped:
+            logger.warning(
+                "correction_repair_target: ownership veto emptied the %s-role target for "
+                "failed %s — the locus classifier missed an own-artifact case (#884)",
+                step_role,
+                failed_task_type,
+            )
+    return stripped
+
+
 @dataclass(frozen=True)
 class CorrectionProtocolResult:
     """Outcome of one correction-protocol run.
@@ -1179,6 +1228,15 @@ class CorrectionRunner:
             for step_idx, (task_type, role) in enumerate(
                 repair_steps_for(envelope.task_type, failure_locus)
             ):
+                # #884: the target union may carry the failed task's own
+                # artifacts (pf-21); a step running under a foreign role must
+                # not receive them.
+                step_expected_artifacts = _apply_ownership_veto(
+                    repair_expected_artifacts,
+                    envelope.task_type,
+                    role,
+                    [str(e) for e in (failed_inputs.get("expected_artifacts") or [])],
+                )
                 repair_task_id = f"repair-{run_id[:12]}-{correction_attempts:02d}-{task_type}"
                 resolved = resolve_agent_config(role, profile)
                 agent_id = resolved.agent_id
@@ -1209,7 +1267,7 @@ class CorrectionRunner:
                     "resolved_config": failed_inputs.get("resolved_config", {}),
                     "subtask_focus": repair_focus,
                     "subtask_description": repair_description,
-                    "expected_artifacts": repair_expected_artifacts,
+                    "expected_artifacts": step_expected_artifacts,
                     "acceptance_criteria": failed_inputs.get("acceptance_criteria", []),
                 }
                 # #667: fay-14's first fill complied with the manifest

--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -706,6 +706,13 @@ async def run_backend_import_check(
 
 _VITEST_SUITE_BROKEN_MARKERS = (
     "No test suite found",
+    # #884: vitest's OTHER no-suite message — the include glob matched zero
+    # files (suite emitted at an undiscoverable path). "No test suite found"
+    # is a file that collects but contains no tests; missing either marker
+    # sends a producing-role defect down the dev repair chain (roll 14
+    # resume #4: a suite-placement failure became a dev rewrite of 7 app
+    # files that shipped a compile break).
+    "No test files found",
     "Failed to resolve import",
     "Failed to load",
     "Transform failed",

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -251,6 +251,21 @@ _REPAIR_STEPS_BY_FAILED_TASK_TYPE_OWN_ARTIFACT: dict[str, list[tuple[str, str]]]
     "qa.test": QA_TEST_REPAIR_STEPS,
 }
 
+def own_artifact_role(failed_task_type: str) -> str | None:
+    """The role that owns *failed_task_type*'s own artifacts, when declared (#884).
+
+    Derived from the own-artifact repair table (never re-typed — the #559
+    rule): the role registered to re-produce a task's own artifacts IS that
+    task's producing role. ``None`` for task types without an entry — their
+    default repair chain already runs under the producing role, so no
+    ownership boundary needs enforcing.
+    """
+    steps = _REPAIR_STEPS_BY_FAILED_TASK_TYPE_OWN_ARTIFACT.get(failed_task_type)
+    if not steps:
+        return None
+    return steps[0][1]
+
+
 # pf-31 Fix E: every task type that produces repair-CANDIDATE emissions, derived
 # from the dispatch tables above (never re-typed — #559). Candidates land in the
 # artifact store for the correction loop's accumulation (RC3), but an ACCEPTED

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -251,6 +251,7 @@ _REPAIR_STEPS_BY_FAILED_TASK_TYPE_OWN_ARTIFACT: dict[str, list[tuple[str, str]]]
     "qa.test": QA_TEST_REPAIR_STEPS,
 }
 
+
 def own_artifact_role(failed_task_type: str) -> str | None:
     """The role that owns *failed_task_type*'s own artifacts, when declared (#884).
 

--- a/tests/unit/capabilities/test_test_runner.py
+++ b/tests/unit/capabilities/test_test_runner.py
@@ -398,9 +398,7 @@ class TestVitestSuiteBroken:
         compile break that blocked the verdict."""
         from squadops.capabilities.handlers.test_runner import _vitest_suite_broken
 
-        assert (
-            _vitest_suite_broken(1, "", "No test files found, exiting with code 1") is True
-        )
+        assert _vitest_suite_broken(1, "", "No test files found, exiting with code 1") is True
 
     def test_real_test_failures_are_not_broken(self):
         from squadops.capabilities.handlers.test_runner import _vitest_suite_broken

--- a/tests/unit/capabilities/test_test_runner.py
+++ b/tests/unit/capabilities/test_test_runner.py
@@ -390,6 +390,18 @@ class TestVitestSuiteBroken:
 
         assert _vitest_suite_broken(1, "", "Error: Failed to resolve import '../Appp.jsx'") is True
 
+    def test_no_test_files_found_is_broken(self):
+        """#884: vitest's OTHER no-suite message — the include glob matched zero
+        files. Roll 14 resume #4: the suite was emitted at an undiscoverable
+        path, this marker was missing, suite_broken stayed None, and the
+        placement defect routed to the dev chain — whose repair shipped a
+        compile break that blocked the verdict."""
+        from squadops.capabilities.handlers.test_runner import _vitest_suite_broken
+
+        assert (
+            _vitest_suite_broken(1, "", "No test files found, exiting with code 1") is True
+        )
+
     def test_real_test_failures_are_not_broken(self):
         from squadops.capabilities.handlers.test_runner import _vitest_suite_broken
 

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -3840,9 +3840,7 @@ class TestOwnershipVeto:
             "app/api/runs/route.ts",
             "app/runs/new/page.tsx",
         ]
-        result = _apply_ownership_veto(
-            target, "qa.test", "dev", ["__tests__/api_runs.test.ts"]
-        )
+        result = _apply_ownership_veto(target, "qa.test", "dev", ["__tests__/api_runs.test.ts"])
 
         assert result == ["app/api/runs/route.ts", "app/runs/new/page.tsx"]
 
@@ -3850,9 +3848,7 @@ class TestOwnershipVeto:
         from adapters.cycles.correction_runner import _apply_ownership_veto
 
         target = ["__tests__/api_runs.test.ts"]
-        result = _apply_ownership_veto(
-            target, "qa.test", "qa", ["__tests__/api_runs.test.ts"]
-        )
+        result = _apply_ownership_veto(target, "qa.test", "qa", ["__tests__/api_runs.test.ts"])
 
         assert result == target
 
@@ -3886,3 +3882,69 @@ class TestOwnershipVeto:
 
         assert own_artifact_role("qa.test") == "qa"
         assert own_artifact_role("development.develop") is None
+
+
+class TestOwnershipVetoWiring(TestCorrectionRunnerStandalone):
+    """#884 wiring: the veto must reach the dispatched repair envelope — a
+    veto computed but not wired leaves the dev chain holding the qa suite
+    exactly as before (the mutation this class exists to kill)."""
+
+    async def test_dev_repair_envelope_excludes_qa_owned_suite(self, cycle):
+        import dataclasses as _dc
+
+        captured: list = []
+
+        def responder(envelope):
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "patch",
+                        "decision_rationale": "patchable",
+                        "affected_task_types": ["development.develop"],
+                    },
+                )
+            if envelope.task_type == "development.correction_repair":
+                captured.append(envelope)
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={"artifacts": [], "summary": "repaired"},
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, _vault, _bus = self._make_runner(responder)
+        # The resume-#3/#4 shape: qa.test failed with NO own-artifact signal
+        # (empty checks → UNKNOWN locus → dev chain), suite + implementation
+        # source in the union via the same-language fallback.
+        failed = _dc.replace(
+            self._failed_envelope(),
+            task_type="qa.test",
+            inputs={
+                "expected_artifacts": ["__tests__/api_runs.test.ts"],
+                "implementation_artifacts": [
+                    "app/api/runs/route.ts",
+                    "app/runs/new/page.tsx",
+                ],
+            },
+        )
+
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=failed,
+            result=TaskResult(task_id="task_failed", status="FAILED", error="suite failed"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+        assert len(captured) == 1
+        target = captured[0].inputs["expected_artifacts"]
+        assert "__tests__/api_runs.test.ts" not in target
+        assert "app/api/runs/route.ts" in target
+        assert "app/runs/new/page.tsx" in target

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -3822,3 +3822,67 @@ class TestRepairRejectionEvidence(TestCorrectionRunnerStandalone):
 
         assert len(captured) == 1
         assert "prior_repair_rejections" not in captured[0].inputs["failure_evidence"]
+
+
+class TestOwnershipVeto:
+    """#884: a repair step running under a foreign role must not receive the
+    failed task's own artifacts. Roll 14 resumes #3/#4: the dev chain was
+    handed eve's suite (rewrote it live-fetch, reversed #877) and 7 app files
+    (its page rewrite shipped an undefined-variable compile break that blocked
+    the verdict). The veto is table-derived from the own-artifact repair map.
+    """
+
+    def test_dev_step_loses_qa_owned_suite_but_keeps_app_files(self):
+        from adapters.cycles.correction_runner import _apply_ownership_veto
+
+        target = [
+            "__tests__/api_runs.test.ts",
+            "app/api/runs/route.ts",
+            "app/runs/new/page.tsx",
+        ]
+        result = _apply_ownership_veto(
+            target, "qa.test", "dev", ["__tests__/api_runs.test.ts"]
+        )
+
+        assert result == ["app/api/runs/route.ts", "app/runs/new/page.tsx"]
+
+    def test_own_role_step_keeps_its_own_artifacts(self):
+        from adapters.cycles.correction_runner import _apply_ownership_veto
+
+        target = ["__tests__/api_runs.test.ts"]
+        result = _apply_ownership_veto(
+            target, "qa.test", "qa", ["__tests__/api_runs.test.ts"]
+        )
+
+        assert result == target
+
+    def test_task_without_own_artifact_entry_is_untouched(self):
+        """development.develop has no own-artifact table entry — its default
+        chain already runs under the producing role, so the veto must no-op
+        even when its own artifacts ride the target."""
+        from adapters.cycles.correction_runner import _apply_ownership_veto
+
+        target = ["app/api/runs/route.ts", "lib/store_use.ts"]
+        result = _apply_ownership_veto(
+            target, "development.develop", "dev", ["app/api/runs/route.ts"]
+        )
+
+        assert result == target
+
+    def test_veto_may_empty_the_target(self):
+        """A dev-chain target consisting ONLY of qa-owned artifacts means the
+        locus classifier missed an own-artifact case — the veto still holds
+        the boundary (empty target) rather than handing the suite across."""
+        from adapters.cycles.correction_runner import _apply_ownership_veto
+
+        result = _apply_ownership_veto(
+            ["__tests__/api_runs.test.ts"], "qa.test", "dev", ["__tests__/api_runs.test.ts"]
+        )
+
+        assert result == []
+
+    def test_owner_role_derives_from_the_own_artifact_table(self):
+        from squadops.cycles.task_plan import own_artifact_role
+
+        assert own_artifact_role("qa.test") == "qa"
+        assert own_artifact_role("development.develop") is None


### PR DESCRIPTION
Closes #884.

Roll 14's resumes #3/#4 both hit the same misroute, and resume #4 showed its full cost: a qa-suite *placement* failure ("No test files found" — the suite emitted at a path vitest's include glob doesn't match) fell through to the #688 same-language fallback, the dev chain was handed eve's suite plus 7 app files, and neo's repair — with zero qa guidance — rewrote the suite live-fetch on #3 and on #4 introduced `router.push(\`/runs/${run.id}\`)` with `run` undefined into `app/runs/new/page.tsx`. The suite passed the vitest-only retest (pages are never imported by the suite), the run **completed**… and the verdict came back `blocked_unverified` because the probes' `next build` died on that exact line. The misroute converted a trivial placement defect into a shipped compile break.

Two facts existed that would each have prevented it; neither was consulted. The fix makes routing honor them in the precedence order ruled in review — facts first, heuristics last:

## 1. The fact source: vitest's second no-suite message (`test_runner.py`)

`_VITEST_SUITE_BROKEN_MARKERS` knew `"No test suite found"` (a file that collects but contains no tests — resume #1's empty stub, routed correctly to qa) but not `"No test files found"` (the include glob matched zero files). One marker line: `suite_broken=True` now fires, `classify_failure_locus` returns OWN_ARTIFACT, and the placement defect routes to `qa.test_repair` → eve, per the existing #568 own-artifact table.

## 2. The ownership veto (`correction_runner.py` + `task_plan.py`)

`_resolve_repair_target` unions the failed task's own artifacts into every target (the pf-21 lesson — kept), including targets dispatched to a **foreign role**. New `_apply_ownership_veto` at the dispatch loop: a repair step whose role differs from the failed task's producing role has that task's own artifacts stripped from its target. Ownership derives from the own-artifact repair table (`own_artifact_role` — never re-typed, the #559 rule); task types without an entry are already repaired by their own role and pass through untouched. If the veto empties a target, that's logged as a locus-classifier miss — the boundary holds rather than handing artifacts across it.

Net precedence: `suite_broken` fact → own-artifact routing; provenance veto at the role boundary; the same-language fallback still exists for its legitimate case (suite ran, app violates contract) but can no longer reach another role's artifacts.

## Tests (all mutation-verified)

- `test_no_test_files_found_is_broken` — the exact resume-#4 stderr; killing the marker fails it.
- `TestOwnershipVeto` (5 tests) — the resume-#3/#4 strip shape, own-role pass-through, no-entry pass-through, veto-empties boundary, and table derivation of the owner role.
- `TestOwnershipVetoWiring` — full correction-protocol run asserting the dispatched dev repair envelope excludes the qa-owned suite while keeping app files; added specifically because the pure-function tests missed an unwired-veto mutation (135 passed with the veto computed but unused — this test kills it).

Full regression: 7090 passed, 1 skipped.

## Not in scope

The second gap resume #4 exposed — the vitest-only retest cannot see page-level type errors, so a compile-broken patch can be *accepted* and only caught at probe prepare (verdict `blocked_unverified`) — is the known stack-2 compile-gate residual (#870's "runtime-api has no node"; the durable fix is SIP-0102's app-container territory). Observed, not filed, pending owner call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX
