### PR TITLE
fix(sip-0102): pin verification before build, not after — plus §11a stack-awareness amendment

### DIFF
--- a/adapters/sandbox/container_backend.py
+++ b/adapters/sandbox/container_backend.py
@@ -78,6 +78,7 @@ class ContainerBackend(NoOpExecutionSandbox):
         http_client_factory: Callable[[], httpx.AsyncClient] | None = None,
         environment_contract_id: str | None = None,
         cache_root: Path | None = None,
+        build_mutates_source: bool = False,
     ) -> None:
         self._container = container
         self._store = store
@@ -91,6 +92,7 @@ class ContainerBackend(NoOpExecutionSandbox):
         self._app_port = app_port
         self._ready_path = ready_path
         self._environment_contract_id = environment_contract_id
+        self._build_mutates_source = build_mutates_source
         self._cache_root = cache_root
         self._readiness_timeout = readiness_timeout_seconds
         self._poll_interval = poll_interval_seconds
@@ -161,18 +163,32 @@ class ContainerBackend(NoOpExecutionSandbox):
         st = self._store.workspace_dir(cycle_id).stat()
         return f"{st.st_uid}:{st.st_gid}"
 
+    def _require_pinned(self, operation: str, revision: WorkspaceRevision) -> None:
+        """§7 item 3: executing against undeclared content is a caller error, not an
+        operation outcome — with the SIP-0102 §11 amendment for stacks whose build
+        rewrites its own source.
+
+        Where the build does not mutate source (the canonical stack), every operation
+        verifies, exactly as before. Where it does, only the operation that runs BEFORE
+        any build can verify: after `next build` has generated `next-env.d.ts` and
+        rewritten `tsconfig.json`, the live tree cannot match the pin, and re-asserting
+        it there was never a true claim about this stack. The guarantee kept is the one
+        that means something — the source we declared is the source we built.
+        """
+        if self._build_mutates_source and operation != OperationName.INSTALL_DEPENDENCIES:
+            return
+        if not self._store.verify_pinned(revision.cycle_id, revision.revision_id):
+            raise WorkspaceStoreError(
+                f"live tree for {revision.cycle_id} does not match declared "
+                f"revision {revision.revision_id}"
+            )
+
     async def _one_shot(
         self, operation: str, revision: WorkspaceRevision
     ) -> tuple[dict, ContainerResult | None]:
         """Run one typed operation; returns the common result fields plus the
         raw container result (None when nothing executed)."""
-        if not self._store.verify_pinned(revision.cycle_id, revision.revision_id):
-            # §7 item 3: executing against undeclared content is a caller
-            # error, not an operation outcome.
-            raise WorkspaceStoreError(
-                f"live tree for {revision.cycle_id} does not match declared "
-                f"revision {revision.revision_id}"
-            )
+        self._require_pinned(operation, revision)
         base = {
             "operation": operation,
             "workspace_revision_id": revision.revision_id,
@@ -279,11 +295,7 @@ class ContainerBackend(NoOpExecutionSandbox):
             await asyncio.sleep(self._poll_interval)
 
     async def start_application(self, *, revision: WorkspaceRevision) -> StartResult:
-        if not self._store.verify_pinned(revision.cycle_id, revision.revision_id):
-            raise WorkspaceStoreError(
-                f"live tree for {revision.cycle_id} does not match declared "
-                f"revision {revision.revision_id}"
-            )
+        self._require_pinned(OperationName.START_APPLICATION, revision)
         base = {
             "operation": OperationName.START_APPLICATION,
             "workspace_revision_id": revision.revision_id,

--- a/adapters/sandbox/factory.py
+++ b/adapters/sandbox/factory.py
@@ -46,6 +46,7 @@ def create_sandbox_service(config: SandboxConfig) -> SandboxService:
             app_port=contract.app_port,
             install_network=contract.install_network,
             environment_contract_id=contract.contract_id(),
+            build_mutates_source=contract.build_mutates_source,
             cache_root=Path(config.cache_root) if config.cache_root else None,
         )
         return SandboxService(

--- a/scripts/dev/audit_delivered_app.py
+++ b/scripts/dev/audit_delivered_app.py
@@ -190,6 +190,7 @@ async def _audit(args: argparse.Namespace) -> int:
         app_port=env.app_port,
         install_network=env.install_network,
         environment_contract_id=env.contract_id(),
+        build_mutates_source=env.build_mutates_source,
         cache_root=_AUDIT_ROOT / "caches",
         timeout_seconds=420.0,
         readiness_timeout_seconds=30.0,

--- a/sips/accepted/SIP-0102-Ephemeral-Application-Sandbox.md
+++ b/sips/accepted/SIP-0102-Ephemeral-Application-Sandbox.md
@@ -477,3 +477,60 @@ implementation-planning choice and moves to the implementation plan.)*
   `test_runner.py`; `acceptance_checks.py` (`CommandExitZeroCheck`);
   `probe_runner.py` (`ExecutionProfile` — the in-process boot+probe path
   this SIP re-homes).
+
+## 11. Post-acceptance amendments
+
+### 11a. Stack #2 entered the sandbox without the generalization this SIP deferred (2026-08-15)
+
+**What changed.** §3 non-goals state *"Not multi-stack generalization (that is v1.6; v1.4
+ships the canonical fastapi+react blueprint only)"*, and §4.2's status note defers the
+`StackBlueprint` schema until a second real stack exists. #822 subsequently added a
+`nextjs_ts` `EnvironmentContract` to the sandbox registry — extending the subsystem to a
+second stack — while the generalization stayed deferred and nothing recorded the gap. The
+environment *contract* seam took a second entry cleanly; every surface around it stayed
+shaped by the canonical stack's behavior.
+
+**Evidence.** Four defects, all one class, measured in a single audit of SIP-0104 window
+roll 1 (`cyc_04d36309d793`, 2026-08-15):
+
+1. `NEXTJS_TS` declared `npm ci`, which EUSAGE-refuses without a `package-lock.json` the
+   scaffold cannot deterministically produce — **the stack-#2 sandbox path was
+   unreachable-green by construction.** The identical correction already existed in
+   `probe_runner`'s `nextjs_next_start` profile (roll 10, `cyc_43a216d43e1e`) and in this
+   SIP's own canonical contract ("no lockfile → npm install"); neither propagated.
+2. `scripts/dev/audit_delivered_app.py` hardcoded the canonical environment and a
+   `backend/routes.py` assembly sentinel, so auditing stack #2 would stand a Next.js tree
+   up with uvicorn and report the auditor's defect as the app's.
+3. `WorkspaceStore._EXCLUDED_SEGMENTS` (§4.6 derived state) listed `dist` — Vite's build
+   output — but not `.next`. Pin verification therefore walked into webpack caches and
+   read binary bytes as UTF-8, raising `UnicodeDecodeError`: not over-pinning, a crash.
+4. **The §4.6 revision-lifecycle model itself.** `next build` GENERATES `next-env.d.ts`
+   and REWRITES the scaffold's frozen `tsconfig.json` (injecting `allowJs`,
+   `skipLibCheck`) — documented Next behavior. No tree on this stack can match its pin
+   once a build has run, so verification before `start_application` asserted an invariant
+   that was never true for this stack.
+
+**The ruling (owner, 2026-08-15).** Finding 4 is a design fork, not a missing list entry,
+and was decided as: **pin verification is enforced before the tree is built, not after.**
+`EnvironmentContract` now declares `build_mutates_source` — a fact about the toolchain,
+declared per stack — and where it is true, only the operation preceding any build
+(`install_dependencies`) verifies. The guarantee kept is the one that carries meaning:
+*the source we declared is the source we built.* Where it is false (the canonical stack)
+behavior is unchanged, and a post-build drift still refuses. Alternatives weighed and
+rejected: excluding `tsconfig.json` from verification (silently drops tamper detection on
+a frozen scaffold file); re-pinning post-build (faithful but larger, and unneeded until
+something consumes a post-build revision); changing the scaffold to emit a tsconfig Next
+will not rewrite (fixes the root cause but moves generator bytes, which would reset
+SIP-0104's measurement window — deferred until that window closes).
+
+**What remains ungeneralized, stated so the next stack meets a boundary rather than
+rediscovering it.** `_EXCLUDED_SEGMENTS` is still one global set, not a per-stack
+declaration: a third stack whose build output is named something else repeats finding 3.
+The honest scope of this amendment is "stack #2 works and the lifecycle claim is now
+true", NOT "the sandbox is stack-general". `SIP-Stack-Blueprint-Contract` still owns that
+generalization — and its own gating condition (*"deferred until a second real stack
+exists"*) is now satisfied, so it is unblocked by its own criterion.
+
+**Consequence to note.** `contract_id()` covers the full declaration by design (§7 items
+4/15), so adding `build_mutates_source` changes every contract id and invalidates
+workspace caches keyed to them — a cache miss, not a correctness risk.

--- a/src/squadops/sandbox/environment.py
+++ b/src/squadops/sandbox/environment.py
@@ -36,6 +36,14 @@ class EnvironmentContract:
     operation_commands: tuple[tuple[str, tuple[str, ...]], ...]  # (operation, argv)
     app_port: int
     install_network: str
+    #: Whether this stack's BUILD writes into its own pinned source (SIP-0102 §11
+    #: amendment). False — the canonical stack's assumption — means the live tree must
+    #: keep matching its revision through every operation, and §4.6's pin verification
+    #: holds throughout. True means the toolchain legitimately rewrites source during
+    #: the build, so the post-build tree cannot match the pin and verifying after a
+    #: build asserts something that was never true for this stack. Declared per stack,
+    #: because it is a fact about the toolchain, not a policy choice.
+    build_mutates_source: bool = False
 
     def __post_init__(self) -> None:
         seen: set[str] = set()
@@ -68,6 +76,7 @@ class EnvironmentContract:
             ],
             "app_port": self.app_port,
             "install_network": self.install_network,
+            "build_mutates_source": self.build_mutates_source,
         }
 
     def contract_id(self) -> str:
@@ -160,6 +169,11 @@ NEXTJS_TS = EnvironmentContract(
     ),
     app_port=8000,
     install_network="bridge",
+    # Measured 2026-08-15 (SIP-0104 window roll 1): `next build` GENERATES
+    # `next-env.d.ts` and REWRITES the scaffold's frozen `tsconfig.json`, injecting
+    # `allowJs` and `skipLibCheck`. Both are documented Next behaviors, so no tree on
+    # this stack can match its pin once a build has run.
+    build_mutates_source=True,
 )
 
 

--- a/src/squadops/sandbox/workspace.py
+++ b/src/squadops/sandbox/workspace.py
@@ -47,6 +47,13 @@ _EXCLUDED_SEGMENTS = frozenset(
         ".sandbox-venv",
         "node_modules",
         "dist",
+        # `next build`'s output, stack #2's equivalent of `dist` (measured 2026-08-15
+        # auditing SIP-0104 window roll 1): omitting it did not merely over-pin, it
+        # CRASHED pin verification — `.next/` holds webpack caches and compiled chunks,
+        # and `current_files` reads every unexcluded file as UTF-8, so the first
+        # non-text byte raised UnicodeDecodeError and the app never reached boot. Added
+        # when #822 brought a second stack whose build output is not named `dist`.
+        ".next",
         "__pycache__",
         ".pytest_cache",
         ".git",

--- a/tests/unit/sandbox/test_container_backend.py
+++ b/tests/unit/sandbox/test_container_backend.py
@@ -243,6 +243,56 @@ class TestContractAndPinning:
         assert "provides no command" in result.unavailable_reason
 
 
+class TestBuildMutatesSource:
+    """SIP-0102 §11: a stack whose BUILD rewrites its own source (measured on
+    nextjs_ts — `next build` generates `next-env.d.ts` and rewrites `tsconfig.json`)
+    can never match its pin after building, so §4.6's verification is enforced only on
+    the operation that precedes any build. The canonical stack is unaffected."""
+
+    def _mutating_backend(self, container, store):
+        return ContainerBackend(
+            container=container,
+            store=store,
+            image="sandbox:pinned",
+            operation_commands=COMMANDS,
+            build_mutates_source=True,
+        )
+
+    async def test_install_still_refuses_a_drifted_tree(self, store, seeded):
+        """The guarantee that survives: the source we declared is the source we built.
+        Install runs before any build, so drift there is still a caller error."""
+        (store.workspace_dir("cyc_1") / "backend/main.py").write_text("drift", encoding="utf-8")
+        with pytest.raises(WorkspaceStoreError, match="does not match declared"):
+            await self._mutating_backend(FakeContainer(), store).install_dependencies(
+                revision=seeded
+            )
+
+    async def test_post_build_operations_tolerate_the_builds_own_writes(self, store, seeded):
+        """Bug caught (SIP-0104 window roll 1): the audited app installed and BUILT
+        successfully, then boot was refused because the build's own `next-env.d.ts` and
+        rewritten `tsconfig.json` no longer matched the pin — asserting an invariant
+        that was never true for this stack."""
+        (store.workspace_dir("cyc_1") / "next-env.d.ts").write_text("gen", encoding="utf-8")
+
+        # Two post-build operations: neither refuses on the pin. The tests run for real
+        # (this fixture provides a test command); start reports NOT_RUN only because the
+        # fixture declares no start command — reaching that verdict IS passing the gate.
+        tested = await self._mutating_backend(FakeContainer(), store).run_backend_tests(
+            revision=seeded
+        )
+        assert tested.ran is True
+        started = await self._mutating_backend(FakeContainer(), store).start_application(
+            revision=seeded
+        )
+        assert "provides no command" in started.unavailable_reason
+
+    async def test_the_canonical_stack_still_verifies_everywhere(self, store, seeded):
+        """Default False keeps stack #1 byte-identical: post-build drift still refuses."""
+        (store.workspace_dir("cyc_1") / "next-env.d.ts").write_text("gen", encoding="utf-8")
+        with pytest.raises(WorkspaceStoreError, match="does not match declared"):
+            await _backend(FakeContainer(), store).start_application(revision=seeded)
+
+
 class TestWorkspaceOwnerUser:
     """Spark shakedown (2026-07-28): with cap_drop_all, root loses DAC_OVERRIDE
     and cannot write a host-owned bind mount on native Linux — the floor smoke

--- a/tests/unit/sandbox/test_workspace_store.py
+++ b/tests/unit/sandbox/test_workspace_store.py
@@ -118,6 +118,21 @@ class TestDerivedStateExclusion:
         )
         assert store.verify_pinned("cyc_1", rev.revision_id)
 
+    def test_stack_two_build_output_including_binaries_does_not_break_the_pin(self, store):
+        """Bug caught (SIP-0104 window roll 1, 2026-08-15): `.next/` — stack #2's build
+        output, the analogue of `dist` — was not excluded, and `current_files` reads
+        every unexcluded file as UTF-8. A webpack cache byte (0xa1) raised
+        UnicodeDecodeError, so pin verification CRASHED and the audited app never
+        reached boot. The binary content is the point of this test: the pre-existing
+        exclusion test wrote its derived state as text and could not catch it."""
+        seed = store.seed("cyc_1", FILES, origin=RevisionOrigin.SCAFFOLD_SEED)
+        ws = store.workspace_dir("cyc_1")
+        (ws / ".next/cache/webpack").mkdir(parents=True)
+        (ws / ".next/cache/webpack/0.pack").write_bytes(b"\x00\xa1\xff binary chunk")
+        (ws / ".next/BUILD_ID").write_text("abc123", encoding="utf-8")
+
+        assert store.verify_pinned("cyc_1", seed.revision_id)
+
     def test_patching_derived_state_paths_is_rejected(self, store):
         """Bug caught: a patch writing into node_modules/dist — content that
         would exist on disk but never in any revision, silently diverging the


### PR DESCRIPTION
**Roll 1's deliverable now audits PASS** — installs, builds, boots, and answers all 5 contract probes over real HTTP. Getting there surfaced two more defects of the class #899 fixed, this time inside the sandbox rather than its callers, and the second one was a design fork rather than a missing list entry.

## The two defects

**`.next` was not derived state.** `_EXCLUDED_SEGMENTS` listed `dist` — Vite's build output — but not `.next`. Since `current_files()` reads every unexcluded file as UTF-8, pin verification walked into webpack caches and raised `UnicodeDecodeError`. Not over-pinning: a crash, before the app could boot. The new test writes genuinely binary content, which is why the pre-existing exclusion test (all text) never caught it.

**`next build` rewrites its own source.** It generates `next-env.d.ts` and rewrites the scaffold's frozen `tsconfig.json`, injecting `allowJs` and `skipLibCheck` — documented Next behavior. So no tree on this stack can match its pin once built, and §4.6's verification before `start_application` was asserting an invariant that was never true here.

## The ruling (option 2)

**Pin verification happens before the tree is built, not after.** `EnvironmentContract` now declares `build_mutates_source` — a fact about the toolchain, declared per stack — and where it is true, only the operation that precedes any build (`install_dependencies`) verifies.

- The canonical stack is **byte-identical** to today (`False` default): post-build drift still refuses, proven by a test.
- The guarantee kept is the one that carries meaning: *the source we declared is the source we built.*
- Alternatives weighed and rejected in the amendment: excluding `tsconfig.json` (silently drops tamper detection on a frozen scaffold file), re-pinning post-build (faithful but larger, and nothing consumes a post-build revision yet), and changing the scaffold's emitted tsconfig (fixes the root cause but moves generator bytes, which would **reset SIP-0104's measurement window** — deferred until it closes).

## SIP-0102 §11a — why this needed a SIP change, not just code

This is the answer to "was the sandbox built without stack awareness?" — and the document is more honest than that framing suggests. §3's non-goals say *"Not multi-stack generalization (that is v1.6)"* and §4.2 defers the `StackBlueprint` schema until a second real stack exists. **It scoped itself to one stack deliberately.**

What went unrecorded: #822 later added a `nextjs_ts` environment contract — extending the subsystem to a second stack — while the generalization stayed deferred. The contract seam took the entry cleanly; everything around it stayed canonical-stack-shaped. Four defects in one audit is the measured cost.

The amendment records the ruling with its evidence, and deliberately states **what is still ungeneralized**: `_EXCLUDED_SEGMENTS` remains one global set, so a third stack whose build output has another name repeats that defect. The honest scope is "stack #2 works and the lifecycle claim is now true", not "the sandbox is stack-general". `SIP-Stack-Blueprint-Contract` still owns generalization — and its own gate (*"deferred until a second real stack exists"*) is now satisfied, so it is unblocked by its own criterion. That is a separate call for the owner.

**Consequence noted:** `contract_id()` covers the full declaration by design (§7 items 4/15), so the new field changes every contract id and invalidates workspace caches keyed to them — a cache miss, not a correctness risk.

## Validation

Full regression **7286 passed, 1 skipped**, ruff clean. Audit exit 0 on `cyc_04d36309d793` / `run_65f385f58656`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
