### PR TITLE
fix(qa): bank suite-authenticity rows on pass, with what was inspected (#986)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -72,6 +72,22 @@ def _frontend_skip_reason(error: str) -> str:
     return NotExecutedReason.SUBJECT_MISSING
 
 
+def _authenticity_row(check: str, offenders: list[str], inspected: list[str]) -> dict[str, Any]:
+    """Build a suite-authenticity check row that is banked pass OR fail (#986).
+
+    The two authenticity detectors used to append a row only when they found
+    something, so a clean suite left no trace and an absent row meant either "looked
+    and found nothing" or "never looked" — an ambiguity that cost an hour of
+    archaeology on `cyc_6651d552e06a` and still did not resolve. ``inspected`` names
+    the files the detector actually read, so an empty inventory beside an executed
+    suite reads as the defect it is instead of as a pass.
+    """
+    row: dict[str, Any] = {"check": check, "passed": not offenders, "inspected": inspected}
+    if offenders:
+        row["offenders"] = offenders
+    return row
+
+
 class QATestHandler(_CycleTaskHandler):
     """Build handler: generates test files from validation plan + source (D1).
 
@@ -805,20 +821,22 @@ class QATestHandler(_CycleTaskHandler):
         # #276 guard holds on the retest path too: a repair must not smuggle a
         # stub-fallback past the correction loop.
         from squadops.capabilities.handlers.stub_detection import (
+            CHECK_NO_SELF_MOCKING,
+            CHECK_NO_STUB_FALLBACK,
             detect_self_mocking_tests,
             detect_stub_fallback_tests,
+            inspected_js_test_paths,
+            inspected_python_test_paths,
         )
 
         stub_offenders = detect_stub_fallback_tests(artifacts)
+        checks.append(
+            _authenticity_row(
+                CHECK_NO_STUB_FALLBACK, stub_offenders, inspected_python_test_paths(artifacts)
+            )
+        )
         if stub_offenders:
             passed = False
-            checks.append(
-                {
-                    "check": "no_stub_fallback_tests",
-                    "offenders": stub_offenders,
-                    "passed": False,
-                }
-            )
             missing.append(f"stub_fallback_tests:{','.join(stub_offenders)}")
             summary = f"{summary}; repaired test masks the entrypoint: {', '.join(stub_offenders)}"
 
@@ -826,16 +844,12 @@ class QATestHandler(_CycleTaskHandler):
         # pass can satisfy that instruction by mocking the subject, and mocking is the
         # cheapest way to make any assertion true.
         mock_offenders = detect_self_mocking_tests(artifacts)
+        mock_paths = [path for path, _ in mock_offenders]
+        checks.append(
+            _authenticity_row(CHECK_NO_SELF_MOCKING, mock_paths, inspected_js_test_paths(artifacts))
+        )
         if mock_offenders:
             passed = False
-            mock_paths = [path for path, _ in mock_offenders]
-            checks.append(
-                {
-                    "check": "no_self_mocking_tests",
-                    "offenders": mock_paths,
-                    "passed": False,
-                }
-            )
             missing.append(f"self_mocking_tests:{','.join(mock_paths)}")
             summary = (
                 f"{summary}; repaired test never invokes the application: {', '.join(mock_paths)}"
@@ -1254,19 +1268,23 @@ class QATestHandler(_CycleTaskHandler):
             # passes). Flag it so acceptance fails and the correction loop
             # regenerates the test against the real module.
             from squadops.capabilities.handlers.stub_detection import (
+                CHECK_NO_SELF_MOCKING,
+                CHECK_NO_STUB_FALLBACK,
                 detect_self_mocking_tests,
                 detect_stub_fallback_tests,
+                inspected_js_test_paths,
+                inspected_python_test_paths,
             )
 
             stub_offenders = detect_stub_fallback_tests(artifacts)
-            if stub_offenders:
-                validation.checks.append(
-                    {
-                        "check": "no_stub_fallback_tests",
-                        "offenders": stub_offenders,
-                        "passed": False,
-                    }
+            validation.checks.append(
+                _authenticity_row(
+                    CHECK_NO_STUB_FALLBACK,
+                    stub_offenders,
+                    inspected_python_test_paths(artifacts),
                 )
+            )
+            if stub_offenders:
                 validation.passed = False
                 validation.missing_components.append(
                     f"stub_fallback_tests:{','.join(stub_offenders)}"
@@ -1280,8 +1298,6 @@ class QATestHandler(_CycleTaskHandler):
                     if validation.summary in ("", "All checks passed")
                     else f"{validation.summary}; {note}"
                 )
-                passed_count = sum(1 for c in validation.checks if c["passed"])
-                validation.coverage_ratio = passed_count / len(validation.checks)
 
             # #915: the TypeScript sibling, and worse — a stub-fallback suite fails
             # loudly because a reconstruction misbehaves, while a self-mocking suite
@@ -1289,15 +1305,13 @@ class QATestHandler(_CycleTaskHandler):
             # cannot do this (the frozen spine invokes the handler and enforcement
             # rejects edits to it); additive files carried the rule only as prose.
             mock_offenders = detect_self_mocking_tests(artifacts)
-            if mock_offenders:
-                mock_paths = [path for path, _ in mock_offenders]
-                validation.checks.append(
-                    {
-                        "check": "no_self_mocking_tests",
-                        "offenders": mock_paths,
-                        "passed": False,
-                    }
+            mock_paths = [path for path, _ in mock_offenders]
+            validation.checks.append(
+                _authenticity_row(
+                    CHECK_NO_SELF_MOCKING, mock_paths, inspected_js_test_paths(artifacts)
                 )
+            )
+            if mock_offenders:
                 validation.passed = False
                 validation.missing_components.append(f"self_mocking_tests:{','.join(mock_paths)}")
                 note = "Generated test never invokes the application: " + "; ".join(
@@ -1308,7 +1322,11 @@ class QATestHandler(_CycleTaskHandler):
                     if validation.summary in ("", "All checks passed")
                     else f"{validation.summary}; {note}"
                 )
-                passed_count = sum(1 for c in validation.checks if c["passed"])
+
+            # Both authenticity rows now bank unconditionally, so the ratio moves on a
+            # clean pass too — recompute once here rather than only on the failure legs.
+            if validation.checks:
+                passed_count = sum(1 for c in validation.checks if c.get("passed"))
                 validation.coverage_ratio = passed_count / len(validation.checks)
 
             evidence_extra["validation_result"] = {

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -21,7 +21,11 @@ from squadops.capabilities.handlers.base import (
     HandlerResult,
 )
 from squadops.capabilities.handlers.prompt_guard import _guard_prompt_size
-from squadops.cycles.check_registry import CHECK_FRONTEND_BUILD
+from squadops.cycles.check_registry import (
+    CHECK_FRONTEND_BUILD,
+    CHECK_NO_SELF_MOCKING_TESTS,
+    CHECK_NO_STUB_FALLBACK_TESTS,
+)
 from squadops.cycles.emission_integrity import emission_stats as _emission_stats
 from squadops.cycles.verification_integrity import NotExecutedReason, ResultStatus
 from squadops.llm.exceptions import LLMError
@@ -821,8 +825,6 @@ class QATestHandler(_CycleTaskHandler):
         # #276 guard holds on the retest path too: a repair must not smuggle a
         # stub-fallback past the correction loop.
         from squadops.capabilities.handlers.stub_detection import (
-            CHECK_NO_SELF_MOCKING,
-            CHECK_NO_STUB_FALLBACK,
             detect_self_mocking_tests,
             detect_stub_fallback_tests,
             inspected_js_test_paths,
@@ -832,7 +834,7 @@ class QATestHandler(_CycleTaskHandler):
         stub_offenders = detect_stub_fallback_tests(artifacts)
         checks.append(
             _authenticity_row(
-                CHECK_NO_STUB_FALLBACK, stub_offenders, inspected_python_test_paths(artifacts)
+                CHECK_NO_STUB_FALLBACK_TESTS, stub_offenders, inspected_python_test_paths(artifacts)
             )
         )
         if stub_offenders:
@@ -846,7 +848,9 @@ class QATestHandler(_CycleTaskHandler):
         mock_offenders = detect_self_mocking_tests(artifacts)
         mock_paths = [path for path, _ in mock_offenders]
         checks.append(
-            _authenticity_row(CHECK_NO_SELF_MOCKING, mock_paths, inspected_js_test_paths(artifacts))
+            _authenticity_row(
+                CHECK_NO_SELF_MOCKING_TESTS, mock_paths, inspected_js_test_paths(artifacts)
+            )
         )
         if mock_offenders:
             passed = False
@@ -1268,8 +1272,6 @@ class QATestHandler(_CycleTaskHandler):
             # passes). Flag it so acceptance fails and the correction loop
             # regenerates the test against the real module.
             from squadops.capabilities.handlers.stub_detection import (
-                CHECK_NO_SELF_MOCKING,
-                CHECK_NO_STUB_FALLBACK,
                 detect_self_mocking_tests,
                 detect_stub_fallback_tests,
                 inspected_js_test_paths,
@@ -1279,7 +1281,7 @@ class QATestHandler(_CycleTaskHandler):
             stub_offenders = detect_stub_fallback_tests(artifacts)
             validation.checks.append(
                 _authenticity_row(
-                    CHECK_NO_STUB_FALLBACK,
+                    CHECK_NO_STUB_FALLBACK_TESTS,
                     stub_offenders,
                     inspected_python_test_paths(artifacts),
                 )
@@ -1308,7 +1310,7 @@ class QATestHandler(_CycleTaskHandler):
             mock_paths = [path for path, _ in mock_offenders]
             validation.checks.append(
                 _authenticity_row(
-                    CHECK_NO_SELF_MOCKING, mock_paths, inspected_js_test_paths(artifacts)
+                    CHECK_NO_SELF_MOCKING_TESTS, mock_paths, inspected_js_test_paths(artifacts)
                 )
             )
             if mock_offenders:

--- a/src/squadops/capabilities/handlers/stub_detection.py
+++ b/src/squadops/capabilities/handlers/stub_detection.py
@@ -180,3 +180,29 @@ def detect_self_mocking_tests(files: list[dict]) -> list[tuple[str, str]]:
         elif _NETWORK_SEAM_MOCK.search(content) and not _APP_ROUTE_IMPORT.search(content):
             offenders.append((path, MOCKS_THE_NETWORK))
     return sorted(offenders)
+
+
+# --- What the detectors were actually shown (#986) ------------------------------
+#
+# Both detectors above report offenders and nothing else, so a clean result is
+# indistinguishable from a detector that was never reached — or that was reached
+# with the wrong file list. Diagnosing one absent row in `cyc_6651d552e06a` cost an
+# hour precisely because the run record could not answer "did it look, and at what?".
+#
+# These return the inventory each detector inspects, so a caller can bank a row
+# whether or not it found anything. An empty inventory alongside an executed suite
+# is then a visible fact rather than a silence.
+
+
+CHECK_NO_STUB_FALLBACK = "no_stub_fallback_tests"
+CHECK_NO_SELF_MOCKING = "no_self_mocking_tests"
+
+
+def inspected_python_test_paths(files: list[dict]) -> list[str]:
+    """Return the paths ``detect_stub_fallback_tests`` will actually examine."""
+    return sorted(path for path, _ in map(_file_field, files) if path and _is_test_file(path))
+
+
+def inspected_js_test_paths(files: list[dict]) -> list[str]:
+    """Return the paths ``detect_self_mocking_tests`` will actually examine."""
+    return sorted(path for path, _ in map(_file_field, files) if path and _is_js_test_file(path))

--- a/src/squadops/capabilities/handlers/stub_detection.py
+++ b/src/squadops/capabilities/handlers/stub_detection.py
@@ -194,10 +194,6 @@ def detect_self_mocking_tests(files: list[dict]) -> list[tuple[str, str]]:
 # is then a visible fact rather than a silence.
 
 
-CHECK_NO_STUB_FALLBACK = "no_stub_fallback_tests"
-CHECK_NO_SELF_MOCKING = "no_self_mocking_tests"
-
-
 def inspected_python_test_paths(files: list[dict]) -> list[str]:
     """Return the paths ``detect_stub_fallback_tests`` will actually examine."""
     return sorted(path for path, _ in map(_file_field, files) if path and _is_test_file(path))

--- a/src/squadops/cycles/check_registry.py
+++ b/src/squadops/cycles/check_registry.py
@@ -52,6 +52,7 @@ class FrameworkCheck:
 # declarable; wiring its CheckResult emission is a later slice (4b).
 CHECK_TESTS_PASS = "tests_pass"
 CHECK_NO_STUB_FALLBACK_TESTS = "no_stub_fallback_tests"
+CHECK_NO_SELF_MOCKING_TESTS = "no_self_mocking_tests"
 CHECK_REQUIRED_FILES = "required_files"
 CHECK_FRONTEND_BUILD = "frontend_build"
 
@@ -63,6 +64,10 @@ FRAMEWORK_CHECKS: dict[str, FrameworkCheck] = {
     CHECK_NO_STUB_FALLBACK_TESTS: FrameworkCheck(
         CHECK_NO_STUB_FALLBACK_TESTS,
         "The passing tests are not stub/placeholder fallbacks (§6.6.1).",
+    ),
+    CHECK_NO_SELF_MOCKING_TESTS: FrameworkCheck(
+        CHECK_NO_SELF_MOCKING_TESTS,
+        "The passing tests invoke the application rather than their own mock (#915).",
     ),
     CHECK_REQUIRED_FILES: FrameworkCheck(
         CHECK_REQUIRED_FILES,

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -1417,6 +1417,60 @@ class TestQARetestExecuteOnly:
         assert stub_row["passed"] is False
         assert "tests/test_api.py" in stub_row["offenders"]
 
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
+    async def test_clean_suite_still_banks_an_authenticity_row(
+        self, _mock_run, mock_context, qa_inputs
+    ):
+        """#986: a passing authenticity check must leave a record, not silence.
+
+        The detectors used to append a row only on a hit, so a run record that
+        omitted ``no_self_mocking_tests`` was consistent with two opposite
+        histories — the suite was checked and clean, or the check never ran over
+        it. `cyc_6651d552e06a` banked exactly that absence and the run could not
+        say which. The row's ``inspected`` list is what separates them.
+        """
+        clean = {
+            **qa_inputs,
+            "retest_files": [
+                {
+                    "filename": "__tests__/runs.test.ts",
+                    "content": (
+                        "import { POST } from '@/app/api/runs/route'\n"
+                        "it('creates', async () => {\n"
+                        "  const res = await POST(new Request('http://t/api/runs'))\n"
+                        "  expect(res.status).toBe(201)\n"
+                        "})\n"
+                    ),
+                }
+            ],
+        }
+        handler = QATestHandler()
+        result = await handler.handle(mock_context, clean)
+
+        assert result.success is True
+        rows = result.outputs["validation_result"]["checks"]
+        mock_row = next(r for r in rows if r["check"] == "no_self_mocking_tests")
+        assert mock_row["passed"] is True
+        assert mock_row["inspected"] == ["__tests__/runs.test.ts"]
+        assert "offenders" not in mock_row
+
+    @patch(_RUN_TESTS_PATH, return_value=_MOCK_TEST_RESULT_PASSED)
+    async def test_authenticity_row_shows_when_a_detector_had_nothing_to_read(
+        self, _mock_run, mock_context, qa_inputs
+    ):
+        """#986: an empty ``inspected`` is the signal that the check was fed the
+        wrong file set — the failure mode a bare pass/absence cannot express."""
+        handler = QATestHandler()
+        result = await handler.handle(mock_context, self._retest_inputs(qa_inputs))
+
+        rows = result.outputs["validation_result"]["checks"]
+        by_check = {r["check"]: r for r in rows}
+        # A python-only repair: the JS detector genuinely had no candidates, and
+        # says so, rather than passing indistinguishably from a real inspection.
+        assert by_check["no_self_mocking_tests"]["inspected"] == []
+        assert by_check["no_stub_fallback_tests"]["inspected"] == ["tests/test_api.py"]
+        assert by_check["no_self_mocking_tests"]["passed"] is True
+
 
 # ---------------------------------------------------------------------------
 # QATestHandler — contract probe emission (SIP-0098 phase 98.5)

--- a/tests/unit/cycles/test_check_registry.py
+++ b/tests/unit/cycles/test_check_registry.py
@@ -12,6 +12,7 @@ import pytest
 
 from squadops.cycles.check_registry import (
     CHECK_FRONTEND_BUILD,
+    CHECK_NO_SELF_MOCKING_TESTS,
     CHECK_NO_STUB_FALLBACK_TESTS,
     CHECK_REQUIRED_FILES,
     CHECK_TESTS_PASS,
@@ -26,6 +27,7 @@ pytestmark = [pytest.mark.domain_orchestration]
 _ALL_IDS = {
     CHECK_TESTS_PASS,
     CHECK_NO_STUB_FALLBACK_TESTS,
+    CHECK_NO_SELF_MOCKING_TESTS,
     CHECK_REQUIRED_FILES,
     CHECK_FRONTEND_BUILD,
 }


### PR DESCRIPTION
## What

The two suite-authenticity detectors — #276 stub-fallback and #915 self-mocking — appended a check row **only when they found an offender**. A clean result left no record at all.

That makes an absent row ambiguous. It is equally consistent with:

- the suite was inspected and was clean, and
- the detector never ran over that suite.

## Why it matters now

`cyc_6651d552e06a` banked exactly that absence. The facts available afterwards:

- the deployed detector flags the run's offending suite when called by hand;
- the run's other qa validation rows (`expected_artifacts`, `non_stub_files`, `tests_pass`) banked normally, so qa's validation did execute;
- `no_self_mocking_tests` is absent from the banked summary.

Nothing in the stored state distinguishes the two histories, and the archaeology — checkpoints, verification summary, artifact refs — did not resolve it, because the distinguishing fact was never written down.

## The change

Both call sites (the main `handle()` path and the execute-only retest path, which each carried their own copy) now append the row unconditionally via one shared builder, carrying `inspected`: the files the detector actually read.

```json
{"check": "no_self_mocking_tests", "passed": true, "inspected": ["__tests__/runs.test.ts"]}
```

An empty `inspected` beside an executed suite now reads as the defect it is, rather than as a pass. That is the state the locus-attribution work needs in order to key on this check at all.

Two smaller items ride along:

- the check-name literals, previously duplicated across the two call sites, move to constants in the module that owns the concern;
- the two duplicated coverage-ratio recomputations on the main path fold into one unconditional pass, since the ratio now moves on a clean result too.

## Tests

Two added to the existing execute-only retest class, which drives the real handler path with no LLM:

- a clean TypeScript suite still banks `no_self_mocking_tests` with `passed: true` and `inspected` naming the file — before this change the row does not exist and the lookup raises;
- a python-only repair banks the JS row with `inspected: []` and the python row with the file it read — the "fed the wrong file set" case a bare pass cannot express.

Full regression: 7602 passed, 1 skipped.

## Scope note

This is the instrument, not yet the attribution fix. It deliberately does not change what the detectors flag, and it does not change which files each path feeds them — the retest path still sees only the repaired files. Whether that narrower input is itself a coverage hole is what the next roll's `inspected` inventory will answer, and it is left for #988 rather than guessed at here.

Closes #986
