### PR TITLE
fix(evidence): a failed task's emission is banked for triage, and used for nothing

### DIFF
--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -1305,6 +1305,19 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         if not filter_spec:
             return {}
 
+        # #971: a FAILED emission is never workspace input, for any caller. Unlike the
+        # repair-candidate exclusion below this one is unconditional and takes no flag —
+        # a candidate is merely unaccepted (the correction loop legitimately reads its
+        # own accumulation), whereas an emission that failed its checks is known-bad.
+        # Storing it is a triage instrument (#971); letting it compose a workspace would
+        # feed known-bad bytes to the next task and, on the acceptance workspace, into
+        # the assembled deliverable.
+        stored_artifacts = [
+            (art_id, ref)
+            for art_id, ref in stored_artifacts
+            if ref.metadata.get("emission_status") != "failed"
+        ]
+
         if not include_repair_candidates:
             from squadops.cycles.task_plan import REPAIR_TASK_TYPES
 
@@ -1594,6 +1607,14 @@ class DispatchedFlowExecutor(FlowExecutionPort):
                 _holder=_last_failed_result,
             ):
                 _holder["result"] = result
+                # #971: bank THIS attempt's emission before the correction loop
+                # decides anything. The callback fires on every failed attempt, so
+                # what lands is the pair the issue asks for — what failed and what
+                # replaced it — rather than only the last failure. Stored marked and
+                # excluded everywhere; see _store_failed_emission.
+                await self._store_failed_emission(
+                    result, _envelope, cycle, run_id, all_artifact_refs
+                )
                 action = await self._handle_task_outcome(
                     result=result,
                     envelope=_envelope,
@@ -4146,8 +4167,19 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         run_id: str,
         envelope: TaskEnvelope,
         producing_task_type: str | None = None,
+        emission_status: str | None = None,
     ) -> ArtifactRef:
-        """Store a task output artifact in the vault."""
+        """Store a task output artifact in the vault.
+
+        ``emission_status`` (#971) marks an emission that did NOT pass. It is
+        provenance, not a type: ``producing_task_type`` stays truthful, because a
+        failed ``qa.test`` emission really was produced by ``qa.test`` and every
+        post-hoc reader — triage, the analyzer audit, the replay harness — wants to
+        know that. What the marker buys is exclusion: a failed emission must never
+        reach a workspace view or the assembled deliverable, and the readers that
+        enforce that (``_resolve_artifact_contents`` here, ``_pull_run_artifacts`` in
+        the audit script) key on this one field.
+        """
         content = art_dict.get("content", "").encode("utf-8")
         metadata: dict[str, Any] = {
             "task_id": envelope.task_id,
@@ -4155,6 +4187,8 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         }
         if producing_task_type:
             metadata["producing_task_type"] = producing_task_type
+        if emission_status:
+            metadata["emission_status"] = emission_status
         ref = ArtifactRef(
             artifact_id=f"art_{uuid4().hex[:12]}",
             project_id=cycle.project_id,
@@ -4169,6 +4203,62 @@ class DispatchedFlowExecutor(FlowExecutionPort):
             metadata=metadata,
         )
         return await self._artifact_vault.store(ref, content)
+
+    async def _store_failed_emission(
+        self,
+        result: Any,
+        envelope: TaskEnvelope,
+        cycle: Cycle,
+        run_id: str,
+        all_artifact_refs: list[str],
+    ) -> None:
+        """Bank a failed attempt's emission so the failure can be READ afterwards (#971).
+
+        Before this, a task that failed lost everything it emitted: the sequential
+        path raises or ``continue``s before ``_collect_artifacts_and_checkpoint``, so
+        the only surviving copy of a file was whatever a later repair produced. The
+        artifact that CAUSED a failure was the one artifact guaranteed absent — and
+        13 of the 17 rejected implementation runs in the 08-14→08-23 census are
+        unreadable for exactly this reason.
+
+        **Triage only.** The emission is recorded and never used: marked
+        ``emission_status="failed"``, kept out of the run's ``stored_artifacts``
+        list, and filtered unconditionally by ``_resolve_artifact_contents``. Two
+        independent guarantees, because the failure mode is feeding known-bad bytes
+        to the next task or into the assembled deliverable. ``audit_delivered_app``
+        carries the third — it reads the vault directly, latest-per-filename, and
+        would otherwise audit a failed emission whenever nothing re-emits that file.
+
+        Best-effort by construction: banking evidence must never alter the control
+        flow of the failure it is recording. #1017 made the same call for the failed
+        retest's ``test_report``.
+        """
+        if getattr(result, "status", None) == "SUCCEEDED":
+            return
+        artifacts = (getattr(result, "outputs", None) or {}).get("artifacts") or []
+        if not artifacts:
+            return
+        new_refs: list[str] = []
+        try:
+            for art in artifacts:
+                ref = await self._store_artifact(
+                    art,
+                    cycle,
+                    run_id,
+                    envelope,
+                    producing_task_type=envelope.task_type,
+                    emission_status="failed",
+                )
+                new_refs.append(ref.artifact_id)
+            if new_refs:
+                all_artifact_refs.extend(new_refs)
+                await self._cycle_registry.append_artifact_refs(run_id, tuple(new_refs))
+        except Exception:
+            logger.warning(
+                "Failed-emission capture did not complete for task %s",
+                envelope.task_id,
+                exc_info=True,
+            )
 
     async def _materialize_run_root(self, cycle: Cycle, run_id: str) -> str:
         """Create a run_root directory and write seed files (e.g. PRD).

--- a/scripts/dev/audit_delivered_app.py
+++ b/scripts/dev/audit_delivered_app.py
@@ -12,6 +12,12 @@ repairs are re-stored under the task's own type (#389 swap), so rejected
 candidates never enter the tree. pf-54 is the canonical trap this rule
 survives: last-wins-by-time would pick a *rejected* repair that boots.
 
+#971 adds the second exclusion: an emission marked ``emission_status="failed"``
+is banked for triage and is never deliverable. The trap there is narrower and
+worse — a failed emission is often the ONLY copy of its file (nothing re-emitted
+it before the run died), so latest-per-filename would audit bytes already proven
+not to work and report on an application the run never produced.
+
 The assembly uses the run's OWN stored skeleton files (the seeding rail stores
 them), so an audit of an old run reflects that run's era, not today's expander.
 
@@ -96,6 +102,8 @@ def _select_deliverable(pulled: Path) -> dict[str, str]:
         meta = json.loads(meta_path.read_text())
         if meta.get("artifact_type") not in _WORKSPACE_ARTIFACT_TYPES:
             continue
+        if (meta.get("metadata") or {}).get("emission_status") == "failed":
+            continue  # #971: a banked failed emission is triage evidence, never the deliverable
         producing = (meta.get("metadata") or {}).get("producing_task_type", "")
         if producing in REPAIR_TASK_TYPES:
             continue  # rejected candidate — accepted repairs re-store under the task type

--- a/tests/unit/cli_tools/test_audit_deliverable_selection.py
+++ b/tests/unit/cli_tools/test_audit_deliverable_selection.py
@@ -20,10 +20,22 @@ sys.modules["audit_delivered_app"] = _mod
 _spec.loader.exec_module(_mod)
 
 
-def _store(tmp_path, art_id, filename, content, producing, created, artifact_type="source"):
+def _store(
+    tmp_path,
+    art_id,
+    filename,
+    content,
+    producing,
+    created,
+    artifact_type="source",
+    emission_status=None,
+):
     d = tmp_path / art_id
     (d / Path(filename).parent).mkdir(parents=True, exist_ok=True)
     (d / filename).write_text(content)
+    metadata = {"producing_task_type": producing}
+    if emission_status:
+        metadata["emission_status"] = emission_status
     (d / "metadata.json").write_text(
         json.dumps(
             {
@@ -31,7 +43,7 @@ def _store(tmp_path, art_id, filename, content, producing, created, artifact_typ
                 "artifact_type": artifact_type,
                 "filename": filename,
                 "created_at": created,
-                "metadata": {"producing_task_type": producing},
+                "metadata": metadata,
             }
         )
     )
@@ -107,3 +119,63 @@ def test_non_workspace_types_excluded(tmp_path):
     files = _mod._select_deliverable(tmp_path)
     assert "report.md" not in files
     assert files == {"backend/routes.py": "CODE"}
+
+
+def test_failed_emission_never_selected_even_as_only_copy(tmp_path):
+    """#971 banks failed emissions; the auditor must never assemble one.
+
+    The dangerous shape is not a failed emission losing to a good one — it is a
+    failed emission being the ONLY copy of a file, which happens whenever the run
+    dies before anything re-emits it. Naive latest-per-filename would then audit
+    known-bad bytes and report on an application the run never actually produced.
+    """
+    _store(
+        tmp_path,
+        "art_failed",
+        "app/api/runs/route.ts",
+        "export async function POST(req) { const body = await req.js",
+        "development.develop",
+        "2026-01-01T10:00",
+        emission_status="failed",
+    )
+    _store(
+        tmp_path,
+        "art_ok",
+        "app/page.tsx",
+        "export default function Page() { return null }",
+        "development.develop",
+        "2026-01-01T10:01",
+    )
+
+    selected = _mod._select_deliverable(tmp_path)
+
+    assert "app/api/runs/route.ts" not in selected
+    assert selected == {"app/page.tsx": "export default function Page() { return null }"}
+
+
+def test_failed_emission_loses_to_the_successful_retry(tmp_path):
+    """The pair is banked; only the passing member is deliverable.
+
+    Ordering must not be what saves this: the failed emission is stored LATER than
+    a hypothetical earlier good one in some retry shapes, so the exclusion has to be
+    by marker, not by time.
+    """
+    _store(
+        tmp_path,
+        "art_ok",
+        "app/api/runs/route.ts",
+        "GOOD",
+        "development.develop",
+        "2026-01-01T10:00",
+    )
+    _store(
+        tmp_path,
+        "art_failed",
+        "app/api/runs/route.ts",
+        "TRUNCATED",
+        "development.develop",
+        "2026-01-01T11:00",
+        emission_status="failed",
+    )
+
+    assert _mod._select_deliverable(tmp_path) == {"app/api/runs/route.ts": "GOOD"}

--- a/tests/unit/cycles/test_failed_emission_capture.py
+++ b/tests/unit/cycles/test_failed_emission_capture.py
@@ -1,0 +1,247 @@
+"""A failed task's emission is banked for triage and used for nothing (#971).
+
+Before this, the one artifact guaranteed absent from a run's vault was the one
+that CAUSED the failure: the sequential path raises or ``continue``s before
+``_collect_artifacts_and_checkpoint``, so only a later repair's output survived.
+13 of the 17 rejected implementation runs in the 08-14→08-23 census are
+unreadable for exactly that reason.
+
+The risk the fix introduces is the opposite one — known-bad bytes reaching a
+later task or the assembled deliverable — so the exclusion is tested harder than
+the capture.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from squadops.cycles.models import ArtifactRef
+from squadops.tasks.models import TaskResult
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+TRUNCATED = "export async function POST(req: Request) {\n  const body = await req.js"
+
+
+@pytest.fixture
+def executor(reply_router):
+    from adapters.cycles.dispatched_flow_executor import DispatchedFlowExecutor
+
+    registry = AsyncMock()
+    registry.get_latest_checkpoint.return_value = None
+    registry.save_checkpoint.return_value = None
+    return DispatchedFlowExecutor(
+        cycle_registry=registry,
+        artifact_vault=AsyncMock(),
+        queue=reply_router.bind(AsyncMock()),
+        squad_profile=AsyncMock(),
+        project_registry=AsyncMock(),
+        reply_router=reply_router,
+    )
+
+
+def _ref(artifact_id: str, filename: str, *, emission_status: str | None = None) -> ArtifactRef:
+    metadata: dict = {
+        "task_id": "task_1",
+        "role": "dev",
+        "producing_task_type": "development.develop",
+    }
+    if emission_status:
+        metadata["emission_status"] = emission_status
+    return ArtifactRef(
+        artifact_id=artifact_id,
+        project_id="test",
+        artifact_type="source",
+        filename=filename,
+        content_hash="abc",
+        size_bytes=len(TRUNCATED),
+        media_type="text/plain",
+        created_at=NOW,
+        metadata=metadata,
+    )
+
+
+def _envelope(task_type: str = "development.develop"):
+    from squadops.tasks.models import TaskEnvelope
+
+    return TaskEnvelope(
+        task_id="task_1",
+        agent_id="neo",
+        cycle_id="cyc_test",
+        pulse_id="pulse_1",
+        project_id="test",
+        task_type=task_type,
+        correlation_id="corr_1",
+        causation_id="corr_1",
+        trace_id="trace_1",
+        span_id="span_1",
+        inputs={"prd": "test"},
+        metadata={"role": "dev"},
+    )
+
+
+def _cycle():
+    from squadops.cycles.models import Cycle, TaskFlowPolicy
+
+    return Cycle(
+        cycle_id="cyc_test",
+        project_id="test",
+        created_at=NOW,
+        created_by="system",
+        prd_ref="prd",
+        squad_profile_id="full",
+        squad_profile_snapshot_ref="sha256:abc",
+        task_flow_policy=TaskFlowPolicy(mode="sequential"),
+        build_strategy="fresh",
+    )
+
+
+def _failed(artifacts: list[dict] | None) -> TaskResult:
+    return TaskResult(
+        task_id="task_1",
+        status="FAILED",
+        outputs={"artifacts": artifacts} if artifacts is not None else {},
+        error="tests_pass failed",
+    )
+
+
+ONE_ARTIFACT = [
+    {
+        "name": "app/api/runs/route.ts",
+        "content": TRUNCATED,
+        "type": "source",
+        "media_type": "text/plain",
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# Capture
+# ---------------------------------------------------------------------------
+
+
+class TestFailedEmissionCapture:
+    async def test_failed_emission_is_stored_marked_and_registered(self, executor):
+        """The bytes that failed are recoverable, and carry the marker that excludes them."""
+        executor._store_artifact = AsyncMock(return_value=_ref("art_f1", "app/api/runs/route.ts"))
+        refs: list[str] = []
+
+        await executor._store_failed_emission(
+            _failed(ONE_ARTIFACT), _envelope(), _cycle(), "run_1", refs
+        )
+
+        kwargs = executor._store_artifact.await_args.kwargs
+        assert kwargs["emission_status"] == "failed"
+        # provenance stays truthful — a failed develop emission really was develop's
+        assert kwargs["producing_task_type"] == "development.develop"
+        assert refs == ["art_f1"]
+        executor._cycle_registry.append_artifact_refs.assert_awaited_once_with("run_1", ("art_f1",))
+
+    async def test_succeeded_result_stores_nothing(self, executor):
+        """The normal path owns successful emissions; double-storing would duplicate them."""
+        executor._store_artifact = AsyncMock()
+        refs: list[str] = []
+
+        result = TaskResult(
+            task_id="task_1", status="SUCCEEDED", outputs={"artifacts": ONE_ARTIFACT}
+        )
+        await executor._store_failed_emission(result, _envelope(), _cycle(), "run_1", refs)
+
+        executor._store_artifact.assert_not_awaited()
+        assert refs == []
+
+    @pytest.mark.parametrize("artifacts", [None, []], ids=["no_outputs", "empty_list"])
+    async def test_failure_with_no_artifacts_registers_nothing(self, executor, artifacts):
+        """A transport retry emits nothing; it must not write an empty ref tuple."""
+        executor._store_artifact = AsyncMock()
+        refs: list[str] = []
+
+        await executor._store_failed_emission(
+            _failed(artifacts), _envelope(), _cycle(), "run_1", refs
+        )
+
+        executor._store_artifact.assert_not_awaited()
+        executor._cycle_registry.append_artifact_refs.assert_not_awaited()
+        assert refs == []
+
+    async def test_vault_failure_does_not_propagate(self, executor):
+        """Banking evidence must never alter the control flow of the failure it records."""
+        executor._store_artifact = AsyncMock(side_effect=RuntimeError("vault down"))
+        refs: list[str] = []
+
+        await executor._store_failed_emission(
+            _failed(ONE_ARTIFACT), _envelope(), _cycle(), "run_1", refs
+        )
+
+        assert refs == []
+        executor._cycle_registry.append_artifact_refs.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Exclusion — the half that carries the risk
+# ---------------------------------------------------------------------------
+
+
+class TestFailedEmissionNeverComposesAWorkspace:
+    @pytest.mark.parametrize("include_repair_candidates", [True, False])
+    async def test_excluded_regardless_of_the_repair_candidate_flag(
+        self, executor, include_repair_candidates
+    ):
+        """Unconditional, unlike the exclusion beside it.
+
+        A repair candidate is merely unaccepted and the correction loop legitimately
+        reads its own accumulation, so that exclusion takes a flag. A failed emission
+        is known-bad to every caller, so this one must not.
+        """
+        good = _ref("art_ok", "app/page.tsx")
+        bad = _ref("art_bad", "app/api/runs/route.ts", emission_status="failed")
+        executor._artifact_vault.retrieve = AsyncMock(
+            side_effect=lambda art_id: {
+                "art_ok": (good, b"export default function Page() { return null }"),
+                "art_bad": (bad, TRUNCATED.encode()),
+            }[art_id]
+        )
+
+        contents = await executor._resolve_artifact_contents(
+            "qa.test",
+            [("art_ok", good), ("art_bad", bad)],
+            include_repair_candidates=include_repair_candidates,
+        )
+
+        assert "app/api/runs/route.ts" not in contents
+        assert contents["app/page.tsx"] == "export default function Page() { return null }"
+
+    async def test_failed_emission_excluded_even_as_the_only_copy(self, executor):
+        """The dangerous shape: nothing re-emits the file, so exclusion leaves a hole.
+
+        A hole is correct. Substituting known-bad bytes would hand the next task a
+        file that has already been proven not to work.
+        """
+        bad = _ref("art_bad", "app/api/runs/route.ts", emission_status="failed")
+        executor._artifact_vault.retrieve = AsyncMock(return_value=(bad, TRUNCATED.encode()))
+
+        contents = await executor._resolve_artifact_contents("qa.test", [("art_bad", bad)])
+
+        assert contents == {}
+
+    async def test_the_pair_is_banked_but_only_the_good_half_composes(self, executor):
+        """A task that fails then succeeds leaves both records; the workspace sees one."""
+        bad = _ref("art_bad", "app/api/runs/route.ts", emission_status="failed")
+        good = _ref("art_good", "app/api/runs/route.ts")
+        executor._artifact_vault.retrieve = AsyncMock(
+            side_effect=lambda art_id: {
+                "art_bad": (bad, TRUNCATED.encode()),
+                "art_good": (good, b"COMPLETE"),
+            }[art_id]
+        )
+
+        contents = await executor._resolve_artifact_contents(
+            "qa.test", [("art_bad", bad), ("art_good", good)]
+        )
+
+        assert contents == {"app/api/runs/route.ts": "COMPLETE"}


### PR DESCRIPTION
Closes #971

First item of the 1.6.3 stack (plan: PR #1080 §2.c). It leads the stack because the repeatability set cannot diagnose a red roll without it.

## The gap

The one artifact guaranteed absent from a run's vault was the one that **caused** the failure. The sequential path raises or `continue`s before `_collect_artifacts_and_checkpoint` (`dispatched_flow_executor.py:3589`), so the only surviving copy of a file was whatever a later repair produced — and a repair's output is precisely not the evidence you want when asking why the original failed.

The bill is measurable. Of the 17 rejected implementation runs between 08-14 and 08-23, **only 4 have a banked test report**; the other 13 can be classified only from the analyzer's own round-0 claim, and #968 exists because nothing verifies those claims against the source.

## Capture

Hooked in `_route_outcome`, which fires on **every** failed attempt rather than only the last — so what lands is the pair the issue asks for: what failed and what replaced it.

Best-effort by construction: banking evidence must never alter the control flow of the failure it records. #1017 made the same call for the failed retest's `test_report`.

## Exclusion — the half that carries the risk

Triage only. A failed emission never feeds a workspace, a repair, or the deliverable, and that gets **three independent guarantees** rather than one:

1. the marked artifact never enters the run's `stored_artifacts` list;
2. `_resolve_artifact_contents` filters it **unconditionally**, with no flag. The repair-candidate exclusion beside it takes one because a candidate is merely unaccepted and the correction loop legitimately reads its own accumulation. A failed emission is known-bad to every caller;
3. `audit_delivered_app._select_deliverable` skips it. That script reads the vault directly, latest-per-filename, bypassing the executor entirely. **Its trap is the narrower and worse one:** a failed emission is often the *only* copy of its file — nothing re-emitted it before the run died — so the auditor would have reported on an application the run never produced. It is also the oracle the repeatability set scores on.

## On the naming

`emission_status` is provenance, not a type: `producing_task_type` stays truthful, because a failed `qa.test` emission really was produced by `qa.test` and every post-hoc reader wants to know that. This is the mark #1017 lacked — it could store *evidence only* precisely because it had no way to render workspace files non-selectable.

## Tests

9 on the executor seam — capture, the `SUCCEEDED` and no-artifact guards, vault failure swallowed, exclusion under both flag settings, exclusion when the failed emission is the only copy, and the pair banked with only the good half composing — plus 2 on the auditor's selection.

Regression suite: **7838 passed, 1 skipped, all gates** (ruff check, ruff format, test-quality lint, pytest).
