### PR TITLE
fix(qa): log which validation check opened the self-eval branch

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -43,6 +43,21 @@ from squadops.capabilities.handlers.emission_log import log_emission_shape
 logger = logging.getLogger(__name__)
 
 
+def failing_check_names(checks: list[dict]) -> list[str]:
+    """Which checks actually opened the self-eval branch (#946).
+
+    Evidence-gap rows are excluded deliberately. They are honest non-passes that
+    ``_validate_output`` already refuses to fail the task on — a correction cannot repair
+    an evaluator limitation — so naming one as the trigger would send a reader chasing a
+    check that did not cause anything.
+    """
+    return [
+        str(c.get("check", "unnamed"))
+        for c in checks
+        if not c.get("passed", True) and not c.get("evidence_gap", False)
+    ]
+
+
 def _frontend_skip_reason(error: str) -> str:
     """Map a frontend-build skip error to a §7 not-executed reason (#407).
 
@@ -1073,6 +1088,25 @@ class QATestHandler(_CycleTaskHandler):
 
             # Self-evaluation loop
             if not validation.passed:
+                # #946: this branch is the SOLE trigger for a second model call, and
+                # nothing recorded which check opened it. The run summary afterwards
+                # showed 29/29 accepted, so the failure was unreadable from stored state
+                # — a whole extra generation, invisible in the record it produced. Roll 1
+                # burned 3,574 tokens here (68% of the qa task's wall clock) and the only
+                # way to learn why was to reconstruct it by hand from artifacts.
+                #
+                # Log the failing checks by name, not the count. "1 check failed" sends a
+                # reader back to the artifacts, which is the state this exists to end.
+                # `expected_artifacts` in particular fails for a reason fill mode makes
+                # invisible (#947): the plan's chosen filename is demoted while the check
+                # still hard-requires it.
+                failing = failing_check_names(validation.checks)
+                logger.info(
+                    "qa_test_handler self_eval trigger: failing_checks=%s missing=%s summary=%r",
+                    failing or ["<none named>"],
+                    validation.missing_components,
+                    validation.summary,
+                )
                 max_self_eval = resolved_config.get("max_self_eval_passes", 1)
                 self_eval_count = 0
 

--- a/tests/unit/capabilities/test_self_eval_trigger_log.py
+++ b/tests/unit/capabilities/test_self_eval_trigger_log.py
@@ -1,0 +1,62 @@
+"""Which check opened the self-eval branch (#946).
+
+Bug this guards: the self-eval branch is the sole trigger for a second model call, and
+nothing recorded what opened it. Window roll 1 spent 3,574 completion tokens there — 68%
+of the qa task's wall clock — and the run summary afterwards showed 29/29 checks accepted,
+so the failure was unreadable from stored state. The only way to learn the cause was to
+reconstruct it by hand from artifacts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.handlers.cycle.qa_test import failing_check_names
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+def test_the_failing_check_is_named_not_counted():
+    """ "1 check failed" sends a reader back to the artifacts, which is the state this
+    exists to end. `expected_artifacts` is the one that matters: under fill mode the
+    plan's chosen filename is demoted while this check still hard-requires it (#947)."""
+    checks = [
+        {"check": "expected_artifacts", "passed": False, "missing": ["__tests__/runs.test.ts"]},
+        {"check": "non_stub_files", "passed": True},
+    ]
+    assert failing_check_names(checks) == ["expected_artifacts"]
+
+
+def test_an_evidence_gap_is_not_reported_as_the_trigger():
+    """Evidence-gap rows are honest non-passes the validator already refuses to fail the
+    task on — a correction cannot repair an evaluator limitation. Naming one would send a
+    reader chasing a check that caused nothing."""
+    checks = [
+        {"check": "acceptance:vc-x", "passed": False, "evidence_gap": True},
+        {"check": "expected_artifacts", "passed": False},
+    ]
+    assert failing_check_names(checks) == ["expected_artifacts"]
+
+
+def test_every_failing_check_is_named_when_several_fail():
+    checks = [
+        {"check": "expected_artifacts", "passed": False},
+        {"check": "non_stub_files", "passed": False},
+        {"check": "test_file_presence", "passed": True},
+    ]
+    assert failing_check_names(checks) == ["expected_artifacts", "non_stub_files"]
+
+
+@pytest.mark.parametrize(
+    "checks,expected",
+    [
+        ([], []),
+        ([{"check": "a", "passed": True}], []),
+        # a row with no `passed` key defaults to passing, matching _validate_output's own rule
+        ([{"check": "a"}], []),
+        # a failing row with no name is still reported rather than silently dropped
+        ([{"passed": False}], ["unnamed"]),
+    ],
+)
+def test_edge_shapes(checks, expected):
+    assert failing_check_names(checks) == expected


### PR DESCRIPTION
`Closes #946`

The self-eval branch is the **sole** trigger for a second model call, and nothing recorded what opened it.

Window roll 1 spent **3,574 completion tokens** there — 68% of the qa task's wall clock, 3.2× its useful output — and the run summary afterwards showed 29/29 checks accepted. The failure was unreadable from stored state. The only way to learn the cause was to reconstruct it by hand from artifacts, which is how #947's mechanism came to be inferred **wrongly** the first time: roll 4 later reproduced roll 1's exact setup and produced the opposite emission, refuting the chain.

## What it logs

The failing checks **by name**, with the missing components and the summary. `1 check failed` sends a reader back to the artifacts, which is the state this exists to end.

Evidence-gap rows are excluded. They are honest non-passes the validator already refuses to fail the task on — a correction cannot repair an evaluator limitation — so naming one would send a reader chasing a check that caused nothing.

## Instrument only

No behaviour changes. No check added or removed. The branch condition is untouched.

That is deliberate, and it is the point: **#947's fix depends on how often `expected_artifacts` is the trigger**, and that turned out to be variance rather than determinism. Frequency is a measurement, not a deduction — this is what makes it measurable.

## Not required by the window

Unlike #948/#951/#915, this has no bearing on what a green roll *means*. Per §2.c of the pre-registration it should **wait until after V7** rather than enlarge the deploy boundary immediately before an evidentiary window. Opened now because the work is cheap and done; merging it is a separate call.