### PR TITLE
fix(prompts): the developer is told the declared success status, not left to plan prose

### DIFF
--- a/src/squadops/capabilities/response_shape.py
+++ b/src/squadops/capabilities/response_shape.py
@@ -156,32 +156,52 @@ def response_surface_instructions(manifest: InterfaceManifest | None) -> list[st
     the gate gets stricter while the author it judges still cannot see the target. This
     is the half that lets the app be right the first time.
 
+    The line also carries the endpoint's declared ``success_status`` (#1042). That fact
+    had exactly one surviving channel to a Next.js implementer — a sentence in plan prose
+    that some author had to remember to write. The skeleton writes it as a TODO comment
+    *inside the fill body*, which the fill replaces (``stack_nextjs_ts.py``), and
+    ``development.develop`` binds no behavioral surface, so nothing else carried it.
+    V38 slot 6 shipped 200 against a declared 201, and ``cyc_e3912098c0cf`` was rejected
+    at the plan gate for the same omission on the same endpoint kind. Same class as the
+    body floor above, one field over: derived and threaded beats remembered and restated.
+
+    A status is rendered only when the manifest DECLARES one. An endpoint that leaves it
+    unset takes the framework default, and which default that should be is the open
+    question in #772 — stating one here would be this module taking a position on it by
+    side effect.
+
     Data only — the prose lives in the appendix asset (CLAUDE.md #448). Empty for a
-    manifest whose endpoints declare no resolvable response, which contributes no
-    section at all rather than an empty heading.
+    manifest whose endpoints declare neither a resolvable response nor a status, which
+    contributes no section at all rather than an empty heading.
     """
     if manifest is None:
         return []
     lines: list[str] = []
     for endpoint in manifest.api.endpoints:
         shape = derive_response_shape(manifest, endpoint.response)
-        if not shape:
-            continue
-        subject = "each element of the array" if shape.is_collection else "the response body"
+        status = endpoint.success_status
         clauses = []
-        if shape.required_fields:
-            fields = ", ".join(f"`{name}`" for name in shape.required_fields)
-            clauses.append(f"{subject} carries {fields}")
-        for element in shape.elements:
-            if element.typeof:
-                clauses.append(f"`{element.field}` is an array of {element.typeof}s")
-            else:
-                required = ", ".join(f"`{name}`" for name in element.required_fields)
-                clauses.append(f"each `{element.field}` element carries {required}")
+        if shape:
+            subject = "each element of the array" if shape.is_collection else "the response body"
+            if shape.required_fields:
+                fields = ", ".join(f"`{name}`" for name in shape.required_fields)
+                clauses.append(f"{subject} carries {fields}")
+            for element in shape.elements:
+                if element.typeof:
+                    clauses.append(f"`{element.field}` is an array of {element.typeof}s")
+                else:
+                    required = ", ".join(f"`{name}`" for name in element.required_fields)
+                    clauses.append(f"each `{element.field}` element carries {required}")
+        if not clauses and status is None:
+            continue
+        # Status first: it is the fact an implementer acts on before it composes a body,
+        # and the one that shipped wrong while the body was right.
+        returns = f"HTTP {status}" if status is not None else ""
+        if shape:
+            body = f"{'a list of ' if shape.is_collection else ''}`{shape.entity}`"
+            returns = f"{returns} with {body}" if returns else body
+        line = f"`{endpoint.method.upper()} {endpoint.path}` returns {returns}"
         if clauses:
-            lines.append(
-                f"`{endpoint.method.upper()} {endpoint.path}` returns "
-                f"{'a list of ' if shape.is_collection else ''}`{shape.entity}` — "
-                + "; ".join(clauses)
-            )
+            line += " — " + "; ".join(clauses)
+        lines.append(line)
     return lines

--- a/src/squadops/prompts/request_templates/request.development_develop_response_surface_appendix.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_response_surface_appendix.md
@@ -1,17 +1,22 @@
 ---
 template_id: request.development_develop_response_surface_appendix
-version: "1"
+version: "2"
 required_variables:
   - response_lines
 optional_variables: []
 ---
-**SUCCESS RESPONSE SHAPE (authoritative — the suite asserts exactly this):**
+**SUCCESS RESPONSE (authoritative — the suite asserts exactly this):**
 {{response_lines}}
 
-Each line states the floor for one endpoint's success body, generated from the interface
-manifest. The generated test shells assert it in their frozen region, so a response that
-omits a listed field — or returns an array of the wrong element kind — fails deterministically
-no matter what the endpoint's status code is.
+Each line states one endpoint's success status and the floor for its response body, generated
+from the interface manifest. The generated test shells assert both in their frozen region, so
+a handler that returns the wrong status — or omits a listed field, or returns an array of the
+wrong element kind — fails deterministically.
+
+Return the stated status explicitly. A line that says `HTTP 201` means the framework default is
+wrong for that endpoint: the skeleton's stub carries the status only as a comment in the body
+you are replacing, so if you do not write it, it is gone. A handler that returns a correct body
+under a 200 the contract pins at 201 fails just as hard as a missing field.
 
 This is a floor, not a schema. Additional fields are yours to choose and nothing checks them;
 optional fields may be omitted entirely; the values are the app's business, only presence and

--- a/tests/unit/capabilities/test_response_shape.py
+++ b/tests/unit/capabilities/test_response_shape.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import pytest
 
-from squadops.capabilities.response_shape import derive_response_shape
+from squadops.capabilities.response_shape import (
+    derive_response_shape,
+    response_surface_instructions,
+)
 from squadops.capabilities.scaffold import InterfaceManifest
 
 _BASE = """
@@ -145,3 +148,66 @@ def test_numeric_and_boolean_collections_map_to_their_javascript_kind(declared, 
     `number` — emitting `typeof x === 'integer'` would fail every correct app."""
     shape = derive_response_shape(_manifest(participants=declared), "Run")
     assert shape.elements[0].typeof == expected_typeof
+
+
+# --- #1042: the declared success status travels with the shape --------------------
+
+
+def _manifest_with(endpoints: str, entities: str = "") -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(
+        f"""
+version: 1
+kind: interface_manifest
+project_id: p
+stack: nextjs_ts
+entities:
+  - name: Run
+    fields:
+      - {{ name: id, type: string, required: true, generated: true }}
+      - {{ name: title, type: string, required: true }}
+{entities}
+api:
+  endpoints:
+{endpoints}
+"""
+    )
+
+
+def test_a_declared_status_is_stated_to_the_developer():
+    """#1042: on nextjs the declared status reached the implementer ONLY as a TODO
+    comment inside the fill body it replaces, plus a plan sentence some author had to
+    remember. V38 slot 6 shipped 200 against a declared 201."""
+    manifest = _manifest_with(
+        "    - { method: POST, path: /api/runs, response: Run, success_status: 201 }\n"
+    )
+    (line,) = response_surface_instructions(manifest)
+    assert line.startswith("`POST /api/runs` returns HTTP 201 with `Run`")
+
+
+def test_an_undeclared_status_states_nothing_rather_than_a_default():
+    """#1042 must not settle #772 by side effect. An endpoint that declares no status
+    takes the framework default, and which default is correct is that issue's open
+    question — asserting one here would answer it silently and in the wrong place."""
+    manifest = _manifest_with("    - { method: GET, path: /api/runs, response: Run }\n")
+    (line,) = response_surface_instructions(manifest)
+    assert "HTTP" not in line
+    assert line.startswith("`GET /api/runs` returns `Run`")
+
+
+def test_a_status_survives_an_endpoint_whose_response_cannot_be_resolved():
+    """#1042: the status and the body floor are independent facts. An endpoint whose
+    response names nothing the manifest defines still has a status the implementer must
+    return — dropping the line because the body is underivable loses the very fact this
+    issue is about."""
+    manifest = _manifest_with(
+        "    - { method: POST, path: /api/ping, response: Unknown, success_status: 202 }\n"
+    )
+    (line,) = response_surface_instructions(manifest)
+    assert line == "`POST /api/ping` returns HTTP 202"
+
+
+def test_an_endpoint_with_neither_a_status_nor_a_shape_contributes_no_line():
+    """A line naming an endpoint and stating nothing about it is noise that reads as
+    guidance — the section must stay empty rather than pad."""
+    manifest = _manifest_with("    - { method: GET, path: /api/health }\n")
+    assert response_surface_instructions(manifest) == []

--- a/tests/unit/cycles/goldens/context_assembly.json
+++ b/tests/unit/cycles/goldens/context_assembly.json
@@ -94,7 +94,7 @@
   },
   "response_surface": [
    "`GET /runs` returns a list of `RunEvent` \u2014 each element of the array carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
-   "`POST /runs` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+   "`POST /runs` returns HTTP 201 with `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
    "`GET /runs/{run_id}` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
    "`POST /runs/{run_id}/join` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
    "`POST /runs/{run_id}/leave` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`"
@@ -156,7 +156,7 @@
   },
   "response_surface": [
    "`GET /runs` returns a list of `RunEvent` \u2014 each element of the array carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
-   "`POST /runs` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+   "`POST /runs` returns HTTP 201 with `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
    "`GET /runs/{run_id}` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
    "`POST /runs/{run_id}/join` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
    "`POST /runs/{run_id}/leave` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`"


### PR DESCRIPTION
## The gap

The manifest declares `success_status: 201`. On `nextjs_ts` the only channel carrying that fact to the implementer was **a sentence in plan prose** that some author had to remember to write.

`ScaffoldStack.skeleton_pins_success_status` (`scaffold.py:1935-1945`) says so directly: FastAPI lands `status_code=` in the frozen route decorator, so the implementer inherits it mechanically. The Next.js skeleton writes it as a TODO comment **inside the fill body, which the fill replaces** (`stack_nextjs_ts.py:481`). And `development.develop` binds no behavioral surface, so nothing else carried it at all.

`framing_consistency.py:134` compensates by firing its omission check only where that flag is False — a gate policing an author's prose in place of a missing derivation.

## Two instances of the same fact failing to travel

1. **V38 slot 6** — shipped 200 against a declared 201. The comment did not survive the fill; it is the reason that flag exists.
2. **`cyc_e3912098c0cf` run 1**, tonight — rejected by `system:plan_validation`:

   > manifest↔plan omission on POST /api/runs: the contract will enforce success 201 but no plan line states it for this endpoint — the implementer will default to 200

   The author chose the **right** convention. Only the restatement was missing. That roll was cancelled to fix this rather than continue.

## Not #1031, not #772

- **#1031** is the author choosing a *bad convention* — 400 where 404 is standard. Here the convention was correct.
- **#772** is the disagreement when a status is **not declared**. Here it is.

The defect is the transport. It is #1029's class one field over: a contract-enforced fact that reaches the agent only if an author restates it, instead of being derived and threaded like the model surface, the error contract, the frozen index, and the response floor.

## The fix

Threaded on the surface that already carries the body floor rather than a new one — same endpoint, same line, one derivation:

> `POST /api/runs` returns **HTTP 201** with `Run` — the response body carries `id`, `title`, `dateTime`, `location`; `participants` is an array of strings

Four deliberate boundaries, each mutation-covered:

| Decision | Why |
|---|---|
| status rendered **only when declared** | an undeclared endpoint takes the framework default, and which default is right is **#772's** open question — emitting one here settles it silently, in the wrong place |
| status and body floor are **independent** | an endpoint whose response names nothing the manifest defines still gets its status line; dropping it because the body is underivable loses the exact fact this fixes |
| neither ⇒ **no line** | a line that names an endpoint and states nothing reads as guidance |
| rendered for **every stack**, not gated on `skeleton_pins_success_status` | the fact is true whether or not the skeleton also pins it, and a stack-dependent brief buys nothing |

**The framing gate's omission check stays.** A second channel is not a reason to remove the first — it just stops being the only thing standing between a declared 201 and a shipped 200.

## Verification

- Regression **7,717 passed**, gate green at 20 workers.
- **5 mutations, all killed** — including "an undeclared status invents 200", which is the one that would quietly answer #772.
- Golden regenerated in the same commit per that harness's stated policy: **2 lines**, the single endpoint that declares a status. Nothing else moved.

Closes #1042
