### PR TITLE
feat(scaffold): report the delta between declared and verified behaviours

### DIFF
--- a/src/squadops/capabilities/scaffold_coverage.py
+++ b/src/squadops/capabilities/scaffold_coverage.py
@@ -1,0 +1,194 @@
+"""What the deterministic layer actually covers, per manifest (#951).
+
+The verification scaffold covers a **derived subset** of the behaviours a manifest
+declares. That is a defensible engineering constraint — a probe cannot be synthesized
+for every shape without inventing request values a correct application would reject.
+The defect is that the difference was never recorded, so **silence read as coverage.**
+
+Window roll 2 (``cyc_2f63e2d841eb``) banked green with join and leave — the entire
+point of the application — untouched by every deterministic layer: five scaffold slots
+covering create, blank-rejection, list, detail and detail-404; two probes, both
+``POST /api/runs``; a boot audit that fires those same two probes. The feature was
+verified only by a freely-authored additive suite, which happened to be a good one.
+Nothing required that and nothing would have reported its absence.
+
+The scaffold's coverage is defined by **what it can derive**, not by what the manifest
+**declares**. This module makes that gap legible: for every declared endpoint, whether
+a probe and/or a scaffold slot reaches it.
+
+Deliberately a *report*, not a gate. Whether an uncovered endpoint should block is a
+separate ruling (SIP-0096 already has ``blocked_unverified`` if it should); being
+**recorded** should not wait on that decision. It is also read-only with respect to
+emission: no shell byte changes, so SIP-0104's Gate 1 pins and ``GENERATOR_VERSION``
+are untouched by adding it.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - annotations only
+    from squadops.capabilities.scaffold import InterfaceManifest
+
+#: A probe's path carries capture placeholders (``/api/runs/{created_id}/join``) while the
+#: manifest declares its own parameter names (``/api/runs/{run_id}/join``). Coverage is a
+#: question about the route, not about whose name for the parameter won, so both sides are
+#: reduced to the same shape before comparison.
+_PARAM = re.compile(r"\{\w*\}")
+
+
+def _route_key(method: str, path: str) -> tuple[str, str]:
+    return method.upper(), _PARAM.sub("{}", path)
+
+
+@dataclass(frozen=True)
+class EndpointCoverage:
+    """One declared endpoint and the deterministic layers that reach it."""
+
+    method: str
+    path: str
+    probe_ids: tuple[str, ...] = ()
+    slot_ids: tuple[str, ...] = ()
+
+    @property
+    def covered(self) -> bool:
+        return bool(self.probe_ids or self.slot_ids)
+
+    def describe(self) -> str:
+        if not self.covered:
+            return f"{self.method} {self.path}: NO deterministic coverage"
+        layers = []
+        if self.slot_ids:
+            layers.append(f"{len(self.slot_ids)} slot(s)")
+        if self.probe_ids:
+            layers.append(f"{len(self.probe_ids)} probe(s)")
+        return f"{self.method} {self.path}: {', '.join(layers)}"
+
+
+@dataclass(frozen=True)
+class ScaffoldCoverage:
+    """The per-manifest delta between what was declared and what is verified."""
+
+    endpoints: tuple[EndpointCoverage, ...]
+
+    @property
+    def declared(self) -> int:
+        return len(self.endpoints)
+
+    @property
+    def covered(self) -> tuple[EndpointCoverage, ...]:
+        return tuple(e for e in self.endpoints if e.covered)
+
+    @property
+    def uncovered(self) -> tuple[EndpointCoverage, ...]:
+        return tuple(e for e in self.endpoints if not e.covered)
+
+    def summary(self) -> str:
+        """One line for the log, naming the uncovered routes rather than counting them.
+
+        A count invites the reading "3 of 4, close enough". The names invite the only
+        question worth asking, which is whether the one left out is the feature.
+        """
+        n = len(self.covered)
+        if not self.uncovered:
+            return f"scaffold coverage: {n}/{self.declared} declared endpoints, none uncovered"
+        missing = ", ".join(f"{e.method} {e.path}" for e in self.uncovered)
+        return (
+            f"scaffold coverage: {n}/{self.declared} declared endpoints; "
+            f"NO deterministic coverage for {missing}"
+        )
+
+    def as_dict(self) -> dict:
+        """Evidence shape — banked so the delta is recoverable after the fact."""
+        return {
+            "declared": self.declared,
+            "covered": len(self.covered),
+            "uncovered": [{"method": e.method, "path": e.path} for e in self.uncovered],
+            "endpoints": [
+                {
+                    "method": e.method,
+                    "path": e.path,
+                    "probe_ids": list(e.probe_ids),
+                    "slot_ids": list(e.slot_ids),
+                }
+                for e in self.endpoints
+            ],
+        }
+
+
+def summarize_coverage(
+    declared: Sequence[tuple[str, str]],
+    probe_routes: Sequence[tuple[str, str, str]],
+    slot_routes: Sequence[tuple[str, str, str]],
+) -> ScaffoldCoverage:
+    """Map declared ``(method, path)`` routes to the probe and slot ids that reach them.
+
+    Takes routes rather than a manifest so it stays stack-neutral: a second scaffold
+    stack derives its behaviours its own way and reports through the same function,
+    the way ``_EMITTERS`` keeps emission itself stack-neutral. Declaration order is
+    preserved, so the report reads in the order of the manifest it is about.
+    """
+    by_probe: dict[tuple[str, str], list[str]] = {}
+    for method, path, probe_id in probe_routes:
+        by_probe.setdefault(_route_key(method, path), []).append(probe_id)
+
+    by_slot: dict[tuple[str, str], list[str]] = {}
+    for method, path, slot_id in slot_routes:
+        by_slot.setdefault(_route_key(method, path), []).append(slot_id)
+
+    return ScaffoldCoverage(
+        endpoints=tuple(
+            EndpointCoverage(
+                method=method,
+                path=path,
+                probe_ids=tuple(by_probe.get(_route_key(method, path), ())),
+                slot_ids=tuple(by_slot.get(_route_key(method, path), ())),
+            )
+            for method, path in declared
+        )
+    )
+
+
+def derive_scaffold_coverage(manifest: InterfaceManifest) -> ScaffoldCoverage:
+    """Coverage for a manifest, deriving the behaviours the emitter would emit.
+
+    The convenience form, for tooling and tests. The emitter itself calls
+    ``summarize_coverage`` directly with the behaviours it already holds rather than
+    paying for a second derivation.
+    """
+    from squadops.capabilities.stack_nextjs_ts_tests import derive_scaffold_behaviors
+
+    behaviors, probes = derive_scaffold_behaviors(manifest)
+    return summarize_coverage(
+        [(ep.method, ep.path) for ep in manifest.api.endpoints],
+        probe_routes(probes),
+        slot_routes(behaviors),
+    )
+
+
+def probe_routes(probes: Sequence[dict]) -> list[tuple[str, str, str]]:
+    """``(method, path, probe_id)`` for each derived probe."""
+    rows = []
+    for probe in probes:
+        request = probe.get("request", {})
+        rows.append(
+            (
+                str(request.get("method", "GET")),
+                str(request.get("path", "")),
+                str(probe.get("id", "")),
+            )
+        )
+    return rows
+
+
+def slot_routes(behaviors: Sequence) -> list[tuple[str, str, str]]:
+    """``(method, path, slot_id)`` for each emitted behaviour.
+
+    The **final** step is what a behaviour asserts on. Prerequisites are setup — a
+    create replayed in order to reach a join is not coverage of the create, and
+    counting it would inflate exactly the number this report exists to deflate.
+    """
+    return [(b.final.method, b.final.url_path, f"slot-{b.behavior_id}") for b in behaviors]

--- a/src/squadops/capabilities/stack_nextjs_ts_tests.py
+++ b/src/squadops/capabilities/stack_nextjs_ts_tests.py
@@ -36,6 +36,7 @@ invocation.
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -54,6 +55,8 @@ if TYPE_CHECKING:  # pragma: no cover - annotations only
 
 #: Where every emitted shell lives. Inside the stack's ``__tests__`` namespace so the
 #: vitest include pattern collects it; the ``.scaffold.test.ts`` suffix marks provenance.
+logger = logging.getLogger(__name__)
+
 SCAFFOLD_TEST_DIR = "__tests__/scaffold"
 
 _STORE_PATH = "lib/store.ts"
@@ -391,14 +394,15 @@ def _shell_source(behavior: _Behavior) -> str:
     return "\n".join(lines)
 
 
-def emit_nextjs_ts_verification_scaffold(
-    manifest: InterfaceManifest, expanded: list[dict[str, str]]
-) -> list[tuple[str, str, tuple[BehaviorSlot, ...]]]:
-    """The stack-#2 behavior shells: ``(path, content, slots)`` per emitted file.
+def derive_scaffold_behaviors(
+    manifest: InterfaceManifest,
+) -> tuple[list[_Behavior], list[dict]]:
+    """The behaviours this manifest yields, and the probes half of them derive from.
 
-    One behavior per file, so a degraded fill degrades one slot's file and attribution
-    stays per-behavior. Deterministic order: probe twins in probe order, then minted read
-    shells in endpoint declaration order.
+    Extracted so the coverage report (#951) reads the **same** derivation the emitter
+    runs rather than a parallel reimplementation of it. A coverage report that computes
+    its own answer is worse than none: it would drift from the shells silently and
+    report a delta that is itself wrong.
     """
     from squadops.capabilities.scaffold_contract import emit_contract_dict
 
@@ -410,6 +414,39 @@ def emit_nextjs_ts_verification_scaffold(
         probe["request"]["path"]: probe for kind, probe in classified if kind == "create"
     }
     behaviors += _minted_read_behaviors(manifest, creates_by_path)
+    return behaviors, probes
+
+
+def emit_nextjs_ts_verification_scaffold(
+    manifest: InterfaceManifest, expanded: list[dict[str, str]]
+) -> list[tuple[str, str, tuple[BehaviorSlot, ...]]]:
+    """The stack-#2 behavior shells: ``(path, content, slots)`` per emitted file.
+
+    One behavior per file, so a degraded fill degrades one slot's file and attribution
+    stays per-behavior. Deterministic order: probe twins in probe order, then minted read
+    shells in endpoint declaration order.
+    """
+    from squadops.capabilities.scaffold_coverage import (
+        probe_routes,
+        slot_routes,
+        summarize_coverage,
+    )
+
+    behaviors, probes = derive_scaffold_behaviors(manifest)
+
+    # #951: the scaffold covers what it can DERIVE, not what the manifest DECLARES, and
+    # the difference used to be recorded nowhere — so silence read as coverage. Roll 2
+    # banked green with join and leave, the whole point of the app, untouched by every
+    # deterministic layer. Emitting the delta here costs nothing and changes no shell
+    # byte (Gate 1's pins and GENERATOR_VERSION are untouched); it is a report, not a
+    # gate, because whether an uncovered endpoint should BLOCK is a separate ruling.
+    coverage = summarize_coverage(
+        [(ep.method, ep.path) for ep in manifest.api.endpoints],
+        probe_routes(probes),
+        slot_routes(behaviors),
+    )
+    log = logger.warning if coverage.uncovered else logger.info
+    log("verification scaffold %s", coverage.summary())
 
     tree = {f["name"]: f["content"] for f in expanded}
     _require_surfaces(behaviors, tree)

--- a/tests/unit/capabilities/test_scaffold_coverage.py
+++ b/tests/unit/capabilities/test_scaffold_coverage.py
@@ -1,0 +1,163 @@
+"""The delta between what a manifest declares and what the scaffold verifies (#951).
+
+Bug this guards: the scaffold covers what it can *derive*, not what the manifest
+*declares*, and the difference was recorded nowhere — so silence read as coverage.
+Window roll 2 (`cyc_2f63e2d841eb`) banked green, 26/26 checks and 9/9 criteria, with
+join and leave — the entire point of the application — untouched by every deterministic
+layer. The feature was carried by a freely-authored additive suite that happened to be
+good; nothing required that and nothing would have reported its absence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.capabilities.scaffold_coverage import (
+    derive_scaffold_coverage,
+    slot_routes,
+    summarize_coverage,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_REFERENCE = Path("examples/03_group_run/interface_manifest.yaml")
+
+#: Roll 2's shape: join and leave folded into ONE endpoint discriminated by a request-body
+#: field, which the probe deriver cannot reach (#948) and no minted read covers.
+_ROLL_2_ROUTES = [
+    ("GET", "/api/runs"),
+    ("POST", "/api/runs"),
+    ("GET", "/api/runs/{run_id}"),
+    ("POST", "/api/runs/{run_id}"),
+]
+
+
+class TestTheDeltaIsReported:
+    def test_an_endpoint_no_layer_reaches_is_named(self):
+        """Roll 2's defect, in one line at seed time instead of by hand days later."""
+        coverage = summarize_coverage(
+            _ROLL_2_ROUTES,
+            probe_routes=[("POST", "/api/runs", "vc-probe-api-runs")],
+            slot_routes=[
+                ("GET", "/api/runs", "slot-vs-get-api-runs"),
+                ("POST", "/api/runs", "slot-vc-probe-api-runs"),
+                ("GET", "/api/runs/{run_id}", "slot-vs-get-api-runs-run-id"),
+            ],
+        )
+        assert [(e.method, e.path) for e in coverage.uncovered] == [("POST", "/api/runs/{run_id}")]
+        assert coverage.declared == 4
+        assert len(coverage.covered) == 3
+
+    def test_the_summary_names_the_route_rather_than_counting_it(self):
+        """A bare count invites "3 of 4, close enough". The name invites the only
+        question worth asking — whether the one left out is the feature."""
+        coverage = summarize_coverage(
+            _ROLL_2_ROUTES, probe_routes=[], slot_routes=[("GET", "/api/runs", "slot-a")]
+        )
+        summary = coverage.summary()
+        assert "POST /api/runs/{run_id}" in summary
+        assert "GET /api/runs/{run_id}" in summary
+
+    def test_full_coverage_says_so_explicitly(self):
+        coverage = summarize_coverage(
+            [("GET", "/api/runs")], probe_routes=[], slot_routes=[("GET", "/api/runs", "slot-a")]
+        )
+        assert coverage.uncovered == ()
+        assert "none uncovered" in coverage.summary()
+
+
+class TestWhatCountsAsCoverage:
+    def test_a_probe_alone_covers_an_endpoint(self):
+        coverage = summarize_coverage(
+            [("POST", "/api/runs")], probe_routes=[("POST", "/api/runs", "p1")], slot_routes=[]
+        )
+        assert coverage.uncovered == ()
+        assert coverage.endpoints[0].probe_ids == ("p1",)
+
+    def test_a_parameter_name_mismatch_still_matches(self):
+        """A probe path carries capture placeholders (`{created_id}`) while the manifest
+        declares its own parameter name (`{run_id}`). Coverage is a question about the
+        route, not about whose name for the parameter won — comparing them literally
+        would report every parameterized endpoint as uncovered."""
+        coverage = summarize_coverage(
+            [("POST", "/api/runs/{run_id}/join")],
+            probe_routes=[("POST", "/api/runs/{created_id}/join", "p-join")],
+            slot_routes=[],
+        )
+        assert coverage.uncovered == ()
+        assert coverage.endpoints[0].probe_ids == ("p-join",)
+
+    def test_declaration_order_is_preserved(self):
+        """The report reads in the order of the manifest it is about."""
+        coverage = summarize_coverage(
+            [("POST", "/b"), ("GET", "/a"), ("DELETE", "/c")], probe_routes=[], slot_routes=[]
+        )
+        assert [(e.method, e.path) for e in coverage.endpoints] == [
+            ("POST", "/b"),
+            ("GET", "/a"),
+            ("DELETE", "/c"),
+        ]
+
+    def test_a_verb_with_no_derivation_source_is_reported_uncovered(self):
+        """PUT/PATCH/DELETE have no source of scaffold behaviours at all, for any
+        manifest. That is the class #951 names as surviving a #948 fix."""
+        coverage = summarize_coverage(
+            [("DELETE", "/api/runs/{run_id}")], probe_routes=[], slot_routes=[]
+        )
+        assert len(coverage.uncovered) == 1
+        assert "NO deterministic coverage" in coverage.uncovered[0].describe()
+
+
+class TestPrerequisitesAreNotCoverage:
+    def test_a_replayed_create_does_not_credit_the_create_endpoint(self):
+        """A behaviour that creates a run in order to read it asserts on the READ. If
+        setup counted, a manifest could reach full coverage while asserting on one
+        endpoint — inflating exactly the number this report exists to deflate."""
+
+        class _Step:
+            def __init__(self, method, url_path):
+                self.method, self.url_path = method, url_path
+
+        class _Behavior:
+            def __init__(self, behavior_id, final, prerequisites):
+                self.behavior_id, self.final, self.prerequisites = (
+                    behavior_id,
+                    final,
+                    prerequisites,
+                )
+
+        behavior = _Behavior(
+            "vs-get-api-runs-run-id",
+            final=_Step("GET", "/api/runs/{run_id}"),
+            prerequisites=(_Step("POST", "/api/runs"),),
+        )
+        assert slot_routes([behavior]) == [
+            ("GET", "/api/runs/{run_id}", "slot-vs-get-api-runs-run-id")
+        ]
+
+
+class TestAgainstTheRealManifest:
+    """The reference manifest is the worked example every other layer is pinned to, so
+    a coverage report that disagreed with it would be reporting on something else."""
+
+    @pytest.mark.skipif(not _REFERENCE.exists(), reason="reference manifest absent")
+    def test_the_reference_manifest_is_fully_covered(self):
+        manifest = InterfaceManifest.from_dict(yaml.safe_load(_REFERENCE.read_text()))
+        coverage = derive_scaffold_coverage(manifest)
+        assert coverage.uncovered == ()
+        assert coverage.declared == len(manifest.api.endpoints)
+        # every endpoint reached by at least one slot — the shells are the floor
+        assert all(e.slot_ids for e in coverage.endpoints)
+
+    @pytest.mark.skipif(not _REFERENCE.exists(), reason="reference manifest absent")
+    def test_the_evidence_shape_carries_the_uncovered_list(self):
+        """Banked so the delta is recoverable after the fact rather than re-derived."""
+        manifest = InterfaceManifest.from_dict(yaml.safe_load(_REFERENCE.read_text()))
+        banked = derive_scaffold_coverage(manifest).as_dict()
+        assert banked["uncovered"] == []
+        assert banked["declared"] == banked["covered"] == len(manifest.api.endpoints)
+        assert {"method", "path", "probe_ids", "slot_ids"} <= set(banked["endpoints"][0])


### PR DESCRIPTION
The scaffold covers what it can **derive**, not what the manifest **declares**, and the difference was recorded nowhere. Silence read as coverage.

`Closes #951`

## What went unnoticed

Window roll 2 (`cyc_2f63e2d841eb`) banked green — 26/26 checks, 9/9 criteria, boot audit pass — while **join and leave, the entire point of the application, went untouched by every deterministic layer:**

| layer | reaches join/leave? |
|---|---|
| 5 scaffold slots | no — create, blank-rejection, list, detail, detail-404 |
| 2 contract probes | no — both `POST /api/runs` |
| boot audit | no — it fires the contract's probes, and there are two |
| authored additive suite | yes — 12 tests |

The suite carrying it was a good one. **Nothing required that and nothing would have reported its absence** — and it is precisely the layer #915 shows can mock itself green.

## What this emits

Per manifest, which declared endpoints a probe and/or a slot reaches. Run against the four banked rolls it reproduces the known facts exactly:

```
roll 1   scaffold coverage: 5/5 declared endpoints, none uncovered
roll 2   scaffold coverage: 3/4 declared endpoints;
         NO deterministic coverage for POST /api/runs/{run_id}
roll 3   scaffold coverage: 5/5 declared endpoints, none uncovered
roll 4   scaffold coverage: 5/5 declared endpoints, none uncovered
```

Roll 2's line is the defect, stated at seed time in one line instead of found by hand days later. Roll 4's detail view also shows join at **1 probe where roll 1 had 2** — the missing duplicate-join probe (#948) is now visible rather than inferred.

## A report, not a gate

Whether an uncovered endpoint should **block** is a separate ruling — SIP-0096 already has `blocked_unverified` if it should. Being *recorded* should not wait on that decision, and coupling the two would have held a cheap fix hostage to a policy question.

Read-only with respect to emission: **no shell byte changes**, so SIP-0104's Gate 1 pins and `GENERATOR_VERSION` are untouched. 4800 tests green, byte pins included.

## Three design points

**`summarize_coverage` takes routes, not a manifest.** That keeps it stack-neutral the way `_EMITTERS` keeps emission stack-neutral — a second scaffold stack derives its behaviours its own way and reports through the same function, rather than this becoming a second place that knows about stack #2.

**`derive_scaffold_behaviors` is extracted from the emitter** so the report reads the *same* derivation rather than a parallel reimplementation. A coverage report that computed its own answer would drift from the shells silently and report a delta that was itself wrong — worse than no report, because it would look authoritative.

**Prerequisites are not coverage.** A create replayed in order to reach a join is setup. Crediting it would let a manifest reach "full coverage" while asserting on one endpoint — inflating exactly the number this exists to deflate.

## The summary names routes rather than counting them

`3/4` invites "close enough." `NO deterministic coverage for POST /api/runs/{run_id}` invites the only question worth asking, which is whether the one left out is the feature. In roll 2's case it was.

## Blocking status

§2.b of the V7 pre-registration, ruled **fix** rather than declare. **Does not merge until the SIP-0104 P6 window closes** — deploy frozen at `d590f73c`.
