### PR TITLE
docs(sip-cba): duty-shaped steward, versioning question, and the pack configuration lifecycle

### DIFF
--- a/sips/proposed/SIP-Capability-Backed-Agents.md
+++ b/sips/proposed/SIP-Capability-Backed-Agents.md
@@ -231,6 +231,7 @@ Umbrella phases; each becomes its own bounded implementation SIP. Per the roadma
 ## 20. Open Questions
 
 1. Storage layout for the workspace — logical projection over the artifact vault, DB-backed, filesystem-like, or hybrid?
+   *Related but distinct: where the PACK CONFIGURATION artifact lives is §26h Q15.*
 2. Manifest format — YAML/TOML/Python entry points/registry?
 3. Plugin discovery — Python packaging, Switchboard, config, or a dedicated registry?
    *Resolved by owner (2026-07-29): **Switchboard is the presumptive substrate** — §21.*
@@ -243,6 +244,8 @@ Umbrella phases; each becomes its own bounded implementation SIP. Per the roadma
 10. Architecture pack — part of this umbrella or a follow-on SIP?
 11. Which native capabilities migrate first after the Design pack?
 12. Do binding contracts declare required model class/context, or is model fit advisory?
+    *Advanced (2026-08-15): **requirements are data, model choice is host resolution** — §26d.
+    Buys a preflight check; the override grain in the configuration artifact remains open.*
 13. Version pinning — exact capability versions or semver ranges in roster bindings?
     *Advanced (2026-07-29): layered scheme with loud load-time enforcement — §21; the
     roster-binding pinning grain (exact vs range) remains open.*
@@ -350,7 +353,7 @@ to be already-loaded into a privileged host).
 
 ## 22. Product Decisions
 
-1. Capability packs are plugin-backed extensions. 2. Packs do not own named agents. 3. Binding contracts are required (agent-agnostic ≠ prerequisite-free). 4. Roster bindings are explicit (install ≠ authority). 5. Assignments activate capabilities. 6. Working-set assembly is first-class. 7. Memory is scoped and promoted, never raw accumulation. 8. Workspace artifacts are shared squad work-state. 9. The Design pack is the reference. 10. Iris applies; Glyph stewards — **and their default runtime postures differ: Iris is cycle-bound, Glyph is duty-shaped, with a published design-system version as the duty's unit of output (§25a)**. 11. Existing agents adopt plugin capabilities before any rewrite. 12. **Skill-mediated tool use extends SIP-0040; capabilities never touch raw tools directly.**
+1. Capability packs are plugin-backed extensions. 2. Packs do not own named agents. 3. Binding contracts are required (agent-agnostic ≠ prerequisite-free). 4. Roster bindings are explicit (install ≠ authority) — **install materializes a configuration STUB, never a binding (§26a)**. 5. Assignments activate capabilities. 6. Working-set assembly is first-class. 7. Memory is scoped and promoted, never raw accumulation. 8. Workspace artifacts are shared squad work-state. 9. The Design pack is the reference. 10. Iris applies; Glyph stewards — **and their default runtime postures differ: Iris is cycle-bound, Glyph is duty-shaped, with a published design-system version as the duty's unit of output (§25a)**. 11. Existing agents adopt plugin capabilities before any rewrite. 12. **Skill-mediated tool use extends SIP-0040; capabilities never touch raw tools directly.** 13. **Pack configuration is one artifact with many editors — file, CLI and console pane all write the same store (§26b).** 14. **A pack declares secrets by NAME; the host resolves them through the existing provider and the pack never holds a value (§26e).** 15. **Configuration verbs are generic over a declared schema; domain actions are capabilities, not CLI commands (§26f).**
 
 ## 23. Relationship to Existing SIPs
 
@@ -472,6 +475,162 @@ The path from there is incremental and keeps that property at every step: make t
 a **versioned resource** → let Iris **select** from it → let Glyph **propose changes** to it.
 Each rung is testable before the next is built, and the first rung answers §25b empirically
 rather than by argument.
+
+## 26. Pack lifecycle, attribution, and configuration (2026-08-15)
+
+§21 settles the substrate — Switchboard loads, packs ship code against a narrow SPI, and
+**declarations are data the host validates and displays without executing pack code**. What
+it does not settle is how an installed pack becomes a *configured, attributed* one. This
+section proposes that mechanism. §21's "code for execution, data for contract" rule is the
+constraint every choice below is derived from.
+
+### 26a. Install, configure, and activate are three events
+
+Conflating them is the failure mode: it produces packs that self-bind on install, or
+configuration that can only happen mid-run.
+
+| Event | What happens | What must NOT happen |
+|---|---|---|
+| **Install** | the pack is discoverable; its declarations are readable | nothing is bound; no pack code runs to read a declaration |
+| **Configure** | the operator produces a binding artifact — attribution, model, secrets, pack parameters | the pack does not bind itself |
+| **Activate** | an assignment binds a capability to an agent for a task/run/duty (§14) | activation is not a RuntimeMode |
+
+**Install materializes a commented configuration stub derived from the pack's declared
+schema** — the operator then edits it. This is the same shape as the profile contract that
+`bootstrap` materializes and `doctor` validates: deterministic generation from data. It
+produces a **stub, never an active binding**, because Product Decision 4 already holds that
+install ≠ authority.
+
+### 26b. One artifact, three editors
+
+Direct file editing, a CLI, and a Continuum pane are all wanted. They must be **editors of
+one authoritative artifact**, never three write paths into three stores.
+
+Three independent paths is the two-seams-one-fact defect this project keeps paying for —
+#856 and #918 are both instances, and both were a second hand-maintained copy of something
+already derived. A pack's configuration is exactly the kind of thing that would sprout a
+console-side copy.
+
+- the artifact is authoritative and versioned;
+- `doctor` validates it, whichever editor wrote it;
+- the console pane and the CLI render from the **same declared schema**, so neither can
+  offer a field the other lacks.
+
+### 26c. Attribution: adopt, mint, or ignore — stated, never inferred
+
+The three cases an importer needs, all expressible in the configuration artifact:
+
+1. **Adopt** — bind pack capabilities to an **existing** agent (Neo gains
+   `architecture-review`). §8's hybrid agents; the migration bridge.
+2. **Mint** — instantiate the pack's suggested default binding (§25c) as a **new roster
+   member named by the importer**. The pack proposes `Iris`; the importer may name it
+   anything, or nothing.
+3. **Ignore** — installed, nothing bound; capabilities remain available for assignment-time
+   activation only.
+
+The roster stays the sole authority in all three (§8). The pack contributes a *suggestion*
+and a capability set; the artifact records what the operator decided.
+
+### 26d. Model: the pack declares requirements, the host resolves
+
+A pack naming a concrete model is portability poison — it is a deploy-specific fact written
+into a distribution unit. **Packs declare capability requirements as data** (context window,
+tool-calling, structured output, vision); the host resolves them against pulled models; the
+operator may override in the configuration artifact.
+
+This resolves **open question 12** toward *requirements are data, model choice is host
+resolution*, and it buys preflight: `doctor` can report "this pack requires vision, no
+pulled model provides it" at configure time rather than mid-cycle (SIP-0095's gate,
+extended).
+
+### 26e. Secrets: declared by name, resolved by the host, never held by the pack
+
+**A tool URL is configuration. A key is not.** The platform already owns secret resolution
+behind `SecretProvider` (env / file / docker_secret).
+
+- the pack declares `requires_secrets: [figma_token]` — **names and purposes, never values**;
+- the operator binds each name to an entry in an existing provider;
+- the pack reaches the tool only through the mediated invoker (§21), never the raw value.
+
+If configuration artifacts hold key material, the platform has minted a second secrets path
+beside the one that exists, and §21's permission scoping degrades from structural to
+advisory. This is the ownership-before-extension rule at its most consequential.
+
+### 26f. Verbs: generic over a declared schema; domain work is a capability
+
+The natural objection is that a pack needs domain-specific verbs and the host cannot
+possibly genericize them. The resolution is that "verb" is covering two different things.
+
+**Configuration is generic; the parameters are domain-specific.** The host never needs to
+know what `brand.primary_hex` *means* — only its type, constraints, and whether it is
+secret, which the declared schema supplies. `--set brand.primary_hex=#1c1e21` is
+domain-specific data through a generic verb.
+
+*This project already runs that pattern.* `CHECK_SPECS` declares `required_params`,
+`optional_params` and `param_types` per check, and plan validation rejects a malformed
+criterion without any semantic knowledge of what `name_prefix` does — the same generic
+validation over per-entry declared schemas, one layer down. (Exercised 2026-08-15: the
+authoring-example guard validates every shipped example's parameters against its spec
+across checks it knows nothing about.)
+
+**Domain actions are not CLI verbs — they are capabilities.** "Sync tokens from Figma", "run
+a contrast audit", "regenerate component exemplars" are real operations, and the capability
+is their container: mediated SPI, typed evidence, permission scoping, evidence-ledger entry.
+A CLI verb gets none of that. So the host does not need to genericize domain verbs; domain
+work has a better home than the CLI.
+
+**The genuine edge case is interactive, one-time operator setup** — authorizing with a
+vendor, pasting a key fetched from a dashboard. Neither configuration-by-flag nor a squad
+capability (no cycle, no artifacts, needs a human). Handle it with a **declarative setup
+form**: the pack declares the fields, which are secret, their validation, and where to
+obtain each; the host renders it as CLI prompts or a console form from the same declaration.
+No pack code executes.
+
+```yaml
+setup:
+  - key: figma.file_key
+    prompt: "Figma file key"
+    validate: "^[A-Za-z0-9]{22}$"
+  - key: figma_token
+    secret: true
+    obtain_at: "https://figma.com/developers/api#access-tokens"
+```
+
+A true browser OAuth exchange does need pack code; it should run as a **declared setup
+handler against the SPI**, not as a free-form CLI command. The line is not "may pack code
+run" — §21 already says it may. It is **"may pack code run before the host has validated
+anything, at CLI-parse time, in the operator's shell"**, and the answer to that is no.
+
+The resulting host surface, uniform across every pack: `packs show` (schema + current
+values, secrets masked), `packs configure --set`, `packs setup` (the declared form),
+`packs doctor` (completeness + resolvability).
+
+### 26g. What this costs that does not exist yet
+
+Stated so the estimate is not discovered later:
+
+- **A console write path.** The console is read-mostly; a configuration pane needs
+  console → config-store writes with the same validation the CLI applies. This is the
+  largest single item here and the one that can be deferred without blocking the rest.
+- **A configuration schema in the pack manifest**, plus its validator — small, and shaped
+  exactly like `CHECK_SPECS`.
+- **Doctor extension** for pack configuration completeness — the category mechanism exists.
+- **Secret-name binding** in the artifact and its resolution at activation — small, because
+  the provider layer exists.
+
+The file-editing mode plus generated CLI plus doctor validation is usable on day one; the
+console pane is an addition, not a prerequisite.
+
+### 26h. Open questions this section raises
+
+15. **Where does the configuration artifact live** — repo-tracked config, the config
+    directory, or DB-backed? Repo-tracked makes it reviewable and diffable and is the
+    presumptive answer; DB-backed is what a console write path would most naturally reach.
+    Whichever is chosen must be the *only* store (§26b).
+16. **Is the pack's suggested default binding versioned with the pack?** If a pack ships
+    `Iris` at v1 and renames its capability set at v2, an importer who minted `Iris` needs
+    to know whether their roster entry is stale — the same consumer/producer versioning
+    question §25b asks about design-system resources, one level up.
 
 ## 24. References
 

--- a/sips/proposed/SIP-Capability-Backed-Agents.md
+++ b/sips/proposed/SIP-Capability-Backed-Agents.md
@@ -168,6 +168,7 @@ A first-party pack shipped with SquadOps that (a) provides real design capabilit
 - **Capabilities:** `design-system-application`, `ux-review`, `component-gap-analysis`, `design-system-stewardship`, `design-system-change-proposal`, `component-pattern-governance`, `design-acceptance-authoring`.
 - **Resource modules (modular, not Continuum-centric):** `design-core`, `ops-console-design` (one module, not *the* system), `fintech-retail-design`, `backspring-etailer-design`, `backspring-brand`, `squadops-labs-dx`. Product context selects modules.
 - **Iris → Glyph gap workflow:** assignment activates Iris (`design-system-application`) → working set loads product/brand modules + prior design memory + template/rubric → Iris produces a design brief + acceptance criteria + a `design_system_gap_report` → runtime/Max routes the gap to an agent bound to `design-system-stewardship` (Glyph) → Glyph produces a `design_system_change_proposal` → governance accepts (canonical) / accepts (project-local) / rejects / defers / marks example → accepted changes become resources; durable learning is *proposed* as candidate memory, never silently saved. Iris identifies gaps and proposes; Iris does not mutate canonical design-system resources.
+- **Runtime posture (§25a):** Iris is activated by a cycle assignment; Glyph's stewardship is not a cycle and runs in duty/ambient windows whose deliverable is a published design-system version. What a version owes its consumers is open — §25b.
 - **Worked gap** (ties to the Continuum Runtime Console SIP): "Add a Duty perspective." Iris finds no reusable visual grammar distinguishing persistent Duty from active Cycle; Glyph proposes badge/chip semantics, health-vs-mode separation, empty/degraded states, and anti-patterns that conflate health and mode.
 
 ## 14. Capability Activation Flow & Runtime Orthogonality
@@ -245,6 +246,11 @@ Umbrella phases; each becomes its own bounded implementation SIP. Per the roadma
 13. Version pinning — exact capability versions or semver ranges in roster bindings?
     *Advanced (2026-07-29): layered scheme with loud load-time enforcement — §21; the
     roster-binding pinning grain (exact vs range) remains open.*
+14. **Design-system version semantics** — when Glyph publishes v1.4, what do projects built
+    against v1.3 owe or receive: pinned library, additive-only, or advisory style guide?
+    *Raised 2026-08-15 — §25b. Distinct from Q13, which is about CAPABILITY versions; this
+    is about the versioned RESOURCE a capability produces. **Blocks the design pack's
+    schema.***
 
 ## 21. Recorded owner decisions (2026-07-29): taxonomy, pack mechanics, trust scope
 
@@ -344,18 +350,128 @@ to be already-loaded into a privileged host).
 
 ## 22. Product Decisions
 
-1. Capability packs are plugin-backed extensions. 2. Packs do not own named agents. 3. Binding contracts are required (agent-agnostic ≠ prerequisite-free). 4. Roster bindings are explicit (install ≠ authority). 5. Assignments activate capabilities. 6. Working-set assembly is first-class. 7. Memory is scoped and promoted, never raw accumulation. 8. Workspace artifacts are shared squad work-state. 9. The Design pack is the reference. 10. Iris applies; Glyph stewards. 11. Existing agents adopt plugin capabilities before any rewrite. 12. **Skill-mediated tool use extends SIP-0040; capabilities never touch raw tools directly.**
+1. Capability packs are plugin-backed extensions. 2. Packs do not own named agents. 3. Binding contracts are required (agent-agnostic ≠ prerequisite-free). 4. Roster bindings are explicit (install ≠ authority). 5. Assignments activate capabilities. 6. Working-set assembly is first-class. 7. Memory is scoped and promoted, never raw accumulation. 8. Workspace artifacts are shared squad work-state. 9. The Design pack is the reference. 10. Iris applies; Glyph stewards — **and their default runtime postures differ: Iris is cycle-bound, Glyph is duty-shaped, with a published design-system version as the duty's unit of output (§25a)**. 11. Existing agents adopt plugin capabilities before any rewrite. 12. **Skill-mediated tool use extends SIP-0040; capabilities never touch raw tools directly.**
 
 ## 23. Relationship to Existing SIPs
 
 - **SIP-0040 (Capability/Skill/Tool)** — this SIP *extends* it (§5); the skill layer is not new.
 - **SIP-0068 / SIP-0072** — generalizes capability-specific + stack-aware build behavior into pluggable, agent-bindable packs.
-- **SIP-0089 / SIP-0090 / SIP-0091** — preserves identity ≠ capability ≠ embodiment ≠ mode; capability activation is not a mode; duty may activate a capability but is not the capability.
+- **SIP-0089 / SIP-0090 / SIP-0091** — preserves identity ≠ capability ≠ embodiment ≠ mode; capability activation is not a mode; duty may activate a capability but is not the capability. **A duty-shaped Glyph additionally makes SIP-0091 a dependency rather than a neighbour — see §25e, which argues for pulling it forward on this evidence.**
 - **SIP-0095** — capability preflight extends the cycle-create preflight gate.
 - **SIP-0070 / SIP-042** — evidence/acceptance and memory build on pulse verification and LanceDB.
 - **Verification Evidence Integrity (proposed, targets 1.4)** — the Evidence Ledger's "evidence is not acceptance" boundary (§12) presumes acceptance signals are themselves integrity-checked; skill evidence adopts the same executed vs not-executed honesty (a skill that could not run is recorded as not-executed with a reason, never silently omitted).
 - **SIP-0064 (`TaskFlowPolicy`) / Campaign** — capability activation respects run-level flow policy; cross-cycle capability-driven squad augmentation is the 2.0 Campaign story.
 - **SIP-0069 + Continuum Runtime Console** — future console visibility into bindings, active capabilities, working sets, evidence, and design workflows.
+
+## 25. Recorded owner decisions (2026-08-15): the steward is duty-shaped, and versioning is the open question
+
+Settled — and one thing corrected — in owner discussion during the SIP-0104 measurement
+window. Recorded in the §21 form so the implementation SIPs (§17) inherit decisions rather
+than reconstruct them.
+
+### 25a. Iris is cycle-bound; Glyph is duty-shaped. That distinction is architectural, not scheduling.
+
+§8 and §13 already split *applies* from *stewards*, and §14 already states that capability
+activation is orthogonal to RuntimeMode. What neither said is the **default posture of each
+agent**, which is the thing that decides what has to be built.
+
+- **Iris runs in `cycle`.** It is activated by an assignment, applies the design system to a
+  target project, and its output belongs to that cycle. Nothing here needs machinery this
+  platform does not have — Iris can be a roster member the way Bob is.
+- **Glyph runs largely in `duty`/`ambient`.** Its work is not a cycle and does not decompose
+  into one.
+
+**Correction recorded, because the first framing in discussion was wrong.** This section
+originally reasoned that "maintain the design system" was an aspiration rather than a duty,
+on the grounds that a duty needs an external trigger and self-directed work is a failure
+mode. The owner's counter stands: stewardship is a real discipline with real, non-cycle
+work — industry research, adding features and capability, incorporating gap feedback from
+projects, exploring new design-system surfaces, running usability testing — and a
+**time-boxed duty window is its natural container**. The correct requirement is not a
+trigger. It is a **unit of output**:
+
+> A Glyph duty window ends with **a published design-system version, or nothing published
+> this window.** That is the deliverable and the stopping condition.
+
+This is what makes the duty falsifiable. A window that produces prose churn and no version
+has produced nothing, and says so.
+
+### 25b. The open question this forces: what is a design-system *version*, and what does it owe its consumers?
+
+If Glyph publishes v1.4 while three delivered projects were built against v1.3, the platform
+must answer what happens. Three coherent answers, and the choice decides what the design
+system *is*:
+
+| Model | Mechanic | What it makes the design system |
+|---|---|---|
+| **Pinned library** | projects pin a version; Iris re-applies only on request; breaking changes allowed | a dependency, with an upgrade cost and a migration story |
+| **Additive-only** | new versions may only add; upgrades are always safe | a growing vocabulary, at the cost of never retiring a mistake |
+| **Advisory style guide** | latest is canonical; drift in shipped projects is tolerated | documentation, not a contract |
+
+§13's gap workflow — Iris files a gap, Glyph proposes, governance accepts *canonical* or
+*project-local* — implies the **pinned-library** reading, since "project-local" only means
+something if canonical is a version a project can be behind. **The SIP has never said so**,
+and the implementation SIPs cannot proceed without it: it determines whether a version
+carries a migration note, whether Iris gains a re-application capability, and whether the
+gap report references a version at all.
+
+**Not settled here.** Recorded as the question that blocks the design pack's schema.
+
+### 25c. A pack may ship a *default binding*, never an identity
+
+The owner's direction is that both agents arrive "via an agent plugin with a default
+identity." Taken literally that contradicts §2, §13 and Product Decision 2 — *"the pack owns
+neither agent"*, *"if packs own identities, the platform stops being reusable."* The
+reconciliation, proposed here for review rather than ruled:
+
+A pack publishes capabilities **and may publish a suggested default binding** — a name, a
+persona, and the capability set it is expected to hold. The roster remains the sole
+authority: it may adopt the default verbatim, rename it, bind the capabilities to an
+existing agent, or ignore the suggestion entirely. Installation becomes one step instead of
+two without moving authority into the pack.
+
+**The acceptance test, which belongs in §18:** install the design pack and bind
+`design-system-application` to an **existing** agent, with no Iris in the roster at all. If
+that works, the default identity is a convenience. If it does not, the pack owns the
+identity and §2's warning has come true.
+
+### 25d. Usability testing is the one listed duty with no substrate
+
+Research, gap incorporation and surface exploration are all executable against resources.
+**Usability testing needs users or a credible proxy, and the platform has neither.** Left
+undecided, it becomes an agent producing plausible findings nobody validated — the
+false-green shape SIP-0096 and SIP-0104 both exist to prevent, relocated into design.
+
+Decide explicitly, before Glyph ships: in scope with a named proxy, delegated to a human as
+a duty output rather than performed, or out of scope and stated as such. Silence is the one
+option that produces fabricated evidence.
+
+### 25e. Sequencing consequence: Glyph is the forcing function for SIP-0091
+
+A duty-shaped steward needs durable duty windows. **SIP-0091 (Duty Durability) has zero code
+and sits in the capacity pool**, and SIP-0090's Phase 2+ is the embodiment substrate for the
+same reason. Nothing has been pushing on either.
+
+Glyph pushes on both harder than anything currently queued: an agent whose entire value is
+bounded self-directed windows producing versioned output is a better justification for duty
+durability than any item that has been offered for it. That argues for pulling 0091 forward
+on Glyph's evidence, rather than treating Glyph as blocked behind it.
+
+**Iris has no such dependency** and can precede Glyph, which also makes it the cheaper first
+proof: Iris applying a versioned design system exercises §13's workflow up to the gap report
+without needing duty machinery at all.
+
+### 25f. The near-term rung that already exists
+
+The minimal design system is already in flight: PR #906 adds a frozen, scaffold-owned,
+element-scoped baseline stylesheet to the `nextjs_ts` skeleton, requiring **zero cooperation
+from any agent** — it styles whatever markup a fill author writes. That is this SIP's thesis
+at its smallest: the framework owns the deterministic spine, the model fills judgment.
+
+The path from there is incremental and keeps that property at every step: make the stylesheet
+a **versioned resource** → let Iris **select** from it → let Glyph **propose changes** to it.
+Each rung is testable before the next is built, and the first rung answers §25b empirically
+rather than by argument.
 
 ## 24. References
 


### PR DESCRIPTION
Docs only. Records an owner design discussion into `SIP-Capability-Backed-Agents`, in the §21 form so the implementation SIPs inherit decisions rather than reconstruct them.

The SIP already split *"Iris applies / Glyph stewards"* (§8, §13) and already stated that capability activation is orthogonal to `RuntimeMode` (§14). **What it never stated was each agent's default posture** — and that is the thing that decides what has to be built.

## §25a — Iris is cycle-bound, Glyph is duty-shaped

Iris is activated by a cycle assignment and needs no machinery this platform lacks; it could be a roster member the way Bob is. Glyph's work is not a cycle and does not decompose into one.

**A correction is recorded rather than quietly dropped.** My first framing in discussion argued that "maintain the design system" was an aspiration rather than a duty, on the grounds that a duty needs an external trigger. That was wrong on the axis. Stewardship is a real discipline with real non-cycle work — industry research, adding capability, incorporating gap feedback, exploring new surfaces, usability testing — and a time-boxed duty window is its natural container.

The correct requirement is not a trigger, it is a **unit of output**:

> A Glyph duty window ends with a published design-system version, or nothing published this window.

That is what makes the duty falsifiable. A window that produces prose churn and no version has produced nothing, and says so.

## §25b — the question this forces, and it blocks the pack's schema

When Glyph publishes v1.4 and three delivered projects were built against v1.3, what happens?

| Model | What the design system becomes |
|---|---|
| Pinned library | a dependency, with an upgrade cost and a migration story |
| Additive-only | a growing vocabulary that can never retire a mistake |
| Advisory style guide | documentation, not a contract |

§13's `canonical` vs `project-local` governance **implies pinned-library** — "project-local" only means something if canonical is a version a project can be behind — but the SIP has never said so. Filed as open question 14, deliberately distinct from Q13: that one is about *capability* versions, this is about the versioned *resource* a capability produces.

Raised, not settled.

## §25c — reconciling "an agent plugin with a default identity"

Taken literally that contradicts Product Decision 2 and §2's warning that a pack owning identities ends reusability. Proposed for review: a pack may publish a suggested **default binding** — name, persona, expected capability set — while the roster remains sole authority to adopt, rename, rebind or ignore it.

**The acceptance test that decides which it actually is**, proposed for §18: install the design pack and bind `design-system-application` to an **existing** agent, with no Iris in the roster. If that works, the default identity is a convenience. If not, the pack owns the identity.

## §25d — usability testing has no substrate

Research, gap incorporation and surface exploration all execute against resources. Usability testing needs users or a credible proxy and the platform has neither. Left undecided it becomes an agent producing plausible findings nobody validated — the exact false-green shape SIP-0096 and SIP-0104 exist to prevent, relocated into design. Decide in scope with a named proxy, delegated to a human, or out of scope.

## §25e — Glyph is the forcing function for SIP-0091

Duty durability has zero code and sits in the capacity pool because nothing has pushed on it. An agent whose entire value is bounded self-directed windows producing versioned output pushes harder than anything currently queued against it — which argues for pulling 0091 forward on that evidence rather than treating Glyph as blocked behind it. Iris has no such dependency and is the cheaper first proof.

## §25f — the near-term rung already exists

PR #906's frozen, element-scoped stylesheet is this SIP's thesis at its smallest: the framework owns the deterministic spine, the model fills judgment, and it needs zero cooperation from any agent. The path is versioned resource → Iris selects → Glyph proposes, each rung testable before the next — and the first rung answers §25b empirically rather than by argument.

Cross-referenced from §13, §20, §22 and §23. Regression **7351**.

---

# §26 — Pack lifecycle, attribution, and configuration

Second commit, same discussion. §21 settled the *substrate*; §26 settles how an installed pack becomes a **configured, attributed** one — derived from §21's "declarations are data the host validates without executing pack code" rather than beside it.

**§26a — three events, not one.** Install / configure / activate. Install materializes a commented configuration **stub** from the declared schema, the way `bootstrap` materializes a profile contract. It never produces a binding: Product Decision 4 already holds that install ≠ authority.

**§26b — one artifact, three editors.** File, CLI and console pane all write the same store. Three independent write paths is the two-seams-one-fact defect this project keeps paying for — #856 and #918 were both a second hand-maintained copy of something already derived, and pack config is exactly the sort of thing that would sprout a console-side copy.

**§26c — attribution is stated, never inferred:** **adopt** (bind to an existing agent — Neo gains `architecture-review`), **mint** (instantiate the suggested default binding under a name the importer chooses), or **ignore**. Roster stays sole authority in all three.

**§26d — packs declare model *requirements*, the host resolves.** A pack naming a concrete model writes a deploy-specific fact into a distribution unit. Advances open question 12 and buys a preflight check: *"this pack requires vision, no pulled model provides it"* at configure time rather than mid-cycle.

**§26e — secrets by name, never by value.** A tool URL is configuration; a key is not. The pack declares `requires_secrets: [figma_token]`, the operator binds it to an existing provider entry, and the pack reaches the tool only through the mediated invoker. Config artifacts holding key material would mint a second secrets path beside the one that exists and degrade §21's permission scoping from structural to advisory.

**§26f — the objection this section exists to answer:** *won't a domain-specific pack need its own verbs?*

"Verb" is covering two things. **Configuration is generic while its parameters are domain-specific** — the host needs types, constraints and secret-ness, not meaning. `CHECK_SPECS` already proves that pattern one layer down: plan validation rejects a malformed criterion with no semantic knowledge of what `name_prefix` does, and the authoring-example guard added today validates parameters across checks it knows nothing about.

**Domain *actions* are capabilities, not CLI verbs.** "Sync tokens from Figma" through a capability gets mediated SPI, typed evidence, permission scoping and a ledger entry; through a CLI verb it gets none of them.

The genuine edge case — interactive one-time setup like pasting a vendor key — gets a **declarative setup form** the host renders from the pack's declaration. The line is not *"may pack code run"* (§21 says it may), it is *"may it run before the host has validated anything, at CLI-parse time, in the operator's shell."*

**§26g** names what this costs that does not exist yet — the console write path is the largest item and the one deferrable without blocking the rest. **§26h** raises two open questions: where the configuration artifact lives, and whether a pack's suggested default binding is versioned with the pack.

Product Decisions 13–15 added. Regression **7351**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr

