### PR TITLE
docs(release): correct the v1.6.3 attribution in CHANGELOG and the release package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,13 @@ true-by-ruling.
   first attempt — against **three** framing runs for the pre-1.6.2 green roll. That is 1.6.2's
   success-status single-sourcing (#1067/#1070A), measured rather than asserted.
 
-**Two of the three failures were the framework wrongly rejecting a working application** (#1087,
-filed from the set). That is the release's most actionable finding, and it matters more than the
-rate.
+**The finding that outranks the rate — corrected 2026-08-25 (record §6):** the cut-time reading
+was that two of the three failures were the framework wrongly rejecting a working application
+(#1087). The stored per-round test reports say otherwise: all three rejected applications failed
+the frozen response floor of the join probe at every round, and the phantom-table assertion was a
+second failure in two of them, never the only one. The loss mode is the repair round not acting on
+a correct round-0 diagnosis — wrong file emitted, nothing emitted, or a correct repair discarded by
+a contract-violating fill (#1094). #1087 stands as a defect; its yield on this set was zero rolls.
 
 ### Fixed
 

--- a/site/content/releases/v1.6.3/index.md
+++ b/site/content/releases/v1.6.3/index.md
@@ -24,9 +24,13 @@ true-by-ruling.
   first attempt — against **three** framing runs for the pre-1.6.2 green roll. That is 1.6.2's
   success-status single-sourcing (#1067/#1070A), measured rather than asserted.
 
-**Two of the three failures were the framework wrongly rejecting a working application** (#1087,
-filed from the set). That is the release's most actionable finding, and it matters more than the
-rate.
+**The finding that outranks the rate — corrected 2026-08-25 (record §6):** the cut-time reading
+was that two of the three failures were the framework wrongly rejecting a working application
+(#1087). The stored per-round test reports say otherwise: all three rejected applications failed
+the frozen response floor of the join probe at every round, and the phantom-table assertion was a
+second failure in two of them, never the only one. The loss mode is the repair round not acting on
+a correct round-0 diagnosis — wrong file emitted, nothing emitted, or a correct repair discarded by
+a contract-violating fill (#1094). #1087 stands as a defect; its yield on this set was zero rolls.
 
 ### Fixed
 

--- a/site/content/releases/v1.6.3/package.yaml
+++ b/site/content/releases/v1.6.3/package.yaml
@@ -17,19 +17,25 @@ narrative: "**The measurement patch line.** 1.6.2 merged roughly twenty fixes an
   \ eight**, and ten consecutive cycles have now framed on the\n  first attempt —\
   \ against **three** framing runs for the pre-1.6.2 green roll. That is 1.6.2's\n\
   \  success-status single-sourcing (#1067/#1070A), measured rather than asserted.\n\
-  \n**Two of the three failures were the framework wrongly rejecting a working application**\
-  \ (#1087,\nfiled from the set). That is the release's most actionable finding, and\
-  \ it matters more than the\nrate.\n\n### Fixed\n\n- **#971** — a failed task's emission\
-  \ is banked for triage instead of discarded. Before this, the\n  one artifact guaranteed\
-  \ absent was the one that *caused* the failure. Triage-only, with three\n  independent\
-  \ exclusions so known-bad bytes can never reach a workspace or the deliverable.\
-  \ The\n  set banked 44/48/11/48/11 failed emissions on the rolls that needed them,\
-  \ and roll 1's root\n  cause was traced by reading artifacts that would not previously\
-  \ have existed.\n- **#1082** — an emission that stopped mid-construct is caught\
-  \ at the task that wrote it, rather\n  than surfacing later as the consumer's test\
-  \ failure. Validated against all 4,513 scannable\n  source artifacts in the banked\
-  \ corpus: 8 flags, every one a genuine truncation, zero false\n  positives. Two\
-  \ false positives found *during* that validation drove real fixes (JSX punctuation\n\
+  \n**The finding that outranks the rate — corrected 2026-08-25 (record §6):** the\
+  \ cut-time reading\nwas that two of the three failures were the framework wrongly\
+  \ rejecting a working application\n(#1087). The stored per-round test reports say\
+  \ otherwise: all three rejected applications failed\nthe frozen response floor of\
+  \ the join probe at every round, and the phantom-table assertion was a\nsecond failure\
+  \ in two of them, never the only one. The loss mode is the repair round not acting\
+  \ on\na correct round-0 diagnosis — wrong file emitted, nothing emitted, or a correct\
+  \ repair discarded by\na contract-violating fill (#1094). #1087 stands as a defect;\
+  \ its yield on this set was zero rolls.\n\n### Fixed\n\n- **#971** — a failed task's\
+  \ emission is banked for triage instead of discarded. Before this, the\n  one artifact\
+  \ guaranteed absent was the one that *caused* the failure. Triage-only, with three\n\
+  \  independent exclusions so known-bad bytes can never reach a workspace or the\
+  \ deliverable. The\n  set banked 44/48/11/48/11 failed emissions on the rolls that\
+  \ needed them, and roll 1's root\n  cause was traced by reading artifacts that would\
+  \ not previously have existed.\n- **#1082** — an emission that stopped mid-construct\
+  \ is caught at the task that wrote it, rather\n  than surfacing later as the consumer's\
+  \ test failure. Validated against all 4,513 scannable\n  source artifacts in the\
+  \ banked corpus: 8 flags, every one a genuine truncation, zero false\n  positives.\
+  \ Two false positives found *during* that validation drove real fixes (JSX punctuation\n\
   \  read as a regex opener; parens counted inside JSX text) rather than a tuned threshold.\n\
   - **#1079** (parity half) — the boot-audit oracle and the in-cycle probe runner\
   \ judge a contract\n  with the same code. The oracle had re-implemented the expectation\


### PR DESCRIPTION
The v1.6.3 notes say two of the three failures were the framework wrongly rejecting a working application. The stored per-round test reports say otherwise (`docs/plans/1-6-3-repeatability-set-record.md` §6, merged in #1093): all three rejected applications failed the frozen response floor of the join probe at every round; the phantom-table assertion (#1087) was a second failure in two of them, never the only one.

#1093 corrected the record and the ROADMAP. This corrects the remaining copies, **in place and dated**, the same shape as the ROADMAP fix — not a silent rewrite, and not a note under `[Unreleased]` that a reader of the 1.6.3 section never sees:

- `CHANGELOG.md` §[1.6.3]
- `site/content/releases/v1.6.3/package.yaml` — `narrative` regenerated from the corrected CHANGELOG via the script's own `changelog_section()`; the captured cycle evidence is untouched
- `site/content/releases/v1.6.3/index.md` — same paragraph

**Still outstanding after this merges:** the published GitHub Release body for v1.6.3 was generated from the CHANGELOG at tag time and carries the old paragraph. `gh release edit v1.6.3 --notes-file` with the corrected section is the follow-up; it is outward-facing, so it is done deliberately, not by this PR.

Refs #1087, #1094
