### PR TITLE
feat(contract): probe body-discriminated child actions from declared values

### DIFF
--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -78,6 +78,34 @@ class RequestShape:
     name: str
     required: tuple[str, ...] = ()
     optional: tuple[str, ...] = ()
+    #: Declared candidate values per field, for fields whose value *selects a behaviour*
+    #: rather than carrying data (#948). A shape that says ``{"action": ("join", "leave")}``
+    #: is stating that those two strings are the whole domain of ``action``.
+    #:
+    #: Why the manifest has to say it rather than the deriver guessing: without declared
+    #: values a synthesized body is ``{"action": "sample"}``, which a CORRECT application
+    #: rejects — so relaxing derivation to probe these endpoints anyway would manufacture
+    #: false failures. Roll 2 folded join and leave into one body-discriminated endpoint
+    #: and bought **zero** behavioural probes as a result; the fix is to let the author
+    #: declare the domain, not to let the deriver invent it.
+    values: tuple[tuple[str, tuple[str, ...]], ...] = ()
+
+    def declared_values(self, field: str) -> tuple[str, ...]:
+        """The declared domain of ``field``, or empty when it carries data not a choice."""
+        return dict(self.values).get(field, ())
+
+    @property
+    def discriminator(self) -> str | None:
+        """The single required field whose value selects a behaviour, if there is one.
+
+        Exactly one, deliberately. Two discriminators would make the probe set a cross
+        product whose size the author never sees, and "which combinations are legal" is a
+        question the shape cannot answer — so a shape declaring two is treated as
+        declaring none, and the endpoint reports as uncovered (#951) rather than being
+        probed on a guess.
+        """
+        declared = [name for name, options in self.values if options and name in self.required]
+        return declared[0] if len(declared) == 1 else None
 
 
 @dataclass(frozen=True)
@@ -308,8 +336,25 @@ class InterfaceManifest:
             ],
             "api": {
                 "base_path": self.api.base_path,
+                # ``values`` is emitted ONLY when declared (#948). It belongs in the
+                # projection — it changes the derived contract's probe set, and a manifest
+                # whose contract differs must not share a hash with one whose contract does
+                # not. But emitting it unconditionally as an empty list would move the hash
+                # of every manifest ever written, invalidating each stored contract binding
+                # to record the absence of a field none of them use. Present-when-declared
+                # keeps both properties: existing manifests hash exactly as before, and a
+                # manifest that adopts the field hashes differently, which is correct.
                 "request_shapes": [
-                    {"name": s.name, "required": list(s.required), "optional": list(s.optional)}
+                    {
+                        "name": s.name,
+                        "required": list(s.required),
+                        "optional": list(s.optional),
+                        **(
+                            {"values": [[f, list(opts)] for f, opts in s.values]}
+                            if s.values
+                            else {}
+                        ),
+                    }
                     for s in self.api.request_shapes
                 ],
                 "endpoints": [
@@ -454,6 +499,11 @@ def _parse_api(raw: dict[str, Any]) -> Api:
             name=str(name),
             required=tuple(str(x) for x in (spec or {}).get("required", [])),
             optional=tuple(str(x) for x in (spec or {}).get("optional", [])),
+            values=tuple(
+                (str(field), tuple(str(v) for v in options))
+                for field, options in ((spec or {}).get("values", {}) or {}).items()
+                if options
+            ),
         )
         for name, spec in (raw.get("request_shapes", {}) or {}).items()
     )

--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -523,6 +523,56 @@ def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, A
                             "expect": {"status": 409, "error_code": conflict_codes[0]},
                         }
                     )
+
+        # #948: the same child actions, expressed the OTHER legal way — one POST at the
+        # parameterized path, discriminated by a request-body field
+        # (``POST /runs/{run_id}`` with ``{"action": "join"}``). The regex above requires
+        # a literal trailing segment, so this shape derived NOTHING: window roll 2 chose
+        # it and bought zero behavioural probes, leaving join and leave — the app's whole
+        # purpose — verified only by a freely-authored suite.
+        #
+        # The fix is NOT to relax the regex. Without declared values the synthesized body
+        # is ``{"action": "sample"}``, which a CORRECT app rejects, so probing on a guess
+        # manufactures false failures. The author declares the domain
+        # (``values: {action: [join, leave]}``) and each declared value becomes a probe.
+        # A shape that declares nothing still derives nothing, and #951's coverage report
+        # now says so out loud instead of leaving it silent.
+        if children or "id" not in response_fields:
+            continue
+        body_children = [
+            child
+            for child in manifest.api.endpoints
+            if child.method == "POST"
+            and re.fullmatch(re.escape(ep.path) + r"/\{(\w+)\}", child.path)
+        ]
+        for child in body_children:
+            child_shape = shapes.get(child.request or "")
+            discriminator = child_shape.discriminator if child_shape else None
+            if not discriminator:
+                continue
+            param = re.findall(r"\{(\w+)\}", child.path)[0]
+            create_probe["capture"] = {param: "id"}
+            create_slug = _slug(ep.path) or "root"
+            for value in child_shape.declared_values(discriminator):
+                child_body = {
+                    field: _probe_sample_value(field, field_types.get(field, "string"))
+                    for field in child_shape.required
+                }
+                child_body[discriminator] = value
+                probes.append(
+                    {
+                        "id": f"vc-probe-{create_slug}-{_slug(value)}",
+                        "subject": "backend",
+                        "request": {"method": "POST", "path": child.path, "json": child_body},
+                        "expect": {"status": child.success_status or 200},
+                    }
+                )
+            # No duplicate-conflict probe here, deliberately. One endpoint carries every
+            # action, so a 409 in ``child.errors`` cannot be attributed to a particular
+            # value — repeating ``leave`` and expecting 409 would fail a correct app.
+            # Guessing which action conflicts is exactly the class of invention this fix
+            # exists to avoid, so the duplicate case stays uncovered AND VISIBLE (#951)
+            # rather than covered by assumption.
     return probes
 
 

--- a/src/squadops/prompts/request_templates/request.manifest_authoring_rules_appendix.md
+++ b/src/squadops/prompts/request_templates/request.manifest_authoring_rules_appendix.md
@@ -41,6 +41,30 @@ resource). Leave it out and two components disagree about what the endpoint retu
 verification contract asserts one status while the generated route serves another, which is
 a contract no correct implementation can satisfy. State it and the disagreement cannot arise.
 
+**declare-the-choices-a-body-carries** — When a request field's *value* selects which
+behavior runs rather than carrying data — an `action` that is either `join` or `leave`, a
+`status` that is either `open` or `closed` — declare its whole domain under the shape's
+`values`:
+
+```yaml
+request_shapes:
+  ParticipantAction:
+    required: [action, name]
+    values:
+      action: [join, leave]
+```
+
+Without this the verification layer cannot test those behaviors at all. It has only the
+field's *name*, so the only body it can build is `{"action": "sample"}` — which a correct
+application rejects. Rather than manufacture that false failure it derives nothing, and the
+endpoint ships with no behavioral check of its own. A design that folded a run's join and
+leave into one such endpoint reached the end of a cycle with its central feature verified by
+nothing deterministic, and every layer reported success.
+
+Declare one such field per shape. Two would make the set of behaviors a cross product, and
+which combinations are legal is not something the shape can state — so a shape naming two is
+read as naming none.
+
 **every-view-declares-anchors** — Every frontend route declares `testids`: the stable
 `data-testid` values the view exposes, root container first. These are the only handles the
 test suite is permitted to query, so a view with none is a view nothing can verify — and

--- a/tests/unit/capabilities/test_scaffold_contract.py
+++ b/tests/unit/capabilities/test_scaffold_contract.py
@@ -337,3 +337,128 @@ class TestChainedActionProbes:
             probe.pop("capture", None)  # orphan the {run_id} placeholders
         errors = VerificationContract.from_dict(raw).lint()
         assert any("no earlier probe capturing it" in e for e in errors)
+
+
+class TestBodyDiscriminatedActionProbes:
+    """#948. The same child actions, expressed the other legal way: ONE POST at the
+    parameterized path with a body field selecting the behavior. The `/runs/{id}/join`
+    regex above requires a literal trailing segment, so this shape derived NOTHING —
+    window roll 2 chose it and bought zero behavioral probes, leaving join and leave,
+    the application's entire purpose, verified only by a freely-authored suite.
+
+    The fix is emphatically NOT relaxing the regex. With only a field NAME the deriver
+    can build `{"action": "sample"}`, which a correct app rejects, so probing on a guess
+    manufactures false failures. The author declares the domain instead."""
+
+    def _folded(self, *, values: dict | None = None, required=("action", "name")) -> dict:
+        """The reference manifest with join/leave folded into one body-discriminated
+        endpoint — roll 2's real shape."""
+        raw = _raw()
+        raw["api"]["endpoints"] = [
+            ep
+            for ep in raw["api"]["endpoints"]
+            if not str(ep["path"]).endswith(("/join", "/leave"))
+        ]
+        raw["api"]["endpoints"].append(
+            {
+                "method": "POST",
+                "path": "/runs/{run_id}",
+                "summary": "join or leave",
+                "request": "ParticipantAction",
+                "response": "RunEvent",
+                "errors": ["run_not_found", "validation_error", "duplicate_participant"],
+            }
+        )
+        shape: dict = {"required": list(required)}
+        if values is not None:
+            shape["values"] = values
+        raw["api"]["request_shapes"]["ParticipantAction"] = shape
+        return raw
+
+    def _probe_ids(self, raw: dict) -> list[str]:
+        manifest = InterfaceManifest.from_dict(raw)
+        return [p["id"] for p in emit_contract_dict(manifest)["behavioral"]["probes"]]
+
+    def test_undeclared_values_still_derive_nothing(self):
+        """The conservative half, and the reason this is a schema change rather than a
+        regex change. A shape carrying only field NAMES cannot be probed without
+        inventing a value, so it is not probed."""
+        ids = self._probe_ids(self._folded())
+        assert ids == ["vc-probe-runs", "vc-probe-runs-rejects-blank"]
+
+    def test_declared_values_derive_one_probe_per_behavior(self):
+        raw = self._folded(values={"action": ["join", "leave"]})
+        manifest = InterfaceManifest.from_dict(raw)
+        probes = {p["id"]: p for p in emit_contract_dict(manifest)["behavioral"]["probes"]}
+        assert "vc-probe-runs-join" in probes
+        assert "vc-probe-runs-leave" in probes
+
+        join = probes["vc-probe-runs-join"]
+        assert join["request"]["path"] == "/runs/{run_id}"
+        # the discriminator carries the DECLARED value; every other required field is sampled
+        assert join["request"]["json"] == {"action": "join", "name": "sample"}
+        assert probes["vc-probe-runs-leave"]["request"]["json"]["action"] == "leave"
+
+    def test_the_create_captures_the_parameter_these_probes_need(self):
+        raw = self._folded(values={"action": ["join", "leave"]})
+        manifest = InterfaceManifest.from_dict(raw)
+        contract = VerificationContract.from_dict(emit_contract_dict(manifest))
+        assert {p.id: p.capture for p in contract.behavioral.probes}["vc-probe-runs"] == {
+            "run_id": "id"
+        }
+        assert contract.lint() == []
+
+    def test_no_duplicate_probe_is_invented_for_a_folded_endpoint(self):
+        """One endpoint carries every action, so a declared 409 cannot be attributed to a
+        particular value. Repeating `leave` and expecting 409 would fail a correct app —
+        guessing which action conflicts is the class of invention this fix avoids."""
+        raw = self._folded(values={"action": ["join", "leave"]})
+        assert not [pid for pid in self._probe_ids(raw) if pid.endswith("-duplicate")]
+
+    def test_two_declared_discriminators_are_read_as_none(self):
+        """Two would make the probe set a cross product whose size the author never sees,
+        and which combinations are legal is not something the shape can state."""
+        raw = self._folded(
+            values={"action": ["join", "leave"], "mode": ["quiet", "loud"]},
+            required=("action", "mode", "name"),
+        )
+        assert self._probe_ids(raw) == ["vc-probe-runs", "vc-probe-runs-rejects-blank"]
+
+    def test_values_on_an_optional_field_do_not_discriminate(self):
+        """A field the request need not carry cannot select the behavior — a probe
+        omitting it would exercise an undeclared default."""
+        raw = self._folded(values={"action": ["join", "leave"]}, required=("name",))
+        assert self._probe_ids(raw) == ["vc-probe-runs", "vc-probe-runs-rejects-blank"]
+
+
+class TestDeclaredValuesAndTheManifestHash:
+    """`values` changes the derived contract, so it must change the manifest hash — a
+    manifest whose contract differs must not share a hash with one whose contract does
+    not. It is emitted only when declared, so no existing manifest's hash moves."""
+
+    def test_a_manifest_without_values_hashes_exactly_as_before(self):
+        """Pinned against the reference manifest, which declares none. If this moves,
+        every stored contract binding in the system has been invalidated to record the
+        absence of a field none of them use."""
+        # Measured on main at 136fffb7, BEFORE `values` existed. A literal, because the
+        # whole claim is that this number did not move — comparing the manifest to itself
+        # would pass no matter what the projection did.
+        assert (
+            _manifest().content_hash()
+            == "bb472e267e53d5ad29406663b4340de45613dd68fa091fe7f2d06a99b7267530"
+        )
+        assert all(s.values == () for s in _manifest().api.request_shapes)
+
+    def test_declaring_values_moves_the_hash(self):
+        raw = _raw()
+        before = InterfaceManifest.from_dict(raw).content_hash()
+        raw["api"]["request_shapes"]["RunEventCreate"]["values"] = {"title": ["a", "b"]}
+        assert InterfaceManifest.from_dict(raw).content_hash() != before
+
+    def test_values_survive_a_dict_roundtrip(self):
+        raw = _raw()
+        raw["api"]["request_shapes"]["RunEventCreate"]["values"] = {"title": ["a", "b"]}
+        manifest = InterfaceManifest.from_dict(raw)
+        shape = next(s for s in manifest.api.request_shapes if s.name == "RunEventCreate")
+        assert shape.declared_values("title") == ("a", "b")
+        assert shape.declared_values("datetime") == ()


### PR DESCRIPTION
A manifest can express a child action two ways, and only one of them was verifiable.

`Closes #948`

| shape | derives |
|---|---|
| `POST /runs/{run_id}/join` — path segment | a behavioural probe |
| `POST /runs/{run_id}` + `{"action": "join"}` — body-discriminated | **nothing** |

Window roll 2 chose the second and bought **zero** behavioural probes. Join and leave — the application's entire purpose — shipped verified only by a freely-authored suite, in a roll that passed 26/26 checks and 9/9 criteria.

## The fix is not relaxing the regex, and that is the whole design

With only a field *name*, the deriver can synthesize `{"action": "sample"}` — which a **correct** application rejects. Probing on a guess manufactures false failures, which is strictly worse than the silence it replaces: a false red costs a correction round and teaches the squad to distrust the contract.

So the author declares the domain instead:

```yaml
request_shapes:
  ParticipantAction:
    required: [action, name]
    values:
      action: [join, leave]
```

**Measured on roll 2's real manifest: 2 probes before, 4 after.**

```
vc-probe-runs                 POST /api/runs         {"title": ..., ...}        -> 201
vc-probe-runs-rejects-blank   POST /api/runs         {"title": "", ...}         -> 400
vc-probe-runs-join            POST /api/runs/{run_id} {"action":"join","name":…} -> 200
vc-probe-runs-leave           POST /api/runs/{run_id} {"action":"leave","name":…}-> 200
```

The create captures the run id into the path parameter exactly as the path-segment form does, and the contract lints clean.

## Conservative by construction

| case | behaviour | why |
|---|---|---|
| no `values` declared | derives nothing | unchanged — this is what makes it a schema change, not a regex change |
| **two** discriminators | read as **none** | a cross product whose size the author never sees; which combinations are legal is not something a shape can state |
| `values` on an optional field | not a discriminator | a probe omitting the field would exercise an undeclared default |

**No duplicate-conflict probe is emitted for a folded endpoint**, deliberately. One endpoint carries every action, so a declared 409 cannot be attributed to a particular value — repeating `leave` and expecting 409 would fail a correct app. Guessing which action conflicts is exactly the class of invention this fix exists to avoid, so that case stays uncovered and (with #951) visible.

## The hash question

`values` belongs in the structural projection: it changes the derived contract, and **a manifest whose contract differs must not share a hash with one whose contract does not.**

But emitting it unconditionally as an empty list would move the hash of every manifest ever written — invalidating each stored contract binding in order to record the absence of a field none of them use. So it is emitted **only when declared**. Existing manifests hash exactly as before; a manifest that adopts the field hashes differently, which is correct.

The reference manifest still hashes `bb472e26…`, pinned as a literal in the test. Comparing the manifest to itself would prove nothing no matter what the projection did.

## Prompt asset

The authoring rules appendix gains `declare-the-choices-a-body-carries`, with its warrant and a YAML snippet, in the same voice as the neighbouring rules. Prose lives in the managed fragment, not in a Python literal (#448).

**The worked example in the manifest template is deliberately unchanged.** Plan step 4a ruled the example is held constant, and it is the strongest prior the author has — adding an action endpoint there would nudge every future manifest toward inventing one.

## Scope note

This is the largest of the §2.b items and the only one that **changes what the squad authors**. V7's manifests will be written under a schema P6's were not, so the two windows stay comparable on recipe — the config hash does not move — but **not on probe counts.** P6's 5 / 2 / 5 / 4 / 5 distribution is the motivation for this fix and must not be reported as a baseline the V7 numbers improve on.

7786 unit tests green, byte pins and both Guard 1 halves included.

**Does not merge until the SIP-0104 P6 window closes** — deploy frozen at `d590f73c`.
