### PR TITLE
fix(qa): 1.6.5 A+B+C+E — fills first, suite runs on what is stored, self-eval merges fills, qa-only budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,27 @@ All notable changes to SquadOps are recorded here. Format loosely follows
 
 ## [Unreleased]
 
-Nothing yet.
+### 1.6.5 line — the qa emission under the completion cap (plan: `docs/plans/1-6-5-plan.md`)
+
+- **A — fills first** (#998 ask 2, ordering half). The qa fill-mode brief (appendix v4) states
+  the emission order: every fill block, then any additive file. A cut at the completion cap now
+  lands on the additive file — which #1082 detects and the self-eval re-emits — never on a fill.
+  Roll 6 of the 1.6.4 set lost all eight fills to an additive file written first.
+- **B — the suite runs on what the task stores** (#1109). `qa.test` derived its suite-execution
+  set before the self-eval loop, so a self-eval re-emission that fixed a blocking typed check was
+  stored but never run; roll 8 failed on a truncated file whose replacement was already in hand,
+  and a correction round was spent rediscovering it. The set is now derived from the artifacts at
+  the moment of the run.
+- **C — the self-eval merges fills** (#947). Under fill mode the self-eval prompt carries a
+  fill-mode addendum naming the slots still unfilled (from the merge record), and its fills fold
+  into the primary emission per slot — a missing or rejected slot takes the followup fill, an
+  already-filled slot keeps its fill and the re-emission is recorded — then pass through the
+  same merge gate (#1087 phantom tables, #1094 element kinds). Replayed on roll 6's banked
+  self-eval fills: 8/8 merged where the handler had discarded all eight.
+- **E — a qa-only completion budget** (#998 ask 2, budget half). `full-38`'s `eve` entry carries
+  `config_overrides: {max_completion_tokens: 12288}`; four of ten qa primary emissions in the
+  1.6.4 set sat at or within 3% of the 8,192 cap. The registry clamp (the V38 pin) and the dev
+  budget are untouched. Changes `resolved_config_hash`; measured by prediction Q5.
 
 ## [1.6.4] — 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to SquadOps are recorded here. Format loosely follows
 - **A — fills first** (#998 ask 2, ordering half). The qa fill-mode brief (appendix v4) states
   the emission order: every fill block, then any additive file. A cut at the completion cap now
   lands on the additive file — which #1082 detects and the self-eval re-emits — never on a fill.
-  Roll 6 of the 1.6.4 set lost all eight fills to an additive file written first.
+  Roll 6 of the previous verification set (`docs/plans/1-6-4-verification-set-record.md`) lost all eight fills to an additive file written first.
 - **B — the suite runs on what the task stores** (#1109). `qa.test` derived its suite-execution
   set before the self-eval loop, so a self-eval re-emission that fixed a blocking typed check was
   stored but never run; roll 8 failed on a truncated file whose replacement was already in hand,
@@ -23,8 +23,8 @@ All notable changes to SquadOps are recorded here. Format loosely follows
   same merge gate (#1087 phantom tables, #1094 element kinds). Replayed on roll 6's banked
   self-eval fills: 8/8 merged where the handler had discarded all eight.
 - **E — a qa-only completion budget** (#998 ask 2, budget half). `full-38`'s `eve` entry carries
-  `config_overrides: {max_completion_tokens: 12288}`; four of ten qa primary emissions in the
-  1.6.4 set sat at or within 3% of the 8,192 cap. The registry clamp (the V38 pin) and the dev
+  `config_overrides: {max_completion_tokens: 12288}`; four of ten qa primary emissions in that
+  set sat at or within 3% of the 8,192 cap. The registry clamp (the V38 pin) and the dev
   budget are untouched. Changes `resolved_config_hash`; measured by prediction Q5.
 
 ## [1.6.4] — 2026-08-26

--- a/config/squad-profiles.yaml
+++ b/config/squad-profiles.yaml
@@ -24,14 +24,19 @@ profiles:
 
   - profile_id: full-38
     name: "Full Squad (qwen3.8)"
-    description: "The `full` roster verbatim on qwen3.8:27b — exists ONLY as the comparison arm of the V38 model-comparison window (docs/plans/1-6-0-v38-model-comparison-preregistration.md). Identical to `full` in every field except model; `full` remains the canonical quality squad and the meaning of every historical record."
+    description: "The `full` roster verbatim on qwen3.8:27b — exists ONLY as the comparison arm of the V38 model-comparison window (docs/plans/1-6-0-v38-model-comparison-preregistration.md). Identical to `full` in every field except model and, since 1.6.5, the qa role's completion budget (eve: max_completion_tokens 12288, #998); `full` remains the canonical quality squad and the meaning of every historical record."
     version: 1
     agents:
       - { agent_id: max, role: lead, model: "qwen3.8:27b", enabled: true }
       - { agent_id: neo, role: dev, model: "qwen3.8:27b", enabled: true }
       - { agent_id: nat, role: strat, model: "qwen3.8:27b", enabled: true }
       - { agent_id: bob, role: builder, model: "qwen3.8:27b", enabled: true }
-      - { agent_id: eve, role: qa, model: "qwen3.8:27b", enabled: true }
+      # 1.6.5 E (#998 ask 2): the qa author's primary emission — eight fill slots plus an
+      # additive suite under a ~17k-token prompt — sat at or within 3% of the 8,192 cap
+      # on four of ten emissions in the 1.6.4 set and lost every fill twice. The override
+      # is scoped to this role on this profile; the registry clamp (the V38 pin) and the
+      # dev budget (decomposition by design) are untouched. Measured by prediction Q5.
+      - { agent_id: eve, role: qa, model: "qwen3.8:27b", enabled: true, config_overrides: { max_completion_tokens: 12288 } }
       - { agent_id: data, role: data, model: "qwen3.8:27b", enabled: true }
 
   - profile_id: full

--- a/src/squadops/capabilities/handlers/cycle/qa_test.py
+++ b/src/squadops/capabilities/handlers/cycle/qa_test.py
@@ -568,6 +568,51 @@ class QATestHandler(_CycleTaskHandler):
         )
         return rendered.content
 
+    async def _self_eval_fill_section(
+        self,
+        context: ExecutionContext,
+        scaffold_input: dict[str, Any],
+        fill_merge_evidence: dict[str, Any] | None,
+    ) -> str:
+        """Render the fill-mode addendum to the self-eval prompt, or "" (1.6.5 C, #947).
+
+        The shared self-eval prompt asks for "the missing files"; under fill mode the
+        missing things are slots, which only a fill block can address. The addendum
+        names the slots whose disposition is not ``filled`` — data from the merge
+        record; every instruction lives in the managed asset (#448).
+        """
+        renderer = getattr(context.ports, "request_renderer", None)
+        if renderer is None or not scaffold_input:
+            return ""
+        unfilled = [
+            f"- `{d['slot_id']}` — {d['disposition']}"
+            + (f": {d['detail']}" if d.get("detail") else "")
+            for d in (fill_merge_evidence or {}).get("dispositions", [])
+            if d.get("disposition") != "filled"
+        ]
+        rendered = await renderer.render(
+            "request.qa_test_self_eval_fill_appendix",
+            {"unfilled_slot_lines": "\n".join(unfilled) or "(none)"},
+        )
+        return rendered.content
+
+    @staticmethod
+    def _suite_files(artifacts: list[dict]) -> list[dict]:
+        """The files the suite runs on: every test artifact the task will store.
+
+        #1109 (1.6.5 B): the suite used to run on the file set computed BEFORE the
+        self-eval loop, so a self-eval re-emission that fixed a blocking typed check
+        was stored and never tested — roll 8 of the 1.6.4 set failed on a truncated
+        file whose replacement was already in ``artifacts``, and a correction round
+        was spent rediscovering it. Deriving the set from ``artifacts`` at the moment
+        of the run makes "what ran" and "what was stored" the same thing.
+        """
+        return [
+            {"filename": a["name"], "content": a["content"]}
+            for a in artifacts
+            if a.get("type") == "test"
+        ]
+
     def _merge_fill_artifacts(
         self,
         scaffold_input: dict[str, Any],
@@ -1215,6 +1260,10 @@ class QATestHandler(_CycleTaskHandler):
                 while not validation.passed and self_eval_count < max_self_eval:
                     self_eval_count += 1
                     followup_prompt = self._build_self_eval_prompt(validation, artifacts)
+                    if scaffold_input:
+                        followup_prompt += await self._self_eval_fill_section(
+                            context, scaffold_input, evidence_extra.get("fill_merge")
+                        )
 
                     try:
                         followup_response = await context.ports.llm.chat_stream_with_usage(
@@ -1239,7 +1288,47 @@ class QATestHandler(_CycleTaskHandler):
                         followup_response.content,
                         followup_response.completion_tokens,
                     )
-                    new_extracted = extract_fenced_files(followup_response.content)
+                    followup_source = followup_response.content
+                    if scaffold_input:
+                        # 1.6.5 C (#947): the self-eval's fills go through the SAME merge
+                        # gate as the primary's — phantom tables (#1087) and element kinds
+                        # (#1094) included — instead of extracting as files named "slot-…"
+                        # that the shell guard then discards.
+                        from squadops.capabilities.verification_scaffold_fill import (
+                            apply_followup_fills,
+                            parse_fill_emission,
+                            strip_fill_blocks,
+                        )
+
+                        followup_fills = parse_fill_emission(followup_source)
+                        followup_source = strip_fill_blocks(followup_source)
+                        if followup_fills.fills:
+                            folded = apply_followup_fills(
+                                fill_emission or parse_fill_emission(""),
+                                followup_fills,
+                                (evidence_extra.get("fill_merge") or {}).get("dispositions", []),
+                            )
+                            fill_emission = folded.emission
+                            artifacts, merged_suite_files, fill_merge_evidence = (
+                                self._merge_fill_artifacts(scaffold_input, fill_emission, artifacts)
+                            )
+                            shell_drop_paths = {m["filename"] for m in merged_suite_files}
+                            evidence_extra["fill_merge"] = fill_merge_evidence
+                            evidence_extra.setdefault("self_eval_fills", []).append(
+                                {
+                                    "pass": self_eval_count,
+                                    "applied": list(folded.applied),
+                                    "skipped_filled": list(folded.skipped_filled),
+                                }
+                            )
+                            logger.info(
+                                "%s self_eval fills: applied=%s skipped_filled=%s counts=%s",
+                                self._handler_name,
+                                list(folded.applied),
+                                list(folded.skipped_filled),
+                                fill_merge_evidence["counts"],
+                            )
+                    new_extracted = extract_fenced_files(followup_source)
                     new_artifacts = [
                         {
                             "name": f["filename"],
@@ -1261,7 +1350,8 @@ class QATestHandler(_CycleTaskHandler):
         else:
             validation = ValidationResult(passed=True, summary="Validation disabled")
 
-        # Run generated tests and build report
+        # Run generated tests and build report — on what the task will store (#1109).
+        extracted = self._suite_files(artifacts)
         test_result, test_report_artifact = await self._run_test_suite(
             capability, sources, extracted
         )

--- a/src/squadops/capabilities/verification_scaffold_fill.py
+++ b/src/squadops/capabilities/verification_scaffold_fill.py
@@ -524,6 +524,65 @@ def merge_fills(
     )
 
 
+@dataclass(frozen=True)
+class FollowupFillMerge:
+    """A later emission's fills folded into an earlier one, per slot (#947, 1.6.5 C)."""
+
+    emission: FillEmission
+    #: slot ids the followup filled that were missing or rejected before.
+    applied: tuple[str, ...] = ()
+    #: slot ids the followup re-emitted although they were already filled — ignored, so a
+    #: self-eval asked for "only what is missing" cannot regress a slot that was fine.
+    skipped_filled: tuple[str, ...] = ()
+
+
+def apply_followup_fills(
+    base: FillEmission,
+    followup: FillEmission,
+    dispositions: Sequence[Mapping[str, Any]],
+) -> FollowupFillMerge:
+    """Fold a self-eval emission's fills into the primary emission.
+
+    A followup fill lands on a slot whose current disposition is anything but
+    ``filled`` (missing, rejected, not_applicable, or a duplicate); a slot already
+    filled keeps its primary fill and the re-emission is recorded, not applied. The
+    followup's own duplicates stay duplicates. Roll 6 of the 1.6.4 set is the case:
+    the primary hit the completion cap with zero fills, the self-eval re-emitted all
+    eight, and the handler threw them away because it only knew how to drop shell
+    paths.
+    """
+    filled = {d["slot_id"] for d in dispositions if d.get("disposition") == DISPOSITION_FILLED}
+    followup_dups = set(followup.duplicates)
+    fills: dict[str, Fill] = {
+        f.slot_id: f for f in base.fills if f.slot_id not in set(base.duplicates)
+    }
+    applied: list[str] = []
+    skipped: list[str] = []
+    for f in followup.fills:
+        if f.slot_id in followup_dups:
+            continue
+        if f.slot_id in filled:
+            skipped.append(f.slot_id)
+            continue
+        fills[f.slot_id] = f
+        applied.append(f.slot_id)
+    applied_set = set(applied)
+    duplicates = tuple(d for d in base.duplicates if d not in applied_set) + tuple(
+        d for d in followup.duplicates if d not in base.duplicates
+    )
+    return FollowupFillMerge(
+        emission=FillEmission(
+            fills=tuple(fills.values()),
+            duplicates=duplicates,
+            language_prefixed=tuple(
+                dict.fromkeys(base.language_prefixed + followup.language_prefixed)
+            ),
+        ),
+        applied=tuple(dict.fromkeys(applied)),
+        skipped_filled=tuple(dict.fromkeys(skipped)),
+    )
+
+
 def strip_fill_blocks(text: str) -> str:
     """The emission with every fill fence removed — what the file extractor may see.
 

--- a/src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md
+++ b/src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md
@@ -1,6 +1,6 @@
 ---
 template_id: request.qa_test_fill_mode_appendix
-version: "3"
+version: "4"
 required_variables:
   - slot_lines
   - shell_files
@@ -87,6 +87,12 @@ Three repair rounds blamed the application, and the application was correct.
 Additive tests are welcome IN ADDITION to fills: whole new test files beside the
 scaffold, emitted as normal ```typescript:__tests__/<name>.test.ts``` fences, under the
 standing rules (declared dependencies only, in-process execution model, no live server).
+
+**Order of emission: every fill block first, then any additive file.** Your completion
+budget is finite and a long emission is cut off at its end. Emitted in this order, a cut
+lands on an additive file — which the framework detects and asks you to re-emit — and
+never on a fill. Emitted the other way round, one long additive file has cost every fill
+on a live roll and the whole task with them.
 
 The plan also asked for the file(s) below. They are **additive and secondary** — a
 whole file here never substitutes for a fill, and filling every slot above comes

--- a/src/squadops/prompts/request_templates/request.qa_test_self_eval_fill_appendix.md
+++ b/src/squadops/prompts/request_templates/request.qa_test_self_eval_fill_appendix.md
@@ -1,0 +1,31 @@
+---
+template_id: request.qa_test_self_eval_fill_appendix
+version: "1"
+required_variables:
+  - unfilled_slot_lines
+---
+
+## FILL MODE — what "missing" means here
+
+This task is in fill mode (the FILL MODE section of the original request still applies:
+assertions only, `all(TABLES.<Entity>)`, the element kind read off the frozen floor). The
+scaffold files are read-only: a path-addressed file at a scaffold path is discarded, and
+a **fill block is the only way to change a slot**.
+
+**Slots that are still not filled** (with the reason the previous fill was refused, where
+there was one):
+{{unfilled_slot_lines}}
+
+If the list reads `(none)`, every slot is already filled — do not re-emit any fill; produce
+only the additive file(s) the validation summary names.
+
+Otherwise, emit one fill block per slot listed, **first, before anything else**:
+
+```fill:slot-<id>
+    expect(body.id).toBeTruthy()
+    expect(all(TABLES.Run)).toHaveLength(1)
+```
+
+A fill re-emitted for a slot that is already filled is ignored. Any additive file the
+validation summary names as missing follows the fills, as a normal
+```typescript:__tests__/<name>.test.ts``` fence.

--- a/tests/unit/capabilities/test_fill_mode_transport.py
+++ b/tests/unit/capabilities/test_fill_mode_transport.py
@@ -462,3 +462,198 @@ def test_containment_findings_reach_outputs_scaffold_evidence(scaffold_input, em
     assert outputs["scaffold_evidence"]["additive_containment"] == [
         "__tests__/live.test.ts: fetches a live server."
     ]
+
+
+# --- 1.6.5 B + C: the self-eval's fills are merged, and the suite runs on what is stored --- #
+
+
+def _self_eval_harness(monkeypatch, primary: str, followup: str):
+    """A qa.test run whose first validation fails and second passes, with the suite
+    call captured — the shape of both corrected rolls in the 1.6.4 set."""
+    from squadops.capabilities.handlers.cycle import qa_test as qa_test_module
+    from squadops.capabilities.handlers.test_runner import RunTestsResult
+
+    suite_calls: list[list[dict]] = []
+
+    async def _canned_suite(capability, sources, extracted):
+        suite_calls.append(extracted)
+        return RunTestsResult(
+            executed=True, exit_code=0, runner="vitest", suite_broken=False, test_failures=()
+        ), {
+            "name": "test_report.md",
+            "content": "r",
+            "media_type": "text/markdown",
+            "type": "document",
+        }
+
+    monkeypatch.setattr(
+        qa_test_module.QATestHandler, "_run_test_suite", staticmethod(_canned_suite)
+    )
+
+    verdicts = iter(
+        [
+            qa_test_module.ValidationResult(
+                passed=False, summary="missing", missing_components=["missing"]
+            ),
+            qa_test_module.ValidationResult(passed=True, summary="All checks passed"),
+        ]
+    )
+
+    async def _canned_validation(self, inputs, artifacts, typed_error_counts=None):
+        return next(verdicts)
+
+    monkeypatch.setattr(qa_test_module.QATestHandler, "_validate_output", _canned_validation)
+
+    context = MagicMock()
+    context.ports.llm.chat_stream_with_usage = AsyncMock(
+        side_effect=[MagicMock(content=primary), MagicMock(content=followup)]
+    )
+    context.ports.llm.default_model = "m"
+    assembled = MagicMock()
+    assembled.content = "system"
+    context.ports.prompt_service.assemble = MagicMock(return_value=assembled)
+    renderer = AsyncMock()
+    renderer.render.return_value = MagicMock(content="SELF-EVAL FILL ADDENDUM")
+    context.ports.request_renderer = renderer
+    return context, suite_calls, renderer
+
+
+def _all_eight_fills(body: str) -> str:
+    slots = [
+        "vc-probe-api-runs",
+        "vc-probe-api-runs-rejects-blank",
+        "vs-get-api-runs",
+        "vs-get-api-runs-run-id",
+        "vs-get-api-runs-run-id-not-found",
+        "vc-probe-api-runs-join",
+        "vc-probe-api-runs-join-duplicate",
+        "vc-probe-api-runs-leave",
+    ]
+    return "".join(f"```fill:slot-{s}\n    {body}\n```\n" for s in slots)
+
+
+_INPUTS = {
+    "prd": "group_run",
+    "artifact_contents": {},
+    "resolved_config": {
+        "dev_capability": "nextjs_ts",
+        "output_validation": True,
+        "max_self_eval_passes": 1,
+    },
+    "subtask_focus": "fill the scaffold",
+    "expected_artifacts": ["__tests__/runs.test.ts"],
+}
+
+
+async def test_roll_6_shape_the_self_evals_fills_are_merged_and_run(scaffold_input, monkeypatch):
+    """#947 through handle(): the primary hit the cap after the additive file with ZERO
+    fills; the self-eval re-emitted all eight. Before 1.6.5 C the handler extracted them
+    as files named "slot-…" and the shell guard discarded every one — the task failed
+    and the executor's re-dispatch was what saved the roll."""
+    primary = (
+        "```typescript:__tests__/runs.test.ts\nimport { x } from '@/app/api/runs/route'\n```\n"
+    )
+    followup = "Fills:\n" + _all_eight_fills("expect(body).toBeTruthy()")
+    context, suite_calls, renderer = _self_eval_harness(monkeypatch, primary, followup)
+
+    result = await QATestHandler().handle(
+        context, {**_INPUTS, "verification_scaffold": scaffold_input}
+    )
+
+    assert result.success is True
+    outputs = result.outputs
+    shells = [a for a in outputs["artifacts"] if a["name"].startswith("__tests__/scaffold/")]
+    assert len(shells) == 8
+    assert all("expect(body).toBeTruthy()" in a["content"] for a in shells)
+    # no "slot-…" pseudo-file survives as an artifact
+    assert not any(a["name"].startswith("slot-") for a in outputs["artifacts"])
+    # the suite ran ONCE, on the merged shells carrying the self-eval's fills (B + C)
+    assert len(suite_calls) == 1
+    ran = {f["filename"]: f["content"] for f in suite_calls[0]}
+    assert all("expect(body).toBeTruthy()" in ran[a["name"]] for a in shells)
+    # the self-eval prompt carried the fill addendum, rendered from the asset with the
+    # eight missing slots named
+    assert renderer.render.await_args.args[0] == "request.qa_test_self_eval_fill_appendix"
+    lines = renderer.render.await_args.args[1]["unfilled_slot_lines"]
+    assert lines.count("— missing") == 8
+    followup_prompt = (
+        context.ports.llm.chat_stream_with_usage.await_args_list[1].args[0][-1].content
+    )
+    assert followup_prompt.endswith("SELF-EVAL FILL ADDENDUM")
+
+
+async def test_roll_8_shape_the_suite_runs_on_the_self_evals_replacement(
+    scaffold_input, monkeypatch
+):
+    """#1109 through handle(): the primary's additive file was truncated at the cap; the
+    self-eval re-emitted it complete. The stored artifact was the complete file and the
+    suite ran on the truncated one — same task, two different files, a correction round
+    spent rediscovering the fix. What ran must be what is stored."""
+    truncated = (
+        "```typescript:__tests__/api.test.ts\nit('x', () => { const s = 'unterminated\n```\n"
+    )
+    complete = "```typescript:__tests__/api.test.ts\nit('x', () => { const s = 'ok' })\n```\n"
+    primary = _all_eight_fills("expect(body.id).toBeTruthy()") + truncated
+    context, suite_calls, _ = _self_eval_harness(monkeypatch, primary, complete)
+
+    result = await QATestHandler().handle(
+        context, {**_INPUTS, "verification_scaffold": scaffold_input}
+    )
+
+    stored = next(a for a in result.outputs["artifacts"] if a["name"] == "__tests__/api.test.ts")
+    assert "const s = 'ok'" in stored["content"]
+    assert len(suite_calls) == 1
+    ran = next(f for f in suite_calls[0] if f["filename"] == "__tests__/api.test.ts")
+    assert ran["content"] == stored["content"]
+    # the fills from the primary survived the self-eval pass untouched
+    shells = [a for a in result.outputs["artifacts"] if a["name"].startswith("__tests__/scaffold/")]
+    assert len(shells) == 8 and all("expect(body.id).toBeTruthy()" in a["content"] for a in shells)
+    # and every shell the suite ran is the stored one
+    ran_by_name = {f["filename"]: f["content"] for f in suite_calls[0]}
+    assert all(ran_by_name[a["name"]] == a["content"] for a in shells)
+
+
+async def test_a_self_eval_re_emission_of_a_filled_slot_does_not_regress_it(
+    scaffold_input, monkeypatch
+):
+    primary = _all_eight_fills("expect(body.id).toBeTruthy()")
+    followup = "```fill:slot-vc-probe-api-runs\n    expect(1).toBe(2)\n```\n"
+    context, _, _ = _self_eval_harness(monkeypatch, primary, followup)
+    result = await QATestHandler().handle(
+        context, {**_INPUTS, "verification_scaffold": scaffold_input}
+    )
+    create_shell = next(
+        a
+        for a in result.outputs["artifacts"]
+        if a["name"].endswith("vc-probe-api-runs.scaffold.test.ts")
+    )
+    assert "expect(body.id).toBeTruthy()" in create_shell["content"]
+    assert "expect(1).toBe(2)" not in create_shell["content"]
+
+
+async def test_the_self_eval_addendum_renders_from_the_real_asset(scaffold_input):
+    from adapters.prompts.filesystem_asset_adapter import FilesystemPromptAssetAdapter
+    from squadops.prompts.renderer import RequestTemplateRenderer
+
+    renderer = RequestTemplateRenderer(
+        FilesystemPromptAssetAdapter(
+            fragments_path=_TEMPLATES.parent / "fragments", templates_path=_TEMPLATES
+        )
+    )
+    context = MagicMock()
+    context.ports.request_renderer = renderer
+    evidence = {
+        "dispositions": [
+            {"slot_id": "slot-vc-probe-api-runs", "disposition": "filled", "detail": ""},
+            {
+                "slot_id": "slot-vc-probe-api-runs-join",
+                "disposition": "rejected",
+                "detail": "phantom table",
+            },
+        ]
+    }
+    out = await QATestHandler()._self_eval_fill_section(context, scaffold_input, evidence)
+    assert "slot-vc-probe-api-runs-join` — rejected: phantom table" in out
+    assert "slot-vc-probe-api-runs` — filled" not in out
+    assert "fill block is the only way to change a slot" in out
+    assert "```fill:slot-<id>" in out

--- a/tests/unit/capabilities/test_verification_scaffold_fill.py
+++ b/tests/unit/capabilities/test_verification_scaffold_fill.py
@@ -385,3 +385,92 @@ class TestElementKindFindings:
         assert "slot-vc-probe-api-runs-join-duplicate" not in kinds
         # stack #1 emits no scaffold: nothing to contradict, nothing threaded
         assert slot_element_kinds(manifest_for_stack("fullstack_fastapi_react")) == {}
+
+
+class TestApplyFollowupFills:
+    """1.6.5 C (#947): a self-eval's fills fold into the primary emission per slot.
+
+    Bug caught: the self-eval re-emits every slot after a cap-exhausted primary (roll 6
+    of the 1.6.4 set) and the handler discards them; or a re-emission of an already-filled
+    slot silently regresses a fill that was fine.
+    """
+
+    @staticmethod
+    def _dispositions(**by_slot):
+        return [{"slot_id": k, "disposition": v, "detail": ""} for k, v in by_slot.items()]
+
+    def test_missing_and_rejected_slots_take_the_followup_fill(self):
+        from squadops.capabilities.verification_scaffold_fill import (
+            apply_followup_fills,
+            parse_fill_emission,
+        )
+
+        base = parse_fill_emission(
+            "```fill:slot-a\n    expect(1).toBe(1)\n```\n```fill:slot-b\n    bad()\n```\n"
+        )
+        followup = parse_fill_emission(
+            "```fill:slot-b\n    expect(2).toBe(2)\n```\n```fill:slot-c\n    expect(3).toBe(3)\n```\n"
+        )
+        out = apply_followup_fills(
+            base,
+            followup,
+            self._dispositions(**{"slot-a": "filled", "slot-b": "rejected", "slot-c": "missing"}),
+        )
+        bodies = {f.slot_id: f.body.strip() for f in out.emission.fills}
+        assert bodies == {
+            "slot-a": "expect(1).toBe(1)",
+            "slot-b": "expect(2).toBe(2)",
+            "slot-c": "expect(3).toBe(3)",
+        }
+        assert out.applied == ("slot-b", "slot-c")
+        assert out.skipped_filled == ()
+
+    def test_a_re_emission_of_a_filled_slot_is_ignored_and_recorded(self):
+        from squadops.capabilities.verification_scaffold_fill import (
+            apply_followup_fills,
+            parse_fill_emission,
+        )
+
+        base = parse_fill_emission("```fill:slot-a\n    expect(1).toBe(1)\n```\n")
+        followup = parse_fill_emission("```fill:slot-a\n    expect(9).toBe(9)\n```\n")
+        out = apply_followup_fills(base, followup, self._dispositions(**{"slot-a": "filled"}))
+        assert [f.body.strip() for f in out.emission.fills] == ["expect(1).toBe(1)"]
+        assert out.applied == ()
+        assert out.skipped_filled == ("slot-a",)
+
+    def test_an_empty_primary_takes_every_followup_fill(self):
+        """Roll 6's shape: cap hit with zero fills, self-eval emits all of them."""
+        from squadops.capabilities.verification_scaffold_fill import (
+            apply_followup_fills,
+            parse_fill_emission,
+        )
+
+        followup = parse_fill_emission(
+            "".join(f"```fill:slot-{i}\n    expect({i}).toBe({i})\n```\n" for i in range(8))
+        )
+        out = apply_followup_fills(
+            parse_fill_emission(""),
+            followup,
+            self._dispositions(**{f"slot-{i}": "missing" for i in range(8)}),
+        )
+        assert len(out.emission.fills) == 8
+        assert len(out.applied) == 8
+
+    def test_a_followup_duplicate_stays_a_duplicate_and_a_resolved_one_clears(self):
+        from squadops.capabilities.verification_scaffold_fill import (
+            apply_followup_fills,
+            parse_fill_emission,
+        )
+
+        base = parse_fill_emission("```fill:slot-a\n    x\n```\n```fill:slot-a\n    y\n```\n")
+        assert base.duplicates == ("slot-a",)
+        followup = parse_fill_emission(
+            "```fill:slot-a\n    z\n```\n```fill:slot-b\n    p\n```\n```fill:slot-b\n    q\n```\n"
+        )
+        out = apply_followup_fills(
+            base, followup, self._dispositions(**{"slot-a": "rejected", "slot-b": "missing"})
+        )
+        # slot-a was a duplicate in the primary; ONE followup fill resolves it
+        assert "slot-a" in out.applied and "slot-a" not in out.emission.duplicates
+        # slot-b is a duplicate in the followup; it stays rejected as such
+        assert "slot-b" in out.emission.duplicates and "slot-b" not in out.applied

--- a/tests/unit/cycles/test_squad_profile_builder.py
+++ b/tests/unit/cycles/test_squad_profile_builder.py
@@ -75,3 +75,19 @@ class TestFullSquadBuilderProfile:
         profiles = await provider.list_profiles()
         ids = {p.profile_id for p in profiles}
         assert ids == {"smoke", "lite", "full", "full-38"}
+
+
+class TestFull38QaCompletionBudget:
+    """1.6.5 E (#998 ask 2). Bug caught: the override is dropped by the loader, applied
+    to every role, or lands on `full` — any of which silently changes what the set
+    measures."""
+
+    async def test_only_eve_on_full_38_carries_the_override(self, provider):
+        profile = await provider.get_profile("full-38")
+        by_role = {a.role: a for a in profile.agents}
+        assert by_role["qa"].config_overrides == {"max_completion_tokens": 12288}
+        assert all(not a.config_overrides for a in profile.agents if a.role != "qa")
+
+    async def test_full_is_untouched(self, provider):
+        profile = await provider.get_profile("full")
+        assert all(not a.config_overrides for a in profile.agents)

--- a/tests/unit/prompts/test_qa_test_fragment.py
+++ b/tests/unit/prompts/test_qa_test_fragment.py
@@ -114,3 +114,21 @@ class TestFillModeBriefInstructions:
         used = set(re.findall(r"\{\{(\w+)\}\}", brief))
 
         assert used == declared, f"declared={sorted(declared)} used={sorted(used)}"
+
+
+class TestFillsAreEmittedFirst:
+    """1.6.5 A (#998 ask 2, ordering half). Bug caught: the brief says fills come first
+    in *priority* but nothing about emission ORDER, so the author wrote the additive file
+    first, hit the completion cap, and lost every fill (1.6.4 set, roll 6)."""
+
+    _APPENDIX = (
+        Path(__file__).resolve().parents[3]
+        / "src/squadops/prompts/request_templates/request.qa_test_fill_mode_appendix.md"
+    )
+
+    def test_the_order_rule_is_stated_and_precedes_the_additive_files_paragraph(self):
+        text = self._APPENDIX.read_text()
+        rule = text.index("**Order of emission: every fill block first, then any additive file.**")
+        additive = text.index("The plan also asked for the file(s) below.")
+        assert rule < additive
+        assert "lands on an additive file" in text


### PR DESCRIPTION
## What

The 1.6.5 plan's §4 step 2 — items **A + B + C + E** on one deploy boundary (`docs/plans/1-6-5-plan.md` rev 3, §2.1). One commit per item plus the CHANGELOG entry.

**One mechanism, three faces** (record §3): the qa author's ~17k-token prompt asks for eight fills and an additive suite; three of eight rolls hit the 8,192-token completion cap, and what happened next was recovered by fallbacks, never by the path that should have.

- **A — fills first** (appendix v4). The brief now states emission *order*, not just priority. A cut at the cap lands on the additive file (#1082 catches it, the self-eval re-emits it), never on a fill. Roll 6 lost all eight fills to an additive file written first.
- **B — the suite runs on what the task stores** (`#1109`). `_suite_files(artifacts)` derives the execution set at the moment of the run instead of the pre-self-eval `extracted`. Roll 8 failed on a truncated file whose complete replacement was already in `artifacts`; the retest passed on the same hash.
- **C — the self-eval merges fills** (`#947`). Fill-mode addendum to the self-eval prompt from a managed asset (`request.qa_test_self_eval_fill_appendix`, v1) naming the unfilled slots from the merge record; `apply_followup_fills` folds the followup's fills per slot (missing/rejected take the fill, filled keeps its own and the re-emission is recorded) and they pass the **same** merge gate (#1087, #1094). Before: extracted as files named `slot-…` and discarded by the shell guard.
- **E — qa-only completion budget.** `full-38` / `eve`: `config_overrides: {max_completion_tokens: 12288}` through the allowlisted seam (`models.py:184` → `task_plan.py:899` → `base.py:351`). Registry clamp and dev budget untouched. Moves `resolved_config_hash` — the 1.6.5 set pre-registers the new one.

**Not built, stated:** raising the registry clamp or the dev budget (§2.2); the zero-character reasoning-exhaustion class (a larger budget makes those longer, not fewer — #998's signatures and A–C handle them).

**Deploy note:** `config/` is baked into the runtime-api image (`src/squadops/api/runtime/Dockerfile:49`), so E needs the rebuild A–C need anyway. Verify *loaded* in-container: `apply_followup_fills`, `_suite_files`, the v4 appendix, and eve's override on the resolved profile.

## Closes

Closes #1109
Closes #947
Closes #998

## Evidence

- **Replay, roll 6 (`cyc_bbc9da03c3c1`), real banked artifacts:** primary `__tests__/runs.test.ts` → 0 fills, 8 missing; the eight banked `slot-*` self-eval fills folded and merged through the gate with the roll's own manifest (`store_tables=['Run']`, element kinds) → **8/8 filled**. Where the handler had discarded all eight.
- **Roll 8 (`cyc_8d262b968f58`):** the truncated bytes were never banked — the run-end re-store (#1111) wrote the task's final state, so both `api.test.ts` artifacts are the same complete 11,966-char file. B's mechanism is pinned at handle() level instead: the primary's truncated additive file is replaced by the self-eval's, and the suite call receives byte-for-byte what is stored.
- **handle()-level tests** (`test_fill_mode_transport.py`): the roll-6 shape (0 fills → 8 via self-eval → suite runs once on merged shells; no `slot-*` pseudo-artifact; the addendum rendered with 8 missing slots), the roll-8 shape (what ran == what stored, fills untouched), a re-emitted filled slot does not regress, the addendum renders from the real asset.
- `apply_followup_fills` unit tests (4), the appendix order rule, the profile override (eve only; `full` untouched).
- **Regression: 7,970 passed, 0 failed** (script exit 0, venv active, no pipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tj9vAj9yumEzAmBLrZnrX
