### PR TITLE
fix(scaffold): show the qa author the error envelope, and stop the brief contradicting itself

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -481,15 +481,25 @@ class QATestHandler(_CycleTaskHandler):
         renderer = getattr(context.ports, "request_renderer", None)
         if renderer is None:
             return ""
+        from squadops.capabilities.scaffold import error_envelope_lines
         from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
         from squadops.capabilities.verification_scaffold_fill import coverage_inventory_lines
 
         record = VerificationScaffoldManifest.from_dict(manifest_dict)
         slot_lines = "\n".join(f"- {line}" for line in coverage_inventory_lines(record))
         shell_parts = [f"**{f['name']}:**\n```typescript\n{f['content']}\n```" for f in files]
+        # #911: half the slots are error behaviors and nothing showed the author the
+        # envelope, so it invented `body.error_code` on two consecutive window rolls.
+        # Keyed on the scaffold record's own stack — the fact is the stack's, not the
+        # run's, so it stays correct when the brief is rendered without a manifest.
+        envelope = "\n".join(f"- {line}" for line in error_envelope_lines(record.stack))
         rendered = await renderer.render(
             "request.qa_test_fill_mode_appendix",
-            {"slot_lines": slot_lines, "shell_files": "\n\n".join(shell_parts)},
+            {
+                "slot_lines": slot_lines,
+                "shell_files": "\n\n".join(shell_parts),
+                "error_envelope": envelope,
+            },
         )
         return rendered.content
 

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -27,7 +27,7 @@ import ast
 import hashlib
 import json
 import re
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -554,6 +554,96 @@ def fill_slot_paths(manifest: InterfaceManifest) -> tuple[str, ...]:
     return _stack(manifest.stack).fill_slots(manifest)
 
 
+@dataclass(frozen=True)
+class ErrorSeam:
+    """How one stack renders the error contract — the facts prompts must not guess.
+
+    The envelope is scaffold-owned: the expander writes it, freezes it, and every probe
+    and fill asserts against it. It was nonetheless absent from every surface an author
+    is shown (#911), and the one surface that described the *raise* convention asserted
+    stack #1's Python facts for every stack (#912). Both prompt surfaces now render from
+    this one declaration, so they cannot disagree with each other or drift from the
+    template that actually emits the bytes.
+
+    ``body_field`` is deliberately per-stack rather than read from the manifest's
+    declared ``error_contract.shape``: the two currently disagree for ``nextjs_ts``
+    (the manifest declares ``message``, the emitted ``lib/errors.ts`` writes ``detail``)
+    and #795 owns that reconciliation. Until it is settled, describing what the code
+    ACTUALLY emits is the only honest thing to tell an author — a brief that quoted the
+    declared shape would be confidently wrong.
+    """
+
+    #: The frozen module, as the author sees it on disk.
+    module: str
+    #: The import form that resolves to it in this stack.
+    import_form: str
+    #: The raise convention, with the constructor's REAL parameter names.
+    raise_form: str
+    #: The second field inside ``error`` — ``message`` (stack #1) or ``detail``.
+    body_field: str
+    #: The framework exception a dev wrongly reaches for on THIS stack, named so the
+    #: prohibition stays specific. ``HTTPException`` is what pf-33/pf-34 actually
+    #: produced; a generic "never a framework exception" would have lost that. Empty
+    #: when the stack has no such attractor — the clause is then omitted rather than
+    #: invented.
+    framework_exception: str = ""
+
+    def envelope_example(self, code: str) -> str:
+        """The literal JSON body a failing request returns, for a real declared code."""
+        return f'{{"error": {{"code": "{code}", "{self.body_field}": "..."}}}}'
+
+
+ERROR_SEAM_FASTAPI = ErrorSeam(
+    module="errors.py",
+    import_form="from .errors import ApiError",
+    raise_form="ApiError(code, message)",
+    body_field="message",
+    framework_exception="HTTPException",
+)
+
+ERROR_SEAM_NEXTJS_TS = ErrorSeam(
+    module="lib/errors.ts",
+    import_form="import { ApiError, errorResponse } from '@/lib/errors'",
+    raise_form="ApiError(code, detail)",
+    body_field="detail",
+)
+
+
+def error_seam_for(stack: str) -> ErrorSeam | None:
+    """The error seam for a stack, or ``None`` when it declares none."""
+    known = _STACKS.get(stack)
+    return known.error_seam if known else None
+
+
+def error_envelope_lines(stack: str, codes: Sequence[ErrorCode] = ()) -> list[str]:
+    """What a failing request's JSON body looks like — for the qa fill author (#911).
+
+    Half the fill slots in a typical build are error behaviors, and nothing the author
+    was shown stated this: the fill brief's only example was a success field, the frozen
+    surface rendered ``errorResponse(err: unknown): Response`` (a return type that
+    reveals nothing), and ``ERROR_STATUS`` rendered as a bare name. So the author
+    invented the path — ``body.error_code`` — on two consecutive window rolls, and no
+    downstream layer could tell the invention from an application defect, because an
+    assertion failure inside a fill is exactly what "the app is wrong" looks like.
+    """
+    seam = error_seam_for(stack)
+    if seam is None:
+        return []
+    sample = codes[0].code if codes else "validation_error"
+    lines = [
+        f"A failing request's JSON body is `{seam.envelope_example(sample)}`. The code is "
+        f"**nested under `error`** — read it as `body.error.code`. There is no top-level "
+        f"`error_code` field; asserting one reads `undefined` and fails.",
+        f"The frozen `{seam.module}` renders this envelope for every contract error; a "
+        f"route cannot vary it.",
+    ]
+    if codes:
+        lines.append(
+            "Declared codes → status: " + ", ".join(f"`{c.code}` → {c.http}" for c in codes) + "."
+        )
+    return lines
+
+
 def error_seam_instructions(manifest: InterfaceManifest | None) -> list[str]:
     """Authoritative error-contract lines for correction/repair prompts (pf-34).
 
@@ -570,18 +660,20 @@ def error_seam_instructions(manifest: InterfaceManifest | None) -> list[str]:
     error contract (author mode, non-scaffold stacks).
     """
     ec = manifest.api.error_contract if manifest is not None else None
-    if ec is None or not ec.codes:
+    seam = error_seam_for(manifest.stack) if manifest is not None else None
+    if ec is None or not ec.codes or seam is None:
         return []
     code_map = ", ".join(f"`{c.code}` → {c.http}" for c in ec.codes)
     return [
         (
-            "on failure raise `ApiError(code, message)` (imported from `.errors`): the "
-            "FIRST argument is the error-code STRING, the second a human message — "
-            "never `ApiError(status_code=..., detail=...)` and never `HTTPException` "
-            "for contract errors; the frozen `errors.py` maps the code to the HTTP "
-            "status and renders the pinned envelope"
+            f"on failure raise `{seam.raise_form}` (`{seam.import_form}`): the FIRST "
+            f"argument is the error-code STRING, the second a human-readable string — "
+            f"never `ApiError(status_code=..., detail=...)`"
+            + (f" and never `{seam.framework_exception}`" if seam.framework_exception else "")
+            + f" for contract errors; the frozen `{seam.module}` maps the code to the "
+            f"HTTP status and renders the pinned envelope"
         ),
-        f"valid error codes (code → HTTP status, mapped by frozen `errors.py`): {code_map}",
+        f"valid error codes (code → HTTP status, mapped by frozen `{seam.module}`): {code_map}",
     ]
 
 
@@ -806,6 +898,15 @@ _TS_CONSTRUCTOR = re.compile(r"constructor\s*\(([^)]*)\)", re.S)
 #: rendered signature is the call form, not the declaration form.
 _TS_PARAM_MODIFIERS = re.compile(r"^(?:(?:public|private|protected|readonly)\s+)+")
 _TS_CONST = re.compile(r"^export\s+const\s+(\w+)", re.M)
+#: #875: a const's TYPE and VALUES are facts no author was shown — `exports
+#: ERROR_STATUS` alone let roll 13's qa author call `.get()` on a Record (a
+#: TypeError inside the tests) and invent the status values it maps. Captures the
+#: annotation and an inline object literal so both can be rendered.
+_TS_CONST_DECL = re.compile(
+    r"^export\s+const\s+(?P<name>\w+)(?:\s*:\s*(?P<type>[^=\n]+?))?\s*=\s*"
+    r"(?P<body>\{[^}]*\})?",
+    re.M,
+)
 _TS_FIELD = re.compile(r"^\s{2}(\w+\??: *[^\n;,]+)", re.M)
 _TS_IMPORT = re.compile(r"""^import\s+[^'"]*from\s+['"]([^'"]+)['"]""", re.M)
 
@@ -833,6 +934,36 @@ def _ts_param_list(params: str) -> list[str]:
             current += ch
     segments.append(current)
     return [" ".join(seg.split()) for seg in segments if seg.strip()]
+
+
+def _ts_const_surface(source: str, names: list[str]) -> list[str]:
+    """Each exported const as ``NAME: type = {k: v, ...}`` where the source declares it.
+
+    #875: rendering the bare name told an author that ``ERROR_STATUS`` exists and nothing
+    more — not that it is a ``Record`` rather than a ``Map``, and not which statuses it
+    maps. Roll 13's qa suite called ``.get()`` on it (a runtime TypeError inside the
+    tests) and asserted a status the map does not contain. Both facts are right there in
+    the frozen source.
+
+    Values are rendered only for an inline object literal, and only when short: the
+    surface index is a reminder of declarations, not a second copy of the file. A const
+    with a computed or long body degrades to name-and-type, which is still strictly more
+    than the name alone.
+    """
+    declared: dict[str, str] = {}
+    for match in _TS_CONST_DECL.finditer(source):
+        name = match.group("name")
+        type_hint = (match.group("type") or "").strip()
+        body = (match.group("body") or "").strip()
+        rendered = name
+        if type_hint:
+            rendered = f"{rendered}: {type_hint}"
+        if body:
+            compact = " ".join(body.split())
+            if len(compact) <= 120:
+                rendered = f"{rendered} = {compact}"
+        declared[name] = rendered
+    return [declared.get(name, name) for name in names]
 
 
 def _ecmascript_surface(source: str) -> str:
@@ -900,7 +1031,7 @@ def _ecmascript_surface(source: str) -> str:
     if classes:
         parts.append("classes " + ", ".join(classes))
     if consts:
-        parts.append("exports " + ", ".join(consts))
+        parts.append("exports " + ", ".join(_ts_const_surface(source, consts)))
     if functions:
         parts.append("functions " + ", ".join(functions))
     if modules:
@@ -1740,6 +1871,15 @@ class ScaffoldStack:
     #: rather than declare it approximately. Set-but-unregistered refuses at emission
     #: (the #838 two-registries-disagree class).
     verification_scaffold: str = ""
+    #: #911/#912: how this stack renders the error contract — the frozen module, the
+    #: import and raise forms, and the envelope's second field. A *value*, not a name:
+    #: unlike the registries the fields above index, this is four short strings with no
+    #: other layer that owns them, and the two prompt surfaces that need it (repair
+    #: instructions and the qa fill brief) must render from ONE declaration or they
+    #: drift apart — which is exactly how a Python `errors.py` came to be described to
+    #: a TypeScript author. Unset means the stack states no seam and both surfaces stay
+    #: silent rather than guessing.
+    error_seam: ErrorSeam | None = None
 
 
 _STACKS: dict[str, ScaffoldStack] = {
@@ -1754,6 +1894,7 @@ _STACKS: dict[str, ScaffoldStack] = {
         # later stack can share one (a FastAPI+Vue stack wants these same backend criteria)
         # without minting a fourth stack vocabulary to express it.
         criteria_pack="fullstack_fastapi_react",
+        error_seam=ERROR_SEAM_FASTAPI,
         probe_profile="fastapi_uvicorn",
         dev_capability="fullstack_fastapi_react",
     ),
@@ -1776,6 +1917,7 @@ _STACKS: dict[str, ScaffoldStack] = {
         # conservative default, and #822 bend 6).
         check_stack="",
         criteria_pack=_NEXTJS_TS_NAME,
+        error_seam=ERROR_SEAM_NEXTJS_TS,
         probe_profile="nextjs_next_start",
         dev_capability=_NEXTJS_TS_NAME,
         # SIP-0104: the first (and so far only) stack with a deterministic test scaffold.

--- a/src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md
+++ b/src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md
@@ -4,7 +4,8 @@ version: "1"
 required_variables:
   - slot_lines
   - shell_files
-optional_variables: []
+optional_variables:
+  - error_envelope
 ---
 ## FILL MODE: a deterministic test scaffold already covers the mechanics (SIP-0104)
 
@@ -15,8 +16,13 @@ mechanical layer is done. Your job is the residual semantic layer only: response
 store effects, cross-operation semantics, PRD-derived properties the contract cannot
 express.
 
-**Already covered deterministically (do not re-test these behaviors mechanically):**
+**YOUR SLOTS — fill every one of these:**
 {{slot_lines}}
+
+Each line names a slot and the behavior its shell already invokes and status-asserts.
+That mechanical half is done, so do not re-assert placement, invocation or the declared
+status inside a fill. **The slot itself still needs your assertions**: what the response
+should CONTAIN and what the store should look like afterwards.
 
 **For the scaffold, emit FILL BLOCKS addressed by slot id — nothing else can address a
 slot:**
@@ -24,6 +30,14 @@ slot:**
 ```fill:slot-<id>
     expect(body.id).toBeTruthy()
     expect(all('runs')).toHaveLength(1)
+```
+
+**Error responses — read the envelope, do not guess it:**
+{{error_envelope}}
+
+```fill:slot-<id>
+    expect(body.error.code).toBe('validation_error')
+    expect(all('runs')).toHaveLength(0)
 ```
 
 Fill EVERY slot listed above — with domain assertions, or with an explicit

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -926,3 +926,122 @@ class TestDomAnchorContract:
         bare_routes = tuple(dataclasses.replace(r, testids=()) for r in m.frontend.routes)
         bare = dataclasses.replace(m, frontend=dataclasses.replace(m.frontend, routes=bare_routes))
         assert scaffold.testid_surface_instructions(bare) == []
+
+
+class TestErrorSeamIsPerStack:
+    """#912 — one shared text asserted stack #1's Python facts for every stack."""
+
+    def test_each_stack_names_its_own_module_import_and_parameter(self):
+        """Bug caught: a nextjs_ts repair is told to edit `errors.py` and pass `message`.
+
+        The file is `lib/errors.ts` and the constructor parameter is `detail`. This is
+        the #902 class in a second location — a shared prompt surface stating one
+        stack's facts as universal — and it fires exactly when a repair is trying to fix
+        an error-envelope defect, which is what window rolls 2 and 3 were both doing.
+        """
+        from squadops.capabilities.scaffold import error_seam_for
+
+        fastapi = error_seam_for("fullstack_fastapi_react")
+        nextjs = error_seam_for("nextjs_ts")
+
+        assert (fastapi.module, fastapi.body_field) == ("errors.py", "message")
+        assert (nextjs.module, nextjs.body_field) == ("lib/errors.ts", "detail")
+        assert "@/lib/errors" in nextjs.import_form
+        assert "ApiError(code, detail)" == nextjs.raise_form
+
+    def test_the_framework_exception_clause_is_named_only_where_one_exists(self):
+        """Bug caught: generalizing the prohibition loses the name that made it work.
+
+        `HTTPException` is what pf-33/pf-34 devs actually reached for on stack #1, so
+        naming it is the point. Next.js has no equivalent attractor, and inventing one
+        would teach a nonexistent fact — the clause is omitted instead.
+        """
+        from squadops.capabilities.scaffold import error_seam_for
+
+        assert error_seam_for("fullstack_fastapi_react").framework_exception == "HTTPException"
+        assert error_seam_for("nextjs_ts").framework_exception == ""
+
+
+class TestErrorEnvelopeLines:
+    """#911 — the envelope's body shape, stated instead of guessed."""
+
+    def test_the_nested_path_is_stated_and_the_invented_one_named(self):
+        """Bug caught: the author asserts `body.error_code` and reads undefined.
+
+        It did exactly that on two consecutive window rolls. Naming the wrong form
+        explicitly is deliberate — #902 established that showing the correct form alone
+        is weaker than showing correct-and-wrong side by side, because the wrong form is
+        what the model already believes.
+        """
+        from squadops.capabilities.scaffold import error_envelope_lines
+
+        lines = error_envelope_lines("nextjs_ts")
+        joined = " ".join(lines)
+
+        assert '{"error": {"code": "validation_error", "detail": "..."}}' in joined
+        assert "body.error.code" in joined
+        assert "error_code" in joined  # the invented form, named as wrong
+
+    def test_each_stack_describes_its_own_envelope(self):
+        """Bug caught: one envelope described for both stacks.
+
+        They genuinely differ — stack #1 emits `message`, stack #2 emits `detail` — so a
+        single description would be wrong for one of them, which is the defect this
+        whole seam exists to stop.
+        """
+        from squadops.capabilities.scaffold import error_envelope_lines
+
+        assert '"message"' in " ".join(error_envelope_lines("fullstack_fastapi_react"))
+        assert '"detail"' in " ".join(error_envelope_lines("nextjs_ts"))
+
+    def test_an_unknown_stack_says_nothing_rather_than_guessing(self):
+        """A stack with no declared seam must produce no lines. A guessed envelope is
+        worse than silence: the author would assert against a shape nothing emits and
+        the failure would look like an application defect."""
+        from squadops.capabilities.scaffold import error_envelope_lines
+
+        assert error_envelope_lines("") == []
+        assert error_envelope_lines("some_future_stack") == []
+
+
+class TestTypeScriptConstSurface:
+    """#875 — a const's type and values are facts, not decoration."""
+
+    def test_a_record_const_renders_its_type_and_values(self):
+        """Bug caught: `exports ERROR_STATUS` tells an author the name and nothing else.
+
+        Roll 13's qa suite called `.get()` on it — a runtime TypeError, since it is a
+        Record and not a Map — and asserted a status the map does not contain. Both
+        facts are in the frozen source the surface is derived from.
+        """
+        from squadops.capabilities.scaffold import _ecmascript_surface
+
+        rendered = _ecmascript_surface(
+            "export const ERROR_STATUS: Record<string, number> = {\n"
+            "  validation_error: 400,\n"
+            "  run_not_found: 404\n"
+            "}\n"
+        )
+
+        assert "Record<string, number>" in rendered
+        assert "validation_error: 400" in rendered
+        assert "run_not_found: 404" in rendered
+
+    def test_a_long_or_computed_const_degrades_to_name_and_type(self):
+        """The surface index is a reminder of declarations, not a second copy of the
+        file. A const built by a call has no literal to show, and an oversized literal
+        would crowd out every other line — both degrade to name-and-type, which is still
+        strictly more than the bare name."""
+        from squadops.capabilities.scaffold import _ecmascript_surface
+
+        computed = _ecmascript_surface("export const CONFIG: AppConfig = buildConfig()\n")
+        assert "CONFIG: AppConfig" in computed
+        assert "buildConfig" not in computed
+
+        long_literal = _ecmascript_surface(
+            "export const BIG: Record<string, string> = {\n"
+            + "".join(f"  key_{i}: 'value_{i}',\n" for i in range(20))
+            + "}\n"
+        )
+        assert "BIG: Record<string, string>" in long_literal
+        assert "key_19" not in long_literal

--- a/tests/unit/cycles/goldens/context_assembly.json
+++ b/tests/unit/cycles/goldens/context_assembly.json
@@ -59,7 +59,7 @@
    "art_config"
   ],
   "error_contract": [
-   "on failure raise `ApiError(code, message)` (imported from `.errors`): the FIRST argument is the error-code STRING, the second a human message \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
+   "on failure raise `ApiError(code, message)` (`from .errors import ApiError`): the FIRST argument is the error-code STRING, the second a human-readable string \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
    "valid error codes (code \u2192 HTTP status, mapped by frozen `errors.py`): `validation_error` \u2192 422, `run_not_found` \u2192 404, `duplicate_participant` \u2192 409, `participant_not_found` \u2192 404"
   ],
   "frozen_surface": [
@@ -115,7 +115,7 @@
    "art_config"
   ],
   "error_contract": [
-   "on failure raise `ApiError(code, message)` (imported from `.errors`): the FIRST argument is the error-code STRING, the second a human message \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
+   "on failure raise `ApiError(code, message)` (`from .errors import ApiError`): the FIRST argument is the error-code STRING, the second a human-readable string \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
    "valid error codes (code \u2192 HTTP status, mapped by frozen `errors.py`): `validation_error` \u2192 422, `run_not_found` \u2192 404, `duplicate_participant` \u2192 409, `participant_not_found` \u2192 404"
   ],
   "frozen_surface": [

--- a/tests/unit/cycles/goldens/correction_context.json
+++ b/tests/unit/cycles/goldens/correction_context.json
@@ -130,7 +130,7 @@
       ],
       "error": "validation failed",
       "error_contract": [
-       "on failure raise `ApiError(code, message)` (imported from `.errors`): the FIRST argument is the error-code STRING, the second a human message \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
+       "on failure raise `ApiError(code, message)` (`from .errors import ApiError`): the FIRST argument is the error-code STRING, the second a human-readable string \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
        "valid error codes (code \u2192 HTTP status, mapped by frozen `errors.py`): `validation_error` \u2192 422, `run_not_found` \u2192 404, `duplicate_participant` \u2192 409, `participant_not_found` \u2192 404"
       ],
       "failed_task_id": "task-development.develop",
@@ -255,7 +255,7 @@
       },
       "error": "no artifacts extracted",
       "error_contract": [
-       "on failure raise `ApiError(code, message)` (imported from `.errors`): the FIRST argument is the error-code STRING, the second a human message \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
+       "on failure raise `ApiError(code, message)` (`from .errors import ApiError`): the FIRST argument is the error-code STRING, the second a human-readable string \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
        "valid error codes (code \u2192 HTTP status, mapped by frozen `errors.py`): `validation_error` \u2192 422, `run_not_found` \u2192 404, `duplicate_participant` \u2192 409, `participant_not_found` \u2192 404"
       ],
       "failed_task_id": "task-qa.test",

--- a/tests/unit/prompts/test_qa_test_fragment.py
+++ b/tests/unit/prompts/test_qa_test_fragment.py
@@ -54,3 +54,63 @@ def test_the_pytest_discovery_rule_is_scoped_to_python_workspaces():
     assert conditioned < pytest_rule
 
     assert "single TypeScript application" in _FRAGMENT
+
+
+class TestFillModeBriefInstructions:
+    """#910 — the brief told the author two opposite things about the same slots."""
+
+    @staticmethod
+    def _brief() -> str:
+        from pathlib import Path
+
+        return (
+            Path(__file__).resolve().parents[3]
+            / "src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md"
+        ).read_text(encoding="utf-8")
+
+    def test_the_slot_list_reads_as_an_instruction_not_a_prohibition(self):
+        """Bug caught: the heading over the fill list says not to test these behaviors.
+
+        It read "Already covered deterministically (do not re-test these behaviors
+        mechanically)" over the exact eight slots the brief then demands be filled.
+        Window roll 3 left all eight unfilled, rolls 1 and 2 left some — a correction
+        round lost per roll to an instruction the author was following.
+        """
+        brief = self._brief()
+        heading = brief.split("{{slot_lines}}")[0].rsplit("\n\n", 1)[-1]
+
+        assert "do not re-test" not in heading.lower(), (
+            "the heading immediately above the slot list must not tell the author to "
+            "skip them — that is the instruction roll 3 obeyed"
+        )
+        assert "fill" in heading.lower()
+
+    def test_the_error_envelope_is_carried_and_shown_in_a_worked_example(self):
+        """Bug caught: the brief's only body example is a success field.
+
+        Four of eight slots are error behaviors. With no error-path example and no
+        envelope statement, the author invents the field name — `body.error_code` on two
+        consecutive window rolls.
+        """
+        brief = self._brief()
+
+        assert "{{error_envelope}}" in brief
+        assert "body.error.code" in brief
+
+    def test_every_declared_variable_is_actually_substituted(self):
+        """Bug caught: a variable declared in the frontmatter but never rendered, or
+        rendered but undeclared — either leaves a literal `{{...}}` in the prompt or an
+        unfilled fact, and both reach the agent silently."""
+        import re
+
+        import yaml
+
+        brief = self._brief()
+        header = brief.split("---")[1]
+        meta = yaml.safe_load(header)
+        declared = set(meta.get("required_variables") or []) | set(
+            meta.get("optional_variables") or []
+        )
+        used = set(re.findall(r"\{\{(\w+)\}\}", brief))
+
+        assert used == declared, f"declared={sorted(declared)} used={sorted(used)}"


### PR DESCRIPTION
Closes #910. Closes #911. Closes #875. Closes #912.

Three fixes against one failure, plus a fourth that could not be separated from them.

**The qa fill author cannot see the error response's body shape, so it invents one.** Window rolls 2 and 3 both died asserting `body.error_code` against a frozen `{ error: { code, detail } }`. Roll 3 exhausted its correction budget on it.

## #910 — the brief contradicted itself

The fill brief rendered the slot list under:

> **Already covered deterministically (do not re-test these behaviors mechanically):**

and then, four paragraphs later, about the same eight slots: *"Fill EVERY slot listed above."*

| Roll | First-pass fills |
|---|---|
| 1 | some slots unfilled |
| 2 | five unfilled |
| 3 | **all eight** unfilled |

Read in order, the author was obeying the first instruction. The heading is now an instruction; the coverage claim moved into the prose beneath it.

## #911 — the envelope, stated instead of guessed

Absent from all three surfaces the author could consult: the brief's only body example was `expect(body.id)`, the frozen surface rendered `errorResponse(err: unknown): Response`, and `ERROR_STATUS` was a bare name. Four of eight slots are error behaviors.

The brief now carries the envelope verbatim plus a worked error-path example beside the success-path one, and names the invented form explicitly — #902 established that showing the correct form alone is weaker than showing correct-and-wrong together, because the wrong form is what the model already believes.

**Nothing downstream could have caught this.** An assertion failure inside a fill — `expected undefined to be 'validation_error'` — is *indistinguishable* from "the app is wrong", because that is what an assertion failure means. Roll 3's analyzer classified it `work_product` and sent three consecutive repairs at the route handlers. No better analyzer would differ; the information to separate the two cases does not exist at that point. Making the name unguessable is the only cure.

## #875 — a const's type and values

`exports ERROR_STATUS` told an author the name and nothing else. Roll 13's suite called `.get()` on it — a runtime TypeError, since it is a `Record` and not a `Map` — and invented the statuses. Now rendered as `ERROR_STATUS: Record<string, number> = { validation_error: 400, ... }`; long or computed literals degrade to name-and-type.

## #912 — a consequence, not scope creep

Doing #911 alone would have minted a **second** error-seam prompt surface beside `error_seam_instructions`, which already owns this concern — and which was itself stack-#1-shaped, telling a TypeScript author about `errors.py` and `ApiError(code, message)`. Both surfaces now render from one `ErrorSeam` per stack, so they cannot drift from each other or from the template that emits the bytes.

## Two deliberate design calls

**`body_field` is per-stack, not read from the manifest.** The manifest declares `message` for `nextjs_ts`; the emitted `lib/errors.ts` writes `detail`. #795 owns that reconciliation. Until it is settled, describing what the code *actually emits* is the only honest thing to tell an author — quoting the declared shape would be confidently wrong.

**`framework_exception` is per-stack for the opposite reason.** My first pass generalized "never `HTTPException`" to "never a framework exception" and **lost the name that made the prohibition work** on stack #1 (pf-33/pf-34). A test caught it. Next.js has no equivalent attractor, so the clause is omitted there rather than invented.

## Verification

Context goldens regenerated deliberately; stack #1's only delta is a more concrete import form (`from .errors import ApiError` rather than "imported from `.errors`"), with `HTTPException` preserved. Regression **7346 passed**.

Agent-side only — no generator change, no byte pins moved, no `GENERATOR_VERSION` bump.

**Not fixed here**, and filed: **#913**, the uncovered surface the window named — the shells pin the status but not the response body, so response-field paths are still re-invented in every fill. That is a generator change and is blocked on #795 settling which envelope is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
