### PR TITLE
feat(release): publish the GitHub Release from the tag, not from memory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+# Publishes a GitHub Release when a v* tag is pushed (#1061).
+#
+# Why this is automated rather than a checklist item: across v1.4.0–v1.6.1,
+# ZERO releases were published at cut time — every one was backfilled later, in
+# two batch sweeps. The step was written into the cut checklist on 2026-08-10
+# and still missed at both subsequent cuts. Pushing a tag reads as completion:
+# the version is stamped, the tag is on the remote, git reports success, and
+# nothing signals that a separate artifact on a different system is outstanding.
+#
+# The body is the version's CHANGELOG section, which is written deliberately,
+# reviewed in the release PR, and guaranteed to exist by rule 4 of
+# tests/unit/architecture/test_docs_version_sync.py before a tag can be cut.
+# So this publishes reviewed content at a later moment, not unread content.
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v1.6.2)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The tag's own tree — the CHANGELOG must be read as it was AT the cut,
+          # not as main looks now, or a later rotation would rewrite history.
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Derive title and body
+        id: notes
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          python scripts/maintainer/release_notes.py "$version" \
+            --body-file "$RUNNER_TEMP/notes.md" --print-title > "$RUNNER_TEMP/title.txt"
+          echo "title=$(cat "$RUNNER_TEMP/title.txt")" >> "$GITHUB_OUTPUT"
+
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — leaving it untouched."
+            exit 0
+          fi
+          # --latest only for a plain semver tag, so a pre-release or an oddly
+          # named tag can never displace the current release.
+          latest_flag="--latest=false"
+          [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && latest_flag="--latest"
+          gh release create "$TAG" \
+            --title "${{ steps.notes.outputs.title }}" \
+            --notes-file "$RUNNER_TEMP/notes.md" \
+            $latest_flag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,11 +236,18 @@ procedure costs: six consecutive releases tagged but never advertised.
 | 3 | Rotate `CHANGELOG.md` — `[Unreleased]` → `[x.y.z] — <date>`, open a fresh `[Unreleased]` |
 | 4 | ROADMAP timeline entry |
 | 5 | SIP promotion sweep — promote what is genuinely implemented; a phased or umbrella SIP with open children stays `accepted`, with the gap named |
-| 6 | `git tag vX.Y.Z` **and** a GitHub Release from the CHANGELOG section, marked **Latest** |
+| 6 | `git tag vX.Y.Z && git push origin vX.Y.Z` — the Release publishes itself from the CHANGELOG section (`.github/workflows/release.yml`, #1061) |
 | 7 | **Capture the release package** — `python scripts/maintainer/build_release_package.py <version> --write --cycle <shakedown-cycle-id>`, commit `site/content/releases/vX.Y.Z/` |
 
-Steps 1–3 are guarded by `tests/unit/architecture/test_docs_version_sync.py`; **4 through 7
-are not**, which is why they are written down.
+Steps 1–3 are guarded by `tests/unit/architecture/test_docs_version_sync.py`, and step 6's
+Release is now automated on tag push. **Steps 4, 5 and 7 remain unguarded**, which is why
+they are written down.
+
+**Why step 6 is automated rather than listed.** Across v1.4.0–v1.6.1, *zero* releases were
+published at cut time — every one was backfilled later. The step sat in the cut checklist
+from 2026-08-10 and was still missed at both subsequent cuts. Pushing a tag reads as
+completion, and nothing signals that a separate artifact on another system is outstanding.
+A step with that record needs removing, not restating (#1061).
 
 **Step 7 is capture, not query.** Cycle evidence lives in a running deploy and is
 unrecoverable once it moves, so the package is snapshotted at the cut and committed —

--- a/scripts/maintainer/release_notes.py
+++ b/scripts/maintainer/release_notes.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Derive a GitHub Release's title and body for a version (#1061).
+
+Called by `.github/workflows/release.yml` on a `v*` tag push. Lives here rather
+than inline in the workflow so the parsing is unit-testable and so a change to
+the CHANGELOG or ROADMAP heading shape breaks a test rather than a release.
+
+The body is the version's CHANGELOG section verbatim. That text is written
+deliberately and reviewed in the release PR, and `test_docs_version_sync.py`
+rule 4 already guarantees the section exists before a tag can be cut — so
+publishing it automatically is publishing reviewed content, not unread content.
+
+Usage:
+    python scripts/maintainer/release_notes.py 1.6.1 --body-file notes.md
+    python scripts/maintainer/release_notes.py 1.6.1 --print-title
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Same shape the docs-drift guard enforces (test_docs_version_sync.py). Both
+# dash styles are present in the file's history, so both must parse.
+SECTION = r"^## \[{v}\] +[—-] +\d{{4}}-\d{{2}}-\d{{2}}\s*$"
+NEXT_SECTION = r"^## \["
+# ROADMAP: "### v1.6.0 (2026-08-21) — the Authorship release"
+ROADMAP_HEADING = r"^### v{v} \(\d{{4}}-\d{{2}}-\d{{2}}\)\s*—\s*(.+?)\s*$"
+
+
+class NotFound(Exception):
+    """A required section is missing — fail the release rather than publish a stub."""
+
+
+def changelog_body(version: str, text: str) -> str:
+    start = re.search(SECTION.format(v=re.escape(version)), text, re.MULTILINE)
+    if not start:
+        raise NotFound(
+            f"CHANGELOG.md has no section for {version}. "
+            "Rotate the changelog before tagging (see CLAUDE.md, Release cut)."
+        )
+    rest = text[start.end() :]
+    end = re.search(NEXT_SECTION, rest, re.MULTILINE)
+    body = (rest[: end.start()] if end else rest).strip()
+    if not body:
+        raise NotFound(f"CHANGELOG.md section for {version} is empty.")
+    return body
+
+
+def release_title(version: str, roadmap: str) -> str:
+    """`v1.6.0 — the Authorship release`, or the bare tag if the ROADMAP is silent.
+
+    A missing ROADMAP entry is not fatal: the release is still worth publishing,
+    and a bare version title is honest. Only the body is load-bearing.
+    """
+    match = re.search(ROADMAP_HEADING.format(v=re.escape(version)), roadmap, re.MULTILINE)
+    if not match:
+        return f"v{version}"
+    # "Current" is a transient marker on the newest entry; it is not part of the name.
+    name = re.sub(r"^Current\s*—\s*", "", match.group(1)).strip()
+    return f"v{version} — {name}" if name else f"v{version}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("version", help="version without the leading v, e.g. 1.6.1")
+    ap.add_argument("--body-file", type=Path, help="write the release body here")
+    ap.add_argument("--print-title", action="store_true", help="print the title to stdout")
+    args = ap.parse_args()
+
+    version = args.version.lstrip("v")
+    try:
+        body = changelog_body(version, (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8"))
+        title = release_title(
+            version, (REPO_ROOT / "docs" / "ROADMAP.md").read_text(encoding="utf-8")
+        )
+    except NotFound as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.body_file:
+        args.body_file.write_text(body + "\n", encoding="utf-8")
+    if args.print_title:
+        print(title)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/maintainer/test_release_notes.py
+++ b/tests/unit/maintainer/test_release_notes.py
@@ -1,0 +1,120 @@
+"""Tests for the release-notes extractor (#1061).
+
+What bug would these catch? A release published with the wrong body, an empty
+body, or the wrong version's content — none of which is visible until after the
+Release is public, because the workflow runs on a tag push with no review step.
+The extractor is the only thing standing between a heading-format change and a
+silently wrong public artifact.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_spec = importlib.util.spec_from_file_location(
+    "release_notes", REPO_ROOT / "scripts" / "maintainer" / "release_notes.py"
+)
+release_notes = importlib.util.module_from_spec(_spec)
+sys.modules["release_notes"] = release_notes
+_spec.loader.exec_module(release_notes)
+
+CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+Work in flight.
+
+## [1.6.1] — 2026-08-22
+
+Patch line body.
+
+- item one
+- item two
+
+## [1.6.0] - 2026-08-21
+
+Authorship body, hyphen-dashed heading.
+
+## [1.5.0] — 2026-08-07
+
+Older body.
+"""
+
+ROADMAP = """# Roadmap
+
+### v1.6.1 (2026-08-22) — Current — the correction-loop patch line
+### v1.6.0 (2026-08-21) — the Authorship release
+### v1.4.9 (2026-01-01) —
+"""
+
+
+class TestChangelogBody:
+    def test_extracts_only_the_requested_version(self):
+        body = release_notes.changelog_body("1.6.1", CHANGELOG)
+        assert body.startswith("Patch line body.")
+        assert "item two" in body
+        # the next section must not bleed in — the failure that would ship one
+        # release carrying the previous release's notes
+        assert "Authorship body" not in body
+        assert "## [1.6.0]" not in body
+
+    def test_handles_both_dash_styles(self):
+        """The file's history contains em-dash and hyphen headings; both must parse."""
+        assert release_notes.changelog_body("1.6.0", CHANGELOG).startswith("Authorship body")
+
+    def test_last_section_runs_to_end_of_file(self):
+        assert release_notes.changelog_body("1.5.0", CHANGELOG) == "Older body."
+
+    def test_unreleased_is_not_matched_as_a_version(self):
+        with pytest.raises(release_notes.NotFound):
+            release_notes.changelog_body("Unreleased", CHANGELOG)
+
+    def test_missing_version_raises_rather_than_returning_empty(self):
+        with pytest.raises(release_notes.NotFound, match="no section for 9.9.9"):
+            release_notes.changelog_body("9.9.9", CHANGELOG)
+
+    def test_empty_section_raises(self):
+        text = "## [2.0.0] — 2026-09-01\n\n## [1.9.9] — 2026-08-01\n\nbody\n"
+        with pytest.raises(release_notes.NotFound, match="is empty"):
+            release_notes.changelog_body("2.0.0", text)
+
+
+class TestReleaseTitle:
+    def test_uses_the_roadmap_name(self):
+        assert release_notes.release_title("1.6.0", ROADMAP) == "v1.6.0 — the Authorship release"
+
+    def test_strips_the_transient_current_marker(self):
+        """'Current' moves every release; it is not part of the release's name."""
+        assert release_notes.release_title("1.6.1", ROADMAP) == (
+            "v1.6.1 — the correction-loop patch line"
+        )
+
+    def test_falls_back_to_bare_version_when_roadmap_is_silent(self):
+        assert release_notes.release_title("1.2.3", ROADMAP) == "v1.2.3"
+
+    def test_empty_roadmap_name_falls_back(self):
+        assert release_notes.release_title("1.4.9", ROADMAP) == "v1.4.9"
+
+
+class TestAgainstTheRealFiles:
+    """The extractor must work on this repo's actual CHANGELOG and ROADMAP —
+    a fixture that drifts from the real file shape proves nothing."""
+
+    def test_current_version_resolves(self):
+        import re
+
+        pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        version = re.search(r'^version = "([^"]+)"', pyproject, re.MULTILINE).group(1)
+        body = release_notes.changelog_body(
+            version, (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        )
+        title = release_notes.release_title(
+            version, (REPO_ROOT / "docs" / "ROADMAP.md").read_text(encoding="utf-8")
+        )
+        assert body.strip()
+        assert title.startswith(f"v{version}")


### PR DESCRIPTION
Closes #1061

## Why automate rather than document

Across v1.4.0 → v1.6.1, **zero releases were published at cut time.** Every one was backfilled later, in two batch sweeps:

| Tag | Tagged | Release published |
|---|---|---|
| v1.4.0 – v1.5.0 | Jul 31 – Aug 7 | **2026-08-08** (the #789 sweep) |
| v1.6.0, v1.6.1 | Aug 21, Aug 22 | **2026-08-23** |

The step was written into the cut checklist on **2026-08-10** and still missed at both subsequent cuts. A documented manual step with a 0-for-8 record needs removing, not restating.

**Why it gets missed is structural.** Pushing a tag reads as completion — the version is stamped, the tag is on the remote, git reports success. Nothing in that finished state signals that a separate artifact on a different system is outstanding.

## What this does

`.github/workflows/release.yml` fires on a `v*` tag push and publishes the Release from the version's CHANGELOG section.

The body is not unreviewed content: it is written deliberately, reviewed in the release PR, and guaranteed to exist by rule 4 of `test_docs_version_sync.py` before a tag can be cut.

Four decisions worth surfacing for review:

- **Checks out the tag, not main.** The CHANGELOG must be read as it was *at the cut*; reading main would let a later rotation rewrite history.
- **`--latest` only for plain semver.** A pre-release or oddly named tag can never displace the current release.
- **An existing Release is left untouched**, so a re-run or a manual publish is never clobbered.
- **A missing or empty section fails the job.** The only outcome worse than no release is a public empty one.

`workflow_dispatch` with a tag input is included for backfills.

## Parsing is testable

Logic lives in `scripts/maintainer/release_notes.py` rather than inline YAML, so a heading-format change breaks a test instead of a release. **11 tests** cover:

- both dash styles present in the file's history (`—` and `-`)
- section-boundary bleed — the bug that would ship one release carrying the previous release's notes
- `[Unreleased]` never matching as a version
- empty sections raising rather than publishing
- the transient "Current" marker stripped from ROADMAP-derived titles
- the **real** CHANGELOG and ROADMAP, not only a fixture

## Validated against the live artifacts

Regenerating v1.6.0, v1.6.1 and v1.5.0 reproduces the published bodies byte-for-byte apart from a trailing newline GitHub appends, and reproduces both titles I created by hand. (v1.5.0's title differs by a `(stabilization)` parenthetical the ROADMAP carries and the hand-written title dropped.)

## Follow-on

CLAUDE.md's cut checklist step 6 collapses to "tag and push". Steps 4, 5 and 7 remain unguarded and stay written down.

`docs/ROADMAP.md`'s hand-maintained "Current" marker is the same class of unguarded restatement and is left for separate work.