### PR TITLE
feat(observability): record what an LLM call actually emitted

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -45,6 +45,52 @@ from squadops.capabilities.handlers.cycle.validation import (
 logger = logging.getLogger(__name__)
 
 
+#: Fence kinds an emission is judged by. Counting them is the difference between
+#: "the author ignored the instruction" and "the author emitted the wrong shape" —
+#: two diagnoses with opposite fixes that were indistinguishable from the outside.
+_EMISSION_FENCES: tuple[tuple[str, str], ...] = (
+    ("fill", "```fill:slot-"),
+    ("path", "```typescript:"),
+    ("py", "```python:"),
+    ("plain", "```"),
+)
+
+
+def _log_emission_shape(handler_name: str, content: object, completion_tokens: object) -> None:
+    """Record what an LLM call actually emitted, in one greppable line.
+
+    **Why this exists (#924).** SIP-0104 window rolls 3 and 5 both ended with every
+    scaffold slot unfilled, and nothing recorded what the qa author emitted: fills are
+    parsed and stripped before extraction, so a successful fill leaves no artifact and
+    a failed one leaves no trace at all. Three separate diagnoses were made from the
+    *result* rather than the emission, and two of them were wrong — the third only
+    landed because the raw completion was reproduced by hand against the live model.
+
+    A protocol whose failures cannot be inspected can only be repaired by guessing.
+    This is deliberately cheap and unconditional: shape, not content. Length, fence
+    counts by kind, and a short head sample — enough to separate "emitted nothing",
+    "emitted the wrong fence", and "emitted fills that the parser rejected" at a
+    glance, without persisting whole completions or their prompt material.
+    """
+    if content is None:
+        return
+    text = str(content)
+    counts = {}
+    for label, marker in _EMISSION_FENCES:
+        counts[label] = text.count(marker)
+    # A plain-fence count includes the addressed ones; report it net so the numbers add up.
+    counts["plain"] = max(0, counts["plain"] - 2 * (counts["fill"] + counts["path"] + counts["py"]))
+    head = " ".join(text[:160].split())
+    logger.info(
+        "%s emission shape: chars=%d completion_tokens=%s fences=%s head=%r",
+        handler_name,
+        len(text),
+        completion_tokens,
+        counts,
+        head,
+    )
+
+
 def _framework_injected_criteria(
     artifacts: list[dict], authored: tuple[TypedCheck, ...]
 ) -> list[TypedCheck]:
@@ -668,6 +714,11 @@ class _CycleTaskHandler(CapabilityHandler):
 
         content = response.content
         llm_duration_ms = (time.perf_counter() - start_time) * 1000
+
+        # #924: unconditional, and deliberately NOT inside the observability block below —
+        # that block is gated on `llm_obs and correlation_context`, so a capture placed
+        # there would go missing in exactly the setups where the emission is unexplained.
+        _log_emission_shape(self._handler_name, content, response.completion_tokens)
 
         # Record LLM generation for LangFuse tracing (SIP-0061 Option B)
         llm_obs = getattr(context.ports, "llm_observability", None)

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -966,6 +966,22 @@ class QATestHandler(_CycleTaskHandler):
         extracted = extract_fenced_files(
             extraction_source, expected_artifacts=inputs.get("expected_artifacts")
         )
+        # #924: the three outcomes below are indistinguishable afterwards, and P3 renders
+        # a REJECTED fill as the same failing state as a MISSING one — so "the author
+        # emitted nothing", "the author emitted fills that were refused", and "the author
+        # emitted a file instead of fills" all present identically as unfilled slots.
+        # Window rolls 3 and 5 were each diagnosed twice from the result rather than the
+        # emission, wrongly, for exactly this reason.
+        logger.info(
+            "%s emission parse: fills=%d duplicate_slots=%d extracted_files=%d "
+            "expected=%s scaffold_bound=%s",
+            self._handler_name,
+            len(fill_emission.fills) if fill_emission else 0,
+            len(fill_emission.duplicates) if fill_emission else 0,
+            len(extracted),
+            inputs.get("expected_artifacts"),
+            bool(scaffold_input),
+        )
         if not extracted and not (fill_emission and fill_emission.fills):
             from squadops.cycles.emission_integrity import no_fenced_blocks_failure
 

--- a/tests/unit/capabilities/test_test_runner.py
+++ b/tests/unit/capabilities/test_test_runner.py
@@ -570,3 +570,109 @@ class TestFailedTestsPassRow:
         assert row["failing_tests"] == ("a.test.ts::creates",)
         assert row["passed"] is False
         assert row["runner"] == "vitest"
+
+
+class TestEmissionShapeCapture:
+    """#924 — what an LLM call emitted must be inspectable after the fact."""
+
+    def test_the_three_diagnoses_are_distinguishable(self, caplog):
+        """Bug caught: a failed emission leaves no trace, so its cause must be guessed.
+
+        SIP-0104 window rolls 3 and 5 both ended with every scaffold slot unfilled and
+        nothing recorded what the qa author emitted — fills are parsed and stripped
+        before extraction, so a success leaves no artifact and a failure leaves nothing
+        at all. Two wrong diagnoses were made from the result rather than the emission.
+
+        These three shapes have opposite fixes and were indistinguishable from outside:
+        emitted fills, emitted nothing while billing a full budget, emitted the wrong
+        fence kind.
+        """
+        import logging
+
+        from squadops.capabilities.handlers.cycle.base import _log_emission_shape
+
+        with caplog.at_level(logging.INFO):
+            _log_emission_shape("qa", "```fill:slot-a\nexpect(1).toBe(1)\n```", 413)
+            _log_emission_shape("qa", "", 6866)
+            _log_emission_shape("qa", "```typescript:__tests__/x.test.ts\nx\n```", 900)
+
+        filled, empty, wrong_fence = (r.getMessage() for r in caplog.records[-3:])
+
+        assert "'fill': 1" in filled
+        # the signature of a reasoning channel eating the budget: billed, emitted nothing
+        assert "chars=0" in empty and "completion_tokens=6866" in empty
+        assert "'path': 1" in wrong_fence and "'fill': 0" in wrong_fence
+
+    def test_a_head_sample_is_recorded_and_bounded(self, caplog):
+        """A shape with no sample cannot distinguish "wrong fence" from "prose apology".
+        Bounded because this runs on every call and must never persist a whole
+        completion or its prompt material."""
+        import logging
+
+        from squadops.capabilities.handlers.cycle.base import _log_emission_shape
+
+        with caplog.at_level(logging.INFO):
+            _log_emission_shape("qa", "I cannot complete this task because " + "x" * 5000, 12)
+
+        message = caplog.records[-1].getMessage()
+        assert "I cannot complete this task" in message
+        assert len(message) < 600
+
+    def test_a_missing_completion_logs_nothing_rather_than_a_false_zero(self, caplog):
+        """`None` means the call did not return content — distinct from an empty string,
+        which means it returned nothing. Logging `chars=0` for both would erase the
+        difference between a transport failure and an empty emission."""
+        import logging
+
+        from squadops.capabilities.handlers.cycle.base import _log_emission_shape
+
+        with caplog.at_level(logging.INFO):
+            _log_emission_shape("qa", None, None)
+
+        assert not [r for r in caplog.records if "emission shape" in r.getMessage()]
+
+    def test_the_fill_seam_capture_is_wired_at_the_parse_site(self):
+        """Bug caught: the one distinction that cannot be recovered afterwards.
+
+        P3 renders a REJECTED fill as the same failing state as a MISSING one, so
+        "emitted nothing", "emitted fills that were refused", and "emitted a file
+        instead of fills" all present identically as unfilled slots. Window roll 5's
+        cause could not be determined from its stored artifacts for exactly that reason
+        — the shells were unfilled, and the zero-extraction guard stayed silent because
+        something else parsed.
+
+        Pinned at the parse site specifically: a capture placed after the merge would
+        report the merged result, which is the thing that already loses the difference.
+        """
+        import ast
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[3]
+            / "src/squadops/capabilities/handlers/cycle/qa_test.py"
+        ).read_text(encoding="utf-8")
+
+        assert "emission parse:" in source, "the fill-seam capture is gone"
+
+        tree = ast.parse(source)
+        parse_calls = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "parse_fill_emission"
+        ]
+        log_lines = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "info"
+            and any(
+                isinstance(a, ast.Constant) and "emission parse:" in str(a.value) for a in node.args
+            )
+        ]
+        assert parse_calls and log_lines, "parse site or capture missing"
+        assert min(log_lines) > min(parse_calls), (
+            "the capture must follow the parse — before it, there is nothing to report"
+        )

--- a/tests/unit/capabilities/test_test_runner.py
+++ b/tests/unit/capabilities/test_test_runner.py
@@ -631,6 +631,50 @@ class TestEmissionShapeCapture:
 
         assert not [r for r in caplog.records if "emission shape" in r.getMessage()]
 
+    def test_the_shape_capture_is_wired_outside_the_observability_gate(self):
+        """Bug caught: the helper exists and nothing calls it — or it is called from
+        inside ``if llm_obs and context.correlation_context:``.
+
+        Both were live while this was written. The first is the unwired-fix shape a
+        pure-function test cannot see: a mutation deleting the call site passed every
+        other test in this class. The second is worse — the capture would go silent in
+        exactly the deployments without observability configured, which are the ones
+        where an unexplained emission is hardest to diagnose.
+        """
+        import ast
+        from pathlib import Path as _Path
+
+        source = (
+            _Path(__file__).resolve().parents[3]
+            / "src/squadops/capabilities/handlers/cycle/base.py"
+        ).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        call_lines = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_log_emission_shape"
+        ]
+        assert call_lines, "the emission-shape capture is defined but never called"
+
+        gated: set[int] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            names = {n.id for n in ast.walk(node.test) if isinstance(n, ast.Name)}
+            if "llm_obs" not in names:
+                continue
+            for stmt in node.body:
+                gated.update(range(stmt.lineno, (stmt.end_lineno or stmt.lineno) + 1))
+
+        inside = sorted(set(call_lines) & gated)
+        assert not inside, (
+            f"the capture is inside the observability gate at {inside} — it would go "
+            f"silent wherever llm_observability is not configured"
+        )
+
     def test_the_fill_seam_capture_is_wired_at_the_parse_site(self):
         """Bug caught: the one distinction that cannot be recovered afterwards.
 


### PR DESCRIPTION
Instrument only. No behavior change, no provider coupling. Supersedes the capture half of #925.

## Why

SIP-0104 window rolls 3 and 5 both ended with **every scaffold slot unfilled**, and nothing recorded what the qa author emitted. Fills are parsed and stripped before extraction, so a success leaves no artifact and a failure leaves no trace. Three diagnoses were made from the *result* rather than the emission — #910, #911, #914 — and **two were wrong**.

Roll 5 makes the cost concrete: after hours of archaeology its cause is **still undetermined**. The shells are stored unfilled, the pre-existing zero-extraction guard stayed silent (so *something* parsed), and the expected test artifact is absent. Three candidates remain and cannot be separated from stored state:

- the author emitted nothing test-shaped
- it emitted a path-addressed file that did not survive
- **it emitted fills that were rejected**

P3 renders a rejected fill as the same failing state as a missing one, so the most likely candidate is also the least visible.

## What ships

**Emission shape, at the completion seam** — length, fence counts by kind, bounded head sample:

```
emission shape: chars=58   completion_tokens=413  fences={'fill': 2, ...}
emission shape: chars=0    completion_tokens=6866 fences={'fill': 0, ...}
emission shape: chars=47   completion_tokens=900  fences={'path': 1, 'fill': 0}
```

Unconditional, and deliberately **outside the observability block** — that block is gated on `llm_obs and correlation_context`, so a capture placed there goes silent in exactly the deployments where an unexplained emission is hardest to diagnose. I made that placement mistake while writing this; a test now kills it.

**Parse outcome, at the fill seam** — fills parsed, duplicate slots rejected, files extracted, expected artifacts, scaffold bound. This is the one that answers roll 5's open question, and it must sit at the **parse** site: a capture after the merge reports the merged result, which is precisely what loses the distinction.

Complements `_log_no_fenced_blocks` (#130) rather than duplicating it — that one fires only when *both* extraction and fills are empty. Its silence on roll 5 was itself evidence, but silence is a poor instrument.

## Verification

Three mutations killed: shape capture unwired · shape capture moved inside the observability gate · fill-seam capture removed. The first two matter most — an earlier version of these tests exercised the helper as a pure function, so deleting its call site passed everything.

Regression **7356**.

## Deliberately not included

The reasoning-budget change measured alongside this — 5,727 completion tokens with reasoning versus **413 without**, for the same eight fill blocks. That measurement stands and is filed, but its implementation was a per-handler boolean switch plus a provider-shaped `think` flag on a provider-neutral port: a workaround, not a seam.

It is also the wrong order. **This instrument is what determines whether the reasoning budget is even the cause.** Shipping a fix and its instrument together, on one measurement, is the same mistake that produced the two wrong diagnoses before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RorRybE7cnwQaNwHqmoodr
