### PR TITLE
feat(qa): additive-suite containment findings — banked, deliberately not enforced

### DIFF
--- a/src/squadops/capabilities/additive_containment.py
+++ b/src/squadops/capabilities/additive_containment.py
@@ -1,0 +1,96 @@
+"""Containment findings for additive test suites — #1022, reporting-only.
+
+SIP-0104 contains the qa author inside deterministic scaffold slots, and
+``verification_scaffold_gate`` validates that surface with named findings. **Additive
+suites — the extra files a qa author writes beyond the scaffold — have no equivalent.**
+They are unconstrained authorship landing in the same tree, and they are where arm A's
+V7 rolls died: every counted red was additive-suite-side while all nine delivered
+applications of the arc passed independent boot audits. The apps were fine; the tests
+were not.
+
+Two checks, both reading the EMITTED BYTES rather than any declaration — the same
+posture as the scaffold gate, and for the same reason: a defect is precisely a gap
+between what the author meant and what it wrote.
+
+- **Execution model.** The suite runs in-process under vitest; there is no server
+  listening. A suite that fetches an absolute URL can only hang or throw.
+  `cyc_6495d9870587` (corpus C3) did exactly this and burned three qa repairs without
+  converging — *after* #877's prompt guidance shipped, which is the evidence that
+  guidance alone does not contain this.
+- **Subject import.** A test that imports no application module is testing nothing it
+  did not itself define. It is the precondition for the self-mocking class: a file that
+  stubs `global.fetch` and imports no route can only assert against its own stub.
+
+**Reporting-only, deliberately, and this is the whole disposition of this module.**
+Nothing here rejects. The findings are computed and banked so the shape of a real gate
+can be argued from what it *would* have flagged across actual rolls, rather than from
+what seems reasonable now — #1022 itself defers the gate's shape to design review, and
+tonight's #1049 is a live demonstration of the cost of deploying a rejection whose
+premise was never checked against real traffic. Promotion to a blocking gate is a
+separate, deliberate call with the banked evidence in hand.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: An absolute http(s) URL passed to a network client. Deliberately not "any URL in the
+#: file": a comment or a fixture string mentioning a URL is not an execution-model
+#: violation, and over-matching prose is how a finding loses its meaning.
+#:
+#: Case-SENSITIVE, and `request` is not in the alternation — both learned from the
+#: control test in the first draft. `new Request('http://test/api/runs')` is the CORRECT
+#: in-process form the scaffold shells themselves emit, and an ignore-case `request`
+#: alternative flags every legitimate suite. A check that fires on the right answer is
+#: worse than no check.
+_LIVE_FETCH_RE = re.compile(r"""\b(?:fetch|axios(?:\.\w+)?|got|superagent)\s*\(\s*[`'"]https?://""")
+
+#: `supertest`-style listeners: the package exists only to bind a server.
+_SERVER_HARNESS_RE = re.compile(r"""\bfrom\s+['"](supertest|node-fetch|undici)['"]""")
+
+#: An import of application code — the alias form the stack's tsconfig defines, a
+#: relative climb out of `__tests__/`, or the store/harness seam the shells use.
+_SUBJECT_IMPORT_RE = re.compile(
+    r"""(?:import|require)\s*(?:[^'"]*from\s*)?['"](@/[^'"]+|\.\.?/[^'"]+)['"]"""
+)
+
+#: Files this pass judges. A non-test file in the emission is somebody else's concern.
+_TEST_SUFFIXES = (".test.ts", ".test.tsx", ".test.js", ".spec.ts", ".spec.tsx", ".spec.js")
+
+#: Scaffold-owned shells are NOT additive: they are generated, gated, and their spine is
+#: frozen. Judging them here would report the generator's own output as an authoring
+#: defect.
+_SCAFFOLD_MARKER = ".scaffold.test."
+
+
+def is_additive_test(path: str) -> bool:
+    """Whether *path* is an author-written test this pass judges."""
+    return path.endswith(_TEST_SUFFIXES) and _SCAFFOLD_MARKER not in path
+
+
+def assess_additive_suite(files: list[dict]) -> list[str]:
+    """Containment findings for the additive files in an emission (empty = clean).
+
+    ``files`` is the emission's artifact shape (``{"name", "content"}``). Pure, so the
+    same function serves the banked evidence today and a gate later without either
+    reimplementing the rule.
+    """
+    findings: list[str] = []
+    for f in sorted(files, key=lambda a: str(a.get("name", ""))):
+        path = str(f.get("name") or "")
+        content = f.get("content")
+        if not is_additive_test(path) or not isinstance(content, str):
+            continue
+        if _LIVE_FETCH_RE.search(content) or _SERVER_HARNESS_RE.search(content):
+            findings.append(
+                f"{path}: fetches a live server. The suite runs in-process under vitest "
+                f"with nothing listening, so this can only hang or throw — call the route "
+                f"handler directly, as the scaffold shells do (#877/C3)."
+            )
+        if not _SUBJECT_IMPORT_RE.search(content):
+            findings.append(
+                f"{path}: imports no application module. A test that imports nothing it "
+                f"did not define asserts only against its own stubs — the precondition "
+                f"for the self-mocking class (#915)."
+            )
+    return findings

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -583,6 +583,7 @@ class QATestHandler(_CycleTaskHandler):
         in exactly one disposition; missing and rejected slots render as failing states
         inside the merged shells, attributed to the fill layer.
         """
+        from squadops.capabilities.additive_containment import assess_additive_suite
         from squadops.capabilities.verification_scaffold import VerificationScaffoldManifest
         from squadops.capabilities.verification_scaffold_fill import (
             measure_assertion_strength,
@@ -625,6 +626,14 @@ class QATestHandler(_CycleTaskHandler):
                 # attempt ran 9. `extracted_files` went 1 -> 0 in a log line nobody read.
                 "additive_files": sorted(a["name"] for a in kept),
             },
+            # #1022: containment findings for the additive surface, banked and NOT
+            # enforced. Every V7 counted red was additive-suite-side while all nine
+            # delivered apps passed independent boot audits — the apps were fine, the
+            # tests were not. The gate's shape is a design-review question (#1022), so
+            # this records what a gate WOULD flag across real rolls first. Deploying a
+            # rejection whose premise was never checked against real traffic is what
+            # #1049 cost tonight.
+            "additive_containment": assess_additive_suite(kept),
         }
         merged_suite_files = [{"filename": f.path, "content": f.content} for f in merged.files]
         return kept + merged_artifacts, merged_suite_files, evidence

--- a/tests/unit/capabilities/test_additive_containment.py
+++ b/tests/unit/capabilities/test_additive_containment.py
@@ -1,0 +1,117 @@
+"""#1022: containment findings for author-written additive suites.
+
+Every V7 counted red was additive-suite-side while all nine delivered applications of
+the arc passed independent boot audits — the apps were fine, the tests were not. These
+findings are banked, not enforced; each test names the bug the finding catches, and the
+over-rejection cases matter as much, because a finding that fires on legitimate suites
+is one nobody will act on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.additive_containment import assess_additive_suite, is_additive_test
+
+
+def _f(name: str, content: str) -> dict:
+    return {"name": name, "content": content}
+
+
+_GOOD = """
+import { describe, expect, it } from 'vitest'
+import * as route from '@/app/api/runs/route'
+describe('runs', () => { it('lists', async () => { expect((await route.GET(new Request('http://test/api/runs'))).status).toBe(200) }) })
+"""
+
+
+def test_a_legitimate_suite_produces_no_findings():
+    """The control, and the one that decides whether anyone trusts the rest. A suite
+    that calls the handler directly and imports the route is exactly what the scaffold
+    shells do — flagging it would make every roll noisy and the findings ignorable.
+
+    Note the handler call passes an absolute URL to `new Request(...)`, which is correct
+    and must NOT read as a live fetch.
+    """
+    assert assess_additive_suite([_f("__tests__/runs.test.ts", _GOOD)]) == []
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "const r = await fetch('http://localhost:3000/api/runs')",
+        'const r = await fetch("https://127.0.0.1:3000/api/runs")',
+        "import request from 'supertest'\nimport * as route from '@/app/api/runs/route'",
+        "const r = await axios.get('http://localhost:3000/api/runs')",
+    ],
+)
+def test_a_live_server_call_is_flagged(body):
+    """C3 (`cyc_6495d9870587`): the additive suite fetched a server that never exists
+    under vitest — three qa repairs, no convergence, and it happened AFTER #877's
+    prompt guidance shipped. Guidance did not contain it; this names it."""
+    content = "import * as route from '@/app/api/runs/route'\n" + body
+    findings = assess_additive_suite([_f("__tests__/x.test.ts", content)])
+    assert len(findings) == 1
+    assert "fetches a live server" in findings[0]
+
+
+def test_a_suite_importing_nothing_is_flagged():
+    """The self-mocking precondition (#915): a file that stubs `global.fetch` and
+    imports no route can only assert against its own stub. V7 attempt-2 roll 1 banked
+    exactly that file, and nothing flagged it in-cycle."""
+    content = "vi.spyOn(global, 'fetch').mockResolvedValueOnce({} as any)\nit('x', () => {})"
+    findings = assess_additive_suite([_f("__tests__/x.test.ts", content)])
+    assert len(findings) == 1
+    assert "imports no application module" in findings[0]
+
+
+@pytest.mark.parametrize(
+    "spec", ["@/app/api/runs/route", "@/lib/store", "../app/api/runs/route", "./helpers"]
+)
+def test_any_first_party_import_satisfies_the_subject_requirement(spec):
+    """Over-rejection guard. A relative helper import is still authorship reaching
+    outside itself; demanding a specific module would flag suites that compose through
+    a local fixture, which is normal and correct."""
+    content = f"import x from '{spec}'\nit('x', () => {{}})"
+    assert assess_additive_suite([_f("__tests__/x.test.ts", content)]) == []
+
+
+def test_a_url_in_prose_or_a_fixture_is_not_an_execution_model_violation():
+    """The finding must mean something. Matching any URL anywhere would fire on a
+    comment or a seeded fixture value, and a finding that cries wolf is one the next
+    author learns to skip."""
+    content = (
+        "import * as route from '@/app/api/runs/route'\n"
+        "// see http://localhost:3000/api/runs for the shape\n"
+        "const seeded = { link: 'https://example.com/x' }\n"
+        "it('x', () => { expect(seeded.link).toBeTruthy() })"
+    )
+    assert assess_additive_suite([_f("__tests__/x.test.ts", content)]) == []
+
+
+def test_scaffold_shells_are_not_judged_as_additive():
+    """Shells are generated, gated, and spine-frozen. Judging them here would report
+    the generator's own output as an authoring defect — and the spine legitimately
+    constructs absolute-URL Requests."""
+    assert is_additive_test("__tests__/scaffold/vc-probe-api-runs.scaffold.test.ts") is False
+    assert (
+        assess_additive_suite([_f("__tests__/scaffold/x.scaffold.test.ts", "fetch('http://x/')")])
+        == []
+    )
+
+
+@pytest.mark.parametrize("name", ["lib/store.ts", "app/page.tsx", "README.md", "vitest.config.ts"])
+def test_non_test_files_are_not_judged(name):
+    """A source file importing nothing, or naming a URL, is somebody else's concern."""
+    assert assess_additive_suite([_f(name, "const u = 'http://localhost:3000'")]) == []
+
+
+def test_findings_are_ordered_so_two_runs_are_comparable():
+    """Emission order is not stable; a diff between two rolls' findings has to be
+    readable without sorting by hand."""
+    files = [
+        _f("__tests__/b.test.ts", "it('x',()=>{})"),
+        _f("__tests__/a.test.ts", "it('x',()=>{})"),
+    ]
+    findings = assess_additive_suite(files)
+    assert [f.split(":")[0] for f in findings] == ["__tests__/a.test.ts", "__tests__/b.test.ts"]

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -212,6 +212,46 @@ class TestMergeFillArtifacts:
         # The fills half is still recorded alongside it — both halves or neither.
         assert "any_fill_touches_the_store" in strength
 
+    def test_the_banked_evidence_carries_the_additive_containment_findings(self, scaffold_input):
+        """#1022: the findings are computed at the merge seam and must reach the record.
+
+        Bug caught, and it is the third instance tonight of one shape: a fact derived
+        one line from where it is banked and never placed there. Every unit test of the
+        assessment passes while the roll's evidence says nothing.
+        """
+        fills = parse_fill_emission(
+            "```fill:slot-vc-probe-api-runs\n    expect(body.id).toBeTruthy()\n```\n"
+        )
+        artifacts = [
+            {
+                "name": "__tests__/live.test.ts",
+                "content": "const r = await fetch('http://localhost:3000/api/runs')",
+                "media_type": "x",
+                "type": "test",
+            }
+        ]
+        _, _, evidence = QATestHandler()._merge_fill_artifacts(scaffold_input, fills, artifacts)
+        findings = evidence["additive_containment"]
+        assert any("fetches a live server" in f for f in findings)
+        assert any("imports no application module" in f for f in findings)
+
+    def test_a_clean_additive_suite_banks_no_containment_findings(self, scaffold_input):
+        """The key is always present so "clean" is distinguishable from "not assessed" —
+        the #986 absence-visible-as-absence rule, one instrument over."""
+        fills = parse_fill_emission(
+            "```fill:slot-vc-probe-api-runs\n    expect(body.id).toBeTruthy()\n```\n"
+        )
+        artifacts = [
+            {
+                "name": "__tests__/ok.test.ts",
+                "content": "import * as r from '@/app/api/runs/route'\nit('x', () => {})",
+                "media_type": "x",
+                "type": "test",
+            }
+        ]
+        _, _, evidence = QATestHandler()._merge_fill_artifacts(scaffold_input, fills, artifacts)
+        assert evidence["additive_containment"] == []
+
     def test_an_emission_that_drops_every_additive_file_banks_an_empty_list(self, scaffold_input):
         """The absence has to be visible AS an absence. If the key vanished when nothing
         survived, the retreat this measures would read as "not measured" rather than


### PR DESCRIPTION
The last of the 1.6.2 four. **Reporting-only — nothing here rejects.** `Refs`, not `Closes`.

## The gap

SIP-0104 contains the qa author inside deterministic scaffold slots, and `verification_scaffold_gate` validates that surface with named findings. **Additive suites — the files an author writes beyond the scaffold — have no equivalent.** They are where arm A's V7 rolls died: every counted red was additive-suite-side while all nine delivered applications of the arc passed independent boot audits. The apps were fine; the tests were not.

## Two checks, both on emitted bytes

| Check | Banked evidence |
|---|---|
| **Execution model** — an absolute-URL fetch cannot work in-process under vitest, where nothing listens | `cyc_6495d9870587` (corpus C3): three qa repairs, no convergence — **after** #877's prompt guidance shipped. Guidance does not contain this class. |
| **Subject import** — a test importing no application module asserts only against what it defined | The precondition for self-mocking (#915). V7 attempt-2 roll 1 banked exactly such a file and nothing flagged it in-cycle. |

## Why reporting-only, and why that is the disposition rather than a shortcut

#1022 defers the gate's shape to design review. These findings are banked so that review can argue from **what a gate would have flagged across real rolls**, instead of from what seems reasonable in advance.

Tonight is the live argument for that order. **#1049** — filed and fixed six hours ago — is a rejection gate whose premise stopped being true, and it cost two re-rolls per cycle and dead-ended a correct framing before anyone noticed. I am not adding a second rejection gate to the same path on the same night I removed one.

Promotion to blocking is a separate deliberate call, with the evidence in hand.

## The over-rejection tests are the load-bearing ones

My first draft's regex was case-insensitive and included `request`, so it flagged:

```ts
new Request('http://test/api/runs')   // the CORRECT in-process form the shells emit
```

The control test caught it before this went anywhere. A check that fires on the right answer is worse than no check — so prose URLs, fixture URLs, relative helper imports, and the scaffold shells themselves are all pinned as non-findings.

## Verification

- Regression **7,738 passed**, gate green at 20 workers.
- **9 mutations, all killed.** One survived the first pass: findings computed and never banked — the **third** instance tonight of one shape, a fact derived a line from where it is recorded and never placed there (#1040's five dev surfaces, #1048's loop state, this one).

## Related

SIP-0104 (the fill-mode containment this extends), #877/#879 (guidance half, merged, demonstrated insufficient), #1002 (detector provenance — the complementary fix), #915, #1049 (why this is not a gate yet).

Refs #1022
