### PR TITLE
fix(verification): name the contract criteria a run did not verify

### DIFF
--- a/src/squadops/cycles/run_report_builder.py
+++ b/src/squadops/cycles/run_report_builder.py
@@ -148,6 +148,15 @@ def _build_verification_lines(summary: RunVerificationSummary) -> list[str]:
     if summary.criteria_total:
         n, m = summary.criteria_coverage
         lines.append(f"Contract criteria: {n}/{m} executed-and-passed")
+        # #945: name the shortfall. Window roll 1 rendered "12/14" with an empty
+        # unverified list, and the two missing criteria were recoverable only by
+        # diffing the lists by hand. A reader seeing a gap cannot otherwise tell a
+        # compile criterion for a file that shipped fine from the one behaviour the
+        # product exists for.
+        if summary.criteria_unverified:
+            lines.append(
+                f"Contract criteria NOT verified: {', '.join(summary.criteria_unverified)}"
+            )
     if summary.failed:
         # #500: reasons inline when the aggregation carried them, so a failed
         # probe is classifiable from the report alone (bare-name fallback kept

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -299,6 +299,29 @@ class RunVerificationSummary:
         ``(0, 0)`` when no criterion ids were carried at all."""
         return len(self.criteria_verified), len(self.criteria_total)
 
+    @property
+    def criteria_unverified(self) -> tuple[str, ...]:
+        """Contract criteria this run did **not** verify, by name (#945).
+
+        The accounting invariant, stated as a derivation so it cannot drift:
+        ``criteria_verified`` and this together account for every entry of
+        ``criteria_total``.
+
+        Why it is worth naming rather than subtracting. SIP-0104 window roll 1 reported
+        *"Contract criteria: 12/14"* with an **empty** ``unverified`` list, and the two
+        it lost — ``vc-compiles-app-api-runs-run-id-route`` and its join sibling — were
+        recoverable only by diffing the two lists by hand. The count was honest; the
+        identity of the gap simply was not available anywhere. A reader sees a shortfall
+        and cannot tell whether it is a compile criterion for a file that shipped fine or
+        the one behaviour the product exists for.
+
+        Derived rather than stored, for the same reason ``required_unmet`` is: a stored
+        copy can disagree with the lists it summarises, and this field's whole job is to
+        prove nothing was dropped between them.
+        """
+        verified = set(self.criteria_verified)
+        return tuple(c for c in self.criteria_total if c not in verified)
+
 
 @dataclass(frozen=True)
 class WaivedCheck:
@@ -358,6 +381,17 @@ class CycleOutcome:
         return len(self.criteria_verified), len(self.criteria_total)
 
     @property
+    def criteria_unverified(self) -> tuple[str, ...]:
+        """Cycle criteria not verified in any run, by name (#945).
+
+        The roll-up's half of the accounting invariant — see
+        ``RunVerificationSummary.criteria_unverified`` for why the names matter and why
+        this is derived rather than stored.
+        """
+        verified = set(self.criteria_verified)
+        return tuple(c for c in self.criteria_total if c not in verified)
+
+    @property
     def required_unmet(self) -> tuple[str, ...]:
         """Required check_ids not-executed in any run (what drove ``blocked_unverified``).
 
@@ -387,6 +421,10 @@ class CycleOutcome:
             ],
             "criteria_verified": list(self.criteria_verified),
             "criteria_total": list(self.criteria_total),
+            # #945: derived, and emitted because a consumer reading only this dict would
+            # otherwise have to rediscover the shortfall by set arithmetic — which is
+            # exactly what nobody did on window roll 1.
+            "criteria_unverified": list(self.criteria_unverified),
             "replay": self.replay.to_dict() if self.replay else None,
         }
 

--- a/tests/unit/cycles/test_criteria_accounting.py
+++ b/tests/unit/cycles/test_criteria_accounting.py
@@ -1,0 +1,109 @@
+"""Every contract criterion is accounted for, by name (#945).
+
+Bug this guards: SIP-0104 window roll 1 reported "Contract criteria: 12/14" with an
+EMPTY unverified list. The two it lost -- `vc-compiles-app-api-runs-run-id-route` and
+its join sibling -- were recoverable only by diffing two lists by hand. The count was
+honest; the identity of the gap was available nowhere, so a reader could not tell a
+compile criterion for a file that shipped fine from the one behaviour the product
+exists for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.run_report_builder import _build_verification_lines
+from squadops.cycles.verification_integrity import (
+    CycleOutcome,
+    RunVerdict,
+    RunVerificationSummary,
+)
+
+pytestmark = [pytest.mark.domain_contracts]
+
+#: Roll 1's real shortfall.
+_LOST = (
+    "vc-compiles-app-api-runs-run-id-join-route",
+    "vc-compiles-app-api-runs-run-id-route",
+)
+
+
+def _summary(*, verified: tuple[str, ...], total: tuple[str, ...]) -> RunVerificationSummary:
+    return RunVerificationSummary(
+        verdict=RunVerdict.ACCEPTED,
+        verified=(),
+        failed=(),
+        unverified=(),
+        required_unmet=(),
+        executed_count=len(verified),
+        passed_count=len(verified),
+        criteria_verified=verified,
+        criteria_total=total,
+    )
+
+
+class TestTheInvariant:
+    def test_verified_and_unverified_account_for_every_criterion(self):
+        s = _summary(verified=("a", "b"), total=("a", "b", *_LOST))
+        assert set(s.criteria_verified) | set(s.criteria_unverified) == set(s.criteria_total)
+
+    def test_roll_ones_lost_criteria_are_named(self):
+        """The whole point: 12/14 must be able to say WHICH two."""
+        total = tuple(f"c{i}" for i in range(12)) + _LOST
+        s = _summary(verified=tuple(f"c{i}" for i in range(12)), total=total)
+        assert s.criteria_unverified == _LOST
+
+    def test_full_coverage_reports_nothing_unverified(self):
+        s = _summary(verified=("a", "b"), total=("a", "b"))
+        assert s.criteria_unverified == ()
+
+    def test_declaration_order_is_preserved(self):
+        """Sorted by the total's own order so the list reads against the contract."""
+        s = _summary(verified=("b",), total=("z", "b", "a"))
+        assert s.criteria_unverified == ("z", "a")
+
+    def test_a_verified_criterion_absent_from_total_does_not_corrupt_the_gap(self):
+        """Defensive: the derivation walks `total`, so an id that somehow appears only
+        in `verified` cannot produce a negative or phantom entry."""
+        s = _summary(verified=("a", "ghost"), total=("a", "b"))
+        assert s.criteria_unverified == ("b",)
+
+
+class TestTheCycleRollUp:
+    def _outcome(self) -> CycleOutcome:
+        return CycleOutcome(
+            verdict=RunVerdict.ACCEPTED,
+            verified=(),
+            failed=(),
+            unverified=(),
+            run_count=1,
+            criteria_verified=("a",),
+            criteria_total=("a", *_LOST),
+        )
+
+    def test_the_roll_up_names_its_own_shortfall(self):
+        assert self._outcome().criteria_unverified == _LOST
+
+    def test_the_wire_shape_carries_it(self):
+        """A consumer reading only the dict would otherwise have to rediscover the
+        shortfall by set arithmetic, which is exactly what nobody did on roll 1."""
+        d = self._outcome().to_dict()
+        assert d["criteria_unverified"] == list(_LOST)
+        assert len(d["criteria_verified"]) + len(d["criteria_unverified"]) == len(
+            d["criteria_total"]
+        )
+
+
+def test_the_report_names_the_missing_criteria():
+    """The surface a human actually reads. `12/14` alone sends them to the artifacts."""
+    total = tuple(f"c{i}" for i in range(12)) + _LOST
+    section = "\n".join(
+        _build_verification_lines(_summary(verified=tuple(f"c{i}" for i in range(12)), total=total))
+    )
+    assert "Contract criteria: 12/14 executed-and-passed" in section
+    assert "vc-compiles-app-api-runs-run-id-route" in section
+
+
+def test_the_report_stays_quiet_when_nothing_is_missing():
+    section = "\n".join(_build_verification_lines(_summary(verified=("a",), total=("a",))))
+    assert "NOT verified" not in section


### PR DESCRIPTION
`Closes #945`

SIP-0104 window roll 1 reported **"Contract criteria: 12/14"** with an **empty** unverified list. The two it lost — `vc-compiles-app-api-runs-run-id-route` and its join sibling — were recoverable only by diffing two stored lists by hand.

The count was honest. The *identity* of the gap was available nowhere.

That is the defect: a reader seeing a shortfall cannot tell a compile criterion for a file that shipped fine from the one behaviour the product exists for. On roll 1 the two lost criteria were on exactly the route the app's core feature lives on.

## The invariant

`criteria_verified` and `criteria_unverified` together account for **every** entry of `criteria_total`, on both the per-run summary and the cycle roll-up.

**Derived, not stored** — for the same reason `required_unmet` already is. A stored copy can disagree with the lists it summarises, and this field's entire job is to prove nothing was dropped between them.

## Surfaced where it gets read

- **The run report** names the missing criteria beneath the count. `12/14` alone sends a reader to the artifacts.
- **`CycleOutcome.to_dict`** carries them, so a consumer reading only the wire shape doesn't have to rediscover the shortfall by set arithmetic — which is precisely what nobody did on roll 1.

## Replayed against the real stored summary

Not a fixture exercise — this is roll 1's actual row, read out of Postgres and run through the new derivation:

```
roll 1 stored: 12/14
NOT verified : ('vc-compiles-app-api-runs-run-id-join-route',
                'vc-compiles-app-api-runs-run-id-route')
```

## How often it bites

Measured across all five banked rolls: **once in five.** Rolls 2–5 account for every criterion. Rare, silent, and on the roll it hit it took the app's central route with it — which is the argument for the invariant rather than for chasing the specific cause.

7786 unit tests green.

## Window status

This bounds what a green roll *means* — a roll can lose criteria and still read complete — so unlike #946/#935 it has a claim on being in the pre-V7 boundary. Your call. **Does not merge until the P6 window closes** regardless; deploy frozen at `d590f73c`.