### PR TITLE
fix(qa): record what the test runner actually did

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -335,6 +335,29 @@ class QATestHandler(_CycleTaskHandler):
             timeout_seconds=capability.test_timeout_seconds,
         )
 
+        # #935: whether the suite actually RAN was recoverable only from an artifact a
+        # human had to open. `tests_pass` is exit-code driven, so "did not execute" and
+        # "executed and passed" are one keystroke apart in the record and neither leaves
+        # a log line. This is the same class as #926's emission capture: when a window
+        # roll needs triage, the first question is what the runner did, and the answer
+        # should not require archaeology.
+        #
+        # `uncollected` is logged beside the counts on purpose. A file the runner never
+        # collected verifies nothing while the collected ones read green — SIP-0104 roll 1
+        # shipped exactly that, and a count of test FILES cannot distinguish the two.
+        logger.info(
+            "qa_test_handler suite: framework=%s executed=%s exit_code=%s tests_passed=%s "
+            "test_files=%s source_files=%s uncollected=%s error=%r",
+            capability.test_framework,
+            test_result.executed,
+            test_result.exit_code,
+            test_result.tests_passed,
+            test_result.test_file_count,
+            test_result.source_file_count,
+            list(test_result.uncollected_test_files or ()),
+            test_result.error,
+        )
+
         report_lines = [
             "# Test Execution Report\n",
             f"**Result:** {test_result.summary}\n",

--- a/tests/unit/capabilities/test_suite_execution_log.py
+++ b/tests/unit/capabilities/test_suite_execution_log.py
@@ -1,0 +1,89 @@
+"""qa.test records what the runner did (#935).
+
+Bug this guards: whether the suite actually RAN was recoverable only from an artifact a
+human had to open. `tests_pass` is exit-code driven, so "did not execute" and "executed
+and passed" sit one keystroke apart in the record and neither left a log line. When a
+window roll needs triage the first question is what the runner did, and the answer should
+not require archaeology.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import pytest
+
+from squadops.capabilities.handlers.cycle.qa_test import QATestHandler
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+@dataclass
+class _Capability:
+    test_framework: str = "vitest"
+    test_timeout_seconds: int = 60
+
+
+@dataclass
+class _Result:
+    executed: bool = True
+    exit_code: int = 0
+    tests_passed: bool = True
+    test_file_count: int = 6
+    source_file_count: int = 12
+    summary: str = "6 files, 17 tests"
+    stdout: str = ""
+    stderr: str = ""
+    error: str | None = None
+    uncollected_test_files: tuple[str, ...] = field(default=())
+
+
+async def _run(monkeypatch, result: _Result):
+    async def _fake(*_a, **_kw):
+        return result
+
+    monkeypatch.setattr("squadops.capabilities.handlers.test_runner.run_build_validation", _fake)
+    return await QATestHandler._run_test_suite(_Capability(), {"a.ts": "x"}, [])
+
+
+async def test_a_passing_run_is_recorded_with_its_counts(monkeypatch, caplog):
+    with caplog.at_level(logging.INFO, logger="squadops.capabilities.handlers.cycle.qa_test"):
+        await _run(monkeypatch, _Result())
+    line = next(m for m in caplog.messages if "suite:" in m)
+    assert "executed=True" in line
+    assert "exit_code=0" in line
+    assert "test_files=6" in line
+    assert "framework=vitest" in line
+
+
+async def test_a_suite_that_never_executed_is_distinguishable_from_one_that_passed(
+    monkeypatch, caplog
+):
+    """The whole point. Exit code 0 with executed=False is not a green suite, and the
+    stored record could not tell the two apart."""
+    never_ran = _Result(executed=False, exit_code=0, tests_passed=False, error="npm not found")
+    with caplog.at_level(logging.INFO, logger="squadops.capabilities.handlers.cycle.qa_test"):
+        await _run(monkeypatch, never_ran)
+    line = next(m for m in caplog.messages if "suite:" in m)
+    assert "executed=False" in line
+    assert "npm not found" in line
+
+
+async def test_uncollected_files_are_named_beside_the_counts(monkeypatch, caplog):
+    """A file the runner never collected verifies nothing while the collected ones read
+    green — SIP-0104 roll 1 shipped exactly that, and a count of test FILES cannot
+    distinguish it."""
+    result = _Result(uncollected_test_files=("__tests__/scaffold/vc-probe-api-runs.test.ts",))
+    with caplog.at_level(logging.INFO, logger="squadops.capabilities.handlers.cycle.qa_test"):
+        await _run(monkeypatch, result)
+    line = next(m for m in caplog.messages if "suite:" in m)
+    assert "vc-probe-api-runs.test.ts" in line
+    assert "test_files=6" in line  # the count still reads green beside it
+
+
+async def test_the_report_artifact_is_unchanged(monkeypatch):
+    """Instrument only — the artifact a human opens must not move."""
+    _result, report = await _run(monkeypatch, _Result())
+    assert report["name"] == "test_report.md"
+    assert "**Exit code:** 0" in report["content"]


### PR DESCRIPTION
`Closes #935`

Whether the suite actually **ran** was recoverable only from an artifact a human had to open.

`tests_pass` is exit-code driven, so *"did not execute"* and *"executed and passed"* sit one keystroke apart in the stored record — and neither left a log line. When a window roll needs triage, the first question is what the runner did, and the answer should not require archaeology.

## What it logs

Framework, `executed`, exit code, `tests_passed`, both file counts, the uncollected list, and the error. Same class as #926's emission capture, which is what ended the last round of artifact archaeology.

**`uncollected` is logged beside the counts deliberately.** A file the runner never collected verifies nothing while the collected ones read green — SIP-0104 roll 1 shipped exactly that — and a count of test *files* cannot distinguish the two. The count and the exception have to appear together, or the count lies.

## Instrument only

No behaviour changes. A test pins that the `test_report.md` artifact a human opens is unmoved.

## Not required by the window

Like #946, this has no bearing on what a green roll *means*. Per §2.c of the pre-registration it should **wait until after V7** rather than widen the deploy boundary before an evidentiary window. Opened now because the work is done; merging it is a separate call.