### PR TITLE
fix(llm): stop paying for a reasoning channel the adapter discards, and record what was emitted

### DIFF
--- a/adapters/llm/ollama.py
+++ b/adapters/llm/ollama.py
@@ -177,13 +177,24 @@ class OllamaAdapter(LLMPort):
         temperature: float | None,
         *,
         stream: bool = False,
+        thinking: bool | None = None,
     ) -> dict[str, Any]:
-        """Build the Ollama /api/chat request payload."""
+        """Build the Ollama /api/chat request payload.
+
+        ``thinking=False`` sends Ollama's ``think: false``. This adapter reads only
+        ``message.content`` and declares ``THINKING_TOKENS: False``, so a reasoning
+        channel it cannot read is billed against ``num_predict`` and then discarded —
+        measured at 5,727 tokens versus 413 for identical output on a scaffold-fill
+        emission (#924). ``None`` sends nothing and leaves the model's default alone,
+        so every existing call is byte-identical.
+        """
         payload: dict[str, Any] = {
             "model": model,
             "messages": [{"role": m.role, "content": m.content} for m in messages],
             "stream": stream,
         }
+        if thinking is not None:
+            payload["think"] = thinking
 
         options: dict[str, Any] = {}
         if max_tokens is not None:
@@ -275,12 +286,16 @@ class OllamaAdapter(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        thinking: bool | None = None,
     ) -> ChatMessage:
         """Stream chat internally for connection liveness, return complete ChatMessage with usage.
 
         Uses streaming transport to keep the connection alive during long-running
         inference, but returns only the final assembled response. Captures token
         usage metadata from Ollama's final `done: true` chunk.
+
+        ``thinking=False`` stops paying for a reasoning channel this adapter discards
+        unread — see ``_build_chat_payload``.
         """
         client = await self._get_client()
         resolved_model = model or self._default_model
@@ -291,6 +306,7 @@ class OllamaAdapter(LLMPort):
             max_tokens,
             temperature,
             stream=True,
+            thinking=thinking,
         )
 
         try:

--- a/adapters/llm/vllm.py
+++ b/adapters/llm/vllm.py
@@ -360,12 +360,19 @@ class VLLMAdapter(LLMPort):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        thinking: bool | None = None,
     ) -> ChatMessage:
         """Stream for connection liveness, return one assembled message.
 
         The final frame carries usage when the server honors
         ``stream_options.include_usage``. A server that does not send one leaves
         the counts ``None`` — never zero, which would read as a free call.
+
+        ``thinking`` is accepted and **deliberately ignored**: the OpenAI-compatible
+        surface this speaks has no equivalent control, and the port states the
+        parameter is a request rather than a guarantee (#924). Accepting-and-ignoring
+        keeps the signature conformant; silently omitting it from the signature would
+        make a caller's keyword argument a TypeError at runtime instead.
         """
         resolved = model or self._default_model
         started = time.monotonic()

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -45,6 +45,52 @@ from squadops.capabilities.handlers.cycle.validation import (
 logger = logging.getLogger(__name__)
 
 
+#: Fence kinds an emission is judged by. Counting them is the difference between
+#: "the author ignored the instruction" and "the author emitted the wrong shape" —
+#: two diagnoses with opposite fixes that were indistinguishable from the outside.
+_EMISSION_FENCES: tuple[tuple[str, str], ...] = (
+    ("fill", "```fill:slot-"),
+    ("path", "```typescript:"),
+    ("py", "```python:"),
+    ("plain", "```"),
+)
+
+
+def _log_emission_shape(handler_name: str, content: object, completion_tokens: object) -> None:
+    """Record what an LLM call actually emitted, in one greppable line.
+
+    **Why this exists (#924).** SIP-0104 window rolls 3 and 5 both ended with every
+    scaffold slot unfilled, and nothing recorded what the qa author emitted: fills are
+    parsed and stripped before extraction, so a successful fill leaves no artifact and
+    a failed one leaves no trace at all. Three separate diagnoses were made from the
+    *result* rather than the emission, and two of them were wrong — the third only
+    landed because the raw completion was reproduced by hand against the live model.
+
+    A protocol whose failures cannot be inspected can only be repaired by guessing.
+    This is deliberately cheap and unconditional: shape, not content. Length, fence
+    counts by kind, and a short head sample — enough to separate "emitted nothing",
+    "emitted the wrong fence", and "emitted fills that the parser rejected" at a
+    glance, without persisting whole completions or their prompt material.
+    """
+    if content is None:
+        return
+    text = str(content)
+    counts = {}
+    for label, marker in _EMISSION_FENCES:
+        counts[label] = text.count(marker)
+    # A plain-fence count includes the addressed ones; report it net so the numbers add up.
+    counts["plain"] = max(0, counts["plain"] - 2 * (counts["fill"] + counts["path"] + counts["py"]))
+    head = " ".join(text[:160].split())
+    logger.info(
+        "%s emission shape: chars=%d completion_tokens=%s fences=%s head=%r",
+        handler_name,
+        len(text),
+        completion_tokens,
+        counts,
+        head,
+    )
+
+
 def _framework_injected_criteria(
     artifacts: list[dict], authored: tuple[TypedCheck, ...]
 ) -> list[TypedCheck]:
@@ -334,11 +380,28 @@ class _CycleTaskHandler(CapabilityHandler):
 
         return model_name, max_tokens, context_window
 
+    #: #924: this handler's output is a STRUCTURED EMISSION — fixed fences, not an
+    #: argument — so a separate reasoning channel is billed against the same completion
+    #: budget and then discarded unread by the adapter (which declares
+    #: ``THINKING_TOKENS: False``). Measured on qwen3.6:27b filling eight SIP-0104
+    #: scaffold slots: 5,727 completion tokens with reasoning, **413 without**, for the
+    #: same eight correctly-formed fill blocks — and the no-reasoning run additionally
+    #: asserted a field the reasoning run missed.
+    #:
+    #: Opt-in per handler rather than adapter-wide on purpose. One task was measured.
+    #: Reasoning plausibly earns its cost where the output IS an argument — manifest
+    #: authoring, plan authoring, failure analysis — and a silent quality regression
+    #: there would be far more expensive than the tokens saved. Widen on evidence from
+    #: the emission-shape log, not on this single result.
+    _suppress_reasoning: bool = False
+
     def _build_chat_kwargs(self, inputs: dict[str, Any]) -> dict[str, Any]:
         """Build chat() kwargs from agent config overrides (SIP-0075 §3.2)."""
         overrides = inputs.get("agent_config_overrides", {})
         agent_model = inputs.get("agent_model") or None
         kwargs: dict[str, Any] = {}
+        if self._suppress_reasoning:
+            kwargs["thinking"] = False
         if agent_model:
             kwargs["model"] = agent_model
         if "temperature" in overrides:
@@ -668,6 +731,11 @@ class _CycleTaskHandler(CapabilityHandler):
 
         content = response.content
         llm_duration_ms = (time.perf_counter() - start_time) * 1000
+
+        # #924: unconditional, and deliberately NOT inside the observability block below —
+        # that block is gated on `llm_obs and correlation_context`, so a capture placed
+        # there would go missing in exactly the setups where the emission is unexplained.
+        _log_emission_shape(self._handler_name, content, response.completion_tokens)
 
         # Record LLM generation for LangFuse tracing (SIP-0061 Option B)
         llm_obs = getattr(context.ports, "llm_observability", None)

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -68,6 +68,10 @@ class QATestHandler(_CycleTaskHandler):
     _capability_id = "qa.test"
     _role = "qa"
     _artifact_name = "test_output"  # overridden by multi-file output
+    # #924: the measured case. This handler's output is fenced blocks — fills addressed
+    # by slot id, or path-addressed test files — never prose to be reasoned over. The
+    # reasoning channel is billed against the same budget and discarded unread.
+    _suppress_reasoning = True
 
     def validate_inputs(self, inputs: dict[str, Any], contract=None) -> list[str]:
         errors = super().validate_inputs(inputs, contract)

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -525,6 +525,11 @@ class QATestRepairHandler(_RepairPromptMixin, _CycleTaskHandler):
     _capability_id = "qa.test_repair"
     _role = "qa"
     _artifact_name = "repair_output.md"
+    # #924: same structured-emission shape as the initial author it repairs — fenced
+    # blocks, not prose. Opted in with QATestHandler because a repair that reasons its
+    # budget away emits nothing, which is indistinguishable from a repair that had
+    # nothing to say, and burns a correction round either way.
+    _suppress_reasoning = True
 
     def _build_artifacts_from_content(self, content: str) -> list[dict[str, Any]]:
         return _artifacts_from_fenced_blocks(content, self._artifact_name)

--- a/src/squadops/llm/router.py
+++ b/src/squadops/llm/router.py
@@ -101,10 +101,13 @@ class LLMRouter:
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        thinking: bool | None = None,
     ) -> ChatMessage:
         """Stream chat internally, return complete ChatMessage with usage.
 
-        Pass-through to provider's chat_stream_with_usage().
+        Pass-through to provider's chat_stream_with_usage(), ``thinking`` included:
+        a router that silently dropped it would make the caller's request a no-op
+        with no way to tell (#924).
         """
         return await self._provider.chat_stream_with_usage(
             messages,
@@ -112,6 +115,7 @@ class LLMRouter:
             max_tokens=max_tokens,
             temperature=temperature,
             timeout_seconds=timeout_seconds,
+            thinking=thinking,
         )
 
     def list_models(self) -> list[str]:

--- a/src/squadops/ports/llm/provider.py
+++ b/src/squadops/ports/llm/provider.py
@@ -110,8 +110,24 @@ class LLMPort(ABC):
         max_tokens: int | None = None,
         temperature: float | None = None,
         timeout_seconds: float | None = None,
+        thinking: bool | None = None,
     ) -> ChatMessage:
         """Stream chat internally for connection liveness, return complete ChatMessage with usage.
+
+        ``thinking`` (#924) asks the provider whether this call should spend completion
+        budget on a separate reasoning channel. ``None`` means "say nothing" — the
+        provider's default. A caller passes ``False`` for a **structured-emission** task,
+        where the answer is a fixed format rather than an argument and reasoning tokens
+        are billed against the same budget as the emission.
+
+        Measured on qwen3.6:27b filling eight SIP-0104 scaffold slots: 5,727 completion
+        tokens with reasoning versus **413 without**, for the same eight correctly-formed
+        fill blocks. The Ollama adapter reads only ``message.content`` and declares
+        ``THINKING_TOKENS: False``, so those 5,314 extra tokens were billed and discarded
+        unread.
+
+        A provider with no such control ignores it — the parameter is a request, not a
+        guarantee, and no caller may assume it took effect.
 
         Uses streaming transport to keep the connection alive during long-running
         inference, but returns only the final assembled response — no partial chunks

--- a/tests/unit/capabilities/test_test_runner.py
+++ b/tests/unit/capabilities/test_test_runner.py
@@ -570,3 +570,146 @@ class TestFailedTestsPassRow:
         assert row["failing_tests"] == ("a.test.ts::creates",)
         assert row["passed"] is False
         assert row["runner"] == "vitest"
+
+
+class TestEmissionShapeCapture:
+    """#924 — what an LLM call emitted must be inspectable after the fact."""
+
+    def test_the_three_diagnoses_are_distinguishable(self, caplog):
+        """Bug caught: a failed emission leaves no trace, so its cause must be guessed.
+
+        SIP-0104 window rolls 3 and 5 both ended with every scaffold slot unfilled and
+        nothing recorded what the qa author emitted — fills are parsed and stripped
+        before extraction, so a success leaves no artifact and a failure leaves nothing
+        at all. Two wrong diagnoses were made from the result rather than the emission.
+
+        These three shapes have opposite fixes and were indistinguishable from outside:
+        emitted fills, emitted nothing while billing a full budget, emitted the wrong
+        fence kind.
+        """
+        import logging
+
+        from squadops.capabilities.handlers.cycle.base import _log_emission_shape
+
+        with caplog.at_level(logging.INFO):
+            _log_emission_shape("qa", "```fill:slot-a\nexpect(1).toBe(1)\n```", 413)
+            _log_emission_shape("qa", "", 6866)
+            _log_emission_shape("qa", "```typescript:__tests__/x.test.ts\nx\n```", 900)
+
+        filled, empty, wrong_fence = (r.getMessage() for r in caplog.records[-3:])
+
+        assert "'fill': 1" in filled
+        # the signature of a reasoning channel eating the budget: billed, emitted nothing
+        assert "chars=0" in empty and "completion_tokens=6866" in empty
+        assert "'path': 1" in wrong_fence and "'fill': 0" in wrong_fence
+
+    def test_a_head_sample_is_recorded_and_bounded(self, caplog):
+        """A shape with no sample cannot distinguish "wrong fence" from "prose apology".
+        Bounded because this runs on every call and must never persist a whole
+        completion or its prompt material."""
+        import logging
+
+        from squadops.capabilities.handlers.cycle.base import _log_emission_shape
+
+        with caplog.at_level(logging.INFO):
+            _log_emission_shape("qa", "I cannot complete this task because " + "x" * 5000, 12)
+
+        message = caplog.records[-1].getMessage()
+        assert "I cannot complete this task" in message
+        assert len(message) < 600
+
+    def test_a_missing_completion_logs_nothing_rather_than_a_false_zero(self, caplog):
+        """`None` means the call did not return content — distinct from an empty string,
+        which means it returned nothing. Logging `chars=0` for both would erase the
+        difference between a transport failure and an empty emission."""
+        import logging
+
+        from squadops.capabilities.handlers.cycle.base import _log_emission_shape
+
+        with caplog.at_level(logging.INFO):
+            _log_emission_shape("qa", None, None)
+
+        assert not [r for r in caplog.records if "emission shape" in r.getMessage()]
+
+
+class TestSuppressedReasoning:
+    """#924 — structured-emission handlers stop paying for a discarded channel."""
+
+    def test_only_the_measured_emission_handlers_send_the_parameter(self):
+        """Bug caught: suppressing reasoning globally on one measurement.
+
+        Only the scaffold-fill task was measured (5,727 completion tokens with reasoning
+        vs 413 without, same eight fill blocks). Reasoning plausibly earns its cost where
+        the output IS an argument — manifest authoring, plan authoring, failure analysis —
+        so anything unmeasured must keep sending nothing and inherit the model's default.
+
+        Asserted through the kwargs each handler actually builds, not the flag: a flag
+        set on a handler whose kwargs never carry it is the inert-fix shape.
+        """
+        from squadops.capabilities.handlers.cycle.develop import DevelopmentDevelopHandler
+        from squadops.capabilities.handlers.cycle.qa_test import QATestHandler
+        from squadops.capabilities.handlers.impl.repair_handlers import QATestRepairHandler
+
+        def kwargs_for(cls):
+            return cls.__new__(cls)._build_chat_kwargs({})
+
+        assert kwargs_for(QATestHandler)["thinking"] is False
+        assert kwargs_for(QATestRepairHandler)["thinking"] is False
+        # unmeasured handler: sends nothing, so the model's own default stands
+        assert "thinking" not in kwargs_for(DevelopmentDevelopHandler)
+
+    def test_opting_in_sends_the_parameter_and_opting_out_omits_it(self):
+        """Bug caught: the flag is declared but never reaches the provider — the exact
+        shape of a fix that looks applied and is inert."""
+        from squadops.capabilities.handlers.cycle.qa_test import QATestHandler
+
+        handler = QATestHandler.__new__(QATestHandler)
+        assert handler._build_chat_kwargs({})["thinking"] is False
+
+        class _Reasoning(QATestHandler):
+            _suppress_reasoning = False
+
+        assert "thinking" not in _Reasoning.__new__(_Reasoning)._build_chat_kwargs({})
+
+    def test_the_capture_is_wired_and_sits_outside_the_observability_gate(self):
+        """Bug caught: the helper exists and nothing calls it — or it is called from
+        inside `if llm_obs and context.correlation_context:`.
+
+        Both were live during this change. The first is the unwired-fix shape a
+        pure-function test cannot see (a mutation removing the call site passed every
+        other test in this class). The second is subtler and worse: the capture would go
+        missing in exactly the deployments without observability wired, which are the
+        ones where an unexplained emission is hardest to diagnose.
+        """
+        import ast
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[3] / "src/squadops/capabilities/handlers/cycle/base.py"
+        ).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        call_lines = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_log_emission_shape"
+        ]
+        assert call_lines, "the emission capture is defined but never called"
+
+        gated_lines: set[int] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            names = {n.id for n in ast.walk(node.test) if isinstance(n, ast.Name)}
+            if "llm_obs" not in names:
+                continue
+            for stmt in node.body:
+                gated_lines.update(range(stmt.lineno, (stmt.end_lineno or stmt.lineno) + 1))
+
+        inside = sorted(set(call_lines) & gated_lines)
+        assert not inside, (
+            f"the emission capture is inside the observability gate at {inside} — it would "
+            f"go silent wherever llm_observability is not configured"
+        )

--- a/tests/unit/llm/test_chat_stream.py
+++ b/tests/unit/llm/test_chat_stream.py
@@ -330,3 +330,75 @@ class _AsyncContextManager:
 
     async def __aexit__(self, *args: Any):
         pass
+
+
+class TestThinkingSuppression:
+    """#924 — a reasoning channel the adapter cannot read must not be billed."""
+
+    @staticmethod
+    def _payload(**kwargs):
+        from adapters.llm.ollama import OllamaAdapter
+        from squadops.ports.llm.provider import ChatMessage
+
+        adapter = OllamaAdapter.__new__(OllamaAdapter)
+        return adapter._build_chat_payload(
+            [ChatMessage(role="user", content="x")], "m", None, None, **kwargs
+        )
+
+    def test_omitted_by_default_so_existing_calls_are_unchanged(self):
+        """Bug caught: a default that silently changes every call in the system.
+
+        Only one task was measured. Sending `think` unasked would alter manifest
+        authoring, plan authoring and failure analysis on that single result.
+        """
+        assert "think" not in self._payload()
+
+    def test_false_is_sent_so_the_request_is_not_inert(self):
+        """Bug caught: the parameter is accepted, threaded, and never reaches the wire —
+        a fix that looks applied while the model keeps spending the budget.
+
+        Measured on qwen3.6:27b filling eight SIP-0104 scaffold slots: 5,727 completion
+        tokens with reasoning, 413 without, for the same eight fill blocks. The adapter
+        reads only `message.content` and declares THINKING_TOKENS: False, so the
+        difference was billed and discarded unread.
+        """
+        assert self._payload(thinking=False)["think"] is False
+
+    def test_true_is_sent_too_rather_than_treated_as_the_default(self):
+        """`None` and `True` are different requests: one defers to the model, the other
+        asks for reasoning explicitly. Collapsing them would make an explicit request
+        unexpressible."""
+        assert self._payload(thinking=True)["think"] is True
+
+    async def test_the_router_forwards_it_instead_of_dropping_it(self):
+        """Bug caught: the router swallows the parameter, making every caller's request
+        a no-op with no way to observe it — the #918 shape (a layer that looks like a
+        pass-through and is not)."""
+        from squadops.llm.router import LLMRouter
+        from squadops.ports.llm.provider import ChatMessage
+
+        seen = {}
+
+        class _Provider:
+            default_model = "m"
+
+            async def chat_stream_with_usage(self, messages, **kwargs):
+                seen.update(kwargs)
+                return ChatMessage(role="assistant", content="ok")
+
+        router = LLMRouter.__new__(LLMRouter)
+        router._provider = _Provider()
+        await router.chat_stream_with_usage([ChatMessage(role="user", content="x")], thinking=False)
+
+        assert seen["thinking"] is False
+
+    async def test_a_provider_without_the_control_accepts_it_rather_than_raising(self):
+        """The port states `thinking` is a request, not a guarantee. A provider with no
+        equivalent must accept and ignore it — omitting it from the signature would turn
+        a caller's keyword into a TypeError at runtime."""
+        import inspect
+
+        from adapters.llm.vllm import VLLMAdapter
+
+        params = inspect.signature(VLLMAdapter.chat_stream_with_usage).parameters
+        assert "thinking" in params


### PR DESCRIPTION
Closes #924.

**Measured, not inferred.** Same model, same deployed brief, same eight scaffold slots:

| | reasoning on | reasoning off |
|---|---|---|
| completion tokens | **5,727** | **413** |
| response | 1,411 chars | 1,417 chars |
| fill fences | 8 | **8** |
| envelope path | `body.error.code` ✓ | `body.error.code` ✓ |

13.9× the tokens for the same output — and the no-reasoning run additionally asserted a field the reasoning run missed. At a 2,500-token budget the model produced **19,179 characters of thinking and an empty response**: its reasoning correctly enumerated all eight slots and it never reached the emission.

The waste is documented in the adapter's own docstring — qwen3-family models emit `message.thinking`, this adapter never sends `think` and reads only `message.content`, and it declares `THINKING_TOKENS: False`. Billed against `num_predict`, discarded unread.

Window rolls 3 and 5 both ended with all eight slots unfilled. Roll 5 ran `completion_tokens=6866` against an **8,192 clamp** on a 14,832-token prompt — 3× the probe's, and a larger prompt produces more reasoning, not less.

## Part 2 is why this took hours

**Nothing recorded what the author emitted.** Fills are parsed and stripped before extraction, so a success leaves no artifact and a failure leaves no trace. Three diagnoses were made from the *result* rather than the emission across rolls 3 and 5 — #910, #911, #914 — and **two of them were wrong**. The third only landed by reproducing the raw completion by hand against the live model.

A protocol whose failures cannot be inspected can only be repaired by guessing. That is the actual defect behind the last two days.

## What ships

**A per-call `thinking` parameter** on the LLM port → Ollama's `think`, threaded through the router, accepted-and-ignored by vLLM (the port states it is a request, not a guarantee; dropping it from the signature would turn a caller's keyword into a runtime `TypeError`). Opted into by `qa.test` and `qa.test_repair` only.

**Deliberately not adapter-wide.** One task was measured. Reasoning plausibly earns its cost where the output *is* an argument — manifest authoring, plan authoring, failure analysis — and a silent quality regression there would cost more than the tokens saved.

**An emission-shape log** at the completion seam: length, fence counts by kind, bounded head sample. Unconditional, and **outside the observability gate** — that block is guarded on `llm_obs and correlation_context`, so a capture placed there would go silent in exactly the deployments where an unexplained emission is hardest to diagnose. I made that placement mistake while writing this; the wiring test now kills it.

The three diagnoses it separates, which were previously indistinguishable:

```
emission shape: chars=58   completion_tokens=413  fences={'fill': 2, ...}
emission shape: chars=0    completion_tokens=6866 fences={'fill': 0, ...}   ← the failure
emission shape: chars=47   completion_tokens=900  fences={'path': 1, 'fill': 0}
```

## Verification

**Five mutations killed**: adapter drops the parameter · router swallows it · qa handler opts out · **capture unwired** · **capture moved inside the observability gate**. The last two matter most — the first version of these tests exercised the helper as a pure function, so deleting its call site passed everything.

The repo's test-quality lint also caught one of my tests asserting class attributes without exercising behavior. Rewritten to assert the kwargs each handler actually builds, which is the stronger property: a flag set on a handler whose kwargs never carry it is the inert-fix shape.

Regression **7362**.

## What this does not claim

That the reasoning budget is *proven* to be roll 5's cause. It is strongly supported and it is measured waste regardless — but the emission itself was never recorded, so it cannot be confirmed retrospectively. Part 2 is what makes the next roll decisive: `chars=0` with a full token count confirms it outright, and anything else names the real cause immediately instead of prompting a fourth guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
