### PR TITLE
fix(gates): the framing omission check reads BOTH channels — #1042 made its premise false

### DIFF
--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -2012,6 +2012,34 @@ def skeleton_pins_success_status_for(stack: str) -> bool:
     return bool(known and known.skeleton_pins_success_status)
 
 
+def brief_carries_success_status_for(stack: str) -> bool:
+    """Whether *stack*'s DEVELOPER BRIEF states declared success statuses (#1049).
+
+    The second deterministic channel, and the sibling of
+    ``skeleton_pins_success_status_for`` above — they are the two ways the fact can
+    reach an implementer without a human remembering to write it down, so they belong
+    side by side and are read together by the framing gate.
+
+    #1042 threads the declared status onto the dev brief's response surface, but only
+    where that surface renders: a scaffoldable stack whose dev capability declares a
+    fill-only template. A stack with no such template gets no appendix, so prose
+    remains its sole channel and the omission check must still block there.
+
+    ``False`` for unknown stacks and unresolvable capabilities — the conservative answer
+    when we cannot prove the fact travels is that it does not.
+    """
+    from squadops.capabilities.dev_capabilities import get_capability
+
+    known = _STACKS.get(stack)
+    if known is None or not is_scaffoldable_stack(stack):
+        return False
+    try:
+        capability = get_capability(known.dev_capability)
+    except ValueError:
+        return False
+    return bool(capability.fill_only_template)
+
+
 def check_stack_for(stack: str) -> str | None:
     """The typed-check evaluator vocabulary for ``stack``, or ``None`` (#503).
 

--- a/src/squadops/cycles/framing_consistency.py
+++ b/src/squadops/cycles/framing_consistency.py
@@ -117,21 +117,34 @@ def validate_manifest_plan_consistency(
 
     Returns error strings in the plan-validation vocabulary (empty = pass).
     """
-    from squadops.capabilities.scaffold import skeleton_pins_success_status_for
+    from squadops.capabilities.scaffold import (
+        brief_carries_success_status_for,
+        skeleton_pins_success_status_for,
+    )
 
     errors: list[str] = []
     lines = _plan_text_lines(plan)
-    # The omission half fires only where plan prose is the sole channel carrying
-    # the status to the implementer. FastAPI's skeleton pins a declared status in
-    # the FROZEN route decorator (pf-39's fix) — the fill inherits it mechanically
-    # and prose silence is harmless. The Next.js skeleton writes it only as a TODO
-    # comment inside the fill body, which the fill replaces — slot 6 proved the
-    # comment does not survive. Status probes bind to the qa task, never the dev
-    # task's criteria_refs, so the typed channel never carries this fact to the
-    # implementer in EITHER authoring mode — the stack's skeleton is the variable.
+    # The omission half fires only where plan prose is the sole channel carrying the
+    # status to the implementer. FastAPI's skeleton pins a declared status in the FROZEN
+    # route decorator (pf-39's fix) — the fill inherits it mechanically and prose silence
+    # is harmless. The Next.js skeleton writes it only as a TODO comment inside the fill
+    # body, which the fill replaces — slot 6 proved the comment does not survive.
+    #
+    # #1049: there are now TWO deterministic channels and the check must fire only when
+    # NEITHER carries the fact. The sentence that stood here — "the typed channel never
+    # carries this fact to the implementer in EITHER authoring mode" — was true when
+    # written and #1042 made it false: the declared status is threaded onto the dev
+    # brief's response surface. Left as-is this check taxed a re-roll per cycle to
+    # enforce a prose restatement of a fact that can no longer be forgotten, and its own
+    # rejection text ("the implementer will default to 200") had become the false part.
+    # Five identical rejections across three cycles, two of them consuming both re-rolls
+    # of one cycle, which is a dead-ended run on a framing that was correct.
+    #
     # The contradiction half stays active regardless: prose that contradicts the
-    # contract misleads the implementer whatever the skeleton pins.
-    status_pinned_by_skeleton = skeleton_pins_success_status_for(manifest.stack)
+    # contract misleads the implementer whatever any other channel says.
+    status_reaches_implementer = skeleton_pins_success_status_for(
+        manifest.stack
+    ) or brief_carries_success_status_for(manifest.stack)
 
     for ep in manifest.api.endpoints:
         enforced = _enforced_success_status(ep)
@@ -170,7 +183,7 @@ def validate_manifest_plan_consistency(
         # Completeness: an enforced non-200 success is exactly the fact the dev
         # will not default to — slot 6's roll died on it. It must be STATED in
         # the plan's prose near the endpoint, or the implementer never sees it.
-        if enforced != 200 and not stated_anywhere and not status_pinned_by_skeleton:
+        if enforced != 200 and not stated_anywhere and not status_reaches_implementer:
             already_contradicted = any(f"on {ep.method} {ep.path}:" in e for e in errors)
             if not already_contradicted:
                 errors.append(

--- a/tests/unit/capabilities/test_scaffold.py
+++ b/tests/unit/capabilities/test_scaffold.py
@@ -9,6 +9,7 @@ CI/local gate; these guard the expander logic itself.
 
 from __future__ import annotations
 
+import dataclasses as dc
 import importlib.util
 from pathlib import Path
 
@@ -1048,3 +1049,55 @@ class TestTypeScriptConstSurface:
         )
         assert "BIG: Record<string, string>" in long_literal
         assert "key_19" not in long_literal
+
+
+class TestBriefCarriesSuccessStatus:
+    """#1049: the second channel the framing omission gate reads.
+
+    The gate blocks a framing only when NEITHER the skeleton nor the dev brief carries
+    a declared success status. This predicate answers the second half, so a wrong
+    answer here either re-arms a re-roll tax on a correct framing or — worse — silences
+    the gate on a stack where prose really is the only channel.
+    """
+
+    def test_the_registered_stacks_report_their_actual_channels(self):
+        from squadops.capabilities.scaffold import (
+            brief_carries_success_status_for,
+            skeleton_pins_success_status_for,
+        )
+
+        # nextjs pins nothing structurally (the TODO comment dies with the fill) but
+        # does render the appendix — which is exactly why #1049 exists.
+        assert skeleton_pins_success_status_for("nextjs_ts") is False
+        assert brief_carries_success_status_for("nextjs_ts") is True
+        assert skeleton_pins_success_status_for("fullstack_fastapi_react") is True
+
+    @pytest.mark.parametrize("stack", ["", "no_such_stack", "NEXTJS_TS"])
+    def test_an_unknown_stack_claims_no_channel(self, stack):
+        """The conservative answer. Claiming a channel we cannot prove would silence
+        the gate on precisely the stack that has no other carrier."""
+        from squadops.capabilities.scaffold import brief_carries_success_status_for
+
+        assert brief_carries_success_status_for(stack) is False
+
+    def test_a_scaffoldable_stack_whose_capability_has_no_appendix_claims_no_channel(
+        self, monkeypatch
+    ):
+        """The guard no registered stack reaches today, and the reason it is written
+        rather than assumed: the dev brief carries the status only where the fill-only
+        appendix renders. A capability with no template renders none, so prose is still
+        the sole channel and the omission check must keep blocking.
+
+        Mutating this to `return True` left the whole suite green — an unreachable
+        guard is exactly the kind that silently stops working when a third stack lands.
+        """
+        from squadops.capabilities import scaffold as scaffold_module
+        from squadops.capabilities.dev_capabilities import get_capability
+
+        real = get_capability
+
+        def _no_appendix(name: str):
+            return dc.replace(real(name), fill_only_template="")
+
+        monkeypatch.setattr("squadops.capabilities.dev_capabilities.get_capability", _no_appendix)
+        assert scaffold_module.brief_carries_success_status_for("nextjs_ts") is False

--- a/tests/unit/cycles/test_framing_consistency.py
+++ b/tests/unit/cycles/test_framing_consistency.py
@@ -10,13 +10,13 @@ from squadops.cycles.framing_consistency import validate_manifest_plan_consisten
 from squadops.cycles.implementation_plan import ImplementationPlan
 
 
-def _manifest(endpoints_yaml: str) -> InterfaceManifest:
+def _manifest(endpoints_yaml: str, stack: str = "nextjs_ts") -> InterfaceManifest:
     return InterfaceManifest.from_yaml(
         f"""
 version: 1
 kind: interface_manifest
 project_id: group_run
-stack: nextjs_ts
+stack: {stack}
 api:
   endpoints:
 {endpoints_yaml}
@@ -115,11 +115,15 @@ class TestContradiction:
 
 
 class TestOmission:
-    def test_slot6_class_enforced_201_never_stated(self):
-        """V38 slot 6: join 201 lived only in the manifest; the plan was
-        silent; the dev defaulted to 200 and the roll died on a fact the
-        implementer never received. The gate names the omission."""
-        manifest = _manifest(JOIN_201)
+    def test_slot6_class_fires_where_no_channel_carries_the_status(self):
+        """V38 slot 6: join 201 lived only in the manifest; the plan was silent; the dev
+        defaulted to 200 and the roll died on a fact the implementer never received.
+
+        Exercised on a stack with NEITHER channel — no skeleton pinning and no dev-brief
+        appendix — because that is now the only condition under which prose is still the
+        sole carrier, and it is the condition the gate exists for.
+        """
+        manifest = _manifest(JOIN_201, stack="no_such_stack")
         plan = _plan(
             [
                 "POST /api/runs returns 201 with the created run.",
@@ -130,6 +134,39 @@ class TestOmission:
         assert len(errors) == 1
         assert "omission on POST /api/runs/{run_id}/join:" in errors[0]
         assert "default to 200" in errors[0]
+
+    def test_the_omission_is_silent_once_the_dev_brief_carries_the_status(self):
+        """#1049: the same framing, on nextjs_ts, must now PASS.
+
+        Bug caught: the check kept rejecting after #1042 threaded the declared status
+        onto the dev brief — enforcing a prose restatement of a fact the implementer is
+        now told directly, and warning that "the implementer will default to 200" when
+        it will not. Five identical rejections across three cycles, two of them
+        consuming both re-rolls of one cycle and dead-ending a correct framing.
+        """
+        manifest = _manifest(JOIN_201)
+        plan = _plan(
+            [
+                "POST /api/runs returns 201 with the created run.",
+                "POST /api/runs/{run_id}/join adds the participant and updates the count.",
+            ]
+        )
+        assert validate_manifest_plan_consistency(manifest, plan) == []
+
+    def test_a_contradiction_still_fires_on_a_stack_with_the_brief_channel(self):
+        """The half that must NOT be softened. Derivation fixes silence; it does not fix
+        a plan that says the wrong thing — a dev reading "returns 200" builds 200 no
+        matter what any appendix also says, and the two channels then disagree."""
+        manifest = _manifest(JOIN_201)
+        plan = _plan(
+            [
+                "POST /api/runs returns 201 with the created run.",
+                "POST /api/runs/{run_id}/join returns 200 once the participant is added.",
+            ]
+        )
+        errors = validate_manifest_plan_consistency(manifest, plan)
+        assert len(errors) == 1
+        assert "contradiction on POST /api/runs/{run_id}/join:" in errors[0]
 
     def test_child_post_default_200_needs_no_statement(self):
         """A child-action POST with no declared status is enforced at 200 —


### PR DESCRIPTION
Filed and fixed tonight, because it is **actively blocking the validation rolls** — not a cleanup.

## The premise the check states is now false

`framing_consistency`'s completeness half rejects a framing when the plan omits a line restating the manifest's declared success status. Its rejection text names the harm it prevents:

> the contract will enforce success 201 but no plan line states it for this endpoint — **the implementer will default to 200 and the probe will reject a faithful build**

**#1042 threads the declared status onto the developer's brief.** The brief now reads ``POST /api/runs` returns HTTP 201 with `Run` — …`. The implementer does not default to 200, because it is told.

## What it costs, measured tonight

**Five identical rejections across three cycles**, all this check:

| Cycle | Rejections |
|---|---|
| `cyc_e3912098c0cf` | 1 |
| `cyc_181c9572bef2` | 2 — both re-rolls consumed |

The framing author omits this line reliably. With `framing_max_rerolls` defaulting to 2, that is a dead-ended run on a framing that was correct.

## The fix

The check already gated on **one** channel — `skeleton_pins_success_status_for`, because FastAPI pins a declared status in the frozen route decorator and prose silence is harmless there. There are now **two**, so the condition names both.

`brief_carries_success_status_for` sits beside its sibling: the dev brief carries the status only where the fill-only appendix renders, which requires a scaffoldable stack whose dev capability declares a template. A stack without one still has prose as its only channel and still blocks. The condition is *"no channel carries it"*, not *"we added a channel somewhere"*.

**The contradiction half is untouched.** Derivation fixes silence; it does not fix a document that says the wrong thing. A dev reading "returns 200" builds 200 no matter what an appendix also says, and the two channels then disagree. Softening that half with the same condition is the obvious wrong turn, so it is mutation-covered.

The stale reasoning is replaced in place rather than left to mislead — the comment reading *"the typed channel never carries this fact to the implementer in EITHER authoring mode"* was true when written and is now the part that is wrong.

## Tests

The slot-6 omission test moves to a stack with **neither** channel — now the only condition under which prose is the sole carrier, and what the gate exists for. Beside it: the same framing on `nextjs_ts` must now pass, and a contradiction on that stack must still fire.

## Verification

- Regression **7,726 passed**, gate green at 20 workers.
- **5 mutations, all killed.** One survived the first pass — `brief_carries_success_status_for` returning `True` regardless of the fill-only template. No registered stack reaches that guard today, so nothing exercised it; an unreachable guard is the kind that stops working silently when a third stack lands. Now tested directly with a stubbed capability.

Closes #1049
