### PR TITLE
fix(scaffold): accept the language-prefixed fill fence, and record it (#987)

### DIFF
--- a/src/squadops/capabilities/verification_scaffold_fill.py
+++ b/src/squadops/capabilities/verification_scaffold_fill.py
@@ -75,8 +75,20 @@ from squadops.capabilities.verification_scaffold import (
 MAX_FILL_LINES = 120
 MAX_FILL_BYTES = 8_000
 
+#: A fill fence, with the language prefix an author reflexively adds made optional (#987).
+#:
+#: The brief teaches ```` ```fill:slot-<id> ````, and an author writing markdown all day
+#: writes ```` ```typescript:fill:slot-<id> ```` anyway. Under the exact-form pattern that
+#: cost a whole pre-V7 shakedown: the fence did not match here, `strip_fill_blocks` left it
+#: in the text, and the file extractor — which reads ``<language>:<path>`` info strings —
+#: took it for a file named ``fill:slot-<id>``. All six fills vanished, and nothing said so.
+#:
+#: The prefixed form is unambiguous, so accepting it loses nothing. It is still *recorded*
+#: (see ``language_prefixed``) rather than silently normalised, because a brief the author
+#: keeps departing from is worth knowing about.
 _FILL_FENCE_RE = re.compile(
-    r"^```fill:(?P<slot_id>slot-[a-z0-9][a-z0-9-]*)[ \t]*\n(?P<body>.*?)^```[ \t]*$",
+    r"^```(?:(?P<lang>[A-Za-z][\w+.-]*):)?"
+    r"fill:(?P<slot_id>slot-[a-z0-9][a-z0-9-]*)[ \t]*\n(?P<body>.*?)^```[ \t]*$",
     re.DOTALL | re.MULTILINE,
 )
 _NOT_APPLICABLE_RE = re.compile(r"^\s*not_applicable:\s*(?P<reason>\S.*)$")
@@ -109,6 +121,9 @@ class FillEmission:
     fills: tuple[Fill, ...] = ()
     #: slot ids that appeared in more than one fill block (all occurrences rejected).
     duplicates: tuple[str, ...] = ()
+    #: slot ids whose fence carried a language prefix (``typescript:fill:slot-…``). Accepted,
+    #: but counted: it measures how far the emission drifts from the form the brief teaches.
+    language_prefixed: tuple[str, ...] = ()
 
 
 #: Symbols ``lib/store.ts`` exports. A fill referencing one of these is asserting on
@@ -155,6 +170,9 @@ def measure_assertion_strength(emission: FillEmission) -> dict:
         "store_slots": store_slots,
         "store_symbols_used": used,
         "any_fill_touches_the_store": bool(store_slots),
+        # #987: accepted-but-noted fence drift. Non-empty means the brief's taught form
+        # and the author's habit disagree, which is worth seeing before it costs a roll.
+        "language_prefixed_fences": list(emission.language_prefixed),
     }
 
 
@@ -167,9 +185,12 @@ def parse_fill_emission(text: str) -> FillEmission:
     """
     fills: list[Fill] = []
     seen: dict[str, int] = {}
+    prefixed: list[str] = []
     for match in _FILL_FENCE_RE.finditer(text):
         slot_id = match.group("slot_id")
         body = match.group("body")
+        if match.group("lang"):
+            prefixed.append(slot_id)
         seen[slot_id] = seen.get(slot_id, 0) + 1
         stripped = [line for line in body.strip("\n").split("\n") if line.strip()]
         na = _NOT_APPLICABLE_RE.match(stripped[0]) if len(stripped) == 1 else None
@@ -178,7 +199,11 @@ def parse_fill_emission(text: str) -> FillEmission:
         else:
             fills.append(Fill(slot_id=slot_id, body=body.strip("\n")))
     duplicates = tuple(sorted(slot_id for slot_id, count in seen.items() if count > 1))
-    return FillEmission(fills=tuple(fills), duplicates=duplicates)
+    return FillEmission(
+        fills=tuple(fills),
+        duplicates=duplicates,
+        language_prefixed=tuple(sorted(set(prefixed))),
+    )
 
 
 #: ``(pattern, human reason)`` — each is a containment rule from the module docstring.

--- a/tests/unit/capabilities/test_fill_assertion_strength.py
+++ b/tests/unit/capabilities/test_fill_assertion_strength.py
@@ -118,4 +118,5 @@ class TestEdges:
             "store_slots": [],
             "store_symbols_used": [],
             "any_fill_touches_the_store": False,
+            "language_prefixed_fences": [],
         }

--- a/tests/unit/capabilities/test_verification_scaffold_fill.py
+++ b/tests/unit/capabilities/test_verification_scaffold_fill.py
@@ -23,6 +23,7 @@ from squadops.capabilities.verification_scaffold_fill import (
     fill_findings,
     merge_fills,
     parse_fill_emission,
+    strip_fill_blocks,
 )
 from tests.unit.capabilities._stack_fixtures import manifest_for_stack
 
@@ -76,6 +77,52 @@ class TestParseFillEmission:
     def test_an_emission_with_no_fill_blocks_parses_empty(self):
         parsed = parse_fill_emission("no fences at all, just prose")
         assert parsed.fills == () and parsed.duplicates == ()
+
+    def test_a_language_prefixed_fence_is_a_fill_and_is_recorded_as_drift(self):
+        """#987: ```typescript:fill:slot-… is the form an author actually writes.
+
+        Under the exact-form pattern it matched nothing here, survived
+        ``strip_fill_blocks``, and the file extractor read it as a file named
+        ``fill:slot-…``. A pre-V7 shakedown lost all six of its fills that way with
+        no finding raised — the emission looked like it had simply said nothing.
+        """
+        text = (
+            "```typescript:fill:slot-vc-probe-api-runs\n"
+            "    expect(body.id).toBeTruthy()\n"
+            "```\n"
+            "```fill:slot-vs-get-api-runs\n"
+            "    expect(body).toEqual([])\n"
+            "```\n"
+        )
+        parsed = parse_fill_emission(text)
+
+        assert [f.slot_id for f in parsed.fills] == [_CREATE_SLOT, _LIST_SLOT]
+        assert parsed.fills[0].body == "    expect(body.id).toBeTruthy()"
+        # Accepted, but not silently: the unprefixed sibling is absent from the record.
+        assert parsed.language_prefixed == (_CREATE_SLOT,)
+
+    def test_a_prefixed_fence_cannot_leak_into_the_file_extractor(self):
+        """The other half of #987 — stripping must remove the prefixed form too, or
+        the same block is both a fill and a bogus additive file named ``fill:slot-…``."""
+        text = (
+            "```typescript:fill:slot-vc-probe-api-runs\n"
+            "    expect(body.id).toBeTruthy()\n"
+            "```\n"
+            "```typescript:__tests__/extra.test.ts\n"
+            "// a genuine additive file\n"
+            "```\n"
+        )
+        stripped = strip_fill_blocks(text)
+
+        assert "fill:slot-" not in stripped
+        assert "__tests__/extra.test.ts" in stripped
+
+    def test_a_prefix_that_is_not_a_language_token_is_not_a_fill(self):
+        """The prefix is optional, not arbitrary: a fence whose info string merely
+        ends in ``fill:slot-…`` is a path-addressed file and stays the extractor's."""
+        text = "```ts:src/fill:slot-vc-probe-api-runs\nconst x = 1\n```\n"
+        assert parse_fill_emission(text).fills == ()
+        assert strip_fill_blocks(text) == text
 
 
 class TestFillFindings:


### PR DESCRIPTION
## What

The fill-fence pattern required the exact form the brief teaches:

````
```fill:slot-vc-probe-api-runs
````

An author writing markdown all day writes this instead:

````
```typescript:fill:slot-vc-probe-api-runs
````

which matched nothing. The fence then survived `strip_fill_blocks`, and the fenced-**file** extractor — which reads `<language>:<path>` info strings — read it as a file named `fill:slot-vc-probe-api-runs`.

## Why it matters

A pre-V7 shakedown lost **all six** of its fills this way, and no finding was raised: from the protocol's side the emission had simply said nothing about any slot. The shells then rendered as the failing states a missing fill is *defined* to produce, so the run read as an authoring failure rather than a parse failure. That is the most expensive shape a defect can take here — it looks exactly like the thing the scaffold exists to detect.

## The change

- The language prefix is now optional in the fence pattern, so both forms parse identically.
- `strip_fill_blocks` removes the prefixed form too — otherwise one block would be both a fill *and* a bogus additive file.
- It is **recorded, not silently normalised**: `FillEmission.language_prefixed` carries the slot ids whose fence was prefixed, surfaced in the banked `fill_merge` evidence as `language_prefixed_fences`. A brief the author keeps departing from is worth seeing before it costs another roll.
- The prefix must be a bare language token. A path-addressed fence that merely *ends* in `fill:slot-…` (`ts:src/fill:slot-x`) is still the file extractor's and is untouched.

## Tests

Four in `TestParseFillEmission`, all of which fail before the change:

- a prefixed fence parses as a fill, alongside an unprefixed sibling, with `language_prefixed` naming only the prefixed one;
- a prefixed fence cannot leak into the file extractor, while a genuine additive-file fence beside it is left intact;
- a non-language prefix is *not* claimed as a fill (the guard against over-matching);
- the empty-emission exact-dict measurement updated for the new evidence key.

Full regression: 7603 passed, 1 skipped.

Closes #987
