### PR TITLE
fix(audit): the oracle and the runner judge a contract with the same code

### DIFF
--- a/scripts/dev/audit_delivered_app.py
+++ b/scripts/dev/audit_delivered_app.py
@@ -49,6 +49,7 @@ import httpx
 
 from adapters.sandbox.container_backend import ContainerBackend
 from adapters.tools.docker import DockerAdapter
+from squadops.capabilities.handlers.probe_runner import evaluate_expectations
 from squadops.capabilities.ui_data_path import (
     LIVE_SERVER,
     SERVED,
@@ -193,22 +194,14 @@ async def _run_probes(contract: VerificationContract, base_url: str) -> list[str
                 payload = resp.json()
             except ValueError:
                 payload = None
-            expected = probe.expect.get("status")
-            if expected is not None and resp.status_code != expected:
-                failures.append(
-                    f"probe {probe.id}: status {resp.status_code} != expected {expected}"
-                )
+            # #1079: the SAME judgment the in-cycle runner applies. This block used
+            # to be a second implementation carrying two of the three expectation
+            # kinds — it had no `json_has` branch — so the oracle was quietly the
+            # more permissive of the two judges of one contract.
+            failure = evaluate_expectations(probe.expect, resp.status_code, payload)
+            if failure is not None:
+                failures.append(f"probe {probe.id}: {failure}")
                 continue
-            error_code = probe.expect.get("error_code")
-            if error_code is not None:
-                actual = (
-                    (payload.get("error") or {}).get("code") if isinstance(payload, dict) else None
-                )
-                if actual != error_code:
-                    failures.append(
-                        f"probe {probe.id}: error_code {actual!r} != expected {error_code!r}"
-                    )
-                    continue
             if probe.capture:
                 captured, missing_key = capture_probe_values(probe, payload)
                 if missing_key is not None:

--- a/src/squadops/capabilities/handlers/probe_runner.py
+++ b/src/squadops/capabilities/handlers/probe_runner.py
@@ -33,6 +33,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -485,6 +486,39 @@ def _wait_ready(profile: ExecutionProfile, port: int) -> bool:
     return False
 
 
+def evaluate_expectations(expect: Mapping[str, Any], status_code: int, payload: Any) -> str | None:
+    """Judge a response against a probe's ``expect`` block. ``None`` means it passed.
+
+    **Extracted because it was written twice (#1079).** The in-cycle runner had all
+    three expectation kinds; ``scripts/dev/audit_delivered_app.py`` — the independent
+    oracle that decides whether a delivered app actually works — re-implemented the
+    block inline and had only two, silently skipping ``json_has``. Two judges of the
+    same contract, and the permissive one was the one whose verdict we trusted most.
+
+    Transport stays with each caller (the runner is sync against a sandbox URL, the
+    auditor async against its own client); only the judgment is shared, because the
+    judgment is what must not differ.
+    """
+    exp_status = expect.get("status")
+    if exp_status is not None and status_code != exp_status:
+        return f"status {status_code} != expected {exp_status}"
+
+    json_has = expect.get("json_has")
+    if json_has:
+        if payload is None:
+            return "response body is not JSON"
+        missing = [key for key in json_has if not _has_key(payload, key)]
+        if missing:
+            return f"response missing key(s): {missing}"
+
+    error_code = expect.get("error_code")
+    if error_code is not None:
+        actual = _error_code_of(payload)
+        if actual != error_code:
+            return f"error_code {actual!r} != expected {error_code!r}"
+    return None
+
+
 def _run_one(
     base_url: str, probe: Probe, profile: ExecutionProfile, context: dict[str, str]
 ) -> ProbeOutcome:
@@ -506,30 +540,10 @@ def _run_one(
     except httpx.HTTPError as exc:
         return ProbeOutcome(probe.id, "failed", f"request error: {exc}")
 
-    expect = probe.expect
-    exp_status = expect.get("status")
-    if exp_status is not None and resp.status_code != exp_status:
-        return ProbeOutcome(
-            probe.id, "failed", f"status {resp.status_code} != expected {exp_status}"
-        )
-
     payload = _json_or_none(resp)
-
-    json_has = expect.get("json_has")
-    if json_has:
-        if payload is None:
-            return ProbeOutcome(probe.id, "failed", "response body is not JSON")
-        missing = [key for key in json_has if not _has_key(payload, key)]
-        if missing:
-            return ProbeOutcome(probe.id, "failed", f"response missing key(s): {missing}")
-
-    error_code = expect.get("error_code")
-    if error_code is not None:
-        actual = _error_code_of(payload)
-        if actual != error_code:
-            return ProbeOutcome(
-                probe.id, "failed", f"error_code {actual!r} != expected {error_code!r}"
-            )
+    failure = evaluate_expectations(probe.expect, resp.status_code, payload)
+    if failure is not None:
+        return ProbeOutcome(probe.id, "failed", failure)
 
     # #651: captures apply only on a passed probe. A missing capture key is a
     # contract violation by the app (the reference fill proves the key exists).

--- a/tests/unit/cli_tools/test_audit_probe_parity.py
+++ b/tests/unit/cli_tools/test_audit_probe_parity.py
@@ -1,0 +1,86 @@
+"""The oracle and the in-cycle runner judge a contract the same way (#1079).
+
+`audit_delivered_app` decides whether a delivered app actually works, independently
+of the run's own verdict. It used to re-implement the probe expectation block inline
+and carried two of the three kinds — no `json_has` branch — so of the two judges of
+one contract, the one whose verdict carried the most weight was the more permissive.
+
+Nothing had caught it because `json_has` has no producer yet (the other half of
+#1079). These tests exist so it cannot regress in the window between a producer
+landing and someone noticing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from squadops.capabilities.handlers.probe_runner import evaluate_expectations
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "dev" / "audit_delivered_app.py"
+_spec = importlib.util.spec_from_file_location("audit_delivered_app_parity", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["audit_delivered_app_parity"] = _mod
+_spec.loader.exec_module(_mod)
+
+
+def test_the_oracle_uses_the_runners_judgment_not_its_own():
+    """One function, not two implementations that agree today.
+
+    Asserting the identity rather than comparing behaviours is the point: matching
+    outputs on sampled inputs is what the previous arrangement had, right up until
+    a third expectation kind was added to one side.
+    """
+    assert _mod.evaluate_expectations is evaluate_expectations
+
+
+class TestExpectationJudgment:
+    def test_a_fully_matching_response_passes(self):
+        expect = {"status": 200, "json_has": ["id", "participants"]}
+        assert evaluate_expectations(expect, 200, {"id": 1, "participants": []}) is None
+
+    def test_missing_key_is_named(self):
+        failure = evaluate_expectations({"json_has": ["id", "participants"]}, 200, {"id": 1})
+        assert failure == "response missing key(s): ['participants']"
+
+    def test_list_response_requires_the_key_in_every_element(self):
+        expect = {"json_has": ["id"]}
+        assert evaluate_expectations(expect, 200, [{"id": 1}, {"id": 2}]) is None
+        assert evaluate_expectations(expect, 200, [{"id": 1}, {"x": 2}]) == (
+            "response missing key(s): ['id']"
+        )
+
+    def test_empty_collection_satisfies_json_has(self):
+        """An empty list has no element that lacks the key.
+
+        Same boundary #1029's floor settled: absence of data is not evidence of a
+        shape defect, and a probe that fails on an empty collection would fail every
+        list endpoint before anything is created.
+        """
+        assert evaluate_expectations({"json_has": ["id"]}, 200, []) is None
+
+    def test_non_json_body_fails_when_a_shape_is_expected(self):
+        assert evaluate_expectations({"json_has": ["id"]}, 200, None) == "response body is not JSON"
+
+    def test_status_is_judged_before_shape(self):
+        """A 500 should report the status, not a list of keys its error body lacks."""
+        failure = evaluate_expectations({"status": 201, "json_has": ["id"]}, 500, {"error": {}})
+        assert failure == "status 500 != expected 201"
+
+    @pytest.mark.parametrize(
+        "payload,expected",
+        [
+            ({"error": {"code": "run_not_found"}}, None),
+            ({"error": {"code": "other"}}, "error_code 'other' != expected 'run_not_found'"),
+            ({}, "error_code None != expected 'run_not_found'"),
+        ],
+        ids=["match", "mismatch", "absent"],
+    )
+    def test_error_code_reads_the_pinned_envelope(self, payload, expected):
+        assert evaluate_expectations({"error_code": "run_not_found"}, 404, payload) == expected
+
+    def test_an_empty_expect_block_passes_anything(self):
+        assert evaluate_expectations({}, 500, None) is None


### PR DESCRIPTION
Closes #1079 (parity half)

Third and last item of the 1.6.3 stack (plan: PR #1080 §2.c), and a **blocking precondition** for the repeatability set under pre-registration §2.b.

## The gap

`audit_delivered_app` decides whether a delivered app actually works, independently of the run's own verdict. It re-implemented the probe expectation block inline and carried **two of the three kinds** — no `json_has` branch — and inlined its own envelope read rather than using `probe_runner._error_code_of`.

Two judges of one contract, and the one whose verdict carries the most weight was the more permissive.

Nothing had caught it because `json_has` still has no producer — the other half of #1079, deliberately left out here because it moves the contract hash and would void the set's freeze. So this is precisely the window in which it bites: a producer lands, and the oracle silently under-checks until someone notices.

## The fix

The duplication was the defect; the missing branch was its symptom. So one judgment is shared rather than a third kind added to a second copy.

`evaluate_expectations(expect, status_code, payload)` is extracted from `_run_one`, and both callers use it. Transport stays with each — the runner is sync against a sandbox URL, the auditor async against its own client — because only the *judgment* must not differ.

## Why it blocks the set

Inheriting V7 §2.a: *a set measuring zero manual intervention cannot require manual intervention to score itself.* #952/#953 were ruled blocking for exactly this reason in the V7 window. The 1.6.3 set's headline metric is boot-audit PASS, so an oracle that skips an expectation kind would make a green set unfalsifiable in the direction least worth trusting.

## Tests

Parity is asserted as **function identity**, not as agreeing outputs — matching behaviour on sampled inputs is exactly what the previous arrangement had, right up until a third expectation kind was added to one side.

Plus the judgment's own cases: list responses requiring the key in every element, the empty-collection boundary #1029 settled, non-JSON bodies, and status being judged before shape (a 500 should report its status, not list the keys its error body lacks).

Regression suite: **7869 passed, 1 skipped, all gates**.
