### PR TITLE
docs(site): separate the framework's verification from the project's measurement

### DIFF
--- a/site/content/architecture.md
+++ b/site/content/architecture.md
@@ -65,9 +65,11 @@ model on an NVIDIA DGX Spark; development runs smaller models locally. No
 per-token cost, no rate limits, no source or requirement text leaving the
 machine.
 
-The cost is throughput, and throughput bounds every measurement window — which
-is why the inference engine sits behind a port with a conformance suite, and why
-alternatives are evaluated against a recorded comparison rather than a vibe.
+The cost is throughput. A local 27B model sets the wall-clock ceiling on every
+cycle, which is why the inference engine sits behind a port with a conformance
+suite every adapter must pass — swapping engines is a configuration change, and
+a candidate engine has to prove it honours the contract before it is trusted
+with a run.
 
 ## Design specs
 

--- a/site/content/evidence.md
+++ b/site/content/evidence.md
@@ -1,15 +1,32 @@
 # Evidence
 
-Agent frameworks are usually demonstrated. This one is measured, and this page
-is the whole record — method, results, and what the results do not support.
+**This page is about how the project evaluates itself — not about what the
+framework does for you.** The two are easy to confuse and worth separating
+before anything else.
 
-## Method
+| | Verification | Measurement |
+|---|---|---|
+| **What** | Checks derived from the design, executed inside every cycle | Windows that score whole cycles, run by the maintainers |
+| **Who gets it** | Anyone running a cycle. It is a framework feature | Nobody. It is how *this project* tests whether the framework works |
+| **Produces** | A cycle verdict and an evidence roll-up | The numbers quoted on this site |
+| **Where** | [Key concepts](key-concepts.md#4-verification-execute-dont-assume) | This page |
+
+Measurement *consumes* verification — a window's scoring rule reads the cycle
+verdict as one of its inputs — which is exactly why they blur. But
+pre-registered windows are research methodology **about** the product, not a
+capability **of** it. Nothing below is something you receive when you run a
+cycle.
+
+What it is instead: the reason to believe the claims made elsewhere on this
+site.
+
+## How the project measures itself
 
 A measurement window is **pre-registered**: the number of runs, the requirement
 document, the deployment hash, and the scoring rule are written down and frozen
 *before the first run*. Once open, nothing is fixed mid-window.
 
-That discipline exists to remove the two ways a result normally flatters itself:
+That discipline removes the two ways a result normally flatters itself:
 
 - **You cannot re-roll.** Every registered slot runs and is scored. A run cannot be
   quietly discarded because it went badly.
@@ -18,7 +35,10 @@ That discipline exists to remove the two ways a result normally flatters itself:
 
 A run scores functional only if the cycle verdict is `accepted`, an independent
 audit confirms the delivered application installs, builds, boots and answers
-every probe its contract specifies, **and** no human intervened.
+every probe its contract specifies, **and** no human intervened. The first
+condition is the framework's own verdict; the second and third are the
+maintainers checking it independently, because a framework grading its own
+homework is not evidence.
 
 ## Results
 
@@ -69,8 +89,9 @@ The honest boundary of both numbers:
 
 It would be easy to publish only the corrected number. Recording both, and the
 order the decisions were taken in, is the point: a measurement programme that
-hides its own instrument failures cannot be trusted about anything else. The
-same rule governs the framework's own verification — a check that did not
-execute is never reported as a pass.
+hides its own instrument failures cannot be trusted about anything else.
 
-[How verification works](key-concepts.md#4-verification-execute-dont-assume){ .md-button }
+The two layers happen to share that principle — the framework never reports an
+unexecuted check as a pass, and the measurement programme never quietly drops a
+run that went badly — but they are separate mechanisms, built at different
+times, for different audiences.

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -6,7 +6,7 @@ authored rather than one it was handed.
 
 ## What separates it
 
-Assuming you already know what agent orchestration is, four things are unusual
+Assuming you already know what agent orchestration is, three things are unusual
 here.
 
 ### The design is authored, then gated
@@ -30,22 +30,30 @@ This is the load-bearing decision in the system. A framework that lets an unrun
 check read as green cannot tell you anything true about its own output —
 including whether it is getting better.
 
-### The claims are measured, not demonstrated
-
-Results come from windows whose size, inputs, deployment hash and scoring rule
-are frozen **before the first run**, so a number cannot be improved by re-rolling
-until it looks good. The most recent: a squad-authored design produced a working
-application with no human intervention in **4 of 6** registered runs, with the
-scoring instrument's own error disclosed on the record.
-
-[The full evidence, and what it does not show](evidence.md){ .md-button }
-
 ### Work is addressed to roles, not personalities
 
 A capability declares which roles may fulfil it; a squad profile decides which
 agent instance and model fills each role. Agent ids are queue addresses, not
 behaviour — swap one and the cycle is unchanged, provided the role is still
 filled. There is no character to prompt-engineer.
+
+---
+
+## Why believe any of it
+
+The three claims above are about the framework. This one is about the project,
+and it is deliberately kept separate: **the numbers on this site come from
+pre-registered measurement windows**, whose size, inputs, deployment hash and
+scoring rule are frozen before the first run — so a result cannot be improved by
+re-rolling until it looks good.
+
+That is not a feature you receive. It is the maintainers' method for testing
+whether the framework works, and the reason to trust the rest of the site. Most
+recently: a squad-authored design produced a working application with no human
+intervention in **4 of 6** registered runs, with the scoring instrument's own
+error disclosed on the record rather than quietly corrected.
+
+[The full evidence, and what it does not show](evidence.md){ .md-button }
 
 ---
 

--- a/site/content/key-concepts.md
+++ b/site/content/key-concepts.md
@@ -56,9 +56,10 @@ the distinction most worth internalising. A cycle that framed a design and then
 implemented it has *two* runs, and they are separate rows with separate
 identities, artifacts, and gate decisions.
 
-Every run records the hash of the configuration it resolved. That is what makes
-two runs comparable, and it is why a measurement window can claim a frozen
-deployment: the run itself carries proof of what it ran under.
+Every run records the hash of the configuration it resolved — squad, models,
+request profile, settings. That is what makes two runs comparable at all: a run
+carries proof of what it executed under, so a difference in outcome can be
+attributed to the change you made rather than to a configuration that drifted.
 
 Runs are the resumability boundary too. Because each workload is its own run
 with its own promoted artifacts, a cycle interrupted after framing can resume


### PR DESCRIPTION
Jason's diagnosis, verbatim: the Evidence page was *"kind of a mashup between how the squad operates and how we (Jason and Claude) operate when building a new feature with FAY or roll windows."* Correct, and worth fixing carefully because the two layers genuinely interlock.

## The two layers

| | Verification | Measurement |
|---|---|---|
| **What** | Checks derived from the design, executed inside every cycle | Windows that score whole cycles, run by the maintainers |
| **Who gets it** | Anyone running a cycle — it is a framework feature | Nobody. It is how *this project* tests whether the framework works |
| **Produces** | A cycle verdict and an evidence roll-up | The numbers quoted on the site |

Measurement **consumes** verification — a window's scoring rule reads the cycle verdict as one input — which is exactly why they blur. But pre-registered windows, frozen deploy hashes and instrument-correction rulings are research methodology **about** the product, not a capability **of** it.

An evaluator reading the old page would reasonably have concluded that pre-registered measurement was something SquadOps does for them. It isn't.

## Changes

**Evidence** opens with the table above, states plainly that nothing on the page is something you receive, and says what it is instead: the reason to believe the claims made elsewhere on the site. Also now explicit that the boot audit and zero-intervention conditions are the maintainers checking the framework's verdict *independently* — a framework grading its own homework is not evidence.

**Overview** had the same defect in smaller form: *"the claims are measured, not demonstrated"* sat as the third of four things that "separate it", beside three genuine framework features. Now three framework claims, plus a separate **"Why believe any of it"** section that says outright it is not a feature you receive.

**Two leaks** where layer-2 vocabulary was propping up layer-1 explanations:

- `key-concepts.md` justified `resolved_config_hash` by saying it lets *a measurement window* claim a frozen deployment. It now says what it actually does for any user: a run carries proof of what it executed under, so a difference in outcome is attributable to the change you made rather than to drift.
- `architecture.md` said throughput *"bounds every measurement window"*. It now says throughput sets the wall-clock ceiling on every cycle.

Both properties stand on their own. Leaning on the measurement programme to justify them was the tell.

## Root cause

The maintainer vocabulary is what recent sessions have been *about*, so it leaks into product description by default. Recorded as a memory so the next session does not re-muddy it — the check is: which layer does this claim belong to?

Grepped the remaining product pages for `pre-registered` / `measurement window` / `re-roll` / `frozen deploy` — clean.

`mkdocs build --strict` passes; every changed page reviewed in a browser.