### PR TITLE
feat(scaffold): pin the success body's declared floor in the frozen shell spine

### DIFF
--- a/src/squadops/capabilities/context_assembly.py
+++ b/src/squadops/capabilities/context_assembly.py
@@ -51,6 +51,13 @@ SURFACE_DOM_TESTID = "dom_testid_surface"
 #: `reset, all, insert, find, nextId`, then repaired to the same invented name because the
 #: repair path was blind identically. A name the author cannot see is a name it will invent.
 SURFACE_FROZEN = "frozen_surface"
+#: #1029: what each endpoint's SUCCESS body must carry. The developer received the error
+#: contract, the model surface, the testids and the frozen index — and nothing about the
+#: shape of a successful response, so the suite derived one from the manifest and the app
+#: decided another. The last green roll spent its entire correction budget reconciling
+#: them; the 1.6.1 shakedown died on it. Pinning the shell without this only makes the
+#: gate stricter than the author it judges can see.
+SURFACE_RESPONSE = "response_surface"
 
 
 @dataclass(frozen=True)
@@ -131,7 +138,13 @@ ACCEPTANCE_WORKSPACE_FILTER = ArtifactFilter(
     by_type_fallback=("document",),
 )
 
-_DEV_SURFACES = (SURFACE_ERROR_CONTRACT, SURFACE_MODEL, SURFACE_TESTID, SURFACE_FROZEN)
+_DEV_SURFACES = (
+    SURFACE_ERROR_CONTRACT,
+    SURFACE_MODEL,
+    SURFACE_TESTID,
+    SURFACE_FROZEN,
+    SURFACE_RESPONSE,
+)
 
 CONTEXT_CONTRACTS: dict[str, ContextAssemblyContract] = {
     # --- build tasks (D3): curated prompt context + acceptance workspace ----
@@ -415,6 +428,9 @@ def manifest_surface_fragments(
     """
     if not contract.manifest_surfaces:
         return {}
+    # #1029 lives in the module that owns the derivation, not in scaffold.py: the
+    # response floor already has one home and a second copy would be a second answer.
+    from squadops.capabilities.response_shape import response_surface_instructions
     from squadops.capabilities.scaffold import (
         error_seam_instructions,
         frozen_surface_index_lines,
@@ -428,6 +444,7 @@ def manifest_surface_fragments(
         SURFACE_TESTID: testid_surface_instructions,
         SURFACE_DOM_TESTID: testid_surface_instructions,
         SURFACE_FROZEN: frozen_surface_index_lines,
+        SURFACE_RESPONSE: response_surface_instructions,
     }
     fragments: dict[str, list[str]] = {}
     for surface in contract.manifest_surfaces:

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -821,7 +821,34 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
         frozen_surface = await self._frozen_surface_section(renderer, inputs)
         if frozen_surface:
             variables["frozen_surface"] = frozen_surface
+        # #1029: what each endpoint's SUCCESS body must carry, same transport as the four
+        # above. The generated shells assert this floor in their frozen region, and until
+        # now the author being judged by it could not see it — so the suite derived the
+        # shape from the manifest, the app decided another, and the disagreement was found
+        # by burning correction rounds (the last green roll's entire budget) or by dying
+        # (the 1.6.1 shakedown). A shape the author cannot see is a shape it will invent.
+        response_surface = await self._response_surface_section(renderer, inputs)
+        if response_surface:
+            variables["response_surface"] = response_surface
         rendered = await renderer.render(capability.fill_only_template, variables)
+        return rendered.content
+
+    async def _response_surface_section(self, renderer: Any, inputs: dict | None) -> str:
+        """Render the SUCCESS RESPONSE SHAPE block from executor-threaded lines, or "".
+
+        The lines are manifest-derived data (``response_shape.response_surface_
+        instructions``) — the same derivation the frozen shell spine asserts, so the
+        brief and the gate cannot describe different shapes. All prose lives in the
+        appendix asset (CLAUDE.md #448).
+        """
+        lines = [str(line).strip() for line in ((inputs or {}).get("response_surface") or [])]
+        lines = [line for line in lines if line]
+        if not lines:
+            return ""
+        rendered = await renderer.render(
+            "request.development_develop_response_surface_appendix",
+            {"response_lines": "\n".join(f"- {line}" for line in lines)},
+        )
         return rendered.content
 
     async def _frozen_surface_section(self, renderer: Any, inputs: dict | None) -> str:

--- a/src/squadops/capabilities/response_shape.py
+++ b/src/squadops/capabilities/response_shape.py
@@ -1,0 +1,141 @@
+"""What a success response must contain, derived from the interface manifest (#1029).
+
+The shells pin statuses, and since #913 the error envelope. Nothing pinned what a
+**success** body contains, so response-field paths were re-invented independently on
+both sides of the contract — the app deciding one shape, the suite asserting another —
+and the disagreement surfaced as burned correction rounds or a dead roll.
+
+The facts were already declared and simply unread. ``entities[].fields`` are typed and
+carry ``required``; endpoints declare ``response: Run`` / ``response: list[Run]``. This
+module is the one derivation those facts flow through, so the frozen shell spine, the
+probes, and the agent briefs cannot disagree about the shape they are each describing —
+a second implementation of this rule is a second answer.
+
+**The pinning budget is deliberately a floor, and every exclusion below is a
+false-positive source rather than an oversight** (the ruling, 2026-08-22):
+
+- **Declared-required fields must be present.** Never an exact field set: a serializer
+  that adds a field is making a legitimate choice, and failing it would spend the
+  budget punishing correctness.
+- **A ``list[X]`` field's elements must match the declared kind of X.** This is the
+  half with teeth. The 1.6.1 shakedown declared ``participants: list[Participant]``
+  (``Participant`` = ``{name: string}``) and two successive dev attempts returned bare
+  strings — `art_cded59f89624` sets ``run.participants = [...current, name]`` and
+  `art_e4ca71914e18` types it ``string[]`` — which no status assertion can see.
+- **Optional fields are never asserted.** Absent is a valid rendering of optional.
+- **Generated fields are asserted present, never to a value.** The id exists; what it
+  equals is the app's business.
+- **Nothing about ordering, extra fields, or nested internals below the first level.**
+
+Empty collections satisfy everything here: an empty array has no elements to violate a
+kind, which keeps a legitimately-empty list from reading as a shape defect.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from squadops.capabilities.scaffold import Entity, InterfaceManifest
+
+#: Manifest primitive tokens → the JavaScript ``typeof`` they must produce. A token
+#: absent here is an entity reference (or a type this pass cannot check), and is
+#: handled by presence of the entity's required fields instead.
+_PRIMITIVE_TYPEOF = {
+    "string": "string",
+    "integer": "number",
+    "number": "number",
+    "float": "number",
+    "boolean": "boolean",
+}
+
+
+@dataclass(frozen=True)
+class ElementExpectation:
+    """What one element of a declared collection field must look like.
+
+    Exactly one of ``typeof``/``required_fields`` is populated: a ``list[string]``
+    constrains the element's primitive kind, a ``list[Participant]`` constrains the
+    fields its elements carry. Both are subset checks.
+    """
+
+    field: str
+    typeof: str = ""
+    required_fields: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ResponseShape:
+    """The floor a success body must clear for one endpoint."""
+
+    entity: str
+    is_collection: bool
+    #: Declared-required field names on the responding entity, in declaration order.
+    required_fields: tuple[str, ...] = ()
+    #: Collection-typed fields of that entity whose element kind is checkable.
+    elements: tuple[ElementExpectation, ...] = ()
+
+    def __bool__(self) -> bool:
+        """Falsey when there is nothing to assert — an entity with no required fields
+        and no typed collections yields no pin, and callers must emit nothing rather
+        than a vacuous ``expect`` that reads as coverage."""
+        return bool(self.required_fields or self.elements)
+
+
+def _element_token(type_str: str) -> str:
+    """The element token of a collection type, or ``""`` for a non-collection.
+
+    Kept local rather than reusing the expander's ``_base_type_name``: that helper
+    unwraps nesting to the *innermost* name, which is the right answer for naming a
+    model class and the wrong one here — this pass must decline to check what it
+    cannot see one level down, not silently assert the inner kind of a nested list.
+    """
+    t = type_str.strip()
+    if t.startswith("list[") and t.endswith("]"):
+        return t[len("list[") : -1].strip()
+    return ""
+
+
+def _required_field_names(entity: Entity) -> tuple[str, ...]:
+    return tuple(f.name for f in entity.fields if f.required)
+
+
+def derive_response_shape(
+    manifest: InterfaceManifest, response: str | None
+) -> ResponseShape | None:
+    """The success-body floor for a ``response:`` declaration, or ``None``.
+
+    ``None`` for an endpoint that declares no response, or one naming something the
+    manifest does not define as an entity — an undeclared shape is not a shape this
+    pass may invent, and asserting against a guess is how a pin becomes a false
+    positive rather than a contract.
+    """
+    if not response:
+        return None
+    raw = response.strip()
+    element = _element_token(raw)
+    is_collection = bool(element)
+    name = element or raw
+    entities = {e.name: e for e in manifest.entities}
+    entity = entities.get(name)
+    if entity is None:
+        return None
+
+    elements: list[ElementExpectation] = []
+    for f in entity.fields:
+        inner = _element_token(f.type)
+        if not inner:
+            continue
+        typeof = _PRIMITIVE_TYPEOF.get(inner, "")
+        if typeof:
+            elements.append(ElementExpectation(field=f.name, typeof=typeof))
+        elif inner in entities:
+            required = _required_field_names(entities[inner])
+            if required:
+                elements.append(ElementExpectation(field=f.name, required_fields=required))
+
+    return ResponseShape(
+        entity=name,
+        is_collection=is_collection,
+        required_fields=_required_field_names(entity),
+        elements=tuple(elements),
+    )

--- a/src/squadops/capabilities/response_shape.py
+++ b/src/squadops/capabilities/response_shape.py
@@ -139,3 +139,49 @@ def derive_response_shape(
         required_fields=_required_field_names(entity),
         elements=tuple(elements),
     )
+
+
+def response_surface_instructions(manifest: InterfaceManifest | None) -> list[str]:
+    """Per-endpoint success-body lines for the developer's brief (#1029).
+
+    The frozen shell spine now asserts this floor, but the developer building the
+    endpoint could not see it: ``development.develop`` receives the error contract, the
+    model surface, the testids and the frozen index, and nothing at all about what a
+    success response must carry. So the suite derived the shape from the manifest, the
+    app decided one independently, and the disagreement was discovered by burning
+    correction rounds — the green roll's whole budget went on it, and the shakedown died
+    on it.
+
+    Pinning the shell without this only converts burned rounds into a deterministic red:
+    the gate gets stricter while the author it judges still cannot see the target. This
+    is the half that lets the app be right the first time.
+
+    Data only — the prose lives in the appendix asset (CLAUDE.md #448). Empty for a
+    manifest whose endpoints declare no resolvable response, which contributes no
+    section at all rather than an empty heading.
+    """
+    if manifest is None:
+        return []
+    lines: list[str] = []
+    for endpoint in manifest.api.endpoints:
+        shape = derive_response_shape(manifest, endpoint.response)
+        if not shape:
+            continue
+        subject = "each element of the array" if shape.is_collection else "the response body"
+        clauses = []
+        if shape.required_fields:
+            fields = ", ".join(f"`{name}`" for name in shape.required_fields)
+            clauses.append(f"{subject} carries {fields}")
+        for element in shape.elements:
+            if element.typeof:
+                clauses.append(f"`{element.field}` is an array of {element.typeof}s")
+            else:
+                required = ", ".join(f"`{name}`" for name in element.required_fields)
+                clauses.append(f"each `{element.field}` element carries {required}")
+        if clauses:
+            lines.append(
+                f"`{endpoint.method.upper()} {endpoint.path}` returns "
+                f"{'a list of ' if shape.is_collection else ''}`{shape.entity}` — "
+                + "; ".join(clauses)
+            )
+    return lines

--- a/src/squadops/capabilities/stack_nextjs_ts_tests.py
+++ b/src/squadops/capabilities/stack_nextjs_ts_tests.py
@@ -41,6 +41,7 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from squadops.capabilities.response_shape import ResponseShape, derive_response_shape
 from squadops.capabilities.scaffold_contract import _slug
 from squadops.capabilities.stack_nextjs_ts import _segments
 from squadops.capabilities.verification_scaffold import (
@@ -113,6 +114,13 @@ class _Behavior:
     #: path stops being re-invented in the fill, which is where window rolls 2/3
     #: died (fills asserting `body.error_code` against the real `{error: {code}}`).
     expect_error_code: str = ""
+    #: #1029: the success-body floor this behavior's response must clear ("" = none).
+    #: The sibling of ``expect_error_code``: #913 moved the ERROR envelope's field path
+    #: out of the fill and into the spine; this does the same for the success body,
+    #: which is where the last green roll spent its entire correction budget (three
+    #: qa rounds, all "expected undefined to be 'sample'"). Error behaviors carry
+    #: ``None`` — a 4xx body is the envelope's business, not the entity's.
+    expect_response: ResponseShape | None = None
 
 
 def _fail_missing_surface(url_path: str, method: str, route_file: str, reason: str) -> None:
@@ -169,7 +177,36 @@ def _classify_probes(probes: list[dict]) -> list[tuple[str, dict]]:
     return classified
 
 
-def _behaviors_from_probes(classified: list[tuple[str, dict]]) -> list[_Behavior]:
+def _response_shapes(manifest: InterfaceManifest) -> dict[tuple[str, str], ResponseShape]:
+    """``(METHOD, path) -> success-body floor`` for every endpoint that declares one.
+
+    Keyed on the endpoint identity the probes carry, so a behavior resolves its shape
+    by the route it actually invokes rather than by position.
+    """
+    shapes: dict[tuple[str, str], ResponseShape] = {}
+    for endpoint in manifest.api.endpoints:
+        shape = derive_response_shape(manifest, endpoint.response)
+        if shape:
+            shapes[(endpoint.method.upper(), endpoint.path)] = shape
+    return shapes
+
+
+def _success_shape(
+    shapes: dict[tuple[str, str], ResponseShape], request: dict, status: int
+) -> ResponseShape | None:
+    """The floor for one probe's response, or ``None``.
+
+    Gated on a 2xx: a rejection probe's body is the error envelope, which #913 already
+    pins, and asserting entity fields on it would fail every correct app.
+    """
+    if not 200 <= int(status) < 300:
+        return None
+    return shapes.get((str(request["method"]).upper(), request["path"]))
+
+
+def _behaviors_from_probes(
+    classified: list[tuple[str, dict]], shapes: dict[tuple[str, str], ResponseShape]
+) -> list[_Behavior]:
     creates_by_path: dict[str, dict] = {}
     child_successes: list[dict] = []
     behaviors: list[_Behavior] = []
@@ -211,6 +248,7 @@ def _behaviors_from_probes(classified: list[tuple[str, dict]]) -> list[_Behavior
                     expect_status=expect,
                     final=_final(probe),
                     probe_id=probe["id"],
+                    expect_response=_success_shape(shapes, request, expect),
                 )
             )
         elif kind == "reject":
@@ -245,6 +283,7 @@ def _behaviors_from_probes(classified: list[tuple[str, dict]]) -> list[_Behavior
                     # A duplicate-conflict probe pins its code; a plain child success
                     # pins none — the .get() above yields "" for it.
                     expect_error_code=error_code,
+                    expect_response=_success_shape(shapes, request, expect),
                 )
             )
             if kind == "child":
@@ -275,6 +314,7 @@ def _minted_read_behaviors(
                     label=f"GET {ep.path} -> {expect}",
                     expect_status=expect,
                     final=_Step(method="GET", url_path=ep.path),
+                    expect_response=derive_response_shape(manifest, ep.response),
                 )
             )
             continue
@@ -298,6 +338,7 @@ def _minted_read_behaviors(
                 expect_status=expect,
                 final=_Step(method="GET", url_path=ep.path, param_expr="created.id"),
                 prerequisites=(create_step,),
+                expect_response=derive_response_shape(manifest, ep.response),
             )
         )
         if any(error_http.get(code) == 404 for code in ep.errors):
@@ -346,6 +387,56 @@ def _invocation_lines(step: _Step, assign: str) -> list[str]:
     if placeholders:
         lines.append(f"      {{ params: {{ {placeholders[0]}: {step.param_expr} }} }},")
     lines.append("    )")
+    return lines
+
+
+def _shape_lines(shape: ResponseShape) -> list[str]:
+    """The frozen-spine assertions for one success-body floor (#1029).
+
+    Subset checks only, matching the derivation's budget: declared-required fields are
+    present, and a declared collection's elements match their declared kind. Never an
+    exact field set, never a value, never ordering — an app that adds a field is making
+    a legitimate choice and failing it would spend the budget punishing correctness.
+
+    Emitted as one named predicate applied to the body (or to each element of a
+    collection response) so a list response and a single response assert the *same*
+    floor. Bracket access with JSON-quoted keys rather than ``toHaveProperty``, whose
+    dotted-path semantics would misread a field name containing a dot.
+
+    An empty collection asserts nothing about elements — legitimately empty is not a
+    shape defect, and the loop simply does not run.
+    """
+    checks: list[str] = []
+    if shape.required_fields:
+        keys = ", ".join(json.dumps(name) for name in shape.required_fields)
+        checks.append(f"    for (const k of [{keys}]) expect(o?.[k]).not.toBeUndefined()")
+    for element in shape.elements:
+        access = f"o?.[{json.dumps(element.field)}] ?? []"
+        if element.typeof:
+            checks.append(
+                f"    for (const e of {access}) expect(typeof e).toBe({json.dumps(element.typeof)})"
+            )
+        else:
+            keys = ", ".join(json.dumps(name) for name in element.required_fields)
+            checks.append(
+                f"    for (const e of {access}) for (const k of [{keys}]) "
+                f"expect(e?.[k]).not.toBeUndefined()"
+            )
+    if not checks:
+        return []
+    lines = [
+        f"    // Response floor for {shape.entity}, derived from the interface manifest (#1029).",
+        "    const expectShape = (o: any) => {",
+        *[f"  {line}" for line in checks],
+        "    }",
+    ]
+    if shape.is_collection:
+        lines += [
+            "    expect(Array.isArray(body)).toBe(true)",
+            "    for (const item of body ?? []) expectShape(item)",
+        ]
+    else:
+        lines.append("    expectShape(body)")
     return lines
 
 
@@ -404,6 +495,12 @@ def _shell_source(behavior: _Behavior, *, store_symbols: tuple[str, ...]) -> str
         # this code, the blueprint owns the shape (#795), and the field path is
         # exactly what fills kept re-inventing (`body.error_code`, rolls 2/3/13/17).
         lines.append(f"    expect(body.error?.code).toBe('{behavior.expect_error_code}')")
+    if behavior.expect_response:
+        # #1029: the success body's turn. Same argument as #913 one status class over —
+        # the manifest declares the entity's required fields and its collections'
+        # element kinds, and until now nothing read them, so both sides invented a
+        # shape and the disagreement cost correction rounds or the roll.
+        lines += _shape_lines(behavior.expect_response)
     lines += [
         f"    {slot_begin_marker(slot_id)}",
         "    // FILL (qa): domain assertions for this behavior — response values and store",
@@ -432,7 +529,8 @@ def derive_scaffold_behaviors(
     contract = emit_contract_dict(manifest)
     probes = contract["behavioral"]["probes"]
     classified = _classify_probes(probes)
-    behaviors = _behaviors_from_probes(classified)
+    shapes = _response_shapes(manifest)
+    behaviors = _behaviors_from_probes(classified, shapes)
     creates_by_path = {
         probe["request"]["path"]: probe for kind, probe in classified if kind == "create"
     }

--- a/src/squadops/capabilities/verification_scaffold_emission.py
+++ b/src/squadops/capabilities/verification_scaffold_emission.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:  # pragma: no cover - annotations only
 #: Bump on ANY emission-affecting change (module docstring). Recorded in every manifest.
 #: 2 (#936) — the shell imports `all` alongside `reset`, so a fill can call the helper
 #: the appendix teaches without adding an import it is forbidden to add.
-GENERATOR_VERSION = 6
+GENERATOR_VERSION = 7
 
 #: The stored manifest artifact's filename (the executor persists it beside the contract).
 VERIFICATION_SCAFFOLD_MANIFEST_FILENAME = "verification_scaffold_manifest.yaml"

--- a/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.development_develop_fill_only_appendix
-version: "5"
+version: "6"
 required_variables:
   - stack
 optional_variables:
@@ -8,6 +8,7 @@ optional_variables:
   - model_surface
   - testid_surface
   - frozen_surface
+  - response_surface
 ---
 ## Fill-only: a walking skeleton is already in your workspace
 
@@ -40,6 +41,8 @@ the fixed slots** — never to rebuild, rewire, or regenerate the scaffold.
 {{testid_surface}}
 
 {{frozen_surface}}
+
+{{response_surface}}
 
 Filling the fixed slots — rather than regenerating the app — is the whole point: the
 skeleton already builds and boots, so a fill that preserves it stays green, while one

--- a/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix_nextjs_ts.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix_nextjs_ts.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.development_develop_fill_only_appendix_nextjs_ts
-version: "1"
+version: "2"
 required_variables:
   - stack
 optional_variables:
@@ -8,6 +8,7 @@ optional_variables:
   - model_surface
   - testid_surface
   - frozen_surface
+  - response_surface
 ---
 ## Fill-only: a walking skeleton is already in your workspace
 
@@ -75,6 +76,8 @@ server component that opts out of prerendering with `export const dynamic =
 {{testid_surface}}
 
 {{frozen_surface}}
+
+{{response_surface}}
 
 Filling the fixed slots — rather than regenerating the app — is the whole point: the
 skeleton already builds and boots, so a fill that preserves it stays green, while one

--- a/src/squadops/prompts/request_templates/request.development_develop_response_surface_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_response_surface_appendix.md
@@ -1,0 +1,23 @@
+---
+template_id: request.development_develop_response_surface_appendix
+version: "1"
+required_variables:
+  - response_lines
+optional_variables: []
+---
+**SUCCESS RESPONSE SHAPE (authoritative — the suite asserts exactly this):**
+{{response_lines}}
+
+Each line states the floor for one endpoint's success body, generated from the interface
+manifest. The generated test shells assert it in their frozen region, so a response that
+omits a listed field — or returns an array of the wrong element kind — fails deterministically
+no matter what the endpoint's status code is.
+
+This is a floor, not a schema. Additional fields are yours to choose and nothing checks them;
+optional fields may be omitted entirely; the values are the app's business, only presence and
+element kind are pinned. Return the listed fields and you cannot fail this check.
+
+Element kind is the one that is easy to miss. A field declared as an array of strings must
+contain strings, not objects wrapping them — returning `[{"name": "ada"}]` where the manifest
+says an array of strings is a contract break the status code cannot show, and it has killed a
+run before.

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-join.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-join.scaffold.test.ts
@@ -30,6 +30,12 @@ describe('scaffold: POST /api/runs/{run_id}/join', () => {
     )
     expect(res.status).toBe(200)
     const body: any = await res.json().catch(() => ({}))
+    // Response floor for RunEvent, derived from the interface manifest (#1029).
+    const expectShape = (o: any) => {
+      for (const k of ["id", "title", "datetime", "location", "participants"]) expect(o?.[k]).not.toBeUndefined()
+      for (const e of o?.["participants"] ?? []) for (const k of ["id", "name"]) expect(e?.[k]).not.toBeUndefined()
+    }
+    expectShape(body)
     // [scaffold-slot:begin slot-vc-probe-api-runs-join]
     // FILL (qa): domain assertions for this behavior — response values and store
     // effects beyond the declared status. `body` is the parsed response JSON.

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-leave.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs-leave.scaffold.test.ts
@@ -39,6 +39,12 @@ describe('scaffold: POST /api/runs/{run_id}/leave', () => {
     )
     expect(res.status).toBe(200)
     const body: any = await res.json().catch(() => ({}))
+    // Response floor for RunEvent, derived from the interface manifest (#1029).
+    const expectShape = (o: any) => {
+      for (const k of ["id", "title", "datetime", "location", "participants"]) expect(o?.[k]).not.toBeUndefined()
+      for (const e of o?.["participants"] ?? []) for (const k of ["id", "name"]) expect(e?.[k]).not.toBeUndefined()
+    }
+    expectShape(body)
     // [scaffold-slot:begin slot-vc-probe-api-runs-leave]
     // FILL (qa): domain assertions for this behavior — response values and store
     // effects beyond the declared status. `body` is the parsed response JSON.

--- a/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vc-probe-api-runs.scaffold.test.ts
@@ -20,6 +20,12 @@ describe('scaffold: POST /api/runs', () => {
     )
     expect(res.status).toBe(201)
     const body: any = await res.json().catch(() => ({}))
+    // Response floor for RunEvent, derived from the interface manifest (#1029).
+    const expectShape = (o: any) => {
+      for (const k of ["id", "title", "datetime", "location", "participants"]) expect(o?.[k]).not.toBeUndefined()
+      for (const e of o?.["participants"] ?? []) for (const k of ["id", "name"]) expect(e?.[k]).not.toBeUndefined()
+    }
+    expectShape(body)
     // [scaffold-slot:begin slot-vc-probe-api-runs]
     // FILL (qa): domain assertions for this behavior — response values and store
     // effects beyond the declared status. `body` is the parsed response JSON.

--- a/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
+++ b/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
@@ -2,25 +2,25 @@
 # The frozen-spine record region enforcement verifies against; regenerate with
 # the generator, never hand-edit (a tampered record refuses to load).
 scaffold_manifest_version: 1
-generator_version: 6
+generator_version: 7
 stack: nextjs_ts
 interface_manifest_hash: ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a
 criteria_pack: nextjs_ts
 expanded_tree_hash: 80e5632052b4c43ce881383bb4058b0531b0252ea688992f5d7102bb35c5f90f
-aggregate_spine_hash: 3b62a339ff2489f65285e0cc780c6fdf97cd794bbfafecf9f143621cae69b0d1
-scaffold_hash: 395a08bc5a78e2333d21c3af6b89981a9551558d191b3db1b87dc84b251ced00
+aggregate_spine_hash: 1ff59445d016f6d7385d713c5f31de7620fe3f065344db6a083bae7b1a0ab962
+scaffold_hash: 6fc46f50369bc9afd34e40607350b2464b74f79a6a8ef62772470037f5e98854
 files:
 - path: __tests__/scaffold/vc-probe-api-runs.scaffold.test.ts
-  content_hash: 9245b8442a684f32bfbb7605185a72274b13afa748eb02ccee80fbe559d21d31
-  spine_hash: 3e3d9877aca8db6fefdf3f17259f45caeebd6b1335d0edf2af54b3c4d2eeed14
+  content_hash: 0c2c8da6a591fc5f54ac1b4ac8b2b7917e2b7cc06466b6770ccb0b2c9e001907
+  spine_hash: 995902980ebbd9f4f9d111f3aab582686c707f1b2e22922b443a988f288df170
   slots:
   - slot_id: slot-vc-probe-api-runs
     behavior: POST /api/runs -> 201
     probe_id: vc-probe-api-runs
     criterion_ids:
     - vc-probe-api-runs
-    begin_line: 23
-    end_line: 27
+    begin_line: 29
+    end_line: 33
 - path: __tests__/scaffold/vc-probe-api-runs-rejects-blank.scaffold.test.ts
   content_hash: 314fe36bceec5d13df33d235a0e8495525f3bdd517fab214dffda82f29882958
   spine_hash: 5004d630e6996fe8b2d79265a1879515b8fedd88a1c9f6b9f66d2f021b0495d6
@@ -33,16 +33,16 @@ files:
     begin_line: 24
     end_line: 28
 - path: __tests__/scaffold/vc-probe-api-runs-join.scaffold.test.ts
-  content_hash: 14f4115aad1800f4a0950a14daf4531c266467722c5ba2d4d7ed959bad19e4a6
-  spine_hash: edbc25e16cbb7cde2a492d20d57df3f0fb1a17749db62ee56fb0ffe4bb8d7c60
+  content_hash: 003064c62efb9936881da29a9bd9910de3c69a9bfbfd748d18a11348b21ae062
+  spine_hash: 74e84ae1b981db9e1160cd092d6e19e0b43d1feaa643296af267e978ccf2fed2
   slots:
   - slot_id: slot-vc-probe-api-runs-join
     behavior: POST /api/runs/{run_id}/join -> 200
     probe_id: vc-probe-api-runs-join
     criterion_ids:
     - vc-probe-api-runs-join
-    begin_line: 33
-    end_line: 37
+    begin_line: 39
+    end_line: 43
 - path: __tests__/scaffold/vc-probe-api-runs-join-duplicate.scaffold.test.ts
   content_hash: 281e6a9c7ee7b276d40fbbc0a3c1948539be811e3de15a93c9b59e9ed150772e
   spine_hash: 817c40b5db71172d489dcc03fe8cf33cdf4e27c5749928f60b57ad1242d32cd1
@@ -55,36 +55,36 @@ files:
     begin_line: 42
     end_line: 46
 - path: __tests__/scaffold/vc-probe-api-runs-leave.scaffold.test.ts
-  content_hash: 84754c4f511e27029c5534f75e08a3f5d7113adf855c758ef57514d30a2dcda8
-  spine_hash: c391a7da2fd66226664154805762332d6cf1d4cb5795bc2047aaceeed53aa9b8
+  content_hash: 1b5e8d7bbb1a9da7e050fd8f56edf993835e553e3224bf372a9f1d8b15260ec7
+  spine_hash: 94125983b218e050bc39c32e833f23f485ef116235712e0acaaef843d804f0fe
   slots:
   - slot_id: slot-vc-probe-api-runs-leave
     behavior: POST /api/runs/{run_id}/leave -> 200
     probe_id: vc-probe-api-runs-leave
     criterion_ids:
     - vc-probe-api-runs-leave
-    begin_line: 42
-    end_line: 46
+    begin_line: 48
+    end_line: 52
 - path: __tests__/scaffold/vs-get-api-runs.scaffold.test.ts
-  content_hash: 9c53dcf9d5e6420b4ead5de51137697c3dc44414139ea2271a3c2a00b989e8e1
-  spine_hash: 5e18437d792a591693e99f11241e87d40449d355d0b937c47d144bf722e79b1f
+  content_hash: 007ab02bd501d28edfb55bdb7b3f632ccaec34ce14690520d4297bd2d499ad32
+  spine_hash: 77927daa169bf88f23f7a4ed6990e348eda44b6325035c688525fda4cea46f8d
   slots:
   - slot_id: slot-vs-get-api-runs
     behavior: GET /api/runs -> 200
     probe_id: ''
     criterion_ids: []
-    begin_line: 19
-    end_line: 23
+    begin_line: 26
+    end_line: 30
 - path: __tests__/scaffold/vs-get-api-runs-run-id.scaffold.test.ts
-  content_hash: 9ce0b15a8b63aa07167795da416c64ae9eae7d1ce4fa71f83dbfbd508ca9bf03
-  spine_hash: 71a16ae4d5cd0204146953f0d7206ca9daa8929ea4148b5f8e9fd7e4940e4222
+  content_hash: c7abcf41efd740359247118b382aa43f5fa416e82a752b023647eebf8d4eaea9
+  spine_hash: b3c5239c1fd9e4f505a2eda6d78d743f74c9f3cce50cac3de261bbdef412aceb
   slots:
   - slot_id: slot-vs-get-api-runs-run-id
     behavior: GET /api/runs/{run_id} -> 200
     probe_id: ''
     criterion_ids: []
-    begin_line: 29
-    end_line: 33
+    begin_line: 35
+    end_line: 39
 - path: __tests__/scaffold/vs-get-api-runs-run-id-not-found.scaffold.test.ts
   content_hash: 89e655f3b68564332e86bbac28839f4eb18f5156b62d002cdc2bafacada87ccb
   spine_hash: eb0ea3bfc46b9c9229487afd382ba6fd1a55a96f04d8bb3a306dd38a5929a8ed

--- a/tests/fixtures/reference_verification_scaffold/vs-get-api-runs-run-id.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vs-get-api-runs-run-id.scaffold.test.ts
@@ -26,6 +26,12 @@ describe('scaffold: GET /api/runs/{run_id}', () => {
     )
     expect(res.status).toBe(200)
     const body: any = await res.json().catch(() => ({}))
+    // Response floor for RunEvent, derived from the interface manifest (#1029).
+    const expectShape = (o: any) => {
+      for (const k of ["id", "title", "datetime", "location", "participants"]) expect(o?.[k]).not.toBeUndefined()
+      for (const e of o?.["participants"] ?? []) for (const k of ["id", "name"]) expect(e?.[k]).not.toBeUndefined()
+    }
+    expectShape(body)
     // [scaffold-slot:begin slot-vs-get-api-runs-run-id]
     // FILL (qa): domain assertions for this behavior — response values and store
     // effects beyond the declared status. `body` is the parsed response JSON.

--- a/tests/fixtures/reference_verification_scaffold/vs-get-api-runs.scaffold.test.ts
+++ b/tests/fixtures/reference_verification_scaffold/vs-get-api-runs.scaffold.test.ts
@@ -16,6 +16,13 @@ describe('scaffold: GET /api/runs', () => {
     )
     expect(res.status).toBe(200)
     const body: any = await res.json().catch(() => ({}))
+    // Response floor for RunEvent, derived from the interface manifest (#1029).
+    const expectShape = (o: any) => {
+      for (const k of ["id", "title", "datetime", "location", "participants"]) expect(o?.[k]).not.toBeUndefined()
+      for (const e of o?.["participants"] ?? []) for (const k of ["id", "name"]) expect(e?.[k]).not.toBeUndefined()
+    }
+    expect(Array.isArray(body)).toBe(true)
+    for (const item of body ?? []) expectShape(item)
     // [scaffold-slot:begin slot-vs-get-api-runs]
     // FILL (qa): domain assertions for this behavior — response values and store
     // effects beyond the declared status. `body` is the parsed response JSON.

--- a/tests/unit/capabilities/test_context_completeness.py
+++ b/tests/unit/capabilities/test_context_completeness.py
@@ -368,3 +368,140 @@ def test_builder_template_declares_the_new_blocks():
     assert "{{contract_expectations}}" in text
     # the instruction that plan-named sections are required on top of the profile's
     assert "required for THIS task" in text
+
+
+# --- #1029: the developer is shown the success-body floor it is judged against ------
+
+
+def _reference_manifest():
+    from squadops.capabilities.scaffold import InterfaceManifest
+
+    return InterfaceManifest.from_yaml(
+        (
+            Path(__file__).resolve().parents[3]
+            / "examples"
+            / "03_group_run"
+            / "interface_manifest.yaml"
+        ).read_text()
+    )
+
+
+def test_the_developer_contract_declares_the_response_surface():
+    """This file's own defect class, one more instance. The frozen shell spine asserts
+    the success body's floor; `development.develop` carried the error contract, the
+    model surface, the testids and the frozen index, and nothing about response shape —
+    so the author was judged against a fact it was never shown."""
+    from squadops.capabilities.context_assembly import SURFACE_RESPONSE
+
+    assert SURFACE_RESPONSE in CONTEXT_CONTRACTS["development.develop"].manifest_surfaces
+
+
+def test_the_response_surface_renders_the_facts_the_shells_assert():
+    """The registry entry is worthless if the derivation produces nothing — a declared
+    surface that renders empty is #846's shape one layer down."""
+    from squadops.capabilities.context_assembly import (
+        SURFACE_RESPONSE,
+        manifest_surface_fragments,
+    )
+
+    fragments = manifest_surface_fragments(
+        CONTEXT_CONTRACTS["development.develop"], _reference_manifest()
+    )
+    lines = fragments[SURFACE_RESPONSE]
+    assert len(lines) == 5
+    create = next(line for line in lines if line.startswith("`POST /runs`"))
+    assert "`id`" in create and "`title`" in create
+    assert "each `participants` element carries" in create
+
+
+def test_the_brief_and_the_shell_pin_the_same_shape():
+    """The design's load-bearing invariant, and the reason this is one derivation.
+
+    Bug caught: the brief and the spine drifting apart. Two independent renderings of
+    "what the response must contain" is two answers, and the failure mode is the exact
+    one #1029 describes — an app built to one description, judged against another —
+    reintroduced inside the fix for it. Every field the shell asserts for an endpoint
+    must be named in that endpoint's brief line.
+    """
+    import re
+
+    from squadops.capabilities.context_assembly import (
+        SURFACE_RESPONSE,
+        manifest_surface_fragments,
+    )
+    from squadops.capabilities.verification_scaffold_emission import emit_verification_scaffold
+    from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+    manifest = manifest_for_stack("nextjs_ts")
+    brief = " ".join(
+        manifest_surface_fragments(CONTEXT_CONTRACTS["development.develop"], manifest)[
+            SURFACE_RESPONSE
+        ]
+    )
+    asserted: set[str] = set()
+    for f in emit_verification_scaffold(manifest).files:
+        for match in re.finditer(r"for \(const k of \[([^\]]+)\]\)", f["content"]):
+            asserted |= {token.strip().strip('"') for token in match.group(1).split(",")}
+    assert asserted, "no shell pinned any field — this test would pass vacuously"
+    missing = sorted(name for name in asserted if f"`{name}`" not in brief)
+    assert not missing, f"the shells assert {missing}, which the developer's brief never names"
+
+
+async def test_dev_response_section_renders_lines_and_gates_on_presence():
+    """A surface nothing renders into a prompt is a declaration, not a fact the agent
+    sees — the third failure this file exists to catch."""
+    from squadops.capabilities.handlers.cycle.develop import DevelopmentDevelopHandler
+
+    handler = DevelopmentDevelopHandler()
+    renderer = MagicMock()
+    renderer.render = AsyncMock(return_value=MagicMock(content="RESPONSE BLOCK"))
+
+    lines = ["`POST /runs` returns `RunEvent` — the response body carries `id`"]
+    out = await handler._response_surface_section(renderer, {"response_surface": lines})
+    assert out == "RESPONSE BLOCK"
+    renderer.render.assert_awaited_once_with(
+        "request.development_develop_response_surface_appendix",
+        {"response_lines": f"- {lines[0]}"},
+    )
+
+    renderer.render.reset_mock()
+    assert await handler._response_surface_section(renderer, {}) == ""
+    assert await handler._response_surface_section(renderer, {"response_surface": ["  "]}) == ""
+    renderer.render.assert_not_awaited()
+
+
+async def test_every_dev_surface_reaches_the_fill_only_prompt():
+    """The render half, generically — for all five dev surfaces, not just the newest.
+
+    Bug caught: a surface that is declared, derived, threaded onto the envelope, turned
+    into a section by its own handler method... and then never added to the template's
+    variables. Every step passes its own test and the agent still never sees the fact —
+    which is this file's whole subject, and a gap that existed for all four earlier
+    surfaces too (mutating the assignment away left the suite green).
+
+    Asserted on the variables the template is rendered with, because that dict is the
+    last point where a fact can be silently dropped.
+    """
+    from squadops.capabilities.context_assembly import (
+        CONTEXT_CONTRACTS as _CONTRACTS,
+    )
+    from squadops.capabilities.handlers.cycle.develop import DevelopmentDevelopHandler
+
+    handler = DevelopmentDevelopHandler()
+    handler._resolved_config = {"build_profile": "nextjs_ts"}
+    renderer = MagicMock()
+    renderer.render = AsyncMock(side_effect=lambda tid, v: MagicMock(content=f"[{tid}]"))
+
+    surfaces = _CONTRACTS["development.develop"].manifest_surfaces
+    inputs = {surface: [f"line for {surface}"] for surface in surfaces}
+    await handler._fill_only_section(renderer, inputs)
+
+    fill_call = next(
+        call for call in renderer.render.await_args_list if "fill_only_appendix" in call.args[0]
+    )
+    variables = fill_call.args[1]
+    missing = sorted(s for s in surfaces if s not in variables)
+    assert not missing, (
+        f"{missing} are declared on development.develop and rendered into a section, but "
+        f"never reach the fill-only template's variables — the agent never sees them"
+    )

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -16,7 +16,10 @@ import pytest
 
 from squadops.capabilities.handlers.cycle.qa_test import QATestHandler
 from squadops.capabilities.scaffold_contract import emit_contract_dict
-from squadops.capabilities.verification_scaffold_emission import emit_verification_scaffold
+from squadops.capabilities.verification_scaffold_emission import (
+    GENERATOR_VERSION,
+    emit_verification_scaffold,
+)
 from squadops.capabilities.verification_scaffold_fill import parse_fill_emission
 from squadops.cycles.task_plan import inject_contract_inputs
 from squadops.cycles.verification_contract import VerificationContract
@@ -61,7 +64,11 @@ class TestInjection:
         scaffold = inputs["verification_scaffold"]
         assert len(scaffold["files"]) == 8
         assert scaffold["manifest"]["stack"] == "nextjs_ts"
-        assert scaffold["manifest"]["generator_version"] == 6
+        # #1029: against the constant, not a literal. This test's subject is that the
+        # scaffold REACHES qa.test on an opted-in stack; pinning the number here made a
+        # legitimate emission bump fail a transport test, and the deliberate value pin
+        # already lives in test_verification_scaffold_reference.
+        assert scaffold["manifest"]["generator_version"] == GENERATOR_VERSION
 
     def test_an_unopted_stack_injects_nothing(self):
         manifest = manifest_for_stack("fullstack_fastapi_react")

--- a/tests/unit/capabilities/test_response_shape.py
+++ b/tests/unit/capabilities/test_response_shape.py
@@ -1,0 +1,147 @@
+"""Tests for the success-body shape derivation (#1029).
+
+The pinning budget is the subject: what the floor must catch, and — equally — what it
+must decline to assert, because every over-pin spends the false-positive budget
+punishing a legitimate app. Each test names the bug it catches.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.response_shape import derive_response_shape
+from squadops.capabilities.scaffold import InterfaceManifest
+
+_BASE = """
+version: 1
+kind: interface_manifest
+project_id: p
+stack: nextjs_ts
+entities:
+  - name: Run
+    fields:
+      - {{ name: id, type: string, required: true, generated: true }}
+      - {{ name: title, type: string, required: true }}
+      - {{ name: distance, type: string, required: false }}
+      - {{ name: participants, type: "{participants}", required: false, default: [] }}
+{extra_entities}
+api:
+  endpoints:
+    - {{ method: GET, path: /api/runs, response: "list[Run]" }}
+"""
+
+_PARTICIPANT_ENTITY = """  - name: Participant
+    fields:
+      - { name: name, type: string, required: true }
+      - { name: joinedAt, type: string, required: false }
+"""
+
+
+def _manifest(participants: str = "list[string]", extra_entities: str = "") -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(
+        _BASE.format(participants=participants, extra_entities=extra_entities)
+    )
+
+
+def test_only_declared_required_fields_are_pinned():
+    """#1029: the floor is required-fields-exist. Pinning optionals would fail an app
+    that legitimately omits one — `distance` is declared `required: false` and an app
+    that never emits it is correct, so asserting it spends the budget on a non-defect."""
+    shape = derive_response_shape(_manifest(), "Run")
+    assert shape.required_fields == ("id", "title")
+    assert "distance" not in shape.required_fields
+    assert "participants" not in shape.required_fields
+
+
+def test_a_generated_field_is_pinned_present_and_nothing_more():
+    """#1029: `id` is `generated: true` — it must exist, and what it equals is the
+    app's business. A value pin here would fail every app with a different id scheme."""
+    shape = derive_response_shape(_manifest(), "Run")
+    assert "id" in shape.required_fields
+    assert all(e.field != "id" for e in shape.elements)
+
+
+def test_a_primitive_collection_pins_its_element_kind():
+    """#1029, the half with teeth. `participants: list[string]` returning objects — or
+    `list[Participant]` returning bare strings — is invisible to every status assertion,
+    and it is what killed the 1.6.1 shakedown."""
+    shape = derive_response_shape(_manifest(participants="list[string]"), "Run")
+    assert [(e.field, e.typeof, e.required_fields) for e in shape.elements] == [
+        ("participants", "string", ())
+    ]
+
+
+def test_an_entity_collection_pins_its_elements_required_fields():
+    """#1029: the shakedown's actual declaration. `list[Participant]` means each element
+    carries Participant's required fields; two dev attempts returned bare strings."""
+    shape = derive_response_shape(
+        _manifest(participants="list[Participant]", extra_entities=_PARTICIPANT_ENTITY), "Run"
+    )
+    element = shape.elements[0]
+    assert element.field == "participants"
+    assert element.required_fields == ("name",)  # NOT joinedAt — optional
+    assert element.typeof == ""
+
+
+@pytest.mark.parametrize(
+    ("response", "expected_collection", "expected_entity"),
+    [("Run", False, "Run"), ("list[Run]", True, "Run"), (" list[Run] ", True, "Run")],
+)
+def test_collection_responses_are_distinguished_from_single_ones(
+    response, expected_collection, expected_entity
+):
+    """#1029: `list[Run]` and `Run` need different assertions — pinning required fields
+    on an array object, or array-ness on a single object, fails a correct app either way."""
+    shape = derive_response_shape(_manifest(), response)
+    assert shape.is_collection is expected_collection
+    assert shape.entity == expected_entity
+
+
+@pytest.mark.parametrize("response", [None, "", "   ", "Unknown", "list[Unknown]"])
+def test_an_undeclared_response_yields_no_pin(response):
+    """#1029: an endpoint with no response, or one naming something the manifest never
+    defines, must produce nothing. Guessing a shape is how a pin becomes a false
+    positive — and `lint()` already owns rejecting an undeclared entity name."""
+    assert derive_response_shape(_manifest(), response) is None
+
+
+def test_a_nested_collection_is_declined_rather_than_guessed():
+    """#1029: `list[list[string]]` — this pass checks one level. Unwrapping to the
+    innermost kind would assert that the OUTER elements are strings, which is false for
+    every correct app; declining is the only safe answer."""
+    shape = derive_response_shape(_manifest(participants="list[list[string]]"), "Run")
+    assert shape.elements == ()
+
+
+def test_an_entity_with_nothing_checkable_is_falsey():
+    """#1029: an entity of only-optional scalars yields no assertions. The shape must
+    read as empty so callers emit nothing — a vacuous `expect` reads as coverage."""
+    manifest = InterfaceManifest.from_yaml(
+        """
+version: 1
+kind: interface_manifest
+project_id: p
+stack: nextjs_ts
+entities:
+  - name: Blob
+    fields:
+      - { name: note, type: string, required: false }
+api:
+  endpoints:
+    - { method: GET, path: /api/blob, response: Blob }
+"""
+    )
+    shape = derive_response_shape(manifest, "Blob")
+    assert shape.required_fields == ()
+    assert not shape
+
+
+@pytest.mark.parametrize(
+    ("declared", "expected_typeof"),
+    [("list[integer]", "number"), ("list[number]", "number"), ("list[boolean]", "boolean")],
+)
+def test_numeric_and_boolean_collections_map_to_their_javascript_kind(declared, expected_typeof):
+    """#1029: the assertion is rendered as a JS `typeof`, so `integer` must become
+    `number` — emitting `typeof x === 'integer'` would fail every correct app."""
+    shape = derive_response_shape(_manifest(participants=declared), "Run")
+    assert shape.elements[0].typeof == expected_typeof

--- a/tests/unit/capabilities/test_verification_scaffold_emission.py
+++ b/tests/unit/capabilities/test_verification_scaffold_emission.py
@@ -236,3 +236,99 @@ class TestValidateEmission:
         )
         with pytest.raises(ScaffoldValidationError, match="disagree"):
             validate_emission(tampered)
+
+
+class TestSuccessBodyPinning:
+    """#1029: the success body's floor is frozen spine, the sibling of #913's envelope.
+
+    Statuses were pinned and the error envelope was pinned; what a success body
+    CONTAINS was not, so response-field paths were invented independently by the app
+    and the suite. Four samples in three days, and the last green roll's entire
+    correction budget — three qa rounds, all "expected undefined to be 'sample'".
+    """
+
+    @staticmethod
+    def _shell(emission, fragment):
+        return next(f for f in emission.files if fragment in f["name"])
+
+    def test_a_success_shell_pins_the_declared_required_fields(self, emission):
+        """The bug: a required field simply absent from the response body, discovered
+        by burning correction rounds instead of at the shell."""
+        content = self._shell(emission, "vc-probe-api-runs.")["content"]
+        assert '["id", "title", "datetime", "location", "participants"]' in content
+        assert "expect(o?.[k]).not.toBeUndefined()" in content
+        assert "expectShape(body)" in content
+
+    def test_a_collection_response_applies_the_same_floor_per_element(self, emission):
+        """The bug: a list endpoint credited on `Array.isArray` alone, so elements of
+        any shape pass. The floor must be the SAME one a single response gets, or the
+        two surfaces disagree about what a Run is."""
+        content = self._shell(emission, "vs-get-api-runs.")["content"]
+        assert "expect(Array.isArray(body)).toBe(true)" in content
+        assert "for (const item of body ?? []) expectShape(item)" in content
+        assert "expectShape(body)" not in content
+
+    def test_a_declared_collection_field_pins_its_element_kind(self, emission):
+        """The half with teeth. The 1.6.1 shakedown declared participants as objects
+        carrying `name` and the app returned bare strings — invisible to every status
+        assertion, and fatal to the roll."""
+        content = self._shell(emission, "vc-probe-api-runs.")["content"]
+        assert (
+            'for (const e of o?.["participants"] ?? []) for (const k of ["id", "name"])' in content
+        )
+
+    def test_the_floor_is_spine_not_slot(self, emission):
+        """Frozen means BEFORE the slot markers. Inside the slot it is fill residue
+        again — deletable by the next re-author, which is the state #1029 describes."""
+        for f in emission.files:
+            content = f["content"]
+            if "expectShape" not in content:
+                continue
+            assert content.index("expectShape") < content.index("scaffold-slot:begin")
+
+    def test_error_shells_carry_no_success_floor(self, emission):
+        """The false-positive direction the gate must never take: a 4xx body is the
+        envelope's business, and asserting entity fields on it would fail every
+        correct app."""
+        for f in emission.files:
+            name = f["name"].rsplit("/", 1)[-1]
+            if "rejects-blank" in name or "duplicate" in name or "not-found" in name:
+                assert "expectShape" not in f["content"], name
+
+    def test_a_primitive_collection_pins_its_javascript_kind(self):
+        """The other rendering of the element rule, and the one the reference manifest
+        does not exercise — mutating the primitive branch away left the whole suite
+        green, because `list[Participant]` takes the entity branch.
+
+        A `list[string]` must emit a `typeof` check. Falling through to the entity
+        branch would emit `for (const k of [])` — a loop over nothing, which passes
+        every app and reads in the shell as if the kind were being checked.
+        """
+
+        def _retype_participants(raw: dict) -> None:
+            entity = next(e for e in raw["entities"] if e["name"] == "RunEvent")
+            field = next(f for f in entity["fields"] if f["name"] == "participants")
+            field["type"] = "list[string]"
+
+        variant = _variant_manifest(_retype_participants)
+        content = next(
+            f["content"]
+            for f in emit_verification_scaffold(variant).files
+            if "vc-probe-api-runs." in f["name"]
+        )
+        assert (
+            'for (const e of o?.["participants"] ?? []) expect(typeof e).toBe("string")' in content
+        )
+        assert "for (const k of [])" not in content
+
+    def test_the_floor_never_asserts_an_exact_field_set_or_a_value(self, emission):
+        """The budget, enforced. Every pin is a subset check: presence and element
+        kind. An equality on the body — or on a field's value — would fail an app that
+        adds a field or generates an id differently, which spends the false-positive
+        budget punishing correctness."""
+        for f in emission.files:
+            for line in f["content"].splitlines():
+                if "expect(o?" not in line and "expect(e?" not in line:
+                    continue
+                assert "not.toBeUndefined()" in line or "expect(typeof e).toBe(" in line, line
+                assert "toEqual" not in line and "toStrictEqual" not in line, line

--- a/tests/unit/capabilities/test_verification_scaffold_reference.py
+++ b/tests/unit/capabilities/test_verification_scaffold_reference.py
@@ -43,17 +43,20 @@ _FIXTURE_DIR = (
 # self-contained evidence that the input end did not move.
 _MANIFEST_HASH = "ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a"
 
-# The fixture's own identity. Regenerated at GENERATOR_VERSION 6 (2026-08-21, #913 — the
-# frozen spine now asserts `body.error?.code` for behaviors whose contract pins a code:
-# the response-field path stops being fill residue, which is where rolls 2/3/13/17 died).
+# The fixture's own identity. Regenerated at GENERATOR_VERSION 7 (2026-08-22, #1029 — the
+# frozen spine now asserts the SUCCESS body's floor as well as the error envelope: the
+# declared-required fields of the responding entity are present, and a declared
+# collection's elements match their declared kind. #913 did this one status class over;
+# success bodies were where the last green roll spent its entire correction budget).
 #
-# Version 6 is the version-4 shape: the SHELLS changed, so the spine hash moves — and the
-# rejection/duplicate shells differ from their siblings, which is the pin discriminating
-# per-behavior emission, not merely reacting to any edit.
+# Version 7 is the version-6 shape: only the SHELLS changed, so the spine hash moves. The
+# rejection shell is the discriminator — a 4xx body is the envelope's business, so it takes
+# NO success floor, and its bytes are unchanged from version 6. A pin that moved every
+# shell equally would not show that the emission is per-behavior.
 #
 # These stop an in-place fixture regeneration from making the byte test self-referential.
-_AGGREGATE_SPINE_HASH = "3b62a339ff2489f65285e0cc780c6fdf97cd794bbfafecf9f143621cae69b0d1"
-_SCAFFOLD_HASH = "395a08bc5a78e2333d21c3af6b89981a9551558d191b3db1b87dc84b251ced00"
+_AGGREGATE_SPINE_HASH = "1ff59445d016f6d7385d713c5f31de7620fe3f065344db6a083bae7b1a0ab962"
+_SCAFFOLD_HASH = "6fc46f50369bc9afd34e40607350b2464b74f79a6a8ef62772470037f5e98854"
 
 
 @pytest.fixture(scope="module")
@@ -72,12 +75,12 @@ def test_the_reference_manifest_is_unmoved():
 def test_generator_version_is_the_fixture_generation(emission):
     """A generator change without a version bump is drift by definition (SIP §4.3);
     a bump without regenerating the fixture is a pin measuring the wrong version."""
-    assert GENERATOR_VERSION == 6
-    assert emission.manifest.generator_version == 6
+    assert GENERATOR_VERSION == 7
+    assert emission.manifest.generator_version == 7
     stored = yaml.safe_load(
         (_FIXTURE_DIR / "verification_scaffold_manifest.yaml").read_text(encoding="utf-8")
     )
-    assert stored["generator_version"] == 6
+    assert stored["generator_version"] == 7
 
 
 def test_emission_reproduces_the_fixture_byte_for_byte(emission):

--- a/tests/unit/cycles/goldens/context_assembly.json
+++ b/tests/unit/cycles/goldens/context_assembly.json
@@ -92,6 +92,13 @@
     "summary": "[dev] designed"
    }
   },
+  "response_surface": [
+   "`GET /runs` returns a list of `RunEvent` \u2014 each element of the array carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+   "`POST /runs` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+   "`GET /runs/{run_id}` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+   "`POST /runs/{run_id}/join` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+   "`POST /runs/{run_id}/leave` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`"
+  ],
   "testid_surface": [
    "`RunsListView` (route `/`): root container `runs-list`; anchors: `runs-list`, `run-item`, `run-participant-count`, `empty-state`, `create-run-link`",
    "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",
@@ -147,6 +154,13 @@
     "summary": "[dev] designed"
    }
   },
+  "response_surface": [
+   "`GET /runs` returns a list of `RunEvent` \u2014 each element of the array carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+   "`POST /runs` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+   "`GET /runs/{run_id}` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+   "`POST /runs/{run_id}/join` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+   "`POST /runs/{run_id}/leave` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`"
+  ],
   "testid_surface": [
    "`RunsListView` (route `/`): root container `runs-list`; anchors: `runs-list`, `run-item`, `run-participant-count`, `empty-state`, `create-run-link`",
    "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",

--- a/tests/unit/cycles/test_scaffold_evidence.py
+++ b/tests/unit/cycles/test_scaffold_evidence.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import pytest
 
 from squadops.capabilities.handlers.test_runner import parse_vitest_failure_rows
-from squadops.capabilities.verification_scaffold_emission import emit_verification_scaffold
+from squadops.capabilities.verification_scaffold_emission import (
+    GENERATOR_VERSION,
+    emit_verification_scaffold,
+)
 from squadops.capabilities.verification_scaffold_fill import merge_fills, parse_fill_emission
 from squadops.cycles.scaffold_evidence import (
     CLASS_APP_CONTRACT,
@@ -272,7 +275,7 @@ class TestSummary:
         )
         d = summary.to_dict()
         # the promotion model's fields (SIP §6/§12) — schema preserved, workflow not built
-        assert d["stack"] == "nextjs_ts" and d["generator_version"] == 6
+        assert d["stack"] == "nextjs_ts" and d["generator_version"] == GENERATOR_VERSION
         assert d["shell_count"] == 8 and d["slot_count"] == 8
         assert d["fill_dispositions"] == {"filled": 1, "missing": 7}
         assert d["additive_test_count"] == 2

--- a/tests/unit/cycles/test_scaffold_region_enforcement.py
+++ b/tests/unit/cycles/test_scaffold_region_enforcement.py
@@ -106,14 +106,16 @@ class TestAdversarialProducerEndToEnd:
                 "frozen spine mutated",
             ),
             (
-                "moving a slot boundary above the assertion",
+                # #1029: re-aimed. The attack hoists the slot-begin marker above the
+                # frozen assertions so they fall inside the editable region; the spine
+                # now also carries the derived success-body floor between the parse and
+                # the marker, so hoisting over only the two original lines no longer
+                # moves the marker at all. The test's own "mutation must change
+                # something" guard is what caught the stale search string.
+                "moving a slot boundary above the assertions",
                 lambda t: t.replace(
-                    "    expect(res.status).toBe(201)\n"
-                    "    const body: any = await res.json().catch(() => ({}))\n"
-                    "    // [scaffold-slot:begin slot-vc-probe-api-runs]",
-                    "    // [scaffold-slot:begin slot-vc-probe-api-runs]\n"
-                    "    expect(res.status).toBe(201)\n"
-                    "    const body: any = await res.json().catch(() => ({}))",
+                    "    expectShape(body)\n    // [scaffold-slot:begin slot-vc-probe-api-runs]",
+                    "    // [scaffold-slot:begin slot-vc-probe-api-runs]\n    expectShape(body)",
                 ),
                 ContractComplianceViolation.SCAFFOLD_REGION_VIOLATION,
                 "frozen spine mutated",


### PR DESCRIPTION
Three phases, one closed loop: **derive once, teach the developer, pin the shell.**

## The gap

The shells pin statuses, and since #913 the error envelope. Nothing pinned what a **success** body contains — so response-field paths were re-invented independently on both sides of the contract, and the disagreement surfaced as burned correction budget or a dead roll. Four samples in three days; the last green roll spent its *entire* correction budget (three qa rounds) on one class of it, all "expected undefined to be 'sample'".

The facts were already declared and simply unread: `entities[].fields` are typed and carry `required`, endpoints declare `response: Run` / `list[Run]`.

## The pinning budget

A floor, not a schema. Every exclusion below is a false-positive source rather than an oversight:

| Pinned | Not pinned, and why |
|---|---|
| declared-**required** fields are present | never an exact field set — a serializer that adds a field is making a legitimate choice |
| a `list[X]` field's elements match X's declared kind | nothing below the first level; a nested list is declined rather than guessed |
| generated fields present | never their value — the id exists, what it equals is the app's business |
| — | optional fields, ever: absent is a valid rendering of optional |
| — | ordering, or anything about extra fields |

An empty collection satisfies everything: no elements, no kind to violate.

Grounded in the banked corpus rather than argued. The green roll declares `participants: list[string]` and its app returns `string[]` — the floor passes it, so the pin costs that roll nothing. The 1.6.1 shakedown declares `list[Participant]` where `Participant` is `{name: string}`, and two successive dev attempts returned bare strings.

> Worth noting: this is the **reverse** of #1029's narrative, which has the app emitting objects and the suite expecting strings. The artifacts say the manifest declared objects and the app built strings — which matters, because it decides which side the teaching half has to reach.

## Replayed before it gates anything

In the qa container, against real vitest, with the green roll's 52 banked artifacts reconstructed to their final versions:

- delivered tree + pins → **27/27 pass**;
- inject a required field's absence into that same working tree → `expected undefined not to be undefined`, that roll's own loss class;
- inject the shakedown's defect → `expected 'object' to be 'string'`.

**Honest negative:** replaying the shakedown tree does *not* exercise the floor. That roll dies earlier on the request-side 400, and its collection is empty wherever the pin runs. The teeth above are proven by controlled injection on a live behavior, not by that replay. Empty-collection short-circuiting is deliberate, but it does mean the element rule only bites on behaviors that populate the collection — join/leave here.

## GENERATOR_VERSION 6 → 7

Per the procedure `test_verification_scaffold_reference.py` documents: bump, regenerate the fixture, update both anti-tautology hashes, say why. **Five of the eight reference shells move; the three error shells are byte-identical** — a 4xx body is the envelope's business, and that is the pin showing this emission is per-behavior rather than a blanket edit.

Three other tests moved with it:

- Two pinned the literal `6` while testing transport and reporting. A legitimate emission bump failed them, so they now assert against the constant; the deliberate value pin stays in the reference test where it belongs.
- The adversarial-producer attack *"moving a slot boundary above the assertion"* searched for the status assertion immediately followed by the slot marker. The floor now sits between them, so the mutation silently became a no-op — caught by that test's own "the mutation must change something" guard. Re-aimed at the new spine.

## Verification

- Regression **7,703 passed**, gate green at 20 workers.
- 7 mutations against phase 2, all killed. One survived the first pass: the primitive element-kind branch, which the reference manifest never exercises because its participants are entities. Dropping it emitted `for (const k of [])` — a loop over nothing that passes every app while reading like a check. Covered now by a variant manifest.
- 7 mutations against phase 1's derivation, all killed.

## Phase 3 — the developer is shown the floor it is judged against

Pinning the shell alone only converts burned rounds into a deterministic red: the gate gets stricter while the author it judges still cannot see the target. `development.develop` received the error contract, the model surface, the testids and the frozen index — and nothing about response shape.

This is the 1.6 defect class exactly: correct machinery wired to fewer paths than it claims, so an agent is judged against a fact it was never shown. A new `response_surface` renders per-endpoint lines from the **same** derivation the spine asserts:

> `POST /api/runs/{run_id}/join` returns `Run` — the response body carries `id`, `title`, `dateTime`, `location`; `participants` is an array of strings

On the 1.6.1 shakedown's manifest that line reads *"each `participants` element carries `name`"* — precisely what both dev attempts got wrong.

The producer lives in `response_shape.py`, the module that owns the derivation, not in `scaffold.py`: the floor already has one home and a second copy would be a second answer. Prose in the appendix asset, Python renders data only (#448).

**The invariant is a test.** Every field the emitted shells assert must be named in that endpoint's brief line — two independent renderings of "what the response must contain" would reintroduce #1029 inside the fix for it.

The context-assembly golden is regenerated in the same commit, per that harness's stated policy. Pure addition: 14 lines, only the new key, on the two dev-facing envelopes.

## A pre-existing gap this closed on the way past

A surface can be declared on the contract, derived, threaded onto the envelope, turned into a section by its own handler method — and then never added to the template's variables. Every step passes its own test and the agent still sees nothing. **No test covered that last step for any of the five dev surfaces.** Closed generically rather than for the new one, and confirmed by dropping a pre-existing surface (`frozen_surface`) and watching the new test fail.

## Deliberately not here

The probe `expect.json_has` producer and the `audit_delivered_app.py` parity fix it requires. That moves the **contract** hash on top of this branch's generator hash, and keeping them apart is what makes a regression attributable. The qa-side brief note (telling fill authors the spine already checks presence and kind, so fills should assert values) follows with it.

**Do not feed a cycle from this without rebuilding** — the deploy is well behind main.

Closes #1029
