### PR TITLE
fix(authoring): builder example shows the profile's required-files floor (#890)

### DIFF
--- a/src/squadops/capabilities/handlers/_plan_authoring_service.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring_service.py
@@ -90,11 +90,32 @@ async def produce_plan(
     )
 
     if offer_builder:
+        # #890: the example is the strongest teaching surface (rolls 15/16 both
+        # reproduced its expected_artifacts verbatim), so it must SHOW the
+        # profile's required-files floor, not hedge it in description prose —
+        # the floor rendered here is the same list validate_builder_floor
+        # rejects on (#888), stated as data per the pf-34 pattern.
+        from squadops.capabilities.handlers.build_profiles import get_profile
+
+        try:
+            floor = list(get_profile(resolved_config["build_profile"]).required_files)
+        except (KeyError, ValueError):
+            floor = []
+        example_artifacts = floor or ["qa_handoff.md"]
+        floor_guideline = (
+            (
+                f"- The build profile requires these files; EVERY one must appear in "
+                f"some task's expected_artifacts (the floor — a per-task list may add "
+                f"files, never subtract one): {', '.join(floor)}\n"
+            )
+            if floor
+            else ""
+        )
         builder_guideline = (
             "- Route packaging, entrypoints, requirements.txt/package.json, "
             "Dockerfile/startup scripts, and qa_handoff.md to `builder.assemble` "
             "tasks (role: builder). Place AFTER all `development.develop` tasks "
-            "and BEFORE any `qa.test` tasks.\n"
+            "and BEFORE any `qa.test` tasks.\n" + floor_guideline
         )
         qa_handoff_guideline = ""
         builder_example = (
@@ -107,8 +128,8 @@ async def produce_plan(
             "Dockerfile if applicable) and write qa_handoff.md summarizing "
             "how to run and test the build.\n"
             "    expected_artifacts:\n"
-            '      - "qa_handoff.md"\n'
-            "    acceptance_criteria:\n"
+            + "".join(f'      - "{name}"\n' for name in example_artifacts)
+            + "    acceptance_criteria:\n"
             '      - "..."\n'
             "    depends_on: [0]\n"
         )

--- a/tests/unit/capabilities/test_plan_authoring_service.py
+++ b/tests/unit/capabilities/test_plan_authoring_service.py
@@ -771,3 +771,33 @@ async def test_the_rules_precede_the_cycle_specific_surfaces(seeded_inputs):
     assert prompt.index("request.plan_authoring_rules_appendix") < prompt.index(
         "request.plan_bind_criteria_appendix"
     )
+
+
+async def test_builder_guideline_and_example_carry_the_profile_floor():
+    """#890: rolls 15/16 both reproduced the builder example's
+    expected_artifacts verbatim — qa_handoff.md only, no Dockerfile — so the
+    example must SHOW the profile's required-files floor (the same list
+    validate_builder_floor rejects on), not hedge it in description prose."""
+    variables = await _render_vars_for(
+        ["lead", "dev", "qa", "builder"],
+        {"implementation_plan": True, "build_profile": "nextjs_ts"},
+    )
+
+    assert "Dockerfile, qa_handoff.md" in variables["builder_guideline"]
+    assert "floor" in variables["builder_guideline"]
+    assert '- "Dockerfile"' in variables["builder_example"]
+    assert '- "qa_handoff.md"' in variables["builder_example"]
+
+
+async def test_unknown_profile_keeps_generic_example():
+    """A profile the registry cannot resolve renders no floor line and the
+    example falls back to the pre-#890 qa_handoff.md shape — the offer gate
+    and #426's nets own the misconfiguration, not this surface."""
+    variables = await _render_vars_for(
+        ["lead", "dev", "qa", "builder"],
+        {"implementation_plan": True, "build_profile": "no_such_profile"},
+    )
+
+    assert "floor" not in variables["builder_guideline"]
+    assert '- "qa_handoff.md"' in variables["builder_example"]
+    assert '- "Dockerfile"' not in variables["builder_example"]


### PR DESCRIPTION
Closes #890.

Rolls 15 and 16 both authored builder tasks reproducing the sole-author example's `expected_artifacts` verbatim — `qa_handoff.md` only, `Dockerfile` hedged in description prose ("Dockerfile if applicable"). The v3 authoring-rules appendix states `builder-floor-coverage` abstractly; the example demonstrated violating it, and the example won 2-for-2 — the measured pattern-beats-prose lesson applied to plan authoring.

## Fix

The strongest teaching surface now tells the truth as data (the pf-34 pattern):

- The builder guideline renders the profile's actual `required_files` — the same list `validate_builder_floor` (#888/#889) rejects on — with the floor semantics stated inline.
- The example's `expected_artifacts` **is** that floor, so pattern-matching authors copy compliance instead of violation.
- Unknown/unresolvable profile renders no floor line and keeps the generic example — the offer gate and #426's nets own misconfiguration.

## Tests

- `test_builder_guideline_and_example_carry_the_profile_floor` — nextjs_ts renders `Dockerfile, qa_handoff.md` in the guideline and both files in the example (mutation-verified: reverting the example to the generic shape fails it).
- `test_unknown_profile_keeps_generic_example` — fallback boundary.

Full regression: 7103 passed, 1 skipped (pipefail-verified).

With #889's gate as the net and this as the teaching, roll 17's plan author copies a compliant example and the gate only fires if the author actively diverges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPptgR4CesATZRtgcYKAdX