### PR TITLE
fix(dev): per-stack fill-only guidance — roll 1's app shipped a dead UI because the author was told stack #1's seam

### DIFF
--- a/src/squadops/capabilities/dev_capabilities.py
+++ b/src/squadops/capabilities/dev_capabilities.py
@@ -51,6 +51,17 @@ class DevelopmentCapability:
     # Materialized into the QA build/test workspace so the frontend build check
     # (#290) and vitest actually run instead of skipping on "no package.json" (#296).
     build_support_files: tuple[str, ...] = ()
+    #: The managed asset carrying this stack's fill-only instruction — which files hold
+    #: the slots, and what the scaffold-owned seams mean. Per stack because the answer
+    #: IS the stack: one asset served both, so a `nextjs_ts` author was told to fill
+    #: `backend/routes.py` and `frontend/src/views/*.jsx` and that `apiFetch` "prefixes
+    #: `/api`" — none of which exist here. It wrote `api('/runs')` against a helper that
+    #: prefixes nothing, and every UI call 404'd in a deliverable that passed every gate
+    #: (SIP-0104 window roll 1, cyc_04d36309d793, measured 2026-08-15).
+    #:
+    #: Empty means NO fill-only appendix rather than another stack's — wrong guidance is
+    #: worse than none (#818's asymmetric-default rule; this defect is the proof).
+    fill_only_template: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -335,6 +346,7 @@ DEV_CAPABILITIES: dict[str, DevelopmentCapability] = {
         ),
         max_completion_tokens=12000,
         test_timeout_seconds=180,
+        fill_only_template="request.development_develop_fill_only_appendix",
     ),
     # #822 stack #2. Bound to the scaffold stack of the same name by
     # ``ScaffoldStack.dev_capability`` (#832), so the two registries can no longer disagree
@@ -434,6 +446,7 @@ DEV_CAPABILITIES: dict[str, DevelopmentCapability] = {
         ),
         max_completion_tokens=12000,
         test_timeout_seconds=180,
+        fill_only_template="request.development_develop_fill_only_appendix_nextjs_ts",
     ),
 }
 

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -767,10 +767,27 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         ``ApiError(code, message)`` — and paid a correction to undo it. Same data, same
         transport, one step earlier.
         """
+        from squadops.capabilities.dev_capabilities import (
+            effective_capability_name,
+            get_capability,
+        )
         from squadops.capabilities.scaffold import is_scaffoldable_stack
 
         stack = str(self._resolved_config.get("build_profile") or "")
         if not is_scaffoldable_stack(stack):
+            return ""
+        # The asset is the STACK's, resolved through its dev capability. One shared asset
+        # is what broke SIP-0104 roll 1: a nextjs_ts author was told to fill
+        # `backend/routes.py` and that `apiFetch` "prefixes /api" — stack #1's layout and
+        # stack #1's seam semantics — so it wrote `api('/runs')` against a helper that
+        # prefixes nothing and every UI call 404'd in an app that passed every gate.
+        # A stack with no declared asset gets NO fill-only appendix: wrong guidance is
+        # worse than none (#818).
+        try:
+            capability = get_capability(effective_capability_name(self._resolved_config))
+        except ValueError:
+            return ""
+        if not capability.fill_only_template:
             return ""
         variables = {"stack": stack}
         error_contract = await self._error_contract_section(renderer, inputs)
@@ -797,9 +814,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         frozen_surface = await self._frozen_surface_section(renderer, inputs)
         if frozen_surface:
             variables["frozen_surface"] = frozen_surface
-        rendered = await renderer.render(
-            "request.development_develop_fill_only_appendix", variables
-        )
+        rendered = await renderer.render(capability.fill_only_template, variables)
         return rendered.content
 
     async def _frozen_surface_section(self, renderer: Any, inputs: dict | None) -> str:

--- a/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix_nextjs_ts.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix_nextjs_ts.md
@@ -1,0 +1,62 @@
+---
+template_id: request.development_develop_fill_only_appendix_nextjs_ts
+version: "1"
+required_variables:
+  - stack
+optional_variables:
+  - error_contract
+  - model_surface
+  - testid_surface
+  - frozen_surface
+---
+## Fill-only: a walking skeleton is already in your workspace
+
+This build was scaffolded (`{{stack}}`). A deterministic tool has **already generated a
+wired, buildable, bootable Next.js App Router application** into your workspace — config,
+data models, the in-memory store, the error envelope, the client fetch helper, and
+route/page **stubs**. It already builds and boots. Your job is to **fill the bodies of the
+fixed slots** — never to rebuild, rewire, or regenerate the scaffold.
+
+**FILL — edit only the stubbed bodies:**
+- API route handlers in `app/**/route.ts` — implement each exported `GET`/`POST`/… inside
+  the existing function. `ApiError` and `errorResponse` from `@/lib/errors` and the store
+  from `@/lib/store` are already imported and wired; use them. A route file's directory
+  IS its URL, so a handler in `app/api/runs/[run_id]/route.ts` serves
+  `/api/runs/<run_id>`.
+- Page components in `app/**/page.tsx` — implement each component's body.
+
+**The client seam, stated exactly — this is where fills go wrong:**
+`api()` from `@/lib/api` fetches **the path you pass it, verbatim. It adds no prefix.**
+Pass the endpoint's FULL declared URL path, exactly as the interface manifest declares
+it:
+
+```ts
+const runs = await api<Run[]>('/api/runs')          // correct — the declared path
+const run  = await api<Run>(`/api/runs/${id}`)      // correct
+await api('/runs')                                  // WRONG — 404, no such route
+```
+
+If your manifest declares `POST /api/runs`, the page calls `api('/api/runs')`. Dropping
+the prefix compiles, passes type-checking, and returns 404 at runtime for every action in
+the UI — a silent break no build or unit check catches.
+
+**DO NOT touch the scaffold-owned surface — it is frozen and verified:**
+- Do NOT change the exported handler **names, signatures, or file locations** in
+  `app/**/route.ts` — the directory determines the URL the app serves.
+- Do NOT edit `lib/models.ts`, `lib/store.ts`, `lib/errors.ts`, `lib/api.ts`,
+  `app/layout.tsx`, `package.json`, `tsconfig.json`, `next.config.mjs`, or
+  `vitest.config.ts`.
+- Do NOT add or remove files, or move a route/page to a different directory.
+
+{{error_contract}}
+
+{{model_surface}}
+
+{{testid_surface}}
+
+{{frozen_surface}}
+
+Filling the fixed slots — rather than regenerating the app — is the whole point: the
+skeleton already builds and boots, so a fill that preserves it stays green, while one
+that rewrites scaffold-owned files is rejected by the verification contract. When in
+doubt, change less: implement the body, keep everything around it exactly as scaffolded.

--- a/tests/unit/capabilities/test_develop_fill_only.py
+++ b/tests/unit/capabilities/test_develop_fill_only.py
@@ -7,11 +7,13 @@ dev-only, content in a managed asset — mirrors 99.2's scaffold_section.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from squadops.capabilities.dev_capabilities import get_capability
 from squadops.capabilities.handlers.cycle.develop import DevelopmentDevelopHandler
 
 pytestmark = [pytest.mark.domain_capabilities]
@@ -68,3 +70,71 @@ def test_fill_only_appendix_asset_is_well_formed():
     assert "backend/routes.py" in text  # the fill slot
     assert "Do NOT" in text  # the frozen-surface discipline
     assert "{{stack}}" in text
+
+
+class TestPerStackAppendix:
+    """SIP-0104 window roll 1 (cyc_04d36309d793, 2026-08-15): one shared asset served
+    both stacks, so a `nextjs_ts` author was instructed to fill `backend/routes.py` and
+    `frontend/src/views/*.jsx` — neither of which exists here — and told that the client
+    seam "prefixes `/api`", which stack #2's seam does not. It wrote `api('/runs')`
+    against a helper that fetches verbatim, and EVERY UI call 404'd in a deliverable that
+    passed 36/36 checks, all 5 probes, the frontend build, and the boot audit.
+    """
+
+    async def test_each_stack_gets_its_own_asset(self):
+        renderer = AsyncMock()
+        renderer.render.return_value = MagicMock(content="X")
+
+        await _handler("nextjs_ts")._fill_only_section(renderer)
+        assert (
+            renderer.render.await_args.args[0]
+            == "request.development_develop_fill_only_appendix_nextjs_ts"
+        )
+
+        renderer.render.reset_mock()
+        await _handler("fullstack_fastapi_react")._fill_only_section(renderer)
+        assert (
+            renderer.render.await_args.args[0] == "request.development_develop_fill_only_appendix"
+        )
+
+    async def test_the_nextjs_author_is_told_this_stacks_layout_and_seam(self):
+        """A live render: the facts must survive the template, and the two failure modes
+        roll 1 shipped must both be addressed — the file layout and the prefix."""
+        from adapters.prompts.filesystem_asset_adapter import FilesystemPromptAssetAdapter
+        from squadops.prompts.renderer import RequestTemplateRenderer
+
+        templates = _APPENDIX.parent
+        renderer = RequestTemplateRenderer(
+            FilesystemPromptAssetAdapter(
+                fragments_path=templates.parent / "fragments", templates_path=templates
+            )
+        )
+
+        out = await _handler("nextjs_ts")._fill_only_section(renderer)
+
+        # this stack's real layout
+        assert "app/**/route.ts" in out
+        assert "app/**/page.tsx" in out
+        # ...and NOT the other stack's, which is what roll 1's author was handed
+        assert "backend/routes.py" not in out
+        assert "frontend/src/views" not in out
+        assert "apiFetch" not in out
+        # the seam semantic that broke the UI, stated with the correct and wrong forms
+        assert "adds no prefix" in out
+        assert "api<Run[]>('/api/runs')" in out
+        assert "await api('/runs')" in out  # the WRONG example, named as wrong
+
+    async def test_a_stack_with_no_declared_asset_gets_no_appendix(self):
+        """Wrong guidance is worse than none (#818): an unregistered stack must not
+        inherit another stack's conventions — which is exactly this defect."""
+        from unittest.mock import patch
+
+        renderer = AsyncMock()
+        handler = _handler("fullstack_fastapi_react")
+        capability = get_capability("fullstack_fastapi_react")
+        with patch(
+            "squadops.capabilities.dev_capabilities.get_capability",
+            return_value=replace(capability, fill_only_template=""),
+        ):
+            assert await handler._fill_only_section(renderer) == ""
+        renderer.render.assert_not_awaited()


### PR DESCRIPTION
Found by opening roll 1's delivered app in a browser. It passed **36/36 checks, all 5 contract probes, `tests_pass`, `frontend_build`, and the boot audit** — and its UI is completely dead. All five page data calls 404:

```
app/page.tsx:39            api<Run[]>('/runs')
app/page.tsx:70            api('/runs', {...})              ← create
app/runs/[run_id]/page.tsx api<Run>(`/runs/${runId}`)       ← detail
                           api(`/runs/${runId}/join`)
                           api(`/runs/${runId}/leave`)
```

The routes are mounted at `/api/runs`; `GET /runs` is a 404 and there are no rewrites.

## The author didn't guess — it was told

One fill-only appendix served both stacks. A `nextjs_ts` author received, verbatim:

- *"Backend route functions in `backend/routes.py`"* — does not exist on this stack
- *"Frontend view components (`frontend/src/views/*.jsx`)"* — does not exist
- *"`apiFetch` is the wired data-access seam; call it (**it prefixes `/api`** and unwraps the error envelope)"* — that is stack #1's helper and stack #1's semantics
- *"Do NOT edit … `frontend/src/main.jsx`, `frontend/src/App.jsx`, `vite.config.js`, `index.html`"* — none of these exist

Stack #1's `api.js` really does `fetch(\`/api${path}\`)`. Stack #2's `lib/api.ts` fetches the path **verbatim**. The author followed the instruction it was given, and every UI call 404'd. This is #866's context-completeness class inverted: not a fact the agent could not see, but a fact it was told wrong.

## The fix

`DevelopmentCapability` gains `fill_only_template`, resolved per stack through the capability that `ScaffoldStack.dev_capability` already binds — reusing an existing registry rather than minting one. `nextjs_ts` gets its own asset describing **its** layout (`app/**/route.ts`, `app/**/page.tsx`, the `lib/` seams) and stating the client contract exactly, with the correct and the wrong call side by side:

```ts
const runs = await api<Run[]>('/api/runs')   // correct — the declared path
await api('/runs')                            // WRONG — 404, no such route
```

**An unset template renders no appendix at all.** Wrong guidance is worse than none (#818's asymmetric-default rule) — this defect is the proof, so a third stack gets silence until someone writes its asset, not stack #1's conventions.

**`lib/api.ts` is deliberately left fetching verbatim.** Hardcoding an `/api` prefix would silently break any manifest that declares its API under a different prefix — #859 makes a distinct prefix a *requirement* of this stack but does not mandate the literal string. The seam is correct; only the instruction was wrong.

## Window safety

Nothing in the scaffold moves: `GENERATOR_VERSION` stays 1, the Gate 1 byte pins hold, and the expanded tree is untouched. This is a prompt-asset and selection change only, so the SIP-0104 measurement window stays comparable and **roll 2, currently in flight, is unaffected** — it will still reproduce the UI defect, which is the honest baseline. The fix applies from roll 3.

## Validation

Full regression **7294 passed, 1 skipped**, ruff clean. The new tests assert both failure modes roll 1 shipped: that a nextjs_ts author sees this stack's layout and *not* `backend/routes.py`, `frontend/src/views`, or `apiFetch`; and that the prefix semantic is stated with both the correct and the wrong form.

## Still open (not in this PR)

Nothing in the pipeline exercises the UI's data path — probes hit the API directly, shells invoke handlers in-process, `frontend_build` only compiles, and the boot audit probes the API. A future roll can still ship a dead front end and bank green. Worth extending the audit to load a page and assert its data renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
