### PR TITLE
feat(qa): record what the fills assert, not just that slots were filled

### DIFF
--- a/docs/plans/1-6-0-v7-fay-window-preregistration.md
+++ b/docs/plans/1-6-0-v7-fay-window-preregistration.md
@@ -210,8 +210,19 @@ never thresholds.
 | **scaffold slot count** — non-gating | scaffold manifest |
 | correction rounds | `runtime_activities` |
 | fills on first attempt / slots | eve emission-parse log line |
+| **whether any fill asserts on the store** — non-gating (#980) | `fill_merge.assertion_strength.any_fill_touches_the_store` |
+| **fill body size, and which slots assert on state** — non-gating (#980) | `fill_merge.assertion_strength` |
 | boot audit result | `audit_delivered_app.py`, recorded **separately** |
 | gate disposition and decider | `cycle_gate_decisions.decided_by` |
+
+**Why assertion strength is recorded and not gated.** Shakedown #1 banked `accepted` with
+14 of 14 criteria after its qa author retreated — 4,896 tokens of fills asserting response
+values *and* store effects on attempt 1, 711 tokens asserting response values alone on
+attempt 3, recorded identically as "8 of 8 fills". An author may legitimately have nothing to
+say about the store for a given behaviour, so this may not reject a roll. What it makes
+impossible is a closing claim that describes assertion strength the window never recorded.
+Read from banked evidence rather than a log line, because logs rotate and the closing record
+is written later.
 
 **The two criteria are never collapsed.** SIP-0104 §13a: the mechanical result and the boot
 audit are recorded as distinct facts, and the closing claim states both rather than a single

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -564,7 +564,10 @@ class QATestHandler(_CycleTaskHandler):
         inside the merged shells, attributed to the fill layer.
         """
         from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
-        from squadops.capabilities.verification_scaffold_fill import merge_fills
+        from squadops.capabilities.verification_scaffold_fill import (
+            measure_assertion_strength,
+            merge_fills,
+        )
 
         record = VerificationScaffoldManifest.from_dict(scaffold_input["manifest"])
         shell_paths = {f.path for f in record.files}
@@ -590,6 +593,11 @@ class QATestHandler(_CycleTaskHandler):
                 {"slot_id": d.slot_id, "detail": d.detail} for d in merged.misaddressed
             ],
             "dropped_shell_rewrites": dropped,
+            # #980: what the fills ASSERT, not just that slots were filled. The shakedown
+            # banked a retreat as a clean success because the record could not tell 8 rich
+            # fills from 8 that had dropped every store assertion. Banked rather than logged
+            # so the per-roll record reads it from stored state.
+            "assertion_strength": measure_assertion_strength(fill_emission),
         }
         merged_suite_files = [{"filename": f.path, "content": f.content} for f in merged.files]
         return kept + merged_artifacts, merged_suite_files, evidence

--- a/src/squadops/capabilities/verification_scaffold_fill.py
+++ b/src/squadops/capabilities/verification_scaffold_fill.py
@@ -111,6 +111,53 @@ class FillEmission:
     duplicates: tuple[str, ...] = ()
 
 
+#: Symbols ``lib/store.ts`` exports. A fill referencing one of these is asserting on
+#: persisted state; a fill referencing none is asserting only on the response it was handed.
+_STORE_SYMBOLS = ("all", "insert", "find", "reset", "TABLES", "nextId")
+
+
+def measure_assertion_strength(emission: FillEmission) -> dict:
+    """How much the fills assert, and whether any of it is about the store (#980).
+
+    **Why this is measured rather than assumed.** The pre-V7 shakedown finished `accepted`
+    with 14 of 14 criteria after its qa author retreated: attempt 1 emitted 4,896 completion
+    tokens of fills asserting response values *and* store effects; attempt 3 emitted 711
+    tokens asserting `body.id`, `body.title` and `body.datetime` and touching the store
+    nowhere. Both were recorded identically as "8 of 8 fills on the first attempt", because
+    the record counted slots and not what the slots say.
+
+    So a roll that retreated was indistinguishable from a roll that was right first time.
+    This does not gate anything — an author may legitimately have nothing to say about the
+    store for a given behaviour — but the closing claim of a measurement window cannot
+    describe assertion strength it never recorded.
+
+    ``store_slots`` is the load-bearing field. ``body_chars`` is the cheap corroborator: the
+    7x drop between those two attempts was visible in data already logged and read by nobody.
+    """
+    bodies = {f.slot_id: f.body for f in emission.fills if not f.is_not_applicable}
+    store_slots = sorted(
+        slot
+        for slot, body in bodies.items()
+        if any(re.search(rf"\b{sym}\s*[(.]", body) for sym in _STORE_SYMBOLS)
+    )
+    used = sorted(
+        {
+            sym
+            for body in bodies.values()
+            for sym in _STORE_SYMBOLS
+            if re.search(rf"\b{sym}\s*[(.]", body)
+        }
+    )
+    return {
+        "filled_slots": len(bodies),
+        "not_applicable_slots": sum(1 for f in emission.fills if f.is_not_applicable),
+        "body_chars": sum(len(b) for b in bodies.values()),
+        "store_slots": store_slots,
+        "store_symbols_used": used,
+        "any_fill_touches_the_store": bool(store_slots),
+    }
+
+
 def parse_fill_emission(text: str) -> FillEmission:
     """Extract fill blocks from an authored emission.
 

--- a/tests/unit/capabilities/test_fill_assertion_strength.py
+++ b/tests/unit/capabilities/test_fill_assertion_strength.py
@@ -1,0 +1,121 @@
+"""What the fills assert, not just that slots were filled (#980).
+
+Bug this guards: a `qa.test` retry can make a failing suite pass by retreating to weaker
+assertions, and the record could not tell that from being right first time.
+
+The pre-V7 shakedown (`cyc_308be9dfc299`) finished `accepted` with 14 of 14 criteria after
+exactly that. Attempt 1 emitted 4,896 completion tokens of fills asserting response values
+**and store effects**. Attempt 3 emitted 711 tokens asserting `body.id`, `body.title` and
+`body.datetime`, touching the store nowhere. Both were recorded identically as "8 of 8 fills,
+first attempt" — the record counted slots, never what the slots say. The dropped half is
+exactly what catches a handler that does not persist.
+
+This measures; it does not gate. An author may legitimately have nothing to say about the
+store for some behaviour. What it makes impossible is a measurement window whose closing claim
+describes assertion strength it never recorded.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.verification_scaffold_fill import (
+    measure_assertion_strength,
+    parse_fill_emission,
+)
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+#: The two real shapes from the shakedown, condensed.
+_RICH = """```fill:slot-a
+expect(body.id).toBeTruthy()
+expect(all(TABLES.Run)).toHaveLength(1)
+```
+```fill:slot-b
+expect(all(TABLES.Run)[0].title).toBe('sample')
+```"""
+
+_RETREAT = """```fill:slot-a
+expect(body.id).toBeDefined()
+```
+```fill:slot-b
+expect(body.title).toBe('sample')
+```"""
+
+
+def _measure(text: str) -> dict:
+    return measure_assertion_strength(parse_fill_emission(text))
+
+
+class TestTheRetreatIsVisible:
+    def test_the_two_shakedown_attempts_are_distinguishable(self):
+        """The whole point. Both filled every slot; only one asserted on state."""
+        rich, retreat = _measure(_RICH), _measure(_RETREAT)
+        assert rich["filled_slots"] == retreat["filled_slots"] == 2
+        assert rich["any_fill_touches_the_store"] is True
+        assert retreat["any_fill_touches_the_store"] is False
+
+    def test_the_slots_that_assert_on_state_are_named(self):
+        """A count would say "2 of 2 touch the store"; the names say WHICH, so a partial
+        retreat — three rich fills and five response-only — is legible too."""
+        assert _measure(_RICH)["store_slots"] == ["slot-a", "slot-b"]
+
+    def test_a_partial_retreat_is_visible(self):
+        mixed = _RICH.split("```fill:slot-b")[0] + _RETREAT.split("```fill:slot-a")[1]
+        m = _measure(mixed)
+        assert m["store_slots"] == ["slot-a"]
+        assert m["any_fill_touches_the_store"] is True, "one rich fill is still some coverage"
+
+    def test_body_size_corroborates(self):
+        """The 7x drop between the real attempts was in data already logged and read by
+        nobody. Cheap, and it moves with the thing that matters."""
+        assert _measure(_RICH)["body_chars"] > _measure(_RETREAT)["body_chars"]
+
+
+class TestWhatCountsAsTouchingTheStore:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "expect(all(TABLES.Run)).toHaveLength(1)",
+            "expect(find(TABLES.Run, body.id)).toBeDefined()",
+            "insert(TABLES.Run, { id: 'x' })",
+            "expect(TABLES.Run).toBe('run')",
+        ],
+    )
+    def test_each_store_symbol_registers(self, body):
+        m = _measure(f"```fill:slot-a\n{body}\n```")
+        assert m["any_fill_touches_the_store"], f"{body!r} asserts on the store"
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "expect(body.id).toBeTruthy()",
+            "expect(body.participants).toEqual([])",
+            # the words appear but not as a call or member access — prose, not a read
+            "// we could check all of the store here later",
+        ],
+    )
+    def test_response_only_fills_do_not_register(self, body):
+        m = _measure(f"```fill:slot-a\n{body}\n```")
+        assert not m["any_fill_touches_the_store"], f"{body!r} does not assert on the store"
+
+
+class TestEdges:
+    def test_a_not_applicable_slot_is_counted_separately_not_as_weak(self):
+        """An explicit NA is a declared judgment, not a retreat, and conflating the two would
+        punish the honest disposition the protocol asks for."""
+        m = _measure("```fill:slot-a\nnot_applicable: no store effect for a read\n```")
+        assert m["filled_slots"] == 0
+        assert m["not_applicable_slots"] == 1
+        assert m["any_fill_touches_the_store"] is False
+
+    def test_an_empty_emission_measures_zero_rather_than_raising(self):
+        m = _measure("no fences here at all")
+        assert m == {
+            "filled_slots": 0,
+            "not_applicable_slots": 0,
+            "body_chars": 0,
+            "store_slots": [],
+            "store_symbols_used": [],
+            "any_fill_touches_the_store": False,
+        }


### PR DESCRIPTION
`Closes #980`

A `qa.test` retry can make a failing suite pass by **retreating to weaker assertions**, and the record could not tell that from being right first time.

## What the shakedown did

`cyc_308be9dfc299` finished **`accepted`, 14 of 14 criteria** — by retreating:

| attempt | fills | completion tokens | what they assert |
|---|---|---|---|
| 1 | 8/8 | **4,896** | response values **and store effects** |
| 3 | 8/8 | **711** | `body.id`, `body.title`, `body.datetime` — response only |

Both were recorded identically as *"8 of 8 fills, first attempt"*. The record counted slots, never what the slots say — and the dropped half is exactly what catches a handler that does not persist, the defect P6 roll 6's three analyses spent a full correction budget hallucinating.

## What this adds

`measure_assertion_strength` lives beside the fill parser, which already carries each body. Its output is **banked into `fill_merge` evidence rather than logged** — logs rotate, and the closing record is written later.

- **`store_slots` is load-bearing, and it names the slots rather than counting them**, so a partial retreat (three rich fills, five response-only) is legible rather than averaged away.
- **`body_chars` is the cheap corroborator.** The 7× drop between the real attempts was sitting in data already logged and read by nobody.

## Measures, does not gate

An author may legitimately have nothing to say about the store for a given behaviour, so this may not reject a roll — the same disposition as #951. What it makes impossible is a closing claim that describes assertion strength the window never recorded, and §4 of the pre-registration now says so explicitly.

**An explicit `not_applicable` is counted separately, not as weakness.** It is a declared judgment the protocol asks for, and conflating the two would punish the honest disposition.

## Verification

13 new tests, built from the two real shakedown shapes — including that both filled every slot and only one asserted on state, that a partial retreat is visible, and that prose mentioning "all of the store" is not mistaken for a read.

7986 unit tests green.

## Window status

Pure instrumentation — it changes no authored artifact and no verdict — so it does not need its own shakedown. But it should land **before roll 1**, because without it a green V7 roll that retreated goes into the release as a success and nobody can tell afterwards.
