### PR TITLE
test(guards): Guard 1a and Guard 1b — authored mode is provenance, not a fork

### DIFF
--- a/tests/unit/cycles/test_authored_mode_equivalence.py
+++ b/tests/unit/cycles/test_authored_mode_equivalence.py
@@ -1,0 +1,128 @@
+"""Guard 1b — same manifest, same downstream bytes, different provenance.
+
+Guard 1a proves nothing *branches* on authoring mode. That is not the same as proving
+the transformation is identical, and the distinction is the whole reason Guard 1 has two
+halves: a fork can also be introduced by a field that only authored manifests carry
+leaking into a hash, an expansion, or a derived contract. Then no code branches and the
+outputs still diverge.
+
+So this is the output half. Feed the **reference manifest** — the same instance the 1.4
+Functional App Yield window was measured against — through both provenances and require
+byte-identical downstream artifacts: the expanded skeleton, the derived verification
+contract, and the manifest's own structural hash.
+
+``Provenance`` already states the invariant in its docstring ("Deliberately NOT part of
+the structural projection … a manifest whose only change is *how it was written* must
+expand to the same skeleton and keep the contract bound to it valid"). Stating an
+invariant is not holding it: the block is five fields, and adding a sixth to
+``_canonical`` — or rendering provenance into an expanded file for traceability, which
+is a genuinely tempting change — would move every bind-mode cycle's manifest hash and
+break the contract binding, with authored mode as the only mode that shows it.
+
+What this does NOT claim: that authored and seeded cycles produce the same *manifest*.
+They obviously do not — that is the release's point. It claims that once a manifest
+exists, everything downstream is blind to who wrote it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from squadops.capabilities.scaffold import InterfaceManifest, Provenance, expand
+from squadops.capabilities.scaffold_contract import emit_contract_yaml
+
+pytestmark = [pytest.mark.domain_cycles]
+
+_REPO = Path(__file__).resolve().parents[3]
+#: The same reference instance M0a pins the deriver against (art_8becd104e9fc).
+_REFERENCE = _REPO / "examples" / "03_group_run" / "interface_manifest.yaml"
+
+#: A realistic authored-mode provenance block: mode, the cycle and task that wrote it,
+#: a non-trivial attempt count. Values chosen to be the kind that WOULD show up in a
+#: hash if the block ever entered the structural projection.
+_AUTHORED = Provenance(
+    mode="authored",
+    cycle_id="cyc_b20f58cc7cbc",
+    task_id="task-run_1a81279d51aa-m001-development.author_manifest",
+    attempts=2,
+)
+
+
+def _seeded() -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_REFERENCE.read_text(encoding="utf-8"))
+
+
+def _authored() -> InterfaceManifest:
+    return dataclasses.replace(_seeded(), provenance=_AUTHORED)
+
+
+def test_the_expanded_skeleton_is_byte_identical():
+    """Bug caught: provenance leaks into an emitted file.
+
+    Rendering "authored by cycle X" into a header comment for traceability is a plausible
+    and well-intentioned change. It would make every authored cycle's skeleton differ
+    from the seeded one it is supposed to be identical to, and the frozen-file
+    enforcement compares content — so authored mode would start failing enforcement for
+    a reason that has nothing to do with the work.
+    """
+    seeded = {f["name"]: f["content"] for f in expand(_seeded())}
+    authored = {f["name"]: f["content"] for f in expand(_authored())}
+
+    assert authored.keys() == seeded.keys()
+    differing = [name for name in seeded if authored[name] != seeded[name]]
+    assert differing == [], f"provenance reached the expanded skeleton: {differing}"
+
+
+def test_the_derived_contract_is_byte_identical():
+    """Bug caught: the contract emitter starts reading provenance.
+
+    The contract is what every downstream check is judged against. If authored and seeded
+    manifests derive different contracts from the same design, the release's yield number
+    is not comparable to the 1.4 window it is meant to extend.
+    """
+    assert emit_contract_yaml(_authored()) == emit_contract_yaml(_seeded())
+
+
+def test_the_structural_hash_is_unmoved():
+    """Bug caught: provenance enters ``_canonical``.
+
+    This is the expensive one. The manifest hash binds the verification contract; moving
+    it invalidates that binding for every bind-mode cycle, and #783 already had to pin
+    ``decisions`` out of the projection for exactly this reason. Authored mode is the
+    only mode carrying provenance, so the damage would appear to be authored mode's
+    fault rather than the projection's.
+    """
+    assert _authored().content_hash() == _seeded().content_hash()
+
+
+def test_the_reference_instance_still_carries_no_provenance():
+    """The seeded side of the comparison must genuinely be seeded.
+
+    If the reference file ever gained a provenance block, every assertion above would be
+    comparing two authored manifests and would pass while proving nothing.
+    """
+    seeded = _seeded()
+    assert seeded.provenance is None or not seeded.provenance.mode
+
+
+@pytest.mark.parametrize(
+    "mutate,label",
+    [
+        (lambda m: dataclasses.replace(m, stack="nextjs_ts"), "stack"),
+        (lambda m: dataclasses.replace(m, persistence="postgres"), "persistence"),
+    ],
+)
+def test_a_structural_change_does_move_the_hash(mutate, label):
+    """The tripwire, without which the three assertions above are unfalsifiable.
+
+    "Byte-identical" is trivially true of a comparison that cannot detect difference. A
+    real structural edit must move the hash, or these tests would keep passing after
+    ``_canonical`` was gutted.
+    """
+    assert mutate(_seeded()).content_hash() != _seeded().content_hash(), (
+        f"changing {label} did not move the manifest hash — the structural projection is "
+        f"not measuring what these equivalence tests assume it measures"
+    )

--- a/tests/unit/cycles/test_authoring_mode_no_fork.py
+++ b/tests/unit/cycles/test_authoring_mode_no_fork.py
@@ -1,0 +1,162 @@
+"""Guard 1a — no execution path branches on authoring mode below framing.
+
+SIP-0103 §3.5's claim is that authored mode is a mode of manifest **provenance, not a
+second pipeline**: post-approval an authored manifest enters ``plan_artifact_refs``
+exactly as a seeded one does, and expander, contract derivation, bind-mode plan
+validation and every 1.4/1.5 enforcement surface operate identically.
+
+The invariant holds today and was unpinned (verified 2026-08-09): the predicate
+``authors_interface_manifest`` has exactly one production call site, inside the framing
+branch of ``build_task_plan``. **Nothing stopped a second one appearing.** That is the
+whole risk — the claim is not defended by a design that makes a fork impossible, it is
+defended by there currently being only one place that asks the question. A single
+``if authors_manifest:`` added to a handler or the executor would falsify the release's
+architectural claim while every functional test stayed green, because both modes would
+still work; they would simply no longer be the same pipeline.
+
+Guard 1b (``test_authored_mode_equivalence``) is the other half and is not redundant
+with this one: a structural test proves nothing *branches*, not that the transformation
+is the same. This file is structure; that one is output.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.domain_cycles]
+
+_REPO = Path(__file__).resolve().parents[3]
+_PRODUCTION_ROOTS = (_REPO / "src", _REPO / "adapters")
+
+#: The predicate that answers "is this cycle authoring its own manifest?".
+_PREDICATE = "authors_interface_manifest"
+#: The one flag it produces, consumed by framing's step builder.
+_FLAG = "authors_manifest"
+#: The module the single legitimate call site lives in. The *function* is
+#: deliberately not pinned — see the framing-branch test.
+_CALL_SITE_MODULE = _REPO / "src" / "squadops" / "cycles" / "task_plan.py"
+
+
+def _production_files() -> list[Path]:
+    return sorted(p for root in _PRODUCTION_ROOTS for p in root.rglob("*.py"))
+
+
+def _calls_to(tree: ast.AST, name: str) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == name
+    ]
+
+
+def test_the_authoring_predicate_has_exactly_one_production_call_site():
+    """Bug caught: a second place asks "are we in authored mode?" and acts on it.
+
+    That is how a provenance flag becomes a pipeline fork. Both modes keep working, so
+    no functional test fails — the release's claim is simply no longer true. Definitions
+    and imports are fine; only *calls* count, because only a call can branch.
+    """
+    sites: list[str] = []
+    for path in _production_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for call in _calls_to(tree, _PREDICATE):
+            sites.append(f"{path.relative_to(_REPO)}:{call.lineno}")
+
+    assert len(sites) == 1, (
+        f"authoring mode is asked about in {len(sites)} places: {sites}. SIP-0103 §3.5 "
+        f"allows exactly one, inside framing — a second call site is a pipeline fork "
+        f"however small it looks."
+    )
+    assert sites[0].startswith("src/squadops/cycles/task_plan.py:")
+
+
+def test_the_one_call_site_is_inside_the_framing_branch():
+    """Bug caught: the predicate stays single-call-site but moves below framing.
+
+    Counting call sites alone would pass if the call were hoisted out of the framing
+    branch and the flag threaded into the implementation path — exactly the shape a
+    well-meaning refactor produces, and it would falsify the release's claim silently.
+
+    Deliberately keyed on the FRAMING guard rather than on an enclosing function name:
+    the plan recorded this call site as ``build_task_plan`` and it has since moved into
+    ``_resolve_workload_steps``, so a name-based assertion would already have rotted
+    once. What must hold is that the call is guarded by ``WorkloadType.FRAMING``,
+    wherever that guard lives.
+    """
+    tree = ast.parse(_CALL_SITE_MODULE.read_text(encoding="utf-8"))
+
+    framing_body_lines: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        if not any(
+            isinstance(cmp, ast.Attribute) and cmp.attr == "FRAMING" for cmp in ast.walk(node.test)
+        ):
+            continue
+        for stmt in node.body:
+            framing_body_lines.update(range(stmt.lineno, (stmt.end_lineno or stmt.lineno) + 1))
+
+    assert framing_body_lines, "task_plan.py no longer has a recognizable FRAMING branch"
+
+    call_lines = {call.lineno for call in _calls_to(tree, _PREDICATE)}
+
+    assert call_lines and call_lines <= framing_body_lines, (
+        f"the authoring predicate is called at {sorted(call_lines)}, outside any "
+        f"FRAMING-guarded branch — authoring mode must not be visible to another workload"
+    )
+
+
+def test_the_authoring_flag_never_leaves_the_framing_step_builder():
+    """Bug caught: the flag is threaded past framing into a downstream consumer.
+
+    ``authors_manifest`` decides one thing — whether framing gains an authoring stage.
+    If it appears in a handler, the executor, or any acceptance surface, authoring mode
+    has become an input to work below framing, which is the fork this guard exists to
+    prevent. Scoped to the single module that legitimately names it.
+    """
+    offenders = {
+        str(path.relative_to(_REPO))
+        for path in _production_files()
+        if _FLAG in path.read_text(encoding="utf-8")
+    }
+
+    assert offenders == {"src/squadops/cycles/task_plan.py"}, (
+        f"the authoring flag reaches {sorted(offenders - {'src/squadops/cycles/task_plan.py'})}; "
+        f"it may only decide framing's step list"
+    )
+
+
+def test_the_executor_reads_authoring_only_for_gate_and_artifact_vocabulary():
+    """Bug caught: the executor starts branching on authoring mode.
+
+    The executor legitimately imports two constants from the authoring module — the
+    machine gate-decision principal and the manifest artifact type — plus two
+    function-local imports for the question gate and the revision restart. None of those
+    is a mode branch. What must never appear there is the *predicate*, and pinning the
+    imported vocabulary keeps this test honest about what it is permitting rather than
+    silently allowing anything the executor cares to import later.
+    """
+    executor = _REPO / "adapters" / "cycles" / "dispatched_flow_executor.py"
+    tree = ast.parse(executor.read_text(encoding="utf-8"))
+
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and (node.module or "").endswith("cycles.manifest_authoring")
+        for alias in node.names
+    }
+
+    assert _PREDICATE not in imported
+    assert imported == {
+        "GATE_DECIDED_BY_NO_QUESTIONS",
+        "MANIFEST_ARTIFACT_TYPE",
+        "open_questions",
+        "REVISION_RESTART_TASK_TYPE",
+    }, (
+        f"the executor's authoring-module vocabulary changed to {sorted(imported)} — new "
+        f"names need review against SIP-0103 §3.5 before they are permitted here"
+    )


### PR DESCRIPTION
Cut-gate items **3 and 5**. Both halves of Guard 1 were verified **unbuilt** on 2026-08-09; the invariant has held only because nothing had broken it yet. Tests only — no production change.

SIP-0103's architectural claim is that authored mode is a mode of manifest **provenance, not a second pipeline**. Guard 1 defends it in two halves, and the plan is explicit that one is not sufficient for the other.

## Guard 1a — structure

No execution path branches on authoring mode below framing.

- the predicate has **exactly one production call site** across `src/` and `adapters/`
- that call sits **inside a FRAMING-guarded branch**
- the `authors_manifest` flag **never leaves** `task_plan.py`
- the executor's authoring-module vocabulary is **pinned to the four names** it legitimately imports — the gate principal, the artifact type, the question-gate helper, the revision restart — none of which is the predicate

The bug this catches is quiet: a single `if authors_manifest:` in a handler falsifies the release's claim while every functional test stays green, because both modes still *work*. They just stop being one pipeline.

**One thing found while building it.** The plan records this call site as `build_task_plan`; it has since moved into `_resolve_workload_steps`. So the test is keyed on the FRAMING guard rather than an enclosing function name — a name-based assertion would already have rotted once, on its first day.

## Guard 1b — output

Same manifest, same downstream bytes, different provenance. The **reference instance** — the one the 1.4 Functional App Yield window was measured against — is fed through both provenances, and the expanded skeleton, the derived verification contract, and the structural hash must all be identical.

1a cannot cover this. A fork can also arrive as a field that only authored manifests carry leaking into a hash or an emitted file: nothing branches, and the outputs diverge anyway.

`Provenance`'s own docstring already states this invariant. Stating it is not holding it — rendering provenance into an emitted file for traceability is a genuinely tempting change, and adding it to `_canonical` would move every bind-mode cycle's manifest hash and break the contract binding, with authored mode as the only mode that shows it. #783 already had to pin `decisions` out of the projection for exactly this reason.

**Two of the six tests exist so the other four cannot be vacuous:** the reference instance must still carry no provenance (otherwise both sides of every comparison are authored), and a real structural edit must still move the hash (otherwise `_canonical` could be gutted and every equivalence assertion would keep passing).

## Verification

| Mutation | Killed |
|---|---|
| a second call site of the authoring predicate | 2 tests |
| provenance enters `_canonical` | 2 tests |
| provenance rendered into an emitted file | 2 tests |
| the structural projection gutted (`stack` + `persistence` dropped) | 2 tests |

Regression **7336 passed**, 1 skipped. Offline and millisecond-scale — no deploy impact, so this is safe to merge during the roll window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
