### PR TITLE
fix(qa): the containment findings actually reach the record — #1052 dropped them

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -694,6 +694,12 @@ class QATestHandler(_CycleTaskHandler):
             correlations,
             additive_count,
             tuple(getattr(test_result, "uncollected_test_files", ()) or ()),
+            # The containment findings' landing. Computed at the merge seam and, until
+            # now, placed only in `execution_evidence` — which nothing persists (#999),
+            # so "banked on every qa emission" was not true of the change that claimed
+            # it. `scaffold_evidence` is in `outputs`, which reaches `failure_evidence`
+            # and therefore the analyzer and the locus classifier.
+            tuple(fill_merge_evidence.get("additive_containment", ()) or ()),
         )
         outputs["scaffold_evidence"] = summary.to_dict()
 

--- a/src/squadops/cycles/scaffold_evidence.py
+++ b/src/squadops/cycles/scaffold_evidence.py
@@ -292,6 +292,12 @@ class ScaffoldEvidenceSummary:
     #: earning its inference spend" question is unanswerable if part of that layer
     #: silently never ran.
     uncollected_test_files: tuple[str, ...] = ()
+    #: #1022/#1052 follow-up: additive-suite containment findings. They were computed at
+    #: the merge seam and landed ONLY in ``execution_evidence``, which nothing persists
+    #: (#999) — so the findings #1052 described as "banked" were computed and dropped.
+    #: That is the fourth instance of the pattern #1052's own PR called out, shipped by
+    #: the change that called it out. This is the landing that makes the claim true.
+    additive_containment: tuple[str, ...] = ()
     observations: tuple[ShellObservation, ...] = ()
     correlations: tuple[CorrelatedFinding, ...] = ()
 
@@ -314,6 +320,7 @@ class ScaffoldEvidenceSummary:
             "fill_dispositions": dict(self.fill_dispositions),
             "additive_test_count": self.additive_test_count,
             "uncollected_test_files": list(self.uncollected_test_files),
+            "additive_containment": list(self.additive_containment),
             "failure_classes": dict(self.failure_classes),
             "uncorrelated_fill_failures": self.uncorrelated_fill_failures,
             "probe_redundant_findings": self.probe_redundant_findings,
@@ -329,6 +336,7 @@ def build_scaffold_evidence_summary(
     correlations: list[CorrelatedFinding],
     additive_test_count: int,
     uncollected_test_files: tuple[str, ...] = (),
+    additive_containment: tuple[str, ...] = (),
 ) -> ScaffoldEvidenceSummary:
     disposition_counts: dict[str, int] = {}
     for disposition in fill_dispositions.values():
@@ -345,6 +353,7 @@ def build_scaffold_evidence_summary(
         additive_test_count=additive_test_count,
         failure_classes=class_counts,
         uncollected_test_files=tuple(uncollected_test_files),
+        additive_containment=tuple(additive_containment),
         observations=tuple(observations),
         correlations=tuple(correlations),
     )

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -343,3 +343,33 @@ async def test_the_evidence_pipeline_lands_in_outputs(scaffold_input, monkeypatc
 
     evidence = {"scaffold_evidence": evidence, "validation_result": {"checks": rows}}
     assert classify_failure_locus(evidence) == FailureLocus.SUBJECT
+
+
+def test_containment_findings_reach_outputs_scaffold_evidence(scaffold_input, emission):
+    """The landing, asserted on `outputs` — the dict that actually leaves the handler.
+
+    Bug caught, on its FIFTH occurrence in one working session: every prior test proved
+    the findings were computed, carried by the summary builder, and serialized — and the
+    handler still never passed them to the builder. Each layer green, the fact nowhere.
+    Asserting on the dataclass or on `to_dict` cannot see this; only `outputs` can.
+    """
+    from unittest.mock import MagicMock
+
+    handler = QATestHandler()
+    outputs: dict = {}
+    test_result = MagicMock()
+    test_result.uncollected_test_files = ()
+    merged = [{"filename": f["name"], "content": f["content"]} for f in emission.files]
+    fill_merge_evidence = {
+        "dispositions": [],
+        "counts": {},
+        "additive_containment": ["__tests__/live.test.ts: fetches a live server."],
+    }
+
+    handler._append_scaffold_evidence(
+        outputs, test_result, merged, fill_merge_evidence, scaffold_input, []
+    )
+
+    assert outputs["scaffold_evidence"]["additive_containment"] == [
+        "__tests__/live.test.ts: fetches a live server."
+    ]

--- a/tests/unit/cycles/test_scaffold_evidence.py
+++ b/tests/unit/cycles/test_scaffold_evidence.py
@@ -390,3 +390,50 @@ class TestUncollectedTestFiles:
             uncollected_test_files=("tests/api/runs.test.ts",),
         )
         assert summary.to_dict()["uncollected_test_files"] == ["tests/api/runs.test.ts"]
+
+
+class TestAdditiveContainmentReachesTheRecord:
+    """#1052 follow-up: the findings must land somewhere that survives the handler.
+
+    Bug caught, and it shipped in the change that named the pattern: #1052 computed the
+    containment findings at the merge seam and placed them only in
+    `evidence_extra["fill_merge"]`, which flows to `TaskResult.execution_evidence` —
+    and #999 establishes that nothing persists that. The PR body and the issue comment
+    both said "banked on every qa emission". They were wrong.
+
+    `scaffold_evidence` is in `outputs`, which `build_failure_evidence` reads, so the
+    findings reach the analyzer and the locus classifier. Full persistence for a passing
+    run is still #999's territory and this does not claim it.
+    """
+
+    def test_the_summary_carries_the_findings(self, emission, dispositions):
+        summary = build_scaffold_evidence_summary(
+            emission.manifest,
+            dispositions,
+            [],
+            [],
+            additive_test_count=1,
+            additive_containment=("__tests__/live.test.ts: fetches a live server.",),
+        )
+        assert summary.additive_containment == ("__tests__/live.test.ts: fetches a live server.",)
+
+    def test_the_findings_survive_to_dict(self, emission, dispositions):
+        """`to_dict` is the shape that actually leaves the process — a field on the
+        dataclass that the serializer drops is the same defect one layer in."""
+        summary = build_scaffold_evidence_summary(
+            emission.manifest,
+            dispositions,
+            [],
+            [],
+            additive_test_count=0,
+            additive_containment=("a: fetches a live server.",),
+        )
+        assert summary.to_dict()["additive_containment"] == ["a: fetches a live server."]
+
+    def test_a_clean_suite_carries_an_empty_list_not_a_missing_key(self, emission, dispositions):
+        """Absence has to read as "assessed, nothing found" rather than "not assessed" —
+        the #986 rule this file's neighbours already keep."""
+        summary = build_scaffold_evidence_summary(
+            emission.manifest, dispositions, [], [], additive_test_count=0
+        )
+        assert summary.to_dict()["additive_containment"] == []


### PR DESCRIPTION
**A defect in work merged a few hours ago, found while auditing PR-to-issue crediting.**

#1052 computed the additive-suite containment findings and placed them in `evidence_extra["fill_merge"]` → `TaskResult.execution_evidence`. **#999 establishes that nothing persists that** — not the verification summary, not checkpoints, not an artifact.

So the findings that PR described as *"banked on every qa emission"* were computed and dropped. The PR body said it. My comment on #1022 said it. Neither was true.

## This is the fifth instance of one pattern tonight

And the fourth was named by the change that then committed the fifth:

| | |
|---|---|
| #1040 | five dev surfaces rendered into sections, never added to the template variables |
| #1048 | loop-state block rendered by the handler, never injected into inputs |
| #1052 | findings computed at the merge seam, never banked — **the PR called this pattern out** |
| here | findings landed only in evidence nothing persists |
| and | the handler still never passed them to the summary builder — caught by mutation |

Every layer had a passing test. The fact reached nobody at every step.

## The fix

The findings land on `ScaffoldEvidenceSummary`, which serializes into `outputs["scaffold_evidence"]`. That dict is read by `build_failure_evidence`, so the findings reach the analyzer and the locus classifier.

**Scoped claim this time:** full persistence for a *passing* run is still #999's territory and this does not claim it. Being precise about which surface this lands on is the whole lesson of the overclaim it fixes.

## Verification

- Regression **7,723 passed**, gate green at 20 workers.
- **4 mutations, all killed.** The fourth survived the first pass — the handler not passing the findings to the builder, with every other layer green. Only an assertion on `outputs` can see that, so that is where the test asserts.

Refs #1022, #999