### PR TITLE
feat(evidence): an empty emission says which kind of nothing it was — #998

### DIFF
--- a/adapters/cycles/correction_runner.py
+++ b/adapters/cycles/correction_runner.py
@@ -280,6 +280,15 @@ def _probe_owned_slots(failure_evidence: Any, failed_inputs: dict[str, Any]) -> 
     return slots
 
 
+def _empty_emission_signature(result: Any) -> list[str]:
+    """The #998 signature a repair step's handler put on its ``emission_failure`` marker,
+    as a zero-or-one-element list so the caller can ``extend`` without branching."""
+    marker = (getattr(result, "outputs", None) or {}).get("emission_failure")
+    if isinstance(marker, dict) and marker.get("signature"):
+        return [str(marker["signature"])]
+    return []
+
+
 def _narrowed_or_scoped(
     probe_slots: list[str], failed_inputs: dict[str, Any], failed_artifacts: list[str]
 ) -> list[str]:
@@ -694,6 +703,12 @@ class CorrectionProtocolResult:
     #: emission failure (`FailureEvidenceCategory.EMISSION_ABSENT`'s shape), not an
     #: attempt at the fix.
     emission_empty: bool = False
+    #: #998: the SIGNATURE of each empty repair emission this round, in step order —
+    #: ``cap_exhausted`` (the model spent its whole completion budget and closed no
+    #: content), ``empty`` (fewer tokens than the budget, nothing returned), or
+    #: ``unextractable``. Two empties with opposite remedies must not read the same on
+    #: the correction event; before this they did not read at all.
+    empty_emission_signatures: tuple[str, ...] = ()
 
 
 class CorrectionRunner:
@@ -1401,6 +1416,7 @@ class CorrectionRunner:
         # the SUBJECT and would point a test re-author at app source files).
         repair_artifacts: list[dict[str, Any]] = []
         repair_steps_ran = False
+        empty_signatures: list[str] = []
         if correction_path == "patch":
             failed_inputs = envelope.inputs or {}
             # #667/#663 S2: the anchor surface rides every repair envelope,
@@ -1523,6 +1539,9 @@ class CorrectionRunner:
                 # #389: surface the repair's emitted files to the executor for
                 # behavioral patch verification.
                 step_artifacts = (repair_result.outputs or {}).get("artifacts") or []
+                # #998: the handler names what kind of nothing it emitted; keep it for
+                # the round's disclosure below.
+                empty_signatures.extend(_empty_emission_signature(repair_result))
                 # #507: re-home repair files onto the failed task's expected
                 # paths before they reach the overlay — a repair emitted under
                 # the wrong directory otherwise lands as a net-new file, patch
@@ -1567,9 +1586,10 @@ class CorrectionRunner:
         if emission_empty:
             logger.warning(
                 "correction: repair emitted no content on attempt %d (%d artifact(s), all "
-                "empty) — the round produced nothing to verify (#1053)",
+                "empty; signature %s) — the round produced nothing to verify (#1053, #998)",
                 correction_attempts,
                 len(repair_artifacts),
+                ", ".join(empty_signatures) or "unreported",
             )
 
         # 8. Emit CORRECTION_COMPLETED
@@ -1580,13 +1600,20 @@ class CorrectionRunner:
             context={"cycle_id": cycle.cycle_id, "run_id": run_id},
             # Disclosed on the event, not only in a log line: "converged in 3" and
             # "converged in 3 after two empty emissions" must not read the same.
-            payload={"correction_path": correction_path, "emission_empty": emission_empty},
+            payload={
+                "correction_path": correction_path,
+                "emission_empty": emission_empty,
+                # #998: "converged in 3 after two empty emissions" must also say WHICH
+                # nothing — the two shapes have opposite remedies.
+                "empty_emission_signatures": list(empty_signatures) if emission_empty else [],
+            },
         )
 
         return CorrectionProtocolResult(
             correction_path=correction_path,
             repair_artifacts=repair_artifacts,
             emission_empty=emission_empty,
+            empty_emission_signatures=tuple(empty_signatures) if emission_empty else (),
         )
 
     # Artifact types a qa.test task emits *about* its run, not *into* its

--- a/adapters/cycles/dispatched_flow_executor.py
+++ b/adapters/cycles/dispatched_flow_executor.py
@@ -2923,9 +2923,10 @@ class DispatchedFlowExecutor(FlowExecutionPort):
         if protocol.emission_empty:
             if refund_empty_emission_attempt(correction_counter, max_corrections, attempt):
                 logger.warning(
-                    "correction attempt %d refunded: the repair emitted no content, so the "
-                    "round is re-taken rather than spent (refund %d of %d, #1053)",
+                    "correction attempt %d refunded: the repair emitted no content (%s), so "
+                    "the round is re-taken rather than spent (refund %d of %d, #1053/#998)",
                     attempt,
+                    ", ".join(protocol.empty_emission_signatures) or "signature unreported",
                     correction_counter["empty_refunds"],
                     max_corrections,
                 )

--- a/src/squadops/capabilities/handlers/cycle/base.py
+++ b/src/squadops/capabilities/handlers/cycle/base.py
@@ -774,6 +774,21 @@ class _CycleTaskHandler(CapabilityHandler):
             "emission_stats": emission_stats(len(content), artifacts),
             "prompt_provenance": provenance,
         }
+        if not content.strip():
+            # #998: an EMPTY emission on the generic path — which every repair handler
+            # rides — carried no marker at all, so the correction loop could refund the
+            # round (#1053) but never say what kind of nothing it was. Three of the
+            # eleven repair rounds in the 1.6.3 set's reds were exactly this. Only
+            # emptiness is flagged here: a document-producing handler legitimately
+            # emits no fences, and that is not a failure of anything.
+            from squadops.cycles.emission_integrity import no_fenced_blocks_failure
+
+            outputs["emission_failure"] = no_fenced_blocks_failure(
+                len(content),
+                inputs.get("expected_artifacts"),
+                completion_tokens=response.completion_tokens,
+                completion_cap=chat_kwargs.get("max_tokens"),
+            )
 
         duration_ms = (time.perf_counter() - start_time) * 1000
 

--- a/src/squadops/capabilities/handlers/cycle/develop.py
+++ b/src/squadops/capabilities/handlers/cycle/develop.py
@@ -549,7 +549,10 @@ class DevelopmentDevelopHandler(_CycleTaskHandler):
                     # #566: marker for the executor's aimed retry + the
                     # correction loop's failure-locus classifier.
                     "emission_failure": no_fenced_blocks_failure(
-                        len(content), inputs.get("expected_artifacts")
+                        len(content),
+                        inputs.get("expected_artifacts"),
+                        completion_tokens=response.completion_tokens,
+                        completion_cap=chat_kwargs.get("max_tokens"),
                     ),
                 },
             )

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -1141,7 +1141,10 @@ class QATestHandler(_CycleTaskHandler):
                     # turns it into aimed feedback; the correction loop's locus
                     # classifier reads it as a test-artifact-locus signal.
                     "emission_failure": no_fenced_blocks_failure(
-                        len(content), inputs.get("expected_artifacts")
+                        len(content),
+                        inputs.get("expected_artifacts"),
+                        completion_tokens=response.completion_tokens,
+                        completion_cap=chat_kwargs.get("max_tokens"),
                     ),
                 },
             )

--- a/src/squadops/cycles/emission_integrity.py
+++ b/src/squadops/cycles/emission_integrity.py
@@ -82,16 +82,65 @@ def emission_integrity_instruction(name: str, error: str) -> str:
 EMISSION_FAILURE_KEY = "emission_failure"
 EMISSION_FAILURE_NO_FENCED_BLOCKS = "no_fenced_blocks"
 
+# #998: what KIND of nothing. Three zero-extraction shapes with three different remedies,
+# previously indistinguishable in the evidence — a correction decision that cannot tell
+# them apart guesses ("safety filter, context overload" was the banked guess for a run
+# whose model had spent its whole completion budget thinking and closed no content).
+#
+# - ``cap_exhausted``: the model generated its full completion budget and produced no
+#   content at all — thought budget exhausted before content (V7 roll 1: 8,192 tokens,
+#   0 characters, 12.7 minutes). Remedy lives at the budget / prompt shape.
+# - ``empty``: fewer tokens than the budget and no content — the model returned nothing
+#   (a transport drop, a refusal, a model that stopped). Remedy: retry, investigate.
+# - ``unextractable``: content came back but nothing in it was a path-addressed fence.
+#   Remedy: the emission format (the #987/#528 class), not the budget.
+SIGNATURE_CAP_EXHAUSTED = "cap_exhausted"
+SIGNATURE_EMPTY = "empty"
+SIGNATURE_UNEXTRACTABLE = "unextractable"
+
+
+def classify_empty_emission(
+    response_chars: int, completion_tokens: int | None, completion_cap: int | None
+) -> str:
+    """Name the zero-extraction shape from the facts the LLM call already reports (#998).
+
+    ``completion_tokens >= completion_cap`` is the cap signal — the provider reports no
+    stop reason through this port, so token count against the requested budget is the
+    observable. Either value unknown means the cap cannot be asserted, and the shape
+    falls to what the character count alone supports.
+    """
+    if response_chars > 0:
+        return SIGNATURE_UNEXTRACTABLE
+    if (
+        completion_tokens is not None
+        and completion_cap is not None
+        and completion_cap > 0
+        and completion_tokens >= completion_cap
+    ):
+        return SIGNATURE_CAP_EXHAUSTED
+    return SIGNATURE_EMPTY
+
 
 def no_fenced_blocks_failure(
     response_chars: int,
     expected_artifacts: list[str] | None,
+    *,
+    completion_tokens: int | None = None,
+    completion_cap: int | None = None,
 ) -> dict[str, Any]:
-    """Build the ``emission_failure`` marker for a zero-extraction failure."""
+    """Build the ``emission_failure`` marker for a zero-extraction failure.
+
+    Carries the token facts and the #998 signature so the evidence says *which* nothing
+    this was; a producer that cannot report tokens still emits a truthful marker with
+    the signature the character count alone supports.
+    """
     return {
         "reason": EMISSION_FAILURE_NO_FENCED_BLOCKS,
         "response_chars": response_chars,
         "expected_artifacts": [str(e) for e in (expected_artifacts or [])],
+        "completion_tokens": completion_tokens,
+        "completion_cap": completion_cap,
+        "signature": classify_empty_emission(response_chars, completion_tokens, completion_cap),
     }
 
 
@@ -150,6 +199,17 @@ def emission_retry_reason_line(marker: dict[str, Any]) -> str:
     reason = marker.get("reason")
     if reason == EMISSION_FAILURE_NO_FENCED_BLOCKS:
         chars = marker.get("response_chars", 0)
+        signature = marker.get("signature")
+        if signature == SIGNATURE_CAP_EXHAUSTED:
+            tokens = marker.get("completion_tokens")
+            cap = marker.get("completion_cap")
+            return (
+                f"the model generated {tokens} tokens — its full {cap}-token completion "
+                f"budget — and closed no content: the budget was spent before any file was "
+                f"written. Emit the file first and keep any reasoning short."
+            )
+        if signature == SIGNATURE_EMPTY:
+            return "the response was empty — no content was returned at all."
         return (
             f"no fenced code block carrying a file path could be extracted "
             f"from the {chars}-character response."

--- a/tests/unit/capabilities/test_build_handlers.py
+++ b/tests/unit/capabilities/test_build_handlers.py
@@ -251,6 +251,9 @@ class TestDevBuildParseFailure:
         marker = result.outputs["emission_failure"]
         assert marker["reason"] == "no_fenced_blocks"
         assert marker["response_chars"] == len(LLM_NO_FENCES_RESPONSE)
+        # #998: content came back with no path-addressed fence — the format, not the
+        # budget, is the defect, and the marker must say so.
+        assert marker["signature"] == "unextractable"
 
 
 class TestDevBuildLLMError:

--- a/tests/unit/capabilities/test_impl_handlers.py
+++ b/tests/unit/capabilities/test_impl_handlers.py
@@ -768,6 +768,36 @@ class TestRepairHandlers:
         assert result.outputs["role"] == "dev"
         assert h.capability_id == "development.correction_repair"
 
+    async def test_an_empty_repair_emission_carries_the_cap_exhausted_signature(self, mock_context):
+        """#998: the generic path every repair rides emitted NO marker for an empty
+        response — roll 5 of the 1.6.3 set banked two 0-byte repair_output.md files and the
+        loop could refund the rounds (#1053) but never say what kind of nothing they were.
+        The model spent its whole completion budget: that is the signature."""
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(role="assistant", content="", completion_tokens=8192),
+        )
+        h = DevelopmentCorrectionRepairHandler()
+        result = await h.handle(
+            mock_context,
+            {"prd": "test", "agent_config_overrides": {"max_completion_tokens": 8192}},
+        )
+        marker = result.outputs["emission_failure"]
+        assert marker["signature"] == "cap_exhausted"
+        assert marker["completion_tokens"] == 8192 and marker["completion_cap"] == 8192
+
+    async def test_a_document_producing_repair_response_is_not_flagged(self, mock_context):
+        """Only emptiness is a failure on the generic path: prose without fences is a
+        document, and flagging it would mark every markdown-producing handler broken."""
+        _set_llm_mock(
+            mock_context,
+            return_value=ChatMessage(
+                role="assistant", content="Repair applied", completion_tokens=12
+            ),
+        )
+        result = await DevelopmentCorrectionRepairHandler().handle(mock_context, {"prd": "test"})
+        assert "emission_failure" not in result.outputs
+
     async def test_dev_repair_extracts_fenced_code_into_per_file_artifacts(self, mock_context):
         # Regression: previously this whole response was wrapped as a single
         # repair_output.md document and the source files never landed.

--- a/tests/unit/cycles/test_correction_runner.py
+++ b/tests/unit/cycles/test_correction_runner.py
@@ -4380,6 +4380,65 @@ class TestEmptyRepairEmission:
         """The banked shape, exactly: one artifact, no content."""
         protocol = await self._run(cycle, [{"name": "repair_output.md", "content": ""}])
         assert protocol.emission_empty is True
+        # #998: a pre-signature responder reports nothing to name; the field is honest.
+        assert protocol.empty_emission_signatures == ()
+
+    async def test_the_empty_emissions_signature_reaches_the_result_and_the_event(self, cycle):
+        """#998: 'converged in 3 after two empty emissions' must also say WHICH nothing.
+        The handler's marker rides the repair result; the protocol result and the
+        CORRECTION_COMPLETED payload carry its signature."""
+        import dataclasses as _dc
+
+        def responder(envelope):
+            if envelope.task_type == "governance.correction_decision":
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "correction_path": "patch",
+                        "decision_rationale": "patchable",
+                        "affected_task_types": ["development.develop"],
+                    },
+                )
+            if envelope.task_type.endswith("correction_repair"):
+                return TaskResult(
+                    task_id=envelope.task_id,
+                    status="SUCCEEDED",
+                    outputs={
+                        "artifacts": [{"name": "repair_output.md", "content": ""}],
+                        "emission_failure": {
+                            "reason": "no_fenced_blocks",
+                            "response_chars": 0,
+                            "completion_tokens": 8192,
+                            "completion_cap": 8192,
+                            "signature": "cap_exhausted",
+                        },
+                    },
+                )
+            return TaskResult(task_id=envelope.task_id, status="SUCCEEDED", outputs={})
+
+        runner, _r, _v, bus = self._make_runner(responder)
+        protocol = await runner.run_correction_protocol(
+            run_id="run_001",
+            cycle=cycle,
+            envelope=_dc.replace(self._failed_envelope(), task_type="qa.test"),
+            result=TaskResult(task_id="task_failed", status="FAILED", error="suite failed"),
+            correction_attempts=0,
+            prior_outputs={},
+            all_artifact_refs=[],
+            stored_artifacts=[],
+            completed_task_ids=[],
+            plan_delta_refs=[],
+        )
+        assert protocol.emission_empty is True
+        assert protocol.empty_emission_signatures == ("cap_exhausted",)
+        completed = [
+            c
+            for c in bus.emit.call_args_list
+            if c.args and c.args[0] == EventType.CORRECTION_COMPLETED
+        ]
+        assert completed, "CORRECTION_COMPLETED was not emitted"
+        assert completed[-1].kwargs["payload"]["empty_emission_signatures"] == ["cap_exhausted"]
 
     async def test_whitespace_only_content_is_also_empty(self, cycle):
         """A file of newlines is not a repair. Judging on length rather than on content

--- a/tests/unit/cycles/test_emission_integrity.py
+++ b/tests/unit/cycles/test_emission_integrity.py
@@ -83,6 +83,11 @@ def test_no_fenced_blocks_marker_shape():
         "reason": EMISSION_FAILURE_NO_FENCED_BLOCKS,
         "response_chars": 6203,
         "expected_artifacts": ["backend/tests/test_runs.py"],
+        # #998: the token facts and the signature ride the marker; a caller that
+        # reports no tokens gets an honest None and the shape the chars alone support.
+        "completion_tokens": None,
+        "completion_cap": None,
+        "signature": "unextractable",
     }
     assert no_fenced_blocks_failure(0, None)["expected_artifacts"] == []
 

--- a/tests/unit/cycles/test_emission_signature.py
+++ b/tests/unit/cycles/test_emission_signature.py
@@ -1,0 +1,81 @@
+"""#998 — what KIND of nothing an empty emission was.
+
+Three zero-extraction shapes with opposite remedies were one marker: the V7 roll-1 void
+spent 8,192 tokens (the whole completion budget) and 12.7 minutes closing no content, and
+the banked analysis guessed "safety filter, context overload". The signature is computed
+from facts the LLM call already reports. Each test names the bug it catches.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from squadops.cycles.emission_integrity import (
+    SIGNATURE_CAP_EXHAUSTED,
+    SIGNATURE_EMPTY,
+    SIGNATURE_UNEXTRACTABLE,
+    classify_empty_emission,
+    emission_retry_reason_line,
+    no_fenced_blocks_failure,
+)
+
+pytestmark = [pytest.mark.domain_orchestration]
+
+
+@pytest.mark.parametrize(
+    ("chars", "tokens", "cap", "expected"),
+    [
+        (0, 8192, 8192, SIGNATURE_CAP_EXHAUSTED),  # the V7 roll-1 shape, exactly
+        (0, 8300, 8192, SIGNATURE_CAP_EXHAUSTED),  # a provider reporting past the cap still hit it
+        (0, 120, 8192, SIGNATURE_EMPTY),  # stopped early with nothing: not a budget problem
+        (0, None, 8192, SIGNATURE_EMPTY),  # tokens unknown → the cap cannot be asserted
+        (0, 8192, None, SIGNATURE_EMPTY),  # cap unknown → likewise
+        (0, 8192, 0, SIGNATURE_EMPTY),  # a zero cap is no cap
+        (2500, 8192, 8192, SIGNATURE_UNEXTRACTABLE),  # content came back; the format is the defect
+        (40, 40, 8192, SIGNATURE_UNEXTRACTABLE),
+    ],
+)
+def test_the_signature_is_read_from_the_calls_own_facts(chars, tokens, cap, expected):
+    assert classify_empty_emission(chars, tokens, cap) == expected
+
+
+def test_the_marker_carries_the_facts_and_the_signature():
+    """Bug caught: a marker that says `no_fenced_blocks` and nothing else — the shape
+    the correction decision guessed against."""
+    marker = no_fenced_blocks_failure(0, ["app/x.ts"], completion_tokens=8192, completion_cap=8192)
+    assert marker["signature"] == SIGNATURE_CAP_EXHAUSTED
+    assert marker["completion_tokens"] == 8192
+    assert marker["completion_cap"] == 8192
+    assert marker["reason"] == "no_fenced_blocks"
+    assert marker["expected_artifacts"] == ["app/x.ts"]
+
+
+def test_a_producer_that_reports_no_tokens_still_emits_a_truthful_marker():
+    """Pre-#998 call sites pass no token facts; the marker must not invent a cap verdict."""
+    marker = no_fenced_blocks_failure(0, None)
+    assert marker["signature"] == SIGNATURE_EMPTY
+    assert marker["completion_tokens"] is None and marker["completion_cap"] is None
+
+
+@pytest.mark.parametrize(
+    ("marker", "fragment"),
+    [
+        (
+            no_fenced_blocks_failure(0, None, completion_tokens=8192, completion_cap=8192),
+            "full 8192-token completion budget",
+        ),
+        (
+            no_fenced_blocks_failure(0, None, completion_tokens=10, completion_cap=8192),
+            "response was empty",
+        ),
+        (
+            no_fenced_blocks_failure(3000, None, completion_tokens=900, completion_cap=8192),
+            "3000-character response",
+        ),
+        ({"reason": "something_else"}, "something_else"),
+    ],
+)
+def test_the_retry_line_names_the_remedy_for_each_signature(marker, fragment):
+    """The retry feedback must not tell a budget-exhausted model to 'use fences' — the
+    two remedies are opposite, and the line is where the next attempt learns which."""
+    assert fragment in emission_retry_reason_line(marker)


### PR DESCRIPTION
Second loop-side item of the 1.6.4 plan (rev 4 §2.1). One commit.

**What was measured.** Three of the eleven repair rounds in the 1.6.3 set's reds emitted zero characters (roll 1 r3; roll 5 r1–r2). #1053 refunds those rounds, but the evidence could not say *which* nothing they were — and the two shapes have opposite remedies. V7's roll-1 void was the same class: 8,192 tokens, the whole completion budget, 0 characters, and a banked analysis guessing "safety filter, context overload".

**What this does.**
- `emission_integrity.classify_empty_emission(chars, completion_tokens, completion_cap)` → `cap_exhausted` / `empty` / `unextractable`, from facts the LLM call already reports (no stop-reason crosses the port, so tokens against the requested cap is the observable). The marker carries the token facts and the signature; `emission_retry_reason_line` names the remedy per signature, so a budget-exhausted model is not told to "use fences".
- Producers: `develop` and `qa.test` pass `response.completion_tokens` and `chat_kwargs["max_tokens"]`. **The generic base path every repair handler rides emitted no marker at all for an empty response** — that is where roll 5's 0-byte `repair_output.md` came from; it now attaches one, for emptiness only (prose without fences is a document, not a failure).
- The runner collects each repair step's signature; `CorrectionProtocolResult.empty_emission_signatures` and the `CORRECTION_COMPLETED` payload carry it; the executor's refund log line names it.

**Not built:** #998's ask 2 (raise the cap / limit thinking / reshape the re-dispatch prompt) — a design question this makes measurable first.

**Verification:** 7,930 regression / 8,344 full unit tree, green. Plan prediction **P4**: every zero-character repair emission carries a named signature, disclosed on the correction event.

Refs #998, #1053