### PR TITLE
fix: the 1.6.4 hash-movers — #1096 frozen model, #1087 root tables, #1079 json_has producer

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -594,7 +594,12 @@ class QATestHandler(_CycleTaskHandler):
         shell_paths = {f.path for f in record.files}
         dropped = sorted(a["name"] for a in artifacts if a["name"] in shell_paths)
         kept = [a for a in artifacts if a["name"] not in shell_paths]
-        merged = merge_fills(list(scaffold_input["files"]), record, fill_emission)
+        merged = merge_fills(
+            list(scaffold_input["files"]),
+            record,
+            fill_emission,
+            store_tables=scaffold_input.get("store_tables"),
+        )
         merged_artifacts = [
             {
                 "name": f.path,

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -614,8 +614,11 @@ def root_persisted_entities(manifest: InterfaceManifest) -> tuple[str, ...]:
     keeps every entity. Narrowing on a guess would remove a table a correct app needs,
     which is the failure this exists to prevent — in the other direction.
     """
-    declared = [e.name for e in manifest.entities]
-    responses = [ep.response for ep in manifest.api.endpoints if ep.response]
+    # Duck-typed like the expander's other manifest readers: the stack modules' tests hand
+    # in bare entity lists, and a manifest with no api section has no typed responses.
+    declared = [e.name for e in (getattr(manifest, "entities", ()) or ())]
+    endpoints = getattr(getattr(manifest, "api", None), "endpoints", ()) or ()
+    responses = [ep.response for ep in endpoints if getattr(ep, "response", None)]
     single = {r.strip() for r in responses if _base_type_name(r) == r.strip()}
     roots = [name for name in declared if name in single]
     if roots:

--- a/src/squadops/capabilities/scaffold.py
+++ b/src/squadops/capabilities/scaffold.py
@@ -590,6 +590,41 @@ def materialize(manifest: InterfaceManifest, dest: Path) -> int:
     return len(files)
 
 
+def root_persisted_entities(manifest: InterfaceManifest) -> tuple[str, ...]:
+    """The entities a correct application persists as rows of their own (#1087).
+
+    A manifest declares an entity for every *shape* it needs — ``Participant`` because
+    ``Run.participants`` is ``list[Participant]``, ``RunSummary`` because ``GET /runs``
+    returns ``list[RunSummary]`` — but only some of those are things the application
+    stores. The rest are embedded in another entity's row or projected from it. Handing
+    the qa author a table for each declared entity told it nothing about which ones a
+    correct app writes, and in the 1.6.3 set two working applications were rejected for
+    ``expect(all(TABLES.Participant)).toHaveLength(1)`` against a table no correct
+    implementation ever touches.
+
+    The manifest already says which are root-persisted, in the one place it is not
+    ambiguous: **an entity returned as a single object by some endpoint** is addressable
+    on its own — created by a POST, read by id — and therefore stored on its own.
+    ``Run`` is (``POST /runs → Run``, ``GET /runs/{id} → Run``); ``RunSummary`` is
+    returned only inside ``list[RunSummary]`` and ``Participant`` is never returned at
+    all. Declaration order is kept so the store's first table is stable.
+
+    Two fallbacks, both deliberate and both widening: a manifest whose endpoints return
+    only collections keeps every entity some endpoint returns; one with no typed responses
+    keeps every entity. Narrowing on a guess would remove a table a correct app needs,
+    which is the failure this exists to prevent — in the other direction.
+    """
+    declared = [e.name for e in manifest.entities]
+    responses = [ep.response for ep in manifest.api.endpoints if ep.response]
+    single = {r.strip() for r in responses if _base_type_name(r) == r.strip()}
+    roots = [name for name in declared if name in single]
+    if roots:
+        return tuple(roots)
+    any_response = {_base_type_name(r) for r in responses}
+    roots = [name for name in declared if name in any_response]
+    return tuple(roots) if roots else tuple(declared)
+
+
 def fill_slot_paths(manifest: InterfaceManifest) -> tuple[str, ...]:
     """Workspace-relative paths of the *fill slots* — the files the dev agent fills
     bodies into. Everything else ``expand`` emits is frozen (scaffold-owned): the

--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -383,6 +383,35 @@ def _probe_sample_value(field_name: str, field_type: str) -> Any:
     return "sample"
 
 
+def _success_expect(
+    manifest: InterfaceManifest, status: int, response: str | None
+) -> dict[str, Any]:
+    """A success probe's ``expect``: the declared status, plus the keys its body must carry.
+
+    **The producer ``json_has`` never had (#1079).** The runner consumed it, the audit
+    script (since #1084) judged it with the same code, SIP-0098 showed it in the contract's
+    own example — and nothing emitted it, so every probe on record asserted status and error
+    code only. The 1.6.3 set measured what that costs: three applications failed the
+    response floor in the suite and all three passed the boot audit, and the record called
+    two of them working. An oracle blind to shape cannot tell a wrong body from a right one.
+
+    Derived, not authored: the keys are ``derive_response_shape``'s required fields for the
+    responding entity — the same derivation the frozen shell spine asserts — so the audit
+    and the suite ask the same question about the same app. ``json_has`` speaks top-level
+    key presence only (on an object, or on every element of a list), so element *kind* stays
+    the shell's business; this is the floor's presence half, rendered a third time. No
+    declared response, or one naming no entity, adds nothing — a probe must not assert a
+    shape the manifest never stated.
+    """
+    from squadops.capabilities.response_shape import derive_response_shape
+
+    expect: dict[str, Any] = {"status": status}
+    shape = derive_response_shape(manifest, response)
+    if shape and shape.required_fields:
+        expect["json_has"] = list(shape.required_fields)
+    return expect
+
+
 def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, Any]]:
     """POST-create probes plus their sequenced child-action probes (#651, v8).
 
@@ -429,7 +458,7 @@ def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, A
             # the skeleton contradicted its own contract and only a dev agent
             # volunteering ``status_code=201`` could close the gap. A manifest that
             # declares no success status keeps the historical 201 expectation.
-            "expect": {"status": ep.success_status or 201},
+            "expect": _success_expect(manifest, ep.success_status or 201, ep.response),
         }
         probes.append(create_probe)
         # #593: the blank-input rejection probe. pf-38 volunteered blank-field
@@ -506,7 +535,9 @@ def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, A
                         "id": f"vc-probe-{create_slug}-{_slug(action)}",
                         "subject": "backend",
                         "request": {"method": "POST", "path": child.path, "json": child_body},
-                        "expect": {"status": child.success_status or 200},
+                        "expect": _success_expect(
+                            manifest, child.success_status or 200, child.response
+                        ),
                     }
                 )
                 conflict_codes = [c for c in child.errors if error_http.get(c) == 409]
@@ -564,7 +595,9 @@ def _probes(manifest: InterfaceManifest, pack: CriteriaPack) -> list[dict[str, A
                         "id": f"vc-probe-{create_slug}-{_slug(value)}",
                         "subject": "backend",
                         "request": {"method": "POST", "path": child.path, "json": child_body},
-                        "expect": {"status": child.success_status or 200},
+                        "expect": _success_expect(
+                            manifest, child.success_status or 200, child.response
+                        ),
                     }
                 )
             # No duplicate-conflict probe here, deliberately. One endpoint carries every

--- a/src/squadops/capabilities/stack_nextjs_ts.py
+++ b/src/squadops/capabilities/stack_nextjs_ts.py
@@ -298,7 +298,15 @@ def _harness_test_source(manifest: Any) -> str:
     declared table via `TABLES`, which additionally demonstrates the accessor the fill briefs
     point authors at.
     """
-    entities = [e.name for e in (getattr(manifest, "entities", ()) or ())]
+    from squadops.capabilities.scaffold import root_persisted_entities
+
+    # #1087: the first ROOT-PERSISTED table, not the first declared entity. On
+    # ``group_run`` the first declared entity is ``Participant`` — an embedded shape —
+    # so every roll's frozen harness demonstrated inserting into a table no correct
+    # application writes, right above the fill the qa author was about to write.
+    entities = (
+        list(root_persisted_entities(manifest)) if getattr(manifest, "entities", None) else []
+    )
     if not entities:
         return _HARNESS_TEST_NO_ENTITIES
     ref = f"TABLES.{entities[0]}"
@@ -386,10 +394,22 @@ def _table_name(entity_name: str) -> str:
 def _store_source(manifest: Any) -> str:
     """The store, with its table names typed from the manifest's entities (#967).
 
+    **Only the root-persisted ones (#1087).** ``TABLES`` used to carry every declared
+    entity, including embedded shapes and response projections no correct application
+    writes; a qa fill asserting on one of those rejected a working app, twice in eight
+    rolls. The handle now exists only for what a correct app stores, so a fill reaching
+    for ``TABLES.Participant`` fails at the fill gate with the real tables named — and
+    under ``next build``'s type check — instead of at runtime with an empty array that
+    reads exactly like a handler that never saved anything.
+
     A manifest declaring no entities keeps an open signature: there is no union to derive,
     and ``never`` would make the store unusable rather than safe.
     """
-    entities = [e.name for e in (getattr(manifest, "entities", ()) or ())]
+    from squadops.capabilities.scaffold import root_persisted_entities
+
+    entities = (
+        list(root_persisted_entities(manifest)) if getattr(manifest, "entities", None) else []
+    )
     if not entities:
         return (
             _STORE_HEADER

--- a/src/squadops/capabilities/stack_nextjs_ts.py
+++ b/src/squadops/capabilities/stack_nextjs_ts.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Collection
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover - annotations only, avoids a scaffold import cycle
@@ -56,14 +57,32 @@ _TS_TYPES = {
 }
 
 
-def _ts_type(raw: str) -> str:
+def _ts_type(raw: str, declared: Collection[str] = ()) -> str:
     """Manifest field type → TypeScript. Unknown types become ``string`` rather than ``any``:
-    ``any`` would silently disable the type checking that is stack #2's entire hygiene tier."""
-    t = (raw or "").strip().lower()
-    inner = re.fullmatch(r"(?:list|array)\[(.+)\]", t)
+    ``any`` would silently disable the type checking that is stack #2's entire hygiene tier.
+
+    ``declared`` is the set of entity and request-shape names the manifest defines. A token
+    naming one passes through **case-preserved**, so ``list[Participant]`` renders
+    ``Participant[]`` — the interface the same file declares three lines up.
+
+    **#1096, and why this parameter exists.** Before it, every entity reference took the
+    unknown-type path: the token was lower-cased (so the name was already gone), missed
+    ``_TS_TYPES``, and became ``string``. The frozen ``lib/models.ts`` then declared
+    ``Run.participants: string[]`` under a ``Participant`` interface it had just defined,
+    the FROZEN FILES surface repeated it to the developer with the word *authoritative*
+    attached, and the response floor — derived from the same manifest — demanded objects
+    carrying ``name``. On every ``nextjs_ts`` roll of the 1.6.3 set the developers who
+    obeyed the frozen file were rejected and the ones who ignored it were accepted. The
+    Python expander's ``_py_type`` always passed entity names through; this is stack #2
+    catching up to stack #1.
+    """
+    t = (raw or "").strip()
+    inner = re.fullmatch(r"(?:list|array)\[(.+)\]", t, re.IGNORECASE)
     if inner:
-        return f"{_ts_type(inner.group(1))}[]"
-    return _TS_TYPES.get(t, "string")
+        return f"{_ts_type(inner.group(1), declared)}[]"
+    if t in declared:
+        return t
+    return _TS_TYPES.get(t.lower(), "string")
 
 
 def _segments(path: str) -> str:
@@ -425,14 +444,20 @@ def _models_source(manifest: Any) -> str:
         "// the fill slots import these rather than restating field names (#822).",
         "",
     ]
-    for entity in getattr(manifest, "entities", ()) or ():
+    entities = tuple(getattr(manifest, "entities", ()) or ())
+    shapes = tuple(getattr(manifest.api, "request_shapes", ()) or ())
+    # The names a field type may reference (#1096): an entity-typed field renders the
+    # interface this file declares for it, never ``string``.
+    declared = frozenset([e.name for e in entities] + [s.name for s in shapes])
+    for entity in entities:
         lines.append(f"export interface {entity.name} {{")
         for field in entity.fields:
             optional = "" if getattr(field, "required", True) else "?"
-            lines.append(f"  {field.name}{optional}: {_ts_type(getattr(field, 'type', 'str'))}")
+            ts = _ts_type(getattr(field, "type", "str"), declared)
+            lines.append(f"  {field.name}{optional}: {ts}")
         lines.append("}")
         lines.append("")
-    for shape in getattr(manifest.api, "request_shapes", ()) or ():
+    for shape in shapes:
         lines.append(f"export interface {shape.name} {{")
         for name in shape.required:
             lines.append(f"  {name}: string")

--- a/src/squadops/capabilities/verification_scaffold_emission.py
+++ b/src/squadops/capabilities/verification_scaffold_emission.py
@@ -49,7 +49,11 @@ if TYPE_CHECKING:  # pragma: no cover - annotations only
 #: Bump on ANY emission-affecting change (module docstring). Recorded in every manifest.
 #: 2 (#936) — the shell imports `all` alongside `reset`, so a fill can call the helper
 #: the appendix teaches without adding an import it is forbidden to add.
-GENERATOR_VERSION = 7
+#: 8 (#1096, #1087, 2026-08-25) — the FROZEN tree moved, not the shells: an entity-typed
+#: field renders its interface (``Participant[]``, not ``string[]``), the store exports a
+#: table only for root-persisted entities, and the harness addresses one of those. Only
+#: ``expanded_tree_hash`` changes; the spine and scaffold hashes are byte-identical to 7.
+GENERATOR_VERSION = 8
 
 #: The stored manifest artifact's filename (the executor persists it beside the contract).
 VERIFICATION_SCAFFOLD_MANIFEST_FILENAME = "verification_scaffold_manifest.yaml"

--- a/src/squadops/capabilities/verification_scaffold_fill.py
+++ b/src/squadops/capabilities/verification_scaffold_fill.py
@@ -61,6 +61,7 @@ deterministic failing assertion naming the slot and the fill layer, shaped as an
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from squadops.capabilities.verification_scaffold import (
@@ -236,8 +237,19 @@ _FORBIDDEN: tuple[tuple[re.Pattern[str], str], ...] = (
 )
 
 
-def fill_findings(fill: Fill) -> list[str]:
-    """Every containment rule this fill violates; empty for a valid fill or explicit NA."""
+#: A store table reference in a fill body — ``TABLES.Run`` (#1087).
+_TABLE_REF_RE = re.compile(r"\bTABLES\.(\w+)")
+
+
+def fill_findings(fill: Fill, store_tables: Sequence[str] | None = None) -> list[str]:
+    """Every containment rule this fill violates; empty for a valid fill or explicit NA.
+
+    ``store_tables`` is the frozen store's exported table set, when the stack has one. A
+    fill asserting on a table outside it is rejected here, deterministically, with the
+    real tables named (#1087) — before it can reach a retest where it reads as an empty
+    array and costs a working application the roll. ``None`` means the stack's store is
+    not table-keyed and the rule does not apply.
+    """
     if fill.is_not_applicable:
         return []
     if not fill.body.strip():
@@ -256,6 +268,16 @@ def fill_findings(fill: Fill) -> list[str]:
     for pattern, reason in _FORBIDDEN:
         if pattern.search(fill.body):
             findings.append(reason)
+    if store_tables is not None:
+        phantom = sorted({m for m in _TABLE_REF_RE.findall(fill.body) if m not in store_tables})
+        if phantom:
+            findings.append(
+                f"asserts on {', '.join(f'`TABLES.{p}`' for p in phantom)}, which the frozen "
+                f"store does not export — a correct application persists only "
+                f"{', '.join(f'`TABLES.{s}`' for s in store_tables) or 'no tables'}; an "
+                f"embedded shape or response projection has no table of its own, so assert on "
+                f"the owning entity's field instead (#1087)"
+            )
     return findings
 
 
@@ -340,6 +362,7 @@ def merge_fills(
     scaffold_files: list[dict[str, str]],
     record: VerificationScaffoldManifest,
     emission: FillEmission,
+    store_tables: Sequence[str] | None = None,
 ) -> FillMergeRecord:
     """Merge an authored fill emission into the scaffold, deterministically.
 
@@ -387,7 +410,7 @@ def merge_fills(
             else:
                 fill = fills_by_slot.get(slot.slot_id)
                 body, disposition = _merged_body(
-                    slot.slot_id, fill, fill_findings(fill) if fill else []
+                    slot.slot_id, fill, fill_findings(fill, store_tables) if fill else []
                 )
             out.extend(body)
             out.append(lines[region.end_line - 1])

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -622,10 +622,16 @@ def inject_contract_inputs(
             )
 
             if verification_scaffold_for(interface_manifest.stack):
+                from squadops.capabilities.scaffold import root_persisted_entities
+
                 emission = emit_verification_scaffold(interface_manifest)
                 inputs["verification_scaffold"] = {
                     "manifest": emission.manifest.to_dict(),
                     "files": [dict(f) for f in emission.files],
+                    # #1087: the tables the frozen store actually exports, so the fill
+                    # merge can reject an assertion on a phantom one with the real
+                    # tables named. Data from the one derivation the store renders.
+                    "store_tables": list(root_persisted_entities(interface_manifest)),
                 }
 
 

--- a/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix_nextjs_ts.md
+++ b/src/squadops/prompts/request_templates/request.development_develop_fill_only_appendix_nextjs_ts.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.development_develop_fill_only_appendix_nextjs_ts
-version: "2"
+version: "3"
 required_variables:
   - stack
 optional_variables:
@@ -27,8 +27,11 @@ fixed slots** — never to rebuild, rewire, or regenerate the scaffold.
 - Page components in `app/**/page.tsx` — implement each component's body.
 
 **The store seam, stated exactly — pass `TABLES.<Entity>`, never a string you invent:**
-`@/lib/store` exports `TABLES`, one entry per declared entity, and its functions accept only
-those values. Write `insert(TABLES.Run, run)` and `all(TABLES.Run)`. A name you make up is a
+`@/lib/store` exports `TABLES`, one entry per entity a correct application stores as rows of
+its own, and its functions accept only those values. An entity that exists only as a shape
+embedded in another (`Run.participants: Participant[]`) or as a response projection has no
+table — store it inside the owning row and project it in the handler. Write
+`insert(TABLES.Run, run)` and `all(TABLES.Run)`. A name you make up is a
 compile error, and the build fails on compile errors — so the cost of inventing one is the
 whole run, not a warning. Read the table names out of `TABLES`; do not retype them as
 strings, and do not add a table of your own.

--- a/src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md
+++ b/src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.qa_test_fill_mode_appendix
-version: "1"
+version: "2"
 required_variables:
   - slot_lines
   - shell_files
@@ -63,9 +63,14 @@ as a failing state):
   `created` is the created entity's parsed JSON.
 
 **Asserting on the store — pass `TABLES.<Entity>`, never a string you invent.**
-`@/lib/store` exports `TABLES`, one entry per declared entity, and its functions accept only
-those values. Write `expect(all(TABLES.Run)).toHaveLength(1)`. A name you make up is a
-compile error, and the build fails on compile errors, so an invented name costs the run.
+`@/lib/store` exports `TABLES`, one entry per entity a correct application stores as rows of
+its own, and its functions accept only those values. Write
+`expect(all(TABLES.Run)).toHaveLength(1)`. An entity that exists only as a shape embedded in
+another (`Run.participants`) or as a response projection has **no table**: it lives inside the
+owning entity's row, so assert on that row's field (`body.participants`, or the row from
+`all(TABLES.Run)`), never on a table for it. A fill naming a table `TABLES` does not
+export is rejected at the fill gate with the real tables named, and a name you make up is a
+compile error — either way an invented table costs the slot, not a warning.
 
 This is spelled out because it has already cost one. The store used to accept any string:
 an application named its table one thing, the suite named it another, and the mismatch

--- a/tests/fixtures/reference_contract/contract_v10_json_has_1079.yaml
+++ b/tests/fixtures/reference_contract/contract_v10_json_has_1079.yaml
@@ -1,0 +1,180 @@
+# Verification contract — emitted by the scaffold expander (SIP-0098).
+# Roll-invariant: framing BINDS these criteria by id; it never authors them.
+# Regenerate with the expander; do not hand-edit.
+contract_version: 1
+skeleton:
+  expander: fullstack_fastapi_react
+  interface_manifest_hash: bb472e267e53d5ad29406663b4340de45613dd68fa091fe7f2d06a99b7267530
+capabilities:
+- python
+- node
+frozen:
+- path: backend/__init__.py
+  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+- path: backend/errors.py
+  sha256: a5c9e04e111584184cd880d15e28e6a6759951c8ce8f31188275fa40d7c7c18d
+- path: backend/main.py
+  sha256: 1d0ea8c4ce2438196a4b3463a5b622f946f3754105c06b09f12aab6452f9a12d
+- path: backend/models.py
+  sha256: 1c090c4856bcc4b5c6310ce4e7bd212e0640a7d7fcc029547a97717374103c59
+- path: backend/requirements.txt
+  sha256: 91c0e75b9979625c004d43c76d8a9876ca3794d101ff277285aef448d5675ab2
+- path: backend/store.py
+  sha256: 20d4c1da14c89030846a20a913dec2a70b924fc22411bc02079483e34c74df5f
+- path: conftest.py
+  sha256: 2573c02000affd3e06d862b7c847a2562937592419e1b39acca473dcb7635b2b
+- path: frontend/index.html
+  sha256: 166c0d4e42057dc9620e02811cb3ba10026c20f0f349c4b17af634c5185c6a15
+- path: frontend/package.json
+  sha256: f10dfb6f40c789a1271871099cacc2ec5276fcadb1a942f621790691525ee936
+- path: frontend/src/App.jsx
+  sha256: ca1e88815f44861acdf107288b0f7e8eca18da664dd1d54e02db4833f1d0588a
+- path: frontend/src/__tests__/harness.test.jsx
+  sha256: 4cb9209071d7fad138a00b907a2aab890fe977036f19ecfba677c6a1e2f2f163
+- path: frontend/src/api.js
+  sha256: d3531b3567f5abbdd38d6182908f8c38683da85f55ccd201b1374afa34c77c78
+- path: frontend/src/main.jsx
+  sha256: 16d0738c63e947395511e47dede172d2c1dd708003e245db11e276eb26ef05ee
+- path: frontend/src/test-setup.js
+  sha256: e22c110d9f7d04d80e583acc0dcc156f6a11473bb0e305ed6cf9575214908d12
+- path: frontend/vite.config.js
+  sha256: f8c5d6638a37327840c2d74f5fd16415bd610da1428d1e335e91e030827d0eae
+fill_files:
+  backend/routes.py:
+    interface:
+    - check: endpoint_defined
+      id: vc-routes-endpoints
+      methods_paths:
+      - GET /runs
+      - POST /runs
+      - GET /runs/{run_id}
+      - POST /runs/{run_id}/join
+      - POST /runs/{run_id}/leave
+    - check: import_present
+      id: vc-routes-apierror
+      module: .errors
+      symbol: ApiError
+    implementation:
+    - check: command_exit_zero
+      id: vc-routes-compiles
+      argv:
+      - python
+      - -m
+      - py_compile
+      - backend/routes.py
+      requires: python
+    - check: module_imports
+      id: vc-routes-imports
+      file: backend/routes.py
+      requires: python
+  frontend/src/views/RunsListView.jsx:
+    interface: []
+    implementation:
+    - check: frontend_compiles
+      id: vc-view-compiles-runs-list-view
+      file: frontend/src/views/RunsListView.jsx
+      requires: node
+  frontend/src/views/CreateRunView.jsx:
+    interface: []
+    implementation:
+    - check: frontend_compiles
+      id: vc-view-compiles-create-run-view
+      file: frontend/src/views/CreateRunView.jsx
+      requires: node
+  frontend/src/views/RunDetailView.jsx:
+    interface: []
+    implementation:
+    - check: frontend_compiles
+      id: vc-view-compiles-run-detail-view
+      file: frontend/src/views/RunDetailView.jsx
+      requires: node
+behavioral:
+  build:
+  - check: frontend_build
+    id: vc-frontend-builds
+    requires: node
+  suite:
+    checks:
+    - check: tests_pass
+      id: vc-suite-passes
+      requires: python
+    coverage_expectations:
+    - 'happy path for each endpoint: GET /runs, POST /runs, GET /runs/{run_id}, POST
+      /runs/{run_id}/join, POST /runs/{run_id}/leave'
+    - validation_error -> HTTP 422
+    - run_not_found -> HTTP 404
+    - duplicate_participant -> HTTP 409
+    - participant_not_found -> HTTP 404
+    - tests are order-independent; module-level state reset per test
+  probes:
+  - id: vc-probe-runs
+    subject: backend
+    request:
+      method: POST
+      path: /runs
+      json:
+        title: sample
+        datetime: '2026-08-01T08:00:00'
+        location: sample
+    expect:
+      status: 201
+      json_has:
+      - id
+      - title
+      - datetime
+      - location
+      - participants
+    capture:
+      run_id: id
+  - id: vc-probe-runs-rejects-blank
+    subject: backend
+    request:
+      method: POST
+      path: /runs
+      json:
+        title: ''
+        datetime: ''
+        location: ''
+    expect:
+      status: 422
+      error_code: validation_error
+    guards: scaffold
+  - id: vc-probe-runs-join
+    subject: backend
+    request:
+      method: POST
+      path: /runs/{run_id}/join
+      json: &id001
+        name: sample
+    expect:
+      status: 200
+      json_has:
+      - id
+      - title
+      - datetime
+      - location
+      - participants
+  - id: vc-probe-runs-join-duplicate
+    subject: backend
+    request:
+      method: POST
+      path: /runs/{run_id}/join
+      json: *id001
+    expect:
+      status: 409
+      error_code: duplicate_participant
+  - id: vc-probe-runs-leave
+    subject: backend
+    request:
+      method: POST
+      path: /runs/{run_id}/leave
+      json:
+        name: sample
+    expect:
+      status: 200
+      json_has:
+      - id
+      - title
+      - datetime
+      - location
+      - participants

--- a/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
+++ b/tests/fixtures/reference_verification_scaffold/verification_scaffold_manifest.yaml
@@ -2,11 +2,11 @@
 # The frozen-spine record region enforcement verifies against; regenerate with
 # the generator, never hand-edit (a tampered record refuses to load).
 scaffold_manifest_version: 1
-generator_version: 7
+generator_version: 8
 stack: nextjs_ts
 interface_manifest_hash: ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e07053a
 criteria_pack: nextjs_ts
-expanded_tree_hash: 7ee51e60f36e82ab2a93390a248c293a570e70db8d607c7b9ae68e0647262e7e
+expanded_tree_hash: e8d768e11c025fe4bf9c693024694106e79e7b8317c45425b53c480f6b1ab764
 aggregate_spine_hash: 1ff59445d016f6d7385d713c5f31de7620fe3f065344db6a083bae7b1a0ab962
 scaffold_hash: 6fc46f50369bc9afd34e40607350b2464b74f79a6a8ef62772470037f5e98854
 files:

--- a/tests/unit/capabilities/test_contract_derivation_reference.py
+++ b/tests/unit/capabilities/test_contract_derivation_reference.py
@@ -51,9 +51,22 @@ _MANIFEST = _REPO / "examples" / "03_group_run" / "interface_manifest.yaml"
 # and prints the `artifacts ingest` command; committing it beside the manifest put
 # a generated artifact in the source tree, in a directory that reads as
 # user-facing examples. It lives here instead: its only consumer is this test.
-_CONTRACT = (
+# The reference contract has two pins with two meanings (2026-08-25, #1079):
+#
+# * ``_EVIDENCE_CONTRACT`` — contract v9, the artifact bind-mode cycles ingested and the
+#   1.4 Functional App Yield window (6/6, five consecutive) was measured against. Its bytes
+#   never change; a file named for a vault artifact must stay that artifact.
+# * ``_CONTRACT`` — the deriver's current form for the same manifest. It differs from v9
+#   in exactly one way: the three success probes carry ``json_has`` (the responding
+#   entity's declared-required fields), the producer ``json_has`` never had (#1079).
+#   Classified **ambiguity_removal** per the M0 divergence taxonomy
+#   (docs/plans/1-6-0-authorship-plan.md): v9 left the success body implicit; derivation
+#   now states it. Not a reference defect, so the 1.4 figure carries no qualification —
+#   it measured a weaker contract that every app passing this one also passes.
+_EVIDENCE_CONTRACT = (
     _REPO / "tests" / "fixtures" / "reference_contract" / "contract_v9_art_4f368ea08799.yaml"
 )
+_CONTRACT = _REPO / "tests" / "fixtures" / "reference_contract" / "contract_v10_json_has_1079.yaml"
 
 # The ingested artifacts, by content hash. Measured 2026-08-07 against the vault:
 #   art_8becd104e9fc — interface manifest v4
@@ -61,7 +74,8 @@ _CONTRACT = (
 # These are the exact bytes the 1.4 FAY window and every bind-mode cycle since have
 # run against. A change here is a change to the evidence base, not a refactor.
 _MANIFEST_SHA256 = "52d8ea7e204e0ceca9c94a60a7b10f18a24519e594ce5c51654674b82a15a826"
-_CONTRACT_SHA256 = "7622f570c949fe9504bfebdcd0562e77e78b4d8bff54d9d670001b7f6482e6fe"
+_EVIDENCE_CONTRACT_SHA256 = "7622f570c949fe9504bfebdcd0562e77e78b4d8bff54d9d670001b7f6482e6fe"
+_CONTRACT_SHA256 = "bdd540d0d916e085dc45dd9eaef2325f9278b432720453f490666de19447b831"
 
 
 def _sha256(path: Path) -> str:
@@ -86,11 +100,16 @@ def test_reference_contract_is_still_the_ingested_artifact():
     below becomes a tautology — the deriver proving it equals itself. This hash is
     what stops that.
     """
-    assert _sha256(_CONTRACT) == _CONTRACT_SHA256, (
+    assert _sha256(_EVIDENCE_CONTRACT) == _EVIDENCE_CONTRACT_SHA256, (
         "tests/fixtures/reference_contract/contract_v9_art_4f368ea08799.yaml no longer "
-        "matches ingested "
-        "contract v9 (art_4f368ea08799). These are the bytes bind-mode cycles load; "
-        "regenerating them locally would make the derivation test tautological."
+        "matches ingested contract v9 (art_4f368ea08799). Those are the bytes the 1.4 "
+        "evidence was measured against; they are history, and history is not regenerated."
+    )
+    assert _sha256(_CONTRACT) == _CONTRACT_SHA256, (
+        "tests/fixtures/reference_contract/contract_v10_json_has_1079.yaml no longer matches "
+        "its pinned hash. Regenerating it in place would make the derivation test below "
+        "tautological — a deriver change is classified per the M0 taxonomy and lands with a "
+        "new hash here, deliberately."
     )
 
 
@@ -129,3 +148,21 @@ def test_the_reference_pair_is_non_trivial():
 
     assert len(deployed["fill_files"]) == 4
     assert len(deployed["behavioral"]["probes"]) == 5
+
+
+def test_the_current_form_differs_from_the_evidence_contract_only_by_json_has():
+    """The classification's own check (#1079, ambiguity_removal): v10 must be v9 plus the
+    success probes' keys and nothing else. Any other drift is a different divergence with a
+    different class, and this test is what makes the classification falsifiable."""
+    v9 = yaml.safe_load(_EVIDENCE_CONTRACT.read_text(encoding="utf-8"))
+    v10 = yaml.safe_load(_CONTRACT.read_text(encoding="utf-8"))
+    for probe in v10["behavioral"]["probes"]:
+        if probe["expect"].get("status", 0) < 300:
+            assert probe["expect"].pop("json_has") == [
+                "id",
+                "title",
+                "datetime",
+                "location",
+                "participants",
+            ]
+    assert v10 == v9

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -64,6 +64,9 @@ class TestInjection:
         scaffold = inputs["verification_scaffold"]
         assert len(scaffold["files"]) == 8
         assert scaffold["manifest"]["stack"] == "nextjs_ts"
+        # #1087: the tables the frozen store exports ride the same input, so the fill
+        # merge can reject a phantom-table assertion with the real tables named.
+        assert scaffold["store_tables"] == ["RunEvent"]
         # #1029: against the constant, not a literal. This test's subject is that the
         # scaffold REACHES qa.test on an opted-in stack; pinning the number here made a
         # legitimate emission bump fail a transport test, and the deliberate value pin
@@ -178,6 +181,24 @@ class TestMergeFillArtifacts:
         assert evidence["counts"]["filled"] == 1
         assert evidence["counts"]["missing"] == 7
         assert len(suite_files) == 8
+
+    def test_a_phantom_table_fill_is_rejected_at_merge_with_the_real_tables_named(
+        self, scaffold_input
+    ):
+        """#1087 end to end through the handler: the fill that rejected rolls 1 and 4."""
+        fills = parse_fill_emission(
+            "```fill:slot-vc-probe-api-runs\n"
+            "    expect(all(TABLES.Participant)).toHaveLength(1)\n```\n"
+        )
+        merged_artifacts, _, evidence = QATestHandler()._merge_fill_artifacts(
+            {**scaffold_input, "store_tables": ["RunEvent"]}, fills, []
+        )
+        assert evidence["counts"]["rejected"] == 1
+        create_shell = next(
+            a for a in merged_artifacts if a["name"].endswith("vc-probe-api-runs.scaffold.test.ts")
+        )
+        assert "`TABLES.RunEvent`" in create_shell["content"]
+        assert "expect(all(TABLES.Participant))" not in create_shell["content"]
 
     def test_the_banked_evidence_names_the_additive_suite_that_survived(self, scaffold_input):
         """#980's other half: a retreat weakens the fills AND drops the additive suite.

--- a/tests/unit/capabilities/test_root_persisted_entities.py
+++ b/tests/unit/capabilities/test_root_persisted_entities.py
@@ -1,0 +1,85 @@
+"""#1087 — which declared entities a correct application stores as rows of their own.
+
+The frozen store used to export a table per declared entity. On ``group_run`` that is
+three tables for one stored thing: ``Participant`` exists only as ``Run.participants``'
+element shape and ``RunSummary`` only as ``GET /runs``' projection, and a qa fill asserting
+``all(TABLES.Participant)`` rejected two working applications in the 1.6.3 set.
+
+Bug classes guarded: an embedded shape or projection getting a table; a genuinely stored
+entity losing its table (the widening fallbacks); the derivation reordering the store.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.capabilities.scaffold import InterfaceManifest, root_persisted_entities
+
+pytestmark = [pytest.mark.domain_capabilities]
+
+_BASE = """
+version: 1
+kind: interface_manifest
+project_id: p
+stack: nextjs_ts
+entities:
+  - name: Participant
+    fields:
+      - {{ name: name, type: string, required: true }}
+  - name: Run
+    fields:
+      - {{ name: id, type: string, required: true, generated: true }}
+      - {{ name: participants, type: "list[Participant]", required: true, default: [] }}
+  - name: RunSummary
+    fields:
+      - {{ name: id, type: string, required: true }}
+api:
+  endpoints:
+{endpoints}
+"""
+
+
+def _manifest(endpoints: str) -> InterfaceManifest:
+    return InterfaceManifest.from_yaml(_BASE.format(endpoints=endpoints))
+
+
+@pytest.mark.parametrize(
+    ("endpoints", "expected"),
+    [
+        # group_run's shape: Run is created and read by id; the others are shape/projection.
+        (
+            """    - { method: POST, path: /api/runs, response: Run }
+    - { method: GET, path: /api/runs, response: "list[RunSummary]" }
+    - { method: GET, path: "/api/runs/{run_id}", response: Run }
+""",
+            ("Run",),
+        ),
+        # Only collections are ever returned: keep every entity some endpoint returns,
+        # never narrow on a guess — RunSummary here might genuinely be stored.
+        (
+            """    - { method: GET, path: /api/runs, response: "list[RunSummary]" }
+""",
+            ("RunSummary",),
+        ),
+        # No typed responses at all: the manifest says nothing, so every entity keeps
+        # its table — the pre-#1087 behaviour, and the only safe one without evidence.
+        (
+            """    - { method: GET, path: /api/health }
+""",
+            ("Participant", "Run", "RunSummary"),
+        ),
+    ],
+)
+def test_root_tables_are_the_single_object_responses_with_widening_fallbacks(endpoints, expected):
+    assert root_persisted_entities(_manifest(endpoints)) == expected
+
+
+def test_declaration_order_is_kept_so_the_first_table_is_stable():
+    """The store's first table is what the harness demonstrates; a derivation that sorted
+    would reorder the frozen harness under an unrelated manifest edit."""
+    m = _manifest(
+        """    - { method: POST, path: /api/summaries, response: RunSummary }
+    - { method: POST, path: /api/runs, response: Run }
+"""
+    )
+    assert root_persisted_entities(m) == ("Run", "RunSummary")

--- a/tests/unit/capabilities/test_scaffold_contract.py
+++ b/tests/unit/capabilities/test_scaffold_contract.py
@@ -312,7 +312,8 @@ class TestChainedActionProbes:
         join = probes["vc-probe-runs-join"]
         assert join.request["path"] == "/runs/{run_id}/join"
         assert join.request["json"] == {"name": "sample"}
-        assert join.expect == {"status": 200}
+        assert join.expect["status"] == 200
+        assert "json_has" in join.expect  # #1079: a success probe carries the floor's keys
 
         # The duplicate expectation is read from the manifest's error contract
         # (duplicate_participant: http 409), never guessed.
@@ -322,7 +323,8 @@ class TestChainedActionProbes:
 
         # leave declares no 409-class error -> happy path only, no duplicate.
         leave = probes["vc-probe-runs-leave"]
-        assert leave.expect == {"status": 200}
+        assert leave.expect["status"] == 200
+        assert "json_has" in leave.expect
         assert "vc-probe-runs-leave-duplicate" not in probes
 
     def test_chained_contract_lints_clean_and_roundtrips_capture(self):
@@ -462,3 +464,53 @@ class TestDeclaredValuesAndTheManifestHash:
         shape = next(s for s in manifest.api.request_shapes if s.name == "RunEventCreate")
         assert shape.declared_values("title") == ("a", "b")
         assert shape.declared_values("datetime") == ()
+
+
+# --------------------------------------------------------------------------- #
+# #1079 — the probes carry the response floor's presence half
+# --------------------------------------------------------------------------- #
+
+
+def test_success_probes_carry_the_required_keys_of_their_declared_response():
+    """Bug caught (#1079): no probe ever carried `json_has`, so the boot audit certified
+    'answers with the right status' and the 1.6.3 record read that as 'works' for two
+    applications the suite had rejected on the response floor. The keys are the
+    responding entity's declared-required fields — the same derivation the shell asserts."""
+    probes = {p["id"]: p for p in emit_contract_dict(_manifest())["behavioral"]["probes"]}
+    create = probes["vc-probe-runs"]
+    assert create["expect"]["status"] == 201
+    assert create["expect"]["json_has"] == ["id", "title", "datetime", "location", "participants"]
+    join = probes["vc-probe-runs-join"]
+    assert join["expect"]["json_has"] == create["expect"]["json_has"]
+
+
+def test_rejection_and_conflict_probes_carry_no_shape():
+    """A 4xx body is the error envelope's business (#913); pinning entity keys on it
+    would fail every correct app."""
+    probes = {p["id"]: p for p in emit_contract_dict(_manifest())["behavioral"]["probes"]}
+    assert "json_has" not in probes["vc-probe-runs-rejects-blank"]["expect"]
+    assert "json_has" not in probes["vc-probe-runs-join-duplicate"]["expect"]
+
+
+def test_a_response_naming_no_entity_adds_no_shape():
+    """A probe must not assert a shape the manifest never stated."""
+    from squadops.capabilities.scaffold_contract import _success_expect
+
+    assert _success_expect(_manifest(), 201, None) == {"status": 201}
+    assert _success_expect(_manifest(), 201, "Nonesuch") == {"status": 201}
+
+
+def test_the_runner_and_the_audit_reject_a_body_missing_a_derived_key():
+    """The probe's keys have to mean something at judgment time: the shared judge
+    (#1084) fails a body missing one, and names it."""
+    from squadops.capabilities.handlers.probe_runner import evaluate_expectations
+
+    create = next(
+        p
+        for p in emit_contract_dict(_manifest())["behavioral"]["probes"]
+        if p["id"] == "vc-probe-runs"
+    )
+    body = {"id": "r1", "title": "t", "datetime": "d", "location": "l"}  # no participants
+    verdict = evaluate_expectations(create["expect"], 201, body)
+    assert verdict == "response missing key(s): ['participants']"
+    assert evaluate_expectations(create["expect"], 201, {**body, "participants": []}) is None

--- a/tests/unit/capabilities/test_stack_nextjs_ts.py
+++ b/tests/unit/capabilities/test_stack_nextjs_ts.py
@@ -490,3 +490,28 @@ def test_the_frozen_model_and_the_response_floor_pin_the_same_element_kind():
                 assert f"  {field.name}: {inner}[]" in models, (field.name, inner)
                 checked += 1
     assert checked >= 1, "the reference manifest must exercise a list-of-entity field"
+
+
+# --------------------------------------------------------------------------- #
+# #1087 — the store hands out tables only for what a correct app persists
+# --------------------------------------------------------------------------- #
+
+
+def test_the_store_exports_a_table_only_for_root_persisted_entities():
+    """Bug caught (#1087): `TABLES` carried `Participant` (an embedded shape) and every
+    other declared entity. Rolls 1 and 4 of the 1.6.3 set asserted on it and rejected
+    working applications. Only `RunEvent` — created by POST, read by id — is stored."""
+    store = next(f["content"] for f in expand(_manifest()) if f["name"] == "lib/store.ts")
+    assert "  RunEvent: 'run_event'," in store
+    assert "Participant" not in store
+
+
+def test_the_frozen_harness_demonstrates_a_root_table_not_the_first_declared_entity():
+    """`Participant` is declared first on group_run; the harness used `entities[0]` and so
+    demonstrated inserting into the phantom table right above the fill slots (#1087).
+    It must address a table the store actually exports, or it stops compiling."""
+    harness = next(
+        f["content"] for f in expand(_manifest()) if f["name"] == "__tests__/harness.test.ts"
+    )
+    assert "TABLES.RunEvent" in harness
+    assert "TABLES.Participant" not in harness

--- a/tests/unit/capabilities/test_stack_nextjs_ts.py
+++ b/tests/unit/capabilities/test_stack_nextjs_ts.py
@@ -427,3 +427,66 @@ class TestStoreUpdateSeam:
             if "lib/store.ts" in line
         )
         assert "update(table: Table, row: Record<string, unknown>)" in store_line
+
+
+# --------------------------------------------------------------------------- #
+# #1096 — the frozen model must not contradict the response floor
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("list[Participant]", "Participant[]"),
+        ("Participant", "Participant"),
+        ("LIST[Participant]", "Participant[]"),
+        ("list[string]", "string[]"),
+        ("integer", "number"),
+        ("Unknownthing", "string"),
+        ("list[list[Participant]]", "Participant[][]"),
+    ],
+)
+def test_ts_type_passes_declared_names_through_and_keeps_the_string_fallback(raw, expected):
+    """#1096: `list[Participant]` rendered `string[]` because the token was lower-cased and
+    then looked up as a primitive. A declared name must survive case-preserved; an
+    undeclared token must still fall to `string`, never `any`."""
+    from squadops.capabilities.stack_nextjs_ts import _ts_type
+
+    assert _ts_type(raw, {"Participant"}) == expected
+
+
+def test_the_frozen_model_types_a_collection_by_the_interface_it_declares():
+    """Bug caught (#1096): the frozen `lib/models.ts` defined `interface Participant` and
+    three lines later declared `Run.participants: string[]`. The developer's brief carried
+    that line under FROZEN FILES as *authoritative*; the floor demanded objects. Both
+    renderings must now say `Participant[]`."""
+    models = next(f["content"] for f in expand(_manifest()) if f["name"] == "lib/models.ts")
+    assert "  participants: Participant[]" in models
+    assert "string[]" not in models
+    index = next(
+        line for line in scaffold.frozen_surface_index_lines(_manifest()) if "models.ts" in line
+    )
+    assert "participants: Participant[]" in index
+
+
+def test_the_frozen_model_and_the_response_floor_pin_the_same_element_kind():
+    """The two derivations that disagreed for the stack's whole life. For every collection
+    field whose element is a declared entity, the floor asserts the element's required
+    fields and the model must declare the element's interface — the same manifest fact,
+    rendered twice, must not read differently."""
+    from squadops.capabilities.response_shape import derive_response_shape
+
+    manifest = _manifest()
+    models = next(f["content"] for f in expand(manifest) if f["name"] == "lib/models.ts")
+    entities = {e.name for e in manifest.entities}
+    checked = 0
+    for entity in manifest.entities:
+        shape = derive_response_shape(manifest, entity.name)
+        floor = {e.field: e for e in (shape.elements if shape else ())}
+        for field in entity.fields:
+            inner = field.type[len("list[") : -1] if field.type.startswith("list[") else ""
+            if inner in entities:
+                assert floor[field.name].required_fields, field.name
+                assert f"  {field.name}: {inner}[]" in models, (field.name, inner)
+                checked += 1
+    assert checked >= 1, "the reference manifest must exercise a list-of-entity field"

--- a/tests/unit/capabilities/test_stack_nextjs_ts.py
+++ b/tests/unit/capabilities/test_stack_nextjs_ts.py
@@ -67,10 +67,12 @@ def test_registering_a_second_stack_leaves_the_first_byte_identical():
     reference = _manifest("fullstack_fastapi_react")
 
     assert reference.content_hash().startswith("bb472e267e53d5ad")
+    # contract v10 (#1079): v9 plus json_has on the success probes, classified
+    # ambiguity_removal — see test_contract_derivation_reference for both pins.
     assert (
         hashlib.sha256(emit_contract_yaml(reference).encode())
         .hexdigest()
-        .startswith("7622f570c949fe95")
+        .startswith("bdd540d0d916e085")
     )
 
 

--- a/tests/unit/capabilities/test_verification_scaffold_fill.py
+++ b/tests/unit/capabilities/test_verification_scaffold_fill.py
@@ -254,3 +254,42 @@ class TestMerge:
         tampered = dataclasses.replace(emission.manifest, files=tampered_files)
         with pytest.raises(ScaffoldValidationError, match="merge moved the spine"):
             merge_fills(list(emission.files), tampered, parse_fill_emission(""))
+
+
+class TestPhantomTableFindings:
+    """#1087: a fill asserting on a table the frozen store does not export is rejected at
+    the fill gate with the real tables named — not discovered at retest as an empty
+    array that reads like a handler that never saved."""
+
+    def test_a_phantom_table_reference_is_rejected_and_the_real_tables_are_named(self):
+        findings = fill_findings(
+            Fill(slot_id=_CREATE_SLOT, body="expect(all(TABLES.Participant)).toHaveLength(1)"),
+            store_tables=["RunEvent"],
+        )
+        assert len(findings) == 1
+        assert "`TABLES.Participant`" in findings[0]
+        assert "`TABLES.RunEvent`" in findings[0]
+        assert "#1087" in findings[0]
+
+    def test_an_exported_table_passes_and_the_rule_is_off_without_a_table_set(self):
+        body = "expect(all(TABLES.RunEvent)).toHaveLength(1)"
+        assert fill_findings(Fill(slot_id=_CREATE_SLOT, body=body), store_tables=["RunEvent"]) == []
+        # A stack whose store is not table-keyed threads no set: the rule must not fire
+        # on vocabulary it has no facts about.
+        phantom = "expect(all(TABLES.Participant)).toHaveLength(1)"
+        assert fill_findings(Fill(slot_id=_CREATE_SLOT, body=phantom)) == []
+
+    def test_the_merge_degrades_the_slot_with_the_phantom_table_named(self, emission):
+        text = f"```fill:{_CREATE_SLOT}\nexpect(all(TABLES.Participant)).toHaveLength(1)\n```\n"
+        record = merge_fills(
+            list(emission.files),
+            emission.manifest,
+            parse_fill_emission(text),
+            store_tables=["RunEvent"],
+        )
+        disposition = record.by_slot()[_CREATE_SLOT]
+        assert disposition.disposition == "rejected"
+        assert "`TABLES.Participant`" in disposition.detail
+        merged = next(f.content for f in record.files if _CREATE_SLOT in f.content)
+        assert "fill rejected" in merged
+        assert "expect(all(TABLES.Participant))" not in merged

--- a/tests/unit/capabilities/test_verification_scaffold_reference.py
+++ b/tests/unit/capabilities/test_verification_scaffold_reference.py
@@ -55,6 +55,12 @@ _MANIFEST_HASH = "ac1e7be378c54d5966680b85824c6f2c2e4d158eb8dec14d081209223e0705
 # shell equally would not show that the emission is per-behavior.
 #
 # These stop an in-place fixture regeneration from making the byte test self-referential.
+# Version 8 (2026-08-25, #1096 + #1087) moved the FROZEN tree and not one shell: the model
+# types `participants` as `Participant[]` instead of `string[]`, the store exports a table
+# only for root-persisted entities, and the harness addresses one of those. So only the
+# manifest's `expanded_tree_hash` changed, and the two pins below are byte-identical to
+# version 7 — which is the evidence that the fix touched exactly the files it meant to and
+# nothing the qa author fills.
 _AGGREGATE_SPINE_HASH = "1ff59445d016f6d7385d713c5f31de7620fe3f065344db6a083bae7b1a0ab962"
 _SCAFFOLD_HASH = "6fc46f50369bc9afd34e40607350b2464b74f79a6a8ef62772470037f5e98854"
 
@@ -75,12 +81,12 @@ def test_the_reference_manifest_is_unmoved():
 def test_generator_version_is_the_fixture_generation(emission):
     """A generator change without a version bump is drift by definition (SIP §4.3);
     a bump without regenerating the fixture is a pin measuring the wrong version."""
-    assert GENERATOR_VERSION == 7
-    assert emission.manifest.generator_version == 7
+    assert GENERATOR_VERSION == 8
+    assert emission.manifest.generator_version == 8
     stored = yaml.safe_load(
         (_FIXTURE_DIR / "verification_scaffold_manifest.yaml").read_text(encoding="utf-8")
     )
-    assert stored["generator_version"] == 7
+    assert stored["generator_version"] == 8
 
 
 def test_emission_reproduces_the_fixture_byte_for_byte(emission):


### PR DESCRIPTION
The three fixes the 1.6.4 plan (rev 4, §2.2) ships together so the generator and contract hashes move once. One commit per fix.

**#1096** — `_ts_type` passes declared entity/shape names through case-preserved, so the frozen `lib/models.ts` types `Run.participants` as `Participant[]` instead of `string[]`. Pinned twice: the function, and the frozen model against the response floor for every list-of-entity field.

**#1087** — `root_persisted_entities()` (manifest seam) derives which entities a correct app stores as rows of their own: those some endpoint returns as a single object, with two widening fallbacks. The `nextjs_ts` store and harness consume it (`TABLES` now carries `RunEvent` only on the reference); the fill merge rejects a fill naming a table the store does not export, deterministically, with the real tables named; the table set rides the `verification_scaffold` input as data; both briefs stop saying "one entry per declared entity". Stack #1's per-entity dicts are the same shape and are left for a follow-up.

**#1079 producer** — success probes derive `json_has` from `derive_response_shape` (the shell's own derivation); rejection/conflict probes carry no shape; a response naming no entity adds nothing. The shared judge (#1084) fails a body missing a derived key and names it.

Regression: **7,897 pass, 0 fail.** The four pins moved as one classified commit (`chore(fixtures)`), per the owner's decision on 2026-08-25:

| pin | what moved | disposition |
|---|---|---|
| scaffold reference fixture | `expanded_tree_hash` only — **no shell changed**, spine and scaffold hashes byte-identical to v7 | `GENERATOR_VERSION` 7 → 8, manifest regenerated, reason recorded in the test |
| reference contract | `json_has` on the three success probes, nothing else | **`ambiguity_removal`** (M0 taxonomy). v9 (`art_4f368ea08799`) kept unchanged as the 1.4 evidence pin; the derived form lands beside it as `contract_v10_json_has_1079.yaml`; a new test asserts v10 − `json_has` == v9, so the classification is falsifiable. No qualification of the 1.4 figure. |

Not in this PR: #1015-A/#968, #998, #1094 (the loop-side pack), the #1021 read.

Refs #1096, #1087, #1079
