### PR TITLE
feat(scaffold): frozen-spine error-envelope pinning (#913)

### DIFF
--- a/src/squadops/capabilities/stack_nextjs_ts_tests.py
+++ b/src/squadops/capabilities/stack_nextjs_ts_tests.py
@@ -108,6 +108,11 @@ class _Behavior:
     final: _Step
     probe_id: str = ""
     prerequisites: tuple[_Step, ...] = field(default=())
+    #: #913: the error code the contract pins for this behavior ("" = none pinned).
+    #: When set, the frozen spine asserts `body.error?.code` — the response-field
+    #: path stops being re-invented in the fill, which is where window rolls 2/3
+    #: died (fills asserting `body.error_code` against the real `{error: {code}}`).
+    expect_error_code: str = ""
 
 
 def _fail_missing_surface(url_path: str, method: str, route_file: str, reason: str) -> None:
@@ -195,6 +200,7 @@ def _behaviors_from_probes(classified: list[tuple[str, dict]]) -> list[_Behavior
     for kind, probe in classified:
         request = probe["request"]
         expect = probe["expect"]["status"]
+        error_code = str(probe["expect"].get("error_code") or "")
         if kind == "create":
             creates_by_path[request["path"]] = probe
             label = f"{request['method']} {request['path']} -> {expect}"
@@ -216,6 +222,7 @@ def _behaviors_from_probes(classified: list[tuple[str, dict]]) -> list[_Behavior
                     expect_status=expect,
                     final=_final(probe),
                     probe_id=probe["id"],
+                    expect_error_code=error_code,
                 )
             )
         else:
@@ -235,6 +242,9 @@ def _behaviors_from_probes(classified: list[tuple[str, dict]]) -> list[_Behavior
                     final=_final(probe, param_expr="created.id"),
                     probe_id=probe["id"],
                     prerequisites=prerequisites,
+                    # A duplicate-conflict probe pins its code; a plain child success
+                    # pins none — the .get() above yields "" for it.
+                    expect_error_code=error_code,
                 )
             )
             if kind == "child":
@@ -388,6 +398,13 @@ def _shell_source(behavior: _Behavior, *, store_symbols: tuple[str, ...]) -> str
     lines += [
         f"    expect(res.status).toBe({behavior.expect_status})",
         "    const body: any = await res.json().catch(() => ({}))",
+    ]
+    if behavior.expect_error_code:
+        # #913: the envelope is frozen spine, not fill residue. The contract pins
+        # this code, the blueprint owns the shape (#795), and the field path is
+        # exactly what fills kept re-inventing (`body.error_code`, rolls 2/3/13/17).
+        lines.append(f"    expect(body.error?.code).toBe('{behavior.expect_error_code}')")
+    lines += [
         f"    {slot_begin_marker(slot_id)}",
         "    // FILL (qa): domain assertions for this behavior — response values and store",
         "    // effects beyond the declared status. `body` is the parsed response JSON.",

--- a/src/squadops/capabilities/verification_scaffold_emission.py
+++ b/src/squadops/capabilities/verification_scaffold_emission.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:  # pragma: no cover - annotations only
 #: Bump on ANY emission-affecting change (module docstring). Recorded in every manifest.
 #: 2 (#936) — the shell imports `all` alongside `reset`, so a fill can call the helper
 #: the appendix teaches without adding an import it is forbidden to add.
-GENERATOR_VERSION = 5
+GENERATOR_VERSION = 6
 
 #: The stored manifest artifact's filename (the executor persists it beside the contract).
 VERIFICATION_SCAFFOLD_MANIFEST_FILENAME = "verification_scaffold_manifest.yaml"

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-join-duplicate.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-join-duplicate.scaffold.test.ts
@@ -38,6 +38,7 @@ describe('scaffold: POST /api/runs/{run_id}/join', () => {
     )
     expect(res.status).toBe(409)
     const body: any = await res.json().catch(() => ({}))
+    expect(body.error?.code).toBe('duplicate_participant')
     // [scaffold-slot:begin slot-vc-probe-api-runs-join-duplicate]
     // FILL (qa): domain assertions for this behavior — response values and store
     // effects beyond the declared status. `body` is the parsed response JSON.

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-rejects-blank.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-rejects-blank.scaffold.test.ts
@@ -20,6 +20,7 @@ describe('scaffold: POST /api/runs', () => {
     )
     expect(res.status).toBe(422)
     const body: any = await res.json().catch(() => ({}))
+    expect(body.error?.code).toBe('validation_error')
     // [scaffold-slot:begin slot-vc-probe-api-runs-rejects-blank]
     // FILL (qa): domain assertions for this behavior — response values and store
     // effects beyond the declared status. `body` is the parsed response JSON.

--- a/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
+++ b/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
@@ -2,13 +2,13 @@
 # The frozen-spine record region enforcement verifies against; regenerate with
 # the generator, never hand-edit (a tampered record refuses to load).
 scaffold_manifest_version: 1
-generator_version: 5
+generator_version: 6
 stack: nextjs_ts
 interface_manifest_hash: ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a
 criteria_pack: nextjs_ts
 expanded_tree_hash: 80e5632052b4c43ce881383bb4058b0531b0252ea688992f5d7102bb35c5f90f
-aggregate_spine_hash: e8f2a59e1e64e3b2d77dc2a2d3aae018a88ba0648393491a6094325f9fba0414
-scaffold_hash: 69d29ab91f692bab9c3f4a2bd72910f39fe27b7ecfc7d41dd99a8bfb62b186f4
+aggregate_spine_hash: 3b62a339ff2489f65285e0cc780c6fdf97cd794bbfafecf9f143621cae69b0d1
+scaffold_hash: 395a08bc5a78e2333d21c3af6b89981a9551558d191b3db1b87dc84b251ced00
 files:
 - path: __tests__/scaffold/vc-probe-api-runs.scaffold.test.ts
   content_hash: 9245b8442a684f32bfbb7605185a72274b13afa748eb02ccee80fbe559d21d31
@@ -22,16 +22,16 @@ files:
     begin_line: 23
     end_line: 27
 - path: __tests__/scaffold/vc-probe-api-runs-rejects-blank.scaffold.test.ts
-  content_hash: c51841d227904da82466e19e6344a4648acb644c248f0dd7eb7895c1b21a47a2
-  spine_hash: f30001086a79480dfd66c893e642e954ce8b6d199c44a4c3cb8687a91b7595a8
+  content_hash: 314fe36bceec5d13df33d235a0e8495525f3bdd517fab214dffda82f29882958
+  spine_hash: 5004d630e6996fe8b2d79265a1879515b8fedd88a1c9f6b9f66d2f021b0495d6
   slots:
   - slot_id: slot-vc-probe-api-runs-rejects-blank
     behavior: POST /api/runs blank required fields -> 422
     probe_id: vc-probe-api-runs-rejects-blank
     criterion_ids:
     - vc-probe-api-runs-rejects-blank
-    begin_line: 23
-    end_line: 27
+    begin_line: 24
+    end_line: 28
 - path: __tests__/scaffold/vc-probe-api-runs-join.scaffold.test.ts
   content_hash: 14f4115aad1800f4a0950a14daf4531c266467722c5ba2d4d7ed959bad19e4a6
   spine_hash: edbc25e16cbb7cde2a492d20d57df3f0fb1a17749db62ee56fb0ffe4bb8d7c60
@@ -44,16 +44,16 @@ files:
     begin_line: 33
     end_line: 37
 - path: __tests__/scaffold/vc-probe-api-runs-join-duplicate.scaffold.test.ts
-  content_hash: cb5ff626a6626db628fb89568d2e6965daafb090b3af5ab152738a21d3bc0490
-  spine_hash: b69a3a8ee4d67352b3332c63f6c28892e274bbfac1d5a8cf1f0f6e21f56c9252
+  content_hash: 281e6a9c7ee7b276d40fbbc0a3c1948539be811e3de15a93c9b59e9ed150772e
+  spine_hash: 817c40b5db71172d489dcc03fe8cf33cdf4e27c5749928f60b57ad1242d32cd1
   slots:
   - slot_id: slot-vc-probe-api-runs-join-duplicate
     behavior: POST /api/runs/{run_id}/join duplicate -> 409
     probe_id: vc-probe-api-runs-join-duplicate
     criterion_ids:
     - vc-probe-api-runs-join-duplicate
-    begin_line: 41
-    end_line: 45
+    begin_line: 42
+    end_line: 46
 - path: __tests__/scaffold/vc-probe-api-runs-leave.scaffold.test.ts
   content_hash: 84754c4f511e27029c5534f75e08a3f5d7113adf855c758ef57514d30a2dcda8
   spine_hash: c391a7da2fd66226664154805762332d6cf1d4cb5795bc2047aaceeed53aa9b8

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -61,7 +61,7 @@ class TestInjection:
         scaffold = inputs["verification_scaffold"]
         assert len(scaffold["files"]) == 8
         assert scaffold["manifest"]["stack"] == "nextjs_ts"
-        assert scaffold["manifest"]["generator_version"] == 5
+        assert scaffold["manifest"]["generator_version"] == 6
 
     def test_an_unopted_stack_injects_nothing(self):
         manifest = manifest_for_stack("fullstack_fastapi_react")

--- a/tests/unit/capabilities/test_verification_scaffold_emission.py
+++ b/tests/unit/capabilities/test_verification_scaffold_emission.py
@@ -114,6 +114,45 @@ class TestInventory:
         assert "__tests__/scaffold/vs-get-api-runs-run-id-not-found.scaffold.test.ts" not in names
 
 
+class TestEnvelopePinning:
+    """#913: behaviors whose contract pins an error code assert the envelope in the
+    FROZEN spine — the response-field path stops being fill residue. Window rolls
+    2/3 (and 13/17 before them) died on fills asserting `body.error_code` against
+    the real `{error: {code}}`; the shell now owns that byte."""
+
+    def test_rejection_and_duplicate_shells_pin_the_contract_code(self, emission):
+        """The bug this catches: the code the contract pins never reaching the
+        spine, leaving the field path to the fill's invention."""
+        pinned = {}
+        for f in emission.files:
+            name = f["name"].rsplit("/", 1)[-1]
+            if "rejects-blank" in name or "duplicate" in name:
+                lines = [ln.strip() for ln in f["content"].splitlines() if "body.error?.code" in ln]
+                pinned[name] = lines
+        assert len(pinned) == 2
+        for name, lines in pinned.items():
+            assert len(lines) == 1, f"{name}: expected exactly one frozen envelope assertion"
+            assert lines[0].startswith("expect(body.error?.code).toBe(")
+
+    def test_the_assertion_is_spine_not_slot(self, emission):
+        """Frozen means BEFORE the slot markers — an assertion inside the slot is
+        fill residue again, deletable by the next re-author."""
+        for f in emission.files:
+            content = f["content"]
+            if "body.error?.code" not in content:
+                continue
+            assert content.index("body.error?.code") < content.index("scaffold-slot:begin")
+
+    def test_success_shells_pin_no_envelope(self, emission):
+        """A success body has no error envelope — asserting one there would fail
+        every correct app (the false-positive direction the gate must never take)."""
+        for f in emission.files:
+            name = f["name"].rsplit("/", 1)[-1]
+            if "rejects-blank" in name or "duplicate" in name or "not-found" in name:
+                continue
+            assert "body.error" not in f["content"], name
+
+
 class TestManifestRecord:
     def test_record_carries_the_attribution_facts(self, nextjs_manifest, emission):
         record = emission.manifest

--- a/tests/unit/capabilities/test_verification_scaffold_reference.py
+++ b/tests/unit/capabilities/test_verification_scaffold_reference.py
@@ -43,18 +43,17 @@ _FIXTURE_DIR = (
 # self-contained evidence that the input end did not move.
 _MANIFEST_HASH = "ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a"
 
-# The fixture's own identity. Regenerated at GENERATOR_VERSION 5 (2026-08-21, #795 — the
-# nextjs error envelope's second field unified to `message`, reconciling the generator with
-# stack #1 and the reference manifests).
+# The fixture's own identity. Regenerated at GENERATOR_VERSION 6 (2026-08-21, #913 — the
+# frozen spine now asserts `body.error?.code` for behaviors whose contract pins a code:
+# the response-field path stops being fill residue, which is where rolls 2/3/13/17 died).
 #
-# Version 5 is the version-3 shape again: the SKELETON changed (lib/errors.ts), so
-# `expanded_tree_hash` moves in the emission record while the shells and the spine hash
-# stay untouched — the pins discriminating input drift from shell drift, exactly as the
-# version-3/version-4 contrast demonstrated.
+# Version 6 is the version-4 shape: the SHELLS changed, so the spine hash moves — and the
+# rejection/duplicate shells differ from their siblings, which is the pin discriminating
+# per-behavior emission, not merely reacting to any edit.
 #
 # These stop an in-place fixture regeneration from making the byte test self-referential.
-_AGGREGATE_SPINE_HASH = "e8f2a59e1e64e3b2d77dc2a2d3aae018a88ba0648393491a6094325f9fba0414"
-_SCAFFOLD_HASH = "69d29ab91f692bab9c3f4a2bd72910f39fe27b7ecfc7d41dd99a8bfb62b186f4"
+_AGGREGATE_SPINE_HASH = "3b62a339ff2489f65285e0cc780c6fdf97cd794bbfafecf9f143621cae69b0d1"
+_SCAFFOLD_HASH = "395a08bc5a78e2333d21c3af6b89981a9551558d191b3db1b87dc84b251ced00"
 
 
 @pytest.fixture(scope="module")
@@ -73,12 +72,12 @@ def test_the_reference_manifest_is_unmoved():
 def test_generator_version_is_the_fixture_generation(emission):
     """A generator change without a version bump is drift by definition (SIP §4.3);
     a bump without regenerating the fixture is a pin measuring the wrong version."""
-    assert GENERATOR_VERSION == 5
-    assert emission.manifest.generator_version == 5
+    assert GENERATOR_VERSION == 6
+    assert emission.manifest.generator_version == 6
     stored = yaml.safe_load(
         (_FIXTURE_DIR / "verification_scaffold_manifest.yaml").read_text(encoding="utf-8")
     )
-    assert stored["generator_version"] == 5
+    assert stored["generator_version"] == 6
 
 
 def test_emission_reproduces_the_fixture_byte_for_byte(emission):

--- a/tests/unit/cycles/test_scaffold_evidence.py
+++ b/tests/unit/cycles/test_scaffold_evidence.py
@@ -272,7 +272,7 @@ class TestSummary:
         )
         d = summary.to_dict()
         # the promotion model's fields (SIP §6/§12) — schema preserved, workflow not built
-        assert d["stack"] == "nextjs_ts" and d["generator_version"] == 5
+        assert d["stack"] == "nextjs_ts" and d["generator_version"] == 6
         assert d["shell_count"] == 8 and d["slot_count"] == 8
         assert d["fill_dispositions"] == {"filled": 1, "missing": 7}
         assert d["additive_test_count"] == 2


### PR DESCRIPTION
## Summary
The shells now own the response-field path for error behaviors: where the derived contract pins a code, the frozen spine asserts `body.error?.code` before the fill slot. Closes the last named boilerplate category SIP-0104's §"Why now" lists (imports, call shapes, placement, **response-field paths**) — the one rolls 2/3/13/17 all died re-inventing. Unblocked by #795's envelope-authority settlement (merged as #1027).

## Verification, three layers
- **Unit**: pinned code present exactly once in rejection/duplicate shells; placement is spine-not-slot (an assertion inside the slot is deletable fill residue again); success shells pin nothing.
- **Ritual**: GENERATOR_VERSION 5→6, fixture regenerated, pins updated — the version-4 shape (shells moved, spine hash moved, and the two pinned shells now differ from siblings, so the pin discriminates per-behavior emission).
- **Behavioral, in the sandbox against banked artifacts**: fresh v6 shells vs slot 5's green app → 9/9 pass (no false rejection — deliberately envelope-second-field-agnostic, so even the detail-era app passes); `lib/errors.ts` mutated to the invented `{error_code}` form → exactly the two pinned shells fail, siblings green.

## Not in this PR
Success-body shape pinning (today's shakedown killer: participants objects-vs-strings) — feasible (entities carry typed fields) but its own derivation design; sizing next.

Full regression 7,647 passed.

Closes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApBek6CA1ibm3Cc5pq57F2