### PR TITLE
fix(authoring): the sole-author path had a private, drifted copy of the check vocabulary

### DIFF
--- a/src/squadops/capabilities/handlers/_plan_authoring_service.py
+++ b/src/squadops/capabilities/handlers/_plan_authoring_service.py
@@ -30,7 +30,10 @@ from squadops.capabilities.handlers.cycle_tasks import (
     _rewrite_manifest_identifiers,
 )
 from squadops.capabilities.handlers.fenced_parser import extract_fenced_files
-from squadops.cycles.acceptance_check_spec import command_safelist_names
+from squadops.cycles.acceptance_check_spec import (
+    command_safelist_names,
+    render_typed_acceptance_vocabulary,
+)
 from squadops.cycles.implementation_plan import (
     ImplementationPlan,
     planner_build_task_types,
@@ -151,49 +154,18 @@ async def produce_plan(
         "A `severity: error` typed check that fails BLOCKS the build (triggers self-eval / correction).\n\n"
         "Typed-check shape: a flat YAML map with `check`, optional `severity` (`error` "
         "default | `warning` | `info`), optional `description`, plus check-specific keys.\n\n"
-        "**Vocabulary (one example each):**\n\n"
-        "```yaml\n"
-        "# endpoint_defined — FastAPI route presence (stack: fastapi)\n"
-        "- check: endpoint_defined\n"
-        "  severity: error\n"
-        '  description: "Backend exposes the user CRUD routes"\n'
-        "  file: backend/main.py\n"
-        '  methods_paths: ["GET /users", "POST /users", "DELETE /users/{uid}"]\n'
-        "\n"
-        "# import_present — Python import (or .ts/.js with frontend flag)\n"
-        "- check: import_present\n"
-        '  description: "Pydantic is wired in for request models"\n'
-        "  file: backend/main.py\n"
-        "  module: pydantic\n"
-        "  symbol: BaseModel\n"
-        "\n"
-        "# field_present — class fields on a Python dataclass / Pydantic v2 model\n"
-        "- check: field_present\n"
-        '  description: "User model carries id and email"\n'
-        "  file: backend/models.py\n"
-        "  class_name: User\n"
-        "  fields: [id, email]\n"
-        "\n"
-        "# regex_match — pattern present count_min times in a file (stack-agnostic)\n"
-        "- check: regex_match\n"
-        '  description: "At least three test functions exist"\n'
-        "  file: tests/test_users.py\n"
-        # Single-quote regex patterns: double quotes interpret backslash escapes
-        # (\w, \.) and break yaml.safe_load. See acceptance_check_spec.CHECK_SPECS.
-        "  pattern: 'def test_\\w+'\n"
-        "  count_min: 3\n"
-        "\n"
-        "# count_at_least — glob match count under workspace (stack-agnostic)\n"
-        "- check: count_at_least\n"
-        '  description: "Non-trivial component coverage on the frontend"\n'
-        '  glob: "frontend/src/components/**/*.tsx"\n'
-        "  min_count: 3\n"
-        "\n"
-        "# command_exit_zero — argv-only safelist of static checkers; cannot run shell strings\n"
-        "- check: command_exit_zero\n"
-        '  description: "Backend file syntactically valid"\n'
-        "  argv: [python, -m, py_compile, backend/main.py]\n"
-        "```\n\n"
+        # #918: the vocabulary is RENDERED from CHECK_SPECS, never restated. A
+        # hand-written copy lived here and drifted from the registry the gate reads:
+        # it labelled `regex_match` "stack-agnostic", demonstrated it on
+        # `tests/test_users.py` (a SOURCE file), and omitted the document-only note
+        # the registry carries. Window roll 4 copied that example near-verbatim —
+        # "At least three test functions exist" became "At least five test functions
+        # exist" against a .ts file — and was system-rejected at the framing gate.
+        # The proposers have rendered the derived vocabulary since #182; this path,
+        # which authors the plan on every CRP but `validation-multirole`, had a
+        # private duplicate. Same class as #856 on the same path.
+        + render_typed_acceptance_vocabulary()
+        + "\n"
         "**Safety rules for `command_exit_zero`:**\n"
         '- `argv` MUST be a YAML list, not a string. `"ruff check src/"` is rejected.\n'
         # #707: rendered from COMMAND_SAFELIST, never restated. This block used to

--- a/tests/unit/prompts/test_authoring_examples_pass_the_gate.py
+++ b/tests/unit/prompts/test_authoring_examples_pass_the_gate.py
@@ -164,3 +164,96 @@ def test_every_example_criterion_uses_a_real_check_with_real_parameters():
                     problems.append(f"{name}: {check} given unknown {sorted(unknown)}")
 
     assert problems == [], "authoring examples teach invalid criteria:\n  " + "\n  ".join(problems)
+
+
+# --------------------------------------------------------------------------- #
+# The sole-author path renders its vocabulary from Python, not from a .md asset,
+# so the asset sweep above cannot see it — and that is exactly where the drift
+# that cost window roll 4 was hiding (#918).
+# --------------------------------------------------------------------------- #
+
+
+def _sole_author_vocabulary() -> str:
+    from squadops.cycles.acceptance_check_spec import render_typed_acceptance_vocabulary
+
+    return render_typed_acceptance_vocabulary()
+
+
+def test_the_sole_author_path_renders_the_derived_vocabulary():
+    """Bug caught: a second, hand-maintained copy of the check vocabulary.
+
+    `_plan_authoring_service` carried its own inline vocabulary block. It drifted from
+    the registry the gate reads — labelling `regex_match` "stack-agnostic", demonstrating
+    it on `tests/test_users.py` (a source file), and omitting the document-only note.
+    Window roll 4 copied that example near-verbatim and was rejected at the framing gate.
+
+    The proposers have rendered the derived vocabulary since #182; the sole-author path —
+    which authors the plan on every CRP but `validation-multirole` — had a private
+    duplicate. Same class as #856, same path.
+    """
+    import inspect
+
+    from squadops.capabilities.handlers import _plan_authoring_service
+
+    source = inspect.getsource(_plan_authoring_service)
+
+    assert "render_typed_acceptance_vocabulary()" in source, (
+        "the sole-author path must render the derived vocabulary, not restate it"
+    )
+    # The specific drifted strings, so a re-introduced hand-copy is caught by content
+    # rather than by hoping someone notices a new block.
+    for drifted in ('"# regex_match — pattern present', "file: tests/test_users.py"):
+        assert drifted not in source, f"a hand-written vocabulary example is back: {drifted!r}"
+
+
+def test_every_vocabulary_example_survives_the_gate_that_judges_it():
+    """Bug caught: the rendered menu demonstrates a criterion production rejects.
+
+    This is the roll-4 defect stated generally. The vocabulary is what a sole author
+    copies from, so an example in it that the gate refuses is a guaranteed rejection
+    shipped to every cycle.
+    """
+    import re as _re
+
+    import yaml as _yaml
+
+    from squadops.cycles.implementation_plan import ImplementationPlan
+
+    criteria: list[dict] = []
+    for block in _re.findall(r"```yaml\n(.*?)```", _sole_author_vocabulary(), _re.S):
+        parsed = _yaml.safe_load(block)
+        if isinstance(parsed, list):
+            criteria.extend(c for c in parsed if isinstance(c, dict))
+
+    assert criteria, "no vocabulary examples parsed — the extractor drifted"
+
+    plan = ImplementationPlan.from_yaml(
+        _yaml.safe_dump(
+            {
+                "version": 1,
+                "project_id": "p",
+                "cycle_id": "c",
+                "run_id": "r",
+                "prd_hash": "h",
+                "summary": {"objective": "o"},
+                "tasks": [
+                    {
+                        "task_index": 0,
+                        "task_type": "qa.test",
+                        "role": "qa",
+                        "agent": "a",
+                        "title": "vocabulary examples",
+                        "focus": "vocabulary examples",
+                        "description": "d",
+                        "expected_artifacts": ["x"],
+                        "acceptance_criteria": criteria,
+                    }
+                ],
+            }
+        )
+    )
+
+    assert plan.validate_criteria_scope() == [], (
+        "the vocabulary shipped to plan authors demonstrates a criterion the gate "
+        "rejects — this is what cost window roll 4 its framing run"
+    )


### PR DESCRIPTION
Closes #918.

**The plan author on every window roll was reading a private, drifted copy of the check vocabulary.**

`_plan_authoring_service` inlined its own hand-written vocabulary block instead of rendering `CHECK_SPECS`. It had drifted from the registry the gate reads:

```
# regex_match — pattern present count_min times in a file (stack-agnostic)
- check: regex_match
  description: "At least three test functions exist"
  file: tests/test_users.py
```

Three defects in five lines: `regex_match` is not stack-agnostic (the gate rejects it on source, on every stack); the example targets a **source file**, the exact shape `validate_criteria_scope` refuses; and it omits the document-only note that `CHECK_SPECS` carries and the derived renderer emits.

**Window roll 4 copied it near-verbatim** — *"At least three test functions exist"* became *"At least five test functions exist"* against `__tests__/runs.test.ts` — and was system-rejected at the framing gate after 67 minutes.

## Why it survived

The **proposers** have rendered the derived vocabulary since #182. The **sole-author path** never did — and it writes the plan on every CRP except `validation-multirole`, which is every roll of this window.

That is the same class as **#856**, on this same file, whose own comment reads: *"the proposers and the brief author have rendered these since #686; this path did not, so the author that actually writes the plan on every CRP was the one never shown them."* #856 fixed it for the authoring **rules**. The **vocabulary** stayed duplicated.

## Correction on #917

#917 fixed this same defect in `request.qa_propose_plan_tasks` — a **proposer** asset. That was a real defect and the fix stands, but these rolls are sole-author and never render it, so **#917 alone would not have changed roll 5.** This is the copy they actually read. I would have launched roll 5 on an unfixed path.

## The fix

Render `render_typed_acceptance_vocabulary()`. The surrounding prose that is genuinely additional is kept — the `command_exit_zero` safety rules and the behavioral > structural > textual hierarchy.

Two tests, both mutation-verified:

| Guard | Mutation that kills it |
|---|---|
| the path renders rather than restates, keyed on the drifted strings | re-introducing the hand-written block |
| every example in the rendered vocabulary survives the gate's own validator | pointing `regex_match`'s own `CheckSpec.example` at a source file |

**The #917 sweep could not have caught this** — it walks `.md` assets and this block is Python. That gap is now closed from the other side.

Regression **7351**. Agent-side plus tests; no generator change, no pins moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
