### PR TITLE
feat(sip-0104): Phase 5 — the evidence pipeline (classification, correlation, banked report fields)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -531,6 +531,71 @@ class QATestHandler(_CycleTaskHandler):
         merged_suite_files = [{"filename": f.path, "content": f.content} for f in merged.files]
         return kept + merged_artifacts, merged_suite_files, evidence
 
+    def _append_scaffold_evidence(
+        self,
+        outputs: dict[str, Any],
+        test_result: Any,
+        merged_suite_files: list[dict[str, Any]],
+        fill_merge_evidence: dict[str, Any],
+        scaffold_input: dict[str, Any],
+        artifacts: list[dict],
+    ) -> None:
+        """Run the P5 pipeline and land its outputs (SIP-0104 §5/§6).
+
+        Two landings: ``outputs["scaffold_evidence"]`` (the full summary — the promotion
+        model's banked fields) and an informational ``scaffold_failure_classification``
+        row in ``validation_result.checks`` (status-bearing like the probe rows, no
+        ``passed`` bool — SIP-0096 credit semantics untouched) so the locus classifier
+        and the correction loop's failure evidence read the classes without re-deriving.
+        """
+        from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
+        from squadops.cycles.scaffold_evidence import (
+            build_scaffold_evidence_summary,
+            classify_shell_failures,
+            correlate,
+        )
+
+        record = VerificationScaffoldManifest.from_dict(scaffold_input["manifest"])
+        dispositions = {
+            d["slot_id"]: d["disposition"]
+            for d in fill_merge_evidence.get("dispositions", [])
+            if isinstance(d, dict)
+        }
+        merged_contents = {m["filename"]: m["content"] for m in merged_suite_files}
+        observations = classify_shell_failures(
+            list(getattr(test_result, "test_failures", ()) or ()),
+            merged_contents,
+            record,
+            dispositions,
+            runner_executed=bool(getattr(test_result, "executed", False)),
+        )
+        probe_rows = [
+            row
+            for row in (outputs.get("validation_result") or {}).get("checks") or []
+            if isinstance(row, dict) and row.get("criterion_id")
+        ]
+        correlations = correlate(observations, probe_rows)
+        shell_paths = set(merged_contents)
+        additive_count = sum(
+            1
+            for a in artifacts
+            if a.get("type") == "test"
+            and str(a.get("name", "")).endswith((".test.ts", ".spec.ts"))
+            and a.get("name") not in shell_paths
+        )
+        summary = build_scaffold_evidence_summary(
+            record, dispositions, observations, correlations, additive_count
+        )
+        outputs["scaffold_evidence"] = summary.to_dict()
+        vr = outputs.setdefault("validation_result", {})
+        vr.setdefault("checks", []).append(
+            {
+                "check": "scaffold_failure_classification",
+                "status": "info",
+                "classes": dict(summary.failure_classes),
+            }
+        )
+
     def _build_focused_prompt(self, inputs: dict[str, Any]) -> str:
         """Build a focused prompt for manifest-driven QA subtasks (SIP-0086).
 
@@ -1177,6 +1242,19 @@ class QATestHandler(_CycleTaskHandler):
         # SIP-0098 98.5: execute seeded behavioral probes and append their rows
         # (both verdict paths, like frontend_build above — additive evidence).
         await self._append_contract_probe_rows(inputs, outputs)
+
+        # SIP-0104 P5: classify shell failures, correlate with the probe rows just
+        # appended, and bank the evidence summary. After the probes on purpose —
+        # correlation joins on the shared criterion id.
+        if scaffold_input:
+            self._append_scaffold_evidence(
+                outputs,
+                test_result,
+                merged_suite_files,
+                fill_merge_evidence,
+                scaffold_input,
+                artifacts,
+            )
 
         duration_ms = (time.perf_counter() - start_time) * 1000
         evidence = HandlerEvidence.create(

--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -53,6 +53,12 @@ class RunTestsResult:
     # run_build_validation — exactly the #306 not-executed case that must not read
     # green once frontend_build is a required check.
     frontend_build: BuildCheckResult | None = None
+    # SIP-0104 P5: per-failure observation rows from the runner's machine report
+    # (vitest JSON reporter): {file, title, messages, line, suite_level}. The evidence
+    # pipeline classifies scaffold-shell failures from these; empty when the runner
+    # produced no machine report (pytest runs, report write failure) — additive, never
+    # load-bearing for the pass/fail verdict.
+    test_failures: tuple[dict, ...] = ()
 
     @property
     def tests_passed(self) -> bool:
@@ -335,13 +341,19 @@ async def run_node_tests(
                 source_file_count=len(source_files),
             )
 
-        # npx vitest run
+        # npx vitest run. The JSON reporter writes the machine report to a file while
+        # verbose keeps stdout human-shaped — the suite-health markers (#626) and the
+        # report readers both stay fed. A missing/unwritable report degrades to
+        # test_failures=() (SIP-0104 P5: observation is additive, never load-bearing).
+        report_path = os.path.join(cwd, _VITEST_REPORT_FILENAME)
         try:
             proc = await asyncio.create_subprocess_exec(
                 "npx",
                 "vitest",
                 "run",
                 "--reporter=verbose",
+                "--reporter=json",
+                f"--outputFile.json={report_path}",
                 cwd=cwd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
@@ -386,6 +398,7 @@ async def run_node_tests(
             # "No test suite found" routed repairs to dev for a defect in the
             # qa role's own file).
             suite_broken=_vitest_suite_broken(exit_code, stdout, stderr),
+            test_failures=tuple(_read_vitest_failure_rows(report_path, cwd)),
         )
 
     except Exception as exc:
@@ -704,6 +717,65 @@ async def run_backend_import_check(
         shutil.rmtree(workspace, ignore_errors=True)
 
 
+#: Where run_node_tests asks vitest's JSON reporter to write the machine report.
+_VITEST_REPORT_FILENAME = ".vitest_report.json"
+
+
+def parse_vitest_failure_rows(report: dict, workspace_root: str) -> list[dict]:
+    """Per-failure observation rows from a vitest JSON report (SIP-0104 P5).
+
+    One row per failed test — ``{file, title, messages, line, suite_level}`` with
+    ``file`` workspace-relative — plus one ``suite_level`` row per suite that died
+    before any test ran (unresolved import / transform crash). Pure, so the evidence
+    pipeline's corpus runs against synthesized and captured reports alike.
+    """
+    from squadops.capabilities.handlers.scaffold_execution import _VITEST_STATUS_FAILED
+
+    root = workspace_root.rstrip("/") + "/"
+    rows: list[dict] = []
+    for suite in report.get("testResults", ()):
+        name = str(suite.get("name", ""))
+        rel = name[len(root) :] if name.startswith(root) else name
+        results = suite.get("assertionResults") or []
+        if suite.get("status") == _VITEST_STATUS_FAILED and not results:
+            rows.append(
+                {
+                    "file": rel,
+                    "title": "",
+                    "messages": [str(suite.get("message", ""))[:2000]],
+                    "line": None,
+                    "suite_level": True,
+                }
+            )
+            continue
+        for result in results:
+            if result.get("status") != _VITEST_STATUS_FAILED:
+                continue
+            location = result.get("location") or {}
+            rows.append(
+                {
+                    "file": rel,
+                    "title": str(result.get("title", "")),
+                    "messages": [str(m)[:2000] for m in (result.get("failureMessages") or [])],
+                    "line": location.get("line"),
+                    "suite_level": False,
+                }
+            )
+    return rows
+
+
+def _read_vitest_failure_rows(report_path: str, workspace_root: str) -> list[dict]:
+    """The observation rows from the written report, or [] (additive, never fatal)."""
+    import json
+
+    try:
+        with open(report_path, encoding="utf-8") as fh:
+            report = json.load(fh)
+    except (OSError, ValueError):
+        return []
+    return parse_vitest_failure_rows(report, workspace_root)
+
+
 _VITEST_SUITE_BROKEN_MARKERS = (
     "No test suite found",
     # #884: vitest's OTHER no-suite message — the include glob matched zero
@@ -830,6 +902,7 @@ async def run_fullstack_tests(
         exit_code=combined_exit_code,
         runner=controlling.runner,
         suite_broken=controlling.suite_broken,
+        test_failures=controlling.test_failures,
         stdout="\n\n".join(combined_stdout_parts)[:_STDOUT_LIMIT],
         stderr="\n\n".join(combined_stderr_parts)[:_STDOUT_LIMIT],
         error="; ".join(error_parts) if error_parts else "",

--- a/src/squadops/cycles/failure_evidence.py
+++ b/src/squadops/cycles/failure_evidence.py
@@ -237,12 +237,45 @@ def classify_failure_locus(failure_evidence: Any) -> str:
         # the suite — for qa.test, OWN_ARTIFACT = eve re-authors the suite.
         if check == f"acceptance:{CHECK_CONTRACT_ASSERTIONS}" and row.get("passed") is False:
             return FailureLocus.OWN_ARTIFACT
+    scaffold_locus = _locus_from_scaffold_classification(checks)
+    if scaffold_locus is not None:
+        return scaffold_locus
     for row in checks:
         if row.get("check") == "tests_pass" and row.get("passed") is False:
             locus = _locus_from_tests_pass_row(row)
             if locus is not None:
                 return locus
     return FailureLocus.UNKNOWN
+
+
+def _locus_from_scaffold_classification(checks: list[dict]) -> str | None:
+    """SIP-0104 P5: the scaffold classification is finer than tests_pass semantics —
+    consulted first when present. app_contract wins over fill (the shell's frozen
+    assertion says the APP violated the contract; repairing the app is the §5 route and
+    the conservative direction); all-fill routes to the fill author. The generator
+    (scaffold_invalid) and infrastructure classes deliberately return None — neither is
+    an LLM-repairable locus, so the legacy signals (or UNKNOWN) decide."""
+    for row in checks:
+        if row.get("check") != "scaffold_failure_classification":
+            continue
+        from squadops.cycles.scaffold_evidence import (
+            CLASS_APP_CONTRACT,
+            CLASS_FILL,
+            CLASS_INFRASTRUCTURE,
+            CLASS_SCAFFOLD_INVALID,
+        )
+
+        classes = row.get("classes") or {}
+        if classes.get(CLASS_APP_CONTRACT):
+            return FailureLocus.SUBJECT
+        if (
+            classes.get(CLASS_FILL)
+            and not classes.get(CLASS_SCAFFOLD_INVALID)
+            and not classes.get(CLASS_INFRASTRUCTURE)
+        ):
+            return FailureLocus.OWN_ARTIFACT
+        return None
+    return None
 
 
 def _locus_from_tests_pass_row(row: dict[str, Any]) -> str | None:

--- a/src/squadops/cycles/scaffold_evidence.py
+++ b/src/squadops/cycles/scaffold_evidence.py
@@ -1,0 +1,337 @@
+"""The scaffold evidence pipeline — SIP-0104 P5 (Gate 5).
+
+Kept explicit and separate, exactly as the plan states it::
+
+    observation → classification → correlation → owner → repair route
+
+- **Observation**: the runner's per-failure rows (``RunTestsResult.test_failures``), the
+  merged shell contents, the scaffold manifest record, and the fill-merge dispositions.
+- **Classification** lands every scaffold-shell failure in one of the SIP §5 classes:
+  ``scaffold_invalid`` / ``app_contract`` / ``fill`` / ``test_infrastructure``. The
+  attribution logic is line-based against the *merged* file's parsed slot regions: a
+  failure inside a slot body belongs to the fill layer; a failure on the spine is the
+  frozen contract assertion firing against the app. A mechanical death of a shell whose
+  only mutable bytes came from a fill is the fill's; one with no fill merged is the
+  generator's (a new uncovered surface — the P6 window rule's subject).
+- **Correlation, not causal equivalence**: a shell failure and a probe failure sharing a
+  criterion id are *grouped* for the router — both observations retained, never
+  auto-collapsed into one, and different criterion ids are never auto-merged. The router
+  deduplicates rounds on the shared criterion, not on either observation alone.
+- **Ownership is assigned from classification; routing consumes ownership** — both are
+  data (``CLASS_OWNERS`` / ``CLASS_ROUTES``), so P5's pipeline stays inspectable and the
+  locus consult (:mod:`failure_evidence`) reads the class summary, never re-derives it.
+
+Non-shell failures (additive tests, the harness proof) are deliberately outside this
+pipeline: their semantics are owned by the existing suite-health machinery, and
+``tests_pass`` credit semantics are untouched (SIP-0096, SIP §10.5).
+
+The summary schema carries the fields the future promotion model needs (SIP §6/§12:
+slot/category, assertion provenance, unique-vs-probe-redundant findings, defect class,
+cycle/stack identity) — **schema preserved, workflow not built**.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# The SIP §5 failure classes.
+CLASS_SCAFFOLD_INVALID = "scaffold_invalid"
+CLASS_APP_CONTRACT = "app_contract"
+CLASS_FILL = "fill"
+CLASS_INFRASTRUCTURE = "test_infrastructure"
+
+#: class → who can act on it (ownership is assigned from classification).
+CLASS_OWNERS: dict[str, str] = {
+    CLASS_SCAFFOLD_INVALID: "scaffold_generator",
+    CLASS_APP_CONTRACT: "dev",
+    CLASS_FILL: "qa",
+    CLASS_INFRASTRUCTURE: "environment",
+}
+
+#: class → repair route (routing consumes ownership). ``scaffold_invalid`` at suite time
+#: means the pre-run gates missed a surface — never an LLM round; the P6 window protocol
+#: names it and it joins the enforced set.
+CLASS_ROUTES: dict[str, str] = {
+    CLASS_SCAFFOLD_INVALID: "name_uncovered_surface_no_llm_round",
+    CLASS_APP_CONTRACT: "dev_repair",
+    CLASS_FILL: "qa_repair_slot_scoped",
+    CLASS_INFRASTRUCTURE: "environment_triage",
+}
+
+
+@dataclass(frozen=True)
+class ShellObservation:
+    """One classified scaffold-shell failure — the pipeline's atom.
+
+    ``criterion_id`` is the bound probe id for spine (app-contract) failures — the join
+    key correlation groups on; empty for fill-layer and generator-layer observations.
+    """
+
+    file: str
+    slot_id: str
+    failure_class: str
+    detail: str = ""
+    criterion_id: str = ""
+    line: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "file": self.file,
+            "slot_id": self.slot_id,
+            "failure_class": self.failure_class,
+            "detail": self.detail,
+            "criterion_id": self.criterion_id,
+            "line": self.line,
+            "owner": CLASS_OWNERS[self.failure_class],
+            "route": CLASS_ROUTES[self.failure_class],
+        }
+
+
+def classify_shell_failures(
+    test_failures: list[dict],
+    merged_contents: dict[str, str],
+    scaffold_manifest: Any,
+    fill_dispositions: dict[str, str],
+    *,
+    runner_executed: bool = True,
+) -> list[ShellObservation]:
+    """Classify every scaffold-shell failure among the runner's observation rows.
+
+    Rows for non-shell files pass through unclassified (the existing machinery owns
+    them). Ambiguity falls toward ``app_contract`` — the dev/subject direction, the same
+    conservative side the test-gaming guard has always chosen: a misroute there costs a
+    dev round; a misroute toward qa invites the suite to be rewritten to agree with a
+    broken app.
+    """
+    from squadops.capabilities.handlers.scaffold_execution import _is_assertion_failure
+    from squadops.capabilities.verification_scaffold import ScaffoldSpineError, parse_slot_regions
+
+    shell_records = {f.path: f for f in scaffold_manifest.files}
+    if not runner_executed:
+        return [
+            ShellObservation(
+                file="",
+                slot_id="",
+                failure_class=CLASS_INFRASTRUCTURE,
+                detail="the runner could not execute the suite — environment triage, "
+                "not a work-product round",
+            )
+        ]
+
+    observations: list[ShellObservation] = []
+    for row in test_failures:
+        path = str(row.get("file", ""))
+        record = shell_records.get(path)
+        if record is None:
+            continue  # additive tests / harness: existing semantics own these
+        slots = list(record.slots)
+        primary_slot = slots[0] if slots else None
+        slot_id = primary_slot.slot_id if primary_slot else ""
+        filled = any(fill_dispositions.get(s.slot_id) == "filled" for s in slots)
+        messages = [str(m) for m in (row.get("messages") or [])]
+
+        if row.get("suite_level") or not _is_assertion_failure(messages):
+            # Mechanical death. The only mutable bytes in a shell are merged fill
+            # bodies: if one was merged, the fill is the variable; if none, the spine
+            # itself failed to execute — a generator surface the gates missed.
+            detail = messages[0][:400] if messages else "mechanical failure"
+            if filled:
+                observations.append(
+                    ShellObservation(
+                        file=path,
+                        slot_id=slot_id,
+                        failure_class=CLASS_FILL,
+                        detail=f"merged fill broke the shell mechanically: {detail}",
+                        line=row.get("line"),
+                    )
+                )
+            else:
+                observations.append(
+                    ShellObservation(
+                        file=path,
+                        slot_id=slot_id,
+                        failure_class=CLASS_SCAFFOLD_INVALID,
+                        detail=f"shell with no merged fill died mechanically — a new "
+                        f"uncovered generator surface: {detail}",
+                        line=row.get("line"),
+                    )
+                )
+            continue
+
+        # Assertion failure: attribute by line against the MERGED file's regions.
+        line = row.get("line")
+        in_slot = None
+        content = merged_contents.get(path)
+        if content is not None and isinstance(line, int):
+            try:
+                for region in parse_slot_regions(content):
+                    if region.begin_line < line < region.end_line:
+                        in_slot = region.slot_id
+                        break
+            except ScaffoldSpineError:
+                in_slot = None  # unparseable merged content → conservative (spine)
+        if in_slot is not None:
+            disposition = fill_dispositions.get(in_slot, "")
+            observations.append(
+                ShellObservation(
+                    file=path,
+                    slot_id=in_slot,
+                    failure_class=CLASS_FILL,
+                    detail=(
+                        f"slot disposition {disposition or 'filled'}: "
+                        f"{messages[0][:400] if messages else 'assertion failed'}"
+                    ),
+                    line=line,
+                )
+            )
+        else:
+            slot_for_criterion = primary_slot
+            observations.append(
+                ShellObservation(
+                    file=path,
+                    slot_id=slot_id,
+                    failure_class=CLASS_APP_CONTRACT,
+                    detail=messages[0][:400] if messages else "spine assertion failed",
+                    criterion_id=(slot_for_criterion.probe_id if slot_for_criterion else ""),
+                    line=line,
+                )
+            )
+    return observations
+
+
+@dataclass(frozen=True)
+class CorrelatedFinding:
+    """One criterion's grouped observations — the router's dedup unit.
+
+    Grouped, never collapsed: both observation lists are retained in full. A finding
+    with both sides is ONE defect observed twice (the §5 dedup rule); a finding with
+    only shell observations is a scaffold-only detection; probe-only findings are the
+    probe layer's existing business and not manufactured here.
+    """
+
+    criterion_id: str
+    shell_observations: tuple[ShellObservation, ...] = ()
+    probe_failures: tuple[dict, ...] = ()
+
+    @property
+    def probe_redundant(self) -> bool:
+        return bool(self.shell_observations) and bool(self.probe_failures)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "criterion_id": self.criterion_id,
+            "shell_observations": [o.to_dict() for o in self.shell_observations],
+            "probe_failures": list(self.probe_failures),
+            "probe_redundant": self.probe_redundant,
+        }
+
+
+def correlate(
+    observations: list[ShellObservation], probe_rows: list[dict]
+) -> list[CorrelatedFinding]:
+    """Group shell and probe failures by shared criterion id — correlation only.
+
+    Different criterion ids are never merged; observations without a criterion id
+    (fill/generator/infrastructure classes) are never pulled into a finding.
+    """
+    failed_probe_rows = [
+        row
+        for row in probe_rows
+        if isinstance(row, dict)
+        and row.get("criterion_id")
+        and str(row.get("status", "")).lower() in ("fail", "failed", "error")
+    ]
+    by_criterion: dict[str, CorrelatedFinding] = {}
+    for observation in observations:
+        if not observation.criterion_id:
+            continue
+        existing = by_criterion.get(observation.criterion_id)
+        shells = (existing.shell_observations if existing else ()) + (observation,)
+        probes = existing.probe_failures if existing else ()
+        by_criterion[observation.criterion_id] = CorrelatedFinding(
+            criterion_id=observation.criterion_id,
+            shell_observations=shells,
+            probe_failures=probes,
+        )
+    for row in failed_probe_rows:
+        criterion_id = str(row["criterion_id"])
+        existing = by_criterion.get(criterion_id)
+        if existing is None:
+            continue  # probe-only failures stay the probe layer's business
+        by_criterion[criterion_id] = CorrelatedFinding(
+            criterion_id=criterion_id,
+            shell_observations=existing.shell_observations,
+            probe_failures=existing.probe_failures + (row,),
+        )
+    return [by_criterion[k] for k in sorted(by_criterion)]
+
+
+@dataclass(frozen=True)
+class ScaffoldEvidenceSummary:
+    """The run-report record — the fields the future promotion model needs (SIP §6/§12).
+
+    Schema preserved, workflow not built: nothing consumes these counts to promote or
+    demote anything yet; they exist so the evidence is being banked from the first roll.
+    """
+
+    stack: str
+    generator_version: int
+    shell_count: int
+    slot_count: int
+    fill_dispositions: dict[str, int]
+    additive_test_count: int
+    failure_classes: dict[str, int]
+    observations: tuple[ShellObservation, ...] = ()
+    correlations: tuple[CorrelatedFinding, ...] = ()
+
+    @property
+    def uncorrelated_fill_failures(self) -> int:
+        """Fill-layer failures with no probe echo — the authored layer's unique-signal
+        candidates (§6's 'failures detected only by fills', pending human reading)."""
+        return sum(1 for o in self.observations if o.failure_class == CLASS_FILL)
+
+    @property
+    def probe_redundant_findings(self) -> int:
+        return sum(1 for c in self.correlations if c.probe_redundant)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stack": self.stack,
+            "generator_version": self.generator_version,
+            "shell_count": self.shell_count,
+            "slot_count": self.slot_count,
+            "fill_dispositions": dict(self.fill_dispositions),
+            "additive_test_count": self.additive_test_count,
+            "failure_classes": dict(self.failure_classes),
+            "uncorrelated_fill_failures": self.uncorrelated_fill_failures,
+            "probe_redundant_findings": self.probe_redundant_findings,
+            "observations": [o.to_dict() for o in self.observations],
+            "correlations": [c.to_dict() for c in self.correlations],
+        }
+
+
+def build_scaffold_evidence_summary(
+    scaffold_manifest: Any,
+    fill_dispositions: dict[str, str],
+    observations: list[ShellObservation],
+    correlations: list[CorrelatedFinding],
+    additive_test_count: int,
+) -> ScaffoldEvidenceSummary:
+    disposition_counts: dict[str, int] = {}
+    for disposition in fill_dispositions.values():
+        disposition_counts[disposition] = disposition_counts.get(disposition, 0) + 1
+    class_counts: dict[str, int] = {}
+    for observation in observations:
+        class_counts[observation.failure_class] = class_counts.get(observation.failure_class, 0) + 1
+    return ScaffoldEvidenceSummary(
+        stack=scaffold_manifest.stack,
+        generator_version=scaffold_manifest.generator_version,
+        shell_count=len(scaffold_manifest.files),
+        slot_count=len(scaffold_manifest.slot_ids()),
+        fill_dispositions=disposition_counts,
+        additive_test_count=additive_test_count,
+        failure_classes=class_counts,
+        observations=tuple(observations),
+        correlations=tuple(correlations),
+    )

--- a/src/squadops/cycles/scaffold_evidence.py
+++ b/src/squadops/cycles/scaffold_evidence.py
@@ -235,12 +235,17 @@ def correlate(
     Different criterion ids are never merged; observations without a criterion id
     (fill/generator/infrastructure classes) are never pulled into a finding.
     """
+    from squadops.cycles.verification_integrity import ResultStatus
+
+    # Probe rows speak ResultStatus (probe_runner emits its literals) — compare against
+    # the owning vocabulary, never raw strings (#380).
+    failing_statuses = {ResultStatus.FAILED, ResultStatus.ERROR}
     failed_probe_rows = [
         row
         for row in probe_rows
         if isinstance(row, dict)
         and row.get("criterion_id")
-        and str(row.get("status", "")).lower() in ("fail", "failed", "error")
+        and str(row.get("status", "")).lower() in failing_statuses
     ]
     by_criterion: dict[str, CorrelatedFinding] = {}
     for observation in observations:

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -211,3 +211,79 @@ async def test_a_fills_only_emission_is_not_a_zero_extraction_failure(scaffold_i
         if a["name"].endswith("vc-probe-api-runs.scaffold.test.ts")
     )
     assert "expect(body.id).toBeTruthy()" in create_shell["content"]
+
+
+async def test_the_evidence_pipeline_lands_in_outputs(scaffold_input, monkeypatch):
+    """P5 wiring: a spine failure among the runner's observation rows classifies as
+    app_contract and lands in BOTH outputs['scaffold_evidence'] (the banked summary)
+    and the validation_result classification row the locus classifier consults."""
+    from squadops.capabilities.handlers.cycle import qa_test as qa_test_module
+    from squadops.capabilities.handlers.test_runner import RunTestsResult
+
+    fill_text = "```fill:slot-vc-probe-api-runs\n    expect(body.id).toBeTruthy()\n```\n"
+    shell_path = "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts"
+
+    async def _canned_suite(capability, sources, extracted):
+        merged_content = next(f["content"] for f in extracted if f["filename"] == shell_path)
+        status_line = next(
+            i
+            for i, line in enumerate(merged_content.split("\n"), start=1)
+            if "expect(res.status).toBe(201)" in line
+        )
+        result = RunTestsResult(
+            executed=True,
+            exit_code=1,
+            runner="vitest",
+            suite_broken=False,
+            test_failures=(
+                {
+                    "file": shell_path,
+                    "title": "POST /api/runs -> 201 [vc-probe-api-runs]",
+                    "messages": ["expected 500 to be 201 // Object.is equality"],
+                    "line": status_line,
+                    "suite_level": False,
+                },
+            ),
+        )
+        return result, {
+            "name": "test_report.md",
+            "content": "r",
+            "media_type": "text/markdown",
+            "type": "document",
+        }
+
+    monkeypatch.setattr(
+        qa_test_module.QATestHandler, "_run_test_suite", staticmethod(_canned_suite)
+    )
+
+    context = MagicMock()
+    context.ports.llm.chat_stream_with_usage = AsyncMock(return_value=MagicMock(content=fill_text))
+    context.ports.llm.default_model = "m"
+    assembled = MagicMock()
+    assembled.content = "system"
+    context.ports.prompt_service.assemble = MagicMock(return_value=assembled)
+    context.ports.request_renderer = None
+
+    result = await QATestHandler().handle(
+        context,
+        {
+            "prd": "group_run",
+            "artifact_contents": {},
+            "resolved_config": {"dev_capability": "nextjs_ts"},
+            "subtask_focus": "fill the scaffold",
+            "expected_artifacts": [],
+            "verification_scaffold": scaffold_input,
+        },
+    )
+
+    evidence = result.outputs["scaffold_evidence"]
+    assert evidence["failure_classes"] == {"app_contract": 1}
+    assert evidence["observations"][0]["criterion_id"] == "vc-probe-api-runs"
+    assert evidence["observations"][0]["owner"] == "dev"
+    assert evidence["fill_dispositions"] == {"filled": 1, "missing": 7}
+    rows = result.outputs["validation_result"]["checks"]
+    classification_row = next(
+        r for r in rows if r.get("check") == "scaffold_failure_classification"
+    )
+    assert classification_row["classes"] == {"app_contract": 1}
+    assert "passed" not in classification_row  # informational — SIP-0096 credit untouched

--- a/tests/unit/cycles/test_failure_evidence.py
+++ b/tests/unit/cycles/test_failure_evidence.py
@@ -663,3 +663,43 @@ class TestExtractionLossSignal:
             self._envelope(), self._result(stats), prior_plan_deltas_count=0
         )
         assert "extraction_loss" not in evidence
+
+
+class TestScaffoldClassificationLocus:
+    """SIP-0104 P5: the scaffold classification row is consulted before tests_pass —
+    it is finer-grained, and misreading it re-opens the exact misrouting (#626/pf-53
+    shaped) the classification exists to end."""
+
+    @staticmethod
+    def _evidence(classes: dict, tests_pass_row: dict | None = None) -> dict:
+        checks = [
+            {"check": "scaffold_failure_classification", "status": "info", "classes": classes}
+        ]
+        if tests_pass_row is not None:
+            checks.append(tests_pass_row)
+        return {"validation_result": {"checks": checks}}
+
+    def test_app_contract_routes_to_subject(self):
+        evidence = self._evidence({"app_contract": 2, "fill": 1})
+        assert classify_failure_locus(evidence) == FailureLocus.SUBJECT
+
+    def test_all_fill_routes_to_own_artifact(self):
+        evidence = self._evidence({"fill": 3})
+        assert classify_failure_locus(evidence) == FailureLocus.OWN_ARTIFACT
+
+    def test_scaffold_invalid_falls_through_not_an_llm_locus(self):
+        """A generator surface is neither qa's nor dev's to repair — the class falls
+        through to the legacy signals rather than inventing a repair target."""
+        evidence = self._evidence(
+            {"scaffold_invalid": 1},
+            {"check": "tests_pass", "passed": False, "executed": True, "suite_broken": False},
+        )
+        assert classify_failure_locus(evidence) == FailureLocus.SUBJECT  # legacy row decides
+
+    def test_infrastructure_with_fill_stays_conservative(self):
+        evidence = self._evidence({"fill": 1, "test_infrastructure": 1})
+        assert classify_failure_locus(evidence) == FailureLocus.UNKNOWN
+
+    def test_an_empty_classification_changes_nothing(self):
+        evidence = self._evidence({})
+        assert classify_failure_locus(evidence) == FailureLocus.UNKNOWN

--- a/tests/unit/cycles/test_scaffold_evidence.py
+++ b/tests/unit/cycles/test_scaffold_evidence.py
@@ -1,0 +1,340 @@
+"""Gate 5's exit corpus: routing per class, correlation grouped-not-collapsed, report fields.
+
+Every case runs against the REAL emission and REAL merged shells, with observation rows in
+the measured vitest shapes (bare chai messages, location.line) — the same rows the runner's
+JSON report produces in production.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.handlers.test_runner import parse_vitest_failure_rows
+from squadops.capabilities.verification_scaffold_emission import emit_verification_scaffold
+from squadops.capabilities.verification_scaffold_fill import merge_fills, parse_fill_emission
+from squadops.cycles.scaffold_evidence import (
+    CLASS_APP_CONTRACT,
+    CLASS_FILL,
+    CLASS_INFRASTRUCTURE,
+    CLASS_SCAFFOLD_INVALID,
+    ShellObservation,
+    build_scaffold_evidence_summary,
+    classify_shell_failures,
+    correlate,
+)
+from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+pytestmark = [pytest.mark.domain_contracts]
+
+_CREATE_SHELL = "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts"
+_LIST_SHELL = "__tests__/scaffold/vs-get-api-runs.scaffold.test.ts"
+
+
+@pytest.fixture(scope="module")
+def emission():
+    return emit_verification_scaffold(manifest_for_stack("nextjs_ts"))
+
+
+@pytest.fixture(scope="module")
+def merged(emission):
+    """The create shell filled; every other slot missing (its injected failing state)."""
+    return merge_fills(
+        list(emission.files),
+        emission.manifest,
+        parse_fill_emission(
+            "```fill:slot-vc-probe-api-runs\n    expect(body.title).toBe('sample')\n```\n"
+        ),
+    )
+
+
+@pytest.fixture(scope="module")
+def merged_contents(merged):
+    return {f.path: f.content for f in merged.files}
+
+
+@pytest.fixture(scope="module")
+def dispositions(merged):
+    return {d.slot_id: d.disposition for d in merged.dispositions}
+
+
+def _line_of(content: str, needle: str) -> int:
+    return next(i for i, line in enumerate(content.split("\n"), start=1) if needle in line)
+
+
+def _classify(emission, merged_contents, dispositions, rows, executed=True):
+    return classify_shell_failures(
+        rows, merged_contents, emission.manifest, dispositions, runner_executed=executed
+    )
+
+
+class TestRoutingPerClass:
+    def test_a_spine_status_failure_is_app_contract_routed_to_dev(
+        self, emission, merged_contents, dispositions
+    ):
+        line = _line_of(merged_contents[_CREATE_SHELL], "expect(res.status).toBe(201)")
+        rows = [
+            {
+                "file": _CREATE_SHELL,
+                "title": "POST /api/runs -> 201 [vc-probe-api-runs]",
+                "messages": ["expected 500 to be 201 // Object.is equality"],
+                "line": line,
+                "suite_level": False,
+            }
+        ]
+        (obs,) = _classify(emission, merged_contents, dispositions, rows)
+        assert obs.failure_class == CLASS_APP_CONTRACT
+        assert obs.criterion_id == "vc-probe-api-runs"  # the correlation join key
+        assert obs.to_dict()["owner"] == "dev"
+        assert obs.to_dict()["route"] == "dev_repair"
+
+    def test_a_fill_assertion_failure_is_fill_class_slot_scoped_to_qa(
+        self, emission, merged_contents, dispositions
+    ):
+        line = _line_of(merged_contents[_CREATE_SHELL], "expect(body.title).toBe('sample')")
+        rows = [
+            {
+                "file": _CREATE_SHELL,
+                "title": "POST /api/runs -> 201 [vc-probe-api-runs]",
+                "messages": ["expected undefined to be 'sample'"],
+                "line": line,
+                "suite_level": False,
+            }
+        ]
+        (obs,) = _classify(emission, merged_contents, dispositions, rows)
+        assert obs.failure_class == CLASS_FILL
+        assert obs.slot_id == "slot-vc-probe-api-runs"
+        assert obs.criterion_id == ""  # fill failures never join probe correlation
+        assert obs.to_dict()["owner"] == "qa"
+        assert obs.to_dict()["route"] == "qa_repair_slot_scoped"
+
+    def test_a_missing_slots_injected_failing_state_is_fill_class(
+        self, emission, merged_contents, dispositions
+    ):
+        """The P3 missing-slot rule ends here: the injected expect() line sits inside the
+        region, so its failure attributes to the fill layer with the disposition named."""
+        line = _line_of(merged_contents[_LIST_SHELL], "expect('fill layer: slot-vs-get-api-runs")
+        rows = [
+            {
+                "file": _LIST_SHELL,
+                "title": "GET /api/runs -> 200 [vs-get-api-runs]",
+                "messages": ["expected 'fill layer: …' to be 'a valid fill …'"],
+                "line": line,
+                "suite_level": False,
+            }
+        ]
+        (obs,) = _classify(emission, merged_contents, dispositions, rows)
+        assert obs.failure_class == CLASS_FILL
+        assert "missing" in obs.detail
+
+    def test_a_mechanical_death_of_a_filled_shell_is_fill_class(
+        self, emission, merged_contents, dispositions
+    ):
+        rows = [
+            {
+                "file": _CREATE_SHELL,
+                "title": "",
+                "messages": ["Transform failed with 1 error:"],
+                "line": None,
+                "suite_level": True,
+            }
+        ]
+        (obs,) = _classify(emission, merged_contents, dispositions, rows)
+        assert obs.failure_class == CLASS_FILL
+        assert "merged fill broke the shell" in obs.detail
+
+    def test_a_mechanical_death_of_an_unfilled_shell_is_scaffold_invalid(
+        self, emission, merged_contents, dispositions
+    ):
+        """The P6 window rule's subject: a spine that dies with no fill merged is a NEW
+        uncovered generator surface — named, never sent to an LLM round."""
+        rows = [
+            {
+                "file": _LIST_SHELL,
+                "title": "GET /api/runs -> 200 [vs-get-api-runs]",
+                "messages": ["Requests is not defined"],
+                "line": None,
+                "suite_level": False,
+            }
+        ]
+        (obs,) = _classify(emission, merged_contents, dispositions, rows)
+        assert obs.failure_class == CLASS_SCAFFOLD_INVALID
+        assert "uncovered generator surface" in obs.detail
+        assert obs.to_dict()["route"] == "name_uncovered_surface_no_llm_round"
+
+    def test_a_runner_that_could_not_execute_is_infrastructure(
+        self, emission, merged_contents, dispositions
+    ):
+        (obs,) = _classify(emission, merged_contents, dispositions, [], executed=False)
+        assert obs.failure_class == CLASS_INFRASTRUCTURE
+        assert obs.to_dict()["owner"] == "environment"
+
+    def test_non_shell_failures_pass_through_unclassified(
+        self, emission, merged_contents, dispositions
+    ):
+        rows = [
+            {
+                "file": "__tests__/extra.test.ts",
+                "title": "t",
+                "messages": ["expected 1 to be 2"],
+                "line": 3,
+                "suite_level": False,
+            }
+        ]
+        assert _classify(emission, merged_contents, dispositions, rows) == []
+
+    def test_an_assertion_failure_without_line_info_falls_to_app_contract(
+        self, emission, merged_contents, dispositions
+    ):
+        """Ambiguity falls toward the dev/subject direction (the test-gaming guard's
+        side): qa must never be invited to rewrite the suite on an ambiguous signal."""
+        rows = [
+            {
+                "file": _CREATE_SHELL,
+                "title": "t",
+                "messages": ["expected 500 to be 201"],
+                "line": None,
+                "suite_level": False,
+            }
+        ]
+        (obs,) = _classify(emission, merged_contents, dispositions, rows)
+        assert obs.failure_class == CLASS_APP_CONTRACT
+
+
+class TestCorrelation:
+    def _shell_obs(self, criterion="vc-probe-api-runs"):
+        return ShellObservation(
+            file=_CREATE_SHELL,
+            slot_id="slot-vc-probe-api-runs",
+            failure_class=CLASS_APP_CONTRACT,
+            criterion_id=criterion,
+        )
+
+    def test_shared_criterion_groups_both_observations_retained(self):
+        """The §5 dedup rule: ONE defect observed twice — grouped, both retained, never
+        collapsed into a single observation."""
+        probe_row = {
+            "check": "vc-probe-api-runs",
+            "criterion_id": "vc-probe-api-runs",
+            "status": "failed",
+            "reason": "status 500 != 201",
+        }
+        findings = correlate([self._shell_obs()], [probe_row])
+        assert len(findings) == 1
+        finding = findings[0]
+        assert len(finding.shell_observations) == 1
+        assert len(finding.probe_failures) == 1  # both sides retained in full
+        assert finding.probe_redundant
+
+    def test_different_criterion_ids_are_never_merged(self):
+        findings = correlate(
+            [self._shell_obs("vc-probe-api-runs"), self._shell_obs("vc-probe-api-runs-join")],
+            [],
+        )
+        assert [f.criterion_id for f in findings] == [
+            "vc-probe-api-runs",
+            "vc-probe-api-runs-join",
+        ]
+
+    def test_a_probe_only_failure_manufactures_no_finding(self):
+        probe_row = {"criterion_id": "vc-probe-api-runs", "status": "failed"}
+        assert correlate([], [probe_row]) == []
+
+    def test_a_shell_only_finding_is_not_probe_redundant(self):
+        findings = correlate([self._shell_obs()], [{"criterion_id": "other", "status": "failed"}])
+        assert len(findings) == 1
+        assert not findings[0].probe_redundant
+
+    def test_passing_probe_rows_never_join(self):
+        probe_row = {"criterion_id": "vc-probe-api-runs", "status": "pass"}
+        findings = correlate([self._shell_obs()], [probe_row])
+        assert findings[0].probe_failures == ()
+
+
+class TestSummary:
+    def test_the_report_fields_are_present_and_counted(self, emission, dispositions):
+        observations = [
+            ShellObservation(
+                file=_CREATE_SHELL,
+                slot_id="slot-vc-probe-api-runs",
+                failure_class=CLASS_APP_CONTRACT,
+                criterion_id="vc-probe-api-runs",
+            ),
+            ShellObservation(
+                file=_LIST_SHELL, slot_id="slot-vs-get-api-runs", failure_class=CLASS_FILL
+            ),
+        ]
+        correlations = correlate(
+            observations,
+            [{"criterion_id": "vc-probe-api-runs", "status": "failed"}],
+        )
+        summary = build_scaffold_evidence_summary(
+            emission.manifest, dispositions, observations, correlations, additive_test_count=2
+        )
+        d = summary.to_dict()
+        # the promotion model's fields (SIP §6/§12) — schema preserved, workflow not built
+        assert d["stack"] == "nextjs_ts" and d["generator_version"] == 1
+        assert d["shell_count"] == 8 and d["slot_count"] == 8
+        assert d["fill_dispositions"] == {"filled": 1, "missing": 7}
+        assert d["additive_test_count"] == 2
+        assert d["failure_classes"] == {CLASS_APP_CONTRACT: 1, CLASS_FILL: 1}
+        assert d["uncorrelated_fill_failures"] == 1
+        assert d["probe_redundant_findings"] == 1
+        assert d["observations"][0]["owner"] == "dev"
+        assert d["correlations"][0]["criterion_id"] == "vc-probe-api-runs"
+
+
+class TestObservationParser:
+    def test_rows_from_a_vitest_report_are_relative_and_shaped(self):
+        report = {
+            "testResults": [
+                {
+                    "name": f"/ws/{_CREATE_SHELL}",
+                    "status": "failed",
+                    "message": "",
+                    "assertionResults": [
+                        {
+                            "status": "failed",
+                            "title": "POST /api/runs -> 201",
+                            "failureMessages": ["expected 500 to be 201 // Object.is equality"],
+                            "location": {"line": 21, "column": 24},
+                        },
+                        {"status": "passed", "title": "other", "failureMessages": []},
+                    ],
+                },
+                {
+                    "name": f"/ws/{_LIST_SHELL}",
+                    "status": "failed",
+                    "message": "Failed to resolve import '@/app/api/run/route'",
+                    "assertionResults": [],
+                },
+            ]
+        }
+        rows = parse_vitest_failure_rows(report, "/ws")
+        assert rows == [
+            {
+                "file": _CREATE_SHELL,
+                "title": "POST /api/runs -> 201",
+                "messages": ["expected 500 to be 201 // Object.is equality"],
+                "line": 21,
+                "suite_level": False,
+            },
+            {
+                "file": _LIST_SHELL,
+                "title": "",
+                "messages": ["Failed to resolve import '@/app/api/run/route'"],
+                "line": None,
+                "suite_level": True,
+            },
+        ]
+
+    def test_a_passing_report_yields_no_rows(self):
+        report = {
+            "testResults": [
+                {
+                    "name": "/ws/a.test.ts",
+                    "status": "passed",
+                    "assertionResults": [{"status": "passed"}],
+                }
+            ]
+        }
+        assert parse_vitest_failure_rows(report, "/ws") == []


### PR DESCRIPTION
Phase 5 of the SIP-0104 plan: **Gate 5 — evidence and convergence**, the observability layer. The pipeline stays explicit and separate, exactly as the plan states it: `observation → classification → correlation → owner → repair route`.

## The pipeline (`cycles/scaffold_evidence.py`)

- **Observation**: `run_node_tests` now runs vitest with the JSON reporter *alongside* verbose (stdout markers for #626 suite-health unchanged) and carries per-failure rows — `{file, title, messages, line, suite_level}` — on `RunTestsResult.test_failures`. Additive and never load-bearing: a missing report degrades to empty rows.
- **Classification** lands every scaffold-shell failure in the SIP §5 classes, with evidence rows carrying slot ids:
  - line-based attribution against the **merged** file's parsed slot regions: inside a slot body → `fill` (including the missing/rejected slots' injected failing states, disposition named); on the spine → `app_contract`, carrying the bound probe id as the correlation key;
  - a mechanical death attributes to the **fill** iff a fill was merged into that shell (the only mutable bytes), else to the **generator** (`scaffold_invalid` — a new uncovered surface, the P6 window rule's subject, routed `name_uncovered_surface_no_llm_round`);
  - a runner that could not execute is `test_infrastructure` — environment triage, never a work-product round;
  - ambiguity falls to `app_contract` (the dev/subject side — the test-gaming guard's direction, unchanged);
  - non-shell failures (additive tests, harness) pass through untouched: existing machinery owns them.
- **Correlation, not causal equivalence**: shell and probe failures sharing a criterion id are grouped with **both observations retained in full** — one dedup unit for the router, never collapsed; different criterion ids never merge; probe-only failures manufacture no finding.
- **Ownership and routing are data** (`CLASS_OWNERS`/`CLASS_ROUTES`): scaffold-invalid → generator, app-contract → dev repair, fill → qa repair slot-scoped, infrastructure → environment triage.

## Wiring

- **qa.test (fill mode)** classifies after the probe rows land, and banks two artifacts: `outputs["scaffold_evidence"]` — the full summary — and an informational `scaffold_failure_classification` row in `validation_result.checks` (status-bearing like the probe rows, **no `passed` bool — `tests_pass` credit semantics and SIP-0096 are untouched**).
- **The locus classifier consults the classification before `tests_pass`**: any `app_contract` → SUBJECT (dev chain); all-`fill` → OWN_ARTIFACT (qa re-authors fills); the generator and infrastructure classes deliberately fall through — neither is an LLM-repairable locus. The classification row rides the existing failure-evidence transport into the correction loop, so repair prompts see the classes without new plumbing.

## Report fields — schema preserved, workflow not built (SIP §6/§12)

`ScaffoldEvidenceSummary` banks the promotion model's fields from the first roll: stack + generator identity, shell/slot counts, fill dispositions, additive test count, per-class failure counts, per-observation owner/route rows, correlations with `probe_redundant` marked, and the `uncorrelated_fill_failures` count (the authored layer's unique-signal candidates). Nothing consumes them to promote anything yet — that is the named §12 follow-on.

## Gate 5 exit criteria

- **Routing tests per class** ✅ — all four classes plus the filled-vs-unfilled mechanical split, the missing-slot failing state, the no-line ambiguity direction, and non-shell pass-through (16-test corpus on the real emission + real merged shells, observation rows in the measured vitest shapes)
- **Correlation tests** ✅ — grouped with both sides retained, distinct ids never merged, probe-only never manufactured, passing probes never join
- **Report fields present** ✅ — asserted field-by-field on the summary, and end-to-end through `handle()` (canned suite result → `scaffold_evidence` + classification row in outputs)

Validation: full regression **7278 passed, 1 skipped**, ruff clean. The enum-shadow net caught one raw-literal comparison during development (probe statuses now compare against `ResultStatus`). No emission changes — GENERATOR_VERSION stays 1; deployed containers need a rebuild to carry P5 before the first window roll.

Next after merge: **rebuild + deploy-prove for P5**, then **Phase 6 — the N=6 zero-mechanical-death window** under the fixed protocol, plus the semantic-value end-to-end test riding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
