### PR TITLE
docs(sip): embodiment — bind execution surface to ACP where offered

### DIFF
--- a/sips/proposed/SIP-Agent-Embodiment-Runtime.md
+++ b/sips/proposed/SIP-Agent-Embodiment-Runtime.md
@@ -144,6 +144,7 @@ is registry metadata, never a second column.
 ```yaml
 runtime_id: goose
 adapter: squadops.runtime.adapters.goose
+protocol: acp                # wire protocol the adapter binds (§4.5); `custom` if none
 capabilities: [shell, filesystem, mcp, streaming, persistent_sessions]
 deployment_modes: [ephemeral, persistent]
 contract: {agent_context: v1, events: v1, checkpoint: v1}
@@ -184,6 +185,30 @@ A runtime adapter (the Goose adapter, the native adapter) is that port's impleme
 selected by `embodiment_runtime` through the adapters factory pattern. Same coordinator,
 same lifecycle machinery, no parallel structure. The contract stays lifecycle-and-
 execution shaped; it must never grow toward replicating any runtime's internal API.
+
+**Wire protocol: bind to ACP where the runtime offers it** *(owner-ruled 2026-08-19)*.
+The Agent Client Protocol — the open JSON-RPC standard for driving a coding agent
+(session/turn model over stdio) — maps nearly one-to-one onto this contract:
+`create_session`/`execute`/`stream`/`cancel` are ACP's session and prompt-turn
+primitives. The rule:
+
+- An execution runtime that speaks ACP is bound through **one shared ACP adapter**;
+  its registry entry declares `protocol: acp`. Goose — the named first foreign
+  embodiment — speaks ACP natively, so its adapter is protocol translation plus
+  evidence capture, not behavior invention, and any future ACP-speaking runtime
+  arrives nearly free.
+- The **port stays protocol-neutral**: a runtime without ACP gets a bespoke adapter
+  (`protocol: custom`), and `squadops-native` needs no wire at all. ACP is the
+  preferred binding, never a requirement the port encodes.
+- **Do not conflate with A2A** (SIP-0085, already implemented): A2A is agent↔agent
+  over HTTP/SSE with agent cards — how something outside talks *to* a SquadOps
+  agent. ACP is client↔agent — how SquadOps *drives* a runtime it embodies an agent
+  through. The two answer different questions and both coexist with the RabbitMQ
+  TaskEnvelope fabric (SIP-031), which remains the native platform's internal
+  transport.
+- Evidence discipline is unchanged by the protocol: ACP notifications map to the
+  normalized runtime events (§4.7), and nothing a runtime reports over ACP is
+  credited as verification.
 
 ### 4.6 Portable context and checkpoints — extend, don't duplicate
 
@@ -414,3 +439,4 @@ four rulings are normative here: **encapsulate, don't redefine** (extend SIP-009
 one runtime axis, orthogonal to location** (the joi-on-native vs joi-on-goose, both on
 Discord, argument); **multi-surface cardinality is an attention budget with a primary
 locus and centralized reconciliation** (finite delegated attention, priced by posture).
+A fifth ruling (2026-08-19, mid-V7): **ACP as the preferred execution-surface wire**, §4.5.

--- a/sips/proposed/SIP-Agent-Embodiment-Runtime.md
+++ b/sips/proposed/SIP-Agent-Embodiment-Runtime.md
@@ -362,6 +362,24 @@ never mints peer agents.
    never shares identity or writable memory with the producing agent. No embodiment,
    projection, or attachment arrangement may route a producer's work to a verifier that
    is the same identity.
+10. **Governance independence — the self-amending-constitution rule** *(owner-raised
+    2026-08-19)*. An agent with presence in a design workspace may **propose and argue
+    for** changes to anything, including its own behavioral contract, role, or
+    governance — but may never **ratify** them. Any proposal that modifies its
+    proposer's own definition is human-accept only and carries an explicit
+    conflict-of-interest flag ("this proposal modifies its proposer"). Same shape as
+    invariant 9, on the governance axis: the loop where an agent shapes the framework
+    that defines it is permitted, legible, and never self-closing.
+11. **Contract changes are prospective and land at embodiment boundaries.** A merged
+    change to an agent's bundle never mutates a live embodiment mid-flight; it takes
+    effect at the next bind (new session/attachment), and the transition is an
+    announced, recorded event ("max re-bound: bundle `X` → `Y`", posted to the surface
+    it stands on). Provenance already stamps every emission with
+    `system_prompt_bundle_hash`, so a design discussion's record distinguishes which
+    version of an agent argued what — the discussant is never rewritten mid-sentence,
+    and identity continuity rests where it always did: one `agent_id`, an unbroken
+    memory and evidence lineage, and deliberate, dated version transitions. The agent
+    is not its current bundle; the agent is the history of its bundles.
 
 ## 7. Amendments to SIP-0090 (applied at acceptance, step-5a discipline)
 
@@ -440,3 +458,6 @@ one runtime axis, orthogonal to location** (the joi-on-native vs joi-on-goose, b
 Discord, argument); **multi-surface cardinality is an attention budget with a primary
 locus and centralized reconciliation** (finite delegated attention, priced by posture).
 A fifth ruling (2026-08-19, mid-V7): **ACP as the preferred execution-surface wire**, §4.5.
+A sixth (2026-08-19, owner-raised meta-concern — an agent present in the workspace that
+designs the framework defining it): **invariants 10 and 11**, governance independence and
+boundary-applied prospective contract changes.


### PR DESCRIPTION
Folds the owner ruling into the proposed Agent Embodiment Runtime SIP:

- **§4.5**: the execution surface binds to **ACP** (Agent Client Protocol — open JSON-RPC, session/turn over stdio) where the runtime offers it; one shared ACP adapter serves every ACP-speaking runtime (Goose natively speaks it, so the first foreign adapter is protocol translation + evidence capture, not behavior invention). The port stays protocol-neutral (`protocol: custom` for others; `squadops-native` needs no wire).
- **§4.3**: registry entries gain a `protocol` field.
- Explicit non-conflation note: **A2A (SIP-0085, implemented)** is agent↔agent — how the outside talks to a SquadOps agent; **ACP (absent today)** is client↔agent — how SquadOps drives a runtime. Both coexist with the RabbitMQ TaskEnvelope fabric (SIP-031).
- Evidence discipline unchanged: ACP notifications map to normalized events; nothing runtime-reported is credited as verification.

Docs-only; SIP remains in design review. **Merge timing at owner's discretion** (V7 window is live — no urgency, no deploy impact).