### PR TITLE
fix(cycles): retry after a failed run — typed workload-position resolution (#880)

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -984,21 +984,66 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             )
             i += 1
 
-    async def _starting_workload_index(self, cycle_id: str, first_run_id: str) -> int:
-        """Workload-sequence index that ``first_run_id`` occupies (#257).
+    @staticmethod
+    def _typed_workload_position(run, workload_sequence, non_cancelled) -> int | None:
+        """#880: a run's own ``workload_type`` is authoritative for its position.
 
-        Runs map positionally to workloads — one run per position, created in
-        sequence order (D14) — so a run's index among the cycle's non-cancelled
-        runs (sorted by run_number) is its workload position. This lets
-        execute_cycle resume mid-sequence without re-running earlier completed
-        workloads or double-executing the resumed run. Returns 0 when the run is
-        the first/only one (the cycle-create entry) or is not found.
+        The purely positional map (D14) counts FAILED runs, so a failed
+        implementation occupies its slot forever and a retry run indexes past
+        the sequence end — sitting ``queued`` with no error, no log, no
+        terminal state (roll 14, `run_ae48ceb8d12d`). The run record has
+        carried its workload_type since #433; resolving from it makes a
+        retry-after-failure map to the SAME position as the run it retries.
+
+        Repeated types are disambiguated by ordinal (this run's rank among
+        non-cancelled runs of its type), clamped to the type's last occurrence
+        — which is exactly the retry case: two implementation runs, one
+        sequence slot, both map to it. ``None`` = no typed answer (legacy run
+        or no sequence); the caller falls back to the positional map.
+        """
+        wt = getattr(run, "workload_type", None)
+        if not wt or not isinstance(workload_sequence, list) or not workload_sequence:
+            return None
+        occurrences = [
+            i
+            for i, entry in enumerate(workload_sequence)
+            if isinstance(entry, dict) and entry.get("type") == wt
+        ]
+        if not occurrences:
+            return None
+        ordinal = sum(
+            1
+            for r in non_cancelled
+            if getattr(r, "workload_type", None) == wt and r.run_number <= run.run_number
+        )
+        return occurrences[min(max(ordinal, 1), len(occurrences)) - 1]
+
+    async def _starting_workload_index(self, cycle_id: str, first_run_id: str) -> int:
+        """Workload-sequence index that ``first_run_id`` occupies (#257, #880).
+
+        Typed resolution first: the run's own ``workload_type`` selects its
+        sequence position (see ``_typed_workload_position`` — the #880 fix, so
+        a failed predecessor no longer displaces a retry past the sequence
+        end). Legacy runs without a type keep the positional map — one run per
+        position among non-cancelled runs sorted by run_number (D14). Returns
+        0 when the run is the first/only one (the cycle-create entry) or is
+        not found.
         """
         all_runs = await self._cycle_registry.list_runs(cycle_id)
         non_cancelled = sorted(
             (r for r in all_runs if r.status != RunStatus.CANCELLED.value),
             key=lambda r: r.run_number,
         )
+        target = next((r for r in non_cancelled if r.run_id == first_run_id), None)
+        if target is not None and getattr(target, "workload_type", None):
+            try:
+                cycle = await self._cycle_registry.get_cycle(cycle_id)
+                sequence = cycle.resolved_config().get("workload_sequence", [])
+            except Exception:
+                sequence = []
+            typed = self._typed_workload_position(target, sequence, non_cancelled)
+            if typed is not None:
+                return typed
         for index, run in enumerate(non_cancelled):
             if run.run_id == first_run_id:
                 return index
@@ -1049,23 +1094,27 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             key=lambda r: r.run_number,
         )
         prior_position = start_index - 1
-        if prior_position >= len(non_cancelled):
+        # #880: prior = the last COMPLETED run AT the preceding position, resolved
+        # the same way run positions are (typed first, positional for legacy).
+        # The bare positional pick chose whatever run sat at index start_index-1 —
+        # on the retry-after-failure shape that was the FAILED implementation, so
+        # forwarding degraded and the retry entered without the framing's promoted
+        # plan (the #796/RC-4 shape, runtime-api log 2026-08-13 00:01:11).
+        sequence = cycle.resolved_config().get("workload_sequence", [])
+        candidates = []
+        for idx, r in enumerate(non_cancelled):
+            typed = self._typed_workload_position(r, sequence, non_cancelled)
+            position = typed if typed is not None else idx
+            if position == prior_position and r.status == RunStatus.COMPLETED.value:
+                candidates.append(r)
+        if not candidates:
             logger.warning(
-                "Cannot rebuild forwarding for cycle %s: no run at workload position %d",
+                "Cannot rebuild forwarding for cycle %s: no completed run at workload position %d",
                 cycle_id,
                 prior_position,
             )
             return None
-        prior_run = non_cancelled[prior_position]
-        if prior_run.status != RunStatus.COMPLETED.value:
-            logger.warning(
-                "Cannot rebuild forwarding for cycle %s: prior workload run %s is %r,"
-                " not completed",
-                cycle_id,
-                prior_run.run_id,
-                prior_run.status,
-            )
-            return None
+        prior_run = max(candidates, key=lambda r: r.run_number)
         return await self._build_forwarding_overrides(cycle, prior_run)
 
     async def _build_forwarding_overrides(

--- a/src/squadops/api/routes/cycles/runs.py
+++ b/src/squadops/api/routes/cycles/runs.py
@@ -61,11 +61,23 @@ def _resolve_retry_workload_type(cycle: Cycle, existing_runs: list[Run]) -> str 
     non_cancelled = [r for r in existing_runs if r.status != RunStatus.CANCELLED.value]
     position = len(non_cancelled)
     if position >= len(workload_sequence):
+        # #880: the overflow IS the natural retry — a failed run still occupies
+        # its slot, so a fresh attempt at the SAME position lands one past the
+        # end. Resolve to the latest non-cancelled run's own workload_type (the
+        # executor maps typed runs to their type's position, so both runs share
+        # the slot). The old error's advice was a closed loop: cancelling a
+        # terminal run is refused by design, and the run this creates would
+        # have sat queued forever regardless.
+        latest = max(non_cancelled, key=lambda r: r.run_number, default=None)
+        latest_type = getattr(latest, "workload_type", None) if latest else None
+        if latest_type:
+            return latest_type
         raise ValidationError(
             f"Cannot resolve workload_type for retry: the new run would occupy "
             f"position {position} but workload_sequence has {len(workload_sequence)} "
-            f"entries. Cancel the run being retried first, or pass workload_type "
-            f"explicitly."
+            f"entries, and the latest run carries no workload_type to re-attempt. "
+            f"Pass workload_type explicitly — or use `runs resume` to re-run the "
+            f"failed run in place from its checkpoint."
         )
     return workload_sequence[position]["type"]
 

--- a/tests/unit/api/test_workload_canon_api.py
+++ b/tests/unit/api/test_workload_canon_api.py
@@ -252,19 +252,40 @@ class TestCreateRunPositionalResolution:
         assert resp.status_code == 200
         assert resp.json()["workload_type"] == "framing"
 
-    def test_out_of_bounds_position_rejected(self, client, mock_cycle_registry):
-        # Sequence exhausted: rejecting beats a silent None-typed run (the
-        # legacy plan shape + no artifact seeding).
+    def test_retry_after_failure_resolves_to_the_failed_runs_workload(
+        self, client, mock_cycle_registry
+    ):
+        # #880: sequence "exhausted" by a FAILED run occupying its slot is the
+        # natural retry, not an error — the new run re-attempts the latest
+        # run's own workload at the same position. This exact fixture used to
+        # 422 with advice that dead-ended both ways (cancelling a terminal run
+        # is refused; the created run sat queued forever).
         mock_cycle_registry.get_cycle.return_value = _MULTI_WORKLOAD_CYCLE
         mock_cycle_registry.list_runs.return_value = [
             _existing_run(1, "completed", "framing"),
             _existing_run(2, "failed", "implementation"),
         ]
         resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs")
+        assert resp.status_code == 200
+        assert resp.json()["workload_type"] == "implementation"
+
+    def test_out_of_bounds_with_untyped_latest_run_still_rejected(
+        self, client, mock_cycle_registry
+    ):
+        # Sequence exhausted AND the latest run carries no workload_type
+        # (legacy): rejecting still beats a silent None-typed run — and the
+        # message no longer advertises the cancel path #522 refuses.
+        mock_cycle_registry.get_cycle.return_value = _MULTI_WORKLOAD_CYCLE
+        mock_cycle_registry.list_runs.return_value = [
+            _existing_run(1, "completed", "framing"),
+            _existing_run(2, "failed", None),
+        ]
+        resp = client.post("/api/v1/projects/hello_squad/cycles/cyc_001/runs")
         assert resp.status_code == 422
         error = resp.json()["detail"]["error"]
         assert error["code"] == "VALIDATION_ERROR"
-        assert "Cancel the run being retried" in error["message"]
+        assert "Cancel the run" not in error["message"]
+        assert "runs resume" in error["message"]
 
     def test_explicit_workload_type_bypasses_resolution(self, client, mock_cycle_registry):
         # Same exhausted-sequence state as above: an explicit param must win.

--- a/tests/unit/cycles/test_execute_cycle.py
+++ b/tests/unit/cycles/test_execute_cycle.py
@@ -293,6 +293,33 @@ class TestStartingWorkloadIndex:
         assert await ex._starting_workload_index("cyc_001", "run_002") == 0
         assert await ex._starting_workload_index("cyc_001", "run_003") == 1
 
+    async def test_retry_after_failed_run_resolves_to_the_same_position(self, mock_registry):
+        """#880 (roll 14, run_ae48ceb8d12d): a failed implementation occupied its
+        slot, so the retry indexed past the 2-entry sequence and sat queued
+        forever with no error. Typed resolution maps both runs to position 1."""
+        cycle = _make_cycle(workload_sequence=[{"type": "framing"}, {"type": "implementation"}])
+        mock_registry.get_cycle.return_value = cycle
+        mock_registry.list_runs.return_value = [
+            _make_run("run_001", 1, "completed", "framing"),
+            _make_run("run_002", 2, "failed", "implementation"),
+            _make_run("run_003", 3, "queued", "implementation"),  # the retry
+        ]
+        ex = self._bare_executor(mock_registry)
+        assert await ex._starting_workload_index("cyc_001", "run_003") == 1
+        assert await ex._starting_workload_index("cyc_001", "run_002") == 1
+        assert await ex._starting_workload_index("cyc_001", "run_001") == 0
+
+    async def test_untyped_runs_keep_the_positional_map(self, mock_registry):
+        """Legacy runs without workload_type must resolve exactly as before —
+        the typed path is additive, never a behavior change for old cycles."""
+        mock_registry.list_runs.return_value = [
+            _make_run("run_001", 1, "completed", None),
+            _make_run("run_002", 2, "failed", None),
+            _make_run("run_003", 3, "queued", None),
+        ]
+        ex = self._bare_executor(mock_registry)
+        assert await ex._starting_workload_index("cyc_001", "run_003") == 2
+
     async def test_unknown_run_defaults_to_zero(self, mock_registry):
         """A run not among the cycle's runs falls back to the start (index 0)."""
         mock_registry.list_runs.return_value = [_make_run("run_001", 1, "completed")]
@@ -429,20 +456,48 @@ class TestForwardingRebuildOnEntry:
         assert executor.execute_run.call_args_list[0][1]["forwarding_overrides"] is None
         executor._artifact_vault.list_artifacts.assert_not_awaited()
 
+    async def test_retry_forwarding_skips_the_failed_run_at_its_own_position(
+        self, executor, mock_registry
+    ):
+        """#880 refusal 2: the bare positional prior pick landed on the FAILED
+        implementation ("prior workload run … is 'failed', not completed" —
+        runtime-api 2026-08-13 00:01:11) and forwarding degraded, so the retry
+        entered without the framing's promoted plan. The prior is now the last
+        COMPLETED run at the preceding POSITION — the framing, past the failed
+        sibling."""
+        cycle = _make_cycle(workload_sequence=[{"type": "framing"}, {"type": "implementation"}])
+        framing = _make_run("run_001", 1, "completed", "framing")
+        failed_impl = _make_run("run_002", 2, "failed", "implementation")
+        mock_registry.list_runs.return_value = [
+            framing,
+            failed_impl,
+            _make_run("run_003", 3, "queued", "implementation"),
+        ]
+        executor._build_forwarding_overrides = AsyncMock(return_value={"k": "v"})
+
+        result = await executor._rebuild_forwarding_overrides_on_entry(cycle, "cyc_001", 1)
+
+        assert result == {"k": "v"}
+        prior = executor._build_forwarding_overrides.await_args.args[1]
+        assert prior.run_id == "run_001"  # the framing, not the failed impl
+
     async def test_missing_prior_run_degrades_to_no_forwarding(self, executor, mock_registry):
         # Defensive: an index pointing past the known runs (registry drift)
-        # must degrade, not IndexError inside the orchestration loop.
+        # must degrade, not IndexError inside the orchestration loop. #880: the
+        # prior is now "last COMPLETED run at the position" — a FAILED run at
+        # the prior position is exactly the no-usable-prior case, so it also
+        # pins that a failed prior never feeds forwarding (the RC-4 shape).
         cycle = _make_cycle(workload_sequence=[{"type": "framing"}, {"type": "implementation"}])
         mock_registry.get_cycle.return_value = cycle
-        run2 = _make_run("run_002", 2, "completed", "implementation")
+        run2 = _make_run("run_002", 2, "failed", "implementation")
         executor._starting_workload_index = AsyncMock(return_value=2)
         mock_registry.list_runs.return_value = [run2]
         mock_registry.get_run.return_value = run2
 
         await executor.execute_cycle("cyc_001", "run_002")
 
-        # start_index 2 on a 2-entry sequence: loop body never runs, but the
-        # rebuild guard must not blow up resolving position 1 of a 1-run list.
+        # start_index 2 on a 2-entry sequence: loop body never runs, and the
+        # rebuild finds no COMPLETED run at position 1 — degrade, no forwarding.
         executor._artifact_vault.list_artifacts.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary
Fixes all three interlocking refusals from #880 (roll 14's stuck-queued retry):
1. **Executor position map**: a run's own `workload_type` is authoritative (`_typed_workload_position` — ordinal-disambiguated, clamped so a failed run and its retry share the slot); untyped legacy runs keep the positional map byte-for-byte.
2. **Forwarding rebuild**: prior = the last **completed** run at the preceding *position* (typed-first), so the retry receives the framing's promoted plan instead of degrading on the failed sibling (the logged RC-4 shape).
3. **CLI resolver**: sequence overflow with a typed latest run now resolves to that type — the natural retry — instead of 422ing with advice #522 refuses by design; the remaining legacy raise names `workload_type` or `runs resume`.

## Why it matters beyond retries
This also unblocks the fix-validation retry program (`fix-retry-validation-corpus.md`): C1–C5 all have FAILED implementation runs and were retry-dead before this.

## Tests
Roll-14 shape end to end at all three layers; legacy-positional and failed-prior-degrade pins keep the old contracts where they should hold. Full regression 7,651 passed.

Closes #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApBek6CA1ibm3Cc5pq57F2