### PR TITLE
docs(2f): S5's admission rule is enforced by the 2c gate, not just written

### DIFF
--- a/docs/plans/stack-blueprint-schema-draft.md
+++ b/docs/plans/stack-blueprint-schema-draft.md
@@ -214,6 +214,25 @@ Recorded because the numbers moved every time and the first ones were wrong: cor
 
 ---
 
+## 4e. 2f — S5's admission rule is enforced, not just written *(2026-08-17)*
+
+S5's rule lived only in `1-6-0-authorship-plan.md`. A release plan is superseded at the cut, which is the failure CLAUDE.md names and SIP-0103 §5d already paid for — so the rule was one release from vanishing.
+
+It is now **enforced by 2c's gate** (`test_stack_blueprint_falsification.py`), which classifies exactly as S5 prescribes:
+
+| a new field… | gate outcome |
+|---|---|
+| populated on both stacks | falsified on each → admitted |
+| populated on **one** stack | fails until a reason is recorded, *and* some stack must populate it |
+| populated on **no** stack | rejected — an optional nothing populates is unevidenced, not optional |
+| read by nothing | rejected outright |
+
+Verified by removing `harness_entry_modules`' recorded reason, which fails with *"unset on nextjs_ts with no recorded reason. Either record why it is optional (and confirm another stack populates it), or delete it."* That is S5's escape valve — a one-stack need declared with its reason — enforced rather than requested.
+
+**What remains for 2f is the statement, not the mechanism.** The rule's permanent home is the Stack Blueprint SIP, which 2g writes. Until then the enforcement outlives the plan even if the prose does not, which is the reverse of the usual failure and the safer direction.
+
+---
+
 ## 5. Open questions carried to 2g
 
 1. **Does the blueprint own the packaging set?** `required_files` and `qa_handoff_expectations` are identical across both stacks — weak evidence they are universal rather than blueprint-owned. Tier 3 above takes that reading; a third stack could overturn it. §4c sharpens the question: the packaging set is plausibly a **deployment-target** fact, not a stack fact.

--- a/tests/unit/capabilities/test_stack_blueprint_falsification.py
+++ b/tests/unit/capabilities/test_stack_blueprint_falsification.py
@@ -27,6 +27,25 @@ and a NEW field with no consumer fails here rather than entering the schema unno
   subtractively — the same reading the schema draft applies to Tier 3 — it must not be a
   blueprint field.
 
+**This file is also where S5's admission rule is ENFORCED (Stage 2f).** S5 states it as
+*"a new blueprint field must be demonstrated on at least two stacks before admission"*, with
+the consequence that *"a one-stack need is expressed as a declared optional capability with its
+reason"*. That is exactly the classification below, and it is enforced rather than asked for:
+
+- populated on both stacks → falsified on each → admitted;
+- populated on **one** stack → ``ALREADY_EMPTY`` on the other → fails until a reason is
+  recorded in ``_DECLARED_OPTIONAL``, and ``test_a_declared_optional_is_populated_by_some_stack``
+  additionally requires that some stack does populate it;
+- populated on **no** stack → rejected. An optional capability nothing populates is not
+  optional, it is unevidenced;
+- read by nothing → rejected outright.
+
+Recorded here because *what a test enforces stays true; what discipline enforces drifts*
+(``test_docs_version_sync``'s own rationale). S5's rule was written only in
+``1-6-0-authorship-plan.md``, and a release plan is superseded at the cut — the failure mode
+CLAUDE.md names and SIP-0103 §5d paid for. The rule's permanent *statement* still belongs in
+the Stack Blueprint SIP at 2g; its permanent *enforcement* is here.
+
 **Four traps this harness had, recorded because each one CHANGED THE ANSWER and the next
 author will hit them.** None is hypothetical; every one produced a wrong finding first:
 


### PR DESCRIPTION
S5's rule — *"a new blueprint field must be demonstrated on at least two stacks before admission"* — lived **only** in `1-6-0-authorship-plan.md`. A release plan is superseded at the cut, which is the failure CLAUDE.md names and SIP-0103 §5d already paid for. The rule was one release from vanishing.

It turns out **2c's gate already enforces it**, and enforces S5's own escape valve with it.

| a new field… | gate outcome |
|---|---|
| populated on **both** stacks | falsified on each → admitted |
| populated on **one** stack | fails until a reason is recorded, *and* some stack must populate it |
| populated on **no** stack | rejected — an optional nothing populates is unevidenced, not optional |
| read by nothing | rejected outright |

**Verified rather than asserted.** Removing `harness_entry_modules`' recorded reason fails with:

> `ScaffoldStack.harness_entry_modules is unset on nextjs_ts with no recorded reason. Either record why it is optional (and confirm another stack populates it), or delete it.`

That is S5's stated consequence — a one-stack need expressed as a declared optional capability with its reason — enforced rather than requested.

Recorded in the test's docstring because *what a test enforces stays true; what discipline enforces drifts*, which is `test_docs_version_sync`'s own rationale for living where it does.

## What remains for 2f

**The statement, not the mechanism.** The rule's permanent home is the Stack Blueprint SIP, which 2g writes. Until then the enforcement outlives the plan even if the prose does not — the reverse of the usual failure, and the safer direction to be caught in.

Docs and one docstring. 109 tests green.