### PR TITLE
fix(handlers): registry completion clamp on the base chat path (#1011)

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -336,7 +336,17 @@ class _CycleTaskHandler(CapabilityHandler):
         return model_name, max_tokens, context_window
 
     def _build_chat_kwargs(self, inputs: dict[str, Any]) -> dict[str, Any]:
-        """Build chat() kwargs from agent config overrides (SIP-0075 §3.2)."""
+        """Build chat() kwargs from agent config overrides (SIP-0075 §3.2).
+
+        #1011: without an explicit ``max_completion_tokens`` override, the
+        registry's per-model completion clamp applies — previously ``max_tokens``
+        was simply omitted here, so every handler riding the base path
+        (correction repairs foremost) ran at capability ceilings the clamped
+        develop/qa handlers never see (a dev repair emitted 12,314 tokens under
+        an 8,192-clamped model, V38 shakedown #2). An explicit override still
+        wins, and a model without a registry entry keeps the old behavior —
+        the clamp cannot invent a budget for a model it does not know.
+        """
         overrides = inputs.get("agent_config_overrides", {})
         agent_model = inputs.get("agent_model") or None
         kwargs: dict[str, Any] = {}
@@ -346,6 +356,8 @@ class _CycleTaskHandler(CapabilityHandler):
             kwargs["temperature"] = overrides["temperature"]
         if "max_completion_tokens" in overrides:
             kwargs["max_tokens"] = overrides["max_completion_tokens"]
+        elif agent_model and (spec := get_model_spec(agent_model)) is not None:
+            kwargs["max_tokens"] = spec.default_max_completion
         if "timeout_seconds" in overrides:
             kwargs["timeout_seconds"] = overrides["timeout_seconds"]
         return kwargs

--- a/tests/unit/capabilities/test_repair_handlers.py
+++ b/tests/unit/capabilities/test_repair_handlers.py
@@ -141,6 +141,66 @@ def _make_context(llm_response="Repair analysis content"):
     return ctx
 
 
+class TestRepairEmissionClamp:
+    """#1011: repair handlers ride the base ``_build_chat_kwargs`` path, which
+    previously passed ``max_tokens`` only when agent overrides carried
+    ``max_completion_tokens`` — the registry's per-model completion clamp never
+    applied, so a dev repair emitted 12,314 tokens under an 8,192-clamped model
+    (V38 shakedown #2) while develop/qa tasks on the same model were clamped."""
+
+    def test_registry_clamp_applies_without_override(self):
+        """The bug this catches: a repair on a registry-known model runs at the
+        capability ceiling instead of the model's completion clamp."""
+        from squadops.llm.model_registry import get_model_spec
+
+        h = DevelopmentRepairHandler()
+        spec = get_model_spec("qwen3.8:27b")
+        assert spec is not None  # premise: the V38 arm is registered (#1008)
+        kwargs = h._build_chat_kwargs({"agent_model": "qwen3.8:27b", "agent_config_overrides": {}})
+        assert kwargs["max_tokens"] == spec.default_max_completion
+
+    def test_explicit_override_still_wins(self):
+        """A profile that deliberately raises (or lowers) the budget keeps
+        authority — the clamp is a default, not a ceiling on operators."""
+        h = DevelopmentRepairHandler()
+        kwargs = h._build_chat_kwargs(
+            {
+                "agent_model": "qwen3.8:27b",
+                "agent_config_overrides": {"max_completion_tokens": 12_000},
+            }
+        )
+        assert kwargs["max_tokens"] == 12_000
+
+    def test_unknown_model_keeps_prior_behavior(self):
+        """No registry entry → no invented budget: max_tokens stays absent,
+        exactly the pre-#1011 behavior (the #1008 lesson runs the other way —
+        an UNregistered model is a registry gap to fix, not a clamp to guess)."""
+        h = DevelopmentRepairHandler()
+        kwargs = h._build_chat_kwargs(
+            {"agent_model": "totally-unregistered:1b", "agent_config_overrides": {}}
+        )
+        assert "max_tokens" not in kwargs
+
+    async def test_clamp_reaches_the_llm_call(self):
+        """Flow half: the clamped budget arrives at chat_stream_with_usage —
+        wiring, not just the kwargs builder."""
+        from squadops.llm.model_registry import get_model_spec
+
+        h = DevelopmentRepairHandler()
+        ctx = _make_context(llm_response="repaired")
+        await h.handle(
+            ctx,
+            {
+                "prd": "Build a widget",
+                "agent_model": "qwen3.8:27b",
+                "agent_config_overrides": {},
+                "prior_outputs": {},
+            },
+        )
+        call = ctx.ports.llm.chat_stream_with_usage.call_args
+        assert call.kwargs["max_tokens"] == get_model_spec("qwen3.8:27b").default_max_completion
+
+
 class TestRepairHandlerHandle:
     async def test_llm_success_returns_artifact(self):
         h = DataAnalyzeVerificationHandler()


### PR DESCRIPTION
## Summary
- The per-model completion clamp now applies to every handler riding `_CycleTaskHandler`'s base chat path — previously `max_tokens` was set only from an explicit `agent_config_overrides.max_completion_tokens`, so correction repairs (and every other base-path rider) ran at capability ceilings while develop/qa were clamped via `_resolve_model_budget`. Observed: 12,314-token repair under an 8,192-clamped model (V38 shakedown #2, declared §2.6); slot 6's three repairs ran 10–18.8k.
- One-seam fix per the issue's direction: no override → registry `default_max_completion`; explicit override still wins; unregistered model → unchanged behavior (no invented budget).
- This also answers the issue's "which other subclasses ride the unclamped base path" question by construction: all of them are now clamped at the same seam.

## Tests
- Clamp applies without override (registry premise asserted); override wins; unknown model keeps prior behavior; flow half asserts the clamped budget reaches `chat_stream_with_usage`.
- Full unit sweep: capabilities 2,064 passed, cycles 2,953 passed; lint/format clean.

Closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApBek6CA1ibm3Cc5pq57F2