### PR TITLE
feat(qa): the retreat had two halves — record the dropped additive suite too

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -617,7 +617,14 @@ class QATestHandler(_CycleTaskHandler):
             # banked a retreat as a clean success because the record could not tell 8 rich
             # fills from 8 that had dropped every store assertion. Banked rather than logged
             # so the per-roll record reads it from stored state.
-            "assertion_strength": measure_assertion_strength(fill_emission),
+            "assertion_strength": {
+                **measure_assertion_strength(fill_emission),
+                # The retreat had TWO halves and the fills are only one. Shakedown #1's
+                # passing attempt also dropped an entire additive suite — 81 store calls
+                # through TABLES, no mocking — and ran 8 test files where the failing
+                # attempt ran 9. `extracted_files` went 1 -> 0 in a log line nobody read.
+                "additive_files": sorted(a["name"] for a in kept),
+            },
         }
         merged_suite_files = [{"filename": f.path, "content": f.content} for f in merged.files]
         return kept + merged_artifacts, merged_suite_files, evidence

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -179,6 +179,50 @@ class TestMergeFillArtifacts:
         assert evidence["counts"]["missing"] == 7
         assert len(suite_files) == 8
 
+    def test_the_banked_evidence_names_the_additive_suite_that_survived(self, scaffold_input):
+        """#980's other half: a retreat weakens the fills AND drops the additive suite.
+
+        Bug caught: shakedown #1's passing attempt discarded an entire additive suite — 81
+        store calls through TABLES, no mocking — and ran 8 test files where the failing
+        attempt ran 9. `extracted_files` went 1 -> 0 in a log line nobody read, and the
+        banked record said only that the slots were filled. Measuring the fills alone
+        records half a retreat, which reads as a whole one.
+
+        A dropped shell rewrite must NOT appear here. It is a rejected attempt to edit
+        frozen structure, not an additive test — counting it would make a suite look
+        richer at the exact moment it was refused.
+        """
+        fills = parse_fill_emission(
+            "```fill:slot-vc-probe-api-runs\n    expect(body.id).toBeTruthy()\n```\n"
+        )
+        artifacts = [
+            {"name": "__tests__/b.test.ts", "content": "// b", "media_type": "x", "type": "test"},
+            {"name": "__tests__/a.test.ts", "content": "// a", "media_type": "x", "type": "test"},
+            {
+                "name": "__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts",
+                "content": "// REWRITTEN",
+                "media_type": "x",
+                "type": "test",
+            },
+        ]
+        _, _, evidence = QATestHandler()._merge_fill_artifacts(scaffold_input, fills, artifacts)
+
+        strength = evidence["assertion_strength"]
+        assert strength["additive_files"] == ["__tests__/a.test.ts", "__tests__/b.test.ts"]
+        # The fills half is still recorded alongside it — both halves or neither.
+        assert "any_fill_touches_the_store" in strength
+
+    def test_an_emission_that_drops_every_additive_file_banks_an_empty_list(self, scaffold_input):
+        """The absence has to be visible AS an absence. If the key vanished when nothing
+        survived, the retreat this measures would read as "not measured" rather than
+        "measured, and everything was dropped" — the same ambiguity #986 removed from the
+        authenticity detectors."""
+        fills = parse_fill_emission(
+            "```fill:slot-vc-probe-api-runs\n    expect(body.id).toBeTruthy()\n```\n"
+        )
+        _, _, evidence = QATestHandler()._merge_fill_artifacts(scaffold_input, fills, [])
+        assert evidence["assertion_strength"]["additive_files"] == []
+
 
 # --- handle(): a fills-only emission is authorship, not emission failure --------- #
 


### PR DESCRIPTION
Rebased onto main from a branch whose PR (**#982**) merged one commit earlier and left this behind — found during a branch audit, six days stranded.

## The gap

#980 gave the record what the fills *assert*, rather than merely that slots were filled. That covered one half of what shakedown #1 actually did.

Its passing attempt did not only weaken the fills. It dropped an **entire additive suite** — 81 store calls through `TABLES`, no mocking, a genuinely good suite written by the repair — and ran 8 test files where the failing attempt ran 9. `extracted_files` went 1 → 0 in a log line nobody read, and the banked evidence said only that the slots were filled.

A measurement of half a retreat reads as a whole one.

## The change

`assertion_strength` now banks the additive files that survived the merge alongside what the fills assert. Both halves or neither.

Three deliberate details, each mutation-covered:

- **Dropped shell rewrites are excluded.** A rejected attempt to edit frozen structure is not an additive test — counting it would make a suite look richer at the exact moment it was refused.
- **Sorted**, so two attempts are comparable.
- **An empty list is banked, not omitted.** The absence has to be visible *as* an absence, or a total retreat reads as "not measured" rather than "measured, and everything was dropped" — the same ambiguity #986 removed from the authenticity detectors.

## The test was replaced, not just rebased

The commit as stranded carried a test that built the banked dict inside itself and asserted the literal it had just set:

```python
banked = {**measure_assertion_strength(...), "additive_files": []}
assert banked["additive_files"] == []
```

It passed with the **entire source change deleted** — confirmed by mutation before this went up — and it never touched `_merge_fill_artifacts`, despite its own docstring claiming it asserted the handler's shape.

Replaced with two tests driven through the real handler, in `test_fill_mode_transport.py` where that harness already exists.

## Verification

- Regression **7,719 passed**, gate green at 20 workers.
- **5 mutations, all killed** — including the two the old test could not see: dropped shell rewrites counted as additive, and the empty list omitted.

## Related

#980/#982 (the half this completes), #1022 (additive-suite containment, still open in 1.6.2 — this is the measurement that pass would want in place first), #986 (absence-visible-as-absence).
