### PR TITLE
fix(harness): V38 shakedown items — qwen3.8 registry clamp parity + bounded JSON re-ask

### DIFF
--- a/src/squadops/capabilities/handlers/impl/_json_extraction.py
+++ b/src/squadops/capabilities/handlers/impl/_json_extraction.py
@@ -180,3 +180,58 @@ def extract_first_json_object(
         )
 
     return parsed
+
+
+#: The corrective message for one bounded re-ask (#1008). Names the defect class
+#: rather than echoing the broken output — the failure observed live was a response
+#: that STOPPED mid-object, so completeness is the instruction that matters.
+JSON_REASK_FEEDBACK = (
+    "Your previous response was not a single complete JSON object "
+    "(it was truncated or unbalanced). Respond again with ONLY the complete "
+    "JSON object — no prose, no code fences, closed braces."
+)
+
+
+async def extract_object_with_reask(
+    content: str,
+    *,
+    reask,
+    logger: Any,
+    handler_name: str,
+) -> tuple[dict[str, Any], str]:
+    """Extract a JSON object, issuing ONE bounded re-ask on extraction failure (#1008).
+
+    The V38 shakedown's `data.analyze_failure` emitted a response that stopped
+    mid-object (703 tokens, uncapped — the model terminated early). The parser
+    rejected it loudly, which is correct — but a single flake then ran the whole
+    correction chain decisionless and collapsed the run. Reproduction showed the
+    same request completing 3 of 3 times, so one retry converts an intermittent
+    total-loss into a logged hiccup. Exactly one: a model that fails twice in a
+    row is a finding, not a retry loop, and falls through to each handler's
+    existing rejection path.
+
+    Args:
+        content: the first response's content.
+        reask: async callable ``(feedback: str) -> str`` — re-issues the handler's
+            chat with the corrective feedback appended, returns the new content.
+            The handler owns the call (model, kwargs, emission logging); this
+            function owns only the policy.
+        logger / handler_name: for the single warning line.
+
+    Returns:
+        ``(parsed_object, content_used)`` — the content that actually parsed, so
+        callers that log or store the raw response keep the right bytes.
+
+    Raises:
+        JSONExtractionError: when the re-asked response also fails extraction.
+    """
+    try:
+        return extract_first_json_object(content), content
+    except JSONExtractionError as exc:
+        logger.warning(
+            "%s: JSON extraction failed (%s); issuing one bounded re-ask (#1008)",
+            handler_name,
+            exc,
+        )
+        retried = await reask(JSON_REASK_FEEDBACK)
+        return extract_first_json_object(retried), retried

--- a/src/squadops/capabilities/handlers/impl/analyze_failure.py
+++ b/src/squadops/capabilities/handlers/impl/analyze_failure.py
@@ -25,7 +25,7 @@ from squadops.capabilities.handlers.base import (
 from squadops.capabilities.handlers.cycle_tasks import _CycleTaskHandler
 from squadops.capabilities.handlers.impl._json_extraction import (
     JSONExtractionError,
-    extract_first_json_object,
+    extract_object_with_reask,
 )
 from squadops.cycles.task_outcome import FailureClassification, TaskOutcome
 from squadops.llm.exceptions import LLMError
@@ -145,6 +145,21 @@ class DataAnalyzeFailureHandler(_CycleTaskHandler):
         content = response.content
         log_emission_shape(self._handler_name, content, response.completion_tokens)
 
+        # #1008: one bounded re-ask when extraction fails (the V38 shakedown's
+        # mid-object truncation) — the handler owns the retried call so model,
+        # kwargs, and emission logging stay on the normal path.
+        async def _reask(feedback: str) -> str:
+            retry_messages = [
+                *messages,
+                ChatMessage(role="assistant", content=content),
+                ChatMessage(role="user", content=feedback),
+            ]
+            retry = await context.ports.llm.chat_stream_with_usage(retry_messages, **chat_kwargs)
+            log_emission_shape(
+                f"{self._handler_name}:json_reask", retry.content, retry.completion_tokens
+            )
+            return retry.content
+
         # Parse JSON, then validate against schema (issue #84).
         # Tolerates <think> blocks, code fences, and prose preamble
         # around the JSON. Validation failure routes to NEEDS_REPLAN
@@ -153,7 +168,9 @@ class DataAnalyzeFailureHandler(_CycleTaskHandler):
         # cyc_4cac11018af7). Raw response is logged on parse failure
         # for triage of new model behavior modes.
         try:
-            raw = extract_first_json_object(content)
+            raw, content = await extract_object_with_reask(
+                content, reask=_reask, logger=logger, handler_name=self._handler_name
+            )
             analysis_model = FailureAnalysis.model_validate(raw)
         except (JSONExtractionError, ValidationError) as exc:
             duration_ms = (time.perf_counter() - start_time) * 1000

--- a/src/squadops/capabilities/handlers/impl/correction_decision.py
+++ b/src/squadops/capabilities/handlers/impl/correction_decision.py
@@ -18,7 +18,7 @@ from squadops.capabilities.handlers.base import (
 from squadops.capabilities.handlers.cycle_tasks import _CycleTaskHandler
 from squadops.capabilities.handlers.impl._json_extraction import (
     JSONExtractionError,
-    extract_first_json_object,
+    extract_object_with_reask,
 )
 from squadops.llm.exceptions import LLMError
 from squadops.llm.models import ChatMessage
@@ -119,13 +119,28 @@ class GovernanceCorrectionDecisionHandler(_CycleTaskHandler):
         content = response.content
         log_emission_shape(self._handler_name, content, response.completion_tokens)
 
+        # #1008: one bounded re-ask when extraction fails (V38 shakedown truncation).
+        async def _reask(feedback: str) -> str:
+            retry_messages = [
+                *messages,
+                ChatMessage(role="assistant", content=content),
+                ChatMessage(role="user", content=feedback),
+            ]
+            retry = await context.ports.llm.chat_stream_with_usage(retry_messages, **chat_kwargs)
+            log_emission_shape(
+                f"{self._handler_name}:json_reask", retry.content, retry.completion_tokens
+            )
+            return retry.content
+
         # Parse JSON decision. Tolerates <think> blocks, code fences,
         # and prose preamble. Falls back to a structured `abort`
         # decision if no balanced JSON object is found anywhere in
-        # the response, and logs a truncated raw response so triage
-        # has the actual model output.
+        # the response (after the #1008 re-ask), and logs a truncated raw
+        # response so triage has the actual model output.
         try:
-            decision = extract_first_json_object(content)
+            decision, content = await extract_object_with_reask(
+                content, reask=_reask, logger=logger, handler_name=self._handler_name
+            )
         except JSONExtractionError as exc:
             logger.warning(
                 "%s: failed to parse correction decision JSON: %s | raw[:500]=%r",

--- a/src/squadops/capabilities/handlers/impl/define_done.py
+++ b/src/squadops/capabilities/handlers/impl/define_done.py
@@ -19,7 +19,7 @@ from squadops.capabilities.handlers.base import (
 from squadops.capabilities.handlers.cycle_tasks import _CycleTaskHandler
 from squadops.capabilities.handlers.impl._json_extraction import (
     JSONExtractionError,
-    extract_first_json_object,
+    extract_object_with_reask,
 )
 from squadops.cycles.task_outcome import TaskOutcome
 from squadops.llm.exceptions import LLMError
@@ -99,6 +99,19 @@ class GovernanceDefineDoneHandler(_CycleTaskHandler):
         content = response.content
         log_emission_shape(self._handler_name, content, response.completion_tokens)
 
+        # #1008: one bounded re-ask when extraction fails (V38 shakedown truncation).
+        async def _reask(feedback: str) -> str:
+            retry_messages = [
+                *messages,
+                ChatMessage(role="assistant", content=content),
+                ChatMessage(role="user", content=feedback),
+            ]
+            retry = await context.ports.llm.chat_stream_with_usage(retry_messages, **chat_kwargs)
+            log_emission_shape(
+                f"{self._handler_name}:json_reask", retry.content, retry.completion_tokens
+            )
+            return retry.content
+
         # Parse the JSON definition of done from the LLM response. Tolerates <think>
         # blocks, code fences, and prose preamble around the JSON —
         # every impl handler is one model tantrum away from a "char 0"
@@ -106,7 +119,9 @@ class GovernanceDefineDoneHandler(_CycleTaskHandler):
         # failure so triage doesn't have to reconstruct what the LLM
         # wrote from token counts alone.
         try:
-            contract_data = extract_first_json_object(content)
+            contract_data, content = await extract_object_with_reask(
+                content, reask=_reask, logger=logger, handler_name=self._handler_name
+            )
         except JSONExtractionError as exc:
             logger.warning(
                 "%s: failed to parse definition of done JSON: %s | raw[:500]=%r",

--- a/src/squadops/llm/model_registry.py
+++ b/src/squadops/llm/model_registry.py
@@ -55,6 +55,17 @@ MODEL_SPECS: dict[str, ModelSpec] = {
         context_window=131_072,
         default_max_completion=8_192,
     ),
+    # qwen3.8:27b is the V38 comparison arm (full-38 profile). The completion
+    # clamp is deliberately IDENTICAL to qwen3.6:27b's: the V38 window compares
+    # stacks, and an unclamped 3.8 (capability ceilings pass through when this
+    # entry is absent — the exact gap the 3.6 comment above narrates) would hand
+    # arm B a 12,000-token dev ceiling arm A never had. Discovered as V38
+    # shakedown finding 3; at 3.8's measured ~24 t/s, 8,192 tokens is ~6 min.
+    "qwen3.8:27b": ModelSpec(
+        name="qwen3.8:27b",
+        context_window=262_144,
+        default_max_completion=8_192,
+    ),
     "llama3:70b": ModelSpec(
         name="llama3:70b",
         context_window=131_072,

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -236,6 +236,56 @@ class TestAnalyzeFailure:
             "rejected" in (result.error or "").lower() or "schema" in (result.error or "").lower()
         )
 
+    async def test_truncated_json_recovers_via_one_reask(self, mock_context):
+        """#1008 (V38 shakedown): the model stopped mid-object once and the whole
+        correction chain ran decisionless. A truncated first response followed by
+        a complete retry must succeed — and with exactly two calls, because the
+        re-ask is bounded."""
+        truncated = '{"classification": "work_product", "analysis_summary": "The check'
+        complete = json.dumps(
+            {
+                "classification": FailureClassification.WORK_PRODUCT,
+                "analysis_summary": "Named import of a default export",
+                "contributing_factors": ["TS2614"],
+            }
+        )
+        mock = AsyncMock(
+            side_effect=[
+                ChatMessage(role="assistant", content=truncated),
+                ChatMessage(role="assistant", content=complete),
+            ]
+        )
+        mock_context.ports.llm.chat = mock
+        mock_context.ports.llm.chat_stream_with_usage = mock
+
+        h = DataAnalyzeFailureHandler()
+        result = await h.handle(mock_context, {"prd": "test", "failure_evidence": {"e": "x"}})
+
+        assert result.success is True
+        assert result.outputs["analysis_summary"] == "Named import of a default export"
+        assert mock.await_count == 2
+
+    async def test_double_extraction_failure_is_bounded_and_rejects(self, mock_context):
+        """The re-ask is ONE re-ask: two truncated responses reject to
+        NEEDS_REPLAN with exactly two LLM calls — a retry loop here would hide a
+        systematic model failure behind unbounded spend."""
+        truncated = '{"classification": "work_product", "analysis_summary": "The'
+        mock = AsyncMock(
+            side_effect=[
+                ChatMessage(role="assistant", content=truncated),
+                ChatMessage(role="assistant", content=truncated),
+            ]
+        )
+        mock_context.ports.llm.chat = mock
+        mock_context.ports.llm.chat_stream_with_usage = mock
+
+        h = DataAnalyzeFailureHandler()
+        result = await h.handle(mock_context, {"prd": "test"})
+
+        assert result.success is False
+        assert result.outputs["outcome_class"] == TaskOutcome.NEEDS_REPLAN
+        assert mock.await_count == 2
+
     async def test_empty_analysis_summary_rejected(self, mock_context):
         """Issue #84: ``analysis_summary: ""`` is the failure mode that
         produced ``analysis_summary: "N/A"`` corrections in the wild."""

--- a/tests/unit/llm/test_model_registry.py
+++ b/tests/unit/llm/test_model_registry.py
@@ -56,3 +56,15 @@ class TestGetModelSpec:
         assert spec is not None
         assert spec.context_window == 131_072
         assert spec.default_max_completion == 8_192
+
+
+def test_qwen38_clamps_identically_to_the_v7_arm():
+    """V38 shakedown finding 3: with no registry entry, the per-model completion
+    clamp never fires and 3.8 dev tasks run at capability ceilings (12,000) the
+    3.6 arm never had — an undeclared inter-arm delta. The comparison is only
+    honest if both arms share the clamp."""
+    spec36 = get_model_spec("qwen3.6:27b")
+    spec38 = get_model_spec("qwen3.8:27b")
+    assert spec38 is not None
+    assert spec38.default_max_completion == spec36.default_max_completion == 8_192
+    assert spec38.context_window == 262_144


### PR DESCRIPTION
Both §2.6 shakedown findings, per the owner's fix-refreeze-shakedown-open ruling:

- **Registry entry for `qwen3.8:27b`** — completion clamp deliberately identical to the 3.6 arm's (8,192): without the entry, arm B's dev tasks ran at capability ceilings (12,000) arm A never had. Context 262,144.
- **`extract_object_with_reask`** — exactly one bounded re-ask on JSON-extraction failure (the mid-object truncation that ran the correction chain decisionless), wired into all three JSON-emitting impl handlers; a second failure falls to the existing rejection paths.

Tests pin recovery (2 calls exactly), boundedness (2 calls exactly on double failure), and clamp parity. Regression 7,615 green.

Merging as part of the delegated V38 sequence (fix → re-freeze → shakedown #2 → open).