### PR TITLE
feat(sip-0104): Phase 4 — region-level enforcement against adversarial producers (Gate 4)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -677,9 +677,8 @@ class CorrectionRunner:
         if bound_record is not None and step_artifacts:
             from squadops.cycles.scaffold_enforcement import (
                 enforce_frozen_ownership,
-                frozen_emission_instruction,
+                enforcement_instruction,
             )
-            from squadops.cycles.task_outcome import ContractComplianceViolation
 
             enforced, integrity_evidence = enforce_frozen_ownership(
                 step_artifacts, bound_record, step_envelope
@@ -689,14 +688,17 @@ class CorrectionRunner:
                 step_artifacts = enforced
                 for record in integrity_evidence:
                     self._emit_scaffold_integrity_evidence(record, step_envelope)
+                    # SIP-0104 P4: one selector covers the frozen-file AND the
+                    # region-level codes — the next attempt is TOLD what enforcement
+                    # rejected instead of fighting it blind (#691; the #884 repair
+                    # class §4.3 prohibits).
+                    instruction = enforcement_instruction(record)
                     if (
-                        enforcement_carry is not None
-                        and record.violation_code
-                        == ContractComplianceViolation.FROZEN_PATH_EMISSION
+                        instruction is not None
+                        and enforcement_carry is not None
+                        and instruction not in enforcement_carry
                     ):
-                        instruction = frozen_emission_instruction(record)
-                        if instruction not in enforcement_carry:
-                            enforcement_carry.append(instruction)
+                        enforcement_carry.append(instruction)
 
         # pf-31 Fix D: drop syntactically invalid .py emissions (truncation
         # guard) — the prior stored version (last known parseable) stays

--- a/src/squadops/capabilities/verification_scaffold_fill.py
+++ b/src/squadops/capabilities/verification_scaffold_fill.py
@@ -64,6 +64,7 @@ import re
 from dataclasses import dataclass
 
 from squadops.capabilities.verification_scaffold import (
+    ScaffoldSpineError,
     ScaffoldValidationError,
     VerificationScaffoldManifest,
     parse_slot_regions,
@@ -368,3 +369,51 @@ def coverage_inventory_lines(record: VerificationScaffoldManifest) -> list[str]:
             bound = f" (mirrors probe {slot.probe_id})" if slot.probe_id else ""
             lines.append(f"{slot.slot_id} — {slot.behavior}{bound}")
     return lines
+
+
+#: Violation kinds for a stored shell emission (P4 region enforcement). ``region`` is the
+#: adversarial/structural class (frozen spine or slot structure changed); ``containment``
+#: is the prohibited-fill class (spine intact, slot body smuggles forbidden content).
+SHELL_VIOLATION_REGION = "region"
+SHELL_VIOLATION_CONTAINMENT = "containment"
+
+
+def shell_emission_violation(file_record, content: str) -> tuple[str, str] | None:
+    """Judge one stored emission against its shell's bound record — ``None`` = legal.
+
+    The single content-based rule P4 enforces on every landing path, any role, any locus
+    (SIP §4.3): the spine and slot structure must be byte-identical to the bound record's,
+    and every slot body must satisfy the fill containment rules. A legal emission is
+    exactly a fill-merge product: body edits inside the markers, nothing else.
+
+    Ordered so the strongest claim wins attribution: unparseable structure, then a changed
+    slot set, then a spine mutation — each ``region`` (the adversarial class) — then body
+    containment (``containment``, the correctable prohibited-fill class). Returns
+    ``(kind, detail)`` for the first violation.
+    """
+    try:
+        regions = parse_slot_regions(content)
+    except ScaffoldSpineError as exc:
+        return (SHELL_VIOLATION_REGION, f"slot structure malformed: {exc}")
+    declared = {slot.slot_id for slot in file_record.slots}
+    parsed = {region.slot_id for region in regions}
+    if parsed != declared:
+        return (
+            SHELL_VIOLATION_REGION,
+            f"slot set changed: bound {sorted(declared)}, emitted {sorted(parsed)}",
+        )
+    emitted_spine = spine_hash(content)
+    if emitted_spine != file_record.spine_hash:
+        return (
+            SHELL_VIOLATION_REGION,
+            f"frozen spine mutated: emitted spine {emitted_spine[:12]}… != bound "
+            f"{file_record.spine_hash[:12]}… (imports, invocation, status assertion and "
+            f"slot markers are frozen; only slot bodies are writable)",
+        )
+    lines = content.split("\n")
+    for region in regions:
+        body = "\n".join(lines[region.begin_line : region.end_line - 1])
+        for pattern, reason in _FORBIDDEN:
+            if pattern.search(body):
+                return (SHELL_VIOLATION_CONTAINMENT, f"slot {region.slot_id}: {reason}")
+    return None

--- a/src/squadops/cycles/bound_scaffold_record.py
+++ b/src/squadops/cycles/bound_scaffold_record.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
+from typing import Any
 
 from squadops.capabilities.scaffold import (
     InterfaceManifest,
@@ -68,6 +69,13 @@ class BoundScaffoldRecord:
     # restoration must never re-derive (D2). Defaults empty so records bound before this
     # field existed deserialize cleanly and simply enforce nothing.
     fill_seeds: tuple[FrozenArtifact, ...] = ()
+    # SIP-0104 P4: the verification-scaffold manifest record for an opted-in stack —
+    # per-shell spine hashes and slot tables, the authority region enforcement verifies
+    # every stored shell emission against. None for unopted stacks and records bound
+    # before this field existed (deserialize cleanly, enforce nothing at region level).
+    # The record's own from_dict refuses tampered aggregates, so a hand-edited stored
+    # record cannot launder itself into an enforcement authority.
+    verification_scaffold: Any = None
 
     def frozen_paths(self) -> frozenset[str]:
         return frozenset(f.path for f in self.frozen)
@@ -102,6 +110,11 @@ class BoundScaffoldRecord:
             "fill_slots": list(self.fill_slots),
             "qa_namespace": list(self.qa_namespace),
             "fill_seeds": [f.to_dict() for f in self.fill_seeds],
+            "verification_scaffold": (
+                self.verification_scaffold.to_dict()
+                if self.verification_scaffold is not None
+                else None
+            ),
         }
 
     @classmethod
@@ -118,7 +131,47 @@ class BoundScaffoldRecord:
             fill_slots=tuple(d.get("fill_slots", [])),
             qa_namespace=tuple(d.get("qa_namespace", [])),
             fill_seeds=tuple(FrozenArtifact.from_dict(f) for f in d.get("fill_seeds", [])),
+            verification_scaffold=_scaffold_record_from(d.get("verification_scaffold")),
         )
+
+
+def _scaffold_record_from(raw: dict | None):
+    if not raw:
+        return None
+    from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
+
+    return VerificationScaffoldManifest.from_dict(raw)
+
+
+def _derive_verification_scaffold(manifest: InterfaceManifest):
+    """The scaffold manifest record for an opted-in stack, or None (SIP-0104 P4).
+
+    Fail-soft by design: a derivation failure here must degrade to file-level
+    enforcement (verification_scaffold=None), never disable the whole bound record —
+    losing frozen-file enforcement to a region-level derivation bug would widen the
+    attack surface exactly when something is already wrong.
+    """
+    from squadops.capabilities.scaffold import verification_scaffold_for
+
+    if not verification_scaffold_for(manifest.stack):
+        return None
+    try:
+        from squadops.capabilities.verification_scaffold_emission import (
+            emit_verification_scaffold,
+        )
+
+        return emit_verification_scaffold(manifest).manifest
+    except Exception:  # pragma: no cover - defensive; seed-time already validated
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "SIP-0104: could not derive the verification-scaffold record for stack %s; "
+            "region-level enforcement disabled for this binding (file-level enforcement "
+            "unaffected)",
+            manifest.stack,
+            exc_info=True,
+        )
+        return None
 
 
 def build_bound_record(
@@ -156,4 +209,5 @@ def build_bound_record(
             for name in sorted(fill_set)
             if name in files
         ),
+        verification_scaffold=_derive_verification_scaffold(manifest),
     )

--- a/src/squadops/cycles/scaffold_enforcement.py
+++ b/src/squadops/cycles/scaffold_enforcement.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 # Per-artifact enforcement dispositions (internal protocol; named so comparison
 # sites never carry raw literals that shadow unrelated enums — #380/#559).
 _DISP_DROP_FROZEN = "drop_frozen"
+_DISP_DROP_SHELL = "drop_shell"
 _DISP_DROP = "drop"
 _DISP_PASS = "pass"
 
@@ -72,6 +73,103 @@ def bound_record_or_none(interface_manifest: Any, run_id: str) -> Any:
         return None
 
 
+def _producer_grants(envelope: Any, bound_record: Any) -> tuple[Any, Any]:
+    """The (qa, builder) write authorizations for this producer, or (None, None).
+
+    A QA producer gets a namespace-scoped grant; the 2.1 authorization classes decide
+    whether a non-frozen emission is inside its lane (allow), another producer's slot
+    (drop), or undeclared (allow — could be a deliverable; §4.6 undeclared-reject stays
+    gated on 3.4). #649: a builder producer gets a fill-surface grant — net-new SOURCE
+    and QA-namespace writes drop with evidence; undeclared non-source paths (handoff
+    docs, reports) remain deliverables and pass.
+    """
+    from squadops.cycles.write_authorization import (
+        WorkspaceOwnership,
+        WriteAuthorization,
+        WriteGrant,
+    )
+
+    qa_authz = None
+    if _is_qa_producer(envelope.task_type):
+        ownership = WorkspaceOwnership.from_record(bound_record)
+        qa_authz = WriteAuthorization(ownership, WriteGrant.for_qa(envelope.task_type, ownership))
+    builder_authz = None
+    if _is_builder_producer(envelope.task_type):
+        ownership = WorkspaceOwnership.from_record(bound_record)
+        builder_authz = WriteAuthorization(
+            ownership, WriteGrant.for_builder(envelope.task_type, ownership)
+        )
+    return qa_authz, builder_authz
+
+
+def _shell_map(bound_record: Any) -> dict[str, Any]:
+    """SIP-0104 P4: the region-frozen verification-scaffold shells, keyed by normalized
+    path — mutable slot bodies inside a frozen, hash-verified spine. Content-based and
+    role-independent: the rule is what the bytes are, not who emitted them (§4.3's "any
+    role, any locus"). Empty for unopted stacks and pre-P4 bound records (no region
+    enforcement; the file-level rules are unchanged)."""
+    from squadops.cycles.write_authorization import normalize_ws_path
+
+    scaffold_record = getattr(bound_record, "verification_scaffold", None)
+    if scaffold_record is None:
+        return {}
+    return {
+        n: shell
+        for shell in scaffold_record.files
+        if (n := normalize_ws_path(shell.path)) is not None
+    }
+
+
+def _shell_verdict(shell: Any, art: dict) -> tuple[str, str] | None:
+    """The region verdict for one emission against its bound shell, or None = legal."""
+    from squadops.capabilities.verification_scaffold_fill import (
+        SHELL_VIOLATION_REGION,
+        shell_emission_violation,
+    )
+
+    content = art.get("content")
+    if not isinstance(content, str):
+        return (SHELL_VIOLATION_REGION, "non-text emission for a shell path")
+    return shell_emission_violation(shell, content)
+
+
+def enforcement_instruction(record: Any) -> str | None:
+    """The next-attempt carry instruction for an enforcement record, or None.
+
+    One selector for both call sites (executor + correction runner), keyed on the
+    violation code so the vocabulary and its transports cannot drift apart.
+    """
+    from squadops.cycles.task_outcome import ContractComplianceViolation
+
+    if record.violation_code == ContractComplianceViolation.FROZEN_PATH_EMISSION:
+        return frozen_emission_instruction(record)
+    if record.violation_code in (
+        ContractComplianceViolation.SCAFFOLD_REGION_VIOLATION,
+        ContractComplianceViolation.PROHIBITED_FILL_EMISSION,
+    ):
+        return shell_emission_instruction(record)
+    return None
+
+
+def shell_emission_instruction(record: Any) -> str:
+    """Authoritative next-attempt instruction for a rejected shell emission (SIP-0104 P4).
+
+    The region-level counterpart of :func:`frozen_emission_instruction`, on the same carry
+    transport: the next repair attempt must be TOLD the spine is frozen and verified, or it
+    fights enforcement blind (#691's lesson at region granularity — and the #884 class this
+    SIP §4.3 exists to end: no repair path, any role, any locus, may modify frozen regions
+    or slot boundaries)."""
+    path = record.normalized_path or record.attempted_path
+    return (
+        f"`{path}` is a verification-scaffold shell: its spine — imports, invocation, "
+        f"status assertion, and the slot markers — is frozen and hash-verified. A prior "
+        f"emission to it was rejected and DISCARDED ({record.detail}). To change this "
+        f"file, edit ONLY the lines between its [scaffold-slot:begin]/[scaffold-slot:end] "
+        f"markers (domain assertions; no imports, no require(), no network access) and "
+        f"keep every other byte exactly as-is."
+    )
+
+
 def frozen_emission_instruction(record: Any) -> str:
     """Authoritative next-attempt instruction for a discarded frozen emission (3.4b signal).
 
@@ -122,36 +220,12 @@ def enforce_frozen_ownership(
     source under test to agree with its own test (the pf-26 class, one step past ``main.py``).
     QA emissions in its namespace, and undeclared paths (deliverables like ``test_report.md``),
     pass through. Non-QA producers are unaffected here (frozen-path drop only)."""
-    from squadops.cycles.scaffold_integrity_evidence import (
-        frozen_path_evidence,
-        unauthorized_slot_evidence,
-    )
-    from squadops.cycles.write_authorization import (
-        AuthzDecision,
-        WorkspaceOwnership,
-        WriteAuthorization,
-        WriteGrant,
-        normalize_ws_path,
-    )
+    from squadops.cycles.write_authorization import normalize_ws_path
 
     frozen = {n for fa in bound_record.frozen if (n := normalize_ws_path(fa.path)) is not None}
-    # A QA producer gets a namespace-scoped grant; the 2.1 authorization classes decide whether
-    # a non-frozen emission is inside its lane (allow), another producer's slot (drop), or
-    # undeclared (allow — could be a deliverable, §4.6 undeclared-reject stays gated on 3.4).
-    qa_authz = None
-    if _is_qa_producer(envelope.task_type):
-        ownership = WorkspaceOwnership.from_record(bound_record)
-        grant = WriteGrant.for_qa(envelope.task_type, ownership)
-        qa_authz = WriteAuthorization(ownership, grant)
-
-    # #649: a builder producer gets a fill-surface grant. Net-new SOURCE and
-    # QA-namespace writes are dropped with evidence; undeclared non-source
-    # paths (handoff docs, reports) remain deliverables and pass.
-    builder_authz = None
-    if _is_builder_producer(envelope.task_type):
-        ownership = WorkspaceOwnership.from_record(bound_record)
-        grant = WriteGrant.for_builder(envelope.task_type, ownership)
-        builder_authz = WriteAuthorization(ownership, grant)
+    shells = _shell_map(bound_record)
+    shell_verdicts: dict[int, tuple[str, str]] = {}
+    qa_authz, builder_authz = _producer_grants(envelope, bound_record)
 
     # Classify first so each evidence record can report how many sibling artifacts in the SAME
     # response were left untouched (per-artifact disposition — restore/drop keep the rest; a
@@ -161,59 +235,130 @@ def enforce_frozen_ownership(
         for art in artifacts
     ]
 
-    def _disposition(art: dict, norm: str | None) -> str:
-        if norm is not None and norm in frozen:
-            return _DISP_DROP_FROZEN
-        if qa_authz is not None and (
-            qa_authz.authorize(_artifact_raw_path(art) or "")
-            == AuthzDecision.FORBIDDEN_UNAUTHORIZED
-        ):
-            return _DISP_DROP
-        if builder_authz is not None:
-            decision = builder_authz.authorize(_artifact_raw_path(art) or "")
-            if decision == AuthzDecision.FORBIDDEN_UNAUTHORIZED:
-                return _DISP_DROP  # another producer's lane (e.g. the QA namespace)
-            if decision == AuthzDecision.FORBIDDEN_UNDECLARED and (norm or "").endswith(
-                _BUILDER_FORBIDDEN_SOURCE_SUFFIXES
-            ):
-                return _DISP_DROP  # net-new source (the fay-7 start.py class)
-        return _DISP_PASS
-
-    dispositions = [_disposition(art, norm) for art, norm in zip(artifacts, norms, strict=True)]
+    dispositions = [
+        _classify(
+            index,
+            art,
+            norm,
+            frozen=frozen,
+            shells=shells,
+            shell_verdicts=shell_verdicts,
+            qa_authz=qa_authz,
+            builder_authz=builder_authz,
+        )
+        for index, (art, norm) in enumerate(zip(artifacts, norms, strict=True))
+    ]
     siblings_retained = sum(1 for d in dispositions if d == _DISP_PASS)
 
     enforced: list[dict] = []
     evidence: list[Any] = []
-    for art, norm, disposition in zip(artifacts, norms, dispositions, strict=True):
-        if disposition == _DISP_DROP_FROZEN:
-            evidence.append(
-                frozen_path_evidence(
-                    producer_task_id=envelope.task_id,
-                    producer_task_type=envelope.task_type,
-                    record=bound_record,
-                    attempted_path=_artifact_raw_path(art) or norm,
-                    normalized_path=norm,
-                    attempted_content=art.get("content"),
-                    siblings_retained=siblings_retained,
-                )
-            )
-            # dropped: NOT appended — the scaffold's own seeded artifact is the copy.
-        elif disposition == _DISP_DROP:
-            evidence.append(
-                unauthorized_slot_evidence(
-                    producer_task_id=envelope.task_id,
-                    producer_task_type=envelope.task_type,
-                    record=bound_record,
-                    attempted_path=_artifact_raw_path(art) or (norm or ""),
-                    normalized_path=norm,
-                    attempted_content=art.get("content"),
-                    siblings_retained=siblings_retained,
-                )
-            )
-            # dropped: NOT appended — the owning producer's already-stored version stays.
+    for index, (art, norm, disposition) in enumerate(
+        zip(artifacts, norms, dispositions, strict=True)
+    ):
+        record_evidence = _drop_evidence(
+            index,
+            art,
+            norm,
+            disposition,
+            envelope=envelope,
+            bound_record=bound_record,
+            shells=shells,
+            shell_verdicts=shell_verdicts,
+            siblings_retained=siblings_retained,
+        )
+        if record_evidence is not None:
+            evidence.append(record_evidence)
         else:
             enforced.append(_restore_fill_slot_ownership(art, norm, bound_record, envelope))
     return enforced, evidence
+
+
+def _classify(
+    index: int,
+    art: dict,
+    norm: str | None,
+    *,
+    frozen: set[str],
+    shells: dict[str, Any],
+    shell_verdicts: dict[int, tuple[str, str]],
+    qa_authz: Any,
+    builder_authz: Any,
+) -> str:
+    """One artifact's enforcement disposition (records shell verdicts as a side table)."""
+    from squadops.cycles.write_authorization import AuthzDecision
+
+    if norm is not None and norm in frozen:
+        return _DISP_DROP_FROZEN
+    if norm is not None and norm in shells:
+        verdict = _shell_verdict(shells[norm], art)
+        if verdict is not None:
+            shell_verdicts[index] = verdict
+            return _DISP_DROP_SHELL
+        # Legal — a fill-merge product (body edits inside intact markers). Falls
+        # through to the producer lanes below like any other writable emission.
+    if qa_authz is not None and (
+        qa_authz.authorize(_artifact_raw_path(art) or "") == AuthzDecision.FORBIDDEN_UNAUTHORIZED
+    ):
+        return _DISP_DROP
+    if builder_authz is not None:
+        decision = builder_authz.authorize(_artifact_raw_path(art) or "")
+        if decision == AuthzDecision.FORBIDDEN_UNAUTHORIZED:
+            return _DISP_DROP  # another producer's lane (e.g. the QA namespace)
+        if decision == AuthzDecision.FORBIDDEN_UNDECLARED and (norm or "").endswith(
+            _BUILDER_FORBIDDEN_SOURCE_SUFFIXES
+        ):
+            return _DISP_DROP  # net-new source (the fay-7 start.py class)
+    return _DISP_PASS
+
+
+def _drop_evidence(
+    index: int,
+    art: dict,
+    norm: str | None,
+    disposition: str,
+    *,
+    envelope: Any,
+    bound_record: Any,
+    shells: dict[str, Any],
+    shell_verdicts: dict[int, tuple[str, str]],
+    siblings_retained: int,
+) -> Any:
+    """The evidence record for a dropped emission (None = pass-through).
+
+    Every drop retains rather than restores (#691): the prior valid version — the
+    scaffold's seeded artifact for frozen paths and shells, the owning producer's
+    stored version for slot lanes — remains the workspace copy.
+    """
+    from squadops.cycles.scaffold_integrity_evidence import (
+        frozen_path_evidence,
+        shell_region_evidence,
+        unauthorized_slot_evidence,
+    )
+
+    common = {
+        "producer_task_id": envelope.task_id,
+        "producer_task_type": envelope.task_type,
+        "record": bound_record,
+        "normalized_path": norm,
+        "attempted_content": art.get("content"),
+        "siblings_retained": siblings_retained,
+    }
+    if disposition == _DISP_DROP_SHELL:
+        kind, detail = shell_verdicts[index]
+        return shell_region_evidence(
+            shell=shells[norm],
+            attempted_path=_artifact_raw_path(art) or (norm or ""),
+            violation_kind=kind,
+            detail=detail,
+            **common,
+        )
+    if disposition == _DISP_DROP_FROZEN:
+        return frozen_path_evidence(attempted_path=_artifact_raw_path(art) or norm, **common)
+    if disposition == _DISP_DROP:
+        return unauthorized_slot_evidence(
+            attempted_path=_artifact_raw_path(art) or (norm or ""), **common
+        )
+    return None
 
 
 def _restore_fill_slot_ownership(

--- a/src/squadops/cycles/scaffold_integrity_evidence.py
+++ b/src/squadops/cycles/scaffold_integrity_evidence.py
@@ -87,6 +87,9 @@ class ScaffoldIntegrityEvidence:
     siblings_retained: int  # sibling artifacts in the SAME response left untouched
     # Set by 3.4 when a targeted correction is issued for this violation.
     correction_requested: bool = False
+    # SIP-0104 P4: the region verdict's human-readable specifics (which check failed and
+    # how) — attribution beyond the hash pair. Empty for the whole-file codes.
+    detail: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -105,6 +108,7 @@ class ScaffoldIntegrityEvidence:
             "disposition": self.disposition,
             "siblings_retained": self.siblings_retained,
             "correction_requested": self.correction_requested,
+            "detail": self.detail,
         }
 
 
@@ -186,4 +190,64 @@ def unauthorized_slot_evidence(
         attempted_sha256=sha256_of(attempted_content),
         disposition=DISPOSITION_DROPPED,
         siblings_retained=siblings_retained,
+    )
+
+
+def shell_region_evidence(
+    *,
+    producer_task_id: str,
+    producer_task_type: str,
+    record: BoundScaffoldRecord,
+    shell: Any,
+    attempted_path: str,
+    normalized_path: str | None,
+    attempted_content: Any,
+    siblings_retained: int,
+    violation_kind: str,
+    detail: str,
+    stage: str = "artifact_storage",
+) -> ScaffoldIntegrityEvidence:
+    """Build the SIP-0104 P4 case: an emission to a verification-scaffold shell violated
+    region rules. ``violation_kind`` maps to the reason code: ``region`` (spine/slot
+    structure mutated — the adversarial class) vs ``containment`` (spine intact, slot
+    body carries prohibited content — the correctable prohibited-fill class).
+
+    The hash pair carries SPINE hashes, not content hashes: the bound spine against the
+    emitted spine when it is computable (structure parsed), else the emitted content's
+    plain hash — so a mismatch names WHICH layer moved, which is the whole point of the
+    attribution fields (SIP §4.3).
+    """
+    from squadops.capabilities.verification_scaffold import (
+        ScaffoldSpineError,
+        spine_hash,
+    )
+    from squadops.cycles.task_outcome import ContractComplianceViolation
+
+    attempted_spine: str | None
+    try:
+        attempted_spine = (
+            spine_hash(attempted_content) if isinstance(attempted_content, str) else None
+        )
+    except ScaffoldSpineError:
+        attempted_spine = sha256_of(attempted_content)
+    return ScaffoldIntegrityEvidence(
+        producer_task_id=producer_task_id,
+        producer_task_type=producer_task_type,
+        stage=stage,
+        kind=KIND_ATTEMPTED_EMISSION,
+        violation_code=(
+            ContractComplianceViolation.SCAFFOLD_REGION_VIOLATION
+            if violation_kind == "region"
+            else ContractComplianceViolation.PROHIBITED_FILL_EMISSION
+        ),
+        attempted_path=attempted_path,
+        normalized_path=normalized_path,
+        bound_run_id=record.run_id,
+        bound_attempt_id=record.attempt_id,
+        manifest_hash=record.manifest_hash,
+        expected_sha256=shell.spine_hash,
+        attempted_sha256=attempted_spine,
+        disposition=DISPOSITION_DROPPED,
+        siblings_retained=siblings_retained,
+        detail=detail,
     )

--- a/src/squadops/cycles/task_outcome.py
+++ b/src/squadops/cycles/task_outcome.py
@@ -59,6 +59,14 @@ class ContractComplianceViolation:
     # Frozen bytes changed AFTER materialization despite no accepted frozen emission — a system
     # enforcement fault (bypass / concurrent writer / bug), NOT producer misconduct (plan D4).
     POST_WRITE_INTEGRITY_FAULT = "post_write_integrity_fault"
+    # SIP-0104 P4: an emission to a verification-scaffold shell that mutates its frozen
+    # spine or slot structure (moved/nested/duplicated markers, edited imports/invocation/
+    # status assertion). The adversarial class the region canonicalization exists to catch.
+    SCAFFOLD_REGION_VIOLATION = "scaffold_region_violation"
+    # SIP-0104 P4: a shell emission whose spine is intact but whose slot BODY smuggles
+    # prohibited content (imports, require(), live-server access). Correctable by the fill
+    # author — SIP §5's prohibited-fill class, distinct from the adversarial one above.
+    PROHIBITED_FILL_EMISSION = "prohibited_fill_emission"
 
 
 # Reason code -> corrective disposition. The producer-fault codes are correctable; the
@@ -69,6 +77,8 @@ CONTRACT_COMPLIANCE_ACTIONS: dict[str, str] = {
     ContractComplianceViolation.UNAUTHORIZED_SLOT_EMISSION: "reject_and_route_to_owner",
     ContractComplianceViolation.UNDECLARED_PATH_EMISSION: "reject_and_update_plan",
     ContractComplianceViolation.POST_WRITE_INTEGRITY_FAULT: "restore_and_stop_attempt",
+    ContractComplianceViolation.SCAFFOLD_REGION_VIOLATION: "reject_and_edit_slot_bodies_only",
+    ContractComplianceViolation.PROHIBITED_FILL_EMISSION: "reject_and_fix_fill_content",
 }
 
 

--- a/tests/unit/cycles/test_contract_compliance_taxonomy.py
+++ b/tests/unit/cycles/test_contract_compliance_taxonomy.py
@@ -16,14 +16,17 @@ def test_every_code_has_a_distinct_corrective_action():
         V.UNAUTHORIZED_SLOT_EMISSION,
         V.UNDECLARED_PATH_EMISSION,
         V.POST_WRITE_INTEGRITY_FAULT,
+        # SIP-0104 P4: the region-level pair — spine/structure vs slot-body containment.
+        V.SCAFFOLD_REGION_VIOLATION,
+        V.PROHIBITED_FILL_EMISSION,
     }
-    assert len(codes) == 4  # distinct codes
+    assert len(codes) == 6  # distinct codes
     assert set(ACTIONS) == codes  # complete mapping — no code without an action
-    assert len(set(ACTIONS.values())) == 4  # each maps to a distinct disposition
+    assert len(set(ACTIONS.values())) == 6  # each maps to a distinct disposition
 
 
 def test_only_the_system_fault_stops_the_attempt():
-    """D4/#16: the post-write integrity fault is a SYSTEM fault that stops the attempt; the three
+    """D4/#16: the post-write integrity fault is a SYSTEM fault that stops the attempt; the
     producer faults are correctable rejections. This split is the point of the taxonomy."""
     stops = {c for c, a in ACTIONS.items() if "stop" in a}
     assert stops == {V.POST_WRITE_INTEGRITY_FAULT}
@@ -31,5 +34,7 @@ def test_only_the_system_fault_stops_the_attempt():
         V.FROZEN_PATH_EMISSION,
         V.UNAUTHORIZED_SLOT_EMISSION,
         V.UNDECLARED_PATH_EMISSION,
+        V.SCAFFOLD_REGION_VIOLATION,
+        V.PROHIBITED_FILL_EMISSION,
     }
     assert all("reject" in ACTIONS[c] for c in producer_faults)

--- a/tests/unit/cycles/test_scaffold_integrity_evidence.py
+++ b/tests/unit/cycles/test_scaffold_integrity_evidence.py
@@ -122,6 +122,7 @@ def test_to_dict_is_stable_and_complete():
         "disposition",
         "siblings_retained",
         "correction_requested",
+        "detail",
     }
     assert d["stage"] == "artifact_storage"
 

--- a/tests/unit/cycles/test_scaffold_region_enforcement.py
+++ b/tests/unit/cycles/test_scaffold_region_enforcement.py
@@ -1,0 +1,305 @@
+"""Gate 4 — the adversarial corpus: the LLM cannot mechanically rewrite the scaffold.
+
+Every case drives the REAL enforcement chokepoint (``enforce_frozen_ownership``) with a
+REAL bound record built from the reference manifest — the same objects a run binds. The
+hash-sufficiency claim (SIP §4.3) is demonstrated here: every mutation class the plan
+names is caught by the slot-elided canonicalization + structure parse + slot-set check +
+body containment. AST-level verification remains the named escalation if a mutation this
+corpus misses ever appears — evidence first, not an undefined future.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from squadops.capabilities.verification_scaffold_emission import emit_verification_scaffold
+from squadops.cycles.bound_scaffold_record import BoundScaffoldRecord, build_bound_record
+from squadops.cycles.scaffold_enforcement import (
+    enforce_frozen_ownership,
+    shell_emission_instruction,
+)
+from squadops.cycles.task_outcome import (
+    CONTRACT_COMPLIANCE_ACTIONS,
+    ContractComplianceViolation,
+)
+from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+pytestmark = [pytest.mark.domain_contracts]
+
+_CREATE_SHELL = "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts"
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    return manifest_for_stack("nextjs_ts")
+
+
+@pytest.fixture(scope="module")
+def record(manifest):
+    return build_bound_record(manifest, run_id="run_x", attempt_id="run_x", created_at="")
+
+
+@pytest.fixture(scope="module")
+def shells(manifest):
+    emission = emit_verification_scaffold(manifest)
+    return {f["name"]: f["content"] for f in emission.files}
+
+
+def _envelope(task_type: str = "qa.test"):
+    return SimpleNamespace(task_id="task-1", task_type=task_type)
+
+
+def _enforce(record, *artifacts, task_type: str = "qa.test"):
+    return enforce_frozen_ownership(list(artifacts), record, _envelope(task_type))
+
+
+def _art(name: str, content: str) -> dict:
+    return {"name": name, "content": content, "type": "test"}
+
+
+class TestBoundRecordCarriesTheScaffold:
+    def test_the_record_binds_shell_spines_and_round_trips(self, record):
+        assert record.verification_scaffold is not None
+        assert len(record.verification_scaffold.files) == 8
+        loaded = BoundScaffoldRecord.from_dict(record.to_dict())
+        assert loaded.verification_scaffold == record.verification_scaffold
+
+    def test_a_pre_p4_record_deserializes_with_region_enforcement_off(self, record):
+        d = record.to_dict()
+        del d["verification_scaffold"]
+        assert BoundScaffoldRecord.from_dict(d).verification_scaffold is None
+
+    def test_shells_are_not_whole_file_frozen(self, record):
+        """Shells are region-frozen, not file-frozen — a legal body edit must not be
+        eaten by the whole-file lane."""
+        assert _CREATE_SHELL not in record.frozen_paths()
+
+
+class TestAdversarialProducerEndToEnd:
+    """The plan's single strongest check: one fixture attempts, in turn, every
+    adversarial move — and each lands in its expected failure class deterministically."""
+
+    @pytest.mark.parametrize(
+        ("label", "mutate", "expected_code", "fragment"),
+        [
+            (
+                "changing an import",
+                lambda t: t.replace("'@/lib/store'", "'@/lib/other'"),
+                ContractComplianceViolation.SCAFFOLD_REGION_VIOLATION,
+                "frozen spine mutated",
+            ),
+            (
+                "changing the invocation strategy",
+                lambda t: t.replace(
+                    "await (routeApiRuns.POST as Handler)(",
+                    "await fetch('http://localhost:3000/api/runs', (",
+                ),
+                ContractComplianceViolation.SCAFFOLD_REGION_VIOLATION,
+                "frozen spine mutated",
+            ),
+            (
+                "modifying a status assertion",
+                lambda t: t.replace("expect(res.status).toBe(201)", "expect(res.status).toBe(200)"),
+                ContractComplianceViolation.SCAFFOLD_REGION_VIOLATION,
+                "frozen spine mutated",
+            ),
+            (
+                "moving a slot boundary above the assertion",
+                lambda t: t.replace(
+                    "    expect(res.status).toBe(201)\n"
+                    "    const body: any = await res.json().catch(() => ({}))\n"
+                    "    // [scaffold-slot:begin slot-vc-probe-api-runs]",
+                    "    // [scaffold-slot:begin slot-vc-probe-api-runs]\n"
+                    "    expect(res.status).toBe(201)\n"
+                    "    const body: any = await res.json().catch(() => ({}))",
+                ),
+                ContractComplianceViolation.SCAFFOLD_REGION_VIOLATION,
+                "frozen spine mutated",
+            ),
+            (
+                "pointing the slot body at a live server",
+                lambda t: t.replace(
+                    "    void body",
+                    "    const live = await fetch('http://localhost:3000/api/runs')",
+                ),
+                ContractComplianceViolation.PROHIBITED_FILL_EMISSION,
+                "fetch()",
+            ),
+            (
+                "smuggling an import into the slot body",
+                lambda t: t.replace("    void body", "    import request from 'supertest'"),
+                ContractComplianceViolation.PROHIBITED_FILL_EMISSION,
+                "import",
+            ),
+        ],
+    )
+    def test_each_shell_attack_lands_in_its_class(
+        self, record, shells, label, mutate, expected_code, fragment
+    ):
+        content = mutate(shells[_CREATE_SHELL])
+        assert content != shells[_CREATE_SHELL], label
+        enforced, evidence = _enforce(record, _art(_CREATE_SHELL, content))
+        assert enforced == [], label  # dropped; the prior valid version stays current
+        assert len(evidence) == 1
+        assert evidence[0].violation_code == expected_code, label
+        assert fragment in evidence[0].detail, (label, evidence[0].detail)
+        assert evidence[0].disposition == "dropped"
+
+    def test_adding_a_dependency_hits_the_whole_file_frozen_lane(self, record):
+        """package.json is file-frozen (SIP-0100) — the dependency attack never reaches
+        region rules."""
+        enforced, evidence = _enforce(record, _art("package.json", '{"dependencies": {}}'))
+        assert enforced == []
+        assert evidence[0].violation_code == ContractComplianceViolation.FROZEN_PATH_EMISSION
+
+    def test_rewriting_another_test_file_hits_the_frozen_lane(self, record):
+        enforced, evidence = _enforce(record, _art("__tests__/harness.test.ts", "// rewritten"))
+        assert enforced == []
+        assert evidence[0].violation_code == ContractComplianceViolation.FROZEN_PATH_EMISSION
+
+    def test_a_legal_body_edit_passes_any_role(self, record, shells):
+        """The one legal shape — body edits inside intact markers — passes for qa AND for
+        a dev-locus repair (content-based, role-independent: §4.3's 'any role, any locus'
+        cuts both ways)."""
+        content = shells[_CREATE_SHELL].replace("    void body", "    expect(body.id).toBeTruthy()")
+        for task_type in ("qa.test", "development.develop"):
+            enforced, evidence = _enforce(record, _art(_CREATE_SHELL, content), task_type=task_type)
+            assert [a["name"] for a in enforced] == [_CREATE_SHELL], task_type
+            assert evidence == [], task_type
+
+    def test_an_additive_test_file_still_passes(self, record):
+        enforced, evidence = _enforce(record, _art("__tests__/extra.test.ts", "// additive"))
+        assert [a["name"] for a in enforced] == ["__tests__/extra.test.ts"]
+        assert evidence == []
+
+
+class TestSlotBoundaryManipulation:
+    """SIP §4.3's second protected class, each manipulation explicit."""
+
+    @pytest.mark.parametrize(
+        ("label", "mutate", "fragment"),
+        [
+            (
+                "deleting a marker pair (region removed)",
+                lambda t: t.replace(
+                    "// [scaffold-slot:begin slot-vc-probe-api-runs]\n", ""
+                ).replace("// [scaffold-slot:end slot-vc-probe-api-runs]\n", ""),
+                "slot set changed",
+            ),
+            (
+                "deleting only the end marker",
+                lambda t: t.replace("    // [scaffold-slot:end slot-vc-probe-api-runs]\n", ""),
+                "slot structure malformed",
+            ),
+            (
+                "duplicating the slot",
+                lambda t: t.replace(
+                    "    // [scaffold-slot:end slot-vc-probe-api-runs]",
+                    "    // [scaffold-slot:end slot-vc-probe-api-runs]\n"
+                    "    // [scaffold-slot:begin slot-vc-probe-api-runs]\n"
+                    "    // [scaffold-slot:end slot-vc-probe-api-runs]",
+                ),
+                "slot structure malformed",
+            ),
+            (
+                "nesting a forged slot",
+                lambda t: t.replace(
+                    "    void body",
+                    "    // [scaffold-slot:begin slot-forged]\n"
+                    "    // [scaffold-slot:end slot-forged]",
+                ),
+                "slot structure malformed",
+            ),
+            (
+                "renaming a slot id",
+                lambda t: t.replace("slot-vc-probe-api-runs]", "slot-vc-probe-api-runz]"),
+                "slot set changed",
+            ),
+            (
+                "injecting a statement adjacent to the slot",
+                lambda t: t.replace(
+                    "    // [scaffold-slot:end slot-vc-probe-api-runs]\n",
+                    "    // [scaffold-slot:end slot-vc-probe-api-runs]\n"
+                    "    globalThis.leaked = true\n",
+                ),
+                "frozen spine mutated",
+            ),
+        ],
+    )
+    def test_each_manipulation_is_caught(self, record, shells, label, mutate, fragment):
+        content = mutate(shells[_CREATE_SHELL])
+        assert content != shells[_CREATE_SHELL], label
+        enforced, evidence = _enforce(record, _art(_CREATE_SHELL, content))
+        assert enforced == [], label
+        assert (
+            evidence[0].violation_code == ContractComplianceViolation.SCAFFOLD_REGION_VIOLATION
+        ), label
+        assert fragment in evidence[0].detail, (label, evidence[0].detail)
+
+
+class TestAttribution:
+    def test_a_spine_mutation_reports_spine_vs_spine(self, record, shells):
+        content = shells[_CREATE_SHELL].replace("'@/lib/store'", "'@/lib/other'")
+        _, evidence = _enforce(record, _art(_CREATE_SHELL, content))
+        e = evidence[0]
+        assert e.expected_sha256 != e.attempted_sha256  # the spine itself moved
+
+    def test_a_containment_violation_shows_the_spine_intact(self, record, shells):
+        """The attribution property: a prohibited fill did NOT move the spine — the hash
+        pair proves which layer the defect lives in."""
+        content = shells[_CREATE_SHELL].replace(
+            "    void body", "    const r = await fetch('http://x')"
+        )
+        _, evidence = _enforce(record, _art(_CREATE_SHELL, content))
+        e = evidence[0]
+        assert e.expected_sha256 == e.attempted_sha256  # spine identical; body was the sin
+
+    def test_sibling_artifacts_survive_a_shell_drop(self, record, shells):
+        content = shells[_CREATE_SHELL].replace("toBe(201)", "toBe(200)")
+        enforced, evidence = _enforce(
+            record,
+            _art(_CREATE_SHELL, content),
+            _art("__tests__/extra.test.ts", "// additive"),
+        )
+        assert [a["name"] for a in enforced] == ["__tests__/extra.test.ts"]
+        assert evidence[0].siblings_retained == 1
+
+
+class TestRepairPathSignal:
+    def test_the_instruction_names_the_shell_and_the_defect(self, record, shells):
+        content = shells[_CREATE_SHELL].replace("toBe(201)", "toBe(200)")
+        _, evidence = _enforce(record, _art(_CREATE_SHELL, content))
+        instruction = shell_emission_instruction(evidence[0])
+        assert _CREATE_SHELL in instruction
+        assert "frozen spine mutated" in instruction
+        assert "slot" in instruction  # tells the repairer where the writable surface is
+
+    def test_the_correction_runner_carries_the_signal_to_the_next_attempt(self, record, shells):
+        """Restore-and-signal on the repair path (Gate 4 exit): a repair step's shell
+        rewrite is dropped IN PLACE and the next attempt's carry receives the
+        instruction — through the runner's own enforcement method."""
+        from adapters.cycles.correction_runner import CorrectionRunner
+
+        runner = CorrectionRunner.__new__(CorrectionRunner)
+        runner._emit_scaffold_integrity_evidence = lambda *a, **k: None
+        content = shells[_CREATE_SHELL].replace("toBe(201)", "toBe(200)")
+        result = SimpleNamespace(outputs={"artifacts": [_art(_CREATE_SHELL, content)]})
+        carry: list[str] = []
+
+        runner._enforce_step_emissions(result, _envelope(), "run_x", record, carry)
+
+        assert result.outputs["artifacts"] == []  # dropped in place — restoration by retention
+        assert len(carry) == 1
+        assert _CREATE_SHELL in carry[0] and "frozen and hash-verified" in carry[0]
+
+    def test_both_new_codes_have_corrective_actions(self):
+        assert (
+            CONTRACT_COMPLIANCE_ACTIONS[ContractComplianceViolation.SCAFFOLD_REGION_VIOLATION]
+            == "reject_and_edit_slot_bodies_only"
+        )
+        assert (
+            CONTRACT_COMPLIANCE_ACTIONS[ContractComplianceViolation.PROHIBITED_FILL_EMISSION]
+            == "reject_and_fix_fill_content"
+        )


### PR DESCRIPTION
Phase 4 of the SIP-0104 plan: **Gate 4 — enforcement against adversarial producers.** With this, Gates 1–4 together establish the core invariant: **the LLM cannot mechanically rewrite the scaffold.** This is the plan's checkpoint before any expensive roll.

## What changed

- **The bound record binds the scaffold** (`bound_scaffold_record.py`): `verification_scaffold` carries the per-shell spine hashes and slot tables for an opted-in stack, derived at bind time. Fail-soft: a derivation failure degrades to file-level enforcement, never disables the bound record; pre-P4 records deserialize with region enforcement off; a tampered stored record refuses to load (the manifest's own aggregate verification).
- **The region lane in `enforce_frozen_ownership`** — shared by BOTH landing paths (executor storage and the correction runner's repair emissions), so the repair path inherited enforcement the moment it landed. Content-based and role-independent (§4.3's "any role, any locus"): an emission to a shell must parse its slot structure, keep the bound slot set, reproduce the bound spine hash, and keep every slot body containment-clean. The only legal shape is exactly a fill-merge product — body edits inside intact markers, which pass for qa *and* for a dev-locus repair.
- **Two taxonomy codes**, each with a distinct corrective action: `scaffold_region_violation` (spine/structure mutated — the adversarial class) and `prohibited_fill_emission` (spine intact, body smuggles imports/network — the correctable prohibited-fill class). Evidence carries a `detail` field and **spine-vs-spine attribution**: a containment violation shows the spine hashes *equal* (the body was the sin); a region violation shows them diverging.
- **Restore-and-signal on the repair path**: drops retain rather than restore (#691 — the prior valid version stays the workspace copy), and one `enforcement_instruction` selector feeds the carry transport for both the frozen-file and region codes, so the next repair attempt is told the spine is frozen instead of fighting enforcement blind (the #884 class, closed structurally).

## Gate 4 exit criteria — all in the corpus (25 tests, real bound record from the reference manifest)

- **The adversarial-producer end-to-end fixture** (the plan's single strongest check): changing an import / changing the invocation strategy / modifying a status assertion / moving a slot boundary → `scaffold_region_violation`; pointing a slot body at a live server / smuggling an import into a body → `prohibited_fill_emission`; adding a dependency (package.json) / rewriting the harness test → the existing `frozen_path_emission` lane. Each lands in its expected class deterministically; a legal body edit passes for any role; additive files pass.
- **Slot-boundary manipulation, each explicit**: deleted marker pair, deleted single marker, duplicated slot, nested forged slot, renamed slot id, statement injected adjacent to a slot — all caught, each with the failing check named in `detail`.
- **Hash-sufficiency demonstrated**: every mutation class the plan names is caught by the slot-elided canonicalization + structure parse + slot-set check + body containment. AST-level verification remains the named escalation on evidence of a miss (none observed).
- **Restore-and-signal proven on the repair path**: driven through the correction runner's own `_enforce_step_emissions` — the shell rewrite drops in place and the next attempt's carry receives the instruction.

Validation: full regression **7256 passed, 1 skipped**, ruff clean. Two taxonomy pins updated (code count 4→6, evidence field set +`detail`) — the pins fired exactly as designed.

## The roll boundary

After this merges, **P1–P4 are complete in code**. Per the plan, the boundary before any experimental roll is P1–P4 **deployed and proven**: rebuild agent + runtime-api images, restart, and verify the loaded modules in-container (the standing rebuild-before-SIP-test rule). P5 (evidence/classification/correlation) can proceed in parallel with that — its schema work has no runtime prerequisite on deployment.

Honest status of one earlier deferral: the P2 **dynamic** skeleton-execution gate remains standing-corpus + CI evidence (the `scaffold skeleton gate` CI job runs the real vitest pair on every PR); per-run wiring stayed out — the P6 window protocol is the named empirical net for the residue, and any mechanical failure it catches names its uncovered surface and joins the enforced set.

Next after merge: **Phase 5 — Gate 5, evidence and convergence** (four-class failure routing, correlation-not-collapse, run-report fields), and the deploy+prove step for the roll boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
