### PR TITLE
feat(sip-0104): Phase 2 — the execution-readiness gates (static bytes-level + skeleton execution)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1908,18 +1908,27 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         (P4), not a file the app tree should carry. It is reachable by run id +
         artifact type.
         """
-        from squadops.capabilities.scaffold import verification_scaffold_for
+        from squadops.capabilities.scaffold import expand, verification_scaffold_for
         from squadops.capabilities.verification_scaffold_emission import (
             VERIFICATION_SCAFFOLD_MANIFEST_ARTIFACT_TYPE,
             VERIFICATION_SCAFFOLD_MANIFEST_FILENAME,
             emit_verification_scaffold,
+        )
+        from squadops.capabilities.verification_scaffold_gate import (
+            validate_execution_readiness,
         )
 
         if not verification_scaffold_for(manifest.stack):
             return []
 
         try:
-            emission = emit_verification_scaffold(manifest)
+            # One tree for emission AND the readiness gate, so the two cannot check
+            # against different expansions. The gate re-reads the EMITTED BYTES (P2):
+            # emission's own validation proves record/output agreement; this proves the
+            # output's mechanical claims hold against the tree and contract.
+            tree = expand(manifest)
+            emission = emit_verification_scaffold(manifest, expanded=tree)
+            validate_execution_readiness(emission, tree, manifest)
         except Exception:
             logger.error(
                 "test-scaffold emission failed for opted-in stack %s (run %s) — failing "

--- a/src/squadops/capabilities/handlers/scaffold_execution.py
+++ b/src/squadops/capabilities/handlers/scaffold_execution.py
@@ -25,6 +25,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shutil
 import tempfile
 from dataclasses import dataclass
@@ -69,14 +70,23 @@ def _first_line(message: str) -> str:
     return message.strip().split("\n", 1)[0][:_MESSAGE_LIMIT]
 
 
+#: The shapes vitest's JSON reporter gives an ``expect()`` mismatch. Measured against a
+#: real gate run (node:20-alpine, vitest 1.6, 2026-08-14): chai serializes the failure as
+#: the BARE message — ``expected 500 to be 201 // Object.is equality`` — with no error-name
+#: prefix; the ``AssertionError:`` form is kept for reporter variants that do prefix.
+_ASSERTION_SHAPES = re.compile(r"^\s*(?:AssertionError\b|expected\b)")
+
+
 def _is_assertion_failure(failure_messages: list[str]) -> bool:
     """An expected stub-behavior failure, as vitest reports expect() mismatches.
 
-    Anything else — TypeError, ReferenceError, SyntaxError, a transform crash — is a
-    mechanical death of the shell itself.
+    Deliberately an ALLOWLIST of assertion shapes, not a blocklist of error names: the
+    gate's safe misclassification direction is expected-as-mechanical (a valid scaffold
+    fails loudly), never mechanical-as-expected (a broken shell ships — the exact tail
+    this SIP exists to end). An unrecognized failure shape is therefore mechanical.
     """
     return bool(failure_messages) and all(
-        message.lstrip().startswith("AssertionError") for message in failure_messages
+        _ASSERTION_SHAPES.match(message) for message in failure_messages
     )
 
 

--- a/src/squadops/capabilities/handlers/scaffold_execution.py
+++ b/src/squadops/capabilities/handlers/scaffold_execution.py
@@ -35,6 +35,10 @@ logger = logging.getLogger(__name__)
 _REPORT_FILENAME = ".scaffold_gate_report.json"
 _MESSAGE_LIMIT = 400
 
+#: vitest's OWN report vocabulary (jest-compatible JSON reporter), named so it cannot be
+#: mistaken for — or drift with — this codebase's status enums (#380).
+_VITEST_STATUS_FAILED = "failed"
+
 
 @dataclass(frozen=True)
 class SkeletonExecutionVerdict:
@@ -113,7 +117,7 @@ def classify_vitest_report(report: dict, scaffold_paths: list[str]) -> SkeletonE
             continue
         collected.append(path)
         results = suite.get("assertionResults") or []
-        if suite.get("status") == "failed" and not results:
+        if suite.get("status") == _VITEST_STATUS_FAILED and not results:
             # The suite died before any test ran: unresolved import, transform
             # failure, a top-level throw — the collection-level mechanical class.
             mechanical.append(
@@ -121,7 +125,7 @@ def classify_vitest_report(report: dict, scaffold_paths: list[str]) -> SkeletonE
             )
             continue
         for result in results:
-            if result.get("status") != "failed":
+            if result.get("status") != _VITEST_STATUS_FAILED:
                 continue
             messages = [str(m) for m in result.get("failureMessages") or []]
             if _is_assertion_failure(messages):

--- a/src/squadops/capabilities/handlers/scaffold_execution.py
+++ b/src/squadops/capabilities/handlers/scaffold_execution.py
@@ -1,0 +1,231 @@
+"""The skeleton-execution gate — Gate 2's dynamic half (SIP-0104 P2).
+
+Collection is not sufficient (plan P2): every behavior shell must actually *execute*
+against the walking skeleton and complete without a mechanical crash. Against stub
+handlers the expected outcome is a wall of **assertion failures** (stubs throw
+``not_implemented`` by design — SIP-0098 §7's bare-skeleton-must-fail rule); those are
+counted and ignored. What fails the gate is the mechanical class: a suite that does not
+collect, a shell the runner never saw, a ``TypeError``/``ReferenceError``/transform crash
+— each is ``scaffold-invalid`` (a generator defect, SIP §5).
+
+Placement: the handlers lane, beside ``test_runner`` — this is subprocess machinery that
+needs the Node toolchain, which exists in the agent containers, not the executor. The
+*classification* is a pure function over the vitest JSON report so its corpus runs
+everywhere; only :func:`run_skeleton_execution_gate` needs npm.
+
+A runner-level failure (no npm, timeout, no report produced) is ``executed=False`` and is
+**infrastructure**, not scaffold-invalid — the SIP's §5 taxonomy distinguishes "the gate
+could not run" from "the gate ran and the scaffold failed it", and conflating them would
+let a broken toolchain condemn a correct generator.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+_REPORT_FILENAME = ".scaffold_gate_report.json"
+_MESSAGE_LIMIT = 400
+
+
+@dataclass(frozen=True)
+class SkeletonExecutionVerdict:
+    """The gate's outcome for one scaffold, executed against its stub skeleton."""
+
+    executed: bool
+    scaffold_valid: bool = False
+    mechanical_failures: tuple[str, ...] = ()
+    assertion_failures: int = 0
+    collected_files: tuple[str, ...] = ()
+    missing_files: tuple[str, ...] = ()
+    error: str = ""
+
+    @property
+    def summary(self) -> str:
+        if not self.executed:
+            return f"gate did not run: {self.error or 'unknown runner failure'}"
+        if self.scaffold_valid:
+            return (
+                f"scaffold executed cleanly against the skeleton "
+                f"({len(self.collected_files)} shell file(s), "
+                f"{self.assertion_failures} expected stub assertion failure(s))"
+            )
+        parts = []
+        if self.missing_files:
+            parts.append(f"{len(self.missing_files)} shell(s) never collected")
+        if self.mechanical_failures:
+            parts.append(f"{len(self.mechanical_failures)} mechanical failure(s)")
+        return "scaffold-invalid: " + ", ".join(parts)
+
+
+def _first_line(message: str) -> str:
+    return message.strip().split("\n", 1)[0][:_MESSAGE_LIMIT]
+
+
+def _is_assertion_failure(failure_messages: list[str]) -> bool:
+    """An expected stub-behavior failure, as vitest reports expect() mismatches.
+
+    Anything else — TypeError, ReferenceError, SyntaxError, a transform crash — is a
+    mechanical death of the shell itself.
+    """
+    return bool(failure_messages) and all(
+        message.lstrip().startswith("AssertionError") for message in failure_messages
+    )
+
+
+def classify_vitest_report(report: dict, scaffold_paths: list[str]) -> SkeletonExecutionVerdict:
+    """Classify a vitest ``--reporter=json`` report for the scaffold files only.
+
+    Non-scaffold suites (the harness proof, authored tests) are outside the gate's
+    subject: their outcomes are the suite run's business, not the generator's.
+    """
+    mechanical: list[str] = []
+    assertion_failures = 0
+    collected: list[str] = []
+
+    by_suffix: dict[str, dict] = {}
+    for suite in report.get("testResults", ()):
+        name = str(suite.get("name", ""))
+        for path in scaffold_paths:
+            if name.endswith(path):
+                by_suffix[path] = suite
+
+    for path in scaffold_paths:
+        suite = by_suffix.get(path)
+        if suite is None:
+            continue
+        collected.append(path)
+        results = suite.get("assertionResults") or []
+        if suite.get("status") == "failed" and not results:
+            # The suite died before any test ran: unresolved import, transform
+            # failure, a top-level throw — the collection-level mechanical class.
+            mechanical.append(
+                f"{path}: suite failed to run: {_first_line(str(suite.get('message', '')))}"
+            )
+            continue
+        for result in results:
+            if result.get("status") != "failed":
+                continue
+            messages = [str(m) for m in result.get("failureMessages") or []]
+            if _is_assertion_failure(messages):
+                assertion_failures += 1
+            else:
+                detail = _first_line(messages[0]) if messages else "no failure message"
+                mechanical.append(f"{path}: {result.get('title', '?')}: {detail}")
+
+    missing = tuple(p for p in scaffold_paths if p not in by_suffix)
+    for path in missing:
+        mechanical.append(
+            f"{path}: never collected by the runner — the shell would silently not exist"
+        )
+    return SkeletonExecutionVerdict(
+        executed=True,
+        scaffold_valid=not mechanical,
+        mechanical_failures=tuple(mechanical),
+        assertion_failures=assertion_failures,
+        collected_files=tuple(collected),
+        missing_files=missing,
+    )
+
+
+async def run_skeleton_execution_gate(
+    skeleton_files: list[dict[str, str]],
+    scaffold_files: list[dict[str, str]],
+    timeout_seconds: int = 240,
+) -> SkeletonExecutionVerdict:
+    """Execute the scaffold against its stub skeleton in an isolated workspace.
+
+    Materializes skeleton + scaffold, ``npm install``s, runs the stack's runner with the
+    JSON reporter, and classifies. The vitest exit code is deliberately ignored — against
+    stubs the suite MUST fail (SIP-0098 §7); the report's failure *types* are the verdict.
+    Never raises.
+    """
+    from squadops.capabilities.handlers.test_runner import _materialize_files
+
+    scaffold_paths = [f["name"] for f in scaffold_files]
+    workspace = tempfile.mkdtemp(prefix="scaffold_gate_")
+    try:
+        _materialize_files(
+            workspace,
+            [{"path": f["name"], "content": f["content"]} for f in skeleton_files]
+            + [{"path": f["name"], "content": f["content"]} for f in scaffold_files],
+        )
+
+        try:
+            install = await asyncio.create_subprocess_exec(
+                "npm",
+                "install",
+                "--no-audit",
+                "--no-fund",
+                cwd=workspace,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError:
+            return SkeletonExecutionVerdict(
+                executed=False, error="npm not found — Node.js is not installed"
+            )
+        try:
+            await asyncio.wait_for(install.communicate(), timeout=timeout_seconds)
+        except TimeoutError:
+            install.kill()
+            await install.wait()
+            return SkeletonExecutionVerdict(
+                executed=False, error=f"npm install timed out after {timeout_seconds}s"
+            )
+        if install.returncode != 0:
+            return SkeletonExecutionVerdict(
+                executed=False, error="npm install failed (dependency resolution error)"
+            )
+
+        report_path = os.path.join(workspace, _REPORT_FILENAME)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "npx",
+                "vitest",
+                "run",
+                "--reporter=json",
+                f"--outputFile={report_path}",
+                cwd=workspace,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError:
+            return SkeletonExecutionVerdict(
+                executed=False, error="npx not found — Node.js is not installed"
+            )
+        try:
+            _, raw_stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return SkeletonExecutionVerdict(
+                executed=False, error=f"vitest timed out after {timeout_seconds}s"
+            )
+
+        try:
+            with open(report_path, encoding="utf-8") as fh:
+                report = json.load(fh)
+        except (OSError, ValueError):
+            # No report at all: vitest itself failed to start (config error, OOM).
+            # Runner-level, not a scaffold verdict.
+            return SkeletonExecutionVerdict(
+                executed=False,
+                error=(
+                    "vitest produced no JSON report — runner-level failure: "
+                    + _first_line(raw_stderr.decode(errors="replace"))
+                ),
+            )
+        return classify_vitest_report(report, scaffold_paths)
+    except Exception as exc:  # never raise — a runner error is infrastructure, not a verdict
+        logger.warning("Skeleton execution gate error: %s", exc, exc_info=True)
+        return SkeletonExecutionVerdict(executed=False, error=str(exc))
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)

--- a/src/squadops/capabilities/verification_scaffold_gate.py
+++ b/src/squadops/capabilities/verification_scaffold_gate.py
@@ -1,0 +1,222 @@
+"""Static execution-readiness gate for the test scaffold — SIP-0104 P2 (Gate 2).
+
+The §4.4 self-check's deterministic half: before an emitted scaffold may become part of a
+run, every mechanical claim its bytes make must hold against the authoritative sources.
+The dynamic half — actually executing the shells against the walking skeleton — lives in
+``handlers.scaffold_execution`` (it needs a Node toolchain; this module needs nothing).
+
+**Every check reads the EMITTED BYTES, never the generator's intent.** P1's derivation
+checks prove what the generator *meant* to reference; a generator bug is precisely a gap
+between what it meant and what it wrote. The decisive Gate 2 case — internally consistent
+inputs, wrong emitted import path — is invisible to intent-level checks and caught here,
+as ``scaffold-invalid`` (SIP §5: a generator defect, never an LLM repair target).
+
+Checks, each against its authoritative source (the contract's precedence):
+
+- **imports resolve** — every ``@/…`` specifier maps to a file in the expanded tree; every
+  bare specifier is a declared dependency in the tree's ``package.json`` (the roll-9
+  ``supertest`` class, closed deterministically for the spine);
+- **referenced symbols exist** — every named import and every ``alias.MEMBER`` usage of a
+  namespace import is exported by the resolved tree file (the roll-14 wrong-module class);
+- **asserted statuses exist in the contract** — every spine status assertion is a status
+  the manifest declares (success statuses per endpoint, defaults matching the probe
+  deriver, plus the error contract's HTTP codes);
+- **criterion identity survives** — each slot's ``slot_id`` and bound ``probe_id`` appear
+  literally in the emitted file, so failure evidence can be traced back without a join
+  through generator state;
+- **placement is collectable** — every file lies where the stack's runner include pattern
+  will find it (the #884 "No test files found" class, closed before a runner exists).
+
+Findings accumulate (the ``manifest_gates`` posture: one report, not one-per-revision);
+:func:`validate_execution_readiness` raises ``ScaffoldValidationError`` carrying them all.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING
+
+from squadops.capabilities.verification_scaffold import ScaffoldValidationError
+
+if TYPE_CHECKING:  # pragma: no cover - annotations only
+    from squadops.capabilities.scaffold import InterfaceManifest
+    from squadops.capabilities.verification_scaffold_emission import (
+        VerificationScaffoldEmission,
+    )
+
+_NAMESPACE_IMPORT_RE = re.compile(r"^import \* as (?P<alias>\w+) from '(?P<spec>[^']+)'$")
+_NAMED_IMPORT_RE = re.compile(r"^import \{(?P<names>[^}]*)\} from '(?P<spec>[^']+)'$")
+_STATUS_ASSERT_RE = re.compile(r"expect\(\w+\.status\)\.toBe\((?P<status>\d{3})\)")
+
+#: Where the stack's runner looks (vitest include ``**/__tests__/**/*.test.ts``). A file
+#: outside this surface collects as nothing and reads as "no test files found" (#884).
+_COLLECTABLE_PREFIX = "__tests__/"
+_COLLECTABLE_SUFFIX = ".test.ts"
+
+
+def _exports(content: str, name: str) -> bool:
+    return bool(
+        re.search(rf"export (?:async )?(?:function|const|class|interface|type) {name}\b", content)
+    )
+
+
+def _resolve_alias(spec: str, tree: dict[str, str]) -> str | None:
+    """A ``@/…`` specifier's tree file, or None. Mirrors the runner's ``@`` alias (root)."""
+    stem = spec[2:]
+    for candidate in (f"{stem}.ts", f"{stem}.tsx", stem):
+        if candidate in tree:
+            return candidate
+    return None
+
+
+def _declared_packages(tree: dict[str, str]) -> set[str]:
+    try:
+        pkg = json.loads(tree.get("package.json", "") or "{}")
+    except ValueError:
+        return set()
+    return set(pkg.get("dependencies", {})) | set(pkg.get("devDependencies", {}))
+
+
+def _allowed_statuses(manifest: InterfaceManifest) -> set[int]:
+    """Statuses the contract declares — the same defaults the probe deriver applies
+    (201 for a parameterless POST create, 200 otherwise), plus the error contract."""
+    allowed: set[int] = set()
+    for ep in manifest.api.endpoints:
+        default = 201 if ep.method == "POST" and "{" not in ep.path else 200
+        allowed.add(ep.success_status or default)
+    contract = manifest.api.error_contract
+    for code in contract.codes if contract else ():
+        allowed.add(code.http)
+    return allowed
+
+
+def _placement_findings(path: str) -> list[str]:
+    if path.startswith(_COLLECTABLE_PREFIX) and path.endswith(_COLLECTABLE_SUFFIX):
+        return []
+    return [
+        f"{path}: outside the runner's collection surface "
+        f"({_COLLECTABLE_PREFIX}**/*{_COLLECTABLE_SUFFIX}) — the suite would run "
+        f"without it and read as covered"
+    ]
+
+
+def _import_findings(
+    path: str, content: str, tree_by_name: dict[str, str], packages: set[str]
+) -> tuple[list[str], dict[str, str]]:
+    """Import-resolution findings, plus the file's resolved namespace aliases."""
+    findings: list[str] = []
+    aliases: dict[str, str] = {}
+    for line in content.split("\n"):
+        stripped = line.strip()
+        if not stripped.startswith("import "):
+            continue
+        ns = _NAMESPACE_IMPORT_RE.match(stripped)
+        named = _NAMED_IMPORT_RE.match(stripped)
+        spec = (ns or named).group("spec") if (ns or named) else ""
+        if not spec:
+            findings.append(f"{path}: unparseable import line {stripped!r}")
+        elif spec.startswith("@/"):
+            resolved = _resolve_alias(spec, tree_by_name)
+            if resolved is None:
+                findings.append(
+                    f"{path}: import {spec!r} resolves to no file in the expanded "
+                    f"tree — the suite dies at collection"
+                )
+            elif ns:
+                aliases[ns.group("alias")] = resolved
+            else:
+                for name in named.group("names").split(","):
+                    name = name.strip()
+                    if name and not _exports(tree_by_name[resolved], name):
+                        findings.append(
+                            f"{path}: imports {name!r} from {spec!r}, which "
+                            f"{resolved} does not export"
+                        )
+        elif spec.startswith("."):
+            findings.append(
+                f"{path}: relative import {spec!r} — the spine imports via the "
+                f"stack's `@` alias only"
+            )
+        elif spec not in packages:
+            findings.append(
+                f"{path}: bare import {spec!r} is not a declared dependency in "
+                f"package.json — the suite dies at collection (the roll-9 class)"
+            )
+    return findings, aliases
+
+
+def _handler_findings(
+    path: str, content: str, aliases: dict[str, str], tree_by_name: dict[str, str]
+) -> list[str]:
+    return [
+        f"{path}: invokes {alias}.{member} but {aliases[alias]} does not export "
+        f"{member!r} — a TypeError at execution"
+        for alias, member in re.findall(r"\b(\w+)\.([A-Z]{2,})\b", content)
+        if alias in aliases and not _exports(tree_by_name[aliases[alias]], member)
+    ]
+
+
+def _status_findings(path: str, content: str, allowed: set[int]) -> list[str]:
+    return [
+        f"{path}: asserts status {status}, which the contract does not "
+        f"declare (allowed: {sorted(allowed)})"
+        for status in _STATUS_ASSERT_RE.findall(content)
+        if int(status) not in allowed
+    ]
+
+
+def _identity_findings(emission: VerificationScaffoldEmission) -> list[str]:
+    """Slot and probe identity must survive into the bytes (plan P2)."""
+    findings: list[str] = []
+    emitted = {f["name"]: f["content"] for f in emission.files}
+    for record in emission.manifest.files:
+        content = emitted.get(record.path, "")
+        for slot in record.slots:
+            if slot.slot_id not in content:
+                findings.append(
+                    f"{record.path}: slot id {slot.slot_id!r} does not appear in the "
+                    f"emitted file — evidence could not be traced to its slot"
+                )
+            if slot.probe_id and slot.probe_id not in content.replace(slot.slot_id, ""):
+                findings.append(
+                    f"{record.path}: bound probe id {slot.probe_id!r} does not survive "
+                    f"into the emitted file — the §5 dedup rule would have nothing to "
+                    f"join on"
+                )
+    return findings
+
+
+def assess_execution_readiness(
+    emission: VerificationScaffoldEmission,
+    tree: list[dict[str, str]],
+    manifest: InterfaceManifest,
+) -> list[str]:
+    """Every readiness claim the emitted bytes fail, as accumulated findings."""
+    tree_by_name = {f["name"]: f["content"] for f in tree}
+    packages = _declared_packages(tree_by_name)
+    allowed = _allowed_statuses(manifest)
+    findings: list[str] = []
+    for f in emission.files:
+        path, content = f["name"], f["content"]
+        findings.extend(_placement_findings(path))
+        import_findings, aliases = _import_findings(path, content, tree_by_name, packages)
+        findings.extend(import_findings)
+        findings.extend(_handler_findings(path, content, aliases, tree_by_name))
+        findings.extend(_status_findings(path, content, allowed))
+    findings.extend(_identity_findings(emission))
+    return findings
+
+
+def validate_execution_readiness(
+    emission: VerificationScaffoldEmission,
+    tree: list[dict[str, str]],
+    manifest: InterfaceManifest,
+) -> None:
+    """Raise ``ScaffoldValidationError`` (scaffold-invalid) unless the emission is ready."""
+    findings = assess_execution_readiness(emission, tree, manifest)
+    if findings:
+        raise ScaffoldValidationError(
+            "scaffold failed the execution-readiness gate (scaffold-invalid, a generator "
+            "defect — never an LLM repair target): " + "; ".join(findings)
+        )

--- a/src/squadops/cycles/authoring_failure.py
+++ b/src/squadops/cycles/authoring_failure.py
@@ -34,6 +34,7 @@ from squadops.cycles.manifest_gates import (
     PROOF_EXPANDS,
     PROOF_LINT,
     PROOF_PARSES,
+    PROOF_SCAFFOLD_READY,
     PROOF_SOURCE_PRD,
     PROOF_STACK_MATCHES_CONFIG,
     PROOF_STATUS_DECLARED,
@@ -99,6 +100,12 @@ _PROOF_CLASS: dict[str, str] = {
     # elimination, not the author's.
     PROOF_CONTRACT_DERIVES: DERIVATION_DEFECT,
     PROOF_CHECKS_LIVE: DERIVATION_DEFECT,
+    # SIP-0104 P2: the manifest already parsed, linted, expanded, and derived a contract;
+    # a scaffold that cannot be validly emitted from it is the GENERATOR's problem by the
+    # same elimination as `contract_derives` — never taught to the author (scaffold
+    # self-repair prohibition, SIP-0104 §4.3: a scaffold defect routes to the scaffold
+    # owner, not to an LLM round).
+    PROOF_SCAFFOLD_READY: DERIVATION_DEFECT,
 }
 
 

--- a/src/squadops/cycles/manifest_authoring_rules.py
+++ b/src/squadops/cycles/manifest_authoring_rules.py
@@ -29,6 +29,7 @@ from squadops.cycles.manifest_gates import (
     PROOF_EXPANDS,
     PROOF_LINT,
     PROOF_PARSES,
+    PROOF_SCAFFOLD_READY,
     PROOF_SOURCE_PRD,
     PROOF_STACK_MATCHES_CONFIG,
     PROOF_STATUS_DECLARED,
@@ -74,6 +75,11 @@ NOT_AUTHOR_FACING: dict[str, str] = {
     "deriver, never in the manifest",
     PROOF_CHECKS_LIVE: "derivation-owned (M6 DERIVATION_DEFECT): a dead-on-arrival check "
     "is emitted by the deriver, not authored",
+    # SIP-0104 P2: an opted-in stack whose test scaffold cannot be validly emitted.
+    # The generator's defect by elimination (the manifest already expanded and derived
+    # a contract); teaching the author anything here would teach a superstition.
+    PROOF_SCAFFOLD_READY: "derivation-owned (M6 DERIVATION_DEFECT): the fix is in the "
+    "scaffold generator or its readiness gate (SIP-0104), never in the manifest",
 }
 
 

--- a/src/squadops/cycles/manifest_gates.py
+++ b/src/squadops/cycles/manifest_gates.py
@@ -42,6 +42,10 @@ PROOF_STATUS_DECLARED = "status_declared"
 #: stack the CYCLE was configured for. A manifest for another stack is unwinnable in the
 #: most literal sense — the expander builds a different application.
 PROOF_STACK_MATCHES_CONFIG = "stack_matches_config"
+#: SIP-0104 P2: a stack that opted into the deterministic test scaffold must be able to
+#: emit one that passes the execution-readiness gate. A manifest whose scaffold cannot be
+#: validly emitted fails here — a free framing re-roll (#522) — rather than at run setup.
+PROOF_SCAFFOLD_READY = "scaffold_ready"
 
 #: Schema-gate proof classes (M2). ``PROOF_SOURCE_PRD`` was ``PROOF_PROVENANCE`` until #803
 #: gave the manifest an actual ``provenance`` block — one word for "where the design came
@@ -103,6 +107,7 @@ def assess_winnability(
     findings.extend(_contract_findings(manifest))
     findings.extend(_testid_findings(manifest))
     findings.extend(_status_findings(manifest))
+    findings.extend(_scaffold_findings(manifest))
     return tuple(findings)
 
 
@@ -316,6 +321,47 @@ def _contract_findings(manifest) -> list[WinnabilityFinding]:
                         )
                     )
     return findings
+
+
+def _scaffold_findings(manifest) -> list[WinnabilityFinding]:
+    """An opted-in stack's test scaffold must emit and pass the readiness gate (SIP-0104).
+
+    Skips silently for a stack with no ``verification_scaffold`` declaration — no scaffold
+    is a declared state, not a defect. An expansion failure also reports nothing here:
+    ``_expander_findings`` owns that root cause, and a second finding for the same defect
+    would read as two problems. What this proof owns is the scaffold-specific tail: a
+    derivation refusal, or emitted bytes that fail the execution-readiness gate — each a
+    run-setup death (SIP-0104 §4.4) converted into a free framing re-roll (#522).
+    """
+    from squadops.capabilities.scaffold import expand, verification_scaffold_for
+
+    if not verification_scaffold_for(str(getattr(manifest, "stack", "") or "")):
+        return []
+    from squadops.capabilities.verification_scaffold_emission import emit_verification_scaffold
+    from squadops.capabilities.verification_scaffold_gate import assess_execution_readiness
+
+    try:
+        tree = expand(manifest)
+    except Exception:  # noqa: BLE001 - PROOF_EXPANDS owns expansion failures
+        return []
+    try:
+        emission = emit_verification_scaffold(manifest, expanded=tree)
+    except Exception as exc:  # noqa: BLE001 - untrusted authored input: one finding
+        return [
+            WinnabilityFinding(
+                PROOF_SCAFFOLD_READY,
+                f"this stack opted into the deterministic test scaffold, but no valid "
+                f"scaffold can be emitted from this manifest ({exc}). The run would die "
+                f"at setup with no deterministic verification story.",
+            )
+        ]
+    return [
+        WinnabilityFinding(
+            PROOF_SCAFFOLD_READY,
+            f"the emitted test scaffold fails its execution-readiness gate: {finding}",
+        )
+        for finding in assess_execution_readiness(emission, tree, manifest)
+    ]
 
 
 def _stack_findings(manifest, expected_stack: str) -> list[WinnabilityFinding]:

--- a/tests/integration/capabilities/test_scaffold_skeleton_execution.py
+++ b/tests/integration/capabilities/test_scaffold_skeleton_execution.py
@@ -1,0 +1,72 @@
+"""Gate 2 end-to-end: the scaffold really executes against the walking skeleton.
+
+The unit corpus proves the classifier against measured report shapes; this proves the
+whole gate against a real Node toolchain — npm install, vitest collection, shell
+execution against the stubs. Requires npm (the agent-container toolchain); skipped where
+Node is absent. First measured 2026-08-14 in node:20-alpine on the reference scaffold:
+9 tests collected (8 shells + harness), harness passed, 8 shells failed as the expected
+stub assertion wall, verdict valid.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from squadops.capabilities.handlers.scaffold_execution import run_skeleton_execution_gate
+from squadops.capabilities.scaffold import expand
+from squadops.capabilities.verification_scaffold_emission import emit_verification_scaffold
+from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(shutil.which("npm") is None, reason="requires the Node toolchain"),
+]
+
+_TIMEOUT = 420
+
+
+@pytest.fixture(scope="module")
+def reference():
+    manifest = manifest_for_stack("nextjs_ts")
+    tree = expand(manifest)
+    return tree, emit_verification_scaffold(manifest, expanded=tree)
+
+
+async def test_the_reference_scaffold_executes_cleanly_against_the_skeleton(reference):
+    """Gate 2's positive exit: every shell collects and executes; the only failures are
+    the expected stub assertion wall (SIP-0098 §7)."""
+    tree, emission = reference
+    verdict = await run_skeleton_execution_gate(
+        tree, list(emission.files), timeout_seconds=_TIMEOUT
+    )
+    assert verdict.executed, verdict.error
+    assert verdict.scaffold_valid, verdict.mechanical_failures
+    assert len(verdict.collected_files) == len(emission.files)
+    assert verdict.assertion_failures == len(emission.files)
+    assert verdict.missing_files == ()
+
+
+async def test_an_injected_runtime_defect_is_caught_as_mechanical(reference):
+    """The dynamic decisive case: statically well-formed (imports resolve, handlers
+    exported, statuses declared) but runtime-broken — a defect only execution can see."""
+    tree, emission = reference
+    files = [
+        (
+            {
+                "name": f["name"],
+                "content": f["content"].replace("new Request(", "new Requests(", 1),
+            }
+            if f["name"] == "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts"
+            else dict(f)
+        )
+        for f in emission.files
+    ]
+    verdict = await run_skeleton_execution_gate(tree, files, timeout_seconds=_TIMEOUT)
+    assert verdict.executed, verdict.error
+    assert not verdict.scaffold_valid
+    assert any(
+        "vc-probe-api-runs.scaffold.test.ts" in failure and "Requests" in failure
+        for failure in verdict.mechanical_failures
+    )

--- a/tests/unit/capabilities/test_scaffold_execution.py
+++ b/tests/unit/capabilities/test_scaffold_execution.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from squadops.capabilities.handlers.scaffold_execution import (
     SkeletonExecutionVerdict,
     classify_vitest_report,
@@ -39,14 +41,42 @@ def _report(*suites: dict) -> dict:
 
 
 class TestClassifier:
+    @pytest.mark.parametrize(
+        ("message", "expected_kind"),
+        [
+            # Measured (node:20-alpine, vitest 1.6, 2026-08-14): chai emits the BARE
+            # message. The prefixed form is kept for reporter variants that do prefix.
+            ("expected 500 to be 201 // Object.is equality", "assertion"),
+            ("AssertionError: expected 500 to be 201", "assertion"),
+            ("expected [ ] to have a length of 1 but got +0", "assertion"),
+            ("TypeError: routeApiRuns.GET is not a function", "mechanical"),
+            ("ReferenceError: Requests is not defined", "mechanical"),
+            ("SyntaxError: Unexpected token", "mechanical"),
+            # Unknown shape → mechanical: the safe misclassification direction.
+            ("something entirely unrecognized", "mechanical"),
+        ],
+    )
+    def test_failure_shape_classification(self, message, expected_kind):
+        verdict = classify_vitest_report(
+            _report(_suite(_SHELL_A, [_failed("t", message)])), [_SHELL_A]
+        )
+        if expected_kind == "assertion":
+            assert verdict.scaffold_valid and verdict.assertion_failures == 1
+        else:
+            assert not verdict.scaffold_valid and verdict.mechanical_failures
+
     def test_stub_assertion_failures_are_expected_and_the_scaffold_is_valid(self):
         """The bare skeleton MUST fail its shells (SIP-0098 §7) — that is not a defect."""
         verdict = classify_vitest_report(
             _report(
                 _suite(
-                    _SHELL_A, [_failed("POST -> 201", "AssertionError: expected 500 to be 201")]
+                    _SHELL_A,
+                    [_failed("POST -> 201", "expected 500 to be 201 // Object.is equality")],
                 ),
-                _suite(_SHELL_B, [_failed("GET -> 200", "AssertionError: expected 500 to be 200")]),
+                _suite(
+                    _SHELL_B,
+                    [_failed("GET -> 200", "expected 500 to be 200 // Object.is equality")],
+                ),
             ),
             [_SHELL_A, _SHELL_B],
         )
@@ -58,7 +88,8 @@ class TestClassifier:
         verdict = classify_vitest_report(
             _report(
                 _suite(
-                    _SHELL_A, [_failed("POST -> 201", "AssertionError: expected 500 to be 201")]
+                    _SHELL_A,
+                    [_failed("POST -> 201", "expected 500 to be 201 // Object.is equality")],
                 ),
                 _suite(
                     _SHELL_B,
@@ -90,7 +121,7 @@ class TestClassifier:
         """Silent non-collection must not read as valid — a missing shell is missing
         coverage that every other signal would report as green (the #884 class)."""
         verdict = classify_vitest_report(
-            _report(_suite(_SHELL_A, [_failed("t", "AssertionError: x")])),
+            _report(_suite(_SHELL_A, [_failed("t", "expected 500 to be 200")])),
             [_SHELL_A, _SHELL_B],
         )
         assert not verdict.scaffold_valid
@@ -117,7 +148,7 @@ class TestClassifier:
         failures must not condemn the generator."""
         verdict = classify_vitest_report(
             _report(
-                _suite(_SHELL_A, [_failed("t", "AssertionError: x")]),
+                _suite(_SHELL_A, [_failed("t", "expected 500 to be 200")]),
                 _suite("__tests__/harness.test.ts", [_failed("h", "TypeError: boom")]),
             ),
             [_SHELL_A],
@@ -140,7 +171,7 @@ class TestClassifier:
                     [
                         _failed(
                             "t",
-                            "AssertionError: expected",
+                            "expected 500 to be 200",
                             "ReferenceError: Requests is not defined",
                         )
                     ],
@@ -166,7 +197,7 @@ class TestRunnerLevelFailures:
 
     def test_summary_states_the_outcome_plainly(self):
         valid = classify_vitest_report(
-            _report(_suite(_SHELL_A, [_failed("t", "AssertionError: x")])), [_SHELL_A]
+            _report(_suite(_SHELL_A, [_failed("t", "expected 500 to be 200")])), [_SHELL_A]
         )
         assert "1 expected stub assertion failure" in valid.summary
         invalid = classify_vitest_report(_report(), [_SHELL_A])

--- a/tests/unit/capabilities/test_scaffold_execution.py
+++ b/tests/unit/capabilities/test_scaffold_execution.py
@@ -51,6 +51,11 @@ class TestClassifier:
             ("expected [ ] to have a length of 1 but got +0", "assertion"),
             ("TypeError: routeApiRuns.GET is not a function", "mechanical"),
             ("ReferenceError: Requests is not defined", "mechanical"),
+            # Measured (defect gate run, 2026-08-14): vitest strips the error-name
+            # prefix from a thrown ReferenceError too — the bare message is all there
+            # is. A blocklist of error-name prefixes would have read this as expected;
+            # the assertion-shape allowlist is what catches it.
+            ("Requests is not defined", "mechanical"),
             ("SyntaxError: Unexpected token", "mechanical"),
             # Unknown shape → mechanical: the safe misclassification direction.
             ("something entirely unrecognized", "mechanical"),

--- a/tests/unit/capabilities/test_scaffold_execution.py
+++ b/tests/unit/capabilities/test_scaffold_execution.py
@@ -1,0 +1,175 @@
+"""The Gate 2 dynamic classifier corpus (SIP-0104 P2).
+
+The classifier is the gate's judgment: which vitest failures are the *expected* wall of
+stub assertion failures, and which are the mechanical class that means the generator shipped
+a broken shell. Misclassifying in either direction is expensive — expected-as-mechanical
+fails every valid scaffold; mechanical-as-expected ships the exact roll-14 tail this SIP
+exists to end.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from squadops.capabilities.handlers.scaffold_execution import (
+    SkeletonExecutionVerdict,
+    classify_vitest_report,
+    run_skeleton_execution_gate,
+)
+
+_SHELL_A = "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts"
+_SHELL_B = "__tests__/scaffold/vs-get-api-runs.scaffold.test.ts"
+
+
+def _suite(path: str, results: list[dict], status: str = "failed", message: str = "") -> dict:
+    return {
+        "name": f"/tmp/ws/{path}",
+        "status": status,
+        "message": message,
+        "assertionResults": results,
+    }
+
+
+def _failed(title: str, *messages: str) -> dict:
+    return {"status": "failed", "title": title, "failureMessages": list(messages)}
+
+
+def _report(*suites: dict) -> dict:
+    return {"testResults": list(suites)}
+
+
+class TestClassifier:
+    def test_stub_assertion_failures_are_expected_and_the_scaffold_is_valid(self):
+        """The bare skeleton MUST fail its shells (SIP-0098 §7) — that is not a defect."""
+        verdict = classify_vitest_report(
+            _report(
+                _suite(
+                    _SHELL_A, [_failed("POST -> 201", "AssertionError: expected 500 to be 201")]
+                ),
+                _suite(_SHELL_B, [_failed("GET -> 200", "AssertionError: expected 500 to be 200")]),
+            ),
+            [_SHELL_A, _SHELL_B],
+        )
+        assert verdict.scaffold_valid
+        assert verdict.assertion_failures == 2
+        assert verdict.mechanical_failures == ()
+
+    def test_a_type_error_is_mechanical_and_names_the_shell(self):
+        verdict = classify_vitest_report(
+            _report(
+                _suite(
+                    _SHELL_A, [_failed("POST -> 201", "AssertionError: expected 500 to be 201")]
+                ),
+                _suite(
+                    _SHELL_B,
+                    [_failed("GET -> 200", "TypeError: routeApiRuns.GET is not a function")],
+                ),
+            ),
+            [_SHELL_A, _SHELL_B],
+        )
+        assert not verdict.scaffold_valid
+        assert verdict.assertion_failures == 1
+        assert any(_SHELL_B in f and "TypeError" in f for f in verdict.mechanical_failures)
+
+    def test_a_suite_that_dies_before_any_test_is_mechanical(self):
+        """The collection-level class: unresolved import / transform crash — the suite
+        reports failed with zero assertion results and a message."""
+        verdict = classify_vitest_report(
+            _report(
+                _suite(_SHELL_A, [], message="Failed to resolve import '@/app/api/run/route'"),
+            ),
+            [_SHELL_A],
+        )
+        assert not verdict.scaffold_valid
+        assert any(
+            "suite failed to run" in f and "Failed to resolve" in f
+            for f in verdict.mechanical_failures
+        )
+
+    def test_a_shell_the_runner_never_saw_is_mechanical(self):
+        """Silent non-collection must not read as valid — a missing shell is missing
+        coverage that every other signal would report as green (the #884 class)."""
+        verdict = classify_vitest_report(
+            _report(_suite(_SHELL_A, [_failed("t", "AssertionError: x")])),
+            [_SHELL_A, _SHELL_B],
+        )
+        assert not verdict.scaffold_valid
+        assert verdict.missing_files == (_SHELL_B,)
+        assert any("never collected" in f for f in verdict.mechanical_failures)
+
+    def test_passing_shells_are_valid(self):
+        """Against a developed app the shells pass — passing is never a gate failure."""
+        verdict = classify_vitest_report(
+            _report(
+                _suite(
+                    _SHELL_A,
+                    [{"status": "passed", "title": "t", "failureMessages": []}],
+                    status="passed",
+                ),
+            ),
+            [_SHELL_A],
+        )
+        assert verdict.scaffold_valid
+        assert verdict.assertion_failures == 0
+
+    def test_non_scaffold_suites_are_outside_the_gate(self):
+        """The harness proof and authored tests are the suite run's business; their
+        failures must not condemn the generator."""
+        verdict = classify_vitest_report(
+            _report(
+                _suite(_SHELL_A, [_failed("t", "AssertionError: x")]),
+                _suite("__tests__/harness.test.ts", [_failed("h", "TypeError: boom")]),
+            ),
+            [_SHELL_A],
+        )
+        assert verdict.scaffold_valid
+
+    def test_a_failure_with_no_message_is_mechanical_not_ignored(self):
+        verdict = classify_vitest_report(
+            _report(_suite(_SHELL_A, [_failed("t")])),
+            [_SHELL_A],
+        )
+        assert not verdict.scaffold_valid
+        assert any("no failure message" in f for f in verdict.mechanical_failures)
+
+    def test_mixed_messages_where_any_is_non_assertion_are_mechanical(self):
+        verdict = classify_vitest_report(
+            _report(
+                _suite(
+                    _SHELL_A,
+                    [
+                        _failed(
+                            "t",
+                            "AssertionError: expected",
+                            "ReferenceError: Requests is not defined",
+                        )
+                    ],
+                )
+            ),
+            [_SHELL_A],
+        )
+        assert not verdict.scaffold_valid
+
+
+class TestRunnerLevelFailures:
+    async def test_missing_node_toolchain_is_infrastructure_not_a_verdict(self):
+        """A broken toolchain must never condemn a correct generator (§5: infrastructure,
+        not scaffold-invalid)."""
+        with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError("npm")):
+            verdict = await run_skeleton_execution_gate(
+                [{"name": "package.json", "content": "{}"}],
+                [{"name": _SHELL_A, "content": "// shell"}],
+            )
+        assert verdict == SkeletonExecutionVerdict(
+            executed=False, error="npm not found — Node.js is not installed"
+        )
+
+    def test_summary_states_the_outcome_plainly(self):
+        valid = classify_vitest_report(
+            _report(_suite(_SHELL_A, [_failed("t", "AssertionError: x")])), [_SHELL_A]
+        )
+        assert "1 expected stub assertion failure" in valid.summary
+        invalid = classify_vitest_report(_report(), [_SHELL_A])
+        assert "scaffold-invalid" in invalid.summary and "never collected" in invalid.summary
+        not_run = SkeletonExecutionVerdict(executed=False, error="npm not found")
+        assert "did not run" in not_run.summary

--- a/tests/unit/capabilities/test_stack_inventory.py
+++ b/tests/unit/capabilities/test_stack_inventory.py
@@ -208,6 +208,10 @@ _GUARD_MODULES = (
     "src/squadops/cycles/implementation_plan.py",
     "src/squadops/cycles/authoring_failure.py",
     "src/squadops/cycles/preflight.py",
+    # SIP-0104 P2: the scaffold execution-readiness gate. assess_* is consumed by the
+    # winnability boundary, validate_* by the executor's seed path — losing either caller
+    # reopens the exact "guard that cannot fire" hole this test exists to close.
+    "src/squadops/capabilities/verification_scaffold_gate.py",
 )
 
 

--- a/tests/unit/capabilities/test_verification_scaffold_gate.py
+++ b/tests/unit/capabilities/test_verification_scaffold_gate.py
@@ -1,0 +1,127 @@
+"""The Gate 2 static corpus — readiness is judged from emitted bytes (SIP-0104 P2).
+
+Every case here injects a GENERATOR defect: the inputs are internally consistent (the
+reference manifest and its own expanded tree), and only the emission is broken. A gate
+that re-derived from the generator's intent would pass every one of these — reading the
+bytes is what makes them catchable, which is the plan's decisive Gate 2 requirement.
+
+These tests tamper ``emission.files`` only. P1's structural validation (record/output
+agreement) is a separate layer with its own corpus; conflating the two here would let a
+readiness regression hide behind a structural failure.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from squadops.capabilities.scaffold import expand
+from squadops.capabilities.verification_scaffold import ScaffoldValidationError
+from squadops.capabilities.verification_scaffold_emission import emit_verification_scaffold
+from squadops.capabilities.verification_scaffold_gate import (
+    assess_execution_readiness,
+    validate_execution_readiness,
+)
+from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+_CREATE_SHELL = "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts"
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    return manifest_for_stack("nextjs_ts")
+
+
+@pytest.fixture(scope="module")
+def tree(manifest):
+    return expand(manifest)
+
+
+@pytest.fixture(scope="module")
+def emission(manifest, tree):
+    return emit_verification_scaffold(manifest, expanded=tree)
+
+
+def _tamper(emission, path: str, old: str, new: str, rename: str | None = None):
+    """A copy of ``emission`` with one file's bytes (and optionally name) altered."""
+    files = []
+    for f in emission.files:
+        if f["name"] == path:
+            content = f["content"].replace(old, new)
+            assert content != f["content"] or rename, f"tamper did not apply: {old!r}"
+            files.append({"name": rename or f["name"], "content": content})
+        else:
+            files.append(f)
+    return dataclasses.replace(emission, files=tuple(files))
+
+
+def test_the_reference_emission_is_ready(emission, tree, manifest):
+    assert assess_execution_readiness(emission, tree, manifest) == []
+
+
+class TestInjectedGeneratorDefects:
+    def test_wrong_emitted_import_path_is_caught(self, emission, tree, manifest):
+        """THE decisive Gate 2 case: manifest and tree agree the route exists; only the
+        emitted specifier is wrong. Intent-level checks cannot see this."""
+        tampered = _tamper(
+            emission, _CREATE_SHELL, "'@/app/api/runs/route'", "'@/app/api/run/route'"
+        )
+        findings = assess_execution_readiness(tampered, tree, manifest)
+        assert any("resolves to no file" in f and "@/app/api/run/route" in f for f in findings)
+
+    def test_invoking_an_unexported_handler_is_caught(self, emission, tree, manifest):
+        tampered = _tamper(emission, _CREATE_SHELL, "routeApiRuns.POST", "routeApiRuns.PSOT")
+        findings = assess_execution_readiness(tampered, tree, manifest)
+        assert any("does not export 'PSOT'" in f for f in findings)
+
+    def test_a_named_import_the_module_lacks_is_caught(self, emission, tree, manifest):
+        tampered = _tamper(
+            emission,
+            _CREATE_SHELL,
+            "import { reset } from '@/lib/store'",
+            "import { restart } from '@/lib/store'",
+        )
+        findings = assess_execution_readiness(tampered, tree, manifest)
+        assert any("'restart'" in f and "does not export" in f for f in findings)
+
+    def test_an_undeclared_bare_dependency_is_caught(self, emission, tree, manifest):
+        """The roll-9 supertest class, closed for the spine."""
+        tampered = _tamper(
+            emission,
+            _CREATE_SHELL,
+            "import { reset } from '@/lib/store'",
+            "import { reset } from '@/lib/store'\nimport { agent } from 'supertest'",
+        )
+        findings = assess_execution_readiness(tampered, tree, manifest)
+        assert any("'supertest'" in f and "not a declared dependency" in f for f in findings)
+
+    def test_a_status_the_contract_does_not_declare_is_caught(self, emission, tree, manifest):
+        tampered = _tamper(emission, _CREATE_SHELL, ".toBe(201)", ".toBe(418)")
+        findings = assess_execution_readiness(tampered, tree, manifest)
+        assert any("asserts status 418" in f for f in findings)
+
+    def test_a_file_outside_the_collection_surface_is_caught(self, emission, tree, manifest):
+        """The #884 class: a suite emitted where the include glob cannot see it."""
+        tampered = _tamper(
+            emission, _CREATE_SHELL, "", "", rename="scaffold/vc-probe-api-runs.test.ts"
+        )
+        findings = assess_execution_readiness(tampered, tree, manifest)
+        assert any("outside the runner's collection surface" in f for f in findings)
+
+    def test_a_stripped_probe_identity_is_caught(self, emission, tree, manifest):
+        """Bound criterion identity must survive into the emitted file (plan P2)."""
+        tampered = _tamper(emission, _CREATE_SHELL, " [vc-probe-api-runs]", "")
+        findings = assess_execution_readiness(tampered, tree, manifest)
+        assert any("probe id 'vc-probe-api-runs' does not survive" in f for f in findings)
+
+
+def test_validate_raises_scaffold_invalid_with_all_findings(emission, tree, manifest):
+    """Findings accumulate — a generator with three defects gets one report naming three,
+    not three rounds of one."""
+    tampered = _tamper(emission, _CREATE_SHELL, ".toBe(201)", ".toBe(418)")
+    tampered = _tamper(tampered, _CREATE_SHELL, "routeApiRuns.POST", "routeApiRuns.PSOT")
+    with pytest.raises(ScaffoldValidationError, match="scaffold-invalid") as exc:
+        validate_execution_readiness(tampered, tree, manifest)
+    message = str(exc.value)
+    assert "418" in message and "PSOT" in message

--- a/tests/unit/cycles/test_manifest_gates.py
+++ b/tests/unit/cycles/test_manifest_gates.py
@@ -343,3 +343,43 @@ def test_the_reference_contract_still_passes_the_new_lint_gate():
     """Polarity guard. A lint step wired into the winnability gate can reject manifests that
     were previously fine, and the reference pair is what every other pin rests on."""
     assert assess_winnability(_REFERENCE.read_text(encoding="utf-8")) == ()
+
+
+class TestScaffoldReadinessProof:
+    """SIP-0104 P2: PROOF_SCAFFOLD_READY converts a run-setup scaffold death into a free
+    framing re-roll. Bug classes: the proof firing on an unopted stack (stack #1 would be
+    rejected for lacking a scaffold it never declared), and an emission failure surfacing
+    only at run setup after the framing gate read the manifest as winnable."""
+
+    def test_the_nextjs_reference_manifest_is_winnable_with_its_scaffold(self):
+        from tests.unit.capabilities._stack_fixtures import manifest_dict_for_stack
+
+        content = yaml.safe_dump(manifest_dict_for_stack("nextjs_ts"), sort_keys=False)
+        assert assess_winnability(content) == ()
+
+    def test_stack_one_never_reaches_the_scaffold_proof(self):
+        """The reference manifest (stack #1) already asserts zero findings above; this
+        pins the reason — no verification_scaffold declaration means the proof skips,
+        not that it passes by luck."""
+        from squadops.capabilities.scaffold import verification_scaffold_for
+        from squadops.cycles.manifest_gates import PROOF_SCAFFOLD_READY
+
+        assert verification_scaffold_for("fullstack_fastapi_react") == ""
+        findings = assess_winnability(_REFERENCE.read_text(encoding="utf-8"))
+        assert PROOF_SCAFFOLD_READY not in _proofs(findings)
+
+    def test_an_emission_refusal_is_a_winnability_finding(self, monkeypatch):
+        from squadops.capabilities import verification_scaffold_emission as emission_module
+        from squadops.capabilities.verification_scaffold import ScaffoldDerivationError
+        from squadops.cycles.manifest_gates import PROOF_SCAFFOLD_READY
+        from tests.unit.capabilities._stack_fixtures import manifest_dict_for_stack
+
+        def _refuse(manifest, **kwargs):
+            raise ScaffoldDerivationError("injected derivation refusal")
+
+        monkeypatch.setattr(emission_module, "emit_verification_scaffold", _refuse)
+        content = yaml.safe_dump(manifest_dict_for_stack("nextjs_ts"), sort_keys=False)
+        findings = assess_winnability(content)
+        assert PROOF_SCAFFOLD_READY in _proofs(findings)
+        detail = next(f.detail for f in findings if f.proof == PROOF_SCAFFOLD_READY)
+        assert "injected derivation refusal" in detail


### PR DESCRIPTION
Phase 2 of the SIP-0104 plan: **Gate 2, the executable artifact** — proving the generated scaffold can execute before any author sees it, and that the gate detects *generator bugs*, not merely missing inputs.

## The two halves

**Static execution-readiness gate** (`capabilities/verification_scaffold_gate.py`, pure) — judged from the **emitted bytes**, never the generator's intent, which is what makes the decisive case catchable: internally consistent inputs + a wrong emitted import path. Checks: every `@/…` import resolves against the expanded tree; named imports and `alias.MEMBER` invocations are exported by the resolved file; bare imports are declared dependencies (the roll-9 `supertest` class); asserted statuses exist in the contract; slot/probe identity survives into the bytes; placement is collectable (the #884 class). Findings accumulate — one report, not one-per-revision.

Wired twice:
- **`PROOF_SCAFFOLD_READY` at the winnability boundary** — a scaffold that cannot be validly emitted costs a free framing re-roll (#522) instead of a failed implementation run. Classified in the M6 taxonomy as DERIVATION_DEFECT (generator-owned by elimination; never taught to the author).
- **The executor seed path** — same tree feeds emission and gate; failure fails run setup loudly (the P1 seam, extended).

Both callers pinned by the guard-wiring inventory test.

**Dynamic skeleton-execution gate** (`capabilities/handlers/scaffold_execution.py`) — materialize stubs + scaffold, `npm install`, `vitest run --reporter=json`, classify. The stub assertion wall is expected and counted (SIP-0098 §7: the bare skeleton must fail); mechanical failures — a suite that dies pre-test, a shell never collected, a runtime crash — are `scaffold-invalid`. Runner-level failures (no npm, timeout, no report) are **infrastructure**, never a verdict. The classifier is pure and its corpus runs everywhere; only the runner needs the node toolchain.

## Real-node validation (node:20-alpine, vitest 1.6, on this branch)

- **Clean reference scaffold**: 9 tests collected (8 shells + harness), harness passed, 8 shells failed as the expected stub wall → verdict **valid, 8 expected assertion failures**.
- **Injected runtime defect** (`new Requests(` — statically well-formed, only execution can see it): verdict **scaffold-invalid**, exactly one mechanical failure naming the shell; the other 7 shells stayed expected.
- The measurement **caught and fixed a real classifier bug**: vitest's JSON reporter emits chai mismatches as bare messages (`expected 500 to be 201 // Object.is equality`) and strips error-name prefixes from thrown errors too (`Requests is not defined`). Classification is therefore an **allowlist of assertion shapes** — unknown shapes stay mechanical, the safe direction — and the corpus pins the measured forms. A blocklist of error-name prefixes would have shipped broken shells.
- A node-gated integration pair (clean + injected defect) is committed; it skips where npm is absent and runs in the agent-container toolchain.

## Gate 2 exit criteria

- imports resolve / handlers exist / statuses in contract / slot boundaries valid / criterion identity survives ✅ (static corpus)
- empty-fill scaffold collects and every shell executes against the skeleton without mechanical crash ✅ (real-node runs + committed e2e pair)
- **the decisive negative test** — consistent inputs + injected generator defect caught as scaffold-invalid ✅ (static: wrong emitted import path; dynamic: injected runtime crash)
- validity failure fails run setup loudly, never an LLM round ✅ (seed-path raise + winnability finding, both pre-LLM)

Validation: full regression **7192 passed, 1 skipped**, ruff clean. No emission bytes changed — GENERATOR_VERSION stays 1 and the P1 byte-equivalence pin holds untouched.

## Sequencing note (named, not silent)

Per-run wiring of the **dynamic** gate into the qa lane is deliberately deferred to P3: it needs the scaffold surfaces in the qa.test envelope, which is exactly the envelope P3 rebuilds for fill mode. Until then the dynamic gate is standing-corpus + integration evidence; the static gate runs per-run at both boundaries. Roll policy (no rolls before P1–P4 proven) covers the window.

Next after merge: **Phase 3 — Gate 3, the bounded agent surface** (merge contract before implementation: slot-id addressing, fill validation, the missing-slot rule, the semantic brief as coverage inventory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
