### PR TITLE
fix(routing): a suite that never invoked the app is the suite's defect (#988)

### DIFF
--- a/src/squadops/cycles/failure_evidence.py
+++ b/src/squadops/cycles/failure_evidence.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from squadops.cycles.acceptance_check_spec import CHECK_CONTRACT_ASSERTIONS
+from squadops.cycles.check_registry import (
+    CHECK_NO_SELF_MOCKING_TESTS,
+    CHECK_NO_STUB_FALLBACK_TESTS,
+)
 from squadops.cycles.emission_integrity import extraction_loss_suspected
 from squadops.cycles.verification_integrity import ResultStatus
 
@@ -245,6 +249,23 @@ def classify_failure_locus(failure_evidence: Any) -> str:
         # guard: the signal comes from the contract, not from the app failing
         # the suite — for qa.test, OWN_ARTIFACT = eve re-authors the suite.
         if check == f"acceptance:{CHECK_CONTRACT_ASSERTIONS}" and row.get("passed") is False:
+            return FailureLocus.OWN_ARTIFACT
+        # #988: the suite never invoked the application — it mocked the route module,
+        # or replaced the fetch seam and imported no route at all (#915), or hid the
+        # entrypoint behind an ImportError stub and tested the reconstruction (#276).
+        # Such a suite's verdict on the app carries no information about the app, so
+        # routing its failure to the dev chain spends the repair budget rewriting
+        # working code against evidence produced by a test of itself. The pre-V7
+        # shakedown did exactly that and exhausted its attempts; roll 6's delivered
+        # app passed a hand boot audit while the cycle rejected it.
+        #
+        # Safe from the test-gaming guard on the same footing as the contract row
+        # above: the signal is structural — read off the suite's own source — not the
+        # app failing the suite, so it cannot be produced BY an app defect.
+        if (
+            check in (CHECK_NO_SELF_MOCKING_TESTS, CHECK_NO_STUB_FALLBACK_TESTS)
+            and row.get("passed") is False
+        ):
             return FailureLocus.OWN_ARTIFACT
     scaffold_locus = _locus_from_scaffold_classification(failure_evidence)
     if scaffold_locus is not None:

--- a/tests/unit/cycles/test_failure_evidence.py
+++ b/tests/unit/cycles/test_failure_evidence.py
@@ -318,6 +318,47 @@ class TestClassifyFailureLocus:
         row = {"check": "tests_pass", "executed": True, "exit_code": 1, "passed": False}
         assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.SUBJECT
 
+    @pytest.mark.parametrize("check", ["no_self_mocking_tests", "no_stub_fallback_tests"])
+    def test_a_suite_that_never_invoked_the_app_is_own_artifact(self, check):
+        """#988: exit 1 alone reads SUBJECT, and must not when the suite is
+        self-referential.
+
+        A suite that mocks the route module, or replaces the fetch seam and imports
+        no route at all, produces a verdict about itself. Sending that to the dev
+        chain spends the repair budget rewriting working code: the pre-V7 shakedown
+        exhausted its attempts that way, and roll 6's delivered app passed a hand
+        boot audit while the cycle rejected it. The offender row must outrank the
+        tests_pass row it appears beside.
+        """
+        evidence = {
+            "validation_result": {
+                "passed": False,
+                "checks": [
+                    {"check": "tests_pass", "executed": True, "exit_code": 1, "passed": False},
+                    {"check": check, "passed": False, "offenders": ["__tests__/runs.test.ts"]},
+                ],
+            }
+        }
+        assert classify_failure_locus(evidence) == FailureLocus.OWN_ARTIFACT
+
+    def test_a_clean_authenticity_row_leaves_the_subject_route_intact(self):
+        """The guard's other side: the row is now banked on a pass too (#986), so a
+        passing one must not divert a genuine app failure away from the dev chain."""
+        evidence = {
+            "validation_result": {
+                "passed": False,
+                "checks": [
+                    {"check": "tests_pass", "executed": True, "exit_code": 1, "passed": False},
+                    {
+                        "check": "no_self_mocking_tests",
+                        "passed": True,
+                        "inspected": ["__tests__/runs.test.ts"],
+                    },
+                ],
+            }
+        }
+        assert classify_failure_locus(evidence) == FailureLocus.SUBJECT
+
     def test_pytest_internal_error_is_unknown(self):
         row = {"check": "tests_pass", "executed": True, "exit_code": 3, "passed": False}
         assert classify_failure_locus(self._evidence_with_check(row)) == FailureLocus.UNKNOWN


### PR DESCRIPTION
> **Stacked on #989** — it uses the `no_self_mocking_tests` registry constant that PR adds. Merge #989 first; the base retargets to `main` automatically.

## What

`classify_failure_locus` scans own-artifact signals **before** consulting the `tests_pass` row. Two signals were in that first scan: missing `expected_artifacts`, and the frozen contract contradicting the suite's own assertions (#629).

The two suite-authenticity rows were not. So a self-mocking (#915) or stub-fallback (#276) suite that failed produced exit 1 and classified `SUBJECT` — routing the repair at the **application**.

## Why that is the worst available answer

A suite that mocks the route module under test, or replaces the `fetch` seam and imports no route at all, returns a verdict *about itself*. The application is not implicated by it in either direction — not as passing, not as failing.

Two runs paid for this:

- the pre-V7 shakedown exhausted its correction attempts rewriting a handler against a suite that reimplemented the API and tested its own fake (round 3 restored a `status: 201` that round 2 had removed from correct code);
- roll 6's delivered app **passed a hand boot audit** — installs, builds, boots, 5 probes — while the cycle rejected it.

## The change

Both authenticity rows join the first scan, so they outrank the `tests_pass` row they sit beside.

This is safe from the test-gaming guard on the same footing as the contract row already there. The guard exists to stop a qa re-author "fixing" a broken app by rewriting tests, so it demands that any own-artifact signal be one an app defect **cannot produce**. These are structural — read off the suite's own source — and no application behaviour can make a suite mock its own route module.

## Tests

Three in the locus class, parametrized across both checks:

- a failing authenticity row beside `tests_pass` exit 1 (which alone reads `SUBJECT`) classifies `OWN_ARTIFACT`;
- the guard's other side: a **passing** authenticity row — now banked on clean runs via #989 — leaves a genuine app failure on the dev chain.

Full regression: 7605 passed, 1 skipped.

Closes #988
