### PR TITLE
docs(v38): ruling (a) — stack comparison, both deltas named; preconditions 2.2/2.3 MET

### DIFF
--- a/docs/plans/1-6-0-v38-model-comparison-preregistration.md
+++ b/docs/plans/1-6-0-v38-model-comparison-preregistration.md
@@ -43,8 +43,8 @@ marginal cost is electricity. Cost-per-verified-outcome is recorded per arm.
 | # | Precondition | State |
 |---|---|---|
 | 2.1 | V7 closed and banked (the A arm exists) | **MET** — amended 4/6, record on `docs/v7-window-record` |
-| 2.2 | Ollama upgraded to a version that serves `qwen3.8:27b`; **`qwen3.6:27b` verified still generating on the GB10 after the upgrade** (the incumbent must not break) | pending |
-| 2.3 | `qwen3.8:27b` pulled; raw throughput measured and recorded in §3 (t/s on the standard prompt shape) | pending |
+| 2.2 | Ollama upgraded to a version that serves `qwen3.8:27b`; **`qwen3.6:27b` verified still generating on the GB10 after the upgrade** (the incumbent must not break) | **MET** — 0.32.14; incumbent verified through the deployed adapter (clean content, 12.3 t/s warm) |
+| 2.3 | `qwen3.8:27b` pulled; raw throughput measured and recorded in §3 (t/s on the standard prompt shape) | **MET** — see §3 |
 | 2.4 | `full-38` profile merged; **`full` untouched** (it is the meaning of every historical record) | this PR |
 | 2.5 | Deploy frozen and recorded in §3. The comparison deploy differs from V7's (`61a12e38`) by **only**: the #1005 instrument fix (`efad69a7`, post-cycle audit only — ruled into the V7 measurement standard), the inert `full-38` profile entry (never referenced by any V7 roll), and — named per the §1 stack-comparison ruling — the host inference server (Ollama 0.21.2 → 0.32.14, incumbent verified through the deployed adapter post-upgrade). Any other delta voids comparability and must instead trigger re-registration | pending — rebuild at merge |
 | 2.6 | **One declared shakedown** on `full-38`, NON-COUNTING, before roll 1: a new model is a new failure surface (structured-output compliance, fence discipline, thinking behavior — the #998 cap-exhaustion class is exactly what a model swap moves). Bar: the cycle reaches a verdict without a *new* harness-attributable mechanical failure. Findings are fixed or declared before the window opens | pending |

--- a/docs/plans/1-6-0-v38-model-comparison-preregistration.md
+++ b/docs/plans/1-6-0-v38-model-comparison-preregistration.md
@@ -13,8 +13,20 @@ in this document changes until the window closes.
 ## 1. Design: one variable, and the honest limits of N=6
 
 Arm B runs the **identical recipe** to V7 attempt 2 — same PRD, same request profile, same
-overrides, same gate policy, same §5 scoring (corrected instrument) — with exactly one
-change: squad profile **`full-38`**, which is the `full` roster verbatim on `qwen3.8:27b`.
+overrides, same gate policy, same §5 scoring (corrected instrument) — with the squad profile
+changed to **`full-38`**, the `full` roster verbatim on `qwen3.8:27b`.
+
+**This is a STACK comparison, not a pure model isolate** *(owner-ruled 2026-08-20)*. Running
+qwen3.8 required upgrading Ollama 0.21.2 → 0.32.14, so two things differ between arms and
+both are named: the model, and the inference server. The server change is behaviorally real:
+under 0.21 the model's reasoning arrived inline in `content` (V7's emission logs show
+thinking prose inside emissions); under 0.32 reasoning routes to a separate `thinking` field
+and `content` arrives clean — same completion-token budget semantics (the #998 class is
+unchanged), different emission shape. The deltas are inseparable in practice — nobody would
+run 3.8 on the old server — so the window measures the decision actually on the table:
+**the incumbent stack (3.6 on 0.21) vs the 3.8 stack (3.8 on 0.32)**, and the closing claim
+words it exactly that way. A pure model isolate would require re-baselining 3.6 on 0.32
+(six more rolls); the owner declined that cost knowingly.
 
 **What this window can claim:** gross differences in the headline (e.g. 2/6 vs 6/6) and
 differences in **texture** — zero-correction rate, first-attempt fill rate, store-assertion
@@ -34,7 +46,7 @@ marginal cost is electricity. Cost-per-verified-outcome is recorded per arm.
 | 2.2 | Ollama upgraded to a version that serves `qwen3.8:27b`; **`qwen3.6:27b` verified still generating on the GB10 after the upgrade** (the incumbent must not break) | pending |
 | 2.3 | `qwen3.8:27b` pulled; raw throughput measured and recorded in §3 (t/s on the standard prompt shape) | pending |
 | 2.4 | `full-38` profile merged; **`full` untouched** (it is the meaning of every historical record) | this PR |
-| 2.5 | Deploy frozen and recorded in §3. The comparison deploy differs from V7's (`61a12e38`) by **only**: the #1005 instrument fix (`efad69a7`, post-cycle audit only — ruled into the V7 measurement standard) and the inert `full-38` profile entry (never referenced by any V7 roll). Any other delta voids comparability and must instead trigger re-registration | pending — rebuild at merge |
+| 2.5 | Deploy frozen and recorded in §3. The comparison deploy differs from V7's (`61a12e38`) by **only**: the #1005 instrument fix (`efad69a7`, post-cycle audit only — ruled into the V7 measurement standard), the inert `full-38` profile entry (never referenced by any V7 roll), and — named per the §1 stack-comparison ruling — the host inference server (Ollama 0.21.2 → 0.32.14, incumbent verified through the deployed adapter post-upgrade). Any other delta voids comparability and must instead trigger re-registration | pending — rebuild at merge |
 | 2.6 | **One declared shakedown** on `full-38`, NON-COUNTING, before roll 1: a new model is a new failure surface (structured-output compliance, fence discipline, thinking behavior — the #998 cap-exhaustion class is exactly what a model swap moves). Bar: the cycle reaches a verdict without a *new* harness-attributable mechanical failure. Findings are fixed or declared before the window opens | pending |
 | 2.7 | Zero unreleased focus leases; nothing in flight at each launch | check at launch |
 
@@ -48,8 +60,8 @@ marginal cost is electricity. Cost-per-verified-outcome is recorded per arm.
 | Squad profile | **`full-38`** (sole intended delta) |
 | Request profile / overrides | `validated-fullstack`; `build_profile=nextjs_ts`, `dev_capability=nextjs_ts` |
 | `resolved_config_hash` | expect `d4d4f662…` unchanged (profile is not an input); re-verify at roll 1 |
-| Model | `qwen3.8:27b`, Ollama version + model digest recorded here at freeze: `_____` |
-| Measured t/s (2.3) | `_____` |
+| Model | `qwen3.8:27b`, digest `22130167c4c2`, Q4_K_M, 27.3B params, 262k context, thinking-capable; **Ollama 0.32.14** |
+| Measured t/s (2.3) | **24.0 t/s** warm generation / 104.8 t/s prompt eval (incumbent same-box warm: 12.3) — 2x at equal parameter count and quantization on a bandwidth-bound chip suggests sparser per-token activation; recorded as an open architecture question, answered by the rolls' quality texture rather than guessed |
 | Deploy — commit + 7 image ids | `_____` at freeze |
 | Gate policy | V7 §7.3(c) verbatim — the same pinned text, unchanged |
 | Audit instrument | `scripts/dev/audit_delivered_app.py` at the frozen deploy commit (carries #1005) |


### PR DESCRIPTION
Recovers two commits orphaned by a merge race on #1006 (I pushed after the merge — my miss).

- **§1/§2.5**: owner ruling (a) folded in — the window is a **stack comparison** (incumbent 3.6-on-Ollama-0.21 vs 3.8-on-0.32), both deltas named, the declined pure-model isolate recorded as a knowing choice, and the emission-shape difference (inline vs routed thinking) documented.
- **§2.2/2.3 → MET** with measurements in §3: Ollama 0.32.14, incumbent verified through the deployed adapter (12.3 t/s warm); `qwen3.8:27b` digest `22130167c4c2`, **24.0 t/s** warm generation / 104.8 prompt eval, architecture question recorded rather than guessed.

Docs-only; needed on main before the §3 freeze so the pre-registration in force is the amended one.