### PR TITLE
fix(plan): the plan stops restating success statuses — part A of #1070

### DIFF
--- a/src/squadops/cycles/framing_consistency.py
+++ b/src/squadops/cycles/framing_consistency.py
@@ -177,12 +177,24 @@ def validate_manifest_plan_consistency(
                 f"will enforce success {enforced} "
                 f"({'declared' if ep.success_status is not None else 'derived default'}) "
                 f'but the plan states {sorted(tokens)} — "{ln[:120]}". The implementer '
-                f"builds the plan; the contract judges the manifest. Align them."
+                f"builds the plan; the contract judges the manifest. REMOVE the status "
+                f"from the plan: the developer's brief already carries the derived "
+                f"status, so the plan restating it adds only the chance of this "
+                f"disagreement (#1070)."
             )
 
-        # Completeness: an enforced non-200 success is exactly the fact the dev
-        # will not default to — slot 6's roll died on it. It must be STATED in
-        # the plan's prose near the endpoint, or the implementer never sees it.
+        # Completeness: an enforced non-200 success is exactly the fact the dev will
+        # not default to — slot 6's roll died on it. It must be STATED in the plan's
+        # prose near the endpoint, or the implementer never sees it.
+        #
+        # #1070 part A: the plan-authoring rule now tells authors NOT to state statuses,
+        # which reads as a contradiction with this check and is not one. This fires only
+        # where `status_reaches_implementer` is false — a stack whose skeleton does not
+        # pin the status AND whose dev capability renders no appendix — and there prose
+        # genuinely is the sole carrier, so the specific instruction in this finding
+        # correctly overrides the general rule. No REGISTERED stack reaches it today
+        # (fastapi pins structurally, nextjs carries the appendix); it is here for the
+        # third stack, and its message states what to do.
         if enforced != 200 and not stated_anywhere and not status_reaches_implementer:
             already_contradicted = any(f"on {ep.method} {ep.path}:" in e for e in errors)
             if not already_contradicted:

--- a/src/squadops/cycles/plan_authoring_rules.py
+++ b/src/squadops/cycles/plan_authoring_rules.py
@@ -40,10 +40,14 @@ AUTHOR_FACING: dict[str, str] = {
     # under-covered floor is an authorable — and authored (roll 15) — defect.
     "validate_builder_floor": "builder-floor-coverage",
     # #1013: the plan's prose must agree with the manifest on enforced success
-    # statuses, and must STATE a non-200 status where the stack's skeleton does
-    # not pin it — the two framing-internal species that cost V38 counted rolls
-    # (roll 1's 201-vs-200 contradiction; slot 6's manifest-only 201).
-    "validate_manifest_plan_consistency": "statuses-must-agree-with-the-manifest",
+    # statuses. #1070 part A: the rule no longer asks the author to STATE a status.
+    # It did, because plan prose was once the only channel carrying a declared status
+    # to the implementer — and #1042/#1063 replaced that with derivation, which #1049
+    # already recognised by making the omission check conditional. What was left was an
+    # instruction to write a second copy of a derived fact, and the only thing a second
+    # copy can add is a disagreement: `cyc_79eebcb82205` was rejected TWICE, on two
+    # differently-named endpoints, for exactly that.
+    "validate_manifest_plan_consistency": "do-not-restate-success-statuses",
 }
 
 # Validators an author is already taught by a different managed asset. Restating them

--- a/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
+++ b/src/squadops/prompts/request_templates/request.plan_authoring_rules_appendix.md
@@ -66,14 +66,18 @@ builder's). The profile list is a floor — a per-task list may add files, never
 one. A plan that leaves a required file unowned passes every task and then fails the
 deliverable-completeness gate at run completion, where nothing can repair it.
 
-**statuses-must-agree-with-the-manifest** — Any line of prose that names an endpoint's
-path and a success status must state the SAME status the interface manifest declares (or
-its derived default: a collection POST with no declared status is enforced at 201). The
-implementer builds your plan; the contract judges the manifest — a plan that teaches 200
-where the manifest declares 201 sends the developer to certain rejection. And where the
-stack's skeleton does not pin the status into frozen code, an enforced non-200 status must
-be STATED in the owning task's description or acceptance criteria — a status that lives
-only in the manifest never reaches the developer, who will default to 200.
+**do-not-restate-success-statuses** — Success statuses are not yours to state. The
+contract derives each endpoint's status from the interface manifest and the endpoint's
+shape, and the developer's brief carries that derived status directly — so a status in
+your prose is a second copy of a fact the implementer already has, and the only thing a
+second copy can add is a disagreement.
+
+Write the behaviour, not the code: *"joining a run adds the participant and returns the
+updated run"*, never *"returns 200"*.
+
+If you do name a status anyway, it must match what the contract will enforce, or the plan
+teaches the developer to build something the contract then rejects. But the right move is
+to leave it out — there is nothing to keep in step with if you never wrote it down.
 
 A verification-only task is legitimate and common: declare `expected_artifacts: []` and
 express what it checks through its acceptance criteria.

--- a/tests/unit/cycles/test_framing_consistency.py
+++ b/tests/unit/cycles/test_framing_consistency.py
@@ -244,3 +244,58 @@ class TestPathBinding:
             ]
         )
         assert validate_manifest_plan_consistency(manifest, plan) == []
+
+
+class TestPlanShouldNotRestateStatuses:
+    """#1070 part A: the plan's copy of the status is redundant and can still contradict.
+
+    Plan prose carried the status because it was once the only channel to the
+    implementer. #1042 and #1063 replaced that by derivation, and #1049 already made the
+    omission check conditional on a channel existing. What was left was an authoring rule
+    instructing the author to write a second copy of a derived fact — and the only thing
+    a second copy can add is a disagreement. `cyc_79eebcb82205` was rejected TWICE, on two
+    differently-named endpoints, for exactly that.
+    """
+
+    def test_the_contradiction_tells_the_author_to_remove_it_not_to_align(self):
+        """Bug caught: advice that perpetuates the copy. "Align them" asks the author to
+        keep two sources in step; the fact is derived and delivered, so the correct move
+        is to delete the restatement — there is nothing to keep in step with."""
+        manifest = _manifest(JOIN_201)
+        plan = _plan(
+            [
+                "POST /api/runs returns 201 with the created run.",
+                "POST /api/runs/{run_id}/join returns 200 once the participant is added.",
+            ]
+        )
+        (error,) = validate_manifest_plan_consistency(manifest, plan)
+        assert "REMOVE the status from the plan" in error
+        assert "Align them" not in error
+
+    def test_a_plan_that_states_no_status_is_clean(self):
+        """The shape the rule now asks for: behaviour, not codes. This must pass without
+        an omission finding on a stack whose brief carries the status."""
+        manifest = _manifest(JOIN_201)
+        plan = _plan(
+            [
+                "POST /api/runs creates a run and returns it.",
+                "POST /api/runs/{run_id}/join adds the participant and returns the run.",
+            ]
+        )
+        assert validate_manifest_plan_consistency(manifest, plan) == []
+
+    def test_an_agreeing_restatement_is_still_tolerated(self):
+        """Redundant is not wrong. Rejecting a plan for stating the RIGHT status would
+        punish authors mid-migration and add a rejection where there is no disagreement."""
+        manifest = _manifest(JOIN_201)
+        plan = _plan(["POST /api/runs/{run_id}/join returns 201 with the updated run."])
+        assert validate_manifest_plan_consistency(manifest, plan) == []
+
+    def test_a_channel_less_stack_still_demands_the_statement(self):
+        """The deliberate exception, and why the rule and this check are not in conflict:
+        where NEITHER the skeleton nor the brief carries the status, prose is genuinely
+        the only carrier and the specific finding overrides the general rule."""
+        manifest = _manifest(JOIN_201, stack="no_such_stack")
+        plan = _plan(["POST /api/runs/{run_id}/join adds the participant."])
+        errors = validate_manifest_plan_consistency(manifest, plan)
+        assert any("omission on POST /api/runs/{run_id}/join:" in e for e in errors)


### PR DESCRIPTION
Part A of #1070. **Removes an authored copy whose reason for existing is gone.** `Refs`, not `Closes` — part B stays open.

## The instruction that created the copy

The plan-authoring rule said it outright:

> an enforced non-200 status **must be STATED** in the owning task's description or acceptance criteria — a status that lives only in the manifest never reaches the developer, who will default to 200.

True when written. **#1042** threads the derived status onto the developer's brief and **#1063** onto the repair's; **#1049** already recognised the shift by making the omission check conditional on a channel existing.

What was left was an instruction to write a second copy of a derived fact. The only thing a second copy can add is a disagreement.

## It did, twice in one roll

```
run 1: POST /api/runs/{run_id}/join          manifest 201, plan states [200]
run 2: POST /api/runs/{run_id}/participants  manifest 201, plan states [200]
```

`cyc_79eebcb82205` — two framing cycles and both re-rolls, spent on two documents disagreeing about an integer neither of them needed to decide. The author was told exactly what was wrong after run 1 and reproduced it on a renamed endpoint.

## The change

The rule becomes **`do-not-restate-success-statuses`**: write the behaviour, not the code — *"joining a run adds the participant and returns the updated run"*, never *"returns 200"*.

A status that **agrees** is still tolerated. Redundant is not wrong, and rejecting it would punish authors mid-migration where there is no disagreement.

The contradiction finding's advice changes with it. *"Align them"* asks the author to keep two sources in step; the correct move is to delete the restatement, because there is nothing to keep in step with. The check itself stays — a plan volunteering a wrong status still teaches the developer to build something the contract rejects.

## The apparent conflict with the omission half is deliberate

The omission check still demands a stated status — but only where **neither** the skeleton nor the brief carries it, and there prose genuinely is the sole carrier, so its specific instruction correctly overrides the general rule. No registered stack reaches it today (fastapi pins structurally, nextjs carries the appendix). It is there for the third stack, and its message says what to do. Documented in place so the next reader does not read it as a contradiction.

## Verification

- Regression **7,820 passed**, gate green at 20 workers.
- **4 mutations, all killed** — including the message reverting to "align them" and the classification pointing at the retired rule id.
- Two of my first-pass mutations were bad rather than survivors: a `pass` before an `append` is a no-op, and one anchor had been reflowed by the formatter. Both re-run properly against the real text.

Refs #1070