### PR TITLE
fix(cycles): carry the inspected-set reference to the record — a clean detector verdict is no longer indistinguishable from one that never looked

### DIFF
--- a/adapters/cycles/postgres_cycle_registry.py
+++ b/adapters/cycles/postgres_cycle_registry.py
@@ -37,6 +37,7 @@ from squadops.cycles.models import (
 )
 from squadops.cycles.pulse_models import PulseVerificationRecord
 from squadops.cycles.verification_integrity import (
+    CheckInspection,
     FailedCheck,
     RunVerdict,
     RunVerificationSummary,
@@ -648,6 +649,18 @@ def _verification_summary_to_dict(summary: RunVerificationSummary) -> dict:
         # Postgres (rather than the in-memory summary) undercounted (#500).
         "criteria_verified": list(summary.criteria_verified),
         "criteria_total": list(summary.criteria_total),
+        # #1002: the bounded inspected-set references. Stored so the question
+        # "did this detector ever see the file?" is answerable from any run
+        # after the fact — which was the whole point of computing it.
+        "inspections": [
+            {
+                "check_id": i.check_id,
+                "subject": i.subject,
+                "subject_ref": i.subject_ref,
+                "subject_count": i.subject_count,
+            }
+            for i in summary.inspections
+        ],
     }
 
 
@@ -675,4 +688,13 @@ def _verification_summary_from_dict(d: dict) -> RunVerificationSummary:
         passed_count=int(d.get("passed_count", 0)),
         criteria_verified=tuple(d.get("criteria_verified", [])),
         criteria_total=tuple(d.get("criteria_total", [])),
+        inspections=tuple(
+            CheckInspection(
+                check_id=i["check_id"],
+                subject=i.get("subject"),
+                subject_ref=i.get("subject_ref"),
+                subject_count=(None if i.get("subject_count") is None else int(i["subject_count"])),
+            )
+            for i in d.get("inspections", [])
+        ),
     )

--- a/src/squadops/cycles/run_report_builder.py
+++ b/src/squadops/cycles/run_report_builder.py
@@ -170,6 +170,20 @@ def _build_verification_lines(summary: RunVerificationSummary) -> list[str]:
         for u in summary.unverified:
             tag = " [required]" if u.required else ""
             lines.append(f"- **{u.check_id}**: {u.reason}{tag}")
+    if summary.inspections:
+        # #1002: a clean detector verdict and a detector that never received the
+        # file are the same line in this report without these counts. `cyc_6495d9870587`
+        # carried a flaggable self-mocking file through three attempts with
+        # `no_self_mocking_tests` reporting clean each time, and nothing recorded
+        # could say which of the two had happened.
+        lines.append("")
+        lines.append("### Inspected subjects")
+        for i in summary.inspections:
+            n = i.subject_count
+            files = "1 file" if n == 1 else f"{n} files"
+            producer = f" (task {i.subject})" if i.subject else ""
+            ref = f" — set {i.subject_ref[:12]}" if i.subject_ref else ""
+            lines.append(f"- **{i.check_id}**{producer}: inspected {files}{ref}")
     if summary.required_unmet:
         lines.append("")
         lines.append(

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -180,6 +180,13 @@ class CheckProvenance:
     executor_ref: str | None = None  # where it ran
     exit_code: int | None = None  # command-backed checks
     output_digest: str | None = None  # bounded digest, never the raw output
+    # #1002: cardinality of the subject set behind ``subject_ref`` — how many files a
+    # file-set-scoped check actually read. The digest alone proves two attempts looked
+    # at different sets; the count says *how* they differ without storing the paths,
+    # which is what keeps this inside §7 (bounded identifiers and hashes, never payload
+    # copies). ``0`` is a real value and the most diagnostic one: a detector that
+    # inspected nothing is indistinguishable from a clean one on its verdict alone.
+    subject_count: int | None = None
 
 
 @dataclass(frozen=True)
@@ -254,6 +261,36 @@ class FailedCheck:
 
 
 @dataclass(frozen=True)
+class CheckInspection:
+    """What one check actually read, as a bounded reference (§7, #1002).
+
+    A detector reports its verdict *and* the file set it inspected, so a clean
+    verdict can be told apart from a detector that never saw the offending file.
+    The producer's raw path list dies at the normalization boundary by design —
+    §7 admits identifiers, hashes, and counts, never payload copies — so what
+    survives to the roll-up is the pair that answers the question: a digest over
+    the inspected set (two attempts inspecting the same files share it) and its
+    cardinality.
+
+    The motivating event (#1002): a file carrying six ``vi.spyOn`` fetch stubs
+    sat in the workspace of a completed repair round, the deployed detector flags
+    that file when handed it directly, and ``no_self_mocking_tests`` still reported
+    clean across every attempt. Nothing in the record could say whether the
+    detector examined the file and disagreed, or never received it. These two
+    fields decide that from any stored run.
+
+    ``subject`` is the producing plan-task id (``CheckResult.subject``), so
+    inspections stay attributable per producer; ``None`` for un-identified
+    producers, exactly as on the result itself.
+    """
+
+    check_id: str
+    subject: str | None
+    subject_ref: str | None
+    subject_count: int | None
+
+
+@dataclass(frozen=True)
 class RunVerificationSummary:
     """Per-run verification roll-up — the honest evidence contract (§6.2, §10).
 
@@ -280,6 +317,12 @@ class RunVerificationSummary:
     # ``unverified`` entries always had. Default-empty so pre-#500 stored
     # summaries reconstruct unchanged.
     failed_detail: tuple[FailedCheck, ...] = ()
+    # #1002: what the file-set-scoped checks actually read — one bounded entry per
+    # (check_id, subject) that declared an inspected set, after §6.5 resolution, so
+    # the disclosure describes the same attempt the verdict does. This is still
+    # "references only": a digest and a count, never the paths. Default-empty, so
+    # producers that declare nothing and pre-#1002 stored summaries are unchanged.
+    inspections: tuple[CheckInspection, ...] = ()
 
     @property
     def pass_rate(self) -> float:
@@ -562,6 +605,7 @@ def aggregate_verification(
     failed: list[str] = []
     failed_detail: list[FailedCheck] = []
     unverified: list[UnverifiedCheck] = []
+    inspections: list[CheckInspection] = []
     seen_ids: set[str] = set()
     # SIP-0098 98.4: contract-criterion coverage, keyed on CheckResult.criterion_id.
     # A criterion is credited only if it executed-and-passed AND never went adverse.
@@ -573,6 +617,18 @@ def aggregate_verification(
     for r in _resolve_final_state(results):
         seen_ids.add(r.check_id)
         family = classify(r)
+        # #1002: carry the bounded inspected-set reference through to the roll-up.
+        # Recorded for every family — a NOT-EXECUTED detector that still reports an
+        # empty inspected set is precisely the case the disclosure exists to name.
+        if r.provenance is not None and r.provenance.subject_count is not None:
+            inspections.append(
+                CheckInspection(
+                    check_id=r.check_id,
+                    subject=r.subject,
+                    subject_ref=r.provenance.subject_ref,
+                    subject_count=r.provenance.subject_count,
+                )
+            )
         if family is EvidenceFamily.EXECUTED_PASSED:
             verified.append(r.check_id)
         elif family is EvidenceFamily.EXECUTED_FAILED:
@@ -646,6 +702,7 @@ def aggregate_verification(
         criteria_verified=tuple(sorted(criteria_passed - criteria_adverse)),
         criteria_total=tuple(sorted(set(contract_criteria) | criteria_passed | criteria_adverse)),
         failed_detail=tuple(failed_detail),
+        inspections=tuple(inspections),
     )
 
 

--- a/src/squadops/cycles/verification_normalize.py
+++ b/src/squadops/cycles/verification_normalize.py
@@ -25,6 +25,7 @@ executor at the dispatch seam):
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 from collections.abc import Mapping
 from typing import Any
 
@@ -107,6 +108,7 @@ def normalize_task_checks(
                     # stamped by the typed-acceptance seam; drives the
                     # evaluator_gap disclosure and contract-bound requiredness.
                     evidence_gap=bool(row.get("evidence_gap", False)),
+                    provenance=_inspection_provenance(row),
                 )
             )
         else:
@@ -124,6 +126,7 @@ def normalize_task_checks(
 
 def _from_passed_row(cid: str, row: Mapping[str, Any]) -> CheckResult:
     """Normalize a check row that carries a boolean ``passed`` (no ``status``)."""
+    provenance = _inspection_provenance(row)
     if row.get("executed") is False:
         # Honor an explicit §7 not-executed reason when the producer supplies one
         # (e.g. frontend_build skipped for missing_tooling, #407); default to
@@ -132,9 +135,36 @@ def _from_passed_row(cid: str, row: Mapping[str, Any]) -> CheckResult:
             check_id=cid,
             status=ResultStatus.SKIPPED,
             reason=_str_or_none(row.get("reason")) or NotExecutedReason.SUBJECT_MISSING,
+            provenance=provenance,
         )
     status = ResultStatus.PASSED if row.get("passed") else ResultStatus.FAILED
-    return CheckResult(check_id=cid, status=status)
+    return CheckResult(check_id=cid, status=status, provenance=provenance)
+
+
+def _inspection_provenance(row: Mapping[str, Any]) -> CheckProvenance | None:
+    """Bounded provenance for a detector row declaring what it read (#1002, §7).
+
+    ``inspected`` — the file set a detector actually examined (#986) — is a payload
+    list, and §7 admits only identifiers, hashes, counts and exit metadata onto
+    ``CheckProvenance``. So the boundedness rule is applied *here*, at the producer
+    adapter that owns the shape translation, rather than asking every producer to
+    pre-digest: the list becomes a digest over its deduplicated, sorted members plus
+    that set's cardinality.
+
+    Sorted and deduplicated so the digest identifies the *set*, not the traversal
+    order — two attempts that read the same files must compare equal, or the
+    disclosure answers a different question than the one asked.
+
+    An absent ``inspected`` key returns ``None`` (this producer declares nothing);
+    an **empty** list does not — a detector that inspected zero files is the
+    strongest form of the #1002 signal and must survive to the record.
+    """
+    inspected = row.get("inspected")
+    if not isinstance(inspected, (list, tuple)):
+        return None
+    paths = sorted({p for p in inspected if isinstance(p, str) and p})
+    digest = hashlib.sha256("\n".join(paths).encode("utf-8")).hexdigest()
+    return CheckProvenance(subject_ref=digest, subject_count=len(paths))
 
 
 def _tests_pass_from_result(tr: Mapping[str, Any], *, is_stub: bool) -> CheckResult:

--- a/tests/unit/cycles/test_postgres_cycle_registry.py
+++ b/tests/unit/cycles/test_postgres_cycle_registry.py
@@ -1007,3 +1007,80 @@ class TestGateWaiverSQL:
         assert run.gate_decisions[0].waiver_reason == "node absent"
         assert run.gate_decisions[1].waived_checks == ()
         assert run.gate_decisions[1].waiver_reason is None
+
+
+class TestInspectionSerialization:
+    """#1002: the inspected-set reference must survive the Postgres round-trip.
+
+    Bug caught: the seam computes what each detector read, the aggregation carries
+    it, and an un-serialized field would drop it at the last hop — leaving the
+    stored run exactly as mute about `cyc_6495d9870587`'s never-flagged
+    self-mocking file as it was before any of it was built.
+    """
+
+    def _summary(self):
+        from squadops.cycles.verification_integrity import (
+            CheckProvenance,
+            CheckResult,
+            aggregate_verification,
+        )
+
+        return aggregate_verification(
+            [
+                CheckResult(
+                    check_id="no_self_mocking_tests",
+                    status="passed",
+                    subject="task-qa-3",
+                    provenance=CheckProvenance(subject_ref="a" * 64, subject_count=1),
+                ),
+                CheckResult(
+                    check_id="no_stub_fallback_tests",
+                    status="passed",
+                    subject="task-qa-3",
+                    provenance=CheckProvenance(subject_ref="b" * 64, subject_count=0),
+                ),
+            ]
+        )
+
+    def test_round_trip_preserves_every_inspection_field(self):
+        from adapters.cycles.postgres_cycle_registry import (
+            _verification_summary_from_dict,
+            _verification_summary_to_dict,
+        )
+
+        summary = self._summary()
+        rebuilt = _verification_summary_from_dict(
+            json.loads(json.dumps(_verification_summary_to_dict(summary)))
+        )
+
+        assert rebuilt.inspections == summary.inspections
+        assert [(i.check_id, i.subject, i.subject_count) for i in rebuilt.inspections] == [
+            ("no_self_mocking_tests", "task-qa-3", 1),
+            ("no_stub_fallback_tests", "task-qa-3", 0),
+        ]
+        assert rebuilt.inspections[0].subject_ref == "a" * 64
+
+    def test_serialized_inspections_are_json_primitives(self):
+        from adapters.cycles.postgres_cycle_registry import _verification_summary_to_dict
+
+        stored = json.loads(json.dumps(_verification_summary_to_dict(self._summary())))
+        assert stored["inspections"][1] == {
+            "check_id": "no_stub_fallback_tests",
+            "subject": "task-qa-3",
+            "subject_ref": "b" * 64,
+            "subject_count": 0,
+        }
+
+    def test_pre_1002_stored_dict_reconstructs_with_no_inspections(self):
+        """A summary written before this field existed must still load — and must
+        not invent an inspection, which would read as a detector inventory that
+        was never recorded."""
+        from adapters.cycles.postgres_cycle_registry import (
+            _verification_summary_from_dict,
+            _verification_summary_to_dict,
+        )
+
+        stored = _verification_summary_to_dict(self._summary())
+        stored.pop("inspections")
+
+        assert _verification_summary_from_dict(stored).inspections == ()

--- a/tests/unit/cycles/test_run_report_builder.py
+++ b/tests/unit/cycles/test_run_report_builder.py
@@ -139,3 +139,45 @@ class TestFailureReasonLine:
 
         report = build_run_report("cyc_001", "run_001", self._run(None), "FAILED")
         assert "Failure Reason" not in report
+
+
+class TestInspectedSubjectsSection:
+    """#1002: the report is where a human reads a run's evidence. Without these
+    counts, 'no_self_mocking_tests: verified' looks the same whether the detector
+    read the offending file and disagreed or never received it — the exact
+    ambiguity that made `cyc_6495d9870587` unresolvable."""
+
+    @staticmethod
+    def _lines(*results):
+        from squadops.cycles.run_report_builder import _build_verification_lines
+
+        return "\n".join(_build_verification_lines(aggregate_verification(list(results))))
+
+    @staticmethod
+    def _result(check_id, subject, count, ref="c" * 64):
+        from squadops.cycles.verification_integrity import CheckProvenance
+
+        return CheckResult(
+            check_id=check_id,
+            status=ResultStatus.PASSED,
+            subject=subject,
+            provenance=CheckProvenance(subject_ref=ref, subject_count=count),
+        )
+
+    def test_an_empty_inventory_is_readable_as_such(self):
+        text = self._lines(self._result("no_self_mocking_tests", "task-qa-3", 0))
+        assert "### Inspected subjects" in text
+        assert "**no_self_mocking_tests** (task task-qa-3): inspected 0 files" in text
+        assert "set cccccccccccc" in text  # the set reference, truncated, not the paths
+
+    def test_single_file_reads_as_one_file(self):
+        """A bare '1 files' is the kind of line a reader skims past; the count is
+        the whole signal, so it has to read cleanly."""
+        text = self._lines(self._result("no_self_mocking_tests", "task-qa-3", 1))
+        assert "inspected 1 file —" in text
+
+    def test_section_absent_when_no_producer_declared_an_inventory(self):
+        """Runs whose detectors declare nothing must not grow an empty heading —
+        a section present with no rows implies the inventory was collected."""
+        text = self._lines(CheckResult(check_id="tests_pass", status=ResultStatus.PASSED))
+        assert "Inspected subjects" not in text

--- a/tests/unit/cycles/test_verification_integrity.py
+++ b/tests/unit/cycles/test_verification_integrity.py
@@ -778,3 +778,92 @@ class TestEvidenceGapAggregation:
         row = next(u for u in summary.unverified if u.check_id == "acceptance:import_present")
         assert row.required is False
         assert row.reason == "typed_acceptance_disabled"
+
+
+# --- #1002: inspected-set disclosure on the roll-up ---------------------------
+
+
+def _inspected(check_id: str, subject: str, count: int, ref: str = "d", **kw) -> CheckResult:
+    return CheckResult(
+        check_id=check_id,
+        status=kw.pop("status", ResultStatus.PASSED),
+        subject=subject,
+        provenance=vi.CheckProvenance(subject_ref=ref, subject_count=count),
+        **kw,
+    )
+
+
+def test_inspections_reach_the_summary_with_the_producer_that_read_them():
+    """#1002: the seam computed the inspected-set reference and the aggregation
+    dropped it, so the roll-up could not say whether a clean detector had seen
+    the offending file. Attribution matters too — an inspection with no producer
+    cannot be matched to the attempt whose emission it covered."""
+    summary = aggregate_verification(
+        [_inspected("no_self_mocking_tests", "task-qa-1", 1, ref="abc123")]
+    )
+    assert len(summary.inspections) == 1
+    i = summary.inspections[0]
+    assert (i.check_id, i.subject, i.subject_count, i.subject_ref) == (
+        "no_self_mocking_tests",
+        "task-qa-1",
+        1,
+        "abc123",
+    )
+
+
+def test_inspection_describes_the_same_attempt_the_verdict_does():
+    """#1002 + §6.5: a repaired-and-re-run check collapses to its final attempt for
+    the verdict. If the disclosure kept every attempt (or the first), the report
+    would credit one attempt and describe the inspected set of another — a record
+    that reads as evidence while pointing at the wrong round."""
+    summary = aggregate_verification(
+        [
+            _inspected("no_self_mocking_tests", "task-qa-1", 4, ref="first", status="failed"),
+            _inspected("no_self_mocking_tests", "task-qa-1", 1, ref="final"),
+        ]
+    )
+    assert summary.verdict is RunVerdict.ACCEPTED
+    assert [(i.subject_count, i.subject_ref) for i in summary.inspections] == [(1, "final")]
+
+
+def test_distinct_producers_of_one_check_each_disclose_their_own_inspection():
+    """#1002: the leading hypothesis is that each attempt inspects only its own
+    emission's files. Collapsing distinct producers under a shared check_id would
+    destroy exactly the comparison that tests it."""
+    summary = aggregate_verification(
+        [
+            _inspected("no_self_mocking_tests", "task-qa-1", 3, ref="wide"),
+            _inspected("no_self_mocking_tests", "task-qa-2", 1, ref="narrow"),
+        ]
+    )
+    assert [(i.subject, i.subject_count) for i in summary.inspections] == [
+        ("task-qa-1", 3),
+        ("task-qa-2", 1),
+    ]
+
+
+def test_a_detector_that_inspected_nothing_is_disclosed_not_dropped():
+    """#1002/#986: zero inspected files beside a passing verdict is the defect the
+    inventory exists to surface. A falsy-count guard would silently discard it and
+    leave the pass looking clean."""
+    summary = aggregate_verification([_inspected("no_stub_fallback_tests", "task-qa-1", 0)])
+    assert summary.verified == ("no_stub_fallback_tests",)
+    assert summary.inspections[0].subject_count == 0
+
+
+def test_provenance_without_an_inspected_set_is_not_reported_as_an_inspection():
+    """#1002: `tests_pass` carries exit-code provenance and inspects no file set.
+    Reporting it as an inspection would put 'inspected None files' in the record
+    and dilute the disclosure with rows that answer nothing."""
+    summary = aggregate_verification(
+        [
+            CheckResult(
+                check_id="tests_pass",
+                status=ResultStatus.PASSED,
+                subject="task-dev-1",
+                provenance=vi.CheckProvenance(exit_code=0),
+            )
+        ]
+    )
+    assert summary.verified == ("tests_pass",)
+    assert summary.inspections == ()

--- a/tests/unit/cycles/test_verification_normalize.py
+++ b/tests/unit/cycles/test_verification_normalize.py
@@ -419,3 +419,128 @@ def test_typed_row_threads_evidence_gap():
     assert gap_row.evidence_gap is True
     plain_row = next(r for r in rows if r.check_id == "acceptance:endpoint_defined")
     assert plain_row.evidence_gap is False
+
+
+# --- #1002: the inspected-set reference survives normalization -----------------
+
+
+def test_inspected_set_becomes_a_bounded_digest_and_count():
+    """#1002: the detector's `inspected` inventory died at this seam, so a clean
+    verdict and a detector that never received the file were the same record.
+    The row must arrive carrying how many files were read and which set."""
+    import hashlib
+
+    rows = normalize_task_checks(
+        {
+            "validation_result": {
+                "checks": [
+                    {
+                        "check": "no_self_mocking_tests",
+                        "passed": True,
+                        "inspected": ["__tests__/ui-flows.test.ts", "__tests__/api.test.ts"],
+                    }
+                ]
+            }
+        },
+        subject="task-qa-1",
+    )
+    prov = _by_id(rows)["no_self_mocking_tests"].provenance
+    assert prov is not None
+    assert prov.subject_count == 2
+    expected = hashlib.sha256(b"__tests__/api.test.ts\n__tests__/ui-flows.test.ts").hexdigest()
+    assert prov.subject_ref == expected
+
+
+def test_inspected_digest_identifies_the_set_not_the_traversal_order():
+    """#1002: the disclosure exists to say whether two attempts read the SAME files.
+    An order- or duplicate-sensitive digest answers a different question — two
+    attempts over one identical file set would compare unequal and read as a
+    scope change that never happened."""
+    a, b = (
+        normalize_task_checks(
+            {"validation_result": {"checks": [{"check": "c", "passed": True, "inspected": paths}]}}
+        )[0].provenance
+        for paths in (["b.ts", "a.ts", "b.ts"], ["a.ts", "b.ts"])
+    )
+    assert a.subject_ref == b.subject_ref
+    assert a.subject_count == b.subject_count == 2
+
+
+@pytest.mark.parametrize(
+    "row,expected_count",
+    [
+        ({"check": "c", "passed": True, "inspected": []}, 0),
+        ({"check": "c", "passed": True, "inspected": ["only.ts"]}, 1),
+        # Non-string members are not paths; counting them would inflate the
+        # inventory and mask an empty one.
+        ({"check": "c", "passed": True, "inspected": ["a.ts", None, "", 7]}, 1),
+    ],
+)
+def test_inspected_counts_only_real_paths_and_zero_survives(row, expected_count):
+    """#1002: an empty inventory beside an executed detector is the strongest form
+    of the signal (#986's whole point). Dropping it as 'nothing to record' — or
+    padding it with junk members — erases exactly the case worth catching."""
+    prov = normalize_task_checks({"validation_result": {"checks": [row]}})[0].provenance
+    assert prov is not None
+    assert prov.subject_count == expected_count
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        {"check": "c", "passed": True},
+        {"check": "c", "passed": True, "inspected": "not-a-list"},
+        {"check": "c", "passed": True, "inspected": None},
+    ],
+)
+def test_producer_that_declares_no_inspected_set_gets_no_inspection_provenance(row):
+    """#1002: absent (or malformed) means 'this producer declares nothing', which
+    must not be recorded as 'inspected 0 files' — that would invent the very
+    defect signal the field exists to report."""
+    prov = normalize_task_checks({"validation_result": {"checks": [row]}})[0].provenance
+    assert prov is None or prov.subject_count is None
+
+
+def test_skipped_detector_still_reports_what_it_inspected():
+    """#1002: a not-executed detector that nonetheless declares an empty inventory
+    is the diagnosis, not noise — the reason says 'skipped', the count says the
+    subject set was empty. Attaching provenance only on the executed path would
+    lose it for the case most likely to need it."""
+    rows = normalize_task_checks(
+        {
+            "validation_result": {
+                "checks": [
+                    {
+                        "check": "no_self_mocking_tests",
+                        "passed": True,
+                        "executed": False,
+                        "reason": NotExecutedReason.MISSING_TOOLING,
+                        "inspected": [],
+                    }
+                ]
+            }
+        }
+    )
+    row = rows[0]
+    assert row.status == ResultStatus.SKIPPED
+    assert row.reason == NotExecutedReason.MISSING_TOOLING
+    assert row.provenance.subject_count == 0
+
+
+def test_typed_acceptance_row_carries_its_inspected_set_too():
+    """#1002: the two producer shapes land in the same `checks` list. Wiring only
+    the boolean branch would make the disclosure silently stack-dependent."""
+    rows = normalize_task_checks(
+        {
+            "validation_result": {
+                "checks": [
+                    {
+                        "check": "acceptance:import_present",
+                        "status": "passed",
+                        "inspected": ["app/api/runs/route.ts"],
+                    }
+                ]
+            }
+        }
+    )
+    assert rows[0].provenance.subject_count == 1


### PR DESCRIPTION
## What

`no_self_mocking_tests` reporting clean and a detector that never received the file were the same row in the record. #986 built the fix for that — an `inspected` inventory naming the files each detector actually read — and it was dropped one hop later: `normalize_task_checks` maps a producer row onto `CheckResult`, which had nowhere to put it.

This carries it to the persisted record.

## The event

`cyc_6495d9870587` / `run_44c68d150155`. A stored artifact from a *completed* repair round (`art_2bd40853c575`, `__tests__/ui-flows.test.ts`) contains `vi.spyOn(global, 'fetch').mockResolvedValueOnce(...)` six times with no route-module import. Handed that file directly, the deployed detector flags it. Across the whole implementation — three qa attempts, three repairs — the detector fired zero times and `no_self_mocking_tests` appears once in the run's **verified** list.

The instrument measured. The measurement was unreachable exactly when it was needed.

## Bounded, not a payload copy

SIP-0096 §7 admits identifiers, hashes, counts and exit metadata onto `CheckProvenance`, and excludes payload copies. A path list is a payload, so the reduction happens at the normalization boundary — the producer adapter that already owns shape translation — rather than asking every producer to pre-digest:

- `subject_ref` — sha256 over the deduplicated, **sorted** members. Sorted so the digest identifies the *set*, not the traversal order; two attempts reading the same files have to compare equal or the disclosure answers a different question than the one asked.
- `subject_count` (new) — the set's cardinality. The digest proves two attempts differed; the count says how.

That keeps the §7 contract intact, so no SIP amendment is involved.

## The whole chain, because a link computed-and-dropped is the bug being fixed

| Hop | Change |
|---|---|
| Normalize seam | `_inspection_provenance` on both producer shapes (boolean rows *and* typed-acceptance rows) and on the not-executed path |
| Aggregation | one `CheckInspection` per `(check_id, subject)`, collected **after** §6.5 final-state resolution, so the disclosure describes the same attempt the verdict does |
| Persistence | serialized both directions by the Postgres registry — answerable from any stored run, not only a live one |
| Run report | `### Inspected subjects` → `**no_self_mocking_tests** (task task-qa-3): inspected 0 files` |

Two edges that decide whether this works at all:

- An **empty** inventory survives as `subject_count == 0`. A detector that inspected nothing is the strongest form of the signal, and a truthiness guard is exactly what would erase it.
- An **absent** `inspected` key stays `None`. A producer that declares nothing must never be recorded as having inspected zero — that invents the defect the field exists to report.

`tests_pass` carries exit-code provenance and inspects no file set; it is not reported as an inspection.

## What this makes answerable

The leading hypothesis from the issue: each attempt inspects only its own emission's files, so a `spyOn` file added in round 2 is invisible to round 3's detector — the same artifact-set-scoping class as #994's rewind behavior. With per-`(check_id, subject)` counts in the stored summary, that reads off any run instead of requiring a replay.

## Verification

- 4 test files, 19 new tests. Every test names the bug it catches.
- **15 mutations run against them, all killed** — including order-sensitive digest, falsy-count guard dropping zero inventories, provenance attached only on the executed path, typed-acceptance branch unwired, collection before §6.5 resolution, and both serialization directions.
- Full regression: **7,674 passed**, 1 skipped.

## One pre-existing failure, not from this branch

`tests/unit/capabilities/test_stack_blueprint_falsification.py::test_the_pass_reports_what_it_did_not_exercise` fails on clean `main`, and at `v1.6.1`. It is a cross-test global-state dependency: `_RUNTIME_ONLY_OBSERVED` is written only inside `test_every_declared_field_is_accounted_for` (line 354), never inside `_classify`, so the disclosure test — which calls `_classify` itself but not that surrounding branch — passes only when a sibling parametrized case reached line 354 **in the same process**. xdist distribution decides that, so the gate can go red or green on identical code. Filed separately.

Closes #1002
