### PR TITLE
fix(scaffold): the shell must import TABLES — #936's defect, recurred at #967

### DIFF
--- a/src/squadops/capabilities/stack_nextjs_ts_tests.py
+++ b/src/squadops/capabilities/stack_nextjs_ts_tests.py
@@ -339,7 +339,7 @@ def _invocation_lines(step: _Step, assign: str) -> list[str]:
     return lines
 
 
-def _shell_source(behavior: _Behavior) -> str:
+def _shell_source(behavior: _Behavior, *, store_symbols: tuple[str, ...]) -> str:
     """Render one behavior shell file: frozen spine plus one empty fill slot."""
     route_files = list(
         dict.fromkeys(
@@ -352,13 +352,19 @@ def _shell_source(behavior: _Behavior) -> str:
         "// The spine — placement, imports, lifecycle, invocation, status assertion — is",
         "// frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.",
         "import { beforeEach, describe, expect, it } from 'vitest'",
-        # `all` is imported for the FILL, not for the spine (#936). The spine only calls
-        # `reset`, but a fill may not add imports — "Assertions only. NO imports" — so any
-        # store helper the fill vocabulary teaches must already be in scope here or the
-        # fill cannot run. The appendix's own worked examples call `all('runs')`, and
-        # every one of them died on `ReferenceError: all is not defined` until this line.
-        # Keep this in step with the vocabulary the appendix teaches.
-        "import { reset, all } from '@/lib/store'",
+        # Imported for the FILL, not for the spine (#936, and #967's recurrence of it).
+        # The spine only calls `reset`, but a fill may not add imports — "Assertions only.
+        # NO imports" — so EVERY store symbol the fill appendix teaches must already be in
+        # scope here or the fill cannot run.
+        #
+        # This has now failed twice for the same reason. #936: the appendix taught
+        # `all('runs')` and every worked example died on `ReferenceError: all is not
+        # defined`. #967: the appendix was changed to teach `TABLES.<Entity>` and this line
+        # was not, so the pre-V7 shakedown produced `ReferenceError: TABLES is not defined`
+        # in six of eight shells. The comment that used to sit here said "keep this in step
+        # with the vocabulary the appendix teaches", which is a request, not a mechanism —
+        # `test_shell_imports_every_symbol_the_fill_brief_teaches` is the mechanism.
+        f"import {{ {', '.join(store_symbols)} }} from '@/lib/store'",
     ]
     for route_file in route_files:
         module = route_file.removesuffix(".ts")
@@ -433,6 +439,16 @@ def emit_nextjs_ts_verification_scaffold(
     )
 
     behaviors, probes = derive_scaffold_behaviors(manifest)
+    # `TABLES` exists only when the manifest declares entities (#967); importing it from a
+    # store that does not export it is the same ReferenceError one step earlier.
+    store_symbols = (
+        ("reset", "all", "TABLES")
+        if getattr(manifest, "entities", ())
+        else (
+            "reset",
+            "all",
+        )
+    )
 
     # #951: the scaffold covers what it can DERIVE, not what the manifest DECLARES, and
     # the difference used to be recorded nowhere — so silence read as coverage. Roll 2
@@ -472,5 +488,5 @@ def emit_nextjs_ts_verification_scaffold(
             criterion_ids=(behavior.probe_id,) if behavior.probe_id else (),
         )
         path = f"{SCAFFOLD_TEST_DIR}/{behavior.behavior_id}.scaffold.test.ts"
-        emitted.append((path, _shell_source(behavior), (slot,)))
+        emitted.append((path, _shell_source(behavior, store_symbols=store_symbols), (slot,)))
     return emitted

--- a/src/squadops/capabilities/verification_scaffold_emission.py
+++ b/src/squadops/capabilities/verification_scaffold_emission.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:  # pragma: no cover - annotations only
 #: Bump on ANY emission-affecting change (module docstring). Recorded in every manifest.
 #: 2 (#936) — the shell imports `all` alongside `reset`, so a fill can call the helper
 #: the appendix teaches without adding an import it is forbidden to add.
-GENERATOR_VERSION = 3
+GENERATOR_VERSION = 4
 
 #: The stored manifest artifact's filename (the executor persists it beside the contract).
 VERIFICATION_SCAFFOLD_MANIFEST_FILENAME = "verification_scaffold_manifest.yaml"

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-join-duplicate.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-join-duplicate.scaffold.test.ts
@@ -2,7 +2,7 @@
 // The spine — placement, imports, lifecycle, invocation, status assertion — is
 // frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
 import { beforeEach, describe, expect, it } from 'vitest'
-import { reset, all } from '@/lib/store'
+import { reset, all, TABLES } from '@/lib/store'
 import * as routeApiRuns from '@/app/api/runs/route'
 import * as routeApiRunsRunIdJoin from '@/app/api/runs/[run_id]/join/route'
 

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-join.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-join.scaffold.test.ts
@@ -2,7 +2,7 @@
 // The spine — placement, imports, lifecycle, invocation, status assertion — is
 // frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
 import { beforeEach, describe, expect, it } from 'vitest'
-import { reset, all } from '@/lib/store'
+import { reset, all, TABLES } from '@/lib/store'
 import * as routeApiRuns from '@/app/api/runs/route'
 import * as routeApiRunsRunIdJoin from '@/app/api/runs/[run_id]/join/route'
 

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-leave.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-leave.scaffold.test.ts
@@ -2,7 +2,7 @@
 // The spine — placement, imports, lifecycle, invocation, status assertion — is
 // frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
 import { beforeEach, describe, expect, it } from 'vitest'
-import { reset, all } from '@/lib/store'
+import { reset, all, TABLES } from '@/lib/store'
 import * as routeApiRuns from '@/app/api/runs/route'
 import * as routeApiRunsRunIdJoin from '@/app/api/runs/[run_id]/join/route'
 import * as routeApiRunsRunIdLeave from '@/app/api/runs/[run_id]/leave/route'

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-rejects-blank.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-rejects-blank.scaffold.test.ts
@@ -2,7 +2,7 @@
 // The spine — placement, imports, lifecycle, invocation, status assertion — is
 // frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
 import { beforeEach, describe, expect, it } from 'vitest'
-import { reset, all } from '@/lib/store'
+import { reset, all, TABLES } from '@/lib/store'
 import * as routeApiRuns from '@/app/api/runs/route'
 
 type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs.scaffold.test.ts
@@ -2,7 +2,7 @@
 // The spine — placement, imports, lifecycle, invocation, status assertion — is
 // frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
 import { beforeEach, describe, expect, it } from 'vitest'
-import { reset, all } from '@/lib/store'
+import { reset, all, TABLES } from '@/lib/store'
 import * as routeApiRuns from '@/app/api/runs/route'
 
 type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response

--- a/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
+++ b/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
@@ -2,17 +2,17 @@
 # The frozen-spine record region enforcement verifies against; regenerate with
 # the generator, never hand-edit (a tampered record refuses to load).
 scaffold_manifest_version: 1
-generator_version: 3
+generator_version: 4
 stack: nextjs_ts
 interface_manifest_hash: ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a
 criteria_pack: nextjs_ts
 expanded_tree_hash: cfa66534e35c8f15344a3f13fc7257ce32b48be70b24f71a7e2a4a4dfaebbd08
-aggregate_spine_hash: dd42983032d035e1fdcd7b4ecd483727ff8bdc1004e5ebb951700f033a5bc30b
-scaffold_hash: 3650c310caa2223e2be48f8b8f8617e25a5a8240f59f120a3fe96ddd9a5ad468
+aggregate_spine_hash: e8f2a59e1e64e3b2d77dc2a2d3aae018a88ba0648393491a6094325f9fba0414
+scaffold_hash: 69d29ab91f692bab9c3f4a2bd72910f39fe27b7ecfc7d41dd99a8bfb62b186f4
 files:
 - path: __tests__/scaffold/vc-probe-api-runs.scaffold.test.ts
-  content_hash: 95f3c6f8560adcf084dbab1f57900d12feb0552873e215365b31eb6b737a05bb
-  spine_hash: 80f84005b4f7e8fd8315909d3048d6169aba44eeea5d386d2794c932b6411e51
+  content_hash: 9245b8442a684f32bfbb7605185a72274b13afa748eb02ccee80fbe559d21d31
+  spine_hash: 3e3d9877aca8db6fefdf3f17259f45caeebd6b1335d0edf2af54b3c4d2eeed14
   slots:
   - slot_id: slot-vc-probe-api-runs
     behavior: POST /api/runs -> 201
@@ -22,8 +22,8 @@ files:
     begin_line: 23
     end_line: 27
 - path: __tests__/scaffold/vc-probe-api-runs-rejects-blank.scaffold.test.ts
-  content_hash: 593a675a2524885a39ccb48114a03564f22d419678c2838b5e65ee7398e4e22a
-  spine_hash: d9c63917adad6acc547425315fc6020eeb55bbabf3192139b1824f04396966f2
+  content_hash: c51841d227904da82466e19e6344a4648acb644c248f0dd7eb7895c1b21a47a2
+  spine_hash: f30001086a79480dfd66c893e642e954ce8b6d199c44a4c3cb8687a91b7595a8
   slots:
   - slot_id: slot-vc-probe-api-runs-rejects-blank
     behavior: POST /api/runs blank required fields -> 422
@@ -33,8 +33,8 @@ files:
     begin_line: 23
     end_line: 27
 - path: __tests__/scaffold/vc-probe-api-runs-join.scaffold.test.ts
-  content_hash: 02d86070d3cd062c7fb8e761ecc6bd09274da37164551dc13056156267b52ea9
-  spine_hash: 31f9b972475333ea72e05d40d533c0ea3909782f71908677218609c62f96acea
+  content_hash: 14f4115aad1800f4a0950a14daf4531c266467722c5ba2d4d7ed959bad19e4a6
+  spine_hash: edbc25e16cbb7cde2a492d20d57df3f0fb1a17749db62ee56fb0ffe4bb8d7c60
   slots:
   - slot_id: slot-vc-probe-api-runs-join
     behavior: POST /api/runs/{run_id}/join -> 200
@@ -44,8 +44,8 @@ files:
     begin_line: 33
     end_line: 37
 - path: __tests__/scaffold/vc-probe-api-runs-join-duplicate.scaffold.test.ts
-  content_hash: b620d6333aa741e98efab665573e1b64615af5268d4d472157cb1501ceea1104
-  spine_hash: 6050c9439735faf63ba1f8ca556e041cb928905f500238bc0ea48c5405c46246
+  content_hash: cb5ff626a6626db628fb89568d2e6965daafb090b3af5ab152738a21d3bc0490
+  spine_hash: b69a3a8ee4d67352b3332c63f6c28892e274bbfac1d5a8cf1f0f6e21f56c9252
   slots:
   - slot_id: slot-vc-probe-api-runs-join-duplicate
     behavior: POST /api/runs/{run_id}/join duplicate -> 409
@@ -55,8 +55,8 @@ files:
     begin_line: 41
     end_line: 45
 - path: __tests__/scaffold/vc-probe-api-runs-leave.scaffold.test.ts
-  content_hash: 9c82bb28de3cfa21b39912ec0fe005c3d55393fcfb149ce75dd3596b4c4ae8d9
-  spine_hash: 1e03254a2a70e3f282d21c5dad66525a40dc2e66421365ebee48ce5f2b196be1
+  content_hash: 84754c4f511e27029c5534f75e08a3f5d7113adf855c758ef57514d30a2dcda8
+  spine_hash: c391a7da2fd66226664154805762332d6cf1d4cb5795bc2047aaceeed53aa9b8
   slots:
   - slot_id: slot-vc-probe-api-runs-leave
     behavior: POST /api/runs/{run_id}/leave -> 200
@@ -66,8 +66,8 @@ files:
     begin_line: 42
     end_line: 46
 - path: __tests__/scaffold/vs-get-api-runs.scaffold.test.ts
-  content_hash: b7000122c4bceb8c495071d90a42cfa2c8eef72726ffced63d6cb8886ced08ba
-  spine_hash: 3f3b2d15229e8974f275052a2eb1396fcd65f4fe086b354c2b244b7b1960d2c9
+  content_hash: 9c53dcf9d5e6420b4ead5de51137697c3dc44414139ea2271a3c2a00b989e8e1
+  spine_hash: 5e18437d792a591693e99f11241e87d40449d355d0b937c47d144bf722e79b1f
   slots:
   - slot_id: slot-vs-get-api-runs
     behavior: GET /api/runs -> 200
@@ -76,8 +76,8 @@ files:
     begin_line: 19
     end_line: 23
 - path: __tests__/scaffold/vs-get-api-runs-run-id.scaffold.test.ts
-  content_hash: 9f2ccf5eaa200ae3aef4ee4fba64d1d25bf2a059725388358401d73231b0d8b6
-  spine_hash: f381d58e78807badf43bd260013adbc159cd59732cbfce8b8ee9f235e0406794
+  content_hash: 9ce0b15a8b63aa07167795da416c64ae9eae7d1ce4fa71f83dbfbd508ca9bf03
+  spine_hash: 71a16ae4d5cd0204146953f0d7206ca9daa8929ea4148b5f8e9fd7e4940e4222
   slots:
   - slot_id: slot-vs-get-api-runs-run-id
     behavior: GET /api/runs/{run_id} -> 200
@@ -86,8 +86,8 @@ files:
     begin_line: 29
     end_line: 33
 - path: __tests__/scaffold/vs-get-api-runs-run-id-not-found.scaffold.test.ts
-  content_hash: b500322d59607b876165bac12fded44c788316f0acf31b715225e682f087905c
-  spine_hash: 391147abed394767122aa9178b4061311d98ebaf4bf8e1c2dc8904a34b4a7e1d
+  content_hash: 89e655f3b68564332e86bbac28839f4eb18f5156b62d002cdc2bafacada87ccb
+  spine_hash: eb0ea3bfc46b9c9229487afd382ba6fd1a55a96f04d8bb3a306dd38a5929a8ed
   slots:
   - slot_id: slot-vs-get-api-runs-run-id-not-found
     behavior: GET /api/runs/{run_id} unknown id -> 404

--- a/tests/fixtures/reference_verification_scaffold/vs-get-api-runs-run-id-not-found.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vs-get-api-runs-run-id-not-found.scaffold.test.ts
@@ -2,7 +2,7 @@
 // The spine — placement, imports, lifecycle, invocation, status assertion — is
 // frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
 import { beforeEach, describe, expect, it } from 'vitest'
-import { reset, all } from '@/lib/store'
+import { reset, all, TABLES } from '@/lib/store'
 import * as routeApiRunsRunId from '@/app/api/runs/[run_id]/route'
 
 type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response

--- a/tests/fixtures/reference_verification_scaffold/vs-get-api-runs-run-id.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vs-get-api-runs-run-id.scaffold.test.ts
@@ -2,7 +2,7 @@
 // The spine — placement, imports, lifecycle, invocation, status assertion — is
 // frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
 import { beforeEach, describe, expect, it } from 'vitest'
-import { reset, all } from '@/lib/store'
+import { reset, all, TABLES } from '@/lib/store'
 import * as routeApiRuns from '@/app/api/runs/route'
 import * as routeApiRunsRunId from '@/app/api/runs/[run_id]/route'
 

--- a/tests/fixtures/reference_verification_scaffold/vs-get-api-runs.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vs-get-api-runs.scaffold.test.ts
@@ -2,7 +2,7 @@
 // The spine — placement, imports, lifecycle, invocation, status assertion — is
 // frozen (SIP-0104 §4.2); the marked fill slot is the qa author's mutable surface.
 import { beforeEach, describe, expect, it } from 'vitest'
-import { reset, all } from '@/lib/store'
+import { reset, all, TABLES } from '@/lib/store'
 import * as routeApiRuns from '@/app/api/runs/route'
 
 type Handler = (req: Request, ctx?: unknown) => Promise<Response> | Response

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -61,7 +61,7 @@ class TestInjection:
         scaffold = inputs["verification_scaffold"]
         assert len(scaffold["files"]) == 8
         assert scaffold["manifest"]["stack"] == "nextjs_ts"
-        assert scaffold["manifest"]["generator_version"] == 3
+        assert scaffold["manifest"]["generator_version"] == 4
 
     def test_an_unopted_stack_injects_nothing(self):
         manifest = manifest_for_stack("fullstack_fastapi_react")

--- a/tests/unit/capabilities/test_fill_vocabulary_is_in_scope.py
+++ b/tests/unit/capabilities/test_fill_vocabulary_is_in_scope.py
@@ -1,4 +1,5 @@
-"""#936 — every helper the fill appendix teaches must already be imported by the shell.
+"""#936, and #967's recurrence — every store symbol the fill appendix teaches must already
+be imported by the shell.
 
 Fills are forbidden from importing ("Assertions only. NO imports"), so a helper the
 appendix demonstrates and the spine does not import is a slot that **cannot run**. Not
@@ -13,6 +14,21 @@ worked perfectly and the roll was lost anyway.
 The two artifacts are edited by different people for different reasons — one is a
 prompt asset, the other a code generator — and nothing connected them. This is the
 connection, asserted against the real emission rather than a copy of it.
+
+**It happened again anyway (#967), and the reason is worth keeping.** This guard was live
+and green while the defect shipped. Its extraction was scoped, reasonably, to what #936
+looked like: *lowercase function calls* appearing *inside ```fill:``` blocks*. #967 taught
+`TABLES.<Entity>` — an uppercase constant, used as member access, demonstrated in prose.
+Three ways past a guard aimed at the last defect's shape.
+
+The pre-V7 shakedown (`cyc_308be9dfc299`) then produced `ReferenceError: TABLES is not
+defined` in six of eight shells, on a roll whose developer had used `TABLES.Run` correctly
+throughout and whose application was sound.
+
+So the extraction is now bounded by **what the store actually exports** rather than by the
+shape the previous defect happened to take, and it reads the whole appendix rather than only
+its fenced examples. A worked example in prose is still a worked example — that is precisely
+how #967 taught it.
 """
 
 from __future__ import annotations
@@ -32,20 +48,34 @@ _APPENDIX = (
     / "src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md"
 )
 
-#: Identifiers a fill body may use that are NOT store helpers — the spine's own
-#: vocabulary and standard matcher surface. Anything else called inside a worked
-#: example has to come from an import the shell makes.
-_NOT_STORE = {"expect", "toBe", "toHaveLength", "toBeTruthy", "toEqual", "it", "describe"}
+
+def _store_exports() -> set[str]:
+    """What ``lib/store.ts`` actually provides — functions AND consts.
+
+    ``export const`` matters: `TABLES` is a const, and a ``export function``-only regex
+    reported it as unexported while the shell imported it (#967).
+    """
+    from squadops.capabilities.scaffold import expand
+
+    expanded = {f["name"]: f["content"] for f in expand(manifest_for_stack("nextjs_ts"))}
+    store = next((c for n, c in expanded.items() if n.endswith("lib/store.ts")), "")
+    return set(re.findall(r"export (?:function|const) (\w+)", store))
 
 
-def _helpers_taught_by_the_appendix() -> set[str]:
-    """Bare function calls inside the appendix's ```fill:``` examples."""
+def _store_symbols_taught_by_the_appendix() -> set[str]:
+    """Store symbols the appendix demonstrates, anywhere in it.
+
+    Bounded by the store's real exports rather than by an identifier shape. #936's version
+    matched lowercase calls inside ```fill:``` blocks, which is what #936 looked like — and
+    #967 walked past all three of those constraints at once. Asking "does the appendix use
+    a name the store exports" cannot be out-scoped by the next defect's shape.
+    """
     text = _APPENDIX.read_text(encoding="utf-8")
     taught: set[str] = set()
-    for block in re.findall(r"```fill:slot-[^\n]*\n(.*?)```", text, re.S):
-        for name in re.findall(r"(?<![.\w])([a-z][A-Za-z0-9_]*)\(", block):
-            if name not in _NOT_STORE:
-                taught.add(name)
+    for symbol in _store_exports():
+        # a call `all(`, or a member access `TABLES.`
+        if re.search(rf"\b{re.escape(symbol)}\s*[(.]", text):
+            taught.add(symbol)
     return taught
 
 
@@ -59,16 +89,22 @@ def _names_imported_from_the_store() -> set[str]:
     return imported
 
 
-def test_every_helper_the_appendix_teaches_is_imported_by_the_shell():
+def test_every_store_symbol_the_appendix_teaches_is_imported_by_the_shell():
     """Bug caught: the appendix demonstrates a call that cannot resolve at runtime.
 
     The #936 defect exactly. An author copying the worked example — which is what worked
     examples are for — emits a slot that throws before asserting anything.
     """
-    taught = _helpers_taught_by_the_appendix()
+    taught = _store_symbols_taught_by_the_appendix()
     imported = _names_imported_from_the_store()
 
-    assert taught, "no helper calls found in the appendix examples — the extractor drifted"
+    assert taught, "no store symbols found in the appendix — the extractor drifted"
+    # Guards the guard: both symbols that have actually bitten must still be detected, or
+    # the extraction has silently narrowed again and this test passes vacuously.
+    assert {"all", "TABLES"} <= taught, (
+        f"the extraction no longer detects the two symbols that have shipped defects "
+        f"(#936's `all`, #967's `TABLES`); it found {sorted(taught)}"
+    )
 
     missing = sorted(taught - imported)
     assert missing == [], (
@@ -91,7 +127,7 @@ def test_the_store_actually_exports_what_the_shell_imports():
     store = next((c for n, c in expanded.items() if n.endswith("lib/store.ts")), None)
     assert store, "the nextjs_ts skeleton no longer emits lib/store.ts"
 
-    exported = set(re.findall(r"export function (\w+)", store))
+    exported = set(re.findall(r"export (?:function|const) (\w+)", store))
     missing = sorted(_names_imported_from_the_store() - exported)
     assert missing == [], (
         f"the shell imports {missing} from the store, which exports {sorted(exported)} — "

--- a/tests/unit/capabilities/test_verification_scaffold_gate.py
+++ b/tests/unit/capabilities/test_verification_scaffold_gate.py
@@ -25,6 +25,22 @@ from squadops.capabilities.verification_scaffold_gate import (
 )
 from tests.unit.capabilities._stack_fixtures import manifest_for_stack
 
+
+#: The shell's real store import. It has changed twice (#936 added `all`, #967 added
+#: `TABLES`), and each time a hardcoded copy in these tampers failed with "tamper did not
+#: apply" — a test breaking for a reason unrelated to what it tests. Derived rather than
+#: restated, so the next change to the fill vocabulary cannot break these.
+def _store_import_line() -> str:
+    emission = emit_verification_scaffold(manifest_for_stack("nextjs_ts"))
+    for f in emission.files:
+        for line in f["content"].splitlines():
+            if "from '@/lib/store'" in line:
+                return line
+    raise AssertionError("no shell imports the store — the spine changed shape")
+
+
+_STORE_IMPORT = _store_import_line()
+
 _CREATE_SHELL = "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts"
 
 
@@ -79,7 +95,7 @@ class TestInjectedGeneratorDefects:
         tampered = _tamper(
             emission,
             _CREATE_SHELL,
-            "import { reset, all } from '@/lib/store'",
+            _STORE_IMPORT,
             "import { restart } from '@/lib/store'",
         )
         findings = assess_execution_readiness(tampered, tree, manifest)
@@ -90,8 +106,8 @@ class TestInjectedGeneratorDefects:
         tampered = _tamper(
             emission,
             _CREATE_SHELL,
-            "import { reset, all } from '@/lib/store'",
-            "import { reset, all } from '@/lib/store'\nimport { agent } from 'supertest'",
+            _STORE_IMPORT,
+            f"{_STORE_IMPORT}\nimport {{ agent }} from 'supertest'",
         )
         findings = assess_execution_readiness(tampered, tree, manifest)
         assert any("'supertest'" in f and "not a declared dependency" in f for f in findings)

--- a/tests/unit/capabilities/test_verification_scaffold_reference.py
+++ b/tests/unit/capabilities/test_verification_scaffold_reference.py
@@ -43,18 +43,18 @@ _FIXTURE_DIR = (
 # self-contained evidence that the input end did not move.
 _MANIFEST_HASH = "ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a"
 
-# The fixture's own identity. Regenerated at GENERATOR_VERSION 3 (2026-08-17, #967 — the
-# store's table names became typed, changing the expanded tree the shells import from).
+# The fixture's own identity. Regenerated at GENERATOR_VERSION 4 (2026-08-17, #967 — the
+# spine now imports `TABLES`, the symbol the fill appendix teaches).
 #
-# BOTH VALUES ARE UNCHANGED FROM VERSION 2, and that is the informative part: the shells
-# themselves did not move. The only fixture byte that changed is the manifest's
-# `expanded_tree_hash`, which the byte test caught. So these pins did what they are for —
-# they distinguished "the tree changed" from "shell emission drifted", which is a
-# distinction a single combined hash could not express.
+# BOTH VALUES MOVED THIS TIME, and the contrast with version 3 is the useful part. Version 3
+# typed the store and left both hashes untouched: the tree changed, the shells did not.
+# Version 4 changes the shells' own import line, so the spine hash moves — which is exactly
+# what a spine hash is for. The two versions together demonstrate the pins discriminating
+# rather than merely reacting.
 #
 # These stop an in-place fixture regeneration from making the byte test self-referential.
-_AGGREGATE_SPINE_HASH = "dd42983032d035e1fdcd7b4ecd483727ff8bdc1004e5ebb951700f033a5bc30b"
-_SCAFFOLD_HASH = "3650c310caa2223e2be48f8b8f8617e25a5a8240f59f120a3fe96ddd9a5ad468"
+_AGGREGATE_SPINE_HASH = "e8f2a59e1e64e3b2d77dc2a2d3aae018a88ba0648393491a6094325f9fba0414"
+_SCAFFOLD_HASH = "69d29ab91f692bab9c3f4a2bd72910f39fe27b7ecfc7d41dd99a8bfb62b186f4"
 
 
 @pytest.fixture(scope="module")
@@ -73,12 +73,12 @@ def test_the_reference_manifest_is_unmoved():
 def test_generator_version_is_the_fixture_generation(emission):
     """A generator change without a version bump is drift by definition (SIP §4.3);
     a bump without regenerating the fixture is a pin measuring the wrong version."""
-    assert GENERATOR_VERSION == 3
-    assert emission.manifest.generator_version == 3
+    assert GENERATOR_VERSION == 4
+    assert emission.manifest.generator_version == 4
     stored = yaml.safe_load(
         (_FIXTURE_DIR / "verification_scaffold_manifest.yaml").read_text(encoding="utf-8")
     )
-    assert stored["generator_version"] == 3
+    assert stored["generator_version"] == 4
 
 
 def test_emission_reproduces_the_fixture_byte_for_byte(emission):

--- a/tests/unit/cycles/test_scaffold_evidence.py
+++ b/tests/unit/cycles/test_scaffold_evidence.py
@@ -272,7 +272,7 @@ class TestSummary:
         )
         d = summary.to_dict()
         # the promotion model's fields (SIP §6/§12) — schema preserved, workflow not built
-        assert d["stack"] == "nextjs_ts" and d["generator_version"] == 3
+        assert d["stack"] == "nextjs_ts" and d["generator_version"] == 4
         assert d["shell_count"] == 8 and d["slot_count"] == 8
         assert d["fill_dispositions"] == {"filled": 1, "missing": 7}
         assert d["additive_test_count"] == 2


### PR DESCRIPTION
**Found by the pre-V7 shakedown** (`cyc_308be9dfc299`): `ReferenceError: TABLES is not defined` in six of eight shells, on a roll whose developer used `TABLES.Run` correctly throughout and whose application was sound.

## The defect

#967 taught the fill appendix to write `TABLES.<Entity>` and left the shell's frozen import at `{ reset, all }`. **A fill may not add imports** — *"Assertions only. NO imports"*, and region enforcement rejects any edit outside the slot. So every fill that *followed the instructions* could not run.

Had this reached V7, **every roll would have failed identically and the window would have been destroyed.** This is the shakedown doing the job §2.e declared it for.

## It is a documented recurrence

The comment directly above that import line — put there by **#936, for exactly this reason** — read:

> *"any store helper the fill vocabulary teaches must already be in scope here or the fill cannot run… **Keep this in step with the vocabulary the appendix teaches.**"*

It was still there, in the right place, when I changed the vocabulary and not the line. **A request is not a mechanism.**

## And the mechanism already existed

`test_fill_vocabulary_is_in_scope` is #936's fix and guards this exact property. **It was green while the defect shipped.** Its extraction was scoped to what #936 looked like — *lowercase function calls* inside ```fill:``` blocks — and #967 taught an *uppercase constant* via *member access* in *prose*. Three ways past a guard aimed at the previous defect's shape.

So that guard is **widened, not duplicated**:

- extraction is now bounded by **what `lib/store.ts` actually exports**, rather than by an identifier shape the next defect can sidestep;
- it reads the whole appendix, not only its fenced examples — a worked example in prose is still a worked example, which is precisely how #967 taught it;
- a **negative control** confirms it now catches what it slept through;
- a guard-the-guard assertion requires both symbols that have actually bitten (`all`, `TABLES`) to still be detected, so the extraction cannot narrow again silently.

I had written a parallel guard first. **Deleting it was the correction** — two tests for one property is the drift this codebase keeps paying for.

Two more copies of the same fact removed while here: the gate's tamper fixtures hardcoded the import line and broke with *"tamper did not apply"* both times it changed. They now derive it from the real emission.

## The pins discriminated, and the contrast is the point

`GENERATOR_VERSION` 3 → 4, fixture regenerated, **both** pinned hashes updated.

| version | change | spine hash | scaffold hash |
|---|---|---|---|
| 3 | typed the store | **unmoved** | **unmoved** |
| 4 | changed the shells' import line | **moved** | **moved** |

Version 3 changed the tree and not the shells; version 4 changes the shells themselves. Two versions demonstrating the pins telling those apart — a distinction a single combined hash could not express.

7973 unit, 7587 regression, green.