### PR TITLE
docs(plan): the set's gate policy covers both approval paths, not just the human one

### DIFF
--- a/docs/plans/1-6-3-repeatability-set-preregistration.md
+++ b/docs/plans/1-6-3-repeatability-set-preregistration.md
@@ -178,6 +178,7 @@ whether a specific 1.6.2 fix bit:
 | Repair-induced regressions | #994 |
 | `criteria_verified` / `criteria_total`, and unevidenced count | #1021 |
 | Completion tokens by role · cycle wall clock | cost, and #998-class cap-exhaustion events |
+| Gate `decided_by`, verbatim | which approval path ran (§6.1) — never inferred |
 
 **Contract size**, non-gating, no floor, read from stored artifacts (V7 §7.1 inherited): probe
 count from `behavioral.probes`, slot count from the `verification_scaffold_manifest`.
@@ -228,6 +229,35 @@ System plan validation passed; no additional judgment applied.
 ```
 
 Recorded `--as-agent`.
+
+### 6.1 Two approval paths, and why the record must name which one ran
+
+The rule above assumes a gate opens for a decision. **It does not always open.** Shakeout 1
+(`cyc_3ba9dc0f67da`) auto-approved via `system:no_open_questions` — the manifest declared no
+unresolved decisions, so nothing was ever put to a human. V7 saw the same split within one
+window: its rolls 1–3 carried an operator approval and roll 4 auto-approved, which is what
+made §7.3 a ruling rather than an afterthought.
+
+Left unstated, "zero manual intervention" would silently mean two different things inside one
+set, and the difference would track **whether the manifest happened to declare an open
+question** — an authoring accident, not a capability difference. That is precisely the
+objection §7.3 raised against candidate ruling (b), and it applies here whether or not the
+approval is counted.
+
+**Therefore, and pre-registered rather than decided later:**
+
+- **Both paths satisfy §5's zero-intervention requirement.** `system:no_open_questions` is the
+  framework deciding under a rule; the §6 constant is the operator applying a fixed text under
+  a rule. Neither is judgment about *this* roll's content, which is the only thing that could
+  bias one roll relative to another.
+- **The per-roll record names the decider verbatim** — the `decided_by` value from
+  `cycle_gate_decisions`, so `system:no_open_questions` and `human:<id>` are distinguishable
+  after the fact without inference.
+- **The split is reported in the closing claim**, as a count. If the set divides across the two
+  paths, that division is a fact about the rolls and is stated; it is not smoothed over, and it
+  is not used to reweight anything.
+- A `system:plan_validation` **rejection** is neither path: the framing re-rolls under
+  `framing_max_rerolls`, and §4 counts it as framing tax.
 
 ---
 


### PR DESCRIPTION
§6 wrote the gate policy as a verbatim approval constant, which assumes a gate opens for a decision. **It does not always open.** Shakeout 1 (`cyc_3ba9dc0f67da`) auto-approved via `system:no_open_questions` — the manifest declared no unresolved decisions, so nothing was ever put to a human and the constant never applied.

Left as it was, "zero manual intervention" would silently mean two different things inside one set, and the difference would track **whether the manifest happened to declare an open question** — an authoring accident, not a capability difference. That is precisely the objection V7 §7.3 raised against its candidate ruling (b), and V7 hit the split for real: rolls 1–3 operator-approved, roll 4 auto-approved.

§6.1 pre-registers the answer rather than leaving it to be settled once the rolls are in and a preference exists:

- **Both paths satisfy §5.** One is the framework deciding under a rule, the other the operator applying a fixed text under a rule. Neither is judgment about *this roll's* content, which is the only thing that could bias one roll relative to another.
- **The per-roll record names the decider verbatim** (`decided_by` from `cycle_gate_decisions`), so the two are distinguishable after the fact without inference. Added as a §4 texture field.
- **The closing claim reports the split as a count** rather than smoothing it, and does not use it to reweight anything.
- A `system:plan_validation` **rejection** is neither path — the framing re-rolls, and §4 counts it as framing tax.

Refs #1080