### PR TITLE
fix(scripts): regression-gate preflight + positive completion evidence (#972)

### DIFF
--- a/scripts/dev/run_regression_tests.sh
+++ b/scripts/dev/run_regression_tests.sh
@@ -11,6 +11,18 @@
 
 set -euo pipefail
 
+# --- #972: tool preflight — fail LOUDLY with the likely cause, first thing. ---
+# A bare "ruff: command not found" buried mid-scroll reads as noise, and a
+# caller piping output (| tail) masks the exit code entirely — at the v1.6.0
+# cut that combination produced a green-looking run in which no gate executed.
+# One clear line, before anything else runs.
+for _tool in ruff pytest python; do
+  if ! command -v "$_tool" >/dev/null 2>&1; then
+    echo "ERROR: '$_tool' not found — activate the virtualenv first: source .venv/bin/activate" >&2
+    exit 127
+  fi
+done
+
 REGRESSION_DIRS=(
     "tests/unit/api/"
     "tests/unit/tasks/"
@@ -55,3 +67,10 @@ echo ""
 # isolation-clean under parallel workers (verified ~4460 tests green). Pass
 # `-n 0` via "$@" to force serial when debugging a single test.
 pytest -n auto "${REGRESSION_DIRS[@]}" "$@"
+
+# #972: positive completion evidence — pipes can mask exit codes at the caller,
+# but a MISSING final line is visible in any scrollback. Printed only when every
+# gate above actually ran and passed (set -e guarantees we cannot reach here
+# otherwise).
+echo ""
+echo "ALL GATES PASSED (ruff check, ruff format, test-quality lint, pytest)"

--- a/tests/unit/scripts/test_run_regression_preflight.py
+++ b/tests/unit/scripts/test_run_regression_preflight.py
@@ -1,0 +1,38 @@
+"""#972: the regression script's tool preflight.
+
+The defect class: a fail-stop gate whose failure is a bare "command not found"
+mid-scroll, combined with a caller piping output (which masks the exit code),
+reads as a green run in which no gate executed — observed at the v1.6.0 cut.
+The preflight makes the failure one loud line, first, with the cause named.
+"""
+
+import subprocess
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "dev" / "run_regression_tests.sh"
+
+
+def test_missing_tool_fails_loudly_with_the_venv_hint():
+    """Bug caught: no venv → bare 'ruff: command not found' buried in output.
+    The preflight must exit 127 before ANY gate output, naming the fix."""
+    result = subprocess.run(
+        ["bash", str(_SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={"HOME": "/tmp", "PATH": "/usr/bin:/bin"},  # no venv on PATH
+        timeout=30,
+    )
+    assert result.returncode == 127
+    assert "activate the virtualenv" in result.stderr
+    assert "source .venv/bin/activate" in result.stderr
+    # Preflight fires BEFORE the gates — no gate banner may have printed.
+    assert "Running ruff lint" not in result.stdout
+
+
+def test_completion_line_is_declared_only_after_the_last_gate():
+    """The positive-evidence line must be the script's final act — a completion
+    line printed before pytest would defeat its purpose (scrollback would show
+    it even when the suite never ran)."""
+    text = _SCRIPT.read_text(encoding="utf-8")
+    assert "ALL GATES PASSED" in text
+    assert text.index("ALL GATES PASSED") > text.index("pytest -n auto")


### PR DESCRIPTION
## Summary
Adjudication first: the script already exits 127 on a missing tool (`set -e`) — the observed exit-0 runs (the issue's and the one at the v1.6.0 cut) were **caller-side pipe masking**. So the fix targets evidence, not exit codes:
- **Preflight**: `ruff`/`pytest`/`python` checked first; a miss is one loud stderr line naming the fix (`source .venv/bin/activate`), before any gate banner.
- **Positive completion line**: `ALL GATES PASSED (…)` as the script's final act — masked exit codes can fake nothing when the *absence* of the line is visible in scrollback.

## Tests
Missing-tool run → 127 + hint + no gate banner ever printed; the completion line is asserted to be declared after the final gate. Full regression green (now ending with the line).

Closes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApBek6CA1ibm3Cc5pq57F2