### PR TITLE
feat(scaffold): a fill contradicting the declared element kind is rejected at the fill gate — #1094

### DIFF
--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -599,6 +599,7 @@ class QATestHandler(_CycleTaskHandler):
             record,
             fill_emission,
             store_tables=scaffold_input.get("store_tables"),
+            slot_element_kinds=scaffold_input.get("slot_element_kinds"),
         )
         merged_artifacts = [
             {

--- a/src/squadops/capabilities/response_shape.py
+++ b/src/squadops/capabilities/response_shape.py
@@ -34,6 +34,7 @@ kind, which keeps a legitimately-empty list from reading as a shape defect.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from squadops.capabilities.scaffold import Entity, InterfaceManifest
 
@@ -97,6 +98,28 @@ def _element_token(type_str: str) -> str:
 
 def _required_field_names(entity: Entity) -> tuple[str, ...]:
     return tuple(f.name for f in entity.fields if f.required)
+
+
+def element_kinds(shape: ResponseShape | None) -> dict[str, dict[str, Any]]:
+    """The declared element kind of each checkable collection field, as plain data (#1094).
+
+    The floor asserts this in the frozen spine; the fill gate needs the same fact to
+    reject a fill that contradicts it — roll 5 of the 1.6.3 set asserted strings on a
+    field the manifest declares as objects, the floor passed a correct repair, the fill
+    failed it, and the loop discarded the fix. One derivation, rendered a third time.
+    """
+    if not shape:
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for element in shape.elements:
+        if element.typeof:
+            out[element.field] = {"kind": "primitive", "typeof": element.typeof}
+        elif element.required_fields:
+            out[element.field] = {
+                "kind": "object",
+                "required_fields": list(element.required_fields),
+            }
+    return out
 
 
 def derive_response_shape(

--- a/src/squadops/capabilities/stack_nextjs_ts_tests.py
+++ b/src/squadops/capabilities/stack_nextjs_ts_tests.py
@@ -538,6 +538,24 @@ def derive_scaffold_behaviors(
     return behaviors, probes
 
 
+def slot_element_kinds_nextjs_ts(manifest: InterfaceManifest) -> dict[str, dict[str, Any]]:
+    """``slot_id → {field → element kind}`` for every behavior shell with a success floor.
+
+    Read off the same ``_Behavior`` list the emitter renders, so the fill gate and the
+    frozen spine cannot disagree about a field's declared kind (#1094). Behaviors with
+    no floor (rejections, conflicts) contribute nothing — their bodies are the envelope's.
+    """
+    from squadops.capabilities.response_shape import element_kinds
+
+    behaviors, _ = derive_scaffold_behaviors(manifest)
+    out: dict[str, dict[str, Any]] = {}
+    for behavior in behaviors:
+        kinds = element_kinds(behavior.expect_response)
+        if kinds:
+            out[f"slot-{behavior.behavior_id}"] = kinds
+    return out
+
+
 def emit_nextjs_ts_verification_scaffold(
     manifest: InterfaceManifest, expanded: list[dict[str, str]]
 ) -> list[tuple[str, str, tuple[BehaviorSlot, ...]]]:

--- a/src/squadops/capabilities/verification_scaffold_emission.py
+++ b/src/squadops/capabilities/verification_scaffold_emission.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -32,7 +32,10 @@ from squadops.capabilities.scaffold import (
     verification_scaffold_for,
 )
 from squadops.capabilities.stack_nextjs_ts import STACK_NAME as _NEXTJS_TS_NAME
-from squadops.capabilities.stack_nextjs_ts_tests import emit_nextjs_ts_verification_scaffold
+from squadops.capabilities.stack_nextjs_ts_tests import (
+    emit_nextjs_ts_verification_scaffold,
+    slot_element_kinds_nextjs_ts,
+)
 from squadops.capabilities.verification_scaffold import (
     SCAFFOLD_MANIFEST_VERSION,
     BehaviorSlot,
@@ -78,6 +81,26 @@ class VerificationScaffoldEmission:
     files: tuple[dict[str, str], ...]
     manifest: VerificationScaffoldManifest
     manifest_yaml: str
+
+
+#: #1094: the per-slot element kinds each stack's shells pin, keyed like ``_EMITTERS`` so
+#: an opted-in stack that emits shells also states what they assert.
+_SLOT_ELEMENT_KINDS: dict[str, Any] = {
+    _NEXTJS_TS_NAME: slot_element_kinds_nextjs_ts,
+}
+
+
+def slot_element_kinds(manifest: InterfaceManifest) -> dict[str, dict[str, Any]]:
+    """``slot_id → {field → declared element kind}`` for ``manifest``'s stack, or ``{}``.
+
+    Data for the fill gate (#1094): a fill asserting a kind the floor contradicts is
+    rejected at merge with the declared kind named, before it can gate a repair. Empty
+    for a stack that emits no scaffold — nothing to contradict.
+    """
+    from squadops.capabilities.scaffold import verification_scaffold_for
+
+    fn = _SLOT_ELEMENT_KINDS.get(verification_scaffold_for(manifest.stack))
+    return fn(manifest) if fn else {}
 
 
 def emit_verification_scaffold(

--- a/src/squadops/capabilities/verification_scaffold_fill.py
+++ b/src/squadops/capabilities/verification_scaffold_fill.py
@@ -61,8 +61,9 @@ deterministic failing assertion naming the slot and the fill layer, shaped as an
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 from squadops.capabilities.verification_scaffold import (
     ScaffoldSpineError,
@@ -241,7 +242,83 @@ _FORBIDDEN: tuple[tuple[re.Pattern[str], str], ...] = (
 _TABLE_REF_RE = re.compile(r"\bTABLES\.(\w+)")
 
 
-def fill_findings(fill: Fill, store_tables: Sequence[str] | None = None) -> list[str]:
+#: A matcher applied to a collection field — ``.participants).toContain(`` and kin — with
+#: the first significant character of its argument captured, which is all the kind check
+#: needs: a quote or digit is a primitive, ``{`` is an object, ``[`` opens an array whose
+#: first element is inspected the same way (#1094).
+_COLLECTION_MATCHER_RE = re.compile(
+    r"\.(?P<field>\w+)\)\s*(?:\.not)?\s*\.to(?:Contain|ContainEqual|Equal|StrictEqual)"
+    r"\(\s*(?P<arg>\[\s*[^\s\]]|[^\s)])"
+)
+#: Property access on an element of a collection field — ``.participants[0].name`` — which
+#: asserts the element is an object.
+_ELEMENT_PROPERTY_RE = re.compile(r"\.(?P<field>\w+)\[\d+\]\.\w+")
+
+
+def _argument_kind(arg: str) -> str | None:
+    """``"primitive"`` / ``"object"`` for a matcher argument's first significant char(s);
+    ``None`` when the argument's kind cannot be read (an identifier, an empty array)."""
+    head = arg.strip()
+    if head.startswith("["):
+        head = head[1:].strip()
+        if not head:
+            return None  # `toEqual([])` — emptiness, not a kind
+    if head[:1] in ("'", '"', "`") or head[:1].isdigit():
+        return "primitive"
+    if head[:1] == "{":
+        return "object"
+    return None
+
+
+def element_kind_findings(body: str, element_kinds: Mapping[str, Mapping[str, Any]]) -> list[str]:
+    """Every collection-field assertion in ``body`` whose element kind contradicts the
+    declared one (#1094). Narrow by design: only a matcher argument or element access
+    whose kind is readable from the text; whether an assertion is *good* is not this
+    function's question.
+
+    Roll 5 of the 1.6.3 set: the manifest declared ``participants: list[Participant]``,
+    the frozen floor asserted each element carries ``name``, and the fill asserted
+    ``expect(body.participants).toContain('sample')`` — strings. A repair that returned
+    the declared objects passed the floor and failed the fill, was rejected, and the
+    loop discarded it. The floor and the fill were contradicting each other inside one
+    test, and the fill won because it ran second.
+    """
+    findings: list[str] = []
+    for m in _COLLECTION_MATCHER_RE.finditer(body):
+        declared = element_kinds.get(m.group("field"))
+        if not declared:
+            continue
+        asserted = _argument_kind(m.group("arg"))
+        if asserted and asserted != declared.get("kind"):
+            findings.append(_kind_finding(m.group("field"), declared, asserted))
+    for m in _ELEMENT_PROPERTY_RE.finditer(body):
+        declared = element_kinds.get(m.group("field"))
+        if declared and declared.get("kind") == "primitive":
+            findings.append(_kind_finding(m.group("field"), declared, "object"))
+    return list(dict.fromkeys(findings))
+
+
+def _kind_finding(field: str, declared: Mapping[str, Any], asserted: str) -> str:
+    if declared.get("kind") == "object":
+        fields = ", ".join(f"`{f}`" for f in declared.get("required_fields", []))
+        return (
+            f"asserts {asserted} elements on `{field}`, which the manifest declares as a list "
+            f"of objects each carrying {fields} — the shell's frozen floor above the slot "
+            f"asserts exactly that, so this assertion cannot pass against a correct "
+            f"application; assert on `{field}[i].<field>` instead (#1094)"
+        )
+    return (
+        f"asserts object elements on `{field}`, which the manifest declares as a list of "
+        f"`{declared.get('typeof', 'primitive')}` values — the shell's frozen floor above the "
+        f"slot asserts exactly that; assert on the values, not on element properties (#1094)"
+    )
+
+
+def fill_findings(
+    fill: Fill,
+    store_tables: Sequence[str] | None = None,
+    element_kinds: Mapping[str, Mapping[str, Any]] | None = None,
+) -> list[str]:
     """Every containment rule this fill violates; empty for a valid fill or explicit NA.
 
     ``store_tables`` is the frozen store's exported table set, when the stack has one. A
@@ -278,6 +355,8 @@ def fill_findings(fill: Fill, store_tables: Sequence[str] | None = None) -> list
                 f"embedded shape or response projection has no table of its own, so assert on "
                 f"the owning entity's field instead (#1087)"
             )
+    if element_kinds:
+        findings.extend(element_kind_findings(fill.body, element_kinds))
     return findings
 
 
@@ -363,6 +442,7 @@ def merge_fills(
     record: VerificationScaffoldManifest,
     emission: FillEmission,
     store_tables: Sequence[str] | None = None,
+    slot_element_kinds: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> FillMergeRecord:
     """Merge an authored fill emission into the scaffold, deterministically.
 
@@ -410,7 +490,11 @@ def merge_fills(
             else:
                 fill = fills_by_slot.get(slot.slot_id)
                 body, disposition = _merged_body(
-                    slot.slot_id, fill, fill_findings(fill, store_tables) if fill else []
+                    slot.slot_id,
+                    fill,
+                    fill_findings(fill, store_tables, (slot_element_kinds or {}).get(slot.slot_id))
+                    if fill
+                    else [],
                 )
             out.extend(body)
             out.append(lines[region.end_line - 1])

--- a/src/squadops/cycles/task_plan.py
+++ b/src/squadops/cycles/task_plan.py
@@ -619,6 +619,7 @@ def inject_contract_inputs(
             from squadops.capabilities.scaffold import verification_scaffold_for
             from squadops.capabilities.verification_scaffold_emission import (
                 emit_verification_scaffold,
+                slot_element_kinds,
             )
 
             if verification_scaffold_for(interface_manifest.stack):
@@ -632,6 +633,10 @@ def inject_contract_inputs(
                     # merge can reject an assertion on a phantom one with the real
                     # tables named. Data from the one derivation the store renders.
                     "store_tables": list(root_persisted_entities(interface_manifest)),
+                    # #1094: what each shell's frozen floor pins for its collection
+                    # fields, so a fill asserting a contradicting element kind is
+                    # rejected at merge rather than at a retest it then loses.
+                    "slot_element_kinds": slot_element_kinds(interface_manifest),
                 }
 
 

--- a/src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md
+++ b/src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.qa_test_fill_mode_appendix
-version: "2"
+version: "3"
 required_variables:
   - slot_lines
   - shell_files
@@ -61,6 +61,13 @@ as a failing state):
   scaffold path is discarded. The shells below are read-only context.
 - `body` is the final response's parsed JSON; where a create precedes the invocation,
   `created` is the created entity's parsed JSON.
+
+**A collection field's element kind is already decided — read it off the frozen floor.**
+The lines above your slot that loop over a collection (`for (const e of o?.["…"] ?? [])`)
+state whether its elements are objects carrying named fields or plain values. Assert in
+that kind: `body.participants[0].name` for objects, `toContain('…')` for values. A fill
+asserting the other kind contradicts the floor inside the same test, cannot pass against a
+correct application, and is rejected at the fill gate with the declared kind named.
 
 **Asserting on the store — pass `TABLES.<Entity>`, never a string you invent.**
 `@/lib/store` exports `TABLES`, one entry per entity a correct application stores as rows of

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -67,6 +67,11 @@ class TestInjection:
         # #1087: the tables the frozen store exports ride the same input, so the fill
         # merge can reject a phantom-table assertion with the real tables named.
         assert scaffold["store_tables"] == ["RunEvent"]
+        # #1094: the declared element kinds ride the same input, per slot.
+        assert scaffold["slot_element_kinds"]["slot-vc-probe-api-runs-join"]["participants"] == {
+            "kind": "object",
+            "required_fields": ["id", "name"],
+        }
         # #1029: against the constant, not a literal. This test's subject is that the
         # scaffold REACHES qa.test on an opted-in stack; pinning the number here made a
         # legitimate emission bump fail a transport test, and the deliberate value pin
@@ -199,6 +204,29 @@ class TestMergeFillArtifacts:
         )
         assert "`TABLES.RunEvent`" in create_shell["content"]
         assert "expect(all(TABLES.Participant))" not in create_shell["content"]
+
+    def test_a_fill_contradicting_the_declared_element_kind_is_rejected_at_merge(
+        self, scaffold_input
+    ):
+        """#1094 through the handler: roll 5's fill on roll 5's kind of manifest."""
+        from squadops.capabilities.verification_scaffold_emission import slot_element_kinds
+
+        kinds = slot_element_kinds(manifest_for_stack("nextjs_ts"))
+        fills = parse_fill_emission(
+            "```fill:slot-vc-probe-api-runs-join\n"
+            "    expect(body.participants).toContain('sample')\n```\n"
+        )
+        merged_artifacts, _, evidence = QATestHandler()._merge_fill_artifacts(
+            {**scaffold_input, "slot_element_kinds": kinds}, fills, []
+        )
+        assert evidence["counts"]["rejected"] == 1
+        join_shell = next(
+            a
+            for a in merged_artifacts
+            if a["name"].endswith("vc-probe-api-runs-join.scaffold.test.ts")
+        )
+        assert "#1094" in join_shell["content"]
+        assert "toContain('sample')" not in join_shell["content"]
 
     def test_the_banked_evidence_names_the_additive_suite_that_survived(self, scaffold_input):
         """#980's other half: a retreat weakens the fills AND drops the additive suite.

--- a/tests/unit/capabilities/test_verification_scaffold_fill.py
+++ b/tests/unit/capabilities/test_verification_scaffold_fill.py
@@ -293,3 +293,95 @@ class TestPhantomTableFindings:
         merged = next(f.content for f in record.files if _CREATE_SLOT in f.content)
         assert "fill rejected" in merged
         assert "expect(all(TABLES.Participant))" not in merged
+
+
+class TestElementKindFindings:
+    """#1094: a fill asserting an element kind the frozen floor contradicts is rejected at
+    the fill gate, keyed on the DECLARED kind — never on the assertion's shape alone.
+
+    The banked vocabulary from the 1.6.3 set is the fixture: rolls 3 and 7 (green) wrote
+    `toContain('sample')` under `list[string]` and were right; roll 5 wrote the identical
+    line under `list[Participant]` and rejected a correct repair with it.
+    """
+
+    OBJECT = {"participants": {"kind": "object", "required_fields": ["name", "joined_at"]}}
+    PRIMITIVE = {"participants": {"kind": "primitive", "typeof": "string"}}
+
+    @pytest.mark.parametrize(
+        ("body", "kinds", "flagged"),
+        [
+            # roll 5's line under roll 5's manifest — the instance
+            ("expect(body.participants).toContain('sample')", "OBJECT", True),
+            ("expect(body.participants).not.toContain('sample')", "OBJECT", True),
+            ("expect(all(TABLES.Run)[0].participants).toContain('sample')", "OBJECT", True),
+            ("expect(body.participants).toEqual(['sample'])", "OBJECT", True),
+            ("expect(body.participants).toContainEqual({ name: 'sample' })", "PRIMITIVE", True),
+            ("expect(body.participants[0].name).toBe('sample')", "PRIMITIVE", True),
+            # the same lines under the kind they agree with — rolls 3/7 and the greens
+            ("expect(body.participants).toContain('sample')", "PRIMITIVE", False),
+            ("expect(body.participants[0].name).toBe('sample')", "OBJECT", False),
+            ("expect(body.participants[0].joined_at).toBeTruthy()", "OBJECT", False),
+            ("expect(body.participants).toContainEqual({ name: 'sample' })", "OBJECT", False),
+            # kind-neutral assertions never fire, under either declaration
+            ("expect(body.participants).toHaveLength(1)", "OBJECT", False),
+            ("expect(body.participants).toEqual([])", "OBJECT", False),
+            ("expect(body.participants).toEqual([])", "PRIMITIVE", False),
+            ("expect(body.participants).toContain(expected)", "OBJECT", False),
+            # a field the floor does not pin is not this rule's business
+            ("expect(body.tags).toContain('x')", "OBJECT", False),
+        ],
+    )
+    def test_only_a_contradiction_of_the_declared_kind_is_a_finding(self, body, kinds, flagged):
+        from squadops.capabilities.verification_scaffold_fill import element_kind_findings
+
+        findings = element_kind_findings(body, getattr(self, kinds))
+        assert bool(findings) is flagged, (body, kinds, findings)
+        if flagged:
+            assert "#1094" in findings[0] and "`participants`" in findings[0]
+
+    def test_the_finding_names_the_declared_kind_and_the_fix(self):
+        from squadops.capabilities.verification_scaffold_fill import element_kind_findings
+
+        [finding] = element_kind_findings(
+            "expect(body.participants).toContain('sample')", self.OBJECT
+        )
+        assert "`name`" in finding and "`joined_at`" in finding
+        assert "participants[i].<field>" in finding
+
+    def test_the_merge_degrades_the_slot_under_its_own_kinds(self, emission):
+        """Roll 5, end to end at the seam: the join slot's fill contradicts the join
+        behavior's floor; the slot is rejected with the declared kind named, and a slot
+        with no pinned collection is untouched by the same assertion."""
+        join = "slot-vc-probe-api-runs-join"
+        text = f"```fill:{join}\nexpect(body.participants).toContain('sample')\n```\n"
+        record = merge_fills(
+            list(emission.files),
+            emission.manifest,
+            parse_fill_emission(text),
+            slot_element_kinds={join: self.OBJECT},
+        )
+        disposition = record.by_slot()[join]
+        assert disposition.disposition == "rejected"
+        assert "#1094" in disposition.detail
+        # the same fill on a slot the kinds map does not cover is a valid fill
+        record = merge_fills(
+            list(emission.files),
+            emission.manifest,
+            parse_fill_emission(text),
+            slot_element_kinds={"slot-vc-probe-api-runs": self.OBJECT},
+        )
+        assert record.by_slot()[join].disposition == "filled"
+
+    def test_the_kinds_are_derived_per_slot_from_the_shells_own_behaviors(self):
+        """The gate reads the fact the floor asserts — one derivation. Every behavior with a
+        success floor on the reference pins `participants` as objects; rejections carry
+        no floor and no kinds."""
+        from squadops.capabilities.verification_scaffold_emission import slot_element_kinds
+
+        kinds = slot_element_kinds(manifest_for_stack("nextjs_ts"))
+        assert kinds["slot-vc-probe-api-runs-join"]["participants"]["kind"] == "object"
+        assert "name" in kinds["slot-vc-probe-api-runs-join"]["participants"]["required_fields"]
+        assert "slot-vc-probe-api-runs-rejects-blank" not in kinds
+        assert "slot-vc-probe-api-runs-join-duplicate" not in kinds
+        # stack #1 emits no scaffold: nothing to contradict, nothing threaded
+        assert slot_element_kinds(manifest_for_stack("fullstack_fastapi_react")) == {}


### PR DESCRIPTION
Third loop-side item of the 1.6.4 plan (rev 4 §2.1). One commit.

**The instance.** Roll 5 (`cyc_421d29473f86`): the manifest declares `participants: list[Participant]`; the frozen floor asserts each element carries `name`; the qa fill asserts `expect(body.participants).toContain('sample')` — strings. Round 3's repair returned the declared objects, **passed the floor and failed the fill**; the candidate was rejected, Fix E excluded it from the next workspace, and #435 terminated the run as `plan_defect`. A correct application was discarded by a test that disagreed with the contract the test was frozen around.

**What this does.**
- `response_shape.element_kinds()` serializes the floor's per-field element kind; `slot_element_kinds()` (stack-dispatched, like the emitter) derives it per slot **from the same `_Behavior` list the shells render** — one derivation, now three renderings (spine, brief, gate).
- It rides the `verification_scaffold` input as data (beside #1087's `store_tables`); `merge_fills` rejects a fill whose matcher argument or element access contradicts the declared kind, with the declared kind and the fix named. Narrow by design: only a kind readable from the text; kind-neutral assertions (`toHaveLength`, `toEqual([])`, identifiers) never fire.
- The qa brief (appendix v3) says where to read the kind off the floor.

**The false-positive guard, on the real corpus.** Replayed over every banked fill of the 1.6.3 set plus shakeout 1 — 72 slots across nine cycles: **only roll 5's join and leave fills flag.** Rolls 3 and 7 are green with the identical `toContain('sample')` line under `list[string]` and are clean — the rule keys on the declaration, never on the assertion's shape.

**Verification:** 7,949 regression / 8,363 full unit tree, green. Plan prediction **P3**: no repair candidate is rejected on fill assertions the floor contradicts.

Refs #1094, #1029, #1087