### PR TITLE
fix(evidence): catch an emission that stopped mid-construct, at the task that wrote it

### DIFF
--- a/docs/architecture/typed-check-menu.md
+++ b/docs/architecture/typed-check-menu.md
@@ -22,6 +22,7 @@ Regenerate: `UPDATE_CHECK_MENU=1 pytest tests/unit/cycles/test_check_governance.
 | `module_imports` | authored | product | yes | yes | yes | yes | error |
 | `regex_match` | authored | product | yes | yes | yes | yes | error |
 | `undefined_names` | injected | product | yes | yes | yes | yes | error |
+| `unterminated_source` | injected | product | yes | yes | yes | yes | error |
 
 `command_exit_zero` ownership is per-command in truth. The forms it may take
 are inventoried below — this replaces the standing caveat that called the

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -16,7 +16,7 @@ from squadops.capabilities.handlers.base import (
     HandlerResult,
 )
 from squadops.cycles.acceptance_check_spec import (
-    CHECK_UNDEFINED_NAMES,
+    CHECK_SPECS,
     CONFIG_OFF_SKIP_REASONS,
     is_check_applicable,
 )
@@ -46,6 +46,22 @@ from squadops.capabilities.handlers.emission_log import log_emission_shape
 logger = logging.getLogger(__name__)
 
 
+#: Checks the framework injects here, derived from the registry rather than
+#: listed beside it (#1082 added the second one, and a hand-kept list is how the
+#: menu and the injector would drift). The filter is exactly what this seam can
+#: satisfy: a framework-injected check whose only parameter is the file the task
+#: emitted. Checks needing more (``fill_slot_signature``'s routes,
+#: ``contract_assertions_match``'s endpoints) are injected where that context
+#: lives, and are excluded here by construction rather than by memory.
+_FILE_SCOPED_FRAMEWORK_CHECKS: tuple[str, ...] = tuple(
+    sorted(
+        name
+        for name, spec in CHECK_SPECS.items()
+        if spec.framework_injected and spec.required_params == frozenset({"file"})
+    )
+)
+
+
 def _framework_injected_criteria(
     artifacts: list[dict], authored: tuple[TypedCheck, ...]
 ) -> list[TypedCheck]:
@@ -65,23 +81,25 @@ def _framework_injected_criteria(
     may have set a different severity, and two rows for one file would double-count in
     the evidence.
     """
-    already = {
-        (c.check, str(c.params.get("file", "")))
-        for c in authored
-        if c.check == CHECK_UNDEFINED_NAMES
-    }
+    already = {(c.check, str(c.params.get("file", ""))) for c in authored}
     injected: list[TypedCheck] = []
-    seen: set[str] = set()
-    for art in artifacts:
-        name = art.get("name") if art.get("name") is not None else art.get("path")
-        if not isinstance(name, str) or not is_check_applicable(CHECK_UNDEFINED_NAMES, name):
-            continue
-        if name in seen or (CHECK_UNDEFINED_NAMES, name) in already:
-            continue
-        seen.add(name)
-        injected.append(
-            TypedCheck(check=CHECK_UNDEFINED_NAMES, params={"file": name}, severity="error")
-        )
+    for check_name in _FILE_SCOPED_FRAMEWORK_CHECKS:
+        spec = CHECK_SPECS[check_name]
+        seen: set[str] = set()
+        for art in artifacts:
+            name = art.get("name") if art.get("name") is not None else art.get("path")
+            if not isinstance(name, str) or not is_check_applicable(check_name, name):
+                continue
+            if name in seen or (check_name, name) in already:
+                continue
+            seen.add(name)
+            injected.append(
+                TypedCheck(
+                    check=check_name,
+                    params={"file": name},
+                    severity=spec.blocking_default,
+                )
+            )
     return injected
 
 

--- a/src/squadops/cycles/acceptance_check_spec.py
+++ b/src/squadops/cycles/acceptance_check_spec.py
@@ -370,6 +370,15 @@ CHECK_ENDPOINT_DEFINED = "endpoint_defined"
 # above — a literal there would silently inject nothing after a rename.
 CHECK_UNDEFINED_NAMES = "undefined_names"
 
+#: #1082: the emission ends inside an unclosed construct — the shape a completion
+#: takes when it runs out of budget mid-file. Narrower than a syntax gate on
+#: purpose: it claims truncation only, so it can be exact on the brace languages
+#: it cannot parse. `frontend_compiles` and `tests_pass` already fail on such a
+#: file, but both run at acceptance — after the producing task is finished — so
+#: the round gets spent by the consumer that tripped over it rather than by the
+#: task that wrote it.
+CHECK_UNTERMINATED_SOURCE = "unterminated_source"
+
 # #629 (1.5 A6/D2): the blocking suite-vs-contract check. Multi-reader constant
 # (injection in task_plan, locus routing in failure_evidence, the evaluator,
 # tests) — same single-source rule as the two above.
@@ -469,6 +478,27 @@ CHECK_SPECS: dict[str, CheckSpec] = {
         notes=(
             "Applied by the framework to .py emissions from handlers on the "
             "typed-acceptance seam (dev, builder); never authored."
+        ),
+        failure_ownership=OWNERSHIP_PRODUCT,
+        qa_available=True,
+        signature_participation=True,
+        outcome_contribution=True,
+        replayable=True,
+        blocking_default="error",
+    ),
+    CHECK_UNTERMINATED_SOURCE: CheckSpec(
+        name=CHECK_UNTERMINATED_SOURCE,
+        applicable_extensions=frozenset({".py", ".ts", ".tsx", ".js", ".jsx"}),
+        required_params=frozenset({"file"}),
+        param_types={"file": str},
+        path_params=frozenset({"file"}),
+        framework_injected=True,
+        example={"file": "app/api/runs/route.ts"},
+        notes=(
+            "Applied by the framework to every scannable emission from handlers on "
+            "the typed-acceptance seam; never authored. Unlike the other file-scoped "
+            "checks it covers the brace languages, because delimiter balance needs no "
+            "parser and therefore no Node (#939's blocker)."
         ),
         failure_ownership=OWNERSHIP_PRODUCT,
         qa_available=True,

--- a/src/squadops/cycles/acceptance_checks.py
+++ b/src/squadops/cycles/acceptance_checks.py
@@ -34,6 +34,7 @@ from squadops.cycles.acceptance_check_spec import (
     CHECK_FILL_SLOT_SIGNATURE,
     CHECK_SPECS,
     CHECK_UNDEFINED_NAMES,
+    CHECK_UNTERMINATED_SOURCE,
     FRONTEND_SUFFIXES,
     HTTP_METHODS,
     CheckSpec,
@@ -41,6 +42,10 @@ from squadops.cycles.acceptance_check_spec import (
     normalize_route,
     parse_method_path,
     parse_method_path_status,
+)
+from squadops.cycles.source_termination import (
+    SCANNABLE_EXTENSIONS,
+    check_termination,
 )
 
 logger = logging.getLogger(__name__)
@@ -307,6 +312,66 @@ def _unparseable_source_skip(file_path: Path) -> CheckOutcome | None:
     if ext != ".py":
         return CheckOutcome.skipped(reason="unsupported_file_extension")
     return None
+
+
+@register_check(CHECK_UNTERMINATED_SOURCE)
+class UnterminatedSourceCheck(BaseCheck):
+    """The emission ends inside an unclosed construct — it was cut off (#1082).
+
+    `cyc_87c12c7f199e` banked a 407-byte route ending on ``throw new`` with three
+    unclosed braces. Nothing questioned it: the bytes look like code, and the
+    checks that would reject it — ``frontend_compiles``, ``tests_pass`` — run at
+    acceptance, long after the producing task finished. So it surfaced as the
+    suite failing two whole test files, one of which merely imported the module,
+    and the analyzer diagnosed from that output instead of from the emission.
+
+    Injected onto the producer's OWN artifacts, so a truncation is charged to the
+    task that wrote it while that task still owns the round.
+
+    **The claim is deliberately narrow.** Not "this file is valid" — only "this
+    file stops mid-construct". On Python that means filtering ``compile``'s
+    SyntaxError down to the EOF-shaped ones; on the brace languages it means
+    delimiter balance and nothing more. Widening it would make this the general
+    syntax gate, which it cannot be on languages it does not parse.
+
+    Validated before it shipped, which is the bar a guard has to clear: swept
+    across all 4,513 scannable source artifacts in the banked corpus, it flagged
+    8 — every one a genuine truncation on inspection, zero false positives. Two
+    false positives found during that sweep drove real fixes rather than a
+    threshold: JSX punctuation (``/>``, ``</``) misread as a regex opener, and
+    parens counted inside JSX text, where an unmatched bracket is legal. A guard
+    that rejects a healthy emission manufactures the defect it exists to prevent.
+    """
+
+    async def evaluate(
+        self,
+        params: dict[str, Any],
+        workspace_root: Path,
+        *,
+        stack: str | None = None,
+    ) -> CheckOutcome:
+        try:
+            file_path = _safe_resolve(params["file"], workspace_root)
+        except _SafetyError as exc:
+            return CheckOutcome.error(reason=exc.reason)
+        if not file_path.is_file():
+            return CheckOutcome.failed(reason="file_not_found", file=str(params["file"]))
+        if file_path.suffix.lower() not in SCANNABLE_EXTENSIONS:
+            return CheckOutcome.skipped(reason="unsupported_file_extension")
+        try:
+            source = file_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return CheckOutcome.error(reason="file_unreadable")
+
+        result = check_termination(source, file_path.suffix)
+        if not result.terminated:
+            return CheckOutcome.failed(
+                reason=f"emission ends mid-construct: {result.reason}",
+                file=str(params["file"]),
+                line=result.line,
+                size_bytes=len(source),
+            )
+        return CheckOutcome.passed(file=str(params["file"]))
 
 
 @register_check(CHECK_UNDEFINED_NAMES)

--- a/src/squadops/cycles/source_termination.py
+++ b/src/squadops/cycles/source_termination.py
@@ -1,0 +1,341 @@
+"""Did this source file stop in the middle of something? (#1082)
+
+A completion that runs out of budget mid-file is stored as if it were whole. The
+bytes look like code, so nothing questions them until something downstream tries
+to parse them — and by then the failure has been re-attributed to the consumer.
+`cyc_87c12c7f199e` shipped a 407-byte route ending on ``throw new`` with three
+unclosed braces; it surfaced as ``tests_pass`` failing two whole test files, one
+of which merely imported the module.
+
+**This module answers one narrow question and refuses the broader one.** It does
+not ask whether the source is valid — only whether it *ends inside an unclosed
+construct*, which is the specific shape truncation takes. A file with a genuine
+syntax error that nonetheless closes everything it opened is somebody else's
+problem; conflating the two would make this check the general syntax gate it is
+not equipped to be, on languages it cannot parse.
+
+**Zero false positives is the bar, and it is higher than catching truncations.**
+A guard that rejects a healthy emission manufactures the defect it exists to
+prevent — the `classify_fences` lesson (``handlers/emission_log.py``), where an
+instrument reported correctly-addressed fences as bare and the wrong diagnosis
+was written down before the vault contradicted it. Every rule here is therefore
+one-sided: an unmatched *closer* is never reported (that is a syntax error, not a
+truncation), and anything the scanner cannot confidently interpret resolves to
+"terminated".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: Extensions this module can scan. Python is handled by the interpreter's own
+#: parser; the brace languages share one scanner.
+PYTHON_EXTENSIONS = frozenset({".py"})
+BRACE_EXTENSIONS = frozenset({".ts", ".tsx", ".js", ".jsx"})
+SCANNABLE_EXTENSIONS = PYTHON_EXTENSIONS | BRACE_EXTENSIONS
+
+_OPENERS = {"{": "}", "(": ")", "[": "]"}
+_CLOSERS = {v: k for k, v in _OPENERS.items()}
+
+#: In JSX, only ``{`` is a delimiter. Element TEXT is prose and may carry an
+#: unmatched bracket — ``Participants ({' '}`` renders a literal "(" whose ")"
+#: lives in a sibling ``{')'}`` expression, and no amount of counting makes those
+#: balance. ``{`` stays safe because it is JSX's own expression delimiter and is
+#: always matched. Scoped by extension rather than by sniffing for JSX, because
+#: the language already draws this line: JSX is only legal in these files.
+_JSX_EXTENSIONS = frozenset({".tsx", ".jsx"})
+
+#: A ``/`` directly after one of these begins a regex literal, not a division.
+#: The distinction matters because a regex may legally contain unbalanced
+#: brackets (``/[{]/``) and counting those would be a false positive. Erring
+#: toward "regex" is the safe direction: a mis-read regex swallows text up to the
+#: next ``/`` and can only ever make the scanner report FEWER unclosed openers.
+_REGEX_PRECEDERS = set("(,=:[!&|?{};+-*%^~<>") | {""}
+
+
+@dataclass(frozen=True)
+class Termination:
+    """Whether a file ends cleanly, and what was left open if not."""
+
+    terminated: bool
+    #: Human-readable reason, empty when terminated.
+    reason: str = ""
+    #: The unclosed opener's 1-based line, when there is one.
+    line: int | None = None
+
+
+TERMINATED = Termination(terminated=True)
+
+
+def _consume_trivia(source: str, i: int, prev_significant: str) -> tuple[int, int, str] | None:
+    """Skip a comment or regex literal starting at ``i``.
+
+    Returns ``(next_index, newlines, error)`` — ``error`` non-empty only for an
+    unterminated block comment. ``None`` when ``i`` does not start trivia.
+    """
+    if source[i] != "/" or i + 1 >= len(source):
+        return None
+    nxt = source[i + 1]
+    if nxt == "/":
+        end = source.find("\n", i)
+        return (len(source) if end == -1 else end, 0, "")
+    if nxt == "*":
+        end = source.find("*/", i + 2)
+        if end == -1:
+            return (len(source), 0, "unterminated block comment")
+        return (end + 2, source.count("\n", i, end), "")
+    # JSX punctuation, not regex. `<Route ... />` and `</div>` are far more
+    # common in this corpus than a regex literal, and misreading one swallows
+    # everything up to the next `/` — which in `path="/"` is inside a string,
+    # unbalancing the rest of the file. Two false positives on complete JSX
+    # (cyc_b7cf604aed46, cyc_02e9af402c82) came from exactly this.
+    if nxt == ">" or prev_significant == "<":
+        return None
+    if prev_significant in _REGEX_PRECEDERS:
+        consumed, _ = _skip_regex(source, i)
+        # An unterminated regex is indistinguishable from a division the
+        # heuristic misread, so treat it as ordinary text rather than guess.
+        if consumed is not None:
+            return (consumed, 0, "")
+    return None
+
+
+def _scan_braces(source: str, tracked: str = "{([") -> Termination:
+    """Walk a brace-language source tracking comments, strings and nesting.
+
+    Deliberately not a tokenizer. It knows just enough to avoid counting
+    delimiters that live inside comments, strings, template literals or regex
+    literals — the four places where a brace does not mean nesting.
+
+    ``tracked`` narrows which openers count; JSX files pass ``"{"`` alone.
+    """
+    stack: list[tuple[str, int]] = []
+    i, line, n = 0, 1, len(source)
+    prev_significant = ""
+
+    while i < n:
+        ch = source[i]
+
+        if ch == "\n":
+            line, i = line + 1, i + 1
+            continue
+
+        # Comments, regex and string/template literals are all "text that is not
+        # code": one branch for the whole category keeps the loop about nesting.
+        skippable = _consume_trivia(source, i, prev_significant) or _consume_literal(
+            source, i, ch, stack, line
+        )
+        if skippable is not None:
+            i, newlines, error = skippable
+            if error:
+                return Termination(False, error, line)
+            line, prev_significant = line + newlines, ch
+            continue
+
+        if ch in _OPENERS and ch in tracked:
+            stack.append((ch, line))
+        elif ch in _CLOSERS and _CLOSERS[ch] in tracked:
+            closed = _close(source, i, ch, stack, line)
+            if closed is None:
+                return Termination(False, "unterminated template literal", line)
+            resumed, newlines = closed
+            if resumed is not None:
+                line, i = line + newlines, resumed
+                continue
+
+        if not ch.isspace():
+            prev_significant = ch
+        i += 1
+
+    if stack:
+        opener, opened_at = stack[0]
+        what = "template literal" if opener == "`" else f"{opener!r}"
+        return Termination(False, f"unclosed {what} opened at line {opened_at}", opened_at)
+    return TERMINATED
+
+
+def _consume_literal(
+    source: str, i: int, ch: str, stack: list[tuple[str, int]], line: int
+) -> tuple[int, int, str] | None:
+    """Skip a quoted string or template literal starting at ``i``.
+
+    Returns ``(next_index, newlines, error)``, or ``None`` when ``ch`` does not
+    open a literal. Both literal kinds are handled here so the main loop keeps
+    one branch for "text that is not code" rather than one per quote character.
+    """
+    if ch in "'\"":
+        end, newlines = _skip_quoted(source, i, ch)
+        if end is None:
+            return (len(source), newlines, f"unterminated {ch!r} string")
+        return (end, newlines, "")
+    if ch == "`":
+        outcome = _enter_template(source, i, stack, line)
+        if outcome is None:
+            return (len(source), 0, "unterminated template literal")
+        end, newlines = outcome
+        return (end, newlines, "")
+    return None
+
+
+def _enter_template(
+    source: str, i: int, stack: list[tuple[str, int]], line: int
+) -> tuple[int, int] | None:
+    """Scan from an opening backtick, pushing a marker if it hits ``${``."""
+    result = _resume_template(source, i + 1)
+    if result is None:
+        return None
+    end, newlines, interpolated = result
+    if interpolated:
+        # The interpolation body is ordinary code and may open braces of its
+        # own, so it goes back through the main loop behind a `\`` marker.
+        stack.append(("`", line))
+    return end, newlines
+
+
+def _close(
+    source: str, i: int, ch: str, stack: list[tuple[str, int]], line: int
+) -> tuple[int | None, int] | None:
+    """Handle a closing delimiter. ``(None, 0)`` when the caller should advance
+    normally, ``(index, newlines)`` when template scanning resumed, ``None`` on
+    an unterminated template."""
+    if stack and stack[-1][0] == _CLOSERS[ch]:
+        stack.pop()
+        return None, 0
+    if stack and stack[-1][0] == "`" and ch == "}":
+        stack.pop()  # closing `${...}` returns to template context
+        result = _resume_template(source, i + 1)
+        if result is None:
+            return None
+        end, newlines, interpolated = result
+        if interpolated:
+            stack.append(("`", line))
+        return end, newlines
+    # An unmatched closer is a syntax error, not a truncation. One-sided by
+    # design: this module never reports it.
+    return None, 0
+
+
+def _skip_quoted(source: str, start: int, quote: str) -> tuple[int | None, int]:
+    """Index just past a single- or double-quoted string, and newlines crossed."""
+    i, newlines, n = start + 1, 0, len(source)
+    while i < n:
+        ch = source[i]
+        if ch == "\\":
+            i += 2
+            continue
+        if ch == quote:
+            return i + 1, newlines
+        if ch == "\n":
+            # An unescaped newline ends these strings in JS/TS. Treat it as the
+            # string ending rather than as truncation: a multi-line quoted string
+            # is a syntax error, and syntax errors are not this module's claim.
+            return i, newlines
+        i += 1
+    return None, newlines
+
+
+def _skip_regex(source: str, start: int) -> tuple[int | None, int]:
+    """Index just past a regex literal's closing ``/``, and newlines crossed."""
+    i, n = start + 1, len(source)
+    in_class = False
+    while i < n:
+        ch = source[i]
+        if ch == "\\":
+            i += 2
+            continue
+        if ch == "\n":
+            return None, 0
+        if ch == "[":
+            in_class = True
+        elif ch == "]":
+            in_class = False
+        elif ch == "/" and not in_class:
+            i += 1
+            while i < n and source[i].isalpha():  # flags
+                i += 1
+            return i, 0
+        i += 1
+    return None, 0
+
+
+def _resume_template(source: str, start: int) -> tuple[int, int, bool] | None:
+    """Scan template text until its closing backtick or an interpolation.
+
+    Returns ``(index, newlines, interpolated)`` — ``interpolated`` True when the
+    scan stopped at a ``${``, whose body the caller feeds back to the main loop.
+    """
+    i, newlines, n = start, 0, len(source)
+    while i < n:
+        ch = source[i]
+        if ch == "\\":
+            i += 2
+            continue
+        if ch == "\n":
+            newlines += 1
+        elif ch == "`":
+            return i + 1, newlines, False
+        elif ch == "$" and i + 1 < n and source[i + 1] == "{":
+            return i + 2, newlines, True
+        i += 1
+    return None
+
+
+def _scan_python(source: str) -> Termination:
+    """Ask CPython, and report only the EOF-shaped failures.
+
+    ``compile`` is exact where the brace scanner is heuristic, so Python gets the
+    real answer. The filter is what keeps the claim narrow: a ``SyntaxError``
+    that is not about running out of input is an ordinary syntax defect, and
+    reporting it here would quietly turn this into the general syntax gate.
+    """
+    try:
+        compile(source, "<emission>", "exec")
+    except SyntaxError as exc:
+        message = str(exc.msg or "")
+        lowered = message.lower()
+        if "unexpected eof" in lowered or "was never closed" in lowered:
+            return Termination(False, message, exc.lineno)
+        # Not every truncation says EOF. A file ending on ``if req:`` reports
+        # "expected an indented block" — an unclosed construct by any reading —
+        # but the same message appears mid-file for an ordinary indentation bug,
+        # so position decides: at the last code line the file ran out, above it
+        # the source is complete and merely wrong.
+        #
+        # Position ALONE is not enough, and an earlier draft that used it alone
+        # was wrong: it flagged every single-line file with any syntax error,
+        # since line 1 is trivially the last line. The message must independently
+        # say something was left open.
+        if "expected an indented block" in lowered and _at_end(exc.lineno, source):
+            return Termination(False, message, exc.lineno)
+        return TERMINATED
+    except ValueError:
+        # Source with NUL bytes and similar; not a truncation claim.
+        return TERMINATED
+    return TERMINATED
+
+
+def _at_end(lineno: int | None, source: str) -> bool:
+    """Is ``lineno`` the last line of ``source`` that carries anything?"""
+    if lineno is None:
+        return False
+    lines = source.splitlines()
+    for idx in range(len(lines) - 1, -1, -1):
+        if lines[idx].strip():
+            return lineno >= idx + 1
+    return False
+
+
+def check_termination(source: str, extension: str) -> Termination:
+    """Does ``source`` end inside an unclosed construct?
+
+    Unscannable extensions resolve to terminated — silence, not a guess. Prose in
+    particular is out of scope: markdown has no delimiter invariant, and
+    "ends mid-sentence" is a heuristic with real false positives on documents
+    that legitimately end in a list item or a fenced block.
+    """
+    ext = extension.lower()
+    if ext in PYTHON_EXTENSIONS:
+        return _scan_python(source)
+    if ext in BRACE_EXTENSIONS:
+        return _scan_braces(source, "{" if ext in _JSX_EXTENSIONS else "{([")
+    return TERMINATED

--- a/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
+++ b/tests/unit/capabilities/handlers/test_typed_acceptance_validation.py
@@ -441,9 +441,10 @@ class TestM13Observability:
         summary_logs = [r for r in caplog.records if "typed_acceptance_summary" in r.getMessage()]
         assert len(summary_logs) == 1
         msg = summary_logs[0].getMessage()
-        # endpoint_defined + the #689-injected undefined_names on main.py.
-        assert "evaluated=2" in msg
-        assert "passed=2" in msg
+        # endpoint_defined + the two framework-injected checks on main.py:
+        # undefined_names (#689) and unterminated_source (#1082).
+        assert "evaluated=3" in msg
+        assert "passed=3" in msg
         assert "blocking_failures=0" in msg
         assert "overall_passed=True" in msg
 

--- a/tests/unit/capabilities/test_builder_assemble_handler.py
+++ b/tests/unit/capabilities/test_builder_assemble_handler.py
@@ -1021,11 +1021,18 @@ class TestTypedAcceptance:
         """Was: no criteria -> no acceptance rows at all. #689 changed that on purpose —
         an assembly that emits a `.py` gets the undefined-name check whether or not the
         plan authored anything, because a call-time NameError in builder-emitted source
-        is the same defect it is anywhere else. The required_files row is unchanged."""
+        is the same defect it is anywhere else. #1082 added the second injected check on
+        the same reasoning: a truncated assembly is a truncated assembly. The
+        required_files row is unchanged."""
         result = await BuilderAssembleHandler().handle(mock_context, builder_inputs)
 
         assert result.success is True
         checks = result.outputs["validation_result"]["checks"]
-        assert [c["check"] for c in checks] == ["required_files", "acceptance:undefined_names"]
-        assert checks[1]["status"] == "passed"
-        assert checks[1]["params"]["file"] == "my_app/__main__.py"
+        assert [c["check"] for c in checks] == [
+            "required_files",
+            "acceptance:undefined_names",
+            "acceptance:unterminated_source",
+        ]
+        for row in checks[1:]:
+            assert row["status"] == "passed"
+            assert row["params"]["file"] == "my_app/__main__.py"

--- a/tests/unit/cycles/test_source_termination.py
+++ b/tests/unit/cycles/test_source_termination.py
@@ -1,0 +1,202 @@
+"""The truncation scanner (#1082).
+
+Two obligations, and the second is the harder one: catch an emission that stopped
+mid-construct, and never flag one that did not. The corpus sweep that gated this
+shipping — 4,513 banked source artifacts, 8 flags, all 8 genuine truncations — is
+the real acceptance evidence; these tests pin the shapes that sweep exercised so
+a later change cannot quietly reintroduce a false positive.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.source_termination import check_termination
+
+pytestmark = [pytest.mark.domain_contracts]
+
+
+# The literal tail of cyc_87c12c7f199e's leave/route.ts, the motivating defect.
+REAL_TRUNCATION = """\
+import { NextRequest, NextResponse } from 'next/server';
+import { ApiError, errorResponse } from '@/lib/errors';
+import { find, insert, TABLES } from '@/lib/store';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { run_id: string } }
+) {
+  try {
+    const body = await request.json();
+    const name: string = body.name;
+
+    if (!name || !String(name).trim()) {
+      throw new
+"""
+
+
+class TestCatchesTruncation:
+    def test_the_motivating_defect(self):
+        """407 bytes ending on `throw new`, three braces open. esbuild called it
+        'Unexpected end of file'; the run called it a qa failure across two test
+        files, one of which only imported the module."""
+        result = check_termination(REAL_TRUNCATION, ".ts")
+        assert not result.terminated
+        assert result.line == 8  # the function body's brace, the outermost one open
+
+    @pytest.mark.parametrize(
+        "source,ext",
+        [
+            ("describe('x', () => {\n  it('y', async () => {\n    expect(res.status", ".ts"),
+            ("const cfg = {\n  body: JSON.stringify({\n    title: 'Run B',", ".ts"),
+            ("export function f(a: number) {\n  return [1, 2,", ".tsx"),
+            ("def handler(req):\n    return {'a': 1,", ".py"),
+            ("def handler(req):\n    if req:", ".py"),
+        ],
+        ids=["mid-expression", "nested-object", "open-array", "py-open-dict", "py-open-block"],
+    )
+    def test_shapes_the_corpus_produced(self, source, ext):
+        assert not check_termination(source, ext).terminated
+
+    def test_unterminated_template_literal(self):
+        source = "const q = `SELECT * FROM ${table} WHERE id ="
+        assert not check_termination(source, ".ts").terminated
+
+
+class TestNeverFlagsHealthySource:
+    @pytest.mark.parametrize(
+        "source,ext",
+        [
+            # A regex holding an unbalanced brace — the classic scanner trap.
+            ("const re = /[{]/;\nexport const ok = true;\n", ".ts"),
+            ("const re = /}/g;\nexport const ok = true;\n", ".ts"),
+            # Braces living inside strings and comments.
+            ("const s = '{';\nconst t = \"}\";\n// { unclosed in a comment\n", ".ts"),
+            ("/* { */\nexport const x = 1;\n", ".ts"),
+            # Template literals, including nested interpolation.
+            ("const a = `x${ y }z`;\nconst b = `${ `${inner}` }`;\n", ".ts"),
+            # JSX, which is where `{` density is highest.
+            (
+                "export default function P() {\n"
+                "  return <div className={cx('a')}>{items.map((i) => (\n"
+                "    <span key={i.id}>{i.name}</span>\n"
+                "  ))}</div>;\n}\n",
+                ".tsx",
+            ),
+            # Division, which must not be read as a regex opener.
+            ("const ratio = total / count / 2;\nexport const r = ratio;\n", ".ts"),
+            # Escaped quotes.
+            ("const s = 'it\\'s {';\nexport const t = s;\n", ".js"),
+            # Python: f-strings, decorators, nested comprehensions.
+            ("x = f'{a}{b}'\ny = [i for i in range(3) if i % 2]\n", ".py"),
+        ],
+        ids=[
+            "regex-with-brace",
+            "regex-with-close-brace",
+            "braces-in-strings",
+            "brace-in-block-comment",
+            "nested-template",
+            "jsx",
+            "division-not-regex",
+            "escaped-quote",
+            "python-fstring",
+        ],
+    )
+    def test_well_formed_source_is_never_flagged(self, source, ext):
+        result = check_termination(source, ext)
+        assert result.terminated, f"false positive: {result.reason}"
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "substantial content here" * 10,  # one line, invalid, NOT truncated
+            "this is not python at all\n",
+            "def f(:\n    pass\n",
+        ],
+        ids=["single-line-prose", "prose", "bad-signature"],
+    )
+    def test_a_syntax_error_alone_is_never_a_truncation_claim(self, source):
+        """Position alone was not enough, and an earlier draft got this wrong.
+
+        Every single-line file with any syntax error has its error on the last
+        line trivially, so a positional rule flagged all of them — caught by the
+        existing output-validation suite, whose fixtures use prose as file
+        content. The message must independently say something was left open.
+        """
+        assert check_termination(source, ".py").terminated
+
+    def test_a_plain_syntax_error_is_not_a_truncation_claim(self):
+        """The claim is 'ends mid-construct', not 'is valid'.
+
+        This file is invalid Python and closes everything it opens. Reporting it
+        would make this the general syntax gate, which it cannot be on the brace
+        languages — and one defect would show up as two.
+        """
+        assert check_termination("def f(:\n    pass\n", ".py").terminated
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            # cyc_b7cf604aed46: `/>` read as a regex opener swallowed text to the
+            # next `/`, which sat inside `path="/"`, unbalancing the whole file.
+            'const x = <Route path="/" element={<div>Runs</div>} />;\n',
+            # `</div>` — the closing-tag slash, same failure.
+            "const x = <div>text</div>;\n",
+        ],
+        ids=["self-closing-tag", "closing-tag"],
+    )
+    def test_jsx_punctuation_is_not_a_regex_opener(self, source):
+        assert check_termination(source, ".tsx").terminated
+
+    def test_jsx_text_may_carry_an_unmatched_bracket(self):
+        """cyc_02e9af402c82's shape, and the reason `(` is untracked in JSX.
+
+        The literal "(" is element TEXT and its ")" lives in a sibling `{')'}`
+        expression. Nothing makes those balance, so counting them at all produces
+        a false positive on a complete, correct file.
+        """
+        source = (
+            "export default function P() {\n"
+            "  return (\n"
+            "    <h2>\n"
+            "      Participants ({' '}\n"
+            "      <span>{n}</span>\n"
+            "      {')'}\n"
+            "    </h2>\n"
+            "  );\n"
+            "}\n"
+        )
+        assert check_termination(source, ".tsx").terminated
+
+    def test_an_unmatched_closer_is_not_reported(self):
+        """One-sided by design: extra closers are a syntax error, never a cut-off."""
+        assert check_termination("export const x = 1;\n}\n", ".ts").terminated
+
+
+class TestScope:
+    def test_parens_are_tracked_outside_jsx_and_not_within(self):
+        """The tradeoff, stated as a test so it cannot drift silently.
+
+        Four of the corpus's eight truncations are `.ts` test files cut mid-call,
+        which only an unclosed `(` reveals. JSX files give that up — element text
+        may hold an unmatched bracket — and keep `{`, which is JSX's own
+        expression delimiter and always balances.
+        """
+        # A cut with NO unclosed brace — only the open paren reveals it.
+        cut = "const created = await createRun(\n  'Morning Loop',\n  '2026-09-02',"
+        assert not check_termination(cut, ".ts").terminated
+        assert check_termination(cut, ".tsx").terminated
+
+    @pytest.mark.parametrize("ext", [".md", ".json", ".yaml", ".txt", ""])
+    def test_unscannable_extensions_resolve_to_terminated(self, ext):
+        """Prose is deliberately out of scope.
+
+        The census's second instance is a qa_handoff.md that stopped mid-paragraph,
+        and it stays uncaught: markdown has no delimiter invariant, and
+        'ends mid-sentence' false-positives on documents that legitimately end in
+        a list item or a fenced block. Silence beats a guess here.
+        """
+        assert check_termination("a paragraph that just stops mid", ext).terminated
+
+    def test_empty_source_is_terminated(self):
+        assert check_termination("", ".ts").terminated


### PR DESCRIPTION
Closes #1082

Second item of the 1.6.3 stack (plan: PR #1080 §2.c). It targets the one loss class in the 08-14→08-23 census that is still live and unguarded.

## The gap

A completion that runs out of budget mid-file is stored as if it were whole. `cyc_87c12c7f199e` banked a 407-byte route ending on `throw new` with three unclosed braces. Nothing questioned it — the bytes look like code — until the suite tried to transform it, and then the failure belonged to somebody else: `tests_pass` red across **two whole test files**, one of which merely imported the module, correction budget already spent, and the analyzer diagnosing from suite output rather than from the emission.

`frontend_compiles` and `tests_pass` do reject such a file. Both run at acceptance, *after* the producing task is finished. This check is injected on the producer's **own** artifacts (the #689 seam), so a truncation is charged to the task that wrote it while that task still owns the round.

## Deliberately narrow

Not "this file is valid" — only "this file ends inside an unclosed construct". Python gets the exact answer from `compile`, filtered to the EOF-shaped errors; the brace languages get delimiter balance and nothing more. Widening it would make this the general syntax gate, which it cannot be on languages it does not parse.

That narrowness is also what makes it viable where a real TypeScript check is not: **delimiter balance needs no parser and therefore no Node**, which is #939's blocker and #1021's suspected mechanism.

## Validation found more than it confirmed

Swept across **all 4,513 scannable source artifacts** in the banked corpus: **8 flags, every one a genuine truncation on inspection, zero false positives.** Three of the eight had been masked by an over-conservative early return.

Two false positives surfaced during the sweep, and each drove a real fix rather than a tuned threshold:

- **JSX punctuation read as a regex opener.** `<Route ... />` made the scanner treat `/>` as a regex, swallowing text to the next `/` — which sat inside `path="/"` — and unbalancing the whole file.
- **Parens counted inside JSX text.** `Participants ({' '}` renders a literal `(` whose `)` lives in a sibling `{')'}` expression. Those never balance, so `(`/`[` are untracked in `.tsx`/`.jsx`; `{` stays, being JSX's own always-matched delimiter. Four of the eight corpus truncations are `.ts` test files that only an unclosed `(` reveals, so the tradeoff is scoped by extension rather than surrendered.

A third false positive came from the test suite rather than the corpus: an earlier Python fallback used position alone ("error on the last line"), which flags every single-line file with any syntax error. The message must independently say something was left open. All three are pinned as tests.

## Out of scope, and said so

Prose. The census's second instance is a `qa_handoff.md` that stopped mid-paragraph; markdown has no delimiter invariant and "ends mid-sentence" false-positives on documents that legitimately end in a list item. Silence beats a guess.

Worth noting: that second instance is attested only by the analyzer's round-0 account — **the truncated bytes were discarded**, which is #971's defect illustrating itself.

## Incidental

`_framework_injected_criteria` now derives its check list from the registry (framework-injected, sole param `file`) rather than naming one check inline, so the menu and the injector cannot drift.

## Tests

31 on the scanner, split between catching the shapes the corpus produced and never flagging healthy ones — regex holding braces, JSX text, nested template interpolation, division-not-regex, escaped quotes, f-strings. Regression suite: **7860 passed, 1 skipped, all gates**.
