### PR TITLE
fix(audit): find wrapped UI call sites, and read 405 as proof the route exists

### DIFF
--- a/scripts/dev/audit_delivered_app.py
+++ b/scripts/dev/audit_delivered_app.py
@@ -114,9 +114,19 @@ async def _run_ui_data_path(files: dict[str, str], stack: str, base_url: str) ->
 
     The contract probes above prove the API answers where the CONTRACT says; this proves
     it answers where the UI ASKS. Roll 1 passed the former and failed the latter on every
-    page action, and nothing noticed. Each distinct path is requested once; only a 404
-    that no route produced (framework HTML rather than the app's JSON envelope) counts as
-    a failure, so an app correctly reporting an unknown id still passes.
+    page action, and nothing noticed. Each distinct path is requested once.
+
+    **Every probe is a GET, whatever verb the UI uses**, and deliberately so: issuing the
+    real verb would mutate the application under audit — a POST probe creates a record —
+    and the audit has to be re-runnable against the same workspace. The cost is that a
+    POST-only route answers 405, which ``classify_ui_response`` reads as SERVED (#953);
+    the alternative, sending real verbs, buys a stronger signal by destroying the
+    property that makes the audit repeatable.
+
+    A path fails only when the answer shows no route is mounted there: a 404 the framework
+    produced (HTML rather than the app's own JSON envelope), or HTML through the JSON seam,
+    which means the call landed on a page. An app correctly reporting an unknown id still
+    passes, and so does one that rejects the probe's method.
     """
     calls = extract_ui_calls(files, stack)
     if not calls:

--- a/src/squadops/capabilities/ui_data_path.py
+++ b/src/squadops/capabilities/ui_data_path.py
@@ -44,8 +44,15 @@ _SEAM_PREFIX: dict[str, str] = {
 #: Files whose calls are the UI's. Route handlers legitimately talk to the store, not HTTP.
 _UI_SUFFIXES = (".tsx", ".jsx")
 
+#: Matched against whole file content, not line by line — a call argument that wraps to the
+#: next line is still one call, and scanning per line silently dropped it (#952). The two
+#: character classes exclude newlines deliberately: a type parameter and a request path each
+#: live on one line, and letting either span lines lets an unbalanced quote swallow the rest
+#: of the file. Only the whitespace between ``(`` and the opening quote may cross a line,
+#: which is exactly the wrap this expression exists to tolerate.
 _CALL_RE = re.compile(
-    r"\b(?P<fn>api|apiFetch|fetch)\s*(?:<[^>()]*>)?\s*\(\s*(?P<quote>['\"`])(?P<path>[^'\"`]*)(?P=quote)"
+    r"\b(?P<fn>api|apiFetch|fetch)\s*(?:<[^>()\n]*>)?\s*"
+    r"\(\s*(?P<quote>['\"`])(?P<path>[^'\"`\n]*)(?P=quote)"
 )
 _TEMPLATE_EXPR_RE = re.compile(r"\$\{[^}]*\}")
 
@@ -73,6 +80,13 @@ def extract_ui_calls(files: dict[str, str], stack: str) -> list[UiCall]:
     live-server class, a different defect, and silently normalizing them would hide it.
     An unknown stack yields nothing rather than guessing a prefix — a wrong prefix
     would invent failures in an app that works.
+
+    Scans whole file content. The first version scanned line by line, so a call written
+    across two lines — ``await api<Run>(`` then the path beneath it, which is what a
+    formatter produces once the call carries a second argument — matched nothing and was
+    never probed (#952). That silence is the worst possible failure for this module: it
+    does not weaken the check, it removes it, and the roll still reads as audited. Roll 1
+    of the SIP-0104 P6 window passed with its join and leave call sites extracted as zero.
     """
     prefix = _SEAM_PREFIX.get(stack)
     if prefix is None:
@@ -81,30 +95,37 @@ def extract_ui_calls(files: dict[str, str], stack: str) -> list[UiCall]:
     for path, content in sorted(files.items()):
         if not path.endswith(_UI_SUFFIXES):
             continue
-        for lineno, line in enumerate(content.split("\n"), start=1):
-            for match in _CALL_RE.finditer(line):
-                written = match.group("path")
-                if not written:
-                    continue
-                concrete = _TEMPLATE_EXPR_RE.sub(SAMPLE_SEGMENT, written)
-                if concrete.startswith(("http://", "https://")):
-                    request_path = concrete
-                elif match.group("fn") == "fetch":
-                    # A raw fetch bypasses the seam, so no prefix is applied to it.
-                    request_path = concrete
-                else:
-                    request_path = prefix + concrete
-                calls.append(
-                    UiCall(
-                        file=path,
-                        line=lineno,
-                        fn=match.group("fn"),
-                        written=written,
-                        request_path=request_path,
-                    )
+        for match in _CALL_RE.finditer(content):
+            written = match.group("path")
+            if not written:
+                continue
+            # The call site is where the failure message must point, so the line is the
+            # one the call OPENS on, not the one its path happens to land on.
+            lineno = content.count("\n", 0, match.start()) + 1
+            concrete = _TEMPLATE_EXPR_RE.sub(SAMPLE_SEGMENT, written)
+            if concrete.startswith(("http://", "https://")):
+                request_path = concrete
+            elif match.group("fn") == "fetch":
+                # A raw fetch bypasses the seam, so no prefix is applied to it.
+                request_path = concrete
+            else:
+                request_path = prefix + concrete
+            calls.append(
+                UiCall(
+                    file=path,
+                    line=lineno,
+                    fn=match.group("fn"),
+                    written=written,
+                    request_path=request_path,
                 )
+            )
     return calls
 
+
+#: The probe is a GET whatever verb the UI uses, because sending the real verb would mutate
+#: the app under audit. A route that exists but rejects GET therefore answers 405, and that
+#: answer proves the route is mounted — see ``classify_ui_response`` (#953).
+METHOD_NOT_ALLOWED = 405
 
 #: Verdicts for one probed UI path.
 SERVED = "served"
@@ -136,12 +157,25 @@ def classify_ui_response(
       ``.catch(() => ({}))`` yields an empty object, and the view renders blank with no
       error anywhere. Roll 1 shipped exactly this on its detail route, and a
       404-only rule (this function's first version) called it served.
+
+    **405 is SERVED, whatever it carries** (#953). The audit probes every call site with a
+    GET regardless of the verb the UI uses, because sending the real verb would mutate the
+    application being audited — a POST probe would create a record, and the audit must be
+    able to run twice. So a POST-only route answers the probe with 405, and Next produces
+    that from the router with no content type. Read as "not JSON", it fell to
+    ``PAGE_NOT_API`` and failed correct applications: P6 rolls 3 and 4 were both failed on
+    join and leave routes that a human then verified by hand. This inverts the evidence.
+    **A 405 is the strongest signal the route exists** — the router matched the path and
+    rejected only the method, which is precisely the question this check asks. A page never
+    answers 405; it answers 200 with HTML, and that case is untouched.
     """
     if request_path.startswith(("http://", "https://")):
         return LIVE_SERVER
     is_json = "json" in content_type.lower()
     if status == 404 and not is_json:
         return ROUTE_MISSING
+    if status == METHOD_NOT_ALLOWED:
+        return SERVED
     if via_seam and not is_json:
         return PAGE_NOT_API
     return SERVED

--- a/tests/unit/capabilities/test_ui_data_path.py
+++ b/tests/unit/capabilities/test_ui_data_path.py
@@ -12,6 +12,7 @@ import pytest
 
 from squadops.capabilities.ui_data_path import (
     LIVE_SERVER,
+    METHOD_NOT_ALLOWED,
     PAGE_NOT_API,
     ROUTE_MISSING,
     SAMPLE_SEGMENT,
@@ -149,6 +150,114 @@ class TestFailureMessages:
         files = {"app/page.tsx": "const r = await fetch('http://localhost:3000/api/runs')"}
         (call,) = extract_ui_calls(files, "nextjs_ts")
         assert "live server" in describe_failure(call, LIVE_SERVER)
+
+
+#: The shape a formatter produces once a call carries a second argument: the opening
+#: `api<Run>(` sits alone and the path lands on the next line. Verbatim from P6 roll 1's
+#: `app/runs/[run_id]/page.tsx` (lines 58 and 88) and reproduced by rolls 3 and 4.
+_WRAPPED_UI = {
+    "app/runs/[run_id]/page.tsx": """'use client';
+import { api } from '@/lib/api';
+export default function Page() {
+  const updatedRun = await api<Run>(
+    `/api/runs/${runId}/join`,
+    { method: 'POST' }
+  );
+  const afterLeave = await api<Run>(
+    `/api/runs/${runId}/leave`,
+    { method: 'POST' }
+  );
+}
+"""
+}
+
+
+class TestWrappedCallSites:
+    """#952. The first version scanned `content.split("\\n")` line by line, so a call
+    written across two lines matched nothing. That does not weaken the check — it removes
+    it, silently, while the roll still reads as audited. P6 roll 1 passed with its join and
+    leave call sites extracted as zero, and the defect class this module exists to catch is
+    exactly the one those two calls could have carried."""
+
+    def test_a_call_whose_path_wraps_to_the_next_line_is_found(self):
+        calls = extract_ui_calls(_WRAPPED_UI, "nextjs_ts")
+        assert [c.request_path for c in calls] == [
+            f"/api/runs/{SAMPLE_SEGMENT}/join",
+            f"/api/runs/{SAMPLE_SEGMENT}/leave",
+        ]
+
+    def test_the_line_reported_is_where_the_call_opens_not_where_the_path_sits(self):
+        """A message pointing at the path line sends a reader to an argument rather than
+        to the call, and the call is what has to change."""
+        calls = extract_ui_calls(_WRAPPED_UI, "nextjs_ts")
+        assert [c.line for c in calls] == [4, 8]
+        assert "app/runs/[run_id]/page.tsx:4" in describe_failure(calls[0], ROUTE_MISSING)
+
+    def test_an_unterminated_quote_does_not_swallow_the_rest_of_the_file(self):
+        """Scanning whole content makes a runaway match possible where line-scanning made
+        it impossible, so the path class excludes newlines. Without that, one stray
+        backtick yields a single call with a multi-line garbage path and every real call
+        after it disappears."""
+        files = {
+            "app/page.tsx": "const a = await api('/api/runs\nconst b = await api('/api/teams')\n"
+        }
+        calls = extract_ui_calls(files, "nextjs_ts")
+        assert [c.request_path for c in calls] == ["/api/teams"]
+
+    def test_a_wrapped_call_and_an_inline_call_are_both_found_in_source_order(self):
+        files = {
+            "app/page.tsx": """const list = await api<Run[]>('/api/runs');
+const joined = await api<Run>(
+  `/api/runs/${runId}/join`,
+  { method: 'POST' }
+);
+"""
+        }
+        calls = extract_ui_calls(files, "nextjs_ts")
+        assert [(c.line, c.request_path) for c in calls] == [
+            (1, "/api/runs"),
+            (2, f"/api/runs/{SAMPLE_SEGMENT}/join"),
+        ]
+
+
+class TestMethodNotAllowed:
+    """#953. The probe is a GET whatever verb the UI uses — sending the real verb would
+    mutate the app under audit and make a second run of the audit meaningless. A POST-only
+    route therefore answers 405 from the router with no content type, which the
+    not-JSON rule read as `PAGE_NOT_API`. P6 rolls 3 and 4 were both failed on correct
+    join and leave routes, each needing a human to boot the app and POST by hand."""
+
+    @pytest.mark.parametrize("content_type", ["", "text/plain", "text/html; charset=utf-8"])
+    def test_a_405_means_the_route_exists_whatever_it_carries(self, content_type):
+        """405 is the strongest available evidence: the router matched the path and
+        rejected only the method."""
+        verdict = classify_ui_response(
+            "/api/runs/x/join", METHOD_NOT_ALLOWED, content_type, via_seam=True
+        )
+        assert verdict == SERVED
+
+    def test_a_page_is_still_caught_after_the_405_rule(self):
+        """The over-correction to guard against: 405 becoming SERVED must not make every
+        non-JSON answer SERVED. A page answers 200 with HTML and never 405."""
+        assert (
+            classify_ui_response("/runs/x", 200, "text/html; charset=utf-8", via_seam=True)
+            == PAGE_NOT_API
+        )
+
+    def test_a_framework_404_is_still_a_missing_route(self):
+        assert classify_ui_response("/api/nope", 404, "text/html") == ROUTE_MISSING
+
+
+def test_the_two_defects_masked_each_other_on_a_correct_app():
+    """The reason these ship together. Roll 1's wrapped join/leave calls were never
+    extracted (#952), so its audit passed vacuously. Fixing extraction alone would have
+    surfaced those same calls into the 405 misread (#953) and failed a correct app —
+    turning a false pass into a false failure. Only both together verify it."""
+    calls = extract_ui_calls(_WRAPPED_UI, "nextjs_ts")
+    assert len(calls) == 2, "extraction must find them at all"
+    for call in calls:
+        # what a correct POST-only route actually answers a GET probe with
+        assert classify_ui_response(call.request_path, METHOD_NOT_ALLOWED, "") == SERVED
 
 
 def test_a_correctly_wired_ui_produces_no_failing_paths():


### PR DESCRIPTION
Two defects in the UI data-path check. They ship together because **they masked each other**, and fixing either alone makes the audit worse than it is today.

`Closes #952` · `Closes #953`

## Why one PR

- Roll 1 **passed** its audit because #952 never found its join and leave calls — a false pass.
- Rolls 3 and 4 **failed** theirs because #953 misread the answer those same calls give — a false failure.

Fix extraction alone and roll 1's newly-found calls fall straight into the 405 misread: a false pass becomes a false failure. Fix classification alone and roll 1 stays vacuous. Only both together verify anything.

## #952 — the extractor scanned line by line

`extract_ui_calls` iterated `content.split("\n")`, so a call written across two lines matched nothing:

```tsx
const updatedRun = await api<Run>(
  `/api/runs/${runId}/join`,
  { method: 'POST' }
);
```

That is the shape a formatter produces as soon as the call takes a second argument — which is to say, **every mutating call**. This is not a weaker check. It is no check, silently, while the roll still reads as audited.

**Measured against P6 roll 1's delivered source, the old expression found 2 of 5 call sites.** It dropped join, leave, *and* the detail-page read. The ledger recorded this as "join and leave were never probed"; it was worse — roll 1's audit pass covered under half its UI.

Scanning whole content makes a runaway match possible where line-scanning made it impossible, so the type-parameter and path classes now exclude newlines. Without that, one stray backtick yields a single multi-line garbage path and silently swallows every real call after it — trading a known blind spot for an unknown one. Only the whitespace between `(` and the opening quote may cross a line, which is exactly the wrap being tolerated.

The reported line is where the call **opens**, not where its path sits. A message pointing at an argument sends the reader somewhere they can't fix.

## #953 — a 405 was read as "this is a page"

Every probe is a GET whatever verb the UI uses, and that is deliberate: issuing the real verb would mutate the app under audit — a POST probe creates a record — and destroy the property that makes the audit re-runnable. **The cost is that a POST-only route answers 405**, which Next produces from the router with no content type. The not-JSON rule read that as `PAGE_NOT_API`.

This inverts the evidence. **A 405 is the strongest available signal that the route exists**: the router matched the path and rejected only the method, which is precisely the question this check asks. P6 rolls 3 and 4 were both failed on correct join and leave routes, each requiring a human to boot the deliverable and POST by hand.

A page never answers 405 — it answers 200 with HTML — so the page-collision case is untouched. A test pins that the correction does not over-reach into "any non-JSON answer is served," which is the obvious way to get this wrong.

## Verified against real workspaces, not only fixtures

| Roll | Old extraction | New extraction | Audit now |
|---|---|---|---|
| 1 (`run_0d8ffad5f128`) | **2 of 5** | 5 of 5 | see below |
| 2 (`run_c23ceeee4796`) | 5 | 5 | unchanged |
| 3 (`run_e336e3bd4304`) | 5 | 5 | see below |
| 4 (`run_ca8b621cf7b6`) | 5 | 5 | **PASS** — was a FAIL |

Roll 4's re-audit, same workspace, with these fixes:

```
PASS — delivered app installs, builds, boots, answers 4 contract probe(s),
and its UI reaches every path it requests
```

Rolls 1 and 3 are re-auditing as this opens; results posted as a comment.

## Consequence for the window ledger

**P6 roll 1's audit pass is weaker than banked** and should be annotated rather than revoked: it passed on 2 of 5 call sites, so its UI wiring for join, leave and the detail read was never verified. Whether it passes on all five is what the re-audit above answers.

This does not change any roll's banked status — no roll is re-scored on an instrument change after the fact — but the closing record should state which rolls were audited by which version of the check.

## Blocking status

These are §2.2 of the V7 pre-registration: **blocking preconditions, not cleanup.** A window measuring "zero manual intervention" cannot require manual intervention to score itself, and rolls 3 and 4 each did.

**Does not merge until the SIP-0104 P6 window closes.** The deploy is frozen at `d590f73c`; this is queued behind roll 6.
