### PR TITLE
docs(plan): 1.6.5 rev 2 — qa-only completion budget (eve 12,288) alongside fills-first

### DIFF
--- a/docs/plans/1-6-5-plan.md
+++ b/docs/plans/1-6-5-plan.md
@@ -1,5 +1,12 @@
 # 1.6.5 — plan
 
+**Revision 2, 2026-08-26.** Adds a qa-only completion budget (§2.1 E) on the strength of the
+emission distribution the cut question surfaced: four of ten qa primary emissions in the 1.6.4 set
+sat at the 8,192 cap or within 3% of it, with the content roughly constant and the reasoning the
+variance. Revision 1 deferred the raise until fills-first was measured; the distribution says the
+budget is tight for this task shape, not merely unlucky, so the raise ships alongside the ordering
+fix — each with its own prediction — rather than after it. The registry clamp is untouched.
+
 **Revision 1, 2026-08-26.** Written at the 1.6.4 cut, from the 1.6.4 verification set record
 (`docs/plans/1-6-4-verification-set-record.md`, §1.1, §3, §5) and nothing else. Every item below
 is something that set observed on frozen deploy `5a697dfa`; the sweep leftovers the 1.6.4 plan
@@ -22,8 +29,22 @@ eight fill slots *and* an additive suite file — hit the 8,192-token completion
 eight rolls (roll 6 primary, roll 8 primary, roll 8 repair). The cap is deliberate:
 `src/squadops/llm/model_registry.py:64-68` clamps `qwen3.8:27b` to 8,192 for comparability with
 `qwen3.6:27b`, and the registry's own comment argues that longer completions drift. Roll 6's
-second attempt authored the same eight fills in 5,498 tokens, so this is variance in how much the
-model writes, not a budget that is always too small.
+second attempt authored the same eight fills in 5,498 tokens, so the work fits under the cap — but
+not with much room. **All ten `qa.test` primary emissions in the set** (eve's `emission shape` log:
+eight rolls plus shakeout 2 and roll 6's re-dispatch), completion tokens ascending:
+
+```
+4418  4947  5045  5498  5743  6292  7947  7963  8192  8192      cap = 8192
+```
+
+Four of ten at the cap or within 3% of it. The content is roughly constant — 7–15k characters,
+~3.5–5k tokens of fills plus suite — and the variance is reasoning on top of it: the near-cap
+emissions run ~1.4 characters per token against ~2.2 for the cheap ones. Both cap hits would have
+closed under ~12k: roll 8 had every fill out and lost only the additive file's tail; roll 6 had
+7,136 characters of additive file written when the cap took the fills. The dev side is a different
+shape — 79 `develop` emissions in the same window, two at the cap, thirteen between 7.2k and 7.8k —
+and its 8,192 clamp is *designed* to force per-file decomposition (`model_registry.py:47-55`);
+nothing here touches it.
 
 What happened after each cap hit is the finding:
 
@@ -49,10 +70,12 @@ not this plan's problem to prove; §3 says how they are carried.
 
 ## 2. The pack
 
-### 2.1 The headline: a truncated qa emission must cost the least important content, and what survives must be used
+### 2.1 The headline: a truncated qa emission must be rarer, must cost the least important content, and what survives must be used
 
-Four items, each one face of §1, ordered by yield per line changed. Together they convert roll 6's
-shape into a green with no correction round and roll 8's into a green with none either.
+Five items, each one face of §1, ordered by yield per line changed. Together they convert roll 6's
+shape into a green with no correction round and roll 8's into a green with none either. E makes the
+cap hit rarer; A–D make it cheap when it happens. They address different halves and are measured
+separately (§3).
 
 **A. Fills first (#998 ask 2, the ordering half).** The qa fill-mode brief tells the author the
 slots and the fence format; it does not say what to write first. On roll 6 the additive file came
@@ -89,6 +112,22 @@ the own-artifact target is the failing slot's shell, resolved through the same `
 through the seam `qa.test` uses (#969's question — a fourth appendix or one composition seam — is
 answered: the seam), so the repair knows the fill protocol and the in-process execution model.
 
+**E. A qa-only completion budget (#998 ask 2, the budget half).** The `full-38` profile's `eve`
+entry gains `config_overrides: {max_completion_tokens: 12288}` — the seam already exists and is
+allowlisted (`src/squadops/cycles/models.py:184`), rides the plan as `agent_config_overrides`
+(`task_plan.py:899`), and wins over the registry clamp at `base.py:351`. Config, not code: the
+registry's 8,192 for `qwen3.8:27b` (`model_registry.py:64-68`) is the V38 comparability pin and
+applies to every role; it stays. Cost when used: ≤ ~3 minutes per emission at 3.8's measured
+~24 t/s, and only on the emissions that need it — the six under 6.3k pay nothing. The registry's
+"coherence drifts past 8k" note is from qwen3.6 at ~10 t/s and is unmeasured on 3.8; Q5 and the
+texture below are where it gets measured. **This changes `resolved_config_hash`**, so the 1.6.5
+set is a new configuration line and its pre-registration records the new hash; no comparison to
+`d4d4f66217d8` is claimed beyond the texture fields.
+
+What E does not fix, stated so the set is not misread: the zero-character exhaustion class (roll
+8's repair, roll 2's develop — 8,192 tokens of reasoning that never closed). A larger budget makes
+those longer, not fewer; A–C and #998's signatures are what handle them.
+
 D is the largest item and the only one that changes the repair path. It is in the pack because
 the record names it (§1.1) and because without it the third net stays a net the set has watched
 fail. It ships last (§4) and, if the set opens before it is ready, the set opens without it and
@@ -96,12 +135,11 @@ says so.
 
 ### 2.2 What is deliberately not built
 
-**Raising the completion cap.** #998 ask 2 offers three remedies; this line takes the ordering one
-and measures. A larger `num_predict` on a 24 t/s model buys minutes per emission for every task
-and, per the registry's own record, coherence drift past 8k. If the set shows fills-first still
-loses fills — a cap hit *inside* the fill sequence — that is the evidence a per-task qa budget
-(`agent_config_overrides.max_completion_tokens`, `base.py:351`) would need, and the next revision
-takes it with the number.
+**Raising the registry clamp, or the dev budget.** E is scoped to the qa role on one profile. The
+registry's per-model clamp stays at 8,192 — it is the pin that made the V38 comparison honest and
+the number every 1.6 record was measured under — and the dev budget stays where its own comment
+puts it: an 8k ceiling that forces decomposition into per-file tasks. If the set's texture shows
+dev emissions crowding the cap the way qa's did, that is a separate revision with its own number.
 
 **#947 option 1 (skip the pass).** Superseded by C: a fill-aware self-eval is the pass that helps.
 
@@ -136,10 +174,13 @@ claim.
 | **Q2** | a self-eval re-emission of fills is merged through the gate (C) | a self-eval emission with `fill: N>0` followed by a shell with no fill |
 | **Q3** | the suite runs on the post-self-eval file set (B) | a failing `test_report.md` whose error names content the stored artifact of the same task does not contain |
 | **Q4** | an own-artifact qa repair whose failing test is a shell targets that shell (D) | a `correction_repair_locus: own_artifact — qa.test re-produces __tests__/…` line when the failed test was a scaffold file |
+| **Q5** | no `qa.test` primary emission reaches its completion cap (E) — read from eve's `emission shape` log, `completion_tokens < 12288` on every primary | one primary at 12,288 |
 | **P1, P3, P5** | carried from 1.6.4 unchanged — unexercised is not passed, and they are on this deploy too | as pre-registered in 1.6.4 |
 
-**Texture, no prediction attached:** qa primary completion tokens per roll and the cap-hit count
-against 3/8; correction rounds against 1.6.4's 2 and 1.6.3's 0/1/3/4 split; wall clock.
+**Texture, no prediction attached:** the full qa primary completion-token distribution against the
+ten in §1 (whether the headroom was consumed, and by how much — the number the next cap decision
+is made with), the cap-hit count against 3/8, and qa wall-clock per emission against the 1.6.4
+set's; correction rounds against 1.6.4's 2 and 1.6.3's 0/1/3/4 split; wall clock.
 
 **A fault-injection arm is the honest way to exercise Q4 and P1/P3/P5.** Eight `full-38` rolls
 produced no dev-side failure and two qa-side ones; the loop-side predictions cannot be read from a
@@ -154,7 +195,9 @@ plan recommends it, because the alternative is shipping D unexercised a second t
 ## 4. Sequencing
 
 1. **File the roll-8 ordering gap and the three §2.3 items** (owner's OK first); give B its number.
-2. **A + B + C together** — one deploy boundary, all three in the qa handler and its appendix.
+2. **A + B + C + E together** — one deploy boundary: three in the qa handler and its appendix, E
+   in `config/squad-profiles.yaml`. Attribution survives the bundling: Q0 is a static check on
+   fence order, Q5 and the token texture read from counts, Q2/Q3 from the handler's own records.
    Replay proof before any rebuild: roll 6's and roll 8's stored emissions through the handler
    paths (`feedback: replay-first`). Regression green.
 3. **D** — the runner change through the 1.6.4 resolver chain, the brief through the qa seam.
@@ -190,4 +233,5 @@ to stack #1.
 
 | rev | date | what changed | evidence |
 |---|---|---|---|
+| 2 | 2026-08-26 | E added: eve-only `max_completion_tokens: 12288` on `full-38`, with Q5 and the distribution texture; §2.2 rescoped from "no raise" to "no registry or dev raise"; §1 carries the ten-emission distribution and the dev-side contrast | eve `emission shape` lines for the set window (ten `qa_test_handler` primaries); neo's 79 `develop` emissions; `models.py:184`, `task_plan.py:899`, `base.py:351`, `model_registry.py:47-68` |
 | 1 | 2026-08-26 | Initial, at the 1.6.4 cut | `1-6-4-verification-set-record.md` §1.1, §3, §4, §5; `qa_test.py:1253-1265`; `model_registry.py:64-68`; #947, #969, #970, #998 as filed |

--- a/docs/plans/1-6-5-plan.md
+++ b/docs/plans/1-6-5-plan.md
@@ -1,5 +1,14 @@
 # 1.6.5 — plan
 
+**Revision 3, 2026-08-26.** Numbers assigned after the owner's go: the roll-8 ordering gap is
+**#1109** (item B); the retry-log/LangFuse instrumentation gap **#1110**; the `test_report.md`
+re-store **#1111**; the root-table single-object edge **#1112**; the PR closure guard **#1113**
+(PR #1114, ships independently). The regression-script item in rev 1–2's §2.3 is **withdrawn**: the
+script exits 127 on a missing `ruff` (`scripts/dev/run_regression_tests.sh:19-24`, #972); the 0
+was the caller's own pipeline masking the code — the case the script's comment names. The v1.6.4
+cut commit message carries the wrong claim; this is its correction. Issue hygiene from the cut is
+done (§5).
+
 **Revision 2, 2026-08-26.** Adds a qa-only completion budget (§2.1 E) on the strength of the
 emission distribution the cut question surfaced: four of ten qa primary emissions in the 1.6.4 set
 sat at the 8,192 cap or within 3% of it, with the content roughly constant and the reasoning the
@@ -88,7 +97,7 @@ and the self-eval already repairs.
 Measurable without a model: the fence order in every qa primary emission, read from the banked
 artifact order. Roll 6 is the falsifier at N=1.
 
-**B. The suite runs on what the task will store (the roll-8 ordering gap; to be filed, §5).**
+**B. The suite runs on what the task will store (#1109).**
 `qa_test.py` recomputes the suite-execution set from `artifacts` after the self-eval loop, so a
 self-eval re-emission that fixed a blocking typed check is the file the suite runs against. One
 call-site change plus the `extracted` bookkeeping it currently bypasses. Replay proof: roll 8's
@@ -149,14 +158,14 @@ that fact recorded.
 
 ### 2.3 Instrumentation, in the pack because it is cheap and the set needs it
 
-- The executor's aimed-retry log line echoes the #998 signature it re-dispatches with, so whether
-  the retry prompt *rendered* the remedy is readable from logs (record §4; the 10,000-character
-  LangFuse cap makes it unreadable there).
-- The qa task's `test_report.md` is not re-stored in its failed form at run end after a passing
-  retest (record §4, last-writer-wins). Cosmetic in outcome, but it is the exact artifact the
-  next triage reads first.
-- `scripts/dev/run_regression_tests.sh` exits 0 when `ruff` is not on the path and runs no tests.
-  Found at this cut; it must fail loudly.
+- **#1110** — the executor's aimed-retry log line echoes the #998 signature it re-dispatches with,
+  so whether the retry prompt *rendered* the remedy is readable from logs (record §4; the
+  10,000-character LangFuse input cap makes it unreadable there).
+- **#1111** — the qa task's `test_report.md` is not re-stored in its failed form at run end after a
+  passing retest (record §4, last-writer-wins). Cosmetic in outcome, but it is the exact artifact
+  the next triage reads first.
+- **#1113** — the PR closure guard (template + `pr-closure.yml`, PR #1114). A workflow guard, not
+  cycle machinery; it ships whenever it merges and is marked Required on `main` by the owner.
 
 ---
 
@@ -194,7 +203,7 @@ plan recommends it, because the alternative is shipping D unexercised a second t
 
 ## 4. Sequencing
 
-1. **File the roll-8 ordering gap and the three §2.3 items** (owner's OK first); give B its number.
+1. **Filed 2026-08-26:** #1109 (B), #1110, #1111, #1112, #1113. Done.
 2. **A + B + C + E together** — one deploy boundary: three in the qa handler and its appendix, E
    in `config/squad-profiles.yaml`. Attribution survives the bundling: Q0 is a static check on
    fence order, Q5 and the token texture read from counts, Q2/Q3 from the handler's own records.
@@ -216,16 +225,16 @@ closes the 1.6 line's known loss modes and 1.7 opens for hardening; a falsified 
 1.6.6 re-measures. The 1.7 slate re-derivation (39 inherited issues, plus #1099 and #242, #372,
 #1041) happens **before** 1.7 opens and is not this plan's work.
 
-**The unfiled findings.** Filing is the owner's act. To file, with the record as evidence: the
-roll-8 ordering gap (B); the executor retry log not echoing the #998 marker; the qa `test_report`
-last-writer-wins re-store; the regression script's silent exit; and the root-table rule's
-single-object-response edge (shakeout 1 and roll 8 declared `RunWithParticipants` / `RunDetail`
-and the store gave each a table — nothing asserted on it, so it is recorded here and not planned).
+**The filed findings.** Filed 2026-08-26 on the owner's go, with the record as evidence: #1109 (the
+roll-8 ordering gap, item B), #1110 (retry log / LangFuse cap), #1111 (`test_report` last-writer-wins),
+#1112 (the root-table rule's single-object-response edge — shakeout 1 and roll 8 declared
+`RunWithParticipants` / `RunDetail` and the store gave each a table; nothing asserted on it, so it
+is recorded and not planned). The regression-script finding was withdrawn before filing (rev 3).
 
-**Issue hygiene from the 1.6.4 cut.** #1096, #1087 (nextjs_ts half), #1079, #1021, #1015-A and
-#1094 shipped in 1.6.4 without `Closes` lines and are open at this writing; they close at the cut
-with the PR named. #998 stays open, narrowed to ask 2's budget half. #1087 stays open, narrowed
-to stack #1.
+**Issue hygiene from the 1.6.4 cut — done 2026-08-26.** #1096, #1079, #1021, #1094 and #1015 (part
+A) closed by hand with the shipping PR and the set evidence named on each; #1087 narrowed to stack
+#1 (its projection edge split out as #1112); #998 narrowed to ask 2's budget half, which item E
+takes. The six PRs shipped without `Closes` lines — #1113 is the guard.
 
 ---
 
@@ -233,5 +242,6 @@ to stack #1.
 
 | rev | date | what changed | evidence |
 |---|---|---|---|
+| 3 | 2026-08-26 | Numbers assigned (#1109–#1113); regression-script item withdrawn as a caller-side masking, not a script defect; cut hygiene recorded done | issues as filed; `run_regression_tests.sh:19-24`; closures on #1096 #1079 #1021 #1094 #1015 |
 | 2 | 2026-08-26 | E added: eve-only `max_completion_tokens: 12288` on `full-38`, with Q5 and the distribution texture; §2.2 rescoped from "no raise" to "no registry or dev raise"; §1 carries the ten-emission distribution and the dev-side contrast | eve `emission shape` lines for the set window (ten `qa_test_handler` primaries); neo's 79 `develop` emissions; `models.py:184`, `task_plan.py:899`, `base.py:351`, `model_registry.py:47-68` |
 | 1 | 2026-08-26 | Initial, at the 1.6.4 cut | `1-6-4-verification-set-record.md` §1.1, §3, §4, §5; `qa_test.py:1253-1265`; `model_registry.py:64-68`; #947, #969, #970, #998 as filed |


### PR DESCRIPTION
Answers the cut question *is a higher limit needed?* with the distribution rather than two rolls.

**All ten `qa.test` primary emissions in the 1.6.4 set** (eve's log): `4418 4947 5045 5498 5743 6292 7947 7963 8192 8192` — four at the cap or within 3%. Content ~constant (7–15k chars), reasoning the variance; both cap hits would have closed under ~12k. Dev side: 79 emissions, 2 at cap, and its clamp forces decomposition by design — untouched.

**Rev 2 adds item E:** `eve` on `full-38` gets `config_overrides: {max_completion_tokens: 12288}` — the seam is allowlisted (`models.py:184`), rides the plan (`task_plan.py:899`), applies at `base.py:351`. Config, not code; the registry clamp (the V38 comparability pin) stays at 8,192. Cost ≤ ~3 min per emission, only when used. Own prediction **Q5** (no qa primary at 12,288) plus the full token distribution as texture, so the next cap decision has a number. States what E does not fix: zero-character reasoning exhaustion. Notes the config hash moves.

§2.2 rescoped from *no raise* to *no registry or dev raise*; §4 bundles E with A+B+C on one deploy boundary, attribution preserved (Q0 static, Q5 from counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tj9vAj9yumEzAmBLrZnrX


No issue: plan revision (docs only)
