### PR TITLE
fix(qa): reject additive suites that mock the subject instead of invoking it

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -758,7 +758,10 @@ class QATestHandler(_CycleTaskHandler):
 
         # #276 guard holds on the retest path too: a repair must not smuggle a
         # stub-fallback past the correction loop.
-        from squadops.capabilities.handlers.stub_detection import detect_stub_fallback_tests
+        from squadops.capabilities.handlers.stub_detection import (
+            detect_self_mocking_tests,
+            detect_stub_fallback_tests,
+        )
 
         stub_offenders = detect_stub_fallback_tests(artifacts)
         if stub_offenders:
@@ -772,6 +775,25 @@ class QATestHandler(_CycleTaskHandler):
             )
             missing.append(f"stub_fallback_tests:{','.join(stub_offenders)}")
             summary = f"{summary}; repaired test masks the entrypoint: {', '.join(stub_offenders)}"
+
+        # #915 on the retest path for the same reason: a repair told to make the suite
+        # pass can satisfy that instruction by mocking the subject, and mocking is the
+        # cheapest way to make any assertion true.
+        mock_offenders = detect_self_mocking_tests(artifacts)
+        if mock_offenders:
+            passed = False
+            mock_paths = [path for path, _ in mock_offenders]
+            checks.append(
+                {
+                    "check": "no_self_mocking_tests",
+                    "offenders": mock_paths,
+                    "passed": False,
+                }
+            )
+            missing.append(f"self_mocking_tests:{','.join(mock_paths)}")
+            summary = (
+                f"{summary}; repaired test never invokes the application: {', '.join(mock_paths)}"
+            )
 
         passed_count = sum(1 for c in checks if c.get("passed"))
         outputs: dict[str, Any] = {
@@ -1167,6 +1189,7 @@ class QATestHandler(_CycleTaskHandler):
             # passes). Flag it so acceptance fails and the correction loop
             # regenerates the test against the real module.
             from squadops.capabilities.handlers.stub_detection import (
+                detect_self_mocking_tests,
                 detect_stub_fallback_tests,
             )
 
@@ -1186,6 +1209,34 @@ class QATestHandler(_CycleTaskHandler):
                 note = (
                     "Generated test masks the real entrypoint behind an "
                     f"ImportError stub: {', '.join(stub_offenders)}"
+                )
+                validation.summary = (
+                    note
+                    if validation.summary in ("", "All checks passed")
+                    else f"{validation.summary}; {note}"
+                )
+                passed_count = sum(1 for c in validation.checks if c["passed"])
+                validation.coverage_ratio = passed_count / len(validation.checks)
+
+            # #915: the TypeScript sibling, and worse — a stub-fallback suite fails
+            # loudly because a reconstruction misbehaves, while a self-mocking suite
+            # asserts what it told its own mock to return and therefore PASSES. Fills
+            # cannot do this (the frozen spine invokes the handler and enforcement
+            # rejects edits to it); additive files carried the rule only as prose.
+            mock_offenders = detect_self_mocking_tests(artifacts)
+            if mock_offenders:
+                mock_paths = [path for path, _ in mock_offenders]
+                validation.checks.append(
+                    {
+                        "check": "no_self_mocking_tests",
+                        "offenders": mock_paths,
+                        "passed": False,
+                    }
+                )
+                validation.passed = False
+                validation.missing_components.append(f"self_mocking_tests:{','.join(mock_paths)}")
+                note = "Generated test never invokes the application: " + "; ".join(
+                    f"{path} {reason}" for path, reason in mock_offenders
                 )
                 validation.summary = (
                     note

--- a/src/squadops/capabilities/handlers/stub_detection.py
+++ b/src/squadops/capabilities/handlers/stub_detection.py
@@ -1,4 +1,16 @@
-"""Detect stub-fallback anti-patterns in generated test files (#276).
+"""Detect generated test files that validate something other than the deliverable.
+
+Two patterns live here, found four months apart in different languages, because they
+are one defect wearing two coats: **the suite runs, passes, and never invokes the
+application.** Whatever else differs, that is the shared shape, and it is why this
+module is the seam rather than two parallel ones.
+
+The module name predates the second pattern and now understates it — nothing here is
+specific to stubs any more. Renaming it touches two call sites and their tests and is
+deliberately not bundled into a fix landing under a deploy freeze; recorded so the next
+reader knows the name is stale rather than the scope narrow.
+
+Detect stub-fallback anti-patterns in generated test files (#276).
 
 A generated test that wraps the entrypoint import in ``except ImportError:`` and
 reconstructs the application inline silently validates a **stub** instead of the
@@ -73,4 +85,98 @@ def detect_stub_fallback_tests(files: list[dict]) -> list[str]:
             continue
         if _IMPORT_GUARD.search(content) and any(ctor in content for ctor in _APP_CONSTRUCTORS):
             offenders.append(path)
+    return sorted(offenders)
+
+
+# --- Self-mocking suites (#915) -------------------------------------------------
+#
+# The TypeScript sibling of the stub-fallback class, and strictly worse: a stub-fallback
+# suite reconstructs the app and then FAILS, because a reconstruction does not behave
+# like the real thing. A self-mocking suite tells a mock what to return and asserts what
+# it was told, so **its natural state is passing.** It agrees with itself by construction.
+#
+# Found in window roll 3 (`cyc_b20f58cc7cbc`): 479 lines that set `global.fetch = vi.fn()`,
+# primed the mock, called `fetch('/api/runs')`, and asserted on the primed value. The
+# application was never invoked. That roll only went red because its scaffold slots were
+# also unfilled; had they been filled, `tests_pass` would have gone green on the fills
+# while this file read as 479 lines of verification.
+#
+# Fills cannot do this — SIP-0104's frozen spine imports the route handler and invokes it,
+# and region enforcement rejects any edit to that. Additive files carry the same rule as
+# prose in the brief and nothing enforced it. This closes that asymmetry.
+
+#: Suffixes of the JS/TS test files a qa author emits. Python suites take the
+#: stub-fallback path above; the two vocabularies never overlap.
+_JS_TEST_SUFFIXES: tuple[str, ...] = (
+    ".test.ts",
+    ".test.tsx",
+    ".test.js",
+    ".test.jsx",
+    ".spec.ts",
+    ".spec.tsx",
+    ".spec.js",
+    ".spec.jsx",
+)
+
+#: Replacing the network seam. Under the in-process execution model (#877) a suite reaches
+#: the app by importing its route handler, so there is no fetch for a correct suite to
+#: stub — the presence of a stub means the suite is talking to something it built.
+_NETWORK_SEAM_MOCK = re.compile(
+    r"""(?x)
+      global(?:This)?\s*\.\s*fetch\s*=                          # global.fetch = ...
+    | (?:vi|jest)\s*\.\s*stubGlobal\s*\(\s*['"`]fetch['"`]      # vi.stubGlobal('fetch', ...)
+    | (?:vi|jest)\s*\.\s*spyOn\s*\(\s*global(?:This)?\s*,\s*['"`]fetch['"`]
+    """
+)
+
+#: Mocking the subject itself. Unconditional: there is no reading under which replacing
+#: the route module under test and then asserting on it verifies the route module.
+_ROUTE_MODULE_MOCK = re.compile(r"""(?:vi|jest)\s*\.\s*mock\s*\(\s*['"`][^'"`]*app/api/""")
+
+#: A real import of an application route module — the in-process model's entry point.
+#: Required as a *statement* rather than as any occurrence of the path, so that a
+#: ``vi.mock('@/app/api/...')`` string cannot satisfy it.
+_APP_ROUTE_IMPORT = re.compile(
+    r"""^\s*(?:import\b[^\n]*?from\s*|.*\brequire\s*\(\s*)['"`][^'"`]*app/api/""",
+    re.MULTILINE,
+)
+
+MOCKS_THE_SUBJECT = "mocks the route module under test and asserts on the mock"
+MOCKS_THE_NETWORK = (
+    "replaces the fetch seam and imports no route module, so the application is "
+    "never invoked — the suite asserts what it told its own mock to return"
+)
+
+
+def _is_js_test_file(path: str) -> bool:
+    """True for the JS/TS test files a qa author emits (``*.test.ts`` / ``*.spec.tsx``…)."""
+    name = path.replace("\\", "/").rsplit("/", 1)[-1]
+    return name.endswith(_JS_TEST_SUFFIXES)
+
+
+def detect_self_mocking_tests(files: list[dict]) -> list[tuple[str, str]]:
+    """Return ``(path, reason)`` for generated suites that assert against their own mock.
+
+    Deliberately two-clause and conservative, mirroring the stub-fallback heuristic. A
+    suite that mocks an *outbound* call while still importing and invoking the real route
+    handler is legitimate and is not flagged — mocking is not the defect, mocking
+    **instead of** invoking is. The discriminator is whether an application route module
+    is imported at all.
+
+    Args:
+        files: extracted-file or artifact dicts (each with a name/filename/path
+            and ``content``).
+
+    Returns:
+        Sorted ``(path, reason)`` pairs; empty when none are found.
+    """
+    offenders: list[tuple[str, str]] = []
+    for f in files:
+        path, content = _file_field(f)
+        if not path or not _is_js_test_file(path):
+            continue
+        if _ROUTE_MODULE_MOCK.search(content):
+            offenders.append((path, MOCKS_THE_SUBJECT))
+        elif _NETWORK_SEAM_MOCK.search(content) and not _APP_ROUTE_IMPORT.search(content):
+            offenders.append((path, MOCKS_THE_NETWORK))
     return sorted(offenders)

--- a/tests/unit/capabilities/test_stub_detection.py
+++ b/tests/unit/capabilities/test_stub_detection.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 import pytest
 
-from squadops.capabilities.handlers.stub_detection import detect_stub_fallback_tests
+from squadops.capabilities.handlers.stub_detection import (
+    MOCKS_THE_NETWORK,
+    MOCKS_THE_SUBJECT,
+    detect_self_mocking_tests,
+    detect_stub_fallback_tests,
+)
 
 pytestmark = [pytest.mark.domain_capabilities]
 
@@ -108,3 +113,153 @@ def test_multiple_offenders_sorted():
 )
 def test_empty_or_nameless_inputs_do_not_crash(files):
     assert detect_stub_fallback_tests(files) == []
+
+
+# --- Self-mocking suites (#915) -------------------------------------------------
+
+#: Window roll 3's real emission (`cyc_b20f58cc7cbc`), condensed: the mock is primed,
+#: the mock is called, and the assertion reads back what the mock was told to return.
+#: 479 lines that never touched the application, and green by construction.
+_SELF_MOCKING = """\
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as any;
+
+describe('POST /api/runs', () => {
+  it('rejects a blank title', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ error_code: 'validation_error' }),
+    });
+    const response = await fetch('/api/runs', { method: 'POST', body: '{}' });
+    const data = await response.json();
+    expect(data.error_code).toBe('validation_error');
+  });
+});
+"""
+
+#: Window roll 2's real additive suite, condensed. The in-process model done right:
+#: the route module is imported and its handler invoked with a real Request. This is
+#: the suite the detector must never flag.
+_REAL_ADDITIVE = """\
+import { beforeEach, describe, expect, it } from 'vitest'
+import { reset, all, insert } from '@/lib/store'
+import * as routeApiRunsRunId from '@/app/api/runs/[run_id]/route'
+import * as routeApiRuns from '@/app/api/runs/route'
+
+type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response
+
+beforeEach(() => reset())
+
+describe('join', () => {
+  it('adds a participant', async () => {
+    const res = await (routeApiRuns.POST as Handler)(
+      new Request('http://test/api/runs', { method: 'POST', body: '{}' }),
+    );
+    expect(res.status).toBe(201);
+  });
+});
+"""
+
+
+class TestSelfMockingSuites:
+    """#915. The TypeScript sibling of the stub-fallback class and strictly worse: a
+    stub-fallback suite reconstructs the app and then fails, because a reconstruction
+    misbehaves. A self-mocking suite asserts what it told its own mock to return, so
+    passing is its natural state. Roll 3 only went red because its scaffold slots were
+    also unfilled — with them filled, 479 lines of nothing would have read as
+    verification."""
+
+    def test_roll_threes_real_suite_is_flagged(self):
+        offenders = detect_self_mocking_tests(
+            [{"name": "__tests__/api/runs.test.ts", "content": _SELF_MOCKING}]
+        )
+        assert offenders == [("__tests__/api/runs.test.ts", MOCKS_THE_NETWORK)]
+
+    def test_the_real_additive_suite_is_not_flagged(self):
+        """The false positive that would matter most. Roll 2's additive suite is the
+        model answer — imports the route module, invokes the handler, asserts on the
+        real response — and a detector that flags it would reject correct work."""
+        assert (
+            detect_self_mocking_tests(
+                [{"name": "__tests__/participants.test.ts", "content": _REAL_ADDITIVE}]
+            )
+            == []
+        )
+
+    def test_mocking_an_outbound_call_while_invoking_the_route_is_legitimate(self):
+        """Mocking is not the defect; mocking INSTEAD of invoking is. A suite that
+        stubs an outbound dependency and still drives the real handler is exactly what
+        a caller should be allowed to write."""
+        content = _REAL_ADDITIVE + "\nglobal.fetch = vi.fn()  // stub the upstream weather API\n"
+        assert (
+            detect_self_mocking_tests([{"name": "__tests__/x.test.ts", "content": content}]) == []
+        )
+
+    def test_mocking_the_route_module_is_flagged_even_when_it_is_also_imported(self):
+        """The hole the import-based discriminator would otherwise leave: mock the
+        subject, import the mock, assert on it. Every clause of the two-clause rule is
+        satisfied and the application is still never invoked, so this one is
+        unconditional."""
+        content = (
+            "import { vi } from 'vitest'\n"
+            "vi.mock('@/app/api/runs/route')\n"
+            "import * as route from '@/app/api/runs/route'\n"
+        )
+        offenders = detect_self_mocking_tests([{"name": "__tests__/y.test.ts", "content": content}])
+        assert offenders == [("__tests__/y.test.ts", MOCKS_THE_SUBJECT)]
+
+    @pytest.mark.parametrize(
+        "stub_line",
+        [
+            "global.fetch = vi.fn()",
+            "globalThis.fetch = vi.fn()",
+            "vi.stubGlobal('fetch', vi.fn())",
+            'vi.spyOn(global, "fetch")',
+        ],
+    )
+    def test_each_way_of_replacing_the_seam_is_recognised(self, stub_line):
+        content = f"import {{ vi }} from 'vitest'\n{stub_line}\nawait fetch('/api/runs')\n"
+        offenders = detect_self_mocking_tests([{"name": "__tests__/z.test.ts", "content": content}])
+        assert offenders == [("__tests__/z.test.ts", MOCKS_THE_NETWORK)]
+
+    def test_a_non_test_file_is_ignored(self):
+        """The delivered client seam legitimately calls fetch; it is not a test."""
+        content = "export async function api(path: string) { return fetch(path) }\n"
+        assert detect_self_mocking_tests([{"name": "lib/api.ts", "content": content}]) == []
+
+    def test_the_two_detectors_do_not_reach_into_each_others_languages(self):
+        """One module, two vocabularies. A Python stub-fallback is not a self-mocking
+        suite and a TypeScript mock is not an ImportError guard; each detector seeing
+        only its own extension is what keeps both heuristics conservative."""
+        files = [
+            {"name": "test_api.py", "content": _STUB_FALLBACK},
+            {"name": "__tests__/runs.test.ts", "content": _SELF_MOCKING},
+        ]
+        assert detect_stub_fallback_tests(files) == ["test_api.py"]
+        assert [path for path, _ in detect_self_mocking_tests(files)] == ["__tests__/runs.test.ts"]
+
+    def test_multiple_offenders_are_sorted(self):
+        files = [
+            {"name": "__tests__/b.test.ts", "content": _SELF_MOCKING},
+            {"name": "__tests__/a.spec.tsx", "content": _SELF_MOCKING},
+            {"name": "__tests__/ok.test.ts", "content": _REAL_ADDITIVE},
+        ]
+        assert [path for path, _ in detect_self_mocking_tests(files)] == [
+            "__tests__/a.spec.tsx",
+            "__tests__/b.test.ts",
+        ]
+
+    @pytest.mark.parametrize(
+        "files",
+        [
+            [],
+            [{"name": "__tests__/empty.test.ts", "content": ""}],
+            [{"name": "", "content": _SELF_MOCKING}],
+            [{"content": _SELF_MOCKING}],
+        ],
+    )
+    def test_empty_or_nameless_inputs_do_not_crash(self, files):
+        assert detect_self_mocking_tests(files) == []


### PR DESCRIPTION
A qa-authored additive suite can replace `global.fetch`, prime the mock, call the mock, and assert on what it was told to return. The application is never invoked, and nothing detects it.

`Closes #915`

## Why this is worse than the class it parallels

#276's stub-fallback suites **fail loudly** — a reconstructed app doesn't behave like the real one. A self-mocking suite **agrees with itself by construction**, so passing is its natural state.

Window roll 3 emitted 479 such lines. It only went red because its scaffold slots were *also* unfilled (#910). Had they been filled, `tests_pass` would have gone green on the strength of the fills while that file contributed nothing and read as 479 lines of verification.

## The asymmetry being closed

Fills **cannot** do this: SIP-0104's frozen spine imports the route handler and invokes it, and region enforcement rejects any edit to that surface. Additive files carried the same in-process rule (#877) **only as prose in the brief**. One half of the qa surface was enforced deterministically and the other half was asked nicely.

## Two clauses, both conservative

Mirrors the existing heuristic's structure rather than inventing a new posture.

| Clause | Trigger | Why |
|---|---|---|
| **Mocks the subject** | `vi.mock('…/app/api/…')` | Unconditional. There is no reading under which replacing the route module under test and then asserting on it verifies the route module. |
| **Mocks the network** | fetch seam replaced **and** no route module imported | Mocking is not the defect — mocking *instead of* invoking is. |

The first clause exists specifically because the second's discriminator would otherwise be satisfied by mock-then-import: mock the subject, import the mock, assert on it, every clause happy, application still never invoked.

**A suite that stubs an outbound dependency while still driving the real handler is legitimate** and is not flagged. That's the false positive that would actually hurt — it would reject correct work.

## Wired at both call sites

Retest included, for the reason #276 already gives: a repair told to make the suite pass can satisfy that instruction by mocking, and **mocking is the cheapest way to make any assertion true.** A guard that only covers the first attempt invites the correction loop to walk straight through it.

## Validated against real emissions, not only fixtures

- **35 test files across the four banked P6 rolls → zero flags.**
- Roll 2's additive suite — the model answer, importing both route modules and invoking their handlers — is clean.
- Roll 3's real emission shape is caught.

## Naming, flagged not fixed

The module is called `stub_detection` and nothing in it is stub-specific any more; it now owns "generated tests that validate something other than the deliverable," which is one defect in two languages. Renaming touches two call sites and their tests, and bundling a rename into a fix landing under a deploy freeze is how a small change becomes a risky one. Recorded in the docstring so the next reader knows the name is stale rather than the scope narrow.

## Blocking status

§2.b of the V7 pre-registration, ruled **fix** rather than declare. **Does not merge until the SIP-0104 P6 window closes** — deploy frozen at `d590f73c`.
