### PR TITLE
fix(release): the package captures cycle evidence instead of reporting that it did

### DIFF
--- a/scripts/maintainer/build_release_package.py
+++ b/scripts/maintainer/build_release_package.py
@@ -130,38 +130,91 @@ def changelog_section(version: str) -> str:
     return match.group(1).strip() if match else ""
 
 
-def cycle_evidence(cycle_ids: list[str], api: str) -> list[dict]:
+def _absent(cycle_id: str, reason: str) -> dict:
+    """A cycle whose evidence could not be captured, WITH why — never a silent gap."""
+    return {"cycle_id": cycle_id, "captured": False, "reason": reason}
+
+
+def _bearer_token() -> str:
+    """The CLI's cached access token, or "" — the API requires one (#1076).
+
+    Read from the same store `squadops login` writes, so a maintainer who can drive
+    the CLI can capture a package without a second credential path.
+    """
+    try:
+        from squadops.cli.auth import load_cached_token
+
+        cached = load_cached_token()
+        return cached.access_token if cached else ""
+    except Exception:  # noqa: BLE001 - capture must degrade to a disclosed absence
+        return ""
+
+
+def cycle_evidence(cycle_ids: list[str], api: str, project: str) -> list[dict]:
     """Verification roll-up per named cycle, or a recorded reason it is absent.
 
-    Absence is disclosed, never silently omitted — an unreachable API and a
-    cycle that genuinely produced nothing must not look the same later.
+        Absence is disclosed, never silently omitted — an unreachable API and a cycle that
+        genuinely produced nothing must not look the same later.
+
+        That promise was not kept, and the failure was invisible in exactly the way the
+        docstring warns about (#1076). Four defects compounded, each silent:
+
+          - the route was `/api/v1/cycles/{id}`; the real one is project-scoped
+          - no Authorization header, and the API requires one
+          - the roll-up field is `cycle_outcome`, not `outcome`
+          - and the guard caught only `JSONDecodeError` — so `{"detail": "Not Found"}`,
+            being perfectly valid JSON, was recorded as `captured: True` with every
+            field null
+
+    The fourth is what hid the first three. A capture that cannot distinguish "the API
+    said no" from "the cycle produced nothing" is not a disclosure mechanism, so the
+    shape check below is the guard: the roll-up must actually be present, or this is
+    recorded as absent WITH the reason.
     """
     evidence = []
+    token = _bearer_token()
     for cycle_id in cycle_ids:
-        raw = run("curl", "-s", "--max-time", "10", f"{api}/api/v1/cycles/{cycle_id}", check=False)
+        url = f"{api}/api/v1/projects/{project}/cycles/{cycle_id}"
+        args = ["curl", "-s", "--max-time", "10"]
+        if token:
+            args += ["-H", f"Authorization: Bearer {token}"]
+        raw = run(*args, url, check=False)
+
         try:
             data = json.loads(raw)
         except (json.JSONDecodeError, TypeError):
             evidence.append(
-                {
-                    "cycle_id": cycle_id,
-                    "captured": False,
-                    "reason": f"runtime API at {api} did not answer at capture time",
-                }
+                _absent(cycle_id, f"runtime API at {api} did not answer at capture time")
             )
             continue
-        outcome = data.get("outcome") or {}
+        if not isinstance(data, dict) or "cycle_outcome" not in data:
+            detail = data.get("detail") if isinstance(data, dict) else None
+            evidence.append(
+                _absent(
+                    cycle_id,
+                    f"runtime API at {api} returned no cycle roll-up"
+                    + (f" ({detail})" if detail else "")
+                    + (" — no cached CLI token; run `squadops login`" if not token else ""),
+                )
+            )
+            continue
+        outcome = data.get("cycle_outcome") or {}
+        if outcome.get("verdict") is None:
+            evidence.append(_absent(cycle_id, f"cycle {cycle_id} carries no verification roll-up"))
+            continue
         evidence.append(
             {
                 "cycle_id": cycle_id,
                 "captured": True,
                 "status": data.get("status"),
                 "verdict": outcome.get("verdict"),
-                "verified": outcome.get("verified", []),
+                "verified": sorted(set(outcome.get("verified", []))),
                 "failed": outcome.get("failed", []),
                 "required_unmet": outcome.get("required_unmet", []),
-                "unverified": [u.get("check") for u in outcome.get("unverified", [])],
-                "run_count": outcome.get("run_count"),
+                "unverified": [
+                    u.get("check_id") or u.get("check") for u in outcome.get("unverified", [])
+                ],
+                "run_count": outcome.get("run_count") or len(data.get("runs", [])),
             }
         )
     return evidence
@@ -262,6 +315,7 @@ def main() -> int:
         help="cycle id representing this release; repeatable",
     )
     parser.add_argument("--api", default="http://localhost:8001", help="runtime API base URL")
+    parser.add_argument("--project", default="group_run", help="project the --cycle ids belong to")
     parser.add_argument(
         "--write", action="store_true", help="write the package; default is a preview to stdout"
     )
@@ -291,7 +345,7 @@ def main() -> int:
         "narrative": changelog_section(version),
         "pull_requests": merged_prs(previous, tag),
         "sip_moves": sip_moves(previous, tag),
-        "cycles": cycle_evidence(args.cycle, args.api) if args.cycle else [],
+        "cycles": cycle_evidence(args.cycle, args.api, args.project) if args.cycle else [],
         "screenshots": screenshots,
     }
 

--- a/site/content/releases/v1.6.2/index.md
+++ b/site/content/releases/v1.6.2/index.md
@@ -1,0 +1,135 @@
+---
+title: v1.6.2
+---
+
+# v1.6.2
+
+**Released 2026-08-23** · [tag `v1.6.2`](https://github.com/backspring-labs/squad-ops/releases/tag/v1.6.2)
+
+The information-flow patch line. Every fix here is one shape: **a fact the system
+already holds, not reaching the agent judged against it** — and the release is the
+first in the 1.6 line validated by a green roll with an independent boot audit.
+
+**Cut evidence.** `cyc_79eebcb82205` / `run_9c879ff5458e`: verdict `accepted`, zero
+failed checks, 5/5 contract probes verified — and the delivered application
+independently **installs, builds, boots, answers every contract probe over real HTTP,
+and its UI reaches every path it requests**. The verdict and the oracle agree, which is
+the standard SIP-0096 exists to hold and the thing 1.6.2 could not previously show.
+
+**Telling an agent what it is judged against:**
+- #1029 — the frozen shell spine pins the success body's declared floor: required fields
+  present, declared collection element kinds honoured. A floor, not a schema — every
+  exclusion is a false-positive source, and the pin was replayed against banked green
+  trees before it gated anything.
+- #1042 — the declared success status reaches the developer by derivation. It previously
+  survived only as a TODO comment inside the fill body the fill replaces.
+- #1060 — the repair receives **every** manifest surface the initial author does. Three
+  were missing; two of them (error contract, model surface) had renderers that had been
+  producing empty output since they were written.
+- #1002 — the detector's inspected-file inventory reaches the record, so a clean verdict
+  is distinguishable from a detector that never saw the file.
+- #1015 (B/C) — the repair is told to change the minimum, and can see "attempt N of M".
+
+**The success status stops being authored three times** (#1067, #1070 part A). The status
+existed in seven places, three of them independently authored — manifest, plan prose,
+handler code — while `scaffold_contract` already derives it from endpoint shape. Five
+incidents in three weeks took four fixes before anyone counted the recurrence.
+- #1067 — a declared status contradicting the derived default must carry a `decisions[]`
+  entry naming the endpoint **and** stating the status. Silence becomes the safe default:
+  the rule decides, and there is nothing to disagree with.
+- #1070 part A — the plan stops restating statuses. The authoring rule had *instructed*
+  the copy ("an enforced non-200 status must be STATED"), because prose was once the only
+  channel to the implementer; #1042 and #1063 replaced it. `cyc_79eebcb82205` was rejected
+  twice, on two differently-named endpoints, for two documents disagreeing about an integer
+  neither needed to decide.
+
+**Correction-loop integrity:**
+- #1053 — an emission containing nothing is not an attempt. A prior roll spent two of
+  three rounds on zero-byte files while holding a correct, stable diagnosis; the refund
+  is bounded so a producer that never emits still terminates.
+- #761 — the `tests_pass` signature stops collapsing where the runner emits no machine
+  report, so A4 can tell REPEAT from SHIFTED on pytest.
+- #1030 — `framing_max_rerolls` defaults to 2; #522's free re-roll was dead code.
+- #880 — `runs retry` after a failed run, broken by construction.
+
+**Evidence integrity:**
+- #1021 — a contract criterion with no result row stops being a silent fourth state;
+  `criteria_unevidenced` separates "never ran" from "ran and failed". Reporting from
+  production on the cut roll.
+- #1022 / #1055 — containment findings for additive suites and for insert-as-update in
+  route handlers. **Banked, deliberately not enforced**: #1049 is this line's own
+  demonstration of what a rejection gate costs when its premise is never checked
+  against real traffic.
+- #980 follow-up — the dropped additive suite is recorded, not just the weakened fills.
+
+**Gates and scaffold:**
+- #1049 — the framing omission check reads both channels. #1042 made its stated premise
+  ("the implementer will default to 200") false, and it was costing one to two re-rolls
+  per cycle, dead-ending correct framings.
+- #1055 — the frozen store gains `update(table, row)`. Its whole write surface was
+  `insert`, which is `push`, so persisting a change had no correct form; two independent
+  authorings on two models both stored duplicates instead.
+- #972 — the regression gate no longer exits 0 when ruff is absent.
+- The blueprint falsification gate stops depending on xdist's work distribution — it
+  passed at 4 workers and failed at 20 on the same commit, so its verdict tracked the
+  machine.
+
+**Not exercised by the cut evidence, stated plainly.** The green roll ran on `98eb805e`.
+Three changes merged after it launched and ride this tag without that roll having tested
+them: #1064 (the store `update` seam — additive, a new export, no existing behaviour
+altered) and **#1067 / #1070 part A, both authoring-facing behaviour changes**. They are
+the right fixes and they are green in CI, but the boot-audit evidence above does not cover
+them, and the first roll of 1.6.3 is what will.
+
+**Known and named, not fixed:** #1021's underlying mechanism (why those two compile
+criteria produce no row), #1054 (a repair routed to qa while the lead named dev task
+types — 3.6 only, never fired on a 3.8 roll), #1070 part B (the manifest's own
+`success_status` field remains authorable where the rule decides it — blocked on the
+reference-manifest question).
+
+## Merged pull requests (29)
+
+| PR | Title | Closes |
+|---|---|---|
+| [#1075](https://github.com/backspring-labs/squad-ops/pull/1075) | chore(release): 1.6.2 — the information-flow patch line | — |
+| [#1073](https://github.com/backspring-labs/squad-ops/pull/1073) | fix(plan): the plan stops restating success statuses — part A of #1070 | — |
+| [#1068](https://github.com/backspring-labs/squad-ops/pull/1068) | fix(gates): a status that overrides the derived default must say why | [#1067](https://github.com/backspring-labs/squad-ops/issues/1067) |
+| [#1072](https://github.com/backspring-labs/squad-ops/pull/1072) | fix(site): transparent favicon — Safari plates opaque icons | — |
+| [#1069](https://github.com/backspring-labs/squad-ops/pull/1069) | test(site): indigo favicon tile to clear Safari's contrast plate | — |
+| [#1066](https://github.com/backspring-labs/squad-ops/pull/1066) | docs(site): record the accepted Safari favicon tradeoff | — |
+| [#1064](https://github.com/backspring-labs/squad-ops/pull/1064) | feat(scaffold): the frozen store gains an update seam — the write it never had | [#1055](https://github.com/backspring-labs/squad-ops/issues/1055) |
+| [#1063](https://github.com/backspring-labs/squad-ops/pull/1063) | fix(correction): the repair sees every fact the initial author is judged against | [#1060](https://github.com/backspring-labs/squad-ops/issues/1060) |
+| [#1062](https://github.com/backspring-labs/squad-ops/pull/1062) | feat(release): publish the GitHub Release from the tag, not from memory | [#1061](https://github.com/backspring-labs/squad-ops/issues/1061) |
+| [#1059](https://github.com/backspring-labs/squad-ops/pull/1059) | feat(scaffold): insert-as-update findings on emitted route handlers — banked, not enforced | — |
+| [#1058](https://github.com/backspring-labs/squad-ops/pull/1058) | docs(site): factual tone, the framing task sequence, and brand assets | — |
+| [#1057](https://github.com/backspring-labs/squad-ops/pull/1057) | fix(qa): the containment findings actually reach the record — #1052 dropped them | — |
+| [#1056](https://github.com/backspring-labs/squad-ops/pull/1056) | fix(correction): an emission containing nothing is not an attempt at the fix | [#1053](https://github.com/backspring-labs/squad-ops/issues/1053) |
+| [#1052](https://github.com/backspring-labs/squad-ops/pull/1052) | feat(qa): additive-suite containment findings — banked, deliberately not enforced | — |
+| [#1051](https://github.com/backspring-labs/squad-ops/pull/1051) | fix(verification): a contract criterion with no evidence stops being a silent fourth state | — |
+| [#1050](https://github.com/backspring-labs/squad-ops/pull/1050) | fix(gates): the framing omission check reads BOTH channels — #1042 made its premise false | [#1049](https://github.com/backspring-labs/squad-ops/issues/1049) |
+| [#1048](https://github.com/backspring-labs/squad-ops/pull/1048) | fix(correction): the repair is told to change the minimum, and can see the loop it is in | — |
+| [#1047](https://github.com/backspring-labs/squad-ops/pull/1047) | fix(correction): the tests_pass signature stops collapsing when the runner emits no machine report | [#761](https://github.com/backspring-labs/squad-ops/issues/761) |
+| [#1046](https://github.com/backspring-labs/squad-ops/pull/1046) | docs(site): separate the framework's verification from the project's measurement | — |
+| [#1045](https://github.com/backspring-labs/squad-ops/pull/1045) | feat(qa): the retreat had two halves — record the dropped additive suite too | — |
+| [#1044](https://github.com/backspring-labs/squad-ops/pull/1044) | docs(site): restructure on Diátaxis — evidence, roadmap, observability, dependencies, diagrams | — |
+| [#1043](https://github.com/backspring-labs/squad-ops/pull/1043) | fix(prompts): the developer is told the declared success status, not left to plan prose | [#1042](https://github.com/backspring-labs/squad-ops/issues/1042) |
+| [#1040](https://github.com/backspring-labs/squad-ops/pull/1040) | feat(scaffold): pin the success body's declared floor in the frozen shell spine | [#1029](https://github.com/backspring-labs/squad-ops/issues/1029) |
+| [#1038](https://github.com/backspring-labs/squad-ops/pull/1038) | docs(site): Squad Ops documentation site — MkDocs Material, colocated with the code | — |
+| [#1037](https://github.com/backspring-labs/squad-ops/pull/1037) | test(2c): the blueprint falsification gate stops depending on xdist's work distribution | — |
+| [#1036](https://github.com/backspring-labs/squad-ops/pull/1036) | fix(cycles): carry the inspected-set reference to the record — a clean detector verdict is no longer indistinguishable from one that never looked | [#1002](https://github.com/backspring-labs/squad-ops/issues/1002) |
+| [#1035](https://github.com/backspring-labs/squad-ops/pull/1035) | fix(cycles): retry after a failed run — typed workload-position resolution (#880) | [#880](https://github.com/backspring-labs/squad-ops/issues/880) |
+| [#1034](https://github.com/backspring-labs/squad-ops/pull/1034) | fix(scripts): regression-gate preflight + positive completion evidence (#972) | [#972](https://github.com/backspring-labs/squad-ops/issues/972) |
+| [#1033](https://github.com/backspring-labs/squad-ops/pull/1033) | fix(cycles): framing_max_rerolls defaults to 2 (#1030) | [#1030](https://github.com/backspring-labs/squad-ops/issues/1030) |
+
+## Cycle evidence
+
+### `cyc_79eebcb82205`
+
+**Verdict:** `accepted` · **Runs:** 4
+
+| | Checks |
+|---|---|
+| Verified | acceptance:frontend_compiles, acceptance:regex_match, acceptance_criteria_prose, expected_artifacts, frontend_build, no_self_mocking_tests, no_stub_fallback_tests, non_stub_files, required_files, tests_pass, vc-probe-api-runs, vc-probe-api-runs-join, vc-probe-api-runs-join-duplicate, vc-probe-api-runs-leave, vc-probe-api-runs-rejects-blank |
+| Failed | — |
+| Required unmet | — |
+| Never executed | — |

--- a/site/content/releases/v1.6.2/package.yaml
+++ b/site/content/releases/v1.6.2/package.yaml
@@ -1,0 +1,305 @@
+version: 1.6.2
+tag: v1.6.2
+previous_tag: v1.6.1
+date: '2026-08-23'
+commit: cca0522b7ab4ecf446b5db889bccc1042545c9ba
+narrative: "The information-flow patch line. Every fix here is one shape: **a fact\
+  \ the system\nalready holds, not reaching the agent judged against it** — and the\
+  \ release is the\nfirst in the 1.6 line validated by a green roll with an independent\
+  \ boot audit.\n\n**Cut evidence.** `cyc_79eebcb82205` / `run_9c879ff5458e`: verdict\
+  \ `accepted`, zero\nfailed checks, 5/5 contract probes verified — and the delivered\
+  \ application\nindependently **installs, builds, boots, answers every contract probe\
+  \ over real HTTP,\nand its UI reaches every path it requests**. The verdict and\
+  \ the oracle agree, which is\nthe standard SIP-0096 exists to hold and the thing\
+  \ 1.6.2 could not previously show.\n\n**Telling an agent what it is judged against:**\n\
+  - #1029 — the frozen shell spine pins the success body's declared floor: required\
+  \ fields\n  present, declared collection element kinds honoured. A floor, not a\
+  \ schema — every\n  exclusion is a false-positive source, and the pin was replayed\
+  \ against banked green\n  trees before it gated anything.\n- #1042 — the declared\
+  \ success status reaches the developer by derivation. It previously\n  survived\
+  \ only as a TODO comment inside the fill body the fill replaces.\n- #1060 — the\
+  \ repair receives **every** manifest surface the initial author does. Three\n  were\
+  \ missing; two of them (error contract, model surface) had renderers that had been\n\
+  \  producing empty output since they were written.\n- #1002 — the detector's inspected-file\
+  \ inventory reaches the record, so a clean verdict\n  is distinguishable from a\
+  \ detector that never saw the file.\n- #1015 (B/C) — the repair is told to change\
+  \ the minimum, and can see \"attempt N of M\".\n\n**The success status stops being\
+  \ authored three times** (#1067, #1070 part A). The status\nexisted in seven places,\
+  \ three of them independently authored — manifest, plan prose,\nhandler code — while\
+  \ `scaffold_contract` already derives it from endpoint shape. Five\nincidents in\
+  \ three weeks took four fixes before anyone counted the recurrence.\n- #1067 — a\
+  \ declared status contradicting the derived default must carry a `decisions[]`\n\
+  \  entry naming the endpoint **and** stating the status. Silence becomes the safe\
+  \ default:\n  the rule decides, and there is nothing to disagree with.\n- #1070\
+  \ part A — the plan stops restating statuses. The authoring rule had *instructed*\n\
+  \  the copy (\"an enforced non-200 status must be STATED\"), because prose was once\
+  \ the only\n  channel to the implementer; #1042 and #1063 replaced it. `cyc_79eebcb82205`\
+  \ was rejected\n  twice, on two differently-named endpoints, for two documents disagreeing\
+  \ about an integer\n  neither needed to decide.\n\n**Correction-loop integrity:**\n\
+  - #1053 — an emission containing nothing is not an attempt. A prior roll spent two\
+  \ of\n  three rounds on zero-byte files while holding a correct, stable diagnosis;\
+  \ the refund\n  is bounded so a producer that never emits still terminates.\n- #761\
+  \ — the `tests_pass` signature stops collapsing where the runner emits no machine\n\
+  \  report, so A4 can tell REPEAT from SHIFTED on pytest.\n- #1030 — `framing_max_rerolls`\
+  \ defaults to 2; #522's free re-roll was dead code.\n- #880 — `runs retry` after\
+  \ a failed run, broken by construction.\n\n**Evidence integrity:**\n- #1021 — a\
+  \ contract criterion with no result row stops being a silent fourth state;\n  `criteria_unevidenced`\
+  \ separates \"never ran\" from \"ran and failed\". Reporting from\n  production\
+  \ on the cut roll.\n- #1022 / #1055 — containment findings for additive suites and\
+  \ for insert-as-update in\n  route handlers. **Banked, deliberately not enforced**:\
+  \ #1049 is this line's own\n  demonstration of what a rejection gate costs when\
+  \ its premise is never checked\n  against real traffic.\n- #980 follow-up — the\
+  \ dropped additive suite is recorded, not just the weakened fills.\n\n**Gates and\
+  \ scaffold:**\n- #1049 — the framing omission check reads both channels. #1042 made\
+  \ its stated premise\n  (\"the implementer will default to 200\") false, and it\
+  \ was costing one to two re-rolls\n  per cycle, dead-ending correct framings.\n\
+  - #1055 — the frozen store gains `update(table, row)`. Its whole write surface was\n\
+  \  `insert`, which is `push`, so persisting a change had no correct form; two independent\n\
+  \  authorings on two models both stored duplicates instead.\n- #972 — the regression\
+  \ gate no longer exits 0 when ruff is absent.\n- The blueprint falsification gate\
+  \ stops depending on xdist's work distribution — it\n  passed at 4 workers and failed\
+  \ at 20 on the same commit, so its verdict tracked the\n  machine.\n\n**Not exercised\
+  \ by the cut evidence, stated plainly.** The green roll ran on `98eb805e`.\nThree\
+  \ changes merged after it launched and ride this tag without that roll having tested\n\
+  them: #1064 (the store `update` seam — additive, a new export, no existing behaviour\n\
+  altered) and **#1067 / #1070 part A, both authoring-facing behaviour changes**.\
+  \ They are\nthe right fixes and they are green in CI, but the boot-audit evidence\
+  \ above does not cover\nthem, and the first roll of 1.6.3 is what will.\n\n**Known\
+  \ and named, not fixed:** #1021's underlying mechanism (why those two compile\n\
+  criteria produce no row), #1054 (a repair routed to qa while the lead named dev\
+  \ task\ntypes — 3.6 only, never fired on a 3.8 roll), #1070 part B (the manifest's\
+  \ own\n`success_status` field remains authorable where the rule decides it — blocked\
+  \ on the\nreference-manifest question)."
+pull_requests:
+- number: 1075
+  title: 'chore(release): 1.6.2 — the information-flow patch line'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1073
+  title: 'fix(plan): the plan stops restating success statuses — part A of #1070'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1068
+  title: 'fix(gates): a status that overrides the derived default must say why'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 1067
+  merged_at: '2026-08-23'
+- number: 1072
+  title: 'fix(site): transparent favicon — Safari plates opaque icons'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1069
+  title: 'test(site): indigo favicon tile to clear Safari''s contrast plate'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1066
+  title: 'docs(site): record the accepted Safari favicon tradeoff'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1064
+  title: 'feat(scaffold): the frozen store gains an update seam — the write it never
+    had'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 1055
+  merged_at: '2026-08-23'
+- number: 1063
+  title: 'fix(correction): the repair sees every fact the initial author is judged
+    against'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 1060
+  merged_at: '2026-08-23'
+- number: 1062
+  title: 'feat(release): publish the GitHub Release from the tag, not from memory'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 1061
+  merged_at: '2026-08-23'
+- number: 1059
+  title: 'feat(scaffold): insert-as-update findings on emitted route handlers — banked,
+    not enforced'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1058
+  title: 'docs(site): factual tone, the framing task sequence, and brand assets'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1057
+  title: 'fix(qa): the containment findings actually reach the record — #1052 dropped
+    them'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1056
+  title: 'fix(correction): an emission containing nothing is not an attempt at the
+    fix'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 1053
+  merged_at: '2026-08-23'
+- number: 1052
+  title: 'feat(qa): additive-suite containment findings — banked, deliberately not
+    enforced'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1051
+  title: 'fix(verification): a contract criterion with no evidence stops being a silent
+    fourth state'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1050
+  title: 'fix(gates): the framing omission check reads BOTH channels — #1042 made
+    its premise false'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 1049
+  merged_at: '2026-08-23'
+- number: 1048
+  title: 'fix(correction): the repair is told to change the minimum, and can see the
+    loop it is in'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1047
+  title: 'fix(correction): the tests_pass signature stops collapsing when the runner
+    emits no machine report'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 761
+  merged_at: '2026-08-23'
+- number: 1046
+  title: 'docs(site): separate the framework''s verification from the project''s measurement'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1045
+  title: 'feat(qa): the retreat had two halves — record the dropped additive suite
+    too'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1044
+  title: 'docs(site): restructure on Diátaxis — evidence, roadmap, observability,
+    dependencies, diagrams'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1043
+  title: 'fix(prompts): the developer is told the declared success status, not left
+    to plan prose'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 1042
+  merged_at: '2026-08-23'
+- number: 1040
+  title: 'feat(scaffold): pin the success body''s declared floor in the frozen shell
+    spine'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 1029
+  merged_at: '2026-08-23'
+- number: 1038
+  title: 'docs(site): Squad Ops documentation site — MkDocs Material, colocated with
+    the code'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-23'
+- number: 1037
+  title: 'test(2c): the blueprint falsification gate stops depending on xdist''s work
+    distribution'
+  author: jasonLadd
+  labels: []
+  closes: []
+  merged_at: '2026-08-22'
+- number: 1036
+  title: 'fix(cycles): carry the inspected-set reference to the record — a clean detector
+    verdict is no longer indistinguishable from one that never looked'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 1002
+  merged_at: '2026-08-22'
+- number: 1035
+  title: 'fix(cycles): retry after a failed run — typed workload-position resolution
+    (#880)'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 880
+  merged_at: '2026-08-22'
+- number: 1034
+  title: 'fix(scripts): regression-gate preflight + positive completion evidence (#972)'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 972
+  merged_at: '2026-08-22'
+- number: 1033
+  title: 'fix(cycles): framing_max_rerolls defaults to 2 (#1030)'
+  author: jasonLadd
+  labels: []
+  closes:
+  - 1030
+  merged_at: '2026-08-22'
+sip_moves: []
+cycles:
+- cycle_id: cyc_79eebcb82205
+  captured: true
+  status: completed
+  verdict: accepted
+  verified:
+  - acceptance:frontend_compiles
+  - acceptance:regex_match
+  - acceptance_criteria_prose
+  - expected_artifacts
+  - frontend_build
+  - no_self_mocking_tests
+  - no_stub_fallback_tests
+  - non_stub_files
+  - required_files
+  - tests_pass
+  - vc-probe-api-runs
+  - vc-probe-api-runs-join
+  - vc-probe-api-runs-join-duplicate
+  - vc-probe-api-runs-leave
+  - vc-probe-api-runs-rejects-blank
+  failed: []
+  required_unmet: []
+  unverified: []
+  run_count: 4
+screenshots: []

--- a/tests/unit/maintainer/test_release_notes.py
+++ b/tests/unit/maintainer/test_release_notes.py
@@ -23,6 +23,13 @@ release_notes = importlib.util.module_from_spec(_spec)
 sys.modules["release_notes"] = release_notes
 _spec.loader.exec_module(release_notes)
 
+_pkg_spec = importlib.util.spec_from_file_location(
+    "build_release_package", REPO_ROOT / "scripts" / "maintainer" / "build_release_package.py"
+)
+build_release_package = importlib.util.module_from_spec(_pkg_spec)
+sys.modules["build_release_package"] = build_release_package
+_pkg_spec.loader.exec_module(build_release_package)
+
 CHANGELOG = """# Changelog
 
 ## [Unreleased]
@@ -118,3 +125,90 @@ class TestAgainstTheRealFiles:
         )
         assert body.strip()
         assert title.startswith(f"v{version}")
+
+
+class TestCycleEvidenceCapture:
+    """#1076: the capture must not report success while capturing nothing.
+
+    `cycle_evidence`'s docstring promised that "an unreachable API and a cycle that
+    genuinely produced nothing must not look the same later". It did not keep that
+    promise, and the failure was invisible in exactly the way the promise warns about:
+    the guard caught only `JSONDecodeError`, so `{"detail": "Not Found"}` — perfectly
+    valid JSON — was recorded as `captured: True` with every field null.
+
+    That is what hid three other defects (wrong route, no auth header, wrong roll-up
+    field name) for as long as the script existed. These tests are on the disclosure,
+    because the disclosure is what makes the rest findable.
+    """
+
+    @staticmethod
+    def _capture(monkeypatch, payload: str):
+        brp = build_release_package
+
+        monkeypatch.setattr(brp, "run", lambda *a, **k: payload)
+        monkeypatch.setattr(brp, "_bearer_token", lambda: "tok")
+        return brp.cycle_evidence(["cyc_1"], "http://api", "proj")[0]
+
+    def test_a_json_error_body_is_recorded_as_absent_not_captured(self, monkeypatch):
+        """The bug, exactly. A 404's JSON body must never read as a captured cycle."""
+        got = self._capture(monkeypatch, '{"detail": "Not Found"}')
+        assert got["captured"] is False
+        assert "Not Found" in got["reason"]
+
+    def test_unparseable_output_is_absent_with_its_reason(self, monkeypatch):
+        got = self._capture(monkeypatch, "curl: (7) connection refused")
+        assert got["captured"] is False
+        assert "did not answer" in got["reason"]
+
+    def test_a_cycle_with_no_rollup_is_absent_not_a_null_verdict(self, monkeypatch):
+        """A real cycle that never produced a roll-up is genuinely absent evidence —
+        recording it as captured-with-nulls is the same lie in a different shape."""
+        got = self._capture(monkeypatch, '{"status": "completed", "cycle_outcome": null}')
+        assert got["captured"] is False
+        assert "no verification roll-up" in got["reason"]
+
+    def test_a_real_rollup_is_captured_from_cycle_outcome(self, monkeypatch):
+        """Reads `cycle_outcome`, the field the API actually returns — the script read
+        `outcome`, which is always absent, so every capture was empty."""
+        payload = (
+            '{"status": "completed", "runs": [1, 2],'
+            ' "cycle_outcome": {"verdict": "accepted", "run_count": 4,'
+            ' "verified": ["b", "a", "a"], "failed": [], "required_unmet": [],'
+            ' "unverified": [{"check_id": "x"}]}}'
+        )
+        got = self._capture(monkeypatch, payload)
+        assert got["captured"] is True
+        assert got["verdict"] == "accepted"
+        assert got["run_count"] == 4
+        assert got["verified"] == ["a", "b"]
+        assert got["unverified"] == ["x"]
+
+    def test_the_request_is_project_scoped_and_authorized(self, monkeypatch):
+        """The route is `/api/v1/projects/{project}/cycles/{id}` and the API rejects an
+        unauthenticated call — the script used the unscoped path and sent no header, so
+        every capture 404'd before any field mapping mattered."""
+        brp = build_release_package
+
+        seen: dict = {}
+
+        def _fake_run(*args, **kwargs):
+            seen["args"] = args
+            return '{"cycle_outcome": {"verdict": "accepted", "run_count": 1}}'
+
+        monkeypatch.setattr(brp, "run", _fake_run)
+        monkeypatch.setattr(brp, "_bearer_token", lambda: "tok-123")
+        brp.cycle_evidence(["cyc_1"], "http://api", "proj")
+
+        assert "http://api/api/v1/projects/proj/cycles/cyc_1" in seen["args"]
+        assert "Authorization: Bearer tok-123" in seen["args"]
+
+    def test_a_missing_token_says_so_in_the_reason(self, monkeypatch):
+        """The maintainer needs to know WHICH failure this was — an expired login and a
+        genuinely absent cycle want different responses."""
+        brp = build_release_package
+
+        monkeypatch.setattr(brp, "run", lambda *a, **k: '{"detail": "Missing header"}')
+        monkeypatch.setattr(brp, "_bearer_token", lambda: "")
+        got = brp.cycle_evidence(["cyc_1"], "http://api", "proj")[0]
+        assert got["captured"] is False
+        assert "squadops login" in got["reason"]


### PR DESCRIPTION
Found running **step 7 of the 1.6.2 cut**. The command printed `--- 29 PRs, 0 SIP moves, 1 cycles, 0 screenshots ---` and wrote a roll-up of nulls.

## Four defects, and the fourth hid the other three

| | |
|---|---|
| route | `/api/v1/cycles/{id}` — the real one is `/api/v1/projects/{project}/cycles/{id}` |
| auth | no `Authorization` header; the API requires one |
| field | reads `outcome`; the API returns `cycle_outcome` |
| **guard** | caught only `JSONDecodeError`, so `{"detail": "Not Found"}` took the **success** path |

`cycle_evidence`'s own docstring promises:

> Absence is disclosed, never silently omitted — an unreachable API and a cycle that genuinely produced nothing must not look the same later.

They looked identical. Valid JSON is valid JSON, so every capture reported `captured: True` with null fields, and nobody had reason to question the route, the header, or the field name.

## Why this is worse than a normal tooling bug

Step 7 is **capture, not query** — cycle evidence lives in a running deploy and is unrecoverable once it moves. A hollow capture is worse than no capture, because it looks like the evidence was taken. v1.6.1's package has an empty `cycles` list, so no false record has shipped; **1.6.2 would have been the first.**

## The fix

Project-scoped route, authorized from the CLI's cached token (the same store `squadops login` writes — no second credential path), reading `cycle_outcome`, and **gated on the roll-up actually being present**.

Absence is recorded *with its reason*, including `run \`squadops login\`` when no token was found — an expired login and a genuinely absent cycle want different responses from the maintainer.

Verified against the real 1.6.2 evidence:

```
cyc_79eebcb82205 → accepted · 4 runs · 15 verified checks named
```

where it previously captured nothing and said it had.

## Verification

- Regression **7,829 passed**, gate green at 20 workers.
- **6 mutations, all killed** — including each of the four original defects reintroduced individually, so a regression to any one of them fails.

## Related

The same shape as this line's other findings — an instrument reporting success while measuring nothing (#1002, #1021, #1052/#1057). Here the instrument was the release record itself.

Closes #1076