### PR TITLE
fix(corrections): a suite failure names which tests failed (#878 full)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -715,20 +715,9 @@ class QATestHandler(_CycleTaskHandler):
                 reason = test_result.error or "runner_error"
                 detail = f"tests_not_executed:{reason}"
                 summary = f"Repaired suite not executed: {reason}"
-            checks.append(
-                {
-                    "check": "tests_pass",
-                    "executed": test_result.executed,
-                    "exit_code": test_result.exit_code,
-                    "tests_passed": test_result.tests_passed,
-                    "passed": False,
-                    # #626: runner identity + the runner-neutral suite-health
-                    # verdict, so locus routing stops reading pytest exit
-                    # semantics into vitest failures.
-                    "runner": test_result.runner,
-                    "suite_broken": test_result.suite_broken,
-                }
-            )
+            from squadops.capabilities.handlers.test_runner import failed_tests_pass_row
+
+            checks.append(failed_tests_pass_row(test_result))
             missing.append(detail)
         else:
             summary = "Repaired suite passed"
@@ -1101,20 +1090,9 @@ class QATestHandler(_CycleTaskHandler):
                 detail = f"tests_not_executed:{reason}"
                 fail_note = f"Tests not executed: {reason}"
 
-            validation.checks.append(
-                {
-                    "check": "tests_pass",
-                    "executed": test_result.executed,
-                    "exit_code": test_result.exit_code,
-                    "tests_passed": test_result.tests_passed,
-                    "passed": False,
-                    # #626: runner identity + the runner-neutral suite-health
-                    # verdict, so locus routing stops reading pytest exit
-                    # semantics into vitest failures.
-                    "runner": test_result.runner,
-                    "suite_broken": test_result.suite_broken,
-                }
-            )
+            from squadops.capabilities.handlers.test_runner import failed_tests_pass_row
+
+            validation.checks.append(failed_tests_pass_row(test_result))
             validation.passed = False
             validation.missing_components.append(detail)
             validation.summary = (

--- a/src/squadops/capabilities/handlers/test_runner.py
+++ b/src/squadops/capabilities/handlers/test_runner.py
@@ -743,6 +743,53 @@ async def run_backend_import_check(
 _VITEST_REPORT_FILENAME = ".vitest_report.json"
 
 
+def failing_test_identities(test_failures) -> tuple[str, ...]:
+    """Stable identities for the tests that failed — ``file::title``, sorted and deduped.
+
+    **Identity only: no messages, no line numbers.** The correction signature's standing
+    rule is that evidence text never alters identity, so a re-described identical failure
+    still reads as a repeat. A suite-level row (the file died before any test ran) has no
+    title and is identified by its file alone — a distinct and correct identity, since the
+    whole file is what failed.
+    """
+    identities = set()
+    for row in test_failures or ():
+        if not isinstance(row, dict):
+            continue
+        file = str(row.get("file") or "")
+        title = str(row.get("title") or "")
+        if not file and not title:
+            continue
+        identities.add(f"{file}::{title}" if title else file)
+    return tuple(sorted(identities))
+
+
+def failed_tests_pass_row(result: RunTestsResult) -> dict:
+    """The ``tests_pass`` check row for a failing run.
+
+    One builder because there are two call sites (first pass and retest) that must not
+    drift: #626 added ``runner``/``suite_broken`` to both by hand, and the next field
+    added to only one of them is a silent, per-path behavior difference. Two seams, one
+    fact — the class of bug this repo has paid for more than once.
+    """
+    return {
+        "check": "tests_pass",
+        "executed": result.executed,
+        "exit_code": result.exit_code,
+        "tests_passed": result.tests_passed,
+        "passed": False,
+        # #626: runner identity + the runner-neutral suite-health verdict, so locus
+        # routing stops reading pytest exit semantics into vitest failures.
+        "runner": result.runner,
+        "suite_broken": result.suite_broken,
+        # #878 (full): WHICH tests failed, so two different suite failures stop
+        # collapsing into one aggregate signature. Empty for runners that produce no
+        # machine report (pytest today) — the signature then falls back byte-identically
+        # to the aggregate form.
+        "failing_tests": failing_test_identities(result.test_failures),
+    }
+
+
 def parse_vitest_failure_rows(report: dict, workspace_root: str) -> list[dict]:
     """Per-failure observation rows from a vitest JSON report (SIP-0104 P5).
 

--- a/src/squadops/cycles/correction_signature.py
+++ b/src/squadops/cycles/correction_signature.py
@@ -39,6 +39,18 @@ def failure_signature(failure_evidence: dict[str, Any]) -> frozenset[tuple[str, 
     ``emission_failure`` — the A3 categories own its routing) or no failing
     rows at all.
 
+    #878 (full): when the row carries ``failing_tests``, the suite contributes
+    **one element per failing test** rather than a single aggregate element.
+    This is what makes the movement table reachable inside a suite: a repair
+    that fixes three of eight failures yields a strict subset, which is
+    ``MOVEMENT_PROGRESS`` and resets the repeat condition, where the aggregate
+    form produced a byte-identical ``tests_pass||failed`` both rounds and read
+    as an exact repeat. Roll 2 of the SIP-0104 window (run_6cb3563d3291) is the
+    canonical loss: round 0 failed on error-envelope assertions, round 1 on five
+    unfilled scaffold slots — two unrelated defects, one collapsed signature, a
+    converging run terminated at round 1. Absent (pytest, which emits no machine
+    report, and every legacy row) falls back to the aggregate element byte-identically.
+
     #878 (minimum): the runner's structured ``suite_broken`` verdict joins the
     reason token when present. It is a machine fact, not prose, so the
     evidence-text rule above is intact — and without it a behavioral failure
@@ -80,7 +92,13 @@ def failure_signature(failure_evidence: dict[str, Any]) -> frozenset[tuple[str, 
         if suite_broken is not None:
             health = "broken" if suite_broken else "ran"
             reason_token = f"{reason_token};suite_health={health}"
-        elements.add((check_id, subject, reason_token))
+        failing_tests = row.get("failing_tests") or ()
+        if failing_tests:
+            for identity in failing_tests:
+                test_file, _, title = str(identity).partition("::")
+                elements.add((check_id, test_file, f"{reason_token};test={title}"))
+        else:
+            elements.add((check_id, subject, reason_token))
     return frozenset(elements) if elements else None
 
 

--- a/tests/unit/capabilities/test_test_runner.py
+++ b/tests/unit/capabilities/test_test_runner.py
@@ -463,3 +463,110 @@ class TestMergedRunnerIdentity:
         assert result.exit_code == 1
         assert result.runner == "vitest"
         assert result.suite_broken is True
+
+
+class TestFailingTestIdentities:
+    """#878 (full) — which tests failed, as a stable identity set."""
+
+    def test_messages_and_lines_never_enter_the_identity(self):
+        """The correction signature's standing rule is that evidence text never alters
+        identity, so the same failure re-described (a different assertion message, a
+        shifted line number) must still compare equal — otherwise every round looks
+        like new work and termination can never fire on a genuinely stuck run.
+        """
+        from squadops.capabilities.handlers.test_runner import failing_test_identities
+
+        first = failing_test_identities(
+            [
+                {
+                    "file": "a.test.ts",
+                    "title": "creates",
+                    "messages": ["expected 500 to be 201"],
+                    "line": 12,
+                    "suite_level": False,
+                }
+            ]
+        )
+        second = failing_test_identities(
+            [
+                {
+                    "file": "a.test.ts",
+                    "title": "creates",
+                    "messages": ["AssertionError: nope"],
+                    "line": 44,
+                    "suite_level": False,
+                }
+            ]
+        )
+
+        assert first == second == ("a.test.ts::creates",)
+
+    def test_identities_are_sorted_deduped_and_suite_rows_use_the_file(self):
+        """Order comes from the runner's report and must not affect comparison; a
+        suite-level row has no title and is the file itself."""
+        from squadops.capabilities.handlers.test_runner import failing_test_identities
+
+        rows = [
+            {"file": "b.test.ts", "title": "z", "suite_level": False},
+            {"file": "a.test.ts", "title": "", "suite_level": True},
+            {"file": "b.test.ts", "title": "z", "suite_level": False},
+        ]
+
+        assert failing_test_identities(rows) == ("a.test.ts", "b.test.ts::z")
+
+    def test_junk_rows_are_dropped_rather_than_producing_empty_identities(self):
+        """A malformed report must not inject a `::`-shaped phantom identity that
+        would make two unrelated rounds compare equal."""
+        from squadops.capabilities.handlers.test_runner import failing_test_identities
+
+        assert failing_test_identities([{}, {"file": "", "title": ""}, "not-a-dict", None]) == ()
+        assert failing_test_identities(None) == ()
+
+
+class TestFailedTestsPassRow:
+    def test_both_qa_seams_build_the_row_through_this_one_builder(self):
+        """#626 added `runner`/`suite_broken` to two hand-written copies of this dict;
+        a third field added to only one seam is a silent per-path behavior difference
+        (first-pass vs retest). This pins that both call sites route through here.
+        """
+        import ast
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[3]
+            / "src/squadops/capabilities/handlers/cycle/qa_test.py"
+        ).read_text(encoding="utf-8")
+
+        calls = sum(
+            1
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "failed_tests_pass_row"
+        )
+
+        assert calls == 2, "both the first-pass and retest seams must use the shared builder"
+        assert '"check": "tests_pass",' not in source, (
+            "a hand-built tests_pass failure row reappeared — route it through "
+            "failed_tests_pass_row so the two seams cannot drift"
+        )
+
+    def test_the_row_carries_the_failing_test_identities(self):
+        from squadops.capabilities.handlers.test_runner import (
+            RunTestsResult,
+            failed_tests_pass_row,
+        )
+
+        row = failed_tests_pass_row(
+            RunTestsResult(
+                executed=True,
+                exit_code=1,
+                runner="vitest",
+                suite_broken=False,
+                test_failures=({"file": "a.test.ts", "title": "creates"},),
+            )
+        )
+
+        assert row["failing_tests"] == ("a.test.ts::creates",)
+        assert row["passed"] is False
+        assert row["runner"] == "vitest"

--- a/tests/unit/cycles/test_correction_signature.py
+++ b/tests/unit/cycles/test_correction_signature.py
@@ -167,3 +167,90 @@ class TestSuiteHealthDiscriminator:
         sig = failure_signature(_evidence([_TESTS_FAIL_ROW]))
 
         assert sig == frozenset({("tests_pass", "backend/tests/test_integration.js", "exit 1")})
+
+
+class TestFailingTestIdentity:
+    """#878 (full) — a suite contributes one element per failing test.
+
+    Without it, every suite failure is the same aggregate element, so two
+    unrelated defects in consecutive rounds read as an exact repeat and the
+    run is terminated as a plan defect while it is actually converging.
+    """
+
+    @staticmethod
+    def _suite(identities: tuple[str, ...]) -> dict:
+        return {
+            "check": "tests_pass",
+            "passed": False,
+            "status": "failed",
+            "reason": "failed",
+            "suite_broken": False,
+            "failing_tests": identities,
+        }
+
+    def test_two_unrelated_suite_failures_are_not_a_repeat(self):
+        """SIP-0104 window roll 2 (run_6cb3563d3291), exactly as it happened.
+
+        Round 0 failed on error-envelope assertions; round 1 on unfilled scaffold
+        slots. Different defects, and the run was fixing them in sequence — but
+        both rounds produced `tests_pass||failed;suite_health=ran` and the run
+        died at round 1.
+        """
+        round0 = failure_signature(
+            _evidence([self._suite(("__tests__/runs.test.ts::rejects a blank title",))])
+        )
+        round1 = failure_signature(
+            _evidence(
+                [self._suite(("__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts::fill",))]
+            )
+        )
+
+        assert classify_movement(round0, round1) != MOVEMENT_REPEAT
+        assert not should_terminate_plan_defect(
+            round0, round1, "tighten_acceptance", "tighten_acceptance"
+        )
+
+    def test_fixing_some_of_the_failures_is_progress(self):
+        """The movement table was unreachable inside a suite before this: partial
+        reduction is the signal that a repair is working, and the aggregate element
+        could not express it."""
+        before = failure_signature(_evidence([self._suite(("f.ts::a", "f.ts::b", "f.ts::c"))]))
+        after = failure_signature(_evidence([self._suite(("f.ts::c",))]))
+
+        assert classify_movement(before, after) == MOVEMENT_PROGRESS
+        assert not should_terminate_plan_defect(before, after, "tighten_acceptance", "add_task")
+
+    def test_the_same_failing_tests_still_repeat(self):
+        """The true positive must survive: shk-4's three identical rounds against one
+        unwinnable task are still an exact repeat, now on a stricter identity."""
+        sig_a = failure_signature(_evidence([self._suite(("f.ts::a", "f.ts::b"))]))
+        sig_b = failure_signature(_evidence([self._suite(("f.ts::b", "f.ts::a"))]))
+
+        assert classify_movement(sig_a, sig_b) == MOVEMENT_REPEAT
+        assert should_terminate_plan_defect(
+            sig_a, sig_b, "tighten_acceptance", "tighten_acceptance"
+        )
+
+    def test_a_row_without_failing_tests_is_byte_identical_to_the_legacy_form(self):
+        """pytest emits no machine report and every pre-#878 row lacks the field, so
+        the fallback must not shift those signatures by even one character."""
+        legacy = failure_signature(_evidence([_TESTS_FAIL_ROW]))
+        with_empty = failure_signature(_evidence([{**_TESTS_FAIL_ROW, "failing_tests": ()}]))
+
+        assert with_empty == legacy
+        assert render_signature(legacy) == ("tests_pass|backend/tests/test_integration.js|exit 1",)
+
+    def test_a_suite_level_death_is_identified_by_its_file(self):
+        """A file that dies before any test runs has no test title. Identifying it by
+        file is correct — the whole file is what failed — and keeps it distinct from
+        an assertion failure inside the same file.
+        """
+        died = failure_signature(_evidence([self._suite(("__tests__/broken.test.ts",))]))
+        asserted = failure_signature(
+            _evidence([self._suite(("__tests__/broken.test.ts::renders",))])
+        )
+
+        assert classify_movement(died, asserted) != MOVEMENT_REPEAT
+        assert render_signature(died) == (
+            "tests_pass|__tests__/broken.test.ts|failed;suite_health=ran;test=",
+        )


### PR DESCRIPTION
Closes #878.

## What it fixes

SIP-0104 window **roll 2** (`run_6cb3563d3291`) was terminated as a `plan_defect` at correction round 1 **while it was converging**:

- **Round 0** — error-envelope assertions failed; the repair patched the route handlers.
- **Round 1** — five verification-scaffold slots were unfilled; the missing-slot rule surfaced them and the analyzer routed to the fill layer correctly.

Two unrelated defects, being fixed in sequence. Both rounds produced the identical `tests_pass||failed;suite_health=ran`, the repeat detector read an exact repeat, and the run was cut. **The app was fine** — 30 checks executed, 29 passed, 8/9 contract criteria.

#887 shipped the minimum fix (`suite_health`), which separates mechanical from behavioral failures. Both rounds here were `ran`, so it could not separate them.

## The fix

A check row carrying `failing_tests` now contributes **one signature element per failing test** instead of one aggregate element.

That makes the movement table reachable inside a suite for the first time. Fixing three of eight failures is now a strict subset — `MOVEMENT_PROGRESS`, which resets the repeat condition. The aggregate form could not express partial progress at all, which is what made #435 a de-facto two-round cap for `qa.test`.

**The true positive is preserved and strengthened.** shk-4's three identical rounds against one unwinnable task still repeat, now on the stricter identity of *the same tests failed* rather than *the suite failed again*.

Identity is `file::title`, sorted and deduped; a suite-level death (the file died before any test ran) is identified by its file alone. **Messages and line numbers are deliberately excluded** — the standing rule is that evidence text never alters a signature, so a re-described identical failure must still read as a repeat. Absent (pytest emits no machine report, and every legacy row) falls back to the aggregate element **byte-identically**.

The data was already there: SIP-0104 P5 added the vitest reporter rows to `RunTestsResult.test_failures`. This plumbs identity into the signature.

## Also: two seams, one fact

The `tests_pass` failure row was hand-built in two places — the first-pass path and the retest path. #626 added `runner`/`suite_broken` to both by hand; a third field added to only one is a silent per-path behavior difference, and this repo has paid for that class before. Both now route through `failed_tests_pass_row`, with an AST test pinning it and rejecting a reintroduced hand-built row.

## Verification

**Not a replay, and I want to be precise about that**: the field being added did not exist at roll 2's runtime, so its stored evidence cannot carry it. The tests encode roll 2's real failure shape instead.

Three mutations killed:

| Mutation | Result |
|---|---|
| revert to the aggregate element (pre-fix behavior) | 3 tests fail |
| let messages leak into the identity | 3 tests fail |
| one seam hand-builds the row again | 1 test fails |

Regression **7326 passed**, 1 skipped.

## Deploy note

Executor-side only, so this needs a `runtime-api` rebuild. It is intended to ride the **roll-3 rebuild alongside #902** — consistent with #907's "exactly one named change" rule rather than an exception to it: that rule exists to keep *gratuitous* variables out of the counting rolls, and a defect that destroys the rolls being measured is part of making the measurement possible. #906 still waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
