### PR TITLE
fix(verification): a contract criterion with no evidence stops being a silent fourth state

### DIFF
--- a/adapters/cycles/postgres_cycle_registry.py
+++ b/adapters/cycles/postgres_cycle_registry.py
@@ -649,6 +649,10 @@ def _verification_summary_to_dict(summary: RunVerificationSummary) -> dict:
         # Postgres (rather than the in-memory summary) undercounted (#500).
         "criteria_verified": list(summary.criteria_verified),
         "criteria_total": list(summary.criteria_total),
+        # #1021: which shortfalls produced NO evidence at all, as opposed to evidence
+        # that went adverse. Derivable only here — the reader cannot recover it from
+        # the other lists, which is the whole complaint.
+        "criteria_unevidenced": list(summary.criteria_unevidenced),
         # #1002: the bounded inspected-set references. Stored so the question
         # "did this detector ever see the file?" is answerable from any run
         # after the fact — which was the whole point of computing it.
@@ -688,6 +692,7 @@ def _verification_summary_from_dict(d: dict) -> RunVerificationSummary:
         passed_count=int(d.get("passed_count", 0)),
         criteria_verified=tuple(d.get("criteria_verified", [])),
         criteria_total=tuple(d.get("criteria_total", [])),
+        criteria_unevidenced=tuple(d.get("criteria_unevidenced", [])),
         inspections=tuple(
             CheckInspection(
                 check_id=i["check_id"],

--- a/src/squadops/cycles/run_report_builder.py
+++ b/src/squadops/cycles/run_report_builder.py
@@ -157,6 +157,16 @@ def _build_verification_lines(summary: RunVerificationSummary) -> list[str]:
             lines.append(
                 f"Contract criteria NOT verified: {', '.join(summary.criteria_unverified)}"
             )
+        # #1021: a shortfall that produced evidence and a shortfall that produced NONE
+        # are different defects — a product failure versus a hole in the evidence chain
+        # — and the combined list above cannot tell them apart. Slot 5 read 12/14 with
+        # `failed` and `unverified` both empty, and nothing said which had happened.
+        if summary.criteria_unevidenced:
+            lines.append(
+                f"  ...of which {len(summary.criteria_unevidenced)} produced NO evidence "
+                f"row at all (never executed, not merely failed): "
+                f"{', '.join(summary.criteria_unevidenced)}"
+            )
     if summary.failed:
         # #500: reasons inline when the aggregation carried them, so a failed
         # probe is classifiable from the report alone (bare-name fallback kept

--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -323,6 +323,16 @@ class RunVerificationSummary:
     # "references only": a digest and a count, never the paths. Default-empty, so
     # producers that declare nothing and pre-#1002 stored summaries are unchanged.
     inspections: tuple[CheckInspection, ...] = ()
+    # #1021: contract criteria that produced NO result row at all — neither credited
+    # nor adverse. `criteria_unverified` already names every shortfall (#945), but it
+    # cannot separate "the check ran and went adverse" from "the check never ran", and
+    # those are different defects: one is a product failure, the other a hole in the
+    # evidence chain. Slot 5 (`run_654b61665fed`) is the banked case — 12 of 14, both
+    # missing criteria `vc-compiles-*`, with `failed` and `unverified` BOTH empty, so
+    # the record could not say which had happened. Default-empty: pre-#1021 stored
+    # summaries reconstruct unchanged, and an author-mode run (no bound contract) has
+    # no declared denominator and so can have no unevidenced criteria.
+    criteria_unevidenced: tuple[str, ...] = ()
 
     @property
     def pass_rate(self) -> float:
@@ -364,6 +374,17 @@ class RunVerificationSummary:
         """
         verified = set(self.criteria_verified)
         return tuple(c for c in self.criteria_total if c not in verified)
+
+    @property
+    def criteria_adverse(self) -> tuple[str, ...]:
+        """Criteria that fell short having actually produced evidence (#1021).
+
+        The complement of ``criteria_unevidenced`` within ``criteria_unverified``, so a
+        reader can tell a product failure from a hole in the evidence chain without
+        diffing three lists by hand — the #945 argument applied one level down.
+        """
+        unevidenced = set(self.criteria_unevidenced)
+        return tuple(c for c in self.criteria_unverified if c not in unevidenced)
 
 
 @dataclass(frozen=True)
@@ -703,6 +724,13 @@ def aggregate_verification(
         criteria_total=tuple(sorted(set(contract_criteria) | criteria_passed | criteria_adverse)),
         failed_detail=tuple(failed_detail),
         inspections=tuple(inspections),
+        # #1021: declared by the contract, and no row carried the id in either
+        # direction. Computed from the contract's set only — a criterion observed on a
+        # row is by definition evidenced, so unioning the observed ids in (as
+        # `criteria_total` does, to never drop unexpected evidence) would be wrong here.
+        criteria_unevidenced=tuple(
+            sorted(set(contract_criteria) - criteria_passed - criteria_adverse)
+        ),
     )
 
 

--- a/tests/unit/cycles/test_postgres_cycle_registry.py
+++ b/tests/unit/cycles/test_postgres_cycle_registry.py
@@ -1084,3 +1084,42 @@ class TestInspectionSerialization:
         stored.pop("inspections")
 
         assert _verification_summary_from_dict(stored).inspections == ()
+
+
+class TestUnevidencedCriteriaSerialization:
+    """#1021: the distinction must survive the round-trip, or it exists only in memory
+    and the stored run is as mute as it was — the same last-hop drop #1002 fixed."""
+
+    @staticmethod
+    def _summary():
+        from squadops.cycles.verification_integrity import CheckResult, aggregate_verification
+
+        return aggregate_verification(
+            [CheckResult(check_id="c1", status="passed", criterion_id="vc-a", subject="t")],
+            contract_criteria=["vc-a", "vc-b"],
+        )
+
+    def test_round_trip_preserves_the_unevidenced_set(self):
+        from adapters.cycles.postgres_cycle_registry import (
+            _verification_summary_from_dict,
+            _verification_summary_to_dict,
+        )
+
+        summary = self._summary()
+        rebuilt = _verification_summary_from_dict(
+            json.loads(json.dumps(_verification_summary_to_dict(summary)))
+        )
+        assert rebuilt.criteria_unevidenced == ("vc-b",)
+        assert rebuilt.criteria_adverse == ()
+
+    def test_pre_1021_stored_dict_reports_no_unevidenced_criteria(self):
+        """A summary written before the field existed must load, and must not invent a
+        shortfall — an absent key means 'not recorded', never 'nothing was evidenced'."""
+        from adapters.cycles.postgres_cycle_registry import (
+            _verification_summary_from_dict,
+            _verification_summary_to_dict,
+        )
+
+        stored = _verification_summary_to_dict(self._summary())
+        stored.pop("criteria_unevidenced")
+        assert _verification_summary_from_dict(stored).criteria_unevidenced == ()

--- a/tests/unit/cycles/test_run_report_builder.py
+++ b/tests/unit/cycles/test_run_report_builder.py
@@ -181,3 +181,42 @@ class TestInspectedSubjectsSection:
         a section present with no rows implies the inventory was collected."""
         text = self._lines(CheckResult(check_id="tests_pass", status=ResultStatus.PASSED))
         assert "Inspected subjects" not in text
+
+
+class TestUnevidencedCriteriaLine:
+    """#1021: the report is where a human reads the shortfall. 'Contract criteria NOT
+    verified: vc-compiles-x' reads as a failure; slot 5's two produced no evidence at
+    all, with `failed` and `unverified` empty. Same words, different defect."""
+
+    @staticmethod
+    def _lines(*results, contract):
+        from squadops.cycles.run_report_builder import _build_verification_lines
+
+        return "\n".join(
+            _build_verification_lines(
+                aggregate_verification(list(results), contract_criteria=contract)
+            )
+        )
+
+    def test_the_unevidenced_shortfall_is_called_out_separately(self):
+        text = self._lines(
+            CheckResult(
+                check_id="c1", status=ResultStatus.PASSED, criterion_id="vc-a", subject="t"
+            ),
+            contract=["vc-a", "vc-b"],
+        )
+        assert "Contract criteria NOT verified: vc-b" in text
+        assert "produced NO evidence row at all" in text
+        assert "vc-b" in text.split("produced NO evidence row at all")[1]
+
+    def test_an_adverse_shortfall_gets_no_unevidenced_line(self):
+        """The false-positive direction: labelling a real failure an instrument gap
+        would point the reader at the harness while the product is broken."""
+        text = self._lines(
+            CheckResult(
+                check_id="c1", status=ResultStatus.FAILED, criterion_id="vc-a", subject="t"
+            ),
+            contract=["vc-a"],
+        )
+        assert "Contract criteria NOT verified: vc-a" in text
+        assert "produced NO evidence" not in text

--- a/tests/unit/cycles/test_verification_integrity.py
+++ b/tests/unit/cycles/test_verification_integrity.py
@@ -867,3 +867,83 @@ def test_provenance_without_an_inspected_set_is_not_reported_as_an_inspection():
     )
     assert summary.verified == ("tests_pass",)
     assert summary.inspections == ()
+
+
+# --- #1021: a criterion with no evidence is a fourth state, now named ---------------
+
+
+class TestUnevidencedCriteria:
+    """#1021: `criteria_verified` came up short with no failure and no disclosure.
+
+    SIP-0096's rule is executed-and-passed credits, everything else disclosed.
+    A contract criterion that produced NO row is neither — it is credited nowhere,
+    failed nowhere, and separable from an adverse criterion nowhere. Slot 5
+    (`run_654b61665fed`) is the banked case: 12 of 14, both missing criteria
+    `vc-compiles-*`, `failed` and `unverified` BOTH empty.
+    """
+
+    def test_a_contract_criterion_with_no_row_is_named(self):
+        """Bug caught: the coverage record under-reports and the reader cannot tell
+        'the check ran and lost its credit in the join' from 'the check never ran'."""
+        summary = aggregate_verification(
+            [_passed("c1", criterion_id="vc-a", subject="t")],
+            contract_criteria=["vc-a", "vc-b"],
+        )
+        assert summary.criteria_verified == ("vc-a",)
+        assert summary.criteria_unevidenced == ("vc-b",)
+        assert summary.criteria_unverified == ("vc-b",)
+
+    def test_an_adverse_criterion_is_not_reported_as_unevidenced(self):
+        """The distinction the field exists for. A criterion whose check ran and failed
+        produced evidence — calling it unevidenced would relabel a product failure as
+        an instrument gap, which is the opposite error and worse."""
+        summary = aggregate_verification(
+            [_failed("c1", criterion_id="vc-a", subject="t")],
+            contract_criteria=["vc-a", "vc-b"],
+        )
+        assert summary.criteria_unevidenced == ("vc-b",)
+        assert summary.criteria_adverse == ("vc-a",)
+
+    def test_a_skipped_criterion_counts_as_evidenced_not_absent(self):
+        """A not-executed row is still a row: the producer reported, with a reason, and
+        that reason is in `unverified`. Only total silence is unevidenced."""
+        summary = aggregate_verification(
+            [_skipped("c1", criterion_id="vc-a", subject="t")],
+            contract_criteria=["vc-a"],
+        )
+        assert summary.criteria_unevidenced == ()
+        assert summary.criteria_adverse == ("vc-a",)
+        assert [u.check_id for u in summary.unverified] == ["c1"]
+
+    def test_the_two_lists_partition_the_shortfall(self):
+        """The accounting invariant, stated as a derivation so it cannot drift: every
+        unverified criterion is either adverse or unevidenced, never both, never
+        neither."""
+        summary = aggregate_verification(
+            [
+                _passed("c1", criterion_id="vc-a", subject="t"),
+                _failed("c2", criterion_id="vc-b", subject="t"),
+            ],
+            contract_criteria=["vc-a", "vc-b", "vc-c", "vc-d"],
+        )
+        assert set(summary.criteria_adverse) | set(summary.criteria_unevidenced) == set(
+            summary.criteria_unverified
+        )
+        assert not set(summary.criteria_adverse) & set(summary.criteria_unevidenced)
+
+    def test_evidence_outside_the_contract_is_never_called_unevidenced(self):
+        """`criteria_total` unions observed ids in so unexpected evidence is never
+        dropped. This must NOT do the same: a criterion seen on a row is evidenced by
+        definition, and unioning would make every such id appear as absent."""
+        summary = aggregate_verification(
+            [_passed("c1", criterion_id="vc-surprise", subject="t")],
+            contract_criteria=["vc-a"],
+        )
+        assert "vc-surprise" in summary.criteria_total
+        assert summary.criteria_unevidenced == ("vc-a",)
+
+    def test_author_mode_has_no_unevidenced_criteria(self):
+        """No bound contract means no declared denominator, so there is nothing that
+        could be absent — the field must stay empty rather than inventing a shortfall."""
+        summary = aggregate_verification([_passed("c1", criterion_id="vc-a", subject="t")])
+        assert summary.criteria_unevidenced == ()


### PR DESCRIPTION
4 of 4 in the 1.6.2 batch. Independent of the other three.

**Read-first, per the issue's own disposition** — and the read changed what the fix is. `Refs`, not `Closes`: the accounting gap is closed, the underlying mechanism is not.

## What the banked reproducer actually shows

Slot 5 (`run_654b61665fed` — the zero-repair roll that refuted the repair hypothesis), replayed:

```
criteria_total 14 / criteria_verified 12
missing: vc-compiles-app-api-runs-route, vc-compiles-app-api-runs-run-id-join-route
unverified: []     failed: []
```

Both missing criteria produced **no row in either direction**. They are in `criteria_total` only because the contract declared them.

SIP-0096's rule is *executed-and-passed credits, everything else disclosed*. This is neither — a silent fourth state. `criteria_unverified` (#945) does name them, but names them **identically to a criterion whose check ran and failed**, which is the issue's exact complaint: no way to tell *"the check ran and credit was lost in the join"* from *"the check never ran."*

## The fix

`criteria_unevidenced` records criteria the contract declared that no row carried. `criteria_adverse` derives the complement, so the two **partition** the shortfall — every unverified criterion is one or the other, never both, never neither. That is tested as an invariant rather than as two lists that can drift apart.

Derived from the contract's declared set, **deliberately not** from `criteria_total`. That field unions observed ids in so unexpected evidence is never dropped; doing the same here would report every observed-but-undeclared criterion as absent — the inverse of the fact.

> Worth noting for the review: the obvious mutation of that expression, `(C | P | A) - P - A`, is algebraically identical to `C - P - A` and correctly survives. The test pins the wrong turn that is actually reachable — deriving from `criteria_total` and subtracting only the passed set.

Serialized both directions, and the run report now separates the two kinds of shortfall instead of printing one list the reader has to interpret.

## What this does not do

It does not explain **why** those two files' compile criteria produce no row while their siblings' do. That mechanism is still open. The banked hint from the issue stands: the runtime-api environment has no Node, so compile truth comes from the qa environment's build, and the credit mapping between those two surfaces is the first suspect.

This makes the question answerable from any stored run rather than by hand-diffing three lists — the same shape as #1002. The instrument comes first; the diagnosis it enables is the follow-up.

## Verification

- Regression **7,729 passed**, gate green at 20 workers.
- **7 mutations, all killed** — including adverse criteria mislabelled as unevidenced, which is the inverse error and the worse one: it would point a reader at the harness while the product is broken.

Refs #1021
