### PR TITLE
fix(version): the framework version comes from the file, not an install-time copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 SquadOps is a multi-agent orchestration framework for software development. It uses a hexagonal architecture (ports & adapters) with dependency injection for testability.
 
-**Framework Version**: 1.6.3 (single-sourced via `importlib.metadata.version("squadops")`)
+**Framework Version**: 1.6.3 (single-sourced from `pyproject.toml`; installed metadata is the
+install-time copy and is used only when no source tree is present — #1089)
 **Python Requirement**: 3.11+ (production runs 3.11); develop and test on **Python 3.12** to match CI
 
 ## Commands

--- a/scripts/maintainer/version_cli.py
+++ b/scripts/maintainer/version_cli.py
@@ -27,18 +27,17 @@ INSTANCES_PATH = REPO_ROOT / "agents" / "instances" / "instances.yaml"
 
 
 def get_framework_version() -> str:
-    """Get framework version from squadops package."""
-    try:
-        # Try importing directly
-        sys.path.insert(0, str(REPO_ROOT / "src"))
-        from squadops import __version__
+    """Read the version from ``pyproject.toml`` — the file this tool edits.
 
-        return __version__
-    except ImportError:
-        # Fall back to parsing pyproject.toml
-        content = PYPROJECT_PATH.read_text()
-        match = re.search(r'version\s*=\s*"([^"]+)"', content)
-        return match.group(1) if match else "unknown"
+    #1089: this used to import ``squadops.__version__``, which on an editable install
+    is a copy made at install time. Bumping 1.6.2 to 1.6.3 therefore announced
+    "Version bumped: 1.4.0 -> 1.6.3" — the edit was right and the claim about the
+    prior state was four minor releases stale. A tool whose output is a correctness
+    claim about a file must read that file.
+    """
+    content = PYPROJECT_PATH.read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    return match.group(1) if match else "unknown"
 
 
 def get_agents() -> list[dict]:

--- a/src/squadops/__init__.py
+++ b/src/squadops/__init__.py
@@ -28,9 +28,9 @@ Quick Start:
     result = await system.task_service.execute_task(request)
 """
 
-from importlib.metadata import version as _pkg_version
+from squadops._version import resolve_version as _resolve_version
 
-__version__ = _pkg_version("squadops")
+__version__ = _resolve_version()
 
 # Core exports for quick access
 from squadops.agents import (

--- a/src/squadops/_version.py
+++ b/src/squadops/_version.py
@@ -1,0 +1,49 @@
+"""Where the framework version comes from (#1089).
+
+``pyproject.toml`` is the single source. Installed metadata is a **copy made at
+install time** — correct for a real install, because the copy is made from the file,
+and stale from the moment the file changes in an editable one, because nothing
+regenerates it.
+
+That drift is not hypothetical. On a tree at 1.6.3 the call documented as
+authoritative returned ``1.4.0``; ``squadops --version`` printed it, and
+``version_cli.py`` — whose entire job is version correctness — announced
+"Version bumped: 1.4.0 -> 1.6.3" while correctly editing 1.6.2.
+
+Its own module rather than a function in ``__init__``: a definition between the
+imports there pushes every later import past ruff's E402, and "where does the version
+come from" is a concern of its own regardless.
+"""
+
+from __future__ import annotations
+
+import re
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+
+_VERSION_RE = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
+
+
+def resolve_version() -> str:
+    """The version, preferring a source checkout over the install-time copy.
+
+    A source tree wins because it is the thing being edited. Otherwise metadata,
+    which is correct for an installed package and is all that exists there — the fix
+    must not trade a stale dev version for a broken production one.
+    """
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except OSError:
+        text = ""
+    # Only trust a pyproject that declares THIS package: a checkout nested inside an
+    # unrelated project must not report the neighbour's version.
+    if 'name = "squadops"' in text:
+        match = _VERSION_RE.search(text)
+        if match:
+            return match.group(1)
+    try:
+        return _pkg_version("squadops")
+    except PackageNotFoundError:
+        return "unknown"

--- a/tests/unit/architecture/test_version_resolution.py
+++ b/tests/unit/architecture/test_version_resolution.py
@@ -1,0 +1,83 @@
+"""The framework version comes from the file, not from an install-time copy (#1089).
+
+`pyproject.toml` is the single source. Installed metadata is a copy made when the
+package was installed — correct for a real install, and stale from the moment the file
+changes in an editable one. On a tree at 1.6.3 the documented-authoritative call
+returned **1.4.0**, the CLI printed it, and `version_cli.py` — whose entire job is
+version correctness — announced "Version bumped: 1.4.0 -> 1.6.3" while correctly
+editing 1.6.2.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+PYPROJECT = REPO / "pyproject.toml"
+
+pytestmark = [pytest.mark.domain_contracts]
+
+
+def _file_version() -> str:
+    m = re.search(r'^version\s*=\s*"([^"]+)"', PYPROJECT.read_text(), re.MULTILINE)
+    assert m, "pyproject.toml has no version"
+    return m.group(1)
+
+
+def test_package_version_matches_the_file_not_the_installed_copy():
+    """The bug, pinned. This fails whenever an editable install goes stale."""
+    import squadops
+
+    assert squadops.__version__ == _file_version()
+
+
+def test_maintainer_tool_reads_the_file_it_edits():
+    """`version_cli.py`'s "from" is a claim about `pyproject.toml`, so it must read it."""
+    import importlib.util
+    import sys
+
+    path = REPO / "scripts" / "maintainer" / "version_cli.py"
+    spec = importlib.util.spec_from_file_location("version_cli_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["version_cli_under_test"] = mod
+    spec.loader.exec_module(mod)
+
+    assert mod.get_framework_version() == _file_version()
+
+
+class TestResolutionOrder:
+    """The order matters in both directions, so both directions are tested."""
+
+    def test_a_foreign_pyproject_is_ignored(self, tmp_path, monkeypatch):
+        """A checkout nested inside an unrelated project must not read the neighbour's
+        version. The guard is the `name = "squadops"` declaration, not the filename."""
+        from squadops._version import resolve_version
+
+        foreign = tmp_path / "pkg" / "squadops"
+        foreign.mkdir(parents=True)
+        (tmp_path / "pyproject.toml").write_text('name = "something-else"\nversion = "9.9.9"\n')
+
+        monkeypatch.setattr("squadops._version.__file__", str(foreign / "_version.py"))
+        # Falls through to metadata rather than reporting 9.9.9.
+        assert resolve_version() != "9.9.9"
+
+    def test_falls_back_to_metadata_with_no_source_tree(self, tmp_path, monkeypatch):
+        """The installed-package case: no `pyproject.toml` anywhere above the package.
+
+        This is the path a deployed container takes, and it must keep working — the
+        fix must not trade a stale dev version for a broken production one.
+        """
+        from squadops._version import resolve_version
+
+        installed = tmp_path / "site-packages" / "squadops"
+        installed.mkdir(parents=True)
+        monkeypatch.setattr("squadops._version.__file__", str(installed / "_version.py"))
+
+        resolved = resolve_version()
+        assert re.fullmatch(r"\d+\.\d+\.\d+", resolved), (
+            f"metadata fallback returned {resolved!r}; a deployed image resolves its "
+            "version this way and has no pyproject.toml to fall back to"
+        )

--- a/tests/unit/cli/test_commands_meta.py
+++ b/tests/unit/cli/test_commands_meta.py
@@ -3,7 +3,6 @@ Unit tests for meta commands: version, status (SIP-0065 §6.3).
 """
 
 import json
-from importlib.metadata import version as pkg_version
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
@@ -85,10 +84,19 @@ def _mock_client_get_health_only(path):
 
 
 class TestVersionFlag:
-    def test_prints_version(self):
+    def test_prints_the_frameworks_own_version(self):
+        """The CLI must agree with the package, whatever the package resolves to.
+
+        This asserted `importlib.metadata.version("squadops")` — the install-time copy
+        — and so pinned the #1089 defect: on a tree at 1.6.3 it demanded the CLI print
+        `1.4.0`, and passed while the CLI was wrong. The invariant worth holding is
+        agreement between the two surfaces, not either one's source.
+        """
+        import squadops
+
         result = runner.invoke(app, ["--version"])
         assert result.exit_code == 0
-        assert pkg_version("squadops") in result.output
+        assert squadops.__version__ in result.output
 
     def test_short_flag(self):
         result = runner.invoke(app, ["-V"])


### PR DESCRIPTION
Closes #1089

CLAUDE.md said the version was *"single-sourced via `importlib.metadata.version('squadops')`"*. On a tree at 1.6.3 that call returned **1.4.0**. `squadops --version` printed it. And `version_cli.py` — whose entire job is version correctness — announced "Version bumped: **1.4.0** -> 1.6.3" while correctly editing 1.6.2.

An editable install writes its metadata once, at install time, and nothing regenerates it when `pyproject.toml` changes. So the surface documented as authoritative had been serving a number four minor releases old, and the tooling repeated it without noticing.

**Deployed containers were unaffected** — the image build reinstalls — which is exactly why it survived. Every place that would have caught it was looking at a correct copy.

## The model

`pyproject.toml` is the single source; installed metadata is the **install-time copy** of it. Resolution follows: a source checkout wins because it's the thing being edited; otherwise metadata, which is correct for an installed package and is all that exists there.

- The fallback is **tested directly** — the fix must not trade a stale dev version for a broken production one.
- Guarded by `name = "squadops"` rather than by filename, so a checkout nested inside an unrelated project cannot report the neighbour's version.
- Lives in its own module rather than as a function in `__init__`: a definition between the imports there pushes every later import past E402, and *"where does the version come from"* is a concern of its own.
- `version_cli.py` now reads the file it edits — its "from → to" line is a correctness claim about `pyproject.toml`.

## One test was pinning the defect

`tests/unit/cli/test_commands_meta.py` asserted the CLI printed `importlib.metadata.version("squadops")`. On a 1.6.3 tree it therefore **demanded the output say 1.4.0**, and passed while the CLI was wrong. It now asserts the CLI agrees with the package — the invariant worth holding, with neither surface's source pinned.

## Why it matters beyond itself

This is the **1.7 hardening class in miniature** — *the signal that says it's fine isn't wired to what ships* — alongside the rebuild that exits 0 with stale agents and #1076's captured-nothing release package.

Found during the v1.6.3 cut. Regression suite **7873 passed, all gates**.