### PR TITLE
fix(authoring): teach the server-component prerender constraint (#996) [POST-WINDOW]

### DIFF
--- a/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix_nextjs_ts.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix_nextjs_ts.md
@@ -52,6 +52,14 @@ If your manifest declares `POST /api/runs`, the page calls `api('/api/runs')`. D
 the prefix compiles, passes type-checking, and returns 404 at runtime for every action in
 the UI — a silent break no build or unit check catches.
 
+**When the page itself fetches, it must not do so at build time.** `next build`
+prerenders server components in Node, where a relative `api('/api/runs')` throws
+`Failed to parse URL` and **the build fails**. A page that fetches data is therefore
+either a client component (`'use client'` at the top, fetch inside `useEffect`) or a
+server component that opts out of prerendering with `export const dynamic =
+'force-dynamic'` above the component. Pick one; a bare server component that awaits
+`api()` in its body costs the build.
+
 **DO NOT touch the scaffold-owned surface — it is frozen and verified:**
 - Do NOT change the exported handler **names, signatures, or file locations** in
   `app/**/route.ts` — the directory determines the URL the app serves.


### PR DESCRIPTION
**Do not merge while the V7 window is open** (§6: no merges, no prompt-asset edits to the live instrument). Stacked per the night-shift routine.

One addition to the fill-only dev appendix, directly under the client-seam section it extends: a page that fetches is either a client component or declares `export const dynamic = 'force-dynamic'` — a bare server component awaiting `api()` fails `next build` at prerender.

Evidence: V7 roll 1 (void, `cyc_8b569ce34074`) — the exact failure, correctly repaired in one round by the correction loop, which proves the knowledge exists downstream while authoring lacks it. The follow-on cost was the whole roll (#994).

Closes #996