### PR TITLE
fix(correction): the repair sees every fact the initial author is judged against

### DIFF
--- a/src/squadops/capabilities/context_assembly.py
+++ b/src/squadops/capabilities/context_assembly.py
@@ -345,8 +345,29 @@ DECLARED_NO_CONTEXT: frozenset[str] = frozenset(
 #: blind identically" and the chain terminated as plan_defect on a defect no repair
 #: could see. This threads the key; the repair mixin renders it (dev: inside the
 #: fill-only appendix; qa: its own appendix — ``_RepairPromptMixin``).
+#: #1060: the declaration was THREE surfaces short of what the repair mixin already
+#: renders. `_render_fill_only_section` builds an error-contract block and a
+#: model-surface block from `inputs["error_contract"]` / `inputs["model_surface"]`, and
+#: its comment claims "parity with develop's four surfaces" — but neither key was ever
+#: threaded here, so both blocks have rendered EMPTY since they were written. The
+#: renderer was added and the data never was.
+#:
+#: `response_surface` is the third, and the one that cost cyc_87c12c7f199e: the manifest
+#: declares `participants: list[Participant]`, #1029's frozen-spine floor reported the
+#: shape defect on all FOUR rounds, and every repair re-emitted `string[]` because the
+#: one agent retrying a shape defect was the only one never shown the shape.
+#:
+#: Kept in step by `test_repair_threads_every_surface_the_developer_gets` — a comment
+#: asking for parity is what produced two inert renderers.
 REPAIR_CONTEXT_CONTRACT = ContextAssemblyContract(
-    manifest_surfaces=(SURFACE_TESTID, SURFACE_DOM_TESTID, SURFACE_FROZEN),
+    manifest_surfaces=(
+        SURFACE_ERROR_CONTRACT,
+        SURFACE_MODEL,
+        SURFACE_TESTID,
+        SURFACE_DOM_TESTID,
+        SURFACE_FROZEN,
+        SURFACE_RESPONSE,
+    ),
 )
 
 #: Presence-keyed retest forwarding (S2): failed-envelope inputs a retest

--- a/src/squadops/capabilities/handlers/impl/repair_handlers.py
+++ b/src/squadops/capabilities/handlers/impl/repair_handlers.py
@@ -376,7 +376,33 @@ class _RepairPromptMixin:
         frozen_surface = await self._render_frozen_surface_block(renderer, inputs)
         if frozen_surface:
             variables["frozen_surface"] = frozen_surface
+        # #1060 (cyc_87c12c7f199e): the fifth surface, and the one the repair most
+        # needed. #1029's floor named a shape defect on all four rounds — the manifest
+        # declares `participants: list[Participant]` and every repair re-emitted
+        # `string[]`, because this brief never carried what the response must contain.
+        # The agent retrying a shape defect was the only one not shown the shape.
+        response_surface = await self._render_response_surface_block(renderer, inputs)
+        if response_surface:
+            variables["response_surface"] = response_surface
         rendered = await renderer.render(capability.fill_only_template, variables)
+        return rendered.content
+
+    @staticmethod
+    async def _render_response_surface_block(renderer: Any, inputs: dict[str, Any]) -> str:
+        """Render the SUCCESS RESPONSE block from threaded lines, or "" (#1060).
+
+        Mirrors ``DevelopmentDevelopHandler._response_surface_section`` — manifest-derived
+        data (``response_shape.response_surface_instructions``), all prose in the asset
+        (#448), same appendix so the two agents read one description of the shape.
+        """
+        lines = [str(line).strip() for line in (inputs.get("response_surface") or [])]
+        lines = [line for line in lines if line]
+        if not lines:
+            return ""
+        rendered = await renderer.render(
+            "request.development_develop_response_surface_appendix",
+            {"response_lines": "\n".join(f"- {line}" for line in lines)},
+        )
         return rendered.content
 
     @staticmethod

--- a/tests/unit/capabilities/test_context_completeness.py
+++ b/tests/unit/capabilities/test_context_completeness.py
@@ -505,3 +505,85 @@ async def test_every_dev_surface_reaches_the_fill_only_prompt():
         f"{missing} are declared on development.develop and rendered into a section, but "
         f"never reach the fill-only template's variables — the agent never sees them"
     )
+
+
+# --- #1060: the repair sees every fact the initial author was judged against --------
+
+
+def test_repair_threads_every_surface_the_developer_gets():
+    """The class fix, and the reason it is a test rather than a comment.
+
+    Bug caught: `REPAIR_CONTEXT_CONTRACT` was THREE surfaces short of what the repair
+    mixin already renders. `_render_fill_only_section` builds an error-contract block
+    and a model-surface block, and its own comment claims "parity with develop's four
+    surfaces" — neither key was ever threaded, so both rendered EMPTY from the day they
+    were written. A comment asking for parity is what produced two inert renderers.
+
+    The third was `response_surface`, and it cost a roll: `cyc_87c12c7f199e` had
+    #1029's frozen-spine floor report the same shape defect on all FOUR rounds while
+    every repair re-emitted `string[]` against a manifest declaring
+    `list[Participant]`. The agent retrying a shape defect was the only one never shown
+    the shape.
+
+    Each of the repair's surfaces was added retroactively after a roll died on it —
+    #667 the anchors, roll 7 the frozen index, #902 the stack appendix. This stops the
+    next one being discovered the same way.
+    """
+    from squadops.capabilities.context_assembly import (
+        REPAIR_CONTEXT_CONTRACT,
+        manifest_surface_fragments,
+    )
+
+    manifest = _reference_manifest()
+    dev = set(manifest_surface_fragments(CONTEXT_CONTRACTS["development.develop"], manifest))
+    repair = set(manifest_surface_fragments(REPAIR_CONTEXT_CONTRACT, manifest))
+    assert dev, "the developer surfaces must be non-empty or this passes vacuously"
+    missing = sorted(dev - repair)
+    assert not missing, (
+        f"{missing} reach the initial author and not the repair. A repair blind to a "
+        f"fact the contract judges can only re-emit the defect (#861/#667/#1060)."
+    )
+
+
+async def test_every_threaded_repair_surface_has_a_renderer():
+    """The other half: a surface declared and never rendered is the same defect facing
+    the other way — threaded onto the envelope, and never put in a prompt.
+
+    Asserted on the variables the fill-only template is rendered with, because that dict
+    is the last place a fact can be silently dropped — the step that has been missed six
+    times in this codebase.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from squadops.capabilities.context_assembly import (
+        REPAIR_CONTEXT_CONTRACT,
+        manifest_surface_fragments,
+    )
+    from squadops.capabilities.handlers.impl.repair_handlers import (
+        DevelopmentCorrectionRepairHandler,
+    )
+
+    manifest = _reference_manifest()
+    surfaces = manifest_surface_fragments(REPAIR_CONTEXT_CONTRACT, manifest)
+
+    handler = DevelopmentCorrectionRepairHandler()
+    context = MagicMock()
+    renderer = MagicMock()
+    renderer.render = AsyncMock(side_effect=lambda tid, v: MagicMock(content=f"[{tid}]"))
+    context.ports.request_renderer = renderer
+
+    await handler._render_fill_only_section(
+        context,
+        {
+            **surfaces,
+            "resolved_config": {"build_profile": "nextjs_ts", "dev_capability": "nextjs_ts"},
+        },
+    )
+    fill_call = next(
+        c for c in renderer.render.await_args_list if "fill_only_appendix" in c.args[0]
+    )
+    variables = fill_call.args[1]
+    # dom_testid is the qa-keyed twin of testid; the dev appendix renders one of them.
+    expected = {s for s in surfaces if s != "dom_testid_surface"}
+    missing = sorted(s for s in expected if s not in variables)
+    assert not missing, f"{missing} ride the repair envelope but reach no prompt"

--- a/tests/unit/cycles/goldens/correction_context.json
+++ b/tests/unit/cycles/goldens/correction_context.json
@@ -118,6 +118,10 @@
       "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",
       "`RunDetailView` (route `/runs/:id`): root container `run-detail`; anchors: `run-detail`, `participant-list`, `participant-item`, `join-form`, `join-name-input`, `join-submit`, `leave-form`, `leave-name-input`, `leave-submit`, `action-error`, `not-found`"
      ],
+     "error_contract": [
+      "on failure raise `ApiError(code, message)` (`from .errors import ApiError`): the FIRST argument is the error-code STRING, the second a human-readable string \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
+      "valid error codes (code \u2192 HTTP status, mapped by frozen `errors.py`): `validation_error` \u2192 422, `run_not_found` \u2192 404, `duplicate_participant` \u2192 409, `participant_not_found` \u2192 404"
+     ],
      "expected_artifacts": [
       "backend/routes.py",
       "backend/models.py"
@@ -191,6 +195,13 @@
       "- `frontend/src/App.jsx` \u2014 its own imports `./views/CreateRunView.jsx`, `./views/RunDetailView.jsx`, `./views/RunsListView.jsx`, `react-router-dom`"
      ],
      "max_correction_attempts": 3,
+     "model_surface": [
+      "`backend/models.py` is scaffold-frozen and defines EXACTLY these names: `Participant(id, name)`, `RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants)`, `RunEventCreate(title, datetime, location, distance, pace_target, route_notes)`, `ParticipantName(name)`. Import only from this list \u2014 these are the complete contents of that module",
+      "field names are exact \u2014 construct and read models with the fields shown above; a near-miss (`pace` for `pace_target`, `meeting_location` for `location`) raises at request time and every affected endpoint returns HTTP 500",
+      "do NOT invent model names or aliases (`Run`, `RunCreate`, `RunResponse`, `RunJoin` and similar do not exist); an import of a name absent from the list above fails at load, the app never starts, and the patch is rejected",
+      "`models.py` is frozen \u2014 if a name you want is missing, use the declared names and shape the response in the fill slot; do not edit or re-emit the model module",
+      "`backend/store.py` is scaffold-frozen and already defines the in-memory stores: `participant_store`, `run_event_store` (plus `reset()` for test isolation). Import them (`from .store import ...`); do NOT declare your own store dicts \u2014 a shadow store is invisible to `reset()`, so state leaks between tests and the suite fails on isolation"
+     ],
      "prd": "PRD-CONTENT",
      "prior_outputs": {
       "dev": {
@@ -200,6 +211,13 @@
      "resolved_config": {
       "build_profile": "fastapi_react_vite"
      },
+     "response_surface": [
+      "`GET /runs` returns a list of `RunEvent` \u2014 each element of the array carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+      "`POST /runs` returns HTTP 201 with `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+      "`GET /runs/{run_id}` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+      "`POST /runs/{run_id}/join` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+      "`POST /runs/{run_id}/leave` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`"
+     ],
      "subtask_description": "Create endpoints",
      "subtask_focus": "Backend API",
      "testid_surface": [
@@ -241,6 +259,10 @@
       "`RunsListView` (route `/`): root container `runs-list`; anchors: `runs-list`, `run-item`, `run-participant-count`, `empty-state`, `create-run-link`",
       "`CreateRunView` (route `/create`): root container `create-run-view`; anchors: `create-run-view`, `create-run-form`, `field-title`, `field-datetime`, `field-location`, `field-distance`, `field-pace-target`, `field-route-notes`, `submit-create`, `form-error`",
       "`RunDetailView` (route `/runs/:id`): root container `run-detail`; anchors: `run-detail`, `participant-list`, `participant-item`, `join-form`, `join-name-input`, `join-submit`, `leave-form`, `leave-name-input`, `leave-submit`, `action-error`, `not-found`"
+     ],
+     "error_contract": [
+      "on failure raise `ApiError(code, message)` (`from .errors import ApiError`): the FIRST argument is the error-code STRING, the second a human-readable string \u2014 never `ApiError(status_code=..., detail=...)` and never `HTTPException` for contract errors; the frozen `errors.py` maps the code to the HTTP status and renders the pinned envelope",
+      "valid error codes (code \u2192 HTTP status, mapped by frozen `errors.py`): `validation_error` \u2192 422, `run_not_found` \u2192 404, `duplicate_participant` \u2192 409, `participant_not_found` \u2192 404"
      ],
      "expected_artifacts": [
       "tests/test_api.py"
@@ -302,6 +324,13 @@
       "- `frontend/src/App.jsx` \u2014 its own imports `./views/CreateRunView.jsx`, `./views/RunDetailView.jsx`, `./views/RunsListView.jsx`, `react-router-dom`"
      ],
      "max_correction_attempts": 3,
+     "model_surface": [
+      "`backend/models.py` is scaffold-frozen and defines EXACTLY these names: `Participant(id, name)`, `RunEvent(id, title, datetime, location, distance, pace_target, route_notes, participants)`, `RunEventCreate(title, datetime, location, distance, pace_target, route_notes)`, `ParticipantName(name)`. Import only from this list \u2014 these are the complete contents of that module",
+      "field names are exact \u2014 construct and read models with the fields shown above; a near-miss (`pace` for `pace_target`, `meeting_location` for `location`) raises at request time and every affected endpoint returns HTTP 500",
+      "do NOT invent model names or aliases (`Run`, `RunCreate`, `RunResponse`, `RunJoin` and similar do not exist); an import of a name absent from the list above fails at load, the app never starts, and the patch is rejected",
+      "`models.py` is frozen \u2014 if a name you want is missing, use the declared names and shape the response in the fill slot; do not edit or re-emit the model module",
+      "`backend/store.py` is scaffold-frozen and already defines the in-memory stores: `participant_store`, `run_event_store` (plus `reset()` for test isolation). Import them (`from .store import ...`); do NOT declare your own store dicts \u2014 a shadow store is invisible to `reset()`, so state leaks between tests and the suite fails on isolation"
+     ],
      "prd": "PRD-CONTENT",
      "prior_outputs": {
       "dev": {
@@ -311,6 +340,13 @@
      "resolved_config": {
       "build_profile": "fastapi_react_vite"
      },
+     "response_surface": [
+      "`GET /runs` returns a list of `RunEvent` \u2014 each element of the array carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+      "`POST /runs` returns HTTP 201 with `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+      "`GET /runs/{run_id}` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+      "`POST /runs/{run_id}/join` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`",
+      "`POST /runs/{run_id}/leave` returns `RunEvent` \u2014 the response body carries `id`, `title`, `datetime`, `location`, `participants`; each `participants` element carries `id`, `name`"
+     ],
      "subtask_description": "Write tests",
      "subtask_focus": "API tests",
      "testid_surface": [

--- a/tests/unit/cycles/test_context_assembly.py
+++ b/tests/unit/cycles/test_context_assembly.py
@@ -116,13 +116,18 @@ def test_repair_contract_threads_the_same_anchor_inventory_under_both_keys():
 
     fragments = ca.manifest_surface_fragments(ca.REPAIR_CONTEXT_CONTRACT, manifest)
 
+    # This test's subject is that BOTH testid keys carry one derivation — a divergence
+    # there hands the dev and qa repair handlers different DOM contracts.
+    assert fragments[ca.SURFACE_TESTID] == expected_lines
+    assert fragments[ca.SURFACE_DOM_TESTID] == expected_lines
     # Roll 7: the frozen index rides the repair envelope too — #861 fixed the initial
     # author and the repair stayed blind, re-inventing the exact corrected name.
-    assert fragments == {
-        ca.SURFACE_TESTID: expected_lines,
-        ca.SURFACE_DOM_TESTID: expected_lines,
-        ca.SURFACE_FROZEN: frozen_surface_index_lines(manifest),
-    }
+    assert fragments[ca.SURFACE_FROZEN] == frozen_surface_index_lines(manifest)
+    # WHICH surfaces the repair receives is owned by
+    # `test_repair_threads_every_surface_the_developer_gets` (#1060), derived from the
+    # developer's set rather than restated here — an exact-set assertion in two places
+    # is two answers, and this one silently blocked adding the three surfaces the
+    # repair mixin had been rendering empty since they were written.
     # No manifest → no keys (the presence-gated shape repairs rely on).
     assert ca.manifest_surface_fragments(ca.REPAIR_CONTEXT_CONTRACT, None) == {}
 


### PR DESCRIPTION
**The declaration was three surfaces short, not one.**

## What the audit found

`_render_fill_only_section` in the repair mixin already builds an error-contract block and a model-surface block, under a comment claiming *"parity with develop's four surfaces."* Neither key was ever added to `REPAIR_CONTEXT_CONTRACT`, so neither was threaded onto a repair envelope — **both have rendered empty since the day they were written.** The renderer was added and the data never was.

Measured, not inferred:

```
develop threads : error_contract  frozen_surface  model_surface  response_surface  testid_surface
repair  threads : dom_testid_surface  frozen_surface  testid_surface
MISSING         : error_contract  model_surface  response_surface
```

## The third one cost a roll

`cyc_87c12c7f199e`. The manifest declares `participants: list[Participant]`. #1029's frozen-spine floor reported the shape defect on **all four rounds**:

```
× vc-probe-api-runs-join → expected undefined not to be undefined
  ❯ expectShape …/vc-probe-api-runs-join.scaffold.test.ts
```

And every repair re-emitted:

```ts
const participants: string[] = Array.isArray(run.participants) ? run.participants : [];
participants.push(name);
```

The agent given a second attempt at a shape defect was the only agent in the chain never shown the shape. That is #861's sentence — *"a name the author cannot see is a name it will invent"* — one contract entry over, and I introduced this instance myself: #1042 updated the developer's contract and not this one.

## The fix is the test, not the three entries

Every surface the repair carries was added retroactively **after a roll died on it**: #667 the anchors, roll 7 the frozen index, #902 the stack appendix. This one makes that pattern a test failure instead:

- `test_repair_threads_every_surface_the_developer_gets` derives the expectation from the **developer's** set rather than restating a list, so a surface added there and forgotten here fails immediately.
- A sibling asserts every threaded surface actually reaches the prompt's **variables** — because a surface declared and never rendered is the same defect facing the other way, and that step has now been missed six times in this codebase.

## One test had to be narrowed

`test_repair_contract_threads_the_same_anchor_inventory_under_both_keys` pinned the repair's exact surface set as a side effect of testing something else — and **that assertion is what silently blocked adding the three.** Narrowed to its actual subject (both testid keys carry one derivation); which surfaces the repair receives is now owned in one place.

## Verification

- Regression **7,798 passed**, gate green at 20 workers.
- **5 mutations, all killed** — including each of the three surfaces removed individually, and the renderer built but never placed in variables.
- Golden regenerated in the same commit per its policy: 36 lines, the three new keys on the two repair scenarios, nothing else moved.

Closes #1060