### PR TITLE
fix(audit): reconstruct concatenated UI paths — false PAGE_NOT_API failed the V7 deciding roll (#1004) [OWNER RULING]

### DIFF
--- a/src/squadops/capabilities/ui_data_path.py
+++ b/src/squadops/capabilities/ui_data_path.py
@@ -56,6 +56,18 @@ _CALL_RE = re.compile(
 )
 _TEMPLATE_EXPR_RE = re.compile(r"\$\{[^}]*\}")
 
+#: A continuation of a concatenated path argument (#1004): ``+`` followed by another
+#: string literal or a bounded expression (an identifier chain, optionally one flat
+#: call — ``runId``, ``params.run_id``, ``encodeURIComponent(id)``). Whitespace around
+#: ``+`` may cross a line, matching the wrap tolerance above. The expression bound is
+#: deliberate: a piece this cannot parse ends the chain, and the caller records the
+#: partial path it can prove rather than guessing — but the bound must stay wide enough
+#: that an author's ordinary style never re-creates the truncation this exists to fix.
+_CONCAT_PIECE_RE = re.compile(
+    r"\s*\+\s*(?:(?P<q>['\"`])(?P<lit>[^'\"`\n]*)(?P=q)"
+    r"|(?P<expr>[A-Za-z_$][\w$.]*(?:\([^()\n]*\))?))"
+)
+
 
 @dataclass(frozen=True)
 class UiCall:
@@ -102,7 +114,25 @@ def extract_ui_calls(files: dict[str, str], stack: str) -> list[UiCall]:
             # The call site is where the failure message must point, so the line is the
             # one the call OPENS on, not the one its path happens to land on.
             lineno = content.count("\n", 0, match.start()) + 1
-            concrete = _TEMPLATE_EXPR_RE.sub(SAMPLE_SEGMENT, written)
+            # #1004: a path built by concatenation — `'/api/runs/' + runId + '/join'` —
+            # used to be truncated to its first literal, so the audit probed a path the
+            # UI never requests and false-failed a functional app (V7 attempt-2 slot 6,
+            # the window's deciding roll). Walk the `+` chain: literals append verbatim,
+            # expressions become the same inert placeholder a template expression gets.
+            concrete_pieces = [_TEMPLATE_EXPR_RE.sub(SAMPLE_SEGMENT, written)]
+            pos = match.end()
+            while (piece := _CONCAT_PIECE_RE.match(content, pos)) is not None:
+                if piece.group("lit") is not None:
+                    concrete_pieces.append(
+                        _TEMPLATE_EXPR_RE.sub(SAMPLE_SEGMENT, piece.group("lit"))
+                    )
+                else:
+                    concrete_pieces.append(SAMPLE_SEGMENT)
+                pos = piece.end()
+            if pos != match.end():
+                # The failure message must show the argument as the author wrote it.
+                written = content[match.start("quote") : pos]
+            concrete = "".join(concrete_pieces)
             if concrete.startswith(("http://", "https://")):
                 request_path = concrete
             elif match.group("fn") == "fetch":

--- a/tests/unit/capabilities/test_ui_data_path.py
+++ b/tests/unit/capabilities/test_ui_data_path.py
@@ -219,6 +219,42 @@ const joined = await api<Run>(
             (2, f"/api/runs/{SAMPLE_SEGMENT}/join"),
         ]
 
+    def test_a_concatenated_path_is_reconstructed_not_truncated(self):
+        """#1004: `'/api/runs/' + runId + '/join'` used to extract as `/api/runs/` —
+        the audit then probed a path the UI never requests, got HTML, and failed a
+        functional app as PAGE_NOT_API. That false-fail landed on the V7 window's
+        deciding roll. Literal pieces append verbatim; expression pieces get the same
+        inert placeholder a template expression gets."""
+        files = {
+            "app/runs/[run_id]/page.tsx": (
+                "await api('/api/runs/' + runId + '/join', { method: 'POST' });\n"
+                "await api('/api/runs/' + params.run_id + '/leave', { method: 'POST' });\n"
+                "await api('/api/runs/' + encodeURIComponent(runId));\n"
+            )
+        }
+        calls = extract_ui_calls(files, "nextjs_ts")
+        assert [c.request_path for c in calls] == [
+            f"/api/runs/{SAMPLE_SEGMENT}/join",
+            f"/api/runs/{SAMPLE_SEGMENT}/leave",
+            f"/api/runs/{SAMPLE_SEGMENT}",
+        ]
+        # The failure message must show the argument as the author wrote it.
+        assert calls[0].written == "'/api/runs/' + runId + '/join'"
+
+    def test_concatenation_across_a_line_wrap_is_one_call(self):
+        """The #952 wrap tolerance must hold for the #1004 chain too: a formatter
+        breaking after `+` is ordinary output, and dropping the tail would re-create
+        the truncation one style later."""
+        files = {"app/page.tsx": ("await api('/api/runs/' +\n  runId +\n  '/join');\n")}
+        calls = extract_ui_calls(files, "nextjs_ts")
+        assert [c.request_path for c in calls] == [f"/api/runs/{SAMPLE_SEGMENT}/join"]
+
+    def test_a_plus_that_is_not_a_path_chain_ends_extraction_cleanly(self):
+        """Arithmetic in a later argument must not be swallowed into the path."""
+        files = {"app/page.tsx": "await api('/api/runs', { retries: 1 + 2 });\n"}
+        calls = extract_ui_calls(files, "nextjs_ts")
+        assert [c.request_path for c in calls] == ["/api/runs"]
+
 
 class TestMethodNotAllowed:
     """#953. The probe is a GET whatever verb the UI uses — sending the real verb would


### PR DESCRIPTION
**Merge as part of the window ruling, not before** — this fix changes the §5 scoring instrument, and what happens to the deciding roll's score is the owner's call.

`extract_ui_calls` truncated `'/api/runs/' + runId + '/join'` to `/api/runs/` (template literals were handled; `+` concatenation was not — the third variant of the #952 extractor class). The audit probed the truncated path, got HTML, and failed a functional app on the window's deciding roll — an app whose cycle verdict was accepted 39/39 with zero corrections and whose join/leave endpoints the audit itself had already proven over real HTTP.

Fix: walk the concatenation chain — literals verbatim, expressions become the same inert placeholder as template expressions, unparseable pieces end the chain conservatively, messages keep the author's exact source.

Verified against the deciding roll's real file: lines 67/92 now reconstruct to `/api/runs/ui-probe-sample/join` and `/leave`. Four new tests (roll-6 shape, line-wrapped chains, arithmetic non-capture, written-as-authored); fail before the fix. Full regression: 7,612 passed.

Closes #1004