### PR TITLE
fix(scaffold): derive and type the store's table names

### DIFF
--- a/src/squadops/capabilities/stack_nextjs_ts.py
+++ b/src/squadops/capabilities/stack_nextjs_ts.py
@@ -246,7 +246,13 @@ export default defineConfig({
 })
 """
 
-_HARNESS_TEST = """// Scaffold-owned harness (SIP-0100). QA suites consume the seams this proves, and must
+_HARNESS_TEST_HEAD = """// Scaffold-owned harness (SIP-0100). QA suites consume the seams this proves, and must
+// not reach past them into the app entry — the boundary that killed pf-25/26 on stack #1.
+import { describe, it, expect } from 'vitest'
+import { reset, insert, all, TABLES } from '@/lib/store'
+"""
+
+_HARNESS_TEST_NO_ENTITIES = """// Scaffold-owned harness (SIP-0100). QA suites consume the seams this proves, and must
 // not reach past them into the app entry — the boundary that killed pf-25/26 on stack #1.
 import { describe, it, expect } from 'vitest'
 import { reset, insert, all } from '@/lib/store'
@@ -263,24 +269,64 @@ describe('scaffold harness', () => {
 })
 """
 
-_STORE = """// In-memory persistence, scaffold-owned and frozen. Module-level state reset per test via
+
+def _harness_test_source(manifest: Any) -> str:
+    """The isolation harness, addressing a real table rather than a magic literal (#967).
+
+    It used `'__probe'`, which a typed `Table` union rejects. Reserving a member for it was
+    the tempting alternative and is exactly the untyped escape hatch #967 removes — a
+    reserved name is a legal string the app could also pick. So the harness uses the first
+    declared table via `TABLES`, which additionally demonstrates the accessor the fill briefs
+    point authors at.
+    """
+    entities = [e.name for e in (getattr(manifest, "entities", ()) or ())]
+    if not entities:
+        return _HARNESS_TEST_NO_ENTITIES
+    ref = f"TABLES.{entities[0]}"
+    return (
+        _HARNESS_TEST_HEAD
+        + f"""
+describe('scaffold harness', () => {{
+  it('provides an isolated store per test', () => {{
+    reset()
+    expect(all({ref})).toHaveLength(0)
+    insert({ref}, {{ id: 'x' }})
+    expect(all({ref})).toHaveLength(1)
+    reset()
+    expect(all({ref})).toHaveLength(0)
+  }})
+}})
+"""
+    )
+
+
+_STORE_HEADER = """// In-memory persistence, scaffold-owned and frozen. Module-level state reset per test via
 // `reset()` — the coverage expectation the contract states for every stack.
-const tables: Record<string, Record<string, unknown>[]> = {}
+//
+// Table names are DERIVED FROM THE MANIFEST'S ENTITIES and typed (#967). Before this the
+// table was a free `string`: the application named one, its test suite named another, and
+// the disagreement surfaced as an empty array at assertion time — indistinguishable from a
+// handler that never persisted at all. SIP-0104 window roll 6 was rejected that way with an
+// application that worked. A name the two sides disagree about is now a COMPILE error
+// listing the legal values, and `next build` runs tsc with errors fatal, so it fails before
+// the suite ever runs."""
+
+_STORE_BODY = """
 
 export function reset(): void {
-  for (const key of Object.keys(tables)) delete tables[key]
+  for (const key of Object.keys(tables)) delete tables[key as Table]
 }
 
-export function all(table: string): Record<string, unknown>[] {
+export function all(table: Table): Record<string, unknown>[] {
   return tables[table] ?? []
 }
 
-export function insert(table: string, row: Record<string, unknown>): Record<string, unknown> {
+export function insert(table: Table, row: Record<string, unknown>): Record<string, unknown> {
   ;(tables[table] ??= []).push(row)
   return row
 }
 
-export function find(table: string, id: string): Record<string, unknown> | undefined {
+export function find(table: Table, id: string): Record<string, unknown> | undefined {
   return (tables[table] ?? []).find((r) => r.id === id)
 }
 
@@ -288,6 +334,47 @@ export function nextId(): string {
   return Math.random().toString(36).slice(2, 10)
 }
 """
+
+
+def _table_name(entity_name: str) -> str:
+    """``RunEvent`` → ``run_event``. The derivation, in one place.
+
+    Exists as a function rather than inline so the tests can pin it and the authoring briefs
+    can render the same values the store exports. The point of #967 is that nobody
+    reproduces this rule by hand — ``TABLES`` is the answer and the type is the enforcement.
+    """
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", entity_name).lower()
+
+
+def _store_source(manifest: Any) -> str:
+    """The store, with its table names typed from the manifest's entities (#967).
+
+    A manifest declaring no entities keeps an open signature: there is no union to derive,
+    and ``never`` would make the store unusable rather than safe.
+    """
+    entities = [e.name for e in (getattr(manifest, "entities", ()) or ())]
+    if not entities:
+        return (
+            _STORE_HEADER
+            + "\n//\n// No entities are declared, so there is no table union to derive and the"
+            + " signature\n// stays open. There is also nothing for two authors to disagree"
+            + " about.\nexport type Table = string\n"
+            + "const tables: Record<string, Record<string, unknown>[]> = {}"
+            + _STORE_BODY
+        )
+    lines = [
+        _STORE_HEADER,
+        "",
+        "export const TABLES = {",
+        *(f"  {name}: '{_table_name(name)}'," for name in entities),
+        "} as const",
+        "",
+        "export type Table = (typeof TABLES)[keyof typeof TABLES]",
+        "",
+        "const tables: Partial<Record<Table, Record<string, unknown>[]>> = {}",
+    ]
+    return "\n".join(lines) + _STORE_BODY
+
 
 _API_CLIENT = """// Client fetch helper, scaffold-owned. Views consume this rather than calling fetch
 // directly, so the error envelope is parsed in exactly one place.
@@ -437,11 +524,11 @@ def expand_nextjs_ts(manifest: InterfaceManifest) -> list[dict[str, str]]:
         {"name": "next.config.mjs", "content": _NEXT_CONFIG},
         {"name": "vitest.config.ts", "content": _VITEST_CONFIG},
         {"name": "lib/models.ts", "content": _models_source(manifest)},
-        {"name": "lib/store.ts", "content": _STORE},
+        {"name": "lib/store.ts", "content": _store_source(manifest)},
         {"name": "lib/errors.ts", "content": _errors_source(manifest)},
         {"name": "lib/api.ts", "content": _API_CLIENT},
         {"name": "app/layout.tsx", "content": _LAYOUT},
-        {"name": "__tests__/harness.test.ts", "content": _HARNESS_TEST},
+        {"name": "__tests__/harness.test.ts", "content": _harness_test_source(manifest)},
     ]
     for path, endpoints in _route_groups(manifest).items():
         files.append({"name": path, "content": _route_stub(path, endpoints)})

--- a/src/squadops/capabilities/verification_scaffold_emission.py
+++ b/src/squadops/capabilities/verification_scaffold_emission.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:  # pragma: no cover - annotations only
 #: Bump on ANY emission-affecting change (module docstring). Recorded in every manifest.
 #: 2 (#936) — the shell imports `all` alongside `reset`, so a fill can call the helper
 #: the appendix teaches without adding an import it is forbidden to add.
-GENERATOR_VERSION = 2
+GENERATOR_VERSION = 3
 
 #: The stored manifest artifact's filename (the executor persists it beside the contract).
 VERIFICATION_SCAFFOLD_MANIFEST_FILENAME = "verification_scaffold_manifest.yaml"

--- a/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix_nextjs_ts.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix_nextjs_ts.md
@@ -25,6 +25,18 @@ fixed slots** — never to rebuild, rewire, or regenerate the scaffold.
   `/api/runs/<run_id>`.
 - Page components in `app/**/page.tsx` — implement each component's body.
 
+**The store seam, stated exactly — pass `TABLES.<Entity>`, never a string you invent:**
+`@/lib/store` exports `TABLES`, one entry per declared entity, and its functions accept only
+those values. Write `insert(TABLES.Run, run)` and `all(TABLES.Run)`. A name you make up is a
+compile error, and the build fails on compile errors — so the cost of inventing one is the
+whole run, not a warning. Read the table names out of `TABLES`; do not retype them as
+strings, and do not add a table of your own.
+
+The reason this is spelled out: the store used to take any string. An application named its
+table one thing, its test suite named it another, and the mismatch showed up as an empty
+array — indistinguishable from a handler that never saved anything. A cycle spent its entire
+repair budget rejecting an application that worked.
+
 **The client seam, stated exactly — this is where fills go wrong:**
 `api()` from `@/lib/api` fetches **the path you pass it, verbatim. It adds no prefix.**
 Pass the endpoint's FULL declared URL path, exactly as the interface manifest declares

--- a/src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md
+++ b/src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md
@@ -62,6 +62,16 @@ as a failing state):
 - `body` is the final response's parsed JSON; where a create precedes the invocation,
   `created` is the created entity's parsed JSON.
 
+**Asserting on the store — pass `TABLES.<Entity>`, never a string you invent.**
+`@/lib/store` exports `TABLES`, one entry per declared entity, and its functions accept only
+those values. Write `expect(all(TABLES.Run)).toHaveLength(1)`. A name you make up is a
+compile error, and the build fails on compile errors, so an invented name costs the run.
+
+This is spelled out because it has already cost one. The store used to accept any string:
+an application named its table one thing, the suite named it another, and the mismatch
+appeared as an empty array — which reads exactly like a handler that never saved anything.
+Three repair rounds blamed the application, and the application was correct.
+
 Additive tests are welcome IN ADDITION to fills: whole new test files beside the
 scaffold, emitted as normal ```typescript:__tests__/<name>.test.ts``` fences, under the
 standing rules (declared dependencies only, in-process execution model, no live server).

--- a/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
+++ b/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
@@ -2,11 +2,11 @@
 # The frozen-spine record region enforcement verifies against; regenerate with
 # the generator, never hand-edit (a tampered record refuses to load).
 scaffold_manifest_version: 1
-generator_version: 2
+generator_version: 3
 stack: nextjs_ts
 interface_manifest_hash: ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a
 criteria_pack: nextjs_ts
-expanded_tree_hash: 6141646f442850aeb79675d56c58e2393c91ab771b92bc6994f55c38205ca4b9
+expanded_tree_hash: cfa66534e35c8f15344a3f13fc7257ce32b48be70b24f71a7e2a4a4dfaebbd08
 aggregate_spine_hash: dd42983032d035e1fdcd7b4ecd483727ff8bdc1004e5ebb951700f033a5bc30b
 scaffold_hash: 3650c310caa2223e2be48f8b8f8617e25a5a8240f59f120a3fe96ddd9a5ad468
 files:

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -61,7 +61,7 @@ class TestInjection:
         scaffold = inputs["verification_scaffold"]
         assert len(scaffold["files"]) == 8
         assert scaffold["manifest"]["stack"] == "nextjs_ts"
-        assert scaffold["manifest"]["generator_version"] == 2
+        assert scaffold["manifest"]["generator_version"] == 3
 
     def test_an_unopted_stack_injects_nothing(self):
         manifest = manifest_for_stack("fullstack_fastapi_react")

--- a/tests/unit/capabilities/test_stack_inventory.py
+++ b/tests/unit/capabilities/test_stack_inventory.py
@@ -430,9 +430,20 @@ def test_the_frozen_store_publishes_its_call_signatures():
         for line in scaffold.frozen_surface_index_lines(_manifest_for("nextjs_ts"))
         if "lib/store.ts" in line
     )
-    assert "`all(table: string)" in line, "the arity roll 8 guessed wrong must be visible"
-    assert "`insert(table: string, row: Record<string, unknown>)" in line
+    assert "`all(table: Table)" in line, "the arity roll 8 guessed wrong must be visible"
+    assert "`insert(table: Table, row: Record<string, unknown>)" in line
     assert "`reset()" in line, "a zero-argument function must show empty parens, not a bare name"
+
+    # #967, the same sentence one level further down: `table: Table` publishes the arity and
+    # withholds the VALUES. An author who can see the type name but not its members guesses
+    # the member — which is exactly what roll 6 did, naming a table the app did not use and
+    # having a working application rejected for it. The index must carry both.
+    assert "defines `Table`" in line
+    assert "TABLES = {" in line, "the legal table names must be visible, not just the type"
+    assert "RunEvent: 'run_event'" in line, (
+        "the derived name must appear literally, entity and table side by side — the mapping "
+        "is what an author needs, not the rule for computing it"
+    )
 
 
 def test_a_generic_function_still_publishes_its_parameters():
@@ -511,7 +522,7 @@ def test_the_frozen_store_publishes_its_types_and_returns():
         for line in scaffold.frozen_surface_index_lines(_manifest_for("nextjs_ts"))
         if "lib/store.ts" in line
     )
-    assert "`find(table: string, id: string)" in line, (
+    assert "`find(table: Table, id: string)" in line, (
         "the parameter type roll 12's repair guessed wrong must be visible"
     )
     assert "`nextId(): string`" in line, (

--- a/tests/unit/capabilities/test_store_typed_tables.py
+++ b/tests/unit/capabilities/test_store_typed_tables.py
@@ -1,0 +1,122 @@
+"""The store's table names are derived and typed (#967).
+
+Bug this guards: the store took a free `string`, so the application named its table one
+thing and its test suite named another. The disagreement surfaced as an empty array at
+assertion time — indistinguishable from a handler that never persisted. SIP-0104 window
+roll 6 spent three correction rounds and its whole budget on it, all three failure analyses
+blamed the application, and the application worked: it installed, built, booted and answered
+all five contract probes over real HTTP.
+
+The fix removes the choice rather than documenting it. A name the two sides disagree about
+is a TypeScript error, and `next build` runs tsc with errors fatal, so it fails before the
+suite runs. Proven against real tsc in the sandbox image, not only asserted here:
+
+    probe_wrong.ts(2,22): error TS2345: Argument of type '"run_store"' is not
+    assignable to parameter of type 'Table'.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.stack_nextjs_ts import (
+    _harness_test_source,
+    _store_source,
+    _table_name,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+
+class _Field:
+    def __init__(self, name):
+        self.name, self.type, self.required = name, "str", True
+
+
+class _Entity:
+    def __init__(self, name):
+        self.name, self.fields = name, (_Field("id"),)
+
+
+class _Manifest:
+    def __init__(self, *names):
+        self.entities = tuple(_Entity(n) for n in names)
+
+
+@pytest.mark.parametrize(
+    "entity,table",
+    [
+        ("RunEvent", "run_event"),
+        ("Run", "run"),
+        ("Participant", "participant"),
+        ("HTTPRequest", "h_t_t_p_request"),  # documents the edge rather than pretending
+    ],
+)
+def test_the_derivation_is_pinned(entity, table):
+    """Pinned because both authoring briefs render these values and `TABLES` exports them —
+    a silent change to the rule would rename every app's tables at once."""
+    assert _table_name(entity) == table
+
+
+class TestTheUnionIsWhatEnforces:
+    def test_every_entity_becomes_a_member(self):
+        src = _store_source(_Manifest("Run", "Participant"))
+        assert "Run: 'run'," in src
+        assert "Participant: 'participant'," in src
+
+    def test_the_accessors_take_the_union_not_a_string(self):
+        """The whole mechanism. `table: string` accepts roll 6's wrong name silently."""
+        src = _store_source(_Manifest("Run"))
+        for fn in ("all(table: Table)", "insert(table: Table,", "find(table: Table,"):
+            assert fn in src
+        assert "table: string" not in src
+
+    def test_the_type_is_derived_from_the_constant_not_restated(self):
+        """`Table` restated as a literal union beside `TABLES` is two places to edit, and the
+        next author updates one. Deriving it makes them incapable of disagreeing."""
+        src = _store_source(_Manifest("Run"))
+        assert "export type Table = (typeof TABLES)[keyof typeof TABLES]" in src
+
+    def test_the_backing_record_is_keyed_by_the_union(self):
+        assert "Partial<Record<Table, Record<string, unknown>[]>>" in _store_source(
+            _Manifest("Run")
+        )
+
+
+class TestTheHarnessDoesNotNeedAnEscapeHatch:
+    def test_it_addresses_a_real_table_through_the_constant(self):
+        """It used `'__probe'`. Reserving a union member for it was the tempting fix and is
+        the untyped escape hatch this change removes — a reserved name is still a legal
+        string the application could pick."""
+        src = _harness_test_source(_Manifest("Run", "Participant"))
+        assert "TABLES.Run" in src
+        assert "__probe" not in src
+
+    def test_it_imports_the_constant_it_uses(self):
+        assert "import { reset, insert, all, TABLES } from '@/lib/store'" in _harness_test_source(
+            _Manifest("Run")
+        )
+
+
+class TestTheNoEntityCase:
+    def test_a_manifest_with_no_entities_keeps_an_open_signature(self):
+        """`never` would make the store unusable rather than safe, and with no entities there
+        is nothing for two authors to disagree about."""
+        src = _store_source(_Manifest())
+        assert "export type Table = string" in src
+        assert "TABLES" not in src
+
+    def test_the_harness_falls_back_with_it(self):
+        """Emitting `TABLES.<something>` against a store that exports no TABLES would not
+        compile — the two fallbacks have to move together."""
+        src = _harness_test_source(_Manifest())
+        assert "TABLES" not in src
+        assert "__probe" in src
+
+
+def test_the_reason_is_recorded_where_an_author_reads_it():
+    """The comment is the only place a reader of the emitted app learns why the type exists.
+    Without it the next contributor relaxes it back to `string` to make something compile."""
+    src = _store_source(_Manifest("Run"))
+    assert "#967" in src
+    assert "COMPILE error" in src

--- a/tests/unit/capabilities/test_verification_scaffold_reference.py
+++ b/tests/unit/capabilities/test_verification_scaffold_reference.py
@@ -43,8 +43,16 @@ _FIXTURE_DIR = (
 # self-contained evidence that the input end did not move.
 _MANIFEST_HASH = "ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a"
 
-# The fixture's own identity, regenerated at GENERATOR_VERSION 2 (2026-08-16, #936). These
-# stop an in-place fixture regeneration from making the byte test self-referential.
+# The fixture's own identity. Regenerated at GENERATOR_VERSION 3 (2026-08-17, #967 — the
+# store's table names became typed, changing the expanded tree the shells import from).
+#
+# BOTH VALUES ARE UNCHANGED FROM VERSION 2, and that is the informative part: the shells
+# themselves did not move. The only fixture byte that changed is the manifest's
+# `expanded_tree_hash`, which the byte test caught. So these pins did what they are for —
+# they distinguished "the tree changed" from "shell emission drifted", which is a
+# distinction a single combined hash could not express.
+#
+# These stop an in-place fixture regeneration from making the byte test self-referential.
 _AGGREGATE_SPINE_HASH = "dd42983032d035e1fdcd7b4ecd483727ff8bdc1004e5ebb951700f033a5bc30b"
 _SCAFFOLD_HASH = "3650c310caa2223e2be48f8b8f8617e25a5a8240f59f120a3fe96ddd9a5ad468"
 
@@ -65,12 +73,12 @@ def test_the_reference_manifest_is_unmoved():
 def test_generator_version_is_the_fixture_generation(emission):
     """A generator change without a version bump is drift by definition (SIP §4.3);
     a bump without regenerating the fixture is a pin measuring the wrong version."""
-    assert GENERATOR_VERSION == 2
-    assert emission.manifest.generator_version == 2
+    assert GENERATOR_VERSION == 3
+    assert emission.manifest.generator_version == 3
     stored = yaml.safe_load(
         (_FIXTURE_DIR / "verification_scaffold_manifest.yaml").read_text(encoding="utf-8")
     )
-    assert stored["generator_version"] == 2
+    assert stored["generator_version"] == 3
 
 
 def test_emission_reproduces_the_fixture_byte_for_byte(emission):

--- a/tests/unit/cycles/test_scaffold_evidence.py
+++ b/tests/unit/cycles/test_scaffold_evidence.py
@@ -272,7 +272,7 @@ class TestSummary:
         )
         d = summary.to_dict()
         # the promotion model's fields (SIP §6/§12) — schema preserved, workflow not built
-        assert d["stack"] == "nextjs_ts" and d["generator_version"] == 2
+        assert d["stack"] == "nextjs_ts" and d["generator_version"] == 3
         assert d["shell_count"] == 8 and d["slot_count"] == 8
         assert d["fill_dispositions"] == {"filled": 1, "missing": 7}
         assert d["additive_test_count"] == 2


### PR DESCRIPTION
`Closes #967`

The store took a free `string`. The application named its table one thing, its test suite named another, and the disagreement surfaced as an **empty array at assertion time** — indistinguishable from a handler that never persisted.

SIP-0104 window roll 6 spent three correction rounds and its entire budget on this. All three failure analyses blamed the application. **The application worked** — it installed, built, booted, and answered all five contract probes over real HTTP.

## The fix removes the choice rather than documenting it

```ts
export const TABLES = { Participant: 'participant', Run: 'run' } as const
export type Table = (typeof TABLES)[keyof typeof TABLES]
export function all(table: Table): Record<string, unknown>[]
```

**Proven against real tsc in the sandbox image, not asserted:**

```
probe_wrong.ts(2,22): error TS2345: Argument of type '"run_store"' is not
                      assignable to parameter of type 'Table'.
```

`run_store` is roll 6's actual key. The `TABLES.Run` form produces no error. And `next build` runs tsc with `ignoreBuildErrors: false`, so a mismatch now fails **`frontend_build`, before the suite runs** — a loud build failure naming the legal values, instead of an assertion failure that reads as a broken handler.

## Details worth a reviewer's attention

**`Table` derives from `TABLES` rather than restating it.** A literal union beside the constant is two declarations that must agree, and the next author updates one. Deriving makes them incapable of disagreeing.

**The harness no longer needs an escape hatch.** It used `'__probe'`, which a typed union rejects. Reserving a member for it was the tempting fix and is exactly the hatch this removes — a reserved name is still a legal string the application could pick. It now addresses a real table through `TABLES`, which doubles as a worked example of the accessor the briefs point authors at.

**No entities → open signature.** `never` would make the store unusable rather than safe, and with no entities there is nothing to disagree about. The harness falls back with it, since emitting `TABLES.x` against a store that exports none would not compile.

## The frozen-surface index needed no change

It already derives from source, and now publishes:

```
`lib/store.ts` — defines `Table`; exports TABLES = { Participant: 'participant', RunEvent: 'run_event', };
functions `reset(): void`, `all(table: Table): …`
```

Two inventory tests pinned `table: string`; they're updated **and strengthened**. Publishing `table: Table` without the members would be roll 8's defect one level down — a type the author can see and cannot resolve. The tests now require the mapping to appear literally.

## The pins, and what they proved

`GENERATOR_VERSION` 2 → 3 with the fixture regenerated, per SIP-0104's documented one-deliberate-act procedure.

**Both pinned hashes are unchanged**, and that is the informative part: the shells are byte-identical. The only fixture byte that moved is the manifest's `expanded_tree_hash`, which the byte test caught. So the pins distinguished *"the tree changed"* from *"shell emission drifted"* — a distinction a single combined hash could not express.

## Verification

- 13 new tests, including the derivation pinned per entity and the no-entity fallback.
- Regression green: **7478**; full unit **7851**.
- Real tsc run against an expanded roll-6 workspace, both probe directions.

## Deploy note

This changes the expanded tree, so it needs a rebuild before the next window opens — and it is the precondition ruled ahead of V7.
