### PR TITLE
docs(site): factual tone, the framing task sequence, and brand assets

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ site_dir: site/_build
 
 theme:
   name: material
+  custom_dir: site/overrides
+  favicon: assets/favicon.svg
   font: false          # no Google Fonts fetch — system stack instead
   # NOTE ON THIRD-PARTY REQUESTS. Setting font:false removes the Google Fonts
   # fetch, but Material lazy-loads mermaid from unpkg.com at runtime on pages
@@ -27,6 +29,8 @@ theme:
   # worth it for a docs site (#1039). Recorded so the next person does not
   # repeat the measurement, and so the claim is not overstated elsewhere.
   icon:
+    # Inlined as SVG (not an <img>), so currentColor follows the active palette.
+    logo: squadops/logo
     repo: fontawesome/brands/github
   features:
     # navigation.instant is DELIBERATELY off: its client-side page swaps wipe

--- a/site/content/architecture.md
+++ b/site/content/architecture.md
@@ -34,7 +34,7 @@ observability, a content-hashed filesystem vault for artifacts.
 
 Two properties fall out of this that matter more than the pattern itself:
 
-**Capabilities are declared, not inferred.** An adapter states what it can do —
+**Capabilities are declared.** An adapter states what it can do —
 model listing, model management, streaming usage — and callers ask the port
 rather than checking which class they were handed. A declared capability that
 does not work fails a conformance suite every adapter must pass.

--- a/site/content/assets/extra.css
+++ b/site/content/assets/extra.css
@@ -44,3 +44,15 @@
   max-width: 100%;
   height: auto;
 }
+
+/* Header lockup. Material's default puts 32px between the logo and the title —
+   wider than the 24px mark itself, which reads as two unrelated elements rather
+   than one lockup. That default is tuned for a header with no wordmark. */
+.md-header .md-header__title {
+  margin-left: 0.35rem;
+}
+
+/* The logo button's own padding contributes the other half of the gap. */
+.md-header .md-logo {
+  padding-right: 0.2rem;
+}

--- a/site/content/assets/favicon.svg
+++ b/site/content/assets/favicon.svg
@@ -1,0 +1,16 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <!-- Squad Ops favicon. A solid tile rather than a transparent mark: tab chrome
+       applies prefers-color-scheme inconsistently, so a transparent icon can land
+       dark-on-dark. Mark scaled to 0.82, leaving 12% edge padding — comfortably
+       inside the 10% floor a maskable icon needs, while staying as large as
+       possible for 16px rendering. A maskable app icon, if ever needed, is a
+       separate asset at heavier padding rather than a shrink of this one. -->
+  <rect width="24" height="24" rx="5" fill="#000000"/>
+  <g transform="translate(12,12) scale(0.82) translate(-12,-12)">
+  <path d="M4.30 8.89 A8.3 8.3 0 0 1 19.70 8.89" fill="none" stroke="#ffffff" stroke-width="2.2" stroke-linecap="round"/>
+  <path d="M19.70 15.11 A8.3 8.3 0 0 1 4.30 15.11" fill="none" stroke="#ffffff" stroke-width="2.2" stroke-linecap="round"/>
+  <path d="M22.01 7.95 L20.12 10.27 L17.38 9.83" fill="none" stroke="#ffffff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M1.99 16.05 L3.88 13.73 L6.62 14.17" fill="none" stroke="#ffffff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M10.05 8.90 15.25 12.00 10.05 15.10Z" fill="#ffffff" stroke="#ffffff" stroke-width="1.5" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/site/content/dependencies.md
+++ b/site/content/dependencies.md
@@ -1,15 +1,14 @@
 # Dependencies
 
-What each library is responsible for, and why it was chosen. Squad Ops keeps its
-dependency surface deliberately small — the hexagonal structure means most
-libraries sit behind a port and are replaceable without touching the domain.
+What each library is responsible for. Most sit behind a port, so replacing one
+is a factory change.
 
 ## Runtime
 
 | Responsibility | Library | Notes |
 |---|---|---|
 | HTTP API | **FastAPI** + **uvicorn** | The runtime API — cycles, runs, gates, artifacts |
-| Data modelling | **Pydantic** | API DTOs and config schema. The *domain* uses frozen dataclasses, not Pydantic — validation belongs at the boundary |
+| Data modelling | **Pydantic** | API DTOs and config schema. Validation runs at the boundary; the domain uses frozen dataclasses |
 | Database | **asyncpg** | Direct async Postgres. No ORM: the cycle registry writes a small, hand-controlled set of queries and an ORM would add a translation layer over a schema that is already explicit |
 | Message queue | **aio-pika** | RabbitMQ client for task dispatch, behind `QueuePort` |
 | Cache | **redis** | Caching and coordination |
@@ -30,16 +29,14 @@ libraries sit behind a port and are replaceable without touching the domain.
 |---|---|
 | Lint and format | **ruff** — one tool, replacing flake8/isort/black |
 | Tests | **pytest** with `pytest-asyncio`, `pytest-xdist`, `pytest-cov` |
-| Integration fixtures | **testcontainers** — real Postgres and RabbitMQ, not mocks |
+| Integration fixtures | **testcontainers** — runs the tests against real Postgres and RabbitMQ |
 | Types | **mypy** |
-| Docs site | **mkdocs-material** (build-time only, not a runtime dependency) |
+| Docs site | **mkdocs-material** — build-time only, installed from `site/requirements.txt` |
 
 ## Where dependencies are declared
 
-This is worth knowing, because it is not where you would expect.
-
-`pyproject.toml` declares almost nothing — only optional extras. The install
-sets live in `requirements/`, one pair per deployment surface:
+`pyproject.toml` declares optional extras only. The install sets live in
+`requirements/`, one pair per deployment surface:
 
 | Pair | Installed by |
 |---|---|
@@ -69,8 +66,8 @@ agent image and a very large one.
     establish that the deployed images work. Nothing has broken because of it
     yet, which is precisely why it is worth writing down.
 
-## What is deliberately absent
+## Excluded by design
 
-- **No ORM.** The cycle registry owns a small explicit schema; migrations are plain SQL.
-- **No agent framework.** No LangChain, LlamaIndex, or CrewAI. The orchestration *is* the product, so wrapping someone else's abstraction over it would put the interesting decisions inside a dependency.
-- **No hosted inference SDK.** Local models are a requirement, not a default.
+- **ORM.** The cycle registry owns an explicit schema; migrations are plain SQL.
+- **Agent frameworks** (LangChain, LlamaIndex, CrewAI). Orchestration is the subject of the project, so it is implemented directly.
+- **Hosted inference SDKs.** Inference is local.

--- a/site/content/evidence.md
+++ b/site/content/evidence.md
@@ -1,97 +1,71 @@
 # Evidence
 
-**This page is about how the project evaluates itself — not about what the
-framework does for you.** The two are easy to confuse and worth separating
-before anything else.
+Measurement windows run by the maintainers to test framework performance. Each
+window is pre-registered: the number of runs, requirement document, deployment
+hash, and scoring rule are committed before the first run.
 
-| | Verification | Measurement |
-|---|---|---|
-| **What** | Checks derived from the design, executed inside every cycle | Windows that score whole cycles, run by the maintainers |
-| **Who gets it** | Anyone running a cycle. It is a framework feature | Nobody. It is how *this project* tests whether the framework works |
-| **Produces** | A cycle verdict and an evidence roll-up | The numbers quoted on this site |
-| **Where** | [Key concepts](key-concepts.md#4-verification-execute-dont-assume) | This page |
+A run scores **functional** when three conditions hold:
 
-Measurement *consumes* verification — a window's scoring rule reads the cycle
-verdict as one of its inputs — which is exactly why they blur. But
-pre-registered windows are research methodology **about** the product, not a
-capability **of** it. Nothing below is something you receive when you run a
-cycle.
+1. The cycle verdict is `accepted`.
+2. An independent audit confirms the delivered application installs, builds,
+   boots, and answers every probe its contract specifies.
+3. No human intervened during the run.
 
-What it is instead: the reason to believe the claims made elsewhere on this
-site.
-
-## How the project measures itself
-
-A measurement window is **pre-registered**: the number of runs, the requirement
-document, the deployment hash, and the scoring rule are written down and frozen
-*before the first run*. Once open, nothing is fixed mid-window.
-
-That discipline removes the two ways a result normally flatters itself:
-
-- **You cannot re-roll.** Every registered slot runs and is scored. A run cannot be
-  quietly discarded because it went badly.
-- **You cannot move the bar.** The scoring rule is committed in advance, so a
-  disappointing number cannot be reinterpreted into a better one.
-
-A run scores functional only if the cycle verdict is `accepted`, an independent
-audit confirms the delivered application installs, builds, boots and answers
-every probe its contract specifies, **and** no human intervened. The first
-condition is the framework's own verdict; the second and third are the
-maintainers checking it independently, because a framework grading its own
-homework is not evidence.
-
-## Results
-
-### Authored-mode window — closed 20 August 2026
+## Authored-mode window — closed 20 August 2026
 
 The squad authored its own interface design, then built against it.
+Pre-registered N = 6, bar ≥ 4/6.
 
 | Measurement | Result |
 |---|---|
-| Under the pre-registered instrument | 3 functional / 6 |
-| Under the corrected instrument | **4 functional / 6 — bar met** |
+| Pre-registered instrument | 3 functional / 6 |
+| Corrected instrument | **4 functional / 6** — bar met |
 
 Both numbers are the record. The deciding run first scored as a failure; the
-cause was a defect in the auditing tool, not the application. The correction was
-ruled **before** the corrected measurement was taken, so the decision could not
-be conditioned on its outcome.
+cause was a defect in the auditing tool. The correction was ruled before the
+corrected measurement was taken, so the ruling was made independently of its
+outcome.
 
-Across the whole arc, **9 of 9 delivered applications** install, build, boot and
-answer their probes. Every failed run failed in the test suite or the measuring
-apparatus — none because the application was broken. Zero manual interventions
-across the window, and no run was re-run to improve the figure.
+Across the arc, 9 of 9 delivered applications install, build, boot, and answer
+their probes. Zero manual interventions across the window. No run was re-run.
 
-### Seeded-mode window — closed 31 July 2026
+## Seeded-mode window — closed 31 July 2026
 
-The squad was *given* a fully specified interface design and built against it.
+The squad received a fully specified interface design and built against it.
+Pre-registered N = 6.
 
-**6 of 6 functional.** This is the weaker claim of the two, and it is the one to
-read carefully: it establishes that given a requirement *and a specified
-interface*, the squad delivers a working application. Whether it could author
-that interface was, deliberately, not measured — which is what the August window
-went on to test.
+**6 of 6 functional.**
 
-## What this does not show
+This window measures implementation against a given design. Authoring the design
+was measured separately, in the August window above.
 
-The honest boundary of both numbers:
+## Scope of these results
 
-- **One technology stack.** A second is in progress. Nothing here speaks to
-  portability across stacks.
-- **Small-to-moderate greenfield web applications**, built from a single
-  requirement document. No evidence at all about large existing codebases,
-  migrations, or work against unfamiliar code.
-- **4 of 6 is a starting point, not a plateau.** The limitations that cost the two
-  failed runs are known and queued.
-- **Local models only.** Nothing here says how the framework behaves against a
-  frontier hosted model, because that is not the configuration it is built for.
+Both windows share the same conditions:
 
-## Why the instrument story is on this page
+| Dimension | Covered |
+|---|---|
+| Application size | Small-to-moderate greenfield web applications |
+| Requirement source | A single requirement document |
+| Technology stack | One (a second is in progress) |
+| Codebase | New projects only |
+| Inference | Local open-weight models, 27B class |
 
-It would be easy to publish only the corrected number. Recording both, and the
-order the decisions were taken in, is the point: a measurement programme that
-hides its own instrument failures cannot be trusted about anything else.
+Results outside those conditions — large existing codebases, migrations,
+multi-stack work, hosted frontier models — have no measurement here.
 
-The two layers happen to share that principle — the framework never reports an
-unexecuted check as a pass, and the measurement programme never quietly drops a
-run that went badly — but they are separate mechanisms, built at different
-times, for different audiences.
+## Method notes
+
+**Pre-registration.** The scoring rule and run count are committed in writing
+before the window opens, and the window record accumulates per-roll rather than
+being edited afterwards.
+
+**Independent audit.** Conditions 2 and 3 above are evaluated outside the
+framework, by a separate auditing script and by inspection of the run's gate
+decisions.
+
+**Instrument corrections.** When the auditing tool is found defective mid-window,
+the disposition is ruled before the corrected measurement is taken, and both
+measurements stay on the record. The August window is the worked example.
+
+Window records live in the repository under `docs/plans/`, one file per window.

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -14,13 +14,58 @@ squadops runs assemble play_game <cycle-id> <run-id> --out ./output
 
 ## How a cycle works
 
-| Stage | What happens |
-|---|---|
-| **Framing** | The squad authors an interface manifest — entities, endpoints, error contracts, screens — from the requirement. Two gates check it: structural completeness, and winnability (the design expands into a skeleton, the derived contract is satisfiable, fill slots enumerate). |
-| **Review** | The cycle pauses for an operator when the design records an unresolved question. Otherwise it proceeds. |
-| **Implementation** | The design expands into a skeleton of frozen files and fill slots. Agents write into the slots. |
-| **Verification** | Tests execute. The application installs, builds, boots, and answers probes over HTTP against the contract derived from the design. |
-| **Correction** | Failures are classified by locus — application, test suite, or harness — and repaired for a bounded number of rounds. |
+A cycle runs as a sequence of workloads. Each workload is a run, and each run
+dispatches an ordered list of tasks to the roles that own them.
+
+**Framing** — produces the interface design and the task plan:
+
+| # | Task | Role |
+|---|---|---|
+| 1 | `data.research_context` | data |
+| 2 | `strategy.frame_objective` | strategy |
+| 3 | `development.design_plan` | dev |
+| 4 | `development.author_manifest` | dev |
+| 5 | `qa.define_test_strategy` | qa |
+| 6 | `governance.prepare_plan_authoring_brief` | lead |
+| 7 | `development.propose_plan_tasks` · `qa.propose_plan_tasks` · `strategy.propose_plan_guidance` | dev · qa · strategy |
+| 8 | `governance.merge_plan` | lead |
+| 9 | `governance.review_plan` | lead |
+
+Step 4 runs in authored mode. It sits after the technical design and before the
+test strategy, so QA writes its strategy against the interface the
+implementation will be held to. Steps 7 are the proposers configured in
+`plan_authoring_contributors`; with none configured, the merger authors the plan
+itself.
+
+The manifest passes two gates before implementation starts: structural
+completeness, and winnability — the design expands into a skeleton, the derived
+contract is satisfiable, and fill slots enumerate.
+
+**Implementation** — builds against the design:
+
+| # | Task | Role |
+|---|---|---|
+| 1 | `development.develop` | dev |
+| 2 | `builder.assemble` | builder |
+| 3 | `qa.test` | qa |
+
+Tests execute here: the application installs, builds, boots, and answers probes
+over HTTP against the derived contract. Failures are classified by locus —
+application, test suite, or harness — and repaired for a bounded number of
+rounds.
+
+**Wrap-up** — records what happened:
+
+| # | Task | Role |
+|---|---|---|
+| 1 | `data.gather_evidence` | data |
+| 2 | `qa.assess_outcomes` | qa |
+| 3 | `data.classify_unresolved` | data |
+| 4 | `governance.closeout_decision` | lead |
+| 5 | `governance.publish_handoff` | lead |
+
+Between workloads, an operator gate can pause the cycle. In authored mode the
+gate fires when the design records an unresolved question.
 
 ## Verification results
 

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -1,110 +1,81 @@
 # Squad Ops
 
-**A multi-agent framework that turns a written requirement into a verified
-application** — running on local open-weight models, against a design the squad
-authored rather than one it was handed.
+Squad Ops builds working applications from a written requirement. A cycle reads
+the requirement, designs the interface, implements it, verifies it by execution,
+and produces a runnable project directory.
 
-## What separates it
+It runs on locally hosted open-weight models. The reference deployment is a Qwen
+27B model on an NVIDIA DGX Spark.
 
-Assuming you already know what agent orchestration is, three things are unusual
-here.
+```bash
+squadops cycles create play_game --squad-profile full --request-profile validated-fullstack
+squadops runs assemble play_game <cycle-id> <run-id> --out ./output
+```
 
-### The design is authored, then gated
+## How a cycle works
 
-Most frameworks orchestrate *implementation* against a design a human supplied.
-Here the squad produces the interface design itself — entities, endpoints, error
-contracts, screens — and that design passes two automated gates before any code
-is written: is it structurally complete, and is it **winnable**, meaning the
-thing it describes can actually be built and verified.
+| Stage | What happens |
+|---|---|
+| **Framing** | The squad authors an interface manifest — entities, endpoints, error contracts, screens — from the requirement. Two gates check it: structural completeness, and winnability (the design expands into a skeleton, the derived contract is satisfiable, fill slots enumerate). |
+| **Review** | The cycle pauses for an operator when the design records an unresolved question. Otherwise it proceeds. |
+| **Implementation** | The design expands into a skeleton of frozen files and fill slots. Agents write into the slots. |
+| **Verification** | Tests execute. The application installs, builds, boots, and answers probes over HTTP against the contract derived from the design. |
+| **Correction** | Failures are classified by locus — application, test suite, or harness — and repaired for a bounded number of rounds. |
 
-A design that cannot be won is rejected in seconds, rather than an hour into a
-build that was never going to converge.
+## Verification results
 
-### Only executed checks count
+Three verdicts, recorded per cycle:
 
-A check that did not run is recorded as `blocked_unverified` — never as a pass,
-never silently as a failure. Every cycle publishes what was verified, what
-failed, what never executed, and what has been chronically inert across runs.
+| Verdict | Meaning |
+|---|---|
+| `accepted` | Every required check executed and passed |
+| `rejected` | A check executed and failed |
+| `blocked_unverified` | A required check never executed |
 
-This is the load-bearing decision in the system. A framework that lets an unrun
-check read as green cannot tell you anything true about its own output —
-including whether it is getting better.
+Each cycle publishes the full roll-up: checks verified, checks failed, checks
+that never executed with a machine-readable reason for each, checks an operator
+waived and why, and checks that have been inert across recent runs.
 
-### Work is addressed to roles, not personalities
+## Work assignment
 
-A capability declares which roles may fulfil it; a squad profile decides which
-agent instance and model fills each role. Agent ids are queue addresses, not
-behaviour — swap one and the cycle is unchanged, provided the role is still
-filled. There is no character to prompt-engineer.
+A **capability** declares the work — `development.develop`, `qa.test` — with its
+inputs, outputs, acceptance checks, and the roles permitted to fulfil it.
 
----
+A **squad profile** binds each role to an agent instance and a model:
 
-## Why believe any of it
+```yaml
+profile_id: full
+agents:
+  - { agent_id: neo, role: dev, model: "qwen3.6:27b", enabled: true }
+  - { agent_id: eve, role: qa,  model: "qwen3.6:27b", enabled: true }
+```
 
-The three claims above are about the framework. This one is about the project,
-and it is deliberately kept separate: **the numbers on this site come from
-pre-registered measurement windows**, whose size, inputs, deployment hash and
-scoring rule are frozen before the first run — so a result cannot be improved by
-re-rolling until it looks good.
+Task plans are generated per run from the workload type and the roles the
+profile fills.
 
-That is not a feature you receive. It is the maintainers' method for testing
-whether the framework works, and the reason to trust the rest of the site. Most
-recently: a squad-authored design produced a working application with no human
-intervention in **4 of 6** registered runs, with the scoring instrument's own
-error disclosed on the record rather than quietly corrected.
+## Measured results
 
-[The full evidence, and what it does not show](evidence.md){ .md-button }
+The most recent measurement window closed 20 August 2026: a squad-authored
+design produced a working application with no human intervention in 4 of 6
+registered runs. Across the arc, 9 of 9 delivered applications install, build,
+boot, and answer their probes.
 
----
-
-## The thesis
-
-Give a small model more structure instead of giving it more parameters.
-
-Everything runs on locally hosted open-weight models — no hosted API, no
-per-token cost, nothing leaving the machine. The reference deployment is a Qwen
-27B model on an NVIDIA DGX Spark. That constraint is the point: effort goes into
-scaffolding, verification and correction rather than into a larger model.
-
-Whether structure can substitute for scale is the open question the project
-exists to answer, and the measurement programme is how it gets answered.
-
----
+[Method, full results, and their limits](evidence.md){ .md-button }
 
 ## Where to go
 
 <div class="grid cards" markdown>
 
--   **[Evidence](evidence.md)**
-
-    Method, results, and the boundary of what they support.
-
--   **[Key concepts](key-concepts.md)**
-
-    Cycles, runs, tasks, gates; capabilities, roles, squad profiles.
-
--   **[Getting started](getting-started.md)**
-
-    Install, bootstrap, run your first cycle.
-
--   **[Architecture](architecture.md)**
-
-    Ports and adapters, distributed execution, dependency choices.
-
--   **[Roadmap](roadmap.md)**
-
-    What ships next, and what each release has to earn first.
-
--   **[Improvement proposals](design/sips/index.md)**
-
-    Every architectural decision, recorded and searchable.
+-   **[Getting started](getting-started.md)** — install, bootstrap, first cycle
+-   **[Key concepts](key-concepts.md)** — cycles, runs, tasks, gates, artifacts
+-   **[Architecture](architecture.md)** — ports, adapters, execution
+-   **[CLI](cli.md)** — command reference
+-   **[Roadmap](roadmap.md)** — 1.7, 1.8, 2.0
+-   **[Improvement proposals](design/sips/index.md)** — 125 design records
 
 </div>
 
 ---
 
-Squad Ops is a research project under active development, not a product. It is
-built in the open at
-[backspring-labs/squad-ops](https://github.com/backspring-labs/squad-ops), where
-every architectural decision is filed as a proposal and every release carries
-the evidence it was cut on.
+Squad Ops is a research project under active development, built at
+[backspring-labs/squad-ops](https://github.com/backspring-labs/squad-ops).

--- a/site/content/key-concepts.md
+++ b/site/content/key-concepts.md
@@ -44,30 +44,26 @@ workload_sequence:
     gate: null
 ```
 
-A cycle's status is derived from its runs: `created`, `active`, `paused`,
-`completed`, `failed`, `cancelled`. **`paused` is the interesting one** — it
-means the cycle is waiting for a human at a gate between workloads, not that
-anything went wrong.
+A cycle's status derives from its runs: `created`, `active`, `paused`,
+`completed`, `failed`, `cancelled`. **`paused` means the cycle is waiting for an
+operator at a gate between workloads.**
 
 ## Runs
 
-**A run is one workload's execution — not a retry of the whole cycle.** This is
-the distinction most worth internalising. A cycle that framed a design and then
-implemented it has *two* runs, and they are separate rows with separate
-identities, artifacts, and gate decisions.
+**A run is one workload's execution.** A cycle that framed a design and then
+implemented it has two runs, each a separate record with its own identity,
+artifacts, and gate decisions.
 
 Every run records the hash of the configuration it resolved — squad, models,
-request profile, settings. That is what makes two runs comparable at all: a run
-carries proof of what it executed under, so a difference in outcome can be
-attributed to the change you made rather than to a configuration that drifted.
+request profile, settings. Two runs sharing a hash executed under identical
+configuration.
 
 Runs are the resumability boundary too. Because each workload is its own run
 with its own promoted artifacts, a cycle interrupted after framing can resume
 into implementation without re-authoring the design.
 
 Workload types are `framing`, `implementation`, `evaluation`, `refinement` and
-`wrapup` — a documented vocabulary rather than a closed enum, since a request
-profile may compose its own.
+`wrapup`. The field is free-form, so a request profile may declare its own.
 
 ## Tasks
 
@@ -82,10 +78,10 @@ Task types read as `role.verb`: `strategy.frame_objective`,
 `development.author_manifest`, `development.develop`, `qa.test`,
 `governance.merge_plan`, `data.analyze_failure`.
 
-The plan is not a fixed script. It is generated per run from the workload type,
-the squad profile, and — once framing has produced them — the implementation
-plan and verification contract. A build workload's task list is therefore
-derived from the design the squad just authored.
+The plan is generated per run from the workload type, the squad profile, and —
+once framing has produced them — the implementation plan and verification
+contract. A build workload's task list derives from the design the squad
+authored in the previous run.
 
 ## Flows and dispatch
 
@@ -99,15 +95,13 @@ The executor runs a plan under a declared **flow mode**:
 
 Dispatch is a request/reply over RabbitMQ: the executor publishes a task
 message, an agent container consumes it, executes the handler for that task
-type, and replies with a result. Agents are separate processes — a task
-crossing to an agent is a real network hop, not a function call, which is why
-the envelope carries everything the agent needs rather than a reference to
-shared memory.
+type, and replies with a result. Agents run as separate processes, so the
+envelope carries every input the handler needs.
 
-**Prefect provides the view, not the control.** Each run opens a flow run and
-every dispatched task nests inside it, so `http://localhost:4200` shows the run
-as a graph with per-task logs. The orchestration decisions are the executor's;
-Prefect is where you watch them.
+**Prefect provides the view.** Each run opens a flow run and every dispatched
+task nests inside it, so `http://localhost:4200` shows the run as a graph with
+per-task logs. The executor makes the orchestration decisions; Prefect renders
+them.
 
 ## Gates
 
@@ -132,10 +126,10 @@ squadops runs gate play_game <cycle-id> <run-id> progress_plan_review --approve
 Everything a task produces goes to the artifact vault, content-hashed and
 immutable. Artifacts start `working`; promotion to `promoted` is one-way.
 
-Promotion is what carries work between workloads: when a framing run completes,
-its *promoted* artifacts — the interface design, the implementation plan, the
-derived contract — are forwarded into the implementation run. Working artifacts
-are not forwarded, so a rejected draft cannot leak into the next workload.
+Promotion carries work between workloads. When a framing run completes, its
+promoted artifacts — the interface design, the implementation plan, the derived
+contract — forward into the implementation run. Only promoted artifacts
+forward.
 
 ---
 
@@ -169,26 +163,25 @@ built — a **schema gate** (does it parse, is it structurally complete) and a
 verified: does the skeleton expand, is the derived contract satisfiable, do the
 fill slots enumerate, do the test anchors cover the screens it promises).
 
-A design that cannot be won is rejected in seconds, rather than an hour into a
-build.
+An unwinnable design is rejected at the gate, before any implementation task
+dispatches.
 
-### 2. Review — only when it is needed
+### 2. Review — question-gated
 
-The cycle stops for a human when the authored design records a genuinely
-**unresolved question** — the squad saying the requirement does not determine
-something, and declining to guess. With no open questions it proceeds.
+The cycle pauses for an operator when the authored design records an
+**unresolved question**: the squad marking something the requirement leaves
+undetermined. With no open questions the cycle proceeds and the gate decision
+records `system:no_open_questions`.
 
-This is deliberate. An earlier version reviewed every design, and the reviews
-became rubber stamps discussing facts the automated gates had already proven,
-while a real unresolved question sat unsurfaced. A gate that is always approved
-teaches nobody anything, and makes a later reader unable to tell a considered
-approval from a reflex.
+The firing rule lives in `cycles/manifest_authoring.py::open_questions`. It keys
+on the design, so a seeded manifest carrying an open question pauses the cycle
+exactly as an authored one does.
 
 ### 3. Implementation — fill the slots
 
 The accepted design expands into a skeleton: some files frozen, others slots to
-be filled. Agents write into the slots; an attempt to write outside them is
-caught rather than merged.
+be filled. Agents write into the slots. Writes outside a slot are rejected at
+the emission gate.
 
 ### 4. Verification — execute, don't assume
 
@@ -205,16 +198,17 @@ flowchart LR
     P -->|no| F[failed]
 ```
 
-Three outcomes, not two. Most systems collapse the left branch into one of the
-others — a check that could not run is reported green because nothing failed,
-or red because nothing passed. Both are lies, and each is wrong in the direction
-that hurts most: the first hides broken verification, the second sends a
-correction round after an application that was never actually tested.
+Each not-executed result carries a machine-readable reason from a fixed
+taxonomy — `config_disabled`, `unsupported_stack`, environment gaps — recorded
+on the roll-up alongside the checks that ran.
 
-The same distinction carries to the cycle verdict. `rejected` means the product
-failed a criterion and the product is what to repair; `blocked_unverified` means
-the framework *cannot honestly claim* it verified anything, and the harness,
-environment or configuration is what to repair.
+The same three-way split applies to the cycle verdict, and each verdict points
+at a different repair target:
+
+| Verdict | Repair target |
+|---|---|
+| `rejected` | The product — a criterion failed |
+| `blocked_unverified` | The harness, environment, or run configuration |
 
 ### 5. Correction — bounded, and aimed
 
@@ -302,13 +296,11 @@ timeout), so a role can be tuned without touching code.
 The profile is resolved at plan time and its hash is recorded on the run, which
 is what makes two runs comparable.
 
-### Identity is a convenience
+### Agent instance ids
 
-`neo`, `eve`, `bob` are **agent instance ids** — addresses on the queue and
-labels in a log. They are not a framework concept, they carry no behaviour, and
-the display names attached to them are for humans reading a trace.
+`neo`, `eve`, `bob` are addresses on the queue and labels in a log. A profile
+assigns one per role, along with the model that instance runs.
 
-Swap the id, and provided the role is still filled the cycle is unchanged. Two
-instances can fill the same role in different profiles; the same id can run a
-different model in a different profile. **Read a task's role, not its name** —
-the name tells you which row of a config file was selected, and nothing more.
+The same id can run a different model in a different profile, and different ids
+can fill the same role across profiles. Task routing resolves by role, so a
+task's role determines its behaviour and its handler.

--- a/site/content/key-concepts.md
+++ b/site/content/key-concepts.md
@@ -151,20 +151,39 @@ flowchart LR
     C -->|rounds exhausted| X([rejected])
 ```
 
-### 1. Framing — the squad authors the design
+### 1. Framing — the design and the plan
 
-The squad reads the requirement and produces an **interface manifest**: the
-entities, endpoints, error contracts, and screens the application will have.
+Nine steps, dispatched in order to the roles that own them:
 
-This is the step that separates Squad Ops from a code generator. The design is
-not supplied; it is written by the agents and then checked before anything is
-built — a **schema gate** (does it parse, is it structurally complete) and a
-**winnability gate** (can the thing it describes actually be built and
-verified: does the skeleton expand, is the derived contract satisfiable, do the
-fill slots enumerate, do the test anchors cover the screens it promises).
+| # | Task | Role | Produces |
+|---|---|---|---|
+| 1 | `data.research_context` | data | Background the later steps read |
+| 2 | `strategy.frame_objective` | strategy | The objective and scope |
+| 3 | `development.design_plan` | dev | The technical design |
+| 4 | `development.author_manifest` | dev | `interface_manifest.yaml` |
+| 5 | `qa.define_test_strategy` | qa | The test approach |
+| 6 | `governance.prepare_plan_authoring_brief` | lead | The brief proposers work from |
+| 7 | `development.propose_plan_tasks`<br>`qa.propose_plan_tasks`<br>`strategy.propose_plan_guidance` | dev<br>qa<br>strategy | Competing task proposals |
+| 8 | `governance.merge_plan` | lead | `implementation_plan.yaml` |
+| 9 | `governance.review_plan` | lead | Sign-off |
 
-An unwinnable design is rejected at the gate, before any implementation task
-dispatches.
+**Step 4 runs in authored mode**, and its position is deliberate: after the
+technical design, so dev is best informed, and before the test strategy, so QA
+writes its strategy against the interface the implementation will be held to.
+
+**Step 7 is configurable.** `plan_authoring_contributors` selects which roles
+propose; the merger runs in sole-author mode when the list is empty.
+
+The manifest carries the entities, endpoints, error contracts and screens. Two
+gates check it before implementation starts:
+
+| Gate | Checks |
+|---|---|
+| **Schema** | Parses, and is structurally complete |
+| **Winnability** | The skeleton expands, the derived contract is satisfiable, fill slots enumerate, and test anchors cover the declared screens |
+
+A design failing either gate returns to step 4 for revision, bounded by the
+cycle's revision budget.
 
 ### 2. Review — question-gated
 

--- a/site/content/observability.md
+++ b/site/content/observability.md
@@ -25,9 +25,8 @@ Every run opens a flow run, and every dispatched task nests inside it. That
 gives you the run as a graph: which task is executing, which failed, how long
 each took, and per-task logs streamed from the agent that ran them.
 
-This is the right surface for *"is it stuck, and where"*. It is not the right
-surface for judging quality — a green Prefect graph means the tasks completed,
-not that the application works.
+Use it to locate a stalled or failed task. A completed Prefect graph reports
+that the tasks ran; the cycle verdict reports what they produced.
 
 ## LangFuse — what the model saw
 
@@ -78,10 +77,10 @@ Every completed cycle produces a roll-up:
 | `waived` | checks an operator explicitly waived, with the reason |
 | `inert` | checks chronically never executing across runs |
 
-The `unverified` and `inert` fields are the ones that make the rest
-trustworthy. A framework that reports only passes and failures cannot tell you
-that its own verification was broken — and a check that has quietly never
-executed for twenty runs is a far worse problem than one that fails loudly.
+`unverified` lists every check that did not execute, each with a reason from a
+fixed taxonomy. `inert` lists checks that have not executed across recent runs
+of the same project, squad profile and request profile — a lookback of ten
+cycles.
 
 ```bash
 squadops cycles show play_game <cycle-id> --json

--- a/site/content/roadmap.md
+++ b/site/content/roadmap.md
@@ -16,10 +16,10 @@ Semantic versioning with an even/odd convention on the minor:
 | | |
 |---|---|
 | **Even minors** | Feature releases, led by a headline design proposal |
-| **Odd minors** | Stabilisation. Feature-free by rule — the home for structural refactors deliberately quarantined out of feature releases, so a regression is unambiguously the refactor |
+| **Odd minors** | Stabilisation. Feature-free by rule, and where structural refactors land so a regression during one is attributable to the refactor |
 | **Patches** | Fixes, from either lane, at any time |
 
-Substance gates a cut, not the calendar.
+Scope completion gates a cut.
 
 ## Shipped
 
@@ -55,7 +55,7 @@ neutrality for the inference layer. Two later things depend on it — an inferen
 engine cannot be swapped safely while a vendor's status vocabulary lives in the
 domain, and 1.8 grades across seams that must be stable first.
 
-**1.8 — automation and learning.** Two co-headliners, deliberately ordered.
+**1.8 — automation and learning.** Two co-headliners, ordered within the release.
 A **cycle evaluation scorecard** turns a cycle outcome into a comparable grade
 and makes the project's own thesis falsifiable via a squad-versus-single-model
 harness. **Campaign orchestration** then relaunches cycles against an objective
@@ -75,8 +75,8 @@ in 1.8 either way, so the choice becomes an adapter swap rather than a redesign.
 Two conventions shape more of the roadmap than any individual feature.
 
 **Rails before mechanism.** A port, a no-op adapter and a wired call site ship
-before the implementation behind them. That is why deferring a capability is
-cheap here: what remains is an adapter swap, not a redesign.
+before the implementation behind them, so adding the implementation later is an
+adapter swap.
 
 **Nothing self-improving acts on raw checks.** Self-improvement consumes graded
 assessments, never the underlying check results — which is why the scorecard has

--- a/site/overrides/.icons/squadops/logo.svg
+++ b/site/overrides/.icons/squadops/logo.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <!-- Squad Ops. A cycle split into two arrows — the gap at 3 and 9 is the gate.
+       Play triangle sits left of geometric centre so the point and the back edge
+       read as evenly spaced from the chevrons. currentColor throughout so the
+       mark follows the active palette. -->
+  <path d="M4.30 8.89 A8.3 8.3 0 0 1 19.70 8.89" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"/>
+  <path d="M19.70 15.11 A8.3 8.3 0 0 1 4.30 15.11" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"/>
+  <path d="M22.01 7.95 L20.12 10.27 L17.38 9.83" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M1.99 16.05 L3.88 13.73 L6.62 14.17" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M10.05 8.90 15.25 12.00 10.05 15.10Z" fill="currentColor" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Three commits.

## 1. `rewrite for factual tone` — a re-land

**Pushed to #1046 but never landed**: that PR merged carrying only its first commit, so this work never reached main. Cherry-picked unchanged, message intact.

Removes three habits across every page:

- **Defining by negation** — "X, not Y", "this is not a feature you receive". These clustered around passages rewritten after a correction, preserving the wrong version as a warning in the product's voice. Now positive statements or deleted. Surviving negations are factual: `unverified` means checks that did not execute, which is the definition of the field.
- **Sermonizing** — "the load-bearing decision in the system", "cannot tell you anything true about its own output", "both are lies". Replaced with mechanism and values: the three verdicts as a table, the not-executed reason taxonomy, the ten-cycle inert lookback.
- **Comparison to unnamed others** — "most frameworks orchestrate implementation against a design a human supplied". Unfalsifiable; removed.

Verified by grep, not by eye — zero occurrences of the sermon phrases, every surviving ` not ` reviewed individually.

## 2. `the framing sequence, by role`

Overview described framing as *"the squad authors an interface manifest"* and skipped the eight other tasks that produce it. Overview and Key concepts now carry the ordered sequence read from `task_plan.py`:

| # | Task | Role |
|---|---|---|
| 1 | `data.research_context` | data |
| 2 | `strategy.frame_objective` | strategy |
| 3 | `development.design_plan` | dev |
| 4 | `development.author_manifest` | dev |
| 5 | `qa.define_test_strategy` | qa |
| 6 | `governance.prepare_plan_authoring_brief` | lead |
| 7 | `development.propose_plan_tasks` · `qa.propose_plan_tasks` · `strategy.propose_plan_guidance` | dev · qa · strategy |
| 8 | `governance.merge_plan` | lead |
| 9 | `governance.review_plan` | lead |

Two facts the summary hid. **Step 4's position is load-bearing** — `build_planning_steps` inserts it after the technical design and before the test strategy, so dev authors while best-informed and QA writes its strategy against the interface implementation will be held to (#791). **Step 7 is configurable** — `plan_authoring_contributors` selects which roles propose, and an empty list puts the merger in sole-author mode, the default for every request profile except `validation-multirole`.

Implementation and wrap-up sequences added for the same reason.

## 3. `logo, favicon, and header lockup`

A mark for the project: a cycle split into two arrows with a play symbol at the centre. The gap at 3 and 9 o'clock is the gate; play reads as run.

- **Installed as a Material custom icon**, not `theme.logo`. `theme.logo` renders an `<img>`, where `currentColor` has nothing to inherit from; the icon path inlines the SVG so the mark follows the palette.
- **Favicon is a solid black rounded tile.** Transparent marks depend on `prefers-color-scheme`, which tab chrome applies inconsistently and can land dark-on-dark. Mark at 0.82, measured 12% edge padding — inside the 10% floor maskable icons need, while staying as large as possible for 16px.
- **Header lockup**: Material's default left 32px between logo and title, wider than the 24px mark itself. Now 15px. Two causes, not one — the title margin tied on specificity with Material's rule, *and* the logo button's own padding contributed the rest regardless.
- **Config bug fixed**: the theme block had grown two `icon:` keys. YAML keeps the last, so the logo declaration was being silently discarded by the `repo:` block.

Rationale for the tile and the scale is recorded in the SVG comments.

---

`mkdocs build --strict` clean, `ruff` clean repo-wide, every change reviewed in a browser.