### PR TITLE
test(site): indigo favicon tile to clear Safari's contrast plate

### DIFF
--- a/site/content/assets/favicon.svg
+++ b/site/content/assets/favicon.svg
@@ -1,20 +1,15 @@
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <!-- Squad Ops favicon. A solid tile rather than a transparent mark: tab chrome
-       applies prefers-color-scheme inconsistently, so a transparent icon can land
-       dark-on-dark. Mark scaled to 0.82, leaving 12% edge padding — comfortably
-       inside the 10% floor a maskable icon needs, while staying as large as
-       possible for 16px rendering. A maskable app icon, if ever needed, is a
-       separate asset at heavier padding rather than a shrink of this one. -->
-  <!-- KNOWN AND ACCEPTED: Safari draws a white frame around this icon.
-       Safari's favicon pipeline flattens alpha to white; Chrome honours it. The
-       only transparency here is the four rounded corners, so in Chrome they are
-       transparent over the tab and invisible, and in Safari they render white
-       and read as an outline.
-       Rounded corners cannot survive that — the rounding IS the transparency —
-       so the only fix is a full-bleed square with no alpha at all. Owner ruled
-       2026-08-23 to keep the rounded tile and accept the Safari rendering.
-       Do not "fix" this by squaring it off without revisiting that call. -->
-  <rect width="24" height="24" rx="5" fill="#000000"/>
+  <!-- Squad Ops favicon.
+       Tile colour: the site's indigo, not black. Safari appears to add a light
+       backing plate to favicons it judges too low-contrast against a dark tab
+       strip — in a sampled tab bar, every dark icon carried a plate while every
+       colourful or light one (including GitHub's transparent white octocat)
+       rendered clean. A near-black tile on a near-black strip is the worst case;
+       colour clears that threshold while keeping the rounded tile.
+       Mark scale 0.82 leaves 12% edge padding, inside the 10% floor a maskable
+       icon needs while staying as large as possible at 16px. A maskable app
+       icon, if ever wanted, is a separate asset at heavier padding. -->
+  <rect width="24" height="24" rx="5" fill="#4f46e5"/>
   <g transform="translate(12,12) scale(0.82) translate(-12,-12)">
   <path d="M4.30 8.89 A8.3 8.3 0 0 1 19.70 8.89" fill="none" stroke="#ffffff" stroke-width="2.2" stroke-linecap="round"/>
   <path d="M19.70 15.11 A8.3 8.3 0 0 1 4.30 15.11" fill="none" stroke="#ffffff" stroke-width="2.2" stroke-linecap="round"/>


### PR DESCRIPTION
Safari draws a light backing plate around our favicon; Chrome is fine.

**The earlier explanation was wrong.** I recorded that Safari flattens alpha to white and that the rounded corners were therefore the cause. A sampled Safari tab bar disproves it: transparent colourful favicons render clean with no plate — an orange asterisk, a blue star, GitHub's transparent white octocat — while every **dark** icon in the same bar carries a plate.

| Icon | | Plate |
|---|---|---|
| orange asterisk, blue star, green circle | colourful | no |
| GitHub octocat | white on transparent | no |
| dark glyph tiles, black circle, **our black tile** | dark | **yes** |

The trigger is darkness, not transparency. `#000000` on a near-black strip is the worst case for whatever contrast threshold Safari applies.

This colours the tile the site's indigo — the cheapest test that keeps the rounded corners you chose. If Safari still plates it, the hypothesis is wrong again and the next move is a transparent white mark, matching the octocat rendering clean two tabs away.

Merging deploys via Pages; Safari is the test. Note Safari caches favicons hard — a new tab or a cleared cache may be needed.