### PR TITLE
fix(correction): the repair target reaches the defect site — #1015 part A

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -310,8 +310,42 @@ def _narrowed_or_scoped(
     )
 
 
+def _verified_implicated_files(
+    failure_analysis: dict[str, Any] | None, failed_inputs: dict[str, Any]
+) -> list[str]:
+    """The analyzer's ``implicated_files``, kept only where the workspace agrees (#968).
+
+    The analyzer's file claims are prose-adjacent — #968 counted three false ones in a
+    single roll, one of them carried verbatim into the correction decision. The cheapest
+    mechanical check is whether the named path is a file the failed task's envelope knows
+    about at all: an implementation artifact, one of its own expected artifacts, or a
+    contract-owned slot. A path outside that set is not a defect site the loop can act
+    on, and is dropped with a log line rather than aimed at.
+    """
+    if not isinstance(failure_analysis, dict):
+        return []
+    claimed = [str(f) for f in (failure_analysis.get("implicated_files") or []) if f]
+    if not claimed:
+        return []
+    known: set[str] = set()
+    for key in ("implementation_artifacts", "expected_artifacts"):
+        known.update(str(x) for x in (failed_inputs.get(key) or []) if x)
+    known.update(str(x) for x in (failed_inputs.get("contract_endpoint_owners") or {}).values())
+    verified = [f for f in dict.fromkeys(claimed) if f in known]
+    dropped = [f for f in claimed if f not in known]
+    if dropped:
+        logger.info(
+            "correction_repair_target: analyzer implicated %s but the workspace has no such "
+            "file — dropped, not aimed at (#968)",
+            ", ".join(dropped),
+        )
+    return verified
+
+
 def _resolve_repair_target(
-    failure_evidence: Any, failed_inputs: dict[str, Any]
+    failure_evidence: Any,
+    failed_inputs: dict[str, Any],
+    failure_analysis: dict[str, Any] | None = None,
 ) -> tuple[list[str], str | None, str | None]:
     """Choose ``(expected_artifacts, focus, description)`` for a patch-path repair.
 
@@ -396,8 +430,17 @@ def _resolve_repair_target(
     # package-scoped implementation surface so a behavioral failure can reach the
     # source under test. Empty surface → byte-identical to the #531 fallback
     # (failed_artifacts, focus, description).
-    scoped_source = _narrowed_or_scoped(probe_slots, failed_inputs, failed_artifacts)
-    target = list(dict.fromkeys([*probe_slots, *failed_artifacts, *scoped_source]))
+    # #1015 part A, the analyzer's half: consulted only when no deterministic site
+    # evidence exists (no failing probe resolved to a slot, no drift). Verified entries
+    # narrow the target exactly as a probe-owned slot does; none → the surface is what
+    # it was.
+    analysis_files = (
+        _verified_implicated_files(failure_analysis, failed_inputs) if not probe_slots else []
+    )
+    scoped_source = _narrowed_or_scoped(
+        [*probe_slots, *analysis_files], failed_inputs, failed_artifacts
+    )
+    target = list(dict.fromkeys([*probe_slots, *analysis_files, *failed_artifacts, *scoped_source]))
     target = _widen_target_for_frontend_build(target, failure_evidence, failed_inputs)
     return (
         target,
@@ -492,6 +535,7 @@ def _locus_and_repair_target(
     failed_task_type: str,
     failure_evidence: Any,
     failed_inputs: dict[str, Any],
+    failure_analysis: dict[str, Any] | None = None,
 ) -> tuple[str, list[str], str | None, str | None]:
     """#568: classify the failure locus and choose the repair target for it.
 
@@ -518,7 +562,9 @@ def _locus_and_repair_target(
             failed_inputs.get("subtask_focus"),
             failed_inputs.get("subtask_description"),
         )
-    expected, focus, description = _resolve_repair_target(failure_evidence, failed_inputs)
+    expected, focus, description = _resolve_repair_target(
+        failure_evidence, failed_inputs, failure_analysis
+    )
     return (failure_locus, expected, focus, description)
 
 
@@ -1368,7 +1414,9 @@ class CorrectionRunner:
                 repair_expected_artifacts,
                 repair_focus,
                 repair_description,
-            ) = _locus_and_repair_target(envelope.task_type, failure_evidence, failed_inputs)
+            ) = _locus_and_repair_target(
+                envelope.task_type, failure_evidence, failed_inputs, analysis_outputs
+            )
 
             for step_idx, (task_type, role) in enumerate(
                 repair_steps_for(envelope.task_type, failure_locus)

--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -200,11 +200,31 @@ def _failed_probe_ids(failure_evidence: Any) -> list[str]:
     if not isinstance(failure_evidence, dict):
         return []
     rows = (failure_evidence.get("validation_result") or {}).get("checks") or []
-    return [
+    ids = [
         str(row.get("check"))
         for row in rows
         if isinstance(row, dict) and row.get("status") == "failed" and row.get("check")
     ]
+    # #1015: the same probe failing INSIDE the suite. A scaffold shell is bound to a
+    # probe id, and when its frozen assertion fails the scaffold evidence classifies
+    # that as ``app_contract`` with ``criterion_id`` = the probe id — structured data,
+    # not the analyzer's prose. The 1.6.3 set's three reds all failed this way, on
+    # ``vc-probe-api-runs-join``, and never as an HTTP probe row; so the #688 chain to
+    # the owning slot started from an empty list every round. Fill-layer and
+    # generator-layer observations carry no criterion and indict no endpoint.
+    from squadops.cycles.scaffold_evidence import CLASS_APP_CONTRACT
+
+    summary = failure_evidence.get("scaffold_evidence")
+    observations = (summary.get("observations") or []) if isinstance(summary, dict) else []
+    for obs in observations:
+        if (
+            isinstance(obs, dict)
+            and obs.get("failure_class") == CLASS_APP_CONTRACT
+            and obs.get("criterion_id")
+            and str(obs["criterion_id"]) not in ids
+        ):
+            ids.append(str(obs["criterion_id"]))
+    return ids
 
 
 def _probe_owned_slots(failure_evidence: Any, failed_inputs: dict[str, Any]) -> list[str]:
@@ -258,6 +278,36 @@ def _probe_owned_slots(failure_evidence: Any, failed_inputs: dict[str, Any]) -> 
             ", ".join(failed_ids),
         )
     return slots
+
+
+def _narrowed_or_scoped(
+    probe_slots: list[str], failed_inputs: dict[str, Any], failed_artifacts: list[str]
+) -> list[str]:
+    """The implementation surface a repair may reach — narrowed when the defect site is known.
+
+    **#1015 part A, the narrowing.** When a failing probe resolves to the slot that owns
+    its endpoint, that slot IS the target and the language-wide surface is not appended.
+    The 1.6.3 set measured the alternative: with the join route in a seven-file "you may
+    emit" list, roll 1's round 2 and roll 4's rounds 2–3 repaired the create route while
+    the decision text named the join handler, and the loop spent its budget beside the
+    defect. Minimality and the attempt counter (#1015 B/C) were in force and did not
+    help a repair aimed at the wrong file. Drift files and the failed task's own
+    artifacts still ride (pf-21: they carry real defects too); only the fallback that
+    exists for the case of *no* site evidence is withheld when site evidence exists.
+
+    With no probe-owned slot the surface is what it was: package scoping, then the
+    #688 language fallback.
+    """
+    if probe_slots:
+        logger.info(
+            "correction_repair_target: narrowed to the slot(s) owning the failing probe(s) — "
+            "%s; the language-wide surface is withheld (#1015)",
+            ", ".join(probe_slots),
+        )
+        return []
+    return _scoped_implementation_surface(
+        failed_inputs.get("implementation_artifacts", []) or [], failed_artifacts
+    )
 
 
 def _resolve_repair_target(
@@ -336,9 +386,7 @@ def _resolve_repair_target(
         # edits only the drifted file + the test and NEVER reaches routes.py →
         # non-convergence. Union it here too; empty surface (author mode) → the scoped
         # set is empty and the target is byte-identical to the pre-pf-27 union.
-        scoped_source = _scoped_implementation_surface(
-            failed_inputs.get("implementation_artifacts", []) or [], failed_artifacts
-        )
+        scoped_source = _narrowed_or_scoped(probe_slots, failed_inputs, failed_artifacts)
         target = list(
             dict.fromkeys([*probe_slots, *drift_files, *failed_artifacts, *scoped_source])
         )
@@ -348,9 +396,7 @@ def _resolve_repair_target(
     # package-scoped implementation surface so a behavioral failure can reach the
     # source under test. Empty surface → byte-identical to the #531 fallback
     # (failed_artifacts, focus, description).
-    scoped_source = _scoped_implementation_surface(
-        failed_inputs.get("implementation_artifacts", []) or [], failed_artifacts
-    )
+    scoped_source = _narrowed_or_scoped(probe_slots, failed_inputs, failed_artifacts)
     target = list(dict.fromkeys([*probe_slots, *failed_artifacts, *scoped_source]))
     target = _widen_target_for_frontend_build(target, failure_evidence, failed_inputs)
     return (

--- a/src/squadops/capabilities/handlers/impl/analyze_failure.py
+++ b/src/squadops/capabilities/handlers/impl/analyze_failure.py
@@ -59,6 +59,11 @@ class FailureAnalysis(BaseModel):
     classification: str = Field(min_length=1)
     analysis_summary: str = Field(min_length=20)
     contributing_factors: list[str] = Field(min_length=1)
+    #: #1015 part A: the implementation files the EVIDENCE names as the defect site —
+    #: optional, empty when the evidence names none. Structured so the repair target can
+    #: consume it; verified against the workspace before it is trusted (#968), never used
+    #: ahead of deterministic site evidence (a failing probe's owning slot, interface drift).
+    implicated_files: list[str] = Field(default_factory=list)
 
     @field_validator("classification")
     @classmethod
@@ -73,6 +78,24 @@ class FailureAnalysis(BaseModel):
         if not all(isinstance(s, str) and len(s.strip()) >= 5 for s in v):
             raise ValueError("each contributing factor must be a string >=5 chars")
         return v
+
+    @field_validator("implicated_files")
+    @classmethod
+    def implicated_files_are_relative_paths(cls, v: list[str]) -> list[str]:
+        cleaned: list[str] = []
+        for item in v:
+            if not isinstance(item, str):
+                raise ValueError("implicated_files entries must be strings")
+            path = item.strip()
+            while path.startswith("./"):
+                path = path[2:]
+            if not path or path.startswith("/") or ".." in path.split("/"):
+                raise ValueError(
+                    f"implicated_files entry {item!r} is not a repository-relative path"
+                )
+            if path not in cleaned:
+                cleaned.append(path)
+        return cleaned
 
 
 class DataAnalyzeFailureHandler(_CycleTaskHandler):
@@ -211,6 +234,7 @@ class DataAnalyzeFailureHandler(_CycleTaskHandler):
             "classification": analysis.get("classification", FailureClassification.EXECUTION),
             "analysis_summary": analysis.get("analysis_summary", ""),
             "contributing_factors": analysis.get("contributing_factors", []),
+            "implicated_files": analysis.get("implicated_files", []),
             "artifacts": [
                 {
                     "name": self._artifact_name,

--- a/src/squadops/capabilities/scaffold_contract.py
+++ b/src/squadops/capabilities/scaffold_contract.py
@@ -266,7 +266,9 @@ def _nextjs_ts_slot_criteria(manifest: InterfaceManifest, path: str) -> dict[str
     general protection against a future stack repeating this is the id linter, now wired at
     derivation, not a second hand-audit of the emitters.
     """
-    return {
+    from squadops.capabilities.stack_nextjs_ts import endpoint_owners_nextjs_ts
+
+    criteria: dict[str, Any] = {
         "interface": [],
         "implementation": [
             {
@@ -278,6 +280,13 @@ def _nextjs_ts_slot_criteria(manifest: InterfaceManifest, path: str) -> dict[str
             }
         ],
     }
+    # #1015: ownership as DATA, since no criterion on this stack can carry it. A page
+    # slot serves no endpoint and gets no key — presence-keyed, so the shape stays
+    # byte-identical for stacks and slots that state ownership another way.
+    endpoints = endpoint_owners_nextjs_ts(manifest).get(path)
+    if endpoints:
+        criteria["endpoints"] = endpoints
+    return criteria
 
 
 _CRITERIA_PACKS: dict[str, CriteriaPack] = {

--- a/src/squadops/capabilities/stack_nextjs_ts.py
+++ b/src/squadops/capabilities/stack_nextjs_ts.py
@@ -600,6 +600,23 @@ def expand_nextjs_ts(manifest: InterfaceManifest) -> list[dict[str, str]]:
     return files
 
 
+def endpoint_owners_nextjs_ts(manifest: InterfaceManifest) -> dict[str, list[str]]:
+    """``route file → ["METHOD /path", …]`` — which fill slot serves which endpoint (#1015).
+
+    Stack #1 states this relation through the ``endpoint_defined`` criterion its pack
+    attaches to ``backend/routes.py``; this stack's pack has no Python AST check to hang
+    it on, so until now the contract said nothing and ``endpoint_owners()`` came back
+    empty — which is why the 1.6.3 set's repair target was the whole application in 18
+    of 18 rounds: the #688 chain from a failing probe to the file that owns its endpoint
+    had no map to walk on this stack. The relation is bend 1's own output
+    (``_route_groups``), so the contract now carries it as data.
+    """
+    return {
+        path: [f"{ep.method} {ep.path}" for ep in endpoints]
+        for path, endpoints in _route_groups(manifest).items()
+    }
+
+
 def fill_slots_nextjs_ts(manifest: InterfaceManifest) -> tuple[str, ...]:
     """The files a dev fills bodies into: every route handler and every page.
 

--- a/src/squadops/cycles/verification_contract.py
+++ b/src/squadops/cycles/verification_contract.py
@@ -260,17 +260,26 @@ class FrozenFile:
 
 @dataclass(frozen=True)
 class FillFile:
-    """A fill slot with its interface and implementation criteria (§6.1)."""
+    """A fill slot with its interface and implementation criteria (§6.1).
+
+    ``endpoints`` (#1015): the ``"METHOD /path"`` tokens this slot serves, for stacks
+    whose pack cannot express ownership as a criterion. Empty means "not stated here" —
+    ``endpoint_owners`` then reads the ``endpoint_defined`` criteria as before.
+    """
 
     path: str
     interface: tuple[Criterion, ...] = ()
     implementation: tuple[Criterion, ...] = ()
+    endpoints: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        out: dict[str, Any] = {
             "interface": [c.to_dict() for c in self.interface],
             "implementation": [c.to_dict() for c in self.implementation],
         }
+        if self.endpoints:  # presence-keyed: absent stays absent, bytes stay stable
+            out["endpoints"] = list(self.endpoints)
+        return out
 
 
 @dataclass(frozen=True)
@@ -479,13 +488,17 @@ class VerificationContract:
 
         owners: dict[str, str] = {}
         for ff in self.fill_files:
+            tokens: list[str] = []
             for crit in ff.interface:
-                if crit.check != CHECK_ENDPOINT_DEFINED:
-                    continue
-                for token in crit.params.get("methods_paths", []) or []:
-                    parsed = parse_method_path(str(token))
-                    if parsed:
-                        owners.setdefault(f"{parsed[0]} {parsed[1]}", ff.path)
+                if crit.check == CHECK_ENDPOINT_DEFINED:
+                    tokens.extend(str(t) for t in (crit.params.get("methods_paths", []) or []))
+            # #1015: a stack whose pack has no endpoint criterion states ownership as
+            # data on the slot instead. Same token grammar, same normalization.
+            tokens.extend(ff.endpoints)
+            for token in tokens:
+                parsed = parse_method_path(token)
+                if parsed:
+                    owners.setdefault(f"{parsed[0]} {parsed[1]}", ff.path)
         return owners
 
     def view_slots(self) -> tuple[str, ...]:
@@ -881,10 +894,14 @@ def _fill_file_from(path: Any, spec: Any) -> FillFile:
     implementation_raw = spec.get("implementation", [])
     if not isinstance(interface_raw, list) or not isinstance(implementation_raw, list):
         raise ValueError(f"fill_files[{path!r}]: interface/implementation must be lists")
+    endpoints_raw = spec.get("endpoints", []) or []
+    if not isinstance(endpoints_raw, list):
+        raise ValueError(f"fill_files[{path!r}]: endpoints must be a list of 'METHOD /path'")
     return FillFile(
         path=str(path),
         interface=tuple(Criterion.from_dict(c) for c in interface_raw),
         implementation=tuple(Criterion.from_dict(c) for c in implementation_raw),
+        endpoints=tuple(str(e) for e in endpoints_raw),
     )
 
 

--- a/src/squadops/prompts/fragments/manifest.yaml
+++ b/src/squadops/prompts/fragments/manifest.yaml
@@ -192,5 +192,5 @@ fragments:
   layer: task_type
   roles:
   - data
-  sha256: fd44a28f65e449c6320b5ee5f1d8121013a03c7baa757965334c4e19c7904779
-manifest_hash: b98e80eb88203649839caecc6d5aba104cc0f994ab9eefbebed88101c7302c38
+  sha256: e1f6e8f83c98935f547def59a6ab4e2f0d09f2bbf50afe9989fa0c5d71cec241
+manifest_hash: 4d3162d175e853ddab6abf6f83f0b9b392d6e2ee1649143922a200f989ec7e38

--- a/src/squadops/prompts/fragments/shared/task_type/task_type.data.analyze_failure.md
+++ b/src/squadops/prompts/fragments/shared/task_type/task_type.data.analyze_failure.md
@@ -1,7 +1,7 @@
 ---
 fragment_id: task_type.data.analyze_failure
 layer: task_type
-version: "1.0.0"
+version: "1.1.0"
 roles: ["data"]
 ---
 ## Failure Analysis (SIP-0079 §7.7)
@@ -56,6 +56,14 @@ Return JSON with these REQUIRED fields:
   that contributed. Each factor must be a concrete observable, not a generic
   phrase.
 
-Empty fields, the literal "N/A", and the literal "unknown" will be rejected.
+And ONE optional field:
+- `implicated_files` (list[string]): repository-relative paths of the implementation
+  files the evidence names as the defect site — a failing check's `file`, a slot's
+  owning route file, a rejected artifact's name. Only paths that appear in the Failure
+  Evidence. Empty when the evidence names none. Never a guess: an entry the workspace
+  does not contain is discarded and counted against the analysis, and a wrong file
+  aims the repair away from the defect for a whole round.
+
+Empty required fields, the literal "N/A", and the literal "unknown" will be rejected.
 
 Return ONLY valid JSON, no markdown fences, no explanation.

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -286,6 +286,54 @@ class TestAnalyzeFailure:
         assert result.outputs["outcome_class"] == TaskOutcome.NEEDS_REPLAN
         assert mock.await_count == 2
 
+    async def test_implicated_files_pass_through_normalized_and_bad_paths_are_rejected(
+        self, mock_context
+    ):
+        """#1015 part A: the analyzer may name the defect site as structured data. Paths
+        are normalized (a leading ./ dropped, duplicates collapsed) and an absolute or
+        parent-escaping path rejects the analysis — a file claim the loop cannot
+        verify must not be shaped like one it can."""
+        analysis = {
+            "classification": FailureClassification.WORK_PRODUCT,
+            "analysis_summary": "join route returns bare strings where objects are declared",
+            "contributing_factors": ["participants element kind mismatch"],
+            "implicated_files": [
+                "./app/api/runs/[run_id]/join/route.ts",
+                "app/api/runs/[run_id]/join/route.ts",
+            ],
+        }
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=json.dumps(analysis)),
+        )
+        result = await DataAnalyzeFailureHandler().handle(mock_context, {"prd": "test"})
+        assert result.success is True
+        assert result.outputs["implicated_files"] == ["app/api/runs/[run_id]/join/route.ts"]
+
+        analysis["implicated_files"] = ["../../etc/passwd"]
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=json.dumps(analysis)),
+        )
+        result = await DataAnalyzeFailureHandler().handle(mock_context, {"prd": "test"})
+        assert result.success is False
+
+    async def test_an_analysis_without_implicated_files_is_still_valid(self, mock_context):
+        """The field is optional: pre-#1015 analyses and analyses of evidence that names
+        no file must not be rejected for its absence."""
+        analysis = {
+            "classification": FailureClassification.EXECUTION,
+            "analysis_summary": "the task timed out before emitting anything at all",
+            "contributing_factors": ["1800s task timeout reached"],
+        }
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content=json.dumps(analysis)),
+        )
+        result = await DataAnalyzeFailureHandler().handle(mock_context, {"prd": "test"})
+        assert result.success is True
+        assert result.outputs["implicated_files"] == []
+
     async def test_empty_analysis_summary_rejected(self, mock_context):
         """Issue #84: ``analysis_summary: ""`` is the failure mode that
         produced ``analysis_summary: "N/A"`` corrections in the wild."""

--- a/tests/unit/capabilities/test_stack_nextjs_ts.py
+++ b/tests/unit/capabilities/test_stack_nextjs_ts.py
@@ -517,3 +517,33 @@ def test_the_frozen_harness_demonstrates_a_root_table_not_the_first_declared_ent
     )
     assert "TABLES.RunEvent" in harness
     assert "TABLES.Participant" not in harness
+
+
+# --------------------------------------------------------------------------- #
+# #1015 — the contract states which route file owns each endpoint
+# --------------------------------------------------------------------------- #
+
+
+def test_the_contract_states_which_route_file_owns_each_endpoint():
+    """Bug caught (#1015, reads §1): `endpoint_owners()` was EMPTY on this stack — no
+    Python criterion to hang ownership on — so a failing probe could never resolve to
+    the file that owns its endpoint and the repair target was the whole application in
+    18 of 18 rounds of the 1.6.3 set. Ownership is bend 1's own output; the contract
+    carries it as data."""
+    from squadops.cycles.verification_contract import VerificationContract
+
+    contract = VerificationContract.from_dict(emit_contract_dict(_manifest()))
+    owners = contract.endpoint_owners()
+    assert owners["POST /api/runs/{run_id}/join"] == "app/api/runs/[run_id]/join/route.ts"
+    assert owners["GET /api/runs"] == "app/api/runs/route.ts"
+    assert owners["POST /api/runs"] == "app/api/runs/route.ts"
+    assert len(owners) == 5
+    # Page slots serve no endpoint and carry no key — presence-keyed, so the stack #1
+    # contract (which states ownership through `endpoint_defined`) is byte-identical.
+    raw = emit_contract_dict(_manifest())["fill_files"]
+    assert "endpoints" not in raw["app/page.tsx"]
+    assert raw["app/api/runs/[run_id]/join/route.ts"]["endpoints"] == [
+        "POST /api/runs/{run_id}/join"
+    ]
+    stack1 = emit_contract_dict(_manifest("fullstack_fastapi_react"))["fill_files"]
+    assert all("endpoints" not in spec for spec in stack1.values())

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -4436,3 +4436,139 @@ class TestEmptyRepairEmission:
             plan_delta_refs=[],
         )
         assert protocol.emission_empty is False
+
+
+class TestSuiteProbeFailuresReachTheOwningSlot:
+    """#1015 part A — the deterministic half, replayed from the 1.6.3 set's roll 4.
+
+    The three reds failed the join probe INSIDE the suite (`app_contract` observation
+    bound to `vc-probe-api-runs-join`), never as an HTTP probe row, so `_failed_probe_ids`
+    returned nothing and the #688 chain never started. And on nextjs_ts the owners map was
+    empty besides. Both fixed, the target must lead with the join route and withhold the
+    language-wide surface the rounds were wasted on.
+    """
+
+    IMPL = [
+        "app/api/runs/route.ts",
+        "app/api/runs/[run_id]/route.ts",
+        "app/api/runs/[run_id]/join/route.ts",
+        "app/api/runs/[run_id]/leave/route.ts",
+        "app/page.tsx",
+        "app/runs/new/page.tsx",
+        "app/runs/[run_id]/page.tsx",
+    ]
+
+    @staticmethod
+    def _nextjs_inputs():
+        from squadops.capabilities.scaffold_contract import emit_contract_dict
+        from squadops.cycles.verification_contract import VerificationContract
+        from tests.unit.capabilities._stack_fixtures import manifest_for_stack
+
+        contract = VerificationContract.from_dict(
+            emit_contract_dict(manifest_for_stack("nextjs_ts"))
+        )
+        return {
+            "expected_artifacts": ["__tests__/runs-api.test.ts", "__tests__/join-leave.test.ts"],
+            "implementation_artifacts": list(TestSuiteProbeFailuresReachTheOwningSlot.IMPL),
+            "contract_probes": [p.to_dict() for p in contract.behavioral.probes],
+            "contract_endpoint_owners": contract.endpoint_owners(),
+        }
+
+    @staticmethod
+    def _observation(failure_class, criterion_id):
+        return {
+            "file": "__tests__/scaffold/x.scaffold.test.ts",
+            "slot_id": "slot-x",
+            "failure_class": failure_class,
+            "criterion_id": criterion_id,
+            "owner": "dev",
+            "route": "dev_repair",
+        }
+
+    def _evidence(self, *observations):
+        return {
+            "validation_result": {
+                "passed": False,
+                "checks": [{"check": "tests_pass", "status": "failed"}],
+            },
+            "scaffold_evidence": {
+                "failure_classes": {"app_contract": 1},
+                "observations": list(observations),
+            },
+        }
+
+    def test_an_app_contract_observation_is_a_failed_probe(self):
+        from adapters.cycles.correction_runner import _failed_probe_ids
+
+        ev = self._evidence(
+            self._observation("app_contract", "vc-probe-api-runs-join"),
+            self._observation("fill", ""),  # a fill-layer failure indicts no endpoint
+            self._observation(
+                "scaffold_invalid", "vc-probe-api-runs"
+            ),  # generator layer: not a probe failure
+            self._observation("app_contract", "vc-probe-api-runs-join"),  # duplicate, once
+        )
+        # A failed `tests_pass` row rides the list as before — it joins no owner and is
+        # inert; the subject here is which OBSERVATIONS become probe ids.
+        assert [i for i in _failed_probe_ids(ev) if i != "tests_pass"] == ["vc-probe-api-runs-join"]
+
+    def test_http_probe_rows_still_lead_and_join_with_suite_observations(self):
+        from adapters.cycles.correction_runner import _failed_probe_ids
+
+        ev = self._evidence(self._observation("app_contract", "vc-probe-api-runs-join"))
+        ev["validation_result"]["checks"].append({"check": "vc-probe-api-runs", "status": "failed"})
+        assert [i for i in _failed_probe_ids(ev) if i != "tests_pass"] == [
+            "vc-probe-api-runs",
+            "vc-probe-api-runs-join",
+        ]
+
+    def test_roll_4_replay_the_join_route_leads_and_the_language_surface_is_withheld(self):
+        """Roll 4 (`cyc_a38814afc16d`), rounds 2–3: the decision named the join handler,
+        the target listed all seven files, the repair emitted the create route. Now the
+        target is the owning slot plus the failed task's own artifacts — nothing else."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        ev = self._evidence(self._observation("app_contract", "vc-probe-api-runs-join"))
+        target, _, _ = _resolve_repair_target(ev, self._nextjs_inputs())
+        assert target[0] == "app/api/runs/[run_id]/join/route.ts"
+        assert "app/api/runs/route.ts" not in target
+        assert not any(t.endswith("page.tsx") for t in target)
+        assert set(target) == {
+            "app/api/runs/[run_id]/join/route.ts",
+            "__tests__/runs-api.test.ts",
+            "__tests__/join-leave.test.ts",
+        }
+
+    def test_without_site_evidence_the_surface_is_what_it_was(self):
+        """The narrowing withholds the fallback only when there is a site to narrow to.
+        A suite-only failure with no probe echo still reaches the source under test
+        through the #688 language fallback — package scoping matches nothing here."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        ev = {
+            "validation_result": {
+                "passed": False,
+                "checks": [{"check": "tests_pass", "status": "failed"}],
+            }
+        }
+        target, _, _ = _resolve_repair_target(ev, self._nextjs_inputs())
+        assert set(self.IMPL) <= set(target)
+
+    def test_drift_files_still_ride_beside_the_narrowed_target(self):
+        """pf-21: a co-occurring interface drift names a real defect too; narrowing withholds
+        only the no-evidence fallback, never named evidence."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        ev = self._evidence(self._observation("app_contract", "vc-probe-api-runs-join"))
+        ev["interface_drift"] = [
+            {
+                "kind": "rename",
+                "file": "app/api/runs/route.ts",
+                "extra": [],
+                "missing": [],
+                "instruction": "x",
+            }
+        ]
+        target, _, _ = _resolve_repair_target(ev, self._nextjs_inputs())
+        assert target[:2] == ["app/api/runs/[run_id]/join/route.ts", "app/api/runs/route.ts"]
+        assert "app/api/runs/[run_id]/leave/route.ts" not in target

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -4572,3 +4572,111 @@ class TestSuiteProbeFailuresReachTheOwningSlot:
         target, _, _ = _resolve_repair_target(ev, self._nextjs_inputs())
         assert target[:2] == ["app/api/runs/[run_id]/join/route.ts", "app/api/runs/route.ts"]
         assert "app/api/runs/[run_id]/leave/route.ts" not in target
+
+
+class TestAnalyzerImplicatedFilesAreVerifiedBeforeUse:
+    """#1015 part A, the analyzer's half, with #968's cheapest check in front of it.
+
+    The analyzer may name the defect site as structured data. It is trusted only where
+    the workspace agrees (the failed task's implementation/expected artifacts or a
+    contract-owned slot), only when no deterministic site evidence exists, and it
+    narrows the target exactly as a probe-owned slot does.
+    """
+
+    INPUTS = {
+        "expected_artifacts": ["__tests__/runs-api.test.ts"],
+        "implementation_artifacts": [
+            "app/api/runs/route.ts",
+            "app/api/runs/[run_id]/join/route.ts",
+            "app/page.tsx",
+        ],
+    }
+    SUITE_FAIL = {
+        "validation_result": {
+            "passed": False,
+            "checks": [{"check": "tests_pass", "status": "failed"}],
+        }
+    }
+
+    def test_a_verified_claim_narrows_the_target(self):
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        target, _, _ = _resolve_repair_target(
+            self.SUITE_FAIL,
+            dict(self.INPUTS),
+            {"implicated_files": ["app/api/runs/[run_id]/join/route.ts"]},
+        )
+        assert target == ["app/api/runs/[run_id]/join/route.ts", "__tests__/runs-api.test.ts"]
+
+    def test_an_unverifiable_claim_is_dropped_and_the_surface_is_what_it_was(self):
+        """#968's shape: a confident path the workspace does not contain. It must not
+        become the target — and its presence must not remove the fallback either."""
+        from adapters.cycles.correction_runner import (
+            _resolve_repair_target,
+            _verified_implicated_files,
+        )
+
+        analysis = {"implicated_files": ["lib/shadow_store.ts", "backend/routes.py"]}
+        assert _verified_implicated_files(analysis, dict(self.INPUTS)) == []
+        target, _, _ = _resolve_repair_target(self.SUITE_FAIL, dict(self.INPUTS), analysis)
+        assert set(self.INPUTS["implementation_artifacts"]) <= set(target)
+
+    def test_deterministic_site_evidence_outranks_the_analyzer(self):
+        """A failing probe's owning slot is contract data; the analyzer's file is a claim.
+        When both exist the slot wins and the claim is not consulted."""
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        inputs = {
+            **self.INPUTS,
+            "contract_probes": [
+                {
+                    "id": "vc-probe-api-runs-join",
+                    "subject": "backend",
+                    "request": {"method": "POST", "path": "/api/runs/{run_id}/join", "json": {}},
+                    "expect": {"status": 200},
+                }
+            ],
+            "contract_endpoint_owners": {
+                "POST /api/runs/{run_id}/join": "app/api/runs/[run_id]/join/route.ts"
+            },
+        }
+        ev = {
+            **self.SUITE_FAIL,
+            "scaffold_evidence": {
+                "failure_classes": {"app_contract": 1},
+                "observations": [
+                    {
+                        "file": "x",
+                        "slot_id": "s",
+                        "failure_class": "app_contract",
+                        "criterion_id": "vc-probe-api-runs-join",
+                        "owner": "dev",
+                        "route": "dev_repair",
+                    }
+                ],
+            },
+        }
+        target, _, _ = _resolve_repair_target(
+            ev, inputs, {"implicated_files": ["app/api/runs/route.ts"]}
+        )
+        assert target[0] == "app/api/runs/[run_id]/join/route.ts"
+        assert "app/api/runs/route.ts" not in target
+
+    def test_the_analysis_reaches_the_resolver_through_the_locus_step(self):
+        from adapters.cycles.correction_runner import _locus_and_repair_target
+
+        _, expected, _, _ = _locus_and_repair_target(
+            "qa.test", self.SUITE_FAIL, dict(self.INPUTS), {"implicated_files": ["app/page.tsx"]}
+        )
+        assert expected[0] == "app/page.tsx"
+        assert "app/api/runs/route.ts" not in expected
+
+    @pytest.mark.parametrize(
+        "analysis", [None, {}, {"implicated_files": []}, {"implicated_files": None}]
+    )
+    def test_no_claim_changes_nothing(self, analysis):
+        from adapters.cycles.correction_runner import _resolve_repair_target
+
+        with_claim, _, _ = _resolve_repair_target(self.SUITE_FAIL, dict(self.INPUTS), analysis)
+        without, _, _ = _resolve_repair_target(self.SUITE_FAIL, dict(self.INPUTS))
+        assert with_claim == without


### PR DESCRIPTION
The 1.6.4 plan's headline loop-side fix (rev 4 §2.1). Two commits: the deterministic half, then the analyzer half.

## What the reads found, and this fixes

Roll 4's rounds 2–3 (and roll 1's round 2) named the join handler in the correction decision and emitted the create route. The runtime-api log showed why: **the repair target was the entire application in 18 of 18 rounds.** Two gaps compounded:

1. **On `nextjs_ts` the contract's `endpoint_owners()` was empty** — the pack has no Python `endpoint_defined` criterion to hang ownership on, so the #688 chain from a failing probe to the file that owns its endpoint had no map to walk. The contract now carries ownership **as data** on each route slot (`endpoints: ["METHOD /path"]`, from bend 1's own `_route_groups`); presence-keyed, so the stack #1 contract v10 stays byte-identical (its pin still passes).
2. **The reds failed the join probe *inside the suite*** — a scaffold `app_contract` observation bound to `vc-probe-api-runs-join` — never as an HTTP probe row, and `_failed_probe_ids` read only the rows. It now reads those observations too (structured data; fill/generator-layer observations carry no criterion and indict nothing).

**The narrowing:** when a failing probe resolves to its owning slot, that slot *is* the target and the language-wide fallback is withheld. Drift files and the failed task's own artifacts still ride (pf-21). Roll 4's evidence replayed through the resolver now yields `app/api/runs/[run_id]/join/route.ts` (+ the qa files the #884 veto removes), where before it yielded seven files.

**The analyzer half (part A as filed, with #968's cheapest slice):** `FailureAnalysis.implicated_files` (optional; fragment v1.1.0, manifest regenerated), consulted only when no deterministic site evidence exists, kept only where the failed task's envelope knows the path. An unverifiable claim is dropped with a log line, and its presence does not remove the fallback.

## Verification

- 7,913 regression / full unit tree green; contract v10 and scaffold reference pins unchanged.
- Plan prediction **P5**: every repair round's emission includes the file the decision named.
- Not exercised here: a live cycle. Shakeout 2 follows the rest of the loop pack (#998, #1094).

Refs #1015, #968, #688