### PR TITLE
fix(gates): a status that overrides the derived default must say why

### DIFF
--- a/src/squadops/cycles/framing_consistency.py
+++ b/src/squadops/cycles/framing_consistency.py
@@ -74,7 +74,7 @@ def _enforced_success_status(ep: Endpoint) -> int | None:
     return 201 if "{" not in ep.path else 200
 
 
-def _path_pattern(path: str) -> re.Pattern[str]:
+def path_pattern(path: str) -> re.Pattern[str]:
     """A conservative regex recognizing *path* in plan prose.
 
     ``{run_id}`` segments match any single non-space segment, so
@@ -150,7 +150,7 @@ def validate_manifest_plan_consistency(
         enforced = _enforced_success_status(ep)
         if enforced is None:
             continue
-        pattern = _path_pattern(ep.path)
+        pattern = path_pattern(ep.path)
         # Method-aware binding: a line naming HTTP methods binds only endpoints
         # whose method it names ("GET /api/runs returns 200" is about the GET,
         # not the collection POST sharing the path). Methodless pathful lines

--- a/src/squadops/cycles/manifest_authoring_rules.py
+++ b/src/squadops/cycles/manifest_authoring_rules.py
@@ -34,6 +34,7 @@ from squadops.cycles.manifest_gates import (
     PROOF_SOURCE_PRD,
     PROOF_STACK_MATCHES_CONFIG,
     PROOF_STATUS_DECLARED,
+    PROOF_STATUS_WARRANTED,
     PROOF_TESTID_COVERAGE,
 )
 
@@ -47,6 +48,11 @@ AUTHOR_FACING: dict[str, tuple[str, ...]] = {
     PROOF_EXPANDS: ("paths-under-scaffold-roots",),
     PROOF_TESTID_COVERAGE: ("every-view-declares-anchors",),
     PROOF_STATUS_DECLARED: ("declare-the-success-status",),
+    # #1067: the sibling of the rule above, and the one that removes the recurrence
+    # rather than gating it. The status is authored in three places and derivable in
+    # one; teaching the author to override it deliberately — or not at all — is what
+    # collapses the copies.
+    PROOF_STATUS_WARRANTED: ("warrant-a-status-that-breaks-convention",),
     # #795: the envelope is blueprint-owned; a declared shape rooted anywhere but
     # `error` describes a body no response will carry (V4 declared FastAPI's default).
     PROOF_ERROR_SHAPE: ("error-shape-is-the-blueprints",),

--- a/src/squadops/cycles/manifest_gates.py
+++ b/src/squadops/cycles/manifest_gates.py
@@ -25,6 +25,7 @@ exists to produce one.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 #: Stable finding classes. Typed rather than free text so M6's authoring failure
@@ -38,6 +39,8 @@ PROOF_CONTRACT_DERIVES = "contract_derives"
 PROOF_CHECKS_LIVE = "checks_live"
 PROOF_TESTID_COVERAGE = "testid_coverage"
 PROOF_STATUS_DECLARED = "status_declared"
+#: #1067: a declared status that contradicts the derived default must carry a warrant.
+PROOF_STATUS_WARRANTED = "status_warranted"
 PROOF_ERROR_SHAPE = "error_shape_agrees"
 #: #838: the manifest declares its own stack, and until VS nothing compared that to the
 #: stack the CYCLE was configured for. A manifest for another stack is unwinnable in the
@@ -108,6 +111,7 @@ def assess_winnability(
     findings.extend(_contract_findings(manifest))
     findings.extend(_testid_findings(manifest))
     findings.extend(_status_findings(manifest))
+    findings.extend(_status_override_findings(manifest))
     findings.extend(_error_shape_findings(manifest))
     findings.extend(_scaffold_findings(manifest))
     return tuple(findings)
@@ -444,6 +448,78 @@ def _status_findings(manifest) -> list[WinnabilityFinding]:
             f"implementation. Declare the status the endpoint returns on success.",
         )
     ]
+
+
+def derived_success_status(method: str, path: str) -> int | None:
+    """The status the contract deriver computes for an endpoint, ignoring declarations.
+
+    Collection POST -> 201, child-action POST -> 200, everything else -> no status probe.
+    Single-sourced here because #1067 is a story about one fact having several homes:
+    `scaffold_contract` applies this rule at three sites (`ep.success_status or 201`,
+    `child.success_status or 200` twice) and `framing_consistency` mirrors it, and adding
+    a fourth copy to police the first three would be the same defect one layer up.
+    """
+    if method.upper() != "POST":
+        return None
+    return 201 if "{" not in path else 200
+
+
+def _status_override_findings(manifest) -> list[WinnabilityFinding]:
+    """A declared status contradicting the derived default needs a stated reason (#1067).
+
+    The 200-vs-201 disagreement recurred five times in three weeks and took four fixes —
+    a gate comparing manifest to plan (#1013), threading the status to the developer
+    (#1042), repairing that gate's stale premise (#1049), and a queued primer to TEACH
+    the convention (#1031). None asked why one integer needed four fixes.
+
+    The answer is that the status is AUTHORED in three places (manifest, plan prose,
+    handler code) and DERIVABLE in one. The rule above is deterministic and correct, and
+    the schema lets an author override it per endpoint with no warrant required. On
+    `cyc_79eebcb82205` the deriver computed 200 for `POST /api/runs/{run_id}/join`, the
+    plan author wrote 200, and a single unexplained manifest override said 201 — so the
+    framing gate rejected the plan for agreeing with the rule.
+
+    This does not forbid the override. A child action that genuinely creates a
+    sub-resource may well return 201, and a rule that forbade it would trade a dice-roll
+    for a wrong answer. It requires the override to be a RECORDED judgment: a
+    `decisions[]` entry that names the endpoint, which makes it challengeable downstream
+    instead of arriving as an unexplained integer.
+
+    Silence is now the safe default and the common case — say nothing and the rule
+    decides, so there is one value and nothing to disagree about.
+    """
+    from squadops.cycles.framing_consistency import path_pattern
+
+    entries = [f"{d.id} {d.choice} {d.warrant} {d.question}" for d in (manifest.decisions or ())]
+    findings: list[WinnabilityFinding] = []
+    for ep in manifest.api.endpoints:
+        derived = derived_success_status(ep.method, ep.path)
+        if derived is None or ep.success_status is None or ep.success_status == derived:
+            continue
+        # The warrant must be ABOUT the status, not merely about the endpoint. Naming the
+        # path alone is too weak: `cyc_79eebcb82205` carried a decision reading "distinct
+        # POST paths /api/runs/{run_id}/join and /api/runs/{run_id}/leave rather than a
+        # shared endpoint" — a real judgment about routing that says nothing about 201,
+        # and a path-only rule accepted it and let the override through unexplained.
+        pattern = path_pattern(ep.path)
+        status_token = re.compile(rf"\b{ep.success_status}\b")
+        if any(pattern.search(e) and status_token.search(e) for e in entries):
+            continue
+        findings.append(
+            WinnabilityFinding(
+                PROOF_STATUS_WARRANTED,
+                f"`{ep.method.upper()} {ep.path}` declares success_status "
+                f"{ep.success_status}, but the contract derives {derived} for this shape "
+                f"({'collection' if derived == 201 else 'child-action'} POST). The "
+                f"declaration wins, so every downstream surface will enforce "
+                f"{ep.success_status} — and nothing records why. Either drop the field "
+                f"and let the derived {derived} stand, or add a `decisions[]` entry "
+                f"that names `{ep.path}` AND states {ep.success_status}, warranting the "
+                f"choice from the PRD. A decision about the endpoint that does not "
+                f"mention the status does not warrant the status.",
+            )
+        )
+    return findings
 
 
 def _error_shape_findings(manifest) -> list[WinnabilityFinding]:

--- a/src/squadops/prompts/request_templates/request.manifest_authoring_rules_appendix.md
+++ b/src/squadops/prompts/request_templates/request.manifest_authoring_rules_appendix.md
@@ -41,6 +41,26 @@ resource). Leave it out and two components disagree about what the endpoint retu
 verification contract asserts one status while the generated route serves another, which is
 a contract no correct implementation can satisfy. State it and the disagreement cannot arise.
 
+**warrant-a-status-that-breaks-convention** — The contract derives a success status from
+the endpoint's shape: a POST to a collection path creates, so 201; a POST to a path with an
+id segment acts on something that already exists, so 200. Declaring the derived value is
+harmless; declaring a *different* one silently overrides the rule for every downstream
+surface, and nothing records why.
+
+So if you declare a status that differs from the shape's default, add a `decisions[]` entry
+that names the endpoint path **and** states the status, warranting it from the PRD:
+
+```yaml
+decisions:
+  - id: join-creates-a-participant
+    choice: "POST /api/runs/{run_id}/join returns 201 — the join creates a participant record"
+    warrant: "PRD §5.4 treats the participant as a created resource"
+```
+
+A decision that names the endpoint but not the status does not warrant the status — a
+routing judgment about the same path is a different judgment. If you have no reason, leave
+the field out and let the derived status stand: one value, and nothing to disagree with.
+
 **declare-the-choices-a-body-carries** — When a request field's *value* selects which
 behavior runs rather than carrying data — an `action` that is either `join` or `leave`, a
 `status` that is either `open` or `closed` — declare its whole domain under the shape's

--- a/tests/unit/cycles/test_manifest_gates.py
+++ b/tests/unit/cycles/test_manifest_gates.py
@@ -413,3 +413,122 @@ class TestScaffoldReadinessProof:
         assert PROOF_SCAFFOLD_READY in _proofs(findings)
         detail = next(f.detail for f in findings if f.proof == PROOF_SCAFFOLD_READY)
         assert "injected derivation refusal" in detail
+
+
+class TestStatusOverrideWarrant:
+    """#1067: a declared status contradicting the derived default needs a stated reason.
+
+    The 200-vs-201 disagreement recurred five times in three weeks and took four fixes —
+    #1013 (a gate comparing manifest to plan), #1042 (thread the status to the dev),
+    #1049 (that gate's premise going stale), #1031 (queued: TEACH the convention). None
+    asked why one integer needed four. The fact is authored in three places and derivable
+    in one, and the schema let an author override the derivation with no warrant.
+    """
+
+    @staticmethod
+    def _manifest(join_status: str = "", decisions: str = "") -> str:
+        status = f", success_status: {join_status}" if join_status else ""
+        block = decisions or "  - { id: d1, choice: c, warrant: w }"
+        return f"""
+version: 1
+kind: interface_manifest
+project_id: p
+stack: nextjs_ts
+source_prd: prd.md
+entities:
+  - name: Run
+    fields:
+      - {{ name: id, type: string, required: true }}
+api:
+  endpoints:
+    - {{ method: POST, path: /api/runs, response: Run, success_status: 201 }}
+    - {{ method: POST, path: "/api/runs/{{run_id}}/join", response: Run{status} }}
+frontend:
+  routes:
+    - {{ path: /, view: V, testids: [a] }}
+decisions:
+{block}
+"""
+
+    def _findings(self, **kw):
+        return [
+            f
+            for f in assess_winnability(self._manifest(**kw), "nextjs_ts")
+            if f.proof == "status_warranted"
+        ]
+
+    def test_an_unwarranted_override_is_flagged(self):
+        """Today's roll: the deriver said 200 for a child action, the plan author said
+        200, and one unexplained manifest override said 201 — so the framing gate
+        rejected the plan for agreeing with the rule."""
+        findings = self._findings(join_status="201")
+        assert len(findings) == 1
+        assert "derives 200" in findings[0].detail
+        assert "child-action" in findings[0].detail
+
+    def test_silence_is_clean_and_is_the_point(self):
+        """Say nothing and the rule decides. One value, nothing to disagree about — the
+        whole reduction this issue is after."""
+        assert self._findings() == []
+
+    def test_a_declaration_agreeing_with_the_derivation_is_clean(self):
+        """Restating the derived value is redundant, not wrong. Flagging it would push
+        authors toward silence for the wrong reason and add noise."""
+        assert self._findings(join_status="200") == []
+
+    def test_a_warrant_naming_the_endpoint_and_the_status_passes(self):
+        """The override is permitted — a child action that genuinely creates a
+        sub-resource may return 201. It must be a recorded, challengeable judgment."""
+        decisions = (
+            "  - { id: join-creates, "
+            'choice: "POST /api/runs/{run_id}/join returns 201; the join creates a '
+            'participant sub-resource", warrant: "PRD 5.4 names the participant a '
+            'created record" }'
+        )
+        assert self._findings(join_status="201", decisions=decisions) == []
+
+    def test_a_decision_naming_the_endpoint_but_not_the_status_does_not_warrant_it(self):
+        """The tightening that mattered, from a real false negative.
+
+        `cyc_79eebcb82205` carried a decision reading "distinct POST paths
+        /api/runs/{run_id}/join and /api/runs/{run_id}/leave rather than a shared
+        endpoint with an action dispatch field" — a genuine judgment about ROUTING that
+        says nothing about 201. A path-only rule accepted it and let the override
+        through unexplained, which makes the warrant requirement decorative.
+        """
+        decisions = (
+            "  - { id: join-leave-separate-endpoints, "
+            'choice: "distinct POST paths /api/runs/{run_id}/join and '
+            '/api/runs/{run_id}/leave rather than a shared endpoint", '
+            'warrant: "single responsibility per handler" }'
+        )
+        findings = self._findings(join_status="201", decisions=decisions)
+        assert len(findings) == 1
+        assert "does not warrant the status" in findings[0].detail
+
+    def test_a_warrant_for_a_DIFFERENT_endpoint_does_not_transfer(self):
+        """Naming 201 somewhere in the decisions is not a warrant for this endpoint —
+        the collection POST's own 201 is stated two lines up and must not launder it."""
+        decisions = (
+            '  - { id: create-201, choice: "POST /api/runs returns 201", warrant: "creation" }'
+        )
+        assert len(self._findings(join_status="201", decisions=decisions)) == 1
+
+    def test_a_non_post_declaring_a_status_is_not_judged(self):
+        """GETs derive no status probe, so there is nothing to contradict and nothing to
+        warrant. Judging them would demand a `decisions[]` entry for a fact no surface
+        enforces — the gate inventing work rather than preventing a disagreement."""
+        manifest = self._manifest().replace(
+            '- { method: POST, path: "/api/runs/{run_id}/join", response: Run }',
+            '- { method: GET, path: "/api/runs/{run_id}", response: Run, success_status: 204 }',
+        )
+        assert [
+            f for f in assess_winnability(manifest, "nextjs_ts") if f.proof == "status_warranted"
+        ] == []
+
+    def test_a_collection_post_declaring_201_is_clean(self):
+        """The reference manifest declares it on the create endpoint, where it AGREES
+        with the derivation. A rule that rejected the artifact the 1.4 evidence was
+        measured against would be the wrong rule — the same guard `_status_findings`
+        states in its own docstring."""
+        assert self._findings() == []


### PR DESCRIPTION
The root-cause fix for the 200-vs-201 recurrence. Removes the class rather than gating it again.

## Why four fixes weren't enough

Five incidents in three weeks, four fixes: **#1013** (a gate comparing manifest to plan), **#1042** (thread the status to the developer), **#1049** (repairing that gate's stale premise), **#1031** queued to *teach* the convention. Every one locally correct. None asked why one integer needed four.

The status is **authored in three places** — manifest, plan prose, handler code — and **derivable in one**. `scaffold_contract` already computes it: collection POST → 201, child-action POST → 200. The schema then lets an author override that per endpoint with no warrant required, so every roll rolls dice on three independent authors agreeing about one integer.

## Today's roll is the clean demonstration

`POST /api/runs/{run_id}/join` is a child action, so the rule says **200**.

- the deriver computed 200
- the plan author wrote 200
- one unexplained manifest override said **201**

Declared wins — so the framing gate rejected the plan **for agreeing with the rule**.

## The change

An override is not forbidden. A child action that genuinely creates a sub-resource may well return 201, and forbidding it would trade a dice-roll for a wrong answer. It must be a **recorded judgment**: a `decisions[]` entry naming the endpoint and stating the status, which makes it challengeable downstream instead of arriving as an unexplained integer.

**Silence becomes the safe default and the common case** — say nothing, the rule decides, and there is nothing to disagree with.

## The warrant must be about the status

My first cut matched any decision naming the path, and it accepted this real entry from today's manifest:

> `join-leave-separate-endpoints` — *"distinct POST paths /api/runs/{run_id}/join and /api/runs/{run_id}/leave rather than a shared endpoint with an action dispatch field"*

A genuine judgment about **routing** that says nothing about 201. A path-only rule let the override through unexplained, which makes the whole requirement decorative. The decision must name the path **and** state the status.

## Single-sourced, deliberately

`derived_success_status` lives in one place. The rule already appears at three sites in `scaffold_contract` and once in `framing_consistency` — adding a fourth copy to police the first three would be this issue's own defect one layer up. `_path_pattern` is promoted to `path_pattern` for the same reason: reused, not duplicated.

## Validation

Run against **every banked manifest**: flags `cyc_79eebcb82205`, clean on the green roll, both failing arms, the 1.6.1 shakedown, and the reference — the artifact the 1.4 evidence was measured against.

- Regression **7,825 passed**, gate green at 20 workers.
- **7 mutations, all killed.** Two survived the first pass: the path-only warrant above, and non-POST endpoints being judged.
- The registry-completeness guard caught the missing proof classification, which is exactly its job. The rule is taught in the authoring asset as `warrant-a-status-that-breaks-convention`.

## Scope note

This narrows **#1031**: the primer is still right for conventions with no derivable answer (404-vs-400 on a failed lookup), and wrong for this one. **#772** wants the same single-source treatment for the *undeclared* case.

Closes #1067