### PR TITLE
feat(sip-0104): Phase 3 — the fill protocol and qa.test fill mode (bounded agent surface)

### DIFF
--- a/src/squadops/capabilities/context_assembly.py
+++ b/src/squadops/capabilities/context_assembly.py
@@ -108,6 +108,11 @@ class ContextAssemblyContract:
     plan_rejection_context: bool = False
     bind_criteria_index: bool = False
     bind_behavioral_surface: bool = False
+    #: SIP-0104 P3: this task receives the deterministic test scaffold (slot table +
+    #: shell files) and authors in fill mode when the stack opts in. Derived from the
+    #: interface manifest at injection (Gate 1 byte-equivalence makes re-derivation
+    #: exact); presence-keyed like every surface here.
+    bind_verification_scaffold: bool = False
 
 
 _EMPTY_CONTRACT = ContextAssemblyContract()
@@ -169,6 +174,7 @@ CONTEXT_CONTRACTS: dict[str, ContextAssemblyContract] = {
         acceptance_workspace=True,
         bind_behavioral_surface=True,
         manifest_surfaces=(SURFACE_FROZEN,),
+        bind_verification_scaffold=True,
     ),
     # --- planning chain (#657): upstream documents on an envelope-local
     # prior_outputs copy; all four authoring types receive a re-roll's
@@ -345,6 +351,9 @@ RETEST_PRESENCE_KEYS: tuple[str, ...] = (
     # the forwarded-vs-reassembled distinction, visible for the first time.
     "workspace_revision_id",
     SURFACE_DOM_TESTID,
+    # SIP-0104 P3: a retest that re-authors from scratch must still be in fill
+    # mode — losing the key would flip it back to whole-suite authorship.
+    "verification_scaffold",
 )
 
 

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -457,6 +457,80 @@ class QATestHandler(_CycleTaskHandler):
         )
         return rendered.content
 
+    async def _fill_mode_section(self, context: ExecutionContext, inputs: dict[str, Any]) -> str:
+        """Render the FILL MODE block when the envelope carries the scaffold, or "".
+
+        SIP-0104 §4.5: the author receives the shells (read-only) and the coverage
+        inventory — data derived from the slot table by the fill module; every
+        instruction lives in the managed asset (#448). Coverage inventory only: no
+        generated coaching (SIP §12 keeps richer briefs as follow-on work).
+        """
+        scaffold_input = inputs.get("verification_scaffold") or {}
+        manifest_dict = scaffold_input.get("manifest")
+        files = scaffold_input.get("files") or []
+        if not manifest_dict or not files:
+            return ""
+        renderer = getattr(context.ports, "request_renderer", None)
+        if renderer is None:
+            return ""
+        from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
+        from squadops.capabilities.verification_scaffold_fill import coverage_inventory_lines
+
+        record = VerificationScaffoldManifest.from_dict(manifest_dict)
+        slot_lines = "\n".join(f"- {line}" for line in coverage_inventory_lines(record))
+        shell_parts = [f"**{f['name']}:**\n```typescript\n{f['content']}\n```" for f in files]
+        rendered = await renderer.render(
+            "request.qa_test_fill_mode_appendix",
+            {"slot_lines": slot_lines, "shell_files": "\n\n".join(shell_parts)},
+        )
+        return rendered.content
+
+    def _merge_fill_artifacts(
+        self,
+        scaffold_input: dict[str, Any],
+        fill_emission: Any,
+        artifacts: list[dict],
+    ) -> tuple[list[dict], list[dict], dict[str, Any]]:
+        """Merge parsed fills into the scaffold and bound the additive surface.
+
+        Returns ``(artifacts, merged_suite_files, fill_merge_evidence)``. A
+        path-addressed emission at a scaffold shell path is DROPPED and recorded — in
+        fill mode the slot protocol is the only way to touch a shell (the SIP §4.3
+        posture; region-level enforcement itself lands in P4). Every declared slot ends
+        in exactly one disposition; missing and rejected slots render as failing states
+        inside the merged shells, attributed to the fill layer.
+        """
+        from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
+        from squadops.capabilities.verification_scaffold_fill import merge_fills
+
+        record = VerificationScaffoldManifest.from_dict(scaffold_input["manifest"])
+        shell_paths = {f.path for f in record.files}
+        dropped = sorted(a["name"] for a in artifacts if a["name"] in shell_paths)
+        kept = [a for a in artifacts if a["name"] not in shell_paths]
+        merged = merge_fills(list(scaffold_input["files"]), record, fill_emission)
+        merged_artifacts = [
+            {
+                "name": f.path,
+                "content": f.content,
+                "media_type": _classify_file(f.path)[1],
+                "type": "test",
+            }
+            for f in merged.files
+        ]
+        evidence = {
+            "dispositions": [
+                {"slot_id": d.slot_id, "disposition": d.disposition, "detail": d.detail}
+                for d in merged.dispositions
+            ],
+            "counts": merged.disposition_counts(),
+            "misaddressed": [
+                {"slot_id": d.slot_id, "detail": d.detail} for d in merged.misaddressed
+            ],
+            "dropped_shell_rewrites": dropped,
+        }
+        merged_suite_files = [{"filename": f.path, "content": f.content} for f in merged.files]
+        return kept + merged_artifacts, merged_suite_files, evidence
+
     def _build_focused_prompt(self, inputs: dict[str, Any]) -> str:
         """Build a focused prompt for manifest-driven QA subtasks (SIP-0086).
 
@@ -730,6 +804,12 @@ class QATestHandler(_CycleTaskHandler):
                 capability_name,
             )
 
+        # SIP-0104 P3: fill mode rides both prompt paths, presence-gated on the
+        # scaffold input — absent input renders nothing and stays byte-identical.
+        fill_section = await self._fill_mode_section(context, inputs)
+        if fill_section:
+            user_prompt = f"{user_prompt}\n{fill_section}"
+
         # #448: include the qa.test task_type fragment (dependency constraint,
         # scope discipline) in the assembled system prompt. The fragment is the
         # externalized owner of task-content guidance — not inline literals.
@@ -794,10 +874,24 @@ class QATestHandler(_CycleTaskHandler):
             chat_response=response,
         )
 
+        scaffold_input = inputs.get("verification_scaffold")
+        fill_emission = None
+        extraction_source = content
+        if scaffold_input:
+            from squadops.capabilities.verification_scaffold_fill import (
+                parse_fill_emission,
+                strip_fill_blocks,
+            )
+
+            # Fill fences would otherwise extract as files named "slot-…" — the fill
+            # protocol and the additive-file surface must not compete for bytes.
+            fill_emission = parse_fill_emission(content)
+            extraction_source = strip_fill_blocks(content)
+
         extracted = extract_fenced_files(
-            content, expected_artifacts=inputs.get("expected_artifacts")
+            extraction_source, expected_artifacts=inputs.get("expected_artifacts")
         )
-        if not extracted:
+        if not extracted and not (fill_emission and fill_emission.fills):
             from squadops.cycles.emission_integrity import no_fenced_blocks_failure
 
             self._log_no_fenced_blocks(content)
@@ -836,6 +930,21 @@ class QATestHandler(_CycleTaskHandler):
         # SIP-0086: Output validation + self-evaluation
         evidence_extra: dict[str, Any] = {}
         output_validation_enabled = resolved_config.get("output_validation", False)
+
+        # SIP-0104 P3: merge fills into the scaffold. The merged shells join BOTH the
+        # stored artifacts and the suite-execution set; shell-path rewrites are dropped
+        # and recorded. shell_drop_paths also guards the self-eval merge below.
+        shell_drop_paths: set[str] = set()
+        if scaffold_input:
+            artifacts, merged_suite_files, fill_merge_evidence = self._merge_fill_artifacts(
+                scaffold_input, fill_emission, artifacts
+            )
+            merged_names = {m["filename"] for m in merged_suite_files}
+            shell_drop_paths = merged_names
+            extracted = [
+                f for f in extracted if f["filename"] not in merged_names
+            ] + merged_suite_files
+            evidence_extra["fill_merge"] = fill_merge_evidence
 
         # #670 / RC-9b: shared across self-eval passes so per-criterion
         # evaluator-error counts accumulate (2-strikes escalation), dev parity
@@ -882,6 +991,9 @@ class QATestHandler(_CycleTaskHandler):
                             "type": "test",
                         }
                         for f in new_extracted
+                        # SIP-0104 P3: a self-eval pass must not rewrite merged shells
+                        # either — the slot protocol is the only shell surface.
+                        if f["filename"] not in shell_drop_paths
                     ]
                     artifacts = self._merge_artifacts(artifacts, new_artifacts, evidence_extra)
                     validation = await self._validate_output(

--- a/src/squadops/capabilities/verification_scaffold_fill.py
+++ b/src/squadops/capabilities/verification_scaffold_fill.py
@@ -342,3 +342,29 @@ def merge_fills(
         dispositions=tuple(dispositions),
         misaddressed=misaddressed,
     )
+
+
+def strip_fill_blocks(text: str) -> str:
+    """The emission with every fill fence removed — what the file extractor may see.
+
+    The fenced-file parser reads ``<language>:<path>`` info strings, so a ``fill:slot-…``
+    fence left in place would extract as a file named ``slot-…`` and the protocol's blocks
+    would compete with the additive-file surface for the same bytes.
+    """
+    return _FILL_FENCE_RE.sub("", text)
+
+
+def coverage_inventory_lines(record: VerificationScaffoldManifest) -> list[str]:
+    """The deterministic layer's coverage, one line per slot — the semantic brief's data.
+
+    Coverage inventory ONLY (SIP §4.5): what is already covered, derived from the slot
+    table. No generated coaching, no semantic planning — the instruction prose around
+    these lines is a managed prompt asset (#448), and richer inference-generated briefs
+    are named follow-on work (SIP §12).
+    """
+    lines: list[str] = []
+    for file_record in record.files:
+        for slot in file_record.slots:
+            bound = f" (mirrors probe {slot.probe_id})" if slot.probe_id else ""
+            lines.append(f"{slot.slot_id} — {slot.behavior}{bound}")
+    return lines

--- a/src/squadops/capabilities/verification_scaffold_fill.py
+++ b/src/squadops/capabilities/verification_scaffold_fill.py
@@ -1,0 +1,344 @@
+"""The fill protocol — SIP-0104 P3, the bounded agent surface (Gate 3).
+
+This module is the **merge contract**, defined before any consumer exists (the plan's P3
+ordering rule — otherwise the fill layer becomes another mini code-generation pipeline):
+what a fill IS, how it is addressed, what it may contain, and how it merges. The qa
+author's entire mechanical surface in fill mode is what this module accepts.
+
+## Addressing (normative)
+
+**Slot id is the only addressing mechanism.** A fill is emitted as a fenced block whose
+info string names the slot::
+
+    ```fill:slot-vc-probe-api-runs
+        expect(body.id).toBeTruthy()
+        expect(all('runs')).toHaveLength(1)
+    ```
+
+No file paths, no line numbers, no diffs. One fill per slot; a slot filled twice is
+rejected (both occurrences — picking a winner would make the emission's meaning depend on
+ordering the author never sees). A fill addressing a slot the scaffold does not declare is
+rejected as misaddressed. The **explicit not-applicable disposition** is a directive body::
+
+    ```fill:slot-vs-get-api-runs
+    not_applicable: the status assertion fully covers this behavior; no state to assert
+    ```
+
+## Containment (normative — SIP §4.5's "a bad fill degrades one slot, not the suite")
+
+A fill body may contain domain assertions and nothing structural:
+
+- **no slot-marker vocabulary** — a body mentioning ``[scaffold-slot:`` could forge or
+  terminate regions and escape its slot;
+- **no imports or dependency loads** — ``import``/``require(`` belong to the frozen spine
+  (SIP §4.2); a fill needing a symbol the spine does not import is asking to widen the
+  spine, which is a scaffold change, not a fill;
+- **no live-server access** — ``fetch(``/``XMLHttpRequest``/``WebSocket`` are the #877
+  class the execution model prohibits;
+- **bounded size** — a runaway emission must not bloat one slot into a de facto file.
+
+Validation findings are deterministic rejections: cheaper than a qa repair round, and a
+rejected fill degrades exactly its own slot (the merge renders the slot as a failing
+state; ``merge`` module section below).
+
+## Merge semantics (normative)
+
+Merge replaces slot *bodies* only, in scaffold order, deterministically: same scaffold +
+same fills ⇒ byte-identical output, and the merged file's **spine hash must equal the
+scaffold's** — containment is verified, not assumed. Per-slot dispositions:
+
+- ``filled`` — a valid fill's body lines replace the seed body verbatim;
+- ``not_applicable`` — recorded with its reason; the body becomes a comment carrying it;
+- ``rejected`` — a containment/duplicate violation; recorded with the finding;
+- ``missing`` — no fill and no disposition.
+
+**A missing or rejected required slot is never silent success**: its body becomes a
+deterministic failing assertion naming the slot and the fill layer, shaped as an
+``expect().toBe`` mismatch so the execution gate classifies it as an assertion failure
+(the fill layer's failing state), never as a mechanical crash (the generator's).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from squadops.capabilities.verification_scaffold import (
+    ScaffoldValidationError,
+    VerificationScaffoldManifest,
+    parse_slot_regions,
+    spine_hash,
+)
+
+#: Size bounds for one fill body. Generous for domain assertions, prohibitive for a file.
+MAX_FILL_LINES = 120
+MAX_FILL_BYTES = 8_000
+
+_FILL_FENCE_RE = re.compile(
+    r"^```fill:(?P<slot_id>slot-[a-z0-9][a-z0-9-]*)[ \t]*\n(?P<body>.*?)^```[ \t]*$",
+    re.DOTALL | re.MULTILINE,
+)
+_NOT_APPLICABLE_RE = re.compile(r"^\s*not_applicable:\s*(?P<reason>\S.*)$")
+_IMPORT_RE = re.compile(r"^\s*import\s", re.MULTILINE)
+
+#: Disposition vocabulary (the P5 evidence layer consumes these).
+DISPOSITION_FILLED = "filled"
+DISPOSITION_NOT_APPLICABLE = "not_applicable"
+DISPOSITION_REJECTED = "rejected"
+DISPOSITION_MISSING = "missing"
+
+
+@dataclass(frozen=True)
+class Fill:
+    """One parsed fill block: a body for its slot, or an explicit NA disposition."""
+
+    slot_id: str
+    body: str = ""
+    not_applicable_reason: str = ""
+
+    @property
+    def is_not_applicable(self) -> bool:
+        return bool(self.not_applicable_reason)
+
+
+@dataclass(frozen=True)
+class FillEmission:
+    """Everything fill-shaped in one authored emission, plus what was malformed."""
+
+    fills: tuple[Fill, ...] = ()
+    #: slot ids that appeared in more than one fill block (all occurrences rejected).
+    duplicates: tuple[str, ...] = ()
+
+
+def parse_fill_emission(text: str) -> FillEmission:
+    """Extract fill blocks from an authored emission.
+
+    Only ``fill:slot-…`` fences are this protocol's; everything else (additive test
+    files as ordinary path-addressed fences, prose) is deliberately left for the
+    existing emission pipeline — the two surfaces must not compete for the same bytes.
+    """
+    fills: list[Fill] = []
+    seen: dict[str, int] = {}
+    for match in _FILL_FENCE_RE.finditer(text):
+        slot_id = match.group("slot_id")
+        body = match.group("body")
+        seen[slot_id] = seen.get(slot_id, 0) + 1
+        stripped = [line for line in body.strip("\n").split("\n") if line.strip()]
+        na = _NOT_APPLICABLE_RE.match(stripped[0]) if len(stripped) == 1 else None
+        if na:
+            fills.append(Fill(slot_id=slot_id, not_applicable_reason=na.group("reason").strip()))
+        else:
+            fills.append(Fill(slot_id=slot_id, body=body.strip("\n")))
+    duplicates = tuple(sorted(slot_id for slot_id, count in seen.items() if count > 1))
+    return FillEmission(fills=tuple(fills), duplicates=duplicates)
+
+
+#: ``(pattern, human reason)`` — each is a containment rule from the module docstring.
+_FORBIDDEN: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(re.escape("[scaffold-slot:")),
+        "mentions the slot-marker vocabulary — a fill must not forge or terminate regions",
+    ),
+    (
+        _IMPORT_RE,
+        "contains an import — imports belong to the frozen spine (SIP-0104 §4.2); a fill "
+        "needing a new symbol is a scaffold change, not a fill",
+    ),
+    (
+        re.compile(r"\brequire\("),
+        "loads a dependency with require() — dependencies belong to the frozen spine",
+    ),
+    (
+        re.compile(r"\bfetch\("),
+        "calls fetch() — no live-server access in the in-process execution model (#877)",
+    ),
+    (
+        re.compile(r"\bXMLHttpRequest\b"),
+        "uses XMLHttpRequest — no live-server access (#877)",
+    ),
+    (
+        re.compile(r"\bWebSocket\b"),
+        "uses WebSocket — no live-server access (#877)",
+    ),
+)
+
+
+def fill_findings(fill: Fill) -> list[str]:
+    """Every containment rule this fill violates; empty for a valid fill or explicit NA."""
+    if fill.is_not_applicable:
+        return []
+    if not fill.body.strip():
+        return [
+            "empty fill body — supply domain assertions, or declare "
+            "`not_applicable: <reason>` explicitly; an empty fill is silent non-coverage"
+        ]
+    findings: list[str] = []
+    lines = fill.body.split("\n")
+    if len(lines) > MAX_FILL_LINES or len(fill.body.encode("utf-8")) > MAX_FILL_BYTES:
+        findings.append(
+            f"oversized ({len(lines)} lines / {len(fill.body.encode('utf-8'))} bytes; "
+            f"bounds {MAX_FILL_LINES} lines / {MAX_FILL_BYTES} bytes) — a fill is domain "
+            f"assertions, not a file"
+        )
+    for pattern, reason in _FORBIDDEN:
+        if pattern.search(fill.body):
+            findings.append(reason)
+    return findings
+
+
+@dataclass(frozen=True)
+class SlotDisposition:
+    """What happened to one slot at merge time — the fill layer's per-slot evidence."""
+
+    slot_id: str
+    disposition: str
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class MergedFile:
+    path: str
+    content: str
+    content_hash: str
+    spine_hash: str
+
+
+@dataclass(frozen=True)
+class FillMergeRecord:
+    """The merge's evidence: merged bytes pinned, every slot's disposition explicit."""
+
+    files: tuple[MergedFile, ...] = ()
+    dispositions: tuple[SlotDisposition, ...] = ()
+    #: fills addressing slot ids the scaffold does not declare (nothing to degrade —
+    #: recorded so a misaddressed fill is visible, not silently dropped).
+    misaddressed: tuple[SlotDisposition, ...] = ()
+
+    def disposition_counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for d in self.dispositions:
+            counts[d.disposition] = counts.get(d.disposition, 0) + 1
+        return counts
+
+    def by_slot(self) -> dict[str, SlotDisposition]:
+        return {d.slot_id: d for d in self.dispositions}
+
+
+def _failing_state(slot_id: str, why: str) -> list[str]:
+    """The deterministic failing assertion for a missing/rejected slot.
+
+    Shaped as an expect().toBe mismatch so the execution gate (P2) classifies it as an
+    assertion failure attributed to the FILL layer — never a mechanical crash, which
+    would misattribute it to the generator.
+    """
+    safe = why.replace("\\", "").replace("'", "")
+    return [
+        f"    // fill layer: {safe}",
+        f"    expect('fill layer: {slot_id}: {safe}').toBe('a valid fill or an explicit "
+        f"not_applicable disposition')",
+    ]
+
+
+def _merged_body(
+    slot_id: str, fill: Fill | None, findings: list[str]
+) -> tuple[list[str], SlotDisposition]:
+    if fill is None:
+        return (
+            _failing_state(slot_id, "no fill and no disposition received"),
+            SlotDisposition(slot_id, DISPOSITION_MISSING, "no fill and no disposition"),
+        )
+    if findings:
+        detail = "; ".join(findings)
+        return (
+            _failing_state(slot_id, f"fill rejected: {detail}"),
+            SlotDisposition(slot_id, DISPOSITION_REJECTED, detail),
+        )
+    if fill.is_not_applicable:
+        return (
+            [f"    // not_applicable (qa): {fill.not_applicable_reason}"],
+            SlotDisposition(slot_id, DISPOSITION_NOT_APPLICABLE, fill.not_applicable_reason),
+        )
+    return (
+        fill.body.split("\n"),
+        SlotDisposition(slot_id, DISPOSITION_FILLED, ""),
+    )
+
+
+def merge_fills(
+    scaffold_files: list[dict[str, str]],
+    record: VerificationScaffoldManifest,
+    emission: FillEmission,
+) -> FillMergeRecord:
+    """Merge an authored fill emission into the scaffold, deterministically.
+
+    Slot-body replacement only, in scaffold order. Every declared slot ends in exactly
+    one disposition; the merged spine is re-hashed and must equal the scaffold record's —
+    containment is *verified* on every merge, never assumed (a violation here is a bug in
+    this module, raised as ``AssertionError`` rather than shipped).
+    """
+    from squadops.capabilities.verification_scaffold import _sha256
+
+    declared = {slot.slot_id for f in record.files for slot in f.slots}
+    duplicate_set = set(emission.duplicates)
+    fills_by_slot = {f.slot_id: f for f in emission.fills if f.slot_id not in duplicate_set}
+    misaddressed = tuple(
+        SlotDisposition(
+            f.slot_id,
+            DISPOSITION_REJECTED,
+            "addresses a slot the scaffold does not declare",
+        )
+        for f in emission.fills
+        if f.slot_id not in declared
+    )
+
+    scaffold_by_path = {f["name"]: f["content"] for f in scaffold_files}
+    merged_files: list[MergedFile] = []
+    dispositions: list[SlotDisposition] = []
+    for file_record in record.files:
+        content = scaffold_by_path[file_record.path]
+        lines = content.split("\n")
+        regions = {r.slot_id: r for r in parse_slot_regions(content)}
+        out: list[str] = []
+        cursor = 1
+        for slot in sorted(file_record.slots, key=lambda s: regions[s.slot_id].begin_line):
+            region = regions[slot.slot_id]
+            out.extend(lines[cursor - 1 : region.begin_line])
+            if slot.slot_id in duplicate_set:
+                body, disposition = (
+                    _failing_state(slot.slot_id, "fill rejected: slot filled more than once"),
+                    SlotDisposition(
+                        slot.slot_id,
+                        DISPOSITION_REJECTED,
+                        "slot filled more than once — one fill per slot",
+                    ),
+                )
+            else:
+                fill = fills_by_slot.get(slot.slot_id)
+                body, disposition = _merged_body(
+                    slot.slot_id, fill, fill_findings(fill) if fill else []
+                )
+            out.extend(body)
+            out.append(lines[region.end_line - 1])
+            cursor = region.end_line + 1
+            dispositions.append(disposition)
+        out.extend(lines[cursor - 1 :])
+        merged = "\n".join(out)
+        merged_spine = spine_hash(merged)
+        if merged_spine != file_record.spine_hash:
+            raise ScaffoldValidationError(
+                f"{file_record.path}: merge moved the spine "
+                f"({merged_spine} != {file_record.spine_hash}) — a defect in merge_fills "
+                f"itself; the merged output must not become the run's qa artifact"
+            )
+        merged_files.append(
+            MergedFile(
+                path=file_record.path,
+                content=merged,
+                content_hash=_sha256(merged),
+                spine_hash=merged_spine,
+            )
+        )
+    return FillMergeRecord(
+        files=tuple(merged_files),
+        dispositions=tuple(dispositions),
+        misaddressed=misaddressed,
+    )

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -609,6 +609,24 @@ def inject_contract_inputs(
         testid_lines = testid_surface_instructions(interface_manifest)
         if testid_lines:
             inputs["dom_testid_surface"] = testid_lines
+        # SIP-0104 P3: the deterministic test scaffold — slot table + shell files —
+        # so qa.test authors in fill mode. Re-derived from the manifest here rather
+        # than threaded from the seed artifacts: Gate 1's byte-equivalence pin makes
+        # the derivation exact within a process, and this composer's every other
+        # surface already derives the same way. Presence-keyed: unopted stacks and
+        # manifest-less calls inject nothing and stay byte-identical.
+        if task_contract.bind_verification_scaffold and interface_manifest is not None:
+            from squadops.capabilities.scaffold import verification_scaffold_for
+            from squadops.capabilities.verification_scaffold_emission import (
+                emit_verification_scaffold,
+            )
+
+            if verification_scaffold_for(interface_manifest.stack):
+                emission = emit_verification_scaffold(interface_manifest)
+                inputs["verification_scaffold"] = {
+                    "manifest": emission.manifest.to_dict(),
+                    "files": [dict(f) for f in emission.files],
+                }
 
 
 def _contract_assertion_criteria(

--- a/src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md
+++ b/src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md
@@ -1,0 +1,52 @@
+---
+template_id: request.qa_test_fill_mode_appendix
+version: "1"
+required_variables:
+  - slot_lines
+  - shell_files
+optional_variables: []
+---
+## FILL MODE: a deterministic test scaffold already covers the mechanics (SIP-0104)
+
+This workspace carries a generated verification scaffold: one test shell per
+contract-derived behavior, with file placement, imports, the store lifecycle, the
+invocation call, and the declared-status assertion **already written and frozen**. The
+mechanical layer is done. Your job is the residual semantic layer only: response values,
+store effects, cross-operation semantics, PRD-derived properties the contract cannot
+express.
+
+**Already covered deterministically (do not re-test these behaviors mechanically):**
+{{slot_lines}}
+
+**For the scaffold, emit FILL BLOCKS addressed by slot id — nothing else can address a
+slot:**
+
+```fill:slot-<id>
+    expect(body.id).toBeTruthy()
+    expect(all('runs')).toHaveLength(1)
+```
+
+Fill EVERY slot listed above — with domain assertions, or with an explicit
+not-applicable disposition when the declared status genuinely says everything:
+
+```fill:slot-<id>
+not_applicable: <one-line reason>
+```
+
+Rules for fill bodies (violations are rejected deterministically and the slot renders
+as a failing state):
+
+- Assertions only. NO imports, NO `require()`, NO `fetch()` or any network access —
+  the suite runs in-process with no server.
+- One fill per slot; a slot filled twice is rejected outright.
+- Never emit or rewrite the scaffold files themselves — a path-addressed file at a
+  scaffold path is discarded. The shells below are read-only context.
+- `body` is the final response's parsed JSON; where a create precedes the invocation,
+  `created` is the created entity's parsed JSON.
+
+Additive tests are welcome IN ADDITION to fills: whole new test files beside the
+scaffold, emitted as normal ```typescript:__tests__/<name>.test.ts``` fences, under the
+standing rules (declared dependencies only, in-process execution model, no live server).
+
+**The scaffold shells (read-only — write your fills against these):**
+{{shell_files}}

--- a/tests/integration/capabilities/test_scaffold_skeleton_execution.py
+++ b/tests/integration/capabilities/test_scaffold_skeleton_execution.py
@@ -67,8 +67,7 @@ async def test_a_garbage_fill_degrades_one_file_and_the_rest_still_execute(refer
     assert verdict.executed, verdict.error
     assert not verdict.scaffold_valid
     assert all(
-        "vc-probe-api-runs.scaffold.test.ts" in failure
-        for failure in verdict.mechanical_failures
+        "vc-probe-api-runs.scaffold.test.ts" in failure for failure in verdict.mechanical_failures
     ), verdict.mechanical_failures
     # the other seven shells collected and executed to their expected stub failures
     assert verdict.assertion_failures == 7

--- a/tests/integration/capabilities/test_scaffold_skeleton_execution.py
+++ b/tests/integration/capabilities/test_scaffold_skeleton_execution.py
@@ -48,6 +48,32 @@ async def test_the_reference_scaffold_executes_cleanly_against_the_skeleton(refe
     assert verdict.missing_files == ()
 
 
+async def test_a_garbage_fill_degrades_one_file_and_the_rest_still_execute(reference):
+    """Gate 3's blast-radius exit, executed for real: a containment-clean but
+    syntactically broken fill merges into its slot, that ONE file dies at collection,
+    and every other shell still executes its expected stub assertion."""
+    from squadops.capabilities.verification_scaffold_fill import merge_fills, parse_fill_emission
+
+    tree, emission = reference
+    merged = merge_fills(
+        list(emission.files),
+        emission.manifest,
+        parse_fill_emission(
+            "```fill:slot-vc-probe-api-runs\n))) this is not TypeScript {{{\n```\n"
+        ),
+    )
+    files = [{"name": f.path, "content": f.content} for f in merged.files]
+    verdict = await run_skeleton_execution_gate(tree, files, timeout_seconds=_TIMEOUT)
+    assert verdict.executed, verdict.error
+    assert not verdict.scaffold_valid
+    assert all(
+        "vc-probe-api-runs.scaffold.test.ts" in failure
+        for failure in verdict.mechanical_failures
+    ), verdict.mechanical_failures
+    # the other seven shells collected and executed to their expected stub failures
+    assert verdict.assertion_failures == 7
+
+
 async def test_an_injected_runtime_defect_is_caught_as_mechanical(reference):
     """The dynamic decisive case: statically well-formed (imports resolve, handlers
     exported, statuses declared) but runtime-broken — a defect only execution can see."""

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -1,0 +1,213 @@
+"""Fill mode reaches the qa author and its output merges — SIP-0104 P3 transport.
+
+Mirrors ``test_frozen_surface_proposer``'s end-to-end shape: the executor-side injection
+that puts the scaffold on the qa.test envelope, the handler section that renders it, a
+real render of the managed asset, and the handle-level proof that a fills-only emission
+is a successful authorship — not a zero-extraction emission failure (#566's class would
+otherwise eat every correct fill-mode output).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from squadops.capabilities.handlers.cycle.qa_test import QATestHandler
+from squadops.capabilities.scaffold_contract import emit_contract_dict
+from squadops.capabilities.verification_scaffold_emission import emit_verification_scaffold
+from squadops.capabilities.verification_scaffold_fill import parse_fill_emission
+from squadops.cycles.task_plan import inject_contract_inputs
+from squadops.cycles.verification_contract import VerificationContract
+from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_TEMPLATES = (
+    Path(__file__).resolve().parents[3] / "src" / "squadops" / "prompts" / "request_templates"
+)
+
+
+@pytest.fixture(scope="module")
+def nextjs_manifest():
+    return manifest_for_stack("nextjs_ts")
+
+
+@pytest.fixture(scope="module")
+def emission(nextjs_manifest):
+    return emit_verification_scaffold(nextjs_manifest)
+
+
+@pytest.fixture(scope="module")
+def scaffold_input(emission):
+    return {
+        "manifest": emission.manifest.to_dict(),
+        "files": [dict(f) for f in emission.files],
+    }
+
+
+def _contract_for(manifest) -> VerificationContract:
+    return VerificationContract.from_dict(emit_contract_dict(manifest))
+
+
+# --- executor-side injection --------------------------------------------------- #
+
+
+class TestInjection:
+    def test_qa_test_receives_the_scaffold_on_an_opted_in_stack(self, nextjs_manifest):
+        inputs: dict = {}
+        inject_contract_inputs(inputs, _contract_for(nextjs_manifest), "qa.test", nextjs_manifest)
+        scaffold = inputs["verification_scaffold"]
+        assert len(scaffold["files"]) == 8
+        assert scaffold["manifest"]["stack"] == "nextjs_ts"
+        assert scaffold["manifest"]["generator_version"] == 1
+
+    def test_an_unopted_stack_injects_nothing(self):
+        manifest = manifest_for_stack("fullstack_fastapi_react")
+        inputs: dict = {}
+        inject_contract_inputs(inputs, _contract_for(manifest), "qa.test", manifest)
+        assert "verification_scaffold" not in inputs
+
+    def test_non_qa_tasks_do_not_carry_it(self, nextjs_manifest):
+        inputs: dict = {}
+        inject_contract_inputs(
+            inputs, _contract_for(nextjs_manifest), "development.develop", nextjs_manifest
+        )
+        assert "verification_scaffold" not in inputs
+
+    def test_a_manifest_less_call_injects_nothing(self, nextjs_manifest):
+        inputs: dict = {}
+        inject_contract_inputs(inputs, _contract_for(nextjs_manifest), "qa.test", None)
+        assert "verification_scaffold" not in inputs
+
+
+# --- handler section ------------------------------------------------------------ #
+
+
+class TestFillModeSection:
+    async def test_renders_slots_and_shells_through_the_asset(self, scaffold_input):
+        context = MagicMock()
+        renderer = AsyncMock()
+        renderer.render.return_value = MagicMock(content="FILL MODE SECTION")
+        context.ports.request_renderer = renderer
+
+        out = await QATestHandler()._fill_mode_section(
+            context, {"verification_scaffold": scaffold_input}
+        )
+
+        assert out == "FILL MODE SECTION"
+        variables = renderer.render.await_args.args[1]
+        assert "slot-vc-probe-api-runs — POST /api/runs -> 201" in variables["slot_lines"]
+        assert "(mirrors probe vc-probe-api-runs)" in variables["slot_lines"]
+        assert "vc-probe-api-runs.scaffold.test.ts" in variables["shell_files"]
+
+    async def test_absent_scaffold_renders_nothing(self):
+        context = MagicMock()
+        context.ports.request_renderer = AsyncMock()
+        out = await QATestHandler()._fill_mode_section(context, {})
+        assert out == ""
+        context.ports.request_renderer.render.assert_not_awaited()
+
+
+async def test_real_asset_renders_slots_and_rules(scaffold_input):
+    """A live render: the slot inventory and the fill grammar must survive the template."""
+    from adapters.prompts.filesystem_asset_adapter import FilesystemPromptAssetAdapter
+    from squadops.prompts.renderer import RequestTemplateRenderer
+
+    renderer = RequestTemplateRenderer(
+        FilesystemPromptAssetAdapter(
+            fragments_path=_TEMPLATES.parent / "fragments", templates_path=_TEMPLATES
+        )
+    )
+    context = MagicMock()
+    context.ports.request_renderer = renderer
+    out = await QATestHandler()._fill_mode_section(
+        context, {"verification_scaffold": scaffold_input}
+    )
+    assert "FILL MODE" in out
+    assert "slot-vc-probe-api-runs" in out
+    assert "not_applicable" in out
+    assert "beforeEach(() => reset())" in out  # the shells themselves are visible
+
+
+# --- merge into artifacts -------------------------------------------------------- #
+
+
+class TestMergeFillArtifacts:
+    def test_merged_shells_join_artifacts_and_shell_rewrites_are_dropped(self, scaffold_input):
+        fills = parse_fill_emission(
+            "```fill:slot-vc-probe-api-runs\n    expect(body.id).toBeTruthy()\n```\n"
+        )
+        artifacts = [
+            # an additive file — kept
+            {
+                "name": "__tests__/extra.test.ts",
+                "content": "// extra",
+                "media_type": "x",
+                "type": "test",
+            },
+            # an attempted wholesale shell rewrite — dropped and recorded
+            {
+                "name": "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts",
+                "content": "// REWRITTEN",
+                "media_type": "x",
+                "type": "test",
+            },
+        ]
+        merged_artifacts, suite_files, evidence = QATestHandler()._merge_fill_artifacts(
+            scaffold_input, fills, artifacts
+        )
+        names = [a["name"] for a in merged_artifacts]
+        assert "__tests__/extra.test.ts" in names
+        create_shell = next(
+            a for a in merged_artifacts if a["name"].endswith("vc-probe-api-runs.scaffold.test.ts")
+        )
+        assert "expect(body.id).toBeTruthy()" in create_shell["content"]
+        assert "REWRITTEN" not in create_shell["content"]
+        assert evidence["dropped_shell_rewrites"] == [
+            "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts"
+        ]
+        assert evidence["counts"]["filled"] == 1
+        assert evidence["counts"]["missing"] == 7
+        assert len(suite_files) == 8
+
+
+# --- handle(): a fills-only emission is authorship, not emission failure --------- #
+
+
+async def test_a_fills_only_emission_is_not_a_zero_extraction_failure(scaffold_input):
+    fill_text = (
+        "Fills below.\n\n```fill:slot-vc-probe-api-runs\n    expect(body.id).toBeTruthy()\n```\n"
+    )
+    context = MagicMock()
+    chat = AsyncMock(return_value=MagicMock(content=fill_text))
+    context.ports.llm.chat_stream_with_usage = chat
+    context.ports.llm.default_model = "m"
+    assembled = MagicMock()
+    assembled.content = "system"
+    context.ports.prompt_service.assemble = MagicMock(return_value=assembled)
+    context.ports.request_renderer = None
+
+    result = await QATestHandler().handle(
+        context,
+        {
+            "prd": "group_run",
+            "artifact_contents": {},
+            "resolved_config": {"dev_capability": "nextjs_ts"},
+            "subtask_focus": "fill the scaffold",
+            "expected_artifacts": [],
+            "verification_scaffold": scaffold_input,
+        },
+    )
+
+    artifact_names = [a["name"] for a in result.outputs["artifacts"]]
+    assert "emission_failure" not in result.outputs
+    merged_shells = [n for n in artifact_names if n.startswith("__tests__/scaffold/")]
+    assert len(merged_shells) == 8
+    create_shell = next(
+        a
+        for a in result.outputs["artifacts"]
+        if a["name"].endswith("vc-probe-api-runs.scaffold.test.ts")
+    )
+    assert "expect(body.id).toBeTruthy()" in create_shell["content"]

--- a/tests/unit/capabilities/test_verification_scaffold_fill.py
+++ b/tests/unit/capabilities/test_verification_scaffold_fill.py
@@ -1,0 +1,209 @@
+"""The Gate 3 corpus — fill-merge round-trip determinism, containment, the negative set.
+
+Runs against the real reference emission, so every containment claim is proven on the
+bytes a run would actually carry. The exit criteria this file owns (plan P3): merge
+round-trip determinism; garbage fill degrades one slot while every other file is
+byte-untouched; oversized/duplicate/misaddressed fills rejected; slot containment proven
+(the merged spine equals the scaffold's, verified on every merge).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.verification_scaffold import ScaffoldValidationError
+from squadops.capabilities.verification_scaffold_emission import emit_verification_scaffold
+from squadops.capabilities.verification_scaffold_fill import (
+    DISPOSITION_FILLED,
+    DISPOSITION_MISSING,
+    DISPOSITION_NOT_APPLICABLE,
+    DISPOSITION_REJECTED,
+    MAX_FILL_LINES,
+    Fill,
+    fill_findings,
+    merge_fills,
+    parse_fill_emission,
+)
+from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+_CREATE_SLOT = "slot-vc-probe-api-runs"
+_LIST_SLOT = "slot-vs-get-api-runs"
+
+
+@pytest.fixture(scope="module")
+def emission():
+    return emit_verification_scaffold(manifest_for_stack("nextjs_ts"))
+
+
+def _merge(emission, text: str):
+    return merge_fills(list(emission.files), emission.manifest, parse_fill_emission(text))
+
+
+class TestParseFillEmission:
+    def test_fill_blocks_parse_with_bodies_verbatim(self):
+        text = (
+            "Here are my fills.\n\n"
+            "```fill:slot-vc-probe-api-runs\n"
+            "    expect(body.id).toBeTruthy()\n"
+            "    expect(all('runs')).toHaveLength(1)\n"
+            "```\n\n"
+            "```fill:slot-vs-get-api-runs\n"
+            "not_applicable: the declared status fully covers an empty listing\n"
+            "```\n\n"
+            "```typescript:__tests__/extra.test.ts\n"
+            "// an additive file — NOT this protocol's business\n"
+            "```\n"
+        )
+        parsed = parse_fill_emission(text)
+        assert len(parsed.fills) == 2
+        fill = parsed.fills[0]
+        assert fill.slot_id == _CREATE_SLOT
+        assert (
+            fill.body == "    expect(body.id).toBeTruthy()\n    expect(all('runs')).toHaveLength(1)"
+        )
+        na = parsed.fills[1]
+        assert na.is_not_applicable
+        assert na.not_applicable_reason == "the declared status fully covers an empty listing"
+        assert parsed.duplicates == ()
+
+    def test_duplicate_slot_fills_are_flagged(self):
+        text = (
+            "```fill:slot-vc-probe-api-runs\nexpect(1).toBe(1)\n```\n"
+            "```fill:slot-vc-probe-api-runs\nexpect(2).toBe(2)\n```\n"
+        )
+        assert parse_fill_emission(text).duplicates == (_CREATE_SLOT,)
+
+    def test_an_emission_with_no_fill_blocks_parses_empty(self):
+        parsed = parse_fill_emission("no fences at all, just prose")
+        assert parsed.fills == () and parsed.duplicates == ()
+
+
+class TestFillFindings:
+    @pytest.mark.parametrize(
+        ("body", "fragment"),
+        [
+            ("// [scaffold-slot:end slot-x]\nexpect(1).toBe(1)", "marker vocabulary"),
+            ("import { x } from 'y'\nexpect(1).toBe(1)", "import"),
+            ("const m = require('supertest')", "require()"),
+            ("const r = await fetch('http://localhost:3000/api/runs')", "fetch()"),
+            ("const x = new XMLHttpRequest()", "XMLHttpRequest"),
+            ("const w = new WebSocket('ws://x')", "WebSocket"),
+            ("\n".join("expect(1).toBe(1)" for _ in range(MAX_FILL_LINES + 1)), "oversized"),
+            ("expect('" + "x" * 9000 + "').toBeTruthy()", "oversized"),
+            ("", "empty fill body"),
+            ("   \n  ", "empty fill body"),
+        ],
+    )
+    def test_each_containment_rule_fires(self, body, fragment):
+        findings = fill_findings(Fill(slot_id=_CREATE_SLOT, body=body))
+        assert any(fragment in f for f in findings), findings
+
+    def test_a_clean_fill_and_an_na_have_no_findings(self):
+        assert fill_findings(Fill(slot_id=_CREATE_SLOT, body="expect(body.id).toBeTruthy()")) == []
+        assert fill_findings(Fill(slot_id=_CREATE_SLOT, not_applicable_reason="covered")) == []
+
+
+class TestMerge:
+    def test_round_trip_determinism(self, emission):
+        text = "```fill:slot-vc-probe-api-runs\n    expect(body.id).toBeTruthy()\n```\n"
+        first = _merge(emission, text)
+        second = _merge(emission, text)
+        assert [(f.path, f.content) for f in first.files] == [
+            (f.path, f.content) for f in second.files
+        ]
+
+    def test_a_valid_fill_replaces_the_seed_body_and_preserves_the_spine(self, emission):
+        merged = _merge(
+            emission, "```fill:slot-vc-probe-api-runs\n    expect(body.id).toBeTruthy()\n```\n"
+        )
+        record = {f.path: f for f in emission.manifest.files}
+        by_path = {f.path: f for f in merged.files}
+        target = "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts"
+        assert "    expect(body.id).toBeTruthy()" in by_path[target].content
+        assert "void body" not in by_path[target].content  # the seed body is gone
+        for path, merged_file in by_path.items():
+            assert merged_file.spine_hash == record[path].spine_hash
+
+    def test_every_declared_slot_gets_exactly_one_disposition(self, emission):
+        merged = _merge(emission, "")
+        assert sorted(d.slot_id for d in merged.dispositions) == sorted(
+            emission.manifest.slot_ids()
+        )
+
+    def test_a_missing_fill_is_a_failing_state_never_silent(self, emission):
+        """The plan's missing-slot rule, and its classification shape: the injected line
+        is an expect().toBe mismatch, so the execution gate reads it as an assertion
+        failure (fill layer), never a mechanical crash (generator)."""
+        merged = _merge(emission, "")
+        assert merged.disposition_counts() == {DISPOSITION_MISSING: len(emission.files)}
+        target = next(f for f in merged.files if _CREATE_SLOT in f.content)
+        assert "no fill and no disposition" in target.content
+        assert f"expect('fill layer: {_CREATE_SLOT}:" in target.content
+
+    def test_not_applicable_is_recorded_with_its_reason(self, emission):
+        merged = _merge(
+            emission,
+            "```fill:slot-vs-get-api-runs\nnot_applicable: status covers an empty list\n```\n",
+        )
+        disposition = merged.by_slot()[_LIST_SLOT]
+        assert disposition.disposition == DISPOSITION_NOT_APPLICABLE
+        assert disposition.detail == "status covers an empty list"
+        listing = next(f for f in merged.files if "vs-get-api-runs.scaffold" in f.path)
+        assert "// not_applicable (qa): status covers an empty list" in listing.content
+
+    def test_a_rejected_fill_degrades_its_slot_with_the_finding_named(self, emission):
+        merged = _merge(
+            emission,
+            "```fill:slot-vc-probe-api-runs\nconst r = await fetch('http://x')\n```\n",
+        )
+        disposition = merged.by_slot()[_CREATE_SLOT]
+        assert disposition.disposition == DISPOSITION_REJECTED
+        assert "fetch()" in disposition.detail
+        target = next(f for f in merged.files if "vc-probe-api-runs.scaffold" in f.path)
+        assert "fill rejected" in target.content
+        assert "fetch('http://x')" not in target.content  # the violating body never merges
+
+    def test_duplicate_fills_reject_the_slot_not_a_winner(self, emission):
+        merged = _merge(
+            emission,
+            "```fill:slot-vc-probe-api-runs\nexpect(1).toBe(1)\n```\n"
+            "```fill:slot-vc-probe-api-runs\nexpect(2).toBe(2)\n```\n",
+        )
+        disposition = merged.by_slot()[_CREATE_SLOT]
+        assert disposition.disposition == DISPOSITION_REJECTED
+        assert "more than once" in disposition.detail
+        target = next(f for f in merged.files if "vc-probe-api-runs.scaffold" in f.path)
+        assert "expect(1).toBe(1)" not in target.content
+        assert "expect(2).toBe(2)" not in target.content
+
+    def test_a_misaddressed_fill_is_recorded_not_silently_dropped(self, emission):
+        merged = _merge(emission, "```fill:slot-nonexistent-behavior\nexpect(1).toBe(1)\n```\n")
+        assert [m.slot_id for m in merged.misaddressed] == ["slot-nonexistent-behavior"]
+        assert all("expect(1).toBe(1)" not in f.content for f in merged.files)
+
+    def test_garbage_fill_degrades_one_file_and_leaves_every_other_byte_identical(self, emission):
+        """Gate 3's blast-radius claim: containment-clean garbage (broken TS) merges into
+        its own slot's file; every other file is byte-identical to the no-fill merge, so
+        the rest of the suite still collects (one behavior per file, P1)."""
+        garbage = "```fill:slot-vc-probe-api-runs\n))) this is not TypeScript {{{\n```\n"
+        merged = _merge(emission, garbage)
+        baseline = _merge(emission, "")
+        assert merged.by_slot()[_CREATE_SLOT].disposition == DISPOSITION_FILLED
+        changed = [
+            f.path
+            for f, b in zip(merged.files, baseline.files, strict=True)
+            if f.content != b.content
+        ]
+        assert changed == ["__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts"]
+
+    def test_merge_refuses_if_its_own_output_moves_the_spine(self, emission):
+        """The containment guard itself: a record whose spine hash cannot be reproduced
+        must refuse, not ship (a defect in the merge is still a defect)."""
+        import dataclasses
+
+        tampered_files = tuple(
+            dataclasses.replace(f, spine_hash="0" * 64) for f in emission.manifest.files
+        )
+        tampered = dataclasses.replace(emission.manifest, files=tampered_files)
+        with pytest.raises(ScaffoldValidationError, match="merge moved the spine"):
+            merge_fills(list(emission.files), tampered, parse_fill_emission(""))


### PR DESCRIPTION
Phase 3 of the SIP-0104 plan: **Gate 3, the bounded agent surface** — the merge contract defined before its consumers, and qa.test switched to fill mode on scaffolded stacks.

## The fill protocol (`capabilities/verification_scaffold_fill.py`)

The merge contract, stated normatively in the module and enforced by its corpus:

- **Slot id is the only addressing mechanism** — `fill:slot-<id>` fences, plus an explicit `not_applicable: <reason>` directive. No paths, no line numbers, no diffs.
- **One fill per slot** — a slot filled twice rejects the slot outright rather than picking a winner.
- **Containment** — a fill body may carry assertions only: no slot-marker vocabulary (region forgery), no `import`/`require()` (the spine owns dependencies), no `fetch()`/XHR/WebSocket (the #877 class), bounded size, and no empty-body silent non-coverage.
- **Deterministic merge with verified containment** — slot-body replacement in scaffold order; the merged spine is re-hashed on every merge and must equal the scaffold record's, or the merge refuses its own output.
- **The missing-slot rule** — every declared slot ends in exactly one disposition (`filled` / `not_applicable` / `rejected` / `missing`); missing and rejected slots render a deterministic `expect().toBe` failing state naming the slot, which the P2 classifier reads as an assertion failure (fill layer), never a mechanical crash (generator).
- Misaddressed fills are recorded, never silently dropped.

## qa.test fill mode

- **Envelope**: `bind_verification_scaffold` on the context contract; `inject_contract_inputs` re-derives the scaffold from the manifest (Gate 1 byte-equivalence makes that exact — same derivation style as every other surface in that composer). Presence-keyed: unopted stacks and manifest-less calls stay byte-identical. Retest-forwarded.
- **Semantic brief = coverage inventory only** (SIP §4.5): one line per slot derived from the slot table; all instruction prose lives in the managed asset `request.qa_test_fill_mode_appendix` (#448). No generated coaching — richer briefs stay SIP §12 follow-on.
- **Handler**: fill fences are parsed and stripped *before* file extraction (they'd otherwise extract as files named `slot-…`); a fills-only emission is authorship, not a #566 zero-extraction failure; merged shells join both the stored artifacts and the executed suite; wholesale shell rewrites (initial and self-eval passes) are dropped and recorded; per-slot dispositions land in evidence. Additive test files ride the existing pipeline unchanged.

## Gate 3 exit criteria — all measured

- **Round-trip determinism** ✅ (corpus)
- **Negative corpus** ✅ — oversized/duplicate/misaddressed/marker-smuggling/import/server-access/empty fills each rejected with the finding named
- **Garbage fill degrades one slot, suite still collects** ✅ — proven structurally in the corpus AND **executed against real node** (node:20-alpine): the merged garbage fill's file dies at `Transform failed`, exactly one mechanical failure, the other 7 shells still execute their expected stub assertions
- **Slot containment** ✅ — merged spine hash equals the scaffold's, verified on every merge and refused on violation

Validation: full regression **7231 passed, 1 skipped**, ruff clean. No emission changes — GENERATOR_VERSION stays 1, the P1 byte pin holds.

## Notes for review

- **Expected-artifacts semantics in fill mode**: the plan's expected suite paths remain satisfiable — the asset instructs the author to emit any expected path as a normal additive fence; shells are always produced by the merge. If plans start expecting scaffold paths, that's a plan-authoring surface to revisit (flagged, not silently absorbed).
- **Fill-mode repair locus is deliberately P4**: bounding what a *repair* may do to shells is exactly P4's restore-and-signal subject ("no repair path may modify frozen regions"); P3 bounds initial authorship and self-eval. Until P4, the interim state from P1 stands (shells not yet frozen-enforced; roll policy covers).
- **P4 can now begin**: Gate 3 passes, which was P4's explicit precondition ("region enforcement must not debug an unstable fill protocol").

Next after merge: **Phase 4 — Gate 4, enforcement against adversarial producers** (frozen-spine + slot-boundary verification on every stored emission, the adversarial corpus, restore-and-signal on the repair path — the checkpoint before any expensive roll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
