### PR TITLE
fix(cli): print data as itself, never as Rich markup

### DIFF
--- a/src/squadops/cli/output.py
+++ b/src/squadops/cli/output.py
@@ -11,9 +11,26 @@ from typing import Any
 
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
 _console = Console()
 _err_console = Console(stderr=True)
+
+
+def _literal(value: Any) -> Text:
+    """Render a data value as itself, never as Rich markup (#931).
+
+    Rich reads ``[...]`` in a string as a style tag and **removes** it. Every value the
+    CLI prints is data, not markup, so a Next.js dynamic route arrived on screen as
+    ``app/runs//page.tsx`` — the segment silently deleted, with nothing to indicate a
+    path had been rewritten between the store and the terminal.
+
+    That is worse than a display bug. The artifact table is the first surface a person
+    reads when triaging a cycle, and it was showing them a filename that does not exist
+    while looking authoritative. Any bracketed data has the same exposure — a JSON list,
+    a parameterised path, a regex.
+    """
+    return Text(str(value))
 
 
 def print_table(
@@ -40,7 +57,7 @@ def print_table(
     for header in headers:
         table.add_column(header)
     for row in rows:
-        table.add_row(*[str(cell) for cell in row])
+        table.add_row(*[_literal(cell) for cell in row])
     _console.print(table)
 
 
@@ -57,7 +74,9 @@ def print_detail(data: dict, *, quiet: bool = False) -> None:
         return
 
     for key, value in data.items():
-        _console.print(f"[bold]{key}:[/bold] {value}")
+        # The label is ours and may carry markup; the value is data and never may.
+        # Interpolating it into the same f-string is what let `[run_id]` disappear.
+        _console.print(Text.assemble((f"{key}: ", "bold"), _literal(value)))
 
 
 def print_json(data: Any) -> None:

--- a/tests/unit/cli/test_output_literal_values.py
+++ b/tests/unit/cli/test_output_literal_values.py
@@ -1,0 +1,82 @@
+"""CLI output renders data as itself, never as Rich markup (#931).
+
+Bug this guards: Rich reads `[...]` in a string as a style tag and removes it, so a
+Next.js dynamic route arrived on screen as `app/runs//page.tsx` — the segment silently
+deleted. The artifact table is the first surface a person reads when triaging a cycle,
+and it was showing a filename that does not exist while looking authoritative.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cli import output
+
+pytestmark = [pytest.mark.domain_cli]
+
+_DYNAMIC_ROUTE = "app/runs/[run_id]/page.tsx"
+
+
+@pytest.fixture
+def rendered(monkeypatch):
+    """Capture what the console actually writes, at a width nothing wraps at."""
+    import io
+
+    from rich.console import Console
+
+    buf = io.StringIO()
+    monkeypatch.setattr(output, "_console", Console(file=buf, width=200))
+    return buf
+
+
+class TestBracketedValuesSurvive:
+    def test_a_dynamic_route_keeps_its_parameter_segment(self, rendered):
+        output.print_table(["Filename"], [[_DYNAMIC_ROUTE]])
+        assert "[run_id]" in rendered.getvalue()
+        assert "runs//page" not in rendered.getvalue()
+
+    def test_the_detail_view_keeps_it_too(self, rendered):
+        """Same defect, second surface — `cycles show` interpolated the value into an
+        f-string alongside its own bold markup."""
+        output.print_detail({"path": _DYNAMIC_ROUTE})
+        assert "[run_id]" in rendered.getvalue()
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "['art_d9b2cb4140c8', 'art_1a54818c341d']",  # a JSON list of artifact ids
+            "/api/runs/{run_id}",  # a parameterised path (braces are safe, pinned anyway)
+            "[bold red]not a style[/bold red]",  # data that looks exactly like markup
+            "expected=['__tests__/runs.test.ts']",  # a log line pasted into a field
+        ],
+    )
+    def test_any_bracketed_data_survives(self, rendered, value):
+        output.print_table(["Value"], [[value]])
+        out = rendered.getvalue()
+        # every non-space character of the input reaches the screen
+        assert all(ch in out for ch in value if not ch.isspace())
+
+    def test_a_value_that_looks_like_markup_is_not_styled(self, rendered):
+        """The dangerous half: `[bold red]` as DATA must not silently become a style and
+        vanish. If it renders as markup the text disappears and the row lies."""
+        output.print_table(["Value"], [["[bold red]"]])
+        assert "[bold red]" in rendered.getvalue()
+
+
+class TestNothingElseMoved:
+    def test_quiet_mode_is_unchanged(self, capsys):
+        """Quiet mode never went through Rich, so it never had the bug — and must not
+        acquire chrome now."""
+        output.print_table(["A", "B"], [[_DYNAMIC_ROUTE, "x"]], quiet=True)
+        assert capsys.readouterr().out == f"{_DYNAMIC_ROUTE}\tx\n"
+
+    def test_headers_and_values_both_appear(self, rendered):
+        output.print_table(["Artifact ID", "Filename"], [["art_1", _DYNAMIC_ROUTE]])
+        out = rendered.getvalue()
+        assert "Artifact ID" in out and "art_1" in out and "[run_id]" in out
+
+    def test_the_detail_label_is_still_emphasised(self, rendered):
+        """The label is ours and may carry markup; only the value is data."""
+        output.print_detail({"status": "completed"})
+        assert "status:" in rendered.getvalue()
+        assert "completed" in rendered.getvalue()


### PR DESCRIPTION
`Closes #931`

Rich reads `[...]` in a string as a style tag and **removes** it. Every value the CLI prints is data, so a Next.js dynamic route arrived on screen with its parameter segment silently deleted.

**Same command, same run, before and after:**

```
before   app/api/runs//route.ts        app/api/runs//leave/ro…
after    app/api/runs/[run_id]/…       app/api/runs/[run_id]/…
```

## Why this is worse than a display bug

The artifact table is the **first surface a person reads when triaging a cycle**, and it was showing a filename that does not exist — while looking authoritative. Nothing indicated a path had been rewritten between the store and the terminal.

Stack #2 puts every parameterised route behind a bracketed directory, so this hit precisely the routes the application's core behaviour lives on, during the window where those routes were under investigation. Anything bracketed had the same exposure: a JSON list of artifact ids, a pasted log line, a regex.

## Two surfaces, one cause

| surface | how it leaked |
|---|---|
| `print_table` | cells interpolated straight into `add_row` |
| `print_detail` | the **value** interpolated into the same f-string as its own `[bold]` label |

Both now render values through `rich.text.Text`. The detail label keeps its emphasis — the label is ours and may carry markup; the value is data and never may.

## Tests worth naming

- **Quiet mode is pinned unchanged.** It never went through Rich, so it never had the bug, and it must not acquire chrome now.
- **A value that *is* `[bold red]`** must render as those characters rather than becoming a style and vanishing. That is the dangerous half — the failure mode is silent deletion, so the test has to assert the characters survive rather than that nothing crashed.

228 CLI tests green.

**Does not merge until the P6 window closes** — deploy frozen at `d590f73c`. This one is display-only and touches no cycle machinery, so it is a candidate for landing early if you want the triage surface fixed before the next window.