### PR TITLE
fix(sip-0104): four defects measured on window roll 1 (sandbox install, audit stack, silent non-collection, rollup pollution)

### DIFF
--- a/scripts/dev/audit_delivered_app.py
+++ b/scripts/dev/audit_delivered_app.py
@@ -49,9 +49,17 @@ from squadops.cycles.verification_contract import (
     capture_probe_values,
     resolve_probe_path,
 )
-from squadops.sandbox.environment import FULLSTACK_FASTAPI_REACT
+from squadops.sandbox.environment import get_environment_contract
 from squadops.sandbox.models import RevisionOrigin
 from squadops.sandbox.workspace import WorkspaceStore
+
+#: One file per stack whose absence means assembly itself failed — the deliverable's
+#: irreducible entry surface. Keyed by stack so a third stack declares its own rather
+#: than inheriting a check that silently cannot hold.
+_ASSEMBLY_SENTINELS: dict[str, str] = {
+    "fullstack_fastapi_react": "backend/routes.py",
+    "nextjs_ts": "package.json",
+}
 
 _VAULT_CONTAINER = "squadops-runtime-api"
 _WORKSPACE_ARTIFACT_TYPES = frozenset({"source", "test", "config"})
@@ -156,15 +164,24 @@ async def _audit(args: argparse.Namespace) -> int:
         files = _select_deliverable(pulled)
     finally:
         shutil.rmtree(pulled, ignore_errors=True)
-    if "backend/routes.py" not in files:
-        print(f"AUDITOR ERROR: no backend/routes.py among {len(files)} selected files")
+    # The stack is the contract's own fact (``skeleton.expander``), never assumed: this
+    # auditor was FastAPI-only until SIP-0104's window needed it for stack #2, and a
+    # hardcoded environment would have stood a Next.js tree up with uvicorn and reported
+    # the AUDITOR's defect as the app's.
+    stack = contract.skeleton.expander
+    sentinel = _ASSEMBLY_SENTINELS.get(stack)
+    if sentinel is None:
+        print(f"AUDITOR ERROR: no assembly sentinel for stack {stack!r}")
         return 2
-    print(f"assembled {len(files)} files (acceptance-aware last-wins)")
+    if sentinel not in files:
+        print(f"AUDITOR ERROR: no {sentinel} among {len(files)} selected files")
+        return 2
+    print(f"assembled {len(files)} files for stack {stack} (acceptance-aware last-wins)")
 
     audit_cycle = f"audit_{args.run_id[:16]}"
     shutil.rmtree(_AUDIT_ROOT / "cycles" / audit_cycle, ignore_errors=True)
     store = WorkspaceStore(_AUDIT_ROOT / "cycles")
-    env = FULLSTACK_FASTAPI_REACT
+    env = get_environment_contract(stack)
     backend = ContainerBackend(
         container=DockerAdapter(),
         store=store,

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -341,6 +341,14 @@ class QATestHandler(_CycleTaskHandler):
             f"**Test files:** {test_result.test_file_count}\n",
             f"**Source files:** {test_result.source_file_count}\n",
         ]
+        if test_result.uncollected_test_files:
+            # SIP-0104 roll 1: a suite the runner never collected verifies nothing while
+            # the collected ones read green. Named in the report a human actually reads.
+            report_lines.append(
+                "\n**NOT COLLECTED (these ran nothing):** "
+                + ", ".join(f"`{p}`" for p in test_result.uncollected_test_files)
+                + "\n"
+            )
         if test_result.stdout:
             report_lines.append(f"\n## stdout\n\n```\n{test_result.stdout}\n```\n")
         if test_result.stderr:
@@ -540,13 +548,19 @@ class QATestHandler(_CycleTaskHandler):
         scaffold_input: dict[str, Any],
         artifacts: list[dict],
     ) -> None:
-        """Run the P5 pipeline and land its outputs (SIP-0104 §5/§6).
+        """Run the P5 pipeline and land its summary (SIP-0104 §5/§6).
 
-        Two landings: ``outputs["scaffold_evidence"]`` (the full summary — the promotion
-        model's banked fields) and an informational ``scaffold_failure_classification``
-        row in ``validation_result.checks`` (status-bearing like the probe rows, no
-        ``passed`` bool — SIP-0096 credit semantics untouched) so the locus classifier
-        and the correction loop's failure evidence read the classes without re-deriving.
+        ONE landing: ``outputs["scaffold_evidence"]`` — the full summary, which
+        ``build_failure_evidence`` threads into the correction loop's evidence (the same
+        transport ``emission_failure`` and ``app_tracebacks`` ride) and the locus
+        classifier reads from there.
+
+        Deliberately NOT a ``validation_result.checks`` row. Roll 1 (cyc_04d36309d793)
+        measured the cost of that: ``normalize_task_checks`` records any row carrying a
+        ``status`` key, so an informational row aggregated as a verification check and
+        surfaced in the cycle outcome's ``unverified`` list with reason ``unspecified``.
+        Non-blocking, but a diagnostic is not evidence and must not be counted as one
+        (SIP-0096 §6.1).
         """
         from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
         from squadops.cycles.scaffold_evidence import (
@@ -584,17 +598,14 @@ class QATestHandler(_CycleTaskHandler):
             and a.get("name") not in shell_paths
         )
         summary = build_scaffold_evidence_summary(
-            record, dispositions, observations, correlations, additive_count
+            record,
+            dispositions,
+            observations,
+            correlations,
+            additive_count,
+            tuple(getattr(test_result, "uncollected_test_files", ()) or ()),
         )
         outputs["scaffold_evidence"] = summary.to_dict()
-        vr = outputs.setdefault("validation_result", {})
-        vr.setdefault("checks", []).append(
-            {
-                "check": "scaffold_failure_classification",
-                "status": "info",
-                "classes": dict(summary.failure_classes),
-            }
-        )
 
     def _build_focused_prompt(self, inputs: dict[str, Any]) -> str:
         """Build a focused prompt for manifest-driven QA subtasks (SIP-0086).

--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -59,6 +59,14 @@ class RunTestsResult:
     # produced no machine report (pytest runs, report write failure) — additive, never
     # load-bearing for the pass/fail verdict.
     test_failures: tuple[dict, ...] = ()
+    # Test files handed to the runner that it never collected — authored suites that
+    # cannot run and therefore verify nothing, while the surrounding suite reads green.
+    # Measured on SIP-0104 window roll 1 (cyc_04d36309d793): qa authored a ~9KB suite at
+    # `tests/api/runs.test.ts`, outside this stack's `**/__tests__/**/*.test.ts` include,
+    # so 9 files went in and 8 collected — the semantic layer's additive half evaporated
+    # silently. Reported, not verdict-changing (promotion to a blocking check is a
+    # deliberate decision, not a side effect of detection).
+    uncollected_test_files: tuple[str, ...] = ()
 
     @property
     def tests_passed(self) -> bool:
@@ -384,6 +392,19 @@ async def run_node_tests(
         stdout = raw_stdout.decode(errors="replace")[:_STDOUT_LIMIT]
         stderr = raw_stderr.decode(errors="replace")[:_STDOUT_LIMIT]
 
+        report = _read_vitest_report(report_path)
+        failure_rows = parse_vitest_failure_rows(report, cwd) if report else []
+        uncollected = (
+            uncollected_test_files(report, cwd, [f["path"] for f in test_files]) if report else []
+        )
+        if uncollected:
+            logger.warning(
+                "vitest collected no suite for %d handed-in test file(s): %s — these "
+                "verify nothing while the collected suites read green",
+                len(uncollected),
+                ", ".join(uncollected),
+            )
+
         exit_code = proc.returncode or 0
         return RunTestsResult(
             executed=True,
@@ -398,7 +419,8 @@ async def run_node_tests(
             # "No test suite found" routed repairs to dev for a defect in the
             # qa role's own file).
             suite_broken=_vitest_suite_broken(exit_code, stdout, stderr),
-            test_failures=tuple(_read_vitest_failure_rows(report_path, cwd)),
+            test_failures=tuple(failure_rows),
+            uncollected_test_files=tuple(uncollected),
         )
 
     except Exception as exc:
@@ -764,16 +786,41 @@ def parse_vitest_failure_rows(report: dict, workspace_root: str) -> list[dict]:
     return rows
 
 
-def _read_vitest_failure_rows(report_path: str, workspace_root: str) -> list[dict]:
-    """The observation rows from the written report, or [] (additive, never fatal)."""
+#: Suffixes that make a handed-in file unambiguously a suite meant to run. A helper
+#: module beside the tests is legitimately uncollected; a `*.test.ts` never is.
+_RUNNABLE_TEST_SUFFIXES = (".test.ts", ".test.tsx", ".spec.ts", ".spec.tsx")
+
+
+def _read_vitest_report(report_path: str) -> dict | None:
     import json
 
     try:
         with open(report_path, encoding="utf-8") as fh:
-            report = json.load(fh)
+            return json.load(fh)
     except (OSError, ValueError):
-        return []
-    return parse_vitest_failure_rows(report, workspace_root)
+        return None
+
+
+def collected_files(report: dict, workspace_root: str) -> set[str]:
+    """Workspace-relative paths of every suite the runner actually collected."""
+    root = workspace_root.rstrip("/") + "/"
+    names = {str(suite.get("name", "")) for suite in report.get("testResults", ())}
+    return {name[len(root) :] if name.startswith(root) else name for name in names}
+
+
+def uncollected_test_files(report: dict, workspace_root: str, handed_in: list[str]) -> list[str]:
+    """Handed-in runnable suites the runner never collected (SIP-0104, roll 1).
+
+    Silent non-collection is the #884 class one step down: not "no test files found"
+    but "this one was ignored", which every other signal reports as green because the
+    files that DID collect passed.
+    """
+    collected = collected_files(report, workspace_root)
+    return sorted(
+        path
+        for path in handed_in
+        if path.endswith(_RUNNABLE_TEST_SUFFIXES) and path not in collected
+    )
 
 
 _VITEST_SUITE_BROKEN_MARKERS = (
@@ -903,6 +950,7 @@ async def run_fullstack_tests(
         runner=controlling.runner,
         suite_broken=controlling.suite_broken,
         test_failures=controlling.test_failures,
+        uncollected_test_files=controlling.uncollected_test_files,
         stdout="\n\n".join(combined_stdout_parts)[:_STDOUT_LIMIT],
         stderr="\n\n".join(combined_stderr_parts)[:_STDOUT_LIMIT],
         error="; ".join(error_parts) if error_parts else "",

--- a/src/squadops/cycles/failure_evidence.py
+++ b/src/squadops/cycles/failure_evidence.py
@@ -96,6 +96,15 @@ def build_failure_evidence(
     ]
     if app_tracebacks:
         evidence["app_tracebacks"] = app_tracebacks[:_MAX_APP_TRACEBACKS]
+    # SIP-0104 P5: the scaffold evidence summary rides the same transport as the two
+    # markers above — it is diagnostic, not a verification check, so it must never
+    # enter validation_result.checks (roll 1 measured that mistake: an informational
+    # row aggregated as an unverified check). The locus classifier reads the classes
+    # from here, and the analyzer's prompt renders the whole evidence dict, so the
+    # per-failure owner/route rows reach the diagnosis too.
+    scaffold_evidence = result_outputs.get("scaffold_evidence")
+    if isinstance(scaffold_evidence, dict):
+        evidence["scaffold_evidence"] = scaffold_evidence
     evidence["failure_category"] = derive_failure_category(evidence)
     return evidence
 
@@ -237,7 +246,7 @@ def classify_failure_locus(failure_evidence: Any) -> str:
         # the suite — for qa.test, OWN_ARTIFACT = eve re-authors the suite.
         if check == f"acceptance:{CHECK_CONTRACT_ASSERTIONS}" and row.get("passed") is False:
             return FailureLocus.OWN_ARTIFACT
-    scaffold_locus = _locus_from_scaffold_classification(checks)
+    scaffold_locus = _locus_from_scaffold_classification(failure_evidence)
     if scaffold_locus is not None:
         return scaffold_locus
     for row in checks:
@@ -248,33 +257,32 @@ def classify_failure_locus(failure_evidence: Any) -> str:
     return FailureLocus.UNKNOWN
 
 
-def _locus_from_scaffold_classification(checks: list[dict]) -> str | None:
+def _locus_from_scaffold_classification(failure_evidence: dict[str, Any]) -> str | None:
     """SIP-0104 P5: the scaffold classification is finer than tests_pass semantics —
     consulted first when present. app_contract wins over fill (the shell's frozen
     assertion says the APP violated the contract; repairing the app is the §5 route and
     the conservative direction); all-fill routes to the fill author. The generator
     (scaffold_invalid) and infrastructure classes deliberately return None — neither is
     an LLM-repairable locus, so the legacy signals (or UNKNOWN) decide."""
-    for row in checks:
-        if row.get("check") != "scaffold_failure_classification":
-            continue
-        from squadops.cycles.scaffold_evidence import (
-            CLASS_APP_CONTRACT,
-            CLASS_FILL,
-            CLASS_INFRASTRUCTURE,
-            CLASS_SCAFFOLD_INVALID,
-        )
-
-        classes = row.get("classes") or {}
-        if classes.get(CLASS_APP_CONTRACT):
-            return FailureLocus.SUBJECT
-        if (
-            classes.get(CLASS_FILL)
-            and not classes.get(CLASS_SCAFFOLD_INVALID)
-            and not classes.get(CLASS_INFRASTRUCTURE)
-        ):
-            return FailureLocus.OWN_ARTIFACT
+    summary = failure_evidence.get("scaffold_evidence")
+    if not isinstance(summary, dict):
         return None
+    from squadops.cycles.scaffold_evidence import (
+        CLASS_APP_CONTRACT,
+        CLASS_FILL,
+        CLASS_INFRASTRUCTURE,
+        CLASS_SCAFFOLD_INVALID,
+    )
+
+    classes = summary.get("failure_classes") or {}
+    if classes.get(CLASS_APP_CONTRACT):
+        return FailureLocus.SUBJECT
+    if (
+        classes.get(CLASS_FILL)
+        and not classes.get(CLASS_SCAFFOLD_INVALID)
+        and not classes.get(CLASS_INFRASTRUCTURE)
+    ):
+        return FailureLocus.OWN_ARTIFACT
     return None
 
 

--- a/src/squadops/cycles/scaffold_evidence.py
+++ b/src/squadops/cycles/scaffold_evidence.py
@@ -287,6 +287,11 @@ class ScaffoldEvidenceSummary:
     fill_dispositions: dict[str, int]
     additive_test_count: int
     failure_classes: dict[str, int]
+    #: Authored suites the runner never collected — additive work that verified nothing
+    #: (SIP-0104 roll 1). Banked beside the counts because §6's "is the authored layer
+    #: earning its inference spend" question is unanswerable if part of that layer
+    #: silently never ran.
+    uncollected_test_files: tuple[str, ...] = ()
     observations: tuple[ShellObservation, ...] = ()
     correlations: tuple[CorrelatedFinding, ...] = ()
 
@@ -308,6 +313,7 @@ class ScaffoldEvidenceSummary:
             "slot_count": self.slot_count,
             "fill_dispositions": dict(self.fill_dispositions),
             "additive_test_count": self.additive_test_count,
+            "uncollected_test_files": list(self.uncollected_test_files),
             "failure_classes": dict(self.failure_classes),
             "uncorrelated_fill_failures": self.uncorrelated_fill_failures,
             "probe_redundant_findings": self.probe_redundant_findings,
@@ -322,6 +328,7 @@ def build_scaffold_evidence_summary(
     observations: list[ShellObservation],
     correlations: list[CorrelatedFinding],
     additive_test_count: int,
+    uncollected_test_files: tuple[str, ...] = (),
 ) -> ScaffoldEvidenceSummary:
     disposition_counts: dict[str, int] = {}
     for disposition in fill_dispositions.values():
@@ -337,6 +344,7 @@ def build_scaffold_evidence_summary(
         fill_dispositions=disposition_counts,
         additive_test_count=additive_test_count,
         failure_classes=class_counts,
+        uncollected_test_files=tuple(uncollected_test_files),
         observations=tuple(observations),
         correlations=tuple(correlations),
     )

--- a/src/squadops/sandbox/environment.py
+++ b/src/squadops/sandbox/environment.py
@@ -132,7 +132,17 @@ NEXTJS_TS = EnvironmentContract(
     image="squadops-sandbox-env:fastapi-react-1.4-dev",
     required_tools=(("node", "20"), ("npm", "10")),
     operation_commands=(
-        (OperationName.INSTALL_DEPENDENCIES, ("npm", "ci", "--no-audit", "--no-fund")),
+        # `npm install`, NOT `npm ci` — the same correction the probe runner's
+        # `nextjs_next_start` profile already carries (roll 10, cyc_43a216d43e1e), and the
+        # rule stack #1's contract states three declarations above ("no lockfile → npm
+        # install"). The scaffold emits no `package-lock.json` (an offline-deterministic
+        # expansion cannot produce one) and `npm ci` EUSAGE-refuses without a lockfile, so
+        # this operation could never succeed on this stack: the sandbox path was
+        # unreachable-green by construction. Measured 2026-08-15 auditing the SIP-0104
+        # window's roll 1 (cyc_04d36309d793), whose deliverable failed install here while
+        # passing every probe on the runner's `npm install` path. Fixing one surface and
+        # not its sibling is the #838 shape; both now match the vitest runner too.
+        (OperationName.INSTALL_DEPENDENCIES, ("npm", "install", "--no-audit", "--no-fund")),
         (OperationName.BUILD_FRONTEND, ("npx", "next", "build")),
         (OperationName.RUN_BACKEND_TESTS, ("npx", "vitest", "run")),
         (

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -281,9 +281,14 @@ async def test_the_evidence_pipeline_lands_in_outputs(scaffold_input, monkeypatc
     assert evidence["observations"][0]["criterion_id"] == "vc-probe-api-runs"
     assert evidence["observations"][0]["owner"] == "dev"
     assert evidence["fill_dispositions"] == {"filled": 1, "missing": 7}
-    rows = result.outputs["validation_result"]["checks"]
-    classification_row = next(
-        r for r in rows if r.get("check") == "scaffold_failure_classification"
-    )
-    assert classification_row["classes"] == {"app_contract": 1}
-    assert "passed" not in classification_row  # informational — SIP-0096 credit untouched
+    # The summary is diagnostic, NOT a verification check: it must not appear among
+    # validation_result.checks, or normalize_task_checks records it and the cycle
+    # outcome reports it as an unverified check (roll 1, cyc_04d36309d793).
+    rows = (result.outputs.get("validation_result") or {}).get("checks") or []
+    assert not any("scaffold" in str(r.get("check", "")) for r in rows)
+
+    # ...and it reaches the correction loop on the failure-evidence transport instead.
+    from squadops.cycles.failure_evidence import FailureLocus, classify_failure_locus
+
+    evidence = {"scaffold_evidence": evidence, "validation_result": {"checks": rows}}
+    assert classify_failure_locus(evidence) == FailureLocus.SUBJECT

--- a/tests/unit/cycles/test_failure_evidence.py
+++ b/tests/unit/cycles/test_failure_evidence.py
@@ -672,12 +672,13 @@ class TestScaffoldClassificationLocus:
 
     @staticmethod
     def _evidence(classes: dict, tests_pass_row: dict | None = None) -> dict:
-        checks = [
-            {"check": "scaffold_failure_classification", "status": "info", "classes": classes}
-        ]
-        if tests_pass_row is not None:
-            checks.append(tests_pass_row)
-        return {"validation_result": {"checks": checks}}
+        """The classification rides the evidence payload, NOT a check row — a
+        diagnostic must never aggregate as a verification check (roll 1's finding)."""
+        checks = [tests_pass_row] if tests_pass_row is not None else []
+        return {
+            "scaffold_evidence": {"failure_classes": classes},
+            "validation_result": {"checks": checks},
+        }
 
     def test_app_contract_routes_to_subject(self):
         evidence = self._evidence({"app_contract": 2, "fill": 1})

--- a/tests/unit/cycles/test_scaffold_evidence.py
+++ b/tests/unit/cycles/test_scaffold_evidence.py
@@ -338,3 +338,52 @@ class TestObservationParser:
             ]
         }
         assert parse_vitest_failure_rows(report, "/ws") == []
+
+
+class TestUncollectedTestFiles:
+    """SIP-0104 roll 1 (cyc_04d36309d793): qa authored ~9KB at `tests/api/runs.test.ts`,
+    outside the stack's `**/__tests__/**/*.test.ts` include — 9 files handed in, 8
+    collected, and the surrounding suite read green. Silent non-coverage of the authored
+    layer is the #884 class one step down, and nothing reported it."""
+
+    _REPORT = {
+        "testResults": [
+            {"name": "/ws/__tests__/scaffold/a.scaffold.test.ts", "status": "passed"},
+            {"name": "/ws/__tests__/extra.test.ts", "status": "passed"},
+        ]
+    }
+
+    def test_a_runnable_suite_the_runner_ignored_is_named(self):
+        from squadops.capabilities.handlers.test_runner import uncollected_test_files
+
+        handed_in = [
+            "__tests__/scaffold/a.scaffold.test.ts",
+            "__tests__/extra.test.ts",
+            "tests/api/runs.test.ts",  # outside the include → never collected
+        ]
+        assert uncollected_test_files(self._REPORT, "/ws", handed_in) == ["tests/api/runs.test.ts"]
+
+    def test_a_non_test_helper_is_not_flagged(self):
+        """A helper module beside the suite is legitimately uncollected; only files that
+        declare themselves suites (`*.test.ts` / `*.spec.ts`) are."""
+        from squadops.capabilities.handlers.test_runner import uncollected_test_files
+
+        handed_in = ["__tests__/helpers/factory.ts", "__tests__/extra.test.ts"]
+        assert uncollected_test_files(self._REPORT, "/ws", handed_in) == []
+
+    def test_everything_collected_reports_nothing(self):
+        from squadops.capabilities.handlers.test_runner import uncollected_test_files
+
+        handed_in = ["__tests__/scaffold/a.scaffold.test.ts", "__tests__/extra.test.ts"]
+        assert uncollected_test_files(self._REPORT, "/ws", handed_in) == []
+
+    def test_the_summary_banks_it(self, emission, dispositions):
+        summary = build_scaffold_evidence_summary(
+            emission.manifest,
+            dispositions,
+            [],
+            [],
+            additive_test_count=1,
+            uncollected_test_files=("tests/api/runs.test.ts",),
+        )
+        assert summary.to_dict()["uncollected_test_files"] == ["tests/api/runs.test.ts"]


### PR DESCRIPTION
Four defects measured while auditing **SIP-0104 window roll 1** (`cyc_04d36309d793`). Two blocked the audit itself; two are evidence-quality gaps the roll exposed. None changes a verdict, and none affects roll 1's standing as a clean window roll.

## 1. The stack-#2 sandbox could never install (blocked the audit)

`NEXTJS_TS`'s environment contract ran `npm ci`, which refuses outright without a `package-lock.json` — reproduced in a clean container: `EUSAGE: The npm ci command can only install with an existing package-lock.json`. The scaffold emits `package.json` only (an offline-deterministic expansion cannot produce a lockfile), so **this operation could never succeed on this stack** — the sandbox path was unreachable-green by construction, and roll 1's deliverable failed install there while passing every probe elsewhere.

This exact correction already existed twice in the codebase and hadn't been propagated: the probe runner's `nextjs_next_start` profile carries it with a comment from roll 10 (`cyc_43a216d43e1e`), and stack #1's own contract states the rule three declarations above (*"no lockfile → npm install"*). Now all three surfaces plus the vitest runner agree.

One consequence, named: `contract_id()` hashes the full declaration, so this changes the contract id and invalidates cached sandbox workspaces keyed to it — a cache miss, not a correctness risk. No test pinned the old command or hash.

## 2. The audit tool was stack-#1-only (blocked the audit)

`audit_delivered_app.py` hardcoded `FULLSTACK_FASTAPI_REACT` and a `backend/routes.py` assembly sentinel, so auditing a nextjs_ts deliverable would stand a Next.js tree up with uvicorn and report **the auditor's** defect as the app's. It now takes the stack from the contract's own `skeleton.expander` and resolves the environment through the existing `get_environment_contract()` accessor (which refuses unknown stacks — no fallback environment), with a per-stack assembly sentinel table.

## 3. Authored suites the runner silently never collected

Roll 1's qa author wrote ~9KB of additive tests at `tests/api/runs.test.ts` — outside this stack's `**/__tests__/**/*.test.ts` include. Nine test files went to the runner; vitest collected eight. The additive half of the semantic layer verified nothing, and every signal read green because the collected suites passed. This is the #884 class one step down: not "no test files found" but "this one was ignored".

Now detected from the JSON report (restricted to files that declare themselves suites — a `*.test.ts`, not a helper module), logged as a warning, named in the test report a human reads, and banked in the evidence summary — §6's "is the authored layer earning its inference spend" question is unanswerable if part of that layer silently never ran.

**Deliberately reported, not verdict-changing.** Making it blocking is a real option — the author's work isn't running and the fix is trivial — but that changes verdict semantics mid-window, so it should be a decision, not a side effect of detection. Flagging for a call.

## 4. The P5 classification polluted the verification rollup

The classification rode a `validation_result.checks` row, and `normalize_task_checks` records **any** row carrying a `status` key — so a diagnostic aggregated as a verification check and surfaced in roll 1's cycle outcome as `unverified: [{check_id: scaffold_failure_classification, reason: unspecified}]`. Non-blocking, but a diagnostic is not evidence (SIP-0096 §6.1).

It now rides the failure-evidence payload beside `emission_failure` and `app_tracebacks` — the transport built for exactly this. The locus classifier reads the classes from there, and as a bonus the analyzer's prompt (which renders the whole evidence dict) now sees the per-failure owner/route rows.

## Validation

Full regression **7282 passed, 1 skipped**, ruff clean. No emission changes — GENERATOR_VERSION stays 1 and the Gate 1 byte pins hold.

After merge: rebuild, re-run the boot audit to close roll 1 on a green audit rather than probe evidence alone, then launch roll 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
