### PR TITLE
fix(correction): emission-side ownership veto (#1014)

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -525,6 +525,62 @@ def _apply_ownership_veto(
     return stripped
 
 
+def _apply_emission_ownership_veto(
+    artifacts: list[dict[str, Any]],
+    failed_task_type: str,
+    step_role: str,
+    failed_own_artifacts: list[str],
+    test_file_patterns: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    """#1014: the emission-side completion of #884's targeting veto.
+
+    #884 edits the repair *brief* — but the failing suite is in the step's
+    context as evidence, and a model can rewrite what it can see: V38 slot 6's
+    dev repairs emitted a full rewrite of the qa-owned suite on all three
+    rounds, storage accepted it, and the overlay handed the retest a suite the
+    dev wrote to match his own changes. This is the storage-side half: a step
+    running under a foreign role may not LAND the failed task's own artifacts
+    either, nor anything on the failed task's test-collection surface (basename
+    patterns plus the ``__tests__/`` convention — over-matching is the safe
+    direction here, same rationale as source-set exclusion; a wrongly dropped
+    borderline file merely leaves the original in the tree).
+
+    Applied AFTER the #507 rebase, so the names filtered are the names the
+    overlay would actually supersede — a wrong-directory emission that #507
+    re-homes onto a qa-owned expected path is caught by the post-rebase name.
+    Same-role steps and task types with no declared owner pass through
+    untouched, mirroring the targeting veto's scope exactly.
+    """
+    from squadops.capabilities.dev_capabilities import matches_test_file_patterns
+    from squadops.cycles.task_plan import own_artifact_role
+
+    owner = own_artifact_role(failed_task_type)
+    if owner is None or step_role == owner:
+        return artifacts
+    own = {str(a) for a in failed_own_artifacts if a}
+    kept: list[dict[str, Any]] = []
+    dropped: list[str] = []
+    for art in artifacts:
+        name = str(art.get("name") or "")
+        if (
+            name in own
+            or matches_test_file_patterns(name, test_file_patterns)
+            or ("__tests__/" in name)
+        ):
+            dropped.append(name)
+        else:
+            kept.append(art)
+    if dropped:
+        logger.info(
+            "correction_repair_emission: ownership veto (#1014) — %s-role step emitted "
+            "%s-owned %s; discarded, never stored",
+            step_role,
+            owner,
+            ", ".join(dropped),
+        )
+    return kept
+
+
 @dataclass(frozen=True)
 class CorrectionProtocolResult:
     """Outcome of one correction-protocol run.
@@ -1333,12 +1389,31 @@ class CorrectionRunner:
                 # the wrong directory otherwise lands as a net-new file, patch
                 # verification runs on the un-patched original, and the
                 # validated repair is discarded by re-dispatch.
+                from squadops.capabilities.dev_capabilities import test_file_patterns_for
                 from squadops.cycles.patch_verification import rebase_artifact_paths
 
+                rebased = rebase_artifact_paths(
+                    [a for a in step_artifacts if isinstance(a, dict)],
+                    failed_inputs.get("expected_artifacts") or [],
+                )
+                # #1014: emission-side ownership veto, post-rebase — a foreign-role
+                # step's emission may not land the failed task's own artifacts or
+                # anything on its test-collection surface (see the veto docstring).
+                # Pattern derivation is failure-isolated like the #870 gate: an
+                # unresolvable capability weakens the veto to its own-set +
+                # ``__tests__/`` halves rather than crashing the protocol.
+                try:
+                    patterns = test_file_patterns_for(failed_inputs.get("resolved_config"))
+                except Exception as exc:
+                    logger.warning("emission ownership veto: pattern surface unavailable: %s", exc)
+                    patterns = ()
                 repair_artifacts.extend(
-                    rebase_artifact_paths(
-                        [a for a in step_artifacts if isinstance(a, dict)],
-                        failed_inputs.get("expected_artifacts") or [],
+                    _apply_emission_ownership_veto(
+                        rebased,
+                        envelope.task_type,
+                        role,
+                        [str(e) for e in (failed_inputs.get("expected_artifacts") or [])],
+                        patterns,
                     )
                 )
 

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -3948,3 +3948,117 @@ class TestOwnershipVetoWiring(TestCorrectionRunnerStandalone):
         assert "__tests__/api_runs.test.ts" not in target
         assert "app/api/runs/route.ts" in target
         assert "app/runs/new/page.tsx" in target
+
+    async def test_dev_repair_emission_of_qa_owned_suite_is_discarded(self, cycle):
+        """#1014 flow half: the targeting veto edits the brief, but the failing
+        suite is in the step's context as evidence and the model can rewrite
+        what it can see — V38 slot 6's dev repairs emitted a full qa-suite
+        rewrite on all three rounds and storage accepted it, so the retest
+        graded the dev by his own tests. The emission veto must drop qa-owned
+        files from what reaches ``repair_artifacts`` (→ overlay → retest →
+        #389 re-store), while the app-file repairs pass through untouched."""
+        import dataclasses as _dc
+
+        def responder(envelope):
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "patch",
+                        "decision_rationale": "patchable",
+                        "affected_task_types": ["development.develop"],
+                    },
+                )
+            if envelope.task_type == "development.correction_repair":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "summary": "repaired",
+                        "artifacts": [
+                            {
+                                "name": "app/api/runs/[run_id]/join/route.ts",
+                                "content": "return new Response(body, { status: 201 })",
+                                "type": "source",
+                            },
+                            # The #884-class overreach: a rewrite of the exact
+                            # file the veto stripped from the brief.
+                            {
+                                "name": "__tests__/api_runs.test.ts",
+                                "content": "// dev-authored suite",
+                                "type": "source",
+                            },
+                            # Basename-pattern match outside __tests__/ — the
+                            # invented-new-filename variant the narrow own-set
+                            # rule would miss.
+                            {
+                                "name": "extra.test.ts",
+                                "content": "// more dev-authored tests",
+                                "type": "source",
+                            },
+                        ],
+                    },
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, _vault, _bus = self._make_runner(responder)
+        failed = _dc.replace(
+            self._failed_envelope(),
+            task_type="qa.test",
+            inputs={
+                "expected_artifacts": ["__tests__/api_runs.test.ts"],
+                "implementation_artifacts": ["app/api/runs/[run_id]/join/route.ts"],
+                "resolved_config": {"dev_capability": "nextjs_ts"},
+            },
+        )
+
+        protocol_result = await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=failed,
+            result=TaskResult(task_id="task_failed", status="FAILED", error="suite failed"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+        names = [a["name"] for a in protocol_result.repair_artifacts]
+        assert "app/api/runs/[run_id]/join/route.ts" in names
+        assert "__tests__/api_runs.test.ts" not in names
+        assert "extra.test.ts" not in names
+
+    async def test_qa_own_artifact_repair_keeps_its_suite_emission(self):
+        """#1014 non-regression: the veto is FOREIGN-role only. A qa-role
+        own-artifact repair re-authoring its own suite (the #568 locus path)
+        must pass through untouched — filtering it would make every qa-side
+        suite repair a silent no-op."""
+        from adapters.cycles.correction_runner import _apply_emission_ownership_veto
+        from squadops.cycles.task_plan import own_artifact_role
+
+        owner = own_artifact_role("qa.test")
+        assert owner is not None  # premise: qa.test declares an owner
+        suite = [{"name": "__tests__/api_runs.test.ts", "content": "fixed", "type": "test"}]
+        kept = _apply_emission_ownership_veto(
+            suite,
+            "qa.test",
+            owner,
+            ["__tests__/api_runs.test.ts"],
+            ("*.test.ts",),
+        )
+        assert kept == suite
+
+    async def test_emission_veto_passthrough_when_no_declared_owner(self):
+        """#1014 scope guard: task types with no own-artifact owner are
+        untouched, mirroring the targeting veto exactly — filtering there
+        would silently drop legitimate repairs for every default-chain task."""
+        from adapters.cycles.correction_runner import _apply_emission_ownership_veto
+
+        arts = [{"name": "__tests__/x.test.ts", "content": "t", "type": "test"}]
+        kept = _apply_emission_ownership_veto(
+            arts, "development.implement", "dev", [], ("*.test.ts",)
+        )
+        assert kept == arts


### PR DESCRIPTION
## Summary
- Completes #884 at the emission boundary: a repair step running under a foreign role can no longer LAND the failed task's own artifacts or anything on its test-collection surface — previously only the *brief* was vetoed, and V38 slot 6's dev repairs stored a full qa-suite rewrite on all three rounds (see #1014 for the incident and mechanism).
- Surface-based match rule as recommended in the issue: own-artifact set ∪ stack `test_file_patterns` ∪ `__tests__/` convention — catches the invented-new-filename variant the narrow rule misses. Over-matching is the safe direction (a dropped borderline file just leaves the original in the tree).
- Applied post-#507-rebase so the filtered names are the names the overlay would supersede; same-role steps (qa re-authoring its own suite on the #568 locus path) and undeclared-owner types pass through untouched; pattern derivation failure-isolated per the #870 precedent.

## Tests
- Flow (standalone runner): dev repair emits app fix + qa-suite rewrite + invented `extra.test.ts` → only the app fix reaches `repair_artifacts`. **Mutation-checked**: neutering the veto call makes this test fail.
- Non-regression: qa own-artifact repair keeps its suite emission (same-role).
- Scope guard: no-declared-owner task types untouched.
- Full `test_correction_runner.py`: 153 passed; lint/format clean.

Closes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApBek6CA1ibm3Cc5pq57F2