### PR TITLE
feat(gates): manifest↔plan consistency + completeness gate (#1013)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -3743,6 +3743,33 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         if interface_content is not None:
             errors.extend(self._validate_interface_manifest(interface_content))
 
+        # #1013: manifest↔plan consistency + completeness — the two framing-internal
+        # species that cost V38 counted rolls (roll 1's 201-vs-200 contradiction; slot
+        # 6's manifest-only 201 the plan never stated). Needs BOTH artifacts, so it
+        # runs after the collection loop; an unparseable manifest defers exactly like
+        # an unreadable plan does (this check only ever adds an earlier rejection,
+        # never a pass). Lands on THIS seam deliberately: the reject must re-roll
+        # framing for free, not fail a run at dispatch (see the ownership note above).
+        if interface_content is not None and parsed_plan is not None:
+            try:
+                from squadops.capabilities.scaffold import InterfaceManifest
+
+                parsed_manifest = InterfaceManifest.from_yaml(interface_content)
+            except Exception:
+                logger.warning(
+                    "Manifest unparseable before gate %r — #1013 consistency check "
+                    "deferred to the manifest's own validation net",
+                    gate_name,
+                    exc_info=True,
+                )
+            else:
+                errors.extend(
+                    classifier.collect(
+                        "validate_manifest_plan_consistency",
+                        parsed_plan.validate_manifest_plan_consistency(parsed_manifest),
+                    )
+                )
+
         # SIP-0098 98.3: bind-mode contract validation. A seeded contract_ref switches the
         # cycle to bind mode — the plan must bind the contract's covered-file criteria by
         # id (validate_criteria_refs) rather than author them, and the contract must be

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -1930,6 +1930,17 @@ class ScaffoldStack:
     #: a TypeScript author. Unset means the stack states no seam and both surfaces stay
     #: silent rather than guessing.
     error_seam: ErrorSeam | None = None
+    #: #1013: whether this stack's skeleton pins a declared ``success_status`` in
+    #: FROZEN structure the fill cannot change. FastAPI does — ``status_code=`` lands
+    #: in the route decorator (the pf-39 fix), so an implementer inherits the status
+    #: mechanically and prose silence is harmless. The Next.js skeleton only writes it
+    #: as a TODO comment INSIDE the fill body, which the fill replaces — V38 slot 6
+    #: proved the comment does not survive (manifest declared 201, dev shipped 200).
+    #: The framing-consistency omission check fires only for stacks where this is
+    #: False: there, plan prose is the sole channel that carries the status to the
+    #: implementer. Default False — silently-wrong has no safe default, and an
+    #: unregistered/unknown stack has no skeleton at all.
+    skeleton_pins_success_status: bool = False
 
 
 _STACKS: dict[str, ScaffoldStack] = {
@@ -1946,6 +1957,9 @@ _STACKS: dict[str, ScaffoldStack] = {
         criteria_pack="fullstack_fastapi_react",
         error_seam=ERROR_SEAM_FASTAPI,
         probe_profile="fastapi_uvicorn",
+        # A declared success_status lands in the frozen route decorator
+        # (``status_code=``, the pf-39 fix) — structural, fill-proof.
+        skeleton_pins_success_status=True,
         dev_capability="fullstack_fastapi_react",
     ),
     # #822 stack #2. Imported below rather than defined here: a second expander inline would
@@ -1983,6 +1997,17 @@ def _stack(stack: str) -> ScaffoldStack:
     if known is None:
         raise ValueError(f"no scaffold expander for stack {stack!r}; available: {sorted(_STACKS)}")
     return known
+
+
+def skeleton_pins_success_status_for(stack: str) -> bool:
+    """Whether *stack*'s skeleton pins declared success statuses in frozen structure (#1013).
+
+    ``False`` for unknown stacks — no registration means no skeleton, so prose is the
+    only channel and the conservative answer is "not pinned". Lives here for the same
+    reason ``check_stack_for`` does: one answer to "which stacks does this system know."
+    """
+    known = _STACKS.get(stack)
+    return bool(known and known.skeleton_pins_success_status)
 
 
 def check_stack_for(stack: str) -> str | None:

--- a/src/squadops/cycles/framing_consistency.py
+++ b/src/squadops/cycles/framing_consistency.py
@@ -1,0 +1,184 @@
+"""Manifest↔plan consistency and completeness validation (#1013).
+
+The two framing-internal defect species that cost V38 counted rolls, both invisible
+to every prior gate because each artifact was *individually* coherent:
+
+- **Contradiction** (roll 1, ``cyc_02e9af402c82``): the manifest declared
+  ``success_status: 201`` for create while the plan's dev criterion said
+  *"returns 200"*. The dev built the plan faithfully; the contract judged the
+  manifest. Nothing compared the two documents.
+- **Omission** (slot 6, ``cyc_cac1e479a462``): the manifest declared join
+  ``success_status: 201`` — and the plan never stated it anywhere. The dev
+  defaulted to 200; the derived probe enforced 201; three repair rounds and the
+  roll died on a fact the implementer was never given. The same class recurred
+  as a *shape* omission on the 1.6.1 shakedown (that half is #913's, not ours).
+
+Both checks are pure functions over the two parsed artifacts, deterministic, and
+land on the inter-workload plan-validation seam — a rejection there re-rolls
+framing for free (#522) instead of spending an implementation run to be caught
+at the verdict.
+
+Status semantics mirror the contract deriver EXACTLY (``scaffold_contract``:
+collection POST defaults to 201, child-action POST to 200, GET derives no
+status probe): the checks compare the plan against what the probes will
+*enforce*, not merely what the manifest *declares* — the pf-39 class, where an
+undeclared collection-POST status silently becomes an enforced 201, is a
+contradiction here the moment the plan says 200.
+
+Deliberately narrow, both directions:
+
+- Only **success-family** tokens (200/201/202/204) participate. Error-status
+  teaching (the 409-duplicate story) varies with prose vagueness the window
+  showed is not deterministic to judge; extending there is future work, not
+  this gate.
+- A plan line binds to an endpoint only when it contains a recognizable form of
+  that endpoint's **path**. Pathless prose ("create returns 200") is never
+  matched — at a rejection gate, a false negative costs a roll we were already
+  losing; a false positive rejects a good framing, which is worse.
+- A matched line that contains the enforced status among its success tokens is
+  consistent, whatever else it mentions — multi-endpoint summary lines must not
+  flag on their neighbors' statuses.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from squadops.capabilities.scaffold import Endpoint, InterfaceManifest
+    from squadops.cycles.implementation_plan import ImplementationPlan
+
+#: Success-family tokens the checks reason about. 3-digit tokens outside this
+#: set (400/404/409/422/...) are error vocabulary and never participate.
+_SUCCESS_STATUSES = frozenset({200, 201, 202, 204})
+
+_STATUS_TOKEN_RE = re.compile(r"\b(2\d\d)\b")
+
+_METHOD_TOKEN_RE = re.compile(r"\b(GET|POST|PUT|PATCH|DELETE)\b")
+
+
+def _enforced_success_status(ep: Endpoint) -> int | None:
+    """The status the derived contract will actually assert for *ep*.
+
+    Mirrors ``scaffold_contract``'s derivation (collection POST → 201, child
+    POST → 200; see the deriver's ``ep.success_status or 201`` /
+    ``child.success_status or 200`` sites) — declared wins, defaults follow.
+    GETs derive no status probe, so there is nothing to enforce and nothing to
+    contradict.
+    """
+    if ep.method.upper() != "POST":
+        return ep.success_status  # declared-only for non-POST; None = unchecked
+    if ep.success_status is not None:
+        return ep.success_status
+    return 201 if "{" not in ep.path else 200
+
+
+def _path_pattern(path: str) -> re.Pattern[str]:
+    """A conservative regex recognizing *path* in plan prose.
+
+    ``{run_id}`` segments match any single non-space segment, so
+    ``/api/runs/{run_id}/join``, ``/api/runs/:id/join`` and
+    ``/api/runs/[run_id]/join`` prose forms all bind. Literal segments match
+    exactly; nothing shorter than the full path binds.
+    """
+    parts = [seg for seg in path.split("/") if seg]
+    rendered = [
+        r"[^/\s]+" if seg.startswith("{") and seg.endswith("}") else re.escape(seg) for seg in parts
+    ]
+    return re.compile("/" + "/".join(rendered) + r"(?![\w/])")
+
+
+def _plan_text_lines(plan: ImplementationPlan) -> list[str]:
+    """Every prose line an implementer's brief is assembled from.
+
+    Task ``focus``/``description`` lines plus string acceptance criteria —
+    the same fields the dispatch path renders into dev briefs. TypedCheck
+    entries are machine-shaped and excluded; their consistency is the typed
+    seam's own concern.
+    """
+    lines: list[str] = []
+    for task in plan.tasks:
+        if task.focus:
+            lines.extend(task.focus.splitlines())
+        if task.description:
+            lines.extend(task.description.splitlines())
+        for criterion in task.acceptance_criteria:
+            if isinstance(criterion, str):
+                lines.extend(criterion.splitlines())
+    return [ln for ln in (ln.strip() for ln in lines) if ln]
+
+
+def validate_manifest_plan_consistency(
+    manifest: InterfaceManifest,
+    plan: ImplementationPlan,
+) -> list[str]:
+    """The #1013 gate: contradiction and completeness, per endpoint.
+
+    Returns error strings in the plan-validation vocabulary (empty = pass).
+    """
+    from squadops.capabilities.scaffold import skeleton_pins_success_status_for
+
+    errors: list[str] = []
+    lines = _plan_text_lines(plan)
+    # The omission half fires only where plan prose is the sole channel carrying
+    # the status to the implementer. FastAPI's skeleton pins a declared status in
+    # the FROZEN route decorator (pf-39's fix) — the fill inherits it mechanically
+    # and prose silence is harmless. The Next.js skeleton writes it only as a TODO
+    # comment inside the fill body, which the fill replaces — slot 6 proved the
+    # comment does not survive. Status probes bind to the qa task, never the dev
+    # task's criteria_refs, so the typed channel never carries this fact to the
+    # implementer in EITHER authoring mode — the stack's skeleton is the variable.
+    # The contradiction half stays active regardless: prose that contradicts the
+    # contract misleads the implementer whatever the skeleton pins.
+    status_pinned_by_skeleton = skeleton_pins_success_status_for(manifest.stack)
+
+    for ep in manifest.api.endpoints:
+        enforced = _enforced_success_status(ep)
+        if enforced is None:
+            continue
+        pattern = _path_pattern(ep.path)
+        # Method-aware binding: a line naming HTTP methods binds only endpoints
+        # whose method it names ("GET /api/runs returns 200" is about the GET,
+        # not the collection POST sharing the path). Methodless pathful lines
+        # bind by path alone.
+        matched_lines = [
+            ln
+            for ln in lines
+            if pattern.search(ln)
+            and (not (methods := set(_METHOD_TOKEN_RE.findall(ln))) or ep.method.upper() in methods)
+        ]
+
+        stated_anywhere = False
+        for ln in matched_lines:
+            tokens = {
+                int(tok) for tok in _STATUS_TOKEN_RE.findall(ln) if int(tok) in _SUCCESS_STATUSES
+            }
+            if not tokens:
+                continue
+            if enforced in tokens:
+                stated_anywhere = True
+                continue
+            errors.append(
+                f"manifest↔plan contradiction on {ep.method} {ep.path}: the contract "
+                f"will enforce success {enforced} "
+                f"({'declared' if ep.success_status is not None else 'derived default'}) "
+                f'but the plan states {sorted(tokens)} — "{ln[:120]}". The implementer '
+                f"builds the plan; the contract judges the manifest. Align them."
+            )
+
+        # Completeness: an enforced non-200 success is exactly the fact the dev
+        # will not default to — slot 6's roll died on it. It must be STATED in
+        # the plan's prose near the endpoint, or the implementer never sees it.
+        if enforced != 200 and not stated_anywhere and not status_pinned_by_skeleton:
+            already_contradicted = any(f"on {ep.method} {ep.path}:" in e for e in errors)
+            if not already_contradicted:
+                errors.append(
+                    f"manifest↔plan omission on {ep.method} {ep.path}: the contract will "
+                    f"enforce success {enforced} but no plan line states it for this "
+                    f"endpoint — the implementer will default to 200 and the probe will "
+                    f"reject a faithful build. State the status in the owning task's "
+                    f"description or acceptance criteria."
+                )
+
+    return errors

--- a/src/squadops/cycles/implementation_plan.py
+++ b/src/squadops/cycles/implementation_plan.py
@@ -349,6 +349,16 @@ class ImplementationPlan:
                 errors.append(f"Task {task.task_index}: role '{task.role}' not in profile")
         return errors
 
+    def validate_manifest_plan_consistency(self, manifest) -> list[str]:
+        """#1013: this plan's prose agrees with *manifest* on enforced success
+        statuses, and states any non-200 status the stack's skeleton does not
+        pin. Logic lives in ``framing_consistency`` (pure, cross-artifact);
+        this method is the seam the plan-gate validators and the #686
+        author-teaching classification both discover."""
+        from squadops.cycles.framing_consistency import validate_manifest_plan_consistency
+
+        return validate_manifest_plan_consistency(manifest, self)
+
     def validate_check_applicability(self, resolved_config: dict) -> list[str]:
         """#715: a ``qa.test`` task's declared artifacts must be able to satisfy the
         required check that judges them.

--- a/src/squadops/cycles/plan_authoring_rules.py
+++ b/src/squadops/cycles/plan_authoring_rules.py
@@ -39,6 +39,11 @@ AUTHOR_FACING: dict[str, str] = {
     # #888: the plan author owns the builder task's expected_artifacts, so an
     # under-covered floor is an authorable — and authored (roll 15) — defect.
     "validate_builder_floor": "builder-floor-coverage",
+    # #1013: the plan's prose must agree with the manifest on enforced success
+    # statuses, and must STATE a non-200 status where the stack's skeleton does
+    # not pin it — the two framing-internal species that cost V38 counted rolls
+    # (roll 1's 201-vs-200 contradiction; slot 6's manifest-only 201).
+    "validate_manifest_plan_consistency": "statuses-must-agree-with-the-manifest",
 }
 
 # Validators an author is already taught by a different managed asset. Restating them

--- a/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.plan_authoring_rules_appendix
-version: "3"
+version: "4"
 required_variables: []
 ---
 ## PLAN SHAPE RULES (authoritative — a plan that breaks one is rejected)
@@ -65,6 +65,15 @@ profile's `required_files` lists appears in SOME task's `expected_artifacts` (us
 builder's). The profile list is a floor — a per-task list may add files, never subtract
 one. A plan that leaves a required file unowned passes every task and then fails the
 deliverable-completeness gate at run completion, where nothing can repair it.
+
+**statuses-must-agree-with-the-manifest** — Any line of prose that names an endpoint's
+path and a success status must state the SAME status the interface manifest declares (or
+its derived default: a collection POST with no declared status is enforced at 201). The
+implementer builds your plan; the contract judges the manifest — a plan that teaches 200
+where the manifest declares 201 sends the developer to certain rejection. And where the
+stack's skeleton does not pin the status into frozen code, an enforced non-200 status must
+be STATED in the owning task's description or acceptance criteria — a status that lives
+only in the manifest never reaches the developer, who will default to 200.
 
 A verification-only task is legitimate and common: declare `expected_artifacts: []` and
 express what it checks through its acceptance criteria.

--- a/tests/unit/capabilities/test_interface_manifest_framing.py
+++ b/tests/unit/capabilities/test_interface_manifest_framing.py
@@ -145,6 +145,9 @@ def _executor_for(manifest_yaml: str | None) -> tuple[DispatchedFlowExecutor, An
     # #424: the seam now rejects a plan-less framing outright
     # (plan_authoring_collapsed), so these interface-manifest-net tests carry a
     # minimal valid plan to keep exercising their own net in isolation.
+    # #1013: the seam also rejects an author-mode plan that never states an
+    # enforced non-200 success status, so the minimal plan states the 201 its
+    # manifests declare — same isolation principle, one more rule to satisfy.
     plan_ref = MagicMock()
     plan_ref.filename = "implementation_plan.yaml"
     plan_ref.artifact_type = "control_implementation_plan"
@@ -158,7 +161,7 @@ def _executor_for(manifest_yaml: str | None) -> tuple[DispatchedFlowExecutor, An
         "    task_type: development.develop\n"
         "    role: dev\n"
         '    focus: "Backend"\n'
-        '    description: "Build"\n'
+        '    description: "Build. POST /runs returns 201 on success."\n'
         "    expected_artifacts:\n"
         '      - "backend/main.py"\n'
         "    depends_on: []\n"

--- a/tests/unit/cycles/test_framing_consistency.py
+++ b/tests/unit/cycles/test_framing_consistency.py
@@ -1,0 +1,209 @@
+"""#1013: manifest↔plan consistency + completeness.
+
+Every test here is keyed to a banked failure: V38 roll 1 (contradiction), V38
+slot 6 (omission), pf-39 (derived-default enforcement), and the false-positive
+shapes a rejection gate must never produce.
+"""
+
+from squadops.capabilities.scaffold import InterfaceManifest
+from squadops.cycles.framing_consistency import validate_manifest_plan_consistency
+from squadops.cycles.implementation_plan import ImplementationPlan
+
+
+def _manifest(endpoints_yaml: str) -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(
+        f"""
+version: 1
+kind: interface_manifest
+project_id: group_run
+stack: nextjs_ts
+api:
+  endpoints:
+{endpoints_yaml}
+frontend:
+  routes:
+    - path: /
+      view: RunsListView
+      testids: [runs-list]
+"""
+    )
+
+
+def _plan(task_lines: list[str]) -> ImplementationPlan:
+    criteria = "\n".join(f"  - '{ln}'" for ln in task_lines) or "  []"
+    return ImplementationPlan.from_yaml(
+        f"""
+version: 1
+project_id: group_run
+cycle_id: cyc_test
+prd_hash: abc123
+summary:
+  approach: test
+tasks:
+- task_index: 0
+  task_type: development.develop
+  role: dev
+  focus: API routes
+  description: Implement the API routes.
+  expected_artifacts: [app/api/runs/route.ts]
+  acceptance_criteria:
+{criteria}
+"""
+    )
+
+
+JOIN_201 = """
+    - method: POST
+      path: /api/runs
+      success_status: 201
+    - method: POST
+      path: "/api/runs/{run_id}/join"
+      success_status: 201
+"""
+
+
+class TestContradiction:
+    def test_roll1_class_plan_states_wrong_status(self):
+        """V38 roll 1: manifest declares 201, a plan line says the endpoint
+        returns 200 — the dev builds the plan, the contract judges the
+        manifest, the roll dies. This gate refuses the framing instead."""
+        manifest = _manifest(JOIN_201)
+        plan = _plan(["POST /api/runs returns 200 with the created run."])
+        errors = validate_manifest_plan_consistency(manifest, plan)
+        assert any("contradiction on POST /api/runs:" in e for e in errors)
+        assert any("enforce success 201" in e for e in errors)
+
+    def test_pf39_class_derived_default_is_enforced(self):
+        """pf-39 / #772: a collection POST with NO declared status is still
+        enforced at 201 by the deriver — a plan saying 200 contradicts the
+        contract even though the manifest never wrote a number."""
+        manifest = _manifest(
+            """
+    - method: POST
+      path: /api/runs
+"""
+        )
+        plan = _plan(["POST /api/runs returns 200."])
+        errors = validate_manifest_plan_consistency(manifest, plan)
+        assert any("contradiction on POST /api/runs:" in e for e in errors)
+        assert any("derived default" in e for e in errors)
+
+    def test_multi_status_line_with_enforced_present_is_consistent(self):
+        """A summary line carrying its own 201 plus a neighbor's 200 must not
+        flag — flagging multi-endpoint prose would reject good framings."""
+        manifest = _manifest(JOIN_201)
+        plan = _plan(
+            [
+                "POST /api/runs returns 201 with the created run; list returns 200.",
+                "POST /api/runs/{run_id}/join returns 201 on success.",
+            ]
+        )
+        assert validate_manifest_plan_consistency(manifest, plan) == []
+
+    def test_error_status_vocabulary_never_participates(self):
+        """Error teaching (400/404/409) is out of scope — a line rejecting
+        blanks with 400 is not a success-status claim."""
+        manifest = _manifest(JOIN_201)
+        plan = _plan(
+            [
+                "POST /api/runs returns 201.",
+                "POST /api/runs rejects blank title with 400 validation_error.",
+                "POST /api/runs/{run_id}/join returns 201; duplicate rejected with 409.",
+            ]
+        )
+        assert validate_manifest_plan_consistency(manifest, plan) == []
+
+
+class TestOmission:
+    def test_slot6_class_enforced_201_never_stated(self):
+        """V38 slot 6: join 201 lived only in the manifest; the plan was
+        silent; the dev defaulted to 200 and the roll died on a fact the
+        implementer never received. The gate names the omission."""
+        manifest = _manifest(JOIN_201)
+        plan = _plan(
+            [
+                "POST /api/runs returns 201 with the created run.",
+                "POST /api/runs/{run_id}/join adds the participant and updates the count.",
+            ]
+        )
+        errors = validate_manifest_plan_consistency(manifest, plan)
+        assert len(errors) == 1
+        assert "omission on POST /api/runs/{run_id}/join:" in errors[0]
+        assert "default to 200" in errors[0]
+
+    def test_child_post_default_200_needs_no_statement(self):
+        """A child-action POST with no declared status is enforced at 200 —
+        the dev's own default — so silence is fine (slot 5's green shape)."""
+        manifest = _manifest(
+            """
+    - method: POST
+      path: /api/runs
+      success_status: 201
+    - method: POST
+      path: "/api/runs/{run_id}/join"
+"""
+        )
+        plan = _plan(
+            [
+                "POST /api/runs returns 201 with the created run.",
+                "POST /api/runs/{run_id}/join adds the participant.",
+            ]
+        )
+        assert validate_manifest_plan_consistency(manifest, plan) == []
+
+    def test_contradiction_suppresses_duplicate_omission_report(self):
+        """A contradicted endpoint is already rejected once — reporting the
+        omission too would double-charge one defect."""
+        manifest = _manifest(JOIN_201)
+        plan = _plan(
+            [
+                "POST /api/runs returns 201.",
+                "POST /api/runs/{run_id}/join returns 200 on success.",
+            ]
+        )
+        errors = validate_manifest_plan_consistency(manifest, plan)
+        join_errors = [e for e in errors if "/join" in e]
+        assert len(join_errors) == 1
+        assert "contradiction" in join_errors[0]
+
+
+class TestPathBinding:
+    def test_pathless_prose_never_binds(self):
+        """Conservative by design: 'create returns 200' with no path form
+        binds to nothing — a false positive rejects a good framing, which is
+        worse than missing pathless prose."""
+        manifest = _manifest(JOIN_201)
+        plan = _plan(
+            [
+                "POST /api/runs returns 201.",
+                "POST /api/runs/{run_id}/join returns 201.",
+                "The create operation returns 200 quickly.",  # pathless — ignored
+            ]
+        )
+        assert validate_manifest_plan_consistency(manifest, plan) == []
+
+    def test_param_segment_prose_forms_bind(self):
+        """Both `{run_id}` and `[run_id]` prose forms of a parameterized path
+        bind to the endpoint (the plan corpus writes both)."""
+        manifest = _manifest(JOIN_201)
+        plan = _plan(
+            [
+                "POST /api/runs returns 201.",
+                "POST /api/runs/[run_id]/join returns 200 on success.",
+            ]
+        )
+        errors = validate_manifest_plan_consistency(manifest, plan)
+        assert any("contradiction on POST /api/runs/{run_id}/join:" in e for e in errors)
+
+    def test_prefix_path_does_not_bind_longer_endpoint(self):
+        """A line about `/api/runs` must not bind `/api/runs/{run_id}/join` —
+        segment-exact matching, no prefix bleed in either direction."""
+        manifest = _manifest(JOIN_201)
+        plan = _plan(
+            [
+                "POST /api/runs returns 201.",
+                "POST /api/runs/{run_id}/join returns 201.",
+                "GET /api/runs returns 200 with the list.",  # GET unchecked; also not join
+            ]
+        )
+        assert validate_manifest_plan_consistency(manifest, plan) == []


### PR DESCRIPTION
## Summary
The deterministic gate for the framing-internal class that cost both V38 counted reds and recurred on the 1.6.1 shakedown: a **contradiction** check (plan prose vs the status the contract will *enforce* — declared or derived default, so the pf-39 class counts) and an **omission** check (an enforced non-200 status must be stated in plan prose wherever the stack's skeleton doesn't pin it into frozen code). Rejection lands at the inter-workload seam → framing re-rolls for free instead of a doomed implementation run.

Design points of note:
- **New per-stack fact at the S1 seam**: `skeleton_pins_success_status` — FastAPI's decorator pins it (pf-39 fix), Next.js's TODO comment doesn't survive the fill (slot 6's proof). The omission half fires only where prose is the sole channel; the typed channel is not a substitute in either mode because status probes bind to qa, never the dev's `criteria_refs`.
- **Conservative binding**: method-aware, full-path-only, success-family tokens only, enforced-status-present ⇒ consistent. A false positive rejects a good framing; the tests pin the false-positive shapes.
- **Taught, not just gated** (#686): `statuses-must-agree-with-the-manifest` added to the authoring-rules asset (v4) and registered `AUTHOR_FACING` — both drift guards fired during development and are satisfied.

## Would-have-caught
- V38 roll 1 (`cyc_02e9af402c82`): manifest 201 / plan "returns 200" → refused at plan validation
- V38 slot 6 (`cyc_cac1e479a462`): manifest-only join 201 → omission named with the remedy
- pf-39: undeclared collection-POST 201 vs plan 200 → contradiction on the derived default

## Tests
10 new, each keyed to a banked failure or a false-positive shape; corpus C1 and C6 retries are this gate's pre-registered acceptance tests (refusal expected on both framings). Full regression 7,640 passed; lint/format clean.

Closes #1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApBek6CA1ibm3Cc5pq57F2