### PR TITLE
fix(cycles): framing_max_rerolls defaults to 2 (#1030)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -631,10 +631,17 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             )
         # #522: framing re-rolls on a system plan-validation rejection. `while`
         # (not `for`) so a re-roll can re-process the SAME workload index — the
-        # re-roll path `continue`s without the tail `i += 1`. Zero re-rolls
-        # (default) is byte-identical to the old `for` loop.
+        # re-roll path `continue`s without the tail `i += 1`.
+        #
+        # #1030: the default is 2, matching `manifest_max_attempts`'s posture — a
+        # system rejection is a stochastic authoring fault that gets bounded
+        # retries BY DEFAULT. It shipped as 0, which no profile overrode, so the
+        # whole #522/#669 machinery (including rejection-context threading into
+        # the re-authoring prompts) was dead code until the first live #1013
+        # rejection dead-ended cyc_9bb225e19448 after a CORRECT refusal. The
+        # knob stays config-overridable; 0 still disables deliberately.
         framing_rerolls = 0
-        max_framing_rerolls = cycle.resolved_config().get("framing_max_rerolls", 0)
+        max_framing_rerolls = int(cycle.resolved_config().get("framing_max_rerolls", 2))
         # #811: operator-requested revisions are counted SEPARATELY from system re-rolls and
         # bounded by ``manifest_max_attempts`` (§5c.6), not ``framing_max_rerolls``. The
         # latter defaults to 0 and the validated profiles do not set it, so sharing it would

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -1405,6 +1405,10 @@ class TestInterWorkloadGatePlanValidation:
             applied_defaults={
                 **cycle.applied_defaults,
                 "implementation_plan": True,
+                # #1030: this class tests the rejection RECORD in isolation; the
+                # re-roll (now on by default) has its own class — disable it here
+                # so a rejection terminates and the record is the last word.
+                "framing_max_rerolls": 0,
             },
         )
 
@@ -1953,6 +1957,42 @@ class TestFramingReroll:
             "implementation",
         ]
 
+    async def test_reroll_is_reachable_under_default_config(
+        self, executor, mock_registry, mock_event_bus
+    ):
+        """#1030: the re-roll branch must fire with NO profile override.
+
+        Every test in this class passed `framing_max_rerolls: 1` explicitly, so
+        the shipped default of 0 — which no profile overrode — left the whole
+        #522/#669 machinery dead code, discovered when the first live #1013
+        rejection dead-ended cyc_9bb225e19448 after a CORRECT refusal. This test
+        pins the default itself: a system rejection under default resolved
+        config re-rolls instead of killing the cycle."""
+        cycle = _make_cycle(workload_sequence=self._seq())  # deliberately no reroll override
+        mock_registry.get_cycle.return_value = cycle
+        run1 = _make_run("run_001", 1, "completed", "framing")
+        run2 = _make_run("run_002", 2, "completed", "framing")
+        run3 = _make_run("run_003", 3, "completed", "implementation")
+        mock_registry.get_run.side_effect = [run1, run2, run3]
+        mock_registry.list_runs.return_value = [run1]
+        executor._reject_invalid_plan_before_workload_gate = AsyncMock(
+            side_effect=[["manifest↔plan contradiction on POST /x"], []]
+        )
+        executor._create_next_workload_run = AsyncMock(side_effect=[run2, run3])
+        executor._poll_inter_workload_gate = AsyncMock(
+            return_value=_gate_decision("progress_plan_review", GateDecisionValue.APPROVED)
+        )
+
+        await executor.execute_cycle("cyc_001", "run_001")
+
+        # The re-roll happened (framing created again), then implementation ran —
+        # the cycle did NOT dead-end at the rejection.
+        assert [c.args[2]["type"] for c in executor._create_next_workload_run.await_args_list] == [
+            "framing",
+            "implementation",
+        ]
+        mock_registry.cancel_run.assert_awaited_once_with("run_001")
+
     async def test_reroll_forwards_rejection_context(self, executor, mock_registry, mock_event_bus):
         """#669: the re-roll's execute_run must receive the prior rejection
         (reasons + rejected plan YAML) on the §6.6 forwarding rail — fay-10
@@ -2056,12 +2096,15 @@ class TestFramingReroll:
         assert executor._create_next_workload_run.await_count == 1  # only the re-roll
         executor._poll_inter_workload_gate.assert_not_awaited()
 
-    async def test_default_zero_rerolls_is_unchanged_behavior(
+    async def test_explicit_zero_disables_rerolls_deliberately(
         self, executor, mock_registry, mock_event_bus
     ):
-        # no framing_max_rerolls set -> default 0 -> first rejection kills the
-        # cycle exactly as before (no cancel, no re-roll)
-        cycle = _make_cycle(workload_sequence=self._seq())
+        # #1030 flipped the default to 2 (the unset default silently disabled the
+        # whole machinery). Zero remains the DELIBERATE off-switch: set
+        # explicitly, the first rejection stops the cycle (no cancel, no re-roll).
+        cycle = _make_cycle(
+            workload_sequence=self._seq(), applied_defaults_extra={"framing_max_rerolls": 0}
+        )
         mock_registry.get_cycle.return_value = cycle
         run1 = _make_run("run_001", 1, "completed", "framing")
         mock_registry.get_run.side_effect = [run1]


### PR DESCRIPTION
## Summary
- The #522/#669 re-roll machinery is on by default (2, matching `manifest_max_attempts`'s posture); explicit `0` remains the deliberate disable. The shipped default of 0 — never overridden by any profile — left the machinery dead code until the first live #1013 rejection dead-ended a cycle after a *correct* refusal (`cyc_9bb225e19448`, the banked reproducer; the overridden relaunch converged green end-to-end).
- **Reachability test added**: the re-roll branch must fire under *default* resolved config — every existing test in the class passed the knob explicitly, which is precisely how the gap survived them. The old default-zero pin is converted to an explicit-disable pin; the rejection-record test class is isolated with explicit 0 so it keeps testing the record in isolation.

Full regression 7,648 passed.

Closes #1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApBek6CA1ibm3Cc5pq57F2