### PR TITLE
fix(scaffold): error-envelope authority settled — nextjs on message, M2 rejects root-contradicting shapes (#795)

### DIFF
--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -616,11 +616,12 @@ class ErrorSeam:
     template that actually emits the bytes.
 
     ``body_field`` is deliberately per-stack rather than read from the manifest's
-    declared ``error_contract.shape``: the two currently disagree for ``nextjs_ts``
-    (the manifest declares ``message``, the emitted ``lib/errors.ts`` writes ``detail``)
-    and #795 owns that reconciliation. Until it is settled, describing what the code
-    ACTUALLY emits is the only honest thing to tell an author — a brief that quoted the
-    declared shape would be confidently wrong.
+    declared ``error_contract.shape`` — the envelope is blueprint-owned (#795's
+    resolution): the generator is the authority, the manifest's ``shape`` is
+    descriptive and gate-checked against it (root key must be ``error``), and both
+    stacks now agree on ``message`` (the nextjs ``detail`` divergence was reconciled
+    generator-side at #795 — the reference manifests and stack #1 already said
+    ``message``, and the generator was the odd one out).
     """
 
     #: The frozen module, as the author sees it on disk.
@@ -629,7 +630,8 @@ class ErrorSeam:
     import_form: str
     #: The raise convention, with the constructor's REAL parameter names.
     raise_form: str
-    #: The second field inside ``error`` — ``message`` (stack #1) or ``detail``.
+    #: The second field inside ``error`` — ``message`` on both stacks since #795's
+    #: reconciliation; the field stays declarative so a future stack CAN differ.
     body_field: str
     #: The framework exception a dev wrongly reaches for on THIS stack, named so the
     #: prohibition stays specific. ``HTTPException`` is what pf-33/pf-34 actually
@@ -654,8 +656,8 @@ ERROR_SEAM_FASTAPI = ErrorSeam(
 ERROR_SEAM_NEXTJS_TS = ErrorSeam(
     module="lib/errors.ts",
     import_form="import { ApiError, errorResponse } from '@/lib/errors'",
-    raise_form="ApiError(code, detail)",
-    body_field="detail",
+    raise_form="ApiError(code, message)",
+    body_field="message",
 )
 
 

--- a/src/squadops/capabilities/stack_nextjs_ts.py
+++ b/src/squadops/capabilities/stack_nextjs_ts.py
@@ -438,17 +438,17 @@ export const ERROR_STATUS: Record<string, number> = {{
 export class ApiError extends Error {{
   constructor(
     public code: string,
-    public detail: string = '',
+    message: string = '',
   ) {{
-    super(code)
+    super(message)
   }}
 }}
 
 export function errorResponse(err: unknown): Response {{
   const code = err instanceof ApiError ? err.code : 'internal_error'
   const status = ERROR_STATUS[code] ?? 500
-  const detail = err instanceof ApiError ? err.detail : ''
-  return Response.json({{ error: {{ code, detail }} }}, {{ status }})
+  const message = err instanceof ApiError ? err.message : ''
+  return Response.json({{ error: {{ code, message }} }}, {{ status }})
 }}
 """
 

--- a/src/squadops/capabilities/verification_scaffold_emission.py
+++ b/src/squadops/capabilities/verification_scaffold_emission.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:  # pragma: no cover - annotations only
 #: Bump on ANY emission-affecting change (module docstring). Recorded in every manifest.
 #: 2 (#936) — the shell imports `all` alongside `reset`, so a fill can call the helper
 #: the appendix teaches without adding an import it is forbidden to add.
-GENERATOR_VERSION = 4
+GENERATOR_VERSION = 5
 
 #: The stored manifest artifact's filename (the executor persists it beside the contract).
 VERIFICATION_SCAFFOLD_MANIFEST_FILENAME = "verification_scaffold_manifest.yaml"

--- a/src/squadops/cycles/manifest_authoring_rules.py
+++ b/src/squadops/cycles/manifest_authoring_rules.py
@@ -26,6 +26,7 @@ from squadops.cycles.manifest_gates import (
     PROOF_CHECKS_LIVE,
     PROOF_CONTRACT_DERIVES,
     PROOF_DECISION_RECORD,
+    PROOF_ERROR_SHAPE,
     PROOF_EXPANDS,
     PROOF_LINT,
     PROOF_PARSES,
@@ -46,6 +47,9 @@ AUTHOR_FACING: dict[str, tuple[str, ...]] = {
     PROOF_EXPANDS: ("paths-under-scaffold-roots",),
     PROOF_TESTID_COVERAGE: ("every-view-declares-anchors",),
     PROOF_STATUS_DECLARED: ("declare-the-success-status",),
+    # #795: the envelope is blueprint-owned; a declared shape rooted anywhere but
+    # `error` describes a body no response will carry (V4 declared FastAPI's default).
+    PROOF_ERROR_SHAPE: ("error-shape-is-the-blueprints",),
     PROOF_SOURCE_PRD: ("name-the-source-prd",),
     PROOF_DECISION_RECORD: ("record-judgments-with-warrants",),
     # #838: AUTHOR_FACING rather than COVERED_ELSEWHERE, though the authoring request's

--- a/src/squadops/cycles/manifest_gates.py
+++ b/src/squadops/cycles/manifest_gates.py
@@ -38,6 +38,7 @@ PROOF_CONTRACT_DERIVES = "contract_derives"
 PROOF_CHECKS_LIVE = "checks_live"
 PROOF_TESTID_COVERAGE = "testid_coverage"
 PROOF_STATUS_DECLARED = "status_declared"
+PROOF_ERROR_SHAPE = "error_shape_agrees"
 #: #838: the manifest declares its own stack, and until VS nothing compared that to the
 #: stack the CYCLE was configured for. A manifest for another stack is unwinnable in the
 #: most literal sense — the expander builds a different application.
@@ -107,6 +108,7 @@ def assess_winnability(
     findings.extend(_contract_findings(manifest))
     findings.extend(_testid_findings(manifest))
     findings.extend(_status_findings(manifest))
+    findings.extend(_error_shape_findings(manifest))
     findings.extend(_scaffold_findings(manifest))
     return tuple(findings)
 
@@ -440,5 +442,42 @@ def _status_findings(manifest) -> list[WinnabilityFinding]:
             f"`success_status`. The derived contract would assert 201 while the scaffold "
             f"emits a route returning 200, so the probe fails against a correct "
             f"implementation. Declare the status the endpoint returns on success.",
+        )
+    ]
+
+
+def _error_shape_findings(manifest) -> list[WinnabilityFinding]:
+    """A declared ``error_contract.shape`` must not contradict the blueprint's envelope (#795).
+
+    The envelope is blueprint-owned: the expander writes ``{"error": {"code", "message"}}``
+    into frozen code and every probe asserts against it. ``shape`` was read by nothing, so
+    V4 roll 1 declared FastAPI's default ``{"detail": "string"}`` and every gate passed —
+    a dev reading the authored contract would write error handling against a key no
+    response carries. This finding makes the ROOT contradiction unrepresentable: the
+    declared shape's root key must be ``error``.
+
+    Deliberately root-only. Banked green manifests declare the vague-but-true
+    ``{"error": "..."}`` and must keep passing — a rule that rejects the artifacts the
+    evidence was measured against is the wrong rule (the ``_status_findings`` principle).
+    Inner-field fidelity is carried by the ErrorSeam teaching, which renders from the
+    generator's own declaration and cannot drift from it.
+    """
+    contract = getattr(manifest.api, "error_contract", None)
+    shape = (getattr(contract, "shape", "") or "").strip()
+    if not shape:
+        return []
+    import re as _re
+
+    root_keys = _re.findall(r'^\s*\{\s*"?(\w+)"?\s*:', shape)
+    if not root_keys or root_keys[0] == "error":
+        return []
+    return [
+        WinnabilityFinding(
+            PROOF_ERROR_SHAPE,
+            f"`error_contract.shape` declares root key `{root_keys[0]}` but the blueprint's "
+            f'frozen envelope is `{{"error": {{"code", "message"}}}}` — the scaffold '
+            f"writes it and every probe asserts it, so a shape rooted elsewhere describes a "
+            f"body no response will ever carry. Declare the `error`-rooted envelope or omit "
+            f"the field.",
         )
     ]

--- a/src/squadops/prompts/request_templates/request.manifest_authoring_rules_appendix.md
+++ b/src/squadops/prompts/request_templates/request.manifest_authoring_rules_appendix.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.manifest_authoring_rules_appendix
-version: "1"
+version: "2"
 required_variables: []
 ---
 ## MANIFEST RULES (authoritative — a manifest that breaks one is rejected)
@@ -70,6 +70,15 @@ read as naming none.
 test suite is permitted to query, so a view with none is a view nothing can verify — and
 the suite will otherwise invent selectors from roles and visible text that the
 implementation never promised.
+
+**error-shape-is-the-blueprints** — If you declare `error_contract.shape`, it must be
+the blueprint's frozen envelope: rooted at `"error"`, i.e. `{"error": {"code", "message"}}`.
+The scaffold writes this envelope into frozen code and every probe asserts it — a shape
+rooted anywhere else (for example a framework default like `{"detail": "..."}`) describes a
+body no response will ever carry, and a developer who trusts your document will write error
+handling against a key that does not exist. Omitting the field entirely is fine; declaring
+the error codes and their HTTP statuses in `error_contract.codes` is the part that is
+genuinely yours to design.
 
 **name-the-source-prd** — Set `source_prd` to the requirements document this design derives
 from. A design with no stated source cannot be reviewed against its source; the reviewer is

--- a/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
+++ b/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
@@ -2,11 +2,11 @@
 # The frozen-spine record region enforcement verifies against; regenerate with
 # the generator, never hand-edit (a tampered record refuses to load).
 scaffold_manifest_version: 1
-generator_version: 4
+generator_version: 5
 stack: nextjs_ts
 interface_manifest_hash: ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a
 criteria_pack: nextjs_ts
-expanded_tree_hash: cfa66534e35c8f15344a3f13fc7257ce32b48be70b24f71a7e2a4a4dfaebbd08
+expanded_tree_hash: 80e5632052b4c43ce881383bb4058b0531b0252ea688992f5d7102bb35c5f90f
 aggregate_spine_hash: e8f2a59e1e64e3b2d77dc2a2d3aae018a88ba0648393491a6094325f9fba0414
 scaffold_hash: 69d29ab91f692bab9c3f4a2bd72910f39fe27b7ecfc7d41dd99a8bfb62b186f4
 files:

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -61,7 +61,7 @@ class TestInjection:
         scaffold = inputs["verification_scaffold"]
         assert len(scaffold["files"]) == 8
         assert scaffold["manifest"]["stack"] == "nextjs_ts"
-        assert scaffold["manifest"]["generator_version"] == 4
+        assert scaffold["manifest"]["generator_version"] == 5
 
     def test_an_unopted_stack_injects_nothing(self):
         manifest = manifest_for_stack("fullstack_fastapi_react")

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -932,22 +932,24 @@ class TestErrorSeamIsPerStack:
     """#912 — one shared text asserted stack #1's Python facts for every stack."""
 
     def test_each_stack_names_its_own_module_import_and_parameter(self):
-        """Bug caught: a nextjs_ts repair is told to edit `errors.py` and pass `message`.
+        """Bug caught: a nextjs_ts repair is told to edit `errors.py`.
 
-        The file is `lib/errors.ts` and the constructor parameter is `detail`. This is
-        the #902 class in a second location — a shared prompt surface stating one
-        stack's facts as universal — and it fires exactly when a repair is trying to fix
-        an error-envelope defect, which is what window rolls 2 and 3 were both doing.
-        """
+        The file is `lib/errors.ts`. This is the #902 class in a second location — a
+        shared prompt surface stating one stack's facts as universal — and it fires
+        exactly when a repair is trying to fix an error-envelope defect, which is what
+        window rolls 2 and 3 were both doing. The body field is `message` on BOTH
+        stacks since #795's reconciliation (the nextjs generator's `detail` was the
+        odd one out against stack #1 and the reference manifests); the per-stack seam
+        stays because module and import genuinely differ."""
         from squadops.capabilities.scaffold import error_seam_for
 
         fastapi = error_seam_for("fullstack_fastapi_react")
         nextjs = error_seam_for("nextjs_ts")
 
         assert (fastapi.module, fastapi.body_field) == ("errors.py", "message")
-        assert (nextjs.module, nextjs.body_field) == ("lib/errors.ts", "detail")
+        assert (nextjs.module, nextjs.body_field) == ("lib/errors.ts", "message")
         assert "@/lib/errors" in nextjs.import_form
-        assert "ApiError(code, detail)" == nextjs.raise_form
+        assert "ApiError(code, message)" == nextjs.raise_form
 
     def test_the_framework_exception_clause_is_named_only_where_one_exists(self):
         """Bug caught: generalizing the prohibition loses the name that made it work.
@@ -978,21 +980,22 @@ class TestErrorEnvelopeLines:
         lines = error_envelope_lines("nextjs_ts")
         joined = " ".join(lines)
 
-        assert '{"error": {"code": "validation_error", "detail": "..."}}' in joined
+        assert '{"error": {"code": "validation_error", "message": "..."}}' in joined
         assert "body.error.code" in joined
         assert "error_code" in joined  # the invented form, named as wrong
 
-    def test_each_stack_describes_its_own_envelope(self):
-        """Bug caught: one envelope described for both stacks.
+    def test_each_stack_describes_the_envelope_its_generator_emits(self):
+        """Bug caught: the brief describing a field the generator does not write.
 
-        They genuinely differ — stack #1 emits `message`, stack #2 emits `detail` — so a
-        single description would be wrong for one of them, which is the defect this
-        whole seam exists to stop.
-        """
+        The description renders from each stack's OWN seam declaration, so it tracks
+        the generator by construction. Since #795's reconciliation both stacks emit
+        `message` (nextjs's `detail` was the odd one out against stack #1 and the
+        reference manifests) — the per-stack seam machinery stays, because module and
+        import genuinely differ and a future stack MAY differ on the field again."""
         from squadops.capabilities.scaffold import error_envelope_lines
 
         assert '"message"' in " ".join(error_envelope_lines("fullstack_fastapi_react"))
-        assert '"detail"' in " ".join(error_envelope_lines("nextjs_ts"))
+        assert '"message"' in " ".join(error_envelope_lines("nextjs_ts"))
 
     def test_an_unknown_stack_says_nothing_rather_than_guessing(self):
         """A stack with no declared seam must produce no lines. A guessed envelope is

--- a/tests/unit/capabilities/test_stack_inventory.py
+++ b/tests/unit/capabilities/test_stack_inventory.py
@@ -541,7 +541,7 @@ def test_the_frozen_error_class_is_named_with_its_constructor():
         for line in scaffold.frozen_surface_index_lines(_manifest_for("nextjs_ts"))
         if "lib/errors.ts" in line
     )
-    assert "classes `ApiError(code: string, detail: string = '')`" in line
+    assert "classes `ApiError(code: string, message: string = '')`" in line
     assert "`errorResponse(err: unknown): Response`" in line, (
         "the catch-seam signature must publish the type that forbids bare-string calls"
     )

--- a/tests/unit/capabilities/test_verification_scaffold_reference.py
+++ b/tests/unit/capabilities/test_verification_scaffold_reference.py
@@ -43,14 +43,14 @@ _FIXTURE_DIR = (
 # self-contained evidence that the input end did not move.
 _MANIFEST_HASH = "ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a"
 
-# The fixture's own identity. Regenerated at GENERATOR_VERSION 4 (2026-08-17, #967 — the
-# spine now imports `TABLES`, the symbol the fill appendix teaches).
+# The fixture's own identity. Regenerated at GENERATOR_VERSION 5 (2026-08-21, #795 — the
+# nextjs error envelope's second field unified to `message`, reconciling the generator with
+# stack #1 and the reference manifests).
 #
-# BOTH VALUES MOVED THIS TIME, and the contrast with version 3 is the useful part. Version 3
-# typed the store and left both hashes untouched: the tree changed, the shells did not.
-# Version 4 changes the shells' own import line, so the spine hash moves — which is exactly
-# what a spine hash is for. The two versions together demonstrate the pins discriminating
-# rather than merely reacting.
+# Version 5 is the version-3 shape again: the SKELETON changed (lib/errors.ts), so
+# `expanded_tree_hash` moves in the emission record while the shells and the spine hash
+# stay untouched — the pins discriminating input drift from shell drift, exactly as the
+# version-3/version-4 contrast demonstrated.
 #
 # These stop an in-place fixture regeneration from making the byte test self-referential.
 _AGGREGATE_SPINE_HASH = "e8f2a59e1e64e3b2d77dc2a2d3aae018a88ba0648393491a6094325f9fba0414"
@@ -73,12 +73,12 @@ def test_the_reference_manifest_is_unmoved():
 def test_generator_version_is_the_fixture_generation(emission):
     """A generator change without a version bump is drift by definition (SIP §4.3);
     a bump without regenerating the fixture is a pin measuring the wrong version."""
-    assert GENERATOR_VERSION == 4
-    assert emission.manifest.generator_version == 4
+    assert GENERATOR_VERSION == 5
+    assert emission.manifest.generator_version == 5
     stored = yaml.safe_load(
         (_FIXTURE_DIR / "verification_scaffold_manifest.yaml").read_text(encoding="utf-8")
     )
-    assert stored["generator_version"] == 4
+    assert stored["generator_version"] == 5
 
 
 def test_emission_reproduces_the_fixture_byte_for_byte(emission):

--- a/tests/unit/cycles/test_manifest_gates.py
+++ b/tests/unit/cycles/test_manifest_gates.py
@@ -21,6 +21,7 @@ import yaml
 
 from squadops.cycles.manifest_gates import (
     PROOF_CONTRACT_DERIVES,
+    PROOF_ERROR_SHAPE,
     PROOF_EXPANDS,
     PROOF_PARSES,
     PROOF_STATUS_DECLARED,
@@ -77,6 +78,35 @@ def test_collection_post_without_success_status_is_unwinnable():
     detail = next(f.detail for f in findings if f.proof == PROOF_STATUS_DECLARED)
     assert "201" in detail and "200" in detail  # names both sides of the disagreement
     assert "success_status" in detail  # names the fix
+
+
+def test_v4_class_foreign_root_error_shape_is_unwinnable():
+    """#795 (V4 roll 1): `error_contract.shape: '{"detail": "string"}'` declared
+    FastAPI's default while the frozen envelope is error-rooted — a dev reading the
+    authored contract writes handling against a key no response carries, and every
+    gate passed because nothing compared them."""
+    data = _reference_dict()
+    data["api"]["error_contract"]["shape"] = '{"detail": "string"}'
+    findings = assess_winnability(_as_yaml(data))
+    assert PROOF_ERROR_SHAPE in _proofs(findings)
+    detail = next(f.detail for f in findings if f.proof == PROOF_ERROR_SHAPE)
+    assert "detail" in detail and "error" in detail
+
+
+def test_vague_but_true_error_shape_passes():
+    """Banked green manifests declare `{"error": "..."}` — under-specified, not
+    wrong. A rule that rejects the artifacts the evidence was measured against is
+    the wrong rule."""
+    data = _reference_dict()
+    data["api"]["error_contract"]["shape"] = '{"error": "..."}'
+    assert PROOF_ERROR_SHAPE not in _proofs(assess_winnability(_as_yaml(data)))
+
+
+def test_absent_error_shape_passes():
+    """The field is optional; silence defers to the blueprint's envelope."""
+    data = _reference_dict()
+    data["api"]["error_contract"].pop("shape", None)
+    assert PROOF_ERROR_SHAPE not in _proofs(assess_winnability(_as_yaml(data)))
 
 
 def test_child_post_without_success_status_is_fine():

--- a/tests/unit/cycles/test_scaffold_evidence.py
+++ b/tests/unit/cycles/test_scaffold_evidence.py
@@ -272,7 +272,7 @@ class TestSummary:
         )
         d = summary.to_dict()
         # the promotion model's fields (SIP §6/§12) — schema preserved, workflow not built
-        assert d["stack"] == "nextjs_ts" and d["generator_version"] == 4
+        assert d["stack"] == "nextjs_ts" and d["generator_version"] == 5
         assert d["shell_count"] == 8 and d["slot_count"] == 8
         assert d["fill_dispositions"] == {"filled": 1, "missing": 7}
         assert d["additive_test_count"] == 2


### PR DESCRIPTION
## Summary
Settles #795 per its own preferred resolution (the envelope is blueprint-owned) and thereby **unblocks #913** (shape pinning in shells needs one envelope truth):

- **Generator half:** nextjs `lib/errors.ts` unified on `message` — stack #1, the reference manifests, and authoring habit all said `message`; the nextjs generator's `detail` was the sole divergence (the ErrorSeam docstring carried this as an open confession). `ApiError` routes message through `super()` (no shadowing parameter property); the changed skeleton `tsc --noEmit`s clean in the real sandbox against a banked window manifest.
- **Gate half:** M2 winnability finding `error_shape_agrees` — a declared `error_contract.shape` must be `error`-rooted. Rejects exactly the V4-roll-1 class (`{"detail": "string"}`); deliberately root-only so banked green manifests (`{"error": "..."}`, vague-but-true) keep passing. Classified `AUTHOR_FACING` + taught in the manifest authoring-rules asset (v2).

## Rituals followed
- GENERATOR_VERSION 4 → 5, fixture regenerated, pins verified: shells and spine hash byte-identical, only `expanded_tree_hash` moved — the version-3 discrimination shape, noted in the pin comment.
- Both #686 drift guards (proof classification ↔ asset rules) fired during development and pass.
- Downstream pins updated deliberately: two `generator_version` literals, the #875 constructor surface.

## Tests
New: V4-class rejection, vague-shape pass, absent-shape pass. Updated: seam/envelope teaching pins to the unified truth. Full regression **7,644 passed**; sandbox tsc clean.

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApBek6CA1ibm3Cc5pq57F2