### PR TITLE
fix(correction): suite-health verdict joins the tests_pass signature (#878 minimum)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -913,10 +913,14 @@ class CorrectionRunner:
                 candidate,
                 "; ".join(termination.repeated_signature),
             )
+            # #878 rider: the rule needs a structural candidate PRESENT on both
+            # decisions, not the same one — naming only the terminal candidate
+            # "on both" misstated roll 14's add_task/tighten_acceptance pair.
             raise _ExecutionError(
                 f"plan_defect: correction terminated at round {correction_attempts} — "
-                f"failure signature repeated from round {termination.first_seen_round} "
-                f"with structural plan-change candidate {candidate!r} on both decisions; "
+                f"failure signature repeated from round {termination.first_seen_round}, "
+                f"structural plan-change candidates on both decisions "
+                f"(terminal: {candidate!r}); "
                 f"the plan, not the work product, is the defect "
                 f"(see {ref.artifact_id})"
             )

--- a/src/squadops/cycles/correction_signature.py
+++ b/src/squadops/cycles/correction_signature.py
@@ -38,6 +38,16 @@ def failure_signature(failure_evidence: dict[str, Any]) -> frozenset[tuple[str, 
     no product signature: an infra round (``extraction_loss`` /
     ``emission_failure`` — the A3 categories own its routing) or no failing
     rows at all.
+
+    #878 (minimum): the runner's structured ``suite_broken`` verdict joins the
+    reason token when present. It is a machine fact, not prose, so the
+    evidence-text rule above is intact — and without it a behavioral failure
+    (suite ran, assertions failed) and a discovery failure (no collectable
+    suite) collapse into one ``tests_pass||failed`` element: roll 15
+    (run_783f50a2d564) was terminated as a false exact-repeat across exactly
+    that pair, one round before the #886 own-artifact routing would have
+    repaired the second failure. Absent/None (legacy rows, non-suite checks)
+    leaves the token byte-identical to the pre-#878 form.
     """
     if not isinstance(failure_evidence, dict):
         return None
@@ -66,6 +76,10 @@ def failure_signature(failure_evidence: dict[str, Any]) -> frozenset[tuple[str, 
             if isinstance(reason, str) and reason
             else str(row.get("status", ResultStatus.FAILED))
         )
+        suite_broken = row.get("suite_broken")
+        if suite_broken is not None:
+            health = "broken" if suite_broken else "ran"
+            reason_token = f"{reason_token};suite_health={health}"
         elements.add((check_id, subject, reason_token))
     return frozenset(elements) if elements else None
 

--- a/tests/unit/cycles/test_correction_signature.py
+++ b/tests/unit/cycles/test_correction_signature.py
@@ -125,3 +125,45 @@ class TestTerminationRule:
     def test_render_is_stable_and_sorted(self):
         sig = frozenset({("b", "f2", "r2"), ("a", "f1", "r1")})
         assert render_signature(sig) == ("a|f1|r1", "b|f2|r2")
+
+
+class TestSuiteHealthDiscriminator:
+    """#878 (minimum): the runner's structured suite_broken verdict joins the
+    tests_pass reason token. Roll 15 (run_783f50a2d564): round 0 = suite RAN,
+    assertions failed; round 1 = "No test files found" (suite_broken=True) —
+    two different defects collapsed into one `tests_pass||failed` element and
+    the run was terminated as a false exact-repeat, one round before the #886
+    own-artifact routing would have repaired the second failure.
+    """
+
+    def test_behavioral_vs_discovery_rounds_are_not_a_repeat(self):
+        ran = _evidence([{**_TESTS_FAIL_ROW, "reason": "failed", "suite_broken": False}])
+        broken = _evidence([{**_TESTS_FAIL_ROW, "reason": "failed", "suite_broken": True}])
+        sig_ran, sig_broken = failure_signature(ran), failure_signature(broken)
+
+        assert sig_ran != sig_broken
+        # the roll-15 shape: candidates on both rounds must STILL not fire
+        assert not should_terminate_plan_defect(
+            sig_ran, sig_broken, "tighten_acceptance", "tighten_acceptance"
+        )
+
+    def test_same_health_repeat_still_terminates(self):
+        """The shk-4 true positive is preserved: two suite-ran rounds with the
+        same aggregate reason remain an exact repeat."""
+        a = failure_signature(
+            _evidence([{**_TESTS_FAIL_ROW, "reason": "failed", "suite_broken": False}])
+        )
+        b = failure_signature(
+            _evidence([{**_TESTS_FAIL_ROW, "reason": "failed", "suite_broken": False}])
+        )
+
+        assert a == b
+        assert should_terminate_plan_defect(a, b, "tighten_acceptance", "add_task")
+
+    def test_legacy_rows_without_verdict_are_byte_identical(self):
+        """Absent suite_broken (None / pre-#626 rows, non-suite checks) the
+        element must not change — signatures recorded before this fix still
+        compare correctly against ones recorded after."""
+        sig = failure_signature(_evidence([_TESTS_FAIL_ROW]))
+
+        assert sig == frozenset({("tests_pass", "backend/tests/test_integration.js", "exit 1")})


### PR DESCRIPTION
Partial fix for #878 — the minimum discriminator; failing-test identity extraction remains open on the issue.

Roll 15 (`run_783f50a2d564`) was killed by a false exact-repeat: round 0 = suite ran, assertions failed (a real app gap — empty-body POST 500s before validation); round 1 = "No test files found" (a placement defect that #886 now routes to eve's own-artifact repair). Both rounds collapsed into the single coarse `tests_pass||failed` signature element, and #435 terminated a **39/40-green, all-probes-passing** run one round before the fixed routing would have repaired the second failure.

The runner's structured `suite_broken` verdict now joins the reason token (`;suite_health=ran|broken`) when present:

- mechanical-vs-behavioral rounds no longer read as repeats (the roll-15 kill, mutation-verified);
- two same-health rounds with the same aggregate reason still repeat — the shk-4 true positive is preserved;
- rows without the verdict (legacy, non-suite checks) produce byte-identical elements, so pre-fix and post-fix signatures compare correctly.

It's a machine fact, not prose — the module's "evidence text never alters the signature" rule is intact.

Rider from the issue: the termination message claimed the terminal candidate appeared "on both decisions"; the rule requires candidate *presence* on both, not identity (roll 14: `add_task` then `tighten_acceptance`). Reworded to name the terminal candidate explicitly.

Full regression: 7093 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX