### PR TITLE
fix(verification): per-file criteria stop superseding each other in the final-state ledger — #1021

### DIFF
--- a/src/squadops/cycles/verification_integrity.py
+++ b/src/squadops/cycles/verification_integrity.py
@@ -551,14 +551,25 @@ def _resolve_final_state(results: Sequence[CheckResult]) -> list[CheckResult]:
     collapsed: each is independent evidence (the correct default — e.g. distinct
     develop tasks emitting ``tests_pass`` must accumulate, "any subject failed →
     rejected"; only the *same* subject re-verified supersedes).
+
+    **The identity includes the criterion (#1021).** A contract-bound typed check is
+    one ``check_id`` (the check *name*, ``acceptance:frontend_compiles``) evaluated once
+    per file, so one develop subtask legitimately records N results under the same
+    ``(check_id, subject)`` — one per criterion. Keyed on those two alone, the last
+    superseded the other N−1 and their criterion ids never reached the credited set:
+    neither verified nor failed, disclosed as unevidenced, and on every ``nextjs_ts``
+    roll of the 1.6.3 set the dropped set was exactly "each subtask's compile criteria
+    but the last" (nine of nine cycles, by id). A framework-spine check carries no
+    criterion and keeps the two-part identity; a criterion re-verified in the same task
+    still supersedes *itself*; distinct criteria stop superseding each other.
     """
     resolved: list[CheckResult] = []
-    final_pos_by_identity: dict[tuple[str, str], int] = {}
+    final_pos_by_identity: dict[tuple[str, str, str | None], int] = {}
     for r in results:
         if r.subject is None:
             resolved.append(r)
             continue
-        identity = (r.check_id, r.subject)
+        identity = (r.check_id, r.subject, r.criterion_id)
         prior = final_pos_by_identity.get(identity)
         if prior is None:
             final_pos_by_identity[identity] = len(resolved)

--- a/tests/unit/cycles/test_verification_integrity.py
+++ b/tests/unit/cycles/test_verification_integrity.py
@@ -947,3 +947,77 @@ class TestUnevidencedCriteria:
         could be absent — the field must stay empty rather than inventing a shortfall."""
         summary = aggregate_verification([_passed("c1", criterion_id="vc-a", subject="t")])
         assert summary.criteria_unevidenced == ()
+
+
+# --------------------------------------------------------------------------- #
+# #1021 — the final-state identity includes the criterion
+# --------------------------------------------------------------------------- #
+
+
+def test_distinct_criteria_of_one_check_in_one_task_are_all_credited():
+    """The 1.6.3 set's roll 4, m000: one develop subtask evaluated `frontend_compiles`
+    for two files. Keyed on (check_id, subject) the second superseded the first and
+    `vc-compiles-app-api-runs-route` was credited nowhere, failed nowhere — nine of nine
+    cycles dropped exactly 'each subtask's compile criteria but the last'."""
+    rows = [
+        _passed(
+            "acceptance:frontend_compiles",
+            subject="m000",
+            criterion_id="vc-compiles-app-api-runs-route",
+        ),
+        _passed(
+            "acceptance:frontend_compiles",
+            subject="m000",
+            criterion_id="vc-compiles-app-api-runs-run-id-route",
+        ),
+    ]
+    s = aggregate_verification(rows, contract_criteria=[r.criterion_id for r in rows])
+    assert s.criteria_verified == (
+        "vc-compiles-app-api-runs-route",
+        "vc-compiles-app-api-runs-run-id-route",
+    )
+    assert s.criteria_coverage == (2, 2)
+    assert (s.executed_count, s.passed_count) == (2, 2)
+
+
+def test_the_same_criterion_re_verified_in_the_same_task_still_supersedes_itself():
+    """#379's guarantee survives: a failed compile of one file, repaired and re-run under
+    the same task and the same criterion, resolves to its FINAL state — not both."""
+    rows = [
+        _failed(
+            "acceptance:frontend_compiles", subject="m000", criterion_id="vc-compiles-app-page"
+        ),
+        _passed(
+            "acceptance:frontend_compiles", subject="m000", criterion_id="vc-compiles-app-page"
+        ),
+    ]
+    s = aggregate_verification(rows, contract_criteria=["vc-compiles-app-page"])
+    assert s.verdict is RunVerdict.ACCEPTED
+    assert s.failed == ()
+    assert s.criteria_verified == ("vc-compiles-app-page",)
+    assert (s.executed_count, s.passed_count) == (1, 1)
+
+
+def test_a_failed_criterion_is_not_hidden_by_a_sibling_that_passed():
+    """The other direction of the same collapse: before #1021 a failing compile could be
+    superseded by the NEXT file's passing compile in the same task and the run would
+    read accepted. The verdict must see the failure."""
+    rows = [
+        _failed("acceptance:frontend_compiles", subject="m001", criterion_id="vc-compiles-join"),
+        _passed("acceptance:frontend_compiles", subject="m001", criterion_id="vc-compiles-leave"),
+    ]
+    s = aggregate_verification(rows, contract_criteria=["vc-compiles-join", "vc-compiles-leave"])
+    assert s.verdict is RunVerdict.REJECTED
+    assert s.criteria_verified == ("vc-compiles-leave",)
+    assert "vc-compiles-join" not in s.criteria_verified
+
+
+def test_a_framework_check_without_a_criterion_keeps_the_two_part_identity():
+    """`tests_pass` carries no criterion; a task's re-run must still supersede its
+    earlier attempt exactly as before."""
+    s = aggregate_verification(
+        [_failed("tests_pass", subject="task-A"), _passed("tests_pass", subject="task-A")]
+    )
+    assert s.verdict is RunVerdict.ACCEPTED
+    assert s.verified == ("tests_pass",)
+    assert (s.executed_count, s.passed_count) == (1, 1)

--- a/tests/unit/cycles/test_verification_normalize.py
+++ b/tests/unit/cycles/test_verification_normalize.py
@@ -544,3 +544,36 @@ def test_typed_acceptance_row_carries_its_inspected_set_too():
         }
     )
     assert rows[0].provenance.subject_count == 1
+
+
+def test_per_file_typed_criteria_under_one_task_all_survive_normalize_and_aggregate():
+    """#1021 end to end: the banked shape of a develop subtask's typed-check evaluation —
+    one `frontend_compiles` row per file, each with its own criterion id, one subject.
+    Every criterion must be credited; before, only the last was."""
+    outputs = {
+        "validation_result": {
+            "passed": True,
+            "checks": [
+                {
+                    "check": "acceptance:frontend_compiles",
+                    "status": "passed",
+                    "criterion_id": "vc-compiles-app-api-runs-run-id-route",
+                },
+                {
+                    "check": "acceptance:frontend_compiles",
+                    "status": "passed",
+                    "criterion_id": "vc-compiles-app-api-runs-run-id-join-route",
+                },
+                {
+                    "check": "acceptance:frontend_compiles",
+                    "status": "passed",
+                    "criterion_id": "vc-compiles-app-api-runs-run-id-leave-route",
+                },
+            ],
+        }
+    }
+    ledger = normalize_task_checks(outputs, subject="task-run_x-m001-development.develop")
+    contract = [r["criterion_id"] for r in outputs["validation_result"]["checks"]]
+    summary = aggregate_verification(ledger, contract_criteria=contract)
+    assert set(summary.criteria_verified) == set(contract)
+    assert summary.criteria_coverage == (3, 3)


### PR DESCRIPTION
The #1021 read named the mechanism (comment on the issue, with the nine-cycle prediction table); this is the fix. One commit, one tuple.

**What was wrong.** `_resolve_final_state` (SIP-0096 §6.5, #379) keyed a result's final state on `(check_id, subject)` — the check *name* and the producing task. A typed check like `acceptance:frontend_compiles` is one name evaluated once per file, so a develop subtask that compiled three route files recorded three results under one identity; the last superseded the other two, and their criterion ids never reached `criteria_passed`. Neither verified nor failed, listed as unevidenced. Predicted set = "each subtask's compile criteria but the last"; matched by id on rolls 1–8 and shakeout 1.

**The fix.** Identity is `(check_id, subject, criterion_id)`. Pinned behaviours hold: a framework check (`criterion_id=None`) keeps the two-part identity, so a task's `tests_pass` re-run still supersedes; a criterion re-verified in the same task supersedes itself. Distinct criteria stop superseding each other — in both directions: a *failed* compile can no longer be hidden by the next file's passing one, which was a false-green path this ledger had open.

**Verification:** 7,954 regression / 8,368 full unit tree, green. Checkable at N=1 on shakeout 2: a green roll's `criteria_verified` equals `criteria_total` (no `vc-compiles-*` in `criteria_unevidenced`).

Refs #1021, #379