### PR TITLE
fix(plan): build-profile required_files are a floor the plan must cover (#888)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -3575,6 +3575,17 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                             parsed_plan.validate_build_config(cycle.resolved_config()),
                         )
                     )
+                    # Roll 15: a plan whose builder task under-covers the build
+                    # profile's required_files converges its whole suite and then
+                    # dies at the #291 completion gate — which has no repair path
+                    # and no incomplete builder task left on resume. Provable
+                    # here; rejection re-rolls framing for free.
+                    errors.extend(
+                        classifier.collect(
+                            "validate_builder_floor",
+                            parsed_plan.validate_builder_floor(cycle.resolved_config()),
+                        )
+                    )
             elif (
                 ref.filename == SEEDED_MANIFEST_FILENAME or artifact_type == MANIFEST_ARTIFACT_TYPE
             ):
@@ -3842,6 +3853,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         # refused by generate_task_plan anyway, but only after the gate
         # approved the plan and the implementation run was admitted.
         errors += plan.validate_build_config(cycle.resolved_config())
+        # Roll 15: builder floor coverage — both seams per the #718/#719 rule.
+        errors += plan.validate_builder_floor(cycle.resolved_config())
         # #715: qa.test artifacts that required tests_pass can never judge.
         errors += plan.validate_check_applicability(cycle.resolved_config())
         if errors:

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -426,6 +426,52 @@ class ImplementationPlan:
             "profile, or author without builder tasks"
         ]
 
+    def validate_builder_floor(self, resolved_config: dict) -> list[str]:
+        """The build profile's ``required_files`` are a run-level FLOOR the plan
+        must assign an owner for — a per-task list may add files, never subtract.
+
+        Roll 15 (run_783f50a2d564): the plan's builder task listed
+        ``qa_handoff.md`` but not ``Dockerfile``; the builder validator honors
+        the active task's list (#107), so bob passed without it, the suite
+        converged after two correction sessions — and the run then died at the
+        #291 completion gate, which has NO repair path and, on any resume, no
+        incomplete builder task left to re-run. A plan that under-covers the
+        floor is deterministically doomed and provable here in microseconds;
+        rejecting re-rolls framing for free (#522).
+
+        Unknown/missing profile returns [] — #426 and the handler's own
+        ``get_profile`` failure own those. Basename comparison on both sides,
+        matching the builder validator and the #291 gate.
+        """
+        import os
+
+        profile_name = resolved_config.get("build_profile")
+        if not profile_name:
+            return []
+        if not any(task.task_type in _BUILDER_ROLE_BUILD_TASK_TYPES for task in self.tasks):
+            return []
+        from squadops.capabilities.handlers.build_profiles import get_profile
+
+        try:
+            profile = get_profile(profile_name)
+        except ValueError:
+            return []
+        owned = {
+            os.path.basename(artifact)
+            for task in self.tasks
+            for artifact in task.expected_artifacts
+        }
+        missing = [rf for rf in profile.required_files if os.path.basename(rf) not in owned]
+        if not missing:
+            return []
+        return [
+            f"Build profile {profile_name!r} requires {list(profile.required_files)} but no "
+            f"plan task's expected_artifacts owns: {missing}. The profile list is a floor — "
+            "a builder task must own every required file (per-task lists may add, never "
+            "subtract), or the run completes its build and still fails the #291 "
+            "deliverable-completeness gate with no repair path."
+        ]
+
     def _regex_on_source_criteria(self):
         """Yield ``(task, criterion, target)`` for every ``regex_match`` criterion
         that targets a non-document file — the #464 violation shared by the fatal

--- a/src/squadops/cycles/plan_authoring_rules.py
+++ b/src/squadops/cycles/plan_authoring_rules.py
@@ -36,6 +36,9 @@ AUTHOR_FACING: dict[str, str] = {
     # declared test conventions, and a rule id naming one stack's runner is how the
     # validator came to assert pytest's patterns against a vitest suite in the first place.
     "validate_check_applicability": "qa-tests-must-be-discoverable",
+    # #888: the plan author owns the builder task's expected_artifacts, so an
+    # under-covered floor is an authorable — and authored (roll 15) — defect.
+    "validate_builder_floor": "builder-floor-coverage",
 }
 
 # Validators an author is already taught by a different managed asset. Restating them

--- a/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.plan_authoring_rules_appendix
-version: "2"
+version: "3"
 required_variables: []
 ---
 ## PLAN SHAPE RULES (authoritative — a plan that breaks one is rejected)
@@ -59,6 +59,12 @@ conventions your stack's guidance states (`test_*.py` / `*_test.py` under pytest
 `*.test.ts` / `*.spec.ts` and their `.tsx` forms under vitest); a directory named
 `__tests__/` is not itself enough. Express verification that produces no such file
 through the acceptance criteria of a verification-only task instead.
+
+**builder-floor-coverage** — When the plan carries a builder task, every file the build
+profile's `required_files` lists appears in SOME task's `expected_artifacts` (usually the
+builder's). The profile list is a floor — a per-task list may add files, never subtract
+one. A plan that leaves a required file unowned passes every task and then fails the
+deliverable-completeness gate at run completion, where nothing can repair it.
 
 A verification-only task is legitimate and common: declare `expected_artifacts: []` and
 express what it checks through its acceptance criteria.

--- a/tests/unit/cycles/test_dispatched_flow_executor.py
+++ b/tests/unit/cycles/test_dispatched_flow_executor.py
@@ -994,8 +994,14 @@ class TestGateRejectsBuilderPlanWithoutBuildProfile:
         "    role: builder\n"
         '    focus: "Package"\n'
         '    description: "Assemble"\n'
+        # #888: floor-compliant for python_cli_builder — the "passes" test
+        # asserts the profile-configured outcome, so its plan must cover the
+        # profile's required_files or the floor rule (correctly) rejects it.
         "    expected_artifacts:\n"
         '      - "qa_handoff.md"\n'
+        '      - "Dockerfile"\n'
+        '      - "__main__.py"\n'
+        '      - "requirements.txt"\n'
         "    depends_on: []\n"
         "summary:\n"
         "  total_tasks: 1\n"

--- a/tests/unit/cycles/test_implementation_plan.py
+++ b/tests/unit/cycles/test_implementation_plan.py
@@ -1355,6 +1355,97 @@ summary:
         assert plan.validate_build_config({}) == []
 
 
+class TestValidateBuilderFloor:
+    """#888: the build profile's required_files are a run-level floor the plan
+    must assign an owner for. Roll 15's plan listed qa_handoff.md but not
+    Dockerfile on its builder task — bob passed (#107 honors the task list),
+    the suite converged, and the run died at the #291 completion gate, which
+    has no repair path and no incomplete builder task left on resume."""
+
+    @staticmethod
+    def _plan(builder_artifacts: list[str]) -> ImplementationPlan:
+        artifacts = "".join(f'\n      - "{a}"' for a in builder_artifacts)
+        return ImplementationPlan.from_yaml(
+            "version: 1\n"
+            "project_id: group_run\n"
+            "cycle_id: cyc_test\n"
+            "prd_hash: abc123\n"
+            "tasks:\n"
+            "  - task_index: 0\n"
+            "    task_type: builder.assemble\n"
+            "    role: builder\n"
+            '    focus: "Package"\n'
+            '    description: "Assemble packaging"\n'
+            f"    expected_artifacts:{artifacts}\n"
+            "    depends_on: []\n"
+            "summary:\n"
+            "  total_tasks: 1\n"
+        )
+
+    def test_roll_15_shape_missing_dockerfile_rejected(self):
+        errors = self._plan(["qa_handoff.md"]).validate_builder_floor(
+            {"build_profile": "nextjs_ts"}
+        )
+        assert len(errors) == 1
+        assert "Dockerfile" in errors[0]
+        assert "floor" in errors[0]
+
+    def test_full_floor_coverage_passes(self):
+        errors = self._plan(["qa_handoff.md", "Dockerfile"]).validate_builder_floor(
+            {"build_profile": "nextjs_ts"}
+        )
+        assert errors == []
+
+    def test_basename_match_accepts_subdir_paths(self):
+        """The #291 gate and the builder validator both compare basenames — a
+        Dockerfile owned at a subpath must satisfy the floor the same way."""
+        errors = self._plan(["docs/qa_handoff.md", "deploy/Dockerfile"]).validate_builder_floor(
+            {"build_profile": "nextjs_ts"}
+        )
+        assert errors == []
+
+    def test_floor_may_be_covered_by_any_task_not_only_builder(self):
+        plan = ImplementationPlan.from_yaml(
+            "version: 1\n"
+            "project_id: group_run\n"
+            "cycle_id: cyc_test\n"
+            "prd_hash: abc123\n"
+            "tasks:\n"
+            "  - task_index: 0\n"
+            "    task_type: development.develop\n"
+            "    role: dev\n"
+            '    focus: "App"\n'
+            '    description: "Build app"\n'
+            "    expected_artifacts:\n"
+            '      - "Dockerfile"\n'
+            "    depends_on: []\n"
+            "  - task_index: 1\n"
+            "    task_type: builder.assemble\n"
+            "    role: builder\n"
+            '    focus: "Package"\n'
+            '    description: "Assemble"\n'
+            "    expected_artifacts:\n"
+            '      - "qa_handoff.md"\n'
+            "    depends_on: [0]\n"
+            "summary:\n"
+            "  total_tasks: 2\n"
+        )
+        assert plan.validate_builder_floor({"build_profile": "nextjs_ts"}) == []
+
+    def test_no_build_profile_defers_to_426(self):
+        assert self._plan(["qa_handoff.md"]).validate_builder_floor({}) == []
+
+    def test_unknown_profile_defers_to_other_nets(self):
+        errors = self._plan(["qa_handoff.md"]).validate_builder_floor(
+            {"build_profile": "no_such_profile"}
+        )
+        assert errors == []
+
+    def test_builderless_plan_owes_no_floor(self):
+        plan = ImplementationPlan.from_yaml(VALID_MANIFEST_YAML)
+        assert plan.validate_builder_floor({"build_profile": "nextjs_ts"}) == []
+
+
 class TestValidateCheckApplicability:
     """#715: a qa.test task whose declared artifacts pytest cannot discover
     fails required tests_pass on any possible content (shk-4: three correction

--- a/tests/unit/cycles/test_plan_gate_seams.py
+++ b/tests/unit/cycles/test_plan_gate_seams.py
@@ -92,3 +92,23 @@ def test_seam_error_channels_stay_distinct():
         f"{_DISPATCH_SEAM} no longer raises — the in-run net's rejection channel "
         "is the raise; a returned value would be silently discarded at its call site"
     )
+
+
+def test_builder_floor_rule_is_wired_at_both_seams():
+    """#888 (the #718/#719 rule applied): the builder-floor validator must be
+    called from BOTH seams — dropping either lets an under-covered plan reach
+    the #291 completion gate, which has no repair path (roll 15's dead end)."""
+    tree = ast.parse(_EXECUTOR_PATH.read_text(encoding="utf-8"))
+
+    seam_sources = {
+        node.name: ast.unparse(node)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef)
+        and node.name in (_PROMOTION_SEAM, _DISPATCH_SEAM)
+    }
+
+    for seam in (_PROMOTION_SEAM, _DISPATCH_SEAM):
+        assert "validate_builder_floor" in seam_sources[seam], (
+            f"{seam} no longer calls validate_builder_floor — an under-covered "
+            "builder plan on this path dies at run completion with no repair path"
+        )


### PR DESCRIPTION
Closes #888.

Roll 15's dead end: the plan's builder task listed `qa_handoff.md` but not `Dockerfile`, bob validated only his task list (#107 — framing may decompose builder work), the suite **converged** (first stack-#2 convergence) — and the run died at the #291 completion gate, which raises a run-level error with no correction chain, and leaves nothing to resume (qa checkpointed complete, builder task can never re-run).

The root problem: the profile's `required_files` are a run-level **floor**, but the per-task list could silently subtract from it — the 1.4.3 "expected_artifacts = floor" lesson, one layer up.

## Fix — shift-left to plan validation

`ImplementationPlan.validate_builder_floor(resolved_config)`: when the plan carries a builder task and a build profile resolves, every profile required file must appear (basename match, same normalization as the builder validator and the #291 gate) in **some** plan task's `expected_artifacts`. Missing → gate rejection → free framing re-roll, before an implementation run is admitted. Unknown/missing profile defers to #426's existing nets; builderless plans owe no floor; coverage may live on any task, not only the builder (if framing assigns a required file to dev, someone owns it — that's what the floor asks).

Wired at **both** plan-gate seams per the #718/#719 rule — the promotion seam (recorded rejection, free re-roll) and the dispatch-admission seam (raises) — and pinned by an AST test that fails if either seam drops the call.

The #291 completion gate stays as the backstop for files no plan could foresee.

## Tests

- `TestValidateBuilderFloor` (7): the exact roll-15 shape (mutation-verified — removing the missing-files computation fails it), full coverage, subdir basename match, any-task ownership, no-profile/unknown-profile deferral, builderless pass.
- `test_builder_floor_rule_is_wired_at_both_seams` — the #718/#719 pin.

Full regression: 7101 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX