### PR TITLE
fix(correction): the repair is told to change the minimum, and can see the loop it is in

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -1358,6 +1358,13 @@ class CorrectionRunner:
                     "subtask_description": repair_description,
                     "expected_artifacts": step_expected_artifacts,
                     "acceptance_criteria": failed_inputs.get("acceptance_criteria", []),
+                    # #1015 part C: the loop's position. Both values were already here
+                    # and simply never crossed into the prompt, so the repair author
+                    # could not tell round 1 from round 3 or know the budget was finite.
+                    "correction_attempt": correction_attempts + 1,
+                    "max_correction_attempts": int(
+                        cycle.resolved_config().get("max_correction_attempts", 3)
+                    ),
                 }
                 # #667: fay-14's first fill complied with the manifest
                 # convention and every repair regenerated the view blind,

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -222,6 +222,13 @@ class _RepairPromptMixin:
             # surface), rendered in handle() for qa repairs; dev repairs receive the
             # same block inside fill_only_section. "" when no surface was threaded.
             "frozen_surface_section": str(inputs.get("frozen_surface_section") or ""),
+            # #1015 part C: the repair could not see the loop. No attempt counter, no
+            # statement that rounds are finite — each round rendered only the fresh
+            # failure, so a dev with no reason to think anything was running out
+            # re-emitted the same approach. V38 slot 4 rounds 1-2 and slot 6 round 1
+            # are the samples. Rendered in handle(); "" when the executor threaded no
+            # counter (author-mode and legacy paths render byte-identically).
+            "loop_state": str(inputs.get("loop_state_section") or ""),
         }
 
     async def handle(
@@ -252,7 +259,40 @@ class _RepairPromptMixin:
         frozen = await self._render_qa_frozen_surface_section(context, inputs)
         if frozen:
             inputs = {**inputs, "frozen_surface_section": frozen}
+        loop_state = await self._render_loop_state_section(context, inputs)
+        if loop_state:
+            inputs = {**inputs, "loop_state_section": loop_state}
         return await super().handle(context, inputs)
+
+    async def _render_loop_state_section(
+        self, context: ExecutionContext, inputs: dict[str, Any]
+    ) -> str:
+        """The correction loop's position, or "" (#1015 part C).
+
+        Data only — the prose lives in the managed asset (CLAUDE.md #448). Both numbers
+        already exist at the dispatch site; they simply never reached the prompt.
+
+        Rounds after the first also carry an explicit persistence note. The observed
+        failure is a repair that re-emits the same approach against the same failure
+        (#864: "diagnoses accurately, then re-emits it — twice"), and a round that
+        renders only the fresh failure gives the author no signal that the previous
+        attempt was already tried and did not work.
+        """
+        attempt = inputs.get("correction_attempt")
+        max_attempts = inputs.get("max_correction_attempts")
+        renderer = getattr(getattr(context, "ports", None), "request_renderer", None)
+        if renderer is None or not isinstance(attempt, int) or not isinstance(max_attempts, int):
+            return ""
+        variables = {"attempt": str(attempt), "max_attempts": str(max_attempts)}
+        if attempt > 1:
+            variables["persistence_note"] = (
+                "\nThe failure has already survived at least one repair. Re-emitting the "
+                "same change will spend this round the same way — reconsider the approach "
+                "before producing the files, and if the previous diagnosis looks right but "
+                "the fix did not take, say so rather than repeating it."
+            )
+        rendered = await renderer.render("request.cycle_repair_loop_state", variables)
+        return rendered.content
 
     async def _render_contract_expectations_section(
         self, context: ExecutionContext, inputs: dict[str, Any]

--- a/src/squadops/prompts/request_templates/request.cycle_repair_loop_state.md
+++ b/src/squadops/prompts/request_templates/request.cycle_repair_loop_state.md
@@ -1,0 +1,15 @@
+---
+template_id: request.cycle_repair_loop_state
+version: "1"
+required_variables:
+  - attempt
+  - max_attempts
+optional_variables:
+  - persistence_note
+---
+
+### Where you are in the correction loop
+
+This is repair attempt **{{attempt}} of {{max_attempts}}**. The loop is finite: when the
+budget is exhausted the run fails, whatever state the work is in.
+{{persistence_note}}

--- a/src/squadops/prompts/request_templates/request.cycle_repair_task.md
+++ b/src/squadops/prompts/request_templates/request.cycle_repair_task.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.cycle_repair_task
-version: "3"
+version: "4"
 required_variables:
   - prd
   - role
@@ -17,6 +17,7 @@ optional_variables:
   - contract_expectations
   - dom_anchor_section
   - frozen_surface_section
+  - loop_state
 ---
 ## Repair Task
 
@@ -37,6 +38,20 @@ Focus: {{subtask_focus}}
 The repair MUST produce the following file(s) by name, using fenced code blocks in the format ` ```language:path/to/file ` so the framework can extract them:
 
 {{expected_artifacts}}
+
+**This is a repair, not a rewrite.** Change the minimum necessary to fix the named failure.
+The file list above is the set you may emit — it is not a list of things that need changing.
+A file you are not fixing must be re-emitted byte-identical to what is already in the
+workspace.
+
+Unrelated changes are how a repair round is lost. Reshaping a response, rewording an error
+string, or refactoring validation while fixing something else introduces new failures that
+the retest attributes to this round, and the round is spent without the original defect
+being resolved. If you believe a change beyond the named failure is required, say why in one
+line rather than making it silently.
+
+Test files are qa-owned: do not emit them. Any test file in your output is discarded.
+{{loop_state}}
 
 ### Acceptance Criteria (narrative)
 

--- a/tests/unit/capabilities/test_repair_carries_stack_guidance.py
+++ b/tests/unit/capabilities/test_repair_carries_stack_guidance.py
@@ -25,6 +25,7 @@ cycle whose initial dev output was correct (diagnostic ``cyc_831dfe6ac551``).
 from __future__ import annotations
 
 import ast
+import pathlib
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -38,6 +39,37 @@ _DEVELOP = _REPO / "src/squadops/capabilities/handlers/cycle/develop.py"
 
 #: The stack-#1 asset. Nothing may render it by name — it belongs to a capability.
 _HARDCODED = "request.development_develop_fill_only_appendix"
+
+
+#: The managed request-template directory, for asserting on shipped prompt bytes.
+_TEMPLATE_DIR = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "src"
+    / "squadops"
+    / "prompts"
+    / "request_templates"
+)
+
+
+def _repair_handler_instance():
+    """An instance — distinct from `_dev_repair_handler` below, which returns the CLASS
+    for `_rendered_template_ids`. Two helpers, two shapes; naming them apart is what
+    stops the next reader silently getting an unbound method."""
+    from squadops.capabilities.handlers.impl.repair_handlers import (
+        DevelopmentCorrectionRepairHandler,
+    )
+
+    return DevelopmentCorrectionRepairHandler()
+
+
+def _renderer_context():
+    from unittest.mock import AsyncMock, MagicMock
+
+    context = MagicMock()
+    renderer = MagicMock()
+    renderer.render = AsyncMock(return_value=MagicMock(content="LOOP STATE"))
+    context.ports.request_renderer = renderer
+    return context, renderer
 
 
 def _rendered_template_ids(handler_cls, resolved_config: dict) -> list[str]:
@@ -186,3 +218,111 @@ def test_both_paths_resolve_the_template_the_same_way():
         assert "capability.fill_only_template" in source, (
             f"{path.name} no longer renders the capability's own template"
         )
+
+
+# --- #1015 parts B/C: minimality, and a repair that can see the loop ---------------
+
+
+class TestRepairMinimalityAndLoopState:
+    """#1015: the repair template mandated broad re-emission and hid the loop.
+
+    V38 slot 6 round 0: the analyzer implicated ONE file and the lead prescribed a
+    one-line patch; the repair nevertheless received seven files under "MUST produce
+    the following file(s) by name", and the dev delivered an 18,756-token 8-file
+    rewrite whose gratuitous changes left the retest red and spent the round.
+    """
+
+    def test_the_template_states_minimality_and_the_ownership_rule(self):
+        """Bug caught: the only focus-shaped constraint in the template was the
+        fill-only section, which guards scaffold-owned *interface* — not change size
+        within files the repair legitimately owns. Nothing said 'do not rewrite'."""
+        body = (_TEMPLATE_DIR / "request.cycle_repair_task.md").read_text()
+        assert "This is a repair, not a rewrite" in body
+        assert "byte-identical" in body
+        assert "Test files are qa-owned" in body
+        assert "{{loop_state}}" in body
+
+    async def test_the_loop_state_renders_the_position_from_threaded_numbers(self):
+        handler = _repair_handler_instance()
+        context, renderer = _renderer_context()
+        out = await handler._render_loop_state_section(
+            context, {"correction_attempt": 1, "max_correction_attempts": 3}
+        )
+        assert out
+        template_id, variables = renderer.render.await_args.args
+        assert template_id == "request.cycle_repair_loop_state"
+        assert variables["attempt"] == "1"
+        assert variables["max_attempts"] == "3"
+        assert "persistence_note" not in variables
+
+    async def test_rounds_after_the_first_carry_the_persistence_note(self):
+        """#864's shape: the repair diagnoses accurately and re-emits the same change.
+        A round rendering only the fresh failure gives no signal that this approach was
+        already tried — so round 2+ has to say the failure survived a repair."""
+        handler = _repair_handler_instance()
+        context, renderer = _renderer_context()
+        await handler._render_loop_state_section(
+            context, {"correction_attempt": 2, "max_correction_attempts": 3}
+        )
+        note = renderer.render.await_args.args[1]["persistence_note"]
+        assert "already survived at least one repair" in note
+
+    @pytest.mark.parametrize(
+        "inputs",
+        [
+            {},
+            {"correction_attempt": 1},
+            {"max_correction_attempts": 3},
+            {"correction_attempt": "1", "max_correction_attempts": "3"},
+        ],
+    )
+    async def test_an_unthreaded_or_malformed_counter_renders_nothing(self, inputs):
+        """Author-mode and legacy paths thread no counter. Rendering 'attempt None of
+        None' would be worse than silence, and a string that looks numeric must not
+        slip through into the prompt as one."""
+        handler = _repair_handler_instance()
+        context, renderer = _renderer_context()
+        assert await handler._render_loop_state_section(context, inputs) == ""
+        renderer.render.assert_not_awaited()
+
+    async def test_the_rendered_section_reaches_the_template_variables(self):
+        """The transport step, asserted where a fact can still be silently dropped.
+
+        Bug caught: the section is rendered by `handle()` and then simply not added to
+        the dict the template is rendered with. Every other step passes its own test
+        and the repair author sees nothing — the same gap #1040 found across all five
+        dev surfaces, in the other handler.
+        """
+        handler = _repair_handler_instance()
+        variables = handler._build_render_variables(
+            "prd", None, {"loop_state_section": "LOOP STATE", "failed_task_type": "qa.test"}
+        )
+        assert variables["loop_state"] == "LOOP STATE"
+
+    async def test_handle_injects_the_section_it_rendered(self, monkeypatch):
+        """The step before that one: `handle()` renders the block and must put it on
+        `inputs` under the key `_build_render_variables` reads. Patching the BASE
+        handler, not the mixin — the mixin's `handle` is the method under test, and
+        replacing it is how the first version of this test passed vacuously."""
+        from squadops.capabilities.handlers.cycle.base import _CycleTaskHandler
+
+        handler = _repair_handler_instance()
+        context, _renderer = _renderer_context()
+        captured: dict = {}
+
+        async def _base_handle(_self, _ctx, inputs):
+            captured.update(inputs)
+            return "handled"
+
+        monkeypatch.setattr(_CycleTaskHandler, "handle", _base_handle, raising=True)
+        handler._resolved_config = {}
+        await handler.handle(
+            context,
+            {
+                "correction_attempt": 2,
+                "max_correction_attempts": 3,
+                "failed_task_type": "qa.test",
+                "resolved_config": {},
+            },
+        )
+        assert captured.get("loop_state_section") == "LOOP STATE"

--- a/tests/unit/cycles/goldens/correction_context.json
+++ b/tests/unit/cycles/goldens/correction_context.json
@@ -18,6 +18,7 @@
       "art_routes",
       "delta_000000000000"
      ],
+     "correction_attempt": 1,
      "correction_decision": {
       "affected_task_types": [
        "development.develop"
@@ -67,6 +68,7 @@
        "summary": "1/2 checks passed"
       }
      },
+     "max_correction_attempts": 3,
      "prd": "PRD-CONTENT",
      "prior_outputs": {
       "dev": {
@@ -102,6 +104,7 @@
       "art_routes",
       "delta_000000000000"
      ],
+     "correction_attempt": 1,
      "correction_decision": {
       "affected_task_types": [
        "development.develop"
@@ -187,6 +190,7 @@
       "- `frontend/src/api.js` \u2014 classes `ApiError(code, message, status)`; functions `apiFetch(path, options = {})`",
       "- `frontend/src/App.jsx` \u2014 its own imports `./views/CreateRunView.jsx`, `./views/RunDetailView.jsx`, `./views/RunsListView.jsx`, `react-router-dom`"
      ],
+     "max_correction_attempts": 3,
      "prd": "PRD-CONTENT",
      "prior_outputs": {
       "dev": {
@@ -224,6 +228,7 @@
       "art_routes",
       "delta_000000000000"
      ],
+     "correction_attempt": 1,
      "correction_decision": {
       "affected_task_types": [
        "development.develop"
@@ -296,6 +301,7 @@
       "- `frontend/src/api.js` \u2014 classes `ApiError(code, message, status)`; functions `apiFetch(path, options = {})`",
       "- `frontend/src/App.jsx` \u2014 its own imports `./views/CreateRunView.jsx`, `./views/RunDetailView.jsx`, `./views/RunsListView.jsx`, `react-router-dom`"
      ],
+     "max_correction_attempts": 3,
      "prd": "PRD-CONTENT",
      "prior_outputs": {
       "dev": {

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -2000,6 +2000,59 @@ class TestCorrectionRunnerStandalone:
         assert captured[0].inputs["dom_testid_surface"] == expected_lines
         assert any("run-detail" in line for line in captured[0].inputs["testid_surface"])
 
+    async def test_repair_envelope_carries_the_loop_position(self, cycle):
+        """#1015 part C: `correction_attempts` and `max_correction_attempts` both
+        existed at this dispatch site and neither crossed into the repair envelope, so
+        the prompt could not tell round 1 from round 3 or say the budget is finite.
+
+        Bug caught: the same transport gap that #1040 closed for the dev surfaces —
+        a value computed one line away from the envelope and never put on it. The
+        handler-side render test passes without this, which is exactly how the fact
+        goes missing while every step looks covered.
+        """
+        import dataclasses as _dc
+
+        captured: list = []
+
+        def responder(envelope):
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "patch",
+                        "decision_rationale": "patchable",
+                        "affected_task_types": ["development.develop"],
+                    },
+                )
+            if envelope.task_type == "development.correction_repair":
+                captured.append(envelope)
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={"artifacts": [], "summary": "repaired"},
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _registry, _vault, _bus = self._make_runner(responder)
+        await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=_dc.replace(self._failed_envelope(), task_type="qa.test"),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="suite failed"),
+            correction_attempts=1,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+        assert len(captured) == 1
+        # attempts=1 already spent, so the repair being dispatched is attempt 2.
+        assert captured[0].inputs["correction_attempt"] == 2
+        assert isinstance(captured[0].inputs["max_correction_attempts"], int)
+
     async def test_no_manifest_threads_no_anchor_keys(self, cycle):
         """Boundary: a manifest-less correction (author mode, non-scaffold
         stacks) must not grow anchor keys — the deriver returns [] and the


### PR DESCRIPTION
2 of 4 in the 1.6.2 batch. Independent of the other three.

**Parts B and C only. Part A is deferred — it is not buildable as the issue specifies it.** Reason below; `Refs`, not `Closes`.

## The sample

V38 slot 6 round 0: the analyzer implicated **one** file, the lead prescribed a **one-line** patch, the repair received **seven** files under *"The repair MUST produce the following file(s) by name"*, and the dev delivered an **18,756-token 8-file rewrite** whose gratuitous changes — response shape, error strings, a validation refactor — left the retest red and spent the round.

## B — the template states minimality

The only focus-shaped constraint in the template was the SIP-0099 fill-only section, which guards scaffold-owned *interface*, not change size inside files the repair legitimately owns. Nothing said "do not rewrite."

Template v4 adds: this is a repair, not a rewrite; the file list is what you **may** emit, not a list of things needing change; re-emit untouched files byte-identical; unrelated changes are how a round is lost. Plus the advisory ownership line — test files are qa-owned and are discarded (enforcement is #1014's half).

## C — the repair can see the loop

`correction_attempts` and `max_correction_attempts` both already existed at the dispatch site, and **neither crossed into the prompt**. The author could not tell round 1 from round 3, or know the budget was finite.

Now renders *"attempt N of M"*, and rounds after the first carry an explicit note that the failure already survived a repair. That targets #864's shape — *"diagnoses accurately, then re-emits it — twice"* — which is what a round rendering only the fresh failure invites. Prose in a managed asset, data from Python (#448).

## Part A, deferred with its reason

The issue says to target from *"the analyzer's implicated files (`failure_analysis`)"*. **The analyzer emits no such field.** Its declared output contract is `classification`, `analysis_summary`, `contributing_factors` — prose. Round 0 "named the join route explicitly" inside a sentence.

Deriving a repair target from prose is the same anti-pattern `correction_signature` bans for signatures, and the issue's own citations argue against it: **#968** (nothing verifies analyzer claims against the source) and **#788** (a repair followed an impossible analyzer recommendation into a worse failure).

Part A needs the analyzer to emit **structured** implicated files first — a schema change whose natural companion is #968's verification slice, currently 1.6.3. Recorded on the issue rather than half-built.

## Verification

- Regression **7,738 passed**, gate green at 20 workers.
- Goldens regenerated in the same commit per that harness's policy: **6 lines**, the two new keys on three repair scenarios, nothing else moved.
- **8 mutations, all killed.** Three survived the first pass and all three were **transport**: the section rendered but not injected, the variable computed but never placed in the template dict, the counter never put on the envelope. Same class #1040 found across all five dev surfaces, in the other handler — every step had a passing test while the fact reached nobody.
- One of my own tests also passed vacuously by patching the mixin's `handle` — the method under test. Now patched at the base.

Refs #1015
