### PR TITLE
fix(rollup): normalizer reads the authenticity row's own verdict (#1000) [RESET-CLASS / POST-WINDOW]

### DIFF
--- a/src/squadops/cycles/verification_normalize.py
+++ b/src/squadops/cycles/verification_normalize.py
@@ -80,10 +80,19 @@ def normalize_task_checks(
             # below (richer + present on a passing run). Skip to avoid double-record.
             continue
         if cid == CHECK_NO_STUB:
-            # Present only when stubs were found → the stub check executed-and-failed,
-            # and its presence flags the synthesized tests_pass as a stub (§6.6.1).
-            stub_detected = True
-            results.append(CheckResult(check_id=cid, status=ResultStatus.FAILED))
+            # #1000: this row used to appear ONLY when stubs were found, so presence
+            # meant executed-and-failed. Since #989 the producer banks it on every
+            # qa validation — pass or fail, with `passed` and `inspected` — so the
+            # row's own verdict must be read, exactly like any boolean row. Presence-
+            # implies-failure here turned a clean repair-then-pass retest into a
+            # phantom failed row, and `elif failed:` rejects on ANY failed check —
+            # a false REJECTED on the most common green-roll recovery path (V7
+            # launch 3 carried the phantom; a repair-then-pass roll would have been
+            # decided by it). Only an actual failure taints the synthesized
+            # tests_pass as a stub (§6.6.1).
+            if row.get("passed") is False:
+                stub_detected = True
+            results.append(_from_passed_row(cid, row))
             continue
         if "status" in row:
             # Typed-acceptance row: carries a CheckOutcome status verbatim.

--- a/tests/unit/cycles/test_verification_normalize.py
+++ b/tests/unit/cycles/test_verification_normalize.py
@@ -107,6 +107,29 @@ def test_no_stub_row_means_tests_pass_credits_normally():
     assert _by_id(normalize_task_checks(out))[CHECK_TESTS_PASS].is_stub is False
 
 
+def test_a_passing_stub_row_is_recorded_passed_and_taints_nothing():
+    """#1000: since #989 the producer banks the authenticity row on EVERY qa
+    validation — a clean suite ships `passed: true` with its `inspected` list.
+    Presence-implies-failure turned that into a phantom FAILED row, and the
+    verdict rule (`elif failed:` — any failed check) then falsely REJECTED any
+    roll whose qa failed once, was repaired, and passed on retest — the most
+    common green-roll recovery path. V7 launch 3 banked the phantom
+    (`failed_detail: {check_id: no_stub_fallback_tests, reason: "", required:
+    false}`) on a clean suite."""
+    out = {
+        "test_result": {"executed": True, "exit_code": 0, "tests_passed": True},
+        "validation_result": {
+            "checks": [
+                {"check": CHECK_NO_STUB, "passed": True, "inspected": []},
+            ]
+        },
+    }
+    r = _by_id(normalize_task_checks(out))
+    assert r[CHECK_NO_STUB].status == ResultStatus.PASSED
+    assert r[CHECK_TESTS_PASS].is_stub is False
+    assert classify(r[CHECK_TESTS_PASS]) is EvidenceFamily.EXECUTED_PASSED
+
+
 def test_failure_only_tests_pass_row_is_not_double_recorded():
     """The handler's failure-only tests_pass row must not produce a second
     CheckResult alongside the synthesized one."""


### PR DESCRIPTION
**Do not merge until the V7 re-register decision** — this is the reset-class fix; deploying it is part of that decision, not a hotfix.

One consumer (`verification_normalize.py`) still assumed the pre-#989 producer contract (row present ⇒ stubs found ⇒ FAILED). Since #989 banks the row unconditionally, a clean retest normalized to a phantom FAILED row, and `elif failed:` rejects on any failed check — so **any roll whose qa fails once, is repaired, and passes on retest would be falsely REJECTED.** Launch 3 banked the phantom on a clean suite; its rejection was independently genuine (required `tests_pass`), which is the only reason this was caught before it decided a roll.

Fix: the row takes the generic passed-field path; only an actual failure sets the §6.6.1 `is_stub` taint. Full consumer sweep done this time — `failure_evidence` and the self-mocking row were already correct.

New test: a `passed: true` row normalizes PASSED, taints nothing, and `tests_pass` credits — fails before the fix. Existing failure-case tests unchanged and green.

Full regression: 7609 passed, 1 skipped.

Closes #1000