### PR TITLE
fix(correction): the tests_pass signature stops collapsing when the runner emits no machine report

### DIFF
--- a/src/squadops/cycles/correction_signature.py
+++ b/src/squadops/cycles/correction_signature.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from squadops.cycles.failure_evidence import FailureEvidenceCategory, derive_failure_category
 from squadops.cycles.verification_integrity import ResultStatus
 
 #: The decision-handler vocabulary value meaning "no structural candidate".
@@ -51,6 +52,30 @@ def failure_signature(failure_evidence: dict[str, Any]) -> frozenset[tuple[str, 
     converging run terminated at round 1. Absent (pytest, which emits no machine
     report, and every legacy row) falls back to the aggregate element byte-identically.
 
+    #761: two further machine facts join the token, both already on the row and
+    both previously unread. ``runner`` and ``exit_code`` are what remain when a
+    runner emits no machine report — pytest today — so the per-test split above
+    cannot fire and the whole suite collapses to one element. ``exit_code``
+    separates "tests failed" (1) from "no tests collected" (5) and "usage error"
+    (4): three different defects that produced one signature, which is the
+    REPEAT-vs-SHIFTED blindness #761 reported. Note the report it was filed from
+    (``tests_pass||failed``, shk-6 roll-4) predates #626 and #878; those closed
+    the vitest half, and this closes the half that was left.
+
+    #761 also folds the round's ``derive_failure_category`` into every element.
+    It is deterministic, machine-derived and round-level, so it never varies
+    within a round and a true repeat stays byte-identical — shk-4's three
+    identical rounds still fire the A4 termination. What it buys is the one
+    distinction the row fields cannot make: a round whose app ERRORED and a
+    round whose assertions merely failed are different failures, and both
+    rendered as ``tests_pass||failed``.
+
+    Deliberately NOT included: ``classify_failure_locus``. It is largely derived
+    from the same signals as the category, and every added token raises the odds
+    that a genuine repeat reads as a shift — whose failure mode is that A4 never
+    terminates and the run burns its whole budget. Over-discrimination is the
+    expensive direction here, so the marginal token has to earn its place.
+
     #878 (minimum): the runner's structured ``suite_broken`` verdict joins the
     reason token when present. It is a machine fact, not prose, so the
     evidence-text rule above is intact — and without it a behavioral failure
@@ -68,6 +93,8 @@ def failure_signature(failure_evidence: dict[str, Any]) -> frozenset[tuple[str, 
     if failure_evidence.get("extraction_loss") is True:
         return None
     elements: set[tuple[str, str, str]] = set()
+    # Round-level and constant across the round's elements (see #761 above).
+    category = derive_failure_category(failure_evidence)
     checks = (failure_evidence.get("validation_result") or {}).get("checks") or []
     for row in checks:
         if not isinstance(row, dict):
@@ -82,16 +109,7 @@ def failure_signature(failure_evidence: dict[str, Any]) -> frozenset[tuple[str, 
         if not check_id:
             continue
         subject = str(row.get("file") or row.get("subject") or "")
-        reason = row.get("reason")
-        reason_token = (
-            str(reason)
-            if isinstance(reason, str) and reason
-            else str(row.get("status", ResultStatus.FAILED))
-        )
-        suite_broken = row.get("suite_broken")
-        if suite_broken is not None:
-            health = "broken" if suite_broken else "ran"
-            reason_token = f"{reason_token};suite_health={health}"
+        reason_token = _reason_token(row, category)
         failing_tests = row.get("failing_tests") or ()
         if failing_tests:
             for identity in failing_tests:
@@ -100,6 +118,44 @@ def failure_signature(failure_evidence: dict[str, Any]) -> frozenset[tuple[str, 
         else:
             elements.add((check_id, subject, reason_token))
     return frozenset(elements) if elements else None
+
+
+def _reason_token(row: dict[str, Any], category: str) -> str:
+    """One failing row's reason token: machine facts only, in a stable order.
+
+    Extracted when the #761 additions pushed ``failure_signature`` past the
+    complexity gate — and it belongs apart anyway, because the ordering here IS
+    the contract. Two rounds must build the token the same way or every
+    comparison is a shift, so the sequence is fixed and append-only rather than
+    conditional on which fields happen to be present.
+    """
+    reason = row.get("reason")
+    token = (
+        str(reason)
+        if isinstance(reason, str) and reason
+        else str(row.get("status", ResultStatus.FAILED))
+    )
+    suite_broken = row.get("suite_broken")
+    if suite_broken is not None:
+        token += f";suite_health={'broken' if suite_broken else 'ran'}"
+    # #761: what a runner with no machine report still supplies. `runner` keeps a
+    # pytest failure from colliding with a vitest one; `exit` separates "tests
+    # failed" (1) from "no tests collected" (5) and "usage error" (4).
+    runner = row.get("runner")
+    if runner:
+        token += f";runner={runner}"
+    exit_code = row.get("exit_code")
+    if isinstance(exit_code, int):
+        token += f";exit={exit_code}"
+    # The ordinary category is the baseline and is OMITTED, so a row carrying none of
+    # the newer fields still renders byte-identically to its pre-#626/#878 form — the
+    # invariant `test_legacy_rows_without_verdict_are_byte_identical` and its siblings
+    # pin, and which a token appended unconditionally would have quietly voided. Only
+    # an EXCEPTIONAL category is worth a token: it is precisely the case where two
+    # rounds differ in a way no row field records.
+    if category != FailureEvidenceCategory.EXECUTED_AND_FAILED:
+        token += f";cat={category}"
+    return token
 
 
 # Movement classes (A4.2). Strings, not an enum — event-payload vocabulary.

--- a/tests/unit/cycles/test_correction_signature.py
+++ b/tests/unit/cycles/test_correction_signature.py
@@ -254,3 +254,101 @@ class TestFailingTestIdentity:
         assert render_signature(died) == (
             "tests_pass|__tests__/broken.test.ts|failed;suite_health=ran;test=",
         )
+
+
+class TestNoMachineReportDiscriminators:
+    """#761: what still collapsed after #626 and #878 closed the vitest half.
+
+    The report #761 was filed from — `repeated_signature: ["tests_pass||failed"]`,
+    shk-6 roll-4 — predates both. `suite_broken` and the per-test split fixed runners
+    that emit a machine report; pytest emits none, so its whole suite still reduced to
+    one element and any two consecutive failures read as an exact REPEAT. A4 then
+    terminates a chain that was making progress.
+    """
+
+    @staticmethod
+    def _row(**kw) -> dict:
+        row = {"check": "tests_pass", "passed": False, "runner": "pytest", "suite_broken": False}
+        row.update(kw)
+        return row
+
+    def _sig(self, **kw):
+        return failure_signature(_evidence([self._row(**kw)]))
+
+    @pytest.mark.parametrize(
+        ("first", "second", "why"),
+        [
+            (1, 5, "test failures vs no tests collected — different defects entirely"),
+            (1, 4, "test failures vs a usage error in the runner invocation"),
+            (5, 2, "nothing collected vs execution interrupted"),
+        ],
+    )
+    def test_two_exit_codes_are_two_signatures(self, first, second, why):
+        """Bug caught: a repair that turns 'no tests collected' into real test failures
+        is progress, and read as an exact repeat it terminates the run instead."""
+        assert classify_movement(self._sig(exit_code=first), self._sig(exit_code=second)) == (
+            MOVEMENT_SHIFTED
+        ), why
+
+    def test_the_same_exit_code_twice_is_still_an_exact_repeat(self):
+        """The other direction, and the one that matters more: A4 exists to catch a
+        stuck chain. Over-discrimination would mean it never fires and the run burns
+        its whole correction budget — the expensive failure mode."""
+        assert classify_movement(self._sig(exit_code=1), self._sig(exit_code=1)) == MOVEMENT_REPEAT
+
+    def test_exit_zero_is_a_real_code_not_an_absent_one(self):
+        """A truthiness guard drops `exit_code: 0`, and 0 on a FAILING row is a real
+        state — a suite the runner reports as clean while the harness rejects it (a
+        broken or empty suite). Collapsing it into "no exit code recorded" loses the
+        discriminator on exactly the confusing case, and reads as the legacy form."""
+        assert "exit=0" in render_signature(self._sig(exit_code=0, suite_broken=True))[0]
+        assert classify_movement(self._sig(exit_code=0), self._sig(exit_code=1)) == (
+            MOVEMENT_SHIFTED
+        )
+
+    def test_two_runners_never_collide(self):
+        """A pytest failure and a vitest failure describe different suites. Sharing one
+        `tests_pass||failed` element made them comparable, which they are not."""
+        pytest_sig = self._sig(exit_code=1)
+        vitest_sig = failure_signature(
+            _evidence([self._row(runner="vitest", exit_code=1, suite_broken=False)])
+        )
+        assert classify_movement(pytest_sig, vitest_sig) == MOVEMENT_SHIFTED
+
+    def test_an_app_error_round_is_distinct_from_an_assertion_failure_round(self):
+        """The distinction no row field can make. `app_tracebacks` moves the round's
+        derived category, so a round whose app blew up stops being byte-identical to a
+        round whose assertions merely failed — both rendered `tests_pass||failed`."""
+        plain = self._sig(exit_code=1)
+        errored = failure_signature(
+            _evidence([self._row(exit_code=1)], app_tracebacks=["Traceback: boom"])
+        )
+        assert "cat=app_error" in render_signature(errored)[0]
+        # The ordinary category is the baseline and carries no token, so rows that
+        # predate these fields keep their exact legacy rendering.
+        assert "cat=" not in render_signature(plain)[0]
+        assert classify_movement(plain, errored) == MOVEMENT_SHIFTED
+
+    def test_the_category_is_constant_within_a_round_so_progress_still_reduces(self):
+        """The risk of a round-level token: if it varied per element, a partial fix
+        would stop being a strict subset and PROGRESS would become SHIFTED — silently
+        re-arming the termination this test suite exists to keep selective."""
+        both = failure_signature(
+            _evidence(
+                [
+                    self._row(exit_code=1, failing_tests=("a.test.ts::x", "a.test.ts::y")),
+                ]
+            )
+        )
+        one = failure_signature(
+            _evidence([self._row(exit_code=1, failing_tests=("a.test.ts::x",))])
+        )
+        assert one < both
+        assert classify_movement(both, one) == MOVEMENT_PROGRESS
+
+    def test_a_row_without_the_new_fields_still_yields_a_signature(self):
+        """Legacy and non-suite rows carry none of `runner`/`exit_code`/`suite_broken`.
+        They must still produce an element — a signature that silently became None
+        would disable A4 for every pre-#626 shape."""
+        sig = failure_signature(_evidence([{"check": "frontend_build", "passed": False}]))
+        assert render_signature(sig) == ("frontend_build||failed",)


### PR DESCRIPTION
1 of 4 in the 1.6.2 batch. Independent of the other three.

## The gap — and the half of it that was already closed

A4's progress-aware termination compares a normalized failure signature round over round. #761 reported it as maximally coarse — `repeated_signature: ["tests_pass||failed"]` — so a chain that fixed one failure and broke another (SHIFTED, real progress) was indistinguishable from one failing identically twice (REPEAT). A4 terminates the second.

**The issue is partly stale and does not say so**, because it was filed before both fixes it needed:

- **#626** added the `suite_broken` verdict.
- **#878** split the element per failing test wherever a machine report exists.

What remained is the runner that emits none — **pytest** — whose entire suite still reduced to one element carrying nothing but the word `failed`.

## What now joins the token

All three are already on the row (`failed_tests_pass_row`) and were simply unread. None is prose, so the module's standing rule — evidence text never alters a signature — is intact.

| Token | Separates |
|---|---|
| `exit` | "test failures" (1) from "no tests collected" (5) and "usage error" (4) — three defects, one signature |
| `runner` | a pytest failure from a vitest one; different suites, previously comparable |
| `cat` | the round's derived category — an app that **errored** vs assertions that merely failed, which no row field records |

## Two decisions worth review

**`cat` is emitted only when the category is not the ordinary `executed_and_failed`.** My first cut appended it unconditionally and broke three existing tests pinning *"a row without the newer fields renders byte-identically to its legacy form"*. That invariant is worth keeping, and omitting the baseline keeps it while losing no discrimination — the baseline is exactly the case where two rounds do **not** differ.

**`classify_failure_locus` is deliberately excluded.** It derives from largely the same signals as the category, and every added token raises the odds a genuine repeat reads as a shift — whose failure mode is that A4 never fires and the run burns its whole correction budget. Over-discrimination is the expensive direction here, so a marginal token has to earn its place.

## The invariant that had to survive

The category is computed **once per round**, not per row, so a partial fix remains a strict subset and still classifies as `PROGRESS`. A per-row category would have converted every progress round into a shift and silently re-armed the termination these tests exist to keep selective. Mutation-covered, and shk-4's canonical true positive still fires.

`_reason_token` was extracted when the additions pushed `failure_signature` past the complexity gate. It belongs apart regardless: the append **order** is the contract, since two rounds must build the token identically or every comparison is a shift.

## Verification

- Regression **7,728 passed**, gate green at 20 workers.
- **6 mutations, all killed.** One survived the first pass — a truthiness guard on `exit_code` dropping a real `exit=0`, which on a failing row means a suite the runner calls clean while the harness rejects it. Now covered.

Closes #761
