### PR TITLE
docs(site): record the accepted Safari favicon tradeoff

### DIFF
--- a/site/content/assets/favicon.svg
+++ b/site/content/assets/favicon.svg
@@ -5,6 +5,15 @@
        inside the 10% floor a maskable icon needs, while staying as large as
        possible for 16px rendering. A maskable app icon, if ever needed, is a
        separate asset at heavier padding rather than a shrink of this one. -->
+  <!-- KNOWN AND ACCEPTED: Safari draws a white frame around this icon.
+       Safari's favicon pipeline flattens alpha to white; Chrome honours it. The
+       only transparency here is the four rounded corners, so in Chrome they are
+       transparent over the tab and invisible, and in Safari they render white
+       and read as an outline.
+       Rounded corners cannot survive that — the rounding IS the transparency —
+       so the only fix is a full-bleed square with no alpha at all. Owner ruled
+       2026-08-23 to keep the rounded tile and accept the Safari rendering.
+       Do not "fix" this by squaring it off without revisiting that call. -->
   <rect width="24" height="24" rx="5" fill="#000000"/>
   <g transform="translate(12,12) scale(0.82) translate(-12,-12)">
   <path d="M4.30 8.89 A8.3 8.3 0 0 1 19.70 8.89" fill="none" stroke="#ffffff" stroke-width="2.2" stroke-linecap="round"/>


### PR DESCRIPTION
No behaviour change — a comment in `favicon.svg` recording a decision.

Safari draws a white frame around the favicon; Chrome renders it correctly. Safari's favicon pipeline flattens alpha to white, and the only transparency in the asset is the four rounded corners: transparent over the tab in Chrome, white in Safari, reading as an outline.

**Rounded corners cannot survive that** — the rounding *is* the transparency. The only fix is a full-bleed square with no alpha, proposed in #1065 and declined: the rounding was a deliberate choice, Chrome is the majority browser, and the corner radius is close to imperceptible at 16px either way.

Recorded in the asset itself so the Safari rendering is not mistaken for a bug and squared off later by someone who has not seen this thread.

The comment also notes the diagnostic error worth not repeating: the file was magnified and declared clean, but that magnification ran in Chrome — the browser that was already working.