### PR TITLE
feat(audit): UI data-path check — does the UI reach its own API?

### DIFF
--- a/scripts/dev/audit_delivered_app.py
+++ b/scripts/dev/audit_delivered_app.py
@@ -43,6 +43,14 @@ import httpx
 
 from adapters.sandbox.container_backend import ContainerBackend
 from adapters.tools.docker import DockerAdapter
+from squadops.capabilities.ui_data_path import (
+    LIVE_SERVER,
+    SERVED,
+    classify_ui_response,
+    describe_failure,
+    expects_json,
+    extract_ui_calls,
+)
 from squadops.cycles.task_plan import REPAIR_TASK_TYPES
 from squadops.cycles.verification_contract import (
     VerificationContract,
@@ -99,6 +107,45 @@ def _select_deliverable(pulled: Path) -> dict[str, str]:
         if filename not in latest or created > latest[filename][0]:
             latest[filename] = (created, content_file)
     return {name: path.read_text() for name, (_, path) in latest.items()}
+
+
+async def _run_ui_data_path(files: dict[str, str], stack: str, base_url: str) -> list[str]:
+    """Put the paths the UI's own source requests to the running app (roll 1's defect).
+
+    The contract probes above prove the API answers where the CONTRACT says; this proves
+    it answers where the UI ASKS. Roll 1 passed the former and failed the latter on every
+    page action, and nothing noticed. Each distinct path is requested once; only a 404
+    that no route produced (framework HTML rather than the app's JSON envelope) counts as
+    a failure, so an app correctly reporting an unknown id still passes.
+    """
+    calls = extract_ui_calls(files, stack)
+    if not calls:
+        return []
+    failures: list[str] = []
+    seen: dict[tuple[str, bool], str] = {}
+    async with httpx.AsyncClient(base_url=base_url, timeout=15.0) as client:
+        for call in calls:
+            cache_key = (call.request_path, expects_json(call.fn))
+            verdict = seen.get(cache_key)
+            if verdict is None:
+                if call.request_path.startswith(("http://", "https://")):
+                    verdict = LIVE_SERVER
+                else:
+                    try:
+                        resp = await client.get(call.request_path)
+                    except httpx.HTTPError as exc:
+                        failures.append(f"{call.location()}: transport error {exc!r}")
+                        continue
+                    verdict = classify_ui_response(
+                        call.request_path,
+                        resp.status_code,
+                        resp.headers.get("content-type", ""),
+                        via_seam=expects_json(call.fn),
+                    )
+                seen[cache_key] = verdict
+            if verdict != SERVED:
+                failures.append(describe_failure(call, verdict))
+    return failures
 
 
 async def _run_probes(contract: VerificationContract, base_url: str) -> list[str]:
@@ -215,15 +262,19 @@ async def _audit(args: argparse.Namespace) -> int:
             return 1
         base_url = start.endpoints[0]
         failures = await _run_probes(contract, base_url)
+        ui_failures = await _run_ui_data_path(files, stack, base_url)
     finally:
         await backend.stop_application(revision=revision, cleanup_handle=start.cleanup_handle)
-    if failures:
-        for line in failures:
-            print(f"FAIL {line}")
+    for line in failures:
+        print(f"FAIL {line}")
+    for line in ui_failures:
+        print(f"FAIL ui-data-path {line}")
+    if failures or ui_failures:
         return 1
     print(
-        f"PASS — delivered app installs, builds, boots, and answers "
-        f"{len(contract.behavioral.probes)} contract probe(s) "
+        f"PASS — delivered app installs, builds, boots, answers "
+        f"{len(contract.behavioral.probes)} contract probe(s), and its UI reaches "
+        f"every path it requests "
         f"[image {env.image}, contract {env.contract_id()[:12]}]"
     )
     return 0

--- a/src/squadops/capabilities/dev_capabilities.py
+++ b/src/squadops/capabilities/dev_capabilities.py
@@ -51,6 +51,17 @@ class DevelopmentCapability:
     # Materialized into the QA build/test workspace so the frontend build check
     # (#290) and vitest actually run instead of skipping on "no package.json" (#296).
     build_support_files: tuple[str, ...] = ()
+    #: The managed asset carrying this stack's fill-only instruction — which files hold
+    #: the slots, and what the scaffold-owned seams mean. Per stack because the answer
+    #: IS the stack: one asset served both, so a `nextjs_ts` author was told to fill
+    #: `backend/routes.py` and `frontend/src/views/*.jsx` and that `apiFetch` "prefixes
+    #: `/api`" — none of which exist here. It wrote `api('/runs')` against a helper that
+    #: prefixes nothing, and every UI call 404'd in a deliverable that passed every gate
+    #: (SIP-0104 window roll 1, cyc_04d36309d793, measured 2026-08-15).
+    #:
+    #: Empty means NO fill-only appendix rather than another stack's — wrong guidance is
+    #: worse than none (#818's asymmetric-default rule; this defect is the proof).
+    fill_only_template: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -335,6 +346,7 @@ DEV_CAPABILITIES: dict[str, DevelopmentCapability] = {
         ),
         max_completion_tokens=12000,
         test_timeout_seconds=180,
+        fill_only_template="request.development_develop_fill_only_appendix",
     ),
     # #822 stack #2. Bound to the scaffold stack of the same name by
     # ``ScaffoldStack.dev_capability`` (#832), so the two registries can no longer disagree
@@ -434,6 +446,7 @@ DEV_CAPABILITIES: dict[str, DevelopmentCapability] = {
         ),
         max_completion_tokens=12000,
         test_timeout_seconds=180,
+        fill_only_template="request.development_develop_fill_only_appendix_nextjs_ts",
     ),
 }
 

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -767,10 +767,27 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         ``ApiError(code, message)`` — and paid a correction to undo it. Same data, same
         transport, one step earlier.
         """
+        from squadops.capabilities.dev_capabilities import (
+            effective_capability_name,
+            get_capability,
+        )
         from squadops.capabilities.scaffold import is_scaffoldable_stack
 
         stack = str(self._resolved_config.get("build_profile") or "")
         if not is_scaffoldable_stack(stack):
+            return ""
+        # The asset is the STACK's, resolved through its dev capability. One shared asset
+        # is what broke SIP-0104 roll 1: a nextjs_ts author was told to fill
+        # `backend/routes.py` and that `apiFetch` "prefixes /api" — stack #1's layout and
+        # stack #1's seam semantics — so it wrote `api('/runs')` against a helper that
+        # prefixes nothing and every UI call 404'd in an app that passed every gate.
+        # A stack with no declared asset gets NO fill-only appendix: wrong guidance is
+        # worse than none (#818).
+        try:
+            capability = get_capability(effective_capability_name(self._resolved_config))
+        except ValueError:
+            return ""
+        if not capability.fill_only_template:
             return ""
         variables = {"stack": stack}
         error_contract = await self._error_contract_section(renderer, inputs)
@@ -797,9 +814,7 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         frozen_surface = await self._frozen_surface_section(renderer, inputs)
         if frozen_surface:
             variables["frozen_surface"] = frozen_surface
-        rendered = await renderer.render(
-            "request.development_develop_fill_only_appendix", variables
-        )
+        rendered = await renderer.render(capability.fill_only_template, variables)
         return rendered.content
 
     async def _frozen_surface_section(self, renderer: Any, inputs: dict | None) -> str:

--- a/src/squadops/capabilities/ui_data_path.py
+++ b/src/squadops/capabilities/ui_data_path.py
@@ -1,0 +1,170 @@
+"""Does the delivered UI actually reach its own API? (measured 2026-08-15)
+
+Every verification layer in the pipeline exercises the API *directly*: contract probes
+issue HTTP against declared endpoint paths, SIP-0104's scaffold shells import route
+handlers and invoke them in-process, ``frontend_build`` compiles, and the sandbox audit
+probes the contract. **Nothing follows the path the UI itself takes.**
+
+SIP-0104 window roll 1 (`cyc_04d36309d793`) shipped the consequence: all five page data
+calls used unprefixed paths (``api('/runs')``) against routes mounted at ``/api/runs``,
+so every list, create, detail, join and leave 404'd — in a deliverable that passed 36/36
+checks, all five probes, ``tests_pass``, ``frontend_build``, and the boot audit. A user
+opening it sees a page that never loads.
+
+This module extracts the request paths the UI's own source will issue and resolves them
+the way that stack's client seam would, so the audit can put those exact paths to the
+running app. The check it enables is narrow and unambiguous: **does the app serve a route
+where the UI asks?** — not whether the response is semantically right, which is the
+contract probes' job.
+
+Deliberately no headless browser. The defect is a wiring fact, decidable from the source
+plus one HTTP round trip per distinct path; a browser would add a runtime dependency to
+answer a question that does not need one.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+#: Placeholder substituted for a template expression (``${runId}``) so a concrete path
+#: can be requested. Deliberately inert: a correct app answers a request for an unknown
+#: id with its own error envelope, which still proves the ROUTE exists.
+SAMPLE_SEGMENT = "ui-probe-sample"
+
+#: How each stack's scaffold-owned client seam turns a call argument into a request path.
+#: Stack #1's `apiFetch` prepends `/api`; stack #2's `api` fetches verbatim. Encoding the
+#: difference here is the point — assuming one stack's convention for the other is the
+#: defect this module exists to catch.
+_SEAM_PREFIX: dict[str, str] = {
+    "fullstack_fastapi_react": "/api",
+    "nextjs_ts": "",
+}
+
+#: Files whose calls are the UI's. Route handlers legitimately talk to the store, not HTTP.
+_UI_SUFFIXES = (".tsx", ".jsx")
+
+_CALL_RE = re.compile(
+    r"\b(?P<fn>api|apiFetch|fetch)\s*(?:<[^>()]*>)?\s*\(\s*(?P<quote>['\"`])(?P<path>[^'\"`]*)(?P=quote)"
+)
+_TEMPLATE_EXPR_RE = re.compile(r"\$\{[^}]*\}")
+
+
+@dataclass(frozen=True)
+class UiCall:
+    """One data call the UI source will make, resolved to a requestable path."""
+
+    file: str
+    line: int
+    fn: str
+    #: The argument exactly as written, for a message that points at real source.
+    written: str
+    #: What the client seam will actually request.
+    request_path: str
+
+    def location(self) -> str:
+        return f"{self.file}:{self.line}"
+
+
+def extract_ui_calls(files: dict[str, str], stack: str) -> list[UiCall]:
+    """Every data call the UI makes, with the path its seam will request.
+
+    Absolute URLs are returned as written (``http://…``): those are the #877
+    live-server class, a different defect, and silently normalizing them would hide it.
+    An unknown stack yields nothing rather than guessing a prefix — a wrong prefix
+    would invent failures in an app that works.
+    """
+    prefix = _SEAM_PREFIX.get(stack)
+    if prefix is None:
+        return []
+    calls: list[UiCall] = []
+    for path, content in sorted(files.items()):
+        if not path.endswith(_UI_SUFFIXES):
+            continue
+        for lineno, line in enumerate(content.split("\n"), start=1):
+            for match in _CALL_RE.finditer(line):
+                written = match.group("path")
+                if not written:
+                    continue
+                concrete = _TEMPLATE_EXPR_RE.sub(SAMPLE_SEGMENT, written)
+                if concrete.startswith(("http://", "https://")):
+                    request_path = concrete
+                elif match.group("fn") == "fetch":
+                    # A raw fetch bypasses the seam, so no prefix is applied to it.
+                    request_path = concrete
+                else:
+                    request_path = prefix + concrete
+                calls.append(
+                    UiCall(
+                        file=path,
+                        line=lineno,
+                        fn=match.group("fn"),
+                        written=written,
+                        request_path=request_path,
+                    )
+                )
+    return calls
+
+
+#: Verdicts for one probed UI path.
+SERVED = "served"
+ROUTE_MISSING = "route_missing"
+PAGE_NOT_API = "page_not_api"
+LIVE_SERVER = "live_server"
+
+#: Call sites that parse the response as JSON unconditionally — the scaffold-owned
+#: seams. Their own contract is "this returns JSON", so any non-JSON answer is a broken
+#: call whatever its status. A raw ``fetch`` makes no such promise and is judged only on
+#: whether a route exists at all.
+_JSON_SEAM_FUNCTIONS = frozenset({"api", "apiFetch"})
+
+
+def classify_ui_response(
+    request_path: str, status: int, content_type: str, *, via_seam: bool = True
+) -> str:
+    """Did the UI's data call reach an API route?
+
+    Two failure shapes, and this stack invites both because App Router serves pages and
+    API handlers from ONE routing tree (#859):
+
+    - ``ROUTE_MISSING`` — a 404 the framework produced (its 404 page is HTML, while an
+      app answering through the scaffold's frozen ``errorResponse`` returns JSON). So a
+      legitimate "no such run" — 404 WITH the envelope — reads as SERVED, because the
+      route did answer. That distinction keeps correct apps passing.
+    - ``PAGE_NOT_API`` — a 200 carrying HTML. The call landed on a *page* whose URL
+      happens to match, so it never 404s: the seam's ``res.json()`` fails, its
+      ``.catch(() => ({}))`` yields an empty object, and the view renders blank with no
+      error anywhere. Roll 1 shipped exactly this on its detail route, and a
+      404-only rule (this function's first version) called it served.
+    """
+    if request_path.startswith(("http://", "https://")):
+        return LIVE_SERVER
+    is_json = "json" in content_type.lower()
+    if status == 404 and not is_json:
+        return ROUTE_MISSING
+    if via_seam and not is_json:
+        return PAGE_NOT_API
+    return SERVED
+
+
+def expects_json(fn: str) -> bool:
+    """Whether this call site parses the response as JSON by construction."""
+    return fn in _JSON_SEAM_FUNCTIONS
+
+
+def describe_failure(call: UiCall, verdict: str) -> str:
+    if verdict == LIVE_SERVER:
+        return (
+            f"{call.location()}: {call.fn}({call.written!r}) targets a live server — the "
+            f"UI must call its own app's paths (#877)"
+        )
+    if verdict == PAGE_NOT_API:
+        return (
+            f"{call.location()}: {call.fn}({call.written!r}) requests "
+            f"{call.request_path!r}, which serves a PAGE, not the API — the response is "
+            f"HTML, so the parsed body is empty and the view renders blank with no error"
+        )
+    return (
+        f"{call.location()}: {call.fn}({call.written!r}) requests {call.request_path!r}, "
+        f"which the app serves no route for — this call 404s for every user"
+    )

--- a/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix_nextjs_ts.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix_nextjs_ts.md
@@ -1,0 +1,62 @@
+---
+template_id: request.development_develop_fill_only_appendix_nextjs_ts
+version: "1"
+required_variables:
+  - stack
+optional_variables:
+  - error_contract
+  - model_surface
+  - testid_surface
+  - frozen_surface
+---
+## Fill-only: a walking skeleton is already in your workspace
+
+This build was scaffolded (`{{stack}}`). A deterministic tool has **already generated a
+wired, buildable, bootable Next.js App Router application** into your workspace — config,
+data models, the in-memory store, the error envelope, the client fetch helper, and
+route/page **stubs**. It already builds and boots. Your job is to **fill the bodies of the
+fixed slots** — never to rebuild, rewire, or regenerate the scaffold.
+
+**FILL — edit only the stubbed bodies:**
+- API route handlers in `app/**/route.ts` — implement each exported `GET`/`POST`/… inside
+  the existing function. `ApiError` and `errorResponse` from `@/lib/errors` and the store
+  from `@/lib/store` are already imported and wired; use them. A route file's directory
+  IS its URL, so a handler in `app/api/runs/[run_id]/route.ts` serves
+  `/api/runs/<run_id>`.
+- Page components in `app/**/page.tsx` — implement each component's body.
+
+**The client seam, stated exactly — this is where fills go wrong:**
+`api()` from `@/lib/api` fetches **the path you pass it, verbatim. It adds no prefix.**
+Pass the endpoint's FULL declared URL path, exactly as the interface manifest declares
+it:
+
+```ts
+const runs = await api<Run[]>('/api/runs')          // correct — the declared path
+const run  = await api<Run>(`/api/runs/${id}`)      // correct
+await api('/runs')                                  // WRONG — 404, no such route
+```
+
+If your manifest declares `POST /api/runs`, the page calls `api('/api/runs')`. Dropping
+the prefix compiles, passes type-checking, and returns 404 at runtime for every action in
+the UI — a silent break no build or unit check catches.
+
+**DO NOT touch the scaffold-owned surface — it is frozen and verified:**
+- Do NOT change the exported handler **names, signatures, or file locations** in
+  `app/**/route.ts` — the directory determines the URL the app serves.
+- Do NOT edit `lib/models.ts`, `lib/store.ts`, `lib/errors.ts`, `lib/api.ts`,
+  `app/layout.tsx`, `package.json`, `tsconfig.json`, `next.config.mjs`, or
+  `vitest.config.ts`.
+- Do NOT add or remove files, or move a route/page to a different directory.
+
+{{error_contract}}
+
+{{model_surface}}
+
+{{testid_surface}}
+
+{{frozen_surface}}
+
+Filling the fixed slots — rather than regenerating the app — is the whole point: the
+skeleton already builds and boots, so a fill that preserves it stays green, while one
+that rewrites scaffold-owned files is rejected by the verification contract. When in
+doubt, change less: implement the body, keep everything around it exactly as scaffolded.

--- a/tests/unit/capabilities/test_develop_fill_only.py
+++ b/tests/unit/capabilities/test_develop_fill_only.py
@@ -7,11 +7,13 @@ dev-only, content in a managed asset — mirrors 99.2's scaffold_section.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from squadops.capabilities.dev_capabilities import get_capability
 from squadops.capabilities.handlers.cycle.develop import DevelopmentDevelopHandler
 
 pytestmark = [pytest.mark.domain_capabilities]
@@ -68,3 +70,71 @@ def test_fill_only_appendix_asset_is_well_formed():
     assert "backend/routes.py" in text  # the fill slot
     assert "Do NOT" in text  # the frozen-surface discipline
     assert "{{stack}}" in text
+
+
+class TestPerStackAppendix:
+    """SIP-0104 window roll 1 (cyc_04d36309d793, 2026-08-15): one shared asset served
+    both stacks, so a `nextjs_ts` author was instructed to fill `backend/routes.py` and
+    `frontend/src/views/*.jsx` — neither of which exists here — and told that the client
+    seam "prefixes `/api`", which stack #2's seam does not. It wrote `api('/runs')`
+    against a helper that fetches verbatim, and EVERY UI call 404'd in a deliverable that
+    passed 36/36 checks, all 5 probes, the frontend build, and the boot audit.
+    """
+
+    async def test_each_stack_gets_its_own_asset(self):
+        renderer = AsyncMock()
+        renderer.render.return_value = MagicMock(content="X")
+
+        await _handler("nextjs_ts")._fill_only_section(renderer)
+        assert (
+            renderer.render.await_args.args[0]
+            == "request.development_develop_fill_only_appendix_nextjs_ts"
+        )
+
+        renderer.render.reset_mock()
+        await _handler("fullstack_fastapi_react")._fill_only_section(renderer)
+        assert (
+            renderer.render.await_args.args[0] == "request.development_develop_fill_only_appendix"
+        )
+
+    async def test_the_nextjs_author_is_told_this_stacks_layout_and_seam(self):
+        """A live render: the facts must survive the template, and the two failure modes
+        roll 1 shipped must both be addressed — the file layout and the prefix."""
+        from adapters.prompts.filesystem_asset_adapter import FilesystemPromptAssetAdapter
+        from squadops.prompts.renderer import RequestTemplateRenderer
+
+        templates = _APPENDIX.parent
+        renderer = RequestTemplateRenderer(
+            FilesystemPromptAssetAdapter(
+                fragments_path=templates.parent / "fragments", templates_path=templates
+            )
+        )
+
+        out = await _handler("nextjs_ts")._fill_only_section(renderer)
+
+        # this stack's real layout
+        assert "app/**/route.ts" in out
+        assert "app/**/page.tsx" in out
+        # ...and NOT the other stack's, which is what roll 1's author was handed
+        assert "backend/routes.py" not in out
+        assert "frontend/src/views" not in out
+        assert "apiFetch" not in out
+        # the seam semantic that broke the UI, stated with the correct and wrong forms
+        assert "adds no prefix" in out
+        assert "api<Run[]>('/api/runs')" in out
+        assert "await api('/runs')" in out  # the WRONG example, named as wrong
+
+    async def test_a_stack_with_no_declared_asset_gets_no_appendix(self):
+        """Wrong guidance is worse than none (#818): an unregistered stack must not
+        inherit another stack's conventions — which is exactly this defect."""
+        from unittest.mock import patch
+
+        renderer = AsyncMock()
+        handler = _handler("fullstack_fastapi_react")
+        capability = get_capability("fullstack_fastapi_react")
+        with patch(
+            "squadops.capabilities.dev_capabilities.get_capability",
+            return_value=replace(capability, fill_only_template=""),
+        ):
+            assert await handler._fill_only_section(renderer) == ""
+        renderer.render.assert_not_awaited()

--- a/tests/unit/capabilities/test_ui_data_path.py
+++ b/tests/unit/capabilities/test_ui_data_path.py
@@ -1,0 +1,159 @@
+"""The UI actually reaches its own API — the gap roll 1 fell through.
+
+The regression case is roll 1's real source (`cyc_04d36309d793`): five page calls with
+unprefixed paths against routes at `/api/runs`, in an app that passed 36/36 checks, all
+five contract probes, `tests_pass`, `frontend_build`, and the boot audit. Nothing in the
+pipeline followed the path the UI itself takes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.ui_data_path import (
+    LIVE_SERVER,
+    PAGE_NOT_API,
+    ROUTE_MISSING,
+    SAMPLE_SEGMENT,
+    SERVED,
+    classify_ui_response,
+    describe_failure,
+    expects_json,
+    extract_ui_calls,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+# Verbatim shapes from roll 1's delivered app/page.tsx and app/runs/[run_id]/page.tsx.
+_ROLL_1_UI = {
+    "app/page.tsx": """'use client';
+import { api } from '@/lib/api';
+export default function Page() {
+  const data = await api<Run[]>('/runs');
+  await api('/runs', { method: 'POST', body: JSON.stringify(formData) });
+}
+""",
+    "app/runs/[run_id]/page.tsx": """'use client';
+import { api } from '@/lib/api';
+export default function Page() {
+  const data = await api<Run>(`/runs/${runId}`);
+  await api(`/runs/${runId}/join`, { method: 'POST' });
+  await api(`/runs/${runId}/leave`, { method: 'POST' });
+}
+""",
+}
+
+_CORRECT_UI = {
+    "app/page.tsx": """'use client';
+import { api } from '@/lib/api';
+const data = await api<Run[]>('/api/runs');
+const one = await api<Run>(`/api/runs/${runId}`);
+"""
+}
+
+
+class TestExtraction:
+    def test_roll_ones_five_calls_are_all_found(self):
+        calls = extract_ui_calls(_ROLL_1_UI, "nextjs_ts")
+        assert [c.request_path for c in calls] == [
+            "/runs",
+            "/runs",
+            f"/runs/{SAMPLE_SEGMENT}",
+            f"/runs/{SAMPLE_SEGMENT}/join",
+            f"/runs/{SAMPLE_SEGMENT}/leave",
+        ]
+        # the message must point at real source, or a failure is unactionable
+        assert calls[0].location() == "app/page.tsx:4"
+
+    def test_the_seam_prefix_is_applied_per_stack(self):
+        """Stack #1's helper prepends `/api`; stack #2's fetches verbatim. Assuming
+        either convention for the other stack is exactly roll 1's defect."""
+        ui = {"src/views/RunsListView.jsx": "const d = await apiFetch('/runs')"}
+        assert extract_ui_calls(ui, "fullstack_fastapi_react")[0].request_path == "/api/runs"
+        assert extract_ui_calls(ui, "nextjs_ts")[0].request_path == "/runs"
+
+    def test_an_unknown_stack_yields_nothing_rather_than_guessing(self):
+        """A guessed prefix would invent failures in an app that works."""
+        assert extract_ui_calls(_ROLL_1_UI, "django_htmx") == []
+
+    def test_route_handlers_are_not_ui(self):
+        """A route handler talking to the store is not a UI data call."""
+        files = {"app/api/runs/route.ts": "const rows = store.all('runs')"}
+        assert extract_ui_calls(files, "nextjs_ts") == []
+
+    def test_a_raw_fetch_bypasses_the_seam_so_takes_no_prefix(self):
+        files = {"app/page.tsx": "const r = await fetch('/api/runs')"}
+        (call,) = extract_ui_calls(files, "fullstack_fastapi_react")
+        assert call.request_path == "/api/runs"
+
+
+class TestClassification:
+    def test_a_framework_404_is_a_missing_route(self):
+        """Next serves its own 404 page as HTML when nothing is mounted at the path."""
+        assert classify_ui_response("/runs", 404, "text/html; charset=utf-8") == ROUTE_MISSING
+
+    def test_an_apps_own_404_envelope_means_the_route_answered(self):
+        """The discriminator that keeps correct apps passing: an unknown id returns 404
+        through the scaffold's frozen errorResponse — JSON, not the framework's page."""
+        assert classify_ui_response("/api/runs/x", 404, "application/json") == SERVED
+
+    @pytest.mark.parametrize("status", [200, 201, 400, 409, 422, 500])
+    def test_any_other_answer_means_the_route_exists(self, status):
+        """This check asks only whether a route is mounted; whether the response is
+        semantically right is the contract probes' question, not this one."""
+        assert classify_ui_response("/api/runs", status, "application/json") == SERVED
+
+    def test_an_absolute_url_is_the_live_server_class(self):
+        assert classify_ui_response("http://localhost:3000/api/runs", 200, "") == LIVE_SERVER
+
+
+class TestPageCollision:
+    """The miss the first version of this check shipped with, caught by running it
+    against roll 1's real app: App Router serves pages and API handlers from ONE tree
+    (#859), so a wrong API path can land on a PAGE instead of 404ing. Roll 1's
+    `api(`/runs/${runId}`)` hit `app/runs/[run_id]/page.tsx` — 200, HTML — and a
+    404-only rule called it served."""
+
+    def test_html_through_the_json_seam_is_a_page_not_the_api(self):
+        assert (
+            classify_ui_response("/runs/x", 200, "text/html; charset=utf-8", via_seam=True)
+            == PAGE_NOT_API
+        )
+
+    def test_a_raw_fetch_may_legitimately_receive_html(self):
+        """`fetch` promises nothing about the body; only the seam parses JSON by
+        construction, so only the seam's calls are held to it."""
+        assert classify_ui_response("/runs/x", 200, "text/html", via_seam=False) == SERVED
+
+    def test_the_seam_functions_are_the_json_ones(self):
+        assert expects_json("api") and expects_json("apiFetch")
+        assert not expects_json("fetch")
+
+    def test_the_message_explains_the_silent_shape(self):
+        files = {"app/runs/[run_id]/page.tsx": "const d = await api<Run>(`/runs/${runId}`)"}
+        (call,) = extract_ui_calls(files, "nextjs_ts")
+        message = describe_failure(call, PAGE_NOT_API)
+        assert "serves a PAGE, not the API" in message
+        assert "renders blank" in message
+
+
+class TestFailureMessages:
+    def test_a_missing_route_message_names_file_line_and_both_paths(self):
+        (call, *_) = extract_ui_calls(_ROLL_1_UI, "nextjs_ts")
+        message = describe_failure(call, ROUTE_MISSING)
+        assert "app/page.tsx:4" in message
+        assert "'/runs'" in message
+        assert "404s for every user" in message
+
+    def test_the_live_server_message_names_its_own_class(self):
+        files = {"app/page.tsx": "const r = await fetch('http://localhost:3000/api/runs')"}
+        (call,) = extract_ui_calls(files, "nextjs_ts")
+        assert "live server" in describe_failure(call, LIVE_SERVER)
+
+
+def test_a_correctly_wired_ui_produces_no_failing_paths():
+    """The check must pass the app roll 1 should have shipped."""
+    calls = extract_ui_calls(_CORRECT_UI, "nextjs_ts")
+    assert [c.request_path for c in calls] == ["/api/runs", f"/api/runs/{SAMPLE_SEGMENT}"]
+    for call in calls:
+        assert classify_ui_response(call.request_path, 200, "application/json") == SERVED


### PR DESCRIPTION
Closes the gap named in #902: **nothing in the pipeline follows the path the UI itself takes.** Contract probes issue HTTP at *declared* paths, SIP-0104's shells import route handlers and invoke them in-process, `frontend_build` only compiles, and the boot audit probes the contract. Roll 1 shipped the consequence — all five page data calls 404'd in an app that passed 36/36 checks, all five probes, `tests_pass`, `frontend_build`, and the audit.

## What it does

`capabilities/ui_data_path.py` extracts the request paths the UI's own source will issue and resolves each through **that stack's** client seam — stack #1's `apiFetch` prepends `/api`, stack #2's `api` fetches verbatim. Encoding that difference is the point: assuming one stack's convention for the other is precisely the defect. An unknown stack yields nothing rather than guessing a prefix, which would invent failures in a working app.

The audit then puts each distinct path to the running app and asks one unambiguous question: **does a route answer where the UI asks?** Whether the response is semantically right stays the contract probes' job.

No headless browser. The defect is a wiring fact, decidable from source plus one request per path; a browser would add a runtime dependency to answer a question that doesn't need one.

## Two failure shapes — the second was found by running the check against the real app

Because App Router serves pages and API handlers from one routing tree (#859), a wrong API path has two ways to fail:

- **`route_missing`** — a 404 the framework produced. Its 404 page is HTML, while an app answering through the scaffold's frozen `errorResponse` returns JSON, so a legitimate "no such run" (404 **with** the envelope) still passes. That discriminator is what keeps correct apps green.
- **`page_not_api`** — a **200 carrying HTML**. The call landed on a *page* whose URL happens to match, so it never 404s: the seam's `res.json()` fails, its `.catch(() => ({}))` yields an empty object, and the view renders blank with no error anywhere.

The first version of this check only knew the 404 rule. Running it against roll 1's real app caught **4 of 5** calls — `api(\`/runs/${runId}\`)` hit `app/runs/[run_id]/page.tsx` and was classified served. That miss is now its own test class. The JSON requirement applies only to seam calls (`api`/`apiFetch`), which parse JSON by construction; a raw `fetch` promises nothing about the body and is judged on route existence alone.

## Verified against the real deliverable

```
FAIL ui-data-path app/page.tsx:39: api('/runs') requests '/runs', which the app serves no route for — this call 404s for every user
FAIL ui-data-path app/page.tsx:70: api('/runs') ...
FAIL ui-data-path app/runs/[run_id]/page.tsx:42: api('/runs/${runId}') requests '/runs/ui-probe-sample', which serves a PAGE, not the API — the response is HTML, so the parsed body is empty and the view renders blank with no error
FAIL ui-data-path app/runs/[run_id]/page.tsx:67: api('/runs/${runId}/join') ...
FAIL ui-data-path app/runs/[run_id]/page.tsx:91: api('/runs/${runId}/leave') ...
```

All five, at file:line, each with its shape. Roll 1's real source is the regression fixture in the unit corpus.

## Scope and consequences

- **The audit now fails on this** (exit 1). That is the point — "the app works" is the audit's question, and a dead UI means it doesn't.
- **Cycle verdict semantics are untouched.** This lives in the audit, not the pipeline, so it does not change what a roll's verdict means mid-window — consistent with the reporting-only ruling.
- **Roll 2, in flight, will fail this audit**, because it was authored before #902's guidance fix. That is the honest baseline: it is a clean *window* roll (the window counts mechanical suite deaths) and a broken *app*. Worth deciding whether a roll banks on window-cleanliness alone or also needs a passing audit — flagging rather than assuming.

## Validation

Full regression **7315 passed, 1 skipped**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
