### PR TITLE
fix(correction): an emission containing nothing is not an attempt at the fix

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -593,6 +593,15 @@ class CorrectionProtocolResult:
 
     correction_path: str
     repair_artifacts: list[dict[str, Any]] = field(default_factory=list)
+    #: #1053: repair steps ran and produced no content at all. Distinct from "produced
+    #: a bad repair" and from "no repair step ran": arm B of the 2026-08-23 pair banked
+    #: `repair_output.md` at ZERO bytes on two of its three rounds, under the handler's
+    #: generic fallback name, while holding a correct and stable diagnosis. Each was
+    #: counted as a spent attempt, so `Max correction attempts (3) exhausted` described
+    #: a loop that had actually tried once. An emission containing nothing is an
+    #: emission failure (`FailureEvidenceCategory.EMISSION_ABSENT`'s shape), not an
+    #: attempt at the fix.
+    emission_empty: bool = False
 
 
 class CorrectionRunner:
@@ -1299,6 +1308,7 @@ class CorrectionRunner:
         # subject-implementation surface (_resolve_repair_target aims repairs at
         # the SUBJECT and would point a test re-author at app source files).
         repair_artifacts: list[dict[str, Any]] = []
+        repair_steps_ran = False
         if correction_path == "patch":
             failed_inputs = envelope.inputs or {}
             # #667/#663 S2: the anchor surface rides every repair envelope,
@@ -1383,6 +1393,7 @@ class CorrectionRunner:
                 # Dispatch the repair step (task_run creation + task events
                 # live in _dispatch_protocol_step, SIP-0087 B2 — so
                 # correction-driven repairs appear in the Prefect UI).
+                repair_steps_ran = True
                 repair_result = await self._dispatch_protocol_step(
                     repair_envelope,
                     run_id,
@@ -1444,17 +1455,37 @@ class CorrectionRunner:
                     )
                 )
 
+        # #1053: did the repair steps that ran produce anything at all? Judged on
+        # emitted CONTENT, not on the artifact count — a zero-byte file is still a file,
+        # and counting it as an attempt is what spent arm B's budget. `repair_steps_ran`
+        # keeps this distinct from a rewind/continue path, which legitimately emits
+        # nothing and must never be refunded.
+        emission_empty = repair_steps_ran and not any(
+            str(a.get("content") or "").strip() for a in repair_artifacts if isinstance(a, dict)
+        )
+        if emission_empty:
+            logger.warning(
+                "correction: repair emitted no content on attempt %d (%d artifact(s), all "
+                "empty) — the round produced nothing to verify (#1053)",
+                correction_attempts,
+                len(repair_artifacts),
+            )
+
         # 8. Emit CORRECTION_COMPLETED
         self._event_bus.emit(
             EventType.CORRECTION_COMPLETED,
             entity_type="run",
             entity_id=run_id,
             context={"cycle_id": cycle.cycle_id, "run_id": run_id},
-            payload={"correction_path": correction_path},
+            # Disclosed on the event, not only in a log line: "converged in 3" and
+            # "converged in 3 after two empty emissions" must not read the same.
+            payload={"correction_path": correction_path, "emission_empty": emission_empty},
         )
 
         return CorrectionProtocolResult(
-            correction_path=correction_path, repair_artifacts=repair_artifacts
+            correction_path=correction_path,
+            repair_artifacts=repair_artifacts,
+            emission_empty=emission_empty,
         )
 
     # Artifact types a qa.test task emits *about* its run, not *into* its

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -130,6 +130,28 @@ def _record_repair_rejection(carry: dict[str, list[str]] | None, task_id: str, e
     del entries[:-_REPAIR_REJECTION_ENTRY_LIMIT]
 
 
+def refund_empty_emission_attempt(
+    correction_counter: dict[str, int], max_corrections: int, attempt: int
+) -> bool:
+    """Hand back a correction attempt whose repair emitted nothing (#1053).
+
+    Mutates ``correction_counter`` in place and returns whether the refund was granted.
+    Pure arithmetic on the shared counter, extracted so the executor and its test drive
+    the SAME rule — a test that re-implements this would keep passing while the rule
+    drifted, which is the failure mode this repo has paid for in other places.
+
+    The allowance is its own key, deliberately: taking it from the correction pool the
+    empty emission is failing to consume would be unbounded by construction. Once spent,
+    an empty round is billed like any other, so a producer that never emits terminates.
+    """
+    refunds = correction_counter.get("empty_refunds", 0)
+    if refunds >= max_corrections:
+        return False
+    correction_counter["empty_refunds"] = refunds + 1
+    correction_counter["n"] = attempt
+    return True
+
+
 class DispatchedFlowExecutor(FlowExecutionPort):
     """Flow executor that dispatches tasks to agent containers via RabbitMQ.
 
@@ -2865,6 +2887,35 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             ),
         )
         correction_path = protocol.correction_path
+
+        # #1053: an emission containing nothing is not an attempt at the fix. Arm B of
+        # the 2026-08-23 pair banked `repair_output.md` at ZERO bytes on two of three
+        # rounds while its diagnosis stayed correct and stable, and each was billed as a
+        # spent attempt — so the run reported an exhausted budget after one real try.
+        # Refund the pre-incremented attempt so the round is re-taken.
+        #
+        # BOUNDED, and separately from the correction budget: a producer that emits
+        # nothing every time must still terminate, and refunding out of the same pool it
+        # is failing to consume would be unbounded by construction. One refund per
+        # correction the budget allows is enough to absorb a transient empty emission
+        # without letting a broken emitter run forever.
+        if protocol.emission_empty:
+            if refund_empty_emission_attempt(correction_counter, max_corrections, attempt):
+                logger.warning(
+                    "correction attempt %d refunded: the repair emitted no content, so the "
+                    "round is re-taken rather than spent (refund %d of %d, #1053)",
+                    attempt,
+                    correction_counter["empty_refunds"],
+                    max_corrections,
+                )
+            else:
+                logger.warning(
+                    "correction attempt %d emitted no content and the refund allowance is "
+                    "spent (%d) — counting it, so a producer that never emits terminates "
+                    "(#1053)",
+                    attempt,
+                    max_corrections,
+                )
 
         if correction_path == "abort":
             raise _ExecutionError(

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -899,6 +899,65 @@ class TestMaxCorrectionAttempts:
         assert RunStatus.FAILED in terminal_statuses
 
 
+class TestEmptyEmissionRefund:
+    """#1053, executor side: the refund, and the bound on it.
+
+    The runner flags an emission containing nothing; this is where the attempt is
+    handed back. Both halves matter — refunding lets a correct diagnosis have another
+    go, and bounding it stops a producer that never emits from looping forever.
+    """
+
+    @staticmethod
+    def _refund(counter: dict, *, empty: bool, max_corrections: int, attempt: int) -> dict:
+        """Drive the EXECUTOR's rule, not a copy of it.
+
+        The first version of this helper re-implemented the arithmetic, which would have
+        kept passing while the real rule drifted. `refund_empty_emission_attempt` is
+        module-level for exactly this reason.
+        """
+        from adapters.cycles.dispatched_flow_executor import refund_empty_emission_attempt
+
+        if empty:
+            refund_empty_emission_attempt(counter, max_corrections, attempt)
+        return counter
+
+    def test_an_empty_emission_hands_the_attempt_back(self):
+        """Arm B's shape: the pre-incremented attempt is returned, so the round is
+        re-taken instead of billed. Without this, two empty files spent a budget of
+        three against a diagnosis that never drifted."""
+        counter = {"n": 1}
+        self._refund(counter, empty=True, max_corrections=3, attempt=0)
+        assert counter["n"] == 0
+        assert counter["empty_refunds"] == 1
+
+    def test_a_real_emission_keeps_its_attempt(self):
+        """The control. Refunding a genuine repair would make the budget bound nothing
+        and a non-converging loop would run until the time budget killed it."""
+        counter = {"n": 1}
+        self._refund(counter, empty=False, max_corrections=3, attempt=0)
+        assert counter["n"] == 1
+        assert "empty_refunds" not in counter
+
+    def test_the_refund_allowance_is_finite(self):
+        """A producer that emits nothing EVERY time must still terminate. Once the
+        allowance is spent the empty round is counted, so exhaustion is reachable."""
+        counter = {"n": 0}
+        for i in range(5):
+            counter["n"] += 1
+            self._refund(counter, empty=True, max_corrections=2, attempt=counter["n"] - 1)
+        assert counter["empty_refunds"] == 2
+        # Three of five rounds were billed, so the budget still advances.
+        assert counter["n"] == 3
+
+    def test_refunds_are_counted_separately_from_the_correction_budget(self):
+        """The allowance cannot come out of the pool it is failing to consume — that is
+        unbounded by construction. `empty_refunds` is its own key."""
+        counter = {"n": 1}
+        self._refund(counter, empty=True, max_corrections=3, attempt=0)
+        assert counter["empty_refunds"] == 1
+        assert counter["n"] == 0
+
+
 # ---------------------------------------------------------------------------
 # Plan delta stored as artifact
 # ---------------------------------------------------------------------------
@@ -4208,3 +4267,119 @@ class TestOwnershipVetoWiring(TestCorrectionRunnerStandalone):
             arts, "development.implement", "dev", [], ("*.test.ts",)
         )
         assert kept == arts
+
+
+class TestEmptyRepairEmission:
+    """#1053: a repair that emits nothing must not be billed as an attempt.
+
+    Arm B of the 2026-08-23 pair (`cyc_d478dda745b9`) banked `repair_output.md` at ZERO
+    bytes on two of its three rounds, under the handler's generic fallback name, while
+    the lead's diagnosis stayed correct and stable across all three. Each empty file was
+    counted, so `Max correction attempts (3) exhausted` described a loop that had
+    actually tried once.
+    """
+
+    # Borrowed, not inherited: subclassing the standalone suite would re-run every one
+    # of its tests under this class's name, which inflates the count and hides which
+    # suite actually covers what.
+    _make_runner = TestCorrectionRunnerStandalone._make_runner
+    _failed_envelope = TestCorrectionRunnerStandalone._failed_envelope
+
+    @staticmethod
+    def _responder(artifacts):
+        def responder(envelope):
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "patch",
+                        "decision_rationale": "patchable",
+                        "affected_task_types": ["development.develop"],
+                    },
+                )
+            if envelope.task_type.endswith("correction_repair"):
+                return TaskResult(
+                    task_id=envelope.task_id, status="SUCCEEDED", outputs={"artifacts": artifacts}
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        return responder
+
+    async def _run(self, cycle, artifacts):
+        import dataclasses as _dc
+
+        runner, _r, _v, _b = self._make_runner(self._responder(artifacts))
+        return await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=_dc.replace(self._failed_envelope(), task_type="qa.test"),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="suite failed"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+
+    async def test_a_zero_byte_emission_is_flagged_empty(self, cycle):
+        """The banked shape, exactly: one artifact, no content."""
+        protocol = await self._run(cycle, [{"name": "repair_output.md", "content": ""}])
+        assert protocol.emission_empty is True
+
+    async def test_whitespace_only_content_is_also_empty(self, cycle):
+        """A file of newlines is not a repair. Judging on length rather than on content
+        would let the same wasted round through under a slightly different emitter."""
+        protocol = await self._run(cycle, [{"name": "repair_output.md", "content": "\n  \n"}])
+        assert protocol.emission_empty is True
+
+    async def test_a_real_emission_is_not_flagged(self, cycle):
+        """The control. Flagging a genuine repair would refund rounds forever and the
+        budget would stop bounding anything."""
+        protocol = await self._run(
+            cycle, [{"name": "app/api/runs/route.ts", "content": "export async function GET() {}"}]
+        )
+        assert protocol.emission_empty is False
+
+    async def test_one_empty_file_beside_a_real_one_is_not_empty(self, cycle):
+        """Judged on the emission as a whole: a repair that wrote a route and an empty
+        note produced something to verify."""
+        protocol = await self._run(
+            cycle,
+            [
+                {"name": "notes.md", "content": ""},
+                {"name": "app/api/runs/route.ts", "content": "export const x = 1"},
+            ],
+        )
+        assert protocol.emission_empty is False
+
+    async def test_a_path_with_no_repair_step_is_never_flagged(self, cycle):
+        """A `continue` decision runs no repair and legitimately emits nothing. Marking
+        it empty would refund an attempt that was never spent on a repair — the
+        distinction `repair_steps_ran` exists for."""
+        import dataclasses as _dc
+
+        def responder(envelope):
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={"correction_path": "continue", "decision_rationale": "proceed"},
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _r, _v, _b = self._make_runner(responder)
+        protocol = await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=_dc.replace(self._failed_envelope(), task_type="qa.test"),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="x"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+        assert protocol.emission_empty is False


### PR DESCRIPTION
## What arm B actually did

It exhausted its correction budget **while holding a correct and stable diagnosis across all three rounds**. It did not fail to fix the bug — it never got another attempt at it.

```
round 0  →  7 route/page files          (a real repair)
round 1  →  repair_output.md   0 bytes
round 2  →  repair_output.md   0 bytes
```

Both empty files were banked under the handler's generic fallback name, and both were billed as spent attempts. So `Max correction attempts (3) exhausted` described a loop that had actually tried **once**.

The diagnosis never drifted, either — #1029's frozen-spine floor pointed straight at the defect and every round named the same two handlers:

> **round 0** — "the join endpoint handler returns a response missing at least one required Run field … and fails to correctly register the participant"
> **round 2** — "three specific, well-scoped implementation bugs in the join and leave endpoint handlers"

This is the best case for the correction loop — a stable, specific, machine-pointed diagnosis — and two of three chances to act on it went to files containing nothing.

## The fix

A zero-byte artifact is an emission failure, not a repair attempt. The runner judges the emission on **content** rather than artifact count — a zero-byte file is still a file, which is exactly how these rounds got counted — and the executor hands the pre-incremented attempt back so the round is re-taken.

Three boundaries, each mutation-covered:

| Boundary | Why |
|---|---|
| `repair_steps_ran` gates it | a rewind/continue path legitimately emits nothing and must never be refunded |
| whitespace-only is empty | judging on length lets the same wasted round through under a marginally different emitter |
| the allowance is **bounded**, in its own counter key | taking it from the pool the empty emission is failing to consume is unbounded by construction; a producer that never emits must still terminate |

Disclosed on the `CORRECTION_COMPLETED` event rather than only in a log line — *"converged in 3"* and *"converged in 3 after two empty emissions"* must not read the same. That is the evidence-integrity rule this line keeps re-learning (#1002, #1021).

`refund_empty_emission_attempt` is module-level so the executor and its test drive the **same** rule. My first version of that test re-implemented the arithmetic, which would have kept passing while the real rule drifted.

## Verification

- Regression **7,728 passed**, gate green at 20 workers.
- **7 mutations, all killed.** Two things worth recording from that run:
  - the unbounded-refund mutation **hangs** rather than failing — correct behaviour, and it left a mutation in the working tree when the harness timed out. The harness now restores on timeout and counts a hang as a kill.
  - two anchors missed after `ruff format` reflowed the expression; re-run against the formatted text rather than reported as skips.

## Related

#566 (zero-extraction marker vocabulary), #431/#528 (extraction loss — the adjacent, distinct class: prose the parser rejected keeps its current handling), #1015/#1048 (repair envelope quality), #414 (budget allocation — note this argues the budget was never the constraint), #1054 (why arm A never reached this path at all).

Closes #1053
