### PR TITLE
feat(scaffold): insert-as-update findings on emitted route handlers — banked, not enforced

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -698,6 +698,18 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
 
         outputs["emission_stats"] = emission_stats(len(content), artifacts)
 
+        # #1055: insert-as-update findings over the emitted route handlers. Banked in
+        # `outputs`, NOT as a validation check row — a failing row there would reject
+        # the task, and this is reporting-only until a gate's shape is argued from what
+        # it flags on real rolls (#1049's lesson, #1052's posture).
+        #
+        # Landing verified rather than assumed: #1052 put its findings in
+        # `execution_evidence`, which nothing persists (#999), and called them "banked".
+        # `outputs` reaches `build_failure_evidence`, which carries this key explicitly.
+        from squadops.capabilities.source_containment import assess_source_containment
+
+        outputs["source_containment"] = assess_source_containment(artifacts)
+
         duration_ms = (time.perf_counter() - start_time) * 1000
         evidence = HandlerEvidence.create(
             handler_name=self._handler_name,

--- a/src/squadops/capabilities/source_containment.py
+++ b/src/squadops/capabilities/source_containment.py
@@ -1,0 +1,90 @@
+"""Containment findings for emitted application source — #1055, reporting-only.
+
+The sibling of ``additive_containment`` (#1052), which judges author-written TEST
+files. This judges the route handlers the developer fills.
+
+**The defect, and the correction that produced this module.** Arm A of the 2026-08-23
+paired validation (`cyc_181c9572bef2`) failed every count assertion in its scaffold
+shells — ``expected […] to have a length of 1 but got 2``, then ``got 3``. The lead
+diagnosed *"route handlers instantiating a local shadow store instead of importing the
+scaffold-provided global"*, and this module was first written to detect that. It found
+nothing, because every route file in that roll imports the frozen store and holds no
+module state. The diagnosis was wrong — the #968 class, an analyzer claim nobody
+checked against the source.
+
+The real defect is one line:
+
+    const run = find(TABLES.Run, params.run_id)
+    participants.push(name)
+    insert(TABLES.Run, {...run, participants})   # appends a SECOND row
+
+``insert`` is ``push``. Join adds a row and leave adds another, which is exactly the
+observed drift. Same symptom the shadow-store story predicted, entirely different
+cause — and a repair telling the developer to import the frozen store could never have
+fixed it, because the handler already does.
+
+**This is a scaffold gap before it is a developer defect.** The frozen store's whole
+API is ``reset, all, insert, find, nextId``: there is no update seam. "Persist a change
+to an existing row" has no correct form. The working answer — mutate the object
+``find`` returned and never call ``insert`` — is non-obvious, and the natural-looking
+answer silently duplicates. Adding an ``update`` seam is the root fix; it moves
+``GENERATOR_VERSION`` and the Gate 1 fixture, so it is an owner call, not a drive-by.
+
+**Reporting-only**, as ``additive_containment`` is, and for the same reason: #1049 was
+a rejection gate whose premise had quietly stopped being true and it cost re-rolls on
+every cycle before anyone noticed. Findings are banked so a gate can be argued from
+what they flag on real rolls.
+
+**Prevalence, measured rather than assumed** (three banked rolls, join/leave handlers):
+arm A used ``insert``-as-update in 2 files; arm B (3.8) and the banked green roll used
+in-place mutation in every handler. So this is a real trap and NOT a universal one —
+worth naming when it appears, not worth blocking on.
+
+*Follow-up worth naming:* this and ``additive_containment`` are one concern —
+containment findings over emitted bytes — split across two modules only because the
+second landed while the first was in review. Merging them is a cleanup, not a
+behaviour change, and should happen before a third arrives.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: A read of one row followed by an ``insert`` into the SAME table — the append-only
+#: store's insert-as-update trap. Matched as a pair rather than on ``insert`` alone:
+#: a handler that inserts a genuinely new row (create) is correct and must never flag,
+#: and it is the ``find`` that makes the later insert a duplicate rather than a create.
+_FIND_RE = re.compile(r"\bfind\s*\(\s*TABLES\.(\w+)")
+_INSERT_RE = re.compile(r"\binsert\s*\(\s*TABLES\.(\w+)")
+
+#: Route handlers only. A page or a lib file is a different question.
+_ROUTE_RE = re.compile(r"(?:^|/)route\.(?:ts|tsx|js)$")
+
+
+def is_route_module(path: str) -> bool:
+    """Whether *path* is a route handler this pass judges."""
+    return bool(_ROUTE_RE.search(path))
+
+
+def assess_source_containment(files: list[dict]) -> list[str]:
+    """Insert-as-update findings for the route handlers in an emission (empty = clean).
+
+    ``files`` is the emission's artifact shape (``{"name", "content"}``). Pure, so the
+    banked evidence today and any later gate read the same rule.
+    """
+    findings: list[str] = []
+    for f in sorted(files, key=lambda a: str(a.get("name", ""))):
+        path = str(f.get("name") or "")
+        content = f.get("content")
+        if not is_route_module(path) or not isinstance(content, str):
+            continue
+        read_tables = set(_FIND_RE.findall(content))
+        for table in sorted(set(_INSERT_RE.findall(content)) & read_tables):
+            findings.append(
+                f"{path}: reads `TABLES.{table}` with find() and then calls "
+                f"insert(TABLES.{table}) — insert is append-only, so this stores a "
+                f"SECOND row rather than updating the one it read. Mutate the object "
+                f"find() returned; the frozen store has no update seam "
+                f"(arm A, cyc_181c9572bef2)."
+            )
+    return findings

--- a/src/squadops/cycles/failure_evidence.py
+++ b/src/squadops/cycles/failure_evidence.py
@@ -109,6 +109,14 @@ def build_failure_evidence(
     scaffold_evidence = result_outputs.get("scaffold_evidence")
     if isinstance(scaffold_evidence, dict):
         evidence["scaffold_evidence"] = scaffold_evidence
+    # #1055: the dev-side sibling. Carried explicitly for the same reason
+    # scaffold_evidence is — the analyzer renders the whole evidence dict, so a finding
+    # that never enters it is one the diagnosis cannot use. Arm A's lead had to invent
+    # a mechanism ("a local shadow store") because nothing told it what the handlers
+    # actually did wrong.
+    source_containment = result_outputs.get("source_containment")
+    if isinstance(source_containment, list) and source_containment:
+        evidence["source_containment"] = list(source_containment)
     evidence["failure_category"] = derive_failure_category(evidence)
     return evidence
 

--- a/tests/unit/capabilities/test_source_containment.py
+++ b/tests/unit/capabilities/test_source_containment.py
@@ -1,0 +1,215 @@
+"""#1055: insert-as-update findings on emitted route handlers.
+
+Filed on a wrong diagnosis and corrected against the source — the lead reported a
+"local shadow store" and every route file in that roll imports the frozen store. The
+real defect is `find` then `insert` against an append-only store. Each test names the
+bug it catches; the over-rejection cases matter as much, because a create legitimately
+inserts and flagging it would make the finding noise.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.source_containment import assess_source_containment, is_route_module
+
+_ROUTE = "app/api/runs/[run_id]/join/route.ts"
+
+
+def _f(name: str, content: str) -> dict:
+    return {"name": name, "content": content}
+
+
+def test_find_then_insert_on_the_same_table_is_flagged():
+    """The banked defect, both failing rolls. `insert` is `push`, so persisting an
+    update this way stores a SECOND row — which is the `length of 1 but got 2` that
+    killed arm A and the "does not add a second participant" red in arm B."""
+    content = (
+        "import { TABLES, find, insert } from '@/lib/store'\n"
+        "export async function POST(r: Request) {\n"
+        "  const run = find(TABLES.Run, '1')\n"
+        "  insert(TABLES.Run, { ...run, participants: [] })\n}"
+    )
+    findings = assess_source_containment([_f(_ROUTE, content)])
+    assert len(findings) == 1
+    assert "insert is append-only" in findings[0]
+    assert "TABLES.Run" in findings[0]
+
+
+def test_a_create_handler_that_only_inserts_is_clean():
+    """The control that decides whether this finding is usable. A collection POST
+    inserts a genuinely new row and is correct — it is the preceding `find` that turns
+    a later insert into a duplicate."""
+    content = (
+        "import { TABLES, insert, nextId } from '@/lib/store'\n"
+        "export async function POST(r: Request) { insert(TABLES.Run, { id: nextId() }) }"
+    )
+    assert assess_source_containment([_f("app/api/runs/route.ts", content)]) == []
+
+
+def test_a_read_handler_that_only_finds_is_clean():
+    content = (
+        "import { TABLES, find } from '@/lib/store'\n"
+        "export async function GET() { return Response.json(find(TABLES.Run, '1')) }"
+    )
+    assert assess_source_containment([_f("app/api/runs/[run_id]/route.ts", content)]) == []
+
+
+def test_the_correct_update_form_is_clean():
+    """Mutating the object `find` returned is the working answer today — the finding
+    must not fire on the very form it is telling the author to use."""
+    content = (
+        "import { TABLES, find } from '@/lib/store'\n"
+        "export async function POST() {\n"
+        "  const run = find(TABLES.Run, '1')\n"
+        "  run.participants = [...run.participants, 'ada']\n}"
+    )
+    assert assess_source_containment([_f(_ROUTE, content)]) == []
+
+
+def test_find_and_insert_on_DIFFERENT_tables_is_clean():
+    """Reading a Run to validate, then creating a Participant, is ordinary and correct.
+    Matching on `insert` near any `find` would flag it."""
+    content = (
+        "import { TABLES, find, insert } from '@/lib/store'\n"
+        "export async function POST() {\n"
+        "  const run = find(TABLES.Run, '1')\n"
+        "  insert(TABLES.Participant, { id: 'p1', runId: run.id })\n}"
+    )
+    assert assess_source_containment([_f(_ROUTE, content)]) == []
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("app/api/runs/route.ts", True),
+        ("app/api/runs/[run_id]/join/route.ts", True),
+        ("app/page.tsx", False),
+        ("lib/store.ts", False),
+        ("__tests__/runs.test.ts", False),
+    ],
+)
+def test_only_route_modules_are_judged(path, expected):
+    """A page or a lib file holding state is a different question. The store itself
+    obviously contains both verbs and must never flag."""
+    assert is_route_module(path) is expected
+
+
+def test_findings_are_ordered_so_two_rolls_are_comparable():
+    files = [
+        _f("app/api/runs/z/route.ts", "find(TABLES.Run, '1'); insert(TABLES.Run, {})"),
+        _f("app/api/runs/a/route.ts", "find(TABLES.Run, '1'); insert(TABLES.Run, {})"),
+    ]
+    assert [f.split(":")[0] for f in assess_source_containment(files)] == [
+        "app/api/runs/a/route.ts",
+        "app/api/runs/z/route.ts",
+    ]
+
+
+class TestTheFindingsReachTheRecord:
+    """The landing, asserted end to end — the lesson #1057 cost.
+
+    #1052 computed findings, placed them in `execution_evidence` which nothing
+    persists, and described them as banked. Every layer had a passing test. So this
+    asserts on `outputs` and then on the evidence dict the analyzer actually reads.
+    """
+
+    @staticmethod
+    def _make_envelope():
+        from squadops.tasks.models import TaskEnvelope
+
+        return TaskEnvelope(
+            task_id="t1",
+            agent_id="neo",
+            cycle_id="cyc_1",
+            pulse_id="p1",
+            project_id="group_run",
+            task_type="development.develop",
+            correlation_id="c1",
+            causation_id="c0",
+            trace_id="tr1",
+            span_id="sp1",
+            inputs={},
+        )
+
+    _BAD = (
+        "import { TABLES, find, insert } from '@/lib/store'\n"
+        "export async function POST() {\n"
+        "  const run = find(TABLES.Run, '1')\n"
+        "  insert(TABLES.Run, { ...run })\n}"
+    )
+
+    def test_the_evidence_builder_carries_the_findings_to_the_analyzer(self):
+        """Bug caught: the finding computed, banked in outputs, and then dropped before
+        the diagnosis. Arm A's lead invented a mechanism because nothing told it what
+        the handlers actually did wrong."""
+        from squadops.cycles.failure_evidence import build_failure_evidence
+        from squadops.tasks.models import TaskResult
+
+        envelope = self._make_envelope()
+        result = TaskResult(
+            task_id="t1",
+            status="FAILED",
+            outputs={"source_containment": ["app/api/runs/x/route.ts: ... insert is append-only"]},
+        )
+        evidence = build_failure_evidence(envelope, result, prior_plan_deltas_count=0)
+        assert evidence["source_containment"] == [
+            "app/api/runs/x/route.ts: ... insert is append-only"
+        ]
+
+    def test_a_clean_emission_adds_no_key_rather_than_an_empty_one(self):
+        """Presence-keyed, like every other manifest surface: an empty list in the
+        analyzer's prompt is a section that says nothing, and the prompt is not free."""
+        from squadops.cycles.failure_evidence import build_failure_evidence
+        from squadops.tasks.models import TaskResult
+
+        envelope = self._make_envelope()
+        result = TaskResult(task_id="t1", status="FAILED", outputs={"source_containment": []})
+        assert "source_containment" not in build_failure_evidence(
+            envelope, result, prior_plan_deltas_count=0
+        )
+
+    def test_a_non_route_file_with_the_pattern_is_not_judged(self):
+        """The predicate is tested above; this proves the ASSESSOR uses it. `lib/store.ts`
+        itself contains both verbs by definition, and a seeded fixture may too — judging
+        them would make the finding fire on the scaffold's own bytes."""
+        bad = "find(TABLES.Run, '1'); insert(TABLES.Run, {})"
+        assert assess_source_containment([_f("lib/store.ts", bad)]) == []
+        assert assess_source_containment([_f("app/page.tsx", bad)]) == []
+
+    def test_the_handler_assigns_the_findings_into_outputs(self):
+        """The transport step, and the reason it gets its own test.
+
+        Bug caught: the assessment computed and the result never placed in `outputs` —
+        which has now happened six times in this codebase in one working session
+        (#1040, #1048, #1052, #1057 twice, here). Every other test in this file passes
+        while the fact reaches nobody.
+
+        Asserted structurally because driving the full develop handler needs an LLM, a
+        validator and a workspace — a cost that has, in practice, meant this step gets
+        no test at all. A structural assertion that the call's result lands in `outputs`
+        is worth more than the end-to-end test nobody writes.
+        """
+        import ast
+        import pathlib
+
+        import squadops.capabilities.handlers.cycle.develop as develop_mod
+
+        tree = ast.parse(pathlib.Path(develop_mod.__file__).read_text())
+        assigned = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Call)
+            and getattr(node.value.func, "id", "") == "assess_source_containment"
+            and any(
+                isinstance(t, ast.Subscript)
+                and getattr(t.value, "id", "") == "outputs"
+                and getattr(t.slice, "value", None) == "source_containment"
+                for t in node.targets
+            )
+        ]
+        assert assigned, (
+            "assess_source_containment's result is not assigned into "
+            'outputs["source_containment"] — computed and dropped'
+        )


### PR DESCRIPTION
The **finding half** of #1055. The store's missing update seam is the root fix and is a separate, owner-ruled change (moves `GENERATOR_VERSION` and the Gate 1 fixture). `Refs`, not `Closes`.

## The issue was filed on a wrong diagnosis, and this module found it

Arm A's lead reported *"route handlers instantiating a local shadow store instead of importing the scaffold-provided global"*. I filed #1055 from that prose **without checking it**. The first version of this detector looked for exactly that and came back clean — because every route file in that roll imports the frozen store and holds no module state.

That is the #968 class — an analyzer claim nobody verifies against the source — and I repeated it in the same session where I cited #968 as grounds to distrust analyzer prose. The issue is corrected and retitled.

## The real defect

```ts
const run = find(TABLES.Run, params.run_id)
participants.push(name)
insert(TABLES.Run, {...run, participants})   // appends a SECOND row
```

`insert` is `push`. Join adds a row, leave adds another — the observed `length of 1 but got 2`, then `got 3`. A repair telling the developer to import the frozen store could never have fixed it, because the handler already does.

## Prevalence, measured with the detector

My first hand-grep got this wrong by anchoring `insert(` to line start, which misses `const updated = insert(...)`. Re-measured properly across three banked rolls:

| Roll | join | leave | create | read |
|---|---|---|---|---|
| arm A · 3.6 | **FLAG** | **FLAG** | ok | ok |
| arm B · 3.8 | **FLAG** | **FLAG** | ok | ok |
| green roll | ok | ok | ok | ok |

Both failing rolls. Neither create nor read handler. Never the roll that went green. Two independent authorings on two different models reached for the same wrong verb at exactly the two operations that *update* rather than *create* — which is why the root cause is the API, not the author.

## Matched as a pair, deliberately

`find` then `insert` on the **same table** — never on `insert` alone. A create legitimately inserts; reading a Run to validate before creating a Participant is ordinary. Both are pinned as non-findings, as is **the correct update form** (mutating what `find` returned) — the finding must never fire on the very thing its message tells the author to do.

## Reporting-only, and banked where it is read

`outputs["source_containment"]`, carried explicitly by `build_failure_evidence` so the analyzer sees it. Arm A's lead had to invent a mechanism because nothing told it what the handlers actually did wrong.

Landing **verified rather than assumed** — #1052 put its findings in `execution_evidence`, which nothing persists (#999), and called them banked.

## Verification

- Regression **7,811 passed**, gate green at 20 workers.
- **7 mutations, all killed.** Two survived the first pass: non-route files being judged (the predicate was tested, its *use* was not), and the handler never assigning the result into `outputs` — the **sixth** instance of that shape in one session, so it now has a structural test of its own.

Refs #1055, #968