### PR TITLE
feat(sip-0104): Phase 1 — the deterministic test scaffold (contract, generator, seed lifecycle, Gate 1 pins)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -427,9 +427,20 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             # design, so the resumed run tests the skeleton instead of the app.
             interface_manifest = await self._load_interface_manifest_for_run(cycle, run)
             if interface_manifest is not None and existing_checkpoint is None:
-                seed_artifact_refs.extend(
-                    await self._seed_skeleton_artifacts(interface_manifest, cycle, run_id)
+                skeleton_refs = await self._seed_skeleton_artifacts(
+                    interface_manifest, cycle, run_id
                 )
+                seed_artifact_refs.extend(skeleton_refs)
+                # SIP-0104: the deterministic test scaffold rides the same seed act, and
+                # only on top of an actually-seeded skeleton — the tree its shells'
+                # imports resolve against is the tree this run carries. Same #881
+                # no-resume rule by construction (this whole branch is seed-time only).
+                if skeleton_refs:
+                    seed_artifact_refs.extend(
+                        await self._seed_verification_scaffold_artifacts(
+                            interface_manifest, cycle, run_id
+                        )
+                    )
 
             # LangFuse + Prefect observability setup
             obs_ctx, flow_run_id = await self._init_run_observability(
@@ -1867,6 +1878,110 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             "Seeded %d walking-skeleton files (stack=%s) for run %s",
             len(seeded_ids),
             manifest.stack,
+            run_id,
+        )
+        return seeded_ids
+
+    async def _seed_verification_scaffold_artifacts(
+        self,
+        manifest: Any,
+        cycle: Cycle,
+        run_id: str,
+    ) -> list[str]:
+        """Emit, validate, and persist the deterministic test scaffold (SIP-0104 P1).
+
+        The lifecycle is explicit — expand → emit → **validate** → persist → expose —
+        and ``emit_verification_scaffold`` refuses before persistence, so an unvalidated
+        scaffold never becomes part of the run's artifact set and nothing downstream
+        needs an invalid-scaffold special case.
+
+        Opt-in gated (SIP-0104 §8): a stack declaring no ``verification_scaffold``
+        seeds nothing and qa authors the whole suite — today's path, silently. Once a
+        stack HAS opted in, an emission failure fails run setup **loudly** (the #845
+        doctrine, same branch as the registry-disagreement raise above): a run whose
+        deterministic verification story cannot be validly emitted is not a degraded
+        run, and it must never consume an LLM correction round (SIP-0104 §4.4).
+
+        Returns the seeded shell artifact ids (workspace files). The scaffold manifest
+        record is stored as its own artifact but deliberately NOT returned: seed refs
+        become workspace files, and the record is evidence for enforcement/diagnosis
+        (P4), not a file the app tree should carry. It is reachable by run id +
+        artifact type.
+        """
+        from squadops.capabilities.scaffold import verification_scaffold_for
+        from squadops.capabilities.verification_scaffold_emission import (
+            VERIFICATION_SCAFFOLD_MANIFEST_ARTIFACT_TYPE,
+            VERIFICATION_SCAFFOLD_MANIFEST_FILENAME,
+            emit_verification_scaffold,
+        )
+
+        if not verification_scaffold_for(manifest.stack):
+            return []
+
+        try:
+            emission = emit_verification_scaffold(manifest)
+        except Exception:
+            logger.error(
+                "test-scaffold emission failed for opted-in stack %s (run %s) — failing "
+                "run setup: an invalid scaffold must never become the run's qa artifact "
+                "or consume an LLM round (SIP-0104 §4.4)",
+                manifest.stack,
+                run_id,
+            )
+            raise
+
+        seeded_ids: list[str] = []
+        for f in emission.files:
+            content = f["content"].encode("utf-8")
+            ref = ArtifactRef(
+                artifact_id=f"art_{uuid4().hex[:12]}",
+                project_id=cycle.project_id,
+                cycle_id=cycle.cycle_id,
+                run_id=run_id,
+                artifact_type="source",
+                filename=f["name"],
+                content_hash=sha256(content).hexdigest(),
+                size_bytes=len(content),
+                media_type="text/plain",
+                created_at=datetime.now(UTC),
+                metadata={
+                    "producing_task_type": "scaffold.test_emit",
+                    "scaffold_seeded": True,
+                    "verification_scaffold": True,
+                },
+            )
+            await self._artifact_vault.store(ref, content)
+            seeded_ids.append(ref.artifact_id)
+
+        record_bytes = emission.manifest_yaml.encode("utf-8")
+        record_ref = ArtifactRef(
+            artifact_id=f"art_{uuid4().hex[:12]}",
+            project_id=cycle.project_id,
+            cycle_id=cycle.cycle_id,
+            run_id=run_id,
+            artifact_type=VERIFICATION_SCAFFOLD_MANIFEST_ARTIFACT_TYPE,
+            filename=VERIFICATION_SCAFFOLD_MANIFEST_FILENAME,
+            content_hash=sha256(record_bytes).hexdigest(),
+            size_bytes=len(record_bytes),
+            media_type="application/yaml",
+            created_at=datetime.now(UTC),
+            metadata={
+                "derived_from": "interface_manifest",
+                "derivation": "verification_scaffold_emission",
+                "generator_version": emission.manifest.generator_version,
+                "aggregate_spine_hash": emission.manifest.aggregate_spine_hash(),
+                "scaffold_hash": emission.manifest.scaffold_hash(),
+            },
+        )
+        await self._artifact_vault.store(record_ref, record_bytes)
+
+        logger.info(
+            "Seeded %d test-scaffold shells + manifest record (stack=%s, generator v%d, "
+            "spine %s) for run %s",
+            len(emission.files),
+            manifest.stack,
+            emission.manifest.generator_version,
+            emission.manifest.aggregate_spine_hash()[:12],
             run_id,
         )
         return seeded_ids

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -1728,6 +1728,18 @@ class ScaffoldStack:
     #: are free-form capabilities for cycles with no scaffold stack at all. Not every dev
     #: capability is a stack; every stack needs one.
     dev_capability: str = ""
+    #: SIP-0104: the test-scaffold emitter this stack opts into — deterministic behavior
+    #: shells with fill slots, emitted beside the skeleton at seed time. A *name* pointing
+    #: at ``verification_scaffold_emission._EMITTERS``, like the three fields above.
+    #:
+    #: The default sides with ``check_stack``, not ``criteria_pack``: an unset field means
+    #: the stack has NOT opted in (SIP-0104 §8 — opt-in is explicit and all-or-nothing) and
+    #: emission is skipped, which is today's behavior — the qa author writes the whole
+    #: suite, visibly. A partial or guessed scaffold is the silently-wrong class, which is
+    #: why a stack whose facts cannot support every derivation must refuse to declare this
+    #: rather than declare it approximately. Set-but-unregistered refuses at emission
+    #: (the #838 two-registries-disagree class).
+    verification_scaffold: str = ""
 
 
 _STACKS: dict[str, ScaffoldStack] = {
@@ -1766,6 +1778,9 @@ _STACKS: dict[str, ScaffoldStack] = {
         criteria_pack=_NEXTJS_TS_NAME,
         probe_profile="nextjs_next_start",
         dev_capability=_NEXTJS_TS_NAME,
+        # SIP-0104: the first (and so far only) stack with a deterministic test scaffold.
+        # Stack #1 deliberately does not declare one — opt-in is explicit, never inherited.
+        verification_scaffold=_NEXTJS_TS_NAME,
     ),
 }
 
@@ -1817,6 +1832,18 @@ def dev_capability_for(stack: str) -> str:
     """The ``DEV_CAPABILITIES`` entry ``stack`` requires, or ``""`` (#832)."""
     known = _STACKS.get(stack)
     return known.dev_capability if known else ""
+
+
+def verification_scaffold_for(stack: str) -> str:
+    """The test-scaffold emitter ``stack`` opts into, or ``""`` (SIP-0104).
+
+    Total, like its three siblings: ``""`` means the stack has not opted in and callers
+    skip emission (today's authored-suite path). The refusal for a *declared but
+    unregistered* emitter belongs to ``verification_scaffold_emission``, the layer that
+    knows the registries disagree.
+    """
+    known = _STACKS.get(stack)
+    return known.verification_scaffold if known else ""
 
 
 def resolve_dev_capability(resolved_config: Mapping[str, Any] | None) -> str | None:

--- a/src/squadops/capabilities/stack_nextjs_ts_tests.py
+++ b/src/squadops/capabilities/stack_nextjs_ts_tests.py
@@ -1,0 +1,433 @@
+"""Stack #2's behavior-shell emitter — the nextjs_ts test scaffold (SIP-0104 P1).
+
+A separate module for the same reason ``stack_nextjs_ts`` is: shell templates are stack-#2
+vocabulary and belong beside it, not interleaved with the stack-neutral orchestration in
+``verification_scaffold_emission``.
+
+Derivation sources, per the contract's precedence (``verification_scaffold``):
+
+- **behavior inventory, request bodies, expected statuses** ← the verification contract's
+  behavioral probes (``scaffold_contract._probes`` — the same derivation the probe runner
+  executes, so a shell and its probe cannot disagree; SIP §5's dedup rule depends on this);
+- **route-file placement and import targets** ← the expanded tree (checked, never assumed);
+- **invocation form** ← the stack's taught execution model (#877): import the handler,
+  invoke with ``new Request(...)``, pass ``{ params }`` for parameterized routes.
+
+The v1 required-coverage inventory, stated so omissions read as omissions (demote, don't
+guess — SIP §4.1):
+
+- one shell per behavioral probe (create, blank-rejection, child action, duplicate-conflict),
+  each an in-process twin of its probe;
+- a shell per parameterless GET endpoint (declared success status, 200 default);
+- success + unknown-id shells per single-parameter GET under a create whose response entity
+  declares ``id`` (the probe capture rule applied to reads); the unknown-id shell exists only
+  when the endpoint declares an error code the error contract maps to 404.
+
+NOT in the inventory (the qa author's additive surface): PUT/DELETE endpoints,
+multi-parameter paths, parameterized GETs with no create chain, and all DOM behavior.
+
+Chained state is derived from the probe list's own sequence semantics: the probe runner
+executes probes in order against one app instance, so a child probe's precondition is the
+success of the child probes before it. A shell is test-isolated (``beforeEach(reset)``), so
+it replays that prefix in-process: create, then each earlier child success, then its own
+invocation.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from squadops.capabilities.scaffold_contract import _slug
+from squadops.capabilities.stack_nextjs_ts import _segments
+from squadops.capabilities.verification_scaffold import (
+    BehaviorSlot,
+    ScaffoldDerivationError,
+    slot_begin_marker,
+    slot_end_marker,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - annotations only
+    from squadops.capabilities.scaffold import InterfaceManifest
+
+#: Where every emitted shell lives. Inside the stack's ``__tests__`` namespace so the
+#: vitest include pattern collects it; the ``.scaffold.test.ts`` suffix marks provenance.
+SCAFFOLD_TEST_DIR = "__tests__/scaffold"
+
+_STORE_PATH = "lib/store.ts"
+_URL_BASE = "http://test"  # the host the stack's taught execution model uses (#877)
+
+
+def _route_file(url_path: str) -> str:
+    """Declared URL → owning route file — the same derivation as the expander (bend 1)."""
+    return f"app/{_segments(url_path)}/route.ts".replace("//", "/")
+
+
+def _alias(route_file: str) -> str:
+    """Deterministic import alias: ``app/api/runs/[run_id]/route`` → ``routeApiRunsRunId``."""
+    parts = route_file.removeprefix("app/").removesuffix("/route.ts").split("/")
+    words: list[str] = []
+    for part in parts:
+        for word in re.split(r"[^a-zA-Z0-9]+", part.strip("[]")):
+            if word:
+                words.append(word[0].upper() + word[1:])
+    return "route" + "".join(words)
+
+
+def _placeholders(url_path: str) -> list[str]:
+    return re.findall(r"\{(\w+)\}", url_path)
+
+
+@dataclass(frozen=True)
+class _Step:
+    """One handler invocation: method + declared URL path + optional JSON body.
+
+    ``param_expr`` is the TypeScript expression for the single path parameter's value
+    (``"created.id"`` for chained steps, ``"'missing'"`` for the unknown-id shell, ``""``
+    for parameterless paths).
+    """
+
+    method: str
+    url_path: str
+    body: Any = None
+    param_expr: str = ""
+
+
+@dataclass(frozen=True)
+class _Behavior:
+    """One behavior shell: its identity, provenance, and invocation plan."""
+
+    behavior_id: str
+    label: str
+    expect_status: int
+    final: _Step
+    probe_id: str = ""
+    prerequisites: tuple[_Step, ...] = field(default=())
+
+
+def _fail_missing_surface(url_path: str, method: str, route_file: str, reason: str) -> None:
+    raise ScaffoldDerivationError(
+        f"the interface manifest declares {method} {url_path}, but the expanded tree "
+        f"{reason} ({route_file}). The generator never reconciles this by inference "
+        f"(SIP-0104 §7): by construction the tree is expand(manifest), so this implies "
+        f"generator-version drift or a mutated workspace."
+    )
+
+
+def _require_surfaces(behaviors: list[_Behavior], expanded: dict[str, str]) -> None:
+    """Every invoked handler must exist in the tree the imports resolve against."""
+    if _STORE_PATH not in expanded:
+        raise ScaffoldDerivationError(
+            f"the expanded tree lacks {_STORE_PATH} — the store seam every shell's "
+            f"lifecycle (beforeEach(reset)) imports. Generator-version drift or a mutated "
+            f"workspace (SIP-0104 §7)."
+        )
+    for behavior in behaviors:
+        for step in (*behavior.prerequisites, behavior.final):
+            route_file = _route_file(step.url_path)
+            content = expanded.get(route_file)
+            if content is None:
+                _fail_missing_surface(step.url_path, step.method, route_file, "has no file")
+            elif f"export async function {step.method}" not in content:
+                _fail_missing_surface(
+                    step.url_path, step.method, route_file, f"does not export {step.method}"
+                )
+
+
+def _classify_probes(probes: list[dict]) -> list[tuple[str, dict]]:
+    """Structurally classify each probe: create / reject / child / duplicate.
+
+    Structural, not id-string, classification (the strings-boundary rule): a rejection twin
+    is guarded by the scaffold; a child touches a parameterized path; a duplicate repeats an
+    earlier child's exact request with a different expectation.
+    """
+    classified: list[tuple[str, dict]] = []
+    seen_child_requests: set[str] = set()
+    for probe in probes:
+        request = probe.get("request", {})
+        key = json.dumps(request, sort_keys=True)
+        if probe.get("guards") == "scaffold":
+            classified.append(("reject", probe))
+        elif "{" in request.get("path", ""):
+            if key in seen_child_requests:
+                classified.append(("duplicate", probe))
+            else:
+                seen_child_requests.add(key)
+                classified.append(("child", probe))
+        else:
+            classified.append(("create", probe))
+    return classified
+
+
+def _behaviors_from_probes(classified: list[tuple[str, dict]]) -> list[_Behavior]:
+    creates_by_path: dict[str, dict] = {}
+    child_successes: list[dict] = []
+    behaviors: list[_Behavior] = []
+
+    def _final(probe: dict, param_expr: str = "") -> _Step:
+        request = probe["request"]
+        return _Step(
+            method=request["method"],
+            url_path=request["path"],
+            body=request.get("json"),
+            param_expr=param_expr,
+        )
+
+    def _chain(request_path: str) -> tuple[_Step, ...]:
+        parent_path = request_path.split("/{", 1)[0]
+        parent = creates_by_path.get(parent_path)
+        if parent is None:
+            # No create to chain from — the behavior is underivable, and underivable
+            # elements are demoted, never guessed (SIP §4.1). Signalled with None below.
+            return ()
+        steps = [_final(parent)]
+        for earlier in child_successes:
+            if earlier["request"]["path"].split("/{", 1)[0] != parent_path:
+                continue
+            steps.append(_final(earlier, param_expr="created.id"))
+        return tuple(steps)
+
+    for kind, probe in classified:
+        request = probe["request"]
+        expect = probe["expect"]["status"]
+        if kind == "create":
+            creates_by_path[request["path"]] = probe
+            label = f"{request['method']} {request['path']} -> {expect}"
+            behaviors.append(
+                _Behavior(
+                    behavior_id=probe["id"],
+                    label=label,
+                    expect_status=expect,
+                    final=_final(probe),
+                    probe_id=probe["id"],
+                )
+            )
+        elif kind == "reject":
+            label = f"{request['method']} {request['path']} blank required fields -> {expect}"
+            behaviors.append(
+                _Behavior(
+                    behavior_id=probe["id"],
+                    label=label,
+                    expect_status=expect,
+                    final=_final(probe),
+                    probe_id=probe["id"],
+                )
+            )
+        else:
+            prerequisites = _chain(request["path"])
+            if not prerequisites:
+                continue  # demoted: no derivable create chain for this child
+            flavor = " duplicate" if kind == "duplicate" else ""
+            # A duplicate's precondition includes its own first, successful firing —
+            # which _chain already appended, because the original child probe was
+            # recorded as a child success before its duplicate is classified.
+            label = f"{request['method']} {request['path']}{flavor} -> {expect}"
+            behaviors.append(
+                _Behavior(
+                    behavior_id=probe["id"],
+                    label=label,
+                    expect_status=expect,
+                    final=_final(probe, param_expr="created.id"),
+                    probe_id=probe["id"],
+                    prerequisites=prerequisites,
+                )
+            )
+            if kind == "child":
+                child_successes.append(probe)
+    return behaviors
+
+
+def _minted_read_behaviors(
+    manifest: InterfaceManifest, creates_by_path: dict[str, dict]
+) -> list[_Behavior]:
+    """GET shells the probe set does not carry: collection reads and reads-by-id."""
+    error_http = {
+        c.code: c.http
+        for c in (manifest.api.error_contract.codes if manifest.api.error_contract else ())
+    }
+    entity_fields = {e.name: {f.name for f in e.fields} for e in manifest.entities}
+    endpoints = {(ep.method, ep.path): ep for ep in manifest.api.endpoints}
+    behaviors: list[_Behavior] = []
+    for ep in manifest.api.endpoints:
+        if ep.method != "GET":
+            continue
+        placeholders = _placeholders(ep.path)
+        expect = ep.success_status or 200
+        if not placeholders:
+            behaviors.append(
+                _Behavior(
+                    behavior_id=f"vs-get-{_slug(ep.path) or 'root'}",
+                    label=f"GET {ep.path} -> {expect}",
+                    expect_status=expect,
+                    final=_Step(method="GET", url_path=ep.path),
+                )
+            )
+            continue
+        if len(placeholders) != 1:
+            continue  # multi-parameter reads are not derivable in v1 — demoted
+        parent_path = ep.path.split("/{", 1)[0]
+        create_probe = creates_by_path.get(parent_path)
+        parent_ep = endpoints.get(("POST", parent_path))
+        parent_entity = getattr(parent_ep, "response", "") if parent_ep else ""
+        if create_probe is None or "id" not in entity_fields.get(parent_entity or "", set()):
+            continue  # no derivable create chain — demoted
+        create_step = _Step(
+            method="POST",
+            url_path=create_probe["request"]["path"],
+            body=create_probe["request"].get("json"),
+        )
+        behaviors.append(
+            _Behavior(
+                behavior_id=f"vs-get-{_slug(ep.path) or 'root'}",
+                label=f"GET {ep.path} -> {expect}",
+                expect_status=expect,
+                final=_Step(method="GET", url_path=ep.path, param_expr="created.id"),
+                prerequisites=(create_step,),
+            )
+        )
+        if any(error_http.get(code) == 404 for code in ep.errors):
+            behaviors.append(
+                _Behavior(
+                    behavior_id=f"vs-get-{_slug(ep.path) or 'root'}-not-found",
+                    label=f"GET {ep.path} unknown id -> 404",
+                    expect_status=404,
+                    final=_Step(method="GET", url_path=ep.path, param_expr="'missing'"),
+                )
+            )
+    return behaviors
+
+
+# --------------------------------------------------------------------------- rendering
+
+
+def _url_expr(step: _Step) -> str:
+    """The Request URL for a step: a plain string, or a template literal for chained ids."""
+    placeholders = _placeholders(step.url_path)
+    if not placeholders:
+        return f"'{_URL_BASE}{step.url_path}'"
+    name = placeholders[0]
+    if step.param_expr == "created.id":
+        return "`" + _URL_BASE + step.url_path.replace("{" + name + "}", "${created.id}") + "`"
+    literal = step.param_expr.strip("'")
+    return f"'{_URL_BASE}{step.url_path.replace('{' + name + '}', literal)}'"
+
+
+def _invocation_lines(step: _Step, assign: str) -> list[str]:
+    """One handler invocation, rendered exactly as the execution model teaches (#877)."""
+    alias = _alias(_route_file(step.url_path))
+    placeholders = _placeholders(step.url_path)
+    open_line = f"{assign}await ({alias}.{step.method} as Handler)("
+    if step.body is not None:
+        request_lines = [
+            f"      new Request({_url_expr(step)}, {{",
+            f"        method: '{step.method}',",
+            "        headers: { 'content-type': 'application/json' },",
+            f"        body: JSON.stringify({json.dumps(step.body)}),",
+            "      }),",
+        ]
+    else:
+        request_lines = [f"      new Request({_url_expr(step)}),"]
+    lines = [f"    {open_line}", *request_lines]
+    if placeholders:
+        lines.append(f"      {{ params: {{ {placeholders[0]}: {step.param_expr} }} }},")
+    lines.append("    )")
+    return lines
+
+
+def _shell_source(behavior: _Behavior) -> str:
+    """Render one behavior shell file: frozen spine plus one empty fill slot."""
+    route_files = list(
+        dict.fromkeys(
+            _route_file(step.url_path) for step in (*behavior.prerequisites, behavior.final)
+        )
+    )
+    slot_id = f"slot-{behavior.behavior_id}"
+    lines = [
+        "// Deterministic verification scaffold (SIP-0104). GENERATED — DO NOT EDIT.",
+        "// The spine — placement, imports, lifecycle, invocation, status assertion — is",
+        "// frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.",
+        "import { beforeEach, describe, expect, it } from 'vitest'",
+        "import { reset } from '@/lib/store'",
+    ]
+    for route_file in route_files:
+        module = route_file.removesuffix(".ts")
+        lines.append(f"import * as {_alias(route_file)} from '@/{module}'")
+    lines += [
+        "",
+        "type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response",
+        "",
+        "beforeEach(() => reset())",
+        "",
+        f"describe('scaffold: {behavior.final.method} {behavior.final.url_path}', () => {{",
+        f"  it('{behavior.label} [{behavior.behavior_id}]', async () => {{",
+    ]
+    for index, step in enumerate(behavior.prerequisites):
+        if index == 0:
+            lines += _invocation_lines(step, assign="const createRes = ")
+            lines.append("    const created: any = await createRes.json().catch(() => ({}))")
+        else:
+            lines += _invocation_lines(step, assign="")
+    lines += _invocation_lines(behavior.final, assign="const res = ")
+    lines += [
+        f"    expect(res.status).toBe({behavior.expect_status})",
+        "    const body: any = await res.json().catch(() => ({}))",
+        f"    {slot_begin_marker(slot_id)}",
+        "    // FILL (qa): domain assertions for this behavior — response values and store",
+        "    // effects beyond the declared status. `body` is the parsed response JSON.",
+        "    void body",
+        f"    {slot_end_marker(slot_id)}",
+        "  })",
+        "})",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def emit_nextjs_ts_verification_scaffold(
+    manifest: InterfaceManifest, expanded: list[dict[str, str]]
+) -> list[tuple[str, str, tuple[BehaviorSlot, ...]]]:
+    """The stack-#2 behavior shells: ``(path, content, slots)`` per emitted file.
+
+    One behavior per file, so a degraded fill degrades one slot's file and attribution
+    stays per-behavior. Deterministic order: probe twins in probe order, then minted read
+    shells in endpoint declaration order.
+    """
+    from squadops.capabilities.scaffold_contract import emit_contract_dict
+
+    contract = emit_contract_dict(manifest)
+    probes = contract["behavioral"]["probes"]
+    classified = _classify_probes(probes)
+    behaviors = _behaviors_from_probes(classified)
+    creates_by_path = {
+        probe["request"]["path"]: probe for kind, probe in classified if kind == "create"
+    }
+    behaviors += _minted_read_behaviors(manifest, creates_by_path)
+
+    tree = {f["name"]: f["content"] for f in expanded}
+    _require_surfaces(behaviors, tree)
+
+    alias_owners: dict[str, str] = {}
+    for behavior in behaviors:
+        for step in (*behavior.prerequisites, behavior.final):
+            route_file = _route_file(step.url_path)
+            owner = alias_owners.setdefault(_alias(route_file), route_file)
+            if owner != route_file:
+                raise ScaffoldDerivationError(
+                    f"route files {owner!r} and {route_file!r} derive the same import alias "
+                    f"{_alias(route_file)!r} — the generator cannot emit unambiguous imports "
+                    f"for this manifest."
+                )
+
+    emitted: list[tuple[str, str, tuple[BehaviorSlot, ...]]] = []
+    for behavior in behaviors:
+        slot = BehaviorSlot(
+            slot_id=f"slot-{behavior.behavior_id}",
+            behavior=behavior.label,
+            probe_id=behavior.probe_id,
+            criterion_ids=(behavior.probe_id,) if behavior.probe_id else (),
+        )
+        path = f"{SCAFFOLD_TEST_DIR}/{behavior.behavior_id}.scaffold.test.ts"
+        emitted.append((path, _shell_source(behavior), (slot,)))
+    return emitted

--- a/src/squadops/capabilities/verification_scaffold.py
+++ b/src/squadops/capabilities/verification_scaffold.py
@@ -32,7 +32,7 @@ line)::
 
 ``slot-<id>`` must match ``slot-[a-z0-9][a-z0-9-]*``. Structure rules, enforced by
 :func:`parse_slot_regions`: begin/end ids must match; no nesting; no duplicate slot id in a
-file (cross-file uniqueness is :meth:`TestScaffoldManifest.lint`'s job); no unclosed region.
+file (cross-file uniqueness is :meth:`VerificationScaffoldManifest.lint`'s job); no unclosed region.
 A line that *mentions* ``[scaffold-slot:`` without being a well-formed marker is an error,
 not spine text — a typo'd marker silently frozen into the spine would freeze the author's
 slot shut.
@@ -82,7 +82,7 @@ from dataclasses import dataclass, field
 
 #: Schema version of the test-scaffold manifest this module defines. Bumped when the
 #: manifest's shape changes; the generator's own version lives with the generator.
-TEST_SCAFFOLD_MANIFEST_VERSION = 1
+SCAFFOLD_MANIFEST_VERSION = 1
 
 #: The order authoritative sources are consulted, and the order disagreements are named in.
 DERIVATION_PRECEDENCE = ("interface_manifest", "criteria_pack", "expanded_tree")
@@ -270,7 +270,7 @@ class BehaviorSlot:
 
 
 @dataclass(frozen=True)
-class TestScaffoldFile:
+class VerificationScaffoldFile:
     """One emitted scaffold file: full-content hash, spine hash, and its slots."""
 
     path: str
@@ -287,7 +287,7 @@ class TestScaffoldFile:
         }
 
     @classmethod
-    def from_dict(cls, d: Mapping) -> TestScaffoldFile:
+    def from_dict(cls, d: Mapping) -> VerificationScaffoldFile:
         return cls(
             path=d["path"],
             content_hash=d["content_hash"],
@@ -298,7 +298,7 @@ class TestScaffoldFile:
 
 def build_scaffold_file(
     path: str, content: str, slots: tuple[BehaviorSlot, ...]
-) -> TestScaffoldFile:
+) -> VerificationScaffoldFile:
     """Pin one emitted file: hashes computed here so generator and validator cannot drift.
 
     ``slots`` supply provenance (behavior, probe/criterion bindings); their region bounds
@@ -323,7 +323,7 @@ def build_scaffold_file(
         )
         for s in slots
     )
-    return TestScaffoldFile(
+    return VerificationScaffoldFile(
         path=path,
         content_hash=_sha256(content),
         spine_hash=spine_hash(content),
@@ -332,7 +332,7 @@ def build_scaffold_file(
 
 
 @dataclass(frozen=True)
-class TestScaffoldManifest:
+class VerificationScaffoldManifest:
     """The scaffold manifest: what the generator emitted, pinned for diagnosis (SIP §4.3).
 
     Everything violation attribution needs (module docstring), nothing more. Aggregates are
@@ -346,7 +346,7 @@ class TestScaffoldManifest:
     interface_manifest_hash: str
     criteria_pack: str
     expanded_tree_hash: str
-    files: tuple[TestScaffoldFile, ...] = field(default=())
+    files: tuple[VerificationScaffoldFile, ...] = field(default=())
 
     def aggregate_spine_hash(self) -> str:
         """SHA-256 over sorted ``path:spine_hash`` lines — the frozen spine's identity."""
@@ -359,7 +359,7 @@ class TestScaffoldManifest:
     def slot_ids(self) -> tuple[str, ...]:
         return tuple(s.slot_id for f in self.files for s in f.slots)
 
-    def find_slot(self, slot_id: str) -> tuple[TestScaffoldFile, BehaviorSlot] | None:
+    def find_slot(self, slot_id: str) -> tuple[VerificationScaffoldFile, BehaviorSlot] | None:
         for f in self.files:
             for s in f.slots:
                 if s.slot_id == slot_id:
@@ -375,10 +375,10 @@ class TestScaffoldManifest:
         and no reason to exist), and a version this schema does not define.
         """
         findings: list[str] = []
-        if self.scaffold_manifest_version != TEST_SCAFFOLD_MANIFEST_VERSION:
+        if self.scaffold_manifest_version != SCAFFOLD_MANIFEST_VERSION:
             findings.append(
                 f"scaffold_manifest_version {self.scaffold_manifest_version} != "
-                f"{TEST_SCAFFOLD_MANIFEST_VERSION} (this schema)"
+                f"{SCAFFOLD_MANIFEST_VERSION} (this schema)"
             )
         seen: dict[str, str] = {}
         for f in self.files:
@@ -407,7 +407,7 @@ class TestScaffoldManifest:
         }
 
     @classmethod
-    def from_dict(cls, d: Mapping) -> TestScaffoldManifest:
+    def from_dict(cls, d: Mapping) -> VerificationScaffoldManifest:
         """Load a stored manifest. Stored aggregates are *verified*, not trusted: a record
         whose derived hashes disagree with its own file table has been hand-edited, and
         loading it quietly would launder the edit into an authority."""
@@ -418,7 +418,7 @@ class TestScaffoldManifest:
             interface_manifest_hash=d["interface_manifest_hash"],
             criteria_pack=d["criteria_pack"],
             expanded_tree_hash=d["expanded_tree_hash"],
-            files=tuple(TestScaffoldFile.from_dict(f) for f in d.get("files", ())),
+            files=tuple(VerificationScaffoldFile.from_dict(f) for f in d.get("files", ())),
         )
         for key, derived in (
             ("aggregate_spine_hash", manifest.aggregate_spine_hash()),

--- a/src/squadops/capabilities/verification_scaffold.py
+++ b/src/squadops/capabilities/verification_scaffold.py
@@ -1,0 +1,433 @@
+"""The test-scaffold contract — SIP-0104 Phase 1, the artifact's definition (not its generator).
+
+This module is the **scaffold contract**: the schema of the test-scaffold manifest, the slot
+marker grammar, the frozen-spine hash canonicalization, and the derivation-source precedence.
+It deliberately lands before any emission code exists, so the generator is written *against*
+a contract rather than becoming the de facto specification (the SIP-0104 plan's Phase 1
+ordering rule).
+
+Placement: capabilities, beside ``scaffold_contract`` — the emission surface. The cycles
+domain (region enforcement, P4; evidence, P5) imports *this* module for the canonicalization,
+the same direction ``bound_scaffold_record`` already imports ``scaffold``. Nothing here
+imports the cycles domain.
+
+## Vocabulary
+
+- **Behavior shell**: one deterministic unit of required coverage — the invocation mechanics
+  and contract-derived status assertion for one behavior, pre-written and frozen (SIP §4.1).
+- **Fill slot**: the single mutable region inside a shell, delimited by slot markers, where
+  the qa author supplies domain assertions. Distinct from the dev-side ``fill_slots`` of
+  ``ScaffoldStack`` (whole files a dev fills); a test-scaffold slot is a *region*.
+- **Spine**: everything in a scaffold file that is not a slot body — including the marker
+  lines themselves. The spine is frozen; slot bodies are mutable.
+
+## Slot marker grammar (normative)
+
+A slot is delimited by two full lines (leading whitespace permitted, nothing else on the
+line)::
+
+    // [scaffold-slot:begin slot-<id>]
+    ... mutable body lines ...
+    // [scaffold-slot:end slot-<id>]
+
+``slot-<id>`` must match ``slot-[a-z0-9][a-z0-9-]*``. Structure rules, enforced by
+:func:`parse_slot_regions`: begin/end ids must match; no nesting; no duplicate slot id in a
+file (cross-file uniqueness is :meth:`TestScaffoldManifest.lint`'s job); no unclosed region.
+A line that *mentions* ``[scaffold-slot:`` without being a well-formed marker is an error,
+not spine text — a typo'd marker silently frozen into the spine would freeze the author's
+slot shut.
+
+## Frozen-spine hash canonicalization (normative)
+
+1. Scaffold files are UTF-8 with ``\\n`` newlines only; a CRLF rewrite is a spine mutation.
+2. A slot *body* is the lines strictly between a begin marker line and its end marker line.
+3. The spine text is the file's lines with every slot body's lines removed, all other lines
+   (markers included) kept verbatim in order, joined with ``\\n``.
+4. ``spine_hash`` is the SHA-256 hex digest of the spine text encoded as UTF-8.
+5. A file whose slot structure does not parse has **no** spine hash — malformed structure is
+   a violation in itself, never hashed around.
+
+Consequence: editing a slot body never moves the spine hash; moving/removing a marker,
+enlarging a region, injecting a statement outside a slot, or editing an import all do. This
+is the v1 hash-sufficiency mechanism; AST-level verification is the named escalation on
+evidence that the adversarial corpus (P4) shows hashing misses (SIP §4.3).
+
+## Derivation-source precedence (normative)
+
+Every frozen element derives from authoritative facts in this precedence::
+
+    interface manifest  →  criteria pack  →  expanded tree
+
+The generator never reconciles a disagreement between sources by inference: a manifest that
+declares a behavior whose implementation surface the expanded tree lacks fails generation as
+a :class:`ScaffoldDerivationError` naming both sides (SIP §7). An element no source can
+derive is demoted to fill content, never frozen as a guess (SIP §4.1, #874).
+
+## Attribution (why the manifest carries what it carries)
+
+A later hash mismatch must be attributable, not just detectable (plan §P1). The manifest
+therefore records the structural facts diagnosis needs: ``generator_version`` +
+``interface_manifest_hash`` (regenerate and compare → **generator drift**),
+``expanded_tree_hash`` (the tree imports were resolved against → **workspace mutation**),
+and per-file ``content_hash``/``spine_hash`` with slot region bounds (stored emission vs.
+record → **producer edit**, and *which region*).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+
+#: Schema version of the test-scaffold manifest this module defines. Bumped when the
+#: manifest's shape changes; the generator's own version lives with the generator.
+TEST_SCAFFOLD_MANIFEST_VERSION = 1
+
+#: The order authoritative sources are consulted, and the order disagreements are named in.
+DERIVATION_PRECEDENCE = ("interface_manifest", "criteria_pack", "expanded_tree")
+
+_SLOT_ID_RE = re.compile(r"^slot-[a-z0-9][a-z0-9-]*$")
+_MARKER_RE = re.compile(
+    r"^\s*// \[scaffold-slot:(?P<kind>begin|end) (?P<slot_id>slot-[a-z0-9][a-z0-9-]*)\]\s*$"
+)
+#: Near-miss detector: any mention of the marker vocabulary that is not a well-formed marker.
+_MARKER_MENTION = "[scaffold-slot:"
+
+
+class ScaffoldSpineError(Exception):
+    """A scaffold file's slot structure is malformed (unparseable markers, nesting, dupes)."""
+
+
+class ScaffoldDerivationError(Exception):
+    """Authoritative sources disagree, or a required source is missing — generation refuses.
+
+    Never raised for an element that is merely *underivable*: those are demoted to fill
+    content. Raised when sources *contradict* (manifest declares a surface the tree lacks),
+    which per SIP §7 implies generator-version drift or a mutated workspace — the message
+    names which sources disagree.
+    """
+
+
+class ScaffoldValidationError(Exception):
+    """An emitted scaffold does not match its own manifest — a generator defect, caught
+    before the scaffold can become the run's qa artifact (scaffold-invalid, SIP §5)."""
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def slot_begin_marker(slot_id: str) -> str:
+    """The exact begin-marker line for ``slot_id`` (no indentation, no trailing newline)."""
+    _require_slot_id(slot_id)
+    return f"// [scaffold-slot:begin {slot_id}]"
+
+
+def slot_end_marker(slot_id: str) -> str:
+    """The exact end-marker line for ``slot_id``."""
+    _require_slot_id(slot_id)
+    return f"// [scaffold-slot:end {slot_id}]"
+
+
+def _require_slot_id(slot_id: str) -> None:
+    if not _SLOT_ID_RE.match(slot_id):
+        raise ValueError(
+            f"invalid slot id {slot_id!r}: must match {_SLOT_ID_RE.pattern!r} "
+            f"(kebab-case, 'slot-' prefix)"
+        )
+
+
+@dataclass(frozen=True)
+class SlotRegion:
+    """One parsed slot region: 1-indexed line numbers of the two marker lines."""
+
+    slot_id: str
+    begin_line: int
+    end_line: int
+
+
+def parse_slot_regions(text: str) -> tuple[SlotRegion, ...]:
+    """Parse the slot regions of a scaffold file, or raise :class:`ScaffoldSpineError`.
+
+    Enforces the structure rules of the marker grammar (module docstring). Line numbers
+    are 1-indexed and name the *marker* lines, matching how region bounds are recorded in
+    the manifest.
+    """
+    regions: list[SlotRegion] = []
+    seen: set[str] = set()
+    open_id: str | None = None
+    open_line = 0
+    for lineno, line in enumerate(text.split("\n"), start=1):
+        match = _MARKER_RE.match(line)
+        if match is None:
+            if _MARKER_MENTION in line:
+                raise ScaffoldSpineError(
+                    f"line {lineno} mentions {_MARKER_MENTION!r} but is not a well-formed "
+                    f"slot marker: {line.strip()!r}. A malformed marker must fail, not be "
+                    f"frozen into the spine."
+                )
+            continue
+        kind, slot_id = match.group("kind"), match.group("slot_id")
+        if kind == "begin":
+            if open_id is not None:
+                raise ScaffoldSpineError(
+                    f"line {lineno}: begin marker for {slot_id!r} while {open_id!r} "
+                    f"(opened line {open_line}) is still open — slots cannot nest."
+                )
+            if slot_id in seen:
+                raise ScaffoldSpineError(
+                    f"line {lineno}: duplicate slot id {slot_id!r} in one file."
+                )
+            open_id, open_line = slot_id, lineno
+        else:
+            if open_id is None:
+                raise ScaffoldSpineError(
+                    f"line {lineno}: end marker for {slot_id!r} with no open slot."
+                )
+            if slot_id != open_id:
+                raise ScaffoldSpineError(
+                    f"line {lineno}: end marker for {slot_id!r} does not match open slot "
+                    f"{open_id!r} (opened line {open_line})."
+                )
+            regions.append(SlotRegion(slot_id=slot_id, begin_line=open_line, end_line=lineno))
+            seen.add(slot_id)
+            open_id = None
+    if open_id is not None:
+        raise ScaffoldSpineError(f"slot {open_id!r} (opened line {open_line}) is never closed.")
+    return tuple(regions)
+
+
+def elide_slot_bodies(text: str) -> str:
+    """The canonical spine text: every slot body removed, markers and all else kept.
+
+    Raises :class:`ScaffoldSpineError` on malformed structure — a file that does not parse
+    has no spine (canonicalization rule 5).
+    """
+    regions = parse_slot_regions(text)
+    body_lines: set[int] = set()
+    for region in regions:
+        body_lines.update(range(region.begin_line + 1, region.end_line))
+    kept = [
+        line for lineno, line in enumerate(text.split("\n"), start=1) if lineno not in body_lines
+    ]
+    return "\n".join(kept)
+
+
+def spine_hash(text: str) -> str:
+    """SHA-256 of the canonical spine text (canonicalization rules 1–5)."""
+    return _sha256(elide_slot_bodies(text))
+
+
+def expanded_tree_hash(files: Iterable[Mapping[str, str]]) -> str:
+    """Identity of an expanded skeleton: SHA-256 over sorted ``path:sha256(content)`` lines.
+
+    Sorted by path so the hash names the tree as a *set* of files, independent of emission
+    order. Recorded in the manifest as the tree imports were resolved against, so a later
+    disagreement is attributable to workspace mutation vs. generator drift.
+    """
+    lines = sorted(f"{f['name']}:{_sha256(f['content'])}" for f in files)
+    return _sha256("\n".join(lines))
+
+
+@dataclass(frozen=True)
+class BehaviorSlot:
+    """One behavior shell's identity and its fill slot's provenance + region bounds.
+
+    ``probe_id`` binds the shell to the contract probe it mirrors (``""`` for shells the
+    generator mints beyond the probe set — their identity is the slot id itself);
+    ``criterion_ids`` carry any bound contract criteria. Region bounds are 1-indexed marker
+    lines in the *emitted* (empty-fill) file.
+    """
+
+    slot_id: str
+    behavior: str
+    probe_id: str = ""
+    criterion_ids: tuple[str, ...] = ()
+    begin_line: int = 0
+    end_line: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "slot_id": self.slot_id,
+            "behavior": self.behavior,
+            "probe_id": self.probe_id,
+            "criterion_ids": list(self.criterion_ids),
+            "begin_line": self.begin_line,
+            "end_line": self.end_line,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Mapping) -> BehaviorSlot:
+        return cls(
+            slot_id=d["slot_id"],
+            behavior=d["behavior"],
+            probe_id=d.get("probe_id", ""),
+            criterion_ids=tuple(d.get("criterion_ids", ())),
+            begin_line=d.get("begin_line", 0),
+            end_line=d.get("end_line", 0),
+        )
+
+
+@dataclass(frozen=True)
+class TestScaffoldFile:
+    """One emitted scaffold file: full-content hash, spine hash, and its slots."""
+
+    path: str
+    content_hash: str
+    spine_hash: str
+    slots: tuple[BehaviorSlot, ...] = ()
+
+    def to_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "content_hash": self.content_hash,
+            "spine_hash": self.spine_hash,
+            "slots": [s.to_dict() for s in self.slots],
+        }
+
+    @classmethod
+    def from_dict(cls, d: Mapping) -> TestScaffoldFile:
+        return cls(
+            path=d["path"],
+            content_hash=d["content_hash"],
+            spine_hash=d["spine_hash"],
+            slots=tuple(BehaviorSlot.from_dict(s) for s in d.get("slots", ())),
+        )
+
+
+def build_scaffold_file(
+    path: str, content: str, slots: tuple[BehaviorSlot, ...]
+) -> TestScaffoldFile:
+    """Pin one emitted file: hashes computed here so generator and validator cannot drift.
+
+    ``slots`` supply provenance (behavior, probe/criterion bindings); their region bounds
+    are *recomputed from the content* and must agree with the parsed structure — a slot the
+    content lacks, or a parsed region no slot claims, is a :class:`ScaffoldValidationError`.
+    """
+    regions = {r.slot_id: r for r in parse_slot_regions(content)}
+    declared = {s.slot_id for s in slots}
+    if set(regions) != declared:
+        raise ScaffoldValidationError(
+            f"{path}: declared slots {sorted(declared)} != parsed regions {sorted(regions)} — "
+            f"the generator's slot table and its emitted content disagree."
+        )
+    bounded = tuple(
+        BehaviorSlot(
+            slot_id=s.slot_id,
+            behavior=s.behavior,
+            probe_id=s.probe_id,
+            criterion_ids=s.criterion_ids,
+            begin_line=regions[s.slot_id].begin_line,
+            end_line=regions[s.slot_id].end_line,
+        )
+        for s in slots
+    )
+    return TestScaffoldFile(
+        path=path,
+        content_hash=_sha256(content),
+        spine_hash=spine_hash(content),
+        slots=bounded,
+    )
+
+
+@dataclass(frozen=True)
+class TestScaffoldManifest:
+    """The scaffold manifest: what the generator emitted, pinned for diagnosis (SIP §4.3).
+
+    Everything violation attribution needs (module docstring), nothing more. Aggregates are
+    derived from per-file hashes and exposed as methods rather than stored fields — a stored
+    aggregate is one more thing a hand edit can make disagree with itself.
+    """
+
+    scaffold_manifest_version: int
+    generator_version: int
+    stack: str
+    interface_manifest_hash: str
+    criteria_pack: str
+    expanded_tree_hash: str
+    files: tuple[TestScaffoldFile, ...] = field(default=())
+
+    def aggregate_spine_hash(self) -> str:
+        """SHA-256 over sorted ``path:spine_hash`` lines — the frozen spine's identity."""
+        return _sha256("\n".join(sorted(f"{f.path}:{f.spine_hash}" for f in self.files)))
+
+    def scaffold_hash(self) -> str:
+        """SHA-256 over sorted ``path:content_hash`` lines — the whole emission's identity."""
+        return _sha256("\n".join(sorted(f"{f.path}:{f.content_hash}" for f in self.files)))
+
+    def slot_ids(self) -> tuple[str, ...]:
+        return tuple(s.slot_id for f in self.files for s in f.slots)
+
+    def find_slot(self, slot_id: str) -> tuple[TestScaffoldFile, BehaviorSlot] | None:
+        for f in self.files:
+            for s in f.slots:
+                if s.slot_id == slot_id:
+                    return f, s
+        return None
+
+    def lint(self) -> list[str]:
+        """Cross-file structural findings; empty when clean.
+
+        Catches what per-file parsing cannot: a slot id claimed by two files (the merge
+        layer addresses fills by slot id alone — P3 — so a duplicate would make addressing
+        ambiguous), a file with no slots (a shell-less scaffold file has no author surface
+        and no reason to exist), and a version this schema does not define.
+        """
+        findings: list[str] = []
+        if self.scaffold_manifest_version != TEST_SCAFFOLD_MANIFEST_VERSION:
+            findings.append(
+                f"scaffold_manifest_version {self.scaffold_manifest_version} != "
+                f"{TEST_SCAFFOLD_MANIFEST_VERSION} (this schema)"
+            )
+        seen: dict[str, str] = {}
+        for f in self.files:
+            if not f.slots:
+                findings.append(f"{f.path}: scaffold file with no behavior slots")
+            for s in f.slots:
+                if s.slot_id in seen:
+                    findings.append(
+                        f"duplicate slot id {s.slot_id!r} in {f.path} and {seen[s.slot_id]}"
+                    )
+                else:
+                    seen[s.slot_id] = f.path
+        return findings
+
+    def to_dict(self) -> dict:
+        return {
+            "scaffold_manifest_version": self.scaffold_manifest_version,
+            "generator_version": self.generator_version,
+            "stack": self.stack,
+            "interface_manifest_hash": self.interface_manifest_hash,
+            "criteria_pack": self.criteria_pack,
+            "expanded_tree_hash": self.expanded_tree_hash,
+            "aggregate_spine_hash": self.aggregate_spine_hash(),
+            "scaffold_hash": self.scaffold_hash(),
+            "files": [f.to_dict() for f in self.files],
+        }
+
+    @classmethod
+    def from_dict(cls, d: Mapping) -> TestScaffoldManifest:
+        """Load a stored manifest. Stored aggregates are *verified*, not trusted: a record
+        whose derived hashes disagree with its own file table has been hand-edited, and
+        loading it quietly would launder the edit into an authority."""
+        manifest = cls(
+            scaffold_manifest_version=d["scaffold_manifest_version"],
+            generator_version=d["generator_version"],
+            stack=d["stack"],
+            interface_manifest_hash=d["interface_manifest_hash"],
+            criteria_pack=d["criteria_pack"],
+            expanded_tree_hash=d["expanded_tree_hash"],
+            files=tuple(TestScaffoldFile.from_dict(f) for f in d.get("files", ())),
+        )
+        for key, derived in (
+            ("aggregate_spine_hash", manifest.aggregate_spine_hash()),
+            ("scaffold_hash", manifest.scaffold_hash()),
+        ):
+            stored = d.get(key)
+            if stored is not None and stored != derived:
+                raise ScaffoldValidationError(
+                    f"stored {key} {stored!r} disagrees with the manifest's own file table "
+                    f"({derived!r}) — the record has been mutated."
+                )
+        return manifest

--- a/src/squadops/capabilities/verification_scaffold_emission.py
+++ b/src/squadops/capabilities/verification_scaffold_emission.py
@@ -1,0 +1,165 @@
+"""Test-scaffold emission — the generator behind the SIP-0104 contract.
+
+Stack-neutral orchestration: resolve the stack's opt-in, run its shell emitter, pin the
+result into a ``VerificationScaffoldManifest``, and validate the emission against its own record
+before anything downstream may treat it as the run's qa artifact (the lifecycle rule:
+expand → emit → **validate** → persist → expose).
+
+Opt-in follows ``ScaffoldStack.verification_scaffold`` (SIP §8: explicit, all-or-nothing): an
+unset field means the stack has not opted in and callers *skip* — qa authors exactly as
+today, which is safe-and-visible. A set field naming an unregistered emitter means the two
+registries disagree — the #838 class — and emission refuses loudly. Asking this module to
+emit for an unopted stack is also a refusal: the caller has contradicted the registry.
+
+``GENERATOR_VERSION`` names the emission behavior. Any change that can move a single
+emitted byte — templates, inventory rules, ordering — MUST bump it: the byte-equivalence
+pin holds per generator version, and enforcement attributes hash mismatches to generator
+drift by exactly this number (SIP §4.3).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import yaml
+
+from squadops.capabilities.scaffold import (
+    criteria_pack_for,
+    expand,
+    qa_test_namespace,
+    verification_scaffold_for,
+)
+from squadops.capabilities.stack_nextjs_ts import STACK_NAME as _NEXTJS_TS_NAME
+from squadops.capabilities.stack_nextjs_ts_tests import emit_nextjs_ts_verification_scaffold
+from squadops.capabilities.verification_scaffold import (
+    SCAFFOLD_MANIFEST_VERSION,
+    BehaviorSlot,
+    ScaffoldDerivationError,
+    ScaffoldValidationError,
+    VerificationScaffoldManifest,
+    build_scaffold_file,
+    expanded_tree_hash,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - annotations only
+    from squadops.capabilities.scaffold import InterfaceManifest
+
+#: Bump on ANY emission-affecting change (module docstring). Recorded in every manifest.
+GENERATOR_VERSION = 1
+
+#: The stored manifest artifact's filename (the executor persists it beside the contract).
+VERIFICATION_SCAFFOLD_MANIFEST_FILENAME = "verification_scaffold_manifest.yaml"
+VERIFICATION_SCAFFOLD_MANIFEST_ARTIFACT_TYPE = "verification_scaffold_manifest"
+
+#: stack-emitter registry, reached ONLY via ``ScaffoldStack.verification_scaffold`` — the explicit
+#: field the stack-inventory test enumerates, never name convention.
+_EMITTERS: dict[
+    str,
+    Callable[
+        [InterfaceManifest, list[dict[str, str]]], list[tuple[str, str, tuple[BehaviorSlot, ...]]]
+    ],
+] = {
+    _NEXTJS_TS_NAME: emit_nextjs_ts_verification_scaffold,
+}
+
+
+@dataclass(frozen=True)
+class VerificationScaffoldEmission:
+    """One validated-emittable scaffold: the files, their manifest, and its artifact text."""
+
+    files: tuple[dict[str, str], ...]
+    manifest: VerificationScaffoldManifest
+    manifest_yaml: str
+
+
+def emit_verification_scaffold(
+    manifest: InterfaceManifest, *, expanded: list[dict[str, str]] | None = None
+) -> VerificationScaffoldEmission:
+    """Emit the test scaffold for ``manifest``'s stack, deterministically.
+
+    ``expanded`` is the tree imports resolve against; by default the expander's own output.
+    It is injectable because *disagreement between the manifest and the tree is a defect
+    this generator must refuse on* (SIP §7) — enforcement and the mutation tests hand in
+    the tree they actually observed.
+    """
+    declared = verification_scaffold_for(manifest.stack)
+    if not declared:
+        raise ScaffoldDerivationError(
+            f"stack {manifest.stack!r} declares no verification_scaffold — it has not opted in "
+            f"(SIP-0104 §8). Callers gate on verification_scaffold_for() and skip; asking for "
+            f"emission anyway contradicts the registry."
+        )
+    emitter = _EMITTERS.get(declared)
+    if emitter is None:
+        raise ScaffoldDerivationError(
+            f"stack {manifest.stack!r} names verification_scaffold {declared!r}, which is not "
+            f"registered (known: {sorted(_EMITTERS)}). The two registries disagree — "
+            f"register the emitter or remove the declaration; never fall back."
+        )
+    tree = expanded if expanded is not None else expand(manifest)
+    shells = emitter(manifest, tree)
+
+    namespace = qa_test_namespace(manifest)
+    for path, _content, _slots in shells:
+        if not any(path.startswith(prefix) for prefix in namespace):
+            raise ScaffoldValidationError(
+                f"emitted scaffold file {path!r} lies outside the stack's qa test "
+                f"namespace {namespace} — the scaffold must live where qa files are "
+                f"authorized to live (SIP-0100 D1)."
+            )
+
+    record = VerificationScaffoldManifest(
+        scaffold_manifest_version=SCAFFOLD_MANIFEST_VERSION,
+        generator_version=GENERATOR_VERSION,
+        stack=manifest.stack,
+        interface_manifest_hash=manifest.content_hash(),
+        criteria_pack=criteria_pack_for(manifest.stack),
+        expanded_tree_hash=expanded_tree_hash(tree),
+        files=tuple(build_scaffold_file(path, content, slots) for path, content, slots in shells),
+    )
+    emission = VerificationScaffoldEmission(
+        files=tuple({"name": path, "content": content} for path, content, _ in shells),
+        manifest=record,
+        manifest_yaml=_manifest_yaml(record),
+    )
+    validate_emission(emission)
+    return emission
+
+
+def _manifest_yaml(record: VerificationScaffoldManifest) -> str:
+    header = (
+        "# Test-scaffold manifest — emitted by the scaffold generator (SIP-0104).\n"
+        "# The frozen-spine record region enforcement verifies against; regenerate with\n"
+        "# the generator, never hand-edit (a tampered record refuses to load).\n"
+    )
+    return header + yaml.safe_dump(record.to_dict(), sort_keys=False, default_flow_style=False)
+
+
+def validate_emission(emission: VerificationScaffoldEmission) -> None:
+    """The P1 validity gate: the emission must match its own manifest, structurally.
+
+    Catches generator defects (scaffold-invalid, SIP §5) before persistence: a slot table
+    disagreeing with emitted content, hash drift between record and bytes, and cross-file
+    slot collisions (namespace placement is refused at emission). P2 extends this gate with
+    execution-readiness (imports resolve, shells run against the skeleton); nothing may
+    weaken it back below this floor.
+    """
+    recorded = {f.path: f for f in emission.manifest.files}
+    emitted = {f["name"]: f["content"] for f in emission.files}
+    if set(recorded) != set(emitted):
+        raise ScaffoldValidationError(
+            f"manifest records files {sorted(recorded)} but the emission carries "
+            f"{sorted(emitted)} — the generator's record and output disagree."
+        )
+    for path, content in emitted.items():
+        rebuilt = build_scaffold_file(path, content, recorded[path].slots)
+        if rebuilt != recorded[path]:
+            raise ScaffoldValidationError(
+                f"{path}: the emitted bytes do not reproduce the manifest's record "
+                f"(hash or region drift) — a generator defect, not an input problem."
+            )
+    findings = emission.manifest.lint()
+    if findings:
+        raise ScaffoldValidationError("scaffold manifest lint failed: " + "; ".join(findings))

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-join-duplicate.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-join-duplicate.scaffold.test.ts
@@ -1,0 +1,47 @@
+// Deterministic verification scaffold (SIP-0104). GENERATED — DO NOT EDIT.
+// The spine — placement, imports, lifecycle, invocation, status assertion — is
+// frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
+import { beforeEach, describe, expect, it } from 'vitest'
+import { reset } from '@/lib/store'
+import * as routeApiRuns from '@/app/api/runs/route'
+import * as routeApiRunsRunIdJoin from '@/app/api/runs/[run_id]/join/route'
+
+type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response
+
+beforeEach(() => reset())
+
+describe('scaffold: POST /api/runs/{run_id}/join', () => {
+  it('POST /api/runs/{run_id}/join duplicate -> 409 [vc-probe-api-runs-join-duplicate]', async () => {
+    const createRes = await (routeApiRuns.POST as Handler)(
+      new Request('http://test/api/runs', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({"title": "sample", "datetime": "2026-08-01T08:00:00", "location": "sample"}),
+      }),
+    )
+    const created: any = await createRes.json().catch(() => ({}))
+    await (routeApiRunsRunIdJoin.POST as Handler)(
+      new Request(`http://test/api/runs/${created.id}/join`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({"name": "sample"}),
+      }),
+      { params: { run_id: created.id } },
+    )
+    const res = await (routeApiRunsRunIdJoin.POST as Handler)(
+      new Request(`http://test/api/runs/${created.id}/join`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({"name": "sample"}),
+      }),
+      { params: { run_id: created.id } },
+    )
+    expect(res.status).toBe(409)
+    const body: any = await res.json().catch(() => ({}))
+    // [scaffold-slot:begin slot-vc-probe-api-runs-join-duplicate]
+    // FILL (qa): domain assertions for this behavior — response values and store
+    // effects beyond the declared status. `body` is the parsed response JSON.
+    void body
+    // [scaffold-slot:end slot-vc-probe-api-runs-join-duplicate]
+  })
+})

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-join.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-join.scaffold.test.ts
@@ -1,0 +1,39 @@
+// Deterministic verification scaffold (SIP-0104). GENERATED — DO NOT EDIT.
+// The spine — placement, imports, lifecycle, invocation, status assertion — is
+// frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
+import { beforeEach, describe, expect, it } from 'vitest'
+import { reset } from '@/lib/store'
+import * as routeApiRuns from '@/app/api/runs/route'
+import * as routeApiRunsRunIdJoin from '@/app/api/runs/[run_id]/join/route'
+
+type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response
+
+beforeEach(() => reset())
+
+describe('scaffold: POST /api/runs/{run_id}/join', () => {
+  it('POST /api/runs/{run_id}/join -> 200 [vc-probe-api-runs-join]', async () => {
+    const createRes = await (routeApiRuns.POST as Handler)(
+      new Request('http://test/api/runs', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({"title": "sample", "datetime": "2026-08-01T08:00:00", "location": "sample"}),
+      }),
+    )
+    const created: any = await createRes.json().catch(() => ({}))
+    const res = await (routeApiRunsRunIdJoin.POST as Handler)(
+      new Request(`http://test/api/runs/${created.id}/join`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({"name": "sample"}),
+      }),
+      { params: { run_id: created.id } },
+    )
+    expect(res.status).toBe(200)
+    const body: any = await res.json().catch(() => ({}))
+    // [scaffold-slot:begin slot-vc-probe-api-runs-join]
+    // FILL (qa): domain assertions for this behavior — response values and store
+    // effects beyond the declared status. `body` is the parsed response JSON.
+    void body
+    // [scaffold-slot:end slot-vc-probe-api-runs-join]
+  })
+})

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-leave.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-leave.scaffold.test.ts
@@ -1,0 +1,48 @@
+// Deterministic verification scaffold (SIP-0104). GENERATED — DO NOT EDIT.
+// The spine — placement, imports, lifecycle, invocation, status assertion — is
+// frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
+import { beforeEach, describe, expect, it } from 'vitest'
+import { reset } from '@/lib/store'
+import * as routeApiRuns from '@/app/api/runs/route'
+import * as routeApiRunsRunIdJoin from '@/app/api/runs/[run_id]/join/route'
+import * as routeApiRunsRunIdLeave from '@/app/api/runs/[run_id]/leave/route'
+
+type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response
+
+beforeEach(() => reset())
+
+describe('scaffold: POST /api/runs/{run_id}/leave', () => {
+  it('POST /api/runs/{run_id}/leave -> 200 [vc-probe-api-runs-leave]', async () => {
+    const createRes = await (routeApiRuns.POST as Handler)(
+      new Request('http://test/api/runs', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({"title": "sample", "datetime": "2026-08-01T08:00:00", "location": "sample"}),
+      }),
+    )
+    const created: any = await createRes.json().catch(() => ({}))
+    await (routeApiRunsRunIdJoin.POST as Handler)(
+      new Request(`http://test/api/runs/${created.id}/join`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({"name": "sample"}),
+      }),
+      { params: { run_id: created.id } },
+    )
+    const res = await (routeApiRunsRunIdLeave.POST as Handler)(
+      new Request(`http://test/api/runs/${created.id}/leave`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({"name": "sample"}),
+      }),
+      { params: { run_id: created.id } },
+    )
+    expect(res.status).toBe(200)
+    const body: any = await res.json().catch(() => ({}))
+    // [scaffold-slot:begin slot-vc-probe-api-runs-leave]
+    // FILL (qa): domain assertions for this behavior — response values and store
+    // effects beyond the declared status. `body` is the parsed response JSON.
+    void body
+    // [scaffold-slot:end slot-vc-probe-api-runs-leave]
+  })
+})

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-rejects-blank.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-rejects-blank.scaffold.test.ts
@@ -1,0 +1,29 @@
+// Deterministic verification scaffold (SIP-0104). GENERATED — DO NOT EDIT.
+// The spine — placement, imports, lifecycle, invocation, status assertion — is
+// frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
+import { beforeEach, describe, expect, it } from 'vitest'
+import { reset } from '@/lib/store'
+import * as routeApiRuns from '@/app/api/runs/route'
+
+type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response
+
+beforeEach(() => reset())
+
+describe('scaffold: POST /api/runs', () => {
+  it('POST /api/runs blank required fields -> 422 [vc-probe-api-runs-rejects-blank]', async () => {
+    const res = await (routeApiRuns.POST as Handler)(
+      new Request('http://test/api/runs', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({"title": "", "datetime": "", "location": ""}),
+      }),
+    )
+    expect(res.status).toBe(422)
+    const body: any = await res.json().catch(() => ({}))
+    // [scaffold-slot:begin slot-vc-probe-api-runs-rejects-blank]
+    // FILL (qa): domain assertions for this behavior — response values and store
+    // effects beyond the declared status. `body` is the parsed response JSON.
+    void body
+    // [scaffold-slot:end slot-vc-probe-api-runs-rejects-blank]
+  })
+})

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs.scaffold.test.ts
@@ -1,0 +1,29 @@
+// Deterministic verification scaffold (SIP-0104). GENERATED — DO NOT EDIT.
+// The spine — placement, imports, lifecycle, invocation, status assertion — is
+// frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
+import { beforeEach, describe, expect, it } from 'vitest'
+import { reset } from '@/lib/store'
+import * as routeApiRuns from '@/app/api/runs/route'
+
+type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response
+
+beforeEach(() => reset())
+
+describe('scaffold: POST /api/runs', () => {
+  it('POST /api/runs -> 201 [vc-probe-api-runs]', async () => {
+    const res = await (routeApiRuns.POST as Handler)(
+      new Request('http://test/api/runs', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({"title": "sample", "datetime": "2026-08-01T08:00:00", "location": "sample"}),
+      }),
+    )
+    expect(res.status).toBe(201)
+    const body: any = await res.json().catch(() => ({}))
+    // [scaffold-slot:begin slot-vc-probe-api-runs]
+    // FILL (qa): domain assertions for this behavior — response values and store
+    // effects beyond the declared status. `body` is the parsed response JSON.
+    void body
+    // [scaffold-slot:end slot-vc-probe-api-runs]
+  })
+})

--- a/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
+++ b/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
@@ -1,0 +1,97 @@
+# Test-scaffold manifest — emitted by the scaffold generator (SIP-0104).
+# The frozen-spine record region enforcement verifies against; regenerate with
+# the generator, never hand-edit (a tampered record refuses to load).
+scaffold_manifest_version: 1
+generator_version: 1
+stack: nextjs_ts
+interface_manifest_hash: ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a
+criteria_pack: nextjs_ts
+expanded_tree_hash: 6141646f442850aeb79675d56c58e2393c91ab771b92bc6994f55c38205ca4b9
+aggregate_spine_hash: 550ecfdd4ab8dde20f696d744ffff32647dfb19749930fa01af714e8399c449f
+scaffold_hash: 8aa15406e13468f453063007c43afee17d6b2cccb5a616b2be10d79031095f9e
+files:
+- path: __tests__/scaffold/vc-probe-api-runs.scaffold.test.ts
+  content_hash: fd7bacf35c234b63d5dc316971477b590607f4dacd9e83a73c94dcfa70da00f8
+  spine_hash: 1a27cef04731bf50cd3abbf943b0693d19f79451ffc826ebf4aceb2a594611e3
+  slots:
+  - slot_id: slot-vc-probe-api-runs
+    behavior: POST /api/runs -> 201
+    probe_id: vc-probe-api-runs
+    criterion_ids:
+    - vc-probe-api-runs
+    begin_line: 23
+    end_line: 27
+- path: __tests__/scaffold/vc-probe-api-runs-rejects-blank.scaffold.test.ts
+  content_hash: 00815dd3cdfad1999c07b3fe61948a87a6fea408d8320abf58e70e291b336ab9
+  spine_hash: 671c508176d8aa7246f52b04eef876a230be380c068dfaca2dd39fce094b2261
+  slots:
+  - slot_id: slot-vc-probe-api-runs-rejects-blank
+    behavior: POST /api/runs blank required fields -> 422
+    probe_id: vc-probe-api-runs-rejects-blank
+    criterion_ids:
+    - vc-probe-api-runs-rejects-blank
+    begin_line: 23
+    end_line: 27
+- path: __tests__/scaffold/vc-probe-api-runs-join.scaffold.test.ts
+  content_hash: f8be55162d36b812738d547dbfe96981e3261e91c86c10b5335936b30fc7a82b
+  spine_hash: 1ba37caa2f6f199a76d776dbf09f9dc66fb0a33d4ab946537fe08f8446eb3627
+  slots:
+  - slot_id: slot-vc-probe-api-runs-join
+    behavior: POST /api/runs/{run_id}/join -> 200
+    probe_id: vc-probe-api-runs-join
+    criterion_ids:
+    - vc-probe-api-runs-join
+    begin_line: 33
+    end_line: 37
+- path: __tests__/scaffold/vc-probe-api-runs-join-duplicate.scaffold.test.ts
+  content_hash: b5c9b4c617c6a212971403db843f1dd08157f88dbc08a07d11a107876b32277c
+  spine_hash: ad50663bb2f2cbb14f4dfb6dd783f197ada85ceda6ef1f223e3772779f6ccb60
+  slots:
+  - slot_id: slot-vc-probe-api-runs-join-duplicate
+    behavior: POST /api/runs/{run_id}/join duplicate -> 409
+    probe_id: vc-probe-api-runs-join-duplicate
+    criterion_ids:
+    - vc-probe-api-runs-join-duplicate
+    begin_line: 41
+    end_line: 45
+- path: __tests__/scaffold/vc-probe-api-runs-leave.scaffold.test.ts
+  content_hash: 81ac86bf6dcd57ad5ecaabd7c3cf65f29cff18e984c91e5a87c9413301eebd95
+  spine_hash: 7bcaf8481ca240e06891a65511bb16724ffaedfcdcff7688660c1f60a2241b42
+  slots:
+  - slot_id: slot-vc-probe-api-runs-leave
+    behavior: POST /api/runs/{run_id}/leave -> 200
+    probe_id: vc-probe-api-runs-leave
+    criterion_ids:
+    - vc-probe-api-runs-leave
+    begin_line: 42
+    end_line: 46
+- path: __tests__/scaffold/vs-get-api-runs.scaffold.test.ts
+  content_hash: 4368ab125564a6abf63234294a1b12006a1c281950f12a12e83253960a4efc46
+  spine_hash: ce04267e0d277e89b5f2735e6623443b7dbde6242c6f7dae027476fd7994f487
+  slots:
+  - slot_id: slot-vs-get-api-runs
+    behavior: GET /api/runs -> 200
+    probe_id: ''
+    criterion_ids: []
+    begin_line: 19
+    end_line: 23
+- path: __tests__/scaffold/vs-get-api-runs-run-id.scaffold.test.ts
+  content_hash: 28b0e05e06ca79ee21accf51e6b8d0c552581a46c582079b001bf86af07e2906
+  spine_hash: f939f2144ebd4e9751f6fdfafc5c204555056e9b166cd4385d5eb9546e167e1b
+  slots:
+  - slot_id: slot-vs-get-api-runs-run-id
+    behavior: GET /api/runs/{run_id} -> 200
+    probe_id: ''
+    criterion_ids: []
+    begin_line: 29
+    end_line: 33
+- path: __tests__/scaffold/vs-get-api-runs-run-id-not-found.scaffold.test.ts
+  content_hash: 47748bb81f33da0e1aa42c0341da63aca4a3364f8e06aad23f1ff359866f9bb2
+  spine_hash: 2e990d4a11c73805b72ec8cf03649ee3e03f91dfe5a9c631b8315eac38b7c87e
+  slots:
+  - slot_id: slot-vs-get-api-runs-run-id-not-found
+    behavior: GET /api/runs/{run_id} unknown id -> 404
+    probe_id: ''
+    criterion_ids: []
+    begin_line: 20
+    end_line: 24

--- a/tests/fixtures/reference_verification_scaffold/vs-get-api-runs-run-id-not-found.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vs-get-api-runs-run-id-not-found.scaffold.test.ts
@@ -1,0 +1,26 @@
+// Deterministic verification scaffold (SIP-0104). GENERATED — DO NOT EDIT.
+// The spine — placement, imports, lifecycle, invocation, status assertion — is
+// frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
+import { beforeEach, describe, expect, it } from 'vitest'
+import { reset } from '@/lib/store'
+import * as routeApiRunsRunId from '@/app/api/runs/[run_id]/route'
+
+type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response
+
+beforeEach(() => reset())
+
+describe('scaffold: GET /api/runs/{run_id}', () => {
+  it('GET /api/runs/{run_id} unknown id -> 404 [vs-get-api-runs-run-id-not-found]', async () => {
+    const res = await (routeApiRunsRunId.GET as Handler)(
+      new Request('http://test/api/runs/missing'),
+      { params: { run_id: 'missing' } },
+    )
+    expect(res.status).toBe(404)
+    const body: any = await res.json().catch(() => ({}))
+    // [scaffold-slot:begin slot-vs-get-api-runs-run-id-not-found]
+    // FILL (qa): domain assertions for this behavior — response values and store
+    // effects beyond the declared status. `body` is the parsed response JSON.
+    void body
+    // [scaffold-slot:end slot-vs-get-api-runs-run-id-not-found]
+  })
+})

--- a/tests/fixtures/reference_verification_scaffold/vs-get-api-runs-run-id.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vs-get-api-runs-run-id.scaffold.test.ts
@@ -1,0 +1,35 @@
+// Deterministic verification scaffold (SIP-0104). GENERATED — DO NOT EDIT.
+// The spine — placement, imports, lifecycle, invocation, status assertion — is
+// frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
+import { beforeEach, describe, expect, it } from 'vitest'
+import { reset } from '@/lib/store'
+import * as routeApiRuns from '@/app/api/runs/route'
+import * as routeApiRunsRunId from '@/app/api/runs/[run_id]/route'
+
+type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response
+
+beforeEach(() => reset())
+
+describe('scaffold: GET /api/runs/{run_id}', () => {
+  it('GET /api/runs/{run_id} -> 200 [vs-get-api-runs-run-id]', async () => {
+    const createRes = await (routeApiRuns.POST as Handler)(
+      new Request('http://test/api/runs', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({"title": "sample", "datetime": "2026-08-01T08:00:00", "location": "sample"}),
+      }),
+    )
+    const created: any = await createRes.json().catch(() => ({}))
+    const res = await (routeApiRunsRunId.GET as Handler)(
+      new Request(`http://test/api/runs/${created.id}`),
+      { params: { run_id: created.id } },
+    )
+    expect(res.status).toBe(200)
+    const body: any = await res.json().catch(() => ({}))
+    // [scaffold-slot:begin slot-vs-get-api-runs-run-id]
+    // FILL (qa): domain assertions for this behavior — response values and store
+    // effects beyond the declared status. `body` is the parsed response JSON.
+    void body
+    // [scaffold-slot:end slot-vs-get-api-runs-run-id]
+  })
+})

--- a/tests/fixtures/reference_verification_scaffold/vs-get-api-runs.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vs-get-api-runs.scaffold.test.ts
@@ -1,0 +1,25 @@
+// Deterministic verification scaffold (SIP-0104). GENERATED — DO NOT EDIT.
+// The spine — placement, imports, lifecycle, invocation, status assertion — is
+// frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
+import { beforeEach, describe, expect, it } from 'vitest'
+import { reset } from '@/lib/store'
+import * as routeApiRuns from '@/app/api/runs/route'
+
+type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response
+
+beforeEach(() => reset())
+
+describe('scaffold: GET /api/runs', () => {
+  it('GET /api/runs -> 200 [vs-get-api-runs]', async () => {
+    const res = await (routeApiRuns.GET as Handler)(
+      new Request('http://test/api/runs'),
+    )
+    expect(res.status).toBe(200)
+    const body: any = await res.json().catch(() => ({}))
+    // [scaffold-slot:begin slot-vs-get-api-runs]
+    // FILL (qa): domain assertions for this behavior — response values and store
+    // effects beyond the declared status. `body` is the parsed response JSON.
+    void body
+    // [scaffold-slot:end slot-vs-get-api-runs]
+  })
+})

--- a/tests/unit/capabilities/test_stack_inventory.py
+++ b/tests/unit/capabilities/test_stack_inventory.py
@@ -45,7 +45,12 @@ import re
 
 import pytest
 
-from squadops.capabilities import dev_capabilities, scaffold, scaffold_contract
+from squadops.capabilities import (
+    dev_capabilities,
+    scaffold,
+    scaffold_contract,
+    verification_scaffold_emission,
+)
 from squadops.capabilities.handlers import build_profiles, probe_runner
 from squadops.capabilities.scaffold import InterfaceManifest
 from squadops.cycles.verification_contract import VerificationContract
@@ -82,7 +87,17 @@ _REGISTRIES: dict[str, tuple[dict, str | None]] = {
     "dev_capability": (dev_capabilities.DEV_CAPABILITIES, "dev_capability"),
     "sandbox contract": (environment._CONTRACTS, None),
     "build profile": (build_profiles.BUILD_PROFILES, None),
+    "verification_scaffold (test-scaffold emitter)": (
+        verification_scaffold_emission._EMITTERS,
+        "verification_scaffold",
+    ),
 }
+
+#: Registries a stack joins by explicit opt-in (SIP-0104 §8): an EMPTY field is a declared
+#: state — the stack has not opted in and emission skips — not a membership gap. A
+#: NON-empty field must still resolve (declared-but-unregistered is the #838 class and
+#: fails membership below). Pinned like _CONVENTION_BOUND so growth is deliberate.
+_OPT_IN = frozenset({"verification_scaffold (test-scaffold emitter)"})
 
 #: Registries with no declaring field. Pinned so the count can only shrink: converting one
 #: to an explicit ``ScaffoldStack`` field is an improvement and updates this set, while
@@ -128,6 +143,8 @@ def test_every_stack_has_a_member_in_every_registry(stack, registry):
     build — the wrong answer being the only one that worked."""
     mapping, field = _REGISTRIES[registry]
     key = _registry_key(stack, field)
+    if not key and registry in _OPT_IN:
+        return  # declared non-membership: the stack has not opted in (SIP-0104 §8)
     assert key, f"stack {stack!r} resolves an empty key for {registry!r}"
     assert key in mapping, (
         f"stack {stack!r} addresses {registry!r} as {key!r}, which is not registered "

--- a/tests/unit/capabilities/test_verification_scaffold.py
+++ b/tests/unit/capabilities/test_verification_scaffold.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 import pytest
 
 from squadops.capabilities.verification_scaffold import (
-    TEST_SCAFFOLD_MANIFEST_VERSION,
+    SCAFFOLD_MANIFEST_VERSION,
     BehaviorSlot,
     ScaffoldSpineError,
     ScaffoldValidationError,
-    TestScaffoldFile,
-    TestScaffoldManifest,
+    VerificationScaffoldFile,
+    VerificationScaffoldManifest,
     build_scaffold_file,
     elide_slot_bodies,
     expanded_tree_hash,
@@ -177,9 +177,9 @@ class TestBuildScaffoldFile:
             build_scaffold_file("x.ts", _SHELL, (_slot("slot-vc-probe-api-runs"),))
 
 
-def _manifest(files: tuple[TestScaffoldFile, ...]) -> TestScaffoldManifest:
-    return TestScaffoldManifest(
-        scaffold_manifest_version=TEST_SCAFFOLD_MANIFEST_VERSION,
+def _manifest(files: tuple[VerificationScaffoldFile, ...]) -> VerificationScaffoldManifest:
+    return VerificationScaffoldManifest(
+        scaffold_manifest_version=SCAFFOLD_MANIFEST_VERSION,
         generator_version=1,
         stack="nextjs_ts",
         interface_manifest_hash="m" * 64,
@@ -189,8 +189,8 @@ def _manifest(files: tuple[TestScaffoldFile, ...]) -> TestScaffoldManifest:
     )
 
 
-def _file(path: str, slot_id: str, spine: str = "s1") -> TestScaffoldFile:
-    return TestScaffoldFile(
+def _file(path: str, slot_id: str, spine: str = "s1") -> VerificationScaffoldFile:
+    return VerificationScaffoldFile(
         path=path, content_hash="c" * 64, spine_hash=spine, slots=(_slot(slot_id),)
     )
 
@@ -207,7 +207,7 @@ class TestManifest:
             (
                 _file("a.ts", "slot-a1"),
                 _file("b.ts", "slot-a1"),
-                TestScaffoldFile(path="c.ts", content_hash="c" * 64, spine_hash="s"),
+                VerificationScaffoldFile(path="c.ts", content_hash="c" * 64, spine_hash="s"),
             )
         )
         findings = m.lint()
@@ -215,7 +215,7 @@ class TestManifest:
         assert any("c.ts: scaffold file with no behavior slots" in f for f in findings)
 
     def test_lint_flags_an_unknown_schema_version(self):
-        m = TestScaffoldManifest(
+        m = VerificationScaffoldManifest(
             scaffold_manifest_version=99,
             generator_version=1,
             stack="nextjs_ts",
@@ -227,14 +227,14 @@ class TestManifest:
 
     def test_round_trip_preserves_identity(self):
         m = _manifest((_file("a.ts", "slot-a1"),))
-        assert TestScaffoldManifest.from_dict(m.to_dict()) == m
+        assert VerificationScaffoldManifest.from_dict(m.to_dict()) == m
 
     def test_a_tampered_stored_aggregate_refuses_to_load(self):
         """A hand-edited record must not launder itself into an enforcement authority."""
         d = _manifest((_file("a.ts", "slot-a1"),)).to_dict()
         d["aggregate_spine_hash"] = "0" * 64
         with pytest.raises(ScaffoldValidationError, match="mutated"):
-            TestScaffoldManifest.from_dict(d)
+            VerificationScaffoldManifest.from_dict(d)
 
     def test_find_slot_returns_owning_file(self):
         m = _manifest((_file("a.ts", "slot-a1"), _file("b.ts", "slot-b2", spine="s2")))

--- a/tests/unit/capabilities/test_verification_scaffold.py
+++ b/tests/unit/capabilities/test_verification_scaffold.py
@@ -1,0 +1,251 @@
+"""The scaffold contract's own guarantees (SIP-0104 P1 commit 1).
+
+Everything here defends the canonicalization the whole SIP rests on: fills must never move
+the spine hash, every structural mutation must, and malformed slot structure must fail
+loudly rather than hash around. The generator (commit 2) and region enforcement (P4) both
+consume these exact functions, so a bug here is a bug in both.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.verification_scaffold import (
+    TEST_SCAFFOLD_MANIFEST_VERSION,
+    BehaviorSlot,
+    ScaffoldSpineError,
+    ScaffoldValidationError,
+    TestScaffoldFile,
+    TestScaffoldManifest,
+    build_scaffold_file,
+    elide_slot_bodies,
+    expanded_tree_hash,
+    parse_slot_regions,
+    slot_begin_marker,
+    slot_end_marker,
+    spine_hash,
+)
+
+_SHELL = """// header line
+import { reset } from '@/lib/store'
+
+it('behavior one', async () => {
+  expect(res.status).toBe(201)
+  // [scaffold-slot:begin slot-vc-probe-api-runs]
+  // FILL: domain assertions.
+  // [scaffold-slot:end slot-vc-probe-api-runs]
+})
+
+it('behavior two', async () => {
+  // [scaffold-slot:begin slot-vs-get-api-runs]
+  // [scaffold-slot:end slot-vs-get-api-runs]
+})
+"""
+
+
+class TestParseSlotRegions:
+    def test_regions_carry_exact_marker_line_numbers(self):
+        """Off-by-one bounds would make P4 enforcement elide the wrong lines."""
+        regions = parse_slot_regions(_SHELL)
+        assert [(r.slot_id, r.begin_line, r.end_line) for r in regions] == [
+            ("slot-vc-probe-api-runs", 6, 8),
+            ("slot-vs-get-api-runs", 12, 13),
+        ]
+
+    def test_indented_markers_parse(self):
+        text = "  // [scaffold-slot:begin slot-a1]\n  // [scaffold-slot:end slot-a1]\n"
+        regions = parse_slot_regions(text)
+        assert [(r.slot_id, r.begin_line, r.end_line) for r in regions] == [("slot-a1", 1, 2)]
+
+    @pytest.mark.parametrize(
+        ("text", "fragment"),
+        [
+            # Unclosed at EOF: the slot would silently swallow the rest of the file.
+            ("// [scaffold-slot:begin slot-a1]\nbody\n", "never closed"),
+            # End with no open region.
+            ("// [scaffold-slot:end slot-a1]\n", "no open slot"),
+            # Nesting: an inner region would let a fill smuggle a second mutable zone.
+            (
+                "// [scaffold-slot:begin slot-a1]\n"
+                "// [scaffold-slot:begin slot-b2]\n"
+                "// [scaffold-slot:end slot-b2]\n"
+                "// [scaffold-slot:end slot-a1]\n",
+                "cannot nest",
+            ),
+            # Mismatched end id.
+            (
+                "// [scaffold-slot:begin slot-a1]\n// [scaffold-slot:end slot-b2]\n",
+                "does not match open slot",
+            ),
+            # Duplicate id in one file: slot addressing (P3) would be ambiguous.
+            (
+                "// [scaffold-slot:begin slot-a1]\n// [scaffold-slot:end slot-a1]\n"
+                "// [scaffold-slot:begin slot-a1]\n// [scaffold-slot:end slot-a1]\n",
+                "duplicate slot id",
+            ),
+            # Near-miss marker: a typo must fail, not become frozen spine text.
+            ("// [scaffold-slot:begin BadId]\n", "not a well-formed"),
+            ("// [scaffold-slot:beginning slot-a1]\n", "not a well-formed"),
+        ],
+    )
+    def test_malformed_structure_raises_with_the_defect_named(self, text, fragment):
+        with pytest.raises(ScaffoldSpineError, match=fragment):
+            parse_slot_regions(text)
+
+
+class TestSpineCanonicalization:
+    def test_editing_a_slot_body_never_moves_the_spine_hash(self):
+        """THE invariant: an authored fill must not read as a spine mutation."""
+        filled = _SHELL.replace(
+            "  // FILL: domain assertions.\n",
+            "  expect(body.id).toBeTruthy()\n  expect(all('runs')).toHaveLength(1)\n",
+        )
+        assert filled != _SHELL
+        assert spine_hash(filled) == spine_hash(_SHELL)
+
+    def test_elision_keeps_markers_and_drops_bodies(self):
+        spine = elide_slot_bodies(_SHELL)
+        assert "// [scaffold-slot:begin slot-vc-probe-api-runs]" in spine
+        assert "// [scaffold-slot:end slot-vc-probe-api-runs]" in spine
+        assert "// FILL: domain assertions." not in spine
+        assert "expect(res.status).toBe(201)" in spine
+
+    @pytest.mark.parametrize(
+        ("mutate", "label"),
+        [
+            # Each of these is a P4 adversarial class; the canonicalization must see all.
+            (lambda t: t.replace("@/lib/store", "@/lib/other"), "import edit"),
+            (lambda t: t.replace("toBe(201)", "toBe(200)"), "status assertion edit"),
+            (
+                lambda t: t.replace(
+                    "// [scaffold-slot:end slot-vc-probe-api-runs]\n})",
+                    "// [scaffold-slot:end slot-vc-probe-api-runs]\n  fetch('http://x')\n})",
+                ),
+                "statement injected adjacent to a slot",
+            ),
+            (
+                lambda t: t.replace(
+                    "  expect(res.status).toBe(201)\n"
+                    "  // [scaffold-slot:begin slot-vc-probe-api-runs]\n",
+                    "  // [scaffold-slot:begin slot-vc-probe-api-runs]\n"
+                    "  expect(res.status).toBe(201)\n",
+                ),
+                "region enlarged upward (assertion swallowed into the slot body)",
+            ),
+        ],
+    )
+    def test_every_structural_mutation_moves_the_spine_hash(self, mutate, label):
+        mutated = mutate(_SHELL)
+        assert mutated != _SHELL, label
+        assert spine_hash(mutated) != spine_hash(_SHELL), label
+
+    def test_crlf_rewrite_is_a_spine_mutation(self):
+        assert spine_hash(_SHELL.replace("\n", "\r\n")) != spine_hash(_SHELL)
+
+
+class TestMarkerBuilders:
+    def test_builders_round_trip_through_the_parser(self):
+        text = f"{slot_begin_marker('slot-x9')}\nbody\n{slot_end_marker('slot-x9')}\n"
+        assert [r.slot_id for r in parse_slot_regions(text)] == ["slot-x9"]
+
+    @pytest.mark.parametrize("bad", ["", "x", "slot-", "slot-A", "vc-probe-x", "slot-a_b"])
+    def test_invalid_slot_ids_are_rejected(self, bad):
+        with pytest.raises(ValueError, match="invalid slot id"):
+            slot_begin_marker(bad)
+
+
+def _slot(slot_id: str, probe_id: str = "") -> BehaviorSlot:
+    return BehaviorSlot(slot_id=slot_id, behavior="b", probe_id=probe_id)
+
+
+class TestBuildScaffoldFile:
+    def test_region_bounds_are_recomputed_from_content(self):
+        f = build_scaffold_file(
+            "__tests__/scaffold/x.scaffold.test.ts",
+            _SHELL,
+            (_slot("slot-vc-probe-api-runs", "vc-probe-api-runs"), _slot("slot-vs-get-api-runs")),
+        )
+        bounds = {s.slot_id: (s.begin_line, s.end_line) for s in f.slots}
+        assert bounds == {
+            "slot-vc-probe-api-runs": (6, 8),
+            "slot-vs-get-api-runs": (12, 13),
+        }
+
+    def test_slot_table_and_content_disagreement_is_a_validation_error(self):
+        """The generator declaring a slot its own emission lacks is a generator defect."""
+        with pytest.raises(ScaffoldValidationError, match="disagree"):
+            build_scaffold_file("x.ts", _SHELL, (_slot("slot-vc-probe-api-runs"),))
+
+
+def _manifest(files: tuple[TestScaffoldFile, ...]) -> TestScaffoldManifest:
+    return TestScaffoldManifest(
+        scaffold_manifest_version=TEST_SCAFFOLD_MANIFEST_VERSION,
+        generator_version=1,
+        stack="nextjs_ts",
+        interface_manifest_hash="m" * 64,
+        criteria_pack="nextjs_ts",
+        expanded_tree_hash="t" * 64,
+        files=files,
+    )
+
+
+def _file(path: str, slot_id: str, spine: str = "s1") -> TestScaffoldFile:
+    return TestScaffoldFile(
+        path=path, content_hash="c" * 64, spine_hash=spine, slots=(_slot(slot_id),)
+    )
+
+
+class TestManifest:
+    def test_aggregates_are_file_order_independent(self):
+        """The hash names a set of files; emission-order refactors must not move it."""
+        a, b = _file("a.ts", "slot-a1"), _file("b.ts", "slot-b2", spine="s2")
+        assert _manifest((a, b)).aggregate_spine_hash() == _manifest((b, a)).aggregate_spine_hash()
+        assert _manifest((a, b)).scaffold_hash() == _manifest((b, a)).scaffold_hash()
+
+    def test_lint_names_cross_file_duplicates_and_empty_files(self):
+        m = _manifest(
+            (
+                _file("a.ts", "slot-a1"),
+                _file("b.ts", "slot-a1"),
+                TestScaffoldFile(path="c.ts", content_hash="c" * 64, spine_hash="s"),
+            )
+        )
+        findings = m.lint()
+        assert any("duplicate slot id 'slot-a1'" in f for f in findings)
+        assert any("c.ts: scaffold file with no behavior slots" in f for f in findings)
+
+    def test_lint_flags_an_unknown_schema_version(self):
+        m = TestScaffoldManifest(
+            scaffold_manifest_version=99,
+            generator_version=1,
+            stack="nextjs_ts",
+            interface_manifest_hash="m" * 64,
+            criteria_pack="nextjs_ts",
+            expanded_tree_hash="t" * 64,
+        )
+        assert any("99" in f for f in m.lint())
+
+    def test_round_trip_preserves_identity(self):
+        m = _manifest((_file("a.ts", "slot-a1"),))
+        assert TestScaffoldManifest.from_dict(m.to_dict()) == m
+
+    def test_a_tampered_stored_aggregate_refuses_to_load(self):
+        """A hand-edited record must not launder itself into an enforcement authority."""
+        d = _manifest((_file("a.ts", "slot-a1"),)).to_dict()
+        d["aggregate_spine_hash"] = "0" * 64
+        with pytest.raises(ScaffoldValidationError, match="mutated"):
+            TestScaffoldManifest.from_dict(d)
+
+    def test_find_slot_returns_owning_file(self):
+        m = _manifest((_file("a.ts", "slot-a1"), _file("b.ts", "slot-b2", spine="s2")))
+        found = m.find_slot("slot-b2")
+        assert found is not None and found[0].path == "b.ts"
+        assert m.find_slot("slot-missing") is None
+
+
+class TestExpandedTreeHash:
+    def test_order_independent_and_content_sensitive(self):
+        files = [{"name": "a.ts", "content": "x"}, {"name": "b.ts", "content": "y"}]
+        assert expanded_tree_hash(files) == expanded_tree_hash(list(reversed(files)))
+        changed = [{"name": "a.ts", "content": "x2"}, {"name": "b.ts", "content": "y"}]
+        assert expanded_tree_hash(changed) != expanded_tree_hash(files)

--- a/tests/unit/capabilities/test_verification_scaffold_emission.py
+++ b/tests/unit/capabilities/test_verification_scaffold_emission.py
@@ -1,0 +1,199 @@
+"""Generator correctness — deterministic output, authoritative derivation (SIP-0104 P1).
+
+P1 owns generation correctness (plan Gate 1): deterministic output, derivation that refuses
+to guess, manifest production. The standing byte-equivalence pin against the committed
+reference fixture lives in ``test_verification_scaffold_reference.py``; this file owns the
+behavior-level and refusal cases.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from squadops.capabilities import verification_scaffold_emission as emission_module
+from squadops.capabilities.scaffold import InterfaceManifest, expand, verification_scaffold_for
+from squadops.capabilities.verification_scaffold import (
+    ScaffoldDerivationError,
+    ScaffoldValidationError,
+    expanded_tree_hash,
+)
+from squadops.capabilities.verification_scaffold_emission import (
+    GENERATOR_VERSION,
+    VerificationScaffoldEmission,
+    emit_verification_scaffold,
+    validate_emission,
+)
+from tests.unit.capabilities._stack_fixtures import manifest_dict_for_stack, manifest_for_stack
+
+
+@pytest.fixture(scope="module")
+def nextjs_manifest():
+    return manifest_for_stack("nextjs_ts")
+
+
+@pytest.fixture(scope="module")
+def emission(nextjs_manifest):
+    return emit_verification_scaffold(nextjs_manifest)
+
+
+def _variant_manifest(mutate) -> InterfaceManifest:
+    raw = manifest_dict_for_stack("nextjs_ts")
+    mutate(raw)
+    return InterfaceManifest.from_yaml(yaml.safe_dump(raw, sort_keys=False))
+
+
+class TestDeterminism:
+    def test_two_emissions_are_byte_identical(self, nextjs_manifest, emission):
+        """The SIP's core generation claim: same inputs + generator version ⇒ same bytes."""
+        again = emit_verification_scaffold(nextjs_manifest)
+        assert again.files == emission.files
+        assert again.manifest_yaml == emission.manifest_yaml
+        assert again.manifest == emission.manifest
+
+
+class TestInventory:
+    def test_reference_inventory_is_probes_plus_reads(self, emission):
+        """The behavior inventory for the reference design: 5 probe twins + 3 read shells.
+
+        A silently shrunken inventory (a classification bug dropping the duplicate twin,
+        say) would pass every structural check while quietly removing required coverage.
+        """
+        assert [f["name"] for f in emission.files] == [
+            "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts",
+            "__tests__/scaffold/vc-probe-api-runs-rejects-blank.scaffold.test.ts",
+            "__tests__/scaffold/vc-probe-api-runs-join.scaffold.test.ts",
+            "__tests__/scaffold/vc-probe-api-runs-join-duplicate.scaffold.test.ts",
+            "__tests__/scaffold/vc-probe-api-runs-leave.scaffold.test.ts",
+            "__tests__/scaffold/vs-get-api-runs.scaffold.test.ts",
+            "__tests__/scaffold/vs-get-api-runs-run-id.scaffold.test.ts",
+            "__tests__/scaffold/vs-get-api-runs-run-id-not-found.scaffold.test.ts",
+        ]
+
+    def test_probe_twins_bind_their_probe_and_minted_shells_bind_none(self, emission):
+        slots = {s.slot_id: s for f in emission.manifest.files for s in f.slots}
+        twin = slots["slot-vc-probe-api-runs-join"]
+        assert twin.probe_id == "vc-probe-api-runs-join"
+        assert twin.criterion_ids == ("vc-probe-api-runs-join",)
+        minted = slots["slot-vs-get-api-runs"]
+        assert minted.probe_id == ""
+        assert minted.criterion_ids == ()
+
+    def test_chained_shells_replay_the_probe_sequence_prefix(self, emission):
+        """The leave twin must join before leaving; the duplicate twin must join twice.
+
+        This is the derivation of probe-runner sequence semantics into isolated tests —
+        getting it wrong makes a correct app fail its own scaffold.
+        """
+        by_name = {f["name"]: f["content"] for f in emission.files}
+        leave = by_name["__tests__/scaffold/vc-probe-api-runs-leave.scaffold.test.ts"]
+        assert leave.count("routeApiRunsRunIdJoin.POST") == 1
+        assert leave.count("routeApiRunsRunIdLeave.POST") == 1
+        assert leave.index("routeApiRunsRunIdJoin.POST") < leave.index(
+            "routeApiRunsRunIdLeave.POST"
+        )
+        duplicate = by_name["__tests__/scaffold/vc-probe-api-runs-join-duplicate.scaffold.test.ts"]
+        assert duplicate.count("routeApiRunsRunIdJoin.POST") == 2
+
+    def test_dynamic_invocations_carry_the_params_argument(self, emission):
+        """The #877 tail this SIP exists to close: `{ params }` is frozen, never invented."""
+        by_name = {f["name"]: f["content"] for f in emission.files}
+        read = by_name["__tests__/scaffold/vs-get-api-runs-run-id.scaffold.test.ts"]
+        assert "{ params: { run_id: created.id } }" in read
+        listing = by_name["__tests__/scaffold/vs-get-api-runs.scaffold.test.ts"]
+        assert "params" not in listing
+
+    def test_unmapped_not_found_omits_the_shell_deterministically(self):
+        """Demote, never guess (#874): no 404 mapping ⇒ no unknown-id shell, same run."""
+        variant = _variant_manifest(
+            lambda raw: raw["api"]["endpoints"][2].__setitem__("errors", [])
+        )
+        result = emit_verification_scaffold(variant)
+        names = [f["name"] for f in result.files]
+        assert "__tests__/scaffold/vs-get-api-runs-run-id.scaffold.test.ts" in names
+        assert "__tests__/scaffold/vs-get-api-runs-run-id-not-found.scaffold.test.ts" not in names
+
+
+class TestManifestRecord:
+    def test_record_carries_the_attribution_facts(self, nextjs_manifest, emission):
+        record = emission.manifest
+        assert record.generator_version == GENERATOR_VERSION
+        assert record.stack == "nextjs_ts"
+        assert record.criteria_pack == "nextjs_ts"
+        assert record.interface_manifest_hash == nextjs_manifest.content_hash()
+        assert record.expanded_tree_hash == expanded_tree_hash(expand(nextjs_manifest))
+
+    def test_manifest_yaml_round_trips_through_the_schema(self, emission):
+        from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
+
+        loaded = VerificationScaffoldManifest.from_dict(yaml.safe_load(emission.manifest_yaml))
+        assert loaded == emission.manifest
+
+
+class TestRefusals:
+    def test_a_stack_that_has_not_opted_in_is_refused(self):
+        assert verification_scaffold_for("fullstack_fastapi_react") == ""
+        with pytest.raises(ScaffoldDerivationError, match="has not opted in"):
+            emit_verification_scaffold(manifest_for_stack("fullstack_fastapi_react"))
+
+    def test_declared_but_unregistered_emitter_is_refused(self, nextjs_manifest, monkeypatch):
+        monkeypatch.delitem(emission_module._EMITTERS, "nextjs_ts")
+        with pytest.raises(ScaffoldDerivationError, match="not registered"):
+            emit_verification_scaffold(nextjs_manifest)
+
+    def test_a_tree_missing_a_declared_route_file_is_refused(self, nextjs_manifest):
+        """SIP §7: manifest-vs-tree disagreement is generator drift or workspace mutation,
+        named — never a best-effort scaffold."""
+        tree = [f for f in expand(nextjs_manifest) if f["name"] != "app/api/runs/route.ts"]
+        with pytest.raises(ScaffoldDerivationError, match="has no file"):
+            emit_verification_scaffold(nextjs_manifest, expanded=tree)
+
+    def test_a_tree_whose_stub_lacks_the_handler_export_is_refused(self, nextjs_manifest):
+        tree = [
+            (
+                {
+                    "name": f["name"],
+                    "content": f["content"].replace(
+                        "export async function POST", "async function POST"
+                    ),
+                }
+                if f["name"] == "app/api/runs/route.ts"
+                else f
+            )
+            for f in expand(nextjs_manifest)
+        ]
+        with pytest.raises(ScaffoldDerivationError, match="does not export POST"):
+            emit_verification_scaffold(nextjs_manifest, expanded=tree)
+
+    def test_a_tree_missing_the_store_seam_is_refused(self, nextjs_manifest):
+        tree = [f for f in expand(nextjs_manifest) if f["name"] != "lib/store.ts"]
+        with pytest.raises(ScaffoldDerivationError, match="lib/store.ts"):
+            emit_verification_scaffold(nextjs_manifest, expanded=tree)
+
+
+class TestValidateEmission:
+    def test_content_drift_from_the_record_is_a_validation_error(self, emission):
+        """The gate must catch a generator whose output and record disagree — the
+        consistent-inputs/broken-generator class P2 extends (plan Gate 2's decisive case)."""
+        files = tuple(
+            (
+                {"name": f["name"], "content": f["content"].replace("toBe(201)", "toBe(200)")}
+                if f["name"] == "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts"
+                else f
+            )
+            for f in emission.files
+        )
+        tampered = VerificationScaffoldEmission(
+            files=files, manifest=emission.manifest, manifest_yaml=emission.manifest_yaml
+        )
+        with pytest.raises(ScaffoldValidationError, match="do not reproduce"):
+            validate_emission(tampered)
+
+    def test_a_missing_file_is_a_validation_error(self, emission):
+        tampered = VerificationScaffoldEmission(
+            files=emission.files[1:],
+            manifest=emission.manifest,
+            manifest_yaml=emission.manifest_yaml,
+        )
+        with pytest.raises(ScaffoldValidationError, match="disagree"):
+            validate_emission(tampered)

--- a/tests/unit/capabilities/test_verification_scaffold_reference.py
+++ b/tests/unit/capabilities/test_verification_scaffold_reference.py
@@ -1,0 +1,122 @@
+"""Gate 1's standing pin — reference manifest + generator version ⇒ byte-identical scaffold.
+
+The M0a guard shape (``test_contract_derivation_reference``) applied to SIP-0104: the
+committed fixture under ``tests/fixtures/reference_verification_scaffold/`` is the scaffold
+GENERATOR_VERSION 1 emits for the reference nextjs_ts manifest, and the generator must keep
+reproducing it byte for byte.
+
+**Both ends are held.** The input end pins the reference manifest's content hash (a deriver
+"matching" a drifted reference proves nothing); the output end pins the fixture's aggregate
+hashes inside this file, so regenerating the fixture in place to match a changed generator
+turns the byte test into a tautology *and still fails here* — the two must move together,
+with a GENERATOR_VERSION bump, as one deliberate act.
+
+**No regeneration hatch, deliberately** (the M0a rationale): a one-env-var regen invites
+exactly the casual update that would let generator drift ship silently. Changing the
+emission means: bump GENERATOR_VERSION, regenerate the fixture, update the two pinned
+hashes here, and say why in the commit.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
+from squadops.capabilities.verification_scaffold_emission import (
+    GENERATOR_VERSION,
+    emit_verification_scaffold,
+)
+from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+_FIXTURE_DIR = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "tests"
+    / "fixtures"
+    / "reference_verification_scaffold"
+)
+
+# The reference nextjs_ts manifest (the shared fixture's /api re-stack of the group_run
+# reference). Also pinned in test_stack_nextjs_ts; repeated here so THIS file is
+# self-contained evidence that the input end did not move.
+_MANIFEST_HASH = "ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a"
+
+# The fixture's own identity, generated once at GENERATOR_VERSION 1 (2026-08-14). These
+# stop an in-place fixture regeneration from making the byte test self-referential.
+_AGGREGATE_SPINE_HASH = "550ecfdd4ab8dde20f696d744ffff32647dfb19749930fa01af714e8399c449f"
+_SCAFFOLD_HASH = "8aa15406e13468f453063007c43afee17d6b2cccb5a616b2be10d79031095f9e"
+
+
+@pytest.fixture(scope="module")
+def emission():
+    return emit_verification_scaffold(manifest_for_stack("nextjs_ts"))
+
+
+def test_the_reference_manifest_is_unmoved():
+    assert manifest_for_stack("nextjs_ts").content_hash() == _MANIFEST_HASH, (
+        "the reference nextjs_ts manifest moved — the byte-equivalence pin below would be "
+        "measuring a different input. If intended, this changes the reference instance the "
+        "Gate 1 evidence is measured against; update deliberately."
+    )
+
+
+def test_generator_version_is_the_fixture_generation(emission):
+    """A generator change without a version bump is drift by definition (SIP §4.3);
+    a bump without regenerating the fixture is a pin measuring the wrong version."""
+    assert GENERATOR_VERSION == 1
+    assert emission.manifest.generator_version == 1
+    stored = yaml.safe_load(
+        (_FIXTURE_DIR / "verification_scaffold_manifest.yaml").read_text(encoding="utf-8")
+    )
+    assert stored["generator_version"] == 1
+
+
+def test_emission_reproduces_the_fixture_byte_for_byte(emission):
+    """Gate 1's exit criterion, exactly as the plan states it."""
+    for f in emission.files:
+        fixture = _FIXTURE_DIR / f["name"].rsplit("/", 1)[-1]
+        assert fixture.exists(), f"fixture missing for emitted file {f['name']}"
+        assert f["content"] == fixture.read_text(encoding="utf-8"), (
+            f"{f['name']}: emitted bytes diverge from the committed reference — either "
+            f"generator drift (bump GENERATOR_VERSION and regenerate deliberately) or an "
+            f"unintended emission change"
+        )
+    assert emission.manifest_yaml == (
+        _FIXTURE_DIR / "verification_scaffold_manifest.yaml"
+    ).read_text(encoding="utf-8")
+
+
+def test_no_fixture_file_is_orphaned(emission):
+    """A deleted shell must fail the pin too — shrinkage is drift, not cleanup."""
+    emitted = {f["name"].rsplit("/", 1)[-1] for f in emission.files}
+    emitted.add("verification_scaffold_manifest.yaml")
+    on_disk = {p.name for p in _FIXTURE_DIR.iterdir()}
+    assert on_disk == emitted
+
+
+def test_the_fixture_is_not_regenerated_in_place(emission):
+    """The anti-tautology end: these hashes only change by editing THIS file."""
+    assert emission.manifest.aggregate_spine_hash() == _AGGREGATE_SPINE_HASH
+    assert emission.manifest.scaffold_hash() == _SCAFFOLD_HASH
+
+
+def test_the_fixture_is_non_trivial(emission):
+    """A pin over an empty scaffold would pass while proving nothing: the reference
+    design must exercise every v1 shell kind — create, rejection, two chained child
+    actions, a duplicate-conflict, a list read, a chained read, and an unknown-id read."""
+    assert len(emission.files) == 8
+    slots = [s for f in emission.manifest.files for s in f.slots]
+    assert len(slots) == 8
+    assert sum(1 for s in slots if s.probe_id) == 5
+
+
+def test_the_stored_fixture_manifest_loads_and_verifies():
+    """The committed record must round-trip the schema, including its aggregate
+    verification — a hand-edited fixture manifest refuses to load."""
+    stored = yaml.safe_load(
+        (_FIXTURE_DIR / "verification_scaffold_manifest.yaml").read_text(encoding="utf-8")
+    )
+    loaded = VerificationScaffoldManifest.from_dict(stored)
+    assert loaded.aggregate_spine_hash() == _AGGREGATE_SPINE_HASH

--- a/tests/unit/cycles/test_executor_interface_manifest.py
+++ b/tests/unit/cycles/test_executor_interface_manifest.py
@@ -164,9 +164,7 @@ class TestSeedVerificationScaffoldArtifacts:
         expected = emit_verification_scaffold(manifest)
 
         executor = _make_executor()
-        ids = await executor._seed_verification_scaffold_artifacts(
-            manifest, _make_cycle(), "run_x"
-        )
+        ids = await executor._seed_verification_scaffold_artifacts(manifest, _make_cycle(), "run_x")
 
         stored_refs = [call.args[0] for call in executor._artifact_vault.store.await_args_list]
         # every shell is a source artifact; the manifest record is stored but NOT among
@@ -196,9 +194,7 @@ class TestSeedVerificationScaffoldArtifacts:
         assert ids == []
         executor._artifact_vault.store.assert_not_awaited()
 
-    async def test_emission_failure_on_an_opted_in_stack_fails_run_setup_loudly(
-        self, monkeypatch
-    ):
+    async def test_emission_failure_on_an_opted_in_stack_fails_run_setup_loudly(self, monkeypatch):
         """The #845 doctrine: an invalid scaffold is not a degraded run. Bug caught: a
         tolerant except here would hand qa a run with no deterministic verification story
         and let the failure surface as burned LLM rounds instead of a setup rejection."""

--- a/tests/unit/cycles/test_executor_interface_manifest.py
+++ b/tests/unit/cycles/test_executor_interface_manifest.py
@@ -151,6 +151,77 @@ class TestSeedSkeletonArtifacts:
         executor._artifact_vault.store.assert_not_awaited()
 
 
+class TestSeedVerificationScaffoldArtifacts:
+    """SIP-0104 P1: the test scaffold rides the seed act, opt-in gated, loud on failure."""
+
+    async def test_opted_in_stack_seeds_shells_and_stores_the_manifest_record(self):
+        from squadops.capabilities.verification_scaffold_emission import (
+            emit_verification_scaffold,
+        )
+        from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+        manifest = manifest_for_stack("nextjs_ts")
+        expected = emit_verification_scaffold(manifest)
+
+        executor = _make_executor()
+        ids = await executor._seed_verification_scaffold_artifacts(
+            manifest, _make_cycle(), "run_x"
+        )
+
+        stored_refs = [call.args[0] for call in executor._artifact_vault.store.await_args_list]
+        # every shell is a source artifact; the manifest record is stored but NOT among
+        # the returned seed ids (it is evidence, not a workspace file)
+        shell_refs = [r for r in stored_refs if r.artifact_type == "source"]
+        record_refs = [
+            r for r in stored_refs if r.artifact_type == "verification_scaffold_manifest"
+        ]
+        assert [r.artifact_id for r in shell_refs] == ids
+        assert {r.filename for r in shell_refs} == {f["name"] for f in expected.files}
+        assert all(r.metadata["verification_scaffold"] for r in shell_refs)
+        assert all(r.metadata["scaffold_seeded"] for r in shell_refs)
+        assert len(record_refs) == 1
+        record = record_refs[0]
+        assert record.filename == "verification_scaffold_manifest.yaml"
+        assert record.artifact_id not in ids
+        assert record.metadata["aggregate_spine_hash"] == expected.manifest.aggregate_spine_hash()
+        assert record.metadata["generator_version"] == expected.manifest.generator_version
+
+    async def test_a_stack_that_has_not_opted_in_seeds_nothing(self):
+        from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+        executor = _make_executor()
+        ids = await executor._seed_verification_scaffold_artifacts(
+            manifest_for_stack("fullstack_fastapi_react"), _make_cycle(), "run_x"
+        )
+        assert ids == []
+        executor._artifact_vault.store.assert_not_awaited()
+
+    async def test_emission_failure_on_an_opted_in_stack_fails_run_setup_loudly(
+        self, monkeypatch
+    ):
+        """The #845 doctrine: an invalid scaffold is not a degraded run. Bug caught: a
+        tolerant except here would hand qa a run with no deterministic verification story
+        and let the failure surface as burned LLM rounds instead of a setup rejection."""
+        import pytest
+
+        from squadops.capabilities import verification_scaffold_emission as emission_module
+        from squadops.capabilities.verification_scaffold import ScaffoldValidationError
+        from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+        def _boom(manifest, **kwargs):
+            raise ScaffoldValidationError("injected generator defect")
+
+        monkeypatch.setattr(emission_module, "emit_verification_scaffold", _boom)
+        # the executor imports the symbol inside the helper, so patch the module attr
+        # it resolves at call time
+        executor = _make_executor()
+        with pytest.raises(ScaffoldValidationError, match="injected generator defect"):
+            await executor._seed_verification_scaffold_artifacts(
+                manifest_for_stack("nextjs_ts"), _make_cycle(), "run_x"
+            )
+        executor._artifact_vault.store.assert_not_awaited()
+
+
 class TestSeedPriorArtifactsDedupe:
     """#881: ids already restored from a checkpoint must not be re-appended.
 


### PR DESCRIPTION
Phase 1 of the SIP-0104 plan (`docs/plans/deterministic-verification-scaffolding-plan.md`): **Gate 1, the deterministic artifact.** P1 owns generation correctness — deterministic output, authoritative derivation, manifest production.

## Commits, in the plan's ordering (contract first, generator second)

1. **The scaffold contract** (`capabilities/verification_scaffold.py`) — scaffold-manifest schema with the attribution facts a hash mismatch needs (generator version, source-manifest hash, expanded-tree hash, per-file spine hashes, slot region bounds); slot-id grammar and marker parsing with a near-miss guard (a typo'd marker fails instead of freezing into the spine); the normative slot-elided spine-hash canonicalization; derivation-source precedence; the three failure types. Placed in capabilities so P4's region enforcement (cycles domain) imports the same canonicalization the generator uses — one definition, two consumers.
2. **The generator** (`stack_nextjs_ts_tests.py` + `verification_scaffold_emission.py`) — behavior shells derive from the verification contract's own behavioral probes (in-process twins: create, blank-rejection, chained child actions, duplicate-conflict) plus minted read shells where derivable (collection GET, read-by-id via the capture chain, unknown-id 404). Underivable behaviors are demoted to the qa author's additive surface, never guessed. Chained state replays the probe sequence's own semantics per isolated test. Opt-in is an explicit `ScaffoldStack.verification_scaffold` field — nextjs_ts opts in, stack #1 deliberately does not — and the stack-inventory test gains the registry row with a pinned opt-in carve-out.
3. **Seed-time lifecycle** — expand → emit → **validate** → persist → expose: emission validates against its own manifest before persistence, rides the same seed act as the skeleton (never on resume, #881 by construction), and a failure on an opted-in stack fails run setup loudly (the #845 doctrine) instead of burning an LLM round. The scaffold-manifest record is stored as evidence (run id + `verification_scaffold_manifest` type), not materialized into the app tree.
4. **Gate 1 pins** — the committed reference fixture (8 shells + manifest for the reference nextjs_ts manifest at GENERATOR_VERSION 1) with both ends held: input manifest hash and fixture aggregate hashes pinned in the test, no regeneration hatch.

## Gate 1 exit criteria

- **Byte-equivalence**: reference manifest + generator version → byte-identical scaffold and manifest ✅ (standing pin, M0a shape)
- **Derivability mutations**: tampered tree (missing route file / missing export / missing store seam) → refusal naming the disagreement; unmapped `not_found` → shell deterministically omitted; unopted stack → refusal; declared-but-unregistered emitter → refusal ✅
- **Stack #1 unmoved**: existing byte-identity pins (`bb472e26…`, `7622f570…`) green; no stack-1 scaffold; opt-in explicit ✅

Validation: full regression suite **7162 passed, 1 skipped**, ruff clean.

## Deliberate interim state (P1→P4 window)

The emitted shells are seeded workspace artifacts but are **not yet in the bound record's frozen set** — region-level enforcement of the scaffold is exactly P4's phase, so until P4 lands a producer could still rewrite a shell wholesale. Covered by the plan's roll policy (no experimental roll before P1–P4 deployed and proven). Also per plan, `qa.test` does not yet know about the scaffold (fill mode is P3): shells simply ride the workspace and execute with the suite.

Next after merge: **Phase 2 — Gate 2, the executable artifact** (skeleton-execution gate + the negative corpus, including the consistent-inputs/broken-generator case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
